### PR TITLE
feat: Add CREATE TABLE constraint parsing support

### DIFF
--- a/crates/ast/src/ddl.rs
+++ b/crates/ast/src/ddl.rs
@@ -1,5 +1,6 @@
 //! Data Definition Language (DDL) AST nodes
 
+use crate::Expression;
 use types::DataType;
 
 /// CREATE TABLE statement
@@ -7,7 +8,7 @@ use types::DataType;
 pub struct CreateTableStmt {
     pub table_name: String,
     pub columns: Vec<ColumnDef>,
-    // TODO: Add constraints
+    pub table_constraints: Vec<TableConstraint>,
 }
 
 /// Column definition
@@ -16,4 +17,36 @@ pub struct ColumnDef {
     pub name: String,
     pub data_type: DataType,
     pub nullable: bool,
+    pub constraints: Vec<ColumnConstraint>,
+}
+
+/// Column-level constraint
+#[derive(Debug, Clone, PartialEq)]
+pub enum ColumnConstraint {
+    PrimaryKey,
+    Unique,
+    Check(Box<Expression>),
+    References {
+        table: String,
+        column: String,
+    },
+}
+
+/// Table-level constraint
+#[derive(Debug, Clone, PartialEq)]
+pub enum TableConstraint {
+    PrimaryKey {
+        columns: Vec<String>,
+    },
+    ForeignKey {
+        columns: Vec<String>,
+        references_table: String,
+        references_columns: Vec<String>,
+    },
+    Unique {
+        columns: Vec<String>,
+    },
+    Check {
+        expr: Box<Expression>,
+    },
 }

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -11,7 +11,7 @@ mod operators;
 mod select;
 mod statement;
 
-pub use ddl::{ColumnDef, CreateTableStmt};
+pub use ddl::{ColumnConstraint, ColumnDef, CreateTableStmt, TableConstraint};
 pub use dml::{Assignment, DeleteStmt, InsertStmt, UpdateStmt};
 pub use expression::{
     Expression, FrameBound, FrameUnit, Quantifier, WindowFrame, WindowFunctionSpec, WindowSpec,

--- a/crates/parser/src/keywords.rs
+++ b/crates/parser/src/keywords.rs
@@ -64,6 +64,13 @@ pub enum Keyword {
     Unbounded,
     Current,
     // Note: Window function names (ROW_NUMBER, RANK, etc.) are identifiers, not keywords
+    // Constraint keywords
+    Primary,
+    Foreign,
+    Key,
+    Unique,
+    Check,
+    References,
 }
 
 impl fmt::Display for Keyword {
@@ -128,6 +135,12 @@ impl fmt::Display for Keyword {
             Keyword::Following => "FOLLOWING",
             Keyword::Unbounded => "UNBOUNDED",
             Keyword::Current => "CURRENT",
+            Keyword::Primary => "PRIMARY",
+            Keyword::Foreign => "FOREIGN",
+            Keyword::Key => "KEY",
+            Keyword::Unique => "UNIQUE",
+            Keyword::Check => "CHECK",
+            Keyword::References => "REFERENCES",
         };
         write!(f, "{}", keyword_str)
     }

--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -188,6 +188,13 @@ impl Lexer {
             // Note: ROW_NUMBER, RANK, DENSE_RANK, NTILE, LAG, LEAD are treated as
             // identifiers (function names), not keywords. They are classified as
             // window functions by the parser's classify_window_function() method.
+            // Constraint keywords
+            "PRIMARY" => Token::Keyword(Keyword::Primary),
+            "FOREIGN" => Token::Keyword(Keyword::Foreign),
+            "KEY" => Token::Keyword(Keyword::Key),
+            "UNIQUE" => Token::Keyword(Keyword::Unique),
+            "CHECK" => Token::Keyword(Keyword::Check),
+            "REFERENCES" => Token::Keyword(Keyword::References),
             _ => Token::Identifier(text),
         };
 

--- a/crates/parser/src/parser/create.rs
+++ b/crates/parser/src/parser/create.rs
@@ -22,11 +22,27 @@ impl Parser {
             }
         };
 
-        // Parse column definitions
+        // Parse column definitions and table constraints
         self.expect_token(Token::LParen)?;
         let mut columns = Vec::new();
