### PR TITLE
Add missing loom:changes-requested label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -37,6 +37,10 @@
   description: PR ready for Judge to review
   color: "10B981"  # emerald-500
 
+- name: loom:changes-requested
+  description: PR requires changes before Judge can approve
+  color: "F59E0B"  # amber-500 - action required
+
 - name: loom:pr
   description: PR approved by Judge, ready for human to merge
   color: "3B82F6"  # blue-500


### PR DESCRIPTION
## Summary
- Adds `loom:changes-requested` label to complete the PR review workflow
- Label was referenced in Judge role documentation but missing from repository
- Enables Judge to properly mark PRs requiring changes

## Problem

The Judge role documentation (`.loom/roles/judge.md:60`) references a `loom:changes-requested` label for marking PRs that need changes, but this label doesn't exist in `.github/labels.yml`.

**Impact**: When Judge requests changes on a PR, the documented workflow fails with "label not found" error, leaving PRs without proper state tracking.

## Solution

Added label definition to `.github/labels.yml`:
```yaml
- name: loom:changes-requested
  description: PR requires changes before Judge can approve
  color: "F59E0B"  # amber-500 - action required
```

## PR Workflow State Machine

With this label, the PR review workflow is now complete:
1. `loom:review-requested` (green) → PR ready for Judge review
2. `loom:reviewing` (amber) → Judge is actively reviewing
3. `loom:changes-requested` (amber) → Author must address feedback
4. → Back to step 1 after fixes
5. `loom:pr` (blue) → Approved, ready for human to merge

## Changes
- **`.github/labels.yml`**: Added `loom:changes-requested` label definition

## Test plan
- [x] Label definition follows existing format and conventions
- [x] Color (F59E0B amber) matches other "action required" states
- [x] Label already created in GitHub: https://github.com/rjwalters/nistmemsql/labels/loom%3Achanges-requested
- [x] Label successfully applied to PR #35 (which has changes requested)

## Related
- Closes #37
- Upstream issue: rjwalters/loom#794
- Applied to: PR #35 (documentation update needing fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)