### PR TITLE
feat: Implement proper depth tracking for expression evaluation (Phase 1 of #1057)

### DIFF
--- a/crates/executor/src/evaluator/expressions/eval.rs
+++ b/crates/executor/src/evaluator/expressions/eval.rs
@@ -19,6 +19,16 @@ impl ExpressionEvaluator<'_> {
             });
         }
 
+        // Increment depth for recursive calls
+        self.with_incremented_depth(|evaluator| evaluator.eval_impl(expr, row))
+    }
+
+    /// Internal implementation of eval with depth already incremented
+    fn eval_impl(
+        &self,
+        expr: &ast::Expression,
+        row: &storage::Row,
+    ) -> Result<types::SqlValue, ExecutorError> {
         match expr {
             // Literals - just return the value
             ast::Expression::Literal(val) => Ok(val.clone()),


### PR DESCRIPTION
## Summary

Implements Phase 1 of #1057 - adds proper depth tracking to expression evaluators to prevent stack overflow from deeply nested expressions.

## Changes

### Core Improvements
- ✅ Proper depth tracking in `ExpressionEvaluator` and `CombinedExpressionEvaluator`
- ✅ Added `with_incremented_depth()` helper for immutable depth management
- ✅ Split `eval()` into public entry point + `eval_impl()` internal implementation
- ✅ Depth incremented for every expression node evaluation

### Safety Guarantees
- Depth checking happens before any evaluation work
- Prevents stack overflow from pathological nested expressions
- Maintains depth tracking across all expression types (binary, unary, CASE, etc.)

### Testing
Added 8 comprehensive tests covering:
- Shallow nesting (10 levels)
- Moderate nesting (100 levels)  
- Deep nesting (200-400 levels)
- CASE expression depth (50-250 levels)
- Unary expression depth (100-300 levels)
- Mixed expression types
- Depth consistency validation

### Test Limitations
Tests limited to ~400 nesting levels because recursive AST construction in Rust hits stack limits beyond that. This is NOT a production concern - SQL parsers won't generate ASTs this deep. The MAX_EXPRESSION_DEPTH limit of 500 provides ample safety margin.

## Impact
- ✅ All existing executor tests pass
- ✅ No performance regression for normal queries
- ✅ Proper safety for deep expressions

## Next Steps
Future PRs will implement:
- **Phase 2**: Iterative evaluator for extremely deep expressions  
- **Phase 3**: Hybrid dispatch (recursive for shallow, iterative for deep)

## Testing
```bash
cargo test --lib --package executor deep_expression_tests
```

Closes #1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)