### PR TITLE
fix: Standardize error message for SELECT * without FROM

### DIFF
--- a/crates/executor/src/select/executor/columns.rs
+++ b/crates/executor/src/select/executor/columns.rs
@@ -36,7 +36,7 @@ impl SelectExecutor<'_> {
                         }
                     } else {
                         return Err(ExecutorError::UnsupportedFeature(
-                            "SELECT * without FROM not supported".to_string(),
+                            "SELECT * requires FROM clause".to_string(),
                         ));
                     }
                 }


### PR DESCRIPTION
## Summary

Standardizes error message for `SELECT *` without FROM clause across the codebase.

**Changes:**
- Updated error message in `columns.rs:39` from `"SELECT * without FROM not supported"` to `"SELECT * requires FROM clause"`
- Ensures consistency with `nonagg.rs:146` which already uses the standardized format
- Fixes test `test_select_star_without_from_fails` which expected the standardized message

**Impact:**
- Test now passes ✅
- More instructive error message (tells user what's needed)
- Consistent error messaging across codebase

**Testing:**
- ✅ `test_select_star_without_from_fails` now passes
- ✅ All executor crate tests pass (229 tests)
- ✅ No other references to old error message in codebase

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)