### PR TITLE
Fix compilation error in test_update_hash_indexes.rs

### DIFF
--- a/tests/test_update_hash_indexes.rs
+++ b/tests/test_update_hash_indexes.rs
@@ -11,18 +11,16 @@ fn test_update_hash_indexes() {
     let mut db = Database::new();
 
     // Create a table with primary key and unique constraint
-    let schema = TableSchema {
-        name: "users".to_string(),
-        columns: vec![
+    let schema = TableSchema::with_all_constraints(
+        "users".to_string(),
+        vec![
             ColumnSchema::new("id".to_string(), DataType::Integer, false),
             ColumnSchema::new("email".to_string(), DataType::Varchar { max_length: Some(100) }, false),
             ColumnSchema::new("username".to_string(), DataType::Varchar { max_length: Some(50) }, false),
         ],
-        primary_key: Some(vec!["id".to_string()]),
-        unique_constraints: vec![vec!["email".to_string()], vec!["username".to_string()]],
-        check_constraints: Vec::new(),
-        foreign_keys: Vec::new(),
-    };
+        Some(vec!["id".to_string()]),
+        vec![vec!["email".to_string()], vec!["username".to_string()]],
+    );
 
     db.create_table(schema).unwrap();
 


### PR DESCRIPTION
## Summary

Fixes the compilation error in `test_update_hash_indexes.rs` that was blocking CI after PR #801 introduced the private `column_index_cache` field to `TableSchema`.

## Changes

- Updated `tests/test_update_hash_indexes.rs:14` to use `TableSchema::with_all_constraints()` constructor instead of struct literal syntax
- Ensures the `column_index_cache` field is properly initialized

## Testing

- ✅ `cargo test --test test_update_hash_indexes` passes
- ✅ Test compiles successfully

## Impact

- Unblocks CI on main branch
- Allows other PRs (like #802) to merge

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)