### PR TITLE
Refactor conversion_function_tests.rs: extract common setup

### DIFF
--- a/crates/executor/tests/conversion_function_tests.rs
+++ b/crates/executor/tests/conversion_function_tests.rs
@@ -11,401 +11,273 @@ mod common;
 
 use common::create_test_evaluator;
 
-// ============================================================================
-// TO_NUMBER Function Tests
-// ============================================================================
+// ==================== HELPER FUNCTIONS ====================
+
+/// Helper to create a function expression
+fn create_function_expr(name: &str, args: Vec<ast::Expression>) -> ast::Expression {
+    ast::Expression::Function {
+        name: name.to_string(),
+        args,
+        character_unit: None,
+    }
+}
+
+/// Helper to evaluate a function and return the result
+fn eval_function(name: &str, args: Vec<ast::Expression>) -> types::SqlValue {
+    let (evaluator, row) = create_test_evaluator();
+    let expr = create_function_expr(name, args);
+    evaluator.eval(&expr, &row).unwrap()
+}
+
+/// Helper to evaluate a function and expect an error
+fn eval_function_expect_error(name: &str, args: Vec<ast::Expression>) {
+    let (evaluator, row) = create_test_evaluator();
+    let expr = create_function_expr(name, args);
+    assert!(evaluator.eval(&expr, &row).is_err());
+}
+
+/// Helper to create a varchar literal expression
+fn varchar_lit(value: &str) -> ast::Expression {
+    ast::Expression::Literal(types::SqlValue::Varchar(value.to_string()))
+}
+
+/// Helper to create a character literal expression
+fn character_lit(value: &str) -> ast::Expression {
+    ast::Expression::Literal(types::SqlValue::Character(value.to_string()))
+}
+
+/// Helper to create a date literal expression
+fn date_lit(date_str: &str) -> ast::Expression {
+    ast::Expression::Literal(types::SqlValue::Date(date_str.to_string()))
+}
+
+/// Helper to create a timestamp literal expression
+fn timestamp_lit(ts_str: &str) -> ast::Expression {
+    ast::Expression::Literal(types::SqlValue::Timestamp(ts_str.to_string()))
+}
+
+/// Helper to create a time literal expression
+fn time_lit(time_str: &str) -> ast::Expression {
+    ast::Expression::Literal(types::SqlValue::Time(time_str.to_string()))
+}
+
+/// Helper to create an integer literal expression
+fn int_lit(value: i64) -> ast::Expression {
+    ast::Expression::Literal(types::SqlValue::Integer(value))
+}
+
+/// Helper to create a smallint literal expression
+fn smallint_lit(value: i16) -> ast::Expression {
+    ast::Expression::Literal(types::SqlValue::Smallint(value))
+}
+
+/// Helper to create a bigint literal expression
+fn bigint_lit(value: i64) -> ast::Expression {
+    ast::Expression::Literal(types::SqlValue::Bigint(value))
+}
+
+/// Helper to create a double literal expression
+fn double_lit(value: f64) -> ast::Expression {
+    ast::Expression::Literal(types::SqlValue::Double(value))
+}
+
+/// Helper to create a float literal expression
+fn float_lit(value: f32) -> ast::Expression {
+    ast::Expression::Literal(types::SqlValue::Float(value))
+}
+
+/// Helper to create a real literal expression
+fn real_lit(value: f32) -> ast::Expression {
+    ast::Expression::Literal(types::SqlValue::Real(value))
+}
+
+/// Helper to create a null literal expression
+fn null_lit() -> ast::Expression {
+    ast::Expression::Literal(types::SqlValue::Null)
+}
+
+// ==================== TO_NUMBER FUNCTION TESTS ====================
 
 #[test]
 fn test_to_number_valid_integer() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("42".to_string()))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_NUMBER", vec![varchar_lit("42")]);
     assert_eq!(result, types::SqlValue::Integer(42));
 }
 
 #[test]
 fn test_to_number_valid_double() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("3.14".to_string()))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_NUMBER", vec![varchar_lit("3.14")]);
     assert_eq!(result, types::SqlValue::Double(3.14));
 }
 
 #[test]
 fn test_to_number_negative_integer() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("-42".to_string()))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_NUMBER", vec![varchar_lit("-42")]);
     assert_eq!(result, types::SqlValue::Integer(-42));
 }
 
 #[test]
 fn test_to_number_negative_double() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("-3.14".to_string()))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_NUMBER", vec![varchar_lit("-3.14")]);
     assert_eq!(result, types::SqlValue::Double(-3.14));
 }
 
 #[test]
 fn test_to_number_with_whitespace() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("  123  ".to_string()))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_NUMBER", vec![varchar_lit("  123  ")]);
     assert_eq!(result, types::SqlValue::Integer(123));
 }
 
 #[test]
 fn test_to_number_with_commas() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("1,234.56".to_string()))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_NUMBER", vec![varchar_lit("1,234.56")]);
     assert_eq!(result, types::SqlValue::Double(1234.56));
 }
 
 #[test]
 fn test_to_number_null_input() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Null)],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_NUMBER", vec![null_lit()]);
     assert_eq!(result, types::SqlValue::Null);
 }
 
 #[test]
 fn test_to_number_invalid_string() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("invalid".to_string()))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("TO_NUMBER", vec![varchar_lit("invalid")]);
 }
 
 #[test]
 fn test_to_number_mixed_alphanumeric() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("abc123".to_string()))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("TO_NUMBER", vec![varchar_lit("abc123")]);
 }
 
 #[test]
 fn test_to_number_zero() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("0".to_string()))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_NUMBER", vec![varchar_lit("0")]);
     assert_eq!(result, types::SqlValue::Integer(0));
 }
 
 #[test]
 fn test_to_number_scientific_notation() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("1.5e2".to_string()))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_NUMBER", vec![varchar_lit("1.5e2")]);
     assert_eq!(result, types::SqlValue::Double(150.0));
 }
 
 #[test]
 fn test_to_number_wrong_arg_count() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Varchar("42".to_string())),
