### PR TITLE
test: Add parser tests for CREATE INDEX and DROP INDEX statements

### DIFF
--- a/crates/parser/src/tests/index.rs
+++ b/crates/parser/src/tests/index.rs
@@ -1,0 +1,158 @@
+//! Tests for INDEX DDL statements (CREATE INDEX, DROP INDEX)
+
+use crate::Parser;
+use ast::Statement;
+
+#[test]
+fn test_create_index_simple() {
+    let sql = "CREATE INDEX idx ON users(email)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.index_name, "IDX");
+            assert_eq!(stmt.table_name, "USERS");
+            assert!(!stmt.unique);
+            assert_eq!(stmt.columns, vec!["EMAIL"]);
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_unique_index() {
+    let sql = "CREATE UNIQUE INDEX idx ON users(email)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert!(stmt.unique, "Expected unique=true");
+            assert_eq!(stmt.index_name, "IDX");
+            assert_eq!(stmt.table_name, "USERS");
+            assert_eq!(stmt.columns, vec!["EMAIL"]);
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_index_multi_column() {
+    let sql = "CREATE INDEX idx ON users(first_name, last_name, email)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.index_name, "IDX");
+            assert_eq!(stmt.table_name, "USERS");
+            assert!(!stmt.unique);
+            assert_eq!(stmt.columns, vec!["FIRST_NAME", "LAST_NAME", "EMAIL"]);
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_unique_index_multi_column() {
+    let sql = "CREATE UNIQUE INDEX idx ON orders(customer_id, order_date)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert!(stmt.unique);
+            assert_eq!(stmt.index_name, "IDX");
+            assert_eq!(stmt.table_name, "ORDERS");
+            assert_eq!(stmt.columns, vec!["CUSTOMER_ID", "ORDER_DATE"]);
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_index_mixed_case_identifiers() {
+    let sql = "CREATE INDEX MyIndex ON MyTable(MyColumn)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.index_name, "MYINDEX");
+            assert_eq!(stmt.table_name, "MYTABLE");
+            assert_eq!(stmt.columns, vec!["MYCOLUMN"]);
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_index_single_column() {
+    let sql = "CREATE INDEX pk ON users(id)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.index_name, "PK");
+            assert_eq!(stmt.table_name, "USERS");
+            assert_eq!(stmt.columns, vec!["ID"]);
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_drop_index_simple() {
+    let sql = "DROP INDEX idx";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok());
+
+    match result.unwrap() {
+        Statement::DropIndex(stmt) => {
+            assert_eq!(stmt.index_name, "IDX");
+        }
+        other => panic!("Expected DropIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_drop_index_mixed_case() {
+    let sql = "DROP INDEX MyIndex";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok());
+
+    match result.unwrap() {
+        Statement::DropIndex(stmt) => {
+            assert_eq!(stmt.index_name, "MYINDEX");
+        }
+        other => panic!("Expected DropIndex, got: {:?}", other),
+    }
+}
+
+// Error cases
+
+#[test]
+fn test_create_index_missing_index_name() {
+    let sql = "CREATE INDEX ON table(col)";
+    assert!(Parser::parse_sql(sql).is_err());
+}
+
+#[test]
+fn test_create_index_missing_table_name() {
+    let sql = "CREATE INDEX idx (col)";
+    assert!(Parser::parse_sql(sql).is_err());
+}
+
+#[test]
+fn test_create_index_empty_column_list() {
+    let sql = "CREATE INDEX idx ON table()";
+    assert!(Parser::parse_sql(sql).is_err());
+}
+
+#[test]
+fn test_drop_index_missing_index_name() {
+    let sql = "DROP INDEX";
+    assert!(Parser::parse_sql(sql).is_err());
+}

--- a/crates/parser/src/tests/mod.rs
+++ b/crates/parser/src/tests/mod.rs
@@ -36,6 +36,7 @@ mod string_functions;
 mod subquery;
 mod transaction;
 mod translation;
+mod index;
 mod trigger;
 mod update;
 mod view;


### PR DESCRIPTION
Closes #763

## Summary

Add comprehensive parser tests for the CREATE INDEX and DROP INDEX functionality added in PR #762.

## Changes

- Created `crates/parser/src/tests/index.rs` with 12 comprehensive tests
- Added `mod index;` to `crates/parser/src/tests/mod.rs`
- Tests cover:
  - Basic CREATE INDEX (single column)
  - CREATE UNIQUE INDEX 
  - Multi-column indexes
  - Identifier normalization (uppercase)
  - Error cases (missing names, empty column lists)
  - Basic DROP INDEX with mixed case handling

## Verification

- All 12 new tests pass
- Full parser test suite passes (708 tests total)
- Follows existing test patterns from view.rs and trigger.rs

## Related

- PR #762 - Added CREATE/DROP INDEX stub implementation (merged 2025-11-01)
- Issue #751 - Original SQLLogicTest improvement task