### PR TITLE
refactor: Remove SqlMode parameter from evaluator core (Phase 2)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -124,7 +124,7 @@ impl CombinedExpressionEvaluator<'_> {
                                 }
 
                                 ExpressionEvaluator::eval_binary_op_static(
-                                    &left_val, op, &right_val, vibesql_types::SqlMode::Standard,
+                                    &left_val, op, &right_val,
                                 )
                             }
                         }
@@ -150,7 +150,7 @@ impl CombinedExpressionEvaluator<'_> {
                                 }
 
                                 ExpressionEvaluator::eval_binary_op_static(
-                                    &left_val, op, &right_val, vibesql_types::SqlMode::Standard,
+                                    &left_val, op, &right_val,
                                 )
                             }
                         }
@@ -159,7 +159,7 @@ impl CombinedExpressionEvaluator<'_> {
                     _ => {
                         let left_val = self.eval(left, row)?;
                         let right_val = self.eval(right, row)?;
-                        ExpressionEvaluator::eval_binary_op_static(&left_val, op, &right_val, vibesql_types::SqlMode::Standard)
+                        ExpressionEvaluator::eval_binary_op_static(&left_val, op, &right_val)
                     }
                 }
             }

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -30,7 +30,6 @@ impl CombinedExpressionEvaluator<'_> {
                 &low_val,
                 &vibesql_ast::BinaryOperator::GreaterThan,
                 &high_val,
-                vibesql_types::SqlMode::Standard,
             )?;
 
             if let vibesql_types::SqlValue::Boolean(true) = gt_result {
@@ -43,7 +42,6 @@ impl CombinedExpressionEvaluator<'_> {
             &expr_val,
             &vibesql_ast::BinaryOperator::GreaterThanOrEqual,
             &low_val,
-            vibesql_types::SqlMode::Standard,
         )?;
 
         // Check if expr <= high
@@ -51,7 +49,6 @@ impl CombinedExpressionEvaluator<'_> {
             &expr_val,
             &vibesql_ast::BinaryOperator::LessThanOrEqual,
             &high_val,
-            vibesql_types::SqlMode::Standard,
         )?;
 
         // Combine with AND/OR depending on negated
@@ -61,18 +58,16 @@ impl CombinedExpressionEvaluator<'_> {
                 &expr_val,
                 &vibesql_ast::BinaryOperator::LessThan,
                 &low_val,
-                vibesql_types::SqlMode::Standard,
             )?;
             let gt_high = ExpressionEvaluator::eval_binary_op_static(
                 &expr_val,
                 &vibesql_ast::BinaryOperator::GreaterThan,
                 &high_val,
-                vibesql_types::SqlMode::Standard,
             )?;
-            ExpressionEvaluator::eval_binary_op_static(&lt_low, &vibesql_ast::BinaryOperator::Or, &gt_high, vibesql_types::SqlMode::Standard)
+            ExpressionEvaluator::eval_binary_op_static(&lt_low, &vibesql_ast::BinaryOperator::Or, &gt_high)
         } else {
             // BETWEEN: expr >= low AND expr <= high
-            ExpressionEvaluator::eval_binary_op_static(&ge_low, &vibesql_ast::BinaryOperator::And, &le_high, vibesql_types::SqlMode::Standard)
+            ExpressionEvaluator::eval_binary_op_static(&ge_low, &vibesql_ast::BinaryOperator::And, &le_high)
         }
     }
 
@@ -244,7 +239,6 @@ impl CombinedExpressionEvaluator<'_> {
                 &expr_val,
                 &vibesql_ast::BinaryOperator::Equal,
                 &value,
-                vibesql_types::SqlMode::Standard,
             )?;
 
             // If we found a match, return TRUE (or FALSE if negated)

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries.rs
@@ -183,7 +183,7 @@ impl CombinedExpressionEvaluator<'_> {
 
                     // Evaluate comparison
                     let cmp_result =
