### PR TITLE
Add scalar subquery AST and error types (Phase 1a)

### DIFF
--- a/crates/ast/src/expression.rs
+++ b/crates/ast/src/expression.rs
@@ -1,6 +1,6 @@
 //! SQL Expression types for use in SELECT, WHERE, and other clauses
 
-use crate::{BinaryOperator, UnaryOperator};
+use crate::{BinaryOperator, SelectStmt, UnaryOperator};
 use types::SqlValue;
 
 /// SQL Expression (can appear in SELECT, WHERE, etc.)
@@ -58,5 +58,8 @@ pub enum Expression {
         /// Optional ELSE result (defaults to NULL if None)
         else_result: Option<Box<Expression>>,
     },
-    // TODO: Add CAST, subqueries, etc.
+
+    /// Scalar subquery (returns single value)
+    /// Example: WHERE salary > (SELECT AVG(salary) FROM employees)
+    ScalarSubquery(Box<SelectStmt>),
 }

--- a/crates/executor/src/errors.rs
+++ b/crates/executor/src/errors.rs
@@ -10,6 +10,8 @@ pub enum ExecutorError {
     UnsupportedExpression(String),
     UnsupportedFeature(String),
     StorageError(String),
+    SubqueryReturnedMultipleRows { expected: usize, actual: usize },
+    SubqueryColumnCountMismatch { expected: usize, actual: usize },
 }
 
 impl std::fmt::Display for ExecutorError {
@@ -31,6 +33,12 @@ impl std::fmt::Display for ExecutorError {
             }
             ExecutorError::UnsupportedFeature(msg) => write!(f, "Unsupported feature: {}", msg),
             ExecutorError::StorageError(msg) => write!(f, "Storage error: {}", msg),
+            ExecutorError::SubqueryReturnedMultipleRows { expected, actual } => {
+                write!(f, "Scalar subquery returned {} rows, expected {}", actual, expected)
+            }
+            ExecutorError::SubqueryColumnCountMismatch { expected, actual } => {
+                write!(f, "Subquery returned {} columns, expected {}", actual, expected)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR implements Phase 1a of the scalar subquery feature (#76), establishing the foundational AST and error types needed for subquery support.

**Changes:**
- Added `Expression::ScalarSubquery(Box<SelectStmt>)` variant to enable subqueries in expressions
- Added `ExecutorError::SubqueryReturnedMultipleRows` for scalar subquery validation
- Added `ExecutorError::SubqueryColumnCountMismatch` for column count validation
- Imported `SelectStmt` into the expression module

**Testing:**
- ✅ `cargo build --package ast` - compiles successfully
- ✅ `cargo build --package executor` - compiles successfully  
- ✅ `cargo build` - full project builds successfully

**Dependencies:**
This is the foundation for:
- #90 (Phase 1b: Parser support)
- #91 (Phase 1c: Execution support)

Together, these three issues complete Phase 1 (#76).

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)