### PR TITLE
Fix executor test sort to use PartialOrd instead of Ord

### DIFF
--- a/crates/executor/src/tests/select_executor.rs
+++ b/crates/executor/src/tests/select_executor.rs
@@ -465,7 +465,9 @@ fn test_group_by_with_count() {
         .into_iter()
         .map(|row| (row.values[0].clone(), row.values[1].clone()))
         .collect::<Vec<_>>();
-    results.sort_by_key(|(dept, _)| dept.clone());
+    results.sort_by(|(a_dept, _), (b_dept, _)| {
+        a_dept.partial_cmp(b_dept).unwrap_or(std::cmp::Ordering::Equal)
+    });
     assert_eq!(results[0], (types::SqlValue::Integer(1), types::SqlValue::Integer(2)));
     assert_eq!(results[1], (types::SqlValue::Integer(2), types::SqlValue::Integer(1)));
 }


### PR DESCRIPTION
## Summary
Fixes compilation error in executor tests by using `sort_by` with `PartialOrd` instead of `sort_by_key` which requires the `Ord` trait.

## Problem
Test `test_group_by_with_count` at line 468 of `select_executor.rs` was using `sort_by_key` which requires `Ord`, but `SqlValue` only implements `PartialOrd` per PR #32.

## Solution
Changed from:
```rust
results.sort_by_key(|(dept, _)| dept.clone());
```

To:
```rust
results.sort_by(|(a_dept, _), (b_dept, _)| {
    a_dept.partial_cmp(b_dept).unwrap_or(std::cmp::Ordering::Equal)
});
```

## Rationale
`SqlValue` correctly implements only `PartialOrd` (not `Ord`) because:
1. SQL NULL comparisons return UNKNOWN (represented as `None`)
2. Type mismatches between values are incomparable
3. Floating-point NaN values cannot be totally ordered per IEEE 754

This fix properly handles SQL:1999 semantics while allowing the test to sort results for assertion purposes.

## Changes
- **crates/executor/src/tests/select_executor.rs**: Updated line 468 to use `sort_by` with `partial_cmp`

## Test Plan
- [x] All 188 workspace tests pass
- [x] No clippy warnings
- [x] Test correctly sorts INTEGER values for assertions
- [x] Unblocks issue #22 (documentation work requiring `cargo coverage`)
- [x] Unblocks PR #35 (blocked on test compilation)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)