### PR TITLE
Fix unused import warnings in parser test modules

### DIFF
--- a/crates/parser/src/tests/lexer/mod.rs
+++ b/crates/parser/src/tests/lexer/mod.rs
@@ -1,5 +1,3 @@
-use super::super::*;
-
 mod errors;
 mod identifiers;
 mod keywords;

--- a/crates/parser/src/tests/select/mod.rs
+++ b/crates/parser/src/tests/select/mod.rs
@@ -1,4 +1,2 @@
-use super::*;
-
 mod basic;
 mod filters;


### PR DESCRIPTION
## Summary

Fixed two unused import warnings in parser test module organization files.

## Changes

- **`crates/parser/src/tests/lexer/mod.rs`**: Removed unused `use super::super::*`
- **`crates/parser/src/tests/select/mod.rs`**: Removed unused `use super::*`

## Rationale

These mod.rs files only organize submodules and don't need the wildcard imports. The imports were causing compiler warnings during test builds.

## Test Results

All 188 tests passing:
- AST: 22 tests
- Catalog: 10 tests
- Executor: 21 tests
- Parser: 83 tests ✓ (no warnings)
- Types: 45 tests
- End-to-end: 6 tests
- Storage: 1 test

## Before

```
warning: unused import: `super::super::*`
 --> crates/parser/src/tests/lexer/mod.rs:1:5
warning: unused import: `super::*`
 --> crates/parser/src/tests/select/mod.rs:1:5
warning: `parser` (lib test) generated 2 warnings
```

## After

No warnings ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)