### PR TITLE
fix: Re-enable error messages and remove unnecessary backtick workaround

### DIFF
--- a/scripts/process_test_results.py
+++ b/scripts/process_test_results.py
@@ -202,9 +202,7 @@ VALUES ({sql_escape(file_path)}, {sql_escape(category)}, {sql_escape(subcategory
         category, subcategory = categorize_test_file(file_path)
 
         # Get error message from lookup, or NULL if not available
-        # Note: Temporarily disabled error messages due to SQL escaping issues
-        # with special characters (backticks, quotes, etc.) in test error output
-        error_message = None  # error_lookup.get(file_path, None)
+        error_message = error_lookup.get(file_path, None)
 
         # Insert into test_results
         statements.append(f"""
@@ -228,10 +226,8 @@ def sql_escape(value: Optional[str]) -> str:
     """Escape a value for SQL, handling NULL and special characters."""
     if value is None:
         return "NULL"
-    # Escape single quotes by doubling them
+    # Escape single quotes by doubling them (SQL standard)
     escaped = value.replace("'", "''")
-    # Remove backticks (used for identifiers in some SQL dialects, confuses parser in strings)
-    escaped = escaped.replace('`', '')
     # Replace newlines with spaces to keep SQL on single line
     escaped = escaped.replace('\n', ' ').replace('\r', ' ')
     # Collapse multiple spaces into single space


### PR DESCRIPTION
## Summary

Investigation revealed that the reported "lexer bug" in issue #1189 does not exist. VibeSQL correctly handles backticks inside string literals per SQL standards.

This PR removes the unnecessary workaround that was added based on a false assumption and re-enables error messages in the dogfooding database.

## Changes

- ✅ Re-enabled `error_message` field in test results (was disabled on line 207)
- ✅ Removed unnecessary backtick removal from `sql_escape()` (was line 234)
- ✅ Updated comments to clarify SQL standard escaping behavior

## Root Cause Analysis

The original issue stemmed from a **misunderstanding** about how VibeSQL's lexer works:

**Incorrect assumption**: Backticks inside single-quoted strings cause parse errors  
**Reality**: The lexer's `tokenize_string()` method correctly treats backticks as regular characters when inside string literals

### Lexer Behavior

Looking at `crates/parser/src/lexer/strings.rs:7-35`:
- `tokenize_string()` has its own loop for string parsing
- Only checks for the closing quote character
- Treats backticks as regular characters (`string_content.push(ch)`)
- Only calls `tokenize_backtick_identifier()` for top-level backticks

This is the **correct SQL behavior** per SQL standards.

## Testing

### Lexer Test
```rust
let mut lexer = Lexer::new("'CREATE TABLE `t` (`col` INT)'");
let tokens = lexer.tokenize().unwrap();
// ✅ SUCCESS: Tokenizes correctly
```

### Full SQL Execution
```sql
CREATE TABLE test (msg VARCHAR(1000));
INSERT INTO test (msg) VALUES ('CREATE TABLE `t` (`col` INT)');
SELECT * FROM test;
```

**Result**: ✅ Data stored correctly with backticks preserved:
```
Varchar("CREATE TABLE `t` (`col` INT)")
```

### Python Unit Tests
```python
# All test cases pass:
✓ Text with backticks: `foo`
✓ CREATE TABLE `t` (`col` INT)
✓ O'Reilly (single quote escaping)
✓ Newline handling
✓ Multiple space collapsing
✓ NULL handling
```

## Impact

**Before this PR**:
- Error messages with backticks were stripped
- Error messages were disabled entirely (set to NULL)
- Loss of valuable debugging information

**After this PR**:
- Error messages with backticks preserved correctly
- Full error messages stored in dogfooding database
- Better debugging and analysis capabilities

## Example

Error messages like this MySQL output now work correctly:
```sql
INSERT INTO test_results (error_message) 
VALUES ('Error near `column_name` at line 42');
```

Stored as: `"Error near `column_name` at line 42"` ✅

Closes #1189

## Test Plan

- [x] Verified lexer handles backticks in strings correctly
- [x] Tested full SQL execution with backticks
- [x] Validated Python `sql_escape()` function with test cases
- [x] Confirmed generated SQL executes successfully in VibeSQL
- [x] Verified error messages with backticks store correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)