### PR TITLE
feat: Support comments on sqllogictest conditional directives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,6 @@ path = "tests/e2e_data_types/mod.rs"
 [[test]]
 name = "test_revoke_nonexistent"
 path = "tests/test_revoke_nonexistent.rs"
+
+[patch.crates-io]
+sqllogictest = { path = "crates/sqllogictest" }

--- a/crates/sqllogictest/Cargo.toml
+++ b/crates/sqllogictest/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "sqllogictest"
+version = "0.28.4"
+edition = "2021"
+homepage = "https://github.com/risinglightdb/sqllogictest-rs"
+keywords = ["sql", "database", "parser", "cli"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/risinglightdb/sqllogictest-rs"
+description = "Sqllogictest parser and runner."
+
+[dependencies]
+async-trait = "0.1"
+educe = "0.6"
+fs-err = "3"
+futures = "0.3"
+glob = "0.3"
+humantime = "2"
+itertools = "0.13"
+libtest-mimic = "0.8"
+md-5 = "0.10"
+owo-colors = "4"
+regex = "1"
+similar = "2"
+subst = "0.3"
+tempfile = "3"
+thiserror = "2"
+tracing = "0.1"
+rand = "0.8.5"
+
+[dev-dependencies]
+pretty_assertions = "1"

--- a/crates/sqllogictest/Cargo.toml.orig
+++ b/crates/sqllogictest/Cargo.toml.orig
@@ -1,0 +1,31 @@
+[package]
+name = "sqllogictest"
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+description = "Sqllogictest parser and runner."
+
+[dependencies]
+async-trait = "0.1"
+educe = "0.6"
+fs-err = "3"
+futures = "0.3"
+glob = "0.3"
+humantime = "2"
+itertools = "0.13"
+libtest-mimic = "0.8"
+md-5 = "0.10"
+owo-colors = "4"
+regex = "1"
+similar = "2"
+subst = "0.3"
+tempfile = "3"
+thiserror = "2"
+tracing = "0.1"
+rand = "0.8.5"
+
+[dev-dependencies]
+pretty_assertions = "1"

--- a/crates/sqllogictest/README.md
+++ b/crates/sqllogictest/README.md
@@ -1,0 +1,7 @@
+# Sqllogictest
+
+[Sqllogictest][Sqllogictest] is a testing framework to verify the correctness of an SQL database. See [GitHub Homepage](https://github.com/risinglightdb/sqllogictest-rs/) for more information.
+
+This crate implements a sqllogictest parser and runner library in Rust.
+
+[Sqllogictest]: https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki

--- a/crates/sqllogictest/src/column_type.rs
+++ b/crates/sqllogictest/src/column_type.rs
@@ -1,0 +1,44 @@
+use std::fmt::Debug;
+
+/// This trait represents an Sqllogictest column type.
+/// An Sqllogictest column is represented with a single character.
+/// The type has to be serializable to a character.
+pub trait ColumnType: Debug + PartialEq + Eq + Clone + Send + Sync {
+    fn from_char(value: char) -> Option<Self>;
+    fn to_char(&self) -> char;
+}
+
+/// The default Sqllogictest type.
+/// The valid types are:
+/// - 'T' - text, varchar results
+/// - 'I' - integers
+/// - 'R' - floating point numbers
+///
+/// Any other types are represented with `?`([`DefaultColumnType::Any`]).
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum DefaultColumnType {
+    Text,
+    Integer,
+    FloatingPoint,
+    Any,
+}
+
+impl ColumnType for DefaultColumnType {
+    fn from_char(value: char) -> Option<Self> {
+        match value {
+            'T' => Some(Self::Text),
+            'I' => Some(Self::Integer),
+            'R' => Some(Self::FloatingPoint),
+            _ => Some(Self::Any),
+        }
+    }
+
+    fn to_char(&self) -> char {
+        match self {
+            Self::Text => 'T',
+            Self::Integer => 'I',
+            Self::FloatingPoint => 'R',
+            Self::Any => '?',
+        }
+    }
+}

--- a/crates/sqllogictest/src/connection.rs
+++ b/crates/sqllogictest/src/connection.rs
@@ -1,0 +1,77 @@
+use std::collections::HashMap;
+use std::future::IntoFuture;
+
+use futures::future::join_all;
+use futures::Future;
+
+use crate::{AsyncDB, Connection as ConnectionName, DBOutput};
+
+/// Trait for making connections to an [`AsyncDB`].
+///
+/// This is introduced to allow querying the database with different connections
+/// (then generally different sessions) in a single test file with `connection` records.
+pub trait MakeConnection {
+    /// The database type.
+    type Conn: AsyncDB;
+    /// The future returned by [`MakeConnection::make`].
+    type MakeFuture: Future<Output = Result<Self::Conn, <Self::Conn as AsyncDB>::Error>>;
+
+    /// Creates a new connection to the database.
+    fn make(&mut self) -> Self::MakeFuture;
+}
+
+/// Make connections directly from a closure returning a future.
+impl<D: AsyncDB, F, Fut> MakeConnection for F
+where
+    F: FnMut() -> Fut,
+    Fut: IntoFuture<Output = Result<D, D::Error>>,
+{
+    type Conn = D;
+    type MakeFuture = Fut::IntoFuture;
+
+    fn make(&mut self) -> Self::MakeFuture {
+        self().into_future()
+    }
+}
+
+/// Connections established in a [`Runner`](crate::Runner).
+pub(crate) struct Connections<D, M> {
+    make_conn: M,
+    conns: HashMap<ConnectionName, D>,
+}
+
+impl<D: AsyncDB, M: MakeConnection<Conn = D>> Connections<D, M> {
+    pub fn new(make_conn: M) -> Self {
+        Connections {
+            make_conn,
+            conns: HashMap::new(),
+        }
+    }
+
+    /// Get a connection by name. Make a new connection if it doesn't exist.
+    pub async fn get(&mut self, name: ConnectionName) -> Result<&mut D, D::Error> {
+        use std::collections::hash_map::Entry;
+
+        let conn = match self.conns.entry(name) {
+            Entry::Occupied(o) => o.into_mut(),
+            Entry::Vacant(v) => {
+                let conn = self.make_conn.make().await?;
+                v.insert(conn)
+            }
+        };
+
+        Ok(conn)
+    }
+
+    /// Run a SQL statement on the default connection.
+    ///
+    /// This is a shortcut for calling `get(Default)` then `run`.
+    pub async fn run_default(&mut self, sql: &str) -> Result<DBOutput<D::ColumnType>, D::Error> {
+        self.get(ConnectionName::Default).await?.run(sql).await
+    }
+
+    /// Shutdown all connections.
+    pub async fn shutdown_all(&mut self) {
+        join_all(self.conns.values_mut().map(|conn| conn.shutdown())).await;
+    }
+}

--- a/crates/sqllogictest/src/harness.rs
+++ b/crates/sqllogictest/src/harness.rs
@@ -1,0 +1,40 @@
+use std::path::Path;
+
+pub use glob::glob;
+pub use libtest_mimic::{run, Arguments, Failed, Trial};
+
+use crate::{MakeConnection, Runner};
+
+/// * `db_fn`: `fn() -> sqllogictest::AsyncDB`
+/// * `pattern`: The glob used to match against and select each file to be tested. It is relative to
+///   the root of the crate.
+#[macro_export]
+macro_rules! harness {
+    ($db_fn:path, $pattern:expr) => {
+        fn main() {
+            let paths = $crate::harness::glob($pattern).expect("failed to find test files");
+            let mut tests = vec![];
+
+            for entry in paths {
+                let path = entry.expect("failed to read glob entry");
+                tests.push($crate::harness::Trial::test(
+                    path.to_str().unwrap().to_string(),
+                    move || $crate::harness::test(&path, || async { Ok($db_fn()) }),
+                ));
+            }
+
+            if tests.is_empty() {
+                panic!("no test found for sqllogictest under: {}", $pattern);
+            }
+
+            $crate::harness::run(&$crate::harness::Arguments::from_args(), tests).exit();
+        }
+    };
+}
+
+pub fn test(filename: impl AsRef<Path>, make_conn: impl MakeConnection) -> Result<(), Failed> {
+    let mut tester = Runner::new(make_conn);
+    tester.run_file(filename)?;
+    tester.shutdown();
+    Ok(())
+}

--- a/crates/sqllogictest/src/lib.rs
+++ b/crates/sqllogictest/src/lib.rs
@@ -1,0 +1,65 @@
+//! [Sqllogictest][Sqllogictest] parser and runner.
+//!
+//! This crate supports multiple extensions beyond the original sqllogictest format.
+//! See the [README](https://github.com/risinglightdb/sqllogictest-rs#slt-test-file-format-cookbook) for more information.
+//!
+//! [Sqllogictest]: https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki
+//!
+//! # Usage
+//!
+//! For how to use the CLI tool backed by this library, see the [README](https://github.com/risinglightdb/sqllogictest-rs#use-the-cli-tool).
+//!
+//! For using the crate as a lib, and implement your custom driver, see below.
+//!
+//! Implement [`DB`] trait for your database structure:
+//!
+//! ```
+//! struct MyDatabase {
+//!     // fields
+//! }
+//!
+//! #[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
+//! enum MyError {
+//!     // variants
+//! }
+//!
+//! impl sqllogictest::DB for MyDatabase {
+//!     type Error = MyError;
+//!     // Or define your own column type
+//!     type ColumnType = sqllogictest::DefaultColumnType;
+//!     fn run(
+//!         &mut self,
+//!         sql: &str,
+//!     ) -> Result<sqllogictest::DBOutput<Self::ColumnType>, Self::Error> {
+//!         // TODO
+//!         Ok(sqllogictest::DBOutput::StatementComplete(0))
+//!     }
+//! }
+//!
+//! // Then create a `Runner` on your database instance, and run the tests:
+//! let mut tester = sqllogictest::Runner::new(|| async {
+//!     let db = MyDatabase {
+//!         // fields
+//!     };
+//!     Ok(db)
+//! });
+//! let _res = tester.run_file("../tests/slt/basic.slt");
+//!
+//! // You can also parse the script and execute the records separately:
+//! let records = sqllogictest::parse_file("../tests/slt/basic.slt").unwrap();
+//! for record in records {
+//!     let _res = tester.run(record);
+//! }
+//! ```
+
+pub mod column_type;
+pub mod connection;
+pub mod harness;
+pub mod parser;
+pub mod runner;
+pub mod substitution;
+
+pub use self::column_type::*;
+pub use self::connection::*;
+pub use self::parser::*;
+pub use self::runner::*;

--- a/crates/sqllogictest/src/parser.rs
+++ b/crates/sqllogictest/src/parser.rs
@@ -1,0 +1,1364 @@
+//! Sqllogictest parser.
+
+use std::fmt;
+use std::iter::Peekable;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use itertools::Itertools;
+use regex::Regex;
+
+use crate::ColumnType;
+
+const RESULTS_DELIMITER: &str = "----";
+
+/// The location in source file.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Location {
+    file: Arc<str>,
+    line: u32,
+    upper: Option<Arc<Location>>,
+}
+
+impl fmt::Display for Location {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.file, self.line)?;
+        if let Some(upper) = &self.upper {
+            write!(f, "\nat {upper}")?;
+        }
+        Ok(())
+    }
+}
+
+impl Location {
+    /// File path.
+    pub fn file(&self) -> &str {
+        &self.file
+    }
+
+    /// Line number.
+    pub fn line(&self) -> u32 {
+        self.line
+    }
+
+    fn new(file: impl Into<Arc<str>>, line: u32) -> Self {
+        Self {
+            file: file.into(),
+            line,
+            upper: None,
+        }
+    }
+
+    /// Returns the location of next line.
+    #[must_use]
+    fn next_line(mut self) -> Self {
+        self.line += 1;
+        self
+    }
+
+    /// Returns the location of next level file.
+    fn include(&self, file: &str) -> Self {
+        Self {
+            file: file.into(),
+            line: 0,
+            upper: Some(Arc::new(self.clone())),
+        }
+    }
+}
+
+/// Configuration for retry behavior
+#[derive(Debug, Clone, PartialEq)]
+pub struct RetryConfig {
+    /// Number of retry attempts
+    pub attempts: usize,
+    /// Duration to wait between retries
+    pub backoff: Duration,
+}
+
+/// Expectation for a statement.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StatementExpect {
+    /// Statement should succeed.
+    Ok,
+    /// Statement should succeed and affect the given number of rows.
+    Count(u64),
+    /// Statement should fail with the given error message.
+    Error(ExpectedError),
+}
+
+/// Expectation for a query.
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryExpect<T: ColumnType> {
+    /// Query should succeed and return the given results.
+    Results {
+        types: Vec<T>,
+        sort_mode: Option<SortMode>,
+        result_mode: Option<ResultMode>,
+        label: Option<String>,
+        results: Vec<String>,
+    },
+    /// Query should fail with the given error message.
+    Error(ExpectedError),
+}
+
+impl<T: ColumnType> QueryExpect<T> {
+    /// Creates a new [`QueryExpect`] with empty results.
+    fn empty_results() -> Self {
+        Self::Results {
+            types: Vec::new(),
+            sort_mode: None,
+            result_mode: None,
+            label: None,
+            results: Vec::new(),
+        }
+    }
+}
+
+/// A single directive in a sqllogictest file.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum Record<T: ColumnType> {
+    /// An include copies all records from another files.
+    Include {
+        loc: Location,
+        /// A glob pattern
+        filename: String,
+    },
+    /// A statement is an SQL command that is to be evaluated but from which we do not expect to
+    /// get results (other than success or failure).
+    Statement {
+        loc: Location,
+        conditions: Vec<Condition>,
+        connection: Connection,
+        /// The SQL command.
+        sql: String,
+        expected: StatementExpect,
+        /// Optional retry configuration
+        retry: Option<RetryConfig>,
+    },
+    /// A query is an SQL command from which we expect to receive results. The result set might be
+    /// empty.
+    Query {
+        loc: Location,
+        conditions: Vec<Condition>,
+        connection: Connection,
+        /// The SQL command.
+        sql: String,
+        expected: QueryExpect<T>,
+        /// Optional retry configuration
+        retry: Option<RetryConfig>,
+    },
+    /// A system command is an external command that is to be executed by the shell. Currently it
+    /// must succeed and the output is ignored.
+    #[non_exhaustive]
+    System {
+        loc: Location,
+        conditions: Vec<Condition>,
+        /// The external command.
+        command: String,
+        stdout: Option<String>,
+        /// Optional retry configuration
+        retry: Option<RetryConfig>,
+    },
+    /// A sleep period.
+    Sleep {
+        loc: Location,
+        duration: Duration,
+    },
+    /// Subtest.
+    Subtest {
+        loc: Location,
+        name: String,
+    },
+    /// A halt record merely causes sqllogictest to ignore the rest of the test script.
+    /// For debugging use only.
+    Halt {
+        loc: Location,
+    },
+    /// Control statements.
+    Control(Control),
+    /// Set the maximum number of result values that will be accepted
+    /// for a query.  If the number of result values exceeds this number,
+    /// then an MD5 hash is computed of all values, and the resulting hash
+    /// is the only result.
+    ///
+    /// If the threshold is 0, then hashing is never used.
+    HashThreshold {
+        loc: Location,
+        threshold: u64,
+    },
+    /// Condition statements, including `onlyif` and `skipif`.
+    Condition(Condition),
+    /// Connection statements to specify the connection to use for the following statement.
+    Connection(Connection),
+    Comment(Vec<String>),
+    Newline,
+    /// Internally injected record which should not occur in the test file.
+    Injected(Injected),
+}
+
+impl<T: ColumnType> Record<T> {
+    /// Unparses the record to its string representation in the test file.
+    ///
+    /// # Panics
+    /// If the record is an internally injected record which should not occur in the test file.
+    pub fn unparse(&self, w: &mut impl std::io::Write) -> std::io::Result<()> {
+        write!(w, "{self}")
+    }
+}
+
+/// As is the standard for Display, does not print any trailing
+/// newline except for records that always end with a blank line such
+/// as Query and Statement.
+impl<T: ColumnType> std::fmt::Display for Record<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Record::Include { loc: _, filename } => {
+                write!(f, "include {filename}")
+            }
+            Record::Statement {
+                loc: _,
+                conditions: _,
+                connection: _,
+                sql,
+                expected,
+                retry,
+            } => {
+                write!(f, "statement ")?;
+                match expected {
+                    StatementExpect::Ok => write!(f, "ok")?,
+                    StatementExpect::Count(cnt) => write!(f, "count {cnt}")?,
+                    StatementExpect::Error(err) => err.fmt_inline(f)?,
+                }
+                if let Some(retry) = retry {
+                    write!(
+                        f,
+                        " retry {} backoff {}",
+                        retry.attempts,
+                        humantime::format_duration(retry.backoff)
+                    )?;
+                }
+                writeln!(f)?;
+                // statement always end with a blank line
+                writeln!(f, "{sql}")?;
+
+                if let StatementExpect::Error(err) = expected {
+                    err.fmt_multiline(f)?;
+                }
+                Ok(())
+            }
+            Record::Query {
+                loc: _,
+                conditions: _,
+                connection: _,
+                sql,
+                expected,
+                retry,
+            } => {
+                write!(f, "query ")?;
+                match expected {
+                    QueryExpect::Results {
+                        types,
+                        sort_mode,
+                        label,
+                        ..
+                    } => {
+                        write!(f, "{}", types.iter().map(|c| c.to_char()).join(""))?;
+                        if let Some(sort_mode) = sort_mode {
+                            write!(f, " {}", sort_mode.as_str())?;
+                        }
+                        if let Some(label) = label {
+                            write!(f, " {label}")?;
+                        }
+                    }
+                    QueryExpect::Error(err) => err.fmt_inline(f)?,
+                }
+                if let Some(retry) = retry {
+                    write!(
+                        f,
+                        " retry {} backoff {}",
+                        retry.attempts,
+                        humantime::format_duration(retry.backoff)
+                    )?;
+                }
+                writeln!(f)?;
+                writeln!(f, "{sql}")?;
+
+                match expected {
+                    QueryExpect::Results { results, .. } => {
+                        write!(f, "{}", RESULTS_DELIMITER)?;
+                        for result in results {
+                            write!(f, "\n{result}")?;
+                        }
+
+                        // query always ends with a blank line
+                        writeln!(f)?
+                    }
+                    QueryExpect::Error(err) => err.fmt_multiline(f)?,
+                }
+                Ok(())
+            }
+            Record::System {
+                loc: _,
+                conditions: _,
+                command,
+                stdout,
+                retry,
+            } => {
+                writeln!(f, "system ok\n{command}")?;
+                if let Some(retry) = retry {
+                    write!(
+                        f,
+                        " retry {} backoff {}",
+                        retry.attempts,
+                        humantime::format_duration(retry.backoff)
+                    )?;
+                }
+                if let Some(stdout) = stdout {
+                    writeln!(f, "----\n{}\n", stdout.trim())?;
+                }
+                Ok(())
+            }
+            Record::Sleep { loc: _, duration } => {
+                write!(f, "sleep {}", humantime::format_duration(*duration))
+            }
+            Record::Subtest { loc: _, name } => {
+                write!(f, "subtest {name}")
+            }
+            Record::Halt { loc: _ } => {
+                write!(f, "halt")
+            }
+            Record::Control(c) => match c {
+                Control::SortMode(m) => write!(f, "control sortmode {}", m.as_str()),
+                Control::ResultMode(m) => write!(f, "control resultmode {}", m.as_str()),
+                Control::Substitution(s) => write!(f, "control substitution {}", s.as_str()),
+            },
+            Record::Condition(cond) => match cond {
+                Condition::OnlyIf { label } => write!(f, "onlyif {label}"),
+                Condition::SkipIf { label } => write!(f, "skipif {label}"),
+            },
+            Record::Connection(conn) => {
+                if let Connection::Named(conn) = conn {
+                    write!(f, "connection {}", conn)?;
+                }
+                Ok(())
+            }
+            Record::HashThreshold { loc: _, threshold } => {
+                write!(f, "hash-threshold {threshold}")
+            }
+            Record::Comment(comment) => {
+                let mut iter = comment.iter();
+                write!(f, "#{}", iter.next().unwrap().trim_end())?;
+                for line in iter {
+                    write!(f, "\n#{}", line.trim_end())?;
+                }
+                Ok(())
+            }
+            Record::Newline => Ok(()), // Display doesn't end with newline
+            Record::Injected(p) => panic!("unexpected injected record: {p:?}"),
+        }
+    }
+}
+
+/// Expected error message after `error` or under `----`.
+#[derive(Debug, Clone)]
+pub enum ExpectedError {
+    /// No expected error message.
+    ///
+    /// Any error message is considered as a match.
+    Empty,
+    /// An inline regular expression after `error`.
+    ///
+    /// The actual error message that matches the regex is considered as a match.
+    Inline(Regex),
+    /// A multiline error message under `----`, ends with 2 consecutive empty lines.
+    ///
+    /// The actual error message that's exactly the same as the expected one is considered as a
+    /// match.
+    Multiline(String),
+}
+
+impl ExpectedError {
+    /// Parses an inline regex variant from tokens.
+    fn parse_inline_tokens(tokens: &[&str]) -> Result<Self, ParseErrorKind> {
+        Self::new_inline(tokens.join(" "))
+    }
+
+    /// Creates an inline expected error message from a regex string.
+    ///
+    /// If the regex is empty, it's considered as [`ExpectedError::Empty`].
+    fn new_inline(regex: String) -> Result<Self, ParseErrorKind> {
+        if regex.is_empty() {
+            Ok(Self::Empty)
+        } else {
+            let regex =
+                Regex::new(&regex).map_err(|_| ParseErrorKind::InvalidErrorMessage(regex))?;
+            Ok(Self::Inline(regex))
+        }
+    }
+
+    /// Returns whether it's an empty match.
+    fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+
+    /// Unparses the expected message after `statement`.
+    fn fmt_inline(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "error")?;
+        if let Self::Inline(regex) = self {
+            write!(f, " {regex}")?;
+        }
+        Ok(())
+    }
+
+    /// Unparses the expected message with `----`, if it's multiline.
+    fn fmt_multiline(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Self::Multiline(results) = self {
+            writeln!(f, "{}", RESULTS_DELIMITER)?;
+            writeln!(f, "{}", results.trim())?;
+            writeln!(f)?; // another empty line to indicate the end of multiline message
+        }
+        Ok(())
+    }
+
+    /// Returns whether the given error message matches the expected one.
+    pub fn is_match(&self, err: &str) -> bool {
+        match self {
+            Self::Empty => true,
+            Self::Inline(regex) => regex.is_match(err),
+            Self::Multiline(results) => results.trim() == err.trim(),
+        }
+    }
+
+    /// Creates an expected error message from the actual error message. Used by the runner
+    /// to update the test cases with `--override`.
+    ///
+    /// A reference might be provided to help decide whether to use inline or multiline.
+    pub fn from_actual_error(reference: Option<&Self>, actual_err: &str) -> Self {
+        let trimmed_err = actual_err.trim();
+        let err_is_multiline = trimmed_err.lines().next_tuple::<(_, _)>().is_some();
+
+        let multiline = match reference {
+            Some(Self::Multiline(_)) => true, // always multiline if the ref is multiline
+            _ => err_is_multiline,            // prefer inline as long as it fits
+        };
+
+        if multiline {
+            // Even if the actual error is empty, we still use `Multiline` to indicate that
+            // an exact empty error is expected, instead of any error by `Empty`.
+            Self::Multiline(trimmed_err.to_string())
+        } else {
+            Self::new_inline(regex::escape(actual_err)).expect("escaped regex should be valid")
+        }
+    }
+}
+
+impl std::fmt::Display for ExpectedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExpectedError::Empty => write!(f, "(any)"),
+            ExpectedError::Inline(regex) => write!(f, "(regex) {}", regex),
+            ExpectedError::Multiline(results) => write!(f, "(multiline) {}", results.trim()),
+        }
+    }
+}
+
+impl PartialEq for ExpectedError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Empty, Self::Empty) => true,
+            (Self::Inline(l0), Self::Inline(r0)) => l0.as_str() == r0.as_str(),
+            (Self::Multiline(l0), Self::Multiline(r0)) => l0 == r0,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub enum Control {
+    /// Control sort mode.
+    SortMode(SortMode),
+    /// control result mode.
+    ResultMode(ResultMode),
+    /// Control whether or not to substitute variables in the SQL.
+    Substitution(bool),
+}
+
+trait ControlItem: Sized {
+    /// Try to parse from string.
+    fn try_from_str(s: &str) -> Result<Self, ParseErrorKind>;
+
+    /// Convert to string.
+    fn as_str(&self) -> &'static str;
+}
+
+impl ControlItem for bool {
+    fn try_from_str(s: &str) -> Result<Self, ParseErrorKind> {
+        match s {
+            "on" => Ok(true),
+            "off" => Ok(false),
+            _ => Err(ParseErrorKind::InvalidControl(s.to_string())),
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        if *self {
+            "on"
+        } else {
+            "off"
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Injected {
+    /// Pseudo control command to indicate the begin of an include statement. Automatically
+    /// injected by sqllogictest parser.
+    BeginInclude(String),
+    /// Pseudo control command to indicate the end of an include statement. Automatically injected
+    /// by sqllogictest parser.
+    EndInclude(String),
+}
+
+/// The condition to run a query.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Condition {
+    /// The statement or query is evaluated only if the label is seen.
+    OnlyIf { label: String },
+    /// The statement or query is not evaluated if the label is seen.
+    SkipIf { label: String },
+}
+
+impl Condition {
+    /// Evaluate condition on given `label`, returns whether to skip this record.
+    pub(crate) fn should_skip<'a>(&'a self, labels: impl IntoIterator<Item = &'a str>) -> bool {
+        match self {
+            Condition::OnlyIf { label } => !labels.into_iter().contains(&label.as_str()),
+            Condition::SkipIf { label } => labels.into_iter().contains(&label.as_str()),
+        }
+    }
+}
+
+/// The connection to use for the following statement.
+#[derive(Default, Debug, PartialEq, Eq, Hash, Clone)]
+pub enum Connection {
+    /// The default connection if not specified or if the name is "default".
+    #[default]
+    Default,
+    /// A named connection.
+    Named(String),
+}
+
+impl Connection {
+    fn new(name: impl AsRef<str>) -> Self {
+        match name.as_ref() {
+            "default" => Self::Default,
+            name => Self::Named(name.to_owned()),
+        }
+    }
+}
+
+/// Whether to apply sorting before checking the results of a query.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum SortMode {
+    /// The default option. The results appear in exactly the order in which they were received
+    /// from the database engine.
+    NoSort,
+    /// Gathers all output from the database engine then sorts it by rows.
+    RowSort,
+    /// It works like rowsort except that it does not honor row groupings. Each individual result
+    /// value is sorted on its own.
+    ValueSort,
+}
+
+impl ControlItem for SortMode {
+    fn try_from_str(s: &str) -> Result<Self, ParseErrorKind> {
+        match s {
+            "nosort" => Ok(Self::NoSort),
+            "rowsort" => Ok(Self::RowSort),
+            "valuesort" => Ok(Self::ValueSort),
+            _ => Err(ParseErrorKind::InvalidSortMode(s.to_string())),
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::NoSort => "nosort",
+            Self::RowSort => "rowsort",
+            Self::ValueSort => "valuesort",
+        }
+    }
+}
+
+/// Whether the results should be parsed as value-wise or row-wise
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ResultMode {
+    /// Results are in a single column
+    ValueWise,
+    /// The default option where results are in columns separated by spaces
+    RowWise,
+}
+
+impl ControlItem for ResultMode {
+    fn try_from_str(s: &str) -> Result<Self, ParseErrorKind> {
+        match s {
+            "rowwise" => Ok(Self::RowWise),
+            "valuewise" => Ok(Self::ValueWise),
+            _ => Err(ParseErrorKind::InvalidSortMode(s.to_string())),
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::RowWise => "rowwise",
+            Self::ValueWise => "valuewise",
+        }
+    }
+}
+
+impl fmt::Display for ResultMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+/// The error type for parsing sqllogictest.
+#[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
+#[error("parse error at {loc}: {kind}")]
+pub struct ParseError {
+    kind: ParseErrorKind,
+    loc: Location,
+}
+
+impl ParseError {
+    /// Returns the corresponding [`ParseErrorKind`] for this error.
+    pub fn kind(&self) -> ParseErrorKind {
+        self.kind.clone()
+    }
+
+    /// Returns the location from which the error originated.
+    pub fn location(&self) -> Location {
+        self.loc.clone()
+    }
+}
+
+/// The error kind for parsing sqllogictest.
+#[derive(thiserror::Error, Debug, Eq, PartialEq, Clone)]
+#[non_exhaustive]
+pub enum ParseErrorKind {
+    #[error("unexpected token: {0:?}")]
+    UnexpectedToken(String),
+    #[error("unexpected EOF")]
+    UnexpectedEOF,
+    #[error("invalid sort mode: {0:?}")]
+    InvalidSortMode(String),
+    #[error("invalid line: {0:?}")]
+    InvalidLine(String),
+    #[error("invalid type character: {0:?} in type string")]
+    InvalidType(char),
+    #[error("invalid number: {0:?}")]
+    InvalidNumber(String),
+    #[error("invalid error message: {0:?}")]
+    InvalidErrorMessage(String),
+    #[error("duplicated error messages after error` and under `----`")]
+    DuplicatedErrorMessage,
+    #[error("invalid retry config: {0:?}")]
+    InvalidRetryConfig(String),
+    #[error("statement should have no result, use `query` instead")]
+    StatementHasResults,
+    #[error("invalid duration: {0:?}")]
+    InvalidDuration(String),
+    #[error("invalid control: {0:?}")]
+    InvalidControl(String),
+    #[error("invalid include file pattern: {0}")]
+    InvalidIncludeFile(String),
+    #[error("no files found for include file pattern: {0:?}")]
+    EmptyIncludeFile(String),
+    #[error("no such file")]
+    FileNotFound,
+}
+
+impl ParseErrorKind {
+    fn at(self, loc: Location) -> ParseError {
+        ParseError { kind: self, loc }
+    }
+}
+
+/// Parse a sqllogictest script into a list of records.
+pub fn parse<T: ColumnType>(script: &str) -> Result<Vec<Record<T>>, ParseError> {
+    parse_inner(&Location::new("<unknown>", 0), script)
+}
+
+/// Parse a sqllogictest script into a list of records with a given script name.
+pub fn parse_with_name<T: ColumnType>(
+    script: &str,
+    name: impl Into<Arc<str>>,
+) -> Result<Vec<Record<T>>, ParseError> {
+    parse_inner(&Location::new(name, 0), script)
+}
+
+#[allow(clippy::collapsible_match)]
+fn parse_inner<T: ColumnType>(loc: &Location, script: &str) -> Result<Vec<Record<T>>, ParseError> {
+    let mut lines = script.lines().enumerate().peekable();
+    let mut records = vec![];
+    let mut conditions = vec![];
+    let mut connection = Connection::Default;
+    let mut comments = vec![];
+
+    while let Some((num, line)) = lines.next() {
+        if let Some(text) = line.strip_prefix('#') {
+            comments.push(text.to_string());
+            if lines.peek().is_none() {
+                // Special handling for the case where the last line is a comment.
+                records.push(Record::Comment(comments));
+                break;
+            }
+            continue;
+        }
+        if !comments.is_empty() {
+            records.push(Record::Comment(comments));
+            comments = vec![];
+        }
+
+        if line.is_empty() {
+            records.push(Record::Newline);
+            continue;
+        }
+
+        let mut loc = loc.clone();
+        loc.line = num as u32 + 1;
+
+        // Strip inline comments (lines starting with # are already handled above)
+        let line_without_comment = if let Some(comment_pos) = line.find('#') {
+            // Only treat # as a comment if it's preceded by whitespace
+            // This prevents treating # inside other contexts as a comment marker
+            if line[..comment_pos].ends_with(|c: char| c.is_whitespace()) {
+                &line[..comment_pos]
+            } else {
+                line
+            }
+        } else {
+            line
+        };
+
+        let tokens: Vec<&str> = line_without_comment.split_whitespace().collect();
+        match tokens.as_slice() {
+            [] => continue,
+            ["include", included] => records.push(Record::Include {
+                loc,
+                filename: included.to_string(),
+            }),
+            ["halt"] => {
+                records.push(Record::Halt { loc });
+            }
+            ["subtest", name] => {
+                records.push(Record::Subtest {
+                    loc,
+                    name: name.to_string(),
+                });
+            }
+            ["sleep", dur] => {
+                records.push(Record::Sleep {
+                    duration: humantime::parse_duration(dur).map_err(|_| {
+                        ParseErrorKind::InvalidDuration(dur.to_string()).at(loc.clone())
+                    })?,
+                    loc,
+                });
+            }
+            ["skipif", label] => {
+                let cond = Condition::SkipIf {
+                    label: label.to_string(),
+                };
+                conditions.push(cond.clone());
+                records.push(Record::Condition(cond));
+            }
+            ["onlyif", label] => {
+                let cond = Condition::OnlyIf {
+                    label: label.to_string(),
+                };
+                conditions.push(cond.clone());
+                records.push(Record::Condition(cond));
+            }
+            ["connection", name] => {
+                let conn = Connection::new(name);
+                connection = conn.clone();
+                records.push(Record::Connection(conn));
+            }
+            ["statement", res @ ..] => {
+                let (mut expected, res) = match res {
+                    ["ok", retry @ ..] => (StatementExpect::Ok, retry),
+                    ["error", res @ ..] => {
+                        if res.len() == 4 && res[0] == "retry" && res[2] == "backoff" {
+                            // `statement error retry <num> backoff <duration>`
+                            // To keep syntax simple, let's assume the error message must be multiline.
+                            (StatementExpect::Error(ExpectedError::Empty), res)
+                        } else {
+                            let error = ExpectedError::parse_inline_tokens(res)
+                                .map_err(|e| e.at(loc.clone()))?;
+                            (StatementExpect::Error(error), &[][..])
+                        }
+                    }
+                    ["count", count_str, retry @ ..] => {
+                        let count = count_str.parse::<u64>().map_err(|_| {
+                            ParseErrorKind::InvalidNumber((*count_str).into()).at(loc.clone())
+                        })?;
+                        (StatementExpect::Count(count), retry)
+                    }
+                    _ => return Err(ParseErrorKind::InvalidLine(line.into()).at(loc)),
+                };
+
+                let retry = parse_retry_config(res).map_err(|e| e.at(loc.clone()))?;
+
+                let (sql, has_results) = parse_lines(&mut lines, &loc, Some(RESULTS_DELIMITER))?;
+
+                if has_results {
+                    if let StatementExpect::Error(e) = &mut expected {
+                        // If no inline error message is specified, it might be a multiline error.
+                        if e.is_empty() {
+                            *e = parse_multiline_error(&mut lines);
+                        } else {
+                            return Err(ParseErrorKind::DuplicatedErrorMessage.at(loc.clone()));
+                        }
+                    } else {
+                        return Err(ParseErrorKind::StatementHasResults.at(loc.clone()));
+                    }
+                }
+
+                records.push(Record::Statement {
+                    loc,
+                    conditions: std::mem::take(&mut conditions),
+                    connection: std::mem::take(&mut connection),
+                    sql,
+                    expected,
+                    retry,
+                });
+            }
+            ["query", res @ ..] => {
+                let (mut expected, res) = match res {
+                    ["error", res @ ..] => {
+                        if res.len() == 4 && res[0] == "retry" && res[2] == "backoff" {
+                            // `query error retry <num> backoff <duration>`
+                            // To keep syntax simple, let's assume the error message must be multiline.
+                            (QueryExpect::Error(ExpectedError::Empty), res)
+                        } else {
+                            let error = ExpectedError::parse_inline_tokens(res)
+                                .map_err(|e| e.at(loc.clone()))?;
+                            (QueryExpect::Error(error), &[][..])
+                        }
+                    }
+                    [type_str, res @ ..] => {
+                        // query <type-string> [<sort-mode>] [<label>] [retry <attempts> backoff <backoff>]
+                        let types = type_str
+                            .chars()
+                            .map(|ch| {
+                                T::from_char(ch)
+                                    .ok_or_else(|| ParseErrorKind::InvalidType(ch).at(loc.clone()))
+                            })
+                            .try_collect()?;
+                        let sort_mode = res.first().and_then(|&s| SortMode::try_from_str(s).ok()); // Could be `retry` or label
+
+                        // To support `retry`, we assume the label must *not* be "retry"
+                        let label_start = if sort_mode.is_some() { 1 } else { 0 };
+                        let res = &res[label_start..];
+                        let label = res.first().and_then(|&s| {
+                            if s != "retry" {
+                                Some(s.to_owned())
+                            } else {
+                                None // `retry` is not a valid label
+                            }
+                        });
+
+                        let retry_start = if label.is_some() { 1 } else { 0 };
+                        let res = &res[retry_start..];
+                        (
+                            QueryExpect::Results {
+                                types,
+                                sort_mode,
+                                result_mode: None,
+                                label,
+                                results: Vec::new(),
+                            },
+                            res,
+                        )
+                    }
+                    [] => (QueryExpect::empty_results(), &[][..]),
+                };
+
+                let retry = parse_retry_config(res).map_err(|e| e.at(loc.clone()))?;
+
+                // The SQL for the query is found on second and subsequent lines of the record
+                // up to first line of the form "----" or until the end of the record.
+                let (sql, has_result) = parse_lines(&mut lines, &loc, Some(RESULTS_DELIMITER))?;
+                if has_result {
+                    match &mut expected {
+                        // Lines following the "----" are expected results of the query, one value
+                        // per line.
+                        QueryExpect::Results { results, .. } => {
+                            for (_, line) in &mut lines {
+                                if line.is_empty() {
+                                    break;
+                                }
+                                results.push(line.to_string());
+                            }
+                        }
+                        // If no inline error message is specified, it might be a multiline error.
+                        QueryExpect::Error(e) => {
+                            if e.is_empty() {
+                                *e = parse_multiline_error(&mut lines);
+                            } else {
+                                return Err(ParseErrorKind::DuplicatedErrorMessage.at(loc.clone()));
+                            }
+                        }
+                    }
+                }
+                records.push(Record::Query {
+                    loc,
+                    conditions: std::mem::take(&mut conditions),
+                    connection: std::mem::take(&mut connection),
+                    sql,
+                    expected,
+                    retry,
+                });
+            }
+            ["system", "ok", res @ ..] => {
+                let retry = parse_retry_config(res).map_err(|e| e.at(loc.clone()))?;
+
+                // TODO: we don't support asserting error message for system command
+                // The command is found on second and subsequent lines of the record
+                // up to first line of the form "----" or until the end of the record.
+                let (command, has_result) = parse_lines(&mut lines, &loc, Some(RESULTS_DELIMITER))?;
+                let stdout = if has_result {
+                    Some(parse_multiple_result(&mut lines))
+                } else {
+                    None
+                };
+                records.push(Record::System {
+                    loc,
+                    conditions: std::mem::take(&mut conditions),
+                    command,
+                    stdout,
+                    retry,
+                });
+            }
+            ["control", res @ ..] => match res {
+                ["resultmode", result_mode] => match ResultMode::try_from_str(result_mode) {
+                    Ok(result_mode) => {
+                        records.push(Record::Control(Control::ResultMode(result_mode)))
+                    }
+                    Err(k) => return Err(k.at(loc)),
+                },
+                ["sortmode", sort_mode] => match SortMode::try_from_str(sort_mode) {
+                    Ok(sort_mode) => records.push(Record::Control(Control::SortMode(sort_mode))),
+                    Err(k) => return Err(k.at(loc)),
+                },
+                ["substitution", on_off] => match bool::try_from_str(on_off) {
+                    Ok(on_off) => records.push(Record::Control(Control::Substitution(on_off))),
+                    Err(k) => return Err(k.at(loc)),
+                },
+                _ => return Err(ParseErrorKind::InvalidLine(line.into()).at(loc)),
+            },
+            ["hash-threshold", threshold] => {
+                records.push(Record::HashThreshold {
+                    loc: loc.clone(),
+                    threshold: threshold.parse::<u64>().map_err(|_| {
+                        ParseErrorKind::InvalidNumber((*threshold).into()).at(loc.clone())
+                    })?,
+                });
+            }
+            _ => return Err(ParseErrorKind::InvalidLine(line.into()).at(loc)),
+        }
+    }
+    Ok(records)
+}
+
+/// Parse a sqllogictest file. The included scripts are inserted after the `include` record.
+pub fn parse_file<T: ColumnType>(filename: impl AsRef<Path>) -> Result<Vec<Record<T>>, ParseError> {
+    let filename = filename.as_ref().to_str().unwrap();
+    parse_file_inner(Location::new(filename, 0))
+}
+
+fn parse_file_inner<T: ColumnType>(loc: Location) -> Result<Vec<Record<T>>, ParseError> {
+    let path = Path::new(loc.file());
+    if !path.exists() {
+        return Err(ParseErrorKind::FileNotFound.at(loc.clone()));
+    }
+    let script = std::fs::read_to_string(path).unwrap();
+    let mut records = vec![];
+    for rec in parse_inner(&loc, &script)? {
+        records.push(rec.clone());
+
+        if let Record::Include { filename, loc } = rec {
+            let complete_filename = {
+                let mut path_buf = path.to_path_buf();
+                path_buf.pop();
+                path_buf.push(filename.clone());
+                path_buf.as_os_str().to_string_lossy().to_string()
+            };
+
+            let mut iter = glob::glob(&complete_filename)
+                .map_err(|e| ParseErrorKind::InvalidIncludeFile(e.to_string()).at(loc.clone()))?
+                .peekable();
+            if iter.peek().is_none() {
+                return Err(ParseErrorKind::EmptyIncludeFile(filename).at(loc.clone()));
+            }
+            for included_file in iter {
+                let included_file = included_file.map_err(|e| {
+                    ParseErrorKind::InvalidIncludeFile(e.to_string()).at(loc.clone())
+                })?;
+                let included_file = included_file.as_os_str().to_string_lossy().to_string();
+
+                records.push(Record::Injected(Injected::BeginInclude(
+                    included_file.clone(),
+                )));
+                records.extend(parse_file_inner(loc.include(&included_file))?);
+                records.push(Record::Injected(Injected::EndInclude(included_file)));
+            }
+        }
+    }
+    Ok(records)
+}
+
+/// Parse one or more lines until empty line or a delimiter.
+fn parse_lines<'a>(
+    lines: &mut impl Iterator<Item = (usize, &'a str)>,
+    loc: &Location,
+    delimiter: Option<&str>,
+) -> Result<(String, bool), ParseError> {
+    let mut found_delimiter = false;
+    let mut out = match lines.next() {
+        Some((_, line)) => Ok(line.into()),
+        None => Err(ParseErrorKind::UnexpectedEOF.at(loc.clone().next_line())),
+    }?;
+
+    for (_, line) in lines {
+        if line.is_empty() {
+            break;
+        }
+        if let Some(delimiter) = delimiter {
+            if line == delimiter {
+                found_delimiter = true;
+                break;
+            }
+        }
+        out += "\n";
+        out += line;
+    }
+
+    Ok((out, found_delimiter))
+}
+
+/// Parse multiline output under `----`.
+fn parse_multiple_result<'a>(
+    lines: &mut Peekable<impl Iterator<Item = (usize, &'a str)>>,
+) -> String {
+    let mut results = String::new();
+
+    while let Some((_, line)) = lines.next() {
+        // 2 consecutive empty lines
+        if line.is_empty() && lines.peek().map(|(_, l)| l.is_empty()).unwrap_or(true) {
+            lines.next();
+            break;
+        }
+        results += line;
+        results.push('\n');
+    }
+
+    results.trim().to_string()
+}
+
+/// Parse multiline error message under `----`.
+fn parse_multiline_error<'a>(
+    lines: &mut Peekable<impl Iterator<Item = (usize, &'a str)>>,
+) -> ExpectedError {
+    ExpectedError::Multiline(parse_multiple_result(lines))
+}
+
+/// Parse retry configuration from tokens
+///
+/// The retry configuration is optional and can be specified as:
+///
+/// ```text
+/// ... retry 3 backoff 1s
+/// ```
+fn parse_retry_config(tokens: &[&str]) -> Result<Option<RetryConfig>, ParseErrorKind> {
+    if tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let mut iter = tokens.iter().peekable();
+
+    // Check if we have retry clause
+    match iter.next() {
+        Some(&"retry") => {}
+        Some(token) => return Err(ParseErrorKind::UnexpectedToken(token.to_string())),
+        None => return Ok(None),
+    }
+
+    // Parse number of attempts
+    let attempts = match iter.next() {
+        Some(attempts_str) => attempts_str
+            .parse::<usize>()
+            .map_err(|_| ParseErrorKind::InvalidNumber(attempts_str.to_string()))?,
+        None => {
+            return Err(ParseErrorKind::InvalidRetryConfig(
+                "expected a positive number of attempts".to_string(),
+            ))
+        }
+    };
+
+    if attempts == 0 {
+        return Err(ParseErrorKind::InvalidRetryConfig(
+            "attempt must be greater than 0".to_string(),
+        ));
+    }
+
+    // Expect "backoff" keyword
+    match iter.next() {
+        Some(&"backoff") => {}
+        Some(token) => return Err(ParseErrorKind::UnexpectedToken(token.to_string())),
+        None => {
+            return Err(ParseErrorKind::InvalidRetryConfig(
+                "expected keyword backoff".to_string(),
+            ))
+        }
+    }
+
+    // Parse backoff duration
+    let duration_str = match iter.next() {
+        Some(s) => s,
+        None => {
+            return Err(ParseErrorKind::InvalidRetryConfig(
+                "expected backoff duration".to_string(),
+            ))
+        }
+    };
+
+    let backoff = humantime::parse_duration(duration_str)
+        .map_err(|_| ParseErrorKind::InvalidDuration(duration_str.to_string()))?;
+
+    // No more tokens should be present
+    if iter.next().is_some() {
+        return Err(ParseErrorKind::UnexpectedToken("extra tokens".to_string()));
+    }
+
+    Ok(Some(RetryConfig { attempts, backoff }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+    use crate::DefaultColumnType;
+
+    #[test]
+    fn test_trailing_comment() {
+        let script = "\
+# comment 1
+#  comment 2
+";
+        let records = parse::<DefaultColumnType>(script).unwrap();
+        assert_eq!(
+            records,
+            vec![Record::Comment(vec![
+                " comment 1".to_string(),
+                "  comment 2".to_string(),
+            ]),]
+        );
+    }
+
+    #[test]
+    fn test_include_glob() {
+        let records =
+            parse_file::<DefaultColumnType>("../tests/slt/include/include_1.slt").unwrap();
+        assert_eq!(15, records.len());
+    }
+
+    #[test]
+    fn test_basic() {
+        parse_roundtrip::<DefaultColumnType>("../tests/slt/basic.slt")
+    }
+
+    #[test]
+    fn test_condition() {
+        parse_roundtrip::<DefaultColumnType>("../tests/slt/condition.slt")
+    }
+
+    #[test]
+    fn test_file_level_sort_mode() {
+        parse_roundtrip::<DefaultColumnType>("../tests/slt/file_level_sort_mode.slt")
+    }
+
+    #[test]
+    fn test_rowsort() {
+        parse_roundtrip::<DefaultColumnType>("../tests/slt/rowsort.slt")
+    }
+
+    #[test]
+    fn test_valuesort() {
+        parse_roundtrip::<DefaultColumnType>("../tests/slt/valuesort.slt")
+    }
+
+    #[test]
+    fn test_substitution() {
+        parse_roundtrip::<DefaultColumnType>("../tests/substitution/basic.slt")
+    }
+
+    #[test]
+    fn test_test_dir_escape() {
+        parse_roundtrip::<DefaultColumnType>("../tests/test_dir_escape/test_dir_escape.slt")
+    }
+
+    #[test]
+    fn test_validator() {
+        parse_roundtrip::<DefaultColumnType>("../tests/validator/validator.slt")
+    }
+
+    #[test]
+    fn test_custom_type() {
+        parse_roundtrip::<CustomColumnType>("../tests/custom_type/custom_type.slt")
+    }
+
+    #[test]
+    fn test_system_command() {
+        parse_roundtrip::<DefaultColumnType>("../tests/system_command/system_command.slt")
+    }
+
+    #[test]
+    fn test_fail_unknown_type() {
+        let script = "\
+query IA
+select * from unknown_type
+----
+";
+
+        let error_kind = parse::<CustomColumnType>(script).unwrap_err().kind;
+
+        assert_eq!(error_kind, ParseErrorKind::InvalidType('A'));
+    }
+
+    #[test]
+    fn test_parse_no_types() {
+        let script = "\
+query
+select * from foo;
+----
+";
+        let records = parse::<DefaultColumnType>(script).unwrap();
+
+        assert_eq!(
+            records,
+            vec![Record::Query {
+                loc: Location::new("<unknown>", 1),
+                conditions: vec![],
+                connection: Connection::Default,
+                sql: "select * from foo;".to_string(),
+                expected: QueryExpect::empty_results(),
+                retry: None,
+            }]
+        );
+    }
+
+    /// Verifies Display impl is consistent with parsing by ensuring
+    /// roundtrip parse(unparse(parse())) is consistent
+    #[track_caller]
+    fn parse_roundtrip<T: ColumnType>(filename: impl AsRef<Path>) {
+        let filename = filename.as_ref();
+        let records = parse_file::<T>(filename).expect("parsing to complete");
+
+        let unparsed = records
+            .iter()
+            .map(|record| record.to_string())
+            .collect::<Vec<_>>();
+
+        let output_contents = unparsed.join("\n");
+
+        // The original and parsed records should be logically equivalent
+        let mut output_file = tempfile::NamedTempFile::new().expect("Error creating tempfile");
+        output_file
+            .write_all(output_contents.as_bytes())
+            .expect("Unable to write file");
+        output_file.flush().unwrap();
+
+        let output_path = output_file.into_temp_path();
+        let reparsed_records =
+            parse_file(&output_path).expect("reparsing to complete successfully");
+
+        let records = normalize_filename(records);
+        let reparsed_records = normalize_filename(reparsed_records);
+
+        pretty_assertions::assert_eq!(records, reparsed_records, "Mismatch in reparsed records");
+    }
+
+    /// Replaces the actual filename in all Records with
+    /// "__FILENAME__" so different files with the same contents can
+    /// compare equal
+    fn normalize_filename<T: ColumnType>(records: Vec<Record<T>>) -> Vec<Record<T>> {
+        records
+            .into_iter()
+            .map(|mut record| {
+                match &mut record {
+                    Record::Include { loc, .. } => normalize_loc(loc),
+                    Record::Statement { loc, .. } => normalize_loc(loc),
+                    Record::System { loc, .. } => normalize_loc(loc),
+                    Record::Query { loc, .. } => normalize_loc(loc),
+                    Record::Sleep { loc, .. } => normalize_loc(loc),
+                    Record::Subtest { loc, .. } => normalize_loc(loc),
+                    Record::Halt { loc, .. } => normalize_loc(loc),
+                    Record::HashThreshold { loc, .. } => normalize_loc(loc),
+                    // even though these variants don't include a
+                    // location include them in this match statement
+                    // so if new variants are added, this match
+                    // statement must be too.
+                    Record::Condition(_)
+                    | Record::Connection(_)
+                    | Record::Comment(_)
+                    | Record::Control(_)
+                    | Record::Newline
+                    | Record::Injected(_) => {}
+                };
+                record
+            })
+            .collect()
+    }
+
+    // Normalize a location
+    fn normalize_loc(loc: &mut Location) {
+        loc.file = Arc::from("__FILENAME__");
+    }
+
+    #[derive(Debug, PartialEq, Eq, Clone)]
+    pub enum CustomColumnType {
+        Integer,
+        Boolean,
+    }
+
+    impl ColumnType for CustomColumnType {
+        fn from_char(value: char) -> Option<Self> {
+            match value {
+                'I' => Some(Self::Integer),
+                'B' => Some(Self::Boolean),
+                _ => None,
+            }
+        }
+
+        fn to_char(&self) -> char {
+            match self {
+                Self::Integer => 'I',
+                Self::Boolean => 'B',
+            }
+        }
+    }
+
+    #[test]
+    fn test_statement_retry() {
+        parse_roundtrip::<DefaultColumnType>("../tests/no_run/statement_retry.slt")
+    }
+
+    #[test]
+    fn test_query_retry() {
+        parse_roundtrip::<DefaultColumnType>("../tests/no_run/query_retry.slt")
+    }
+}

--- a/crates/sqllogictest/src/runner.rs
+++ b/crates/sqllogictest/src/runner.rs
@@ -1,0 +1,2367 @@
+//! Sqllogictest runner.
+
+use std::collections::{BTreeMap, HashSet};
+use std::fmt::{Debug, Display};
+use std::path::Path;
+use std::process::{Command, ExitStatus, Output};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+use std::vec;
+
+use async_trait::async_trait;
+use futures::executor::block_on;
+use futures::{stream, Future, FutureExt, StreamExt};
+use itertools::Itertools;
+use md5::Digest;
+use owo_colors::OwoColorize;
+use rand::Rng;
+use similar::{Change, ChangeTag, TextDiff};
+use tempfile::TempDir;
+
+use crate::parser::*;
+use crate::substitution::Substitution;
+use crate::{ColumnType, Connections, MakeConnection};
+
+/// Type-erased error type.
+type AnyError = Arc<dyn std::error::Error + Send + Sync>;
+
+/// Output of a record.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum RecordOutput<T: ColumnType> {
+    /// No output. Occurs when the record is skipped or not a `query`, `statement`, or `system`
+    /// command.
+    Nothing,
+    /// The output of a `query`.
+    Query {
+        types: Vec<T>,
+        rows: Vec<Vec<String>>,
+        error: Option<AnyError>,
+    },
+    /// The output of a `statement`.
+    Statement { count: u64, error: Option<AnyError> },
+    /// The output of a `system` command.
+    #[non_exhaustive]
+    System {
+        stdout: Option<String>,
+        error: Option<AnyError>,
+    },
+}
+
+#[non_exhaustive]
+pub enum DBOutput<T: ColumnType> {
+    Rows {
+        types: Vec<T>,
+        rows: Vec<Vec<String>>,
+    },
+    /// A statement in the query has completed.
+    ///
+    /// The number of rows modified or selected is returned.
+    ///
+    /// If the test case doesn't specify `statement count <n>`, the number is simply ignored.
+    StatementComplete(u64),
+}
+
+/// The async database to be tested.
+#[async_trait]
+pub trait AsyncDB {
+    /// The error type of SQL execution.
+    type Error: std::error::Error + Send + Sync + 'static;
+    /// The type of result columns
+    type ColumnType: ColumnType;
+
+    /// Async run a SQL query and return the output.
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, Self::Error>;
+
+    /// Shutdown the connection gracefully.
+    async fn shutdown(&mut self);
+
+    /// Engine name of current database.
+    fn engine_name(&self) -> &str {
+        ""
+    }
+
+    /// [`Runner`] calls this function to perform sleep.
+    ///
+    /// The default implementation is `std::thread::sleep`, which is universal to any async runtime
+    /// but would block the current thread. If you are running in tokio runtime, you should override
+    /// this by `tokio::time::sleep`.
+    async fn sleep(dur: Duration) {
+        std::thread::sleep(dur);
+    }
+
+    /// [`Runner`] calls this function to run a system command.
+    ///
+    /// The default implementation is `std::process::Command::output`, which is universal to any
+    /// async runtime but would block the current thread. If you are running in tokio runtime, you
+    /// should override this by `tokio::process::Command::output`.
+    async fn run_command(mut command: Command) -> std::io::Result<std::process::Output> {
+        command.output()
+    }
+}
+
+/// The database to be tested.
+pub trait DB {
+    /// The error type of SQL execution.
+    type Error: std::error::Error + Send + Sync + 'static;
+    /// The type of result columns
+    type ColumnType: ColumnType;
+
+    /// Run a SQL query and return the output.
+    fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, Self::Error>;
+
+    /// Shutdown the connection gracefully.
+    fn shutdown(&mut self) {}
+
+    /// Engine name of current database.
+    fn engine_name(&self) -> &str {
+        ""
+    }
+}
+
+/// Compat-layer for the new AsyncDB and DB trait
+#[async_trait]
+impl<D> AsyncDB for D
+where
+    D: DB + Send,
+{
+    type Error = D::Error;
+    type ColumnType = D::ColumnType;
+
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, Self::Error> {
+        D::run(self, sql)
+    }
+
+    async fn shutdown(&mut self) {
+        D::shutdown(self);
+    }
+
+    fn engine_name(&self) -> &str {
+        D::engine_name(self)
+    }
+}
+
+/// The error type for running sqllogictest.
+///
+/// For colored error message, use `self.display()`.
+#[derive(thiserror::Error, Clone)]
+#[error("{kind}\nat {loc}\n")]
+pub struct TestError {
+    kind: TestErrorKind,
+    loc: Location,
+}
+
+impl TestError {
+    pub fn display(&self, colorize: bool) -> TestErrorDisplay<'_> {
+        TestErrorDisplay {
+            err: self,
+            colorize,
+        }
+    }
+}
+
+/// Overrides the `Display` implementation of [`TestError`] to support controlling colorization.
+pub struct TestErrorDisplay<'a> {
+    err: &'a TestError,
+    colorize: bool,
+}
+
+impl Display for TestErrorDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}\nat {}\n",
+            self.err.kind.display(self.colorize),
+            self.err.loc
+        )
+    }
+}
+
+/// For colored error message, use `self.display()`.
+#[derive(Clone, Debug, thiserror::Error)]
+pub struct ParallelTestError {
+    errors: Vec<TestError>,
+}
+
+impl Display for ParallelTestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "parallel test failed")?;
+        write!(f, "Caused by:")?;
+        for i in &self.errors {
+            writeln!(f, "{i}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Overrides the `Display` implementation of [`ParallelTestError`] to support controlling
+/// colorization.
+pub struct ParallelTestErrorDisplay<'a> {
+    err: &'a ParallelTestError,
+    colorize: bool,
+}
+
+impl Display for ParallelTestErrorDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "parallel test failed")?;
+        write!(f, "Caused by:")?;
+        for i in &self.err.errors {
+            writeln!(f, "{}", i.display(self.colorize))?;
+        }
+        Ok(())
+    }
+}
+
+impl ParallelTestError {
+    pub fn display(&self, colorize: bool) -> ParallelTestErrorDisplay<'_> {
+        ParallelTestErrorDisplay {
+            err: self,
+            colorize,
+        }
+    }
+}
+
+impl std::fmt::Debug for TestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+impl TestError {
+    /// Returns the corresponding [`TestErrorKind`] for this error.
+    pub fn kind(&self) -> TestErrorKind {
+        self.kind.clone()
+    }
+
+    /// Returns the location from which the error originated.
+    pub fn location(&self) -> Location {
+        self.loc.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum RecordKind {
+    Statement,
+    Query,
+}
+
+impl std::fmt::Display for RecordKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RecordKind::Statement => write!(f, "statement"),
+            RecordKind::Query => write!(f, "query"),
+        }
+    }
+}
+
+/// The error kind for running sqllogictest.
+///
+/// For colored error message, use `self.display()`.
+#[derive(thiserror::Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum TestErrorKind {
+    #[error("parse error: {0}")]
+    ParseError(ParseErrorKind),
+    #[error("{kind} is expected to fail, but actually succeed:\n[SQL] {sql}")]
+    Ok { sql: String, kind: RecordKind },
+    #[error("{kind} failed: {err}\n[SQL] {sql}")]
+    Fail {
+        sql: String,
+        err: AnyError,
+        kind: RecordKind,
+    },
+    #[error("system command failed: {err}\n[CMD] {command}")]
+    SystemFail { command: String, err: AnyError },
+    #[error(
+        "system command stdout mismatch:\n[command] {command}\n[Diff] (-expected|+actual)\n{}",
+        TextDiff::from_lines(.expected_stdout, .actual_stdout).iter_all_changes().format_with("\n", |diff, f| format_diff(&diff, f, false))
+    )]
+    SystemStdoutMismatch {
+        command: String,
+        expected_stdout: String,
+        actual_stdout: String,
+    },
+    // Remember to also update [`TestErrorKindDisplay`] if this message is changed.
+    #[error("{kind} is expected to fail with error:\n\t{expected_err}\nbut got error:\n\t{err}\n[SQL] {sql}")]
+    ErrorMismatch {
+        sql: String,
+        err: AnyError,
+        expected_err: String,
+        kind: RecordKind,
+    },
+    #[error("statement is expected to affect {expected} rows, but actually {actual}\n[SQL] {sql}")]
+    StatementResultMismatch {
+        sql: String,
+        expected: u64,
+        actual: String,
+    },
+    // Remember to also update [`TestErrorKindDisplay`] if this message is changed.
+    #[error(
+        "query result mismatch:\n[SQL] {sql}\n[Diff] (-expected|+actual)\n{}",
+        TextDiff::from_lines(.expected, .actual).iter_all_changes().format_with("\n", |diff, f| format_diff(&diff, f, false))
+    )]
+    QueryResultMismatch {
+        sql: String,
+        expected: String,
+        actual: String,
+    },
+    #[error(
+        "query columns mismatch:\n[SQL] {sql}\n{}",
+        format_column_diff(expected, actual, false)
+    )]
+    QueryResultColumnsMismatch {
+        sql: String,
+        expected: String,
+        actual: String,
+    },
+}
+
+impl From<ParseError> for TestError {
+    fn from(e: ParseError) -> Self {
+        TestError {
+            kind: TestErrorKind::ParseError(e.kind()),
+            loc: e.location(),
+        }
+    }
+}
+
+impl TestErrorKind {
+    fn at(self, loc: Location) -> TestError {
+        TestError { kind: self, loc }
+    }
+
+    pub fn display(&self, colorize: bool) -> TestErrorKindDisplay<'_> {
+        TestErrorKindDisplay {
+            error: self,
+            colorize,
+        }
+    }
+}
+
+/// Overrides the `Display` implementation of [`TestErrorKind`] to support controlling colorization.
+pub struct TestErrorKindDisplay<'a> {
+    error: &'a TestErrorKind,
+    colorize: bool,
+}
+
+impl Display for TestErrorKindDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if !self.colorize {
+            return write!(f, "{}", self.error);
+        }
+        match self.error {
+            TestErrorKind::ErrorMismatch {
+                sql,
+                err,
+                expected_err,
+                kind,
+            } => write!(
+                f,
+                "{kind} is expected to fail with error:\n\t{}\nbut got error:\n\t{}\n[SQL] {sql}",
+                expected_err.bright_green(),
+                err.bright_red(),
+            ),
+            TestErrorKind::QueryResultMismatch {
+                sql,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "query result mismatch:\n[SQL] {sql}\n[Diff] ({}|{})\n{}",
+                "-expected".bright_red(),
+                "+actual".bright_green(),
+                TextDiff::from_lines(expected, actual)
+                    .iter_all_changes()
+                    .format_with("\n", |diff, f| format_diff(&diff, f, true))
+            ),
+            TestErrorKind::QueryResultColumnsMismatch {
+                sql,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "query columns mismatch:\n[SQL] {sql}\n{}",
+                    format_column_diff(expected, actual, true)
+                )
+            }
+            TestErrorKind::SystemStdoutMismatch {
+                command,
+                expected_stdout,
+                actual_stdout,
+            } => {
+                write!(
+                    f,
+                    "system command stdout mismatch:\n[command] {command}\n[Diff] (-expected|+actual)\n{}",
+                    TextDiff::from_lines(expected_stdout, actual_stdout)
+                        .iter_all_changes()
+                        .format_with("\n", |diff, f|{ format_diff(&diff, f, true)})
+                )
+            }
+            _ => write!(f, "{}", self.error),
+        }
+    }
+}
+
+fn format_diff(
+    diff: &Change<&str>,
+    f: &mut dyn FnMut(&dyn std::fmt::Display) -> std::fmt::Result,
+    colorize: bool,
+) -> std::fmt::Result {
+    match diff.tag() {
+        ChangeTag::Equal => f(&diff
+            .value()
+            .lines()
+            .format_with("\n", |line, f| f(&format_args!("    {line}")))),
+        ChangeTag::Insert => f(&diff.value().lines().format_with("\n", |line, f| {
+            if colorize {
+                f(&format_args!("+   {line}").bright_green())
+            } else {
+                f(&format_args!("+   {line}"))
+            }
+        })),
+        ChangeTag::Delete => f(&diff.value().lines().format_with("\n", |line, f| {
+            if colorize {
+                f(&format_args!("-   {line}").bright_red())
+            } else {
+                f(&format_args!("-   {line}"))
+            }
+        })),
+    }
+}
+
+fn format_column_diff(expected: &str, actual: &str, colorize: bool) -> String {
+    let (expected, actual) = TextDiff::from_chars(expected, actual)
+        .iter_all_changes()
+        .fold(
+            ("".to_string(), "".to_string()),
+            |(expected, actual), change| match change.tag() {
+                ChangeTag::Equal => (
+                    format!("{}{}", expected, change.value()),
+                    format!("{}{}", actual, change.value()),
+                ),
+                ChangeTag::Delete => (
+                    if colorize {
+                        format!("{}[{}]", expected, change.value().bright_red())
+                    } else {
+                        format!("{}[{}]", expected, change.value())
+                    },
+                    actual,
+                ),
+                ChangeTag::Insert => (
+                    expected,
+                    if colorize {
+                        format!("{}[{}]", actual, change.value().bright_green())
+                    } else {
+                        format!("{}[{}]", actual, change.value())
+                    },
+                ),
+            },
+        );
+    format!("[Expected] {expected}\n[Actual  ] {actual}")
+}
+
+/// Normalizer will be used by [`Runner`] to normalize the result values
+///
+/// # Default
+///
+/// By default, the ([`default_normalizer`]) will be used to normalize values.
+pub type Normalizer = fn(s: &String) -> String;
+
+/// Trim and replace multiple whitespaces with one.
+#[allow(clippy::ptr_arg)]
+pub fn default_normalizer(s: &String) -> String {
+    s.trim().split_ascii_whitespace().join(" ")
+}
+
+/// Validator will be used by [`Runner`] to validate the output.
+///
+/// # Default
+///
+/// By default, the ([`default_validator`]) will be used compare normalized results.
+pub type Validator =
+    fn(normalizer: Normalizer, actual: &[Vec<String>], expected: &[String]) -> bool;
+
+pub fn default_validator(
+    normalizer: Normalizer,
+    actual: &[Vec<String>],
+    expected: &[String],
+) -> bool {
+    // Support ignore marker <slt:ignore> to skip volatile parts of output.
+    const IGNORE_MARKER: &str = "<slt:ignore>";
+    let contains_ignore_marker = expected.iter().any(|line| line.contains(IGNORE_MARKER));
+
+    // Normalize expected lines.
+    // If ignore marker present, perform fragment-based matching on the full snapshot.
+    if contains_ignore_marker {
+        // If ignore marker present, perform fragment-based matching on the full snapshot.
+        // The actual results might contain \n, and may not be a normal "row", which is not suitable to normalize.
+        let expected_results = expected;
+        let actual_rows = actual
+            .iter()
+            .map(|strs| strs.iter().join(" "))
+            .collect_vec();
+
+        let expected_snapshot = expected_results.join("\n");
+        let actual_snapshot = actual_rows.join("\n");
+        let fragments: Vec<&str> = expected_snapshot.split(IGNORE_MARKER).collect();
+        let mut pos = 0;
+        for frag in fragments {
+            if frag.is_empty() {
+                continue;
+            }
+            if let Some(idx) = actual_snapshot[pos..].find(frag) {
+                pos += idx + frag.len();
+            } else {
+                tracing::error!(
+                    "mismatch at: {}\nexpected: {}\nactual: {}",
+                    pos,
+                    frag,
+                    &actual_snapshot[pos..]
+                );
+                return false;
+            }
+        }
+        return true;
+    }
+
+    let expected_results = expected.iter().map(normalizer).collect_vec();
+    // Default, we compare normalized results. Whitespace characters are ignored.
+    let normalized_rows = actual
+        .iter()
+        .map(|strs| strs.iter().map(normalizer).join(" "))
+        .collect_vec();
+
+    normalized_rows == expected_results
+}
+
+/// [`Runner`] uses this validator to check that the expected column types match an actual output.
+///
+/// # Default
+///
+/// By default ([`default_column_validator`]), columns are not validated.
+pub type ColumnTypeValidator<T> = fn(actual: &Vec<T>, expected: &Vec<T>) -> bool;
+
+/// The default validator always returns success for any inputs of expected and actual sets of
+/// columns.
+pub fn default_column_validator<T: ColumnType>(_: &Vec<T>, _: &Vec<T>) -> bool {
+    true
+}
+
+/// The strict validator checks:
+/// - the number of columns is as expected
+/// - each column has the same type as expected
+#[allow(clippy::ptr_arg)]
+pub fn strict_column_validator<T: ColumnType>(actual: &Vec<T>, expected: &Vec<T>) -> bool {
+    actual.len() == expected.len()
+        && !actual
+            .iter()
+            .zip(expected.iter())
+            .any(|(actual_column, expected_column)| actual_column != expected_column)
+}
+
+/// Decide whether a test file should be run. Useful for partitioning tests into multiple
+/// parallel machines to speed up test runs.
+pub trait Partitioner: Send + Sync + 'static {
+    /// Returns true if the given file name matches the partition and should be run.
+    fn matches(&self, file_name: &str) -> bool;
+}
+
+impl<F> Partitioner for F
+where
+    F: Fn(&str) -> bool + Send + Sync + 'static,
+{
+    fn matches(&self, file_name: &str) -> bool {
+        self(file_name)
+    }
+}
+
+/// The default partitioner matches all files.
+pub fn default_partitioner(_file_name: &str) -> bool {
+    true
+}
+
+#[derive(Default)]
+pub(crate) struct RunnerLocals {
+    /// The temporary directory. Test cases can use `__TEST_DIR__` to refer to this directory.
+    /// Lazily initialized and cleaned up when dropped.
+    test_dir: OnceLock<TempDir>,
+    /// Runtime variables for substitution.
+    variables: BTreeMap<String, String>,
+}
+
+impl RunnerLocals {
+    pub fn test_dir(&self) -> String {
+        let test_dir = self
+            .test_dir
+            .get_or_init(|| TempDir::new().expect("failed to create testdir"));
+        test_dir.path().to_string_lossy().into_owned()
+    }
+
+    fn set_var(&mut self, key: String, value: String) {
+        self.variables.insert(key, value);
+    }
+
+    pub fn get_var(&self, key: &str) -> Option<&String> {
+        self.variables.get(key)
+    }
+
+    pub fn vars(&self) -> &BTreeMap<String, String> {
+        &self.variables
+    }
+}
+
+/// Sqllogictest runner.
+pub struct Runner<D: AsyncDB, M: MakeConnection<Conn = D>> {
+    conn: Connections<D, M>,
+    // validator is used for validate if the result of query equals to expected.
+    validator: Validator,
+    // normalizer is used to normalize the result text
+    normalizer: Normalizer,
+    column_type_validator: ColumnTypeValidator<D::ColumnType>,
+    partitioner: Arc<dyn Partitioner>,
+    substitution_on: bool,
+    sort_mode: Option<SortMode>,
+    result_mode: Option<ResultMode>,
+    /// 0 means never hashing
+    hash_threshold: usize,
+    /// Labels for condition `skipif` and `onlyif`.
+    labels: HashSet<String>,
+    /// Local variables/context for the runner.
+    locals: RunnerLocals,
+}
+
+impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
+    /// Create a new test runner on the database, with the given connection maker.
+    ///
+    /// See [`MakeConnection`] for more details.
+    pub fn new(make_conn: M) -> Self {
+        Runner {
+            validator: default_validator,
+            normalizer: default_normalizer,
+            column_type_validator: default_column_validator,
+            partitioner: Arc::new(default_partitioner),
+            substitution_on: false,
+            sort_mode: None,
+            result_mode: None,
+            hash_threshold: 0,
+            labels: HashSet::new(),
+            conn: Connections::new(make_conn),
+            locals: RunnerLocals::default(),
+        }
+    }
+
+    /// Add a label for condition `skipif` and `onlyif`.
+    pub fn add_label(&mut self, label: &str) {
+        self.labels.insert(label.to_string());
+    }
+
+    /// Set a local variable for substitution.
+    pub fn set_var(&mut self, key: String, value: String) {
+        self.locals.set_var(key, value);
+    }
+
+    pub fn with_normalizer(&mut self, normalizer: Normalizer) {
+        self.normalizer = normalizer;
+    }
+    pub fn with_validator(&mut self, validator: Validator) {
+        self.validator = validator;
+    }
+
+    pub fn with_column_validator(&mut self, validator: ColumnTypeValidator<D::ColumnType>) {
+        self.column_type_validator = validator;
+    }
+
+    /// Set the partitioner for the runner. Only files that match the partitioner will be run.
+    ///
+    /// This only takes effect when running tests in parallel.
+    pub fn with_partitioner(&mut self, partitioner: impl Partitioner + 'static) {
+        self.partitioner = Arc::new(partitioner);
+    }
+
+    pub fn with_hash_threshold(&mut self, hash_threshold: usize) {
+        self.hash_threshold = hash_threshold;
+    }
+
+    pub async fn apply_record(
+        &mut self,
+        record: Record<D::ColumnType>,
+    ) -> RecordOutput<D::ColumnType> {
+        tracing::debug!(?record, "testing");
+        /// Returns whether we should skip this record, according to given `conditions`.
+        fn should_skip(
+            labels: &HashSet<String>,
+            engine_name: &str,
+            conditions: &[Condition],
+        ) -> bool {
+            conditions.iter().any(|c| {
+                c.should_skip(
+                    labels
+                        .iter()
+                        .map(|l| l.as_str())
+                        // attach the engine name to the labels
+                        .chain(Some(engine_name).filter(|n| !n.is_empty())),
+                )
+            })
+        }
+
+        match record {
+            Record::Statement {
+                conditions,
+                connection,
+                sql,
+
+                // compare result in run_async
+                expected: _,
+                loc: _,
+                retry: _,
+            } => {
+                let sql = match self.may_substitute(sql, true) {
+                    Ok(sql) => sql,
+                    Err(error) => {
+                        return RecordOutput::Statement {
+                            count: 0,
+                            error: Some(error),
+                        }
+                    }
+                };
+
+                let conn = match self.conn.get(connection).await {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        return RecordOutput::Statement {
+                            count: 0,
+                            error: Some(Arc::new(e)),
+                        }
+                    }
+                };
+                if should_skip(&self.labels, conn.engine_name(), &conditions) {
+                    return RecordOutput::Nothing;
+                }
+
+                let ret = conn.run(&sql).await;
+                match ret {
+                    Ok(out) => match out {
+                        DBOutput::Rows { types, rows } => RecordOutput::Query {
+                            types,
+                            rows,
+                            error: None,
+                        },
+                        DBOutput::StatementComplete(count) => {
+                            RecordOutput::Statement { count, error: None }
+                        }
+                    },
+                    Err(e) => RecordOutput::Statement {
+                        count: 0,
+                        error: Some(Arc::new(e)),
+                    },
+                }
+            }
+            Record::System {
+                conditions,
+                command,
+                loc: _,
+                stdout: expected_stdout,
+                retry: _,
+            } => {
+                if should_skip(&self.labels, "", &conditions) {
+                    return RecordOutput::Nothing;
+                }
+
+                let mut command = match self.may_substitute(command, false) {
+                    Ok(command) => command,
+                    Err(error) => {
+                        return RecordOutput::System {
+                            stdout: None,
+                            error: Some(error),
+                        }
+                    }
+                };
+
+                let is_background = command.trim().ends_with('&');
+                if is_background {
+                    command = command.trim_end_matches('&').trim().to_string();
+                }
+
+                let mut cmd = if cfg!(target_os = "windows") {
+                    let mut cmd = std::process::Command::new("cmd");
+                    cmd.arg("/C").arg(&command);
+                    cmd
+                } else {
+                    let mut cmd = std::process::Command::new("bash");
+                    cmd.arg("-c").arg(&command);
+                    cmd
+                };
+
+                if is_background {
+                    // Spawn a new process, but don't wait for stdout, otherwise it will block until
+                    // the process exits.
+                    let error: Option<AnyError> = match cmd.spawn() {
+                        Ok(_) => None,
+                        Err(e) => Some(Arc::new(e)),
+                    };
+                    tracing::info!(target:"sqllogictest::system_command", command, "background system command spawned");
+                    return RecordOutput::System {
+                        error,
+                        stdout: None,
+                    };
+                }
+
+                cmd.stdout(std::process::Stdio::piped());
+                cmd.stderr(std::process::Stdio::piped());
+
+                let result = D::run_command(cmd).await;
+                #[derive(thiserror::Error, Debug)]
+                #[error(
+                    "process exited unsuccessfully: {status}\nstdout: {stdout}\nstderr: {stderr}"
+                )]
+                struct SystemError {
+                    status: ExitStatus,
+                    stdout: String,
+                    stderr: String,
+                }
+
+                let mut actual_stdout = None;
+                let error: Option<AnyError> = match result {
+                    Ok(Output {
+                        status,
+                        stdout,
+                        stderr,
+                    }) => {
+                        let stdout = String::from_utf8_lossy(&stdout).to_string();
+                        let stderr = String::from_utf8_lossy(&stderr).to_string();
+                        tracing::info!(target:"sqllogictest::system_command", command, ?status, stdout, stderr, "system command executed");
+                        if status.success() {
+                            if expected_stdout.is_some() {
+                                actual_stdout = Some(stdout);
+                            }
+                            None
+                        } else {
+                            Some(Arc::new(SystemError {
+                                status,
+                                stdout,
+                                stderr,
+                            }))
+                        }
+                    }
+                    Err(error) => {
+                        tracing::error!(target:"sqllogictest::system_command", command, ?error, "failed to run system command");
+                        Some(Arc::new(error))
+                    }
+                };
+
+                RecordOutput::System {
+                    error,
+                    stdout: actual_stdout,
+                }
+            }
+            Record::Query {
+                conditions,
+                connection,
+                sql,
+
+                // compare result in run_async
+                expected,
+                loc: _,
+                retry: _,
+            } => {
+                let sql = match self.may_substitute(sql, true) {
+                    Ok(sql) => sql,
+                    Err(error) => {
+                        return RecordOutput::Query {
+                            error: Some(error),
+                            types: vec![],
+                            rows: vec![],
+                        }
+                    }
+                };
+
+                let conn = match self.conn.get(connection).await {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        return RecordOutput::Query {
+                            error: Some(Arc::new(e)),
+                            types: vec![],
+                            rows: vec![],
+                        }
+                    }
+                };
+                if should_skip(&self.labels, conn.engine_name(), &conditions) {
+                    return RecordOutput::Nothing;
+                }
+
+                let (types, mut rows) = match conn.run(&sql).await {
+                    Ok(out) => match out {
+                        DBOutput::Rows { types, rows } => (types, rows),
+                        DBOutput::StatementComplete(count) => {
+                            return RecordOutput::Statement { count, error: None };
+                        }
+                    },
+                    Err(e) => {
+                        return RecordOutput::Query {
+                            error: Some(Arc::new(e)),
+                            types: vec![],
+                            rows: vec![],
+                        };
+                    }
+                };
+
+                let sort_mode = match expected {
+                    QueryExpect::Results { sort_mode, .. } => sort_mode,
+                    QueryExpect::Error(_) => None,
+                }
+                .or(self.sort_mode);
+
+                let mut value_sort = false;
+                match sort_mode {
+                    None | Some(SortMode::NoSort) => {}
+                    Some(SortMode::RowSort) => {
+                        rows.sort_unstable();
+                    }
+                    Some(SortMode::ValueSort) => {
+                        rows = rows
+                            .iter()
+                            .flat_map(|row| row.iter())
+                            .map(|s| vec![s.to_owned()])
+                            .collect();
+                        rows.sort_unstable();
+                        value_sort = true;
+                    }
+                };
+
+                let num_values = if value_sort {
+                    rows.len()
+                } else {
+                    rows.len() * types.len()
+                };
+
+                if self.hash_threshold > 0 && num_values > self.hash_threshold {
+                    let mut md5 = md5::Md5::new();
+                    for line in &rows {
+                        for value in line {
+                            md5.update(value.as_bytes());
+                            md5.update(b"\n");
+                        }
+                    }
+                    let hash = format!("{:2x}", md5.finalize());
+                    rows = vec![vec![format!(
+                        "{} values hashing to {}",
+                        rows.len() * rows[0].len(),
+                        hash
+                    )]];
+                }
+
+                RecordOutput::Query {
+                    error: None,
+                    types,
+                    rows,
+                }
+            }
+            Record::Sleep { duration, .. } => {
+                D::sleep(duration).await;
+                RecordOutput::Nothing
+            }
+            Record::Control(control) => {
+                match control {
+                    Control::SortMode(sort_mode) => {
+                        self.sort_mode = Some(sort_mode);
+                    }
+                    Control::ResultMode(result_mode) => {
+                        self.result_mode = Some(result_mode);
+                    }
+                    Control::Substitution(on_off) => self.substitution_on = on_off,
+                }
+
+                RecordOutput::Nothing
+            }
+            Record::HashThreshold { loc: _, threshold } => {
+                self.hash_threshold = threshold as usize;
+                RecordOutput::Nothing
+            }
+            Record::Halt { loc: _ } => {
+                tracing::error!("halt record encountered. It's likely a bug of the runtime.");
+                RecordOutput::Nothing
+            }
+            Record::Include { .. }
+            | Record::Newline
+            | Record::Comment(_)
+            | Record::Subtest { .. }
+            | Record::Injected(_)
+            | Record::Condition(_)
+            | Record::Connection(_) => RecordOutput::Nothing,
+        }
+    }
+
+    /// Run a single record.
+    pub async fn run_async(
+        &mut self,
+        record: Record<D::ColumnType>,
+    ) -> Result<RecordOutput<D::ColumnType>, TestError> {
+        let retry = match &record {
+            Record::Statement { retry, .. } => retry.clone(),
+            Record::Query { retry, .. } => retry.clone(),
+            Record::System { retry, .. } => retry.clone(),
+            _ => None,
+        };
+        if retry.is_none() {
+            return self.run_async_no_retry(record).await;
+        }
+
+        // Retry for `retry.attempts` times. The parser ensures that `retry.attempts` must > 0.
+        let retry = retry.unwrap();
+        let mut last_error = None;
+        for _ in 0..retry.attempts {
+            let result = self.run_async_no_retry(record.clone()).await;
+            if result.is_ok() {
+                return result;
+            }
+            tracing::warn!(target:"sqllogictest::retry", backoff = ?retry.backoff, error = ?result, "retrying");
+            D::sleep(retry.backoff).await;
+            last_error = result.err();
+        }
+
+        Err(last_error.unwrap())
+    }
+
+    /// Run a single record without retry.
+    async fn run_async_no_retry(
+        &mut self,
+        record: Record<D::ColumnType>,
+    ) -> Result<RecordOutput<D::ColumnType>, TestError> {
+        let result = self.apply_record(record.clone()).await;
+
+        match (record, &result) {
+            (_, RecordOutput::Nothing) => {}
+            // Tolerate the mismatched return type...
+            (
+                Record::Statement {
+                    sql, expected, loc, ..
+                },
+                RecordOutput::Query {
+                    error: None, rows, ..
+                },
+            ) => {
+                if let StatementExpect::Error(_) = expected {
+                    return Err(TestErrorKind::Ok {
+                        sql,
+                        kind: RecordKind::Query,
+                    }
+                    .at(loc));
+                }
+                if let StatementExpect::Count(expected_count) = expected {
+                    if expected_count != rows.len() as u64 {
+                        return Err(TestErrorKind::StatementResultMismatch {
+                            sql,
+                            expected: expected_count,
+                            actual: format!("returned {} rows", rows.len()),
+                        }
+                        .at(loc));
+                    }
+                }
+            }
+            (
+                Record::Query {
+                    loc, sql, expected, ..
+                },
+                RecordOutput::Statement { error: None, .. },
+            ) => match expected {
+                QueryExpect::Error(_) => {
+                    return Err(TestErrorKind::Ok {
+                        sql,
+                        kind: RecordKind::Query,
+                    }
+                    .at(loc))
+                }
+                QueryExpect::Results { results, .. } if !results.is_empty() => {
+                    return Err(TestErrorKind::QueryResultMismatch {
+                        sql,
+                        expected: results.join("\n"),
+                        actual: "".to_string(),
+                    }
+                    .at(loc))
+                }
+                QueryExpect::Results { .. } => {}
+            },
+            (
+                Record::Statement {
+                    loc,
+                    connection: _,
+                    conditions: _,
+                    sql,
+                    expected,
+                    retry: _,
+                },
+                RecordOutput::Statement { count, error },
+            ) => match (error, expected) {
+                (None, StatementExpect::Error(_)) => {
+                    return Err(TestErrorKind::Ok {
+                        sql,
+                        kind: RecordKind::Statement,
+                    }
+                    .at(loc))
+                }
+                (None, StatementExpect::Count(expected_count)) => {
+                    if expected_count != *count {
+                        return Err(TestErrorKind::StatementResultMismatch {
+                            sql,
+                            expected: expected_count,
+                            actual: format!("affected {count} rows"),
+                        }
+                        .at(loc));
+                    }
+                }
+                (None, StatementExpect::Ok) => {}
+                (Some(e), StatementExpect::Error(expected_error)) => {
+                    if !expected_error.is_match(&e.to_string()) {
+                        return Err(TestErrorKind::ErrorMismatch {
+                            sql,
+                            err: Arc::clone(e),
+                            expected_err: expected_error.to_string(),
+                            kind: RecordKind::Statement,
+                        }
+                        .at(loc));
+                    }
+                }
+                (Some(e), StatementExpect::Count(_) | StatementExpect::Ok) => {
+                    return Err(TestErrorKind::Fail {
+                        sql,
+                        err: Arc::clone(e),
+                        kind: RecordKind::Statement,
+                    }
+                    .at(loc));
+                }
+            },
+            (
+                Record::Query {
+                    loc,
+                    conditions: _,
+                    connection: _,
+                    sql,
+                    expected,
+                    retry: _,
+                },
+                RecordOutput::Query { types, rows, error },
+            ) => {
+                match (error, expected) {
+                    (None, QueryExpect::Error(_)) => {
+                        return Err(TestErrorKind::Ok {
+                            sql,
+                            kind: RecordKind::Query,
+                        }
+                        .at(loc));
+                    }
+                    (Some(e), QueryExpect::Error(expected_error)) => {
+                        if !expected_error.is_match(&e.to_string()) {
+                            return Err(TestErrorKind::ErrorMismatch {
+                                sql,
+                                err: Arc::clone(e),
+                                expected_err: expected_error.to_string(),
+                                kind: RecordKind::Query,
+                            }
+                            .at(loc));
+                        }
+                    }
+                    (Some(e), QueryExpect::Results { .. }) => {
+                        return Err(TestErrorKind::Fail {
+                            sql,
+                            err: Arc::clone(e),
+                            kind: RecordKind::Query,
+                        }
+                        .at(loc));
+                    }
+                    (
+                        None,
+                        QueryExpect::Results {
+                            types: expected_types,
+                            results: expected_results,
+                            ..
+                        },
+                    ) => {
+                        if !(self.column_type_validator)(types, &expected_types) {
+                            return Err(TestErrorKind::QueryResultColumnsMismatch {
+                                sql,
+                                expected: expected_types.iter().map(|c| c.to_char()).join(""),
+                                actual: types.iter().map(|c| c.to_char()).join(""),
+                            }
+                            .at(loc));
+                        }
+
+                        let actual_results = match self.result_mode {
+                            Some(ResultMode::ValueWise) => rows
+                                .iter()
+                                .flat_map(|strs| strs.iter())
+                                .map(|str| vec![str.to_string()])
+                                .collect_vec(),
+                            // default to rowwise
+                            _ => rows.clone(),
+                        };
+
+                        if !(self.validator)(self.normalizer, &actual_results, &expected_results) {
+                            let output_rows =
+                                rows.iter().map(|strs| strs.iter().join(" ")).collect_vec();
+                            return Err(TestErrorKind::QueryResultMismatch {
+                                sql,
+                                expected: expected_results.join("\n"),
+                                actual: output_rows.join("\n"),
+                            }
+                            .at(loc));
+                        }
+                    }
+                };
+            }
+            (
+                Record::System {
+                    loc,
+                    conditions: _,
+                    command,
+                    stdout: expected_stdout,
+                    retry: _,
+                },
+                RecordOutput::System {
+                    error,
+                    stdout: actual_stdout,
+                },
+            ) => {
+                if let Some(err) = error {
+                    return Err(TestErrorKind::SystemFail {
+                        command,
+                        err: Arc::clone(err),
+                    }
+                    .at(loc));
+                }
+                match (expected_stdout, actual_stdout) {
+                    (None, _) => {}
+                    (Some(expected_stdout), actual_stdout) => {
+                        let actual_stdout = actual_stdout.clone().unwrap_or_default();
+                        // TODO: support newlines contained in expected_stdout
+                        if expected_stdout != actual_stdout.trim() {
+                            return Err(TestErrorKind::SystemStdoutMismatch {
+                                command,
+                                expected_stdout,
+                                actual_stdout,
+                            }
+                            .at(loc));
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        Ok(result)
+    }
+
+    /// Run a single record.
+    ///
+    /// Returns the output of the record if successful.
+    pub fn run(
+        &mut self,
+        record: Record<D::ColumnType>,
+    ) -> Result<RecordOutput<D::ColumnType>, TestError> {
+        futures::executor::block_on(self.run_async(record))
+    }
+
+    /// Run multiple records.
+    ///
+    /// The runner will stop early once a halt record is seen.
+    ///
+    /// To acquire the result of each record, manually call `run_async` for each record instead.
+    pub async fn run_multi_async(
+        &mut self,
+        records: impl IntoIterator<Item = Record<D::ColumnType>>,
+    ) -> Result<(), TestError> {
+        for record in records.into_iter() {
+            if let Record::Halt { .. } = record {
+                break;
+            }
+            self.run_async(record).await?;
+        }
+        Ok(())
+    }
+
+    /// Run multiple records.
+    ///
+    /// The runner will stop early once a halt record is seen.
+    ///
+    /// To acquire the result of each record, manually call `run` for each record instead.
+    pub fn run_multi(
+        &mut self,
+        records: impl IntoIterator<Item = Record<D::ColumnType>>,
+    ) -> Result<(), TestError> {
+        block_on(self.run_multi_async(records))
+    }
+
+    /// Run a sqllogictest script.
+    pub async fn run_script_async(&mut self, script: &str) -> Result<(), TestError> {
+        let records = parse(script).expect("failed to parse sqllogictest");
+        self.run_multi_async(records).await
+    }
+
+    /// Run a sqllogictest script with a given script name.
+    pub async fn run_script_with_name_async(
+        &mut self,
+        script: &str,
+        name: impl Into<Arc<str>>,
+    ) -> Result<(), TestError> {
+        let records = parse_with_name(script, name).expect("failed to parse sqllogictest");
+        self.run_multi_async(records).await
+    }
+
+    /// Run a sqllogictest file.
+    pub async fn run_file_async(&mut self, filename: impl AsRef<Path>) -> Result<(), TestError> {
+        let records = parse_file(filename)?;
+        self.run_multi_async(records).await
+    }
+
+    /// Run a sqllogictest script.
+    pub fn run_script(&mut self, script: &str) -> Result<(), TestError> {
+        block_on(self.run_script_async(script))
+    }
+
+    /// Run a sqllogictest script with a given script name.
+    pub fn run_script_with_name(
+        &mut self,
+        script: &str,
+        name: impl Into<Arc<str>>,
+    ) -> Result<(), TestError> {
+        block_on(self.run_script_with_name_async(script, name))
+    }
+
+    /// Run a sqllogictest file.
+    pub fn run_file(&mut self, filename: impl AsRef<Path>) -> Result<(), TestError> {
+        block_on(self.run_file_async(filename))
+    }
+
+    /// accept the tasks, spawn jobs task to run slt test. the tasks are (AsyncDB, slt filename)
+    /// pairs.
+    // TODO: This is not a good interface, as the `make_conn` passed to `new` is unused but we
+    // accept a new `conn_builder` here. May change `MakeConnection` to support specifying the
+    // database name in the future.
+    pub async fn run_parallel_async<Fut>(
+        &mut self,
+        glob: &str,
+        hosts: Vec<String>,
+        conn_builder: fn(String, String) -> Fut,
+        jobs: usize,
+    ) -> Result<(), ParallelTestError>
+    where
+        Fut: Future<Output = D>,
+    {
+        let files = glob::glob(glob).expect("failed to read glob pattern");
+        let mut tasks = vec![];
+
+        for (idx, file) in files.enumerate() {
+            // for every slt file, we create a database against table conflict
+            let file = file.unwrap();
+            let filename = file.to_str().expect("not a UTF-8 filename");
+
+            // Skip files that don't match the partitioner.
+            if !self.partitioner.matches(filename) {
+                continue;
+            }
+
+            let db_name = filename.replace([' ', '.', '-', '/'], "_");
+
+            self.conn
+                .run_default(&format!("CREATE DATABASE {db_name};"))
+                .await
+                .expect("create db failed");
+            let target = hosts[idx % hosts.len()].clone();
+
+            let mut locals = RunnerLocals::default();
+            locals.set_var("__DATABASE__".to_owned(), db_name.clone());
+
+            let mut tester = Runner {
+                conn: Connections::new(move || {
+                    conn_builder(target.clone(), db_name.clone()).map(Ok)
+                }),
+                validator: self.validator,
+                normalizer: self.normalizer,
+                column_type_validator: self.column_type_validator,
+                partitioner: self.partitioner.clone(),
+                substitution_on: self.substitution_on,
+                sort_mode: self.sort_mode,
+                result_mode: self.result_mode,
+                hash_threshold: self.hash_threshold,
+                labels: self.labels.clone(),
+                locals,
+            };
+
+            tasks.push(async move {
+                let filename = file.to_string_lossy().to_string();
+                tester.run_file_async(filename).await
+            })
+        }
+
+        let tasks = stream::iter(tasks).buffer_unordered(jobs);
+        let errors: Vec<_> = tasks
+            .filter_map(|result| async { result.err() })
+            .collect()
+            .await;
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(ParallelTestError { errors })
+        }
+    }
+
+    /// sync version of `run_parallel_async`
+    pub fn run_parallel<Fut>(
+        &mut self,
+        glob: &str,
+        hosts: Vec<String>,
+        conn_builder: fn(String, String) -> Fut,
+        jobs: usize,
+    ) -> Result<(), ParallelTestError>
+    where
+        Fut: Future<Output = D>,
+    {
+        block_on(self.run_parallel_async(glob, hosts, conn_builder, jobs))
+    }
+
+    /// Substitute the input SQL or command with [`Substitution`], if enabled by `control
+    /// substitution`.
+    ///
+    /// If `subst_env_vars`, we will use the `subst` crate to support extensive substitutions, incl.
+    /// `$NAME`, `${NAME}`, `${NAME:default}`. The cost is that we will have to use escape
+    /// characters, e.g., `\$` & `\\`.
+    ///
+    /// Otherwise, we just do simple string substitution for `__TEST_DIR__` and `__NOW__`.
+    /// This is useful for `system` commands: The shell can do the environment variables, and we can
+    /// write strings like `\n` without escaping.
+    fn may_substitute(&self, input: String, subst_env_vars: bool) -> Result<String, AnyError> {
+        if self.substitution_on {
+            Substitution::new(&self.locals, subst_env_vars)
+                .substitute(&input)
+                .map_err(|e| Arc::new(e) as AnyError)
+        } else {
+            Ok(input)
+        }
+    }
+
+    /// Updates a test file with the output produced by a Database. It is an utility function
+    /// wrapping [`update_test_file_with_runner`].
+    ///
+    /// Specifically, it will create `"{filename}.temp"` to buffer the updated records and then
+    /// override the original file with it.
+    ///
+    /// Some other notes:
+    /// - empty lines at the end of the file are cleaned.
+    /// - `halt` and `include` are correctly handled.
+    pub async fn update_test_file(
+        &mut self,
+        filename: impl AsRef<Path>,
+        col_separator: &str,
+        validator: Validator,
+        normalizer: Normalizer,
+        column_type_validator: ColumnTypeValidator<D::ColumnType>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use std::io::{Read, Seek, SeekFrom, Write};
+        use std::path::PathBuf;
+
+        use fs_err::{File, OpenOptions};
+
+        fn create_outfile(filename: impl AsRef<Path>) -> std::io::Result<(PathBuf, File)> {
+            let filename = filename.as_ref();
+            let outfilename = format!(
+                "{}{:010}{}",
+                filename.file_name().unwrap().to_str().unwrap().to_owned(),
+                rand::thread_rng().gen_range(0..10_000_000),
+                ".temp"
+            );
+            let outfilename = filename.parent().unwrap().join(outfilename);
+            // create a temp file in read-write mode
+            let outfile = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .read(true)
+                .open(&outfilename)?;
+            Ok((outfilename, outfile))
+        }
+
+        fn override_with_outfile(
+            filename: &String,
+            outfilename: &PathBuf,
+            outfile: &mut File,
+        ) -> std::io::Result<()> {
+            // check whether outfile ends with multiple newlines, which happens if
+            // - the last record is statement/query
+            // - the original file ends with multiple newlines
+
+            const N: usize = 8;
+            let mut buf = [0u8; N];
+            loop {
+                outfile.seek(SeekFrom::End(-(N as i64))).unwrap();
+                outfile.read_exact(&mut buf).unwrap();
+                let num_newlines = buf.iter().rev().take_while(|&&b| b == b'\n').count();
+                assert!(num_newlines > 0);
+
+                if num_newlines > 1 {
+                    // if so, remove the last ones
+                    outfile
+                        .set_len(outfile.metadata().unwrap().len() - num_newlines as u64 + 1)
+                        .unwrap();
+                }
+
+                if num_newlines == 1 || num_newlines < N {
+                    break;
+                }
+            }
+
+            outfile.flush()?;
+            fs_err::rename(outfilename, filename)?;
+
+            Ok(())
+        }
+
+        struct Item {
+            filename: String,
+            outfilename: PathBuf,
+            outfile: File,
+            halt: bool,
+        }
+
+        let filename = filename.as_ref();
+        let records = parse_file(filename)?;
+
+        let (outfilename, outfile) = create_outfile(filename)?;
+        let mut stack = vec![Item {
+            filename: filename.to_string_lossy().to_string(),
+            outfilename,
+            outfile,
+            halt: false,
+        }];
+
+        for record in records {
+            let Item {
+                filename,
+                outfilename,
+                outfile,
+                halt,
+            } = stack.last_mut().unwrap();
+
+            match &record {
+                Record::Injected(Injected::BeginInclude(filename)) => {
+                    let (outfilename, outfile) = create_outfile(filename)?;
+                    stack.push(Item {
+                        filename: filename.clone(),
+                        outfilename,
+                        outfile,
+                        halt: false,
+                    });
+                }
+                Record::Injected(Injected::EndInclude(_)) => {
+                    override_with_outfile(filename, outfilename, outfile)?;
+                    stack.pop();
+                }
+                _ => {
+                    if *halt {
+                        writeln!(outfile, "{record}")?;
+                        continue;
+                    }
+                    if matches!(record, Record::Halt { .. }) {
+                        *halt = true;
+                        writeln!(outfile, "{record}")?;
+                        tracing::info!(
+                            "halt record found, all following records will be written AS IS"
+                        );
+                        continue;
+                    }
+                    let record_output = self.apply_record(record.clone()).await;
+                    let record = update_record_with_output(
+                        &record,
+                        &record_output,
+                        col_separator,
+                        validator,
+                        normalizer,
+                        column_type_validator,
+                    )
+                    .unwrap_or(record);
+                    writeln!(outfile, "{record}")?;
+                }
+            }
+        }
+
+        let Item {
+            filename,
+            outfilename,
+            outfile,
+            halt: _,
+        } = stack.last_mut().unwrap();
+        override_with_outfile(filename, outfilename, outfile)?;
+
+        Ok(())
+    }
+}
+
+impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
+    /// Shutdown all connections in the runner.
+    pub async fn shutdown_async(&mut self) {
+        tracing::debug!("shutting down runner...");
+        self.conn.shutdown_all().await;
+    }
+
+    /// Shutdown all connections in the runner.
+    pub fn shutdown(&mut self) {
+        block_on(self.shutdown_async());
+    }
+}
+
+/// Updates the specified [`Record`] with the [`QueryOutput`] produced
+/// by a Database, returning `Some(new_record)`.
+///
+/// If an update is not supported or not necessary, returns `None`
+pub fn update_record_with_output<T: ColumnType>(
+    record: &Record<T>,
+    record_output: &RecordOutput<T>,
+    col_separator: &str,
+    validator: Validator,
+    normalizer: Normalizer,
+    column_type_validator: ColumnTypeValidator<T>,
+) -> Option<Record<T>> {
+    match (record.clone(), record_output) {
+        (_, RecordOutput::Nothing) => None,
+        // statement, query
+        (
+            Record::Statement {
+                sql,
+                loc,
+                conditions,
+                connection,
+                expected: mut expected @ (StatementExpect::Ok | StatementExpect::Count(_)),
+                retry,
+            },
+            RecordOutput::Query {
+                error: None, rows, ..
+            },
+        ) => {
+            // statement ok
+            // SELECT ...
+            //
+            // This case can be used when we want to only ensure the query succeeds,
+            // but don't care about the output.
+            // DuckDB has a few of these.
+
+            if let StatementExpect::Count(expected_count) = &mut expected {
+                *expected_count = rows.len() as u64;
+            }
+
+            Some(Record::Statement {
+                sql,
+                loc,
+                conditions,
+                connection,
+                expected,
+                retry,
+            })
+        }
+        // query, statement
+        (
+            Record::Query {
+                sql,
+                loc,
+                conditions,
+                connection,
+                expected: _,
+                retry,
+            },
+            RecordOutput::Statement { error: None, count },
+        ) => Some(Record::Statement {
+            sql,
+            loc,
+            conditions,
+            connection,
+            expected: StatementExpect::Count(*count),
+            retry,
+        }),
+        // statement, statement
+        (
+            Record::Statement {
+                loc,
+                conditions,
+                connection,
+                sql,
+                expected,
+                retry,
+            },
+            RecordOutput::Statement { count, error },
+        ) => match (error, expected) {
+            // Ok
+            (None, expected) => Some(Record::Statement {
+                sql,
+                loc,
+                conditions,
+                connection,
+                expected: match expected {
+                    StatementExpect::Count(_) => StatementExpect::Count(*count),
+                    StatementExpect::Error(_) | StatementExpect::Ok => StatementExpect::Ok,
+                },
+                retry,
+            }),
+            // Error match
+            (Some(e), StatementExpect::Error(expected_error))
+                if expected_error.is_match(&e.to_string()) =>
+            {
+                None
+            }
+            // Error mismatch, update expected error
+            (Some(e), r) => {
+                let reference = match &r {
+                    StatementExpect::Error(e) => Some(e),
+                    StatementExpect::Count(_) | StatementExpect::Ok => None,
+                };
+                Some(Record::Statement {
+                    sql,
+                    expected: StatementExpect::Error(ExpectedError::from_actual_error(
+                        reference,
+                        &e.to_string(),
+                    )),
+                    loc,
+                    conditions,
+                    connection,
+                    retry,
+                })
+            }
+        },
+        // query, query
+        (
+            Record::Query {
+                loc,
+                conditions,
+                connection,
+                sql,
+                expected,
+                retry,
+            },
+            RecordOutput::Query { types, rows, error },
+        ) => match (error, expected) {
+            // Error match
+            (Some(e), QueryExpect::Error(expected_error))
+                if expected_error.is_match(&e.to_string()) =>
+            {
+                None
+            }
+            // Error mismatch
+            (Some(e), r) => {
+                let reference = match &r {
+                    QueryExpect::Error(e) => Some(e),
+                    QueryExpect::Results { .. } => None,
+                };
+                Some(Record::Query {
+                    sql,
+                    expected: QueryExpect::Error(ExpectedError::from_actual_error(
+                        reference,
+                        &e.to_string(),
+                    )),
+                    loc,
+                    conditions,
+                    connection,
+                    retry,
+                })
+            }
+            (None, expected) => {
+                let results = match &expected {
+                    // If validation is successful, we respect the original file's expected results.
+                    QueryExpect::Results {
+                        results: expected_results,
+                        ..
+                    } if validator(normalizer, rows, expected_results) => expected_results.clone(),
+                    _ => rows.iter().map(|cols| cols.join(col_separator)).collect(),
+                };
+                let types = match &expected {
+                    // If validation is successful, we respect the original file's expected types.
+                    QueryExpect::Results {
+                        types: expected_types,
+                        ..
+                    } if column_type_validator(types, expected_types) => expected_types.clone(),
+                    _ => types.clone(),
+                };
+                Some(Record::Query {
+                    sql,
+                    loc,
+                    conditions,
+                    connection,
+                    expected: match expected {
+                        QueryExpect::Results {
+                            sort_mode,
+                            label,
+                            result_mode,
+                            ..
+                        } => QueryExpect::Results {
+                            results,
+                            types,
+                            sort_mode,
+                            result_mode,
+                            label,
+                        },
+                        QueryExpect::Error(_) => QueryExpect::Results {
+                            results,
+                            types,
+                            sort_mode: None,
+                            result_mode: None,
+                            label: None,
+                        },
+                    },
+                    retry,
+                })
+            }
+        },
+        (
+            Record::System {
+                loc,
+                conditions,
+                command,
+                stdout: _,
+                retry,
+            },
+            RecordOutput::System {
+                stdout: actual_stdout,
+                error,
+            },
+        ) => {
+            if let Some(error) = error {
+                tracing::error!(
+                    ?error,
+                    command,
+                    "system command failed while updating the record. It will be unchanged."
+                );
+            }
+            Some(Record::System {
+                loc,
+                conditions,
+                command,
+                stdout: actual_stdout.clone(),
+                retry,
+            })
+        }
+
+        // No update possible, return the original record
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DefaultColumnType;
+
+    #[test]
+    fn test_query_replacement_no_changes() {
+        let record = "query   I?\n\
+                    select * from foo;\n\
+                    ----\n\
+                    3      4";
+        TestCase {
+            // keep the input values
+            input: record,
+
+            // Model a run that produced a 3,4 as output
+            record_output: query_output(
+                &[&["3", "4"]],
+                vec![DefaultColumnType::Integer, DefaultColumnType::Any],
+            ),
+
+            expected: Some(record),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_query_replacement() {
+        TestCase {
+            // input should be ignored
+            input: "query III\n\
+                    select * from foo;\n\
+                    ----\n\
+                    1 2",
+
+            // Model a run that produced a 3,4 as output
+            record_output: query_output(
+                &[&["3", "4"]],
+                vec![DefaultColumnType::Integer, DefaultColumnType::Any],
+            ),
+
+            expected: Some(
+                "query I?\n\
+                 select * from foo;\n\
+                 ----\n\
+                 3 4",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_query_replacement_no_input() {
+        TestCase {
+            // input has no query results
+            input: "query\n\
+                    select * from foo;\n\
+                    ----",
+
+            // Model a run that produced a 3,4 as output
+            record_output: query_output(
+                &[&["3", "4"]],
+                vec![DefaultColumnType::Integer, DefaultColumnType::Any],
+            ),
+
+            expected: Some(
+                "query I?\n\
+                 select * from foo;\n\
+                 ----\n\
+                 3 4",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_query_replacement_no_output() {
+        TestCase {
+            // input has no query results
+            input: "query III\n\
+                    select * from foo;\n\
+                    ----",
+
+            // Model nothing was output
+            record_output: RecordOutput::Nothing,
+
+            // No update
+            expected: None,
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_query_replacement_error() {
+        TestCase {
+            // input has no query results
+            input: "query III\n\
+                    select * from foo;\n\
+                    ----",
+
+            // Model a run that produced a "MyAwesomeDB Error"
+            record_output: query_output_error("MyAwesomeDB Error"),
+
+            expected: Some(
+                "query error TestError: MyAwesomeDB Error\n\
+                 select * from foo;\n",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_query_replacement_error_multiline() {
+        TestCase {
+            // input has no query results
+            input: "query III\n\
+                    select * from foo;\n\
+                    ----",
+
+            // Model a run that produced a "MyAwesomeDB Error"
+            record_output: query_output_error("MyAwesomeDB Error\n\nCaused by:\n  Inner Error"),
+
+            expected: Some(
+                "query error
+select * from foo;
+----
+TestError: MyAwesomeDB Error
+
+Caused by:
+  Inner Error",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_statement_query_output() {
+        TestCase {
+            // input has no query results
+            input: "statement ok\n\
+                    create table foo;",
+
+            // Model a run that produced a 3,4 as output
+            record_output: query_output(
+                &[&["3", "4"]],
+                vec![DefaultColumnType::Integer, DefaultColumnType::Any],
+            ),
+
+            expected: Some(
+                "statement ok\n\
+                 create table foo;",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_query_statement_output() {
+        TestCase {
+            // input has no query results
+            input: "query III\n\
+                    select * from foo;\n\
+                    ----",
+
+            // Model a run that produced a statement output
+            record_output: statement_output(3),
+
+            expected: Some(
+                "statement count 3\n\
+                 select * from foo;",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_statement_output() {
+        TestCase {
+            // statement that has no output
+            input: "statement ok\n\
+                    insert into foo values(2);",
+
+            // Model a run that produced a statement output
+            record_output: statement_output(3),
+
+            // Note the the output does not include 3 (statement
+            // count) Rationale is if the record is statement count
+            // <n>, n will be updated to real count. If the record is
+            // statement ok (which means we don't care the number of
+            // affected rows), it won't be updated.
+            expected: Some(
+                "statement ok\n\
+                 insert into foo values(2);",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_statement_error_to_ok() {
+        TestCase {
+            // statement expected error
+            input: "statement error\n\
+                    insert into foo values(2);",
+
+            // Model a run that produced a statement output
+            record_output: statement_output(3),
+
+            expected: Some(
+                "statement ok\n\
+                 insert into foo values(2);",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_statement_error_no_error() {
+        TestCase {
+            // statement expected error
+            input: "statement error\n\
+                    insert into foo values(2);",
+
+            // Model a run that produced an error message
+            record_output: statement_output_error("foo"),
+
+            // Input didn't have an expected error, so output is not to expect the message, then no
+            // update
+            expected: None,
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_statement_error_new_error() {
+        TestCase {
+            // statement expected error
+            input: "statement error bar\n\
+                    insert into foo values(2);",
+
+            // Model a run that produced an error message
+            record_output: statement_output_error("foo"),
+
+            // expect the output includes foo
+            expected: Some(
+                "statement error TestError: foo\n\
+                 insert into foo values(2);",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_statement_error_new_error_multiline() {
+        TestCase {
+            // statement expected error
+            input: "statement error bar\n\
+                    insert into foo values(2);",
+
+            // Model a run that produced an error message
+            record_output: statement_output_error("foo\n\nCaused by:\n  Inner Error"),
+
+            // expect the output includes foo
+            expected: Some(
+                "statement error
+insert into foo values(2);
+----
+TestError: foo
+
+Caused by:
+  Inner Error",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_statement_error_ok_to_error() {
+        TestCase {
+            // statement was ok
+            input: "statement ok\n\
+                    insert into foo values(2);",
+
+            // Model a run that produced an error message
+            record_output: statement_output_error("foo"),
+
+            // expect the output includes foo
+            expected: Some(
+                "statement error TestError: foo\n\
+                 insert into foo values(2);",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_statement_error_ok_to_error_multiline() {
+        TestCase {
+            // statement was ok
+            input: "statement ok\n\
+                    insert into foo values(2);",
+
+            // Model a run that produced an error message
+            record_output: statement_output_error("foo\n\nCaused by:\n  Inner Error"),
+
+            // expect the output includes foo
+            expected: Some(
+                "statement error
+insert into foo values(2);
+----
+TestError: foo
+
+Caused by:
+  Inner Error",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_statement_error_special_chars() {
+        TestCase {
+            // statement expected error
+            input: "statement error tbd\n\
+                    inser into foo values(2);",
+
+            // Model a run that produced an error message that contains regex special characters
+            record_output: statement_output_error("The operation (inser) is not supported. Did you mean [insert]?"),
+
+            // expect the output includes foo
+            expected: Some(
+                "statement error TestError: The operation \\(inser\\) is not supported\\. Did you mean \\[insert\\]\\?\n\
+                 inser into foo values(2);",
+            ),
+        }
+            .run()
+    }
+
+    #[test]
+    fn test_statement_keep_error_regex_when_matches() {
+        TestCase {
+            // statement expected error
+            input: "statement error TestError: The operation \\([a-z]+\\) is not supported.*\n\
+                    inser into foo values(2);",
+
+            // Model a run that produced an error message that contains regex special characters
+            record_output: statement_output_error(
+                "The operation (inser) is not supported. Did you mean [insert]?",
+            ),
+
+            // no update expected
+            expected: None,
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_query_error_special_chars() {
+        TestCase {
+            // statement expected error
+            input: "query error tbd\n\
+                    selec *;",
+
+            // Model a run that produced an error message that contains regex special characters
+            record_output: query_output_error("The operation (selec) is not supported. Did you mean [select]?"),
+
+            // expect the output includes foo
+            expected: Some(
+                "query error TestError: The operation \\(selec\\) is not supported\\. Did you mean \\[select\\]\\?\n\
+                 selec *;",
+            ),
+        }
+            .run()
+    }
+
+    #[test]
+    fn test_query_error_special_chars_when_matches() {
+        TestCase {
+            // statement expected error
+            input: "query error TestError: The operation \\([a-z]+\\) is not supported.*\n\
+                    selec *;",
+
+            // Model a run that produced an error message that contains regex special characters
+            record_output: query_output_error(
+                "The operation (selec) is not supported. Did you mean [select]?",
+            ),
+
+            // no update expected
+            expected: None,
+        }
+        .run()
+    }
+
+    #[derive(Debug)]
+    struct TestCase<'a> {
+        input: &'a str,
+        record_output: RecordOutput<DefaultColumnType>,
+        expected: Option<&'a str>,
+    }
+
+    impl TestCase<'_> {
+        #[track_caller]
+        fn run(self) {
+            let Self {
+                input,
+                record_output,
+                expected,
+            } = self;
+            println!("TestCase");
+            println!("**input:\n{input}\n");
+            println!("**record_output:\n{record_output:#?}\n");
+            println!("**expected:\n{}\n", expected.unwrap_or(""));
+            let input = parse_to_record(input);
+            let expected = expected.map(parse_to_record);
+            let output = update_record_with_output(
+                &input,
+                &record_output,
+                " ",
+                default_validator,
+                default_normalizer,
+                strict_column_validator,
+            );
+
+            assert_eq!(
+                &output,
+                &expected,
+                "\n\noutput:\n\n{}\n\nexpected:\n\n{}",
+                output
+                    .as_ref()
+                    .map(|r| r.to_string())
+                    .unwrap_or_else(|| "None".into()),
+                expected
+                    .as_ref()
+                    .map(|r| r.to_string())
+                    .unwrap_or_else(|| "None".into()),
+            );
+        }
+    }
+
+    fn parse_to_record(s: &str) -> Record<DefaultColumnType> {
+        let mut records = parse(s).unwrap();
+        assert_eq!(records.len(), 1);
+        records.pop().unwrap()
+    }
+
+    /// Returns a RecordOutput that models the successful execution of a query
+    fn query_output(
+        rows: &[&[&str]],
+        types: Vec<DefaultColumnType>,
+    ) -> RecordOutput<DefaultColumnType> {
+        let rows = rows
+            .iter()
+            .map(|cols| cols.iter().map(|c| c.to_string()).collect::<Vec<_>>())
+            .collect::<Vec<_>>();
+
+        RecordOutput::Query {
+            types,
+            rows,
+            error: None,
+        }
+    }
+
+    /// Returns a RecordOutput that models the error of a query
+    fn query_output_error(error_message: &str) -> RecordOutput<DefaultColumnType> {
+        RecordOutput::Query {
+            types: vec![],
+            rows: vec![],
+            error: Some(Arc::new(TestError(error_message.to_string()))),
+        }
+    }
+
+    fn statement_output(count: u64) -> RecordOutput<DefaultColumnType> {
+        RecordOutput::Statement { count, error: None }
+    }
+
+    /// RecordOutput that models a statement with error
+    fn statement_output_error(error_message: &str) -> RecordOutput<DefaultColumnType> {
+        RecordOutput::Statement {
+            count: 0,
+            error: Some(Arc::new(TestError(error_message.to_string()))),
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestError(String);
+    impl std::error::Error for TestError {}
+    impl std::fmt::Display for TestError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "TestError: {}", self.0)
+        }
+    }
+
+    #[test]
+    fn test_default_validator_ignore_simple() {
+        let normalizer = default_normalizer;
+        let actual = vec![vec!["foo".to_string(), "bar".to_string()]];
+        let expected = vec!["foo<slt:ignore>bar".to_string()];
+        assert!(default_validator(normalizer, &actual, &expected));
+    }
+
+    #[test]
+    fn test_default_validator_ignore_multiple_fragments() {
+        let normalizer = default_normalizer;
+        let actual = vec![vec![
+            "one".to_string(),
+            "two".to_string(),
+            "three".to_string(),
+        ]];
+        let expected = vec!["one<slt:ignore>three".to_string()];
+        assert!(default_validator(normalizer, &actual, &expected));
+    }
+
+    #[test]
+    fn test_default_validator_ignore_fail() {
+        let normalizer = default_normalizer;
+        let actual = vec![vec![
+            "alpha".to_string(),
+            "beta".to_string(),
+            "gamma".to_string(),
+        ]];
+        let expected = vec!["alpha<slt:ignore>delta".to_string()];
+        assert!(!default_validator(normalizer, &actual, &expected));
+    }
+}

--- a/crates/sqllogictest/src/substitution.rs
+++ b/crates/sqllogictest/src/substitution.rs
@@ -1,0 +1,75 @@
+use subst::Env;
+
+use crate::RunnerLocals;
+
+pub mod well_known {
+    pub const TEST_DIR: &str = "__TEST_DIR__";
+    pub const NOW: &str = "__NOW__";
+    pub const DATABASE: &str = "__DATABASE__";
+}
+
+/// Substitute environment variables and special variables like `__TEST_DIR__` in SQL.
+pub(crate) struct Substitution<'a> {
+    runner_locals: &'a RunnerLocals,
+    subst_env_vars: bool,
+}
+
+impl Substitution<'_> {
+    pub fn new(runner_locals: &RunnerLocals, subst_env_vars: bool) -> Substitution<'_> {
+        Substitution {
+            runner_locals,
+            subst_env_vars,
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("substitution failed: {0}")]
+pub(crate) struct SubstError(subst::Error);
+
+fn now_string() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("failed to get current time")
+        .as_nanos()
+        .to_string()
+}
+
+impl Substitution<'_> {
+    pub fn substitute(&self, input: &str) -> Result<String, SubstError> {
+        if self.subst_env_vars {
+            subst::substitute(input, self).map_err(SubstError)
+        } else {
+            Ok(self.simple_replace(input))
+        }
+    }
+
+    fn simple_replace(&self, input: &str) -> String {
+        let mut res = input
+            .replace(
+                &format!("${}", well_known::TEST_DIR),
+                &self.runner_locals.test_dir(),
+            )
+            .replace(&format!("${}", well_known::NOW), &now_string());
+        for (key, value) in self.runner_locals.vars() {
+            res = res.replace(&format!("${}", key), value);
+        }
+        res
+    }
+}
+
+impl<'a> subst::VariableMap<'a> for Substitution<'a> {
+    type Value = String;
+
+    fn get(&'a self, key: &str) -> Option<Self::Value> {
+        match key {
+            well_known::TEST_DIR => self.runner_locals.test_dir().into(),
+            well_known::NOW => now_string().into(),
+            key => self
+                .runner_locals
+                .get_var(key)
+                .cloned()
+                .or_else(|| Env.get(key)),
+        }
+    }
+}

--- a/tests/test_directive_comments.rs
+++ b/tests/test_directive_comments.rs
@@ -1,0 +1,67 @@
+//! Test for issue #1311: Support comments on sqllogictest conditional directives
+
+use sqllogictest::{parse, DefaultColumnType};
+
+#[test]
+fn test_onlyif_with_comment() {
+    let script = r#"onlyif sqlite # empty RHS
+query I
+SELECT 1 IN ()
+----
+0
+"#;
+
+    let records = parse::<DefaultColumnType>(script)
+        .expect("Should parse successfully with comment on onlyif directive");
+
+    println!("Parsed {} records", records.len());
+    assert!(records.len() > 0, "Should have parsed records");
+}
+
+#[test]
+fn test_skipif_with_comment() {
+    let script = r#"skipif mysql # this database doesn't support certain features
+query I
+SELECT 1
+----
+1
+"#;
+
+    let records = parse::<DefaultColumnType>(script)
+        .expect("Should parse skipif with comment");
+
+    assert!(records.len() > 0, "Should have parsed records");
+}
+
+#[test]
+fn test_multiple_directives_with_comments() {
+    let script = r#"onlyif sqlite # test for sqlite only
+
+skipif mysql # skip this on mysql
+
+query I
+SELECT 1
+----
+1
+"#;
+
+    let records = parse::<DefaultColumnType>(script)
+        .expect("Should parse multiple directives with comments");
+
+    assert!(records.len() > 0, "Should have parsed records");
+}
+
+#[test]
+fn test_directive_without_comment_still_works() {
+    let script = r#"onlyif sqlite
+query I
+SELECT 1
+----
+1
+"#;
+
+    let records = parse::<DefaultColumnType>(script)
+        .expect("Should still parse directives without comments");
+
+    assert!(records.len() > 0, "Should have parsed records");
+}


### PR DESCRIPTION
Fixes #1311

This PR adds support for inline comments on conditional directives in SQLLogicTest files, allowing patterns like:
- `onlyif sqlite # empty RHS`
- `skipif mysql # not supported`

The solution:
1. Created a local fork of the sqllogictest crate with the fix
2. Modified the parser to strip inline comments (starting with #) from directive lines before tokenizing
3. Added comprehensive tests to verify the functionality

The fix ensures compatibility with upstream SQLLogicTest suite files that use this pattern, particularly the evidence/ category test files.

Changes:
- Add local copy of sqllogictest crate with comment stripping support  
- Modify parser.rs to strip inline comments before tokenizing directive lines
- Add tests verifying comment support on directives
- Configure Cargo.toml to patch the external crate