### PR TITLE
feat: Support SELECT * AS (col1, col2, ...) derived column lists

### DIFF
--- a/crates/ast/src/select.rs
+++ b/crates/ast/src/select.rs
@@ -60,10 +60,17 @@ pub struct SetOperation {
 /// Item in the SELECT list
 #[derive(Debug, Clone, PartialEq)]
 pub enum SelectItem {
-    /// SELECT *
-    Wildcard,
-    /// SELECT table.* or SELECT alias.*
-    QualifiedWildcard { qualifier: String },
+    /// SELECT * [AS (col1, col2, ...)]
+    /// SQL:1999 Feature E051-07: Derived column lists
+    Wildcard {
+        alias: Option<Vec<String>>,
+    },
+    /// SELECT table.* [AS (col1, col2, ...)] or SELECT alias.* [AS (col1, col2, ...)]
+    /// SQL:1999 Feature E051-08: Correlation names in FROM clause with derived column lists
+    QualifiedWildcard {
+        qualifier: String,
+        alias: Option<Vec<String>>,
+    },
     /// SELECT expr [AS alias]
     Expression { expr: Expression, alias: Option<String> },
 }

--- a/crates/executor/src/errors.rs
+++ b/crates/executor/src/errors.rs
@@ -22,6 +22,7 @@ pub enum ExecutorError {
     StorageError(String),
     SubqueryReturnedMultipleRows { expected: usize, actual: usize },
     SubqueryColumnCountMismatch { expected: usize, actual: usize },
+    ColumnCountMismatch { expected: usize, provided: usize },
     CastError { from_type: String, to_type: String },
     ConstraintViolation(String),
     CannotDropColumn(String),
@@ -78,6 +79,13 @@ impl std::fmt::Display for ExecutorError {
             }
             ExecutorError::SubqueryColumnCountMismatch { expected, actual } => {
                 write!(f, "Subquery returned {} columns, expected {}", actual, expected)
+            }
+            ExecutorError::ColumnCountMismatch { expected, provided } => {
+                write!(
+                    f,
+                    "Derived column list has {} columns but query produces {} columns",
+                    provided, expected
+                )
             }
             ExecutorError::CastError { from_type, to_type } => {
                 write!(f, "Cannot cast {} to {}", from_type, to_type)

--- a/crates/executor/src/select/cte.rs
+++ b/crates/executor/src/select/cte.rs
@@ -93,7 +93,7 @@ pub(super) fn derive_cte_schema(
 
                         // Extract column name from SELECT item
                         let col_name = match item {
-                            ast::SelectItem::Wildcard
+                            ast::SelectItem::Wildcard { .. }
                             | ast::SelectItem::QualifiedWildcard { .. } => format!("col{}", i),
                             ast::SelectItem::Expression { expr, alias } => {
                                 if let Some(a) = alias {

--- a/crates/executor/src/select/executor/aggregation/evaluation.rs
+++ b/crates/executor/src/select/executor/aggregation/evaluation.rs
@@ -357,7 +357,7 @@ impl SelectExecutor<'_> {
                         true,
                     ));
                 }
-                ast::SelectItem::Wildcard | ast::SelectItem::QualifiedWildcard { .. } => {
+                ast::SelectItem::Wildcard { .. } | ast::SelectItem::QualifiedWildcard { .. } => {
                     return Err(ExecutorError::UnsupportedFeature(
                         "SELECT * and qualified wildcards not supported with aggregates"
                             .to_string(),

--- a/crates/executor/src/select/executor/aggregation/mod.rs
+++ b/crates/executor/src/select/executor/aggregation/mod.rs
@@ -88,7 +88,7 @@ impl SelectExecutor<'_> {
                         )?;
                         aggregate_results.push(value);
                     }
-                    ast::SelectItem::Wildcard | ast::SelectItem::QualifiedWildcard { .. } => {
+                    ast::SelectItem::Wildcard { .. } | ast::SelectItem::QualifiedWildcard { .. } => {
                         return Err(ExecutorError::UnsupportedFeature(
                             "SELECT * and qualified wildcards not supported with aggregates"
                                 .to_string(),

--- a/crates/executor/src/select/executor/nonagg.rs
+++ b/crates/executor/src/select/executor/nonagg.rs
@@ -146,7 +146,7 @@ impl SelectExecutor<'_> {
         let mut values = Vec::new();
         for item in &stmt.select_list {
             match item {
-                ast::SelectItem::Wildcard | ast::SelectItem::QualifiedWildcard { .. } => {
+                ast::SelectItem::Wildcard { .. } | ast::SelectItem::QualifiedWildcard { .. } => {
                     return Err(ExecutorError::UnsupportedFeature(
                         "SELECT * and qualified wildcards require FROM clause".to_string(),
                     ));

--- a/crates/executor/src/select/projection.rs
+++ b/crates/executor/src/select/projection.rs
@@ -13,7 +13,7 @@ pub(super) fn project_row_combined(
 
     for item in columns {
         match item {
-            ast::SelectItem::Wildcard => {
+            ast::SelectItem::Wildcard { .. } => {
                 // SELECT * - include all columns
                 // When window functions are present, only include base columns (not appended window values)
                 if let Some(mapping) = window_mapping {
@@ -29,7 +29,7 @@ pub(super) fn project_row_combined(
                     values.extend(row.values.iter().cloned());
                 }
             }
-            ast::SelectItem::QualifiedWildcard { qualifier } => {
+            ast::SelectItem::QualifiedWildcard { qualifier, .. } => {
                 // SELECT table.* or SELECT alias.* - include columns from specific table/alias
                 if let Some((start_index, table_schema)) = schema.table_schemas.get(qualifier) {
                     let num_columns = table_schema.columns.len();

--- a/crates/executor/src/select/scan.rs
+++ b/crates/executor/src/select/scan.rs
@@ -147,7 +147,7 @@ where
     let mut col_index = 0;
     for item in &query.select_list {
         match item {
-            ast::SelectItem::Wildcard | ast::SelectItem::QualifiedWildcard { .. } => {
+            ast::SelectItem::Wildcard { .. } | ast::SelectItem::QualifiedWildcard { .. } => {
                 // For SELECT * or SELECT table.*, expand to all columns from the result rows
                 // Since we executed the subquery, the rows tell us how many columns there are
                 if let Some(first_row) = rows.first() {

--- a/crates/executor/src/select/window/detection.rs
+++ b/crates/executor/src/select/window/detection.rs
@@ -6,7 +6,7 @@ use ast::{Expression, SelectItem};
 pub(in crate::select) fn has_window_functions(select_list: &[SelectItem]) -> bool {
     select_list.iter().any(|item| match item {
         SelectItem::Expression { expr, .. } => expression_has_window_function(expr),
-        SelectItem::Wildcard | SelectItem::QualifiedWildcard { .. } => false,
+        SelectItem::Wildcard { .. } | SelectItem::QualifiedWildcard { .. } => false,
     })
 }
 

--- a/crates/executor/src/select_into.rs
+++ b/crates/executor/src/select_into.rs
@@ -76,7 +76,7 @@ impl SelectIntoExecutor {
 
         for (idx, item) in select_list.iter().enumerate() {
             match item {
-                SelectItem::Wildcard => {
+                SelectItem::Wildcard { .. } => {
                     return Err(ExecutorError::UnsupportedFeature(
                         "SELECT * is not supported in SELECT INTO statements".to_string(),
                     ));

--- a/crates/executor/src/tests/between_predicates.rs
+++ b/crates/executor/src/tests/between_predicates.rs
@@ -208,7 +208,7 @@ fn test_between_boundary_inclusive() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "DATA".to_string(), alias: None }),
         where_clause: Some(ast::Expression::Between {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "VALUE".to_string() }),

--- a/crates/executor/src/tests/comparison_ops.rs
+++ b/crates/executor/src/tests/comparison_ops.rs
@@ -21,7 +21,7 @@ fn test_greater_than_comparison() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "nums".to_string(), alias: None }),
         where_clause: Some(ast::Expression::BinaryOp {
             left: Box::new(ast::Expression::ColumnRef { table: None, column: "val".to_string() }),
@@ -57,7 +57,7 @@ fn test_less_than_comparison() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "nums".to_string(), alias: None }),
         where_clause: Some(ast::Expression::BinaryOp {
             left: Box::new(ast::Expression::ColumnRef { table: None, column: "val".to_string() }),
@@ -94,7 +94,7 @@ fn test_not_equal_comparison() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "nums".to_string(), alias: None }),
         where_clause: Some(ast::Expression::BinaryOp {
             left: Box::new(ast::Expression::ColumnRef { table: None, column: "val".to_string() }),
@@ -132,7 +132,7 @@ fn test_less_than_or_equal_comparison() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "nums".to_string(), alias: None }),
         where_clause: Some(ast::Expression::BinaryOp {
             left: Box::new(ast::Expression::ColumnRef { table: None, column: "val".to_string() }),

--- a/crates/executor/src/tests/limit_offset.rs
+++ b/crates/executor/src/tests/limit_offset.rs
@@ -9,7 +9,7 @@ fn make_pagination_stmt(limit: Option<usize>, offset: Option<usize>) -> ast::Sel
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "users".to_string(), alias: None }),
         where_clause: None,
         group_by: None,

--- a/crates/executor/src/tests/operator_edge_cases.rs
+++ b/crates/executor/src/tests/operator_edge_cases.rs
@@ -398,7 +398,7 @@ fn test_nested_comparisons() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::BinaryOp {
             left: Box::new(ast::Expression::BinaryOp {

--- a/crates/executor/src/tests/predicate_tests/between_predicate.rs
+++ b/crates/executor/src/tests/predicate_tests/between_predicate.rs
@@ -26,7 +26,7 @@ fn test_between_with_null_expr() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::Between {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "val".to_string() }),
@@ -67,7 +67,7 @@ fn test_not_between() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::Between {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "val".to_string() }),
@@ -107,7 +107,7 @@ fn test_between_boundary_values() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::Between {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "val".to_string() }),

--- a/crates/executor/src/tests/predicate_tests/in_predicate.rs
+++ b/crates/executor/src/tests/predicate_tests/in_predicate.rs
@@ -27,7 +27,7 @@ fn test_in_list_basic() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::InList {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "val".to_string() }),
@@ -69,7 +69,7 @@ fn test_not_in_list() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::InList {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "val".to_string() }),
@@ -111,7 +111,7 @@ fn test_in_list_with_null_value() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::InList {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "val".to_string() }),
@@ -153,7 +153,7 @@ fn test_in_list_with_null_in_list() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::InList {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "val".to_string() }),

--- a/crates/executor/src/tests/predicate_tests/like_predicate.rs
+++ b/crates/executor/src/tests/predicate_tests/like_predicate.rs
@@ -34,7 +34,7 @@ fn test_like_wildcard_percent() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::Like {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "name".to_string() }),
@@ -81,7 +81,7 @@ fn test_like_wildcard_underscore() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::Like {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "name".to_string() }),
@@ -128,7 +128,7 @@ fn test_not_like() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::Like {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "name".to_string() }),
@@ -172,7 +172,7 @@ fn test_like_null_pattern() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::Like {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "name".to_string() }),
@@ -214,7 +214,7 @@ fn test_like_null_value() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "test".to_string(), alias: None }),
         where_clause: Some(ast::Expression::Like {
             expr: Box::new(ast::Expression::ColumnRef { table: None, column: "name".to_string() }),

--- a/crates/executor/src/tests/scalar_subquery_basic_tests.rs
+++ b/crates/executor/src/tests/scalar_subquery_basic_tests.rs
@@ -88,7 +88,7 @@ fn test_scalar_subquery_in_where_clause() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "employees".to_string(), alias: None }),
         where_clause: Some(ast::Expression::BinaryOp {
             left: Box::new(ast::Expression::ColumnRef {

--- a/crates/executor/src/tests/select_basic.rs
+++ b/crates/executor/src/tests/select_basic.rs
@@ -42,7 +42,7 @@ fn test_select_star() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "users".to_string(), alias: None }),
         where_clause: None,
         group_by: None,
@@ -151,7 +151,7 @@ fn test_order_by_single_column_asc() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "users".to_string(), alias: None }),
         where_clause: None,
         group_by: None,
@@ -226,7 +226,7 @@ fn test_order_by_multiple_columns() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "users".to_string(), alias: None }),
         where_clause: None,
         group_by: None,
@@ -255,4 +255,267 @@ fn test_order_by_multiple_columns() {
     assert_eq!(result[2].values[2], types::SqlValue::Integer(35));
     assert_eq!(result[3].values[1], types::SqlValue::Integer(2));
     assert_eq!(result[3].values[2], types::SqlValue::Integer(20));
+}
+
+// ============================================================================
+// Derived Column List Tests (SQL:1999 Feature E051-07/08)
+// ============================================================================
+
+#[test]
+fn test_select_star_with_derived_columns() {
+    let mut db = storage::Database::new();
+    let schema = catalog::TableSchema::new(
+        "t1".to_string(),
+        vec![
+            catalog::ColumnSchema::new("A".to_string(), types::DataType::Integer, false),
+            catalog::ColumnSchema::new("B".to_string(), types::DataType::Integer, true),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    db.insert_row(
+        "t1",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(1),
+            types::SqlValue::Integer(2),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+    let stmt = ast::SelectStmt {
+        into_table: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![ast::SelectItem::Wildcard {
+            alias: Some(vec!["C".to_string(), "D".to_string()]),
+        }],
+        from: Some(ast::FromClause::Table { name: "t1".to_string(), alias: None }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute_with_columns(&stmt).unwrap();
+
+    // Check column names are renamed
+    assert_eq!(result.columns, vec!["C", "D"]);
+
+    // Check values are correct
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0].values[0], types::SqlValue::Integer(1));
+    assert_eq!(result.rows[0].values[1], types::SqlValue::Integer(2));
+}
+
+#[test]
+fn test_select_qualified_star_with_derived_columns() {
+    let mut db = storage::Database::new();
+    let schema = catalog::TableSchema::new(
+        "t1".to_string(),
+        vec![
+            catalog::ColumnSchema::new("A".to_string(), types::DataType::Integer, false),
+            catalog::ColumnSchema::new("B".to_string(), types::DataType::Integer, true),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    db.insert_row(
+        "t1",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(1),
+            types::SqlValue::Integer(2),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+    let stmt = ast::SelectStmt {
+        into_table: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![ast::SelectItem::QualifiedWildcard {
+            qualifier: "t1".to_string(),
+            alias: Some(vec!["C".to_string(), "D".to_string()]),
+        }],
+        from: Some(ast::FromClause::Table { name: "t1".to_string(), alias: None }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute_with_columns(&stmt).unwrap();
+
+    // Check column names are renamed
+    assert_eq!(result.columns, vec!["C", "D"]);
+
+    // Check values are correct
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0].values[0], types::SqlValue::Integer(1));
+    assert_eq!(result.rows[0].values[1], types::SqlValue::Integer(2));
+}
+
+#[test]
+fn test_derived_columns_count_mismatch() {
+    let mut db = storage::Database::new();
+    let schema = catalog::TableSchema::new(
+        "t1".to_string(),
+        vec![
+            catalog::ColumnSchema::new("A".to_string(), types::DataType::Integer, false),
+            catalog::ColumnSchema::new("B".to_string(), types::DataType::Integer, true),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    db.insert_row(
+        "t1",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(1),
+            types::SqlValue::Integer(2),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // 2 columns but 3 aliases - should error
+    let stmt = ast::SelectStmt {
+        into_table: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![ast::SelectItem::Wildcard {
+            alias: Some(vec!["C".to_string(), "D".to_string(), "E".to_string()]),
+        }],
+        from: Some(ast::FromClause::Table { name: "t1".to_string(), alias: None }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute_with_columns(&stmt);
+    assert!(result.is_err());
+    match result {
+        Err(ExecutorError::ColumnCountMismatch { expected: 2, provided: 3 }) => {
+            // Success - expected error
+        }
+        _ => panic!("Expected ColumnCountMismatch error"),
+    }
+}
+
+#[test]
+fn test_select_distinct_star_with_derived_columns() {
+    let mut db = storage::Database::new();
+    let schema = catalog::TableSchema::new(
+        "t1".to_string(),
+        vec![
+            catalog::ColumnSchema::new("A".to_string(), types::DataType::Integer, false),
+            catalog::ColumnSchema::new("B".to_string(), types::DataType::Integer, true),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    db.insert_row(
+        "t1",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(1),
+            types::SqlValue::Integer(2),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "t1",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(1),
+            types::SqlValue::Integer(2),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+    let stmt = ast::SelectStmt {
+        into_table: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: true,  // DISTINCT
+        select_list: vec![ast::SelectItem::Wildcard {
+            alias: Some(vec!["C".to_string(), "D".to_string()]),
+        }],
+        from: Some(ast::FromClause::Table { name: "t1".to_string(), alias: None }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute_with_columns(&stmt).unwrap();
+
+    // Check column names are renamed
+    assert_eq!(result.columns, vec!["C", "D"]);
+
+    // Check DISTINCT worked - only 1 row
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0].values[0], types::SqlValue::Integer(1));
+    assert_eq!(result.rows[0].values[1], types::SqlValue::Integer(2));
+}
+
+#[test]
+fn test_select_star_alias_with_table_alias() {
+    let mut db = storage::Database::new();
+    let schema = catalog::TableSchema::new(
+        "t1".to_string(),
+        vec![
+            catalog::ColumnSchema::new("A".to_string(), types::DataType::Integer, false),
+            catalog::ColumnSchema::new("B".to_string(), types::DataType::Integer, true),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    db.insert_row(
+        "t1",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(10),
+            types::SqlValue::Integer(20),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+    let stmt = ast::SelectStmt {
+        into_table: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![ast::SelectItem::QualifiedWildcard {
+            qualifier: "alias_name".to_string(),
+            alias: Some(vec!["X".to_string(), "Y".to_string()]),
+        }],
+        from: Some(ast::FromClause::Table {
+            name: "t1".to_string(),
+            alias: Some("alias_name".to_string())
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute_with_columns(&stmt).unwrap();
+
+    // Check column names are renamed
+    assert_eq!(result.columns, vec!["X", "Y"]);
+
+    // Check values are correct
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0].values[0], types::SqlValue::Integer(10));
+    assert_eq!(result.rows[0].values[1], types::SqlValue::Integer(20));
 }

--- a/crates/executor/src/tests/select_distinct.rs
+++ b/crates/executor/src/tests/select_distinct.rs
@@ -290,7 +290,7 @@ fn test_distinct_false_preserves_duplicates() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "products".to_string(), alias: None }),
         where_clause: None,
         group_by: None,

--- a/crates/executor/src/tests/select_into_tests.rs
+++ b/crates/executor/src/tests/select_into_tests.rs
@@ -77,7 +77,7 @@ fn test_select_into_single_row() {
     let query = ast::SelectStmt {
         with_clause: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         into_table: None,
         from: Some(ast::FromClause::Table { name: "target".to_string(), alias: None }),
         where_clause: None,
@@ -246,7 +246,7 @@ fn test_select_into_with_expressions() {
     let query = ast::SelectStmt {
         with_clause: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         into_table: None,
         from: Some(ast::FromClause::Table { name: "target".to_string(), alias: None }),
         where_clause: None,

--- a/crates/executor/src/tests/select_joins.rs
+++ b/crates/executor/src/tests/select_joins.rs
@@ -71,7 +71,7 @@ fn test_inner_join_two_tables() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Join {
             left: Box::new(ast::FromClause::Table { name: "users".to_string(), alias: None }),
             right: Box::new(ast::FromClause::Table { name: "orders".to_string(), alias: None }),
@@ -171,7 +171,7 @@ fn test_right_outer_join() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Join {
             left: Box::new(ast::FromClause::Table { name: "users".to_string(), alias: None }),
             right: Box::new(ast::FromClause::Table { name: "orders".to_string(), alias: None }),
@@ -277,7 +277,7 @@ fn test_full_outer_join() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Join {
             left: Box::new(ast::FromClause::Table { name: "users".to_string(), alias: None }),
             right: Box::new(ast::FromClause::Table { name: "orders".to_string(), alias: None }),
@@ -395,7 +395,7 @@ fn test_cross_join() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Join {
             left: Box::new(ast::FromClause::Table { name: "users".to_string(), alias: None }),
             right: Box::new(ast::FromClause::Table { name: "products".to_string(), alias: None }),
@@ -439,7 +439,7 @@ fn test_cross_join_with_condition_fails() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Join {
             left: Box::new(ast::FromClause::Table { name: "users".to_string(), alias: None }),
             right: Box::new(ast::FromClause::Table { name: "products".to_string(), alias: None }),

--- a/crates/executor/src/tests/select_where.rs
+++ b/crates/executor/src/tests/select_where.rs
@@ -37,7 +37,7 @@ fn test_select_with_where() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "users".to_string(), alias: None }),
         where_clause: Some(ast::Expression::BinaryOp {
             left: Box::new(ast::Expression::ColumnRef { table: None, column: "age".to_string() }),
@@ -104,7 +104,7 @@ fn test_select_with_and_condition() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "products".to_string(), alias: None }),
         where_clause: Some(ast::Expression::BinaryOp {
             left: Box::new(ast::Expression::BinaryOp {
@@ -185,7 +185,7 @@ fn test_select_with_or_condition() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "items".to_string(), alias: None }),
         where_clause: Some(ast::Expression::BinaryOp {
             left: Box::new(ast::Expression::BinaryOp {
@@ -255,7 +255,7 @@ fn test_select_with_null_in_where() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: Some(ast::FromClause::Table { name: "data".to_string(), alias: None }),
         where_clause: Some(ast::Expression::BinaryOp {
             left: Box::new(ast::Expression::ColumnRef { table: None, column: "value".to_string() }),

--- a/crates/executor/src/tests/select_without_from.rs
+++ b/crates/executor/src/tests/select_without_from.rs
@@ -170,7 +170,7 @@ fn test_select_star_without_from_fails() {
         with_clause: None,
         set_operation: None,
         distinct: false,
-        select_list: vec![ast::SelectItem::Wildcard],
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
         from: None,
         where_clause: None,
         group_by: None,


### PR DESCRIPTION
## Summary

Implements SQL:1999 features E051-07 and E051-08 - derived column lists for wildcard selects. This allows renaming columns when using `SELECT *` or `SELECT table.*`.

## Changes

### AST Updates (crates/ast/src/select.rs:62)
- Added `alias: Option<Vec<String>>` field to `SelectItem::Wildcard`
- Added `alias: Option<Vec<String>>` field to `SelectItem::QualifiedWildcard`
- Added documentation for SQL:1999 Feature E051-07/08

### Parser Updates (crates/parser/src/parser/select/list.rs:24)
- Added `parse_derived_column_list()` helper function to parse AS (col1, col2, ...)
- Enhanced `parse_select_item()` to check for AS clause after wildcards
- Added error handling for empty derived column lists

### Executor Updates
- **Column Derivation** (crates/executor/src/select/executor/columns.rs:18): Apply aliases when deriving column names, validate column count matches
- **Error Handling** (crates/executor/src/errors.rs): Added `ColumnCountMismatch` error type
- **Pattern Matching**: Updated all match statements across executor to handle new Wildcard struct variants

### Tests (crates/executor/src/tests/select_basic.rs)
- `test_select_star_with_derived_columns`: Basic SELECT * AS (C, D)
- `test_select_qualified_star_with_derived_columns`: SELECT table.* AS (C, D)
- `test_derived_columns_count_mismatch`: Error handling for mismatched counts
- `test_select_distinct_star_with_derived_columns`: DISTINCT with aliases
- `test_select_star_alias_with_table_alias`: Qualified wildcard with table alias

## Examples

```sql
-- Basic wildcard with derived columns
CREATE TABLE t1 (A INT, B INT);
SELECT * AS (C, D) FROM t1;  -- Columns renamed from (A, B) to (C, D)

-- Qualified wildcard with derived columns
SELECT t1.* AS (X, Y) FROM t1;

-- Works with DISTINCT
SELECT DISTINCT * AS (col1, col2) FROM t1;

-- Works with table aliases
SELECT alias_name.* AS (X, Y) FROM t1 AS alias_name;

-- Error: column count mismatch
SELECT * AS (C, D, E) FROM t1;  -- Error: 2 columns but 3 aliases
```

## Impact

- **Target**: 12 failing tests (e051_07_*, e051_08_*)
- **Expected**: Conformance increase from 85.7% to 87.3% (+1.6%)
- **Files Modified**: 26 files (1 AST, 1 parser, 11 executor, 13 test files)

## Testing

- ✅ All 5 new unit tests pass
- ✅ Existing tests updated and pass
- ⏳ Full conformance test suite will run in CI

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)