### PR TITLE
feat: Replace HTML results table with Monaco editor terminal view

### DIFF
--- a/web-demo/src/main.ts
+++ b/web-demo/src/main.ts
@@ -1,9 +1,8 @@
 import './styles/main.css'
 import { initTheme } from './theme'
 import { initDatabase } from './db/wasm'
-import type { Database } from './db/types'
+import type { Database, QueryResult, ExecuteResult } from './db/types'
 import { validateSql } from './editor/validation'
-import { ResultsComponent } from './components/Results'
 import { ThemeToggleComponent } from './components/ThemeToggle'
 import { ExamplesComponent } from './components/Examples'
 import type { ExampleSelectEvent } from './components/Examples'
@@ -109,13 +108,13 @@ async function loadMonaco(): Promise<Monaco> {
 
 function getLayoutElements(): {
   editorContainer: HTMLDivElement | null
-  results: HTMLDivElement | null
+  resultsEditorContainer: HTMLDivElement | null
   runButton: HTMLButtonElement | null
   themeToggleContainer: HTMLDivElement | null
 } {
   return {
     editorContainer: document.querySelector<HTMLDivElement>('#editor'),
-    results: document.querySelector<HTMLDivElement>('#results'),
+    resultsEditorContainer: document.querySelector<HTMLDivElement>('#results'),
     runButton: document.querySelector<HTMLButtonElement>('#execute-btn'),
     themeToggleContainer: document.querySelector<HTMLDivElement>('#theme-toggle'),
   }
@@ -237,10 +236,87 @@ function setupThemeSync(themeToggleContainer: HTMLDivElement | null, monaco: Mon
   })
 }
 
