### PR TITLE
fix: Add validation for empty trigger bodies

### DIFF
--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -135,6 +135,7 @@ impl Parser {
 
         let mut sql_parts = vec!["BEGIN".to_string()];
         let mut depth = 1; // Track BEGIN/END nesting
+        let mut has_statements = false; // Track if body contains any statements
 
         // Collect tokens until matching END
         loop {
@@ -142,6 +143,7 @@ impl Parser {
                 Token::Keyword(Keyword::Begin) => {
                     sql_parts.push("BEGIN".to_string());
                     depth += 1;
+                    has_statements = true; // Nested BEGIN counts as content
                     self.advance();
                 }
                 Token::Keyword(Keyword::End) => {
@@ -165,9 +167,17 @@ impl Parser {
                 token => {
                     // Collect other tokens
                     sql_parts.push(format!("{:?}", token));
+                    has_statements = true; // Any token between BEGIN/END counts as statement
                     self.advance();
                 }
             }
+        }
+
+        // Validate that the trigger body is not empty
+        if !has_statements {
+            return Err(ParseError {
+                message: "Trigger body cannot be empty (BEGIN...END with no statements is invalid)".to_string(),
+            });
         }
 
         let raw_sql = sql_parts.join(" ");


### PR DESCRIPTION
## Summary

Adds validation to reject `CREATE TRIGGER` statements with empty bodies (`BEGIN END` with no statements between them).

## Changes

- Modified `parse_trigger_action` in `crates/vibesql-parser/src/parser/trigger.rs`
- Added `has_statements` flag to track if trigger body contains any statements
- Returns `ParseError` if trigger body is completely empty

## Rationale

Empty trigger bodies (`BEGIN END` with no statements) are MySQL-specific behavior and not standard SQL. Most SQL databases (PostgreSQL, SQLite, etc.) reject empty trigger bodies as invalid.

## Testing

The fix addresses test failures in:
- `evidence/slt_lang_createtrigger.test`
- `evidence/slt_lang_droptrigger.test`

Note: There may be some test compatibility issues to resolve with the `preprocess_for_mysql` function, which currently treats VibeSQL as MySQL-compatible. This PR implements the validation but may require adjustments to the test preprocessing strategy.

## Related

Closes #1424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>