### PR TITLE
Complete AST module refactoring (DML, SELECT, statement)

### DIFF
--- a/crates/ast/src/dml.rs
+++ b/crates/ast/src/dml.rs
@@ -1,0 +1,47 @@
+//! Data Manipulation Language (DML) statements
+//!
+//! This module contains INSERT, UPDATE, and DELETE statement types.
+
+use crate::Expression;
+
+// ============================================================================
+// INSERT Statement
+// ============================================================================
+
+/// INSERT statement
+#[derive(Debug, Clone, PartialEq)]
+pub struct InsertStmt {
+    pub table_name: String,
+    pub columns: Vec<String>,
+    pub values: Vec<Vec<Expression>>, // Can insert multiple rows
+}
+
+// ============================================================================
+// UPDATE Statement
+// ============================================================================
+
+/// UPDATE statement
+#[derive(Debug, Clone, PartialEq)]
+pub struct UpdateStmt {
+    pub table_name: String,
+    pub assignments: Vec<Assignment>,
+    pub where_clause: Option<Expression>,
+}
+
+/// Column assignment (column = value)
+#[derive(Debug, Clone, PartialEq)]
+pub struct Assignment {
+    pub column: String,
+    pub value: Expression,
+}
+
+// ============================================================================
+// DELETE Statement
+// ============================================================================
+
+/// DELETE statement
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeleteStmt {
+    pub table_name: String,
+    pub where_clause: Option<Expression>,
+}

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -5,135 +5,18 @@
 //! preserves the semantic structure of SQL queries.
 
 mod ddl;
+mod dml;
 mod expression;
 mod operators;
+mod select;
+mod statement;
 
 pub use ddl::{ColumnDef, CreateTableStmt};
+pub use dml::{Assignment, DeleteStmt, InsertStmt, UpdateStmt};
 pub use expression::Expression;
 pub use operators::{BinaryOperator, UnaryOperator};
-
-// ============================================================================
-// Top-level SQL Statements
-// ============================================================================
-
-/// A complete SQL statement
-#[derive(Debug, Clone, PartialEq)]
-pub enum Statement {
-    Select(SelectStmt),
-    Insert(InsertStmt),
-    Update(UpdateStmt),
-    Delete(DeleteStmt),
-    CreateTable(CreateTableStmt),
-    // TODO: Add more statement types (ALTER, DROP, etc.)
-}
-
-// ============================================================================
-// SELECT Statement
-// ============================================================================
-
-/// SELECT statement structure
-#[derive(Debug, Clone, PartialEq)]
-pub struct SelectStmt {
-    pub select_list: Vec<SelectItem>,
-    pub from: Option<FromClause>,
-    pub where_clause: Option<Expression>,
-    pub group_by: Option<Vec<Expression>>,
-    pub having: Option<Expression>,
-    pub order_by: Option<Vec<OrderByItem>>,
-    pub limit: Option<usize>,
-    pub offset: Option<usize>,
-}
-
-/// Item in the SELECT list
-#[derive(Debug, Clone, PartialEq)]
-pub enum SelectItem {
-    /// SELECT *
-    Wildcard,
-    /// SELECT expr [AS alias]
-    Expression { expr: Expression, alias: Option<String> },
-}
-
-/// FROM clause
-#[derive(Debug, Clone, PartialEq)]
-pub enum FromClause {
-    Table {
-        name: String,
-        alias: Option<String>,
-    },
-    Join {
-        left: Box<FromClause>,
-        right: Box<FromClause>,
-        join_type: JoinType,
-        condition: Option<Expression>,
-    },
-    // TODO: Add subqueries, etc.
-}
-
-/// JOIN types
-#[derive(Debug, Clone, PartialEq)]
-pub enum JoinType {
-    Inner,
-    LeftOuter,
-    RightOuter,
-    FullOuter,
-    Cross,
-}
-
-/// ORDER BY item
-#[derive(Debug, Clone, PartialEq)]
-pub struct OrderByItem {
-    pub expr: Expression,
-    pub direction: OrderDirection,
-}
-
-/// Sort direction
-#[derive(Debug, Clone, PartialEq)]
-pub enum OrderDirection {
-    Asc,
-    Desc,
-}
-
-// ============================================================================
-// INSERT Statement
-// ============================================================================
-
-/// INSERT statement
-#[derive(Debug, Clone, PartialEq)]
-pub struct InsertStmt {
-    pub table_name: String,
-    pub columns: Vec<String>,
-    pub values: Vec<Vec<Expression>>, // Can insert multiple rows
-}
-
-// ============================================================================
-// UPDATE Statement
-// ============================================================================
-
-/// UPDATE statement
-#[derive(Debug, Clone, PartialEq)]
-pub struct UpdateStmt {
-    pub table_name: String,
-    pub assignments: Vec<Assignment>,
-    pub where_clause: Option<Expression>,
-}
-
-/// Column assignment (column = value)
-#[derive(Debug, Clone, PartialEq)]
-pub struct Assignment {
-    pub column: String,
-    pub value: Expression,
-}
-
-// ============================================================================
-// DELETE Statement
-// ============================================================================
-
-/// DELETE statement
-#[derive(Debug, Clone, PartialEq)]
-pub struct DeleteStmt {
-    pub table_name: String,
-    pub where_clause: Option<Expression>,
-}
+pub use select::{FromClause, JoinType, OrderByItem, OrderDirection, SelectItem, SelectStmt};
+pub use statement::Statement;
 
 
 

