### PR TITLE
feat: Add DuckDB benchmarking for performance comparison

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,6 +1,7 @@
 
 import pytest
 import sqlite3
+import duckdb
 import nistmemsql
 import json
 import platform
@@ -44,11 +45,27 @@ def nistmemsql_db():
     conn.close()
 
 @pytest.fixture
+def duckdb_db():
+    """Create DuckDB in-memory database connection"""
+    conn = duckdb.connect(':memory:')
+    yield conn
+    conn.close()
+
+@pytest.fixture
 def both_databases(sqlite_db, nistmemsql_db):
     """Provide both databases for head-to-head comparison"""
     return {
         'sqlite': sqlite_db,
         'nistmemsql': nistmemsql_db
+    }
+
+@pytest.fixture
+def all_databases(sqlite_db, nistmemsql_db, duckdb_db):
+    """Provide all three databases for comprehensive comparison"""
+    return {
+        'sqlite': sqlite_db,
+        'nistmemsql': nistmemsql_db,
+        'duckdb': duckdb_db
     }
 
 @pytest.fixture

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -2,4 +2,5 @@ pytest>=7.0.0
 pytest-benchmark>=4.0.0
 pytest-json-report>=1.5.0
 psutil>=5.9.0
+duckdb>=0.9.0
 nistmemsql

--- a/benchmarks/test_micro_benchmarks.py
+++ b/benchmarks/test_micro_benchmarks.py
@@ -1,8 +1,9 @@
 """
-Tier 1 Micro-Benchmarks: Basic operations comparison between nistmemsql and SQLite.
+Tier 1 Micro-Benchmarks: Basic operations comparison between nistmemsql, SQLite, and DuckDB.
 
 These benchmarks establish fundamental performance characteristics for single-table operations.
 Following the pattern from #650, expanded to cover INSERT, UPDATE, DELETE, WHERE, and aggregates.
+Now includes DuckDB as an industry-standard baseline for in-memory analytical databases.
 """
 import pytest
 import random
@@ -12,7 +13,7 @@ import random
 # Helper Functions
 # ============================================================================
 
-def setup_test_table(connection, num_rows, is_sqlite=True):
+def setup_test_table(connection, num_rows, db_type='sqlite'):
     """Helper function to create and populate test table.
 
     Creates table with schema matching #650 requirements:
@@ -21,6 +22,11 @@ def setup_test_table(connection, num_rows, is_sqlite=True):
     - value: INTEGER NOT NULL
 
     Uses deterministic random data (seed=42) for reproducibility.
+
+    Args:
+        connection: Database connection
+        num_rows: Number of rows to insert
+        db_type: One of 'sqlite', 'nistmemsql', or 'duckdb'
     """
     cursor = connection.cursor()
 
@@ -36,9 +42,10 @@ def setup_test_table(connection, num_rows, is_sqlite=True):
     # Use deterministic seed for reproducibility
     random.seed(42)
 
-    # Insert test data
+    # Insert test data based on database type
     for i in range(num_rows):
-        if is_sqlite:
+        if db_type in ['sqlite', 'duckdb']:
+            # SQLite and DuckDB both support parameterized queries
             cursor.execute(
                 "INSERT INTO test_table (id, name, value) VALUES (?, ?, ?)",
                 (i, f"name_{i % 100}", random.randint(1, 1000))
@@ -50,7 +57,8 @@ def setup_test_table(connection, num_rows, is_sqlite=True):
                 f"INSERT INTO test_table (id, name, value) VALUES ({i}, 'name_{i % 100}', {value})"
             )
 
-    if is_sqlite:
+    # Commit for SQLite and DuckDB
+    if db_type in ['sqlite', 'duckdb']:
         connection.commit()
 
 
@@ -121,6 +129,38 @@ def test_insert_1k_nistmemsql(benchmark, nistmemsql_db):
     benchmark(run_inserts)
 
 
