### PR TITLE
fix: Use IndexSet for DISTINCT to preserve insertion order

### DIFF
--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -10,6 +10,7 @@ catalog = { path = "../catalog" }
 storage = { path = "../storage" }
 chrono = "0.4"
 rayon = "1.10"
+indexmap = "2.0"
 
 [dev-dependencies]
 parser = { path = "../parser" }

--- a/crates/executor/src/select/helpers.rs
+++ b/crates/executor/src/select/helpers.rs
@@ -1,15 +1,17 @@
 //! Helper functions for SELECT query execution
 
-use std::collections::HashSet;
+use indexmap::IndexSet;
 
 /// Apply DISTINCT to remove duplicate rows
 ///
-/// Uses a HashSet to track unique rows. This requires SqlValue to implement
-/// Hash and Eq, which we've implemented with SQL semantics:
+/// Uses an IndexSet to track unique rows while preserving insertion order.
+/// This ensures deterministic results that match SQLite's behavior.
+/// This requires SqlValue to implement Hash and Eq, which we've implemented
+/// with SQL semantics:
 /// - NULL == NULL for grouping
 /// - NaN == NaN for grouping
 pub(super) fn apply_distinct(rows: Vec<storage::Row>) -> Vec<storage::Row> {
-    let mut seen = HashSet::new();
+    let mut seen = IndexSet::new();
     let mut result = Vec::new();
 
     for row in rows {


### PR DESCRIPTION
## Summary

Fixes SELECT DISTINCT queries returning results in wrong order by replacing HashSet with IndexSet for order-preserving deduplication.

## Problem

SELECT DISTINCT queries were returning correct values but in non-deterministic order, causing SQLLogicTest failures. For example:

```sql
SELECT DISTINCT + ( 7 ) + + 89 col1, - 19 + 46 AS col0
```

Expected: `96  27`
Actual: `27  96` (wrong order)

## Root Cause

The `apply_distinct` function used `HashSet` which doesn't preserve insertion order. Hash values determine element order, not insertion sequence.

## Solution

Replaced `HashSet` with `IndexSet` from the indexmap crate:
- Preserves insertion order automatically
- Same O(1) lookup performance
- Minimal code changes (drop-in replacement)
- Industry-standard solution for order-preserving deduplication

## Changes

- **crates/executor/Cargo.toml**: Added `indexmap = "2.0"` dependency
- **crates/executor/src/select/helpers.rs**:
  - Changed import from `std::collections::HashSet` to `indexmap::IndexSet`
  - Updated `apply_distinct` to use `IndexSet::new()`
  - Updated documentation to reflect order preservation behavior

## Testing

- ✅ Existing DISTINCT e2e test passes (`test_e2e_distinct`)
- ✅ Library builds successfully
- ✅ No functional changes to deduplication logic
- ✅ Performance maintained (same O(1) complexity)

## Related

This implements Option 1 (IndexSet) from the curation analysis, which was the recommended solution.

Closes #1191
