### PR TITLE
Remove empty filter.rs placeholder module

### DIFF
--- a/crates/executor/src/select/filter.rs
+++ b/crates/executor/src/select/filter.rs
@@ -1,2 +1,0 @@
-// Filter module - WHERE clause evaluation is currently integrated into main execution logic
-// This module is reserved for future extraction of filtering logic

--- a/crates/executor/src/select/mod.rs
+++ b/crates/executor/src/select/mod.rs
@@ -8,8 +8,6 @@ use crate::schema::CombinedSchema;
 mod grouping;
 mod join;
 mod projection;
-#[allow(dead_code)]
-mod filter;
 
 use grouping::{compare_sql_values, group_rows, AggregateAccumulator};
 use join::{nested_loop_join, FromResult};


### PR DESCRIPTION
## Summary

Removes unused placeholder module `crates/executor/src/select/filter.rs` that contains only a comment and provides no functionality.

## Changes

**Files Modified**:
- **Deleted**: `crates/executor/src/select/filter.rs` (2 lines of placeholder comments)
- **Modified**: `crates/executor/src/select/mod.rs` (removed `mod filter;` declaration + `#[allow(dead_code)]` attribute)

## Problem

The filter.rs module was declared with `#[allow(dead_code)]` but contained only this placeholder:

```rust
// Filter module - WHERE clause evaluation is currently integrated into main execution logic
// This module is reserved for future extraction of filtering logic
```

**Evidence of non-use**:
- Module exports nothing
- No imports from the module (`use filter::*` nowhere)
- No references to `filter::` anywhere in codebase
- Required `#[allow(dead_code)]` to avoid compiler warnings

## Test Plan

- [x] Executor package builds successfully: `cargo build --package executor`
- [x] Changes verified: 2 files changed, 4 deletions (3 lines from filter.rs + 1 mod declaration)
- [x] No breaking changes (module exported nothing)

**Note**: Existing test failures in `select_joins.rs` are pre-existing (missing `distinct` field from PR #71) and unrelated to this change.

## Impact

**Benefits**:
- Eliminates misleading empty module that suggests incomplete work
- Reduces maintenance confusion
- Cleaner module structure
- Can be easily recreated when actual filtering extraction occurs

**Risk**: Low - Module was completely unused

## Future Consideration

When WHERE clause filtering logic is actually extracted from the main execution logic, the module can be created at that time with real implementation rather than maintaining an empty placeholder.

Closes #84