### PR TITLE
Add package.json with pnpm helper scripts for agent compatibility

### DIFF
--- a/crates/ast/tests/complex_expressions.rs
+++ b/crates/ast/tests/complex_expressions.rs
@@ -22,9 +22,7 @@ fn test_case_expression_simple() {
                 result: Expression::Literal(SqlValue::Varchar("inactive".to_string())),
             },
         ],
-        else_result: Some(Box::new(Expression::Literal(SqlValue::Varchar(
-            "unknown".to_string(),
-        )))),
+        else_result: Some(Box::new(Expression::Literal(SqlValue::Varchar("unknown".to_string())))),
     };
     match expr {
         Expression::Case { .. } => {} // Success
@@ -39,10 +37,7 @@ fn test_case_expression_searched() {
         when_clauses: vec![CaseWhen {
             conditions: vec![Expression::BinaryOp {
                 op: BinaryOperator::GreaterThan,
-                left: Box::new(Expression::ColumnRef {
-                    table: None,
-                    column: "age".to_string(),
-                }),
+                left: Box::new(Expression::ColumnRef { table: None, column: "age".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(18))),
             }],
             result: Expression::Literal(SqlValue::Varchar("adult".to_string())),
@@ -64,17 +59,11 @@ fn test_scalar_subquery() {
         select_list: vec![SelectItem::Expression {
             expr: Expression::Function {
                 name: "AVG".to_string(),
-                args: vec![Expression::ColumnRef {
-                    table: None,
-                    column: "salary".to_string(),
-                }],
+                args: vec![Expression::ColumnRef { table: None, column: "salary".to_string() }],
             },
             alias: None,
         }],
-        from: Some(FromClause::Table {
-            name: "employees".to_string(),
-            alias: None,
-        }),
+        from: Some(FromClause::Table { name: "employees".to_string(), alias: None }),
         where_clause: None,
         group_by: None,
         having: None,
@@ -97,16 +86,10 @@ fn test_in_expression() {
         set_operation: None,
         distinct: false,
         select_list: vec![SelectItem::Expression {
-            expr: Expression::ColumnRef {
-                table: None,
-                column: "department_id".to_string(),
-            },
+            expr: Expression::ColumnRef { table: None, column: "department_id".to_string() },
             alias: None,
         }],
-        from: Some(FromClause::Table {
-            name: "departments".to_string(),
-            alias: None,
-        }),
+        from: Some(FromClause::Table { name: "departments".to_string(), alias: None }),
         where_clause: None,
         group_by: None,
         having: None,
@@ -116,10 +99,7 @@ fn test_in_expression() {
     };
 
     let expr = Expression::In {
-        expr: Box::new(Expression::ColumnRef {
-            table: None,
-            column: "dept_id".to_string(),
-        }),
+        expr: Box::new(Expression::ColumnRef { table: None, column: "dept_id".to_string() }),
         subquery: Box::new(subquery),
         negated: false,
     };
@@ -136,10 +116,7 @@ fn test_not_in_expression() {
         set_operation: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard],
-        from: Some(FromClause::Table {
-            name: "excluded".to_string(),
-            alias: None,
-        }),
+        from: Some(FromClause::Table { name: "excluded".to_string(), alias: None }),
         where_clause: None,
         group_by: None,
         having: None,
@@ -149,10 +126,7 @@ fn test_not_in_expression() {
     };
 
     let expr = Expression::In {
-        expr: Box::new(Expression::ColumnRef {
-            table: None,
-            column: "id".to_string(),
-        }),
+        expr: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
         subquery: Box::new(subquery),
         negated: true,
     };

--- a/crates/ast/tests/expressions.rs
+++ b/crates/ast/tests/expressions.rs
@@ -35,8 +35,7 @@ fn test_column_reference_expression() {
 
 #[test]
 fn test_qualified_column_reference() {
-    let expr =
-        Expression::ColumnRef { table: Some("users".to_string()), column: "id".to_string() };
+    let expr = Expression::ColumnRef { table: Some("users".to_string()), column: "id".to_string() };
 
     match expr {
         Expression::ColumnRef { table: Some(t), column: c } if t == "users" && c == "id" => {} // Success
@@ -74,8 +73,7 @@ fn test_binary_operation_equality() {
 
 #[test]
 fn test_function_call_count_star() {
-    let expr =
-        Expression::Function { name: "COUNT".to_string(), args: vec![Expression::Wildcard] };
+    let expr = Expression::Function { name: "COUNT".to_string(), args: vec![Expression::Wildcard] };
 
     match expr {
         Expression::Function { name, .. } if name == "COUNT" => {} // Success

--- a/crates/ast/tests/select_stmt.rs
+++ b/crates/ast/tests/select_stmt.rs
@@ -160,16 +160,10 @@ fn test_select_distinct() {
         set_operation: None,
         distinct: true,
         select_list: vec![SelectItem::Expression {
-            expr: Expression::ColumnRef {
-                table: None,
-                column: "country".to_string(),
-            },
+            expr: Expression::ColumnRef { table: None, column: "country".to_string() },
             alias: None,
         }],
-        from: Some(FromClause::Table {
-            name: "users".to_string(),
-            alias: None,
-        }),
+        from: Some(FromClause::Table { name: "users".to_string(), alias: None }),
         where_clause: None,
         group_by: None,
         having: None,
@@ -193,10 +187,7 @@ fn test_select_with_group_by() {
             },
             alias: None,
         }],
-        from: Some(FromClause::Table {
-            name: "orders".to_string(),
-            alias: None,
-        }),
+        from: Some(FromClause::Table { name: "orders".to_string(), alias: None }),
         where_clause: None,
         group_by: Some(vec![Expression::ColumnRef {
             table: None,
@@ -217,23 +208,14 @@ fn test_select_with_having() {
         set_operation: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard],
-        from: Some(FromClause::Table {
-            name: "sales".to_string(),
-            alias: None,
-        }),
+        from: Some(FromClause::Table { name: "sales".to_string(), alias: None }),
         where_clause: None,
-        group_by: Some(vec![Expression::ColumnRef {
-            table: None,
-            column: "region".to_string(),
-        }]),
+        group_by: Some(vec![Expression::ColumnRef { table: None, column: "region".to_string() }]),
         having: Some(Expression::BinaryOp {
             op: BinaryOperator::GreaterThan,
             left: Box::new(Expression::Function {
                 name: "SUM".to_string(),
-                args: vec![Expression::ColumnRef {
-                    table: None,
-                    column: "amount".to_string(),
-                }],
+                args: vec![Expression::ColumnRef { table: None, column: "amount".to_string() }],
             }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1000))),
         }),
@@ -251,10 +233,7 @@ fn test_select_with_limit() {
         set_operation: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard],
-        from: Some(FromClause::Table {
-            name: "products".to_string(),
-            alias: None,
-        }),
+        from: Some(FromClause::Table { name: "products".to_string(), alias: None }),
         where_clause: None,
         group_by: None,
         having: None,
@@ -272,10 +251,7 @@ fn test_select_with_offset() {
         set_operation: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard],
-        from: Some(FromClause::Table {
-            name: "items".to_string(),
-            alias: None,
-        }),
+        from: Some(FromClause::Table { name: "items".to_string(), alias: None }),
         where_clause: None,
         group_by: None,
         having: None,
@@ -293,18 +269,12 @@ fn test_order_by_desc() {
         set_operation: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard],
-        from: Some(FromClause::Table {
-            name: "posts".to_string(),
-            alias: None,
-        }),
+        from: Some(FromClause::Table { name: "posts".to_string(), alias: None }),
         where_clause: None,
         group_by: None,
         having: None,
         order_by: Some(vec![OrderByItem {
-            expr: Expression::ColumnRef {
-                table: None,
-                column: "created_at".to_string(),
-            },
+            expr: Expression::ColumnRef { table: None, column: "created_at".to_string() },
             direction: OrderDirection::Desc,
         }]),
         limit: None,
@@ -321,14 +291,8 @@ fn test_order_by_desc() {
 #[test]
 fn test_inner_join() {
     let from = FromClause::Join {
-        left: Box::new(FromClause::Table {
-            name: "users".to_string(),
-            alias: None,
-        }),
-        right: Box::new(FromClause::Table {
-            name: "orders".to_string(),
-            alias: None,
-        }),
+        left: Box::new(FromClause::Table { name: "users".to_string(), alias: None }),
+        right: Box::new(FromClause::Table { name: "orders".to_string(), alias: None }),
         join_type: JoinType::Inner,
         condition: Some(Expression::BinaryOp {
             op: BinaryOperator::Equal,
@@ -343,10 +307,7 @@ fn test_inner_join() {
         }),
     };
     match from {
-        FromClause::Join {
-            join_type: JoinType::Inner,
-            ..
-        } => {} // Success
+        FromClause::Join { join_type: JoinType::Inner, .. } => {} // Success
         _ => panic!("Expected INNER JOIN"),
     }
 }
@@ -354,22 +315,13 @@ fn test_inner_join() {
 #[test]
 fn test_left_outer_join() {
     let from = FromClause::Join {
-        left: Box::new(FromClause::Table {
-            name: "customers".to_string(),
-            alias: None,
-        }),
-        right: Box::new(FromClause::Table {
-            name: "orders".to_string(),
-            alias: None,
-        }),
+        left: Box::new(FromClause::Table { name: "customers".to_string(), alias: None }),
+        right: Box::new(FromClause::Table { name: "orders".to_string(), alias: None }),
         join_type: JoinType::LeftOuter,
         condition: None,
     };
     match from {
-        FromClause::Join {
-            join_type: JoinType::LeftOuter,
-            ..
-        } => {} // Success
+        FromClause::Join { join_type: JoinType::LeftOuter, .. } => {} // Success
         _ => panic!("Expected LEFT OUTER JOIN"),
     }
 }
@@ -377,22 +329,13 @@ fn test_left_outer_join() {
 #[test]
 fn test_right_outer_join() {
     let from = FromClause::Join {
-        left: Box::new(FromClause::Table {
-            name: "products".to_string(),
-            alias: None,
-        }),
-        right: Box::new(FromClause::Table {
-            name: "categories".to_string(),
-            alias: None,
-        }),
+        left: Box::new(FromClause::Table { name: "products".to_string(), alias: None }),
+        right: Box::new(FromClause::Table { name: "categories".to_string(), alias: None }),
         join_type: JoinType::RightOuter,
         condition: None,
     };
     match from {
-        FromClause::Join {
-            join_type: JoinType::RightOuter,
-            ..
-        } => {} // Success
+        FromClause::Join { join_type: JoinType::RightOuter, .. } => {} // Success
         _ => panic!("Expected RIGHT OUTER JOIN"),
     }
 }
@@ -400,22 +343,13 @@ fn test_right_outer_join() {
 #[test]
 fn test_full_outer_join() {
     let from = FromClause::Join {
-        left: Box::new(FromClause::Table {
-            name: "table1".to_string(),
-            alias: None,
-        }),
-        right: Box::new(FromClause::Table {
-            name: "table2".to_string(),
-            alias: None,
-        }),
+        left: Box::new(FromClause::Table { name: "table1".to_string(), alias: None }),
+        right: Box::new(FromClause::Table { name: "table2".to_string(), alias: None }),
         join_type: JoinType::FullOuter,
         condition: None,
     };
     match from {
-        FromClause::Join {
-            join_type: JoinType::FullOuter,
-            ..
-        } => {} // Success
+        FromClause::Join { join_type: JoinType::FullOuter, .. } => {} // Success
         _ => panic!("Expected FULL OUTER JOIN"),
     }
 }
@@ -423,22 +357,13 @@ fn test_full_outer_join() {
 #[test]
 fn test_cross_join() {
     let from = FromClause::Join {
-        left: Box::new(FromClause::Table {
-            name: "colors".to_string(),
-            alias: None,
-        }),
-        right: Box::new(FromClause::Table {
-            name: "sizes".to_string(),
-            alias: None,
-        }),
+        left: Box::new(FromClause::Table { name: "colors".to_string(), alias: None }),
+        right: Box::new(FromClause::Table { name: "sizes".to_string(), alias: None }),
         join_type: JoinType::Cross,
         condition: None,
     };
     match from {
-        FromClause::Join {
-            join_type: JoinType::Cross,
-            ..
-        } => {} // Success
+        FromClause::Join { join_type: JoinType::Cross, .. } => {} // Success
         _ => panic!("Expected CROSS JOIN"),
     }
 }
@@ -454,16 +379,10 @@ fn test_from_subquery() {
         set_operation: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard],
-        from: Some(FromClause::Table {
-            name: "users".to_string(),
-            alias: None,
-        }),
+        from: Some(FromClause::Table { name: "users".to_string(), alias: None }),
         where_clause: Some(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef {
-                table: None,
-                column: "active".to_string(),
-            }),
+            left: Box::new(Expression::ColumnRef { table: None, column: "active".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Boolean(true))),
         }),
         group_by: None,
@@ -473,10 +392,8 @@ fn test_from_subquery() {
         offset: None,
     };
 
-    let from = FromClause::Subquery {
-        query: Box::new(subquery),
-        alias: "active_users".to_string(),
-    };
+    let from =
+        FromClause::Subquery { query: Box::new(subquery), alias: "active_users".to_string() };
     match from {
         FromClause::Subquery { alias, .. } if alias == "active_users" => {} // Success
         _ => panic!("Expected subquery in FROM clause"),
@@ -485,10 +402,7 @@ fn test_from_subquery() {
 
 #[test]
 fn test_table_with_alias() {
-    let from = FromClause::Table {
-        name: "employees".to_string(),
-        alias: Some("e".to_string()),
-    };
+    let from = FromClause::Table { name: "employees".to_string(), alias: Some("e".to_string()) };
     match from {
         FromClause::Table { alias: Some(a), .. } if a == "e" => {} // Success
         _ => panic!("Expected table with alias"),

--- a/crates/ast/tests/statements.rs
+++ b/crates/ast/tests/statements.rs
@@ -32,7 +32,9 @@ fn test_create_insert_statement() {
     let stmt = Statement::Insert(InsertStmt {
         table_name: "users".to_string(),
         columns: vec!["name".to_string()],
-        source: InsertSource::Values(vec![vec![Expression::Literal(SqlValue::Varchar("Alice".to_string()))]]),
+        source: InsertSource::Values(vec![vec![Expression::Literal(SqlValue::Varchar(
+            "Alice".to_string(),
+        ))]]),
     });
 
     match stmt {

--- a/crates/executor/src/select/window/collection.rs
+++ b/crates/executor/src/select/window/collection.rs
@@ -5,7 +5,9 @@ use crate::errors::ExecutorError;
 use ast::{Expression, SelectItem, WindowFunctionSpec};
 
 /// Collect all window functions from SELECT list
-pub(super) fn collect_window_functions(select_list: &[SelectItem]) -> Result<Vec<WindowFunctionInfo>, ExecutorError> {
+pub(super) fn collect_window_functions(
+    select_list: &[SelectItem],
+) -> Result<Vec<WindowFunctionInfo>, ExecutorError> {
     let mut window_functions = Vec::new();
 
     for (idx, item) in select_list.iter().enumerate() {
@@ -46,11 +48,7 @@ fn collect_from_expression(
                 collect_from_expression(arg, select_index, window_functions)?;
             }
         }
-        Expression::Case {
-            when_clauses,
-            else_result,
-            ..
-        } => {
+        Expression::Case { when_clauses, else_result, .. } => {
             for when_clause in when_clauses {
                 for cond in &when_clause.conditions {
                     collect_from_expression(cond, select_index, window_functions)?;

--- a/crates/executor/src/select/window/detection.rs
+++ b/crates/executor/src/select/window/detection.rs
@@ -21,17 +21,11 @@ pub(in crate::select) fn expression_has_window_function(expr: &Expression) -> bo
         Expression::Function { args, .. } => {
             args.iter().any(|arg| expression_has_window_function(arg))
         }
-        Expression::Case {
-            when_clauses,
-            else_result,
-            ..
-        } => {
+        Expression::Case { when_clauses, else_result, .. } => {
             when_clauses.iter().any(|when_clause| {
                 when_clause.conditions.iter().any(|cond| expression_has_window_function(cond))
                     || expression_has_window_function(&when_clause.result)
-            }) || else_result
-                .as_ref()
-                .map_or(false, |e| expression_has_window_function(e))
+            }) || else_result.as_ref().map_or(false, |e| expression_has_window_function(e))
         }
         _ => false,
     }

--- a/crates/executor/src/select/window/mod.rs
+++ b/crates/executor/src/select/window/mod.rs
@@ -71,10 +71,8 @@ pub(super) fn evaluate_window_functions(
         window_results.push(values);
 
         // Build mapping: WindowFunctionKey -> column index
-        let key = WindowFunctionKey::from_expression(
-            &win_func.function_spec,
-            &win_func.window_spec,
-        );
+        let key =
+            WindowFunctionKey::from_expression(&win_func.function_spec, &win_func.window_spec);
         let col_idx = base_column_count + idx;
         window_mapping.insert(key, col_idx);
     }

--- a/crates/executor/src/select/window/order_by.rs
+++ b/crates/executor/src/select/window/order_by.rs
@@ -9,7 +9,9 @@ use std::collections::HashMap;
 use types::SqlValue;
 
 /// Collect window functions from ORDER BY expressions
-pub(in crate::select) fn collect_order_by_window_functions(order_by: &[ast::OrderByItem]) -> Vec<(WindowFunctionSpec, ast::WindowSpec)> {
+pub(in crate::select) fn collect_order_by_window_functions(
+    order_by: &[ast::OrderByItem],
+) -> Vec<(WindowFunctionSpec, ast::WindowSpec)> {
     let mut window_functions = Vec::new();
 
     for item in order_by {
@@ -41,11 +43,7 @@ fn collect_window_functions_from_expression(
                 collect_window_functions_from_expression(arg, window_functions);
             }
         }
-        Expression::Case {
-            when_clauses,
-            else_result,
-            ..
-        } => {
+        Expression::Case { when_clauses, else_result, .. } => {
             for when_clause in when_clauses {
                 for cond in &when_clause.conditions {
                     collect_window_functions_from_expression(cond, window_functions);
@@ -81,17 +79,15 @@ fn collect_window_functions_from_expression(
             collect_window_functions_from_expression(substring, window_functions);
             collect_window_functions_from_expression(string, window_functions);
         }
-        Expression::Trim {
-            removal_char,
-            string,
-            ..
-        } => {
+        Expression::Trim { removal_char, string, .. } => {
             if let Some(removal_char) = removal_char {
                 collect_window_functions_from_expression(removal_char, window_functions);
             }
             collect_window_functions_from_expression(string, window_functions);
         }
-        Expression::Exists { .. } | Expression::ScalarSubquery(_) | Expression::QuantifiedComparison { .. } => {
+        Expression::Exists { .. }
+        | Expression::ScalarSubquery(_)
+        | Expression::QuantifiedComparison { .. } => {
             // These don't contain window functions in their expressions
         }
         Expression::AggregateFunction { .. } => {
@@ -103,7 +99,9 @@ fn collect_window_functions_from_expression(
         Expression::Literal(_) | Expression::ColumnRef { .. } => {
             // These are leaf nodes
         }
-        Expression::CurrentDate | Expression::CurrentTime { .. } | Expression::CurrentTimestamp { .. } => {
+        Expression::CurrentDate
+        | Expression::CurrentTime { .. }
+        | Expression::CurrentTimestamp { .. } => {
             // Current date/time functions don't contain window functions
         }
     }
@@ -121,9 +119,8 @@ pub(in crate::select) fn evaluate_order_by_window_functions(
     }
 
     // Build mapping from existing functions to avoid duplicates
-    let existing_keys: std::collections::HashSet<_> = existing_mapping
-        .map(|m| m.keys().collect())
-        .unwrap_or_default();
+    let existing_keys: std::collections::HashSet<_> =
+        existing_mapping.map(|m| m.keys().collect()).unwrap_or_default();
 
     let mut window_results: Vec<Vec<SqlValue>> = Vec::new();
     let mut window_mapping = HashMap::new();

--- a/crates/executor/src/select/window/types.rs
+++ b/crates/executor/src/select/window/types.rs
@@ -30,27 +30,18 @@ impl WindowFunctionKey {
         // Add function name and args
         match function {
             WindowFunctionSpec::Aggregate { name, args } => {
-                let args_str = args
-                    .iter()
-                    .map(|expr| format!("{:?}", expr))
-                    .collect::<Vec<_>>()
-                    .join(",");
+                let args_str =
+                    args.iter().map(|expr| format!("{:?}", expr)).collect::<Vec<_>>().join(",");
                 key_parts.push(format!("{}({})", name, args_str));
             }
             WindowFunctionSpec::Ranking { name, args } => {
-                let args_str = args
-                    .iter()
-                    .map(|expr| format!("{:?}", expr))
-                    .collect::<Vec<_>>()
-                    .join(",");
+                let args_str =
+                    args.iter().map(|expr| format!("{:?}", expr)).collect::<Vec<_>>().join(",");
                 key_parts.push(format!("{}({})", name, args_str));
             }
             WindowFunctionSpec::Value { name, args } => {
-                let args_str = args
-                    .iter()
-                    .map(|expr| format!("{:?}", expr))
-                    .collect::<Vec<_>>()
-                    .join(",");
+                let args_str =
+                    args.iter().map(|expr| format!("{:?}", expr)).collect::<Vec<_>>().join(",");
                 key_parts.push(format!("{}({})", name, args_str));
             }
         }

--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -304,7 +304,8 @@ impl Lexer {
                 // Verify we got at least one exponent digit
                 if self.position == exp_start {
                     return Err(LexerError {
-                        message: "Invalid scientific notation: expected digits after 'E'".to_string(),
+                        message: "Invalid scientific notation: expected digits after 'E'"
+                            .to_string(),
                         position: self.position,
                     });
                 }
@@ -341,7 +342,10 @@ impl Lexer {
             }
         }
 
-        Err(LexerError { message: "Unterminated string literal".to_string(), position: self.position })
+        Err(LexerError {
+            message: "Unterminated string literal".to_string(),
+            position: self.position,
+        })
     }
 
     /// Skip whitespace characters.
@@ -426,7 +430,7 @@ mod tests {
             (".2E+2", ".2E+2"),
             ("2E10", "2E10"),
             ("2.E-5", "2.E-5"),
-            ("2.5e10", "2.5e10"),  // lowercase e
+            ("2.5e10", "2.5e10"), // lowercase e
             (".5E2", ".5E2"),
             ("123.456E-78", "123.456E-78"),
         ];
@@ -450,11 +454,7 @@ mod tests {
     #[test]
     fn test_decimal_point_start() {
         // Test numbers starting with decimal point
-        let test_cases = vec![
-            (".5", ".5"),
-            (".123", ".123"),
-            (".2E+2", ".2E+2"),
-        ];
+        let test_cases = vec![(".5", ".5"), (".123", ".123"), (".2E+2", ".2E+2")];
 
         for (input, expected) in test_cases {
             let mut lexer = Lexer::new(input);
@@ -473,9 +473,9 @@ mod tests {
     fn test_invalid_scientific_notation() {
         // Test invalid E-notation should fail
         let invalid_cases = vec![
-            "2E",      // No exponent digits
-            "2E+",     // No exponent digits after sign
-            "2E-",     // No exponent digits after sign
+            "2E",  // No exponent digits
+            "2E+", // No exponent digits after sign
+            "2E-", // No exponent digits after sign
         ];
 
         for input in invalid_cases {

--- a/crates/parser/src/parser/alter.rs
+++ b/crates/parser/src/parser/alter.rs
@@ -53,14 +53,17 @@ pub fn parse_alter_table(parser: &mut crate::Parser) -> Result<AlterTableStmt, P
             parser.expect_keyword(Keyword::Column)?;
             parse_alter_column(parser, table_name)
         }
-        _ => Err(ParseError {
-            message: "Expected ADD, DROP, or ALTER after table name".to_string(),
-        }),
+        _ => {
+            Err(ParseError { message: "Expected ADD, DROP, or ALTER after table name".to_string() })
+        }
     }
 }
 
 /// Parse ADD COLUMN
-fn parse_add_column(parser: &mut crate::Parser, table_name: String) -> Result<AlterTableStmt, ParseError> {
+fn parse_add_column(
+    parser: &mut crate::Parser,
+    table_name: String,
+) -> Result<AlterTableStmt, ParseError> {
     let column_name = parser.parse_identifier()?;
     let data_type = parser.parse_data_type()?;
 
@@ -78,17 +81,13 @@ fn parse_add_column(parser: &mut crate::Parser, table_name: String) -> Result<Al
             Token::Keyword(Keyword::Primary) => {
                 parser.advance();
                 parser.expect_keyword(Keyword::Key)?;
-                constraints.push(ColumnConstraint {
-                    name: None,
-                    kind: ColumnConstraintKind::PrimaryKey,
-                });
+                constraints
+                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey });
             }
             Token::Keyword(Keyword::Unique) => {
                 parser.advance();
-                constraints.push(ColumnConstraint {
-                    name: None,
-                    kind: ColumnConstraintKind::Unique,
-                });
+                constraints
+                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::Unique });
             }
             Token::Keyword(Keyword::Default) => {
                 parser.advance();
@@ -104,45 +103,36 @@ fn parse_add_column(parser: &mut crate::Parser, table_name: String) -> Result<Al
                 parser.expect_token(crate::token::Token::RParen)?;
                 constraints.push(ColumnConstraint {
                     name: None,
-                    kind: ColumnConstraintKind::References {
-                        table: ref_table,
-                        column: ref_column,
-                    },
+                    kind: ColumnConstraintKind::References { table: ref_table, column: ref_column },
                 });
             }
             _ => break,
         }
     }
 
-    let column_def = ColumnDef {
-        name: column_name,
-        data_type,
-        nullable,
-        constraints,
-    };
+    let column_def = ColumnDef { name: column_name, data_type, nullable, constraints };
 
-    Ok(AlterTableStmt::AddColumn(AddColumnStmt {
-        table_name,
-        column_def,
-    }))
+    Ok(AlterTableStmt::AddColumn(AddColumnStmt { table_name, column_def }))
 }
 
 /// Parse DROP COLUMN
-fn parse_drop_column(parser: &mut crate::Parser, table_name: String) -> Result<AlterTableStmt, ParseError> {
-    let if_exists = parser.try_consume_keyword(Keyword::If)
-        && parser.try_consume_keyword(Keyword::Exists);
+fn parse_drop_column(
+    parser: &mut crate::Parser,
+    table_name: String,
+) -> Result<AlterTableStmt, ParseError> {
+    let if_exists =
+        parser.try_consume_keyword(Keyword::If) && parser.try_consume_keyword(Keyword::Exists);
 
     let column_name = parser.parse_identifier()?;
 
-    Ok(AlterTableStmt::DropColumn(DropColumnStmt {
-        table_name,
-        column_name,
-        if_exists,
-    }))
+    Ok(AlterTableStmt::DropColumn(DropColumnStmt { table_name, column_name, if_exists }))
 }
 
 /// Parse ALTER COLUMN
-fn parse_alter_column(parser: &mut crate::Parser, table_name: String) -> Result<AlterTableStmt, ParseError> {
+fn parse_alter_column(
+    parser: &mut crate::Parser,
+    table_name: String,
+) -> Result<AlterTableStmt, ParseError> {
     let column_name = parser.parse_identifier()?;
 
     match parser.peek() {
@@ -196,14 +186,15 @@ fn parse_alter_column(parser: &mut crate::Parser, table_name: String) -> Result<
                 }),
             }
         }
-        _ => Err(ParseError {
-            message: "Expected SET or DROP after column name".to_string(),
-        }),
+        _ => Err(ParseError { message: "Expected SET or DROP after column name".to_string() }),
     }
 }
 
 /// Parse ADD CONSTRAINT
-fn parse_add_constraint(parser: &mut crate::Parser, table_name: String) -> Result<AlterTableStmt, ParseError> {
+fn parse_add_constraint(
+    parser: &mut crate::Parser,
+    table_name: String,
+) -> Result<AlterTableStmt, ParseError> {
     let constraint_name = if parser.try_consume_keyword(Keyword::Constraint) {
         Some(parser.parse_identifier()?)
     } else {
@@ -214,23 +205,18 @@ fn parse_add_constraint(parser: &mut crate::Parser, table_name: String) -> Resul
     // For now, create a placeholder
     let constraint = TableConstraint {
         name: constraint_name,
-        kind: TableConstraintKind::PrimaryKey {
-            columns: vec!["placeholder".to_string()],
-        },
+        kind: TableConstraintKind::PrimaryKey { columns: vec!["placeholder".to_string()] },
     };
 
-    Ok(AlterTableStmt::AddConstraint(AddConstraintStmt {
-        table_name,
-        constraint,
-    }))
+    Ok(AlterTableStmt::AddConstraint(AddConstraintStmt { table_name, constraint }))
 }
 
 /// Parse DROP CONSTRAINT
-fn parse_drop_constraint(parser: &mut crate::Parser, table_name: String) -> Result<AlterTableStmt, ParseError> {
+fn parse_drop_constraint(
+    parser: &mut crate::Parser,
+    table_name: String,
+) -> Result<AlterTableStmt, ParseError> {
     let constraint_name = parser.parse_identifier()?;
 
-    Ok(AlterTableStmt::DropConstraint(DropConstraintStmt {
-        table_name,
-        constraint_name,
-    }))
+    Ok(AlterTableStmt::DropConstraint(DropConstraintStmt { table_name, constraint_name }))
 }

--- a/crates/parser/src/parser/create/constraints.rs
+++ b/crates/parser/src/parser/create/constraints.rs
@@ -4,7 +4,9 @@ use super::super::*;
 
 impl Parser {
     /// Parse column-level constraints (PRIMARY KEY, UNIQUE, CHECK, REFERENCES)
-    pub(in crate::parser) fn parse_column_constraints(&mut self) -> Result<Vec<ast::ColumnConstraint>, ParseError> {
+    pub(in crate::parser) fn parse_column_constraints(
+        &mut self,
+    ) -> Result<Vec<ast::ColumnConstraint>, ParseError> {
         let mut constraints = Vec::new();
 
         loop {
@@ -112,7 +114,9 @@ impl Parser {
     }
 
     /// Parse table-level constraints (PRIMARY KEY, FOREIGN KEY, UNIQUE, CHECK)
-    pub(in crate::parser) fn parse_table_constraint(&mut self) -> Result<ast::TableConstraint, ParseError> {
+    pub(in crate::parser) fn parse_table_constraint(
+        &mut self,
+    ) -> Result<ast::TableConstraint, ParseError> {
         // Check for optional CONSTRAINT keyword
         let name = if self.peek_keyword(Keyword::Constraint) {
             self.advance(); // consume CONSTRAINT
@@ -268,9 +272,7 @@ impl Parser {
                 self.expect_token(Token::LParen)?;
                 let expr = self.parse_expression()?;
                 self.expect_token(Token::RParen)?;
-                ast::TableConstraintKind::Check {
-                    expr: Box::new(expr),
-                }
+                ast::TableConstraintKind::Check { expr: Box::new(expr) }
             }
             _ => {
                 return Err(ParseError {

--- a/crates/parser/src/parser/create/mod.rs
+++ b/crates/parser/src/parser/create/mod.rs
@@ -8,4 +8,3 @@
 mod constraints;
 mod table;
 mod types;
-

--- a/crates/parser/src/parser/create/table.rs
+++ b/crates/parser/src/parser/create/table.rs
@@ -52,15 +52,10 @@ impl Parser {
             let constraints = self.parse_column_constraints()?;
 
             // Determine nullability based on constraints
-            let nullable = !constraints.iter()
-                .any(|c| matches!(&c.kind, ast::ColumnConstraintKind::NotNull));
+            let nullable =
+                !constraints.iter().any(|c| matches!(&c.kind, ast::ColumnConstraintKind::NotNull));
 
-            columns.push(ast::ColumnDef {
-                name,
-                data_type,
-                nullable,
-                constraints,
-            });
+            columns.push(ast::ColumnDef { name, data_type, nullable, constraints });
 
             if matches!(self.peek(), Token::Comma) {
                 self.advance();
@@ -76,10 +71,6 @@ impl Parser {
             self.advance();
         }
 
-        Ok(ast::CreateTableStmt {
-            table_name,
-            columns,
-            table_constraints,
-        })
+        Ok(ast::CreateTableStmt { table_name, columns, table_constraints })
     }
 }

--- a/crates/parser/src/parser/create/types.rs
+++ b/crates/parser/src/parser/create/types.rs
@@ -160,7 +160,9 @@ impl Parser {
 
                     // Check for CHARACTERS or OCTETS modifier
                     // For MVP, we accept both but treat them the same (as character count)
-                    if self.try_consume_keyword(Keyword::Characters) || self.try_consume_keyword(Keyword::Octets) {
+                    if self.try_consume_keyword(Keyword::Characters)
+                        || self.try_consume_keyword(Keyword::Octets)
+                    {
                         // Modifier consumed, continue
                     }
 
@@ -193,7 +195,9 @@ impl Parser {
                         };
 
                         // Check for CHARACTERS or OCTETS modifier
-                        if self.try_consume_keyword(Keyword::Characters) || self.try_consume_keyword(Keyword::Octets) {
+                        if self.try_consume_keyword(Keyword::Characters)
+                            || self.try_consume_keyword(Keyword::Octets)
+                        {
                             // Modifier consumed, continue
                         }
 
@@ -223,7 +227,9 @@ impl Parser {
                 };
 
                 // Check for CHARACTERS or OCTETS modifier
-                if self.try_consume_keyword(Keyword::Characters) || self.try_consume_keyword(Keyword::Octets) {
+                if self.try_consume_keyword(Keyword::Characters)
+                    || self.try_consume_keyword(Keyword::Octets)
+                {
                     // Modifier consumed, continue
                 }
 
@@ -235,7 +241,9 @@ impl Parser {
     }
 
     /// Parse interval field (YEAR, MONTH, DAY, HOUR, MINUTE, SECOND)
-    pub(in crate::parser) fn parse_interval_field(&mut self) -> Result<types::IntervalField, ParseError> {
+    pub(in crate::parser) fn parse_interval_field(
+        &mut self,
+    ) -> Result<types::IntervalField, ParseError> {
         let field_upper = match self.peek() {
             Token::Identifier(field) => field.to_uppercase(),
             _ => {
@@ -254,9 +262,7 @@ impl Parser {
             "HOUR" => Ok(types::IntervalField::Hour),
             "MINUTE" => Ok(types::IntervalField::Minute),
             "SECOND" => Ok(types::IntervalField::Second),
-            _ => Err(ParseError {
-                message: format!("Unknown interval field: {}", field_upper),
-            }),
+            _ => Err(ParseError { message: format!("Unknown interval field: {}", field_upper) }),
         }
     }
 
@@ -287,13 +293,9 @@ impl Parser {
                         return Ok(true); // WITH TIME ZONE
                     }
                 }
-                return Err(ParseError {
-                    message: "Expected ZONE after WITH TIME".to_string(),
-                });
+                return Err(ParseError { message: "Expected ZONE after WITH TIME".to_string() });
             }
-            return Err(ParseError {
-                message: "Expected TIME after WITH".to_string(),
-            });
+            return Err(ParseError { message: "Expected TIME after WITH".to_string() });
         }
 
         // Check for WITHOUT identifier
@@ -323,9 +325,7 @@ impl Parser {
                         message: "Expected ZONE after WITHOUT TIME".to_string(),
                     });
                 }
-                return Err(ParseError {
-                    message: "Expected TIME after WITHOUT".to_string(),
-                });
+                return Err(ParseError { message: "Expected TIME after WITHOUT".to_string() });
             }
         }
 

--- a/crates/parser/src/parser/expressions/functions.rs
+++ b/crates/parser/src/parser/expressions/functions.rs
@@ -104,7 +104,7 @@ impl Parser {
             // Check if this is followed by FROM keyword
             if matches!(self.peek(), Token::Keyword(Keyword::From)) {
                 self.advance(); // consume FROM
-                // first_expr is the removal_char, now parse the string
+                                // first_expr is the removal_char, now parse the string
                 removal_char = Some(Box::new(first_expr));
                 let string = self.parse_primary_expression()?;
 
@@ -171,10 +171,8 @@ impl Parser {
 
         // Check if this is an aggregate function
         let function_name_upper = first.to_uppercase();
-        let is_aggregate = matches!(
-            function_name_upper.as_str(),
-            "COUNT" | "SUM" | "AVG" | "MIN" | "MAX"
-        );
+        let is_aggregate =
+            matches!(function_name_upper.as_str(), "COUNT" | "SUM" | "AVG" | "MIN" | "MAX");
 
         // Parse optional DISTINCT for aggregate functions
         let distinct = if is_aggregate && matches!(self.peek(), Token::Keyword(Keyword::Distinct)) {
@@ -196,10 +194,7 @@ impl Parser {
             self.advance(); // consume '*'
             self.expect_token(Token::RParen)?;
             // Represent * as a special wildcard expression
-            args.push(ast::Expression::ColumnRef {
-                table: None,
-                column: "*".to_string(),
-            });
+            args.push(ast::Expression::ColumnRef { table: None, column: "*".to_string() });
         } else {
             // Parse comma-separated argument list
             loop {
@@ -234,11 +229,7 @@ impl Parser {
 
         // Return appropriate expression type
         if is_aggregate {
-            Ok(Some(ast::Expression::AggregateFunction {
-                name: first,
-                distinct,
-                args,
-            }))
+            Ok(Some(ast::Expression::AggregateFunction { name: first, distinct, args }))
         } else {
             Ok(Some(ast::Expression::Function { name: first, args }))
         }
@@ -255,25 +246,16 @@ impl Parser {
         match name_upper.as_str() {
             // Ranking functions
             "ROW_NUMBER" | "RANK" | "DENSE_RANK" | "NTILE" => {
-                ast::WindowFunctionSpec::Ranking {
-                    name: name_upper,
-                    args,
-                }
+                ast::WindowFunctionSpec::Ranking { name: name_upper, args }
             }
 
             // Value functions
             "LAG" | "LEAD" | "FIRST_VALUE" | "LAST_VALUE" => {
-                ast::WindowFunctionSpec::Value {
-                    name: name_upper,
-                    args,
-                }
+                ast::WindowFunctionSpec::Value { name: name_upper, args }
             }
 
             // Aggregate functions (SUM, AVG, COUNT, MIN, MAX, etc.)
-            _ => ast::WindowFunctionSpec::Aggregate {
-                name: name_upper,
-                args,
-            },
+            _ => ast::WindowFunctionSpec::Aggregate { name: name_upper, args },
         }
     }
 
@@ -289,11 +271,7 @@ impl Parser {
         // Check for empty OVER()
         if matches!(self.peek(), Token::RParen) {
             self.advance();
-            return Ok(ast::WindowSpec {
-                partition_by,
-                order_by,
-                frame,
-            });
+            return Ok(ast::WindowSpec { partition_by, order_by, frame });
         }
 
         // Parse PARTITION BY clause
@@ -344,20 +322,13 @@ impl Parser {
         }
 
         // Parse frame clause (ROWS/RANGE)
-        if matches!(
-            self.peek(),
-            Token::Keyword(Keyword::Rows) | Token::Keyword(Keyword::Range)
-        ) {
+        if matches!(self.peek(), Token::Keyword(Keyword::Rows) | Token::Keyword(Keyword::Range)) {
             frame = Some(self.parse_frame_clause()?);
         }
 
         self.expect_token(Token::RParen)?;
 
-        Ok(ast::WindowSpec {
-            partition_by,
-            order_by,
-            frame,
-        })
+        Ok(ast::WindowSpec { partition_by, order_by, frame })
     }
 
     /// Parse frame clause (ROWS/RANGE BETWEEN ... AND ...)
@@ -392,20 +363,12 @@ impl Parser {
 
             let end = self.parse_frame_bound()?;
 
-            Ok(ast::WindowFrame {
-                unit,
-                start,
-                end: Some(end),
-            })
+            Ok(ast::WindowFrame { unit, start, end: Some(end) })
         } else {
             // Single bound (defaults to CURRENT ROW as end)
             let start = self.parse_frame_bound()?;
 
-            Ok(ast::WindowFrame {
-                unit,
-                start,
-                end: None,
-            })
+            Ok(ast::WindowFrame { unit, start, end: None })
         }
     }
 
@@ -435,8 +398,8 @@ impl Parser {
 
             Token::Keyword(Keyword::Current) => {
                 self.advance(); // consume CURRENT
-                // Expect ROW (note: not ROWS, this is "CURRENT ROW" singular)
-                // We need to match against an identifier "ROW" since there's no Keyword::Row
+                                // Expect ROW (note: not ROWS, this is "CURRENT ROW" singular)
+                                // We need to match against an identifier "ROW" since there's no Keyword::Row
                 if let Token::Identifier(ref id) = self.peek() {
                     if id.to_uppercase() == "ROW" {
                         self.advance();

--- a/crates/parser/src/parser/expressions/identifiers.rs
+++ b/crates/parser/src/parser/expressions/identifiers.rs
@@ -2,7 +2,9 @@ use super::*;
 
 impl Parser {
     /// Parse identifier-based expressions (column references, qualified names)
-    pub(super) fn parse_identifier_expression(&mut self) -> Result<Option<ast::Expression>, ParseError> {
+    pub(super) fn parse_identifier_expression(
+        &mut self,
+    ) -> Result<Option<ast::Expression>, ParseError> {
         match self.peek() {
             Token::Identifier(id) => {
                 let first = id.clone();

--- a/crates/parser/src/parser/expressions/literals.rs
+++ b/crates/parser/src/parser/expressions/literals.rs
@@ -66,7 +66,9 @@ impl Parser {
                     Token::String(s) => {
                         let timestamp_str = s.clone();
                         self.advance();
-                        Ok(Some(ast::Expression::Literal(types::SqlValue::Timestamp(timestamp_str))))
+                        Ok(Some(ast::Expression::Literal(types::SqlValue::Timestamp(
+                            timestamp_str,
+                        ))))
                     }
                     _ => Err(ParseError {
                         message: "Expected string literal after TIMESTAMP keyword".to_string(),

--- a/crates/parser/src/parser/expressions/mod.rs
+++ b/crates/parser/src/parser/expressions/mod.rs
@@ -1,10 +1,10 @@
 use super::*;
 
 // Submodules
-mod operators;
-mod literals;
-mod identifiers;
 mod functions;
+mod identifiers;
+mod literals;
+mod operators;
 mod special_forms;
 mod subqueries;
 

--- a/crates/parser/src/parser/expressions/operators.rs
+++ b/crates/parser/src/parser/expressions/operators.rs
@@ -56,7 +56,9 @@ impl Parser {
     }
 
     /// Parse multiplicative expression (handles * and /)
-    pub(super) fn parse_multiplicative_expression(&mut self) -> Result<ast::Expression, ParseError> {
+    pub(super) fn parse_multiplicative_expression(
+        &mut self,
+    ) -> Result<ast::Expression, ParseError> {
         let mut left = self.parse_comparison_expression()?;
 
         while matches!(self.peek(), Token::Symbol('*') | Token::Symbol('/')) {
@@ -279,10 +281,7 @@ impl Parser {
             // Expect NULL
             self.expect_keyword(Keyword::Null)?;
 
-            left = ast::Expression::IsNull {
-                expr: Box::new(left),
-                negated,
-            };
+            left = ast::Expression::IsNull { expr: Box::new(left), negated };
         }
 
         Ok(left)
@@ -295,18 +294,12 @@ impl Parser {
             Token::Symbol('+') => {
                 self.advance();
                 let expr = self.parse_unary_expression()?;
-                Ok(ast::Expression::UnaryOp {
-                    op: ast::UnaryOperator::Plus,
-                    expr: Box::new(expr),
-                })
+                Ok(ast::Expression::UnaryOp { op: ast::UnaryOperator::Plus, expr: Box::new(expr) })
             }
             Token::Symbol('-') => {
                 self.advance();
                 let expr = self.parse_unary_expression()?;
-                Ok(ast::Expression::UnaryOp {
-                    op: ast::UnaryOperator::Minus,
-                    expr: Box::new(expr),
-                })
+                Ok(ast::Expression::UnaryOp { op: ast::UnaryOperator::Minus, expr: Box::new(expr) })
             }
             _ => self.parse_primary_expression(),
         }
@@ -321,9 +314,7 @@ impl Parser {
         // Empty list check
         if matches!(self.peek(), Token::RParen) {
             // Empty list - SQL standard requires at least one value in IN list
-            return Err(ParseError {
-                message: "Expected at least one value in list".to_string(),
-            });
+            return Err(ParseError { message: "Expected at least one value in list".to_string() });
         }
 
         // Parse first expression

--- a/crates/parser/src/parser/expressions/special_forms.rs
+++ b/crates/parser/src/parser/expressions/special_forms.rs
@@ -48,9 +48,14 @@ impl Parser {
                             self.advance(); // consume _TIMESTAMP
                             "CURRENT_TIMESTAMP"
                         }
-                        _ => return Err(ParseError {
-                            message: format!("Expected DATE, TIME, or TIMESTAMP after CURRENT, found {}", id),
-                        }),
+                        _ => {
+                            return Err(ParseError {
+                                message: format!(
+                                    "Expected DATE, TIME, or TIMESTAMP after CURRENT, found {}",
+                                    id
+                                ),
+                            })
+                        }
                     };
 
                     return Ok(Some(ast::Expression::Function {
@@ -59,7 +64,10 @@ impl Parser {
                     }));
                 } else {
                     return Err(ParseError {
-                        message: format!("Expected identifier after CURRENT, found {:?}", self.peek()),
+                        message: format!(
+                            "Expected identifier after CURRENT, found {:?}",
+                            self.peek()
+                        ),
                     });
                 }
             }
@@ -173,7 +181,10 @@ impl Parser {
                     // Expect closing parenthesis
                     self.expect_token(Token::RParen)?;
 
-                    Ok(Some(ast::Expression::Exists { subquery: Box::new(subquery), negated: true }))
+                    Ok(Some(ast::Expression::Exists {
+                        subquery: Box::new(subquery),
+                        negated: true,
+                    }))
                 } else {
                     // It's a unary NOT operator on another expression
                     // Parse the inner expression
@@ -195,7 +206,9 @@ impl Parser {
     }
 
     /// Parse current date/time functions (CURRENT_DATE, CURRENT_TIME[(precision)], CURRENT_TIMESTAMP[(precision)])
-    pub(super) fn parse_current_datetime_function(&mut self) -> Result<Option<ast::Expression>, ParseError> {
+    pub(super) fn parse_current_datetime_function(
+        &mut self,
+    ) -> Result<Option<ast::Expression>, ParseError> {
         match self.peek() {
             Token::Keyword(Keyword::CurrentDate) => {
                 self.advance(); // consume CURRENT_DATE
@@ -206,16 +219,21 @@ impl Parser {
                 let precision = if self.try_consume(&Token::LParen) {
                     let prec_str = match self.peek() {
                         Token::Number(n) => n.clone(),
-                        _ => return Err(ParseError {
-                            message: "Expected integer precision for CURRENT_TIME".to_string(),
-                        }),
+                        _ => {
+                            return Err(ParseError {
+                                message: "Expected integer precision for CURRENT_TIME".to_string(),
+                            })
+                        }
                     };
                     let prec: u32 = prec_str.parse().map_err(|_| ParseError {
                         message: format!("Invalid precision value: {}", prec_str),
                     })?;
                     if prec > 9 {
                         return Err(ParseError {
-                            message: format!("CURRENT_TIME precision must be between 0 and 9, got {}", prec),
+                            message: format!(
+                                "CURRENT_TIME precision must be between 0 and 9, got {}",
+                                prec
+                            ),
                         });
                     }
                     self.advance(); // consume the number
@@ -231,16 +249,22 @@ impl Parser {
                 let precision = if self.try_consume(&Token::LParen) {
                     let prec_str = match self.peek() {
                         Token::Number(n) => n.clone(),
-                        _ => return Err(ParseError {
-                            message: "Expected integer precision for CURRENT_TIMESTAMP".to_string(),
-                        }),
+                        _ => {
+                            return Err(ParseError {
+                                message: "Expected integer precision for CURRENT_TIMESTAMP"
+                                    .to_string(),
+                            })
+                        }
                     };
                     let prec: u32 = prec_str.parse().map_err(|_| ParseError {
                         message: format!("Invalid precision value: {}", prec_str),
                     })?;
                     if prec > 9 {
                         return Err(ParseError {
-                            message: format!("CURRENT_TIMESTAMP precision must be between 0 and 9, got {}", prec),
+                            message: format!(
+                                "CURRENT_TIMESTAMP precision must be between 0 and 9, got {}",
+                                prec
+                            ),
                         });
                     }
                     self.advance(); // consume the number

--- a/crates/parser/src/parser/helpers.rs
+++ b/crates/parser/src/parser/helpers.rs
@@ -71,9 +71,7 @@ impl Parser {
                 self.advance();
                 Ok(identifier)
             }
-            _ => Err(ParseError {
-                message: "Expected identifier".to_string(),
-            }),
+            _ => Err(ParseError { message: "Expected identifier".to_string() }),
         }
     }
 
@@ -106,11 +104,7 @@ impl Parser {
                 self.advance();
                 identifier
             }
-            _ => {
-                return Err(ParseError {
-                    message: "Expected identifier".to_string(),
-                })
-            }
+            _ => return Err(ParseError { message: "Expected identifier".to_string() }),
         };
 
         // Check if there's a dot followed by another identifier
@@ -123,9 +117,7 @@ impl Parser {
                     identifier
                 }
                 _ => {
-                    return Err(ParseError {
-                        message: "Expected identifier after '.'".to_string(),
-                    })
+                    return Err(ParseError { message: "Expected identifier after '.'".to_string() })
                 }
             };
             Ok(format!("{}.{}", first_part, second_part))

--- a/crates/parser/src/parser/mod.rs
+++ b/crates/parser/src/parser/mod.rs
@@ -68,44 +68,36 @@ impl Parser {
                 let delete_stmt = self.parse_delete_statement()?;
                 Ok(ast::Statement::Delete(delete_stmt))
             }
-            Token::Keyword(Keyword::Create) => {
-                match self.peek_next_keyword(Keyword::Table) {
-                    true => {
-                        let create_stmt = self.parse_create_table_statement()?;
-                        Ok(ast::Statement::CreateTable(create_stmt))
-                    }
-                    false => {
-                        match self.peek_next_keyword(Keyword::Schema) {
-                            true => {
-                                let create_stmt = self.parse_create_schema_statement()?;
-                                Ok(ast::Statement::CreateSchema(create_stmt))
-                            }
-                            false => Err(ParseError {
-                                message: "Expected TABLE or SCHEMA after CREATE".to_string(),
-                            }),
-                        }
-                    }
+            Token::Keyword(Keyword::Create) => match self.peek_next_keyword(Keyword::Table) {
+                true => {
+                    let create_stmt = self.parse_create_table_statement()?;
+                    Ok(ast::Statement::CreateTable(create_stmt))
                 }
-            }
-            Token::Keyword(Keyword::Drop) => {
-                match self.peek_next_keyword(Keyword::Table) {
+                false => match self.peek_next_keyword(Keyword::Schema) {
                     true => {
-                        let drop_stmt = self.parse_drop_table_statement()?;
-                        Ok(ast::Statement::DropTable(drop_stmt))
+                        let create_stmt = self.parse_create_schema_statement()?;
+                        Ok(ast::Statement::CreateSchema(create_stmt))
                     }
-                    false => {
-                        match self.peek_next_keyword(Keyword::Schema) {
-                            true => {
-                                let drop_stmt = self.parse_drop_schema_statement()?;
-                                Ok(ast::Statement::DropSchema(drop_stmt))
-                            }
-                            false => Err(ParseError {
-                                message: "Expected TABLE or SCHEMA after DROP".to_string(),
-                            }),
-                        }
-                    }
+                    false => Err(ParseError {
+                        message: "Expected TABLE or SCHEMA after CREATE".to_string(),
+                    }),
+                },
+            },
+            Token::Keyword(Keyword::Drop) => match self.peek_next_keyword(Keyword::Table) {
+                true => {
+                    let drop_stmt = self.parse_drop_table_statement()?;
+                    Ok(ast::Statement::DropTable(drop_stmt))
                 }
-            }
+                false => match self.peek_next_keyword(Keyword::Schema) {
+                    true => {
+                        let drop_stmt = self.parse_drop_schema_statement()?;
+                        Ok(ast::Statement::DropSchema(drop_stmt))
+                    }
+                    false => Err(ParseError {
+                        message: "Expected TABLE or SCHEMA after DROP".to_string(),
+                    }),
+                },
+            },
             Token::Keyword(Keyword::Alter) => {
                 let alter_stmt = self.parse_alter_table_statement()?;
                 Ok(ast::Statement::AlterTable(alter_stmt))
@@ -142,17 +134,13 @@ impl Parser {
                 let release_stmt = self.parse_release_savepoint_statement()?;
                 Ok(ast::Statement::ReleaseSavepoint(release_stmt))
             }
-            Token::Keyword(Keyword::Set) => {
-                match self.peek_keyword(Keyword::Schema) {
-                    true => {
-                        let set_stmt = self.parse_set_schema_statement()?;
-                        Ok(ast::Statement::SetSchema(set_stmt))
-                    }
-                    false => Err(ParseError {
-                        message: "Expected SCHEMA after SET".to_string(),
-                    }),
+            Token::Keyword(Keyword::Set) => match self.peek_keyword(Keyword::Schema) {
+                true => {
+                    let set_stmt = self.parse_set_schema_statement()?;
+                    Ok(ast::Statement::SetSchema(set_stmt))
                 }
-            }
+                false => Err(ParseError { message: "Expected SCHEMA after SET".to_string() }),
+            },
             _ => {
                 Err(ParseError { message: format!("Expected statement, found {:?}", self.peek()) })
             }
@@ -185,12 +173,16 @@ impl Parser {
     }
 
     /// Parse ROLLBACK TO SAVEPOINT statement
-    pub fn parse_rollback_to_savepoint_statement(&mut self) -> Result<ast::RollbackToSavepointStmt, ParseError> {
+    pub fn parse_rollback_to_savepoint_statement(
+        &mut self,
+    ) -> Result<ast::RollbackToSavepointStmt, ParseError> {
         transaction::parse_rollback_to_savepoint_statement(self)
     }
 
     /// Parse RELEASE SAVEPOINT statement
-    pub fn parse_release_savepoint_statement(&mut self) -> Result<ast::ReleaseSavepointStmt, ParseError> {
+    pub fn parse_release_savepoint_statement(
+        &mut self,
+    ) -> Result<ast::ReleaseSavepointStmt, ParseError> {
         transaction::parse_release_savepoint_statement(self)
     }
 

--- a/crates/parser/src/parser/schema.rs
+++ b/crates/parser/src/parser/schema.rs
@@ -9,20 +9,16 @@ pub fn parse_create_schema(parser: &mut crate::Parser) -> Result<CreateSchemaStm
     parser.expect_keyword(Keyword::Create)?;
     parser.expect_keyword(Keyword::Schema)?;
 
-    let if_not_exists = parser.peek_keyword(Keyword::If)
-        && {
-            parser.advance();
-            parser.expect_keyword(Keyword::Not)?;
-            parser.expect_keyword(Keyword::Exists)?;
-            true
-        };
+    let if_not_exists = parser.peek_keyword(Keyword::If) && {
+        parser.advance();
+        parser.expect_keyword(Keyword::Not)?;
+        parser.expect_keyword(Keyword::Exists)?;
+        true
+    };
 
     let schema_name = parser.parse_qualified_identifier()?;
 
-    Ok(CreateSchemaStmt {
-        schema_name,
-        if_not_exists,
-    })
+    Ok(CreateSchemaStmt { schema_name, if_not_exists })
 }
 
 /// Parse DROP SCHEMA statement
@@ -30,12 +26,11 @@ pub fn parse_drop_schema(parser: &mut crate::Parser) -> Result<DropSchemaStmt, P
     parser.expect_keyword(Keyword::Drop)?;
     parser.expect_keyword(Keyword::Schema)?;
 
-    let if_exists = parser.peek_keyword(Keyword::If)
-        && {
-            parser.advance();
-            parser.expect_keyword(Keyword::Exists)?;
-            true
-        };
+    let if_exists = parser.peek_keyword(Keyword::If) && {
+        parser.advance();
+        parser.expect_keyword(Keyword::Exists)?;
+        true
+    };
 
     let schema_name = parser.parse_qualified_identifier()?;
 
@@ -50,11 +45,7 @@ pub fn parse_drop_schema(parser: &mut crate::Parser) -> Result<DropSchemaStmt, P
         false
     };
 
-    Ok(DropSchemaStmt {
-        schema_name,
-        if_exists,
-        cascade,
-    })
+    Ok(DropSchemaStmt { schema_name, if_exists, cascade })
 }
 
 /// Parse SET SCHEMA statement

--- a/crates/parser/src/parser/select/statement.rs
+++ b/crates/parser/src/parser/select/statement.rs
@@ -243,11 +243,7 @@ impl Parser {
                 self.advance();
                 name
             }
-            _ => {
-                return Err(ParseError {
-                    message: "Expected CTE name (identifier)".to_string(),
-                })
-            }
+            _ => return Err(ParseError { message: "Expected CTE name (identifier)".to_string() }),
         };
 
         // Parse optional column list: (col1, col2, ...)
@@ -256,9 +252,7 @@ impl Parser {
 
             // Check for empty column list
             if matches!(self.peek(), Token::RParen) {
-                return Err(ParseError {
-                    message: "CTE column list cannot be empty".to_string(),
-                });
+                return Err(ParseError { message: "CTE column list cannot be empty".to_string() });
             }
 
             let mut cols = Vec::new();
@@ -311,9 +305,7 @@ impl Parser {
 
         // Expect closing paren
         if !matches!(self.peek(), Token::RParen) {
-            return Err(ParseError {
-                message: "Expected ')' after CTE query".to_string(),
-            });
+            return Err(ParseError { message: "Expected ')' after CTE query".to_string() });
         }
         self.advance(); // consume ')'
 

--- a/crates/parser/src/parser/transaction.rs
+++ b/crates/parser/src/parser/transaction.rs
@@ -4,7 +4,9 @@ use crate::keywords::Keyword;
 use crate::parser::ParseError;
 
 /// Parse BEGIN [TRANSACTION] or START TRANSACTION statement
-pub(super) fn parse_begin_statement(parser: &mut super::Parser) -> Result<ast::BeginStmt, ParseError> {
+pub(super) fn parse_begin_statement(
+    parser: &mut super::Parser,
+) -> Result<ast::BeginStmt, ParseError> {
     // Consume BEGIN or START
     if parser.peek_keyword(Keyword::Begin) {
         parser.consume_keyword(Keyword::Begin)?;
@@ -23,7 +25,9 @@ pub(super) fn parse_begin_statement(parser: &mut super::Parser) -> Result<ast::B
 }
 
 /// Parse COMMIT statement
-pub(super) fn parse_commit_statement(parser: &mut super::Parser) -> Result<ast::CommitStmt, ParseError> {
+pub(super) fn parse_commit_statement(
+    parser: &mut super::Parser,
+) -> Result<ast::CommitStmt, ParseError> {
     // Consume COMMIT
     parser.consume_keyword(Keyword::Commit)?;
 
@@ -31,7 +35,9 @@ pub(super) fn parse_commit_statement(parser: &mut super::Parser) -> Result<ast::
 }
 
 /// Parse ROLLBACK statement
-pub(super) fn parse_rollback_statement(parser: &mut super::Parser) -> Result<ast::RollbackStmt, ParseError> {
+pub(super) fn parse_rollback_statement(
+    parser: &mut super::Parser,
+) -> Result<ast::RollbackStmt, ParseError> {
     // Consume ROLLBACK
     parser.consume_keyword(Keyword::Rollback)?;
 
@@ -39,7 +45,9 @@ pub(super) fn parse_rollback_statement(parser: &mut super::Parser) -> Result<ast
 }
 
 /// Parse SAVEPOINT statement
-pub(super) fn parse_savepoint_statement(parser: &mut super::Parser) -> Result<ast::SavepointStmt, ParseError> {
+pub(super) fn parse_savepoint_statement(
+    parser: &mut super::Parser,
+) -> Result<ast::SavepointStmt, ParseError> {
     // Consume SAVEPOINT
     parser.consume_keyword(Keyword::Savepoint)?;
 
@@ -50,14 +58,20 @@ pub(super) fn parse_savepoint_statement(parser: &mut super::Parser) -> Result<as
             parser.advance();
             savepoint_name
         }
-        _ => return Err(ParseError { message: "Expected savepoint name after SAVEPOINT".to_string() }),
+        _ => {
+            return Err(ParseError {
+                message: "Expected savepoint name after SAVEPOINT".to_string(),
+            })
+        }
     };
 
     Ok(ast::SavepointStmt { name })
 }
 
 /// Parse ROLLBACK TO SAVEPOINT statement
-pub(super) fn parse_rollback_to_savepoint_statement(parser: &mut super::Parser) -> Result<ast::RollbackToSavepointStmt, ParseError> {
+pub(super) fn parse_rollback_to_savepoint_statement(
+    parser: &mut super::Parser,
+) -> Result<ast::RollbackToSavepointStmt, ParseError> {
     // Consume ROLLBACK
     parser.consume_keyword(Keyword::Rollback)?;
 
@@ -74,14 +88,20 @@ pub(super) fn parse_rollback_to_savepoint_statement(parser: &mut super::Parser) 
             parser.advance();
             savepoint_name
         }
-        _ => return Err(ParseError { message: "Expected savepoint name after ROLLBACK TO SAVEPOINT".to_string() }),
+        _ => {
+            return Err(ParseError {
+                message: "Expected savepoint name after ROLLBACK TO SAVEPOINT".to_string(),
+            })
+        }
     };
 
     Ok(ast::RollbackToSavepointStmt { name })
 }
 
 /// Parse RELEASE SAVEPOINT statement
-pub(super) fn parse_release_savepoint_statement(parser: &mut super::Parser) -> Result<ast::ReleaseSavepointStmt, ParseError> {
+pub(super) fn parse_release_savepoint_statement(
+    parser: &mut super::Parser,
+) -> Result<ast::ReleaseSavepointStmt, ParseError> {
     // Consume RELEASE
     parser.consume_keyword(Keyword::Release)?;
 
@@ -95,7 +115,11 @@ pub(super) fn parse_release_savepoint_statement(parser: &mut super::Parser) -> R
             parser.advance();
             savepoint_name
         }
-        _ => return Err(ParseError { message: "Expected savepoint name after RELEASE SAVEPOINT".to_string() }),
+        _ => {
+            return Err(ParseError {
+                message: "Expected savepoint name after RELEASE SAVEPOINT".to_string(),
+            })
+        }
     };
 
     Ok(ast::ReleaseSavepointStmt { name })

--- a/crates/parser/src/tests/alter_table.rs
+++ b/crates/parser/src/tests/alter_table.rs
@@ -40,16 +40,14 @@ fn test_parse_alter_table_drop_column() {
     let stmt = result.unwrap();
 
     match stmt {
-        ast::Statement::AlterTable(alter) => {
-            match alter {
-                ast::AlterTableStmt::DropColumn(drop) => {
-                    assert_eq!(drop.table_name, "users");
-                    assert_eq!(drop.column_name, "email");
-                    assert!(!drop.if_exists);
-                }
-                _ => panic!("Expected DROP COLUMN"),
+        ast::Statement::AlterTable(alter) => match alter {
+            ast::AlterTableStmt::DropColumn(drop) => {
+                assert_eq!(drop.table_name, "users");
+                assert_eq!(drop.column_name, "email");
+                assert!(!drop.if_exists);
             }
-        }
+            _ => panic!("Expected DROP COLUMN"),
+        },
         _ => panic!("Expected ALTER TABLE statement"),
     }
 }
@@ -61,16 +59,14 @@ fn test_parse_alter_table_drop_column_if_exists() {
     let stmt = result.unwrap();
 
     match stmt {
-        ast::Statement::AlterTable(alter) => {
-            match alter {
-                ast::AlterTableStmt::DropColumn(drop) => {
-                    assert_eq!(drop.table_name, "users");
-                    assert_eq!(drop.column_name, "email");
-                    assert!(drop.if_exists);
-                }
-                _ => panic!("Expected DROP COLUMN"),
+        ast::Statement::AlterTable(alter) => match alter {
+            ast::AlterTableStmt::DropColumn(drop) => {
+                assert_eq!(drop.table_name, "users");
+                assert_eq!(drop.column_name, "email");
+                assert!(drop.if_exists);
             }
-        }
+            _ => panic!("Expected DROP COLUMN"),
+        },
         _ => panic!("Expected ALTER TABLE statement"),
     }
 }
@@ -82,20 +78,16 @@ fn test_parse_alter_table_alter_column_set_not_null() {
     let stmt = result.unwrap();
 
     match stmt {
-        ast::Statement::AlterTable(alter) => {
-            match alter {
-                ast::AlterTableStmt::AlterColumn(alter_col) => {
-                    match alter_col {
-                        ast::AlterColumnStmt::SetNotNull { table_name, column_name } => {
-                            assert_eq!(table_name, "users");
-                            assert_eq!(column_name, "email");
-                        }
-                        _ => panic!("Expected SET NOT NULL"),
-                    }
+        ast::Statement::AlterTable(alter) => match alter {
+            ast::AlterTableStmt::AlterColumn(alter_col) => match alter_col {
+                ast::AlterColumnStmt::SetNotNull { table_name, column_name } => {
+                    assert_eq!(table_name, "users");
+                    assert_eq!(column_name, "email");
                 }
-                _ => panic!("Expected ALTER COLUMN"),
-            }
-        }
+                _ => panic!("Expected SET NOT NULL"),
+            },
+            _ => panic!("Expected ALTER COLUMN"),
+        },
         _ => panic!("Expected ALTER TABLE statement"),
     }
 }
@@ -107,20 +99,16 @@ fn test_parse_alter_table_alter_column_drop_not_null() {
     let stmt = result.unwrap();
 
     match stmt {
-        ast::Statement::AlterTable(alter) => {
-            match alter {
-                ast::AlterTableStmt::AlterColumn(alter_col) => {
-                    match alter_col {
-                        ast::AlterColumnStmt::DropNotNull { table_name, column_name } => {
-                            assert_eq!(table_name, "users");
-                            assert_eq!(column_name, "email");
-                        }
-                        _ => panic!("Expected DROP NOT NULL"),
-                    }
+        ast::Statement::AlterTable(alter) => match alter {
+            ast::AlterTableStmt::AlterColumn(alter_col) => match alter_col {
+                ast::AlterColumnStmt::DropNotNull { table_name, column_name } => {
+                    assert_eq!(table_name, "users");
+                    assert_eq!(column_name, "email");
                 }
-                _ => panic!("Expected ALTER COLUMN"),
-            }
-        }
+                _ => panic!("Expected DROP NOT NULL"),
+            },
+            _ => panic!("Expected ALTER COLUMN"),
+        },
         _ => panic!("Expected ALTER TABLE statement"),
     }
 }

--- a/crates/parser/src/tests/case_expression.rs
+++ b/crates/parser/src/tests/case_expression.rs
@@ -6,9 +6,8 @@ use super::*;
 
 #[test]
 fn test_parse_searched_case_simple() {
-    let result = Parser::parse_sql(
-        "SELECT CASE WHEN x > 0 THEN 'positive' ELSE 'non-positive' END FROM t;"
-    );
+    let result =
+        Parser::parse_sql("SELECT CASE WHEN x > 0 THEN 'positive' ELSE 'non-positive' END FROM t;");
     assert!(result.is_ok(), "Simple searched CASE should parse: {:?}", result);
 
     let stmt = result.unwrap();
@@ -43,7 +42,7 @@ fn test_parse_searched_case_multiple_when() {
             WHEN x < 0 THEN 'negative'
             WHEN x = 0 THEN 'zero'
             WHEN x > 0 THEN 'positive'
-         END FROM t;"
+         END FROM t;",
     );
     assert!(result.is_ok(), "Searched CASE with multiple WHEN should parse: {:?}", result);
 
@@ -61,9 +60,7 @@ fn test_parse_searched_case_multiple_when() {
 
 #[test]
 fn test_parse_searched_case_no_else() {
-    let result = Parser::parse_sql(
-        "SELECT CASE WHEN status = 'active' THEN 1 END FROM users;"
-    );
+    let result = Parser::parse_sql("SELECT CASE WHEN status = 'active' THEN 1 END FROM users;");
     assert!(result.is_ok(), "CASE without ELSE should parse: {:?}", result);
 
     let stmt = result.unwrap();
@@ -85,7 +82,7 @@ fn test_parse_simple_case() {
             WHEN 'active' THEN 1
             WHEN 'inactive' THEN 0
             ELSE 99
-         END FROM users;"
+         END FROM users;",
     );
     assert!(result.is_ok(), "Simple CASE should parse: {:?}", result);
 
@@ -125,9 +122,8 @@ fn test_parse_case_with_alias() {
 
 #[test]
 fn test_parse_case_in_where() {
-    let result = Parser::parse_sql(
-        "SELECT * FROM t WHERE CASE WHEN x > 0 THEN TRUE ELSE FALSE END;"
-    );
+    let result =
+        Parser::parse_sql("SELECT * FROM t WHERE CASE WHEN x > 0 THEN TRUE ELSE FALSE END;");
     assert!(result.is_ok(), "CASE in WHERE clause should parse: {:?}", result);
 
     let stmt = result.unwrap();
@@ -144,7 +140,7 @@ fn test_parse_case_in_where() {
 #[test]
 fn test_parse_case_in_order_by() {
     let result = Parser::parse_sql(
-        "SELECT * FROM t ORDER BY CASE WHEN priority = 'high' THEN 1 ELSE 2 END;"
+        "SELECT * FROM t ORDER BY CASE WHEN priority = 'high' THEN 1 ELSE 2 END;",
     );
     assert!(result.is_ok(), "CASE in ORDER BY should parse: {:?}", result);
 }
@@ -155,7 +151,7 @@ fn test_parse_nested_case() {
         "SELECT CASE
             WHEN x > 0 THEN CASE WHEN y > 0 THEN 'both positive' ELSE 'x positive' END
             ELSE 'x not positive'
-         END FROM t;"
+         END FROM t;",
     );
     assert!(result.is_ok(), "Nested CASE should parse: {:?}", result);
 
@@ -183,16 +179,14 @@ fn test_parse_case_with_complex_conditions() {
             WHEN age >= 18 AND age < 65 THEN 'adult'
             WHEN age >= 65 THEN 'senior'
             ELSE 'minor'
-         END FROM users;"
+         END FROM users;",
     );
     assert!(result.is_ok(), "CASE with complex conditions should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_case_with_null() {
-    let result = Parser::parse_sql(
-        "SELECT CASE WHEN x = NULL THEN 0 ELSE x END FROM t;"
-    );
+    let result = Parser::parse_sql("SELECT CASE WHEN x = NULL THEN 0 ELSE x END FROM t;");
     assert!(result.is_ok(), "CASE with NULL comparison should parse: {:?}", result);
 }
 
@@ -202,7 +196,7 @@ fn test_parse_case_with_function_calls() {
         "SELECT CASE
             WHEN LENGTH(name) > 10 THEN SUBSTRING(name, 1, 10)
             ELSE name
-         END FROM users;"
+         END FROM users;",
     );
     assert!(result.is_ok(), "CASE with function calls should parse: {:?}", result);
 }
@@ -213,7 +207,7 @@ fn test_parse_multiple_case_in_select() {
         "SELECT
             CASE WHEN x > 0 THEN 'pos' ELSE 'neg' END AS x_sign,
             CASE WHEN y > 0 THEN 'pos' ELSE 'neg' END AS y_sign
-         FROM t;"
+         FROM t;",
     );
     assert!(result.is_ok(), "Multiple CASE in SELECT should parse: {:?}", result);
 
@@ -236,7 +230,7 @@ fn test_parse_case_web_demo_query() {
                 ELSE 'Premium'
             END as price_category
         FROM products
-        ORDER BY unit_price;"
+        ORDER BY unit_price;",
     );
     assert!(result.is_ok(), "Web demo CASE query should parse: {:?}", result);
 
@@ -266,26 +260,20 @@ fn test_parse_case_web_demo_query() {
 
 #[test]
 fn test_parse_case_error_no_when() {
-    let result = Parser::parse_sql(
-        "SELECT CASE ELSE 'default' END FROM t;"
-    );
+    let result = Parser::parse_sql("SELECT CASE ELSE 'default' END FROM t;");
     assert!(result.is_err(), "CASE without WHEN should fail");
     // The error can be either about missing WHEN or about unexpected ELSE keyword
 }
 
 #[test]
 fn test_parse_case_error_missing_then() {
-    let result = Parser::parse_sql(
-        "SELECT CASE WHEN x > 0 'positive' END FROM t;"
-    );
+    let result = Parser::parse_sql("SELECT CASE WHEN x > 0 'positive' END FROM t;");
     assert!(result.is_err(), "CASE without THEN should fail");
 }
 
 #[test]
 fn test_parse_case_error_missing_end() {
-    let result = Parser::parse_sql(
-        "SELECT CASE WHEN x > 0 THEN 'positive' FROM t;"
-    );
+    let result = Parser::parse_sql("SELECT CASE WHEN x > 0 THEN 'positive' FROM t;");
     assert!(result.is_err(), "CASE without END should fail");
 }
 
@@ -293,9 +281,7 @@ fn test_parse_case_error_missing_end() {
 
 #[test]
 fn test_parse_case_comma_separated_when() {
-    let result = Parser::parse_sql(
-        "SELECT CASE 0 WHEN 2, 2 THEN 1 ELSE 0 END;"
-    );
+    let result = Parser::parse_sql("SELECT CASE 0 WHEN 2, 2 THEN 1 ELSE 0 END;");
     assert!(result.is_ok(), "CASE with comma-separated WHEN should parse: {:?}", result);
 
     let stmt = result.unwrap();
@@ -314,7 +300,7 @@ fn test_parse_case_comma_separated_when() {
 #[test]
 fn test_parse_case_multiple_values() {
     let result = Parser::parse_sql(
-        "SELECT CASE status WHEN 'active', 'pending', 'new' THEN 'open' ELSE 'closed' END;"
+        "SELECT CASE status WHEN 'active', 'pending', 'new' THEN 'open' ELSE 'closed' END;",
     );
     assert!(result.is_ok(), "CASE with multiple values should parse: {:?}", result);
 
@@ -333,10 +319,12 @@ fn test_parse_case_multiple_values() {
 
 #[test]
 fn test_parse_case_mixed_single_and_multiple() {
-    let result = Parser::parse_sql(
-        "SELECT CASE x WHEN 1, 2 THEN 'low' WHEN 10 THEN 'high' END;"
+    let result = Parser::parse_sql("SELECT CASE x WHEN 1, 2 THEN 'low' WHEN 10 THEN 'high' END;");
+    assert!(
+        result.is_ok(),
+        "CASE with mixed single and multiple values should parse: {:?}",
+        result
     );
-    assert!(result.is_ok(), "CASE with mixed single and multiple values should parse: {:?}", result);
 
     let stmt = result.unwrap();
     if let ast::Statement::Select(select) = stmt {

--- a/crates/parser/src/tests/cast.rs
+++ b/crates/parser/src/tests/cast.rs
@@ -182,9 +182,7 @@ fn test_parse_cast_to_timestamp() {
 
 #[test]
 fn test_parse_cast_in_where_clause() {
-    let result = Parser::parse_sql(
-        "SELECT * FROM users WHERE CAST(age AS VARCHAR(10)) = '25';"
-    );
+    let result = Parser::parse_sql("SELECT * FROM users WHERE CAST(age AS VARCHAR(10)) = '25';");
     assert!(result.is_ok(), "CAST in WHERE should parse: {:?}", result);
 }
 
@@ -196,9 +194,8 @@ fn test_parse_cast_nested_expression() {
 
 #[test]
 fn test_parse_multiple_casts() {
-    let result = Parser::parse_sql(
-        "SELECT CAST(a AS INTEGER), CAST(b AS VARCHAR(20)), CAST(c AS FLOAT);"
-    );
+    let result =
+        Parser::parse_sql("SELECT CAST(a AS INTEGER), CAST(b AS VARCHAR(20)), CAST(c AS FLOAT);");
     assert!(result.is_ok(), "Multiple CASTs should parse: {:?}", result);
 
     let stmt = result.unwrap();

--- a/crates/parser/src/tests/cte.rs
+++ b/crates/parser/src/tests/cte.rs
@@ -14,9 +14,7 @@ fn test_parse_cte_basic() {
 
 #[test]
 fn test_parse_cte_simple() {
-    let result = Parser::parse_sql(
-        "WITH cte AS (SELECT id FROM users) SELECT * FROM cte;"
-    );
+    let result = Parser::parse_sql("WITH cte AS (SELECT id FROM users) SELECT * FROM cte;");
     assert!(result.is_ok(), "Simple CTE should parse: {:?}", result);
 }
 
@@ -31,7 +29,7 @@ fn test_parse_cte_multiple() {
 #[test]
 fn test_parse_cte_with_column_list() {
     let result = Parser::parse_sql(
-        "WITH cte (user_id, user_name) AS (SELECT id, name FROM users) SELECT * FROM cte;"
+        "WITH cte (user_id, user_name) AS (SELECT id, name FROM users) SELECT * FROM cte;",
     );
     assert!(result.is_ok(), "CTE with column list should parse: {:?}", result);
 }
@@ -124,7 +122,7 @@ fn test_parse_cte_complex_query() {
         SELECT region, product, SUM(amount) AS product_sales
         FROM orders
         WHERE region IN (SELECT region FROM top_regions)
-        GROUP BY region, product;"
+        GROUP BY region, product;",
     );
     assert!(result.is_ok(), "Complex multi-CTE query should parse: {:?}", result);
 }
@@ -146,7 +144,7 @@ fn test_parse_cte_case_insensitive() {
 #[test]
 fn test_parse_cte_with_distinct() {
     let result = Parser::parse_sql(
-        "WITH unique_regions AS (SELECT DISTINCT region FROM sales) SELECT * FROM unique_regions;"
+        "WITH unique_regions AS (SELECT DISTINCT region FROM sales) SELECT * FROM unique_regions;",
     );
     assert!(result.is_ok(), "CTE with DISTINCT should parse: {:?}", result);
 }
@@ -169,9 +167,7 @@ fn test_parse_cte_with_subquery_in_cte() {
 
 #[test]
 fn test_parse_cte_empty_column_list() {
-    let result = Parser::parse_sql(
-        "WITH cte () AS (SELECT id FROM users) SELECT * FROM cte;"
-    );
+    let result = Parser::parse_sql("WITH cte () AS (SELECT id FROM users) SELECT * FROM cte;");
     // Empty column list should fail
     assert!(result.is_err(), "CTE with empty column list should fail to parse");
 }

--- a/crates/parser/src/tests/display.rs
+++ b/crates/parser/src/tests/display.rs
@@ -252,9 +252,6 @@ fn test_token_display_eof() {
 
 #[test]
 fn test_lexer_error_display() {
-    let error = LexerError {
-        message: "Unexpected character".to_string(),
-        position: 42,
-    };
+    let error = LexerError { message: "Unexpected character".to_string(), position: 42 };
     assert_eq!(format!("{}", error), "Lexer error at position 42: Unexpected character");
 }

--- a/crates/parser/src/tests/exists.rs
+++ b/crates/parser/src/tests/exists.rs
@@ -7,7 +7,7 @@ use super::*;
 #[test]
 fn test_parse_exists_simple() {
     let result = Parser::parse_sql(
-        "SELECT * FROM customers WHERE EXISTS (SELECT * FROM orders WHERE customer_id = 1);"
+        "SELECT * FROM customers WHERE EXISTS (SELECT * FROM orders WHERE customer_id = 1);",
     );
     assert!(result.is_ok(), "Simple EXISTS should parse: {:?}", result);
 
@@ -32,7 +32,7 @@ fn test_parse_exists_simple() {
 #[test]
 fn test_parse_not_exists() {
     let result = Parser::parse_sql(
-        "SELECT * FROM customers WHERE NOT EXISTS (SELECT * FROM orders WHERE customer_id = 1);"
+        "SELECT * FROM customers WHERE NOT EXISTS (SELECT * FROM orders WHERE customer_id = 1);",
     );
     assert!(result.is_ok(), "NOT EXISTS should parse: {:?}", result);
 
@@ -61,9 +61,7 @@ fn test_parse_exists_with_correlated_subquery() {
 #[test]
 fn test_parse_exists_with_select_1() {
     // Common idiom: SELECT 1 in EXISTS (doesn't matter what's selected)
-    let result = Parser::parse_sql(
-        "SELECT * FROM customers WHERE EXISTS (SELECT 1 FROM orders);"
-    );
+    let result = Parser::parse_sql("SELECT * FROM customers WHERE EXISTS (SELECT 1 FROM orders);");
     assert!(result.is_ok(), "EXISTS with SELECT 1 should parse: {:?}", result);
 }
 
@@ -88,7 +86,7 @@ fn test_parse_multiple_exists() {
     let result = Parser::parse_sql(
         "SELECT * FROM customers WHERE
          EXISTS (SELECT 1 FROM orders WHERE customer_id = 1) AND
-         EXISTS (SELECT 1 FROM payments WHERE customer_id = 1);"
+         EXISTS (SELECT 1 FROM payments WHERE customer_id = 1);",
     );
     assert!(result.is_ok(), "Multiple EXISTS should parse: {:?}", result);
 }
@@ -110,7 +108,7 @@ fn test_parse_nested_exists() {
             SELECT 1 FROM orders WHERE customer_id = 1 AND EXISTS (
                 SELECT 1 FROM order_items WHERE order_id = orders.id
             )
-        );"
+        );",
     );
     assert!(result.is_ok(), "Nested EXISTS should parse: {:?}", result);
 }
@@ -123,7 +121,7 @@ fn test_parse_exists_with_complex_subquery() {
             WHERE customer_id = customers.id
             AND total > 100
             AND status IN ('shipped', 'delivered')
-        );"
+        );",
     );
     assert!(result.is_ok(), "EXISTS with complex subquery should parse: {:?}", result);
 }
@@ -134,16 +132,15 @@ fn test_parse_not_exists_anti_join_pattern() {
     let result = Parser::parse_sql(
         "SELECT * FROM customers c WHERE NOT EXISTS (
             SELECT 1 FROM orders o WHERE o.customer_id = c.id
-        );"
+        );",
     );
     assert!(result.is_ok(), "NOT EXISTS anti-join pattern should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_exists_parenthesized() {
-    let result = Parser::parse_sql(
-        "SELECT * FROM customers WHERE (EXISTS (SELECT 1 FROM orders));"
-    );
+    let result =
+        Parser::parse_sql("SELECT * FROM customers WHERE (EXISTS (SELECT 1 FROM orders));");
     assert!(result.is_ok(), "Parenthesized EXISTS should parse: {:?}", result);
 }
 
@@ -155,7 +152,7 @@ fn test_parse_exists_with_group_by() {
             WHERE customer_id = customers.id
             GROUP BY order_date
             HAVING COUNT(*) > 5
-        );"
+        );",
     );
     assert!(result.is_ok(), "EXISTS with GROUP BY should parse: {:?}", result);
 }

--- a/crates/parser/src/tests/in_list.rs
+++ b/crates/parser/src/tests/in_list.rs
@@ -38,7 +38,8 @@ fn test_parse_in_with_integer_list() {
 
 #[test]
 fn test_parse_in_with_string_list() {
-    let result = Parser::parse_sql("SELECT * FROM users WHERE name IN ('Alice', 'Bob', 'Charlie');");
+    let result =
+        Parser::parse_sql("SELECT * FROM users WHERE name IN ('Alice', 'Bob', 'Charlie');");
     assert!(result.is_ok(), "IN with string list should parse: {:?}", result);
 }
 
@@ -56,7 +57,8 @@ fn test_parse_in_with_single_value() {
 
 #[test]
 fn test_parse_not_in_with_value_list() {
-    let result = Parser::parse_sql("SELECT * FROM users WHERE status NOT IN ('inactive', 'banned');");
+    let result =
+        Parser::parse_sql("SELECT * FROM users WHERE status NOT IN ('inactive', 'banned');");
     assert!(result.is_ok(), "NOT IN with value list should parse: {:?}", result);
 
     let stmt = result.unwrap();
@@ -83,7 +85,7 @@ fn test_parse_in_with_expressions() {
 #[test]
 fn test_parse_in_list_with_and() {
     let result = Parser::parse_sql(
-        "SELECT * FROM users WHERE age > 18 AND status IN ('active', 'pending');"
+        "SELECT * FROM users WHERE age > 18 AND status IN ('active', 'pending');",
     );
     assert!(result.is_ok(), "IN list with AND should parse: {:?}", result);
 }
@@ -91,16 +93,15 @@ fn test_parse_in_list_with_and() {
 #[test]
 fn test_parse_in_list_with_or() {
     let result = Parser::parse_sql(
-        "SELECT * FROM products WHERE category IN ('electronics', 'computers') OR price < 100;"
+        "SELECT * FROM products WHERE category IN ('electronics', 'computers') OR price < 100;",
     );
     assert!(result.is_ok(), "IN list with OR should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_multiple_in_lists() {
-    let result = Parser::parse_sql(
-        "SELECT * FROM data WHERE type IN ('A', 'B') AND status IN (1, 2, 3);"
-    );
+    let result =
+        Parser::parse_sql("SELECT * FROM data WHERE type IN ('A', 'B') AND status IN (1, 2, 3);");
     assert!(result.is_ok(), "Multiple IN lists should parse: {:?}", result);
 }
 
@@ -113,14 +114,15 @@ fn test_parse_in_empty_list_should_error() {
 
 #[test]
 fn test_parse_in_list_with_null() {
-    let result = Parser::parse_sql("SELECT * FROM users WHERE status IN ('active', NULL, 'pending');");
+    let result =
+        Parser::parse_sql("SELECT * FROM users WHERE status IN ('active', NULL, 'pending');");
     assert!(result.is_ok(), "IN list with NULL should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_in_list_complex_expression() {
     let result = Parser::parse_sql(
-        "SELECT * FROM orders WHERE (customer_id IN (1, 2, 3) AND total > 100) OR status = 'vip';"
+        "SELECT * FROM orders WHERE (customer_id IN (1, 2, 3) AND total > 100) OR status = 'vip';",
     );
     assert!(result.is_ok(), "Complex expression with IN list should parse: {:?}", result);
 }

--- a/crates/parser/src/tests/insert.rs
+++ b/crates/parser/src/tests/insert.rs
@@ -25,7 +25,7 @@ fn test_parse_insert_basic() {
             }
         }
         _ => panic!("Expected INSERT statement"),
-        }
+    }
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn test_insert_with_default() {
                 ast::InsertSource::Values(values) => {
                     assert_eq!(values.len(), 1); // One row
                     assert_eq!(values[0].len(), 2); // Two values
-                    // Check that first value is DEFAULT
+                                                    // Check that first value is DEFAULT
                     match &values[0][0] {
                         ast::Expression::Default => {
                             // Success - parsed as Default expression
@@ -50,10 +50,10 @@ fn test_insert_with_default() {
                     }
                     // Check that second value is a string literal
                     match &values[0][1] {
-                    ast::Expression::Literal(types::SqlValue::Varchar(s)) => {
-                    assert_eq!(s, "Alice");
-                    }
-                    _ => panic!("Expected string literal 'Alice', got {:?}", values[0][1]),
+                        ast::Expression::Literal(types::SqlValue::Varchar(s)) => {
+                            assert_eq!(s, "Alice");
+                        }
+                        _ => panic!("Expected string literal 'Alice', got {:?}", values[0][1]),
                     }
                 }
                 _ => panic!("Expected VALUES source"),
@@ -76,18 +76,24 @@ fn test_insert_multiple_defaults() {
                 ast::InsertSource::Values(values) => {
                     assert_eq!(values.len(), 1); // One row
                     assert_eq!(values[0].len(), 2); // Two values
-                    // Check that both values are DEFAULT
+                                                    // Check that both values are DEFAULT
                     match &values[0][0] {
                         ast::Expression::Default => {
                             // Success - parsed as Default expression
                         }
-                        _ => panic!("Expected DEFAULT expression for first value, got {:?}", values[0][0]),
+                        _ => panic!(
+                            "Expected DEFAULT expression for first value, got {:?}",
+                            values[0][0]
+                        ),
                     }
                     match &values[0][1] {
                         ast::Expression::Default => {
                             // Success - parsed as Default expression
                         }
-                        _ => panic!("Expected DEFAULT expression for second value, got {:?}", values[0][1]),
+                        _ => panic!(
+                            "Expected DEFAULT expression for second value, got {:?}",
+                            values[0][1]
+                        ),
                     }
                 }
                 _ => panic!("Expected VALUES source"),

--- a/crates/parser/src/tests/lexer/comments.rs
+++ b/crates/parser/src/tests/lexer/comments.rs
@@ -10,11 +10,7 @@ fn test_line_comment_simple() {
 
     assert_eq!(
         tokens,
-        vec![
-            Token::Keyword(Keyword::Select),
-            Token::Number("1".to_string()),
-            Token::Eof,
-        ]
+        vec![Token::Keyword(Keyword::Select), Token::Number("1".to_string()), Token::Eof,]
     );
 }
 
@@ -26,11 +22,7 @@ fn test_line_comment_at_end() {
 
     assert_eq!(
         tokens,
-        vec![
-            Token::Keyword(Keyword::Select),
-            Token::Number("1".to_string()),
-            Token::Eof,
-        ]
+        vec![Token::Keyword(Keyword::Select), Token::Number("1".to_string()), Token::Eof,]
     );
 }
 
@@ -45,11 +37,7 @@ SELECT 1 -- inline comment
 
     assert_eq!(
         tokens,
-        vec![
-            Token::Keyword(Keyword::Select),
-            Token::Number("1".to_string()),
-            Token::Eof,
-        ]
+        vec![Token::Keyword(Keyword::Select), Token::Number("1".to_string()), Token::Eof,]
     );
 }
 

--- a/crates/parser/src/tests/like.rs
+++ b/crates/parser/src/tests/like.rs
@@ -87,16 +87,15 @@ fn test_parse_not_like() {
 
 #[test]
 fn test_parse_like_with_and() {
-    let result = Parser::parse_sql(
-        "SELECT * FROM users WHERE name LIKE 'J%' AND email LIKE '%@gmail.com';"
-    );
+    let result =
+        Parser::parse_sql("SELECT * FROM users WHERE name LIKE 'J%' AND email LIKE '%@gmail.com';");
     assert!(result.is_ok(), "LIKE with AND should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_like_with_or() {
     let result = Parser::parse_sql(
-        "SELECT * FROM products WHERE name LIKE 'Widget%' OR name LIKE 'Gadget%';"
+        "SELECT * FROM products WHERE name LIKE 'Widget%' OR name LIKE 'Gadget%';",
     );
     assert!(result.is_ok(), "LIKE with OR should parse: {:?}", result);
 }
@@ -104,7 +103,7 @@ fn test_parse_like_with_or() {
 #[test]
 fn test_parse_like_in_complex_expression() {
     let result = Parser::parse_sql(
-        "SELECT * FROM users WHERE (name LIKE 'A%' OR name LIKE 'B%') AND active = TRUE;"
+        "SELECT * FROM users WHERE (name LIKE 'A%' OR name LIKE 'B%') AND active = TRUE;",
     );
     assert!(result.is_ok(), "LIKE in complex expression should parse: {:?}", result);
 }
@@ -112,7 +111,7 @@ fn test_parse_like_in_complex_expression() {
 #[test]
 fn test_parse_multiple_like_conditions() {
     let result = Parser::parse_sql(
-        "SELECT * FROM files WHERE filename LIKE '%.pdf' AND path NOT LIKE '/tmp/%';"
+        "SELECT * FROM files WHERE filename LIKE '%.pdf' AND path NOT LIKE '/tmp/%';",
     );
     assert!(result.is_ok(), "Multiple LIKE conditions should parse: {:?}", result);
 }

--- a/crates/parser/src/tests/literals.rs
+++ b/crates/parser/src/tests/literals.rs
@@ -22,14 +22,12 @@ fn test_parse_date_literal() {
         ast::Statement::Select(select) => {
             assert_eq!(select.select_list.len(), 1);
             match &select.select_list[0] {
-                ast::SelectItem::Expression { expr, alias: _ } => {
-                    match expr {
-                        ast::Expression::Literal(types::SqlValue::Date(s)) => {
-                            assert_eq!(s, "2024-01-01");
-                        }
-                        _ => panic!("Expected DATE literal, got {:?}", expr),
+                ast::SelectItem::Expression { expr, alias: _ } => match expr {
+                    ast::Expression::Literal(types::SqlValue::Date(s)) => {
+                        assert_eq!(s, "2024-01-01");
                     }
-                }
+                    _ => panic!("Expected DATE literal, got {:?}", expr),
+                },
                 _ => panic!("Expected expression"),
             }
         }
@@ -80,14 +78,12 @@ fn test_parse_time_literal() {
         ast::Statement::Select(select) => {
             assert_eq!(select.select_list.len(), 1);
             match &select.select_list[0] {
-                ast::SelectItem::Expression { expr, alias: _ } => {
-                    match expr {
-                        ast::Expression::Literal(types::SqlValue::Time(s)) => {
-                            assert_eq!(s, "14:30:00");
-                        }
-                        _ => panic!("Expected TIME literal, got {:?}", expr),
+                ast::SelectItem::Expression { expr, alias: _ } => match expr {
+                    ast::Expression::Literal(types::SqlValue::Time(s)) => {
+                        assert_eq!(s, "14:30:00");
                     }
-                }
+                    _ => panic!("Expected TIME literal, got {:?}", expr),
+                },
                 _ => panic!("Expected expression"),
             }
         }
@@ -114,19 +110,15 @@ fn test_parse_time_literal_with_fractional_seconds() {
 
     let stmt = result.unwrap();
     match stmt {
-        ast::Statement::Select(select) => {
-            match &select.select_list[0] {
-                ast::SelectItem::Expression { expr, alias: _ } => {
-                    match expr {
-                        ast::Expression::Literal(types::SqlValue::Time(s)) => {
-                            assert_eq!(s, "14:30:00.123");
-                        }
-                        _ => panic!("Expected TIME literal"),
-                    }
+        ast::Statement::Select(select) => match &select.select_list[0] {
+            ast::SelectItem::Expression { expr, alias: _ } => match expr {
+                ast::Expression::Literal(types::SqlValue::Time(s)) => {
+                    assert_eq!(s, "14:30:00.123");
                 }
-                _ => panic!("Expected expression"),
-            }
-        }
+                _ => panic!("Expected TIME literal"),
+            },
+            _ => panic!("Expected expression"),
+        },
         _ => panic!("Expected SELECT statement"),
     }
 }
@@ -145,14 +137,12 @@ fn test_parse_timestamp_literal() {
         ast::Statement::Select(select) => {
             assert_eq!(select.select_list.len(), 1);
             match &select.select_list[0] {
-                ast::SelectItem::Expression { expr, alias: _ } => {
-                    match expr {
-                        ast::Expression::Literal(types::SqlValue::Timestamp(s)) => {
-                            assert_eq!(s, "2024-01-01 14:30:00");
-                        }
-                        _ => panic!("Expected TIMESTAMP literal, got {:?}", expr),
+                ast::SelectItem::Expression { expr, alias: _ } => match expr {
+                    ast::Expression::Literal(types::SqlValue::Timestamp(s)) => {
+                        assert_eq!(s, "2024-01-01 14:30:00");
                     }
-                }
+                    _ => panic!("Expected TIMESTAMP literal, got {:?}", expr),
+                },
                 _ => panic!("Expected expression"),
             }
         }
@@ -167,19 +157,15 @@ fn test_parse_timestamp_literal_with_fractional_seconds() {
 
     let stmt = result.unwrap();
     match stmt {
-        ast::Statement::Select(select) => {
-            match &select.select_list[0] {
-                ast::SelectItem::Expression { expr, alias: _ } => {
-                    match expr {
-                        ast::Expression::Literal(types::SqlValue::Timestamp(s)) => {
-                            assert_eq!(s, "2024-01-01 14:30:00.123456");
-                        }
-                        _ => panic!("Expected TIMESTAMP literal"),
-                    }
+        ast::Statement::Select(select) => match &select.select_list[0] {
+            ast::SelectItem::Expression { expr, alias: _ } => match expr {
+                ast::Expression::Literal(types::SqlValue::Timestamp(s)) => {
+                    assert_eq!(s, "2024-01-01 14:30:00.123456");
                 }
-                _ => panic!("Expected expression"),
-            }
-        }
+                _ => panic!("Expected TIMESTAMP literal"),
+            },
+            _ => panic!("Expected expression"),
+        },
         _ => panic!("Expected SELECT statement"),
     }
 }
@@ -187,7 +173,7 @@ fn test_parse_timestamp_literal_with_fractional_seconds() {
 #[test]
 fn test_parse_timestamp_literal_in_insert() {
     let result = Parser::parse_sql(
-        "INSERT INTO logs (id, created) VALUES (1, TIMESTAMP '2024-01-01 12:00:00');"
+        "INSERT INTO logs (id, created) VALUES (1, TIMESTAMP '2024-01-01 12:00:00');",
     );
     assert!(result.is_ok(), "TIMESTAMP in INSERT should parse: {:?}", result);
 }
@@ -206,14 +192,12 @@ fn test_parse_interval_year_literal() {
         ast::Statement::Select(select) => {
             assert_eq!(select.select_list.len(), 1);
             match &select.select_list[0] {
-                ast::SelectItem::Expression { expr, alias: _ } => {
-                    match expr {
-                        ast::Expression::Literal(types::SqlValue::Interval(s)) => {
-                            assert_eq!(s, "5 YEAR");
-                        }
-                        _ => panic!("Expected INTERVAL literal, got {:?}", expr),
+                ast::SelectItem::Expression { expr, alias: _ } => match expr {
+                    ast::Expression::Literal(types::SqlValue::Interval(s)) => {
+                        assert_eq!(s, "5 YEAR");
                     }
-                }
+                    _ => panic!("Expected INTERVAL literal, got {:?}", expr),
+                },
                 _ => panic!("Expected expression"),
             }
         }
@@ -246,19 +230,15 @@ fn test_parse_interval_year_to_month_literal() {
 
     let stmt = result.unwrap();
     match stmt {
-        ast::Statement::Select(select) => {
-            match &select.select_list[0] {
-                ast::SelectItem::Expression { expr, alias: _ } => {
-                    match expr {
-                        ast::Expression::Literal(types::SqlValue::Interval(s)) => {
-                            assert_eq!(s, "1-6 YEAR TO MONTH");
-                        }
-                        _ => panic!("Expected INTERVAL literal"),
-                    }
+        ast::Statement::Select(select) => match &select.select_list[0] {
+            ast::SelectItem::Expression { expr, alias: _ } => match expr {
+                ast::Expression::Literal(types::SqlValue::Interval(s)) => {
+                    assert_eq!(s, "1-6 YEAR TO MONTH");
                 }
-                _ => panic!("Expected expression"),
-            }
-        }
+                _ => panic!("Expected INTERVAL literal"),
+            },
+            _ => panic!("Expected expression"),
+        },
         _ => panic!("Expected SELECT statement"),
     }
 }
@@ -276,19 +256,15 @@ fn test_parse_interval_day_to_second_literal() {
 
     let stmt = result.unwrap();
     match stmt {
-        ast::Statement::Select(select) => {
-            match &select.select_list[0] {
-                ast::SelectItem::Expression { expr, alias: _ } => {
-                    match expr {
-                        ast::Expression::Literal(types::SqlValue::Interval(s)) => {
-                            assert_eq!(s, "5 12:30:45 DAY TO SECOND");
-                        }
-                        _ => panic!("Expected INTERVAL literal"),
-                    }
+        ast::Statement::Select(select) => match &select.select_list[0] {
+            ast::SelectItem::Expression { expr, alias: _ } => match expr {
+                ast::Expression::Literal(types::SqlValue::Interval(s)) => {
+                    assert_eq!(s, "5 12:30:45 DAY TO SECOND");
                 }
-                _ => panic!("Expected expression"),
-            }
-        }
+                _ => panic!("Expected INTERVAL literal"),
+            },
+            _ => panic!("Expected expression"),
+        },
         _ => panic!("Expected SELECT statement"),
     }
 }
@@ -300,7 +276,7 @@ fn test_parse_interval_day_to_second_literal() {
 #[test]
 fn test_parse_mixed_date_time_literals() {
     let result = Parser::parse_sql(
-        "SELECT DATE '2024-01-01', TIME '14:30:00', TIMESTAMP '2024-01-01 14:30:00';"
+        "SELECT DATE '2024-01-01', TIME '14:30:00', TIMESTAMP '2024-01-01 14:30:00';",
     );
     assert!(result.is_ok(), "Mixed date/time literals should parse: {:?}", result);
 

--- a/crates/parser/src/tests/null_functions.rs
+++ b/crates/parser/src/tests/null_functions.rs
@@ -30,7 +30,8 @@ fn test_parse_coalesce_with_null() {
 
 #[test]
 fn test_parse_coalesce_in_where() {
-    let result = Parser::parse_sql("SELECT * FROM users WHERE COALESCE(status, 'active') = 'active';");
+    let result =
+        Parser::parse_sql("SELECT * FROM users WHERE COALESCE(status, 'active') = 'active';");
     assert!(result.is_ok(), "COALESCE in WHERE should parse: {:?}", result);
 }
 
@@ -97,14 +98,15 @@ fn test_parse_nullif_nested() {
 
 #[test]
 fn test_parse_coalesce_and_nullif_combined() {
-    let result = Parser::parse_sql("SELECT COALESCE(NULLIF(status, 'unknown'), 'active') FROM users;");
+    let result =
+        Parser::parse_sql("SELECT COALESCE(NULLIF(status, 'unknown'), 'active') FROM users;");
     assert!(result.is_ok(), "COALESCE with NULLIF should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_nullif_in_case() {
     let result = Parser::parse_sql(
-        "SELECT CASE WHEN NULLIF(balance, 0) = NULL THEN 'zero' ELSE 'non-zero' END FROM accounts;"
+        "SELECT CASE WHEN NULLIF(balance, 0) = NULL THEN 'zero' ELSE 'non-zero' END FROM accounts;",
     );
     assert!(result.is_ok(), "NULLIF in CASE should parse: {:?}", result);
 }

--- a/crates/parser/src/tests/quantified.rs
+++ b/crates/parser/src/tests/quantified.rs
@@ -6,37 +6,47 @@ use super::*;
 
 #[test]
 fn test_parse_all_with_greater_than() {
-    let result = Parser::parse_sql("SELECT * FROM employees WHERE salary > ALL (SELECT salary FROM dept WHERE dept_id = 10);");
+    let result = Parser::parse_sql(
+        "SELECT * FROM employees WHERE salary > ALL (SELECT salary FROM dept WHERE dept_id = 10);",
+    );
     assert!(result.is_ok(), "ALL with > should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_all_with_less_than() {
-    let result = Parser::parse_sql("SELECT * FROM products WHERE price < ALL (SELECT price FROM competitors);");
+    let result = Parser::parse_sql(
+        "SELECT * FROM products WHERE price < ALL (SELECT price FROM competitors);",
+    );
     assert!(result.is_ok(), "ALL with < should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_all_with_equals() {
-    let result = Parser::parse_sql("SELECT * FROM orders WHERE quantity = ALL (SELECT quantity FROM inventory);");
+    let result = Parser::parse_sql(
+        "SELECT * FROM orders WHERE quantity = ALL (SELECT quantity FROM inventory);",
+    );
     assert!(result.is_ok(), "ALL with = should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_all_with_not_equals() {
-    let result = Parser::parse_sql("SELECT * FROM users WHERE status <> ALL (SELECT status FROM blacklist);");
+    let result = Parser::parse_sql(
+        "SELECT * FROM users WHERE status <> ALL (SELECT status FROM blacklist);",
+    );
     assert!(result.is_ok(), "ALL with <> should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_all_with_greater_or_equal() {
-    let result = Parser::parse_sql("SELECT * FROM items WHERE rating >= ALL (SELECT rating FROM reviews);");
+    let result =
+        Parser::parse_sql("SELECT * FROM items WHERE rating >= ALL (SELECT rating FROM reviews);");
     assert!(result.is_ok(), "ALL with >= should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_all_with_less_or_equal() {
-    let result = Parser::parse_sql("SELECT * FROM bids WHERE amount <= ALL (SELECT amount FROM max_bids);");
+    let result =
+        Parser::parse_sql("SELECT * FROM bids WHERE amount <= ALL (SELECT amount FROM max_bids);");
     assert!(result.is_ok(), "ALL with <= should parse: {:?}", result);
 }
 
@@ -46,25 +56,32 @@ fn test_parse_all_with_less_or_equal() {
 
 #[test]
 fn test_parse_any_with_greater_than() {
-    let result = Parser::parse_sql("SELECT * FROM employees WHERE salary > ANY (SELECT salary FROM dept WHERE dept_id = 10);");
+    let result = Parser::parse_sql(
+        "SELECT * FROM employees WHERE salary > ANY (SELECT salary FROM dept WHERE dept_id = 10);",
+    );
     assert!(result.is_ok(), "ANY with > should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_any_with_less_than() {
-    let result = Parser::parse_sql("SELECT * FROM products WHERE price < ANY (SELECT price FROM competitors);");
+    let result = Parser::parse_sql(
+        "SELECT * FROM products WHERE price < ANY (SELECT price FROM competitors);",
+    );
     assert!(result.is_ok(), "ANY with < should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_any_with_equals() {
-    let result = Parser::parse_sql("SELECT * FROM orders WHERE status = ANY (SELECT status FROM valid_statuses);");
+    let result = Parser::parse_sql(
+        "SELECT * FROM orders WHERE status = ANY (SELECT status FROM valid_statuses);",
+    );
     assert!(result.is_ok(), "ANY with = should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_any_with_not_equals() {
-    let result = Parser::parse_sql("SELECT * FROM users WHERE role <> ANY (SELECT role FROM admin_roles);");
+    let result =
+        Parser::parse_sql("SELECT * FROM users WHERE role <> ANY (SELECT role FROM admin_roles);");
     assert!(result.is_ok(), "ANY with <> should parse: {:?}", result);
 }
 
@@ -74,19 +91,25 @@ fn test_parse_any_with_not_equals() {
 
 #[test]
 fn test_parse_some_with_greater_than() {
-    let result = Parser::parse_sql("SELECT * FROM employees WHERE salary > SOME (SELECT salary FROM dept WHERE dept_id = 10);");
+    let result = Parser::parse_sql(
+        "SELECT * FROM employees WHERE salary > SOME (SELECT salary FROM dept WHERE dept_id = 10);",
+    );
     assert!(result.is_ok(), "SOME with > should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_some_with_less_than() {
-    let result = Parser::parse_sql("SELECT * FROM products WHERE price < SOME (SELECT price FROM competitors);");
+    let result = Parser::parse_sql(
+        "SELECT * FROM products WHERE price < SOME (SELECT price FROM competitors);",
+    );
     assert!(result.is_ok(), "SOME with < should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_some_with_equals() {
-    let result = Parser::parse_sql("SELECT * FROM orders WHERE quantity = SOME (SELECT quantity FROM inventory);");
+    let result = Parser::parse_sql(
+        "SELECT * FROM orders WHERE quantity = SOME (SELECT quantity FROM inventory);",
+    );
     assert!(result.is_ok(), "SOME with = should parse: {:?}", result);
 }
 
@@ -105,7 +128,7 @@ fn test_parse_quantified_with_complex_subquery() {
 #[test]
 fn test_parse_quantified_in_where_with_and() {
     let result = Parser::parse_sql(
-        "SELECT * FROM products WHERE price < ANY (SELECT price FROM competitors) AND stock > 0;"
+        "SELECT * FROM products WHERE price < ANY (SELECT price FROM competitors) AND stock > 0;",
     );
     assert!(result.is_ok(), "Quantified with AND should parse: {:?}", result);
 }
@@ -137,7 +160,7 @@ fn test_parse_multiple_quantified_comparisons() {
 #[test]
 fn test_parse_quantified_with_arithmetic() {
     let result = Parser::parse_sql(
-        "SELECT * FROM products WHERE price * 0.9 < ANY (SELECT price FROM competitors);"
+        "SELECT * FROM products WHERE price * 0.9 < ANY (SELECT price FROM competitors);",
     );
     assert!(result.is_ok(), "Quantified with arithmetic should parse: {:?}", result);
 }
@@ -173,14 +196,19 @@ fn test_parse_all_any_some_are_case_insensitive() {
 
     for sql in sql_variants {
         let result = Parser::parse_sql(sql);
-        assert!(result.is_ok(), "Case-insensitive quantifier should parse: {} -> {:?}", sql, result);
+        assert!(
+            result.is_ok(),
+            "Case-insensitive quantifier should parse: {} -> {:?}",
+            sql,
+            result
+        );
     }
 }
 
 #[test]
 fn test_parse_quantified_with_parenthesized_expression() {
     let result = Parser::parse_sql(
-        "SELECT * FROM employees WHERE (salary * 1.1) > ALL (SELECT salary FROM dept);"
+        "SELECT * FROM employees WHERE (salary * 1.1) > ALL (SELECT salary FROM dept);",
     );
     assert!(result.is_ok(), "Quantified with parenthesized expr should parse: {:?}", result);
 }

--- a/crates/parser/src/tests/select/position.rs
+++ b/crates/parser/src/tests/select/position.rs
@@ -58,7 +58,9 @@ fn test_parse_position_substring_found() {
                         );
                         assert_eq!(
                             **string,
-                            ast::Expression::Literal(types::SqlValue::Varchar("hello world".to_string()))
+                            ast::Expression::Literal(types::SqlValue::Varchar(
+                                "hello world".to_string()
+                            ))
                         );
                     }
                     _ => panic!("Expected Position expression"),
@@ -90,10 +92,7 @@ fn test_parse_position_with_column() {
                         );
                         assert_eq!(
                             **string,
-                            ast::Expression::ColumnRef {
-                                table: None,
-                                column: "name".to_string()
-                            }
+                            ast::Expression::ColumnRef { table: None, column: "name".to_string() }
                         );
                     }
                     _ => panic!("Expected Position expression"),

--- a/crates/parser/src/tests/set_operations.rs
+++ b/crates/parser/src/tests/set_operations.rs
@@ -18,7 +18,8 @@ fn test_parse_union_all() {
 
 #[test]
 fn test_parse_union_multiple_columns() {
-    let result = Parser::parse_sql("SELECT id, name FROM users UNION SELECT id, name FROM customers;");
+    let result =
+        Parser::parse_sql("SELECT id, name FROM users UNION SELECT id, name FROM customers;");
     assert!(result.is_ok(), "UNION with multiple columns should parse: {:?}", result);
 }
 
@@ -32,14 +33,15 @@ fn test_parse_union_with_where() {
 
 #[test]
 fn test_parse_union_with_order_by() {
-    let result = Parser::parse_sql("SELECT name FROM users UNION SELECT name FROM customers ORDER BY name;");
+    let result =
+        Parser::parse_sql("SELECT name FROM users UNION SELECT name FROM customers ORDER BY name;");
     assert!(result.is_ok(), "UNION with ORDER BY should parse: {:?}", result);
 }
 
 #[test]
 fn test_parse_union_three_queries() {
     let result = Parser::parse_sql(
-        "SELECT id FROM users UNION SELECT id FROM customers UNION SELECT id FROM vendors;"
+        "SELECT id FROM users UNION SELECT id FROM customers UNION SELECT id FROM vendors;",
     );
     assert!(result.is_ok(), "UNION with three queries should parse: {:?}", result);
 }
@@ -47,7 +49,7 @@ fn test_parse_union_three_queries() {
 #[test]
 fn test_parse_union_with_subquery() {
     let result = Parser::parse_sql(
-        "SELECT id FROM users UNION SELECT id FROM (SELECT customer_id AS id FROM orders) AS subq;"
+        "SELECT id FROM users UNION SELECT id FROM (SELECT customer_id AS id FROM orders) AS subq;",
     );
     assert!(result.is_ok(), "UNION with subquery should parse: {:?}", result);
 }
@@ -117,7 +119,7 @@ fn test_parse_except_with_where() {
 #[test]
 fn test_parse_except_multiple_columns() {
     let result = Parser::parse_sql(
-        "SELECT id, name FROM products EXCEPT SELECT id, name FROM discontinued_products;"
+        "SELECT id, name FROM products EXCEPT SELECT id, name FROM discontinued_products;",
     );
     assert!(result.is_ok(), "EXCEPT with multiple columns should parse: {:?}", result);
 }
@@ -144,9 +146,7 @@ fn test_parse_union_and_except() {
 
 #[test]
 fn test_parse_set_operation_with_aliases() {
-    let result = Parser::parse_sql(
-        "SELECT u.id FROM users u UNION SELECT c.id FROM customers c;"
-    );
+    let result = Parser::parse_sql("SELECT u.id FROM users u UNION SELECT c.id FROM customers c;");
     assert!(result.is_ok(), "Set operation with table aliases should parse: {:?}", result);
 }
 
@@ -179,7 +179,12 @@ fn test_parse_set_operation_case_insensitive() {
 
     for sql in sql_variants {
         let result = Parser::parse_sql(sql);
-        assert!(result.is_ok(), "Case-insensitive set operation should parse: {} -> {:?}", sql, result);
+        assert!(
+            result.is_ok(),
+            "Case-insensitive set operation should parse: {} -> {:?}",
+            sql,
+            result
+        );
     }
 }
 
@@ -194,7 +199,7 @@ fn test_parse_complex_set_operation_chain() {
 #[test]
 fn test_parse_set_operation_with_distinct() {
     let result = Parser::parse_sql(
-        "SELECT DISTINCT name FROM users UNION SELECT DISTINCT name FROM customers;"
+        "SELECT DISTINCT name FROM users UNION SELECT DISTINCT name FROM customers;",
     );
     assert!(result.is_ok(), "Set operation with DISTINCT should parse: {:?}", result);
 }

--- a/crates/parser/src/tests/string_functions.rs
+++ b/crates/parser/src/tests/string_functions.rs
@@ -184,8 +184,11 @@ fn test_substring_syntaxes_equivalent() {
     };
 
     // Both should be Function expressions with same args
-    if let (ast::Expression::Function { name: name1, args: args1 },
-            ast::Expression::Function { name: name2, args: args2 }) = (comma_expr, from_for_expr) {
+    if let (
+        ast::Expression::Function { name: name1, args: args1 },
+        ast::Expression::Function { name: name2, args: args2 },
+    ) = (comma_expr, from_for_expr)
+    {
         assert_eq!(name1.to_uppercase(), name2.to_uppercase());
         assert_eq!(args1.len(), args2.len());
         assert_eq!(args1.len(), 3);

--- a/crates/parser/src/tests/window_functions.rs
+++ b/crates/parser/src/tests/window_functions.rs
@@ -348,10 +348,7 @@ fn test_unbounded_following() {
                 ast::Expression::WindowFunction { over, .. } => {
                     let frame = over.frame.as_ref().unwrap();
                     assert_eq!(frame.start, ast::FrameBound::CurrentRow);
-                    assert_eq!(
-                        frame.end.as_ref().unwrap(),
-                        &ast::FrameBound::UnboundedFollowing
-                    );
+                    assert_eq!(frame.end.as_ref().unwrap(), &ast::FrameBound::UnboundedFollowing);
                 }
                 _ => panic!("Expected WindowFunction"),
             },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "nistmemsql",
+  "version": "0.1.0",
+  "private": true,
+  "description": "SQL Conformance Testing Database - pnpm helper scripts for Cargo commands",
+  "scripts": {
+    "check:all": "cargo fmt -- --check && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all && cargo build --all",
+    "check:ci": "cargo fmt -- --check && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all",
+    "test": "cargo test --all",
+    "test:lib": "cargo test --lib",
+    "test:integration": "cargo test --test '*'",
+    "build": "cargo build --all",
+    "build:release": "cargo build --release --all",
+    "fmt": "cargo fmt --all",
+    "fmt:check": "cargo fmt -- --check",
+    "lint": "cargo clippy --all-targets --all-features -- -D warnings",
+    "clean": "cargo clean"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `package.json` file with pnpm script aliases for common Cargo commands, enabling agents to use consistent development commands across different project types.

## Changes

- Created `package.json` with helper scripts:
  - `check:all` - Run all quality checks (fmt, clippy, test, build)
  - `check:ci` - Run CI-appropriate checks (fmt check, clippy, test)
  - `test` - Run full test suite
  - `test:lib` - Run library tests only
  - `test:integration` - Run integration tests
  - `build` - Build all workspace crates
  - `build:release` - Build release version
  - `fmt` - Format code with cargo fmt
  - `fmt:check` - Check formatting without making changes
  - `lint` - Run clippy lints
  - `clean` - Clean build artifacts

- Applied cargo fmt formatting fixes for code consistency

## Test Plan

Verified all scripts work correctly:
- ✅ `pnpm test` - Runs cargo test successfully
- ✅ `pnpm build` - Builds all workspace crates
- ✅ `pnpm fmt` - Formats code
- ✅ `pnpm lint` - Runs clippy (detects pre-existing issues as expected)
- ✅ Scripts return proper exit codes (0 for success, non-zero for failure)

## Benefits

1. **Agent Compatibility**: Agents can use `pnpm check:ci` regardless of project technology
2. **Easier Onboarding**: Developers familiar with npm/pnpm can use familiar commands
3. **Documentation**: Scripts serve as clear documentation of development tasks
4. **Flexibility**: Easy to add more complex command chains without modifying agent roles
5. **Cross-Platform**: npm/pnpm scripts work consistently across shells

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>