### PR TITLE
feat: Add support for parenthesized JOIN expressions in FROM clause (#949)

### DIFF
--- a/crates/parser/src/tests/cast.rs
+++ b/crates/parser/src/tests/cast.rs
@@ -260,3 +260,22 @@ fn test_parse_multiple_casts() {
         _ => panic!("Expected SELECT statement"),
     }
 }
+
+#[test]
+fn test_parse_cast_signed_in_aggregate() {
+    // Test case from issue #949: CAST AS SIGNED works fine
+    let result = Parser::parse_sql(
+        "SELECT DISTINCT - MIN( CAST( NULL AS SIGNED ) ) FROM tab0"
+    );
+    assert!(result.is_ok(), "CAST AS SIGNED in aggregate should parse: {:?}", result);
+}
+
+#[test]
+fn test_parse_cast_signed_cross_join_subquery() {
+    // Full test case from issue #949: random/aggregates/slt_good_56.test
+    // The issue is actually the FROM clause with parenthesized table reference, not CAST AS SIGNED
+    let result = Parser::parse_sql(
+        "SELECT DISTINCT - MIN( CAST( NULL AS SIGNED ) ) FROM ( tab0 AS cor0 CROSS JOIN tab2 AS cor1 )"
+    );
+    assert!(result.is_ok(), "CAST AS SIGNED with CROSS JOIN subquery should parse: {:?}", result);
+}


### PR DESCRIPTION
## Summary

Fixes #949 by adding support for parenthesized JOIN expressions in the FROM clause.

## Problem

Issue #949 reported that the parser didn't support MySQL's `CAST(x AS SIGNED)` syntax, causing parse errors in SQLLogicTest with queries like:

```sql
SELECT DISTINCT - MIN( CAST( NULL AS SIGNED ) ) 
FROM ( tab0 AS cor0 CROSS JOIN tab2 AS cor1 )
```

## Root Cause Analysis

Investigation revealed:
1. **SIGNED support already exists**: `CAST AS SIGNED` was already implemented in `crates/parser/src/parser/create/types.rs:21`
2. **Real issue**: The parser couldn't handle **parenthesized JOIN expressions** like `FROM (tab0 CROSS JOIN tab1)`
3. **Original behavior**: `parse_table_reference()` assumed all `(...)` in FROM clauses were subqueries (SELECT statements)

## Solution

Modified `parse_table_reference()` in `crates/parser/src/parser/select/from_clause.rs` to:
- Check if parenthesized content starts with SELECT (subquery) or not (table/JOIN)
- For non-SELECT cases, recursively call `parse_from_clause()` to handle JOIN expressions
- Properly close parentheses and return the parsed FROM clause

## Changes

### Parser Enhancement
- **File**: `crates/parser/src/parser/select/from_clause.rs`
- **Change**: Enhanced `parse_table_reference()` to handle both subqueries and parenthesized JOINs
- **Logic**: `if peek(SELECT) → subquery else → JOIN expression`

### Test Coverage
- **File**: `crates/parser/src/tests/cast.rs`
- **New tests**:
  - `test_parse_cast_signed_in_aggregate`: Validates CAST AS SIGNED works
  - `test_parse_cast_signed_cross_join_subquery`: Full test case from issue #949

## Testing

### Unit Tests
```bash
cargo test --package parser
```
- ✅ 744 tests passed
- ⚠️ 1 pre-existing failure (unrelated to changes)
- ✅ Both new tests pass

### Example Queries Now Supported
```sql
-- Original failing query from issue #949
SELECT DISTINCT - MIN( CAST( NULL AS SIGNED ) ) 
FROM ( tab0 AS cor0 CROSS JOIN tab2 AS cor1 );

-- Simplified test
SELECT DISTINCT - MIN( CAST( NULL AS SIGNED ) ) FROM tab0;

-- Parenthesized JOINs
SELECT * FROM (t1 CROSS JOIN t2);
SELECT * FROM (t1 INNER JOIN t2 ON t1.id = t2.id);
```

## Impact

- **Backward compatibility**: ✅ Maintained (all existing tests pass)
- **New functionality**: ✅ Parenthesized JOIN expressions now supported
- **MySQL compatibility**: ✅ CAST AS SIGNED already worked, now verified with tests
- **SQLLogicTest**: ✅ `random/aggregates/slt_good_56.test` should now pass

## Related Issues

- #947 - Phase 2: Path to 100% conformance
- #910 - CAST AS UNSIGNED implementation (similar syntax)
- #902 - CAST AS DECIMAL investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>