### PR TITLE
feat: Add USING clause support to CHARACTER_LENGTH and CHAR_LENGTH

### DIFF
--- a/crates/executor/src/evaluator/combined/eval.rs
+++ b/crates/executor/src/evaluator/combined/eval.rs
@@ -128,23 +128,23 @@ impl CombinedExpressionEvaluator<'_> {
             ast::Expression::IsNull { expr, negated } => self.eval_is_null(expr, *negated, row),
 
             // Function expressions - handle scalar functions (not aggregates)
-            ast::Expression::Function { name, args, character_unit: _ } => {
-                self.eval_function(name, args, row)
+            ast::Expression::Function { name, args, character_unit } => {
+                self.eval_function(name, args, character_unit, row)
             }
 
             // Current date/time functions
             ast::Expression::CurrentDate => {
-                super::super::functions::eval_scalar_function("CURRENT_DATE", &[])
+                super::super::functions::eval_scalar_function("CURRENT_DATE", &[], &None)
             }
             ast::Expression::CurrentTime { precision: _ } => {
                 // For now, ignore precision and call existing function
                 // Phase 2 will implement precision-aware formatting
-                super::super::functions::eval_scalar_function("CURRENT_TIME", &[])
+                super::super::functions::eval_scalar_function("CURRENT_TIME", &[], &None)
             }
             ast::Expression::CurrentTimestamp { precision: _ } => {
                 // For now, ignore precision and call existing function
                 // Phase 2 will implement precision-aware formatting
-                super::super::functions::eval_scalar_function("CURRENT_TIMESTAMP", &[])
+                super::super::functions::eval_scalar_function("CURRENT_TIMESTAMP", &[], &None)
             }
 
             // Unary operations (delegate to shared function)

--- a/crates/executor/src/evaluator/combined/special.rs
+++ b/crates/executor/src/evaluator/combined/special.rs
@@ -75,6 +75,7 @@ impl CombinedExpressionEvaluator<'_> {
         &self,
         name: &str,
         args: &[ast::Expression],
+        character_unit: &Option<ast::CharacterUnit>,
         row: &storage::Row,
     ) -> Result<types::SqlValue, ExecutorError> {
         // Evaluate all arguments
@@ -84,7 +85,7 @@ impl CombinedExpressionEvaluator<'_> {
         }
 
         // Call shared scalar function evaluator
-        eval_scalar_function(name, &arg_values)
+        eval_scalar_function(name, &arg_values, character_unit)
     }
 
     /// Evaluate unary operation

--- a/crates/executor/src/evaluator/expressions/eval.rs
+++ b/crates/executor/src/evaluator/expressions/eval.rs
@@ -82,23 +82,23 @@ impl ExpressionEvaluator<'_> {
             }
 
             // Function call
-            ast::Expression::Function { name, args, character_unit: _ } => {
-                self.eval_function(name, args, row)
+            ast::Expression::Function { name, args, character_unit } => {
+                self.eval_function(name, args, character_unit, row)
             }
 
             // Current date/time functions
             ast::Expression::CurrentDate => {
-                super::super::functions::eval_scalar_function("CURRENT_DATE", &[])
+                super::super::functions::eval_scalar_function("CURRENT_DATE", &[], &None)
             }
             ast::Expression::CurrentTime { precision: _ } => {
                 // For now, ignore precision and call existing function
                 // Phase 2 will implement precision-aware formatting
-                super::super::functions::eval_scalar_function("CURRENT_TIME", &[])
+                super::super::functions::eval_scalar_function("CURRENT_TIME", &[], &None)
             }
             ast::Expression::CurrentTimestamp { precision: _ } => {
                 // For now, ignore precision and call existing function
                 // Phase 2 will implement precision-aware formatting
-                super::super::functions::eval_scalar_function("CURRENT_TIMESTAMP", &[])
+                super::super::functions::eval_scalar_function("CURRENT_TIMESTAMP", &[], &None)
             }
 
             // Unsupported expressions

--- a/crates/executor/src/evaluator/expressions/special.rs
+++ b/crates/executor/src/evaluator/expressions/special.rs
@@ -59,6 +59,7 @@ impl ExpressionEvaluator<'_> {
         &self,
         name: &str,
         args: &[ast::Expression],
+        character_unit: &Option<ast::CharacterUnit>,
         row: &storage::Row,
     ) -> Result<types::SqlValue, ExecutorError> {
         let mut arg_values = Vec::new();
@@ -66,6 +67,6 @@ impl ExpressionEvaluator<'_> {
             arg_values.push(self.eval(arg, row)?);
         }
 
