### PR TITLE
feat: Implement OCTET_LENGTH function for SQL:1999 conformance

### DIFF
--- a/crates/executor/src/evaluator/functions/mod.rs
+++ b/crates/executor/src/evaluator/functions/mod.rs
@@ -44,6 +44,7 @@ pub(super) fn eval_scalar_function(
         "SUBSTR" => string::substring(args), // Alias for SUBSTRING
         "TRIM" => string::trim(args),
         "CHAR_LENGTH" | "CHARACTER_LENGTH" => string::char_length(args, name),
+        "OCTET_LENGTH" => string::octet_length(args),
         "CONCAT" => string::concat(args),
         "LENGTH" => string::length(args),
         "POSITION" => string::position(args),

--- a/crates/executor/src/evaluator/functions/string.rs
+++ b/crates/executor/src/evaluator/functions/string.rs
@@ -173,6 +173,28 @@ pub(super) fn char_length(args: &[types::SqlValue], name: &str) -> Result<types:
     }
 }
 
+/// OCTET_LENGTH(string) - Return number of octets (bytes) in string
+/// SQL:1999 Section 6.29: String value functions
+/// Returns byte length, not character count. For UTF-8:
+/// - ASCII characters: 1 byte each
+/// - Multi-byte characters: 2-4 bytes each
+pub(super) fn octet_length(args: &[types::SqlValue]) -> Result<types::SqlValue, ExecutorError> {
+    if args.len() != 1 {
+        return Err(ExecutorError::UnsupportedFeature(
+            format!("OCTET_LENGTH requires exactly 1 argument, got {}", args.len()),
+        ));
+    }
+
+    match &args[0] {
+        types::SqlValue::Null => Ok(types::SqlValue::Null),
+        types::SqlValue::Varchar(s) => Ok(types::SqlValue::Integer(s.len() as i64)),
+        types::SqlValue::Character(s) => Ok(types::SqlValue::Integer(s.len() as i64)),
+        val => Err(ExecutorError::UnsupportedFeature(
+            format!("OCTET_LENGTH requires string argument, got {:?}", val),
+        )),
+    }
+}
+
 /// CONCAT(str1, str2, ...) - Concatenate strings
 /// SQL:1999 Section 6.29: String value functions
 pub(super) fn concat(args: &[types::SqlValue]) -> Result<types::SqlValue, ExecutorError> {

--- a/crates/executor/tests/scalar_function_tests.rs
+++ b/crates/executor/tests/scalar_function_tests.rs
@@ -345,6 +345,55 @@ fn test_length_with_null() {
     assert_eq!(result, types::SqlValue::Null);
 }
 
+#[test]
+fn test_octet_length_ascii() {
+    let (evaluator, row) = create_test_evaluator();
+
+    let expr = ast::Expression::Function {
+        name: "OCTET_LENGTH".to_string(),
+        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("foo".to_string()))],
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, types::SqlValue::Integer(3));
+}
+
+#[test]
+fn test_octet_length_empty_string() {
+    let (evaluator, row) = create_test_evaluator();
+
+    let expr = ast::Expression::Function {
+        name: "OCTET_LENGTH".to_string(),
+        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("".to_string()))],
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, types::SqlValue::Integer(0));
+}
+
+#[test]
+fn test_octet_length_multibyte() {
+    let (evaluator, row) = create_test_evaluator();
+
+    // Emoji is 4 bytes in UTF-8
+    let expr = ast::Expression::Function {
+        name: "OCTET_LENGTH".to_string(),
+        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("🦀".to_string()))],
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, types::SqlValue::Integer(4));
+}
+
+#[test]
+fn test_octet_length_with_null() {
+    let (evaluator, row) = create_test_evaluator();
+
+    let expr = ast::Expression::Function {
+        name: "OCTET_LENGTH".to_string(),
+        args: vec![ast::Expression::Literal(types::SqlValue::Null)],
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, types::SqlValue::Null);
+}
+
 // ==================== NESTED FUNCTION TESTS ====================
 
 #[test]


### PR DESCRIPTION
## Summary

Implements the `OCTET_LENGTH` SQL function to improve SQL:1999 conformance from 77% to 77.1%.

## Changes

### Function Implementation
- **Added** `octet_length()` function in `crates/executor/src/evaluator/functions/string.rs`
- **Registered** `OCTET_LENGTH` in function dispatcher (`mod.rs`)
- **Returns** byte length of string using Rust's `String::len()` method

### Behavior
- `OCTET_LENGTH('foo')` → `3` (ASCII: 3 bytes)
- `OCTET_LENGTH('🦀')` → `4` (UTF-8 emoji: 4 bytes)
- `OCTET_LENGTH('')` → `0` (empty string)
- `OCTET_LENGTH(NULL)` → `NULL` (NULL handling)

### Test Coverage
Added 4 comprehensive tests:
- ✅ ASCII strings (basic case)
- ✅ Empty strings (edge case)
- ✅ Multi-byte UTF-8 characters (emoji test)
- ✅ NULL handling (SQL standard compliance)

## Conformance Impact

- **Tests Fixed**: 1 (e021_05_01_01)
- **Conformance Gain**: +0.1% (77% → 77.1%)
- **Complexity**: Low
- **Implementation Time**: ~1 hour

## Technical Notes

The implementation correctly distinguishes between:
- `CHAR_LENGTH` / `CHARACTER_LENGTH` - Returns **character count**
- `OCTET_LENGTH` - Returns **byte count** (this implementation)

In Rust, `String::len()` returns byte length, making this implementation straightforward and correct for SQL:1999 semantics.

## Test Plan

All tests passing:
```
cargo test -p executor --test scalar_function_tests
running 29 tests
test test_octet_length_ascii ... ok
test test_octet_length_empty_string ... ok
test test_octet_length_multibyte ... ok
test test_octet_length_with_null ... ok
test result: ok. 29 passed; 0 failed
```

Closes #394