### PR TITLE
GRANT Phase 2.4: WITH GRANT OPTION support

### DIFF
--- a/crates/executor/tests/grant_tests.rs
+++ b/crates/executor/tests/grant_tests.rs
@@ -409,3 +409,146 @@ fn test_grant_all_privileges_to_multiple_grantees() {
         "Clerk should have REFERENCES"
     );
 }
+
+#[test]
+fn test_grant_with_grant_option_stored_in_catalog() {
+    let mut db = Database::new();
+
+    // Create a test table
+    let schema = TableSchema::new(
+        "users".to_string(),
+        vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+    );
+    db.create_table(schema).unwrap();
+
+    // Grant SELECT privilege WITH GRANT OPTION
+    let grant_stmt = ast::GrantStmt {
+        privileges: vec![ast::PrivilegeType::Select],
+        object_type: ast::ObjectType::Table,
+        object_name: "users".to_string(),
+        grantees: vec!["manager".to_string()],
+        with_grant_option: true,
+    };
+
+    let result = GrantExecutor::execute_grant(&grant_stmt, &mut db);
+    assert!(result.is_ok(), "Failed to execute GRANT: {:?}", result.err());
+
+    // Verify the with_grant_option flag was stored correctly
+    let grants = db.catalog.get_grants_for_grantee("manager");
+    assert_eq!(grants.len(), 1, "Should have exactly one grant");
+    assert!(
+        grants[0].with_grant_option,
+        "with_grant_option should be true"
+    );
+}
+
+#[test]
+fn test_grant_without_grant_option_stored_in_catalog() {
+    let mut db = Database::new();
+
+    // Create a test table
+    let schema = TableSchema::new(
+        "users".to_string(),
+        vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+    );
+    db.create_table(schema).unwrap();
+
+    // Grant SELECT privilege WITHOUT GRANT OPTION
+    let grant_stmt = ast::GrantStmt {
+        privileges: vec![ast::PrivilegeType::Select],
+        object_type: ast::ObjectType::Table,
+        object_name: "users".to_string(),
+        grantees: vec!["clerk".to_string()],
+        with_grant_option: false,
+    };
+
+    let result = GrantExecutor::execute_grant(&grant_stmt, &mut db);
+    assert!(result.is_ok(), "Failed to execute GRANT: {:?}", result.err());
+
+    // Verify the with_grant_option flag was stored correctly
+    let grants = db.catalog.get_grants_for_grantee("clerk");
+    assert_eq!(grants.len(), 1, "Should have exactly one grant");
+    assert!(
+        !grants[0].with_grant_option,
+        "with_grant_option should be false"
+    );
+}
+
+#[test]
+fn test_grant_all_privileges_with_grant_option() {
+    let mut db = Database::new();
+
+    // Create a test table
+    let schema = TableSchema::new(
+        "products".to_string(),
+        vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+    );
+    db.create_table(schema).unwrap();
+
+    // Grant ALL PRIVILEGES WITH GRANT OPTION
+    let grant_stmt = ast::GrantStmt {
+        privileges: vec![ast::PrivilegeType::AllPrivileges],
+        object_type: ast::ObjectType::Table,
+        object_name: "products".to_string(),
+        grantees: vec!["admin".to_string()],
+        with_grant_option: true,
+    };
+
+    let result = GrantExecutor::execute_grant(&grant_stmt, &mut db);
+    assert!(result.is_ok(), "Failed to execute GRANT: {:?}", result.err());
+
+    // Verify all expanded privileges have with_grant_option = true
+    let grants = db.catalog.get_grants_for_grantee("admin");
+    assert_eq!(
+        grants.len(),
+        5,
+        "ALL PRIVILEGES should expand to 5 table privileges"
+    );
+
+    // All 5 grants should have with_grant_option = true
+    for grant in grants {
+        assert!(
+            grant.with_grant_option,
+            "All expanded privileges should have with_grant_option = true"
+        );
+    }
+}
+
+#[test]
+fn test_grant_multiple_grantees_with_grant_option() {
+    let mut db = Database::new();
+
+    // Create a test table
+    let schema = TableSchema::new(
+        "orders".to_string(),
+        vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+    );
+    db.create_table(schema).unwrap();
+
+    // Grant SELECT privilege to multiple grantees WITH GRANT OPTION
+    let grant_stmt = ast::GrantStmt {
+        privileges: vec![ast::PrivilegeType::Select],
+        object_type: ast::ObjectType::Table,
+        object_name: "orders".to_string(),
+        grantees: vec!["manager".to_string(), "clerk".to_string()],
+        with_grant_option: true,
+    };
+
+    let result = GrantExecutor::execute_grant(&grant_stmt, &mut db);
+    assert!(result.is_ok(), "Failed to execute GRANT: {:?}", result.err());
+
+    // Verify both grantees have with_grant_option = true
+    let manager_grants = db.catalog.get_grants_for_grantee("manager");
+    assert_eq!(manager_grants.len(), 1);
+    assert!(
+        manager_grants[0].with_grant_option,
+        "Manager's grant should have with_grant_option = true"
+    );
+
+    let clerk_grants = db.catalog.get_grants_for_grantee("clerk");
+    assert_eq!(clerk_grants.len(), 1);
+    assert!(
+        clerk_grants[0].with_grant_option,
+        "Clerk's grant should have with_grant_option = true"
+    );
+}

