### PR TITLE
Fix test compilation errors and achieve 83.3% code coverage

### DIFF
--- a/crates/catalog/src/tests.rs
+++ b/crates/catalog/src/tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::{Catalog, CatalogError, ColumnSchema, TableSchema};
 
     #[test]
     fn test_column_schema_creation() {

--- a/crates/executor/src/tests.rs
+++ b/crates/executor/src/tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::{ExecutorError, ExpressionEvaluator, SelectExecutor};
 
     // ========================================================================
     // Expression Evaluator Tests
@@ -568,7 +568,13 @@ mod tests {
             .into_iter()
             .map(|row| (row.values[0].clone(), row.values[1].clone()))
             .collect::<Vec<_>>();
-        results.sort_by_key(|(dept, _)| dept.clone());
+        // Sort by dept (first value) - comparing integers directly
+        results.sort_by(|(a, _), (b, _)| {
+            match (a, b) {
+                (types::SqlValue::Integer(x), types::SqlValue::Integer(y)) => x.cmp(y),
+                _ => std::cmp::Ordering::Equal,
+            }
+        });
         assert_eq!(results[0], (types::SqlValue::Integer(1), types::SqlValue::Integer(2)));
         assert_eq!(results[1], (types::SqlValue::Integer(2), types::SqlValue::Integer(1)));
     }


### PR DESCRIPTION
## Summary

Fixed test compilation errors and verified code coverage exceeds the 70% target. Current workspace coverage is 83.3%.

## Changes

### Task 1: Fix Test Compilation Errors ✅

**catalog/src/tests.rs**:
- Updated imports from `use super::*` to explicit `use crate::{...}`
- Added `Catalog`, `CatalogError`, `ColumnSchema`, `TableSchema` imports
- Fixed 31 compilation errors

**executor/src/tests.rs**:
- Updated imports to use `crate::{ExecutorError, ExpressionEvaluator, SelectExecutor}`
- Fixed SqlValue sorting issue in `test_group_by` using custom comparator
- Fixed 22 compilation errors

### Task 2: Generate Coverage Baseline ✅

Generated coverage report using `cargo-llvm-cov`:
- **Overall Coverage**: 83.3% (2465/2958 lines)
- Report available at `target/coverage/html/html/index.html`
- LCOV format available at `target/coverage/lcov.info`

### Task 3: Assess Coverage Requirements ✅

**Conclusion**: No additional tests needed - we already exceed the 70% target!

**Per-crate highlights**:
- ast: 93.7%
- parser: 75-97% (various modules)
- executor/select.rs: 63.9% (largest file, still contributes well)
- catalog: 89-100% (most modules)
- types: Well-covered by existing tests

**Low coverage areas** (acceptable):
- Error Display implementations: 0% (not business logic)
- Keywords module: 0% (static data)

## Test Results

All workspace tests pass (cargo test --workspace)
- Catalog tests: 10 passing
- Executor tests: 11 passing  
- Total coverage: 83.3% (exceeds 70% requirement)
- Coverage report successfully generated

## Verification

Ran the full verification checklist from issue #9:
- [x] cargo test --workspace passes with 0 errors
- [x] cargo coverage generates HTML report without errors
- [x] Overall workspace coverage ≥70% (83.3%)
- [x] No crate has <50% coverage
- [x] Coverage report accessible

Closes #9