### PR TITLE
Docs: Clean up ADR index and remove pending decisions

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -22,26 +22,12 @@ See `docs/templates/ADR_TEMPLATE.md` for the full template.
 |----|-------|--------|------|---------|
 | 0001 | **Language Choice: Rust** | ✅ **Accepted** | 2024-10-25 | **Rust chosen** for type safety, pattern matching, compiler feedback, and correctness focus |
 | 0002 | **Parser Strategy: Hand-Written** | ✅ **Accepted** | 2024-10-25 | **Hand-written recursive descent + Pratt parser** chosen for full control, TDD alignment, and SQL:1999 flexibility |
-| 0003 | [Pending] Storage Architecture | Proposed | TBD | Design in-memory storage engine structure (HashMap-based) |
-| 0004 | [Pending] Testing Framework | Proposed | TBD | sqltest integration approach |
-| 0005 | [Pending] ODBC Implementation | Proposed | TBD | Approach for ODBC driver (odbc-rs) |
-| 0006 | [Pending] JDBC Implementation | Proposed | TBD | Approach for JDBC driver (jni-rs) |
 
 ## Decisions by Category
 
 ### Core Technology Stack
 - [ADR-0001](docs/decisions/0001-language-choice.md) - **Language Choice: Rust** ✅ (Accepted 2024-10-25)
 - [ADR-0002](docs/decisions/0002-parser-strategy.md) - **Parser Strategy: Hand-Written** ✅ (Accepted 2024-10-25)
-
-### Architecture
-- [ADR-0003](docs/decisions/0003-storage-architecture.md) - Storage Architecture (Proposed)
-
-### Testing
-- [ADR-0004](docs/decisions/0004-testing-framework.md) - Testing Framework (Proposed)
-
-### Protocols
-- [ADR-0005](docs/decisions/0005-odbc-implementation.md) - ODBC Implementation (Proposed)
-- [ADR-0006](docs/decisions/0006-jdbc-implementation.md) - JDBC Implementation (Proposed)
 
 ## Decision Process
 
@@ -76,10 +62,7 @@ Create an ADR when:
 - **ADR-0002**: Parser Strategy - Hand-Written Recursive Descent (2024-10-25)
 
 ### Pending Review
-- ADR-0003: Storage Architecture
-- ADR-0004: Testing Framework
-- ADR-0005: ODBC Implementation
-- ADR-0006: JDBC Implementation
+[None yet - future ADRs will be created as architectural decisions arise]
 
 ### Superseded/Deprecated
 [None yet]
@@ -103,5 +86,5 @@ When making architectural decisions:
 ---
 
 **Last Updated**: 2025-10-26
-**Total ADRs**: 2 accepted, 4 pending
-**Status**: Foundation building - language and parser strategy chosen!
+**Total ADRs**: 2 accepted, 0 pending
+**Status**: Foundation established - language and parser strategy implemented!

--- a/docs/decisions/0002-parser-strategy.md
+++ b/docs/decisions/0002-parser-strategy.md
@@ -1,7 +1,7 @@
 # ADR-0002: Parser Strategy for SQL:1999
 
 **Status**: Accepted
-**Date**: 2025-10-25
+**Date**: 2024-10-25
 **Deciders**: Claude Code + User
 **Technical Story**: Choose parser implementation approach for SQL:1999 FULL compliance
 


### PR DESCRIPTION
## Summary

Cleans up the ADR (Architecture Decision Record) index to reflect the current state of the project. Removes references to pending ADRs that were placeholders and updates documentation to accurately represent implemented decisions.

## Changes

**DECISIONS.md**:
- Removed 4 pending ADR entries that were never created (ADR-0003 through ADR-0006)
- Updated summary statistics to show 2 accepted, 0 pending
- Updated status message to reflect foundation established
- Cleaned up category sections to remove pending placeholders

**docs/decisions/0002-parser-strategy.md**:
- Fixed date typo (2025 → 2024) to match actual decision date

## Impact

- Documentation now accurately reflects project state
- No placeholder ADRs that might confuse contributors
- Clear indication that foundation decisions are complete
- Easier to see what architectural decisions have actually been made

## Testing

- [x] Documentation changes only - no code impact
- [x] All markdown files valid
- [x] No broken links

This is a documentation-only change with no impact on functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>