### PR TITLE
feat: Support TRIM without explicit character specification

### DIFF
--- a/crates/executor/tests/string_function_tests.rs
+++ b/crates/executor/tests/string_function_tests.rs
@@ -68,3 +68,104 @@ fn test_substring_both_syntaxes_equivalent() {
     assert_eq!(comma_result, from_for_result);
     assert_eq!(comma_result, types::SqlValue::Varchar("ell".to_string()));
 }
+
+// ============================================================================
+// TRIM Function Tests
+// ============================================================================
+
+#[test]
+fn test_trim_from_no_char() {
+    let (evaluator, row) = create_test_evaluator();
+    let expr = ast::Expression::Trim {
+        position: None, // Defaults to BOTH
+        removal_char: None, // Defaults to space
+        string: Box::new(ast::Expression::Literal(types::SqlValue::Varchar("  hello  ".to_string()))),
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, types::SqlValue::Varchar("hello".to_string()));
+}
+
+#[test]
+fn test_trim_both_from_no_char() {
+    let (evaluator, row) = create_test_evaluator();
+    let expr = ast::Expression::Trim {
+        position: Some(ast::TrimPosition::Both),
+        removal_char: None, // Defaults to space
+        string: Box::new(ast::Expression::Literal(types::SqlValue::Varchar("  hello  ".to_string()))),
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, types::SqlValue::Varchar("hello".to_string()));
+}
+
+#[test]
+fn test_trim_leading_from_no_char() {
+    let (evaluator, row) = create_test_evaluator();
+    let expr = ast::Expression::Trim {
+        position: Some(ast::TrimPosition::Leading),
+        removal_char: None, // Defaults to space
+        string: Box::new(ast::Expression::Literal(types::SqlValue::Varchar("  hello  ".to_string()))),
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, types::SqlValue::Varchar("hello  ".to_string()));
+}
+
+#[test]
+fn test_trim_trailing_from_no_char() {
+    let (evaluator, row) = create_test_evaluator();
+    let expr = ast::Expression::Trim {
+        position: Some(ast::TrimPosition::Trailing),
+        removal_char: None, // Defaults to space
+        string: Box::new(ast::Expression::Literal(types::SqlValue::Varchar("  hello  ".to_string()))),
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, types::SqlValue::Varchar("  hello".to_string()));
+}
+
+#[test]
+fn test_trim_from_only_spaces() {
+    let (evaluator, row) = create_test_evaluator();
+    let expr = ast::Expression::Trim {
+        position: None,
+        removal_char: None, // Defaults to space
+        string: Box::new(ast::Expression::Literal(types::SqlValue::Varchar("    ".to_string()))),
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, types::SqlValue::Varchar("".to_string()));
+}
+
+#[test]
+fn test_trim_from_empty_string() {
+    let (evaluator, row) = create_test_evaluator();
+    let expr = ast::Expression::Trim {
+        position: None,
+        removal_char: None, // Defaults to space
+        string: Box::new(ast::Expression::Literal(types::SqlValue::Varchar("".to_string()))),
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, types::SqlValue::Varchar("".to_string()));
+}
+
+#[test]
+fn test_trim_from_no_spaces() {
+    let (evaluator, row) = create_test_evaluator();
+    let expr = ast::Expression::Trim {
+        position: None,
+        removal_char: None, // Defaults to space
+        string: Box::new(ast::Expression::Literal(types::SqlValue::Varchar("hello".to_string()))),
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, types::SqlValue::Varchar("hello".to_string()));
+}
+
+#[test]
+fn test_trim_with_char_still_works() {
+    // Verify existing functionality is preserved
+    let (evaluator, row) = create_test_evaluator();
+    let expr = ast::Expression::Trim {
+        position: Some(ast::TrimPosition::Both),
+        removal_char: Some(Box::new(ast::Expression::Literal(types::SqlValue::Varchar("x".to_string())))),
+        string: Box::new(ast::Expression::Literal(types::SqlValue::Varchar("xfoox".to_string()))),
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, types::SqlValue::Varchar("foo".to_string()));
+}

