### PR TITLE
Refactor crates/executor/src/tests/select_basic.rs (737 lines)

### DIFF
--- a/crates/executor/src/tests/mod.rs
+++ b/crates/executor/src/tests/mod.rs
@@ -3,7 +3,9 @@
 //! Tests are organized by feature area:
 //! - `expression_eval`: Expression evaluator tests (literals, column refs, binary ops)
 //! - `limit_offset`: LIMIT/OFFSET pagination tests
-//! - `select_basic`: Basic SELECT tests (wildcards, columns, ORDER BY)
+//! - `select_basic_projection`: Basic SELECT projection tests (wildcards, specific columns)
+//! - `select_order_by`: ORDER BY clause tests
+//! - `select_derived_columns`: Derived column lists (SQL:1999 E051-07/08) tests
 //! - `select_where`: WHERE clause filtering tests
 //! - `select_distinct`: DISTINCT keyword tests for duplicate removal
 //! - `aggregate_count_sum_avg_tests`: COUNT, SUM, AVG functions with NULL handling
@@ -42,8 +44,10 @@ mod privilege_checker_tests;
 mod scalar_subquery_basic_tests;
 mod scalar_subquery_correlated_tests;
 mod scalar_subquery_error_tests;
-mod select_basic;
+mod select_basic_projection;
+mod select_derived_columns;
 mod select_distinct;
+mod select_order_by;
 mod select_into_tests;
 mod select_joins;
 mod select_where;

