### PR TITLE
refactor: Split update_tests.rs into focused test modules

### DIFF
--- a/crates/executor/tests/update_constraint_tests.rs
+++ b/crates/executor/tests/update_constraint_tests.rs
@@ -767,4 +767,3 @@ fn setup_test_table(db: &mut Database) {
             other => panic!("Expected ConstraintViolation, got {:?}", other),
         }
     }
-

--- a/crates/executor/tests/update_default_tests.rs
+++ b/crates/executor/tests/update_default_tests.rs
@@ -1,61 +1,9 @@
-use executor::{UpdateExecutor, ExecutorError};
+use executor::UpdateExecutor;
 use storage::{Database, Row};
 use catalog::{ColumnSchema, TableSchema};
 use types::{DataType, SqlValue};
 use ast::{Assignment, BinaryOperator, Expression, UpdateStmt};
 
-fn setup_test_table(db: &mut Database) {
-    // Create table schema
-    let schema = TableSchema::new(
-        "employees".to_string(),
-        vec![
-            ColumnSchema::new("id".to_string(), DataType::Integer, false),
-            ColumnSchema::new("name".to_string(), DataType::Varchar { max_length: Some(50) }, false),
-            ColumnSchema::new("salary".to_string(), DataType::Integer, true),
-            ColumnSchema::new(
-                "department".to_string(),
-                DataType::Varchar { max_length: Some(50) },
-                true,
-            ),
-        ],
-    );
-
-    db.create_table(schema).unwrap();
-
-    // Insert test data
-    db.insert_row(
-        "employees",
-        Row::new(vec![
-            SqlValue::Integer(1),
-            SqlValue::Varchar("Alice".to_string()),
-            SqlValue::Integer(45000),
-            SqlValue::Varchar("Engineering".to_string()),
-        ]),
-    )
-    .unwrap();
-
-    db.insert_row(
-        "employees",
-        Row::new(vec![
-            SqlValue::Integer(2),
-            SqlValue::Varchar("Bob".to_string()),
-            SqlValue::Integer(48000),
-            SqlValue::Varchar("Engineering".to_string()),
-        ]),
-    )
-    .unwrap();
-
-    db.insert_row(
-        "employees",
-        Row::new(vec![
-            SqlValue::Integer(3),
-            SqlValue::Varchar("Charlie".to_string()),
-            SqlValue::Integer(42000),
-            SqlValue::Varchar("Sales".to_string()),
-        ]),
-    )
-    .unwrap();
-}
 
 #[test]
 fn test_update_with_default_value() {


### PR DESCRIPTION
## Summary

This PR splits the large `update_tests.rs` file (2,871 lines) into 4 focused test modules for better organization and maintainability.

## Changes

- **update_basic_tests.rs** (246 lines) - Basic UPDATE operations and WHERE clause tests
- **update_constraint_tests.rs** (771 lines) - PRIMARY KEY, UNIQUE, NOT NULL, and CHECK constraint validation
- **update_default_tests.rs** (167 lines) - DEFAULT keyword functionality
- **update_subquery_tests.rs** (1,857 lines) - Scalar subqueries, IN/NOT IN subqueries, and complex subquery scenarios

## Test Results

All 41 tests pass successfully:
- ✅ 7 basic tests
- ✅ 12 constraint tests
- ✅ 2 default tests
- ✅ 20 subquery tests

## Test Plan

Verified all tests compile and pass:
```bash
cargo test -p executor --test update_basic_tests --test update_constraint_tests --test update_default_tests --test update_subquery_tests
```

Closes #433