### PR TITLE
docs: Add verification report for issue #990 (duplicate of #935)

### DIFF
--- a/VERIFICATION_REPORT_990.md
+++ b/VERIFICATION_REPORT_990.md
@@ -1,0 +1,119 @@
+# Verification Report: Issue #990
+
+## Issue Summary
+**Title**: SQLLogicTest: COUNT(*) not evaluated in arithmetic expressions
+**Number**: #990
+**Status**: ✅ ALREADY FIXED (Duplicate of #935)
+
+## Investigation Results
+
+### Finding
+Issue #990 was already fixed by PR #940 (commit 8bf671f), which resolved issue #935.
+
+### Evidence
+
+**1. Commit 8bf671f (PR #940)**
+```
+fix: Support COUNT(*) in arithmetic expressions with unary operators (#935) (#940)
+
+COUNT(*) failed when used with unary operators (+, -) in arithmetic
+expressions like `SELECT + 60 * COUNT(*) FROM table`.
+```
+
+**2. Issue #990 Example**
+```sql
+SELECT + + 5 + 92 * COUNT( * )
+Expected: 97
+Actual (before fix): 5.000
+```
+
+**3. Issue #935 Example (Fixed by PR #940)**
+```sql
+SELECT + 60 * ( + + COUNT( * ) ) FROM tab1 cor0
+```
+
+Both issues involve:
+- Multiple unary plus operators (`+ +`)
+- COUNT(*) in arithmetic expressions
+- Same error pattern: COUNT(*) returning 0 or being ignored
+
+### Root Cause (Already Fixed)
+
+The fix addressed two problems:
+
+1. **Aggregate Detection**: Added UnaryOp case to `expression_has_aggregate()` to recursively detect aggregates inside unary expressions.
+
+2. **Aggregate Evaluation**: Added explicit UnaryOp handling to `evaluate_with_aggregates()` that:
+   - Recursively evaluates inner expression with aggregate context
+   - Applies unary operator to the result
+   - Added `eval_unary_op()` helper method
+
+### Test Verification
+
+Created and ran new tests to verify the fix works:
+
+**Test 1**: `test_issue_990_multiple_unary_plus`
+```rust
+// SELECT + + 5 + 92 * COUNT(*) FROM test (1 row)
+// Expected: 97 (5 + 92 * 1)
+```
+✅ PASSED
+
+**Test 2**: `test_issue_990_simpler_case`
+```rust
+// SELECT 5 + 92 * COUNT(*) FROM test (1 row)
+// Expected: 97 (5 + 92 * 1)
+```
+✅ PASSED
+
+**Test 3**: From PR #940
+```rust
+// SELECT + 60 * ( + + COUNT( * ) ) FROM tab1 (5 rows)
+// Expected: 300 (60 * 5)
+```
+✅ PASSED (already in test suite)
+
+### Code Changes (Already Applied)
+
+**Files Modified by PR #940:**
+- `crates/executor/src/select/executor/aggregation/detection.rs`: Added UnaryOp detection
+- `crates/executor/src/select/executor/aggregation/evaluation.rs`: Added UnaryOp evaluation with helper method
+- `tests/test_count_star.rs`: Added comprehensive tests
+
+### Dependencies
+
+Issue #990 mentioned it was blocked by:
+- Issue #988: Hash mismatch in SQLLogicTest (formatting issue)
+- Issue #989: Aggregate functions return numeric format (formatting issue)
+
+These were SQLLogicTest formatting issues, not execution bugs. The actual execution issue was fixed by PR #940.
+
+## Conclusion
+
+**Issue #990 is a duplicate of issue #935 and has already been fixed by PR #940.**
+
+The fix:
+1. ✅ Handles COUNT(*) in arithmetic expressions
+2. ✅ Handles multiple unary operators with COUNT(*)
+3. ✅ Has comprehensive test coverage
+4. ✅ All related tests pass
+
+## Recommendation
+
+**Close issue #990 as duplicate of #935 (already fixed).**
+
+### Verification Steps Completed
+- [x] Investigated codebase for COUNT(*) handling
+- [x] Found commit 8bf671f (PR #940) that fixes the issue
+- [x] Verified fix covers the exact case from #990
+- [x] Created and ran verification tests
+- [x] Confirmed all tests pass
+- [x] Documented findings in this report
+
+---
+
+**Report Generated**: 2025-11-08
+**Verified By**: Builder Agent (Loom)
+**Related Issues**: #935 (fixed), #988 (formatting), #989 (formatting)
+**Related PR**: #940
+**Related Commit**: 8bf671f

--- a/tests/test_issue_990.rs
+++ b/tests/test_issue_990.rs
@@ -1,0 +1,159 @@
+//! Test for issue #990: COUNT(*) not evaluated in arithmetic expressions
+//!
+//! Reproduces the exact failing case from SQLLogicTest
+
+use executor::SelectExecutor;
+
+#[test]
+fn test_issue_990_multiple_unary_plus() {
+    // From the issue: SELECT + + 5 + 92 * COUNT( * )
+    // Expected: 97 (assuming 1 row: 5 + 92 * 1 = 97)
+    // Actual: 5.000 (bug - COUNT(*) returns 0 or is ignored)
+
+    let mut db = storage::Database::new();
+    let schema = catalog::TableSchema::new(
+        "test".to_string(),
+        vec![catalog::ColumnSchema::new(
+            "id".to_string(),
+            types::DataType::Integer,
+            false,
+        )],
+    );
+    db.create_table(schema).unwrap();
+
+    // Insert 1 row
+    db.insert_row(
+        "test",
+        storage::Row::new(vec![types::SqlValue::Integer(1)]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // Build the exact expression from the issue: + + 5 + 92 * COUNT(*)
+    let stmt = ast::SelectStmt {
+        into_table: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![ast::SelectItem::Expression {
+            expr: ast::Expression::BinaryOp {
+                left: Box::new(ast::Expression::UnaryOp {
+                    op: ast::UnaryOperator::Plus,
+                    expr: Box::new(ast::Expression::UnaryOp {
+                        op: ast::UnaryOperator::Plus,
+                        expr: Box::new(ast::Expression::Literal(types::SqlValue::Integer(5))),
+                    }),
+                }),
+                op: ast::BinaryOperator::Plus,
+                right: Box::new(ast::Expression::BinaryOp {
+                    left: Box::new(ast::Expression::Literal(types::SqlValue::Integer(92))),
+                    op: ast::BinaryOperator::Multiply,
+                    right: Box::new(ast::Expression::AggregateFunction {
+                        name: "COUNT".to_string(),
+                        distinct: false,
+                        args: vec![ast::Expression::Wildcard],
+                    }),
+                }),
+            },
+            alias: None,
+        }],
+        from: Some(ast::FromClause::Table {
+            name: "test".to_string(),
+            alias: None,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 1);
+
+    // Expected: 97 (5 + 92 * 1)
+    println!("Result: {:?}", result[0].values[0]);
+
+    match &result[0].values[0] {
+        types::SqlValue::Integer(n) => assert_eq!(*n, 97, "Expected 97, got {}", n),
+        types::SqlValue::Numeric(n) => {
+            // Check if it's close to 97 (allowing for floating point comparison)
+            assert!(((*n as f64) - 97.0).abs() < 0.001, "Expected 97, got {}", n);
+        }
+        other => panic!("Expected Integer or Numeric, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_issue_990_simpler_case() {
+    // Simpler case: SELECT 5 + 92 * COUNT(*) FROM test
+    let mut db = storage::Database::new();
+    let schema = catalog::TableSchema::new(
+        "test".to_string(),
+        vec![catalog::ColumnSchema::new(
+            "id".to_string(),
+            types::DataType::Integer,
+            false,
+        )],
+    );
+    db.create_table(schema).unwrap();
+
+    // Insert 1 row
+    db.insert_row(
+        "test",
+        storage::Row::new(vec![types::SqlValue::Integer(1)]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // Build: 5 + 92 * COUNT(*)
+    let stmt = ast::SelectStmt {
+        into_table: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![ast::SelectItem::Expression {
+            expr: ast::Expression::BinaryOp {
+                left: Box::new(ast::Expression::Literal(types::SqlValue::Integer(5))),
+                op: ast::BinaryOperator::Plus,
+                right: Box::new(ast::Expression::BinaryOp {
+                    left: Box::new(ast::Expression::Literal(types::SqlValue::Integer(92))),
+                    op: ast::BinaryOperator::Multiply,
+                    right: Box::new(ast::Expression::AggregateFunction {
+                        name: "COUNT".to_string(),
+                        distinct: false,
+                        args: vec![ast::Expression::Wildcard],
+                    }),
+                }),
+            },
+            alias: None,
+        }],
+        from: Some(ast::FromClause::Table {
+            name: "test".to_string(),
+            alias: None,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 1);
+
+    println!("Simpler case result: {:?}", result[0].values[0]);
+
+    // Expected: 97 (5 + 92 * 1)
+    match &result[0].values[0] {
+        types::SqlValue::Integer(n) => assert_eq!(*n, 97, "Expected 97, got {}", n),
+        types::SqlValue::Numeric(n) => {
+            assert!(((*n as f64) - 97.0).abs() < 0.001, "Expected 97, got {}", n);
+        }
+        other => panic!("Expected Integer or Numeric, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary

This PR documents that issue #990 was already fixed by PR #940 (commit 8bf671f), which resolved issue #935.

## Investigation

Issue #990 reported that COUNT(*) was not being evaluated in arithmetic expressions with unary operators, causing queries like `SELECT + + 5 + 92 * COUNT(*) FROM test` to return incorrect results (5.000 instead of 97).

### Findings

1. **Already Fixed**: PR #940 fixed this exact issue by adding support for:
   - Aggregate detection in UnaryOp expressions
   - Aggregate evaluation for UnaryOp expressions
   - Comprehensive test coverage

2. **Verification**: Created and ran tests for the specific case from #990 - all tests pass.

3. **Root Cause**: The fix addressed two problems:
   - `expression_has_aggregate()` wasn't checking UnaryOp expressions
   - `evaluate_with_aggregates()` wasn't handling UnaryOp expressions

## Changes

- ✅ Added `VERIFICATION_REPORT_990.md` with detailed analysis
- ✅ Added `tests/test_issue_990.rs` with verification tests
- ✅ Closed issue #990 as duplicate of #935

## Testing

All tests pass:
- `test_issue_990_multiple_unary_plus` ✅
- `test_issue_990_simpler_case` ✅
- All existing COUNT(*) tests ✅

## Related

- Closes #990 (duplicate, already fixed)
- Related to #935 (fixed by PR #940)
- Related to #988, #989 (SQLLogicTest formatting issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>