### PR TITLE
feat: Implement REINDEX statement for SQLite compatibility

### DIFF
--- a/crates/vibesql-ast/src/ddl/schema.rs
+++ b/crates/vibesql-ast/src/ddl/schema.rs
@@ -168,3 +168,13 @@ pub struct DropIndexStmt {
     pub if_exists: bool,
     pub index_name: String,
 }
+
+/// REINDEX statement
+///
+/// Rebuilds indexes to reclaim space or improve query performance.
+/// Syntax: REINDEX [database_name | table_name | index_name]
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReindexStmt {
+    /// Optional target: database name, table name, or index name
+    pub target: Option<String>,
+}

--- a/crates/vibesql-ast/src/lib.rs
+++ b/crates/vibesql-ast/src/lib.rs
@@ -23,11 +23,12 @@ pub use ddl::{
     DropCollationStmt, DropColumnStmt, DropConstraintStmt, DropDomainStmt, DropIndexStmt,
     DropRoleStmt, DropSchemaStmt, DropSequenceStmt, DropTableStmt, DropTranslationStmt,
     DropTriggerStmt, DropTypeStmt, DropViewStmt, FetchOrientation, FetchStmt, IndexColumn,
-    InsertMethod, IsolationLevel, OpenCursorStmt, ReferentialAction, ReleaseSavepointStmt,
-    RollbackStmt, RollbackToSavepointStmt, RowFormat, SavepointStmt, SchemaElement, SetCatalogStmt,
-    SetNamesStmt, SetSchemaStmt, SetTimeZoneStmt, SetTransactionStmt, TableConstraint,
-    TableConstraintKind, TableOption, TimeZoneSpec, TransactionAccessMode, TriggerAction,
-    TriggerEvent, TriggerGranularity, TriggerTiming, TypeAttribute, TypeDefinition,
+    InsertMethod, IsolationLevel, OpenCursorStmt, ReferentialAction, ReindexStmt,
+    ReleaseSavepointStmt, RollbackStmt, RollbackToSavepointStmt, RowFormat, SavepointStmt,
+    SchemaElement, SetCatalogStmt, SetNamesStmt, SetSchemaStmt, SetTimeZoneStmt,
+    SetTransactionStmt, TableConstraint, TableConstraintKind, TableOption, TimeZoneSpec,
+    TransactionAccessMode, TriggerAction, TriggerEvent, TriggerGranularity, TriggerTiming,
+    TypeAttribute, TypeDefinition,
 };
 pub use dml::{
     Assignment, ConflictClause, DeleteStmt, InsertSource, InsertStmt, UpdateStmt, WhereClause,

--- a/crates/vibesql-ast/src/statement.rs
+++ b/crates/vibesql-ast/src/statement.rs
@@ -10,9 +10,9 @@ use crate::{
     DropAssertionStmt, DropCharacterSetStmt, DropCollationStmt, DropDomainStmt, DropIndexStmt,
     DropRoleStmt, DropSchemaStmt, DropSequenceStmt, DropTableStmt, DropTranslationStmt,
     DropTriggerStmt, DropTypeStmt, DropViewStmt, FetchStmt, GrantStmt, InsertStmt, OpenCursorStmt,
-    ReleaseSavepointStmt, RevokeStmt, RollbackStmt, RollbackToSavepointStmt, SavepointStmt,
-    SelectStmt, SetCatalogStmt, SetNamesStmt, SetSchemaStmt, SetTimeZoneStmt, SetTransactionStmt,
-    UpdateStmt,
+    ReindexStmt, ReleaseSavepointStmt, RevokeStmt, RollbackStmt, RollbackToSavepointStmt,
+    SavepointStmt, SelectStmt, SetCatalogStmt, SetNamesStmt, SetSchemaStmt, SetTimeZoneStmt,
+    SetTransactionStmt, UpdateStmt,
 };
 
 // ============================================================================
@@ -66,6 +66,7 @@ pub enum Statement {
     DropTrigger(DropTriggerStmt),
     CreateIndex(CreateIndexStmt),
     DropIndex(DropIndexStmt),
+    Reindex(ReindexStmt),
     CreateAssertion(CreateAssertionStmt),
     DropAssertion(DropAssertionStmt),
     // Cursor operations (SQL:1999 Feature E121)

--- a/crates/vibesql-executor/src/index_ddl/mod.rs
+++ b/crates/vibesql-executor/src/index_ddl/mod.rs
@@ -1,4 +1,4 @@
-//! CREATE INDEX and DROP INDEX statement execution
+//! CREATE INDEX, DROP INDEX, and REINDEX statement execution
 //!
 //! This module provides executors for index DDL operations.
 //!
@@ -6,18 +6,21 @@
 //!
 //! - `create_index.rs` - CREATE INDEX executor
 //! - `drop_index.rs` - DROP INDEX executor
+//! - `reindex.rs` - REINDEX executor
 
 pub mod create_index;
 pub mod drop_index;
+pub mod reindex;
 
-use vibesql_ast::{CreateIndexStmt, DropIndexStmt};
+use vibesql_ast::{CreateIndexStmt, DropIndexStmt, ReindexStmt};
 pub use create_index::CreateIndexExecutor;
 pub use drop_index::DropIndexExecutor;
+pub use reindex::ReindexExecutor;
 use vibesql_storage::Database;
 
 use crate::errors::ExecutorError;
 
-/// Unified executor for index operations (CREATE and DROP INDEX)
+/// Unified executor for index operations (CREATE, DROP, and REINDEX INDEX)
 ///
 /// This struct provides backward compatibility with the original API,
 /// delegating to specialized executors for each operation.
@@ -38,5 +41,13 @@ impl IndexExecutor {
         database: &mut Database,
     ) -> Result<String, ExecutorError> {
         DropIndexExecutor::execute(stmt, database)
+    }
+
+    /// Execute a REINDEX statement (delegates to ReindexExecutor)
+    pub fn execute_reindex(
+        stmt: &ReindexStmt,
+        database: &Database,
+    ) -> Result<String, ExecutorError> {
+        ReindexExecutor::execute(stmt, database)
     }
 }

--- a/crates/vibesql-executor/src/index_ddl/reindex.rs
+++ b/crates/vibesql-executor/src/index_ddl/reindex.rs
@@ -1,0 +1,177 @@
+//! REINDEX statement execution
+//!
+//! REINDEX rebuilds indexes to reclaim space or improve query performance.
+//! This is a no-op implementation for SQLite compatibility - the database
+//! maintains indexes automatically, so explicit reindexing is not needed.
+
+use vibesql_ast::ReindexStmt;
+use vibesql_storage::Database;
+
+use crate::errors::ExecutorError;
+
+/// Executor for REINDEX statements
+pub struct ReindexExecutor;
+
+impl ReindexExecutor {
+    /// Execute a REINDEX statement
+    ///
+    /// # Arguments
+    ///
+    /// * `stmt` - The REINDEX statement AST node
+    /// * `database` - The database to reindex
+    ///
+    /// # Returns
+    ///
+    /// Success message or error
+    ///
+    /// # Implementation Note
+    ///
+    /// This is a no-op implementation. VibeSQL maintains indexes automatically,
+    /// so explicit reindexing is not required. However, we parse and validate
+    /// the target (if specified) for SQLite compatibility and better error messages.
+    pub fn execute(stmt: &ReindexStmt, database: &Database) -> Result<String, ExecutorError> {
+        match &stmt.target {
+            None => {
+                // REINDEX with no target - reindex all indexes
+                // No-op: all indexes are already maintained optimally
+                Ok("REINDEX completed successfully - all indexes are optimized".to_string())
+            }
+            Some(target) => {
+                // REINDEX with specific target (database, table, or index name)
+                // Validate that the target exists
+
+                // First try as an index name
+                if database.index_exists(target) {
+                    // It's an index - reindexing is not needed but we pretend to succeed
+                    return Ok(format!("REINDEX completed successfully - index '{}' is optimized", target));
+                }
+
+                // Try as a table name
+                if database.get_table(target).is_some() {
+                    // It's a table - reindex all its indexes
+                    return Ok(format!("REINDEX completed successfully - all indexes for table '{}' are optimized", target));
+                }
+
+                // Not found - error out
+                Err(ExecutorError::TableNotFound(target.clone()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vibesql_ast::{ColumnDef, CreateIndexStmt, CreateTableStmt, IndexColumn, OrderDirection};
+    use vibesql_types::DataType;
+
+    use super::*;
+    use crate::{index_ddl::create_index::CreateIndexExecutor, CreateTableExecutor};
+
+    fn create_test_table(db: &mut Database) {
+        let stmt = CreateTableStmt {
+            table_name: "users".to_string(),
+            columns: vec![
+                ColumnDef {
+                    name: "id".to_string(),
+                    data_type: DataType::Integer,
+                    nullable: false,
+                    constraints: vec![],
+                    default_value: None,
+                    comment: None,
+                },
+                ColumnDef {
+                    name: "email".to_string(),
+                    data_type: DataType::Varchar { max_length: Some(255) },
+                    nullable: false,
+                    constraints: vec![],
+                    default_value: None,
+                    comment: None,
+                },
+                ColumnDef {
+                    name: "name".to_string(),
+                    data_type: DataType::Varchar { max_length: Some(100) },
+                    nullable: true,
+                    constraints: vec![],
+                    default_value: None,
+                    comment: None,
+                },
+            ],
+            table_constraints: vec![],
+            table_options: vec![],
+        };
+
+        CreateTableExecutor::execute(&stmt, db).unwrap();
+    }
+
+    #[test]
+    fn test_reindex_all() {
+        let db = Database::new();
+
+        // REINDEX with no target should succeed
+        let reindex_stmt = ReindexStmt { target: None };
+        let result = ReindexExecutor::execute(&reindex_stmt, &db);
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("optimized"));
+    }
+
+    #[test]
+    fn test_reindex_specific_index() {
+        let mut db = Database::new();
+        create_test_table(&mut db);
+
+        // Create index
+        let create_stmt = CreateIndexStmt {
+            index_name: "idx_users_email".to_string(),
+            if_not_exists: false,
+            table_name: "users".to_string(),
+            unique: false,
+            columns: vec![IndexColumn {
+                column_name: "email".to_string(),
+                direction: OrderDirection::Asc,
+            }],
+        };
+        CreateIndexExecutor::execute(&create_stmt, &mut db).unwrap();
+
+        // Reindex the specific index
+        let reindex_stmt = ReindexStmt { target: Some("idx_users_email".to_string()) };
+        let result = ReindexExecutor::execute(&reindex_stmt, &db);
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("optimized"));
+    }
+
+    #[test]
+    fn test_reindex_table() {
+        let mut db = Database::new();
+        create_test_table(&mut db);
+
+        // Create an index on the table
+        let create_stmt = CreateIndexStmt {
+            index_name: "idx_users_email".to_string(),
+            if_not_exists: false,
+            table_name: "users".to_string(),
+            unique: false,
+            columns: vec![IndexColumn {
+                column_name: "email".to_string(),
+                direction: OrderDirection::Asc,
+            }],
+        };
+        CreateIndexExecutor::execute(&create_stmt, &mut db).unwrap();
+
+        // Reindex the table
+        let reindex_stmt = ReindexStmt { target: Some("users".to_string()) };
+        let result = ReindexExecutor::execute(&reindex_stmt, &db);
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("optimized"));
+    }
+
+    #[test]
+    fn test_reindex_nonexistent_target() {
+        let db = Database::new();
+
+        // Try to reindex non-existent object
+        let reindex_stmt = ReindexStmt { target: Some("nonexistent".to_string()) };
+        let result = ReindexExecutor::execute(&reindex_stmt, &db);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(ExecutorError::TableNotFound(_))));
+    }
+}

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -39,7 +39,7 @@ pub use drop_table::DropTableExecutor;
 pub use errors::ExecutorError;
 pub use evaluator::ExpressionEvaluator;
 pub use grant::GrantExecutor;
-pub use index_ddl::{CreateIndexExecutor, DropIndexExecutor, IndexExecutor};
+pub use index_ddl::{CreateIndexExecutor, DropIndexExecutor, IndexExecutor, ReindexExecutor};
 pub use insert::InsertExecutor;
 pub use persistence::load_sql_dump;
 pub use privilege_checker::PrivilegeChecker;

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -146,6 +146,7 @@ pub enum Keyword {
     Translation,
     View,
     Index,
+    Reindex,
     Assertion,
     Specific,
     // Trigger-specific keywords
@@ -372,6 +373,7 @@ impl fmt::Display for Keyword {
             Keyword::Translation => "TRANSLATION",
             Keyword::View => "VIEW",
             Keyword::Index => "INDEX",
+            Keyword::Reindex => "REINDEX",
             Keyword::Assertion => "ASSERTION",
             Keyword::Specific => "SPECIFIC",
             Keyword::Before => "BEFORE",

--- a/crates/vibesql-parser/src/lexer/keywords.rs
+++ b/crates/vibesql-parser/src/lexer/keywords.rs
@@ -147,6 +147,7 @@ pub(super) fn map_keyword(upper_text: String) -> Token {
         "SPECIFIC" => Token::Keyword(Keyword::Specific),
         "VIEW" => Token::Keyword(Keyword::View),
         "INDEX" => Token::Keyword(Keyword::Index),
+        "REINDEX" => Token::Keyword(Keyword::Reindex),
         "ASSERTION" => Token::Keyword(Keyword::Assertion),
         // Trigger-specific keywords
         "BEFORE" => Token::Keyword(Keyword::Before),

--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -1,4 +1,4 @@
-//! Parser for CREATE INDEX and DROP INDEX statements
+//! Parser for CREATE INDEX, DROP INDEX, and REINDEX statements
 
 use super::{ParseError, Parser};
 use crate::{keywords::Keyword, token::Token};
@@ -103,5 +103,25 @@ impl Parser {
         let index_name = self.parse_identifier()?;
 
         Ok(vibesql_ast::DropIndexStmt { if_exists, index_name })
+    }
+
+    /// Parse REINDEX statement
+    ///
+    /// Syntax:
+    ///   REINDEX [database_name | table_name | index_name]
+    pub(super) fn parse_reindex_statement(&mut self) -> Result<vibesql_ast::ReindexStmt, ParseError> {
+        // Expect REINDEX keyword
+        self.expect_keyword(Keyword::Reindex)?;
+
+        // Check for optional target (database, table, or index name)
+        let target = if self.peek() == &Token::Semicolon || self.peek() == &Token::Eof {
+            // No target specified - reindex all
+            None
+        } else {
+            // Parse optional identifier (could be database, table, or index name)
+            Some(self.parse_identifier()?)
+        };
+
+        Ok(vibesql_ast::ReindexStmt { target })
     }
 }

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -170,6 +170,10 @@ impl Parser {
                     })
                 }
             }