+function isQueryResult(result: QueryResult | ExecuteResult): result is QueryResult {
+  return 'columns' in result && 'rows' in result
+}
+
+function formatValueForDisplay(value: unknown): string {
+  if (value === null) {
+    return 'NULL'
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  return String(value)
+}
+
+function formatResultAsAsciiTable(result: QueryResult | ExecuteResult): string {
+  if (!isQueryResult(result)) {
+    // For execute results (INSERT, UPDATE, DELETE, etc.)
+    const msg = result.message || 'Query executed successfully'
+    const rows = result.rows_affected
+    return rows !== undefined ? `${msg}\n(${rows} row${rows === 1 ? '' : 's'} affected)` : msg
+  }
+
+  if (result.rows.length === 0) {
+    return '(0 rows)'
+  }
+
+  // Parse JSON strings into arrays
+  const parsedRows = result.rows.map(rowStr => {
+    try {
+      return JSON.parse(rowStr) as unknown[]
+    } catch {
+      return [rowStr]
+    }
+  })
+
+  // Calculate column widths
+  const columnWidths: number[] = result.columns.map(col => col.length)
+  parsedRows.forEach(row => {
+    row.forEach((value, colIndex) => {
+      const strValue = formatValueForDisplay(value)
+      columnWidths[colIndex] = Math.max(columnWidths[colIndex], strValue.length)
+    })
+  })
+
+  // Build the table
+  const lines: string[] = []
+
+  // Top border
+  const topBorder = '+' + columnWidths.map(w => '-'.repeat(w + 2)).join('+') + '+'
+  lines.push(topBorder)
+
+  // Header row
+  const headerCells = result.columns.map((col, i) => ` ${col.padEnd(columnWidths[i])} `)
+  lines.push('|' + headerCells.join('|') + '|')
+
+  // Header separator
+  lines.push(topBorder)
+
+  // Data rows
+  parsedRows.forEach(row => {
+    const cells = row.map((value, i) => {
+      const strValue = formatValueForDisplay(value)
+      return ` ${strValue.padEnd(columnWidths[i])} `
+    })
+    lines.push('|' + cells.join('|') + '|')
+  })
+
+  // Bottom border
+  lines.push(topBorder)
+
+  // Row count
+  const rowCount = result.rows.length
+  lines.push(`(${rowCount} row${rowCount === 1 ? '' : 's'})`)
+
+  return lines.join('\n')
+}
+
 function createExecutionHandler(
   editor: MonacoEditor,
   database: Database | null,
-  resultsComponent: ResultsComponent,
+  resultsEditor: MonacoEditor,
   refreshTables: () => void
 ): () => void {
   return () => {
@@ -253,11 +329,11 @@ function createExecutionHandler(
 
     if (!database) {
       console.error('Database core is not ready yet.')
-      resultsComponent.showError('Database not ready. Please refresh the page.')
+      const currentValue = resultsEditor.getValue()
+      const errorMsg = '\n-- ERROR: Database not ready. Please refresh the page.\n'
+      resultsEditor.setValue(currentValue + errorMsg)
       return
     }
-
-    resultsComponent.setLoading(true)
 
     // Use setTimeout to allow UI to update before blocking execution
     setTimeout(() => {
@@ -272,11 +348,33 @@ function createExecutionHandler(
 
         const executionTime = performance.now() - startTime
 
-        resultsComponent.showResults(result, executionTime)
+        // Format the output
+        const currentValue = resultsEditor.getValue()
+        const separator = currentValue ? '\n\n' : ''
+        const sqlComment = `-- Query:\n${sql}\n\n`
+        const resultTable = formatResultAsAsciiTable(result)
+        const timing = `\nExecuted in ${executionTime.toFixed(2)}ms`
+
+        const newOutput = separator + sqlComment + resultTable + timing
+        resultsEditor.setValue(currentValue + newOutput)
+
+        // Scroll to bottom
+        const lineCount = resultsEditor.getModel()?.getLineCount() || 0
+        resultsEditor.revealLine(lineCount)
+
         refreshTables()
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
-        resultsComponent.showError(message)
+        const currentValue = resultsEditor.getValue()
+        const separator = currentValue ? '\n\n' : ''
+        const sqlComment = `-- Query:\n${sql}\n\n`
+        const errorMsg = `ERROR: ${message}`
+        resultsEditor.setValue(currentValue + separator + sqlComment + errorMsg)
+
+        // Scroll to bottom
+        const lineCount = resultsEditor.getModel()?.getLineCount() || 0
+        resultsEditor.revealLine(lineCount)
+
         console.error(`Execution error: ${message}`)
       }
     }, 10)
@@ -288,6 +386,11 @@ async function bootstrap(): Promise<void> {
 
   if (!layout.editorContainer) {
     console.error('Failed to find #editor container')
+    return
+  }
+
+  if (!layout.resultsEditorContainer) {
+    console.error('Failed to find #results container')
     return
   }
 
@@ -303,6 +406,21 @@ async function bootstrap(): Promise<void> {
     fontSize: 14,
     smoothScrolling: true,
     scrollBeyondLastLine: false,
+  })
+
+  const resultsEditor = monaco.editor.create(layout.resultsEditorContainer, {
+    value: '-- Query results will appear here\n-- Press Ctrl/Cmd + Enter to run queries',
+    language: 'sql',
+    theme: 'vs-dark',
+    readOnly: true,
+    minimap: { enabled: false },
+    automaticLayout: true,
+    fontFamily:
+      'JetBrains Mono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+    fontSize: 14,
+    smoothScrolling: true,
+    scrollBeyondLastLine: false,
+    lineNumbers: 'off',
   })
 
   setupThemeSync(layout.themeToggleContainer, monaco)
@@ -345,8 +463,6 @@ async function bootstrap(): Promise<void> {
   })
   applyValidationMarkers(monaco, editor)
 
-  const resultsComponent = new ResultsComponent()
-
   // Initialize Examples sidebar
   const examplesComponent = new ExamplesComponent()
   examplesComponent.onSelect((event: ExampleSelectEvent) => {
@@ -364,7 +480,7 @@ async function bootstrap(): Promise<void> {
     console.warn(`Database switching to ${dbId} not yet implemented`)
   })
 
-  const execute = createExecutionHandler(editor, database, resultsComponent, refreshTables)
+  const execute = createExecutionHandler(editor, database, resultsEditor, refreshTables)
 
   registerShortcuts(monaco, editor, execute)
   layout.runButton?.addEventListener('click', execute)


### PR DESCRIPTION
## Summary

Replaces the HTML table results display with a second Monaco editor instance that shows query results in ASCII table format. This creates a terminal-like SQL interface similar to psql or mysql, with command history and better dark mode support.

## Changes

- **Added second Monaco editor** for results display (read-only, no line numbers)
- **Implemented ASCII table formatter** that converts QueryResult/ExecuteResult to terminal-style output
- **Command history preserved** - results append to editor instead of replacing
- **Removed ResultsComponent** - no longer needed with Monaco-based display
- **Theme syncing** works for both editors automatically

## Example Output Format

```
-- Query:
SELECT * FROM employees;

+----+---------------+-------------+--------+
| id | name          | department  | salary |
+----+---------------+-------------+--------+
| 1  | Alice Johnson | Engineering | 95000  |
| 2  | Bob Smith     | Engineering | 87000  |
+----+---------------+-------------+--------+

(2 rows)
Executed in 0.45ms

-- Query:
SELECT COUNT(*) FROM employees;

+---------+
| count   |
+---------+
| 6       |
+---------+

(1 row)
Executed in 0.23ms
```

## Benefits

- ✅ **Better dark mode appearance** - Uses Monaco's native theme instead of HTML/CSS
- ✅ **Terminal-like experience** - Feels like psql, mysql, or other SQL CLIs
- ✅ **Command history** - See all previous queries and results
- ✅ **Consistent formatting** - Monospace font with proper alignment
- ✅ **Read-only display** - Results editor is read-only to prevent accidental edits

## Test Plan

- [x] Build passes without TypeScript errors
- [x] Linter passes (ESLint)
- [x] Formatter passes (Prettier)
- [ ] Manual test: Run SELECT queries and verify ASCII table output
- [ ] Manual test: Run INSERT/UPDATE queries and verify message output
- [ ] Manual test: Theme toggle works for both editors
- [ ] Manual test: Command history accumulates in results editor
- [ ] Manual test: Scroll to bottom after each query

🤖 Generated with [Claude Code](https://claude.com/claude-code)