+def test_insert_1k_duckdb(benchmark, duckdb_db):
+    """Benchmark INSERT operations on DuckDB (1K rows)."""
+    # Setup: Create empty table (once)
+    cursor = duckdb_db.cursor()
+    cursor.execute("""
+        CREATE TABLE test_table (
+            id INTEGER PRIMARY KEY,
+            name VARCHAR(20) NOT NULL,
+            value INTEGER NOT NULL
+        )
+    """)
+
+    # Track next ID to insert
+    next_id = [0]  # Use list to allow modification in closure
+
+    def run_inserts():
+        # Reset random seed for deterministic data
+        random.seed(42)
+        cursor = duckdb_db.cursor()
+        start_id = next_id[0]
+        # Insert 1K rows with incrementing IDs
+        for i in range(1000):
+            cursor.execute(
+                "INSERT INTO test_table (id, name, value) VALUES (?, ?, ?)",
+                (start_id + i, f"name_{i % 100}", random.randint(1, 1000))
+            )
+        next_id[0] += 1000
+        duckdb_db.commit()
+
+    benchmark(run_inserts)
+
+
 def test_insert_10k_sqlite(benchmark, sqlite_db):
     """Benchmark INSERT operations on SQLite (10K rows)."""
     cursor = sqlite_db.cursor()
@@ -172,6 +212,34 @@ def test_insert_10k_nistmemsql(benchmark, nistmemsql_db):
                 f"INSERT INTO test_table (id, name, value) VALUES ({start_id + i}, 'name_{i % 100}', {value})"
             )
         next_id[0] += 10000
+
+    benchmark(run_inserts)
+
+
+def test_insert_10k_duckdb(benchmark, duckdb_db):
+    """Benchmark INSERT operations on DuckDB (10K rows)."""
+    cursor = duckdb_db.cursor()
+    cursor.execute("""
+        CREATE TABLE test_table (
+            id INTEGER PRIMARY KEY,
+            name VARCHAR(20) NOT NULL,
+            value INTEGER NOT NULL
+        )
+    """)
+
+    next_id = [0]
+
+    def run_inserts():
+        random.seed(42)
+        cursor = duckdb_db.cursor()
+        start_id = next_id[0]
+        for i in range(10000):
+            cursor.execute(
+                "INSERT INTO test_table (id, name, value) VALUES (?, ?, ?)",
+                (start_id + i, f"name_{i % 100}", random.randint(1, 1000))
+            )
+        next_id[0] += 10000
+        duckdb_db.commit()
 
     benchmark(run_inserts)
 
@@ -238,7 +306,7 @@ def test_insert_100k_nistmemsql(benchmark, nistmemsql_db):
 def test_update_1k_sqlite(benchmark, sqlite_db):
     """Benchmark UPDATE operations on SQLite (1K rows)."""
     # Setup: Pre-populate table
-    setup_test_table(sqlite_db, 1000, is_sqlite=True)
+    setup_test_table(sqlite_db, 1000, db_type='sqlite')
 
     def run_updates():
         cursor = sqlite_db.cursor()
@@ -255,7 +323,7 @@ def test_update_1k_sqlite(benchmark, sqlite_db):
 def test_update_1k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark UPDATE operations on nistmemsql (1K rows)."""
     # Setup: Pre-populate table
-    setup_test_table(nistmemsql_db, 1000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 1000, db_type='nistmemsql')
 
     def run_updates():
         cursor = nistmemsql_db.cursor()
@@ -269,7 +337,7 @@ def test_update_1k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_update_10k_sqlite(benchmark, sqlite_db):
     """Benchmark UPDATE operations on SQLite (10K rows)."""
-    setup_test_table(sqlite_db, 10000, is_sqlite=True)
+    setup_test_table(sqlite_db, 10000, db_type='sqlite')
 
     def run_updates():
         cursor = sqlite_db.cursor()
@@ -285,7 +353,7 @@ def test_update_10k_sqlite(benchmark, sqlite_db):
 
 def test_update_10k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark UPDATE operations on nistmemsql (10K rows)."""
-    setup_test_table(nistmemsql_db, 10000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 10000, db_type='nistmemsql')
 
     def run_updates():
         cursor = nistmemsql_db.cursor()
@@ -299,7 +367,7 @@ def test_update_10k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_update_100k_sqlite(benchmark, sqlite_db):
     """Benchmark UPDATE operations on SQLite (100K rows)."""
-    setup_test_table(sqlite_db, 100000, is_sqlite=True)
+    setup_test_table(sqlite_db, 100000, db_type='sqlite')
 
     def run_updates():
         cursor = sqlite_db.cursor()
