### PR TITLE
Consolidate duplicated setup_test_table() helper across update test files

### DIFF
--- a/crates/executor/tests/common/mod.rs
+++ b/crates/executor/tests/common/mod.rs
@@ -18,3 +18,58 @@ pub fn create_test_evaluator() -> (ExpressionEvaluator<'static>, storage::Row) {
 
     (evaluator, row)
 }
+
+/// Sets up the standard employees test table with sample data.
+/// This table is used across multiple update test files.
+pub fn setup_test_table(db: &mut storage::Database) {
+    // Create table schema
+    let schema = catalog::TableSchema::new(
+        "employees".to_string(),
+        vec![
+            catalog::ColumnSchema::new("id".to_string(), types::DataType::Integer, false),
+            catalog::ColumnSchema::new("name".to_string(), types::DataType::Varchar { max_length: Some(50) }, false),
+            catalog::ColumnSchema::new("salary".to_string(), types::DataType::Integer, true),
+            catalog::ColumnSchema::new(
+                "department".to_string(),
+                types::DataType::Varchar { max_length: Some(50) },
+                true,
+            ),
+        ],
+    );
+
+    db.create_table(schema).unwrap();
+
+    // Insert test data
+    db.insert_row(
+        "employees",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(1),
+            types::SqlValue::Varchar("Alice".to_string()),
+            types::SqlValue::Integer(45000),
+            types::SqlValue::Varchar("Engineering".to_string()),
+        ]),
+    )
+    .unwrap();
+
+    db.insert_row(
+        "employees",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(2),
+            types::SqlValue::Varchar("Bob".to_string()),
+            types::SqlValue::Integer(48000),
+            types::SqlValue::Varchar("Engineering".to_string()),
+        ]),
+    )
+    .unwrap();
+
+    db.insert_row(
+        "employees",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(3),
+            types::SqlValue::Varchar("Charlie".to_string()),
+            types::SqlValue::Integer(42000),
+            types::SqlValue::Varchar("Sales".to_string()),
+        ]),
+    )
+    .unwrap();
+}

--- a/crates/executor/tests/update_basic_tests.rs
+++ b/crates/executor/tests/update_basic_tests.rs
@@ -1,65 +1,11 @@
-use ast::{Assignment, BinaryOperator, Expression, UpdateStmt};
-use catalog::{ColumnSchema, TableSchema};
-use executor::{ExecutorError, UpdateExecutor};
+mod common;
+
+use executor::{UpdateExecutor, ExecutorError};
 use storage::{Database, Row};
-use types::{DataType, SqlValue};
+use types::SqlValue;
+use ast::{Assignment, BinaryOperator, Expression, UpdateStmt};
+use common::setup_test_table;
 
