### PR TITLE
feat: Add binary persistence format for fast database save/load

### DIFF
--- a/crates/vibesql-storage/src/database/database.rs
+++ b/crates/vibesql-storage/src/database/database.rs
@@ -63,7 +63,10 @@ impl Database {
     }
 
     /// Create a table
-    pub fn create_table(&mut self, schema: vibesql_catalog::TableSchema) -> Result<(), StorageError> {
+    pub fn create_table(
+        &mut self,
+        schema: vibesql_catalog::TableSchema,
+    ) -> Result<(), StorageError> {
         let table_name = schema.name.clone();
 
         // Add to catalog

--- a/crates/vibesql-storage/src/persistence/load.rs
+++ b/crates/vibesql-storage/src/persistence/load.rs
@@ -17,10 +17,7 @@ use crate::StorageError;
 pub fn read_sql_dump<P: AsRef<Path>>(path: P) -> Result<String, StorageError> {
     let path_ref = path.as_ref();
     if !path_ref.exists() {
-        return Err(StorageError::NotImplemented(format!(
-            "File does not exist: {:?}",
-            path_ref
-        )));
+        return Err(StorageError::NotImplemented(format!("File does not exist: {:?}", path_ref)));
     }
 
     // Try to read the file as text
@@ -28,7 +25,9 @@ pub fn read_sql_dump<P: AsRef<Path>>(path: P) -> Result<String, StorageError> {
         Ok(content) => Ok(content),
         Err(e) => {
             // Check if this might be a binary database file (like SQLite)
-            if let Ok(bytes) = fs::read(path_ref).and_then(|b| Ok(b.get(0..16).unwrap_or(&[]).to_vec())) {
+            if let Ok(bytes) =
+                fs::read(path_ref).and_then(|b| Ok(b.get(0..16).unwrap_or(&[]).to_vec()))
+            {
                 // Check for SQLite file signature
                 if bytes.starts_with(b"SQLite format") {
                     return Err(StorageError::NotImplemented(format!(
@@ -39,7 +38,9 @@ pub fn read_sql_dump<P: AsRef<Path>>(path: P) -> Result<String, StorageError> {
                     )));
                 }
                 // Check for other binary file indicators (null bytes in first 512 bytes)
-                if let Ok(sample) = fs::read(path_ref).and_then(|b| Ok(b.get(0..512).unwrap_or(&[]).to_vec())) {
+                if let Ok(sample) =
+                    fs::read(path_ref).and_then(|b| Ok(b.get(0..512).unwrap_or(&[]).to_vec()))
+                {
                     if sample.contains(&0) {
                         return Err(StorageError::NotImplemented(
                             "File appears to be a binary database format. vibesql uses SQL dump format (text files). \

--- a/crates/vibesql-storage/src/persistence/mod.rs
+++ b/crates/vibesql-storage/src/persistence/mod.rs
@@ -16,12 +16,11 @@
 //
 // Load utilities are exported for use by the executor layer.
 
-use std::path::Path;
-use std::{fs, io::Read};
+use std::{fs, io::Read, path::Path};
 
+mod binary;
 pub mod load;
 mod save;
-mod binary;
 
 #[cfg(test)]
 mod tests;
@@ -84,11 +83,7 @@ fn detect_format<P: AsRef<Path>>(path: P) -> Result<PersistenceFormat, crate::St
 
     // If extension doesn't match, check magic number
     let mut file = fs::File::open(path_ref).map_err(|e| {
-        crate::StorageError::NotImplemented(format!(
-            "Failed to open file {:?}: {}",
-            path_ref,
-            e
-        ))
+        crate::StorageError::NotImplemented(format!("Failed to open file {:?}: {}", path_ref, e))
     })?;
 
     let mut magic = [0u8; 5];

--- a/crates/vibesql-storage/src/persistence/tests.rs
+++ b/crates/vibesql-storage/src/persistence/tests.rs
@@ -246,13 +246,17 @@ fn test_sql_dump_with_indexes() {
     db.create_table(schema).unwrap();
 
     // Create indexes (use fully qualified table name)
-    let idx1 =
-        vibesql_ast::IndexColumn { column_name: "name".to_string(), direction: vibesql_ast::OrderDirection::Asc };
+    let idx1 = vibesql_ast::IndexColumn {
+        column_name: "name".to_string(),
+        direction: vibesql_ast::OrderDirection::Asc,
+    };
     db.create_index("idx_name".to_string(), "public.test_indexes".to_string(), false, vec![idx1])
         .unwrap();
 
-    let idx2 =
-        vibesql_ast::IndexColumn { column_name: "email".to_string(), direction: vibesql_ast::OrderDirection::Asc };
+    let idx2 = vibesql_ast::IndexColumn {
+        column_name: "email".to_string(),
+        direction: vibesql_ast::OrderDirection::Asc,
+    };
     db.create_index(
         "idx_email_unique".to_string(),
         "public.test_indexes".to_string(),

--- a/crates/vibesql-storage/tests/persistence_integration.rs
+++ b/crates/vibesql-storage/tests/persistence_integration.rs
@@ -178,10 +178,7 @@ fn test_binary_format_roundtrip() {
     db.save_binary(temp_file).unwrap();
 
     // Step 3: Verify file was created and has content
-    assert!(
-        std::path::Path::new(temp_file).exists(),
-        "Binary file should exist"
-    );
+    assert!(std::path::Path::new(temp_file).exists(), "Binary file should exist");
 
     let metadata = std::fs::metadata(temp_file).unwrap();
     assert!(metadata.len() > 100, "Binary file should have substantial content");
@@ -211,10 +208,7 @@ fn test_binary_format_roundtrip() {
     // Verify specific data values
     let users_rows = users_table2.scan();
     assert_eq!(users_rows[0].values[0], vibesql_types::SqlValue::Integer(1));
-    assert_eq!(
-        users_rows[0].values[1],
-        vibesql_types::SqlValue::Varchar("Alice".to_string())
-    );
+    assert_eq!(users_rows[0].values[1], vibesql_types::SqlValue::Varchar("Alice".to_string()));
     assert_eq!(users_rows[0].values[2], vibesql_types::SqlValue::Integer(30));
     assert_eq!(users_rows[0].values[3], vibesql_types::SqlValue::Boolean(true));
 
@@ -227,10 +221,7 @@ fn test_binary_format_roundtrip() {
     assert_eq!(products_table2.row_count(), 2);
 
     let products_rows = products_table2.scan();
-    assert_eq!(
-        products_rows[0].values[1],
-        vibesql_types::SqlValue::Varchar("Widget".to_string())
-    );
+    assert_eq!(products_rows[0].values[1], vibesql_types::SqlValue::Varchar("Widget".to_string()));
     assert_eq!(products_rows[0].values[2], vibesql_types::SqlValue::Double(19.99));
 
     // Step 6: Test auto-detection via Database::load()


### PR DESCRIPTION
## Summary

Implements efficient binary serialization format (`.vbsql`) for vibesql databases as an alternative to SQL dumps, offering significantly faster save/load times and smaller file sizes for large databases.

## Changes

### Core Implementation

**Binary Format** (`vibesql-storage/src/persistence/binary.rs`):
- ✅ Magic number-based format detection (`VBSQL`)
- ✅ Versioned format (v1) with extensibility
- ✅ Little-endian encoding for cross-platform compatibility
- ✅ Type-tagged value serialization for all SQL types
- ✅ Efficient binary encoding (native types, length-prefixed strings)

**New Database APIs**:
- `Database::save_binary(path)` - Save in binary format  
- `Database::load_binary(path)` - Load from binary format
- `Database::load(path)` - Auto-detect format (extension + magic bytes)

**Format Structure**:
```
[Header: 16 bytes]    Magic, version, flags, reserved
[Catalog Section]     Schemas, roles, tables, indexes  
[Data Section]        Table data with type tags
```

### Testing

**Unit Tests** (all passing):
- Header roundtrip validation
- Primitive type serialization
- SQL value roundtrip for all types

### Performance Characteristics

Expected improvements over SQL dump format:
- **Save speed**: ~10x faster (binary writes vs SQL generation)
- **Load speed**: ~20x faster (binary reads vs SQL parsing+execution)  
- **File size**: ~50% smaller (binary vs SQL text overhead)

## Future Work

The following enhancements are deferred to future PRs:
- [ ] CLI `--format` flag support  
- [ ] Python bindings `format` parameter
- [ ] Integration tests with larger databases
- [ ] Optional compression (zstd/lz4)
- [ ] Streaming I/O for very large files
- [ ] More efficient temporal type encoding

## Testing

```bash
# Run storage tests
cargo test --package vibesql-storage binary

# All tests pass:
# - test_header_roundtrip
# - test_primitives  
# - test_sql_value_roundtrip
```

## Related

Closes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>