### PR TITLE
Fix decimal formatting in query results

### DIFF
--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -323,8 +323,7 @@ impl fmt::Display for SqlValue {
             SqlValue::Smallint(i) => write!(f, "{}", i),
             SqlValue::Bigint(i) => write!(f, "{}", i),
             SqlValue::Unsigned(u) => write!(f, "{}", u),
-            // Format Numeric - show whole numbers without decimals,
-            // fractional numbers with up to 3 decimal places
+            // Format Numeric - always show with 3 decimal places
             SqlValue::Numeric(n) => {
                 if n.is_nan() {
                     write!(f, "NaN")
@@ -334,11 +333,8 @@ impl fmt::Display for SqlValue {
                     } else {
                         write!(f, "-Infinity")
                     }
-                } else if n.fract() == 0.0 {
-                    // Whole number - display without decimals
-                    write!(f, "{}", *n as i64)
                 } else {
-                    // Has fractional part - show with 3 decimal places
+                    // Always show with 3 decimal places, even for whole numbers
                     write!(f, "{:.3}", n)
                 }
             }

--- a/crates/types/tests/type_display_tests.rs
+++ b/crates/types/tests/type_display_tests.rs
@@ -49,7 +49,7 @@ fn test_bigint_display() {
 #[test]
 fn test_numeric_display() {
     let value = SqlValue::Numeric(123.45);
-    assert_eq!(format!("{}", value), "123.45");
+    assert_eq!(format!("{}", value), "123.450");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes SQLLogicTest decimal formatting issues (#956).

Previously, Numeric values displayed whole numbers without decimals (e.g., '7' instead of '7.000') and values with fewer than 3 decimal places with fewer places (e.g., '-9178.0' instead of '-9178.000').

SQLLogicTest expects consistent decimal formatting with exactly 3 decimal places for numeric query results. This fix updates the Display implementation for Numeric values to always format with 3 decimal places.

## Changes

- Updated Numeric Display implementation in `crates/types/src/lib.rs` to always format with .3f (3 decimal places)
- Removed conditional logic that was hiding decimals for whole numbers  
- Updated test expectation in `crates/types/tests/type_display_tests.rs` to match new formatting behavior

## Expected Impact

- All 56 affected test files should now pass
- Pass rate should increase from ~14% to ~25%
- No regressions in currently passing tests