### PR TITLE
Improve error messages when reserved keywords are used as identifiers

### DIFF
--- a/crates/parser/src/parser/helpers.rs
+++ b/crates/parser/src/parser/helpers.rs
@@ -71,7 +71,17 @@ impl Parser {
                 self.advance();
                 Ok(identifier)
             }
-            _ => Err(ParseError { message: "Expected identifier".to_string() }),
+            Token::Keyword(kw) => {
+                Err(ParseError {
+                    message: format!(
+                        "Expected identifier, found reserved keyword '{}'. Use delimited identifiers (e.g., \"{}\") to use keywords as names, or choose a different identifier.",
+                        kw, kw
+                    ),
+                })
+            }
+            _ => Err(ParseError {
+                message: format!("Expected identifier, found {:?}", self.peek())
+            }),
         }
     }
 


### PR DESCRIPTION
## Summary

Improves parser error messages when users accidentally use SQL reserved keywords as identifiers. Instead of a generic "Expected identifier" error, users now get a helpful message that:
- Identifies the specific reserved keyword that was encountered
- Suggests using delimited identifiers (e.g., "ROLE") to use keywords as names
- Recommends choosing a different identifier

## Changes

**Implementation** (`crates/parser/src/parser/helpers.rs`):
- Enhanced `parse_identifier()` to detect `Token::Keyword` before the wildcard case
- Added specific error message with keyword name and fix suggestions
- Maintains existing behavior for non-keyword tokens

**Test Coverage** (`crates/parser/src/tests/errors.rs`):
- Added 9 comprehensive tests covering both `SELECT INTO` and `NEXT VALUE FOR` contexts
- Tests verify error messages include:
  - "reserved keyword" phrase
  - Specific keyword name (e.g., "SELECT", "TABLE", "WHERE")
  - Suggestion to use delimited identifiers
- Tests confirm delimited identifiers work correctly with keywords

## Example Error Messages

**Before:**
```
Expected identifier
```

**After:**
```
Expected identifier, found reserved keyword 'ROLE'. Use delimited identifiers 
(e.g., "ROLE") to use keywords as names, or choose a different identifier.
```

## Test Results

- ✅ All 9 new tests pass
- ✅ All existing tests pass (except 1 pre-existing failure unrelated to these changes)
- ✅ Verified delimited identifiers still work correctly

## SQL:1999 Compliance

This improves usability for SQL:1999 reserved keywords (Section 5.2 - Names and identifiers, Section 5.4 - Reserved words) by teaching users about delimited identifier syntax.

Closes #615