### PR TITLE
fix: Handle reversed bounds in BETWEEN operator correctly

### DIFF
--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -5,7 +5,8 @@ use crate::errors::ExecutorError;
 
 impl ExpressionEvaluator<'_> {
     /// Evaluate BETWEEN predicate
-    /// If symmetric: swaps low and high if low > high before evaluation
+    /// Standard BETWEEN: returns false if low > high (per SQLite behavior)
+    /// BETWEEN SYMMETRIC: swaps low and high if low > high before evaluation
     pub(super) fn eval_between(
         &self,
         expr: &vibesql_ast::Expression,
@@ -19,13 +20,20 @@ impl ExpressionEvaluator<'_> {
         let mut low_val = self.eval(low, row)?;
         let mut high_val = self.eval(high, row)?;
 
-        // For SYMMETRIC: swap bounds if low > high
-        if symmetric {
-            let gt_result =
-                self.eval_binary_op(&low_val, &vibesql_ast::BinaryOperator::GreaterThan, &high_val)?;
+        // Check if bounds are reversed (low > high)
+        let gt_result =
+            self.eval_binary_op(&low_val, &vibesql_ast::BinaryOperator::GreaterThan, &high_val)?;
 
-            if let vibesql_types::SqlValue::Boolean(true) = gt_result {
+        if let vibesql_types::SqlValue::Boolean(true) = gt_result {
+            if symmetric {
+                // For SYMMETRIC: swap bounds to normalize range
                 std::mem::swap(&mut low_val, &mut high_val);
+            } else {
+                // For standard BETWEEN with reversed bounds: return empty set
+                // Per SQLite behavior: BETWEEN 57.93 AND 43.23 returns no rows
+                // - BETWEEN with reversed bounds returns false
+                // - NOT BETWEEN with reversed bounds returns true
+                return Ok(vibesql_types::SqlValue::Boolean(negated));
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes reversed bounds handling in BETWEEN operator to match SQLite behavior.

**Before:** BETWEEN with reversed bounds (e.g., `col BETWEEN 57.93 AND 43.23` where `57.93 > 43.23`) was evaluated incorrectly

**After:** Returns empty set (false) for standard BETWEEN with reversed bounds, matching SQLite reference implementation

## Changes

- **crates/vibesql-executor/src/evaluator/expressions/predicates.rs:7-55**: Added check for reversed bounds before SYMMETRIC handling
- **crates/vibesql-executor/src/evaluator/combined/predicates.rs:10-79**: Same fix for combined evaluator

## Behavior

| Case | Before | After (Correct) |
|------|--------|-----------------|
| `col BETWEEN 57.93 AND 43.23` | Incorrect evaluation | Returns false (empty set) |
| `col NOT BETWEEN 57.93 AND 43.23` | Incorrect evaluation | Returns true |
| `col BETWEEN SYMMETRIC 57.93 AND 43.23` | Swaps to 43.23-57.93 ✓ | No change (still swaps) ✓ |

## Test Plan

- ✅ Code compiles without errors (only pre-existing warnings)
- ✅ Verified SQLite reference behavior via manual testing
- 🔄 SQLLogicTest files to verify (submodule initializing):
  - `index/between/10/slt_good_1.test` (line 90)
  - `index/between/100/slt_good_3.test` (line 896)

## Related

Closes #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)