### PR TITLE
fix: Quote 'day' identifier in test_sum_window_running_total

### DIFF
--- a/crates/vibesql-executor/src/tests/select_window_aggregate.rs
+++ b/crates/vibesql-executor/src/tests/select_window_aggregate.rs
@@ -71,8 +71,8 @@ fn test_sum_window_running_total() {
     let db = create_test_db();
     let executor = SelectExecutor::new(&db);
 
-    // SELECT id, SUM(amount) OVER (ORDER BY day) as running_total FROM sales
-    let query = "SELECT id, SUM(amount) OVER (ORDER BY day) as running_total FROM sales";
+    // SELECT id, SUM(amount) OVER (ORDER BY "day") as running_total FROM sales
+    let query = "SELECT id, SUM(amount) OVER (ORDER BY \"day\") as running_total FROM sales";
     let stmt = Parser::parse_sql(query).unwrap();
 
     if let vibesql_ast::Statement::Select(select_stmt) = stmt {


### PR DESCRIPTION
## Summary

Fixes #1443 - The test `test_sum_window_running_total` was failing with a parsing error because `day` is a SQL keyword.

## Changes

- Quote the `day` identifier in the SQL query: `ORDER BY "day"` instead of `ORDER BY day`
- Updated comment to reflect the quoted identifier

## Root Cause

The parser treats `DAY` as a SQL keyword (used in date/time functions like `DAY(date)`), not as a column identifier. When the test query used `ORDER BY day` without quotes, the parser expected an expression after seeing the keyword, causing the error: "Expected expression, found Keyword(Day)".

## Verification

Tested with the vibesql binary:
- **Unquoted**: `ORDER BY day` → ParseError: "Expected expression, found Keyword(Day)"  
- **Quoted**: `ORDER BY "day"` → Parses successfully

## Test Plan

- [x] Verified parser accepts quoted identifier with vibesql binary
- [x] Verified parser rejects unquoted identifier with same error as issue
- [ ] Run full executor test suite once compilation errors on main are resolved

## Related

Discovered during Judge review of PR #1430

🤖 Generated with [Claude Code](https://claude.com/claude-code)