### PR TITLE
fix: Wire up trigger DDL execution in test runners

### DIFF
--- a/tests/sqllogictest/db_adapter.rs
+++ b/tests/sqllogictest/db_adapter.rs
@@ -297,6 +297,16 @@ impl NistMemSqlDB {
                     .map_err(|e| TestError::Execution(format!("Execution error: {:?}", e)))?;
                 Ok(DBOutput::StatementComplete(0))
             }
+            vibesql_ast::Statement::CreateTrigger(create_trigger_stmt) => {
+                vibesql_executor::TriggerExecutor::create_trigger(&mut self.db, &create_trigger_stmt)
+                    .map_err(|e| TestError::Execution(format!("Execution error: {:?}", e)))?;
+                Ok(DBOutput::StatementComplete(0))
+            }
+            vibesql_ast::Statement::DropTrigger(drop_trigger_stmt) => {
+                vibesql_executor::TriggerExecutor::drop_trigger(&mut self.db, &drop_trigger_stmt)
+                    .map_err(|e| TestError::Execution(format!("Execution error: {:?}", e)))?;
+                Ok(DBOutput::StatementComplete(0))
+            }
             // Unimplemented statements return success for now
             vibesql_ast::Statement::BeginTransaction(_)
             | vibesql_ast::Statement::Commit(_)
@@ -314,8 +324,6 @@ impl NistMemSqlDB {
             | vibesql_ast::Statement::DropCharacterSet(_)
             | vibesql_ast::Statement::CreateTranslation(_)
             | vibesql_ast::Statement::DropTranslation(_)
-            | vibesql_ast::Statement::CreateTrigger(_)
-            | vibesql_ast::Statement::DropTrigger(_)
             | vibesql_ast::Statement::DeclareCursor(_)
             | vibesql_ast::Statement::OpenCursor(_)
             | vibesql_ast::Statement::Fetch(_)

--- a/tests/sqllogictest_runner.rs
+++ b/tests/sqllogictest_runner.rs
@@ -263,11 +263,15 @@ impl NistMemSqlDB {
                     .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
                 Ok(DBOutput::StatementComplete(0))
             }
-            vibesql_ast::Statement::CreateTrigger(_) => {
-                Err(TestError("CREATE TRIGGER not supported - triggers are not implemented".to_string()))
+            vibesql_ast::Statement::CreateTrigger(stmt) => {
+                vibesql_executor::TriggerExecutor::create_trigger(&mut self.db, &stmt)
+                    .map(|_msg| DBOutput::StatementComplete(0))
+                    .map_err(|e| TestError(format!("Execution error: {:?}", e)))
             }
-            vibesql_ast::Statement::DropTrigger(_) => {
-                Err(TestError("DROP TRIGGER not supported - triggers are not implemented".to_string()))
+            vibesql_ast::Statement::DropTrigger(stmt) => {
+                vibesql_executor::TriggerExecutor::drop_trigger(&mut self.db, &stmt)
+                    .map(|_msg| DBOutput::StatementComplete(0))
+                    .map_err(|e| TestError(format!("Execution error: {:?}", e)))
             }
             vibesql_ast::Statement::BeginTransaction(_)
             | vibesql_ast::Statement::Commit(_)


### PR DESCRIPTION
## Summary

Wires up the existing trigger DDL executor to the test runners, resolving the "not implemented" errors that were blocking trigger validation tests.

Closes #1409

## Changes

### Modified Files

1. **tests/sqllogictest_runner.rs:266-275**
   - Replaced hardcoded "triggers are not implemented" errors with calls to `TriggerExecutor::create_trigger()` and `TriggerExecutor::drop_trigger()`
   
2. **tests/sqllogictest/db_adapter.rs:300-309**
   - Added proper execution handlers for `CreateTrigger` and `DropTrigger` statements
   - Removed these statements from the unsupported statement match arms

## Implementation Details

The trigger DDL executor in `crates/vibesql-executor/src/trigger_ddl.rs` already implements proper validation:
- **CREATE TRIGGER**: Validates target table exists (line 21-23)
- **DROP TRIGGER**: Validates trigger exists (line 48-50)

Previously, the test runners were returning hardcoded errors instead of calling the executor, preventing these validations from running.

## Test Results

After wiring up the executor:
- CREATE TRIGGER on non-existent table → Properly returns `TableNotFound` error
- DROP TRIGGER on non-existent trigger → Properly returns `TriggerNotFound` error
- Valid CREATE/DROP operations → Execute successfully

## Known Issues

Test runs reveal that the catalog does not yet enforce uniqueness constraints on trigger names (duplicate triggers can be created). This is a separate issue from the wiring problem and should be addressed in a follow-up PR.

## Test Plan

- [x] Built project successfully with changes
- [x] Verified CREATE TRIGGER/DROP TRIGGER are no longer returning "not implemented"
- [x] Confirmed validation errors are propagated correctly from the executor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>