### PR TITLE
fix: Remove duplicate pattern matches for DEFAULT and TRIM

### DIFF
--- a/crates/executor/src/evaluator/combined/eval.rs
+++ b/crates/executor/src/evaluator/combined/eval.rs
@@ -170,21 +170,6 @@ impl<'a> CombinedExpressionEvaluator<'a> {
                 }
             }
 
-            // TRIM expression - handle position and custom removal character
-            ast::Expression::Trim { position, removal_char, string } => {
-                let string_val = self.eval(string, row)?;
-                let removal_val = if let Some(removal) = removal_char {
-                    Some(self.eval(removal, row)?)
-                } else {
-                    None
-                };
-                super::super::functions::string::trim_advanced(
-                    string_val,
-                    position.clone(),
-                    removal_val,
-                )
-            }
-
             // Unsupported expressions
             _ => Err(ExecutorError::UnsupportedExpression(format!("{:?}", expr))),
         }

--- a/crates/executor/src/evaluator/expressions/eval.rs
+++ b/crates/executor/src/evaluator/expressions/eval.rs
@@ -124,10 +124,6 @@ impl<'a> ExpressionEvaluator<'a> {
             ast::Expression::AggregateFunction { .. } => Err(ExecutorError::UnsupportedExpression(
                 "Aggregate functions should be evaluated in aggregation context".to_string(),
             )),
-
-            ast::Expression::Default => Err(ExecutorError::UnsupportedExpression(
-                "DEFAULT keyword is only valid in INSERT and UPDATE statements".to_string(),
-            )),
         }
     }
 

--- a/crates/executor/src/select/executor/utils.rs
+++ b/crates/executor/src/select/executor/utils.rs
@@ -104,7 +104,6 @@ impl<'a> SelectExecutor<'a> {
             ast::Expression::CurrentDate => false,
             ast::Expression::CurrentTime { .. } => false,
             ast::Expression::CurrentTimestamp { .. } => false,
-            ast::Expression::Default => false, // DEFAULT keyword doesn't reference columns
         }
     }
 }

--- a/crates/parser/src/parser/expressions/special_forms.rs
+++ b/crates/parser/src/parser/expressions/special_forms.rs
@@ -196,11 +196,6 @@ impl Parser {
                     }))
                 }
             }
-            // DEFAULT keyword - represents default value
-            Token::Keyword(Keyword::Default) => {
-                self.advance(); // consume DEFAULT
-                Ok(Some(ast::Expression::Default))
-            }
             _ => Ok(None),
         }
     }


### PR DESCRIPTION
## Summary
This PR fixes compiler warnings caused by duplicate pattern matches for DEFAULT and TRIM expressions that were causing unreachable code warnings.

## Context
While investigating issue #464 (Support DEFAULT keyword in INSERT and UPDATE statements), I discovered that the DEFAULT keyword support **already exists and is fully functional** in the codebase. However, there were duplicate pattern matches causing compiler warnings.

## Changes
- **Parser** (`crates/parser/src/parser/expressions/special_forms.rs`): Remove duplicate DEFAULT pattern match (lines 200-203)
- **Executor** (`crates/executor/src/evaluator/expressions/eval.rs`): Remove duplicate DEFAULT pattern match (lines 128-130)
- **Executor** (`crates/executor/src/evaluator/combined/eval.rs`): Remove duplicate TRIM pattern match (lines 174-186)
- **Executor** (`crates/executor/src/select/executor/utils.rs`): Remove duplicate DEFAULT pattern match (line 107)

## Test Coverage
All existing tests pass:
- ✅ Parser tests: 7 DEFAULT-related tests passing
- ✅ INSERT DEFAULT tests: 4 tests passing
- ✅ UPDATE DEFAULT tests: 2 tests passing

## Impact
- Eliminates 4 compiler warnings about unreachable patterns
- No functional changes - DEFAULT keyword continues to work as before
- Improves code clarity by removing redundant code

Closes #464