### PR TITLE
Add Scientific Notation (E-notation) Support

### DIFF
--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -106,7 +106,16 @@ impl Lexer {
                     })
                 }
             }
-            '+' | '-' | '*' | '/' | '.' => {
+            '.' => {
+                // Check if this is the start of a decimal number (e.g., .2, .5E+10)
+                if !self.is_eof() && self.peek(1).map(|c| c.is_ascii_digit()).unwrap_or(false) {
+                    self.tokenize_number()
+                } else {
+                    self.advance();
+                    Ok(Token::Symbol('.'))
+                }
+            }
+            '+' | '-' | '*' | '/' => {
                 let symbol = ch;
                 self.advance();
                 Ok(Token::Symbol(symbol))
@@ -233,10 +242,13 @@ impl Lexer {
     }
 
     /// Tokenize a number literal.
+    /// Supports integers, decimals, and scientific notation (E-notation).
+    /// Examples: 42, 3.14, 2.5E+10, 1.2E-5, .2E+2
     fn tokenize_number(&mut self) -> Result<Token, LexerError> {
         let start = self.position;
         let mut has_dot = false;
 
+        // Parse the main number (digits and optional decimal point)
         while !self.is_eof() {
             let ch = self.current_char();
             if ch.is_ascii_digit() {
@@ -246,6 +258,36 @@ impl Lexer {
                 self.advance();
             } else {
                 break;
+            }
+        }
+
+        // Check for scientific notation (E-notation)
+        if !self.is_eof() {
+            let ch = self.current_char();
+            if ch == 'E' || ch == 'e' {
+                self.advance();
+
+                // Optional sign (+/-)
+                if !self.is_eof() {
+                    let sign = self.current_char();
+                    if sign == '+' || sign == '-' {
+                        self.advance();
+                    }
+                }
+
+                // Exponent digits (required)
+                let exp_start = self.position;
+                while !self.is_eof() && self.current_char().is_ascii_digit() {
+                    self.advance();
+                }
+
+                // Verify we got at least one exponent digit
+                if self.position == exp_start {
+                    return Err(LexerError {
+                        message: "Invalid scientific notation: expected digits after 'E'".to_string(),
+                        position: self.position,
+                    });
+                }
             }
         }
 
@@ -348,5 +390,78 @@ impl Lexer {
     /// Check if we've reached end of input.
     fn is_eof(&self) -> bool {
         self.position >= self.input.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scientific_notation() {
+        // Test various E-notation formats
+        let test_cases = vec![
+            ("2.5E+10", "2.5E+10"),
+            ("1.2E-5", "1.2E-5"),
+            (".2E+2", ".2E+2"),
+            ("2E10", "2E10"),
+            ("2.E-5", "2.E-5"),
+            ("2.5e10", "2.5e10"),  // lowercase e
+            (".5E2", ".5E2"),
+            ("123.456E-78", "123.456E-78"),
+        ];
+
+        for (input, expected) in test_cases {
+            let mut lexer = Lexer::new(input);
+            let tokens = lexer.tokenize().expect(&format!("Failed to tokenize: {}", input));
+
+            // Should have exactly 2 tokens: the number and EOF
+            assert_eq!(tokens.len(), 2, "Input: {}", input);
+
+            match &tokens[0] {
+                Token::Number(n) => assert_eq!(n, expected, "Input: {}", input),
+                other => panic!("Expected Number token for {}, got {:?}", input, other),
+            }
+
+            assert_eq!(tokens[1], Token::Eof);
+        }
+    }
+
+    #[test]
+    fn test_decimal_point_start() {
+        // Test numbers starting with decimal point
+        let test_cases = vec![
+            (".5", ".5"),
+            (".123", ".123"),
+            (".2E+2", ".2E+2"),
+        ];
+
+        for (input, expected) in test_cases {
+            let mut lexer = Lexer::new(input);
+            let tokens = lexer.tokenize().expect(&format!("Failed to tokenize: {}", input));
+
+            assert_eq!(tokens.len(), 2, "Input: {}", input);
+
+            match &tokens[0] {
+                Token::Number(n) => assert_eq!(n, expected, "Input: {}", input),
+                other => panic!("Expected Number token for {}, got {:?}", input, other),
+            }
+        }
+    }
+
+    #[test]
+    fn test_invalid_scientific_notation() {
+        // Test invalid E-notation should fail
+        let invalid_cases = vec![
+            "2E",      // No exponent digits
+            "2E+",     // No exponent digits after sign
+            "2E-",     // No exponent digits after sign
+        ];
+
+        for input in invalid_cases {
+            let mut lexer = Lexer::new(input);
+            let result = lexer.tokenize();
+            assert!(result.is_err(), "Expected error for input: {}", input);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Implements comprehensive scientific notation (E-notation) support in the lexer to handle numbers like `2.5E+10`, `1.2E-5`, `.2E+2`, etc.

### Changes Made

- ✅ Updated `tokenize_number()` to recognize E/e followed by optional +/- and required exponent digits
- ✅ Added support for numbers starting with decimal point (e.g., `.2`, `.5E+10`)
- ✅ Modified `next_token()` to distinguish decimal-starting numbers from dot operator
- ✅ Added validation for malformed E-notation (missing exponent digits)
- ✅ Included comprehensive unit tests for valid and invalid E-notation formats

### Test Results

**Lexer Unit Tests**: ✅ All 3 new tests pass
- `test_scientific_notation` - validates E-notation formats
- `test_decimal_point_start` - validates decimal-leading numbers
- `test_invalid_scientific_notation` - validates error handling

**Conformance Tests**: Note that SQL:1999 conformance tests (e011_02_03_*) still fail due to missing unary operator support in the parser, which is tracked separately in issue #324. The lexer is correctly tokenizing E-notation; parser improvements are needed for full test passage.

### Examples Supported

```sql
SELECT 2.5E+10;   -- Large numbers with positive exponent
SELECT 1.2E-5;    -- Small numbers with negative exponent
SELECT .2E+2;     -- Decimal-leading with E-notation
SELECT 2E10;      -- Integer with exponent
SELECT 2.5e10;    -- Lowercase 'e' supported
```

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)