### PR TITLE
Phase 3: Split executor/select.rs into execution modules

### DIFF
--- a/crates/executor/src/select/filter.rs
+++ b/crates/executor/src/select/filter.rs
@@ -1,0 +1,2 @@
+// Filter module - WHERE clause evaluation is currently integrated into main execution logic
+// This module is reserved for future extraction of filtering logic

--- a/crates/executor/src/select/grouping.rs
+++ b/crates/executor/src/select/grouping.rs
@@ -1,0 +1,160 @@
+use std::cmp::Ordering;
+
+/// Accumulator for aggregate functions
+#[derive(Debug, Clone)]
+pub(super) enum AggregateAccumulator {
+    Count(i64),
+    Sum(i64),
+    Avg { sum: i64, count: i64 },
+    Min(Option<types::SqlValue>),
+    Max(Option<types::SqlValue>),
+}
+
+impl AggregateAccumulator {
+    pub(super) fn new(function_name: &str) -> Result<Self, crate::errors::ExecutorError> {
+        match function_name.to_uppercase().as_str() {
+            "COUNT" => Ok(AggregateAccumulator::Count(0)),
+            "SUM" => Ok(AggregateAccumulator::Sum(0)),
+            "AVG" => Ok(AggregateAccumulator::Avg { sum: 0, count: 0 }),
+            "MIN" => Ok(AggregateAccumulator::Min(None)),
+            "MAX" => Ok(AggregateAccumulator::Max(None)),
+            _ => Err(crate::errors::ExecutorError::UnsupportedExpression(format!(
+                "Unknown aggregate function: {}",
+                function_name
+            ))),
+        }
+    }
+
+    pub(super) fn accumulate(&mut self, value: &types::SqlValue) {
+        match (self, value) {
+            // COUNT - counts non-NULL values
+            (AggregateAccumulator::Count(_), types::SqlValue::Null) => {}
+            (AggregateAccumulator::Count(ref mut count), _) => {
+                *count += 1;
+            }
+
+            // SUM - sums integer values, ignores NULLs
+            (AggregateAccumulator::Sum(ref mut sum), types::SqlValue::Integer(val)) => {
+                *sum += val;
+            }
+            (AggregateAccumulator::Sum(_), types::SqlValue::Null) => {}
+
+            // AVG - computes average of integer values, ignores NULLs
+            (
+                AggregateAccumulator::Avg { ref mut sum, ref mut count },
+                types::SqlValue::Integer(val),
+            ) => {
+                *sum += val;
+                *count += 1;
+            }
+            (AggregateAccumulator::Avg { .. }, types::SqlValue::Null) => {}
+
+            // MIN - finds minimum value, ignores NULLs
+            (AggregateAccumulator::Min(ref mut current_min), val @ types::SqlValue::Integer(_))
+            | (AggregateAccumulator::Min(ref mut current_min), val @ types::SqlValue::Varchar(_))
+            | (AggregateAccumulator::Min(ref mut current_min), val @ types::SqlValue::Boolean(_)) => {
+                if let Some(ref current) = current_min {
+                    if compare_sql_values(val, current) == Ordering::Less {
+                        *current_min = Some(val.clone());
+                    }
+                } else {
+                    *current_min = Some(val.clone());
+                }
+            }
+            (AggregateAccumulator::Min(_), types::SqlValue::Null) => {}
+
+            // MAX - finds maximum value, ignores NULLs
+            (AggregateAccumulator::Max(ref mut current_max), val @ types::SqlValue::Integer(_))
+            | (AggregateAccumulator::Max(ref mut current_max), val @ types::SqlValue::Varchar(_))
+            | (AggregateAccumulator::Max(ref mut current_max), val @ types::SqlValue::Boolean(_)) => {
+                if let Some(ref current) = current_max {
+                    if compare_sql_values(val, current) == Ordering::Greater {
+                        *current_max = Some(val.clone());
+                    }
+                } else {
+                    *current_max = Some(val.clone());
+                }
+            }
+            (AggregateAccumulator::Max(_), types::SqlValue::Null) => {}
+
+            _ => {
+                // Type mismatch or unsupported type - ignore for now
+            }
+        }
+    }
+
+    pub(super) fn finalize(&self) -> types::SqlValue {
+        match self {
+            AggregateAccumulator::Count(count) => types::SqlValue::Integer(*count),
+            AggregateAccumulator::Sum(sum) => types::SqlValue::Integer(*sum),
+            AggregateAccumulator::Avg { sum, count } => {
+                if *count == 0 {
+                    types::SqlValue::Null
+                } else {
+                    types::SqlValue::Integer(sum / count)
+                }
+            }
+            AggregateAccumulator::Min(val) => val.clone().unwrap_or(types::SqlValue::Null),
+            AggregateAccumulator::Max(val) => val.clone().unwrap_or(types::SqlValue::Null),
+        }
+    }
+}
+
+/// Compare two SqlValues for ordering purposes (SQL ORDER BY semantics)
+///
+/// Uses the PartialOrd trait implementation with SQL-specific NULL handling:
+/// - NULL values sort last (NULLS LAST - SQL:1999 default for ASC)
+/// - Incomparable values (type mismatches, NaN) default to Equal for sort stability
+pub(super) fn compare_sql_values(a: &types::SqlValue, b: &types::SqlValue) -> Ordering {
+    match (a.is_null(), b.is_null()) {
+        // Both NULL - equal
+        (true, true) => Ordering::Equal,
+        // First is NULL - sorts last (greater)
+        (true, false) => Ordering::Greater,
+        // Second is NULL - first sorts first (less)
+        (false, true) => Ordering::Less,
+        // Neither NULL - use PartialOrd trait
+        (false, false) => {
+            // partial_cmp returns None for incomparable values (type mismatch, NaN)
+            // Default to Equal to maintain sort stability
+            PartialOrd::partial_cmp(a, b).unwrap_or(Ordering::Equal)
+        }
+    }
+}
+
+/// Grouped rows: (group key values, rows in group)
+pub(super) type GroupedRows = Vec<(Vec<types::SqlValue>, Vec<storage::Row>)>;
+
+/// Group rows by GROUP BY expressions
+pub(super) fn group_rows(
+    rows: &[storage::Row],
+    group_by_exprs: &[ast::Expression],
+    evaluator: &crate::evaluator::ExpressionEvaluator,
+) -> Result<GroupedRows, crate::errors::ExecutorError> {
+    let mut groups: GroupedRows = Vec::new();
+
+    for row in rows {
+        // Evaluate GROUP BY expressions to get the group key
+        let mut key = Vec::new();
+        for expr in group_by_exprs {
+            let value = evaluator.eval(expr, row)?;
+            key.push(value);
+        }
+
+        // Find existing group or create new one
+        let mut found = false;
+        for (existing_key, group_rows) in &mut groups {
+            if existing_key == &key {
+                group_rows.push(row.clone());
+                found = true;
+                break;
+            }
+        }
+
+        if !found {
+            groups.push((key, vec![row.clone()]));
+        }
+    }
+
+    Ok(groups)
+}

