### PR TITLE
docs: Update references to deleted analyze_failure_patterns.py

### DIFF
--- a/docs/analysis/index_test_analysis.md
+++ b/docs/analysis/index_test_analysis.md
@@ -241,7 +241,7 @@ SQLLOGICTEST_TIME_BUDGET=300 cargo test test_sqllogictest_suite --release -- --n
 "
 
 # Analyze failure patterns
-./scripts/analyze_failure_patterns.py --category index
+./scripts/analyze_test_failures.py
 ```
 
 ### Regression Detection

--- a/docs/archive/investigations/ISSUE_960_INVESTIGATION.md
+++ b/docs/archive/investigations/ISSUE_960_INVESTIGATION.md
@@ -139,7 +139,7 @@ cargo test --test sqllogictest_suite -- --exact random/aggregates/slt_good_129.t
 SQLLOGICTEST_TIME_BUDGET=1200 cargo test --test sqllogictest_suite
 
 # Analyze results
-python3 scripts/analyze_failure_patterns.py target/sqllogictest_results_analysis.json
+python3 scripts/analyze_test_failures.py
 ```
 
 ## Related Issues

--- a/docs/roadmaps/PUNCHLIST_100_CONFORMANCE.md
+++ b/docs/roadmaps/PUNCHLIST_100_CONFORMANCE.md
@@ -144,10 +144,10 @@ Examples:
 
 ### Analyze Results
 ```bash
-python3 scripts/analyze_failure_patterns.py target/sqllogictest_results_analysis.json
+python3 scripts/analyze_test_failures.py
 ```
 
-Identifies high-impact fix opportunities.
+Identifies high-impact fix opportunities through failure clustering and pattern analysis.
 
 ## Workflow for Fixing One Category
 

--- a/docs/sqllogictest/SQLLOGICTEST_ROADMAP.md
+++ b/docs/sqllogictest/SQLLOGICTEST_ROADMAP.md
@@ -87,7 +87,7 @@ Top failure categories:
    ./scripts/run_remote_sqllogictest.sh
 
    # Analyze new results
-   python3 scripts/analyze_failure_patterns.py target/sqllogictest_results_analysis.json
+   python3 scripts/run_parallel_tests.py --analyze
    ```
 
 ### Phase 2: Medium-Impact Fixes (Target: Week 2-3)
@@ -215,7 +215,7 @@ Schedule after implementing #956 and #957 (Quick Wins).
 - `scripts/run_remote_sqllogictest.sh` - Run full test suite remotely
 - `scripts/run_parallel_tests.py` - Run tests with parallel workers
 - `scripts/aggregate_worker_results.py` - Combine worker results
-- `scripts/analyze_failure_patterns.py` - Analyze failure patterns
+- `scripts/analyze_test_failures.py` - Analyze failures with clustering and pattern detection
 
 ### Data Files
 

--- a/docs/sqllogictest/SQLLOGICTEST_SUITE_STATUS.md
+++ b/docs/sqllogictest/SQLLOGICTEST_SUITE_STATUS.md
@@ -92,23 +92,7 @@ python3 scripts/aggregate_worker_results.py \
 - `target/sqllogictest_results_analysis.json` - Detailed failure analysis
 - `target/failure_pattern_analysis.md` - Human-readable failure patterns
 
-### 3. `analyze_failure_patterns.py` - Pattern Analysis
-
-Analyzes test failures to identify root causes and high-impact fixes.
-
-```bash
-# Analyze failure patterns
-python3 scripts/analyze_failure_patterns.py \
-  target/sqllogictest_results_analysis.json
-
-# Output: target/failure_pattern_analysis.md
-# Groups failures by:
-# - Error type frequency
-# - Tests affected per issue
-# - Estimated impact of fixes
-```
-
-### 4. `process_test_results.py` - Dogfooding Database
+### 3. `process_test_results.py` - Dogfooding Database
 
 Stores test results in VibeSQL, demonstrating real-world database usage.
 
@@ -132,7 +116,7 @@ Stores test results in VibeSQL, demonstrating real-world database usage.
 - `target/sqllogictest_results.sql` - Full database dump
 - Can be loaded into web demo for live querying
 
-### 5. `query_test_results.py` - Results Viewer
+### 4. `query_test_results.py` - Results Viewer
 
 Query the dogfooding database to analyze test results.
 
@@ -296,21 +280,7 @@ python3 scripts/aggregate_worker_results.py /tmp/sqllogictest_results
 - `target/sqllogictest_results_analysis.json` - Detailed analysis with error messages
 - `target/failure_pattern_analysis.md` - Human-readable summary
 
-### Step 3: Analyze Failure Patterns
-
-```bash
-# (automatically done by aggregator, but can re-run)
-python3 scripts/analyze_failure_patterns.py \
-  target/sqllogictest_results_analysis.json
-```
-
-**Identifies**:
-- Top failing categories
-- Error type frequencies
-- Tests affected by each issue
-- Estimated impact of fixes
-
-### Step 4: Store in Dogfooding Database
+### Step 3: Store in Dogfooding Database
 
 ```bash
 # Load results into VibeSQL
