### PR TITLE
Enable multi-table predicate pushdown tests

### DIFF
--- a/crates/vibesql-executor/src/tests/predicate_pushdown.rs
+++ b/crates/vibesql-executor/src/tests/predicate_pushdown.rs
@@ -76,7 +76,6 @@ fn test_table_local_predicate_applied_at_scan() {
 }
 
 #[test]
-#[ignore] // TODO: Implement predicate pushdown optimization in execute_without_aggregation
 fn test_multi_table_with_local_predicates() {
     // Verify that table-local predicates reduce intermediate results
     // before Cartesian product in multi-table FROM
@@ -176,7 +175,6 @@ fn test_multi_table_with_local_predicates() {
 }
 
 #[test]
-#[ignore] // TODO: Implement predicate pushdown optimization in execute_without_aggregation
 fn test_table_local_predicate_with_explicit_join() {
     // Test that table-local predicates work with explicit JOIN syntax
     let mut db = vibesql_storage::Database::new();


### PR DESCRIPTION
## Summary

- Enables two previously ignored tests for multi-table predicate pushdown optimization
- No implementation changes needed - the optimization was already working correctly

## Background

Issue #1524 requested predicate pushdown for multi-table queries. Upon investigation, I discovered the infrastructure was already fully implemented:

1. **Predicate decomposition** (optimizer/where_pushdown.rs:132-152): Breaks down WHERE clauses into table-local, equijoin, and complex predicates
2. **Table scan filtering** (select/scan/table.rs:136-151): Applies table-local predicates during scans  
3. **WHERE threading** (select/scan/join_scan.rs:30-32): Passes WHERE clause through FROM execution

The two ignored tests were simply never enabled after the implementation was completed.

## Changes

**crates/vibesql-executor/src/tests/predicate_pushdown.rs**:
- Removed `#[ignore]` from `test_multi_table_with_local_predicates` (line 79)
- Removed `#[ignore]` from `test_table_local_predicate_with_explicit_join` (line 179)

## Test Results

✅ All 4 predicate pushdown tests pass
✅ All 856 executor tests pass  
✅ No regressions

The optimization is confirmed working:
- `SELECT * FROM t1, t2, t3 WHERE t1.id = 5 AND t2.id = 7` now filters at scan time
- Instead of: 10 × 10 × 10 = 1000 rows → filter → 10 rows
- We get: 1 × 1 × 10 = 10 rows (much more efficient!)

## Performance Impact

This optimization significantly reduces intermediate result sizes for multi-table queries with table-local predicates, preventing Cartesian product explosions.

Closes #1524

🤖 Generated with [Claude Code](https://claude.com/claude-code)