+        let mut table_constraints = Vec::new();
 
         loop {
+            // Check if this is a table-level constraint
+            if self.peek_keyword(Keyword::Primary)
+                || self.peek_keyword(Keyword::Foreign)
+                || self.peek_keyword(Keyword::Unique)
+                || self.peek_keyword(Keyword::Check)
+            {
+                table_constraints.push(self.parse_table_constraint()?);
+                if matches!(self.peek(), Token::Comma) {
+                    self.advance();
+                    continue;
+                } else {
+                    break;
+                }
+            }
+
             // Parse column name
             let name = match self.peek() {
                 Token::Identifier(col) => {
@@ -49,7 +65,15 @@ impl Parser {
                 true
             };
 
-            columns.push(ast::ColumnDef { name, data_type, nullable });
+            // Parse column constraints
+            let constraints = self.parse_column_constraints()?;
+
+            columns.push(ast::ColumnDef {
+                name,
+                data_type,
+                nullable,
+                constraints,
+            });
 
             if matches!(self.peek(), Token::Comma) {
                 self.advance();
@@ -65,7 +89,11 @@ impl Parser {
             self.advance();
         }
 
-        Ok(ast::CreateTableStmt { table_name, columns })
+        Ok(ast::CreateTableStmt {
+            table_name,
+            columns,
+            table_constraints,
+        })
     }
 
     /// Parse data type
@@ -325,5 +353,215 @@ impl Parser {
 
         // No timezone modifier - default to WITHOUT TIME ZONE
         Ok(false)
+    }
+
+    /// Parse column-level constraints (PRIMARY KEY, UNIQUE, CHECK, REFERENCES)
+    fn parse_column_constraints(&mut self) -> Result<Vec<ast::ColumnConstraint>, ParseError> {
+        let mut constraints = Vec::new();
+
+        loop {
+            match self.peek() {
+                Token::Keyword(Keyword::Primary) => {
+                    self.advance(); // consume PRIMARY
+                    self.expect_keyword(Keyword::Key)?;
+                    constraints.push(ast::ColumnConstraint::PrimaryKey);
+                }
+                Token::Keyword(Keyword::Unique) => {
+                    self.advance(); // consume UNIQUE
+                    constraints.push(ast::ColumnConstraint::Unique);
+                }
+                Token::Keyword(Keyword::Check) => {
+                    self.advance(); // consume CHECK
+                    self.expect_token(Token::LParen)?;
+                    let expr = self.parse_expression()?;
+                    self.expect_token(Token::RParen)?;
+                    constraints.push(ast::ColumnConstraint::Check(Box::new(expr)));
+                }
+                Token::Keyword(Keyword::References) => {
+                    self.advance(); // consume REFERENCES
+                    let table = match self.peek() {
+                        Token::Identifier(t) => {
+                            let table_name = t.clone();
+                            self.advance();
+                            table_name
+                        }
+                        _ => {
+                            return Err(ParseError {
+                                message: "Expected table name after REFERENCES".to_string(),
+                            })
+                        }
+                    };
+
+                    self.expect_token(Token::LParen)?;
+                    let column = match self.peek() {
+                        Token::Identifier(c) => {
+                            let col_name = c.clone();
+                            self.advance();
+                            col_name
+                        }
+                        _ => {
+                            return Err(ParseError {
+                                message: "Expected column name in REFERENCES".to_string(),
+                            })
+                        }
+                    };
+                    self.expect_token(Token::RParen)?;
+
+                    constraints.push(ast::ColumnConstraint::References { table, column });
+                }
+                _ => break,
+            }
+        }
+
+        Ok(constraints)
+    }
+
+    /// Parse table-level constraints (PRIMARY KEY, FOREIGN KEY, UNIQUE, CHECK)
+    fn parse_table_constraint(&mut self) -> Result<ast::TableConstraint, ParseError> {
+        match self.peek() {
+            Token::Keyword(Keyword::Primary) => {
+                self.advance(); // consume PRIMARY
+                self.expect_keyword(Keyword::Key)?;
+                self.expect_token(Token::LParen)?;
+
+                let mut columns = Vec::new();
+                loop {
+                    match self.peek() {
+                        Token::Identifier(col) => {
+                            columns.push(col.clone());
+                            self.advance();
+                        }
+                        _ => {
+                            return Err(ParseError {
+                                message: "Expected column name in PRIMARY KEY".to_string(),
+                            })
+                        }
+                    }
+
+                    if matches!(self.peek(), Token::Comma) {
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+
+                self.expect_token(Token::RParen)?;
+                Ok(ast::TableConstraint::PrimaryKey { columns })
+            }
+            Token::Keyword(Keyword::Foreign) => {
+                self.advance(); // consume FOREIGN
+                self.expect_keyword(Keyword::Key)?;
+                self.expect_token(Token::LParen)?;
+
+                let mut columns = Vec::new();
+                loop {
+                    match self.peek() {
+                        Token::Identifier(col) => {
+                            columns.push(col.clone());
+                            self.advance();
+                        }
+                        _ => {
+                            return Err(ParseError {
+                                message: "Expected column name in FOREIGN KEY".to_string(),
+                            })
+                        }
+                    }
+
+                    if matches!(self.peek(), Token::Comma) {
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+
+                self.expect_token(Token::RParen)?;
+                self.expect_keyword(Keyword::References)?;
+
+                let references_table = match self.peek() {
+                    Token::Identifier(t) => {
+                        let table_name = t.clone();
+                        self.advance();
+                        table_name
+                    }
+                    _ => {
+                        return Err(ParseError {
+                            message: "Expected table name after REFERENCES".to_string(),
+                        })
+                    }
+                };
+
+                self.expect_token(Token::LParen)?;
+
+                let mut references_columns = Vec::new();
+                loop {
+                    match self.peek() {
+                        Token::Identifier(col) => {
+                            references_columns.push(col.clone());
+                            self.advance();
+                        }
+                        _ => {
+                            return Err(ParseError {
+                                message: "Expected column name in REFERENCES".to_string(),
+                            })
+                        }
+                    }
+
+                    if matches!(self.peek(), Token::Comma) {
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+
+                self.expect_token(Token::RParen)?;
+
+                Ok(ast::TableConstraint::ForeignKey {
+                    columns,
+                    references_table,
+                    references_columns,
+                })
+            }
+            Token::Keyword(Keyword::Unique) => {
+                self.advance(); // consume UNIQUE
+                self.expect_token(Token::LParen)?;
+
+                let mut columns = Vec::new();
+                loop {
+                    match self.peek() {
+                        Token::Identifier(col) => {
+                            columns.push(col.clone());
+                            self.advance();
+                        }
+                        _ => {
+                            return Err(ParseError {
+                                message: "Expected column name in UNIQUE".to_string(),
+                            })
+                        }
+                    }
+
+                    if matches!(self.peek(), Token::Comma) {
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+
+                self.expect_token(Token::RParen)?;
+                Ok(ast::TableConstraint::Unique { columns })
+            }
+            Token::Keyword(Keyword::Check) => {
+                self.advance(); // consume CHECK
+                self.expect_token(Token::LParen)?;
+                let expr = self.parse_expression()?;
+                self.expect_token(Token::RParen)?;
+                Ok(ast::TableConstraint::Check {
+                    expr: Box::new(expr),
+                })
+            }
+            _ => Err(ParseError {
+                message: "Expected table constraint keyword (PRIMARY, FOREIGN, UNIQUE, CHECK)"
+                    .to_string(),
+            }),
+        }
     }
 }

--- a/crates/parser/src/tests/create_table.rs
+++ b/crates/parser/src/tests/create_table.rs
@@ -438,3 +438,329 @@ fn test_parse_create_table_all_phase2_types() {
         _ => panic!("Expected CREATE TABLE statement"),
     }
 }
+
+// ========================================================================
+// Constraint Tests (Issue #214)
+// ========================================================================
+
+#[test]
+fn test_parse_create_table_with_primary_key() {
+    let result = Parser::parse_sql("CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(100));");
+    assert!(result.is_ok(), "Should parse column-level PRIMARY KEY");
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "users");
+            assert_eq!(create.columns.len(), 2);
+            assert_eq!(create.columns[0].name, "id");
+            assert_eq!(create.columns[0].constraints.len(), 1);
+            assert!(matches!(
+                create.columns[0].constraints[0],
+                ast::ColumnConstraint::PrimaryKey
+            ));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_with_unique() {
+    let result = Parser::parse_sql("CREATE TABLE users (email VARCHAR(100) UNIQUE);");
+    assert!(result.is_ok(), "Should parse UNIQUE constraint");
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].constraints.len(), 1);
+            assert!(matches!(
+                create.columns[0].constraints[0],
+                ast::ColumnConstraint::Unique
+            ));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_with_check_constraint() {
+    let result = Parser::parse_sql("CREATE TABLE products (price NUMERIC(10, 2) CHECK (price > 0));");
+    assert!(result.is_ok(), "Should parse CHECK constraint");
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].constraints.len(), 1);
+            assert!(matches!(
+                create.columns[0].constraints[0],
+                ast::ColumnConstraint::Check(_)
+            ));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_with_references() {
+    let result = Parser::parse_sql("CREATE TABLE orders (customer_id INTEGER REFERENCES customers(id));");
+    assert!(result.is_ok(), "Should parse REFERENCES constraint");
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].constraints.len(), 1);
+            match &create.columns[0].constraints[0] {
+                ast::ColumnConstraint::References { table, column } => {
+                    assert_eq!(table, "customers");
+                    assert_eq!(column, "id");
+                }
+                _ => panic!("Expected REFERENCES constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_with_table_level_primary_key() {
+    let result = Parser::parse_sql(
+        "CREATE TABLE order_items (
+            order_id INTEGER,
+            product_id INTEGER,
+            quantity INTEGER,
+            PRIMARY KEY (order_id, product_id)
+        );"
+    );
+    assert!(result.is_ok(), "Should parse table-level PRIMARY KEY");
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_constraints.len(), 1);
+            match &create.table_constraints[0] {
+                ast::TableConstraint::PrimaryKey { columns } => {
+                    assert_eq!(columns.len(), 2);
+                    assert_eq!(columns[0], "order_id");
+                    assert_eq!(columns[1], "product_id");
+                }
+                _ => panic!("Expected PRIMARY KEY constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_with_foreign_key() {
+    let result = Parser::parse_sql(
+        "CREATE TABLE orders (
+            id INTEGER PRIMARY KEY,
+            customer_id INTEGER,
+            FOREIGN KEY (customer_id) REFERENCES customers(id)
+        );"
+    );
+    assert!(result.is_ok(), "Should parse FOREIGN KEY constraint");
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_constraints.len(), 1);
+            match &create.table_constraints[0] {
+                ast::TableConstraint::ForeignKey {
+                    columns,
+                    references_table,
+                    references_columns,
+                } => {
+                    assert_eq!(columns.len(), 1);
+                    assert_eq!(columns[0], "customer_id");
+                    assert_eq!(references_table, "customers");
+                    assert_eq!(references_columns.len(), 1);
+                    assert_eq!(references_columns[0], "id");
+                }
+                _ => panic!("Expected FOREIGN KEY constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_with_table_level_unique() {
+    let result = Parser::parse_sql(
+        "CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            email VARCHAR(100),
+            username VARCHAR(50),
+            UNIQUE (email, username)
+        );"
+    );
+    assert!(result.is_ok(), "Should parse table-level UNIQUE constraint");
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_constraints.len(), 1);
+            match &create.table_constraints[0] {
+                ast::TableConstraint::Unique { columns } => {
+                    assert_eq!(columns.len(), 2);
+                    assert_eq!(columns[0], "email");
+                    assert_eq!(columns[1], "username");
+                }
+                _ => panic!("Expected UNIQUE constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_with_table_level_check() {
+    let result = Parser::parse_sql(
+        "CREATE TABLE products (
+            price NUMERIC(10, 2),
+            discount NUMERIC(10, 2),
+            CHECK (discount < price)
+        );"
+    );
+    assert!(result.is_ok(), "Should parse table-level CHECK constraint");
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_constraints.len(), 1);
+            assert!(matches!(
+                create.table_constraints[0],
+                ast::TableConstraint::Check { .. }
+            ));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_northwind_categories_table() {
+    let result = Parser::parse_sql(
+        "CREATE TABLE Categories (
+            CategoryID INTEGER PRIMARY KEY,
+            CategoryName VARCHAR(15),
+            Description VARCHAR(255)
+        );"
+    );
+    assert!(result.is_ok(), "Should parse northwind Categories table");
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "Categories");
+            assert_eq!(create.columns.len(), 3);
+            assert_eq!(create.columns[0].name, "CategoryID");
+            assert_eq!(create.columns[0].constraints.len(), 1);
+            assert!(matches!(
+                create.columns[0].constraints[0],
+                ast::ColumnConstraint::PrimaryKey
+            ));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_with_multiple_constraints() {
+    let result = Parser::parse_sql(
+        "CREATE TABLE employees (
+            id INTEGER PRIMARY KEY,
+            email VARCHAR(100) UNIQUE,
+            salary NUMERIC(10, 2) CHECK (salary > 0),
+            department_id INTEGER REFERENCES departments(id)
+        );"
+    );
+    assert!(result.is_ok(), "Should parse multiple column constraints");
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 4);
+
+            // id has PRIMARY KEY
+            assert_eq!(create.columns[0].constraints.len(), 1);
+            assert!(matches!(
+                create.columns[0].constraints[0],
+                ast::ColumnConstraint::PrimaryKey
+            ));
+
+            // email has UNIQUE
+            assert_eq!(create.columns[1].constraints.len(), 1);
+            assert!(matches!(
+                create.columns[1].constraints[0],
+                ast::ColumnConstraint::Unique
+            ));
+
+            // salary has CHECK
+            assert_eq!(create.columns[2].constraints.len(), 1);
+            assert!(matches!(
+                create.columns[2].constraints[0],
+                ast::ColumnConstraint::Check(_)
+            ));
+
+            // department_id has REFERENCES
+            assert_eq!(create.columns[3].constraints.len(), 1);
+            assert!(matches!(
+                create.columns[3].constraints[0],
+                ast::ColumnConstraint::References { .. }
+            ));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_northwind_products_table() {
+    let result = Parser::parse_sql(
+        "CREATE TABLE products (
+            product_id INTEGER PRIMARY KEY,
+            product_name VARCHAR(100) NOT NULL,
+            category_id INTEGER,
+            unit_price DECIMAL(10, 2),
+            FOREIGN KEY (category_id) REFERENCES categories(category_id)
+        );"
+    );
+    assert!(result.is_ok(), "Should parse northwind products table with FOREIGN KEY");
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "products");
+            assert_eq!(create.columns.len(), 4);
+
+            // product_id has PRIMARY KEY
+            assert_eq!(create.columns[0].name, "product_id");
+            assert_eq!(create.columns[0].constraints.len(), 1);
+            assert!(matches!(
+                create.columns[0].constraints[0],
+                ast::ColumnConstraint::PrimaryKey
+            ));
+
+            // product_name has NOT NULL (nullable = false)
+            assert_eq!(create.columns[1].name, "product_name");
+            assert!(!create.columns[1].nullable, "product_name should be NOT NULL");
+
+            // Table has FOREIGN KEY constraint
+            assert_eq!(create.table_constraints.len(), 1);
+            match &create.table_constraints[0] {
+                ast::TableConstraint::ForeignKey {
+                    columns,
+                    references_table,
+                    references_columns,
+                } => {
+                    assert_eq!(columns.len(), 1);
+                    assert_eq!(columns[0], "category_id");
+                    assert_eq!(references_table, "categories");
+                    assert_eq!(references_columns.len(), 1);
+                    assert_eq!(references_columns[0], "category_id");
+                }
+                _ => panic!("Expected FOREIGN KEY constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 constraint support for CREATE TABLE statements, enabling parsing of northwind.sql and employees.sql databases.

**Changes:**
- Added AST types for column and table-level constraints (PRIMARY KEY, UNIQUE, CHECK, REFERENCES, FOREIGN KEY)
- Implemented parser logic to recognize and parse constraint syntax
- Added constraint keywords to lexer (PRIMARY, FOREIGN, KEY, UNIQUE, CHECK, REFERENCES)
- Created 11 comprehensive parser tests including real-world northwind table examples
- All 368 parser tests pass

**Constraints Supported:**
- Column-level: PRIMARY KEY, UNIQUE, CHECK, REFERENCES
- Table-level: PRIMARY KEY, FOREIGN KEY, UNIQUE, CHECK

**Note:** This is a parse-only implementation (Phase 1). Constraints are stored in the AST but not validated or enforced during execution.

## Test Plan

- [x] Parser tests for all constraint types (11 new tests)
- [x] Full test suite passes (368 parser tests)
- [x] Verified parsing of northwind Categories and Products tables
- [x] Verified parsing of column and table-level constraints
- [x] All existing tests continue to pass

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)