### PR TITLE
Set SQL Editor and Examples sidebar to 50vh height

### DIFF
--- a/web-demo/src/components/Editor.ts
+++ b/web-demo/src/components/Editor.ts
@@ -47,7 +47,7 @@ export class EditorComponent extends Component<EditorState> {
       <div class="sql-editor">
         <textarea
           id="sql-input"
-          class="w-full h-64 p-4 font-mono text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 resize-y focus:outline-none focus:ring-2 focus:ring-primary-light"
+          class="w-full h-[50vh] p-4 font-mono text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 resize-y focus:outline-none focus:ring-2 focus:ring-primary-light"
           placeholder="Enter SQL query here... (Ctrl+Enter or Cmd+Enter to execute)"
           aria-label="SQL Query Editor"
         >${this.escapeHtml(this.state.value)}</textarea>

--- a/web-demo/src/components/Examples.ts
+++ b/web-demo/src/components/Examples.ts
@@ -69,7 +69,7 @@ export class ExamplesComponent extends Component<ExamplesState> {
           </p>
         </div>
 
-        <div class="divide-y divide-border">
+        <div class="divide-y divide-border overflow-y-auto max-h-[50vh]">
           ${exampleCategories.map(category => this.renderCategory(category, expandedCategories)).join('')}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Set SQL Editor textarea height from `h-64` to `h-[50vh]`
- Set Examples sidebar max height to `max-h-[50vh]` with scroll overflow
- Improves visual alignment between sidebar and editor sections

## Changes
- `web-demo/src/components/Editor.ts`: Updated textarea class to use `h-[50vh]`
- `web-demo/src/components/Examples.ts`: Added `overflow-y-auto max-h-[50vh]` to categories container

## Test Plan
- [ ] Load web demo and verify SQL Editor spans ~50% of viewport height
- [ ] Verify Examples sidebar matches editor height
- [ ] Verify Examples sidebar scrolls when content exceeds height
- [ ] Test on different viewport sizes
- [ ] Verify layout remains responsive on mobile/tablet

## Screenshots
N/A - UI layout improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)