### PR TITLE
Refactor evaluate_with_aggregates: Extract 285-line function into focused sub-functions

### DIFF
--- a/crates/executor/src/select/executor/aggregation.rs
+++ b/crates/executor/src/select/executor/aggregation.rs
@@ -143,254 +143,29 @@ impl<'a> SelectExecutor<'a> {
         evaluator: &CombinedExpressionEvaluator,
     ) -> Result<types::SqlValue, ExecutorError> {
         match expr {
-            // New AggregateFunction variant
-            ast::Expression::AggregateFunction { name, distinct, args } => {
-                let mut acc = AggregateAccumulator::new(name, *distinct)?;
-
-                // Special handling for COUNT(*)
-                if name.to_uppercase() == "COUNT" && args.len() == 1 {
-                    let is_count_star = matches!(args[0], ast::Expression::Wildcard)
-                        || matches!(
-                            &args[0],
-                            ast::Expression::ColumnRef { table: None, column } if column == "*"
-                        );
-
-                    if is_count_star {
-                        // COUNT(*) - count all rows (DISTINCT not allowed with *)
-                        if *distinct {
-                            return Err(ExecutorError::UnsupportedExpression(
-                                "COUNT(DISTINCT *) is not valid SQL".to_string()
-                            ));
-                        }
-                        for _ in group_rows {
-                            acc.accumulate(&types::SqlValue::Integer(1));
-                        }
-                        return Ok(acc.finalize());
-                    }
-                }
-
-                // Regular aggregate - evaluate argument for each row
-                if args.len() != 1 {
-                    return Err(ExecutorError::UnsupportedExpression(format!(
-                        "Aggregate functions expect 1 argument, got {}",
-                        args.len()
-                    )));
-                }
-
-                for row in group_rows {
-                    let value = evaluator.eval(&args[0], row)?;
-                    acc.accumulate(&value);
-                }
-
-                Ok(acc.finalize())
-            }
-
-            // Old Function variant (backwards compatibility)
-            ast::Expression::Function { name, args } => {
-                let mut acc = AggregateAccumulator::new(name, false)?;
-
-                // Special handling for COUNT(*)
-                if name.to_uppercase() == "COUNT" && args.len() == 1 {
-                    // Parser represents COUNT(*) as either Wildcard or ColumnRef { column: "*" }
-                    let is_count_star = matches!(args[0], ast::Expression::Wildcard)
-                        || matches!(
-                            &args[0],
-                            ast::Expression::ColumnRef { table: None, column } if column == "*"
-                        );
-
-                    if is_count_star {
-                        // COUNT(*) - count all rows
-                        for _ in group_rows {
-                            acc.accumulate(&types::SqlValue::Integer(1));
-                        }
-                        return Ok(acc.finalize());
-                    }
-                }
-
-                // Regular aggregate - evaluate argument for each row
-                if args.len() != 1 {
-                    return Err(ExecutorError::UnsupportedExpression(format!(
-                        "Aggregate functions expect 1 argument, got {}",
-                        args.len()
-                    )));
-                }
-
-                for row in group_rows {
-                    let value = evaluator.eval(&args[0], row)?;
-                    acc.accumulate(&value);
-                }
-
-                Ok(acc.finalize())
+            // Aggregate functions (both new and old variants)
+            ast::Expression::AggregateFunction { .. } | ast::Expression::Function { .. } => {
+                self.evaluate_aggregate_function(expr, group_rows, evaluator)
             }
 
             // Binary operation - recursively evaluate both sides
             ast::Expression::BinaryOp { left, op, right } => {
-                let left_val =
-                    self.evaluate_with_aggregates(left, group_rows, _group_key, evaluator)?;
-                let right_val =
-                    self.evaluate_with_aggregates(right, group_rows, _group_key, evaluator)?;
-
-                // Reuse the binary op evaluation logic from ExpressionEvaluator
-                // Create a temporary evaluator for this
-                let temp_schema = catalog::TableSchema::new("temp".to_string(), vec![]);
-                let temp_evaluator = ExpressionEvaluator::new(&temp_schema);
-                temp_evaluator.eval_binary_op(&left_val, op, &right_val)
+                self.evaluate_binary_op_with_aggregates(left, op, right, group_rows, _group_key, evaluator)
             }
 
             // Scalar subquery - delegate to evaluator
             ast::Expression::ScalarSubquery(_) | ast::Expression::Exists { .. } => {
-                // Use first row from group as context for subquery evaluation
-                if let Some(first_row) = group_rows.first() {
-                    evaluator.eval(expr, first_row)
-                } else {
-                    Ok(types::SqlValue::Null)
-                }
+                self.evaluate_scalar_subquery_with_aggregates(expr, group_rows, evaluator)
             }
 
             // IN with subquery - special handling for aggregate left-hand side
             ast::Expression::In { expr: left_expr, subquery, negated } => {
-                // Evaluate left-hand expression (which may be an aggregate)
-                let left_val = self.evaluate_with_aggregates(left_expr, group_rows, _group_key, evaluator)?;
-
-                // Execute subquery to get values to compare against
-                let database = self.database;
-                let select_executor = crate::select::SelectExecutor::new(database);
-                let rows = select_executor.execute(subquery)?;
-
-                // Check subquery column count
-                if subquery.select_list.len() != 1 {
-                    return Err(ExecutorError::SubqueryColumnCountMismatch {
-                        expected: 1,
-                        actual: subquery.select_list.len(),
-                    });
-                }
-
-                // If left value is NULL, result is NULL
-                if matches!(left_val, types::SqlValue::Null) {
-                    return Ok(types::SqlValue::Null);
-                }
-
-                let mut found_null = false;
-
-                // Check each row from subquery
-                for subquery_row in &rows {
-                    let subquery_val = subquery_row
-                        .get(0)
-                        .ok_or(ExecutorError::ColumnIndexOutOfBounds { index: 0 })?;
-
-                    // Track if we encounter NULL
-                    if matches!(subquery_val, types::SqlValue::Null) {
-                        found_null = true;
-                        continue;
-                    }
-
-                    // Compare using equality
-                    if left_val == *subquery_val {
-                        return Ok(types::SqlValue::Boolean(!negated));
-                    }
-                }
-
-                // No match found
-                if found_null {
-                    Ok(types::SqlValue::Null)
-                } else {
-                    Ok(types::SqlValue::Boolean(*negated))
-                }
+                self.evaluate_in_predicate_with_aggregates(left_expr, subquery, *negated, group_rows, _group_key, evaluator)
             }
 
             // Quantified comparison - special handling for aggregate left-hand side
             ast::Expression::QuantifiedComparison { expr: left_expr, op, quantifier, subquery } => {
-                // Evaluate left-hand expression (which may be an aggregate)
-                let left_val = self.evaluate_with_aggregates(left_expr, group_rows, _group_key, evaluator)?;
-
-                // Execute subquery
-                let database = self.database;
-                let select_executor = crate::select::SelectExecutor::new(database);
-                let rows = select_executor.execute(subquery)?;
-
-                // Empty subquery special cases
-                if rows.is_empty() {
-                    return Ok(types::SqlValue::Boolean(matches!(quantifier, ast::Quantifier::All)));
-                }
-
-                // If left value is NULL, return NULL
-                if matches!(left_val, types::SqlValue::Null) {
-                    return Ok(types::SqlValue::Null);
-                }
-
-                let mut has_null = false;
-
-                match quantifier {
-                    ast::Quantifier::All => {
-                        for subquery_row in &rows {
-                            if subquery_row.values.len() != 1 {
-                                return Err(ExecutorError::SubqueryColumnCountMismatch {
-                                    expected: 1,
-                                    actual: subquery_row.values.len(),
-                                });
-                            }
-
-                            let right_val = &subquery_row.values[0];
-
-                            if matches!(right_val, types::SqlValue::Null) {
-                                has_null = true;
-                                continue;
-                            }
-
-                            // Create temp evaluator for comparison
-                            let temp_schema = catalog::TableSchema::new("temp".to_string(), vec![]);
-                            let temp_evaluator = ExpressionEvaluator::new(&temp_schema);
-                            let cmp_result = temp_evaluator.eval_binary_op(&left_val, op, right_val)?;
-
-                            match cmp_result {
-                                types::SqlValue::Boolean(false) => return Ok(types::SqlValue::Boolean(false)),
-                                types::SqlValue::Null => has_null = true,
-                                _ => {}
-                            }
-                        }
-
-                        if has_null {
-                            Ok(types::SqlValue::Null)
-                        } else {
-                            Ok(types::SqlValue::Boolean(true))
-                        }
-                    }
-
-                    ast::Quantifier::Any | ast::Quantifier::Some => {
-                        for subquery_row in &rows {
-                            if subquery_row.values.len() != 1 {
-                                return Err(ExecutorError::SubqueryColumnCountMismatch {
-                                    expected: 1,
-                                    actual: subquery_row.values.len(),
-                                });
-                            }
-
-                            let right_val = &subquery_row.values[0];
-
-                            if matches!(right_val, types::SqlValue::Null) {
-                                has_null = true;
-                                continue;
-                            }
-
-                            // Create temp evaluator for comparison
-                            let temp_schema = catalog::TableSchema::new("temp".to_string(), vec![]);
-                            let temp_evaluator = ExpressionEvaluator::new(&temp_schema);
-                            let cmp_result = temp_evaluator.eval_binary_op(&left_val, op, right_val)?;
-
-                            match cmp_result {
-                                types::SqlValue::Boolean(true) => return Ok(types::SqlValue::Boolean(true)),
-                                types::SqlValue::Null => has_null = true,
-                                _ => {}
-                            }
-                        }
-
-                        if has_null {
-                            Ok(types::SqlValue::Null)
-                        } else {
-                            Ok(types::SqlValue::Boolean(false))
-                        }
-                    }
-                }
+                self.evaluate_quantified_comparison_with_aggregates(left_expr, op, quantifier, subquery, group_rows, _group_key, evaluator)
             }
 
             // Other expressions that might contain subqueries or be useful in HAVING:
@@ -416,6 +191,262 @@ impl<'a> SelectExecutor<'a> {
                 "Unsupported expression in aggregate context: {:?}",
                 expr
             ))),
+        }
+    }
+
+    /// Evaluate aggregate function expressions (COUNT, SUM, AVG, MIN, MAX)
+    /// Handles both AggregateFunction and Function variants (for backwards compatibility)
+    fn evaluate_aggregate_function(
+        &self,
+        expr: &ast::Expression,
+        group_rows: &[storage::Row],
+        evaluator: &CombinedExpressionEvaluator,
+    ) -> Result<types::SqlValue, ExecutorError> {
+        // Extract name, distinct, and args from either variant
+        let (name, distinct, args) = match expr {
+            ast::Expression::AggregateFunction { name, distinct, args } => {
+                (name, *distinct, args)
+            }
+            ast::Expression::Function { name, args } => {
+                (name, false, args)
+            }
+            _ => unreachable!("evaluate_aggregate_function called with non-aggregate expression"),
+        };
+
+        let mut acc = AggregateAccumulator::new(name, distinct)?;
+
+        // Special handling for COUNT(*)
+        if name.to_uppercase() == "COUNT" && args.len() == 1 {
+            let is_count_star = matches!(args[0], ast::Expression::Wildcard)
+                || matches!(
+                    &args[0],
+                    ast::Expression::ColumnRef { table: None, column } if column == "*"
+                );
+
+            if is_count_star {
+                // COUNT(*) - count all rows (DISTINCT not allowed with *)
+                if distinct {
+                    return Err(ExecutorError::UnsupportedExpression(
+                        "COUNT(DISTINCT *) is not valid SQL".to_string()
+                    ));
+                }
+                for _ in group_rows {
+                    acc.accumulate(&types::SqlValue::Integer(1));
+                }
+                return Ok(acc.finalize());
+            }
+        }
+
+        // Regular aggregate - evaluate argument for each row
+        if args.len() != 1 {
+            return Err(ExecutorError::UnsupportedExpression(format!(
+                "Aggregate functions expect 1 argument, got {}",
+                args.len()
+            )));
+        }
+
+        for row in group_rows {
+            let value = evaluator.eval(&args[0], row)?;
+            acc.accumulate(&value);
+        }
+
+        Ok(acc.finalize())
+    }
+
+    /// Evaluate binary operations in aggregate context
+    fn evaluate_binary_op_with_aggregates(
+        &self,
+        left: &ast::Expression,
+        op: &ast::BinaryOperator,
+        right: &ast::Expression,
+        group_rows: &[storage::Row],
+        group_key: &[types::SqlValue],
+        evaluator: &CombinedExpressionEvaluator,
+    ) -> Result<types::SqlValue, ExecutorError> {
+        let left_val = self.evaluate_with_aggregates(left, group_rows, group_key, evaluator)?;
+        let right_val = self.evaluate_with_aggregates(right, group_rows, group_key, evaluator)?;
+
+        // Reuse the binary op evaluation logic from ExpressionEvaluator
+        let temp_schema = catalog::TableSchema::new("temp".to_string(), vec![]);
+        let temp_evaluator = ExpressionEvaluator::new(&temp_schema);
+        temp_evaluator.eval_binary_op(&left_val, op, &right_val)
+    }
+
+    /// Evaluate scalar subqueries and EXISTS expressions in aggregate context
+    fn evaluate_scalar_subquery_with_aggregates(
+        &self,
+        expr: &ast::Expression,
+        group_rows: &[storage::Row],
+        evaluator: &CombinedExpressionEvaluator,
+    ) -> Result<types::SqlValue, ExecutorError> {
+        // Use first row from group as context for subquery evaluation
+        if let Some(first_row) = group_rows.first() {
+            evaluator.eval(expr, first_row)
+        } else {
+            Ok(types::SqlValue::Null)
+        }
+    }
+
+    /// Evaluate IN predicate with subquery in aggregate context
+    fn evaluate_in_predicate_with_aggregates(
+        &self,
+        left_expr: &ast::Expression,
+        subquery: &ast::SelectStmt,
+        negated: bool,
+        group_rows: &[storage::Row],
+        group_key: &[types::SqlValue],
+        evaluator: &CombinedExpressionEvaluator,
+    ) -> Result<types::SqlValue, ExecutorError> {
+        // Evaluate left-hand expression (which may be an aggregate)
+        let left_val = self.evaluate_with_aggregates(left_expr, group_rows, group_key, evaluator)?;
+
+        // Execute subquery to get values to compare against
+        let database = self.database;
+        let select_executor = crate::select::SelectExecutor::new(database);
+        let rows = select_executor.execute(subquery)?;
+
+        // Check subquery column count
+        if subquery.select_list.len() != 1 {
+            return Err(ExecutorError::SubqueryColumnCountMismatch {
+                expected: 1,
+                actual: subquery.select_list.len(),
+            });
+        }
+
+        // If left value is NULL, result is NULL
+        if matches!(left_val, types::SqlValue::Null) {
+            return Ok(types::SqlValue::Null);
+        }
+
+        let mut found_null = false;
+
+        // Check each row from subquery
+        for subquery_row in &rows {
+            let subquery_val = subquery_row
+                .get(0)
+                .ok_or(ExecutorError::ColumnIndexOutOfBounds { index: 0 })?;
+
+            // Track if we encounter NULL
+            if matches!(subquery_val, types::SqlValue::Null) {
+                found_null = true;
+                continue;
+            }
+
+            // Compare using equality
+            if left_val == *subquery_val {
+                return Ok(types::SqlValue::Boolean(!negated));
+            }
+        }
+
+        // No match found
+        if found_null {
+            Ok(types::SqlValue::Null)
+        } else {
+            Ok(types::SqlValue::Boolean(negated))
+        }
+    }
+
+    /// Evaluate quantified comparison (ALL/ANY/SOME) with subquery in aggregate context
+    fn evaluate_quantified_comparison_with_aggregates(
+        &self,
+        left_expr: &ast::Expression,
+        op: &ast::BinaryOperator,
+        quantifier: &ast::Quantifier,
+        subquery: &ast::SelectStmt,
+        group_rows: &[storage::Row],
+        group_key: &[types::SqlValue],
+        evaluator: &CombinedExpressionEvaluator,
+    ) -> Result<types::SqlValue, ExecutorError> {
+        // Evaluate left-hand expression (which may be an aggregate)
+        let left_val = self.evaluate_with_aggregates(left_expr, group_rows, group_key, evaluator)?;
+
+        // Execute subquery
+        let database = self.database;
+        let select_executor = crate::select::SelectExecutor::new(database);
+        let rows = select_executor.execute(subquery)?;
+
+        // Empty subquery special cases
+        if rows.is_empty() {
+            return Ok(types::SqlValue::Boolean(matches!(quantifier, ast::Quantifier::All)));
+        }
+
+        // If left value is NULL, return NULL
+        if matches!(left_val, types::SqlValue::Null) {
+            return Ok(types::SqlValue::Null);
+        }
+
+        let mut has_null = false;
+
+        match quantifier {
+            ast::Quantifier::All => {
+                for subquery_row in &rows {
+                    if subquery_row.values.len() != 1 {
+                        return Err(ExecutorError::SubqueryColumnCountMismatch {
+                            expected: 1,
+                            actual: subquery_row.values.len(),
+                        });
+                    }
+
+                    let right_val = &subquery_row.values[0];
+
+                    if matches!(right_val, types::SqlValue::Null) {
+                        has_null = true;
+                        continue;
+                    }
+
+                    // Create temp evaluator for comparison
+                    let temp_schema = catalog::TableSchema::new("temp".to_string(), vec![]);
+                    let temp_evaluator = ExpressionEvaluator::new(&temp_schema);
+                    let cmp_result = temp_evaluator.eval_binary_op(&left_val, op, right_val)?;
+
+                    match cmp_result {
+                        types::SqlValue::Boolean(false) => return Ok(types::SqlValue::Boolean(false)),
+                        types::SqlValue::Null => has_null = true,
+                        _ => {}
+                    }
+                }
+
+                if has_null {
+                    Ok(types::SqlValue::Null)
+                } else {
+                    Ok(types::SqlValue::Boolean(true))
+                }
+            }
+
+            ast::Quantifier::Any | ast::Quantifier::Some => {
+                for subquery_row in &rows {
+                    if subquery_row.values.len() != 1 {
+                        return Err(ExecutorError::SubqueryColumnCountMismatch {
+                            expected: 1,
+                            actual: subquery_row.values.len(),
+                        });
+                    }
+
+                    let right_val = &subquery_row.values[0];
+
+                    if matches!(right_val, types::SqlValue::Null) {
+                        has_null = true;
+                        continue;
+                    }
+
+                    // Create temp evaluator for comparison
+                    let temp_schema = catalog::TableSchema::new("temp".to_string(), vec![]);
+                    let temp_evaluator = ExpressionEvaluator::new(&temp_schema);
+                    let cmp_result = temp_evaluator.eval_binary_op(&left_val, op, right_val)?;
+
+                    match cmp_result {
+                        types::SqlValue::Boolean(true) => return Ok(types::SqlValue::Boolean(true)),
+                        types::SqlValue::Null => has_null = true,
+                        _ => {}
+                    }
+                }
+
+                if has_null {
+                    Ok(types::SqlValue::Null)
+                } else {
+                    Ok(types::SqlValue::Boolean(false))
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Refactored the massive `evaluate_with_aggregates` function by extracting specialized evaluation logic into 5 focused functions, dramatically improving code organization and maintainability.

## Problem

The original `evaluate_with_aggregates` function was **285 lines long** with:
- 6+ distinct expression types in one giant match statement
- ~40 lines of duplicated code between AggregateFunction/Function variants
- Complex logic for IN predicates (48 lines) and quantified comparisons (100+ lines)
- High cyclomatic complexity (~20)

## Solution

**Extracted 5 specialized functions:**

1. **`evaluate_aggregate_function`** (58 lines)
   - Unified handling for both AggregateFunction and Function variants
   - Eliminates duplication between variants
   - Special case for COUNT(*)

2. **`evaluate_binary_op_with_aggregates`** (18 lines)
   - Recursive binary operation evaluation
   - Clear delegation to ExpressionEvaluator

3. **`evaluate_scalar_subquery_with_aggregates`** (13 lines)
   - Scalar subqueries and EXISTS expressions
   - Simple and focused

4. **`evaluate_in_predicate_with_aggregates`** (58 lines)
   - IN predicate with subquery handling
   - NULL semantics and negation support

5. **`evaluate_quantified_comparison_with_aggregates`** (102 lines)
   - ALL/ANY/SOME quantified comparisons
   - Separate logic for each quantifier type

**Main function now serves as clear dispatcher** (~60 lines):
- Simple match statement routing to specialized functions
- Documents all supported aggregate contexts
- Easy to understand control flow

## Benefits

✅ **Reduced complexity**: 285-line function → 60-line dispatcher + 5 focused functions  
✅ **Eliminated duplication**: Merged AggregateFunction/Function handling (~40 lines removed)  
✅ **Improved testability**: Each expression type can be unit tested independently  
✅ **Better debugging**: Stack traces show which specific evaluation function failed  
✅ **Clearer git history**: Changes to IN predicates won't touch aggregate logic  
✅ **Easier reviews**: PRs touching one expression type are isolated  
✅ **Future extensibility**: Adding new expression types is clearer  

## Testing

- ✅ All 227 executor tests pass
- ✅ No behavioral changes
- ✅ Pure refactoring with no API changes
- ✅ Compilation succeeds with no warnings

## Metrics

**Before:**
- Function count: 5
- Main function: 285 lines
- Cyclomatic complexity: ~20

**After:**
- Function count: 10 (+5 specialized functions)
- Main function: 60 lines (dispatcher)
- Cyclomatic complexity: ~5 per function
- File size: 501 → 532 lines (+31 for function signatures/documentation)

## Risk Assessment

**Risk Level**: Low

- Pure refactoring with zero behavioral changes
- All logic stays within same module
- No external API changes
- Function signature of `evaluate_with_aggregates` remains unchanged
- Existing comprehensive test suite verifies correctness

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)