### PR TITLE
Fix transaction_tests.rs compilation errors: missing conflict_clause field

### DIFF
--- a/crates/vibesql-executor/src/tests/transaction_tests.rs
+++ b/crates/vibesql-executor/src/tests/transaction_tests.rs
@@ -131,6 +131,7 @@ fn test_transaction_insert_commit() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
             vibesql_ast::Expression::Literal(SqlValue::Varchar("Alice".to_string())),
         ]]),
+        conflict_clause: None,
     };
     let rows = InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
     assert_eq!(rows, 1);
@@ -163,6 +164,7 @@ fn test_transaction_insert_rollback() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
             vibesql_ast::Expression::Literal(SqlValue::Varchar("Alice".to_string())),
         ]]),
+        conflict_clause: None,
     };
     let rows = InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
     assert_eq!(rows, 1);
@@ -192,6 +194,7 @@ fn test_transaction_multiple_operations_commit() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
             vibesql_ast::Expression::Literal(SqlValue::Varchar("Alice".to_string())),
         ]]),
+        conflict_clause: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt1).unwrap();
 
@@ -206,6 +209,7 @@ fn test_transaction_multiple_operations_commit() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(2)),
             vibesql_ast::Expression::Literal(SqlValue::Varchar("Bob".to_string())),
         ]]),
+        conflict_clause: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt2).unwrap();
 
@@ -234,6 +238,7 @@ fn test_transaction_multiple_operations_rollback() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
             vibesql_ast::Expression::Literal(SqlValue::Varchar("Alice".to_string())),
         ]]),
+        conflict_clause: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt1).unwrap();
 
@@ -248,6 +253,7 @@ fn test_transaction_multiple_operations_rollback() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(2)),
             vibesql_ast::Expression::Literal(SqlValue::Varchar("Bob".to_string())),
         ]]),
+        conflict_clause: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt2).unwrap();
 
@@ -283,6 +289,7 @@ fn test_transaction_isolation() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
             vibesql_ast::Expression::Literal(SqlValue::Varchar("Alice".to_string())),
         ]]),
+        conflict_clause: None,
     };
     InsertExecutor::execute(&mut db1, &insert_stmt).unwrap();
 
@@ -318,6 +325,7 @@ fn test_transaction_nested_operations() {
                 vibesql_ast::Expression::Literal(SqlValue::Integer(i)),
                 vibesql_ast::Expression::Literal(SqlValue::Varchar(format!("User{}", i))),
             ]]),
+            conflict_clause: None,
         };
         InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
     }
@@ -347,6 +355,7 @@ fn test_transaction_empty_rollback() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
             vibesql_ast::Expression::Literal(SqlValue::Varchar("Alice".to_string())),
         ]]),
+        conflict_clause: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
 
@@ -375,6 +384,7 @@ fn test_multiple_transactions() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
             vibesql_ast::Expression::Literal(SqlValue::Varchar("Alice".to_string())),
         ]]),
+        conflict_clause: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt1).unwrap();
     CommitExecutor::execute(&CommitStmt, &mut db).unwrap();
@@ -388,6 +398,7 @@ fn test_multiple_transactions() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(2)),
             vibesql_ast::Expression::Literal(SqlValue::Varchar("Bob".to_string())),
         ]]),
+        conflict_clause: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt2).unwrap();
     RollbackExecutor::execute(&RollbackStmt, &mut db).unwrap();


### PR DESCRIPTION
Closes #1323

Fixes all 11 instances of missing `conflict_clause` field in `InsertStmt` initializations in transaction_tests.rs.

The `conflict_clause` field was added to the InsertStmt struct but these test initializations were not updated. This field is required to be present in all InsertStmt constructors.

All instances are set to `None` for standard insert operations without conflict resolution behavior.