--- a/crates/ast/src/select.rs
+++ b/crates/ast/src/select.rs
@@ -1,0 +1,72 @@
+//! SELECT statement types
+//!
+//! This module contains all types related to SELECT queries including
+//! SELECT items, FROM clauses, JOINs, and ORDER BY.
+
+use crate::Expression;
+
+// ============================================================================
+// SELECT Statement
+// ============================================================================
+
+/// SELECT statement structure
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectStmt {
+    pub select_list: Vec<SelectItem>,
+    pub from: Option<FromClause>,
+    pub where_clause: Option<Expression>,
+    pub group_by: Option<Vec<Expression>>,
+    pub having: Option<Expression>,
+    pub order_by: Option<Vec<OrderByItem>>,
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+}
+
+/// Item in the SELECT list
+#[derive(Debug, Clone, PartialEq)]
+pub enum SelectItem {
+    /// SELECT *
+    Wildcard,
+    /// SELECT expr [AS alias]
+    Expression { expr: Expression, alias: Option<String> },
+}
+
+/// FROM clause
+#[derive(Debug, Clone, PartialEq)]
+pub enum FromClause {
+    Table {
+        name: String,
+        alias: Option<String>,
+    },
+    Join {
+        left: Box<FromClause>,
+        right: Box<FromClause>,
+        join_type: JoinType,
+        condition: Option<Expression>,
+    },
+    // TODO: Add subqueries, etc.
+}
+
+/// JOIN types
+#[derive(Debug, Clone, PartialEq)]
+pub enum JoinType {
+    Inner,
+    LeftOuter,
+    RightOuter,
+    FullOuter,
+    Cross,
+}
+
+/// ORDER BY item
+#[derive(Debug, Clone, PartialEq)]
+pub struct OrderByItem {
+    pub expr: Expression,
+    pub direction: OrderDirection,
+}
+
+/// Sort direction
+#[derive(Debug, Clone, PartialEq)]
+pub enum OrderDirection {
+    Asc,
+    Desc,
+}

--- a/crates/ast/src/statement.rs
+++ b/crates/ast/src/statement.rs
@@ -1,0 +1,20 @@
+//! Top-level SQL statement types
+//!
+//! This module defines the Statement enum that represents all possible SQL statements.
+
+use crate::{CreateTableStmt, DeleteStmt, InsertStmt, SelectStmt, UpdateStmt};
+
+// ============================================================================
+// Top-level SQL Statements
+// ============================================================================
+
+/// A complete SQL statement
+#[derive(Debug, Clone, PartialEq)]
+pub enum Statement {
+    Select(SelectStmt),
+    Insert(InsertStmt),
+    Update(UpdateStmt),
+    Delete(DeleteStmt),
+    CreateTable(CreateTableStmt),
+    // TODO: Add more statement types (ALTER, DROP, etc.)
+}


### PR DESCRIPTION
## Summary

Completed Phase 2.4 of AST module refactoring by extracting the remaining statement types from lib.rs into focused, well-organized modules.

## Changes

### New Modules Created

1. **`dml.rs`** (39 lines)
   - INSERT statement (`InsertStmt`)
   - UPDATE statement (`UpdateStmt`, `Assignment`)
   - DELETE statement (`DeleteStmt`)
   - All DML (Data Manipulation Language) statements in one focused module

2. **`select.rs`** (70 lines)
   - SELECT statement (`SelectStmt`)
   - SELECT list items (`SelectItem`)
   - FROM clause (`FromClause`)
   - JOIN types (`JoinType`)
   - ORDER BY (`OrderByItem`, `OrderDirection`)
   - All SELECT-related types organized together

3. **`statement.rs`** (20 lines)
   - Top-level `Statement` enum
   - Clean separation of statement type enumeration from implementations

### Refactored `lib.rs`

- Reduced from 478 lines to ~370 lines (after removing extracted code)
- Now serves as thin re-export layer with clear module structure
- Added module declarations: `dml`, `select`, `statement`
- Comprehensive re-exports for all public types

## Module Organization

```
crates/ast/src/
├── ddl.rs (19 lines) - DDL statements
├── dml.rs (39 lines) - DML statements (NEW)
├── expression.rs (46 lines) - Expression types
├── operators.rs (39 lines) - Operators
├── select.rs (70 lines) - SELECT types (NEW)
├── statement.rs (20 lines) - Statement enum (NEW)
└── lib.rs (370 lines) - Re-exports + tests
```

## Verification

✅ All 22 AST tests passing
✅ All 188 workspace tests passing
✅ No clippy warnings
✅ Each file appropriately sized and focused
✅ Clear separation of concerns by statement type

## Dependencies

This completes Phase 2.4 of the AST refactoring initiative (#13).

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>