--- a/crates/parser/src/tests/string_functions.rs
+++ b/crates/parser/src/tests/string_functions.rs
@@ -196,3 +196,127 @@ fn test_substring_syntaxes_equivalent() {
         panic!("Both should be Function expressions");
     }
 }
+
+// ========================================================================
+// TRIM Function Tests
+// ========================================================================
+
+#[test]
+fn test_trim_from_without_char() {
+    let result = Parser::parse_sql("SELECT TRIM(FROM '  foo  ')");
+    assert!(result.is_ok(), "TRIM(FROM string) should parse: {:?}", result);
+
+    let stmt = result.unwrap();
+    if let ast::Statement::Select(select) = stmt {
+        assert_eq!(select.select_list.len(), 1);
+
+        if let ast::SelectItem::Expression { expr, .. } = &select.select_list[0] {
+            if let ast::Expression::Trim { position, removal_char, string } = expr {
+                // Position should be None (defaults to BOTH)
+                assert_eq!(*position, None);
+                // removal_char should be None (defaults to space)
+                assert!(removal_char.is_none());
+                // String should be the literal
+                if let ast::Expression::Literal(types::SqlValue::Varchar(s)) = string.as_ref() {
+                    assert_eq!(s, "  foo  ");
+                } else {
+                    panic!("Expected string literal");
+                }
+            } else {
+                panic!("Expected Trim expression");
+            }
+        } else {
+            panic!("Expected Expression SelectItem");
+        }
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_trim_both_from_without_char() {
+    let result = Parser::parse_sql("SELECT TRIM(BOTH FROM '  foo  ')");
+    assert!(result.is_ok(), "TRIM(BOTH FROM string) should parse: {:?}", result);
+
+    let stmt = result.unwrap();
+    if let ast::Statement::Select(select) = stmt {
+        if let ast::SelectItem::Expression { expr, .. } = &select.select_list[0] {
+            if let ast::Expression::Trim { position, removal_char, .. } = expr {
+                // Position should be BOTH
+                assert_eq!(*position, Some(ast::TrimPosition::Both));
+                // removal_char should be None (defaults to space)
+                assert!(removal_char.is_none());
+            } else {
+                panic!("Expected Trim expression");
+            }
+        }
+    }
+}
+
+#[test]
+fn test_trim_leading_from_without_char() {
+    let result = Parser::parse_sql("SELECT TRIM(LEADING FROM '  foo')");
+    assert!(result.is_ok(), "TRIM(LEADING FROM string) should parse: {:?}", result);
+
+    let stmt = result.unwrap();
+    if let ast::Statement::Select(select) = stmt {
+        if let ast::SelectItem::Expression { expr, .. } = &select.select_list[0] {
+            if let ast::Expression::Trim { position, removal_char, .. } = expr {
+                // Position should be LEADING
+                assert_eq!(*position, Some(ast::TrimPosition::Leading));
+                // removal_char should be None (defaults to space)
+                assert!(removal_char.is_none());
+            } else {
+                panic!("Expected Trim expression");
+            }
+        }
+    }
+}
+
+#[test]
+fn test_trim_trailing_from_without_char() {
+    let result = Parser::parse_sql("SELECT TRIM(TRAILING FROM 'foo  ')");
+    assert!(result.is_ok(), "TRIM(TRAILING FROM string) should parse: {:?}", result);
+
+    let stmt = result.unwrap();
+    if let ast::Statement::Select(select) = stmt {
+        if let ast::SelectItem::Expression { expr, .. } = &select.select_list[0] {
+            if let ast::Expression::Trim { position, removal_char, .. } = expr {
+                // Position should be TRAILING
+                assert_eq!(*position, Some(ast::TrimPosition::Trailing));
+                // removal_char should be None (defaults to space)
+                assert!(removal_char.is_none());
+            } else {
+                panic!("Expected Trim expression");
+            }
+        }
+    }
+}
+
+#[test]
+fn test_trim_with_char_still_works() {
+    // Verify existing functionality is preserved
+    let result = Parser::parse_sql("SELECT TRIM(BOTH 'x' FROM 'xfoox')");
+    assert!(result.is_ok(), "TRIM(BOTH 'x' FROM string) should still parse: {:?}", result);
+
+    let stmt = result.unwrap();
+    if let ast::Statement::Select(select) = stmt {
+        if let ast::SelectItem::Expression { expr, .. } = &select.select_list[0] {
+            if let ast::Expression::Trim { position, removal_char, .. } = expr {
+                // Position should be BOTH
+                assert_eq!(*position, Some(ast::TrimPosition::Both));
+                // removal_char should be Some('x')
+                assert!(removal_char.is_some());
+                if let Some(boxed_expr) = removal_char {
+                    if let ast::Expression::Literal(types::SqlValue::Varchar(c)) = boxed_expr.as_ref() {
+                        assert_eq!(c, "x");
+                    } else {
+                        panic!("Expected string literal for removal char");
+                    }
+                }
+            } else {
+                panic!("Expected Trim expression");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements support for TRIM function variants that omit the character to trim (defaults to space), completing SQL:1999 E021-09 conformance.

## Changes Made

### Parser Updates
- **File**: `crates/parser/src/parser/expressions/functions.rs`
- **Change**: Added early check for FROM keyword after position specification
- **Logic**: When `FROM` appears immediately after BOTH/LEADING/TRAILING keywords (or at start), set `removal_char = None` instead of trying to parse an expression
- **Impact**: Handles 4 new TRIM syntax variants without breaking existing functionality

### Test Coverage

**Parser Tests** (5 new tests in `crates/parser/src/tests/string_functions.rs`):
- `test_trim_from_without_char` - TRIM(FROM 'str')
- `test_trim_both_from_without_char` - TRIM(BOTH FROM 'str')
- `test_trim_leading_from_without_char` - TRIM(LEADING FROM 'str')
- `test_trim_trailing_from_without_char` - TRIM(TRAILING FROM 'str')
- `test_trim_with_char_still_works` - Regression test

**Executor Tests** (8 new tests in `crates/executor/tests/string_function_tests.rs`):
- `test_trim_from_no_char` - Basic space trimming
- `test_trim_both_from_no_char` - Explicit BOTH
- `test_trim_leading_from_no_char` - Leading spaces only
- `test_trim_trailing_from_no_char` - Trailing spaces only
- `test_trim_from_only_spaces` - Empty result
- `test_trim_from_empty_string` - Empty input
- `test_trim_from_no_spaces` - No-op case
- `test_trim_with_char_still_works` - Regression test

All tests pass ✅

## SQL:1999 Conformance Impact

**Tests Now Passing**:
- `e021_09_01_04`: `SELECT TRIM(BOTH FROM 'foo')`
- `e021_09_01_05`: `SELECT TRIM(FROM 'foo')`
- `e021_09_01_07`: `SELECT TRIM(LEADING FROM 'foo')`
- `e021_09_01_09`: `SELECT TRIM(TRAILING FROM 'foo')`

**Expected Conformance**: +4 tests → **87.0%** (644/739)

## Implementation Details

### Root Cause
The parser always attempted to parse an expression after position keywords, causing a parse error when FROM appeared immediately.

### Solution
Added a check at `functions.rs:107-119` to detect FROM keyword before attempting expression parsing. When found, sets `removal_char = None` (which the executor already handles correctly as defaulting to space).

### Backward Compatibility
✅ All existing TRIM variants continue to work:
- `TRIM('foo')` - implicit both sides, space
- `TRIM('x' FROM 'xfoox')` - both sides with char
- `TRIM(BOTH 'x' FROM 'xfoox')` - explicit both with char
- `TRIM(LEADING 'x' FROM 'xfoo')` - leading with char
- `TRIM(TRAILING 'x' FROM 'foox')` - trailing with char

## Testing
```bash
# Run parser tests
cargo test --package parser string_functions::test_trim

# Run executor tests  
cargo test --test test_string_functions

# Run conformance verification (in CI)
cargo test --test sqltest_conformance
```

## Related Issues
Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>