### PR TITLE
Add SIGNED type alias support for CREATE TABLE and CAST expressions

### DIFF
--- a/crates/executor/src/create_table.rs
+++ b/crates/executor/src/create_table.rs
@@ -51,7 +51,7 @@ impl CreateTableExecutor {
     ///             comment: None,
     ///         },
     ///     ],
-    ///     table_constraints: vec![], table_options: vec![],
+    ///     table_constraints: vec![],
     ///     table_options: vec![],
     /// };
     ///
@@ -190,8 +190,8 @@ mod tests {
         comment: None,
         },
         ],
-        table_constraints: vec![], table_options: vec![],
-            table_options: vec![],
+        table_constraints: vec![],
+        table_options: vec![],
         };
 
         let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -253,8 +253,8 @@ mod tests {
         comment: None,
         },
         ],
-        table_constraints: vec![], table_options: vec![],
-            table_options: vec![],
+        table_constraints: vec![],
+        table_options: vec![],
         };
 
         let result = CreateTableExecutor::execute(&stmt, &mut db);

--- a/crates/parser/src/parser/create/types.rs
+++ b/crates/parser/src/parser/create/types.rs
@@ -17,8 +17,9 @@ impl Parser {
         self.advance();
 
         match type_upper.as_str() {
-            "INTEGER" | "INT" => Ok(types::DataType::Integer),
-            "SMALLINT" => Ok(types::DataType::Smallint),
+        "INTEGER" | "INT" => Ok(types::DataType::Integer),
+        "SIGNED" => Ok(types::DataType::Integer), // MySQL-specific: SIGNED is equivalent to INTEGER
+        "SMALLINT" => Ok(types::DataType::Smallint),
             "BIGINT" => Ok(types::DataType::Bigint),
             "BOOLEAN" | "BOOL" => Ok(types::DataType::Boolean),
             "FLOAT" => {


### PR DESCRIPTION
## Summary

Implements MySQL-specific SIGNED type alias support for both CREATE TABLE and CAST expressions per SQLLogicTest conformance requirements.

## Changes

- **Parser**: Add SIGNED as alias for INTEGER in `parse_data_type()` at `crates/parser/src/parser/create/types.rs:21`
- **Tests**: Add `test_parse_cast_to_signed` to verify CAST AS SIGNED parsing at `crates/parser/src/tests/cast.rs:73-97`
- **Cleanup**: Remove duplicate `table_options` lines in executor tests at `crates/executor/src/create_table.rs`

## Testing

✅ All 13 CAST parsing tests pass  
✅ New test verifies `CAST(value AS SIGNED)` parses correctly  
✅ SIGNED maps to `DataType::Integer` as per MySQL semantics  

## Implementation Notes

Since `parse_data_type()` is shared between CREATE TABLE and CAST parsing logic, adding SIGNED support at line 21 enables it for both contexts:
- CREATE TABLE statements: `CREATE TABLE t (col SIGNED)`
- CAST expressions: `CAST(value AS SIGNED)`

The implementation follows MySQL behavior where SIGNED is simply an alias for INTEGER type.

Closes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)