-                        ExpressionEvaluator::eval_binary_op_static(&left_val, op, right_val, vibesql_types::SqlMode::Standard)?;
+                        ExpressionEvaluator::eval_binary_op_static(&left_val, op, right_val)?;
 
                     match cmp_result {
                         vibesql_types::SqlValue::Boolean(false) => {
@@ -228,7 +228,7 @@ impl CombinedExpressionEvaluator<'_> {
 
                     // Evaluate comparison
                     let cmp_result =
-                        ExpressionEvaluator::eval_binary_op_static(&left_val, op, right_val, vibesql_types::SqlMode::Standard)?;
+                        ExpressionEvaluator::eval_binary_op_static(&left_val, op, right_val)?;
 
                     match cmp_result {
                         vibesql_types::SqlValue::Boolean(true) => {
@@ -318,7 +318,6 @@ impl CombinedExpressionEvaluator<'_> {
                 &expr_val,
                 &vibesql_ast::BinaryOperator::Equal,
                 subquery_val,
-                vibesql_types::SqlMode::Standard,
             )?;
 
             // If we found a match, return TRUE (or FALSE if negated)

--- a/crates/vibesql-executor/src/evaluator/core.rs
+++ b/crates/vibesql-executor/src/evaluator/core.rs
@@ -114,10 +114,7 @@ impl<'a> ExpressionEvaluator<'a> {
         op: &vibesql_ast::BinaryOperator,
         right: &vibesql_types::SqlValue,
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
-        let sql_mode = self.database
-            .map(|db| db.sql_mode())
-            .unwrap_or(vibesql_types::SqlMode::Standard);
-        Self::eval_binary_op_static(left, op, right, sql_mode)
+        Self::eval_binary_op_static(left, op, right)
     }
 
     /// Static version of eval_binary_op for shared logic
@@ -127,9 +124,8 @@ impl<'a> ExpressionEvaluator<'a> {
         left: &vibesql_types::SqlValue,
         op: &vibesql_ast::BinaryOperator,
         right: &vibesql_types::SqlValue,
-        sql_mode: vibesql_types::SqlMode,
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
-        super::operators::OperatorRegistry::eval_binary_op(left, op, right, sql_mode)
+        super::operators::OperatorRegistry::eval_binary_op(left, op, right)
     }
 
     /// Clear the CSE cache

--- a/crates/vibesql-executor/src/evaluator/operators/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/mod.rs
@@ -14,7 +14,7 @@ use arithmetic::ArithmeticOps;
 use comparison::ComparisonOps;
 use logical::LogicalOps;
 use string::StringOps;
-use vibesql_types::{SqlMode, SqlValue};
+use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;
 
@@ -38,7 +38,6 @@ impl OperatorRegistry {
         left: &SqlValue,
         op: &vibesql_ast::BinaryOperator,
         right: &SqlValue,
-        _sql_mode: SqlMode,
     ) -> Result<SqlValue, ExecutorError> {
         use vibesql_ast::BinaryOperator::*;
 
@@ -85,21 +84,21 @@ mod tests {
 
         // NULL + anything = NULL
         assert!(matches!(
-            OperatorRegistry::eval_binary_op(&SqlValue::Null, &Plus, &SqlValue::Integer(1), SqlMode::Standard)
+            OperatorRegistry::eval_binary_op(&SqlValue::Null, &Plus, &SqlValue::Integer(1))
                 .unwrap(),
             SqlValue::Null
         ));
 
         // anything + NULL = NULL
         assert!(matches!(
-            OperatorRegistry::eval_binary_op(&SqlValue::Integer(1), &Plus, &SqlValue::Null, SqlMode::Standard)
+            OperatorRegistry::eval_binary_op(&SqlValue::Integer(1), &Plus, &SqlValue::Null)
                 .unwrap(),
             SqlValue::Null
         ));
 
         // NULL comparison NULL = NULL
         assert!(matches!(
-            OperatorRegistry::eval_binary_op(&SqlValue::Null, &Equal, &SqlValue::Null, SqlMode::Standard).unwrap(),
+            OperatorRegistry::eval_binary_op(&SqlValue::Null, &Equal, &SqlValue::Null).unwrap(),
             SqlValue::Null
         ));
     }

--- a/crates/vibesql-executor/src/optimizer/expressions.rs
+++ b/crates/vibesql-executor/src/optimizer/expressions.rs
@@ -78,7 +78,7 @@ pub fn optimize_expression(
             if let (Expression::Literal(left_val), Expression::Literal(right_val)) =
                 (&left_opt, &right_opt)
             {
-                match ExpressionEvaluator::eval_binary_op_static(left_val, op, right_val, vibesql_types::SqlMode::Standard) {
+                match ExpressionEvaluator::eval_binary_op_static(left_val, op, right_val) {
                     Ok(result) => Ok(Expression::Literal(result)),
                     Err(_) => Ok(Expression::BinaryOp {
                         left: Box::new(left_opt),

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs
@@ -46,7 +46,6 @@ pub(super) fn evaluate(
                     &low_val,
                     &vibesql_ast::BinaryOperator::GreaterThan,
                     &high_val,
-                    vibesql_types::SqlMode::Standard,
                 )?;
 
                 if let vibesql_types::SqlValue::Boolean(true) = gt_result {
@@ -59,7 +58,6 @@ pub(super) fn evaluate(
                 &test_val,
                 &vibesql_ast::BinaryOperator::GreaterThanOrEqual,
                 &low_val,
-                vibesql_types::SqlMode::Standard,
             )?;
 
             // Check if test_val <= high
@@ -67,7 +65,6 @@ pub(super) fn evaluate(
                 &test_val,
                 &vibesql_ast::BinaryOperator::LessThanOrEqual,
                 &high_val,
-                vibesql_types::SqlMode::Standard,
             )?;
 
             // Combine with AND/OR depending on negated
@@ -77,19 +74,16 @@ pub(super) fn evaluate(
                     &test_val,
                     &vibesql_ast::BinaryOperator::LessThan,
                     &low_val,
-                    vibesql_types::SqlMode::Standard,
                 )?;
                 let gt_high = ExpressionEvaluator::eval_binary_op_static(
                     &test_val,
                     &vibesql_ast::BinaryOperator::GreaterThan,
                     &high_val,
-                    vibesql_types::SqlMode::Standard,
                 )?;
                 ExpressionEvaluator::eval_binary_op_static(
                     &lt_low,
                     &vibesql_ast::BinaryOperator::Or,
                     &gt_high,
-                    vibesql_types::SqlMode::Standard,
                 )
             } else {
                 // BETWEEN: test_val >= low AND test_val <= high
@@ -97,7 +91,6 @@ pub(super) fn evaluate(
                     &ge_low,
                     &vibesql_ast::BinaryOperator::And,
                     &le_high,
-                    vibesql_types::SqlMode::Standard,
                 )
             }
         }
@@ -119,7 +112,6 @@ pub(super) fn evaluate(
                     &test_val,
                     &vibesql_ast::BinaryOperator::Equal,
                     list_val,
-                    vibesql_types::SqlMode::Standard,
                 )?;
 
                 if let vibesql_types::SqlValue::Boolean(true) = eq_result {

--- a/crates/vibesql-executor/src/tests/operator_edge_cases/binary_arithmetic.rs
+++ b/crates/vibesql-executor/src/tests/operator_edge_cases/binary_arithmetic.rs
@@ -98,7 +98,6 @@ fn test_integer_division_with_floats() {
         &vibesql_types::SqlValue::Float(10.7),
         &vibesql_ast::BinaryOperator::IntegerDivide,
         &vibesql_types::SqlValue::Float(3.2),
-        vibesql_types::SqlMode::Standard,
     )
     .unwrap();
     assert_eq!(result, vibesql_types::SqlValue::Integer(3));
@@ -113,7 +112,6 @@ fn test_integer_division_negative_operands() {
         &vibesql_types::SqlValue::Integer(96),
         &vibesql_ast::BinaryOperator::IntegerDivide,
         &vibesql_types::SqlValue::Integer(-2),
-        vibesql_types::SqlMode::Standard,
     )
     .unwrap();
     assert_eq!(result, vibesql_types::SqlValue::Integer(-48));
@@ -123,7 +121,6 @@ fn test_integer_division_negative_operands() {
         &vibesql_types::SqlValue::Integer(-96),
         &vibesql_ast::BinaryOperator::IntegerDivide,
         &vibesql_types::SqlValue::Integer(2),
-        vibesql_types::SqlMode::Standard,
     )
     .unwrap();
     assert_eq!(result, vibesql_types::SqlValue::Integer(-48));
@@ -133,7 +130,6 @@ fn test_integer_division_negative_operands() {
         &vibesql_types::SqlValue::Integer(-96),
         &vibesql_ast::BinaryOperator::IntegerDivide,
         &vibesql_types::SqlValue::Integer(-2),
-        vibesql_types::SqlMode::Standard,
     )
     .unwrap();
     assert_eq!(result, vibesql_types::SqlValue::Integer(48));
@@ -148,7 +144,6 @@ fn test_integer_division_by_zero() {
         &vibesql_types::SqlValue::Integer(5),
         &vibesql_ast::BinaryOperator::IntegerDivide,
         &vibesql_types::SqlValue::Integer(0),
-        vibesql_types::SqlMode::Standard,
     );
     assert!(matches!(result, Err(ExecutorError::DivisionByZero)));
 }
@@ -162,7 +157,6 @@ fn test_integer_division_equal_operands() {
         &vibesql_types::SqlValue::Integer(5),
         &vibesql_ast::BinaryOperator::IntegerDivide,
         &vibesql_types::SqlValue::Integer(5),
-        vibesql_types::SqlMode::Standard,
     )
     .unwrap();
     assert_eq!(result, vibesql_types::SqlValue::Integer(1));
@@ -177,7 +171,6 @@ fn test_modulo_operator() {
         &vibesql_types::SqlValue::Integer(10),
         &vibesql_ast::BinaryOperator::Modulo,
         &vibesql_types::SqlValue::Integer(3),
-        vibesql_types::SqlMode::Standard,
     )
     .unwrap();
     assert_eq!(result, vibesql_types::SqlValue::Integer(1));
@@ -187,7 +180,6 @@ fn test_modulo_operator() {
         &vibesql_types::SqlValue::Integer(15),
         &vibesql_ast::BinaryOperator::Modulo,
         &vibesql_types::SqlValue::Integer(4),
-        vibesql_types::SqlMode::Standard,
     )
     .unwrap();
     assert_eq!(result, vibesql_types::SqlValue::Integer(3));


### PR DESCRIPTION
## Summary

This PR completes Phase 2 of the SqlMode removal refactoring (#1280), removing SqlMode handling from the expression evaluator core layer.

**Parent Issue**: #1280  
**Depends on**: #1285 (Phase 1) ✅ Merged

## Changes

1. **Removed SqlMode retrieval logic** from `evaluator/core.rs` (lines 117-119)
   - The sql_mode value was only used to pass to operator functions
   - After Phase 1, operators no longer need this parameter

2. **Updated function signatures**:
   - `eval_binary_op()`: Removed sql_mode retrieval and passthrough
   - `eval_binary_op_static()`: Removed sql_mode parameter completely

3. **Cleaned up imports**:
   - Removed `SqlMode` import from `evaluator/operators/mod.rs`

4. **Updated all call sites** throughout the codebase to remove SqlMode argument

## Files Modified

- `crates/vibesql-executor/src/evaluator/core.rs` - Core changes
- `crates/vibesql-executor/src/evaluator/operators/mod.rs` - Import cleanup
- `crates/vibesql-executor/src/evaluator/combined/eval.rs` - Call site updates
- `crates/vibesql-executor/src/evaluator/combined/predicates.rs` - Call site updates
- `crates/vibesql-executor/src/evaluator/combined/subqueries.rs` - Call site updates
- `crates/vibesql-executor/src/optimizer/expressions.rs` - Call site updates
- `crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs` - Call site updates
- `crates/vibesql-executor/src/tests/operator_edge_cases/binary_arithmetic.rs` - Test updates

## Test Plan

```bash
cargo test --package vibesql-executor
```

All tests pass successfully.

## Success Criteria

- ✅ SqlMode retrieval logic removed from evaluator core
- ✅ No SqlMode references in evaluator (except types import to be removed in later phases)
- ✅ All tests pass
- ✅ No compilation errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)