### PR TITLE
feat: Add support for LONG data type

### DIFF
--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -26,7 +26,7 @@ impl Parser {
             "UNSIGNED" => Ok(vibesql_types::DataType::Unsigned), /* MySQL-specific: UNSIGNED is 64-bit */
             // unsigned integer
             "SMALLINT" => Ok(vibesql_types::DataType::Smallint),
-            "BIGINT" => Ok(vibesql_types::DataType::Bigint),
+            "BIGINT" | "LONG" => Ok(vibesql_types::DataType::Bigint),
             "BOOLEAN" | "BOOL" => Ok(vibesql_types::DataType::Boolean),
             "FLOAT" => {
                 // Parse FLOAT(precision) or FLOAT

--- a/crates/vibesql-parser/src/tests/create_table/numeric_types.rs
+++ b/crates/vibesql-parser/src/tests/create_table/numeric_types.rs
@@ -35,6 +35,31 @@ fn test_parse_create_table_integer_types() {
 }
 
 #[test]
+fn test_parse_create_table_long_type() {
+    // LONG is an alias for BIGINT (MySQL/Oracle compatibility)
+    let result = Parser::parse_sql("CREATE TABLE test (id LONG, value LONG COMMENT 'test');");
+    assert!(result.is_ok(), "Should parse LONG type");
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 2);
+
+            match create.columns[0].data_type {
+                vibesql_types::DataType::Bigint => {} // LONG maps to Bigint
+                _ => panic!("Expected LONG to map to Bigint, got {:?}", create.columns[0].data_type),
+            }
+
+            match create.columns[1].data_type {
+                vibesql_types::DataType::Bigint => {} // LONG maps to Bigint
+                _ => panic!("Expected LONG to map to Bigint, got {:?}", create.columns[1].data_type),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
 fn test_parse_create_table_float_types() {
     let result = Parser::parse_sql("CREATE TABLE floats (a FLOAT, b REAL, c DOUBLE PRECISION);");
     assert!(result.is_ok(), "Should parse floating point types");


### PR DESCRIPTION
## Summary

Adds parser support for the LONG data type as an alias for BIGINT, providing compatibility with MySQL and Oracle databases.

## Changes

- **Parser**: Added "LONG" as an alias for BIGINT in type parsing (crates/vibesql-parser/src/parser/create/types.rs:29)
- **Tests**: Added unit test `test_parse_create_table_long_type` to verify LONG type parsing
- Follows existing pattern for type aliases (e.g., INT/INTEGER, NUMERIC/DECIMAL)

## Test Results

✅ Unit test passes: `test_parse_create_table_long_type`
✅ CLI test verified: CREATE TABLE, INSERT, and SELECT with LONG columns work correctly
✅ LONG values correctly stored as Bigint type
✅ No regression in existing numeric type tests

## Example Usage

```sql
CREATE TABLE test (id LONG, value LONG COMMENT 'test comment');
INSERT INTO test VALUES (1, 100);
SELECT * FROM test;
```

Closes #1528

🤖 Generated with [Claude Code](https://claude.com/claude-code)