### PR TITLE
Fix: Add missing .gitmodules for sqltest submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/sqltest"]
+	path = third_party/sqltest
+	url = https://github.com/elliotchance/sqltest.git


### PR DESCRIPTION
## Problem

PR #298 added `third_party/sqltest` as a git submodule but did not include the `.gitmodules` configuration file. This is causing CI failures on all PRs that use the new test infrastructure:

```
fatal: No url found for submodule path 'third_party/sqltest' in .gitmodules
```

Both `conformance-tests` and `rust-tests` CI jobs are failing on checkout.

## Solution

This PR adds the missing `.gitmodules` file with the proper configuration for the sqltest submodule:

```ini
[submodule "third_party/sqltest"]
	path = third_party/sqltest
	url = https://github.com/elliotchance/sqltest.git
```

## Impact

- ✅ Unblocks PR #299 (CI coverage tracking)
- ✅ Fixes CI for all future PRs using the test infrastructure
- ✅ Properly configures the sqltest submodule

## Testing

- Verified submodule initialization works: `git submodule update --init --recursive`
- Submodule successfully cloned to commit `1951ddf`

## References

- Blocks: #299
- Related: #298 (PR that added the submodule)