### PR TITLE
Fix hardcoded rows_affected in WASM execute() for INSERT statements

### DIFF
--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -97,9 +97,14 @@ impl Database {
                     JsValue::from_str(&format!("Execution error: {:?}", e))
                 })?;
 
+                let row_count = insert_stmt.values.len();
                 let result = ExecuteResult {
-                    rows_affected: 1,
-                    message: format!("1 row inserted into '{}'", insert_stmt.table_name),
+                    rows_affected: row_count,
+                    message: format!("{} row{} inserted into '{}'",
+                        row_count,
+                        if row_count == 1 { "" } else { "s" },
+                        insert_stmt.table_name
+                    ),
                 };
 
                 serde_wasm_bindgen::to_value(&result).map_err(|e| {


### PR DESCRIPTION
## Summary

Fixes hardcoded `rows_affected: 1` in WASM `Database.execute()` method for INSERT statements. The method now correctly reports the actual number of rows inserted for multi-row INSERT statements.

## Changes

**File**: `crates/wasm-bindings/src/lib.rs:100-107`

- Calculate actual row count: `let row_count = insert_stmt.values.len();`
- Use computed count for `rows_affected` field
- Add proper pluralization: `"1 row"` vs `"N rows"`

## Problem

**Before**:
```rust
let result = ExecuteResult {
    rows_affected: 1,  // ❌ Always 1
    message: format!("1 row inserted into '{}'", insert_stmt.table_name),
};
```

**After**:
```rust
let row_count = insert_stmt.values.len();
let result = ExecuteResult {
    rows_affected: row_count,  // ✅ Actual count
    message: format!("{} row{} inserted into '{}'",
        row_count,
        if row_count == 1 { "" } else { "s" },
        insert_stmt.table_name
    ),
};
```

## Test Plan

- [x] WASM bindings package compiles successfully
- [x] Existing test `test_database_creation` passes
- [x] Row count calculated from `insert_stmt.values.len()`
- [x] Message pluralization handles single/multiple rows

## Impact

Fixes incorrect reporting for statements like:
```sql
INSERT INTO users VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie');
```

Now correctly reports "3 rows inserted" instead of "1 row inserted".

Closes #83