### PR TITLE
Fix CI: Prevent label-external-issues workflow from failing on push events

### DIFF
--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -10,11 +10,11 @@ permissions:
 
 jobs:
   label_external:
-    if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     steps:
       - name: Check if author is a collaborator
         id: check
+        if: github.event_name == 'issues'
         uses: actions/github-script@v7
         with:
           script: |
@@ -35,7 +35,7 @@ jobs:
             }
 
       - name: Add 'external' label if not a collaborator
-        if: fromJSON(steps.check.outputs.result).isCollaborator == false
+        if: github.event_name == 'issues' && fromJSON(steps.check.outputs.result).isCollaborator == false
         uses: actions/github-script@v7
         with:
           script: |
@@ -47,7 +47,7 @@ jobs:
             });
 
       - name: Post welcome comment on external issues
-        if: fromJSON(steps.check.outputs.result).isCollaborator == false
+        if: github.event_name == 'issues' && fromJSON(steps.check.outputs.result).isCollaborator == false
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
The label-external-issues workflow was incorrectly running and failing on push events to main, despite being configured only for issues events. Added event type checks to all steps to prevent execution on non-issues events.