### PR TITLE
Address remaining clippy warnings: Achieve zero warnings

### DIFF
--- a/crates/executor/src/evaluator/expressions/operators.rs
+++ b/crates/executor/src/evaluator/expressions/operators.rs
@@ -34,7 +34,11 @@ pub(crate) fn eval_unary_op(
         (Minus, SqlValue::Double(n)) => Ok(SqlValue::Double(-n)),
         (Minus, SqlValue::Numeric(s)) => {
             // Negate numeric string: if starts with -, remove it; otherwise add -
-            let negated = if s.starts_with('-') { s[1..].to_string() } else { format!("-{}", s) };
+            let negated = if let Some(stripped) = s.strip_prefix('-') {
+                stripped.to_string()
+            } else {
+                format!("-{}", s)
+            };
             Ok(SqlValue::Numeric(negated))
         }
 

--- a/crates/executor/src/evaluator/functions/numeric/basic.rs
+++ b/crates/executor/src/evaluator/functions/numeric/basic.rs
@@ -43,22 +43,18 @@ pub fn sign(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     match &args[0] {
         SqlValue::Null => Ok(SqlValue::Null),
         SqlValue::Integer(n) => {
-            let sign = if *n < 0 {
-                -1
-            } else if *n > 0 {
-                1
-            } else {
-                0
+            let sign = match n.cmp(&0) {
+                std::cmp::Ordering::Less => -1,
+                std::cmp::Ordering::Greater => 1,
+                std::cmp::Ordering::Equal => 0,
             };
             Ok(SqlValue::Integer(sign))
         }
         SqlValue::Bigint(n) => {
-            let sign = if *n < 0 {
-                -1
-            } else if *n > 0 {
-                1
-            } else {
-                0
+            let sign = match n.cmp(&0) {
+                std::cmp::Ordering::Less => -1,
+                std::cmp::Ordering::Greater => 1,
+                std::cmp::Ordering::Equal => 0,
             };
             Ok(SqlValue::Bigint(sign))
         }

--- a/crates/executor/src/evaluator/functions/numeric/decimal.rs
+++ b/crates/executor/src/evaluator/functions/numeric/decimal.rs
@@ -71,9 +71,8 @@ fn format_number(n: f64, decimals: usize) -> String {
     let decimal_part = if parts.len() > 1 { parts[1] } else { "" };
 
     // Add thousand separators to integer part
-    let with_commas = if integer_part.starts_with('-') {
+    let with_commas = if let Some(positive_part) = integer_part.strip_prefix('-') {
         // Handle negative numbers
-        let positive_part = &integer_part[1..];
         let formatted_positive = add_thousand_separators(positive_part);
         format!("-{}", formatted_positive)
     } else {

--- a/crates/executor/src/evaluator/tests.rs
+++ b/crates/executor/src/evaluator/tests.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod tests {
+mod evaluator_tests {
     use super::super::ExpressionEvaluator;
     use crate::errors::ExecutorError;
     use catalog::{ColumnSchema, TableSchema};

--- a/crates/executor/src/schema.rs
+++ b/crates/executor/src/schema.rs
@@ -2,17 +2,17 @@ use std::collections::HashMap;
 
 /// Represents the combined schema from multiple tables (for JOINs)
 #[derive(Debug, Clone)]
-pub(crate) struct CombinedSchema {
+pub struct CombinedSchema {
     /// Map from table name to (start_index, TableSchema)
     /// start_index is where this table's columns begin in the combined row
-    pub(crate) table_schemas: HashMap<String, (usize, catalog::TableSchema)>,
+    pub table_schemas: HashMap<String, (usize, catalog::TableSchema)>,
     /// Total number of columns across all tables
-    pub(crate) total_columns: usize,
+    pub total_columns: usize,
 }
 
 impl CombinedSchema {
     /// Create a new combined schema from a single table
-    pub(crate) fn from_table(table_name: String, schema: catalog::TableSchema) -> Self {
+    pub fn from_table(table_name: String, schema: catalog::TableSchema) -> Self {
         let total_columns = schema.columns.len();
         let mut table_schemas = HashMap::new();
         table_schemas.insert(table_name, (0, schema));
@@ -20,7 +20,7 @@ impl CombinedSchema {
     }
 
     /// Create a new combined schema from a derived table (subquery result)
-    pub(crate) fn from_derived_table(
+    pub fn from_derived_table(
         alias: String,
         column_names: Vec<String>,
         column_types: Vec<types::DataType>,
@@ -53,7 +53,7 @@ impl CombinedSchema {
     }
 
     /// Combine two schemas (for JOIN operations)
-    pub(crate) fn combine(
+    pub fn combine(
         left: CombinedSchema,
         right_table: String,
         right_schema: catalog::TableSchema,
@@ -66,7 +66,7 @@ impl CombinedSchema {
     }
 
     /// Look up a column by name (optionally qualified with table name)
-    pub(crate) fn get_column_index(&self, table: Option<&str>, column: &str) -> Option<usize> {
+    pub fn get_column_index(&self, table: Option<&str>, column: &str) -> Option<usize> {
         if let Some(table_name) = table {
             // Qualified column reference (table.column)
             if let Some((start_index, schema)) = self.table_schemas.get(table_name) {

--- a/crates/executor/src/select/executor/aggregation/evaluation.rs
+++ b/crates/executor/src/select/executor/aggregation/evaluation.rs
@@ -220,6 +220,7 @@ impl SelectExecutor<'_> {
     }
 
     /// Evaluate quantified comparison (ALL/ANY/SOME) with subquery in aggregate context
+    #[allow(clippy::too_many_arguments)]
     pub(in crate::select::executor) fn evaluate_quantified_comparison_with_aggregates(
         &self,
         left_expr: &ast::Expression,

--- a/crates/executor/src/select/executor/columns.rs
+++ b/crates/executor/src/select/executor/columns.rs
@@ -57,62 +57,67 @@ impl SelectExecutor<'_> {
 
     /// Derive a column name from an expression
     pub(super) fn derive_expression_name(&self, expr: &ast::Expression) -> String {
-        match expr {
-            ast::Expression::ColumnRef { table: _, column } => column.clone(),
-            ast::Expression::Function { name, args, character_unit: _ } => {
-                // For functions, use name(args) format
-                let args_str = if args.is_empty() {
-                    "*".to_string()
-                } else {
-                    args.iter()
-                        .map(|arg| self.derive_expression_name(arg))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                };
-                format!("{}({})", name, args_str)
-            }
-            ast::Expression::AggregateFunction { name, distinct, args } => {
-                // For aggregate functions, use name(DISTINCT args) format
-                let distinct_str = if *distinct { "DISTINCT " } else { "" };
-                let args_str = if args.is_empty() {
-                    "*".to_string()
-                } else {
-                    args.iter()
-                        .map(|arg| self.derive_expression_name(arg))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                };
-                format!("{}({}{})", name, distinct_str, args_str)
-            }
-            ast::Expression::BinaryOp { left, op, right } => {
-                // For binary operations, create descriptive name
-                format!(
-                    "({} {} {})",
-                    self.derive_expression_name(left),
-                    match op {
-                        ast::BinaryOperator::Plus => "+",
-                        ast::BinaryOperator::Minus => "-",
-                        ast::BinaryOperator::Multiply => "*",
-                        ast::BinaryOperator::Divide => "/",
-                        ast::BinaryOperator::Equal => "=",
-                        ast::BinaryOperator::NotEqual => "!=",
-                        ast::BinaryOperator::LessThan => "<",
-                        ast::BinaryOperator::LessThanOrEqual => "<=",
-                        ast::BinaryOperator::GreaterThan => ">",
-                        ast::BinaryOperator::GreaterThanOrEqual => ">=",
-                        ast::BinaryOperator::And => "AND",
-                        ast::BinaryOperator::Or => "OR",
-                        ast::BinaryOperator::Concat => "||",
-                        _ => "?",
-                    },
-                    self.derive_expression_name(right)
-                )
-            }
-            ast::Expression::Literal(val) => {
-                // For literals, use the value representation
-                format!("{:?}", val)
-            }
-            _ => "?column?".to_string(), // Default for other expression types
+        derive_expression_name_impl(expr)
+    }
+}
+
+/// Helper function to derive a column name from an expression
+fn derive_expression_name_impl(expr: &ast::Expression) -> String {
+    match expr {
+        ast::Expression::ColumnRef { table: _, column } => column.clone(),
+        ast::Expression::Function { name, args, character_unit: _ } => {
+            // For functions, use name(args) format
+            let args_str = if args.is_empty() {
+                "*".to_string()
+            } else {
+                args.iter()
+                    .map(derive_expression_name_impl)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            format!("{}({})", name, args_str)
         }
+        ast::Expression::AggregateFunction { name, distinct, args } => {
+            // For aggregate functions, use name(DISTINCT args) format
+            let distinct_str = if *distinct { "DISTINCT " } else { "" };
+            let args_str = if args.is_empty() {
+                "*".to_string()
+            } else {
+                args.iter()
+                    .map(derive_expression_name_impl)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            format!("{}({}{})", name, distinct_str, args_str)
+        }
+        ast::Expression::BinaryOp { left, op, right } => {
+            // For binary operations, create descriptive name
+            format!(
+                "({} {} {})",
+                derive_expression_name_impl(left),
+                match op {
+                    ast::BinaryOperator::Plus => "+",
+                    ast::BinaryOperator::Minus => "-",
+                    ast::BinaryOperator::Multiply => "*",
+                    ast::BinaryOperator::Divide => "/",
+                    ast::BinaryOperator::Equal => "=",
+                    ast::BinaryOperator::NotEqual => "!=",
+                    ast::BinaryOperator::LessThan => "<",
+                    ast::BinaryOperator::LessThanOrEqual => "<=",
+                    ast::BinaryOperator::GreaterThan => ">",
+                    ast::BinaryOperator::GreaterThanOrEqual => ">=",
+                    ast::BinaryOperator::And => "AND",
+                    ast::BinaryOperator::Or => "OR",
+                    ast::BinaryOperator::Concat => "||",
+                    _ => "?",
+                },
+                derive_expression_name_impl(right)
+            )
+        }
+        ast::Expression::Literal(val) => {
+            // For literals, use the value representation
+            format!("{:?}", val)
+        }
+        _ => "?column?".to_string(), // Default for other expression types
     }
 }

--- a/crates/executor/src/select/executor/utils.rs
+++ b/crates/executor/src/select/executor/utils.rs
@@ -2,108 +2,113 @@
 
 use super::builder::SelectExecutor;
 
+/// Check if an expression references a column (which requires FROM clause)
+fn expression_references_column(expr: &ast::Expression) -> bool {
+    match expr {
+        ast::Expression::ColumnRef { .. } => true,
+        ast::Expression::Default => false, // DEFAULT doesn't reference columns
+
+        ast::Expression::BinaryOp { left, right, .. } => {
+            expression_references_column(left) || expression_references_column(right)
+        }
+
+        ast::Expression::UnaryOp { expr, .. } => expression_references_column(expr),
+
+        ast::Expression::Function { args, .. } => {
+            args.iter().any(expression_references_column)
+        }
+
+        ast::Expression::AggregateFunction { args, .. } => {
+            args.iter().any(expression_references_column)
+        }
+
+        ast::Expression::IsNull { expr, .. } => expression_references_column(expr),
+
+        ast::Expression::InList { expr, values, .. } => {
+            expression_references_column(expr)
+                || values.iter().any(expression_references_column)
+        }
+
+        ast::Expression::Between { expr, low, high, .. } => {
+            expression_references_column(expr)
+                || expression_references_column(low)
+                || expression_references_column(high)
+        }
+
+        ast::Expression::Cast { expr, .. } => expression_references_column(expr),
+
+        ast::Expression::Position { substring, string, character_unit: _ } => {
+            expression_references_column(substring)
+                || expression_references_column(string)
+        }
+
+        ast::Expression::Trim { removal_char, string, .. } => {
+            removal_char.as_ref().is_some_and(|e| expression_references_column(e))
+                || expression_references_column(string)
+        }
+
+        ast::Expression::Like { expr, pattern, .. } => {
+            expression_references_column(expr)
+                || expression_references_column(pattern)
+        }
+
+        ast::Expression::In { expr, .. } => {
+            // Note: subquery could reference outer columns but that's a different case
+            expression_references_column(expr)
+        }
+
+        ast::Expression::QuantifiedComparison { expr, .. } => {
+            expression_references_column(expr)
+        }
+
+        ast::Expression::Case { operand, when_clauses, else_result } => {
+            operand.as_ref().is_some_and(|e| expression_references_column(e))
+                || when_clauses.iter().any(|when_clause| {
+                    when_clause
+                        .conditions
+                        .iter()
+                        .any(expression_references_column)
+                        || expression_references_column(&when_clause.result)
+                })
+                || else_result.as_ref().is_some_and(|e| expression_references_column(e))
+        }
+
+        ast::Expression::WindowFunction { function, over } => {
+            // Check window function arguments
+            let args_reference_column = match function {
+                ast::WindowFunctionSpec::Aggregate { args, .. }
+                | ast::WindowFunctionSpec::Ranking { args, .. }
+                | ast::WindowFunctionSpec::Value { args, .. } => {
+                    args.iter().any(expression_references_column)
+                }
+            };
+
+            // Check PARTITION BY and ORDER BY clauses
+            let partition_references = over.partition_by.as_ref().is_some_and(|exprs| {
+                exprs.iter().any(expression_references_column)
+            });
+
+            let order_references = over.order_by.as_ref().is_some_and(|items| {
+                items.iter().any(|item| expression_references_column(&item.expr))
+            });
+
+            args_reference_column || partition_references || order_references
+        }
+
+        // These don't contain column references:
+        ast::Expression::Literal(_) => false,
+        ast::Expression::Wildcard => false,
+        ast::Expression::ScalarSubquery(_) => false, // Subquery has its own scope
+        ast::Expression::Exists { .. } => false,     // Subquery has its own scope
+        ast::Expression::CurrentDate => false,
+        ast::Expression::CurrentTime { .. } => false,
+        ast::Expression::CurrentTimestamp { .. } => false,
+    }
+}
+
 impl SelectExecutor<'_> {
     /// Check if an expression references a column (which requires FROM clause)
     pub(super) fn expression_references_column(&self, expr: &ast::Expression) -> bool {
-        match expr {
-            ast::Expression::ColumnRef { .. } => true,
-            ast::Expression::Default => false, // DEFAULT doesn't reference columns
-
-            ast::Expression::BinaryOp { left, right, .. } => {
-                self.expression_references_column(left) || self.expression_references_column(right)
-            }
-
-            ast::Expression::UnaryOp { expr, .. } => self.expression_references_column(expr),
-
-            ast::Expression::Function { args, .. } => {
-                args.iter().any(|arg| self.expression_references_column(arg))
-            }
-
-            ast::Expression::AggregateFunction { args, .. } => {
-                args.iter().any(|arg| self.expression_references_column(arg))
-            }
-
-            ast::Expression::IsNull { expr, .. } => self.expression_references_column(expr),
-
-            ast::Expression::InList { expr, values, .. } => {
-                self.expression_references_column(expr)
-                    || values.iter().any(|v| self.expression_references_column(v))
-            }
-
-            ast::Expression::Between { expr, low, high, .. } => {
-                self.expression_references_column(expr)
-                    || self.expression_references_column(low)
-                    || self.expression_references_column(high)
-            }
-
-            ast::Expression::Cast { expr, .. } => self.expression_references_column(expr),
-
-            ast::Expression::Position { substring, string, character_unit: _ } => {
-                self.expression_references_column(substring)
-                    || self.expression_references_column(string)
-            }
-
-            ast::Expression::Trim { removal_char, string, .. } => {
-                removal_char.as_ref().is_some_and(|e| self.expression_references_column(e))
-                    || self.expression_references_column(string)
-            }
-
-            ast::Expression::Like { expr, pattern, .. } => {
-                self.expression_references_column(expr)
-                    || self.expression_references_column(pattern)
-            }
-
-            ast::Expression::In { expr, .. } => {
-                // Note: subquery could reference outer columns but that's a different case
-                self.expression_references_column(expr)
-            }
-
-            ast::Expression::QuantifiedComparison { expr, .. } => {
-                self.expression_references_column(expr)
-            }
-
-            ast::Expression::Case { operand, when_clauses, else_result } => {
-                operand.as_ref().is_some_and(|e| self.expression_references_column(e))
-                    || when_clauses.iter().any(|when_clause| {
-                        when_clause
-                            .conditions
-                            .iter()
-                            .any(|cond| self.expression_references_column(cond))
-                            || self.expression_references_column(&when_clause.result)
-                    })
-                    || else_result.as_ref().is_some_and(|e| self.expression_references_column(e))
-            }
-
-            ast::Expression::WindowFunction { function, over } => {
-                // Check window function arguments
-                let args_reference_column = match function {
-                    ast::WindowFunctionSpec::Aggregate { args, .. }
-                    | ast::WindowFunctionSpec::Ranking { args, .. }
-                    | ast::WindowFunctionSpec::Value { args, .. } => {
-                        args.iter().any(|arg| self.expression_references_column(arg))
-                    }
-                };
-
-                // Check PARTITION BY and ORDER BY clauses
-                let partition_references = over.partition_by.as_ref().is_some_and(|exprs| {
-                    exprs.iter().any(|e| self.expression_references_column(e))
-                });
-
-                let order_references = over.order_by.as_ref().is_some_and(|items| {
-                    items.iter().any(|item| self.expression_references_column(&item.expr))
-                });
-
-                args_reference_column || partition_references || order_references
-            }
-
-            // These don't contain column references:
-            ast::Expression::Literal(_) => false,
-            ast::Expression::Wildcard => false,
-            ast::Expression::ScalarSubquery(_) => false, // Subquery has its own scope
-            ast::Expression::Exists { .. } => false,     // Subquery has its own scope
-            ast::Expression::CurrentDate => false,
-            ast::Expression::CurrentTime { .. } => false,
-            ast::Expression::CurrentTimestamp { .. } => false,
-        }
+        expression_references_column(expr)
     }
 }

--- a/crates/executor/src/select/window/evaluation.rs
+++ b/crates/executor/src/select/window/evaluation.rs
@@ -118,9 +118,8 @@ fn evaluate_window_function_for_partition(
                     "COUNT" => {
                         // COUNT(*) or COUNT(expr)
                         // Check if arg is the special "*" column reference
-                        let arg_expr = if args.is_empty() {
-                            None
-                        } else if matches!(&args[0], Expression::ColumnRef { column, .. } if column == "*")
+                        let arg_expr = if args.is_empty()
+                            || matches!(&args[0], Expression::ColumnRef { column, .. } if column == "*")
                         {
                             None // COUNT(*) should count all rows
                         } else {

--- a/crates/executor/tests/advanced_function_tests.rs
+++ b/crates/executor/tests/advanced_function_tests.rs
@@ -1,5 +1,8 @@
 //! Tests for advanced scalar functions (math, trigonometry, and conditional functions)
 
+// Allow approximate constants in tests - these are test data values, not mathematical constants
+#![allow(clippy::approx_constant)]
+
 mod common;
 
 use common::create_test_evaluator;

--- a/crates/executor/tests/foreign_key_tests.rs
+++ b/crates/executor/tests/foreign_key_tests.rs
@@ -23,5 +23,5 @@ fn test_foreign_key_enforcement_exists() {
     "#;
 
     // This is a basic smoke test - if we get here, the basic FK infrastructure is working
-    assert!(true);
+    // No assertion needed - test passes if no error occurs
 }

--- a/crates/executor/tests/scalar_function_tests.rs
+++ b/crates/executor/tests/scalar_function_tests.rs
@@ -1,5 +1,8 @@
 //! Tests for new scalar functions (numeric and string functions)
 
+// Allow approximate constants in tests - these are test data values, not mathematical constants
+#![allow(clippy::approx_constant)]
+
 mod common;
 
 use common::create_test_evaluator;

--- a/crates/executor/tests/update_constraint_tests.rs
+++ b/crates/executor/tests/update_constraint_tests.rs
@@ -1,7 +1,6 @@
 mod common;
 
 use ast::{Assignment, BinaryOperator, Expression, UpdateStmt};
-use catalog::{ColumnSchema, TableSchema};
 use common::setup_test_table;
 use executor::{ExecutorError, UpdateExecutor};
 use storage::{Database, Row};

--- a/crates/storage/src/database.rs
+++ b/crates/storage/src/database.rs
@@ -23,6 +23,7 @@ pub struct Savepoint {
 
 /// Transaction state
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum TransactionState {
     /// No active transaction
     None,

--- a/crates/wasm-bindings/src/tests.rs
+++ b/crates/wasm-bindings/src/tests.rs
@@ -1,7 +1,7 @@
 //! Test utilities and validation tests for WASM bindings
 
 #[cfg(test)]
-mod tests {
+mod wasm_tests {
     use super::super::*;
 
     #[test]
@@ -138,8 +138,8 @@ mod tests {
 
                     // Look for database (within next 5 lines)
                     let mut database = String::new();
-                    for j in (i + 1)..(i + 6).min(lines.len()) {
-                        if let Some(db_line) = lines[j].strip_prefix("        database: '") {
+                    for line in lines.iter().skip(i + 1).take(5) {
+                        if let Some(db_line) = line.strip_prefix("        database: '") {
                             if let Some(db_end) = db_line.find("'") {
                                 database = db_line[..db_end].to_string();
                                 break;

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -2,6 +2,9 @@
 //!
 //! These tests exercise the full pipeline: parse SQL → execute → verify results.
 
+// Allow approximate constants in tests - these are test data values, not mathematical constants
+#![allow(clippy::approx_constant)]
+
 use catalog::{ColumnSchema, TableSchema};
 use executor::SelectExecutor;
 use parser::Parser;

--- a/tests/sqltest_conformance.rs
+++ b/tests/sqltest_conformance.rs
@@ -33,11 +33,11 @@ impl Default for SqlField {
     }
 }
 
-impl SqlField {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for SqlField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SqlField::Single(s) => s.clone(),
-            SqlField::Multiple(v) => v.join("; "),
+            SqlField::Single(s) => write!(f, "{}", s),
+            SqlField::Multiple(v) => write!(f, "{}", v.join("; ")),
         }
     }
 }


### PR DESCRIPTION
## Summary

Completes the clippy warning cleanup started in PR #496 by addressing all remaining ~17 warnings. The codebase now passes `cargo clippy --workspace --all-targets --all-features -- -D warnings` with zero warnings.

## Changes

### Architectural Decisions (Per User Guidance)

**1. Made CombinedSchema fully public**
- Changed visibility from `pub(crate)` to `pub`
- Resolves private_interfaces warning
- File: `crates/executor/src/schema.rs`
- Rationale: Type is exposed in public API, should be usable externally

**2. Accepted too_many_arguments**
- Added `#[allow(clippy::too_many_arguments)]` 
- File: `crates/executor/src/select/executor/aggregation/evaluation.rs:223`
- Rationale: Function complexity is intentional for aggregation logic

**3. Accepted large_enum_variant**
- Added `#[allow(clippy::large_enum_variant)]`
- File: `crates/storage/src/database.rs`
- Rationale: Performance optimization deferred; can revisit if issues arise

### Quick Wins Fixed (14 Warnings)

**Code Quality Improvements:**
- **Manual string stripping** (2 fixes): Used `strip_prefix()` instead of manual slicing
- **Comparison chains** (2 fixes): Refactored to use `match` with `Ordering::cmp`
- **Match vs matches!** (1 fix): Converted verbose match to `matches!` macro
- **Useless drop** (1 fix): Removed unnecessary `drop()` call
- **Identical if blocks** (1 fix): Simplified duplicate conditional logic
- **Recursive parameters** (2 fixes): Extracted helper functions for clarity

**Test-Only Fixes:**
- **Module inception** (2 fixes): Renamed inner test modules to avoid name conflicts
- **Loop variable indexing** (1 fix): Used `.iter().skip().take()` for cleaner code
- **Assert true** (1 fix): Removed meaningless assertion
- **Regex in loop** (1 fix): Moved compilation outside loop for performance
- **Unused field** (1 fix): Added `#[allow(dead_code)]` for test-only field
- **Custom to_string** (1 fix): Implemented proper `Display` trait
- **Unused imports** (1 fix): Removed unused imports (auto-fixed)

**Mathematical Constants:**
- Added `#[allow(clippy::approx_constant)]` to test files using π and e approximations
- Files: `tests/end_to_end.rs`, `crates/executor/tests/advanced_function_tests.rs`, `crates/executor/tests/scalar_function_tests.rs`

## Test Results

✅ Clippy passes with `-D warnings` (zero warnings)  
✅ All 500+ workspace tests passing  
✅ No functional changes or regressions  
✅ Build succeeds across all targets

## Impact

- **100% warning reduction**: 17 → 0 warnings
- Codebase now enforces zero-warning policy with `-D warnings`
- Improved code quality and maintainability
- Better developer experience
- No breaking changes to public API

## Files Modified

19 files changed:
- 4 architectural decision files (schema, aggregation, database)
- 10 code quality improvement files
- 5 test-only files

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>