### PR TITLE
feat: Display actual column names in web demo query results

### DIFF
--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -16,7 +16,7 @@ pub use delete::DeleteExecutor;
 pub use errors::ExecutorError;
 pub use evaluator::ExpressionEvaluator;
 pub use insert::InsertExecutor;
-pub use select::SelectExecutor;
+pub use select::{SelectExecutor, SelectResult};
 pub use update::UpdateExecutor;
 
 #[cfg(test)]

--- a/crates/executor/tests/column_names_tests.rs
+++ b/crates/executor/tests/column_names_tests.rs
@@ -1,0 +1,150 @@
+//! Tests for column name derivation in SELECT queries
+
+use executor::SelectExecutor;
+
+fn create_test_database() -> storage::Database {
+    let mut db = storage::Database::new();
+
+    // Create employees table
+    let create_stmt = parser::Parser::parse_sql(
+        "CREATE TABLE employees (
+            id INTEGER,
+            name VARCHAR(100),
+            department VARCHAR(50),
+            salary INTEGER
+        )",
+    )
+    .unwrap();
+
+    if let ast::Statement::CreateTable(create_table) = create_stmt {
+        executor::CreateTableExecutor::execute(&create_table, &mut db).unwrap();
+    }
+
+    // Insert some test data
+    let insert_stmt = parser::Parser::parse_sql(
+        "INSERT INTO employees (id, name, department, salary) VALUES
+        (1, 'John Smith', 'Engineering', 75000),
+        (2, 'Jane Doe', 'Sales', 82000),
+        (3, 'Bob Wilson', 'Engineering', 68000)",
+    )
+    .unwrap();
+
+    if let ast::Statement::Insert(insert) = insert_stmt {
+        executor::InsertExecutor::execute(&mut db, &insert).unwrap();
+    }
+
+    db
+}
+
+#[test]
+fn test_column_names_simple_select() {
+    let db = create_test_database();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = parser::Parser::parse_sql("SELECT id, name FROM employees").unwrap();
+    if let ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute_with_columns(&select_stmt).unwrap();
+        assert_eq!(result.columns, vec!["id", "name"]);
+        assert_eq!(result.rows.len(), 3);
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_column_names_with_alias() {
+    let db = create_test_database();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = parser::Parser::parse_sql("SELECT name AS employee_name, salary AS annual_salary FROM employees").unwrap();
+    if let ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute_with_columns(&select_stmt).unwrap();
+        assert_eq!(result.columns, vec!["employee_name", "annual_salary"]);
+        assert_eq!(result.rows.len(), 3);
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_column_names_star_expansion() {
+    let db = create_test_database();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = parser::Parser::parse_sql("SELECT * FROM employees").unwrap();
+    if let ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute_with_columns(&select_stmt).unwrap();
+        assert_eq!(result.columns, vec!["id", "name", "department", "salary"]);
+        assert_eq!(result.rows.len(), 3);
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_column_names_functions() {
+    let db = create_test_database();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = parser::Parser::parse_sql("SELECT COUNT(*), AVG(salary) FROM employees").unwrap();
+    if let ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute_with_columns(&select_stmt).unwrap();
+        assert_eq!(result.columns.len(), 2);
+        assert!(result.columns[0].contains("COUNT"));
+        assert!(result.columns[1].contains("AVG"));
+        assert_eq!(result.rows.len(), 1);
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_column_names_expressions() {
+    let db = create_test_database();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = parser::Parser::parse_sql("SELECT salary * 12 FROM employees").unwrap();
+    if let ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute_with_columns(&select_stmt).unwrap();
+        assert_eq!(result.columns.len(), 1);
+        // Expression should have a generated name
+        assert!(result.columns[0].contains("salary") || result.columns[0].contains("*"));
+        assert_eq!(result.rows.len(), 3);
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_column_names_mixed() {
+    let db = create_test_database();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = parser::Parser::parse_sql("SELECT id, name AS emp_name, salary * 12 FROM employees").unwrap();
+    if let ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute_with_columns(&select_stmt).unwrap();
+        assert_eq!(result.columns.len(), 3);
+        assert_eq!(result.columns[0], "id");
+        assert_eq!(result.columns[1], "emp_name");
+        // Third column is an expression
+        assert!(result.columns[2].contains("salary") || result.columns[2].contains("*"));
+        assert_eq!(result.rows.len(), 3);
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_column_names_function_with_alias() {
+    let db = create_test_database();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = parser::Parser::parse_sql("SELECT COUNT(*) AS total_employees FROM employees").unwrap();
+    if let ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute_with_columns(&select_stmt).unwrap();
+        assert_eq!(result.columns, vec!["total_employees"]);
+        assert_eq!(result.rows.len(), 1);
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -127,20 +127,14 @@ impl Database {
             _ => return Err(JsValue::from_str("query() method requires a SELECT statement")),
         };
 
-        // Execute the query
+        // Execute the query with column metadata
         let select_executor = executor::SelectExecutor::new(&self.db);
-        let rows = select_executor
-            .execute(&select_stmt)
+        let result = select_executor
+            .execute_with_columns(&select_stmt)
             .map_err(|e| JsValue::from_str(&format!("Execution error: {:?}", e)))?;
 
-        // Extract column names (simplified - assumes we can derive from first row or schema)
-        let columns = if !rows.is_empty() {
-            // For now, use generic column names
-            // In a real implementation, we'd extract from the schema
-            (0..rows[0].values.len()).map(|i| format!("col{}", i)).collect()
-        } else {
-            Vec::new()
-        };
+        let columns = result.columns;
+        let rows = result.rows;
 
         // Convert rows to JSON strings
         let row_strings: Vec<String> = rows


### PR DESCRIPTION
## Summary

Implements column name metadata in SELECT query results, replacing generic "col0", "col1" names with actual SQL column names (id, name, salary, etc.) in the web demo.

## Changes Made

### Backend (Rust Executor)
- **Added `SelectResult` struct** containing both column names and rows (crates/executor/src/select/mod.rs:26-31)
- **Implemented `execute_with_columns()` method** in `SelectExecutor` (crates/executor/src/select/mod.rs:79-101)
- **Added `derive_column_names()` method** to extract column names from SELECT list (crates/executor/src/select/mod.rs:103-150):
  - Handles aliases (AS clause)
  - Expands wildcards (*) to actual table column names  
  - Derives names from column references
  - Generates names for functions (COUNT(*), AVG(salary))
  - Creates descriptive names for expressions (salary * 12)
- **Added `derive_expression_name()` helper** for generating names from expressions (crates/executor/src/select/mod.rs:152-197)
- **Exported `SelectResult`** from executor crate (crates/executor/src/lib.rs:19)

### WASM Bindings
- **Updated `query()` method** to use `execute_with_columns()` (crates/wasm-bindings/src/lib.rs:130-137)
- Now populates `QueryResult.columns` with real column names instead of generic "col0", "col1", etc.

### Frontend
- **No changes needed** - `QueryResult` struct already had columns field at line 16
- Web demo now displays proper column headers automatically

### Tests
- **Added comprehensive test suite** in `column_names_tests.rs`:
  - Simple SELECT with specific columns
  - SELECT with aliases (AS clause)
  - SELECT * (wildcard expansion)
  - Functions (COUNT, AVG)
  - Expressions (arithmetic)
  - Mixed queries
- **All 221 existing tests still pass**
- **7 new tests added, all passing**

## SQL:1999 Compliance

Follows SQL:1999 column name derivation rules:
1. Use alias when provided (SELECT name AS employee_name → "employee_name")
2. Use column name for simple references (SELECT id → "id")
3. Use function notation for function calls (SELECT COUNT(*) → "COUNT(*)")
4. Generate descriptive names for expressions (SELECT salary * 12 → "(salary * 12)")

## Test Results

```
Running tests/column_names_tests.rs
running 7 tests
test test_column_names_function_with_alias ... ok
test test_column_names_functions ... ok
test test_column_names_expressions ... ok
test test_column_names_mixed ... ok
test test_column_names_star_expansion ... ok
test test_column_names_with_alias ... ok
test test_column_names_simple_select ... ok

test result: ok. 7 passed; 0 failed
```

All 228 tests pass (221 existing + 7 new).

## Example Output

**Before:**
```
col0  col1          col2
----  ----          ----
1     John Smith    75000
2     Jane Doe      82000
```

**After:**
```
id    name          salary
--    ----          ------
1     John Smith    75000
2     Jane Doe      82000
```

## Implementation Notes

- Maintains backward compatibility by keeping existing `execute()` method
- New `execute_with_columns()` method returns both columns and rows
- Efficient implementation reuses existing query execution
- No breaking changes to existing code

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>