### PR TITLE
perf: Add executemany() method and statement caching for UPDATE optimization

### DIFF
--- a/benchmarks/test_update.py
+++ b/benchmarks/test_update.py
@@ -20,6 +20,23 @@ def test_update_1k_nistmemsql(benchmark, nistmemsql_db):
     _run_update_test(benchmark, nistmemsql_db, 1000, 'nistmemsql')
 
 
+def test_update_1k_nistmemsql_batch(benchmark, nistmemsql_db):
+    """Benchmark batched UPDATE operations on nistmemsql (1k rows) using executemany."""
+    setup_test_table(nistmemsql_db, 1000, 'nistmemsql')
+
+    def run_updates():
+        cursor = nistmemsql_db.cursor()
+        # Create list of all UPDATE statements
+        statements = [
+            f"UPDATE test_table SET value = value + 1 WHERE id = {i}"
+            for i in range(1000)
+        ]
+        # Execute them all at once with executemany
+        cursor.executemany(statements)
+
+    benchmark(run_updates)
+
+
 def test_update_1k_duckdb(benchmark, duckdb_db):
     """Benchmark UPDATE operations on DuckDB (1k rows)."""
     setup_test_table(duckdb_db, 1000, 'duckdb')


### PR DESCRIPTION
## Summary

Implements infrastructure improvements for UPDATE query performance optimization as outlined in #815:

- ✅ **executemany() method**: New DB-API 2.0 compatible batch execution method
- ✅ **Statement caching**: Per-cursor cache (max 1000) for parsed SQL statements
- ✅ **Benchmark suite**: Added test_update_1k_nistmemsql_batch to track improvements

## Changes

### Python Bindings (`crates/python-bindings/src/lib.rs`)

1. **New `executemany()` method**: Executes multiple SQL statements in a single call, reducing FFI overhead
2. **Statement cache**: HashMap-based cache at cursor level to avoid reparsing identical SQL
3. **Refactored execute()**: Now uses internal `execute_internal()` helper for code reuse

### Benchmarks (`benchmarks/test_update.py`)

- Added `test_update_1k_nistmemsql_batch` to demonstrate and track batch execution performance

## Performance Analysis

### Current Results
```
test_update_1k_sqlite           1.28ms (1.0x baseline)
test_update_1k_nistmemsql       48.4ms (37.8x slower than SQLite)
test_update_1k_nistmemsql_batch 49.4ms (38.6x slower than SQLite)
```

### Findings

The optimizations provide infrastructure but don't significantly improve the benchmark because:

1. **FFI overhead is NOT the bottleneck**: Batching shows no improvement
2. **Each UPDATE is unique**: 1000 different SQL strings means 1000 cache misses
3. **Real bottleneck**: Per-statement execution overhead dominates:
   - SQL parsing (even with caching, still need to parse unique statements)
   - Schema lookups (2 catalog lookups per UPDATE)
   - Expression evaluation
   - Constraint validation (already optimized with early exits)

### Path Forward

To achieve the 5x improvement goal (<10ms for 1k UPDATEs), we need:

1. **Prepared statements with parameter binding** (highest impact)
   - Parse once: `UPDATE table SET value = value + 1 WHERE id = ?`
   - Execute 1000 times with different parameters
   - Would eliminate 999 parse operations

2. **Schema lookup caching** (medium impact)
   - Cache table schema at cursor level
   - Avoid repeated catalog lookups

3. **Batch constraint validation** (low-medium impact)
   - Collect all updates first
   - Validate constraints once for the batch
   - Requires careful SQL semantics preservation

## Testing

✅ All 44 UPDATE tests pass
✅ No regressions in functionality
✅ New benchmark tracks batch execution

## Related Issues

Closes #815 (partial - provides foundation, full optimization requires prepared statements)

## Test Plan

- [x] Run UPDATE test suite: `cargo test --package executor -- update`
- [x] Run benchmarks: `pytest test_update.py -v --benchmark-only`
- [x] Verify no regressions in other test suites
- [x] Confirm executemany() works correctly with different statement types

🤖 Generated with [Claude Code](https://claude.com/claude-code)