### PR TITLE
refactor: Split aggregation.rs (550 lines) into focused modules

### DIFF
--- a/crates/executor/src/select/executor/aggregation/detection.rs
+++ b/crates/executor/src/select/executor/aggregation/detection.rs
@@ -1,0 +1,36 @@
+//! Aggregate detection helpers for SelectExecutor
+
+use super::super::builder::SelectExecutor;
+
+impl<'a> SelectExecutor<'a> {
+    /// Check if SELECT list contains aggregate functions
+    pub(in crate::select::executor) fn has_aggregates(
+        &self,
+        select_list: &[ast::SelectItem],
+    ) -> bool {
+        select_list.iter().any(|item| match item {
+            ast::SelectItem::Expression { expr, .. } => self.expression_has_aggregate(expr),
+            _ => false,
+        })
+    }
+
+    /// Check if an expression contains aggregate functions
+    #[allow(clippy::only_used_in_recursion)]
+    pub(in crate::select::executor) fn expression_has_aggregate(
+        &self,
+        expr: &ast::Expression,
+    ) -> bool {
+        match expr {
+            // New AggregateFunction variant
+            ast::Expression::AggregateFunction { .. } => true,
+            // Old Function variant (backwards compatibility)
+            ast::Expression::Function { name, .. } => {
+                matches!(name.to_uppercase().as_str(), "COUNT" | "SUM" | "AVG" | "MIN" | "MAX")
+            }
+            ast::Expression::BinaryOp { left, right, .. } => {
+                self.expression_has_aggregate(left) || self.expression_has_aggregate(right)
+            }
+            _ => false,
+        }
+    }
+}

