### PR TITLE
Enable correlated subqueries in DELETE operations

### DIFF
--- a/crates/executor/tests/delete_tests.rs
+++ b/crates/executor/tests/delete_tests.rs
@@ -118,7 +118,6 @@ fn setup_customers_orders_db() -> Database {
 }
 
 #[test]
-#[ignore] // TODO: Correlated subqueries not yet fully implemented (outer context not used by SelectExecutor)
 fn test_delete_with_exists_correlated() {
     let mut db = setup_customers_orders_db();
 
@@ -149,7 +148,6 @@ fn test_delete_with_exists_correlated() {
 }
 
 #[test]
-#[ignore] // TODO: Correlated subqueries not yet fully implemented
 fn test_delete_with_not_exists_correlated() {
     let mut db = setup_customers_orders_db();
 
@@ -222,7 +220,6 @@ fn test_delete_with_not_exists_empty_result() {
 }
 
 #[test]
-#[ignore] // TODO: Correlated subqueries not yet fully implemented
 fn test_delete_with_exists_and_other_conditions() {
     let mut db = setup_customers_orders_db();
 
@@ -273,7 +270,6 @@ fn test_delete_with_exists_uncorrelated() {
 }
 
 #[test]
-#[ignore] // TODO: Correlated subqueries not yet fully implemented
 fn test_delete_with_exists_complex_subquery() {
     let mut db = setup_customers_orders_db();
 
@@ -306,7 +302,6 @@ fn test_delete_with_exists_complex_subquery() {
 }
 
 #[test]
-#[ignore] // TODO: Correlated subqueries not yet fully implemented
 fn test_delete_with_nested_exists() {
     let mut db = Database::new();
 
@@ -381,7 +376,6 @@ fn test_delete_with_nested_exists() {
 }
 
 #[test]
-#[ignore] // TODO: Correlated subqueries not yet fully implemented
 fn test_delete_with_or_exists() {
     let mut db = setup_customers_orders_db();
 
@@ -407,7 +401,6 @@ fn test_delete_with_or_exists() {
 }
 
 #[test]
-#[ignore] // TODO: Correlated subqueries not yet fully implemented
 fn test_delete_exists_with_select_star() {
     let mut db = setup_customers_orders_db();
 
@@ -424,7 +417,6 @@ fn test_delete_exists_with_select_star() {
 }
 
 #[test]
-#[ignore] // TODO: Correlated subqueries not yet fully implemented
 fn test_delete_exists_with_select_multiple_columns() {
     let mut db = setup_customers_orders_db();
 


### PR DESCRIPTION
## Summary

Enables full correlated subquery support in DELETE operations by removing `#[ignore]` attributes from 8 tests. The infrastructure for correlated subqueries was already fully implemented - the tests were simply marked as ignored.

## Changes

- Removed `#[ignore]` attributes from 8 correlated subquery tests in `crates/executor/tests/delete_tests.rs`
- All tests now pass successfully (11/11 DELETE tests passing)

## Tests Enabled

✅ `test_delete_with_exists_correlated` - Basic correlated EXISTS  
✅ `test_delete_with_not_exists_correlated` - Correlated NOT EXISTS  
✅ `test_delete_with_exists_and_other_conditions` - EXISTS with multiple conditions  
✅ `test_delete_with_exists_complex_subquery` - Complex correlated subquery with additional filters  
✅ `test_delete_with_nested_exists` - Nested correlated subqueries  
✅ `test_delete_with_or_exists` - EXISTS in OR expressions  
✅ `test_delete_exists_with_select_star` - EXISTS with SELECT *  
✅ `test_delete_exists_with_select_multiple_columns` - EXISTS with multiple columns  

## Implementation

The existing implementation already correctly:
- Passes outer context from DELETE executor to subqueries via `ExpressionEvaluator`
- SelectExecutor accepts and uses outer context via `CombinedExpressionEvaluator`
- Column resolution checks outer schema when column not found in inner schema
- Handles nested and complex correlated subqueries with proper depth tracking

## Test Results

```bash
$ cargo test --package executor --test delete_tests
running 11 tests
test test_delete_with_exists_correlated ... ok
test test_delete_with_not_exists_correlated ... ok
test test_delete_with_exists_and_other_conditions ... ok
test test_delete_with_exists_complex_subquery ... ok
test test_delete_with_nested_exists ... ok
test test_delete_with_or_exists ... ok
test test_delete_exists_with_select_star ... ok
test test_delete_exists_with_select_multiple_columns ... ok
test test_delete_with_exists_uncorrelated ... ok
test test_delete_with_exists_empty_result ... ok
test test_delete_with_not_exists_empty_result ... ok

test result: ok. 11 passed; 0 failed; 0 ignored
```

Closes #1093

🤖 Generated with [Claude Code](https://claude.com/claude-code)