### PR TITLE
fix: Adjust demo layout to fit content on single screen

### DIFF
--- a/web-demo/src/components/Examples.ts
+++ b/web-demo/src/components/Examples.ts
@@ -69,7 +69,7 @@ export class ExamplesComponent extends Component<ExamplesState> {
           </p>
         </div>
 
-        <div class="divide-y divide-border overflow-y-auto max-h-[50vh]">
+        <div class="divide-y divide-border overflow-y-auto max-h-[80vh]">
           ${exampleCategories.map(category => this.renderCategory(category, expandedCategories)).join('')}
         </div>
       </div>

--- a/web-demo/src/styles/main.css
+++ b/web-demo/src/styles/main.css
@@ -9,11 +9,11 @@
   }
 
   #editor {
-    @apply min-h-[50vh];
+    @apply min-h-[35vh];
   }
 
   #results {
-    @apply min-h-[40vh];
+    @apply min-h-[35vh];
   }
 
   .button {


### PR DESCRIPTION
## Summary
- Reduced SQL editor height from 50vh to 35vh
- Reduced results panel height from 40vh to 35vh  
- Increased examples sidebar height from 50vh to 80vh

## Motivation
The previous layout required scrolling to see all content. These adjustments ensure the entire interface fits within a single viewport on standard displays, improving usability and visual balance.

## Test Plan
- [x] Tested locally with dev server
- [x] Verified all content is visible without scrolling
- [x] Confirmed examples sidebar spans both editor sections appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)