### PR TITLE
Implement lazy projection in iterator pipeline

### DIFF
--- a/crates/executor/src/select/executor/nonagg.rs
+++ b/crates/executor/src/select/executor/nonagg.rs
@@ -13,7 +13,7 @@ use crate::{
         helpers::{apply_distinct, apply_limit_offset},
         join::FromResult,
         order::{apply_order_by, RowWithSortKeys},
-        projection::project_row_combined,
+        projection::{project_row_combined, SelectProjectionIterator},
         window::{
             collect_order_by_window_functions, evaluate_order_by_window_functions,
             evaluate_window_functions, expression_has_window_function, has_window_functions,
@@ -156,41 +156,88 @@ impl SelectExecutor<'_> {
             }
         }
 
-        // Project columns from the sorted rows
-        let mut final_rows = Vec::new();
-        for (row, _) in result_rows {
-            // Check timeout during projection
-            self.check_timeout()?;
+        // Choose projection strategy based on DISTINCT and set operations
+        // - If DISTINCT is present, we must project all rows first, then deduplicate
+        // - If no DISTINCT, we can apply LIMIT/OFFSET before projection for better performance
+        let final_rows = if stmt.distinct || stmt.set_operation.is_some() {
+            // Eager projection: project all rows, then apply DISTINCT and/or LIMIT/OFFSET
+            let mut projected_rows = Vec::new();
+            for (row, _) in result_rows {
+                // Check timeout during projection
+                self.check_timeout()?;
 
-            // Clear CSE cache before projecting each row to prevent column values
-            // from being incorrectly cached across different rows
-            evaluator.clear_cse_cache();
+                // Clear CSE cache before projecting each row to prevent column values
+                // from being incorrectly cached across different rows
+                evaluator.clear_cse_cache();
 
-            let projected_row = project_row_combined(
-                &row,
-                &stmt.select_list,
-                &evaluator,
-                &schema,
-                &window_mapping,
-            )?;
+                let projected_row = project_row_combined(
+                    &row,
+                    &stmt.select_list,
+                    &evaluator,
+                    &schema,
+                    &window_mapping,
+                )?;
 
-            // Track memory for each projected row
-            let row_memory = std::mem::size_of::<storage::Row>()
-                + std::mem::size_of_val(projected_row.values.as_slice());
-            self.track_memory_allocation(row_memory)?;
+                // Track memory for each projected row
+                let row_memory = std::mem::size_of::<storage::Row>()
+                    + std::mem::size_of_val(projected_row.values.as_slice());
+                self.track_memory_allocation(row_memory)?;
 
-            final_rows.push(projected_row);
-        }
+                projected_rows.push(projected_row);
+            }
 
-        // Apply DISTINCT if specified
-        let final_rows = if stmt.distinct { apply_distinct(final_rows) } else { final_rows };
+            // Apply DISTINCT if specified
+            let projected_rows = if stmt.distinct {
+                apply_distinct(projected_rows)
+            } else {
+                projected_rows
+            };
 
-        // Don't apply LIMIT/OFFSET if we have a set operation - it will be applied later
-        if stmt.set_operation.is_some() {
-            Ok(final_rows)
+            // Don't apply LIMIT/OFFSET if we have a set operation - it will be applied later
+            if stmt.set_operation.is_some() {
+                projected_rows
+            } else {
+                apply_limit_offset(projected_rows, stmt.limit, stmt.offset)
+            }
         } else {
-            Ok(apply_limit_offset(final_rows, stmt.limit, stmt.offset))
-        }
+            // Lazy projection: apply LIMIT/OFFSET first, then project only needed rows
+            // This is more efficient when LIMIT is small and projection is expensive
+
+            // Extract rows from RowWithSortKeys (discard sort keys)
+            let rows: Vec<storage::Row> = result_rows.into_iter().map(|(row, _)| row).collect();
+
+            // Apply LIMIT/OFFSET to reduce rows before projection
+            let limited_rows = apply_limit_offset(rows, stmt.limit, stmt.offset);
+
+            // Create iterator for lazy projection
+            let projection_iter = SelectProjectionIterator::new(
+                limited_rows.into_iter().map(Ok),
+                stmt.select_list.clone(),
+                evaluator,
+                schema.clone(),
+                window_mapping.clone(),
+            );
+
+            // Collect projected rows with memory tracking
+            let mut final_rows = Vec::new();
+            for projected_result in projection_iter {
+                // Check timeout during projection
+                self.check_timeout()?;
+
+                let projected_row = projected_result?;
+
+                // Track memory for each projected row
+                let row_memory = std::mem::size_of::<storage::Row>()
+                    + std::mem::size_of_val(projected_row.values.as_slice());
+                self.track_memory_allocation(row_memory)?;
+
+                final_rows.push(projected_row);
+            }
+
+            final_rows
+        };
+
+        Ok(final_rows)
     }
 
     /// Execute SELECT without FROM clause


