### PR TITLE
feat: Support CHARACTERS and OCTETS length modifiers in string types

### DIFF
--- a/crates/parser/src/keywords.rs
+++ b/crates/parser/src/keywords.rs
@@ -108,6 +108,8 @@ pub enum Keyword {
     Trailing,
     // Data type keywords
     Varying,
+    Characters,
+    Octets,
     // SUBSTRING function keywords
     For,
 }
@@ -209,6 +211,8 @@ impl fmt::Display for Keyword {
             Keyword::Leading => "LEADING",
             Keyword::Trailing => "TRAILING",
             Keyword::Varying => "VARYING",
+            Keyword::Characters => "CHARACTERS",
+            Keyword::Octets => "OCTETS",
             Keyword::For => "FOR",
         };
         write!(f, "{}", keyword_str)

--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -243,6 +243,8 @@ impl Lexer {
             "TRAILING" => Token::Keyword(Keyword::Trailing),
             // Data type keywords
             "VARYING" => Token::Keyword(Keyword::Varying),
+            "CHARACTERS" => Token::Keyword(Keyword::Characters),
+            "OCTETS" => Token::Keyword(Keyword::Octets),
             // SUBSTRING function keywords
             "FOR" => Token::Keyword(Keyword::For),
             _ => Token::Identifier(text),

--- a/crates/parser/src/parser/create/types.rs
+++ b/crates/parser/src/parser/create/types.rs
@@ -139,7 +139,7 @@ impl Parser {
                 Ok(types::DataType::Interval { start_field, end_field })
             }
             "VARCHAR" => {
-                // Parse VARCHAR or VARCHAR(n)
+                // Parse VARCHAR or VARCHAR(n) or VARCHAR(n CHARACTERS) or VARCHAR(n OCTETS)
                 // Length is optional - if not specified, defaults to None (unlimited)
                 let max_length = if matches!(self.peek(), Token::LParen) {
                     self.advance(); // consume LParen
@@ -157,6 +157,13 @@ impl Parser {
                             })
                         }
                     };
+
+                    // Check for CHARACTERS or OCTETS modifier
+                    // For MVP, we accept both but treat them the same (as character count)
+                    if self.try_consume_keyword(Keyword::Characters) || self.try_consume_keyword(Keyword::Octets) {
+                        // Modifier consumed, continue
+                    }
+
                     self.expect_token(Token::RParen)?;
                     Some(len)
                 } else {
@@ -184,6 +191,12 @@ impl Parser {
                                 })
                             }
                         };
+
+                        // Check for CHARACTERS or OCTETS modifier
+                        if self.try_consume_keyword(Keyword::Characters) || self.try_consume_keyword(Keyword::Octets) {
+                            // Modifier consumed, continue
+                        }
+
                         self.expect_token(Token::RParen)?;
                         len
                     } else {
@@ -208,6 +221,12 @@ impl Parser {
                         })
                     }
                 };
+
+                // Check for CHARACTERS or OCTETS modifier
+                if self.try_consume_keyword(Keyword::Characters) || self.try_consume_keyword(Keyword::Octets) {
+                    // Modifier consumed, continue
+                }
+
                 self.expect_token(Token::RParen)?;
                 Ok(types::DataType::Character { length })
             }

--- a/crates/parser/src/tests/create_table.rs
+++ b/crates/parser/src/tests/create_table.rs
@@ -804,3 +804,143 @@ fn test_parse_character_varying_without_length() {
         _ => panic!("Expected CREATE TABLE statement"),
     }
 }
