### PR TITLE
feat: Add support for UNION/EXCEPT/INTERSECT DISTINCT quantifiers

### DIFF
--- a/crates/parser/src/parser/select/statement.rs
+++ b/crates/parser/src/parser/select/statement.rs
@@ -100,12 +100,15 @@ impl Parser {
                 ast::SetOperator::Except
             };
 
-            // Check for ALL keyword (default is DISTINCT)
+            // Check for ALL or DISTINCT quantifier (default is DISTINCT if omitted)
             let all = if self.peek_keyword(Keyword::All) {
                 self.consume_keyword(Keyword::All)?;
                 true
+            } else if self.peek_keyword(Keyword::Distinct) {
+                self.consume_keyword(Keyword::Distinct)?;
+                false // DISTINCT = remove duplicates (same as default)
             } else {
-                false
+                false // Default behavior is DISTINCT
             };
 
             // Parse the right-hand side SELECT statement

--- a/crates/parser/src/tests/set_operations.rs
+++ b/crates/parser/src/tests/set_operations.rs
@@ -203,3 +203,25 @@ fn test_parse_set_operation_with_distinct() {
     );
     assert!(result.is_ok(), "Set operation with DISTINCT should parse: {:?}", result);
 }
+
+// ========================================================================
+// Explicit DISTINCT Quantifier Tests (SQL:1999 Features E071-01, E071-03)
+// ========================================================================
+
+#[test]
+fn test_parse_union_distinct() {
+    let result = Parser::parse_sql("SELECT id FROM users UNION DISTINCT SELECT id FROM customers;");
+    assert!(result.is_ok(), "UNION DISTINCT should parse: {:?}", result);
+}
+
+#[test]
+fn test_parse_except_distinct() {
+    let result = Parser::parse_sql("SELECT a FROM t1 EXCEPT DISTINCT SELECT b FROM t2;");
+    assert!(result.is_ok(), "EXCEPT DISTINCT should parse: {:?}", result);
+}
+
+#[test]
+fn test_parse_intersect_distinct() {
+    let result = Parser::parse_sql("SELECT id FROM users INTERSECT DISTINCT SELECT id FROM customers;");
+    assert!(result.is_ok(), "INTERSECT DISTINCT should parse: {:?}", result);
+}


### PR DESCRIPTION
## Summary
Adds support for explicit DISTINCT quantifiers in set operations (UNION, EXCEPT, INTERSECT), implementing SQL:1999 Core compliance requirements.

## Changes
- **Parser**: Extended set operation quantifier parsing in `crates/parser/src/parser/select/statement.rs:103-112`
  - Now accepts `UNION DISTINCT`, `EXCEPT DISTINCT`, `INTERSECT DISTINCT`
  - DISTINCT is semantically equivalent to default behavior (removes duplicates)
- **Tests**: Added 3 test cases in `crates/parser/src/tests/set_operations.rs`
  - `test_parse_union_distinct`
  - `test_parse_except_distinct`
  - `test_parse_intersect_distinct`

## SQL:1999 Core Features Implemented
- ✅ **E071-01**: UNION DISTINCT
- ✅ **E071-03**: EXCEPT DISTINCT  
- ✅ **E071-05**: INTERSECT DISTINCT (implicit)

## Test Results
- All 530 parser tests pass
- 3 new DISTINCT-specific tests added and passing
- Expected to fix 6 conformance test failures

## Implementation Details
- No AST changes required (existing `all: bool` field where `false` = DISTINCT)
- Parser change is minimal (~5 lines) with clear comments
- Follows existing code patterns and test conventions

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)