+            Token::Keyword(Keyword::Reindex) => {
+                let reindex_stmt = self.parse_reindex_statement()?;
+                Ok(vibesql_ast::Statement::Reindex(reindex_stmt))
+            }
             Token::Keyword(Keyword::Begin) | Token::Keyword(Keyword::Start) => {
                 let begin_stmt = self.parse_begin_statement()?;
                 Ok(vibesql_ast::Statement::BeginTransaction(begin_stmt))

--- a/tests/sqllogictest/db_adapter.rs
+++ b/tests/sqllogictest/db_adapter.rs
@@ -301,6 +301,11 @@ impl NistMemSqlDB {
                     .map_err(|e| TestError::Execution(format!("Execution error: {:?}", e)))?;
                 Ok(DBOutput::StatementComplete(0))
             }
+            vibesql_ast::Statement::Reindex(reindex_stmt) => {
+                vibesql_executor::IndexExecutor::execute_reindex(&reindex_stmt, &self.db)
+                    .map_err(|e| TestError::Execution(format!("Execution error: {:?}", e)))?;
+                Ok(DBOutput::StatementComplete(0))
+            }
             // Unimplemented statements return success for now
             vibesql_ast::Statement::BeginTransaction(_)
             | vibesql_ast::Statement::Commit(_)

--- a/tests/sqllogictest_benchmark.rs
+++ b/tests/sqllogictest_benchmark.rs
@@ -428,6 +428,11 @@ impl NistMemSqlDB {
                     .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
                 Ok(DBOutput::StatementComplete(0))
             }
+            vibesql_ast::Statement::Reindex(reindex_stmt) => {
+                vibesql_executor::IndexExecutor::execute_reindex(&reindex_stmt, &self.db)
+                    .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
+                Ok(DBOutput::StatementComplete(0))
+            }
             _ => Ok(DBOutput::StatementComplete(0)),
         }
     }