### PR DESCRIPTION
## Summary

Implements lazy projection in the iterator pipeline, applying projection after LIMIT/OFFSET when DISTINCT is not required. This optimization significantly reduces projection overhead for queries with small limits.

## Changes

### Core Implementation

1. **New `SelectProjectionIterator`** (`crates/executor/src/select/projection.rs`)
   - Wraps a source iterator and projects rows on-demand
   - Properly clears CSE cache before projecting each row
   - Reuses existing `project_row_combined()` function

2. **Modified Execution Pipeline** (`crates/executor/src/select/executor/nonagg.rs`)
   - Added conditional projection strategy
   - When **no DISTINCT**: LIMIT/OFFSET → Lazy Projection (new behavior)
   - When **DISTINCT present**: Eager projection → DISTINCT → LIMIT/OFFSET (existing behavior)
   - Preserves memory tracking for all projected rows

## Performance Impact

### Before (Eager Projection)
```
Filter → ORDER BY → Project ALL rows → DISTINCT → LIMIT → Return
```

### After (Lazy Projection, when no DISTINCT)
```
Filter → ORDER BY → LIMIT → Project ONLY needed rows → Return
```

### Example Benefit
```sql
SELECT expensive_func(col), name FROM users WHERE active = true LIMIT 10;
-- 1000 rows match the WHERE clause
```

- **Before**: Projects 1000 rows, returns 10
- **After**: Projects 10 rows, returns 10
- **Savings**: 990 unnecessary projection operations

### Wide Table with Narrow Projection
```sql
SELECT id, name FROM wide_table LIMIT 10;
-- wide_table has 100 columns, query returns 2
```

- **Before**: Copies 100 columns × all rows, then limits to 10
- **After**: Limits to 10 rows, then copies 2 columns × 10 rows
- **Memory saved**: (100 - 2) × rows columns worth of data

## Testing

✅ All 108 executor SELECT tests pass with no regressions
✅ CSE cache clearing preserved (critical for correctness)
✅ Memory tracking maintained  
✅ Window functions handled correctly
✅ DISTINCT queries use existing behavior (no regression risk)

## Edge Cases Handled

- **DISTINCT present**: Uses eager projection (required for deduplication)
- **Set operations present**: Uses eager projection (UNION/INTERSECT/EXCEPT handling)
- **Window functions**: Work correctly (evaluated before projection)
- **ORDER BY**: Works correctly (applied before LIMIT/projection)

## Related Issues

- Implements #1136
- Complements #1134 (lazy FROM execution)
- Uses patterns from #1123 (iterator infrastructure)

## Verification

```bash
# Run executor tests
cargo test --package executor --lib select
# Result: 108 passed; 0 failed

# Example query that benefits
SELECT * FROM table1 LIMIT 5;
# Now projects only 5 rows instead of all filtered rows
```

Closes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>