--- a/crates/executor/src/tests/select_basic_projection.rs
+++ b/crates/executor/src/tests/select_basic_projection.rs
@@ -1,0 +1,121 @@
+//! Basic SELECT projection tests (no WHERE, no aggregates, no JOINs)
+//!
+//! Tests for fundamental SELECT projection functionality including wildcards and column selection.
+
+use super::super::*;
+
+/// Test SELECT * from a table
+#[test]
+fn test_select_star() {
+    let mut db = storage::Database::new();
+    let schema = catalog::TableSchema::new(
+        "users".to_string(),
+        vec![
+            catalog::ColumnSchema::new("id".to_string(), types::DataType::Integer, false),
+            catalog::ColumnSchema::new(
+                "name".to_string(),
+                types::DataType::Varchar { max_length: Some(100) },
+                true,
+            ),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    db.insert_row(
+        "users",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(1),
+            types::SqlValue::Varchar("Alice".to_string()),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "users",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(2),
+            types::SqlValue::Varchar("Bob".to_string()),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+    let stmt = ast::SelectStmt {
+        into_table: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
+        from: Some(ast::FromClause::Table { name: "users".to_string(), alias: None }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].values[0], types::SqlValue::Integer(1));
+    assert_eq!(result[0].values[1], types::SqlValue::Varchar("Alice".to_string()));
+    assert_eq!(result[1].values[0], types::SqlValue::Integer(2));
+    assert_eq!(result[1].values[1], types::SqlValue::Varchar("Bob".to_string()));
+}
+
+/// Test SELECT specific columns from a table
+#[test]
+fn test_select_specific_columns() {
+    let mut db = storage::Database::new();
+    let schema = catalog::TableSchema::new(
+        "users".to_string(),
+        vec![
+            catalog::ColumnSchema::new("id".to_string(), types::DataType::Integer, false),
+            catalog::ColumnSchema::new(
+                "name".to_string(),
+                types::DataType::Varchar { max_length: Some(100) },
+                true,
+            ),
+            catalog::ColumnSchema::new("age".to_string(), types::DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    db.insert_row(
+        "users",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(1),
+            types::SqlValue::Varchar("Alice".to_string()),
+            types::SqlValue::Integer(25),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+    let stmt = ast::SelectStmt {
+        into_table: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![
+            ast::SelectItem::Expression {
+                expr: ast::Expression::ColumnRef { table: None, column: "name".to_string() },
+                alias: None,
+            },
+            ast::SelectItem::Expression {
+                expr: ast::Expression::ColumnRef { table: None, column: "age".to_string() },
+                alias: None,
+            },
+        ],
+        from: Some(ast::FromClause::Table { name: "users".to_string(), alias: None }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].values.len(), 2);
+    assert_eq!(result[0].values[0], types::SqlValue::Varchar("Alice".to_string()));
+    assert_eq!(result[0].values[1], types::SqlValue::Integer(25));
+}

--- a/crates/executor/src/tests/select_order_by.rs
+++ b/crates/executor/src/tests/select_order_by.rs
@@ -1,0 +1,146 @@
+//! Basic SELECT ORDER BY tests
+//!
+//! Tests for ORDER BY functionality including single and multiple column ordering.
+
+use super::super::*;
+
+/// Test ORDER BY single column ascending
+#[test]
+fn test_order_by_single_column_asc() {
+    let mut db = storage::Database::new();
+    let schema = catalog::TableSchema::new(
+        "users".to_string(),
+        vec![
+            catalog::ColumnSchema::new("id".to_string(), types::DataType::Integer, false),
+            catalog::ColumnSchema::new("age".to_string(), types::DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    db.insert_row(
+        "users",
+        storage::Row::new(vec![types::SqlValue::Integer(1), types::SqlValue::Integer(30)]),
+    )
+    .unwrap();
+    db.insert_row(
+        "users",
+        storage::Row::new(vec![types::SqlValue::Integer(2), types::SqlValue::Integer(20)]),
+    )
+    .unwrap();
+    db.insert_row(
+        "users",
+        storage::Row::new(vec![types::SqlValue::Integer(3), types::SqlValue::Integer(25)]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+    let stmt = ast::SelectStmt {
+        into_table: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
+        from: Some(ast::FromClause::Table { name: "users".to_string(), alias: None }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: Some(vec![ast::OrderByItem {
+            expr: ast::Expression::ColumnRef { table: None, column: "age".to_string() },
+            direction: ast::OrderDirection::Asc,
+        }]),
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 3);
+    assert_eq!(result[0].values[1], types::SqlValue::Integer(20));
+    assert_eq!(result[1].values[1], types::SqlValue::Integer(25));
+    assert_eq!(result[2].values[1], types::SqlValue::Integer(30));
+}
+
+/// Test ORDER BY multiple columns with different directions
+#[test]
+fn test_order_by_multiple_columns() {
+    let mut db = storage::Database::new();
+    let schema = catalog::TableSchema::new(
+        "users".to_string(),
+        vec![
+            catalog::ColumnSchema::new("id".to_string(), types::DataType::Integer, false),
+            catalog::ColumnSchema::new("dept".to_string(), types::DataType::Integer, false),
+            catalog::ColumnSchema::new("age".to_string(), types::DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    db.insert_row(
+        "users",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(1),
+            types::SqlValue::Integer(2),
+            types::SqlValue::Integer(35),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "users",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(2),
+            types::SqlValue::Integer(1),
+            types::SqlValue::Integer(30),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "users",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(3),
+            types::SqlValue::Integer(2),
+            types::SqlValue::Integer(20),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "users",
+        storage::Row::new(vec![
+            types::SqlValue::Integer(4),
+            types::SqlValue::Integer(1),
+            types::SqlValue::Integer(25),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+    let stmt = ast::SelectStmt {
+        into_table: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![ast::SelectItem::Wildcard { alias: None }],
+        from: Some(ast::FromClause::Table { name: "users".to_string(), alias: None }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: Some(vec![
+            ast::OrderByItem {
+                expr: ast::Expression::ColumnRef { table: None, column: "dept".to_string() },
+                direction: ast::OrderDirection::Asc,
+            },
+            ast::OrderByItem {
+                expr: ast::Expression::ColumnRef { table: None, column: "age".to_string() },
+                direction: ast::OrderDirection::Desc,
+            },
+        ]),
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 4);
+    assert_eq!(result[0].values[1], types::SqlValue::Integer(1));
+    assert_eq!(result[0].values[2], types::SqlValue::Integer(30));
+    assert_eq!(result[1].values[1], types::SqlValue::Integer(1));
+    assert_eq!(result[1].values[2], types::SqlValue::Integer(25));
+    assert_eq!(result[2].values[1], types::SqlValue::Integer(2));
+    assert_eq!(result[2].values[2], types::SqlValue::Integer(35));
+    assert_eq!(result[3].values[1], types::SqlValue::Integer(2));
+    assert_eq!(result[3].values[2], types::SqlValue::Integer(20));
+}


### PR DESCRIPTION
This PR addresses issue #806 by refactoring the large select_basic.rs test file (737 lines) into three smaller, more focused test files:

- **select_basic_projection.rs**: Basic projection tests (SELECT *, specific columns)
- **select_order_by.rs**: ORDER BY clause tests  
- **select_derived_columns.rs**: SQL:1999 derived column lists tests

## Changes Made

1. Split the original 737-line file into three logical groups
2. Updated  to include the new test modules
3. Removed the original  file
4. Preserved all existing test functionality

This improves code maintainability and makes it easier to find and run specific types of SELECT tests.

Closes #806