### PR TITLE
fix: Resolve clippy warnings in types and catalog crates

### DIFF
--- a/crates/catalog/src/tests.rs
+++ b/crates/catalog/src/tests.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod tests {
+mod catalog_tests {
     use crate::{Catalog, CatalogError, ColumnSchema, TableSchema};
 
     #[test]

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -649,7 +649,7 @@ mod tests {
 
     #[test]
     fn test_float_value_has_float_type() {
-        let value = SqlValue::Float(3.14);
+        let value = SqlValue::Float(2.5);
         assert_eq!(value.get_type(), DataType::Float);
     }
 
@@ -661,7 +661,7 @@ mod tests {
 
     #[test]
     fn test_double_value_has_double_type() {
-        let value = SqlValue::Double(3.14159);
+        let value = SqlValue::Double(123.456);
         assert_eq!(value.get_type(), DataType::DoublePrecision);
     }
 
@@ -722,8 +722,8 @@ mod tests {
 
     #[test]
     fn test_float_display() {
-        let value = SqlValue::Float(3.14);
-        assert_eq!(format!("{}", value), "3.14");
+        let value = SqlValue::Float(2.5);
+        assert_eq!(format!("{}", value), "2.5");
     }
 
     #[test]
@@ -734,8 +734,8 @@ mod tests {
 
     #[test]
     fn test_double_display() {
-        let value = SqlValue::Double(3.14159);
-        assert_eq!(format!("{}", value), "3.14159");
+        let value = SqlValue::Double(123.456);
+        assert_eq!(format!("{}", value), "123.456");
     }
 
     #[test]
@@ -825,8 +825,8 @@ mod tests {
 
     #[test]
     fn test_float_hash() {
-        let v1 = SqlValue::Float(3.14);
-        let v2 = SqlValue::Float(3.14);
+        let v1 = SqlValue::Float(2.5);
+        let v2 = SqlValue::Float(2.5);
         assert_eq!(calculate_hash(&v1), calculate_hash(&v2));
     }
 
@@ -854,8 +854,8 @@ mod tests {
 
     #[test]
     fn test_double_hash() {
-        let v1 = SqlValue::Double(3.14159);
-        let v2 = SqlValue::Double(3.14159);
+        let v1 = SqlValue::Double(123.456);
+        let v2 = SqlValue::Double(123.456);
         assert_eq!(calculate_hash(&v1), calculate_hash(&v2));
     }
 


### PR DESCRIPTION
## Summary
Fix clippy warnings in types and catalog crates to maintain zero-warning policy.

## Changes

### Types Crate (`crates/types/src/lib.rs`)
- **Fixed 8 `approx_constant` warnings**: Replaced test values `3.14` and `3.14159` (PI approximations) with `2.5` and `123.456`
- Affected tests: `test_float_value_has_float_type`, `test_double_value_has_double_type`, `test_float_display`, `test_double_display`, `test_float_hash`, `test_double_hash`
- Rationale: Test values don't need to be mathematical constants - arbitrary values work equally well

### Catalog Crate (`crates/catalog/src/tests.rs`)
- **Fixed `module_inception` warning**: Renamed inner module from `tests` to `catalog_tests`
- Issue: File named `tests.rs` containing a module named `tests` triggers clippy warning
- Solution: Rename inner module to avoid name collision

## Test Results

```
✓ All 477 tests passing (100%)
✓ Zero new warnings introduced
✓ Original warnings (9 total) eliminated:
  - 8 approx_constant warnings in types crate
  - 1 module_inception warning in catalog crate
```

## Verification

```bash
# Before (main branch)
cargo clippy --workspace --all-targets -- -D warnings
# → 9 errors (8 PI + 1 module_inception)

# After (this PR)
cargo clippy --workspace --all-targets -- -D warnings  
# → 0 errors for modified files (original warnings fixed)
# → Pre-existing bool_assert_comparison warnings in unmodified files remain

# All tests pass
cargo test --workspace
# → 477 tests passing
```

## Impact

- **Severity**: Low (cosmetic fix for code quality)
- **CI**: Enables enforcement of `-D warnings` flag for modified crates
- **Code Quality**: Maintains project's zero-warning standard
- **Risk**: None - test value changes don't affect logic

## Files Changed

- `crates/types/src/lib.rs` (11 lines: 6 test value replacements)
- `crates/catalog/src/tests.rs` (1 line: module rename)

Closes #144