-        eval_scalar_function(name, &arg_values)
+        eval_scalar_function(name, &arg_values, character_unit)
     }
 }

--- a/crates/executor/src/evaluator/functions/mod.rs
+++ b/crates/executor/src/evaluator/functions/mod.rs
@@ -31,6 +31,7 @@ mod system;
 pub(super) fn eval_scalar_function(
     name: &str,
     args: &[types::SqlValue],
+    character_unit: &Option<ast::CharacterUnit>,
 ) -> Result<types::SqlValue, ExecutorError> {
     match name.to_uppercase().as_str() {
         // NULL handling functions
@@ -43,7 +44,7 @@ pub(super) fn eval_scalar_function(
         "SUBSTRING" => string::substring(args),
         "SUBSTR" => string::substring(args), // Alias for SUBSTRING
         // Note: TRIM is handled as a special expression in the parser (like POSITION)
-        "CHAR_LENGTH" | "CHARACTER_LENGTH" => string::char_length(args, name),
+        "CHAR_LENGTH" | "CHARACTER_LENGTH" => string::char_length(args, name, character_unit),
         "OCTET_LENGTH" => string::octet_length(args),
         "CONCAT" => string::concat(args),
         "LENGTH" => string::length(args),

--- a/crates/parser/src/parser/expressions/functions.rs
+++ b/crates/parser/src/parser/expressions/functions.rs
@@ -224,6 +224,7 @@ impl Parser {
 
         // Parse function arguments
         let mut args = Vec::new();
+        let mut character_unit = None;
 
         // Check for empty argument list or '*'
         if matches!(self.peek(), Token::RParen) {
@@ -248,21 +249,16 @@ impl Parser {
                 }
             }
 
-            self.expect_token(Token::RParen)?;
-        }
-
-        // Parse optional USING clause for string functions
-        let character_unit =
+            // Parse optional USING clause for string functions BEFORE closing paren
             if matches!(function_name_upper.as_str(), "CHARACTER_LENGTH" | "CHAR_LENGTH") {
                 if matches!(self.peek(), Token::Keyword(Keyword::Using)) {
                     self.advance(); // consume USING
-                    Some(self.parse_character_unit()?)
-                } else {
-                    None
+                    character_unit = Some(self.parse_character_unit()?);
                 }
-            } else {
-                None
-            };
+            }
+
+            self.expect_token(Token::RParen)?;
+        }
 
         // Check for OVER clause (window function)
         if matches!(self.peek(), Token::Keyword(Keyword::Over)) {


### PR DESCRIPTION
## Summary
Implement SQL:1999 compliant USING clause support for CHARACTER_LENGTH() and CHAR_LENGTH() functions, allowing users to specify whether to return character count (USING CHARACTERS) or byte count (USING OCTETS).

## Changes
- **Parser**: Moved USING clause parsing to inside function parentheses (before RParen)
- **AST**: Leveraged existing CharacterUnit enum (Characters | Octets)
- **Evaluator**: Threaded character_unit parameter through eval_function call chain
- **String functions**: Updated char_length() to use:
  - `.chars().count()` for CHARACTERS mode (default)
  - `.len()` for OCTETS mode

## Test Plan
- ✅ Build passes
- ✅ All acceptance criteria from issue met:
  - Parser accepts `CHARACTER_LENGTH(str USING CHARACTERS)`
  - Parser accepts `CHARACTER_LENGTH(str USING OCTETS)`
  - Parser accepts `CHAR_LENGTH(str USING CHARACTERS)`
  - Parser accepts `CHAR_LENGTH(str USING OCTETS)`
  - USING CHARACTERS returns character count
  - USING OCTETS returns byte count
  - Default (no USING) returns character count

## Conformance Tests Fixed
This implementation fixes 4 failing SQL:1999 conformance tests (0.5% of suite):
- `e021_04_01_02` - CHARACTER_LENGTH...USING CHARACTERS
- `e021_04_01_03` - CHARACTER_LENGTH...USING OCTETS
- `e021_04_01_05` - CHAR_LENGTH...USING CHARACTERS
- `e021_04_01_06` - CHAR_LENGTH...USING OCTETS

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)