### PR TITLE
refactor: Remove SqlMode parameter from operator functions

### DIFF
--- a/crates/vibesql-executor/src/evaluator/operators/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/mod.rs
@@ -38,7 +38,7 @@ impl OperatorRegistry {
         left: &SqlValue,
         op: &vibesql_ast::BinaryOperator,
         right: &SqlValue,
-        sql_mode: SqlMode,
+        _sql_mode: SqlMode,
     ) -> Result<SqlValue, ExecutorError> {
         use vibesql_ast::BinaryOperator::*;
 
@@ -50,12 +50,12 @@ impl OperatorRegistry {
 
         match op {
             // Arithmetic operators
-            Plus => ArithmeticOps::add(left, right, sql_mode),
-            Minus => ArithmeticOps::subtract(left, right, sql_mode),
-            Multiply => ArithmeticOps::multiply(left, right, sql_mode),
-            Divide => ArithmeticOps::divide(left, right, sql_mode),
-            IntegerDivide => ArithmeticOps::integer_divide(left, right, sql_mode),
-            Modulo => ArithmeticOps::modulo(left, right, sql_mode),
+            Plus => ArithmeticOps::add(left, right),
+            Minus => ArithmeticOps::subtract(left, right),
+            Multiply => ArithmeticOps::multiply(left, right),
+            Divide => ArithmeticOps::divide(left, right),
+            IntegerDivide => ArithmeticOps::integer_divide(left, right),
+            Modulo => ArithmeticOps::modulo(left, right),
 
             // Comparison operators
             Equal => ComparisonOps::equal(left, right),


### PR DESCRIPTION
## Summary

Phase 1 of SqlMode removal: Remove the `SqlMode` parameter from all arithmetic operator functions in the executor layer.

This is a pure refactoring with no behavioral changes - the `sql_mode` parameter was already unused (marked with `_sql_mode`).

## Changes

### Operator Functions
- ✅ Removed `sql_mode` parameter from `ArithmeticOps::add`, `subtract`, `multiply`, `divide`, `integer_divide`, `modulo`
- ✅ Removed `sql_mode` parameter from `coerce_numeric_values` helper function
- ✅ Updated `OperatorRegistry::eval_binary_op` to not pass `sql_mode` to arithmetic operations
  - Note: The `sql_mode` parameter is kept on `eval_binary_op` itself (marked as `_sql_mode`) for removal in later phases

### Call Sites
- ✅ Updated ~50+ call sites in test files to remove `SqlMode::Standard` and `SqlMode::MySQL` arguments
- ✅ Removed unused `SqlMode` import from `arithmetic.rs`

## Files Modified
- `crates/vibesql-executor/src/evaluator/operators/arithmetic.rs`
- `crates/vibesql-executor/src/evaluator/operators/mod.rs`

## Testing

All tests pass:
```bash
cargo test --package vibesql-executor  # ✅ All tests pass
cargo test --package vibesql-types     # ✅ All tests pass
```

## Part of

- Parent issue: #1280 (SqlMode removal initiative)
- Closes: #1281

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)