-            ast::Expression::Literal(types::SqlValue::Varchar("extra".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("TO_NUMBER", vec![varchar_lit("42"), varchar_lit("extra")]);
 }
 
 #[test]
 fn test_to_number_non_string_argument() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_NUMBER".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Integer(42))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("TO_NUMBER", vec![int_lit(42)]);
 }
 
-// ============================================================================
-// TO_DATE Function Tests
-// ============================================================================
+// ==================== TO_DATE FUNCTION TESTS ====================
 
 #[test]
 fn test_to_date_basic() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_DATE".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Varchar("2023-12-25".to_string())),
-            ast::Expression::Literal(types::SqlValue::Varchar("YYYY-MM-DD".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_DATE", vec![varchar_lit("2023-12-25"), varchar_lit("YYYY-MM-DD")]);
     assert_eq!(result, types::SqlValue::Date("2023-12-25".to_string()));
 }
 
 #[test]
 fn test_to_date_different_format() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_DATE".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Varchar("25/12/2023".to_string())),
-            ast::Expression::Literal(types::SqlValue::Varchar("DD/MM/YYYY".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_DATE", vec![varchar_lit("25/12/2023"), varchar_lit("DD/MM/YYYY")]);
     assert_eq!(result, types::SqlValue::Date("2023-12-25".to_string()));
 }
 
 #[test]
 fn test_to_date_null_input() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_DATE".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Null),
-            ast::Expression::Literal(types::SqlValue::Varchar("YYYY-MM-DD".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_DATE", vec![null_lit(), varchar_lit("YYYY-MM-DD")]);
     assert_eq!(result, types::SqlValue::Null);
 }
 
 #[test]
 fn test_to_date_null_format() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_DATE".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Varchar("2023-12-25".to_string())),
-            ast::Expression::Literal(types::SqlValue::Null),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_DATE", vec![varchar_lit("2023-12-25"), null_lit()]);
     assert_eq!(result, types::SqlValue::Null);
 }
 
 #[test]
 fn test_to_date_invalid_format() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_DATE".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Varchar("2023-12-25".to_string())),
-            ast::Expression::Literal(types::SqlValue::Varchar("DD/MM/YYYY".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("TO_DATE", vec![varchar_lit("2023-12-25"), varchar_lit("DD/MM/YYYY")]);
 }
 
 #[test]
 fn test_to_date_wrong_arg_count() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_DATE".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Varchar("2023-12-25".to_string()))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("TO_DATE", vec![varchar_lit("2023-12-25")]);
 }
 
 #[test]
 fn test_to_date_non_string_arguments() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_DATE".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Integer(20231225)),
-            ast::Expression::Literal(types::SqlValue::Varchar("YYYY-MM-DD".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("TO_DATE", vec![int_lit(20231225), varchar_lit("YYYY-MM-DD")]);
 }
 
-// ============================================================================
-// TO_TIMESTAMP Function Tests
-// ============================================================================
+// ==================== TO_TIMESTAMP FUNCTION TESTS ====================
 
 #[test]
 fn test_to_timestamp_basic() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_TIMESTAMP".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Varchar("2023-12-25 14:30:45".to_string())),
-            ast::Expression::Literal(types::SqlValue::Varchar("YYYY-MM-DD HH24:MI:SS".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function(
+        "TO_TIMESTAMP",
+        vec![varchar_lit("2023-12-25 14:30:45"), varchar_lit("YYYY-MM-DD HH24:MI:SS")],
+    );
     assert_eq!(result, types::SqlValue::Timestamp("2023-12-25 14:30:45".to_string()));
 }
 
 #[test]
 fn test_to_timestamp_null_input() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_TIMESTAMP".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Null),
-            ast::Expression::Literal(types::SqlValue::Varchar("YYYY-MM-DD HH24:MI:SS".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function(
+        "TO_TIMESTAMP",
+        vec![null_lit(), varchar_lit("YYYY-MM-DD HH24:MI:SS")],
+    );
     assert_eq!(result, types::SqlValue::Null);
 }
 
 #[test]
 fn test_to_timestamp_null_format() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_TIMESTAMP".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Varchar("2023-12-25 14:30:45".to_string())),
-            ast::Expression::Literal(types::SqlValue::Null),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_TIMESTAMP", vec![varchar_lit("2023-12-25 14:30:45"), null_lit()]);
     assert_eq!(result, types::SqlValue::Null);
 }
 
 #[test]
 fn test_to_timestamp_wrong_arg_count() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_TIMESTAMP".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Varchar(
-            "2023-12-25 14:30:45".to_string(),
-        ))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("TO_TIMESTAMP", vec![varchar_lit("2023-12-25 14:30:45")]);
 }
 
 #[test]
 fn test_to_timestamp_non_string_arguments() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_TIMESTAMP".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Integer(20231225)),
-            ast::Expression::Literal(types::SqlValue::Varchar("YYYY-MM-DD HH24:MI:SS".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error(
+        "TO_TIMESTAMP",
+        vec![int_lit(20231225), varchar_lit("YYYY-MM-DD HH24:MI:SS")],
+    );
 }
 
 #[test]
 fn test_to_date_with_character_type() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_DATE".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Character("2023-12-25".to_string())),
-            ast::Expression::Literal(types::SqlValue::Character("YYYY-MM-DD".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function(
+        "TO_DATE",
+        vec![character_lit("2023-12-25"), character_lit("YYYY-MM-DD")],
+    );
     assert_eq!(result, types::SqlValue::Date("2023-12-25".to_string()));
 }
 
 #[test]
 fn test_to_timestamp_with_character_type() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_TIMESTAMP".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Character("2023-12-25 14:30:45".to_string())),
-            ast::Expression::Literal(types::SqlValue::Character(
-                "YYYY-MM-DD HH24:MI:SS".to_string(),
-            )),
+    let result = eval_function(
+        "TO_TIMESTAMP",
+        vec![
+            character_lit("2023-12-25 14:30:45"),
+            character_lit("YYYY-MM-DD HH24:MI:SS"),
         ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    );
     assert_eq!(result, types::SqlValue::Timestamp("2023-12-25 14:30:45".to_string()));
 }
 
-// ============================================================================
-// TO_CHAR Function Tests
-// ============================================================================
+// ==================== TO_CHAR FUNCTION TESTS ====================
 
 #[test]
 fn test_to_char_date() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Date("2023-12-25".to_string())),
-            ast::Expression::Literal(types::SqlValue::Varchar("YYYY-MM-DD".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_CHAR", vec![date_lit("2023-12-25"), varchar_lit("YYYY-MM-DD")]);
     match result {
         types::SqlValue::Varchar(s) => {
             assert_eq!(s, "2023-12-25");
@@ -416,16 +288,13 @@ fn test_to_char_date() {
 
 #[test]
 fn test_to_char_timestamp() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Timestamp("2023-12-25 14:30:45".to_string())),
-            ast::Expression::Literal(types::SqlValue::Varchar("YYYY-MM-DD HH24:MI:SS".to_string())),
+    let result = eval_function(
+        "TO_CHAR",
+        vec![
+            timestamp_lit("2023-12-25 14:30:45"),
+            varchar_lit("YYYY-MM-DD HH24:MI:SS"),
         ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    );
     match result {
         types::SqlValue::Varchar(s) => {
             assert_eq!(s, "2023-12-25 14:30:45");
@@ -436,16 +305,7 @@ fn test_to_char_timestamp() {
 
 #[test]
 fn test_to_char_integer() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Integer(42)),
-            ast::Expression::Literal(types::SqlValue::Varchar("999".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_CHAR", vec![int_lit(42), varchar_lit("999")]);
     match result {
         types::SqlValue::Varchar(_) => {
             // Accept any varchar result - the specific formatting depends on format_number implementation
@@ -456,16 +316,7 @@ fn test_to_char_integer() {
 
 #[test]
 fn test_to_char_double() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Double(3.14)),
-            ast::Expression::Literal(types::SqlValue::Varchar("999.99".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_CHAR", vec![double_lit(3.14), varchar_lit("999.99")]);
     match result {
         types::SqlValue::Varchar(_) => {
             // Accept any varchar result - the specific formatting depends on format_number implementation
@@ -476,111 +327,43 @@ fn test_to_char_double() {
 
 #[test]
 fn test_to_char_null_value() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Null),
-            ast::Expression::Literal(types::SqlValue::Varchar("YYYY-MM-DD".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_CHAR", vec![null_lit(), varchar_lit("YYYY-MM-DD")]);
     assert_eq!(result, types::SqlValue::Null);
 }
 
 #[test]
 fn test_to_char_null_format() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Date("2023-12-25".to_string())),
-            ast::Expression::Literal(types::SqlValue::Null),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_CHAR", vec![date_lit("2023-12-25"), null_lit()]);
     assert_eq!(result, types::SqlValue::Null);
 }
 
 #[test]
 fn test_to_char_wrong_arg_count() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Date("2023-12-25".to_string()))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("TO_CHAR", vec![date_lit("2023-12-25")]);
 }
 
 #[test]
 fn test_to_char_all_numeric_types() {
-    let (evaluator, row) = create_test_evaluator();
-
     // Test Smallint
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Smallint(42)),
-            ast::Expression::Literal(types::SqlValue::Varchar("999".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_CHAR", vec![smallint_lit(42), varchar_lit("999")]);
     assert!(matches!(result, types::SqlValue::Varchar(_)));
 
     // Test Bigint
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Bigint(42000)),
-            ast::Expression::Literal(types::SqlValue::Varchar("999999".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_CHAR", vec![bigint_lit(42000), varchar_lit("999999")]);
     assert!(matches!(result, types::SqlValue::Varchar(_)));
 
     // Test Float
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Float(3.14)),
-            ast::Expression::Literal(types::SqlValue::Varchar("999.99".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_CHAR", vec![float_lit(3.14), varchar_lit("999.99")]);
     assert!(matches!(result, types::SqlValue::Varchar(_)));
 
     // Test Real
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Real(2.71)),
-            ast::Expression::Literal(types::SqlValue::Varchar("999.99".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_CHAR", vec![real_lit(2.71), varchar_lit("999.99")]);
     assert!(matches!(result, types::SqlValue::Varchar(_)));
 }
 
 #[test]
 fn test_to_char_time() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Time("14:30:45".to_string())),
-            ast::Expression::Literal(types::SqlValue::Varchar("HH24:MI:SS".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("TO_CHAR", vec![time_lit("14:30:45"), varchar_lit("HH24:MI:SS")]);
     match result {
         types::SqlValue::Varchar(s) => {
             assert_eq!(s, "14:30:45");
@@ -591,35 +374,14 @@ fn test_to_char_time() {
 
 #[test]
 fn test_to_char_non_string_format() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "TO_CHAR".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Date("2023-12-25".to_string())),
-            ast::Expression::Literal(types::SqlValue::Integer(123)),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("TO_CHAR", vec![date_lit("2023-12-25"), int_lit(123)]);
 }
 
-// ============================================================================
-// CAST Function Tests
-// ============================================================================
+// ==================== CAST FUNCTION TESTS ====================
 
 #[test]
 fn test_cast_integer_to_varchar() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "CAST".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Integer(42)),
-            ast::Expression::Literal(types::SqlValue::Varchar("VARCHAR".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("CAST", vec![int_lit(42), varchar_lit("VARCHAR")]);
     match result {
         types::SqlValue::Varchar(s) => assert_eq!(s, "42"),
         types::SqlValue::Character(s) => assert_eq!(s, "42"),
@@ -629,118 +391,45 @@ fn test_cast_integer_to_varchar() {
 
 #[test]
 fn test_cast_varchar_to_integer() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "CAST".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Varchar("42".to_string())),
-            ast::Expression::Literal(types::SqlValue::Varchar("INTEGER".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("CAST", vec![varchar_lit("42"), varchar_lit("INTEGER")]);
     assert_eq!(result, types::SqlValue::Integer(42));
 }
 
 #[test]
 fn test_cast_integer_to_double() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "CAST".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Integer(42)),
-            ast::Expression::Literal(types::SqlValue::Varchar("DOUBLE".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("CAST", vec![int_lit(42), varchar_lit("DOUBLE")]);
     assert_eq!(result, types::SqlValue::Double(42.0));
 }
 
 #[test]
 fn test_cast_double_to_integer_unsupported() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "CAST".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Double(42.9)),
-            ast::Expression::Literal(types::SqlValue::Varchar("INTEGER".to_string())),
-        ],
-        character_unit: None,
-    };
     // Note: Double to Integer cast is not currently supported in the implementation
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("CAST", vec![double_lit(42.9), varchar_lit("INTEGER")]);
 }
 
 #[test]
 fn test_cast_smallint_to_bigint() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "CAST".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Smallint(42)),
-            ast::Expression::Literal(types::SqlValue::Varchar("BIGINT".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("CAST", vec![smallint_lit(42), varchar_lit("BIGINT")]);
     assert_eq!(result, types::SqlValue::Bigint(42));
 }
 
 #[test]
 fn test_cast_varchar_to_date() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "CAST".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Varchar("2023-12-25".to_string())),
-            ast::Expression::Literal(types::SqlValue::Varchar("DATE".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row).unwrap();
+    let result = eval_function("CAST", vec![varchar_lit("2023-12-25"), varchar_lit("DATE")]);
     assert_eq!(result, types::SqlValue::Date("2023-12-25".to_string()));
 }
 
 #[test]
 fn test_cast_unsupported_type() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "CAST".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Integer(42)),
-            ast::Expression::Literal(types::SqlValue::Varchar("BLOB".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("CAST", vec![int_lit(42), varchar_lit("BLOB")]);
 }
 
 #[test]
 fn test_cast_wrong_arg_count() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "CAST".to_string(),
-        args: vec![ast::Expression::Literal(types::SqlValue::Integer(42))],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("CAST", vec![int_lit(42)]);
 }
 
 #[test]
 fn test_cast_invalid_conversion() {
-    let (evaluator, row) = create_test_evaluator();
-    let expr = ast::Expression::Function {
-        name: "CAST".to_string(),
-        args: vec![
-            ast::Expression::Literal(types::SqlValue::Varchar("invalid".to_string())),
-            ast::Expression::Literal(types::SqlValue::Varchar("INTEGER".to_string())),
-        ],
-        character_unit: None,
-    };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    eval_function_expect_error("CAST", vec![varchar_lit("invalid"), varchar_lit("INTEGER")]);
 }


### PR DESCRIPTION
## Summary

Refactored `crates/executor/tests/conversion_function_tests.rs` to extract common setup patterns and improve code organization:

- **Added helper functions** for creating expressions and evaluating functions, eliminating repetitive boilerplate
- **Created literal helper functions** for all SQL value types (varchar, date, timestamp, int, etc.)
- **Reorganized tests by conversion type** with clear section markers:
  - `TO_NUMBER`: String to numeric conversions
  - `TO_DATE`: String to date with format
  - `TO_TIMESTAMP`: String to timestamp with format
  - `TO_CHAR`: Date/number to formatted string
  - `CAST`: Standard SQL type conversion
- **Reduced file size** from 746 lines to 435 lines (42% reduction)
- **All 46 tests pass** - functionality unchanged

This refactoring improves maintainability by reducing duplication and making the test structure more consistent with other refactored test files in the codebase.

## Test plan

- [x] All conversion function tests pass: `cargo test -p executor --test conversion_function_tests`
- [x] Verified no functionality changes - only refactoring

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)