### PR TITLE
Fix COUNT(*) in SELECT without FROM clause

### DIFF
--- a/crates/executor/src/select/executor/aggregation/detection.rs
+++ b/crates/executor/src/select/executor/aggregation/detection.rs
@@ -23,12 +23,31 @@ impl SelectExecutor<'_> {
         match expr {
             // New AggregateFunction variant
             ast::Expression::AggregateFunction { .. } => true,
-            // Old Function variant (backwards compatibility)
-            ast::Expression::Function { name, .. } => {
-                matches!(name.to_uppercase().as_str(), "COUNT" | "SUM" | "AVG" | "MIN" | "MAX")
+            // Old Function variant (backwards compatibility for aggregates)
+            ast::Expression::Function { name, args, .. } => {
+                // Check if this is an aggregate function name
+                if matches!(name.to_uppercase().as_str(), "COUNT" | "SUM" | "AVG" | "MIN" | "MAX") {
+                    return true;
+                }
+                // Otherwise, check if any arguments contain aggregates
+                args.iter().any(|arg| self.expression_has_aggregate(arg))
             }
             ast::Expression::BinaryOp { left, right, .. } => {
                 self.expression_has_aggregate(left) || self.expression_has_aggregate(right)
+            }
+            ast::Expression::UnaryOp { expr, .. } => {
+                self.expression_has_aggregate(expr)
+            }
+            ast::Expression::Cast { expr, .. } => {
+                self.expression_has_aggregate(expr)
+            }
+            ast::Expression::Case { operand, when_clauses, else_result } => {
+                operand.as_ref().is_some_and(|e| self.expression_has_aggregate(e))
+                    || when_clauses.iter().any(|when_clause| {
+                        when_clause.conditions.iter().any(|c| self.expression_has_aggregate(c))
+                            || self.expression_has_aggregate(&when_clause.result)
+                    })
+                    || else_result.as_ref().is_some_and(|e| self.expression_has_aggregate(e))
             }
             _ => false,
         }


### PR DESCRIPTION
## Summary

This PR fixes aggregate function detection in SELECT queries without FROM clauses. Previously, queries like `SELECT + COUNT(*)` or `SELECT COUNT(*) * 2` would fail with "Column reference requires FROM clause" error.

## Problem

The `expression_has_aggregate()` function only checked for direct aggregate expressions and recursed through binary operators, but missed aggregates wrapped in:
- Unary operators (e.g., `+COUNT(*)`, `-COUNT(*)`)
- Function arguments (e.g., `COALESCE(..., COUNT(*))`)
- Cast expressions
- Case expressions

This caused the query router to incorrectly send queries with aggregates to `execute_select_without_from()` instead of `execute_with_aggregation()`.

## Solution

Enhanced `expression_has_aggregate()` in `detection.rs` to recursively check:
1. **UnaryOp**: Check the wrapped expression
2. **Function**: Check all function arguments for nested aggregates (not just detect aggregate function names)
3. **Cast**: Check the casted expression
4. **Case**: Check operand, all when conditions/results, and else result

## Changes

- Modified `crates/executor/src/select/executor/aggregation/detection.rs`
  - Added UnaryOp case to recursively check expressions
  - Enhanced Function case to check arguments for nested aggregates
  - Added Cast case to check casted expressions
  - Added Case case to check all branches

## Test Plan

The failing test cases from the issue should now pass:

- ✅ \`SELECT ALL + COUNT( * ) AS col0\` (unary plus)
- ✅ \`SELECT - 29 * 10 * - - 49 + - COUNT( * ) col0\` (arithmetic with unary minus)
- ✅ \`SELECT - COALESCE ( - + 99, 11 ) * - - COUNT( * ), + 4 AS col0\` (function wrapping)
- ✅ \`SELECT - - ( - + 51 ) + COALESCE ( ... COUNT( ALL 8 ) ... ) + - + COUNT( * )\` (complex nesting)

Tested files:
- \`random/expr/slt_good_1.test\`
- \`random/expr/slt_good_100.test\`
- \`random/expr/slt_good_17.test\`
- \`random/expr/slt_good_4.test\`

Closes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>