--- a/tests/sqllogictest_runner.rs
+++ b/tests/sqllogictest_runner.rs
@@ -155,6 +155,11 @@ impl NistMemSqlDB {
                     .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
                 Ok(DBOutput::StatementComplete(0))
             }
+            vibesql_ast::Statement::Reindex(reindex_stmt) => {
+                vibesql_executor::IndexExecutor::execute_reindex(&reindex_stmt, &self.db)
+                    .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
+                Ok(DBOutput::StatementComplete(0))
+            }
             vibesql_ast::Statement::SetNames(set_stmt) => {
                 vibesql_executor::SchemaExecutor::execute_set_names(&set_stmt, &mut self.db)
                     .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;

--- a/tests/sqltest_conformance.rs
+++ b/tests/sqltest_conformance.rs
@@ -338,6 +338,11 @@ impl SqltestRunner {
                     .map_err(|e| format!("Execution error: {:?}", e))?;
                 Ok(true)
             }
+            vibesql_ast::Statement::Reindex(reindex_stmt) => {
+                vibesql_executor::IndexExecutor::execute_reindex(&reindex_stmt, db)
+                    .map_err(|e| format!("Execution error: {:?}", e))?;
+                Ok(true)
+            }
             vibesql_ast::Statement::BeginTransaction(_)
             | vibesql_ast::Statement::Commit(_)
             | vibesql_ast::Statement::Rollback(_)

--- a/tests/test_issue_898.rs
+++ b/tests/test_issue_898.rs
@@ -74,6 +74,11 @@ impl NistMemSqlDB {
                     .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
                 Ok(DBOutput::StatementComplete(0))
             }
+            vibesql_ast::Statement::Reindex(reindex_stmt) => {
+                vibesql_executor::IndexExecutor::execute_reindex(&reindex_stmt, &self.db)
+                    .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
+                Ok(DBOutput::StatementComplete(0))
+            }
             _ => Ok(DBOutput::StatementComplete(0)),
         }
     }


### PR DESCRIPTION
Closes #1318

## Summary
Implements REINDEX statement support for SQLite compatibility.

## Changes
- Added ReindexStmt AST node
- Implemented parser for REINDEX with optional target
- Created ReindexExecutor (no-op implementation)
- Added REINDEX keyword to lexer
- Updated all statement dispatchers

## Syntax Supported
- REINDEX (all indexes)
- REINDEX index_name  
- REINDEX table_name

## Implementation Notes
This is a no-op implementation since VibeSQL maintains indexes automatically.