### PR TITLE
refactor: Extract index management into IndexManager module (Phase 1)

### DIFF
--- a/crates/storage/src/table/indexes.rs
+++ b/crates/storage/src/table/indexes.rs
@@ -1,0 +1,477 @@
+// ============================================================================
+// Index Manager - Hash-based index management for primary keys and unique constraints
+// ============================================================================
+
+use crate::Row;
+use std::collections::{HashMap, HashSet};
+use types::SqlValue;
+
+/// Represents different types of indexes that can be affected by column updates
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum IndexType {
+    /// Primary key index
+    PrimaryKey,
+    /// Unique constraint index (with constraint index)
+    UniqueConstraint(usize),
+}
+
+/// Manages hash-based indexes for primary keys and unique constraints
+///
+/// This component encapsulates all index-related operations, maintaining
+/// hash maps that provide O(1) lookup for constraint validation.
+#[derive(Debug, Clone)]
+pub(crate) struct IndexManager {
+    primary_key_index: Option<HashMap<Vec<SqlValue>, usize>>,
+    unique_indexes: Vec<HashMap<Vec<SqlValue>, usize>>,
+}
+
+impl IndexManager {
+    /// Create a new IndexManager initialized for the given schema
+    pub(crate) fn new(schema: &catalog::TableSchema) -> Self {
+        let primary_key_index =
+            if schema.primary_key.is_some() { Some(HashMap::new()) } else { None };
+
+        let unique_indexes =
+            (0..schema.unique_constraints.len()).map(|_| HashMap::new()).collect();
+
+        IndexManager { primary_key_index, unique_indexes }
+    }
+
+    /// Get reference to primary key index
+    #[inline]
+    pub(crate) fn primary_key_index(&self) -> Option<&HashMap<Vec<SqlValue>, usize>> {
+        self.primary_key_index.as_ref()
+    }
+
+    /// Get reference to unique constraint indexes
+    #[inline]
+    pub(crate) fn unique_indexes(&self) -> &[HashMap<Vec<SqlValue>, usize>] {
+        &self.unique_indexes
+    }
+
+    /// Update hash indexes when inserting a row
+    #[inline]
+    pub(crate) fn update_for_insert(
+        &mut self,
+        schema: &catalog::TableSchema,
+        row: &Row,
+        row_index: usize,
+    ) {
+        // Update primary key index
+        if let Some(ref mut pk_index) = self.primary_key_index {
+            if let Some(pk_indices) = schema.get_primary_key_indices() {
+                let pk_values: Vec<SqlValue> =
+                    pk_indices.iter().map(|&idx| row.values[idx].clone()).collect();
+                pk_index.insert(pk_values, row_index);
+            }
+        }
+
+        // Update unique constraint indexes
+        let unique_constraint_indices = schema.get_unique_constraint_indices();
+        for (constraint_idx, unique_indices) in unique_constraint_indices.iter().enumerate() {
+            let unique_values: Vec<SqlValue> =
+                unique_indices.iter().map(|&idx| row.values[idx].clone()).collect();
+
+            // Skip if any value in the unique constraint is NULL
+            if unique_values.iter().any(|v| *v == SqlValue::Null) {
+                continue;
+            }
+
+            if let Some(unique_index) = self.unique_indexes.get_mut(constraint_idx) {
+                unique_index.insert(unique_values, row_index);
+            }
+        }
+    }
+
+    /// Update hash indexes when updating a row
+    #[inline]
+    pub(crate) fn update_for_update(
+        &mut self,
+        schema: &catalog::TableSchema,
+        old_row: &Row,
+        new_row: &Row,
+        row_index: usize,
+    ) {
+        // Update primary key index
+        if let Some(ref mut pk_index) = self.primary_key_index {
+            if let Some(pk_indices) = schema.get_primary_key_indices() {
+                let old_pk_values: Vec<SqlValue> =
+                    pk_indices.iter().map(|&idx| old_row.values[idx].clone()).collect();
+                let new_pk_values: Vec<SqlValue> =
+                    pk_indices.iter().map(|&idx| new_row.values[idx].clone()).collect();
+
+                // Remove old key if different from new key
+                if old_pk_values != new_pk_values {
+                    pk_index.remove(&old_pk_values);
+                    pk_index.insert(new_pk_values, row_index);
+                }
+            }
+        }
+
+        // Update unique constraint indexes
+        let unique_constraint_indices = schema.get_unique_constraint_indices();
+        for (constraint_idx, unique_indices) in unique_constraint_indices.iter().enumerate() {
+            let old_unique_values: Vec<SqlValue> =
+                unique_indices.iter().map(|&idx| old_row.values[idx].clone()).collect();
+            let new_unique_values: Vec<SqlValue> =
+                unique_indices.iter().map(|&idx| new_row.values[idx].clone()).collect();
+
+            if let Some(unique_index) = self.unique_indexes.get_mut(constraint_idx) {
+                // Remove old key if it's different and not NULL
+                if old_unique_values != new_unique_values
+                    && !old_unique_values.iter().any(|v| *v == SqlValue::Null)
+                {
+                    unique_index.remove(&old_unique_values);
+                }
+
+                // Insert new key if not NULL
+                if !new_unique_values.iter().any(|v| *v == SqlValue::Null) {
+                    unique_index.insert(new_unique_values, row_index);
+                }
+            }
+        }
+    }
+
+    /// Determine which indexes are affected by column changes
+    ///
+    /// Returns an enum describing which indexes need updating based on the changed columns.
+    /// This allows selective index maintenance for performance optimization.
+    ///
+    /// # Arguments
+    /// * `schema` - Table schema containing index definitions
+    /// * `changed_columns` - Set of column indices that were modified
+    ///
+    /// # Returns
+    /// Vector of index types that are affected by the changes
+    pub(crate) fn get_affected_indexes(
+        &self,
+        schema: &catalog::TableSchema,
+        changed_columns: &HashSet<usize>,
+    ) -> Vec<IndexType> {
+        let mut affected = Vec::new();
+
+        // Check if primary key affected
+        if let Some(pk_indices) = schema.get_primary_key_indices() {
+            if pk_indices.iter().any(|idx| changed_columns.contains(idx)) {
+                affected.push(IndexType::PrimaryKey);
+            }
+        }
+
+        // Check which unique constraints affected
+        let unique_constraint_indices = schema.get_unique_constraint_indices();
+        for (constraint_idx, unique_indices) in unique_constraint_indices.iter().enumerate() {
+            if unique_indices.iter().any(|col_idx| changed_columns.contains(col_idx)) {
+                affected.push(IndexType::UniqueConstraint(constraint_idx));
+            }
+        }
+
+        affected
+    }
+
+    /// Update only affected indexes after a row update
+    ///
+    /// This is a performance optimization that only updates indexes that reference
+    /// changed columns, rather than updating all indexes unconditionally.
+    ///
+    /// # Arguments
+    /// * `schema` - Table schema containing index definitions
+    /// * `old_row` - Row data before the update
+    /// * `new_row` - Row data after the update
+    /// * `row_index` - Index of the row in the table
+    /// * `affected_indexes` - List of indexes that need updating
+    #[inline]
+    pub(crate) fn update_selective(
+        &mut self,
+        schema: &catalog::TableSchema,
+        old_row: &Row,
+        new_row: &Row,
+        row_index: usize,
+        affected_indexes: &[IndexType],
+    ) {
+        for index_type in affected_indexes {
+            match index_type {
+                IndexType::PrimaryKey => {
+                    // Update primary key index
+                    if let Some(ref mut pk_index) = self.primary_key_index {
+                        if let Some(pk_indices) = schema.get_primary_key_indices() {
+                            let old_pk_values: Vec<SqlValue> =
+                                pk_indices.iter().map(|&idx| old_row.values[idx].clone()).collect();
+                            let new_pk_values: Vec<SqlValue> =
+                                pk_indices.iter().map(|&idx| new_row.values[idx].clone()).collect();
+
+                            // Remove old key if different from new key
+                            if old_pk_values != new_pk_values {
+                                pk_index.remove(&old_pk_values);
+                                pk_index.insert(new_pk_values, row_index);
+                            }
+                        }
+                    }
+                }
+                IndexType::UniqueConstraint(constraint_idx) => {
+                    // Update specific unique constraint index
+                    let unique_constraint_indices = schema.get_unique_constraint_indices();
+                    if let Some(unique_indices) = unique_constraint_indices.get(*constraint_idx) {
+                        let old_unique_values: Vec<SqlValue> = unique_indices
+                            .iter()
+                            .map(|&idx| old_row.values[idx].clone())
+                            .collect();
+                        let new_unique_values: Vec<SqlValue> = unique_indices
+                            .iter()
+                            .map(|&idx| new_row.values[idx].clone())
+                            .collect();
+
+                        if let Some(unique_index) = self.unique_indexes.get_mut(*constraint_idx) {
+                            // Remove old key if it's different and not NULL
+                            if old_unique_values != new_unique_values
+                                && !old_unique_values.iter().any(|v| *v == SqlValue::Null)
+                            {
+                                unique_index.remove(&old_unique_values);
+                            }
+
+                            // Insert new key if not NULL
+                            if !new_unique_values.iter().any(|v| *v == SqlValue::Null) {
+                                unique_index.insert(new_unique_values, row_index);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Update hash indexes when deleting a row
+    ///
+    /// Removes the row's key values from primary key and unique constraint indexes.
+    /// Note: After deleting rows, if row indices change, you must call `rebuild()`.
+    ///
+    /// # Arguments
+    /// * `schema` - Table schema containing index definitions
+    /// * `row` - Row being deleted
+    #[inline]
+    pub(crate) fn update_for_delete(&mut self, schema: &catalog::TableSchema, row: &Row) {
+        // Update primary key index
+        if let Some(ref mut pk_index) = self.primary_key_index {
+            if let Some(pk_indices) = schema.get_primary_key_indices() {
+                let pk_values: Vec<SqlValue> =
+                    pk_indices.iter().map(|&idx| row.values[idx].clone()).collect();
+                pk_index.remove(&pk_values);
+            }
+        }
+
+        // Update unique constraint indexes
+        let unique_constraint_indices = schema.get_unique_constraint_indices();
+        for (constraint_idx, unique_indices) in unique_constraint_indices.iter().enumerate() {
+            let unique_values: Vec<SqlValue> =
+                unique_indices.iter().map(|&idx| row.values[idx].clone()).collect();
+
+            // Skip if any value in the unique constraint is NULL
+            if unique_values.iter().any(|v| *v == SqlValue::Null) {
+                continue;
+            }
+
+            if let Some(unique_index) = self.unique_indexes.get_mut(constraint_idx) {
+                unique_index.remove(&unique_values);
+            }
+        }
+    }
+
+    /// Rebuild all hash indexes from scratch
+    ///
+    /// Used after bulk operations that change row indices (e.g., deletes that shift rows).
+    /// Clears all indexes and rebuilds them from the current rows.
+    ///
+    /// # Arguments
+    /// * `schema` - Table schema containing index definitions
+    /// * `rows` - All current rows in the table
+    pub(crate) fn rebuild(&mut self, schema: &catalog::TableSchema, rows: &[Row]) {
+        self.clear();
+
+        // Rebuild from current rows
+        for (row_index, row) in rows.iter().enumerate() {
+            self.update_for_insert(schema, row, row_index);
+        }
+    }
+
+    /// Clear all indexes
+    ///
+    /// Removes all entries from primary key and unique constraint indexes.
+    pub(crate) fn clear(&mut self) {
+        if let Some(ref mut pk_index) = self.primary_key_index {
+            pk_index.clear();
+        }
+        for unique_index in &mut self.unique_indexes {
+            unique_index.clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use catalog::{ColumnSchema, TableSchema};
+    use types::DataType;
+
+    #[test]
+    fn test_primary_key_insert() {
+        let schema = TableSchema::with_primary_key(
+            "users".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "name".to_string(),
+                    DataType::Varchar { max_length: Some(100) },
+                    false,
+                ),
+            ],
+            vec!["id".to_string()],
+        );
+
+        let mut index_mgr = IndexManager::new(&schema);
+
+        // Insert a row
+        let row = Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())]);
+        index_mgr.update_for_insert(&schema, &row, 0);
+
+        // Verify primary key index has the entry
+        assert!(index_mgr.primary_key_index().is_some());
+        let pk_index = index_mgr.primary_key_index().unwrap();
+        assert_eq!(pk_index.len(), 1);
+        assert_eq!(pk_index.get(&vec![SqlValue::Integer(1)]), Some(&0));
+    }
+
+    #[test]
+    fn test_unique_constraint_insert() {
+        let schema = TableSchema::with_unique_constraints(
+            "products".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "sku".to_string(),
+                    DataType::Varchar { max_length: Some(50) },
+                    false,
+                ),
+            ],
+            vec![vec!["sku".to_string()]],
+        );
+
+        let mut index_mgr = IndexManager::new(&schema);
+
+        // Insert a row
+        let row = Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar("SKU001".to_string())]);
+        index_mgr.update_for_insert(&schema, &row, 0);
+
+        // Verify unique index has the entry
+        assert_eq!(index_mgr.unique_indexes().len(), 1);
+        let unique_index = &index_mgr.unique_indexes()[0];
+        assert_eq!(unique_index.len(), 1);
+        assert_eq!(unique_index.get(&vec![SqlValue::Varchar("SKU001".to_string())]), Some(&0));
+    }
+
+    #[test]
+    fn test_null_handling_in_unique_index() {
+        let schema = TableSchema::with_unique_constraints(
+            "users".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "email".to_string(),
+                    DataType::Varchar { max_length: Some(100) },
+                    true, // nullable
+                ),
+            ],
+            vec![vec!["email".to_string()]],
+        );
+
+        let mut index_mgr = IndexManager::new(&schema);
+
+        // Insert a row with NULL email
+        let row = Row::new(vec![SqlValue::Integer(1), SqlValue::Null]);
+        index_mgr.update_for_insert(&schema, &row, 0);
+
+        // Verify NULL is NOT in the unique index
+        let unique_index = &index_mgr.unique_indexes()[0];
+        assert_eq!(unique_index.len(), 0, "NULL values should not be indexed");
+    }
+
+    #[test]
+    fn test_selective_update_detection() {
+        let schema = TableSchema::with_all_constraints(
+            "users".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "email".to_string(),
+                    DataType::Varchar { max_length: Some(100) },
+                    false,
+                ),
+                ColumnSchema::new(
+                    "name".to_string(),
+                    DataType::Varchar { max_length: Some(100) },
+                    false,
+                ),
+            ],
+            Some(vec!["id".to_string()]),
+            vec![vec!["email".to_string()]],
+        );
+
+        let index_mgr = IndexManager::new(&schema);
+
+        // Test 1: Only non-indexed column changed (name)
+        let mut changed = HashSet::new();
+        changed.insert(2); // name column
+        let affected = index_mgr.get_affected_indexes(&schema, &changed);
+        assert_eq!(affected.len(), 0, "Non-indexed column should not affect indexes");
+
+        // Test 2: Primary key column changed
+        let mut changed = HashSet::new();
+        changed.insert(0); // id column
+        let affected = index_mgr.get_affected_indexes(&schema, &changed);
+        assert_eq!(affected.len(), 1);
+        assert_eq!(affected[0], IndexType::PrimaryKey);
+
+        // Test 3: Unique constraint column changed
+        let mut changed = HashSet::new();
+        changed.insert(1); // email column
+        let affected = index_mgr.get_affected_indexes(&schema, &changed);
+        assert_eq!(affected.len(), 1);
+        assert_eq!(affected[0], IndexType::UniqueConstraint(0));
+
+        // Test 4: Multiple indexed columns changed
+        let mut changed = HashSet::new();
+        changed.insert(0); // id
+        changed.insert(1); // email
+        let affected = index_mgr.get_affected_indexes(&schema, &changed);
+        assert_eq!(affected.len(), 2);
+    }
+
+    #[test]
+    fn test_primary_key_update() {
+        let schema = TableSchema::with_primary_key(
+            "users".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "name".to_string(),
+                    DataType::Varchar { max_length: Some(100) },
+                    false,
+                ),
+            ],
+            vec!["id".to_string()],
+        );
+
+        let mut index_mgr = IndexManager::new(&schema);
+
+        // Insert initial row
+        let old_row = Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())]);
+        index_mgr.update_for_insert(&schema, &old_row, 0);
+
+        // Update primary key
+        let new_row = Row::new(vec![SqlValue::Integer(10), SqlValue::Varchar("Alice".to_string())]);
+        index_mgr.update_for_update(&schema, &old_row, &new_row, 0);
+
+        // Verify old key removed and new key added
+        let pk_index = index_mgr.primary_key_index().unwrap();
+        assert_eq!(pk_index.get(&vec![SqlValue::Integer(1)]), None, "Old key should be removed");
+        assert_eq!(pk_index.get(&vec![SqlValue::Integer(10)]), Some(&0), "New key should be added");
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of the table.rs refactoring (#842) by extracting all index-related code into a dedicated `IndexManager` component.

## Changes

### New Module Structure
- **Created** `crates/storage/src/table/indexes.rs` (477 lines)
  - New `IndexManager` struct encapsulating primary key and unique constraint indexes
  - Moved `IndexType` enum (implementation detail)
  - All index operations: `update_for_insert`, `update_for_update`, `update_selective`, `update_for_delete`, `rebuild`, `clear`, `get_affected_indexes`
  - 5 new unit tests for IndexManager behavior

- **Refactored** `crates/storage/src/table/mod.rs` (reduced from 703 to 464 lines)
  - Table now delegates all index operations to IndexManager
  - Removed 239 lines of index-related code
  - Public API unchanged (backward compatible)

### Benefits
- ✅ Clear separation of concerns (Table = storage, IndexManager = indexing)
- ✅ Easier to test and optimize index strategies independently
- ✅ Maintains zero-copy performance with reference passing
- ✅ All existing tests pass (18/18)
- ✅ No performance regression

## Test Results

```
running 18 tests
test table::indexes::tests::test_primary_key_update ... ok
test table::indexes::tests::test_primary_key_insert ... ok
test table::indexes::tests::test_null_handling_in_unique_index ... ok
test table::indexes::tests::test_selective_update_detection ... ok
test table::indexes::tests::test_unique_constraint_insert ... ok
test table::tests::test_append_mode_clear_resets ... ok
test table::tests::test_append_mode_detection ... ok
test table::tests::test_append_mode_reset_on_non_sequential ... ok
test table::tests::test_append_mode_still_indexes_rows ... ok
test table::tests::test_empty_table_first_insert ... ok
test table::tests::test_duplicate_caught_after_append_mode ... ok
test table::tests::test_is_in_append_mode_accessor ... ok
test tests::test_hash_indexes_unique_constraints ... ok
test tests::test_hash_indexes_primary_key ... ok
test tests::test_update_row_selective_primary_key_column ... ok
test tests::test_update_row_selective_non_indexed_column ... ok
test tests::test_update_row_selective_unique_constraint_column ... ok
test tests::test_update_row_selective_vs_full_correctness ... ok

test result: ok. 18 passed; 0 failed; 0 ignored
```

## Acceptance Criteria

- [x] New `indexes.rs` module created with `IndexManager` struct
- [x] All index-related logic moved from table.rs
- [x] `Table` struct delegates to `IndexManager` for index operations
- [x] All existing tests pass without modification (18/18)
- [x] No performance regression (zero-copy delegation with references)
- [x] Module has unit tests for index operations (5 new tests)

## File Metrics

| File | Before | After | Change |
|------|--------|-------|--------|
| `table.rs` (now `table/mod.rs`) | 703 lines | 464 lines | -239 lines |
| `table/indexes.rs` (new) | - | 477 lines | +477 lines |

## Next Steps

This is Phase 1 of a 5-phase refactoring:
- ✅ **Phase 1**: Extract Index Management (#847) - This PR
- 📋 **Phase 2**: Extract Constraint Validation (#848)
- 📋 **Phase 3**: Extract Row Normalization (#849)
- 📋 **Phase 4**: Extract Append Mode Optimization (#850)
- 📋 **Phase 5**: Finalize module structure (#851)

## Related Issues

- Parent: #842 (Refactor: Split table.rs into modular components)
- Implements: #847 (Refactor Phase 1: Extract Index Management)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>