@@ -315,7 +383,7 @@ def test_update_100k_sqlite(benchmark, sqlite_db):
 
 def test_update_100k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark UPDATE operations on nistmemsql (100K rows)."""
-    setup_test_table(nistmemsql_db, 100000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 100000, db_type='nistmemsql')
 
     def run_updates():
         cursor = nistmemsql_db.cursor()
@@ -334,7 +402,7 @@ def test_update_100k_nistmemsql(benchmark, nistmemsql_db):
 def test_delete_1k_sqlite(benchmark, sqlite_db):
     """Benchmark DELETE operations on SQLite (1K rows)."""
     # Setup: Pre-populate table
-    setup_test_table(sqlite_db, 1000)
+    setup_test_table(sqlite_db, 1000, db_type='sqlite')
 
     def run_deletes():
         cursor = sqlite_db.cursor()
@@ -350,7 +418,7 @@ def test_delete_1k_sqlite(benchmark, sqlite_db):
 
 def test_delete_1k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark DELETE operations on nistmemsql (1K rows)."""
-    setup_test_table(nistmemsql_db, 1000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 1000, db_type='nistmemsql')
 
     def run_deletes():
         cursor = nistmemsql_db.cursor()
@@ -364,7 +432,7 @@ def test_delete_1k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_delete_10k_sqlite(benchmark, sqlite_db):
     """Benchmark DELETE operations on SQLite (10K rows)."""
-    setup_test_table(sqlite_db, 10000, is_sqlite=True)
+    setup_test_table(sqlite_db, 10000, db_type='sqlite')
 
     def run_deletes():
         cursor = sqlite_db.cursor()
@@ -380,7 +448,7 @@ def test_delete_10k_sqlite(benchmark, sqlite_db):
 
 def test_delete_10k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark DELETE operations on nistmemsql (10K rows)."""
-    setup_test_table(nistmemsql_db, 10000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 10000, db_type='nistmemsql')
 
     def run_deletes():
         cursor = nistmemsql_db.cursor()
@@ -394,7 +462,7 @@ def test_delete_10k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_delete_100k_sqlite(benchmark, sqlite_db):
     """Benchmark DELETE operations on SQLite (100K rows)."""
-    setup_test_table(sqlite_db, 100000, is_sqlite=True)
+    setup_test_table(sqlite_db, 100000, db_type='sqlite')
 
     def run_deletes():
         cursor = sqlite_db.cursor()
@@ -410,7 +478,7 @@ def test_delete_100k_sqlite(benchmark, sqlite_db):
 
 def test_delete_100k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark DELETE operations on nistmemsql (100K rows)."""
-    setup_test_table(nistmemsql_db, 100000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 100000, db_type='nistmemsql')
 
     def run_deletes():
         cursor = nistmemsql_db.cursor()
@@ -428,7 +496,7 @@ def test_delete_100k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_select_where_1k_sqlite(benchmark, sqlite_db):
     """Benchmark SELECT with WHERE clause on SQLite (filter 10% of 1K rows)."""
-    setup_test_table(sqlite_db, 1000)
+    setup_test_table(sqlite_db, 1000, db_type='sqlite')
 
     def run_query():
         cursor = sqlite_db.cursor()
@@ -441,7 +509,7 @@ def test_select_where_1k_sqlite(benchmark, sqlite_db):
 
 def test_select_where_1k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark SELECT with WHERE clause on nistmemsql (filter 10% of 1K rows)."""
-    setup_test_table(nistmemsql_db, 1000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 1000, db_type='nistmemsql')
 
     def run_query():
         cursor = nistmemsql_db.cursor()
@@ -454,7 +522,7 @@ def test_select_where_1k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_select_where_10k_sqlite(benchmark, sqlite_db):
     """Benchmark SELECT with WHERE clause on SQLite (filter 10% of 10K rows)."""
-    setup_test_table(sqlite_db, 10000, is_sqlite=True)
+    setup_test_table(sqlite_db, 10000, db_type='sqlite')
 
     def run_query():
         cursor = sqlite_db.cursor()
@@ -467,7 +535,7 @@ def test_select_where_10k_sqlite(benchmark, sqlite_db):
 
 def test_select_where_10k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark SELECT with WHERE clause on nistmemsql (filter 10% of 10K rows)."""
-    setup_test_table(nistmemsql_db, 10000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 10000, db_type='nistmemsql')
 
     def run_query():
         cursor = nistmemsql_db.cursor()
@@ -480,7 +548,7 @@ def test_select_where_10k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_select_where_100k_sqlite(benchmark, sqlite_db):
     """Benchmark SELECT with WHERE clause on SQLite (filter 10% of 100K rows)."""
-    setup_test_table(sqlite_db, 100000, is_sqlite=True)
+    setup_test_table(sqlite_db, 100000, db_type='sqlite')
 
     def run_query():
         cursor = sqlite_db.cursor()
