### PR TITLE
Implement scalar subquery parser (Phase 1b)

### DIFF
--- a/crates/parser/src/tests/subquery.rs
+++ b/crates/parser/src/tests/subquery.rs
@@ -1,7 +1,11 @@
-//! Tests for subquery parsing
+//! Tests for subquery parsing (both IN and scalar subqueries)
 
 use crate::Parser;
 use ast::Expression;
+
+// ============================================================================
+// IN Operator Subquery Tests (from PR #96)
+// ============================================================================
 
 #[test]
 fn test_parse_in_subquery() {
@@ -82,6 +86,134 @@ fn test_parse_in_subquery_simple_column() {
                     }
                 }
                 other => panic!("Expected IN expression, got {:?}", other),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+// ============================================================================
+// Scalar Subquery Tests (from PR #100)
+// ============================================================================
+
+#[test]
+fn test_parse_scalar_subquery_simple() {
+    // Test: (SELECT 1)
+    let sql = "SELECT (SELECT 1)";
+    let stmt = Parser::parse_sql(sql).unwrap();
+
+    match stmt {
+        ast::Statement::Select(select) => {
+            assert_eq!(select.select_list.len(), 1);
+            match &select.select_list[0] {
+                ast::SelectItem::Expression { expr, alias: _ } => {
+                    // Should be a ScalarSubquery
+                    match expr {
+                        Expression::ScalarSubquery(subquery) => {
+                            // Verify the subquery structure
+                            assert_eq!(subquery.select_list.len(), 1);
+                            match &subquery.select_list[0] {
+                                ast::SelectItem::Expression { expr, .. } => {
+                                    match expr {
+                                        Expression::Literal(_) => {
+                                            // Expected literal 1
+                                        }
+                                        _ => panic!("Expected literal in subquery"),
+                                    }
+                                }
+                                _ => panic!("Expected expression in subquery select list"),
+                            }
+                        }
+                        _ => panic!("Expected ScalarSubquery, got {:?}", expr),
+                    }
+                }
+                _ => panic!("Expected expression in select list"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_parse_scalar_subquery_in_where() {
+    // Test: WHERE x > (SELECT AVG(y) FROM t)
+    let sql = "SELECT * FROM users WHERE salary > (SELECT AVG(salary) FROM employees)";
+    let stmt = Parser::parse_sql(sql).unwrap();
+
+    match stmt {
+        ast::Statement::Select(select) => {
+            // Check WHERE clause
+            let where_clause = select.where_clause.unwrap();
+            match where_clause {
+                Expression::BinaryOp { op: _, left: _, right } => {
+                    // Right side should be the scalar subquery
+                    match *right {
+                        Expression::ScalarSubquery(subquery) => {
+                            // Verify it's selecting AVG
+                            assert_eq!(subquery.select_list.len(), 1);
+                            match &subquery.select_list[0] {
+                                ast::SelectItem::Expression { expr, .. } => {
+                                    match expr {
+                                        Expression::Function { name, .. } => {
+                                            assert_eq!(name.to_uppercase(), "AVG");
+                                        }
+                                        _ => panic!("Expected function call in subquery"),
+                                    }
+                                }
+                                _ => panic!("Expected expression in subquery"),
+                            }
+                        }
+                        _ => panic!("Expected ScalarSubquery on right side of comparison"),
+                    }
+                }
+                _ => panic!("Expected binary operation in WHERE clause"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_parse_scalar_subquery_in_select() {
+    // Test: SELECT id, (SELECT COUNT(*) FROM t2) FROM t1
+    let sql = "SELECT id, (SELECT COUNT(*) FROM orders) FROM users";
+    let stmt = Parser::parse_sql(sql).unwrap();
+
+    match stmt {
+        ast::Statement::Select(select) => {
+            // Should have 2 items in select list
+            assert_eq!(select.select_list.len(), 2);
+
+            // First should be id column
+            match &select.select_list[0] {
+                ast::SelectItem::Expression { expr, .. } => match expr {
+                    Expression::ColumnRef { column, .. } => {
+                        assert_eq!(column, "id");
+                    }
+                    _ => panic!("Expected column reference"),
+                },
+                _ => panic!("Expected expression"),
+            }
+
+            // Second should be scalar subquery
+            match &select.select_list[1] {
+                ast::SelectItem::Expression { expr, .. } => match expr {
+                    Expression::ScalarSubquery(subquery) => {
+                        // Verify it's COUNT(*)
+                        assert_eq!(subquery.select_list.len(), 1);
+                        match &subquery.select_list[0] {
+                            ast::SelectItem::Expression { expr, .. } => match expr {
+                                Expression::Function { name, .. } => {
+                                    assert_eq!(name.to_uppercase(), "COUNT");
+                                }
+                                _ => panic!("Expected function"),
+                            },
+                            _ => panic!("Expected expression"),
+                        }
+                    }
+                    _ => panic!("Expected ScalarSubquery, got {:?}", expr),
+                },
+                _ => panic!("Expected expression"),
             }
         }
         _ => panic!("Expected SELECT statement"),


### PR DESCRIPTION
## Summary

This PR implements Phase 1b of the scalar subquery feature (#76), adding parser support for scalar subqueries in expressions as specified in #90.

**Changes:**
- Modified `parse_primary_expression()` to detect and parse `(SELECT ...)` as scalar subqueries
- Smart detection: Peeks at token after `(` to distinguish subqueries from parenthesized expressions
- Added comprehensive parser tests (3 tests, all passing)

**Parser Features:**
- ✅ Parses `(SELECT 1)` as scalar subquery
- ✅ Parses `WHERE salary > (SELECT AVG(salary) FROM employees)`
- ✅ Parses `SELECT id, (SELECT COUNT(*) FROM orders) FROM users`
- ✅ Maintains backward compatibility with regular parenthesized expressions

**Testing:**
- ✅ `cargo build` - compiles successfully
- ✅ `cargo test` - all tests pass (including 3 new parser tests)
- ✅ Existing functionality unaffected
- ✅ All acceptance criteria met

**Implementation:**
When the parser encounters `(` in a primary expression context:
1. Advance past the `(`
2. Peek at next token
3. If it's `SELECT`: parse as `ScalarSubquery(Box<SelectStmt>)`
4. Otherwise: parse as regular parenthesized expression

**Dependencies:**
- ✅ Requires #89 (Phase 1a - AST and error types) - MERGED
- Blocks #91 (Phase 1c - Execution support)

Together with #91, this completes Phase 1 (#76) of the subquery feature.

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)