### PR TITLE
feat: GRANT Phase 2.2 - Multiple privileges and grantees

### DIFF
--- a/crates/parser/src/parser/grant.rs
+++ b/crates/parser/src/parser/grant.rs
@@ -2,22 +2,22 @@
 
 use crate::keywords::Keyword;
 use crate::parser::ParseError;
+use crate::token::Token;
 use ast::*;
 
 /// Parse GRANT statement
 ///
-/// Phase 2.1: Only supports GRANT SELECT ON TABLE table_name TO role_name
+/// Phase 2.2: Supports multiple privileges and grantees
 ///
 /// Grammar:
 /// ```text
-/// GRANT SELECT ON TABLE table_name TO grantee
+/// GRANT privilege_list ON TABLE table_name TO grantee_list
 /// ```
 pub fn parse_grant(parser: &mut crate::Parser) -> Result<GrantStmt, ParseError> {
     parser.expect_keyword(Keyword::Grant)?;
 
-    // For Phase 2.1: Only handle SELECT
-    parser.expect_keyword(Keyword::Select)?;
-    let privileges = vec![PrivilegeType::Select];
+    // Parse comma-separated privilege list
+    let privileges = parse_privilege_list(parser)?;
 
     parser.expect_keyword(Keyword::On)?;
     parser.expect_keyword(Keyword::Table)?;
@@ -26,13 +26,80 @@ pub fn parse_grant(parser: &mut crate::Parser) -> Result<GrantStmt, ParseError> 
     let object_name = parser.parse_qualified_identifier()?;
 
     parser.expect_keyword(Keyword::To)?;
-    let grantee = parser.parse_identifier()?;
+
+    // Parse comma-separated grantee list
+    let grantees = parse_identifier_list(parser)?;
 
     Ok(GrantStmt {
         privileges,
         object_type: ObjectType::Table,
         object_name,
-        grantees: vec![grantee],
+        grantees,
         with_grant_option: false,
     })
+}
+
+/// Parse a comma-separated list of privileges
+///
+/// Supports: SELECT, INSERT, UPDATE, DELETE
+fn parse_privilege_list(parser: &mut crate::Parser) -> Result<Vec<PrivilegeType>, ParseError> {
+    let mut privileges = vec![];
+
+    loop {
+        let priv_type = match parser.peek() {
+            Token::Keyword(Keyword::Select) => {
+                parser.advance();
+                PrivilegeType::Select
+            }
+            Token::Keyword(Keyword::Insert) => {
+                parser.advance();
+                PrivilegeType::Insert
+            }
+            Token::Keyword(Keyword::Update) => {
+                parser.advance();
+                PrivilegeType::Update
+            }
+            Token::Keyword(Keyword::Delete) => {
+                parser.advance();
+                PrivilegeType::Delete
+            }
+            _ => {
+                return Err(ParseError {
+                    message: format!(
+                        "Expected privilege keyword (SELECT, INSERT, UPDATE, DELETE), found {:?}",
+                        parser.peek()
+                    ),
+                })
+            }
+        };
+
+        privileges.push(priv_type);
+
+        // Check for comma indicating more privileges
+        if parser.peek() == &Token::Comma {
+            parser.advance(); // consume comma
+        } else {
+            break;
+        }
+    }
+
+    Ok(privileges)
+}
+
+/// Parse a comma-separated list of identifiers
+fn parse_identifier_list(parser: &mut crate::Parser) -> Result<Vec<String>, ParseError> {
+    let mut identifiers = vec![];
+
+    loop {
+        identifiers.push(parser.parse_identifier()?);
+
+        // Check for comma indicating more identifiers
+        if parser.peek() == &Token::Comma {
+            parser.advance(); // consume comma
+        } else {
+            break;
+        }
+    }
+
+    Ok(identifiers)
 }


### PR DESCRIPTION
## Summary
Implements GRANT Phase 2.2, extending the GRANT statement to support comma-separated lists of privileges and grantees. This enables flexible privilege assignment patterns like granting multiple privileges to multiple roles in a single statement.

## Changes
### Parser Updates (`crates/parser/src/parser/grant.rs`)
- Added `parse_privilege_list()` helper function
  - Parses comma-separated privilege keywords (SELECT, INSERT, UPDATE, DELETE)
  - Returns `Vec<PrivilegeType>`
- Added `parse_identifier_list()` helper function
  - Parses comma-separated identifiers (role names)
  - Returns `Vec<String>`
- Updated `parse_grant()` to use new helper functions

### Test Coverage
**Parser Tests** (`crates/parser/src/tests/grant.rs`):
- ✅ `test_parse_grant_multiple_privileges` - 3 privileges to 1 grantee
- ✅ `test_parse_grant_all_privilege_types` - All 4 privilege types
- ✅ `test_parse_grant_multiple_grantees` - 1 privilege to 3 grantees
- ✅ `test_parse_grant_multiple_privileges_and_grantees` - Matrix case (2×2)

**Executor Tests** (`crates/executor/tests/grant_tests.rs`):
- ✅ `test_grant_multiple_privileges` - Verifies all 3 privileges stored
- ✅ `test_grant_all_four_privilege_types` - Verifies all 4 privilege types
- ✅ `test_grant_matrix_multiple_privileges_and_grantees` - Matrix verification (2 privileges × 2 grantees = 4 grants)

## Examples
```sql
-- Multiple privileges to single grantee
GRANT SELECT, INSERT, UPDATE ON TABLE users TO manager;

-- Single privilege to multiple grantees
GRANT SELECT ON TABLE users TO role1, role2, role3;

-- Multiple privileges to multiple grantees (matrix expansion)
GRANT SELECT, INSERT ON TABLE products TO r1, r2;
-- Creates 4 grant records: (r1,SELECT), (r1,INSERT), (r2,SELECT), (r2,INSERT)
```

## Test Results
All tests passing:
- 7 parser tests ✅
- 7 executor tests ✅
- Full GRANT test suite: **14/14 passing**

## Dependencies
- ✅ #484 (GRANT Phase 2.1) - Merged

## Next Steps
After this PR is merged, proceed to Phase 2.3 (#486) to add ALL PRIVILEGES support.

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)