@@ -493,7 +561,7 @@ def test_select_where_100k_sqlite(benchmark, sqlite_db):
 
 def test_select_where_100k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark SELECT with WHERE clause on nistmemsql (filter 10% of 100K rows)."""
-    setup_test_table(nistmemsql_db, 100000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 100000, db_type='nistmemsql')
 
     def run_query():
         cursor = nistmemsql_db.cursor()
@@ -510,7 +578,7 @@ def test_select_where_100k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_count_1k_sqlite(benchmark, sqlite_db):
     """Benchmark COUNT(*) aggregation on SQLite (1K rows)."""
-    setup_test_table(sqlite_db, 1000)
+    setup_test_table(sqlite_db, 1000, db_type='sqlite')
 
     def run_query():
         cursor = sqlite_db.cursor()
@@ -523,7 +591,7 @@ def test_count_1k_sqlite(benchmark, sqlite_db):
 
 def test_count_1k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark COUNT(*) aggregation on nistmemsql (1K rows)."""
-    setup_test_table(nistmemsql_db, 1000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 1000, db_type='nistmemsql')
 
     def run_query():
         cursor = nistmemsql_db.cursor()
@@ -536,7 +604,7 @@ def test_count_1k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_count_10k_sqlite(benchmark, sqlite_db):
     """Benchmark COUNT(*) aggregation on SQLite (10K rows)."""
-    setup_test_table(sqlite_db, 10000, is_sqlite=True)
+    setup_test_table(sqlite_db, 10000, db_type='sqlite')
 
     def run_query():
         cursor = sqlite_db.cursor()
@@ -549,7 +617,7 @@ def test_count_10k_sqlite(benchmark, sqlite_db):
 
 def test_count_10k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark COUNT(*) aggregation on nistmemsql (10K rows)."""
-    setup_test_table(nistmemsql_db, 10000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 10000, db_type='nistmemsql')
 
     def run_query():
         cursor = nistmemsql_db.cursor()
@@ -562,7 +630,7 @@ def test_count_10k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_count_100k_sqlite(benchmark, sqlite_db):
     """Benchmark COUNT(*) aggregation on SQLite (100K rows)."""
-    setup_test_table(sqlite_db, 100000, is_sqlite=True)
+    setup_test_table(sqlite_db, 100000, db_type='sqlite')
 
     def run_query():
         cursor = sqlite_db.cursor()
@@ -575,7 +643,7 @@ def test_count_100k_sqlite(benchmark, sqlite_db):
 
 def test_count_100k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark COUNT(*) aggregation on nistmemsql (100K rows)."""
-    setup_test_table(nistmemsql_db, 100000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 100000, db_type='nistmemsql')
 
     def run_query():
         cursor = nistmemsql_db.cursor()
@@ -588,7 +656,7 @@ def test_count_100k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_sum_1k_sqlite(benchmark, sqlite_db):
     """Benchmark SUM(value) aggregation on SQLite (1K rows)."""
-    setup_test_table(sqlite_db, 1000)
+    setup_test_table(sqlite_db, 1000, db_type='sqlite')
 
     def run_query():
         cursor = sqlite_db.cursor()
@@ -601,7 +669,7 @@ def test_sum_1k_sqlite(benchmark, sqlite_db):
 
 def test_sum_1k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark SUM(value) aggregation on nistmemsql (1K rows)."""
-    setup_test_table(nistmemsql_db, 1000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 1000, db_type='nistmemsql')
 
     def run_query():
         cursor = nistmemsql_db.cursor()
@@ -614,7 +682,7 @@ def test_sum_1k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_sum_10k_sqlite(benchmark, sqlite_db):
     """Benchmark SUM(value) aggregation on SQLite (10K rows)."""
-    setup_test_table(sqlite_db, 10000, is_sqlite=True)
+    setup_test_table(sqlite_db, 10000, db_type='sqlite')
 
     def run_query():
         cursor = sqlite_db.cursor()
@@ -627,7 +695,7 @@ def test_sum_10k_sqlite(benchmark, sqlite_db):
 
 def test_sum_10k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark SUM(value) aggregation on nistmemsql (10K rows)."""
-    setup_test_table(nistmemsql_db, 10000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 10000, db_type='nistmemsql')
 
     def run_query():
         cursor = nistmemsql_db.cursor()
@@ -640,7 +708,7 @@ def test_sum_10k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_sum_100k_sqlite(benchmark, sqlite_db):
     """Benchmark SUM(value) aggregation on SQLite (100K rows)."""
