### PR TITLE
fix: Fix Eq/Ord implementation for SqlValue to ensure BTreeMap consistency

### DIFF
--- a/crates/vibesql-types/src/sql_value/mod.rs
+++ b/crates/vibesql-types/src/sql_value/mod.rs
@@ -9,7 +9,7 @@ use crate::{DataType, temporal::{Date, Time, Timestamp, Interval, IntervalField}
 /// SQL Values - runtime representation of data
 ///
 /// Represents actual values in SQL, including NULL.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum SqlValue {
     Integer(i64),
     Smallint(i16),


### PR DESCRIPTION
## Summary

Fixes critical regression in PR #1297 that caused ~760 test failures in parallel execution due to inconsistent `Eq`/`Ord` implementations for `SqlValue`.

## Problem

PR #1297 introduced BTreeMap for index storage but caused test failures because:

1. `PartialEq` was derived, using IEEE 754 semantics where `NaN != NaN`
2. `Eq` implementation was empty, relying on the derived `PartialEq`
3. `Ord` implementation treated `NaN == NaN` for ordering purposes

This violated BTreeMap's core requirement that `Eq` and `Ord` must be consistent (i.e., if `a == b` then `a.cmp(b) == Ordering::Equal`). The inconsistency caused BTreeMap internal corruption, leading to incorrect query results in parallel test execution.

## Root Cause

The issue manifested only in parallel execution because:
- BTreeMap structure depends on consistent ordering
- Non-deterministic test execution order exposed the corruption
- Serial execution happened to avoid triggering the edge cases

## Solution

Implemented custom `PartialEq` that treats `NaN == NaN` for all float types (`Float`, `Real`, `Double`, `Numeric`), ensuring consistency with the `Ord` implementation.

This provides:
- **Total equality** for grouping/DISTINCT operations
- **Consistent BTreeMap keys** (NaN values are treated as equal)
- **Proper total ordering** required by BTreeMap

## Changes

**Modified files:**
- `crates/vibesql-types/src/sql_value/mod.rs`: Removed derived `PartialEq`
- `crates/vibesql-types/src/sql_value/comparison.rs`: Added custom `PartialEq` implementation

## Testing

- ✅ Builds successfully: `cargo build --release`
- ✅ Unit tests pass: `cargo test --release --lib -p vibesql-types`
- ⏳ Parallel execution testing (CI will verify)

## Impact

- **Fixes**: Parallel test execution failures (~760 tests)
- **Preserves**: BTreeMap performance benefits from #1297
- **No breaking changes**: Only internal trait implementation

Closes #1298

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>