### PR TITLE
test: Add regression tests for multi-column SELECT ordering

### DIFF
--- a/crates/cli/src/executor/tests.rs
+++ b/crates/cli/src/executor/tests.rs
@@ -128,3 +128,19 @@ fn test_create_table_row_count() {
     let result = executor.execute("CREATE TABLE test (id INT PRIMARY KEY)").unwrap();
     assert_eq!(result.row_count, 0, "CREATE TABLE should return row count of 0 (DDL)");
 }
+
+#[test]
+fn test_multi_column_select_order() {
+    // Regression test for issue #1170
+    // Multi-column SELECT should preserve left-to-right column order
+    let mut executor = SqlExecutor::new(None).unwrap();
+    let result = executor.execute("SELECT 74 AS col0, 50 AS col1").unwrap();
+
+    assert_eq!(result.rows.len(), 1, "Should return 1 row");
+    assert_eq!(result.rows[0].len(), 2, "Should return 2 columns");
+
+    // Values should be in the same order as specified in SELECT: 74 first, then 50
+    // Note: Values are formatted as debug strings like "Integer(74)"
+    assert_eq!(result.rows[0][0], "Integer(74)", "First column should be 74");
+    assert_eq!(result.rows[0][1], "Integer(50)", "Second column should be 50");
+}

--- a/tests/sqllogictest_runner.rs
+++ b/tests/sqllogictest_runner.rs
@@ -562,3 +562,20 @@ SELECT pk FROM tab0 WHERE col3 >= 94 OR (col1 IN (63.39,21.7,52.63,42.27,35.11,7
 
     tester.run_script(script).expect("IN subquery test should pass");
 }
+
+// Issue #1170: Reproduction test for multi-column SELECT column ordering
+#[tokio::test]
+async fn test_issue_1170_multi_column_select_order() {
+    let mut tester = sqllogictest::Runner::new(|| async { Ok(NistMemSqlDB::new()) });
+
+    // Test with the exact syntax from the issue
+    let script = r#"
+query II
+SELECT + + 74 AS col0, 50 col1
+----
+74
+50
+"#;
+
+    tester.run_script(script).expect("Multi-column SELECT order test should pass");
+}


### PR DESCRIPTION
## Summary

Investigation of issue #1170 revealed that the reported bug **cannot be reproduced** in the current codebase. This PR adds comprehensive regression tests to prevent the issue from occurring in the future.

## Investigation Results

### Tests Added

1. **CLI Executor Test** (`crates/cli/src/executor/tests.rs`):
   - `test_multi_column_select_order()` - Verifies multi-column SELECT through CLI executor
   - ✅ PASSES - Returns columns in correct order [74, 50]

2. **SQLLogicTest Runner Test** (`tests/sqllogictest_runner.rs`):  
   - `test_issue_1170_multi_column_select_order()` - Tests exact query from issue
   - ✅ PASSES - Returns columns in correct order [74, 50]
   - Uses exact syntax: `SELECT + + 74 AS col0, 50 col1`

### Code Analysis

Examined all relevant code paths for column ordering:

- ✅ `execute_select_without_from()` (nonagg.rs:419-456) - Correctly iterates `select_list` in order
- ✅ `format_result_rows()` (sqllogictest_runner.rs:37-101) - Correctly preserves order during flattening
- ✅ `project_row_combined()` (projection.rs:6-15) - Correctly iterates columns in order

### Conclusion

**The issue described in #1170 does not exist in the current codebase.** Column ordering is working correctly across all execution paths.

## Test Plan

- ✅ Both new tests pass
- ✅ All existing tests pass
- ✅ Tested with exact query syntax from issue

## Related

Relates to #1170 (cannot reproduce)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>