### PR TITLE
fix: Update COUNT arithmetic tests to expect Numeric type

### DIFF
--- a/tests/test_count_star.rs
+++ b/tests/test_count_star.rs
@@ -49,7 +49,7 @@ fn test_count_star_in_multiplication() {
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 1);
     // -18 * COUNT(*) = -18 * 2 = -36
-    assert_eq!(result[0].values[0], types::SqlValue::Integer(-36));
+    assert_eq!(result[0].values[0], types::SqlValue::Numeric(-36.0));
 }
 
 #[test]
@@ -101,7 +101,7 @@ fn test_count_star_in_addition() {
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 1);
     // COUNT(*) + COUNT(*) = 3 + 3 = 6
-    assert_eq!(result[0].values[0], types::SqlValue::Integer(6));
+    assert_eq!(result[0].values[0], types::SqlValue::Numeric(6.0));
 }
 
 #[test]
@@ -164,7 +164,7 @@ fn test_count_star_complex_expression() {
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 1);
     // 10 + (COUNT(*) * 2) - 5 = 10 + (4 * 2) - 5 = 10 + 8 - 5 = 13
-    assert_eq!(result[0].values[0], types::SqlValue::Integer(13));
+    assert_eq!(result[0].values[0], types::SqlValue::Numeric(13.0));
 }
 
 #[test]
@@ -234,7 +234,7 @@ fn test_count_star_with_unary_operators() {
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 1);
     // + 60 * ( + + COUNT(*) ) = + 60 * ( + + 5 ) = + 60 * 5 = + 300 = 300
-    assert_eq!(result[0].values[0], types::SqlValue::Integer(300));
+    assert_eq!(result[0].values[0], types::SqlValue::Numeric(300.0));
 }
 
 #[test]
@@ -289,5 +289,5 @@ fn test_count_star_with_negative_unary() {
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 1);
     // - COUNT(*) * 9 = -3 * 9 = -27
-    assert_eq!(result[0].values[0], types::SqlValue::Integer(-27));
+    assert_eq!(result[0].values[0], types::SqlValue::Numeric(-27.0));
 }


### PR DESCRIPTION
## Summary

Fixes test failures after PR #1185 which preserves Numeric type through arithmetic operations. Tests now correctly expect Numeric results instead of Integer when arithmetic involves COUNT() aggregate functions.

## Problem

After PR #1185, arithmetic operations like `Numeric * Integer` now preserve the Numeric type (previously converted to Float). The tests in `test_count_star.rs` were still expecting Integer results, causing 5 test failures:

```
test test_count_star_complex_expression ... FAILED
test test_count_star_in_addition ... FAILED
test test_count_star_in_multiplication ... FAILED
test test_count_star_with_negative_unary ... FAILED
test test_count_star_with_unary_operators ... FAILED
```

**Example failure**:
```rust
assertion failed: left == right
  left: Numeric(-36.0)  // Actual result after PR #1185
 right: Integer(-36)    // Old expectation
```

## Solution

Updated 5 test assertions to expect `Numeric` type instead of `Integer`:

| Test | Expression | Old Expectation | New Expectation |
|------|-----------|----------------|-----------------|
| `test_count_star_in_multiplication` | `-18 * COUNT(*)` | `Integer(-36)` | `Numeric(-36.0)` |
| `test_count_star_in_addition` | `COUNT(*) + COUNT(*)` | `Integer(6)` | `Numeric(6.0)` |
| `test_count_star_complex_expression` | `10 + (COUNT(*) * 2) - 5` | `Integer(13)` | `Numeric(13.0)` |
| `test_count_star_with_unary_operators` | `+ 60 * ( + + COUNT(*) )` | `Integer(300)` | `Numeric(300.0)` |
| `test_count_star_with_negative_unary` | `- COUNT(*) * 9` | `Integer(-27)` | `Numeric(-27.0)` |

## Background

### Type Evolution Timeline:
1. **PR #1175**: Changed COUNT/SUM/AVG to return `Numeric` (was `Integer`)
2. **PR #1185**: Modified arithmetic to preserve `Numeric` through operations
   - Before: `Numeric * Integer` → `Float`
   - After: `Numeric * Integer` → `Numeric`
3. **This PR**: Updates tests to expect the new `Numeric` results

## Testing

### Before Fix:
```bash
$ cargo test test_count_star --release
test result: FAILED. 0 passed; 5 failed; 0 ignored; 0 measured
```

### After Fix:
```bash
$ cargo test test_count_star --release
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured
```

All affected tests now pass:
- ✅ test_count_star_in_multiplication
- ✅ test_count_star_in_addition  
- ✅ test_count_star_complex_expression
- ✅ test_count_star_with_unary_operators
- ✅ test_count_star_with_negative_unary

## Files Changed

- `tests/test_count_star.rs`: Updated 5 test assertions from Integer to Numeric

## Related

- Depends on: PR #1185
- Related to: PR #1175, Issue #1184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>