--- a/crates/executor/src/select/join.rs
+++ b/crates/executor/src/select/join.rs
@@ -1,0 +1,163 @@
+use crate::errors::ExecutorError;
+use crate::evaluator::CombinedExpressionEvaluator;
+use crate::schema::CombinedSchema;
+
+/// Result of executing a FROM clause
+pub(super) struct FromResult {
+    pub(super) schema: CombinedSchema,
+    pub(super) rows: Vec<storage::Row>,
+}
+
+/// Perform nested loop join between two FROM results
+pub(super) fn nested_loop_join(
+    left: FromResult,
+    right: FromResult,
+    join_type: &ast::JoinType,
+    condition: &Option<ast::Expression>,
+) -> Result<FromResult, ExecutorError> {
+    match join_type {
+        ast::JoinType::Inner => nested_loop_inner_join(left, right, condition),
+        ast::JoinType::LeftOuter => nested_loop_left_outer_join(left, right, condition),
+        _ => Err(ExecutorError::UnsupportedFeature(format!(
+            "JOIN type {:?} not yet implemented",
+            join_type
+        ))),
+    }
+}
+
+/// Nested loop INNER JOIN implementation
+pub(super) fn nested_loop_inner_join(
+    left: FromResult,
+    right: FromResult,
+    condition: &Option<ast::Expression>,
+) -> Result<FromResult, ExecutorError> {
+    // Extract right table name (assume single table for now)
+    let right_table_name = right
+        .schema
+        .table_schemas
+        .keys()
+        .next()
+        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
+        .clone();
+
+    let right_schema = right
+        .schema
+        .table_schemas
+        .get(&right_table_name)
+        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
+        .1
+        .clone();
+
+    // Combine schemas
+    let combined_schema = CombinedSchema::combine(left.schema, right_table_name, right_schema);
+    let evaluator = CombinedExpressionEvaluator::new(&combined_schema);
+
+    // Nested loop join algorithm
+    let mut result_rows = Vec::new();
+    for left_row in &left.rows {
+        for right_row in &right.rows {
+            // Concatenate rows
+            let mut combined_values = left_row.values.clone();
+            combined_values.extend(right_row.values.clone());
+            let combined_row = storage::Row::new(combined_values);
+
+            // Evaluate join condition
+            let matches = if let Some(cond) = condition {
+                match evaluator.eval(cond, &combined_row)? {
+                    types::SqlValue::Boolean(true) => true,
+                    types::SqlValue::Boolean(false) => false,
+                    types::SqlValue::Null => false,
+                    other => {
+                        return Err(ExecutorError::InvalidWhereClause(format!(
+                            "JOIN condition must evaluate to boolean, got: {:?}",
+                            other
+                        )))
+                    }
+                }
+            } else {
+                true // No condition = CROSS JOIN
+            };
+
+            if matches {
+                result_rows.push(combined_row);
+            }
+        }
+    }
+
+    Ok(FromResult { schema: combined_schema, rows: result_rows })
+}
+
+/// Nested loop LEFT OUTER JOIN implementation
+pub(super) fn nested_loop_left_outer_join(
+    left: FromResult,
+    right: FromResult,
+    condition: &Option<ast::Expression>,
+) -> Result<FromResult, ExecutorError> {
+    // Extract right table name and schema
+    let right_table_name = right
+        .schema
+        .table_schemas
+        .keys()
+        .next()
+        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
+        .clone();
+
+    let right_schema = right
+        .schema
+        .table_schemas
+        .get(&right_table_name)
+        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
+        .1
+        .clone();
+
+    let right_column_count = right_schema.columns.len();
+
+    // Combine schemas
+    let combined_schema = CombinedSchema::combine(left.schema, right_table_name, right_schema);
+    let evaluator = CombinedExpressionEvaluator::new(&combined_schema);
+
+    // Nested loop LEFT OUTER JOIN algorithm
+    let mut result_rows = Vec::new();
+    for left_row in &left.rows {
+        let mut matched = false;
+
+        for right_row in &right.rows {
+            // Concatenate rows
+            let mut combined_values = left_row.values.clone();
+            combined_values.extend(right_row.values.clone());
+            let combined_row = storage::Row::new(combined_values);
+
+            // Evaluate join condition
+            let matches = if let Some(cond) = condition {
+                match evaluator.eval(cond, &combined_row)? {
+                    types::SqlValue::Boolean(true) => true,
+                    types::SqlValue::Boolean(false) => false,
+                    types::SqlValue::Null => false,
+                    other => {
+                        return Err(ExecutorError::InvalidWhereClause(format!(
+                            "JOIN condition must evaluate to boolean, got: {:?}",
+                            other
+                        )))
+                    }
+                }
+            } else {
+                true // No condition = CROSS JOIN
+            };
+
+            if matches {
+                result_rows.push(combined_row);
+                matched = true;
+            }
+        }
+
+        // If no match found, add left row with NULLs for right columns
+        if !matched {
+            let mut combined_values = left_row.values.clone();
+            // Add NULL values for all right table columns
+            combined_values.extend(vec![types::SqlValue::Null; right_column_count]);
+            result_rows.push(storage::Row::new(combined_values));
+        }
+    }
+
+    Ok(FromResult { schema: combined_schema, rows: result_rows })
+}

