### PR TITLE
fix: Extend MySQL dialect mode to handle unary operators

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/special.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/special.rs
@@ -171,6 +171,9 @@ impl CombinedExpressionEvaluator<'_> {
         row: &vibesql_storage::Row,
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
         let val = self.eval(expr, row)?;
-        super::super::expressions::operators::eval_unary_op(op, &val)
+        let sql_mode = self.database
+            .map(|db| db.sql_mode())
+            .unwrap_or(vibesql_types::SqlMode::Standard);
+        super::super::expressions::operators::eval_unary_op(op, &val, sql_mode)
     }
 }

--- a/crates/vibesql-executor/src/evaluator/core.rs
+++ b/crates/vibesql-executor/src/evaluator/core.rs
@@ -284,6 +284,11 @@ impl<'a> CombinedExpressionEvaluator<'a> {
         self.cse_cache.borrow_mut().clear();
     }
 
+    /// Get the database reference
+    pub(crate) fn database(&self) -> Option<&vibesql_storage::Database> {
+        self.database
+    }
+
     /// Get column index with caching to avoid repeated schema lookups
     pub(crate) fn get_column_index_cached(
         &self,

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -199,7 +199,10 @@ impl ExpressionEvaluator<'_> {
             // Unary operations
             vibesql_ast::Expression::UnaryOp { op, expr } => {
                 let val = self.eval(expr, row)?;
-                super::operators::eval_unary_op(op, &val)
+                let sql_mode = self.database
+                    .map(|db| db.sql_mode())
+                    .unwrap_or(vibesql_types::SqlMode::Standard);
+                super::operators::eval_unary_op(op, &val, sql_mode)
             }
 
             vibesql_ast::Expression::IsNull { expr, negated } => {

--- a/crates/vibesql-executor/src/evaluator/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/mod.rs
@@ -15,3 +15,5 @@ mod tests;
 
 // Re-export public API
 pub use core::{CombinedExpressionEvaluator, ExpressionEvaluator};
+// Re-export eval_unary_op for use in other modules
+pub(crate) use expressions::operators::eval_unary_op;

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/binary_op.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/binary_op.rs
@@ -38,65 +38,10 @@ pub(super) fn evaluate_unary(
     evaluator: &CombinedExpressionEvaluator,
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
     let val = executor.evaluate_with_aggregates(inner_expr, group_rows, group_key, evaluator)?;
-    // Evaluate unary operator on the result
-    eval_unary_op(op, &val)
-}
-
-/// Evaluate a unary operation on a value
-fn eval_unary_op(
-    op: &vibesql_ast::UnaryOperator,
-    val: &vibesql_types::SqlValue,
-) -> Result<vibesql_types::SqlValue, ExecutorError> {
-    use vibesql_ast::UnaryOperator::*;
-    use vibesql_types::SqlValue;
-
-    match (op, val) {
-        // Unary plus - identity operation (return value unchanged)
-        (Plus, SqlValue::Integer(n)) => Ok(SqlValue::Integer(*n)),
-        (Plus, SqlValue::Smallint(n)) => Ok(SqlValue::Smallint(*n)),
-        (Plus, SqlValue::Bigint(n)) => Ok(SqlValue::Bigint(*n)),
-        (Plus, SqlValue::Float(n)) => Ok(SqlValue::Float(*n)),
-        (Plus, SqlValue::Real(n)) => Ok(SqlValue::Real(*n)),
-        (Plus, SqlValue::Double(n)) => Ok(SqlValue::Double(*n)),
-        (Plus, SqlValue::Numeric(s)) => Ok(SqlValue::Numeric(*s)),
-
-        // Unary minus - negation
-        (Minus, SqlValue::Integer(n)) => Ok(SqlValue::Integer(-n)),
-        (Minus, SqlValue::Smallint(n)) => Ok(SqlValue::Smallint(-n)),
-        (Minus, SqlValue::Bigint(n)) => Ok(SqlValue::Bigint(-n)),
-        (Minus, SqlValue::Float(n)) => Ok(SqlValue::Float(-n)),
-        (Minus, SqlValue::Real(n)) => Ok(SqlValue::Real(-n)),
-        (Minus, SqlValue::Double(n)) => Ok(SqlValue::Double(-n)),
-        (Minus, SqlValue::Numeric(f)) => Ok(SqlValue::Numeric(-*f)),
-
-        // NULL propagation - unary operations on NULL return NULL
-        (Plus | Minus, SqlValue::Null) => Ok(SqlValue::Null),
-
-        // Unary NOT - logical negation
-        (Not, SqlValue::Boolean(b)) => Ok(SqlValue::Boolean(!b)),
-        (Not, SqlValue::Null) => Ok(SqlValue::Null), // NULL propagation for NOT
-
-        // Type errors
-        (Plus, val) => Err(ExecutorError::TypeMismatch {
-            left: val.clone(),
-            op: "unary +".to_string(),
-            right: SqlValue::Null,
-        }),
-        (Minus, val) => Err(ExecutorError::TypeMismatch {
-            left: val.clone(),
-            op: "unary -".to_string(),
-            right: SqlValue::Null,
-        }),
-        (Not, val) => Err(ExecutorError::TypeMismatch {
-            left: val.clone(),
-            op: "NOT".to_string(),
-            right: SqlValue::Null,
-        }),
-
-        // Other unary operators are handled elsewhere
-        _ => Err(ExecutorError::UnsupportedExpression(format!(
-            "Unary operator {:?} not supported in aggregate context",
-            op
-        ))),
-    }
+    // Get SQL mode from database (via evaluator)
+    let sql_mode = evaluator.database()
+        .map(|db| db.sql_mode())
+        .unwrap_or(vibesql_types::SqlMode::Standard);
+    // Use shared eval_unary_op implementation
+    crate::evaluator::eval_unary_op(op, &val, sql_mode)
 }


### PR DESCRIPTION
## Summary

Extends PR #1230's SQL dialect mode implementation to handle unary plus and minus operators, fixing inconsistent decimal formatting in arithmetic expressions for MySQL compatibility.

## Problem

Issue #1253 identified that unary operators (+, -) were not respecting SQL mode, causing inconsistent formatting:
- `SELECT - 42` returned `42` (Integer) instead of `42.000` (Numeric)  
- `SELECT + 42` returned `42` instead of `42.000`
- Mixed expressions produced inconsistent Integer vs Numeric results

This caused widespread test failures in the MySQL 8.x compatibility test suite (random/* tests).

## Solution

Modified unary operator evaluation to respect SQL mode:

1. **Updated `eval_unary_op()`** to accept `sql_mode` parameter
2. **MySQL mode**: Unary +/- on exact numeric types (Integer, Smallint, Bigint) now return Numeric type
3. **Standard mode**: Behavior unchanged (returns same type as input)
4. **Updated call sites**: All locations now pass sql_mode from database context

## Changes

### Core Implementation
- `evaluator/expressions/operators.rs`: Added sql_mode parameter, implemented MySQL mode conversion
- `evaluator/expressions/eval.rs`: Pass sql_mode to unary operations  
- `evaluator/combined/special.rs`: Pass sql_mode to unary operations
- `evaluator/core.rs`: Added `database()` getter for CombinedExpressionEvaluator
- `evaluator/mod.rs`: Re-export eval_unary_op for cross-module use
- `select/executor/aggregation/evaluation/binary_op.rs`: Use shared eval_unary_op with sql_mode

### Tests
- Added `test_unary_plus_mysql_mode`
- Added `test_unary_minus_mysql_mode`
- Added `test_unary_plus_standard_mode`
- Added `test_unary_minus_standard_mode`
- Updated all existing unary operator tests

## Test Results

✅ All 10 unary operator tests pass
✅ Compilation successful  
✅ No regressions in existing tests

## Expected Impact

This fix should improve pass rate in random/* test suite by addressing a major category of formatting inconsistencies. Combined with PR #1230's binary operator fixes, this provides comprehensive MySQL dialect support for arithmetic operations.

## Related

- Closes #1253
- Builds on #1230 (SQL dialect modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>