### PR TITLE
Remove debug eprintln! statements from executor

### DIFF
--- a/crates/executor/src/evaluator/window/aggregates.rs
+++ b/crates/executor/src/evaluator/window/aggregates.rs
@@ -29,9 +29,6 @@ where
 {
     let mut count = 0i64;
 
-    eprintln!("DEBUG COUNT: frame={:?}, partition.len()={}, arg_expr.is_none()={}",
-              frame, partition.len(), arg_expr.is_none());
-
     for idx in frame.clone() {
         if idx >= partition.len() {
             break;


### PR DESCRIPTION
Remove debug eprintln! statement from COUNT window function

## Changes
- Removed debug eprintln! statement from  function in 
- The statement was printing frame bounds, partition length, and argument expression info
- No functional changes to the COUNT window function logic

## Testing
- All executor tests pass (227 tests)
- All window function tests pass (54 tests)
- Code compiles successfully

## Issue
Closes #389