@@ -325,7 +295,7 @@ python3 scripts/analyze_failure_patterns.py \
 - test_results entries for each file
 - test_files status update
 
-### Step 5: Query and Analyze
+### Step 4: Query and Analyze
 
 ```bash
 # View progress
@@ -516,7 +486,7 @@ python3 scripts/query_test_results.py --preset progress
 ### Test Scripts
 - `scripts/run_parallel_tests.py` - Run full test suite with workers
 - `scripts/aggregate_worker_results.py` - Combine worker results
-- `scripts/analyze_failure_patterns.py` - Identify failure patterns
+- `scripts/analyze_test_failures.py` - Analyze failures with clustering and pattern detection
 - `scripts/process_test_results.py` - Store results in dogfooding database
 - `scripts/query_test_results.py` - Query dogfooding database
 

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -103,14 +103,18 @@ Fixing this ONE issue could improve our pass rate by 8-10%.
 Instead of creating issues for individual test failures, analyze failure categories:
 
 ```bash
-# Use the analysis file to categorize failures
-python3 scripts/analyze_failure_patterns.py target/sqllogictest_results_analysis.json
+# Analyze test failures with clustering and pattern analysis
+python3 scripts/analyze_test_failures.py
+
+# Or run via the test runner
+python3 scripts/run_parallel_tests.py --analyze
 ```
 
-**Output should group by:**
+**Output includes:**
 - Error type frequency
 - Common error patterns
 - Impact analysis (how many tests affected)
+- Clustered failures by similarity
 
 ### 2. Prioritization Matrix
 
@@ -230,18 +234,7 @@ Target: 95-100% (580-613/613)
 
 ## Tools to Build
 
-### 1. Failure Pattern Analyzer
-
-```bash
-# Analyze patterns in failures
-python3 scripts/analyze_failure_patterns.py \
-  target/sqllogictest_results_analysis.json \
-  --group-by error_type \
-  --show-impact \
-  --output target/failure_patterns.md
-```
-
-### 2. Test Run Comparator
+### 1. Test Run Comparator
 
 ```bash
 # Compare two test runs


### PR DESCRIPTION
## Summary

Updates documentation to remove all references to the deleted `analyze_failure_patterns.py` script (removed in PR #1211). All documentation now correctly references `analyze_test_failures.py` as the single-step analysis tool.

## Changes

Updated 6 documentation files to remove references to the deleted script:

1. **docs/testing/TESTING.md** (2 references)
   - Updated root cause analysis section to use `analyze_test_failures.py`
   - Removed separate "Failure Pattern Analyzer" section (functionality now integrated)
   - Updated tool numbering accordingly

2. **docs/sqllogictest/SQLLOGICTEST_SUITE_STATUS.md** (4 references)
   - Removed entire section describing `analyze_failure_patterns.py`
   - Updated workflow steps (removed Step 3 "Analyze Failure Patterns")
   - Updated test scripts list
   - Renumbered subsequent sections

3. **docs/sqllogictest/SQLLOGICTEST_ROADMAP.md** (2 references)
   - Updated validation workflow to use `run_parallel_tests.py --analyze`
   - Updated Scripts section to reference `analyze_test_failures.py`

4. **docs/analysis/index_test_analysis.md** (1 reference)
   - Updated test execution commands to use `analyze_test_failures.py`

5. **docs/roadmaps/PUNCHLIST_100_CONFORMANCE.md** (1 reference)
   - Updated "Analyze Results" section to use `analyze_test_failures.py`
   - Added description of clustering and pattern analysis

6. **docs/archive/investigations/ISSUE_960_INVESTIGATION.md** (1 reference)
   - Updated testing workflow to use `analyze_test_failures.py`

## Verification

Confirmed cleanup is complete:
```bash
grep -r "analyze_failure_patterns" docs/
# Returns no results (except DOGFOODING.md historical reference)
```

The only remaining reference is in `DOGFOODING.md` line 80, which is a historical reference documenting the decision to remove the script. This doesn't need updating as it describes past actions, not current workflow.

## Testing

All changes are documentation-only. The updated commands reference existing, working scripts:
- ✅ `analyze_test_failures.py` exists and works correctly
- ✅ `run_parallel_tests.py --analyze` correctly calls the analyzer
- ✅ Workflow is now simplified (single-step instead of two-step)

Closes #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>