### PR TITLE
Phase 1: Implement SQLite wrapper for sqllogictest framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 glob = "0.3"
 md-5 = "0.10"
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [workspace]
 members = [

--- a/tests/sqllogictest_sqlite.rs
+++ b/tests/sqllogictest_sqlite.rs
@@ -1,0 +1,249 @@
+//! SQLite wrapper for sqllogictest framework comparison testing.
+
+use async_trait::async_trait;
+use md5::{Digest, Md5};
+use rusqlite::{Connection, types::ValueRef};
+use sqllogictest::{AsyncDB, DBOutput, DefaultColumnType};
+
+#[derive(Debug)]
+struct TestError(String);
+
+impl std::fmt::Display for TestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for TestError {}
+
+struct SqliteDB {
+    conn: Connection,
+}
+
+impl SqliteDB {
+    fn new() -> Result<Self, TestError> {
+        let conn = Connection::open_in_memory()
+            .map_err(|e| TestError(format!("Failed to create connection: {}", e)))?;
+        Ok(Self { conn })
+    }
+
+    /// Format and optionally hash result rows (matching vibesql's logic)
+    fn format_result_rows(
+        &self,
+        rows: &[Vec<String>],
+        types: Vec<DefaultColumnType>,
+    ) -> Result<DBOutput<DefaultColumnType>, TestError> {
+        let total_values: usize = rows.iter().map(|r| r.len()).sum();
+
+        if total_values > 8 {
+            // Hash the results for large result sets
+            let mut hasher = Md5::new();
+            let mut sort_keys: Vec<_> = rows.iter().map(|row| row.join(" ")).collect();
+            sort_keys.sort();
+            for key in &sort_keys {
+                hasher.update(key);
+                hasher.update("\n");
+            }
+            let hash = format!("{:x}", hasher.finalize());
+            let hash_string = format!("{} values hashing to {}", total_values, hash);
+            Ok(DBOutput::Rows {
+                types: vec![DefaultColumnType::Text],
+                rows: vec![vec![hash_string]],
+            })
+        } else {
+            // Flatten multi-column results: each value becomes its own row
+            let mut flattened_rows: Vec<Vec<String>> = Vec::new();
+            let mut flattened_types: Vec<DefaultColumnType> = Vec::new();
+
+            if !types.is_empty() {
+                flattened_types = vec![types[0].clone(); total_values];
+            }
+
+            for row in rows {
+                for val in row {
+                    flattened_rows.push(vec![val.clone()]);
+                }
+            }
+
+            Ok(DBOutput::Rows { types: flattened_types, rows: flattened_rows })
+        }
+    }
+
+    fn execute_sql(&mut self, sql: &str) -> Result<DBOutput<DefaultColumnType>, TestError> {
+        let trimmed = sql.trim();
+
+        // Check if this is a query (SELECT) or a statement (INSERT, UPDATE, etc.)
+        let is_query = trimmed.to_uppercase().starts_with("SELECT");
+
+        if is_query {
+            self.execute_query(sql)
+        } else {
+            self.execute_statement(sql)
+        }
+    }
+
+    fn execute_query(&self, sql: &str) -> Result<DBOutput<DefaultColumnType>, TestError> {
+        let mut stmt = self.conn.prepare(sql)
+            .map_err(|e| TestError(format!("Failed to prepare query: {}", e)))?;
+
+        let column_count = stmt.column_count();
+        let mut rows = Vec::new();
+        let mut types = Vec::new();
+
+        let mut db_rows = stmt.query([])
+            .map_err(|e| TestError(format!("Failed to execute query: {}", e)))?;
+
+        // Determine column types from first row
+        let mut first_row = true;
+        while let Some(row) = db_rows.next()
+            .map_err(|e| TestError(format!("Failed to fetch row: {}", e)))? {
+
+            let mut row_values = Vec::new();
+            for i in 0..column_count {
+                let value = row.get_ref(i)
+                    .map_err(|e| TestError(format!("Failed to get column {}: {}", i, e)))?;
+
+                // Determine type from first row
+                if first_row {
+                    types.push(match value {
+                        ValueRef::Integer(_) => DefaultColumnType::Integer,
+                        ValueRef::Real(_) => DefaultColumnType::FloatingPoint,
+                        ValueRef::Text(_) => DefaultColumnType::Text,
+                        ValueRef::Blob(_) => DefaultColumnType::Text,
+                        ValueRef::Null => DefaultColumnType::Any,
+                    });
+                }
+
+                row_values.push(Self::format_value(value, types.get(i)));
+            }
+
+            rows.push(row_values);
+            first_row = false;
+        }
+
+        if rows.is_empty() {
+            return Ok(DBOutput::Rows { types: vec![], rows: vec![] });
+        }
+
+        self.format_result_rows(&rows, types)
+    }
+
+    fn execute_statement(&mut self, sql: &str) -> Result<DBOutput<DefaultColumnType>, TestError> {
+        let rows_affected = self.conn.execute(sql, [])
+            .map_err(|e| TestError(format!("Failed to execute statement: {}", e)))?;
+        Ok(DBOutput::StatementComplete(rows_affected as u64))
+    }
+
+    fn format_value(value: ValueRef, expected_type: Option<&DefaultColumnType>) -> String {
+        match value {
+            ValueRef::Integer(i) => {
+                if matches!(expected_type, Some(DefaultColumnType::FloatingPoint)) {
+                    format!("{:.3}", i as f64)
+                } else {
+                    i.to_string()
+                }
+            }
+            ValueRef::Real(f) => {
+                if f.fract() == 0.0 {
+                    format!("{:.1}", f)
+                } else {
+                    f.to_string()
+                }
+            }
+            ValueRef::Text(s) => String::from_utf8_lossy(s).to_string(),
+            ValueRef::Blob(b) => format!("{:?}", b),
+            ValueRef::Null => "NULL".to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl AsyncDB for SqliteDB {
+    type Error = TestError;
+    type ColumnType = DefaultColumnType;
+
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, Self::Error> {
+        self.execute_sql(sql)
+    }
+
+    async fn shutdown(&mut self) {
+        // SQLite connection will be closed automatically on drop
+    }
+}
+
+#[tokio::test]
+async fn test_basic_select() {
+    let mut tester = sqllogictest::Runner::new(|| async { SqliteDB::new() });
+
+    let script = r#"
+statement ok
+CREATE TABLE test (x INTEGER, y INTEGER)
+
+statement ok
+INSERT INTO test VALUES (1, 2)
+
+statement ok
+INSERT INTO test VALUES (3, 4)
+
+query II rowsort
+SELECT * FROM test
+----
+1
+2
+3
+4
+
+query I
+SELECT x FROM test WHERE y = 4
+----
+3
+"#;
+
+    tester.run_script(script).expect("Basic SELECT test should pass");
+}
+
+#[tokio::test]
+async fn test_arithmetic() {
+    let mut tester = sqllogictest::Runner::new(|| async { SqliteDB::new() });
+
+    let script = r#"
+query I
+SELECT 1 + 1
+----
+2
+
+query I
+SELECT 10 - 3
+----
+7
+
+query I
+SELECT 4 * 5
+----
+20
+"#;
+
+    tester.run_script(script).expect("Arithmetic test should pass");
+}
+
+#[tokio::test]
+async fn test_data_types() {
+    let mut tester = sqllogictest::Runner::new(|| async { SqliteDB::new() });
+
+    let script = r#"
+statement ok
+CREATE TABLE types_test (id INTEGER, name TEXT, value REAL)
+
+statement ok
+INSERT INTO types_test VALUES (1, 'hello', 3.14)
+
+query IRT
+SELECT * FROM types_test
+----
+1
+hello
+3.14
+"#;
+
+    tester.run_script(script).expect("Data types test should pass");
+}


### PR DESCRIPTION
## Summary
This PR implements Phase 1 of the SQLite wrapper for the sqllogictest framework, enabling us to run the same test files against both vibesql and SQLite3.

## Changes
- ✅ Added `rusqlite` dependency to `Cargo.toml` with `bundled` feature for portability
- ✅ Created `tests/sqllogictest_sqlite.rs` with `SqliteDB` struct
- ✅ Implemented `AsyncDB` trait for `SqliteDB`
  - Implemented `run()` method to execute SQL via rusqlite
  - Handle both query (SELECT) and statement (INSERT, UPDATE, DELETE, etc.) execution
  - Format results to match sqllogictest expectations
- ✅ Implemented result row formatting (matching vibesql's format)
  - Small results (≤8 values) are flattened with each value as a separate row
  - Large results (>8 values) are hashed using MD5
- ✅ Handle column type mapping (Integer, FloatingPoint, Text, Blob, Null → Any)
- ✅ Added three basic sanity tests to verify SQLite wrapper works

## Acceptance Criteria
All acceptance criteria from issue #1113 are met:
- ✅ SQLite wrapper can execute basic SELECT, INSERT, UPDATE, DELETE statements
- ✅ Results are formatted correctly for sqllogictest validation
- ✅ Three passing tests demonstrating SQLite wrapper functionality
- ✅ No compilation warnings or errors in wrapper code

## Test Results
```
running 3 tests
test test_arithmetic ... ok
test test_data_types ... ok
test test_basic_select ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured
```

## Technical Implementation Details
- Used `Connection::open_in_memory()` for test isolation
- Matched the result formatting logic from `NistMemSqlDB::format_result_rows()` in `tests/sqllogictest_runner.rs:37-102`
- Implemented proper type handling using `ValueRef` from rusqlite
- Ensured consistent value formatting across integer, float, and text types

Closes #1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)