### PR TITLE
fix: Add Expression::Trim handler to combined evaluator

### DIFF
--- a/crates/executor/src/evaluator/combined/eval.rs
+++ b/crates/executor/src/evaluator/combined/eval.rs
@@ -140,6 +140,17 @@ impl<'a> CombinedExpressionEvaluator<'a> {
                 }
             }
 
+            // TRIM expression - handle position and custom removal character
+            ast::Expression::Trim { position, removal_char, string } => {
+                let string_val = self.eval(string, row)?;
+                let removal_val = if let Some(removal) = removal_char {
+                    Some(self.eval(removal, row)?)
+                } else {
+                    None
+                };
+                super::super::functions::string::trim_advanced(string_val, position.clone(), removal_val)
+            }
+
             // Unsupported expressions
             _ => Err(ExecutorError::UnsupportedExpression(format!("{:?}", expr))),
         }

--- a/crates/executor/src/evaluator/functions/mod.rs
+++ b/crates/executor/src/evaluator/functions/mod.rs
@@ -21,7 +21,7 @@ mod conversion;
 mod datetime;
 mod null_handling;
 mod numeric;
-mod string;
+pub(crate) mod string;
 mod system;
 
 /// Evaluate a scalar function on given argument values


### PR DESCRIPTION
## Summary

Fixes the incomplete TRIM function executor support by adding the missing Expression::Trim handler in the combined expression evaluator. TRIM expressions now work correctly in all query contexts, including subqueries and joins.

## Changes

- **Added trim_advanced() function** in `crates/executor/src/evaluator/functions/string.rs`
  - Supports TRIM with position (BOTH/LEADING/TRAILING) 
  - Supports custom removal character
  - Handles NULL values correctly
  - Uses Rust's built-in trim_matches for efficiency

- **Made string module accessible** in `crates/executor/src/evaluator/functions/mod.rs`
  - Changed from private `mod string` to `pub(crate) mod string`
  - Allows trim_advanced to be called from combined evaluator

- **Added Expression::Trim handler** in `crates/executor/src/evaluator/combined/eval.rs`
  - Evaluates string and removal_char expressions
  - Calls trim_advanced with evaluated values
  - Handles position parameter correctly

## Test Results

All 7 TRIM tests pass successfully:
- ✅ test_trim_basic
- ✅ test_trim_leading_only  
- ✅ test_trim_trailing_only
- ✅ test_trim_no_spaces
- ✅ test_trim_only_spaces
- ✅ test_trim_preserves_internal_spaces
- ✅ test_trim_null

## Technical Details

The parser already created Expression::Trim AST nodes correctly, and the basic expression evaluator (expressions/eval.rs) already had an eval_trim implementation. The bug was that the combined expression evaluator (used for queries with subqueries, joins, etc.) did not handle Expression::Trim, causing it to fall through to the catch-all "UnsupportedExpression" error.

Closes #423