-    setup_test_table(sqlite_db, 100000, is_sqlite=True)
+    setup_test_table(sqlite_db, 100000, db_type='sqlite')
 
     def run_query():
         cursor = sqlite_db.cursor()
@@ -653,7 +721,7 @@ def test_sum_100k_sqlite(benchmark, sqlite_db):
 
 def test_sum_100k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark SUM(value) aggregation on nistmemsql (100K rows)."""
-    setup_test_table(nistmemsql_db, 100000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 100000, db_type='nistmemsql')
 
     def run_query():
         cursor = nistmemsql_db.cursor()
@@ -666,7 +734,7 @@ def test_sum_100k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_avg_1k_sqlite(benchmark, sqlite_db):
     """Benchmark AVG(value) aggregation on SQLite (1K rows)."""
-    setup_test_table(sqlite_db, 1000)
+    setup_test_table(sqlite_db, 1000, db_type='sqlite')
 
     def run_query():
         cursor = sqlite_db.cursor()
@@ -679,7 +747,7 @@ def test_avg_1k_sqlite(benchmark, sqlite_db):
 
 def test_avg_1k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark AVG(value) aggregation on nistmemsql (1K rows)."""
-    setup_test_table(nistmemsql_db, 1000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 1000, db_type='nistmemsql')
 
     def run_query():
         cursor = nistmemsql_db.cursor()
@@ -692,7 +760,7 @@ def test_avg_1k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_avg_10k_sqlite(benchmark, sqlite_db):
     """Benchmark AVG(value) aggregation on SQLite (10K rows)."""
-    setup_test_table(sqlite_db, 10000, is_sqlite=True)
+    setup_test_table(sqlite_db, 10000, db_type='sqlite')
 
     def run_query():
         cursor = sqlite_db.cursor()
