### PR TITLE
feat: Implement OUT and INOUT parameters for procedures (Phase 4)

### DIFF
--- a/crates/vibesql-executor/src/procedural/context.rs
+++ b/crates/vibesql-executor/src/procedural/context.rs
@@ -41,6 +41,9 @@ pub struct ExecutionContext {
     max_recursion: usize,
     /// Whether this is a function context (read-only, cannot modify data)
     pub(crate) is_function: bool,
+    /// Track which parameters are OUT/INOUT and their target variable names
+    /// Key: parameter name (uppercase), Value: target variable name (as specified in CALL)
+    out_parameters: HashMap<String, String>,
 }
 
 impl ExecutionContext {
@@ -53,6 +56,7 @@ impl ExecutionContext {
             recursion_depth: 0,
             max_recursion: MAX_RECURSION_DEPTH,
             is_function: false,
+            out_parameters: HashMap::new(),
         }
     }
 
@@ -65,6 +69,7 @@ impl ExecutionContext {
             recursion_depth: depth,
             max_recursion: MAX_RECURSION_DEPTH,
             is_function: false,
+            out_parameters: HashMap::new(),
         }
     }
 
@@ -151,6 +156,17 @@ impl ExecutionContext {
     /// Get all parameters (for OUT/INOUT return)
     pub fn get_all_parameters(&self) -> &HashMap<String, SqlValue> {
         &self.parameters
+    }
+
+    /// Register an OUT or INOUT parameter with its target variable name
+    pub fn register_out_parameter(&mut self, param_name: &str, target_var_name: String) {
+        self.out_parameters.insert(param_name.to_uppercase(), target_var_name);
+    }
+
+    /// Get all OUT/INOUT parameters for return
+    /// Returns a HashMap of parameter name -> target variable name
+    pub fn get_out_parameters(&self) -> &HashMap<String, String> {
+        &self.out_parameters
     }
 }
 

--- a/crates/vibesql-storage/src/database/core.rs
+++ b/crates/vibesql-storage/src/database/core.rs
@@ -38,6 +38,10 @@ pub struct Database {
     current_role: Option<String>,
     /// Whether security checks are enabled (can be disabled for testing)
     security_enabled: bool,
+    /// Session variables (MySQL-style @variables)
+    /// Key: normalized variable name (uppercase)
+    /// Value: variable value
+    session_variables: HashMap<String, vibesql_types::SqlValue>,
 }
 
 impl Database {
@@ -55,6 +59,7 @@ impl Database {
             current_role: None,
             // Disabled by default for backward compatibility
             security_enabled: false,
+            session_variables: HashMap::new(),
         }
     }
 
@@ -70,6 +75,7 @@ impl Database {
         self.transaction_manager = TransactionManager::new();
         self.current_role = None;
         self.security_enabled = false;
+        self.session_variables.clear();
     }
 
     /// Record a change in the current transaction (if any)
@@ -352,6 +358,27 @@ impl Database {
     /// Enable security checks
     pub fn enable_security(&mut self) {
         self.security_enabled = true;
+    }
+
+    // ============================================================================
+    // Session Variables
+    // ============================================================================
+
+    /// Set a session variable (MySQL-style @variable)
+    pub fn set_session_variable(&mut self, name: &str, value: vibesql_types::SqlValue) {
+        let normalized_name = name.to_uppercase();
+        self.session_variables.insert(normalized_name, value);
+    }
+
+    /// Get a session variable value
+    pub fn get_session_variable(&self, name: &str) -> Option<&vibesql_types::SqlValue> {
+        let normalized_name = name.to_uppercase();
+        self.session_variables.get(&normalized_name)
+    }
+
+    /// Clear all session variables
+    pub fn clear_session_variables(&mut self) {
+        self.session_variables.clear();
     }
 
     // ============================================================================


### PR DESCRIPTION
## Summary

Implements OUT and INOUT parameter support for stored procedures (Phase 4 of #1375), allowing procedures to return values to callers via session variables.

## Implementation

### Session Variables
- Added `session_variables` HashMap to `Database` for MySQL-style `@variable` storage
- Implemented `get_session_variable()` and `set_session_variable()` methods
- Variables are case-insensitive (normalized to uppercase)
- Support for `clear_session_variables()`

### OUT Parameter Tracking
- Enhanced `ExecutionContext` with `out_parameters` HashMap
- Tracks parameter name → target variable mappings
- `register_out_parameter()` and `get_out_parameters()` methods

### Parameter Binding (crates/vibesql-executor/src/advanced_objects.rs:357-385)
- **IN parameters**: Evaluate expression and bind value
- **OUT parameters**: Initialize to NULL, register target session variable
- **INOUT parameters**: Bind input value AND register target session variable
- Added `extract_variable_name()` helper to validate targets are variables, not literals

### Expression Evaluation
- `evaluate_expression()` now handles `@variable` references (reads from session variables)
- `SET` statements can assign to session variables: `SET @var = value`

### Return Values (crates/vibesql-executor/src/advanced_objects.rs:418-427)
- After procedure execution, OUT/INOUT parameter values copied to target session variables
- Values accessible in subsequent queries

## Test Plan

Manual testing confirms:
- ✅ OUT parameters initialize to NULL
- ✅ INOUT parameters receive input values
- ✅ SET can modify OUT/INOUT parameters
- ✅ Values returned to session variables after execution
- ✅ Session variables accessible in subsequent queries
- ✅ Error when passing literal to OUT parameter
- ✅ Multiple OUT/INOUT parameters work
- ✅ Mix of IN, OUT, INOUT works correctly

## Files Modified

- `crates/vibesql-storage/src/database/core.rs` - Session variables support
- `crates/vibesql-executor/src/procedural/context.rs` - OUT parameter tracking
- `crates/vibesql-executor/src/advanced_objects.rs` - Parameter binding and return
- `crates/vibesql-executor/src/procedural/executor.rs` - Session variable evaluation

## Example Usage

```sql
-- OUT parameter
CREATE PROCEDURE get_count(OUT total INT)
BEGIN
  SET total = 42;
END;

CALL get_count(@result);
-- @result now contains 42

-- INOUT parameter
CREATE PROCEDURE increment(INOUT counter INT)
BEGIN
  SET counter = counter + 1;
END;

SET @count = 5;
CALL increment(@count);
-- @count now contains 6
```

## Related

- Closes #1390
- Depends on: #1386 (Phase 3)
- Part of: #1375 (Stored procedures epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)