--- a/crates/parser/src/keywords.rs
+++ b/crates/parser/src/keywords.rs
@@ -122,6 +122,7 @@ pub enum Keyword {
     // GRANT keywords
     Grant,
     Privileges,
+    Option,
 }
 
 impl fmt::Display for Keyword {
@@ -231,6 +232,7 @@ impl fmt::Display for Keyword {
             Keyword::CurrentTimestamp => "CURRENT_TIMESTAMP",
             Keyword::Grant => "GRANT",
             Keyword::Privileges => "PRIVILEGES",
+            Keyword::Option => "OPTION",
         };
         write!(f, "{}", keyword_str)
     }

--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -262,6 +262,7 @@ impl Lexer {
             // GRANT keywords
             "GRANT" => Token::Keyword(Keyword::Grant),
             "PRIVILEGES" => Token::Keyword(Keyword::Privileges),
+            "OPTION" => Token::Keyword(Keyword::Option),
             // Role management keywords
             "ROLE" => Token::Keyword(Keyword::Role),
             _ => Token::Identifier(upper_text),  // Regular identifiers are normalized to uppercase

--- a/crates/parser/src/parser/grant.rs
+++ b/crates/parser/src/parser/grant.rs
@@ -7,11 +7,11 @@ use ast::*;
 
 /// Parse GRANT statement
 ///
-/// Phase 2.2: Supports multiple privileges and grantees
+/// Phase 2.4: Supports WITH GRANT OPTION
 ///
 /// Grammar:
 /// ```text
-/// GRANT privilege_list ON TABLE table_name TO grantee_list
+/// GRANT privilege_list ON TABLE table_name TO grantee_list [WITH GRANT OPTION]
 /// ```
 pub fn parse_grant(parser: &mut crate::Parser) -> Result<GrantStmt, ParseError> {
     parser.expect_keyword(Keyword::Grant)?;
@@ -30,12 +30,22 @@ pub fn parse_grant(parser: &mut crate::Parser) -> Result<GrantStmt, ParseError> 
     // Parse comma-separated grantee list
     let grantees = parse_identifier_list(parser)?;
 
+    // Parse optional WITH GRANT OPTION clause
+    let with_grant_option = if parser.peek() == &Token::Keyword(Keyword::With) {
+        parser.advance(); // consume WITH
+        parser.expect_keyword(Keyword::Grant)?;
+        parser.expect_keyword(Keyword::Option)?;
+        true
+    } else {
+        false
+    };
+
     Ok(GrantStmt {
         privileges,
         object_type: ObjectType::Table,
         object_name,
         grantees,
-        with_grant_option: false,
+        with_grant_option,
     })
 }
 

--- a/crates/parser/src/tests/grant.rs
+++ b/crates/parser/src/tests/grant.rs
@@ -173,3 +173,68 @@ fn test_parse_grant_all_case_insensitive() {
         other => panic!("Expected Grant statement, got {:?}", other),
     }
 }
