### PR TITLE
fix: Remove clippy warnings in truncate_cascade_tests.rs

### DIFF
--- a/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
@@ -12,7 +12,7 @@ use vibesql_ast::{
     ColumnConstraint, ColumnConstraintKind, ColumnDef, CreateTableStmt, Expression, InsertStmt,
     InsertSource, TableConstraint, TableConstraintKind, TruncateCascadeOption, TruncateTableStmt,
 };
-use vibesql_storage::{Database, Row};
+use vibesql_storage::Database;
 use vibesql_types::{DataType, SqlValue};
 
 use crate::{CreateTableExecutor, InsertExecutor, TruncateTableExecutor};
@@ -105,7 +105,7 @@ fn insert_row(db: &mut Database, table_name: &str, values: Vec<SqlValue>) {
         columns: vec![],
         source: InsertSource::Values(vec![values
             .into_iter()
-            .map(|v| Expression::Literal(v))
+            .map(Expression::Literal)
             .collect()]),
         conflict_clause: None,
         on_duplicate_key_update: None,


### PR DESCRIPTION
## Summary

Fixed two clippy warnings in `truncate_cascade_tests.rs` that were introduced during PR #1415:

- ✅ Removed unused `Row` import from `vibesql_storage`
- ✅ Simplified redundant closure: `.map(|v| Expression::Literal(v))` → `.map(Expression::Literal)`

## Changes

**File**: `crates/vibesql-executor/src/tests/truncate_cascade_tests.rs`

1. **Line 15** - Removed unused import:
   ```diff
   -use vibesql_storage::{Database, Row};
   +use vibesql_storage::Database;
   ```

2. **Line 108** - Simplified redundant closure:
   ```diff
   -    .map(|v| Expression::Literal(v))
   +    .map(Expression::Literal)
   ```

## Context

These warnings appeared after PR #1415 switched from `CreateTableExecutor` to catalog API for test setup. The `Row` type became unused, and Clippy correctly identified that the closure can be simplified using function coercion.

## Testing

- ✅ Verified clippy warnings are resolved
- ✅ Confirmed no new warnings introduced in the test file
- ✅ Ran truncate_cascade tests - same results as main branch (2 passed, 5 pre-existing failures)
- ✅ Pre-existing test failures are unrelated to these changes

## Related Issues

Closes #1439

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)