+
+#[test]
+fn test_parse_char_with_characters_modifier() {
+    let result = Parser::parse_sql("CREATE TABLE t (x CHAR(10 CHARACTERS));");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "t");
+            assert_eq!(create.columns.len(), 1);
+            assert_eq!(create.columns[0].name, "x");
+            match create.columns[0].data_type {
+                types::DataType::Character { length: 10 } => {} // Success
+                _ => panic!("Expected CHAR(10) data type"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_char_with_octets_modifier() {
+    let result = Parser::parse_sql("CREATE TABLE t (x CHAR(10 OCTETS));");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "t");
+            assert_eq!(create.columns.len(), 1);
+            assert_eq!(create.columns[0].name, "x");
+            match create.columns[0].data_type {
+                types::DataType::Character { length: 10 } => {} // Success
+                _ => panic!("Expected CHAR(10) data type"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_varchar_with_characters_modifier() {
+    let result = Parser::parse_sql("CREATE TABLE t (x VARCHAR(20 CHARACTERS));");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "t");
+            assert_eq!(create.columns.len(), 1);
+            assert_eq!(create.columns[0].name, "x");
+            match create.columns[0].data_type {
+                types::DataType::Varchar { max_length: Some(20) } => {} // Success
+                _ => panic!("Expected VARCHAR(20) data type"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_varchar_with_octets_modifier() {
+    let result = Parser::parse_sql("CREATE TABLE t (x VARCHAR(20 OCTETS));");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "t");
+            assert_eq!(create.columns.len(), 1);
+            assert_eq!(create.columns[0].name, "x");
+            match create.columns[0].data_type {
+                types::DataType::Varchar { max_length: Some(20) } => {} // Success
+                _ => panic!("Expected VARCHAR(20) data type"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_character_varying_with_characters_modifier() {
+    let result = Parser::parse_sql("CREATE TABLE t (x CHARACTER VARYING(30 CHARACTERS));");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "t");
+            assert_eq!(create.columns.len(), 1);
+            assert_eq!(create.columns[0].name, "x");
+            match create.columns[0].data_type {
+                types::DataType::Varchar { max_length: Some(30) } => {} // Success
+                _ => panic!("Expected VARCHAR(30) data type"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_character_varying_with_octets_modifier() {
+    let result = Parser::parse_sql("CREATE TABLE t (x CHARACTER VARYING(30 OCTETS));");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "t");
+            assert_eq!(create.columns.len(), 1);
+            assert_eq!(create.columns[0].name, "x");
+            match create.columns[0].data_type {
+                types::DataType::Varchar { max_length: Some(30) } => {} // Success
+                _ => panic!("Expected VARCHAR(30) data type"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_char_without_modifier_still_works() {
+    let result = Parser::parse_sql("CREATE TABLE t (x CHAR(10));");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "t");
+            assert_eq!(create.columns.len(), 1);
+            assert_eq!(create.columns[0].name, "x");
+            match create.columns[0].data_type {
+                types::DataType::Character { length: 10 } => {} // Success
+                _ => panic!("Expected CHAR(10) data type"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}


### PR DESCRIPTION
## Summary

Implements SQL:1999 standard syntax for specifying whether string type lengths are measured in characters or octets (bytes).

## Changes

**Keywords Added:**
- `CHARACTERS` - Specifies length in characters
- `OCTETS` - Specifies length in octets/bytes

**Syntax Support:**
- `CHAR(n CHARACTERS)` and `CHAR(n OCTETS)`
- `VARCHAR(n CHARACTERS)` and `VARCHAR(n OCTETS)`
- `CHARACTER VARYING(n CHARACTERS)` and `CHARACTER VARYING(n OCTETS)`

**Implementation:**
- Added `Characters` and `Octets` keywords to AST enum (crates/parser/src/keywords.rs:111-112)
- Added keyword recognition to lexer (crates/parser/src/lexer.rs:246-247)
- Modified parser to accept optional length modifiers after string length in:
  - `VARCHAR` parsing (crates/parser/src/parser/create/types.rs:161-165)
  - `CHAR` parsing (crates/parser/src/parser/create/types.rs:225-228)
  - `CHARACTER VARYING` parsing (crates/parser/src/parser/create/types.rs:195-198)
- Both modifiers treated identically for MVP (as character count, since Rust strings are UTF-8)
- Default behavior unchanged when no modifier specified

**Tests:**
- Added 7 comprehensive unit tests covering all syntax variants
- All 446 parser tests pass successfully

## Test Plan

✅ Unit tests: `CHAR(10 CHARACTERS)`, `CHAR(10 OCTETS)`
✅ Unit tests: `VARCHAR(20 CHARACTERS)`, `VARCHAR(20 OCTETS)`
✅ Unit tests: `CHARACTER VARYING(30 CHARACTERS)`, `CHARACTER VARYING(30 OCTETS)`
✅ Unit test: `CHAR(10)` - verify default behavior still works
✅ All existing parser tests continue to pass

## SQL Standard Compliance

Per SQL:1999 standard, character string types can specify whether length is measured in:
- **CHARACTERS**: Number of characters (default)
- **OCTETS**: Number of bytes/octets

This implementation provides syntax support and treats both modifiers identically for MVP. Future enhancements could add distinct handling for byte vs character length semantics.

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>