--- a/crates/executor/src/select/projection.rs
+++ b/crates/executor/src/select/projection.rs
@@ -1,0 +1,24 @@
+/// Project columns from a row based on SELECT list (combined schema version)
+pub(super) fn project_row_combined(
+    row: &storage::Row,
+    columns: &[ast::SelectItem],
+    evaluator: &crate::evaluator::CombinedExpressionEvaluator,
+) -> Result<storage::Row, crate::errors::ExecutorError> {
+    let mut values = Vec::new();
+
+    for item in columns {
+        match item {
+            ast::SelectItem::Wildcard => {
+                // SELECT * - include all columns
+                values.extend(row.values.iter().cloned());
+            }
+            ast::SelectItem::Expression { expr, alias: _ } => {
+                // Evaluate the expression
+                let value = evaluator.eval(expr, row)?;
+                values.push(value);
+            }
+        }
+    }
+
+    Ok(storage::Row::new(values))
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 of the executor modularization effort by splitting the 728-line `select.rs` file into 5 focused modules organized by execution responsibility.

## Changes

### Module Structure Created
- **mod.rs (388 lines)**: Main SELECT execution coordination
  - Orchestrates execution flow
  - Manages aggregation and non-aggregation paths
  - Coordinates all sub-modules

- **grouping.rs (160 lines)**: GROUP BY and aggregate functions
  - `AggregateAccumulator` enum (COUNT, SUM, AVG, MIN, MAX)
  - `compare_sql_values()` for SQL ORDER BY semantics
  - `group_rows()` for GROUP BY operations

- **join.rs (163 lines)**: JOIN operations
  - `FromResult` struct for combined schema and rows
  - `nested_loop_join()` dispatcher
  - `nested_loop_inner_join()` for INNER JOIN
  - `nested_loop_left_outer_join()` for LEFT OUTER JOIN

- **projection.rs (24 lines)**: Column projection
  - `project_row_combined()` for SELECT list evaluation
  - Handles wildcard expansion

- **filter.rs (2 lines)**: Placeholder for future extraction
  - Reserved for WHERE clause logic extraction

### Implementation Approach
- Followed incremental extraction strategy from issue guidance
- Used `pub(super)` visibility for clean module-internal APIs
- Maintained same public interface through `SelectExecutor`
- Preserved all existing functionality

### Verification
- ✅ All 45 tests passing across workspace
- ✅ No new clippy warnings
- ✅ Each module < 200 lines (except coordinator mod.rs)
- ✅ Clear separation of concerns maintained
- ✅ Git detected rename automatically

## Test Plan

Ran full test suite:
```bash
cargo test --all
cargo clippy --all-targets
```

All tests pass with no new warnings.

## Context

This is Phase 3 of the three-phase executor refactoring (#10):
- Phase 1 (#12): Split executor tests ✅
- Phase 2 (#13): Split AST modules ✅
- **Phase 3 (this PR)**: Split executor/select.rs ✅

This was the most complex phase due to tight interdependencies in active execution logic, but the detailed extraction strategy in the issue made it straightforward to implement incrementally.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>