### PR TITLE
Fix: Handle unary plus/minus operators after NOT keyword

### DIFF
--- a/crates/parser/src/parser/expressions/special_forms.rs
+++ b/crates/parser/src/parser/expressions/special_forms.rs
@@ -191,8 +191,8 @@ impl Parser {
                     }))
                 } else {
                     // It's a unary NOT operator on another expression
-                    // Parse the inner expression
-                    let expr = self.parse_primary_expression()?;
+                    // Parse the inner expression (including unary operators like +/-)
+                    let expr = self.parse_unary_expression()?;
 
                     Ok(Some(ast::Expression::UnaryOp {
                         op: ast::UnaryOperator::Not,

--- a/web-demo/test-results/.last-run.json
+++ b/web-demo/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
Fixes #963

## Problem
Parser was failing on expressions with unary plus/minus operators after NOT keyword, such as:
- `SELECT * FROM tab0 WHERE NOT + col2 * col2 = col0`
- `SELECT ALL + 84 FROM tab1 WHERE NOT + col0 <= NULL`

This was affecting 42 SQLLogicTest files with parse errors.

## Root Cause
In `parse_special_form()`, when handling unary NOT, the parser called `parse_primary_expression()` instead of `parse_unary_expression()`. This prevented parsing of unary +/- operators that follow NOT.

## Solution
Changed the NOT handler to call `parse_unary_expression()` instead of `parse_primary_expression()`. This allows the parser to correctly handle unary operators at any expression level after NOT.

## Example
Before: ✗ `NOT + col0` → ParseError
After: ✓ `NOT + col0` → UnaryOp { Not, UnaryOp { Plus, Identifier(col0) } }