+
+#[test]
+fn test_grant_with_grant_option() {
+    let sql = "GRANT SELECT ON TABLE users TO manager WITH GRANT OPTION";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        ast::Statement::Grant(grant_stmt) => {
+            assert_eq!(grant_stmt.privileges.len(), 1);
+            assert_eq!(grant_stmt.privileges[0], ast::PrivilegeType::Select);
+            assert_eq!(grant_stmt.object_name.to_string(), "USERS");
+            assert_eq!(grant_stmt.grantees, vec!["MANAGER"]);
+            assert!(grant_stmt.with_grant_option);
+        }
+        other => panic!("Expected Grant statement, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_grant_without_grant_option() {
+    let sql = "GRANT SELECT ON TABLE users TO manager";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        ast::Statement::Grant(grant_stmt) => {
+            assert_eq!(grant_stmt.privileges.len(), 1);
+            assert_eq!(grant_stmt.privileges[0], ast::PrivilegeType::Select);
+            assert_eq!(grant_stmt.object_name.to_string(), "USERS");
+            assert_eq!(grant_stmt.grantees, vec!["MANAGER"]);
+            assert!(!grant_stmt.with_grant_option);
+        }
+        other => panic!("Expected Grant statement, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_grant_with_grant_option_case_insensitive() {
+    let sql = "grant select on table users to manager with grant option";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        ast::Statement::Grant(grant_stmt) => {
+            assert!(grant_stmt.with_grant_option);
+        }
+        other => panic!("Expected Grant statement, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_grant_all_privileges_with_grant_option() {
+    let sql = "GRANT ALL PRIVILEGES ON TABLE users TO manager WITH GRANT OPTION";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        ast::Statement::Grant(grant_stmt) => {
+            assert_eq!(grant_stmt.privileges[0], ast::PrivilegeType::AllPrivileges);
+            assert!(grant_stmt.with_grant_option);
+        }
+        other => panic!("Expected Grant statement, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 2.4 of the GRANT statement evolution: `WITH GRANT OPTION` support.

This adds the ability to grant privileges with the option for grantees to re-grant those privileges to other roles, completing the SQL:1999 standard implementation for basic GRANT functionality.

### Changes Made

**Keywords & Lexer:**
- Added `Option` keyword to keywords.rs enum and Display trait
- Added `OPTION` token mapping in lexer.rs

**Parser:**
- Updated `parse_grant()` to parse optional `WITH GRANT OPTION` clause
- Updated grammar documentation to Phase 2.4
- Added 4 comprehensive parser tests covering:
  - WITH GRANT OPTION present (uppercase)
  - WITH GRANT OPTION absent (default false)
  - Case insensitive parsing
  - ALL PRIVILEGES with WITH GRANT OPTION

**Executor:**
- Added 4 executor tests verifying catalog storage:
  - with_grant_option flag stored correctly when true
  - with_grant_option flag stored correctly when false
  - ALL PRIVILEGES expansion preserves with_grant_option flag
  - Multiple grantees all receive with_grant_option flag

### Grammar

```sql
GRANT privilege_list ON TABLE table_name TO grantee_list [WITH GRANT OPTION]
```

**Examples:**
```sql
GRANT SELECT ON TABLE users TO manager WITH GRANT OPTION;
GRANT ALL PRIVILEGES ON TABLE orders TO admin WITH GRANT OPTION;
```

## Test Plan

- [x] All parser tests pass (14 tests including 4 new)
- [x] All executor tests pass (13 tests including 4 new)
- [x] Full workspace library tests pass (739 tests)
- [x] Verified `with_grant_option` flag correctly parsed and stored
- [x] Verified backward compatibility (statements without WITH GRANT OPTION still work)

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)