### PR TITLE
Refactor: Extract transaction management from Database into TransactionManager

### DIFF
--- a/crates/storage/src/database/mod.rs
+++ b/crates/storage/src/database/mod.rs
@@ -4,6 +4,8 @@
 
 mod database;
 pub mod indexes;
+pub mod transactions;
 
-pub use database::{Database, Savepoint, TransactionChange, TransactionState};
+pub use database::Database;
 pub use indexes::{IndexData, IndexManager, IndexMetadata};
+pub use transactions::{Savepoint, TransactionChange, TransactionManager, TransactionState};

--- a/crates/storage/src/database/transactions.rs
+++ b/crates/storage/src/database/transactions.rs
@@ -1,0 +1,213 @@
+// ============================================================================
+// Transaction Management
+// ============================================================================
+
+use crate::{Row, StorageError, Table};
+use std::collections::HashMap;
+
+/// A single change made during a transaction
+#[derive(Debug, Clone)]
+pub enum TransactionChange {
+    Insert { table_name: String, row: Row },
+    Update { table_name: String, old_row: Row, new_row: Row },
+    Delete { table_name: String, row: Row },
+}
+
+/// A savepoint within a transaction
+#[derive(Debug, Clone)]
+pub struct Savepoint {
+    pub name: String,
+    /// Index in the changes vector where this savepoint was created
+    pub snapshot_index: usize,
+}
+
+/// Transaction state
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum TransactionState {
+    /// No active transaction
+    None,
+    /// Transaction is active
+    Active {
+        /// Transaction ID for debugging
+        id: u64,
+        /// Original catalog snapshot for full rollback
+        original_catalog: catalog::Catalog,
+        /// Original table snapshots for full rollback
+        original_tables: HashMap<String, Table>,
+        /// Stack of savepoints (newest at end)
+        savepoints: Vec<Savepoint>,
+        /// All changes made since transaction start (for incremental undo)
+        changes: Vec<TransactionChange>,
+    },
+}
+
+/// Transaction manager - handles all transaction lifecycle and savepoint operations
+#[derive(Debug, Clone)]
+pub struct TransactionManager {
+    /// Current transaction state
+    transaction_state: TransactionState,
+    /// Next transaction ID
+    next_transaction_id: u64,
+}
+
+impl TransactionManager {
+    /// Create a new transaction manager
+    pub fn new() -> Self {
+        TransactionManager {
+            transaction_state: TransactionState::None,
+            next_transaction_id: 1,
+        }
+    }
+
+    /// Record a change in the current transaction (if any)
+    pub fn record_change(&mut self, change: TransactionChange) {
+        if let TransactionState::Active { changes, .. } = &mut self.transaction_state {
+            changes.push(change);
+        }
+    }
+
+    /// Begin a new transaction
+    pub fn begin_transaction(
+        &mut self,
+        catalog: &catalog::Catalog,
+        tables: &HashMap<String, Table>,
+    ) -> Result<(), StorageError> {
+        match self.transaction_state {
+            TransactionState::None => {
+                // Create snapshots of catalog and all current tables
+                let original_catalog = catalog.clone();
+                let original_tables = tables.clone();
+
+                let transaction_id = self.next_transaction_id;
+                self.next_transaction_id += 1;
+
+                self.transaction_state = TransactionState::Active {
+                    id: transaction_id,
+                    original_catalog,
+                    original_tables,
+                    savepoints: Vec::new(),
+                    changes: Vec::new(),
+                };
+                Ok(())
+            }
+            TransactionState::Active { .. } => {
+                Err(StorageError::TransactionError("Transaction already active".to_string()))
+            }
+        }
+    }
+
+    /// Commit the current transaction
+    pub fn commit_transaction(&mut self) -> Result<(), StorageError> {
+        match self.transaction_state {
+            TransactionState::None => {
+                Err(StorageError::TransactionError("No active transaction to commit".to_string()))
+            }
+            TransactionState::Active { .. } => {
+                // Transaction committed - just clear the state
+                // Changes are already in the tables
+                self.transaction_state = TransactionState::None;
+                Ok(())
+            }
+        }
+    }
+
+    /// Rollback the current transaction
+    pub fn rollback_transaction(
+        &mut self,
+        catalog: &mut catalog::Catalog,
+        tables: &mut HashMap<String, Table>,
+    ) -> Result<(), StorageError> {
+        match &self.transaction_state {
+            TransactionState::None => {
+                Err(StorageError::TransactionError("No active transaction to rollback".to_string()))
+            }
+            TransactionState::Active { original_catalog, original_tables, .. } => {
+                // Restore catalog and all tables from snapshots
+                *catalog = original_catalog.clone();
+                *tables = original_tables.clone();
+                self.transaction_state = TransactionState::None;
+                Ok(())
+            }
+        }
+    }
+
+    /// Check if we're currently in a transaction
+    pub fn in_transaction(&self) -> bool {
+        matches!(self.transaction_state, TransactionState::Active { .. })
+    }
+
+    /// Get current transaction ID (for debugging)
+    pub fn transaction_id(&self) -> Option<u64> {
+        match &self.transaction_state {
+            TransactionState::Active { id, .. } => Some(*id),
+            TransactionState::None => None,
+        }
+    }
+
+    /// Create a savepoint within the current transaction
+    pub fn create_savepoint(&mut self, name: String) -> Result<(), StorageError> {
+        match &mut self.transaction_state {
+            TransactionState::None => {
+                Err(StorageError::TransactionError("No active transaction".to_string()))
+            }
+            TransactionState::Active { savepoints, changes, .. } => {
+                let savepoint = Savepoint { name, snapshot_index: changes.len() };
+                savepoints.push(savepoint);
+                Ok(())
+            }
+        }
+    }
+
+    /// Rollback to a named savepoint - returns the changes that need to be undone
+    pub fn rollback_to_savepoint(&mut self, name: String) -> Result<Vec<TransactionChange>, StorageError> {
+        match &mut self.transaction_state {
+            TransactionState::None => {
+                Err(StorageError::TransactionError("No active transaction".to_string()))
+            }
+            TransactionState::Active { savepoints, changes, .. } => {
+                // Find the savepoint
+                let savepoint_idx =
+                    savepoints.iter().position(|sp| sp.name == name).ok_or_else(|| {
+                        StorageError::TransactionError(format!("Savepoint '{}' not found", name))
+                    })?;
+
+                let snapshot_index = savepoints[savepoint_idx].snapshot_index;
+
+                // Collect changes to undo (from snapshot_index to end)
+                let changes_to_undo: Vec<_> = changes.drain(snapshot_index..).collect();
+
+                // Destroy later savepoints
+                savepoints.truncate(savepoint_idx + 1);
+
+                Ok(changes_to_undo)
+            }
+        }
+    }
+
+    /// Release (destroy) a named savepoint
+    pub fn release_savepoint(&mut self, name: String) -> Result<(), StorageError> {
+        match &mut self.transaction_state {
+            TransactionState::None => {
+                Err(StorageError::TransactionError("No active transaction".to_string()))
+            }
+            TransactionState::Active { savepoints, .. } => {
+                let savepoint_idx =
+                    savepoints.iter().position(|sp| sp.name == name).ok_or_else(|| {
+                        StorageError::TransactionError(format!("Savepoint '{}' not found", name))
+                    })?;
+
+                // Remove the savepoint
+                savepoints.remove(savepoint_idx);
+
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Default for TransactionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## Summary

Refactored `database.rs` by extracting all transaction management logic into a dedicated `TransactionManager` in a new `transactions.rs` module. This addresses issue #1028.

### Changes Made

- **Created `transactions.rs` module** with:
  - `TransactionChange`, `Savepoint`, and `TransactionState` types (moved from `database.rs`)
  - New `TransactionManager` struct that encapsulates all transaction lifecycle logic
  - Clean separation of transaction state and operations

- **Updated `database.rs`**:
  - Replaced transaction fields with single `TransactionManager` field
  - All transaction methods now delegate to the manager
  - Removed 134 lines (528 → 394 lines)
  - Kept `undo_change` helper in Database for proper table name resolution

- **Updated module exports** in `mod.rs` to expose new transaction types

### Benefits

✅ **Reduced complexity**: Database struct now has fewer responsibilities  
✅ **Better separation of concerns**: Transaction logic isolated from table/schema management  
✅ **Improved testability**: Transaction logic can be tested independently  
✅ **Maintained API compatibility**: All existing public methods preserved  
✅ **Future extensibility**: Easier to add MVCC, isolation levels, or optimistic locking

### Testing

- ✅ All storage tests pass (27/27)
- ✅ Transaction-specific integration tests pass (2/2)
- ✅ Savepoint functionality verified
- ✅ Table lookup resolution works correctly

### Acceptance Criteria

- ✅ Transaction logic extracted to separate module/struct
- ✅ All existing tests pass (especially transaction tests)
- ✅ Public API unchanged (backward compatible)
- ✅ Database.rs reduced from 528 to 394 lines

Closes #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)