--- a/crates/executor/src/select/executor/aggregation/mod.rs
+++ b/crates/executor/src/select/executor/aggregation/mod.rs
@@ -1,0 +1,143 @@
+//! Aggregation execution methods for SelectExecutor
+
+#[path = "detection.rs"]
+mod detection;
+
+#[path = "evaluation.rs"]
+mod evaluation;
+
+use super::builder::SelectExecutor;
+use crate::errors::ExecutorError;
+use crate::evaluator::CombinedExpressionEvaluator;
+use crate::select::cte::CteResult;
+use crate::select::filter::apply_where_filter_combined;
+use crate::select::grouping::group_rows;
+use crate::select::helpers::{apply_distinct, apply_limit_offset};
+use std::collections::HashMap;
+
+impl<'a> SelectExecutor<'a> {
+    /// Execute SELECT with aggregation/GROUP BY
+    pub(in crate::select::executor) fn execute_with_aggregation(
+        &self,
+        stmt: &ast::SelectStmt,
+        cte_results: &HashMap<String, CteResult>,
+    ) -> Result<Vec<storage::Row>, ExecutorError> {
+        // Execute FROM clause (handles JOINs, subqueries, CTEs)
+        let from_result = match &stmt.from {
+            Some(from_clause) => self.execute_from(from_clause, cte_results)?,
+            None => {
+                return Err(ExecutorError::UnsupportedFeature(
+                    "SELECT without FROM not yet implemented".to_string(),
+                ))
+            }
+        };
+
+        eprintln!(
+            "DEBUG AGG: schema keys={:?}",
+            from_result.schema.table_schemas.keys().collect::<Vec<_>>()
+        );
+        eprintln!(
+            "DEBUG AGG: outer_row={}, outer_schema={:?}",
+            self._outer_row.is_some(),
+            self._outer_schema.map(|s| s.table_schemas.keys().collect::<Vec<_>>())
+        );
+
+        // Create evaluator with outer context if available (outer schema is already a CombinedSchema)
+        let evaluator =
+            if let (Some(outer_row), Some(outer_schema)) = (self._outer_row, self._outer_schema) {
+                eprintln!(
+                    "DEBUG AGG: Creating evaluator WITH outer context, outer tables={:?}",
+                    outer_schema.table_schemas.keys().collect::<Vec<_>>()
+                );
+                CombinedExpressionEvaluator::with_database_and_outer_context(
+                    &from_result.schema,
+                    self.database,
+                    outer_row,
+                    outer_schema,
+                )
+            } else {
+                eprintln!("DEBUG AGG: Creating evaluator WITHOUT outer context");
+                CombinedExpressionEvaluator::with_database(&from_result.schema, self.database)
+            };
+
+        // Apply WHERE clause to filter joined rows
+        let filtered_rows =
+            apply_where_filter_combined(from_result.rows, stmt.where_clause.as_ref(), &evaluator)?;
+
+        // Group rows
+        let groups = if let Some(group_by_exprs) = &stmt.group_by {
+            group_rows(&filtered_rows, group_by_exprs, &evaluator)?
+        } else {
+            // No GROUP BY - treat all rows as one group
+            vec![(Vec::new(), filtered_rows)]
+        };
+
+        // Compute aggregates for each group and apply HAVING
+        let mut result_rows = Vec::new();
+        for (group_key, group_rows) in groups {
+            // Compute aggregates for this group
+            let mut aggregate_results = Vec::new();
+            for item in &stmt.select_list {
+                match item {
+                    ast::SelectItem::Expression { expr, .. } => {
+                        let value = self.evaluate_with_aggregates(
+                            expr,
+                            &group_rows,
+                            &group_key,
+                            &evaluator,
+                        )?;
+                        aggregate_results.push(value);
+                    }
+                    ast::SelectItem::Wildcard => {
+                        return Err(ExecutorError::UnsupportedFeature(
+                            "SELECT * not supported with aggregates".to_string(),
+                        ))
+                    }
+                }
+            }
+
+            // Apply HAVING filter
+            let include_group = if let Some(having_expr) = &stmt.having {
+                let having_result = self.evaluate_with_aggregates(
+                    having_expr,
+                    &group_rows,
+                    &group_key,
+                    &evaluator,
+                )?;
+                match having_result {
+                    types::SqlValue::Boolean(true) => true,
+                    types::SqlValue::Boolean(false) | types::SqlValue::Null => false,
+                    other => {
+                        return Err(ExecutorError::InvalidWhereClause(format!(
+                            "HAVING must evaluate to boolean, got: {:?}",
+                            other
+                        )))
+                    }
+                }
+            } else {
+                true
+            };
+
+            if include_group {
+                result_rows.push(storage::Row::new(aggregate_results));
+            }
+        }
+
+        // Apply ORDER BY if present
+        let result_rows = if let Some(order_by) = &stmt.order_by {
+            self.apply_order_by_to_aggregates(result_rows, stmt, order_by)?
+        } else {
+            result_rows
+        };
+
+        // Apply DISTINCT if specified
+        let result_rows = if stmt.distinct { apply_distinct(result_rows) } else { result_rows };
+
+        // Don't apply LIMIT/OFFSET if we have a set operation - it will be applied later
+        if stmt.set_operation.is_some() {
+            Ok(result_rows)
+        } else {
+            Ok(apply_limit_offset(result_rows, stmt.limit, stmt.offset))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Refactors the 550-line `aggregation.rs` file into a modular directory structure for improved code organization and maintainability.

## Changes

Split `crates/executor/src/select/executor/aggregation.rs` into three focused modules:

- **aggregation/mod.rs** (~130 lines) - Main execution logic
  - `execute_with_aggregation()` - Entry point for SELECT with aggregation/GROUP BY
  
- **aggregation/detection.rs** (~36 lines) - Aggregate detection helpers
  - `has_aggregates()` - Check if SELECT list contains aggregate functions
  - `expression_has_aggregate()` - Recursive aggregate detection in expressions
  
- **aggregation/evaluation.rs** (~400 lines) - Expression evaluation with aggregates
  - `evaluate_with_aggregates()` - Main evaluation dispatcher
  - `evaluate_aggregate_function()` - Core aggregate execution (COUNT, SUM, AVG, MIN, MAX)
  - `evaluate_binary_op_with_aggregates()` - Binary operations in aggregate context
  - `evaluate_scalar_subquery_with_aggregates()` - Subquery handling
  - `evaluate_in_predicate_with_aggregates()` - IN predicates with aggregates
  - `evaluate_quantified_comparison_with_aggregates()` - ANY/ALL comparisons
  - `apply_order_by_to_aggregates()` - Sorting aggregated results

All functions maintain `pub(in crate::select::executor)` visibility to ensure proper access from sibling modules.

## Test Plan

- ✅ `cargo build -p executor --lib` - Compiles successfully
- ✅ `cargo test -p executor` - All executor tests pass
- ✅ `cargo clippy -p executor` - No new warnings (pre-existing warnings unrelated to changes)
- ✅ Code formatted with `cargo fmt`

## Risk Assessment

**Risk Level**: Low
- Pure refactor, no functionality changes
- All existing tests pass
- Internal module reorganization only
- No public API changes

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)