### PR TITLE
feat: Complete spatial index implementation (Steps 3-4 from #1362)

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -16,6 +16,7 @@ pub enum ExecutorError {
     ColumnAlreadyExists(String),
     IndexNotFound(String),
     IndexAlreadyExists(String),
+    InvalidIndexDefinition(String),
     SchemaNotFound(String),
     SchemaAlreadyExists(String),
     SchemaNotEmpty(String),
@@ -133,6 +134,7 @@ impl std::fmt::Display for ExecutorError {
             }
             ExecutorError::IndexNotFound(name) => write!(f, "Index '{}' not found", name),
             ExecutorError::IndexAlreadyExists(name) => write!(f, "Index '{}' already exists", name),
+            ExecutorError::InvalidIndexDefinition(msg) => write!(f, "Invalid index definition: {}", msg),
             ExecutorError::SchemaNotFound(name) => write!(f, "Schema '{}' not found", name),
             ExecutorError::SchemaAlreadyExists(name) => {
                 write!(f, "Schema '{}' already exists", name)

--- a/crates/vibesql-executor/tests/spatial_index_tests.rs
+++ b/crates/vibesql-executor/tests/spatial_index_tests.rs
@@ -1,0 +1,233 @@
+//! Integration tests for spatial indexes
+
+use vibesql_ast::{ColumnDef, CreateIndexStmt, CreateTableStmt, IndexColumn, OrderDirection};
+use vibesql_executor::{CreateIndexExecutor, CreateTableExecutor, DropIndexExecutor, InsertExecutor};
+use vibesql_storage::Database;
+use vibesql_types::{DataType, SqlValue};
+
+#[test]
+fn test_create_spatial_index_basic() {
+    let mut db = Database::new();
+
+    // Create table with geometry column
+    let create_table_stmt = CreateTableStmt {
+        table_name: "places".to_string(),
+        columns: vec![
+            ColumnDef {
+                name: "id".to_string(),
+                data_type: DataType::Integer,
+                nullable: false,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+            ColumnDef {
+                name: "location".to_string(),
+                data_type: DataType::Varchar { max_length: Some(1000) },
+                nullable: true,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+        ],
+        table_constraints: vec![],
+        table_options: vec![],
+    };
+
+    CreateTableExecutor::execute(&create_table_stmt, &mut db).unwrap();
+
+    // Create spatial index
+    let create_index_stmt = CreateIndexStmt {
+        index_name: "idx_location".to_string(),
+        if_not_exists: false,
+        table_name: "places".to_string(),
+        index_type: vibesql_ast::IndexType::Spatial,
+        columns: vec![IndexColumn {
+            column_name: "location".to_string(),
+            direction: OrderDirection::Asc,
+        }],
+    };
+
+    let result = CreateIndexExecutor::execute(&create_index_stmt, &mut db);
+    assert!(result.is_ok(), "Failed to create spatial index: {:?}", result.err());
+    assert!(db.spatial_index_exists("idx_location"));
+}
+
+#[test]
+fn test_spatial_index_multiple_columns_error() {
+    let mut db = Database::new();
+
+    // Create table
+    let create_table_stmt = CreateTableStmt {
+        table_name: "places".to_string(),
+        columns: vec![
+            ColumnDef {
+                name: "id".to_string(),
+                data_type: DataType::Integer,
+                nullable: false,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+            ColumnDef {
+                name: "location1".to_string(),
+                data_type: DataType::Varchar { max_length: Some(1000) },
+                nullable: true,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+            ColumnDef {
+                name: "location2".to_string(),
+                data_type: DataType::Varchar { max_length: Some(1000) },
+                nullable: true,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+        ],
+        table_constraints: vec![],
+        table_options: vec![],
+    };
+
+    CreateTableExecutor::execute(&create_table_stmt, &mut db).unwrap();
+
+    // Try to create spatial index on multiple columns (should fail)
+    let create_index_stmt = CreateIndexStmt {
+        index_name: "idx_location".to_string(),
+        if_not_exists: false,
+        table_name: "places".to_string(),
+        index_type: vibesql_ast::IndexType::Spatial,
+        columns: vec![
+            IndexColumn {
+                column_name: "location1".to_string(),
+                direction: OrderDirection::Asc,
+            },
+            IndexColumn {
+                column_name: "location2".to_string(),
+                direction: OrderDirection::Asc,
+            },
+        ],
+    };
+
+    let result = CreateIndexExecutor::execute(&create_index_stmt, &mut db);
+    assert!(result.is_err(), "Expected error for multiple columns");
+}
+
+#[test]
+fn test_drop_spatial_index() {
+    let mut db = Database::new();
+
+    // Create table with geometry column
+    let create_table_stmt = CreateTableStmt {
+        table_name: "places".to_string(),
+        columns: vec![
+            ColumnDef {
+                name: "id".to_string(),
+                data_type: DataType::Integer,
+                nullable: false,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+            ColumnDef {
+                name: "location".to_string(),
+                data_type: DataType::Varchar { max_length: Some(1000) },
+                nullable: true,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+        ],
+        table_constraints: vec![],
+        table_options: vec![],
+    };
+
+    CreateTableExecutor::execute(&create_table_stmt, &mut db).unwrap();
+
+    // Create spatial index
+    let create_index_stmt = CreateIndexStmt {
+        index_name: "idx_location".to_string(),
+        if_not_exists: false,
+        table_name: "places".to_string(),
+        index_type: vibesql_ast::IndexType::Spatial,
+        columns: vec![IndexColumn {
+            column_name: "location".to_string(),
+            direction: OrderDirection::Asc,
+        }],
+    };
+
+    CreateIndexExecutor::execute(&create_index_stmt, &mut db).unwrap();
+    assert!(db.spatial_index_exists("idx_location"));
+
+    // Drop spatial index
+    let drop_stmt = vibesql_ast::DropIndexStmt {
+        index_name: "idx_location".to_string(),
+        if_exists: false,
+    };
+
+    let result = DropIndexExecutor::execute(&drop_stmt, &mut db);
+    assert!(result.is_ok(), "Failed to drop spatial index: {:?}", result.err());
+    assert!(!db.spatial_index_exists("idx_location"));
+}
+
+#[test]
+fn test_spatial_index_if_not_exists() {
+    let mut db = Database::new();
+
+    // Create table
+    let create_table_stmt = CreateTableStmt {
+        table_name: "places".to_string(),
+        columns: vec![
+            ColumnDef {
+                name: "id".to_string(),
+                data_type: DataType::Integer,
+                nullable: false,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+            ColumnDef {
+                name: "location".to_string(),
+                data_type: DataType::Varchar { max_length: Some(1000) },
+                nullable: true,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+        ],
+        table_constraints: vec![],
+        table_options: vec![],
+    };
+
+    CreateTableExecutor::execute(&create_table_stmt, &mut db).unwrap();
+
+    // Create spatial index
+    let create_index_stmt = CreateIndexStmt {
+        index_name: "idx_location".to_string(),
+        if_not_exists: false,
+        table_name: "places".to_string(),
+        index_type: vibesql_ast::IndexType::Spatial,
+        columns: vec![IndexColumn {
+            column_name: "location".to_string(),
+            direction: OrderDirection::Asc,
+        }],
+    };
+
+    CreateIndexExecutor::execute(&create_index_stmt, &mut db).unwrap();
+
+    // Try to create again with IF NOT EXISTS (should succeed)
+    let create_index_stmt2 = CreateIndexStmt {
+        index_name: "idx_location".to_string(),
+        if_not_exists: true,
+        table_name: "places".to_string(),
+        index_type: vibesql_ast::IndexType::Spatial,
+        columns: vec![IndexColumn {
+            column_name: "location".to_string(),
+            direction: OrderDirection::Asc,
+        }],
+    };
+
+    let result = CreateIndexExecutor::execute(&create_index_stmt2, &mut db);
+    assert!(result.is_ok(), "IF NOT EXISTS should succeed");
+}

--- a/crates/vibesql-storage/src/database/mod.rs
+++ b/crates/vibesql-storage/src/database/mod.rs
@@ -6,6 +6,6 @@ mod database;
 pub mod indexes;
 pub mod transactions;
 
-pub use database::Database;
+pub use database::{Database, SpatialIndexMetadata};
 pub use indexes::{IndexData, IndexManager, IndexMetadata};
 pub use transactions::{Savepoint, TransactionChange, TransactionManager, TransactionState};

--- a/crates/vibesql-storage/src/lib.rs
+++ b/crates/vibesql-storage/src/lib.rs
@@ -9,7 +9,7 @@ pub mod persistence;
 pub mod row;
 pub mod table;
 
-pub use database::{Database, IndexData, IndexManager, IndexMetadata, TransactionState};
+pub use database::{Database, IndexData, IndexManager, IndexMetadata, SpatialIndexMetadata, TransactionState};
 pub use error::StorageError;
 pub use index::{SpatialIndex, SpatialIndexEntry, extract_mbr_from_sql_value};
 pub use persistence::load::{parse_sql_statements, read_sql_dump};


### PR DESCRIPTION
## Summary

Completes the spatial index implementation for vibesql, building on the R-tree foundation from PR #1361. This PR implements:

- **Step 1**: Catalog integration for spatial indexes
- **Step 2**: CREATE SPATIAL INDEX execution
- **Step 3**: DROP SPATIAL INDEX execution
- **Step 4**: DML index maintenance (INSERT/UPDATE/DELETE)

## Changes

### Catalog Integration
- Added `SpatialIndexMetadata` struct to track spatial index metadata (index name, table name, column name, creation timestamp)
- Added `spatial_indexes` HashMap to Database struct for storing spatial indexes separately from B-tree indexes
- Exported SpatialIndexMetadata from vibesql-storage crate
- Integrated spatial index cleanup in DROP TABLE CASCADE behavior

### CREATE SPATIAL INDEX
- Implemented spatial index creation in CreateIndexExecutor
- Validates that spatial indexes must be on exactly one column (returns error for multi-column)
- Extracts MBRs from all existing rows using `extract_mbr_from_sql_value`
- Uses `bulk_load` for efficient index construction
- Stores metadata with creation timestamp
- Handles IF NOT EXISTS clause properly
- Checks for index existence across both B-tree and spatial indexes to prevent name conflicts

### DROP SPATIAL INDEX
- Updated DropIndexExecutor to handle both B-tree and spatial indexes
- Checks spatial indexes first, then falls back to B-tree indexes
- Handles IF EXISTS clause
- Provides clear success messages distinguishing between index types

### DML Index Maintenance
- Added spatial index maintenance for INSERT operations (extracts MBR and inserts into spatial index)
- Added spatial index maintenance for UPDATE operations (removes old MBR, inserts new MBR, but only if geometry changed)
- Added spatial index maintenance for DELETE operations (removes MBR from spatial index)
- NULL geometries are properly skipped during index maintenance

### Error Handling
- Added `InvalidIndexDefinition` error variant for validation errors
- Proper error messages for multi-column spatial indexes: "SPATIAL indexes must be defined on exactly one column"
- Clear error messages for missing columns

### Tests
- Added comprehensive integration tests in `spatial_index_tests.rs`:
  - `test_create_spatial_index_basic` - Basic spatial index creation
  - `test_spatial_index_multiple_columns_error` - Validates multi-column rejection
  - `test_drop_spatial_index` - DROP SPATIAL INDEX functionality
  - `test_spatial_index_if_not_exists` - IF NOT EXISTS clause handling
- All existing tests continue to pass (no regressions)

## Implementation Notes

- **Separate storage**: Spatial indexes are stored separately from B-tree indexes due to different data structures (RTree vs BTreeMap)
- **Case-insensitive**: Index name handling via normalization to uppercase (matches existing B-tree behavior)
- **NULL handling**: NULL geometries are skipped during index maintenance
- **MBR extraction**: Handles all geometry types (POINT, LINESTRING, POLYGON, MULTI*)
- **Efficient bulk loading**: Uses R-tree bulk_load for initial index construction (O(n log n) instead of O(n²))

## What's NOT Implemented (Future Work)

The following steps from issue #1362 are intentionally deferred to future PRs:

- **Step 5**: Query optimizer integration (automatic index usage for spatial predicates like ST_Contains, ST_Intersects)
- **Step 6**: Performance benchmarks (10k/100k row datasets to measure speedup)

These are deferred because:
1. They are complex enough to warrant separate PRs
2. The current implementation provides a solid foundation that can be extended
3. This PR is already substantial and fully functional for DDL and DML operations

## Test Plan

```bash
# Run spatial index tests
cargo test --test spatial_index_tests --package vibesql-executor

# Run full test suite
cargo test --package vibesql-executor

# All tests pass ✓
```

## Breaking Changes

None. This is a pure feature addition with no changes to existing APIs.

## Related Issues & PRs

- Closes #1362 (partial - Steps 1-4 complete)
- Builds on PR #1361 (R-tree foundation and parser) - MERGED
- Related to #1354 (Phase 4 Part 1 - Measurements) - MERGED
- Related to #1334 (Phase 3 - Spatial predicates) - MERGED

## Checklist

- [x] Code compiles without errors
- [x] All existing tests pass
- [x] New tests added for spatial index functionality
- [x] Documentation added (code comments, error messages)
- [x] No breaking changes
- [x] Follows existing code patterns (matches B-tree index implementation style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>