@@ -705,7 +773,7 @@ def test_avg_10k_sqlite(benchmark, sqlite_db):
 
 def test_avg_10k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark AVG(value) aggregation on nistmemsql (10K rows)."""
-    setup_test_table(nistmemsql_db, 10000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 10000, db_type='nistmemsql')
 
     def run_query():
         cursor = nistmemsql_db.cursor()
@@ -718,7 +786,7 @@ def test_avg_10k_nistmemsql(benchmark, nistmemsql_db):
 
 def test_avg_100k_sqlite(benchmark, sqlite_db):
     """Benchmark AVG(value) aggregation on SQLite (100K rows)."""
-    setup_test_table(sqlite_db, 100000, is_sqlite=True)
+    setup_test_table(sqlite_db, 100000, db_type='sqlite')
 
     def run_query():
         cursor = sqlite_db.cursor()
@@ -731,10 +799,306 @@ def test_avg_100k_sqlite(benchmark, sqlite_db):
 
 def test_avg_100k_nistmemsql(benchmark, nistmemsql_db):
     """Benchmark AVG(value) aggregation on nistmemsql (100K rows)."""
-    setup_test_table(nistmemsql_db, 100000, is_sqlite=False)
+    setup_test_table(nistmemsql_db, 100000, db_type='nistmemsql')
 
     def run_query():
         cursor = nistmemsql_db.cursor()
+        cursor.execute("SELECT AVG(value) FROM test_table")
+        result = cursor.fetchone()[0]
+        assert result is not None
+
+    benchmark(run_query)
+
+
+def test_insert_100k_duckdb(benchmark, duckdb_db):
+    """Benchmark INSERT operations on DuckDB (100K rows)."""
+    cursor = duckdb_db.cursor()
+    cursor.execute("""
+        CREATE TABLE test_table (
+            id INTEGER PRIMARY KEY,
+            name VARCHAR(20) NOT NULL,
+            value INTEGER NOT NULL
+        )
+    """)
+
+    next_id = [0]
+
+    def run_inserts():
+        random.seed(42)
+        cursor = duckdb_db.cursor()
+        start_id = next_id[0]
+        for i in range(100000):
+            cursor.execute(
+                "INSERT INTO test_table (id, name, value) VALUES (?, ?, ?)",
+                (start_id + i, f"name_{i % 100}", random.randint(1, 1000))
+            )
+        next_id[0] += 100000
+        duckdb_db.commit()
+
+    benchmark(run_inserts)
+
+
+# ============================================================================
+# UPDATE Benchmarks - DuckDB
+# ============================================================================
+
+def test_update_1k_duckdb(benchmark, duckdb_db):
+    """Benchmark UPDATE operations on DuckDB (1K rows)."""
+    setup_test_table(duckdb_db, 1000, db_type='duckdb')
+
+    def run_updates():
+        cursor = duckdb_db.cursor()
+        for i in range(1000):
+            cursor.execute(
+                "UPDATE test_table SET value = value + 1 WHERE id = ?",
+                (i,)
+            )
+        duckdb_db.commit()
+
+    benchmark(run_updates)
+
+
+def test_update_10k_duckdb(benchmark, duckdb_db):
+    """Benchmark UPDATE operations on DuckDB (10K rows)."""
+    setup_test_table(duckdb_db, 10000, db_type='duckdb')
+
+    def run_updates():
+        cursor = duckdb_db.cursor()
+        for i in range(10000):
+            cursor.execute(
+                "UPDATE test_table SET value = value + 1 WHERE id = ?",
+                (i,)
+            )
+        duckdb_db.commit()
+
+    benchmark(run_updates)
+
+
+def test_update_100k_duckdb(benchmark, duckdb_db):
+    """Benchmark UPDATE operations on DuckDB (100K rows)."""
+    setup_test_table(duckdb_db, 100000, db_type='duckdb')
+
+    def run_updates():
+        cursor = duckdb_db.cursor()
+        for i in range(100000):
+            cursor.execute(
+                "UPDATE test_table SET value = value + 1 WHERE id = ?",
+                (i,)
+            )
+        duckdb_db.commit()
+
+    benchmark(run_updates)
+
+
+# ============================================================================
+# DELETE Benchmarks - DuckDB
+# ============================================================================
+
+def test_delete_1k_duckdb(benchmark, duckdb_db):
+    """Benchmark DELETE operations on DuckDB (1K rows)."""
+    setup_test_table(duckdb_db, 1000, db_type='duckdb')
+
+    def run_deletes():
+        cursor = duckdb_db.cursor()
+        for i in range(1000):
+            cursor.execute(
+                "DELETE FROM test_table WHERE id = ?",
+                (i,)
+            )
+        duckdb_db.commit()
+
+    benchmark(run_deletes)
+
+
+def test_delete_10k_duckdb(benchmark, duckdb_db):
+    """Benchmark DELETE operations on DuckDB (10K rows)."""
+    setup_test_table(duckdb_db, 10000, db_type='duckdb')
+
+    def run_deletes():
+        cursor = duckdb_db.cursor()
+        for i in range(10000):
+            cursor.execute(
+                "DELETE FROM test_table WHERE id = ?",
+                (i,)
+            )
+        duckdb_db.commit()
+
+    benchmark(run_deletes)
+
+
+def test_delete_100k_duckdb(benchmark, duckdb_db):
+    """Benchmark DELETE operations on DuckDB (100K rows)."""
+    setup_test_table(duckdb_db, 100000, db_type='duckdb')
+
+    def run_deletes():
+        cursor = duckdb_db.cursor()
+        for i in range(100000):
+            cursor.execute(
+                "DELETE FROM test_table WHERE id = ?",
+                (i,)
+            )
+        duckdb_db.commit()
+
+    benchmark(run_deletes)
+
+
+# ============================================================================
+# SELECT with WHERE Clause Benchmarks - DuckDB
+# ============================================================================
+
+def test_select_where_1k_duckdb(benchmark, duckdb_db):
+    """Benchmark SELECT with WHERE clause on DuckDB (filter 10% of 1K rows)."""
+    setup_test_table(duckdb_db, 1000, db_type='duckdb')
+
+    def run_query():
+        cursor = duckdb_db.cursor()
+        cursor.execute("SELECT * FROM test_table WHERE id < 100")
+        rows = cursor.fetchall()
+        assert len(rows) == 100
+
+    benchmark(run_query)
+
+
+def test_select_where_10k_duckdb(benchmark, duckdb_db):
+    """Benchmark SELECT with WHERE clause on DuckDB (filter 10% of 10K rows)."""
+    setup_test_table(duckdb_db, 10000, db_type='duckdb')
+
+    def run_query():
+        cursor = duckdb_db.cursor()
+        cursor.execute("SELECT * FROM test_table WHERE id < 1000")
+        rows = cursor.fetchall()
+        assert len(rows) == 1000
+
+    benchmark(run_query)
+
+
+def test_select_where_100k_duckdb(benchmark, duckdb_db):
+    """Benchmark SELECT with WHERE clause on DuckDB (filter 10% of 100K rows)."""
+    setup_test_table(duckdb_db, 100000, db_type='duckdb')
+
+    def run_query():
+        cursor = duckdb_db.cursor()
+        cursor.execute("SELECT * FROM test_table WHERE id < 10000")
+        rows = cursor.fetchall()
+        assert len(rows) == 10000
+
+    benchmark(run_query)
+
+
+# ============================================================================
+# Aggregate Operation Benchmarks (COUNT, SUM, AVG) - DuckDB
+# ============================================================================
+
+def test_count_1k_duckdb(benchmark, duckdb_db):
+    """Benchmark COUNT(*) aggregation on DuckDB (1K rows)."""
+    setup_test_table(duckdb_db, 1000, db_type='duckdb')
+
+    def run_query():
+        cursor = duckdb_db.cursor()
+        cursor.execute("SELECT COUNT(*) FROM test_table")
+        result = cursor.fetchone()[0]
+        assert result == 1000
+
+    benchmark(run_query)
+
+
+def test_count_10k_duckdb(benchmark, duckdb_db):
+    """Benchmark COUNT(*) aggregation on DuckDB (10K rows)."""
+    setup_test_table(duckdb_db, 10000, db_type='duckdb')
+
+    def run_query():
+        cursor = duckdb_db.cursor()
+        cursor.execute("SELECT COUNT(*) FROM test_table")
+        result = cursor.fetchone()[0]
+        assert result == 10000
+
+    benchmark(run_query)
+
+
+def test_count_100k_duckdb(benchmark, duckdb_db):
+    """Benchmark COUNT(*) aggregation on DuckDB (100K rows)."""
+    setup_test_table(duckdb_db, 100000, db_type='duckdb')
+
+    def run_query():
+        cursor = duckdb_db.cursor()
+        cursor.execute("SELECT COUNT(*) FROM test_table")
+        result = cursor.fetchone()[0]
+        assert result == 100000
+
+    benchmark(run_query)
+
+
+def test_sum_1k_duckdb(benchmark, duckdb_db):
+    """Benchmark SUM(value) aggregation on DuckDB (1K rows)."""
+    setup_test_table(duckdb_db, 1000, db_type='duckdb')
+
+    def run_query():
+        cursor = duckdb_db.cursor()
+        cursor.execute("SELECT SUM(value) FROM test_table")
+        result = cursor.fetchone()[0]
+        assert result is not None
+
+    benchmark(run_query)
+
+
+def test_sum_10k_duckdb(benchmark, duckdb_db):
+    """Benchmark SUM(value) aggregation on DuckDB (10K rows)."""
+    setup_test_table(duckdb_db, 10000, db_type='duckdb')
+
+    def run_query():
+        cursor = duckdb_db.cursor()
+        cursor.execute("SELECT SUM(value) FROM test_table")
+        result = cursor.fetchone()[0]
+        assert result is not None
+
+    benchmark(run_query)
+
+
+def test_sum_100k_duckdb(benchmark, duckdb_db):
+    """Benchmark SUM(value) aggregation on DuckDB (100K rows)."""
+    setup_test_table(duckdb_db, 100000, db_type='duckdb')
+
+    def run_query():
+        cursor = duckdb_db.cursor()
+        cursor.execute("SELECT SUM(value) FROM test_table")
+        result = cursor.fetchone()[0]
+        assert result is not None
+
+    benchmark(run_query)
+
+
+def test_avg_1k_duckdb(benchmark, duckdb_db):
+    """Benchmark AVG(value) aggregation on DuckDB (1K rows)."""
+    setup_test_table(duckdb_db, 1000, db_type='duckdb')
+
+    def run_query():
+        cursor = duckdb_db.cursor()
+        cursor.execute("SELECT AVG(value) FROM test_table")
+        result = cursor.fetchone()[0]
+        assert result is not None
+
+    benchmark(run_query)
+
+
+def test_avg_10k_duckdb(benchmark, duckdb_db):
+    """Benchmark AVG(value) aggregation on DuckDB (10K rows)."""
+    setup_test_table(duckdb_db, 10000, db_type='duckdb')
+
+    def run_query():
+        cursor = duckdb_db.cursor()
+        cursor.execute("SELECT AVG(value) FROM test_table")
+        result = cursor.fetchone()[0]
+        assert result is not None
+
+    benchmark(run_query)
+
+
+def test_avg_100k_duckdb(benchmark, duckdb_db):
+    """Benchmark AVG(value) aggregation on DuckDB (100K rows)."""
+    setup_test_table(duckdb_db, 100000, db_type='duckdb')
+
+    def run_query():
+        cursor = duckdb_db.cursor()
         cursor.execute("SELECT AVG(value) FROM test_table")
         result = cursor.fetchone()[0]
         assert result is not None

--- a/benchmarks/utils/database_setup.py
+++ b/benchmarks/utils/database_setup.py
@@ -1,5 +1,6 @@
 """Database connection and setup utilities"""
 import sqlite3
+import duckdb
 import nistmemsql
 
 def create_sqlite_connection(in_memory=True):
@@ -10,6 +11,11 @@ def create_sqlite_connection(in_memory=True):
 def create_nistmemsql_connection():
     """Create nistmemsql connection"""
     return nistmemsql.connect()
+
+def create_duckdb_connection(in_memory=True):
+    """Create DuckDB connection"""
+    db_path = ':memory:' if in_memory else 'test.duckdb'
+    return duckdb.connect(db_path)
 
 def execute_sql_both(sqlite_conn, nistmemsql_conn, sql, params=None):
     """Execute SQL on both databases and return results"""
@@ -30,5 +36,35 @@ def execute_sql_both(sqlite_conn, nistmemsql_conn, sql, params=None):
     else:
         nistmemsql_cursor.execute(sql)
     results['nistmemsql'] = nistmemsql_cursor.fetchall()
+
+    return results
+
+def execute_sql_all(sqlite_conn, nistmemsql_conn, duckdb_conn, sql, params=None):
+    """Execute SQL on all three databases and return results"""
+    results = {}
+
+    # SQLite execution
+    sqlite_cursor = sqlite_conn.cursor()
+    if params:
+        sqlite_cursor.execute(sql, params)
+    else:
+        sqlite_cursor.execute(sql)
+    results['sqlite'] = sqlite_cursor.fetchall()
+
+    # nistmemsql execution
+    nistmemsql_cursor = nistmemsql_conn.cursor()
+    if params:
+        nistmemsql_cursor.execute(sql, params)
+    else:
+        nistmemsql_cursor.execute(sql)
+    results['nistmemsql'] = nistmemsql_cursor.fetchall()
+
+    # DuckDB execution
+    duckdb_cursor = duckdb_conn.cursor()
+    if params:
+        duckdb_cursor.execute(sql, params)
+    else:
+        duckdb_cursor.execute(sql)
+    results['duckdb'] = duckdb_cursor.fetchall()
 
     return results


### PR DESCRIPTION
## Summary

Add DuckDB as a third comparison baseline in our benchmark suite to provide competitive context for nistmemsql's performance against an industry-leading in-memory analytical database.

## Changes

### Dependencies
- Add `duckdb>=0.9.0` to `benchmarks/requirements.txt`

### Test Infrastructure  
- Add `duckdb_db` fixture to `benchmarks/conftest.py`
- Add `all_databases` fixture for three-way comparisons
- Update `database_setup.py` with DuckDB utilities:
  - `create_duckdb_connection()` helper
  - `execute_sql_all()` for three-database execution

### Benchmarks
- Update `setup_test_table()` helper to support `db_type='duckdb'`
- Add 21 DuckDB benchmark test variants covering:
  - **INSERT operations**: 1K, 10K, 100K rows
  - **UPDATE operations**: 1K, 10K, 100K rows
  - **DELETE operations**: 1K, 10K, 100K rows
  - **SELECT with WHERE**: 1K, 10K, 100K rows
  - **COUNT aggregation**: 1K, 10K, 100K rows
  - **SUM aggregation**: 1K, 10K, 100K rows
  - **AVG aggregation**: 1K, 10K, 100K rows

## Why DuckDB?

DuckDB is a strong comparison baseline because:
- **In-process, in-memory database** (like nistmemsql)
- **Designed for analytical workloads** with columnar storage
- **Exceptional performance** on aggregations and complex queries
- **Widely adopted** and provides a respected industry benchmark

## Benefits

- **Competitive context**: Shows nistmemsql performance vs. industry-leading analytical database
- **Marketing value**: Enables performance comparisons like "X% faster than DuckDB on operation Y"
- **Development insight**: Identifies specific areas where we excel or need optimization
- **Validation**: Confirms our benchmarks are realistic and comparable

## Test Plan

- ✅ Python syntax validation passed
- ✅ All files compile successfully
- ✅ 21 DuckDB test variants added (matching existing SQLite/nistmemsql pattern)
- ⏳ Benchmarks can be run with: `pytest benchmarks/test_micro_benchmarks.py -k duckdb --benchmark-only`

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)