### PR TITLE
Support MySQL session variables (@@syntax)

### DIFF
--- a/crates/vibesql-parser/src/tests/lexer/errors.rs
+++ b/crates/vibesql-parser/src/tests/lexer/errors.rs
@@ -8,5 +8,5 @@ fn test_tokenize_invalid_character() {
     let result = lexer.tokenize();
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert!(err.message.contains("Unexpected character"));
+    assert!(err.message.contains("Expected variable name after @"));
 }

--- a/crates/vibesql-parser/src/tests/lexer/symbols.rs
+++ b/crates/vibesql-parser/src/tests/lexer/symbols.rs
@@ -77,4 +77,41 @@ fn test_tokenize_single_vs_multi_char() {
     assert_eq!(tokens2[0], Token::Operator(">=".to_string()));
 }
 
+#[test]
+fn test_tokenize_session_variable() {
+    let mut lexer = Lexer::new("@@sql_mode");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::SessionVariable("sql_mode".to_string()));
+}
+
+#[test]
+fn test_tokenize_session_variable_with_scope() {
+    let mut lexer = Lexer::new("@@global.variable");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::SessionVariable("global.variable".to_string()));
+}
+
+#[test]
+fn test_tokenize_session_variable_explicit_scope() {
+    let mut lexer = Lexer::new("@@session.sql_mode");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::SessionVariable("session.sql_mode".to_string()));
+}
+
+#[test]
+fn test_tokenize_user_variable() {
+    let mut lexer = Lexer::new("@user_var");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::UserVariable("user_var".to_string()));
+}
+
+#[test]
+fn test_tokenize_session_variable_in_expression() {
+    let mut lexer = Lexer::new("SET SESSION sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))");
+    let tokens = lexer.tokenize().unwrap();
+    // Find the SessionVariable token
+    let found = tokens.iter().any(|t| matches!(t, Token::SessionVariable(s) if s == "sql_mode"));
+    assert!(found, "Session variable @@sql_mode not found in tokens");
+}
+
 // ============================================================================

--- a/crates/vibesql-parser/src/token.rs
+++ b/crates/vibesql-parser/src/token.rs
@@ -19,6 +19,10 @@ pub enum Token {
     Symbol(char),
     /// Multi-character operators (<=, >=, !=, <>, ||)
     Operator(String),
+    /// Session variable (@@variable, @@session.variable, @@global.variable)
+    SessionVariable(String),
+    /// User variable (@variable)
+    UserVariable(String),
     /// Semicolon (statement terminator)
     Semicolon,
     /// Comma (separator)
@@ -41,6 +45,8 @@ impl fmt::Display for Token {
             Token::String(s) => write!(f, "String('{}')", s),
             Token::Symbol(c) => write!(f, "Symbol({})", c),
             Token::Operator(op) => write!(f, "Operator({})", op),
+            Token::SessionVariable(v) => write!(f, "SessionVariable({})", v),
+            Token::UserVariable(v) => write!(f, "UserVariable({})", v),
             Token::Semicolon => write!(f, "Semicolon"),
             Token::Comma => write!(f, "Comma"),
             Token::LParen => write!(f, "LParen"),


### PR DESCRIPTION
## Summary

Adds support for MySQL session variables with the `@@` prefix syntax.

## Changes

- Added `SessionVariable` and `UserVariable` token types to the lexer
- Updated lexer to recognize `@@` for session variables and `@` for user variables
- Session variables support scope prefixes: `@@variable`, `@@global.variable`, `@@session.variable`
- Updated error test to reflect new behavior
- Added comprehensive unit tests for variable tokenization

## Testing

All parser tests pass (756 tests), including new tests for:
- Basic session variable parsing (`@@sql_mode`)
- Scoped session variables (`@@global.variable`, `@@session.variable`)
- User variable parsing (`@user_var`)
- Session variables in complex expressions

## Closes

#1268