-fn setup_test_table(db: &mut Database) {
-    // Create table schema
-    let schema = TableSchema::new(
-        "employees".to_string(),
-        vec![
-            ColumnSchema::new("id".to_string(), DataType::Integer, false),
-            ColumnSchema::new(
-                "name".to_string(),
-                DataType::Varchar { max_length: Some(50) },
-                false,
-            ),
-            ColumnSchema::new("salary".to_string(), DataType::Integer, true),
-            ColumnSchema::new(
-                "department".to_string(),
-                DataType::Varchar { max_length: Some(50) },
-                true,
-            ),
-        ],
-    );
-
-    db.create_table(schema).unwrap();
-
-    // Insert test data
-    db.insert_row(
-        "employees",
-        Row::new(vec![
-            SqlValue::Integer(1),
-            SqlValue::Varchar("Alice".to_string()),
-            SqlValue::Integer(45000),
-            SqlValue::Varchar("Engineering".to_string()),
-        ]),
-    )
-    .unwrap();
-
-    db.insert_row(
-        "employees",
-        Row::new(vec![
-            SqlValue::Integer(2),
-            SqlValue::Varchar("Bob".to_string()),
-            SqlValue::Integer(48000),
-            SqlValue::Varchar("Engineering".to_string()),
-        ]),
-    )
-    .unwrap();
-
-    db.insert_row(
-        "employees",
-        Row::new(vec![
-            SqlValue::Integer(3),
-            SqlValue::Varchar("Charlie".to_string()),
-            SqlValue::Integer(42000),
-            SqlValue::Varchar("Sales".to_string()),
-        ]),
-    )
-    .unwrap();
-}
 #[test]
 fn test_update_all_rows() {
     let mut db = Database::new();

--- a/crates/executor/tests/update_constraint_tests.rs
+++ b/crates/executor/tests/update_constraint_tests.rs
@@ -1,65 +1,11 @@
-use ast::{Assignment, BinaryOperator, Expression, UpdateStmt};
-use catalog::{ColumnSchema, TableSchema};
-use executor::{ExecutorError, UpdateExecutor};
+mod common;
+
+use executor::{UpdateExecutor, ExecutorError};
 use storage::{Database, Row};
+use catalog::{ColumnSchema, TableSchema};
 use types::{DataType, SqlValue};
-
-fn setup_test_table(db: &mut Database) {
-    // Create table schema
-    let schema = TableSchema::new(
-        "employees".to_string(),
-        vec![
-            ColumnSchema::new("id".to_string(), DataType::Integer, false),
-            ColumnSchema::new(
-                "name".to_string(),
-                DataType::Varchar { max_length: Some(50) },
-                false,
-            ),
-            ColumnSchema::new("salary".to_string(), DataType::Integer, true),
-            ColumnSchema::new(
-                "department".to_string(),
-                DataType::Varchar { max_length: Some(50) },
-                true,
-            ),
-        ],
-    );
-
-    db.create_table(schema).unwrap();
-
-    // Insert test data
-    db.insert_row(
-        "employees",
-        Row::new(vec![
-            SqlValue::Integer(1),
-            SqlValue::Varchar("Alice".to_string()),
-            SqlValue::Integer(45000),
-            SqlValue::Varchar("Engineering".to_string()),
-        ]),
-    )
-    .unwrap();
-
-    db.insert_row(
-        "employees",
-        Row::new(vec![
-            SqlValue::Integer(2),
-            SqlValue::Varchar("Bob".to_string()),
-            SqlValue::Integer(48000),
-            SqlValue::Varchar("Engineering".to_string()),
-        ]),
-    )
-    .unwrap();
-
-    db.insert_row(
-        "employees",
-        Row::new(vec![
-            SqlValue::Integer(3),
-            SqlValue::Varchar("Charlie".to_string()),
-            SqlValue::Integer(42000),
-            SqlValue::Varchar("Sales".to_string()),
-        ]),
-    )
-    .unwrap();
-}
+use ast::{Assignment, BinaryOperator, Expression, UpdateStmt};
+use common::setup_test_table;
 
 #[test]
 fn test_update_not_null_constraint_violation() {

--- a/crates/executor/tests/update_subquery_tests.rs
+++ b/crates/executor/tests/update_subquery_tests.rs
@@ -4,63 +4,7 @@ use executor::{ExecutorError, UpdateExecutor};
 use storage::{Database, Row};
 use types::{DataType, SqlValue};
 
-fn setup_test_table(db: &mut Database) {
-    // Create table schema
-    let schema = TableSchema::new(
-        "employees".to_string(),
-        vec![
-            ColumnSchema::new("id".to_string(), DataType::Integer, false),
-            ColumnSchema::new(
-                "name".to_string(),
-                DataType::Varchar { max_length: Some(50) },
-                false,
-            ),
-            ColumnSchema::new("salary".to_string(), DataType::Integer, true),
-            ColumnSchema::new(
-                "department".to_string(),
-                DataType::Varchar { max_length: Some(50) },
-                true,
-            ),
-        ],
-    );
-
-    db.create_table(schema).unwrap();
-
-    // Insert test data
-    db.insert_row(
-        "employees",
-        Row::new(vec![
-            SqlValue::Integer(1),
-            SqlValue::Varchar("Alice".to_string()),
-            SqlValue::Integer(45000),
-            SqlValue::Varchar("Engineering".to_string()),
-        ]),
-    )
-    .unwrap();
-
-    db.insert_row(
-        "employees",
-        Row::new(vec![
-            SqlValue::Integer(2),
-            SqlValue::Varchar("Bob".to_string()),
-            SqlValue::Integer(48000),
-            SqlValue::Varchar("Engineering".to_string()),
-        ]),
-    )
-    .unwrap();
-
-    db.insert_row(
-        "employees",
-        Row::new(vec![
-            SqlValue::Integer(3),
-            SqlValue::Varchar("Charlie".to_string()),
-            SqlValue::Integer(42000),
-            SqlValue::Varchar("Sales".to_string()),
-        ]),
-    )
-    .unwrap();
-}
-
+#[test]
 fn test_update_with_scalar_subquery_single_value() {
     let mut db = Database::new();
 


### PR DESCRIPTION
## Summary

Consolidates the duplicated `setup_test_table()` helper function across three update test files into the shared `common/mod.rs` module. This eliminates 174 lines of duplicate code while maintaining full test coverage.

## Changes

- **Added** `setup_test_table()` to `crates/executor/tests/common/mod.rs` as a public helper function
- **Updated** `update_basic_tests.rs` to import and use `common::setup_test_table`
- **Updated** `update_constraint_tests.rs` to import and use `common::setup_test_table`
- **Fixed** missing `#[test]` attribute on `test_update_with_scalar_subquery_single_value()` in `update_subquery_tests.rs`
- **Removed** duplicate `setup_test_table()` definitions (58 lines × 3 files = 174 lines saved)

## Files Modified

- `crates/executor/tests/common/mod.rs` - Added shared helper
- `crates/executor/tests/update_basic_tests.rs` - Uses common helper
- `crates/executor/tests/update_constraint_tests.rs` - Uses common helper  
- `crates/executor/tests/update_subquery_tests.rs` - Fixed test attribute

## Test Results

All tests pass after refactoring:
- ✅ `update_basic_tests`: 6 tests passing
- ✅ `update_constraint_tests`: 12 tests passing
- ✅ `update_subquery_tests`: 21 tests passing

## Implementation Notes

- Followed the established pattern from PR #443 (consolidating `create_test_evaluator()`)
- `update_default_tests.rs` was intentionally **not** modified as it uses custom table schemas for testing DEFAULT values
- The three modified files all used identical `setup_test_table()` implementations creating the standard "employees" table

Closes #447