### PR TITLE
fix: Make INSERT_METHOD table option equals sign optional

### DIFF
--- a/crates/vibesql-parser/src/parser/table_options.rs
+++ b/crates/vibesql-parser/src/parser/table_options.rs
@@ -79,7 +79,8 @@ impl Parser {
     }
 
     fn parse_insert_method_option(&mut self) -> Result<vibesql_ast::TableOption, ParseError> {
-        self.expect_token(Token::Symbol('='))?;
+        // Optional = sign
+        self.try_consume(&Token::Symbol('='));
         let method = if self.try_consume_keyword(Keyword::First) {
             vibesql_ast::InsertMethod::First
         } else if self.try_consume_keyword(Keyword::Last) {

--- a/crates/vibesql-parser/src/tests/create_table/mysql_table_options.rs
+++ b/crates/vibesql-parser/src/tests/create_table/mysql_table_options.rs
@@ -44,7 +44,7 @@ fn test_parse_create_table_with_connection() {
 #[test]
 fn test_parse_create_table_with_insert_method() {
     let result = Parser::parse_sql("CREATE TABLE t1 (c1 INT) INSERT_METHOD = LAST;");
-    assert!(result.is_ok(), "Should parse INSERT_METHOD option");
+    assert!(result.is_ok(), "Should parse INSERT_METHOD option with =");
 
     let stmt = result.unwrap();
     match stmt {
@@ -53,6 +53,66 @@ fn test_parse_create_table_with_insert_method() {
             match &create.table_options[0] {
                 vibesql_ast::TableOption::InsertMethod(method) => {
                     assert_eq!(method, &vibesql_ast::InsertMethod::Last);
+                }
+                _ => panic!("Expected InsertMethod option"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_with_insert_method_without_equals() {
+    let result = Parser::parse_sql("CREATE TABLE t1 (c1 INT) INSERT_METHOD LAST;");
+    assert!(result.is_ok(), "Should parse INSERT_METHOD option without =");
+
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_options.len(), 1);
+            match &create.table_options[0] {
+                vibesql_ast::TableOption::InsertMethod(method) => {
+                    assert_eq!(method, &vibesql_ast::InsertMethod::Last);
+                }
+                _ => panic!("Expected InsertMethod option"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_with_insert_method_first() {
+    let result = Parser::parse_sql("CREATE TABLE t1 (c1 INT) INSERT_METHOD FIRST;");
+    assert!(result.is_ok(), "Should parse INSERT_METHOD FIRST without =");
+
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_options.len(), 1);
+            match &create.table_options[0] {
+                vibesql_ast::TableOption::InsertMethod(method) => {
+                    assert_eq!(method, &vibesql_ast::InsertMethod::First);
+                }
+                _ => panic!("Expected InsertMethod option"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_with_insert_method_no() {
+    let result = Parser::parse_sql("CREATE TABLE t1 (c1 INT) INSERT_METHOD NO;");
+    assert!(result.is_ok(), "Should parse INSERT_METHOD NO without =");
+
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_options.len(), 1);
+            match &create.table_options[0] {
+                vibesql_ast::TableOption::InsertMethod(method) => {
+                    assert_eq!(method, &vibesql_ast::InsertMethod::No);
                 }
                 _ => panic!("Expected InsertMethod option"),
             }
@@ -161,6 +221,41 @@ fn test_parse_create_table_sqllogictest_style() {
                     assert_eq!(*value, Some(4));
                 }
                 _ => panic!("Expected KeyBlockSize option"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_sqllogictest_with_insert_method() {
+    // Test the exact statement from the SQLLogicTest suite that was failing
+    let result = Parser::parse_sql(
+        "CREATE TABLE `t17126` (`c1` MULTIPOLYGON COMMENT 'text156797', `c2` MULTIPOLYGON COMMENT 'text156799') KEY_BLOCK_SIZE 4.2 INSERT_METHOD LAST;"
+    );
+    assert!(result.is_ok(), "Should parse SQLLogicTest CREATE TABLE with INSERT_METHOD without =");
+
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "t17126");
+            assert_eq!(create.columns.len(), 2);
+            assert_eq!(create.table_options.len(), 2);
+
+            // Check KEY_BLOCK_SIZE option
+            match &create.table_options[0] {
+                vibesql_ast::TableOption::KeyBlockSize(value) => {
+                    assert_eq!(*value, Some(4));
+                }
+                _ => panic!("Expected KeyBlockSize option"),
+            }
+
+            // Check INSERT_METHOD option
+            match &create.table_options[1] {
+                vibesql_ast::TableOption::InsertMethod(method) => {
+                    assert_eq!(method, &vibesql_ast::InsertMethod::Last);
+                }
+                _ => panic!("Expected InsertMethod option"),
             }
         }
         _ => panic!("Expected CREATE TABLE statement"),


### PR DESCRIPTION
Fixes #1310

## Summary
The `INSERT_METHOD` table option parser incorrectly required an `=` sign, but MySQL allows both syntaxes:
- `INSERT_METHOD = LAST` (with `=`) - currently works
- `INSERT_METHOD LAST` (without `=`) - now fixed

## Changes
- Modified `parse_insert_method_option()` to use `try_consume()` instead of `expect_token()` to make the `=` optional
- Made it consistent with other table options like `KEY_BLOCK_SIZE`, `CONNECTION`, etc.
- Added comprehensive tests for both syntax variants (FIRST, LAST, NO)
- Added test for the exact SQLLogicTest case that was failing

## Testing
- All existing tests pass
- Added 4 new test cases covering the optional `=` syntax
- Verified SQLLogicTest example now parses correctly