### PR TITLE
Phase 2.3: Move DDL types to separate module

### DIFF
--- a/crates/ast/src/ddl.rs
+++ b/crates/ast/src/ddl.rs
@@ -1,0 +1,19 @@
+//! Data Definition Language (DDL) AST nodes
+
+use types::DataType;
+
+/// CREATE TABLE statement
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateTableStmt {
+    pub table_name: String,
+    pub columns: Vec<ColumnDef>,
+    // TODO: Add constraints
+}
+
+/// Column definition
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnDef {
+    pub name: String,
+    pub data_type: DataType,
+    pub nullable: bool,
+}

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -4,7 +4,11 @@
 //! as parsed from SQL text. The AST is a tree representation that
 //! preserves the semantic structure of SQL queries.
 
+mod ddl;
+
 use types::SqlValue;
+
+pub use ddl::{ColumnDef, CreateTableStmt};
 
 // ============================================================================
 // Top-level SQL Statements
@@ -127,26 +131,6 @@ pub struct Assignment {
 pub struct DeleteStmt {
     pub table_name: String,
     pub where_clause: Option<Expression>,
-}
-
-// ============================================================================
-// CREATE TABLE Statement
-// ============================================================================
-
-/// CREATE TABLE statement
-#[derive(Debug, Clone, PartialEq)]
-pub struct CreateTableStmt {
-    pub table_name: String,
-    pub columns: Vec<ColumnDef>,
-    // TODO: Add constraints
-}
-
-/// Column definition
-#[derive(Debug, Clone, PartialEq)]
-pub struct ColumnDef {
-    pub name: String,
-    pub data_type: types::DataType,
-    pub nullable: bool,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Extract DDL (Data Definition Language) types to separate module as part of the AST refactoring effort (#13).

## Changes

- Created `crates/ast/src/ddl.rs` with `CreateTableStmt` and `ColumnDef` structures
- Added module declaration and public exports to `lib.rs`
- Removed old DDL definitions from `lib.rs` (previously at lines 137-150)
- Maintained all existing functionality and test coverage

## Test Results

✅ All 22 AST tests pass
✅ No clippy warnings
✅ File sizes as expected:
  - `ddl.rs`: 19 lines
  - `lib.rs`: 549 lines (reduced from 566)

## Verification

```bash
cargo test --package ast
# All tests pass

cargo clippy --package ast --all-targets
# No warnings
```

Closes #30