### PR TITLE
feat: Add support for hex and binary literals (x'...' and b'...')

### DIFF
--- a/crates/vibesql-parser/src/parser/expressions/identifiers.rs
+++ b/crates/vibesql-parser/src/parser/expressions/identifiers.rs
@@ -10,6 +10,76 @@ impl Parser {
                 let first = id.clone();
                 self.advance();
 
+                // Check for hex/binary literal (x'...' or b'...')
+                let first_upper = first.to_uppercase();
+                if (first_upper == "X" || first_upper == "B") && matches!(self.peek(), Token::String(_)) {
+                    if let Token::String(s) = self.peek() {
+                        let string_val = s.clone();
+                        self.advance();
+
+                        if first_upper == "X" {
+                            // Parse hex literal: x'303132' -> "\x30\x31\x32"
+                            // Validate and decode hex string
+                            if string_val.len() % 2 != 0 {
+                                return Err(ParseError {
+                                    message: format!("Hex literal must have even number of digits: x'{}'", string_val),
+                                });
+                            }
+
+                            let mut bytes = Vec::new();
+                            for i in (0..string_val.len()).step_by(2) {
+                                let hex_byte = &string_val[i..i + 2];
+                                match u8::from_str_radix(hex_byte, 16) {
+                                    Ok(byte) => bytes.push(byte),
+                                    Err(_) => {
+                                        return Err(ParseError {
+                                            message: format!("Invalid hex digit in literal: x'{}'", string_val),
+                                        });
+                                    }
+                                }
+                            }
+
+                            // Convert bytes to string (UTF-8 lossy conversion for compatibility)
+                            let result = String::from_utf8_lossy(&bytes).to_string();
+                            return Ok(Some(vibesql_ast::Expression::Literal(
+                                vibesql_types::SqlValue::Varchar(result),
+                            )));
+                        } else {
+                            // Parse binary literal: b'01010101' -> "U"
+                            if !string_val.chars().all(|c| c == '0' || c == '1') {
+                                return Err(ParseError {
+                                    message: format!("Binary literal must contain only 0 and 1: b'{}'", string_val),
+                                });
+                            }
+
+                            if string_val.len() % 8 != 0 {
+                                return Err(ParseError {
+                                    message: format!("Binary literal must have length divisible by 8: b'{}'", string_val),
+                                });
+                            }
+
+                            let mut bytes = Vec::new();
+                            for i in (0..string_val.len()).step_by(8) {
+                                let binary_byte = &string_val[i..i + 8];
+                                match u8::from_str_radix(binary_byte, 2) {
+                                    Ok(byte) => bytes.push(byte),
+                                    Err(_) => {
+                                        return Err(ParseError {
+                                            message: format!("Invalid binary literal: b'{}'", string_val),
+                                        });
+                                    }
+                                }
+                            }
+
+                            // Convert bytes to string
+                            let result = String::from_utf8_lossy(&bytes).to_string();
+                            return Ok(Some(vibesql_ast::Expression::Literal(
+                                vibesql_types::SqlValue::Varchar(result),
+                            )));
+                        }
+                    }
+                }
+
                 // Check for function call (identifier followed by '(')
                 if matches!(self.peek(), Token::LParen) {
                     // This is handled by parse_function_call, return None


### PR DESCRIPTION
## Summary
- Fixed parser bug where hex literals like `x'303132'` were incorrectly parsed as column references
- Added support for hex literals (`x'...'` and `X'...'`) and binary literals (`b'...'` and `B'...'`)
- Queries like `SELECT x'303132' IN (SELECT * FROM t1)` now execute successfully

## Changes

### Parser (crates/vibesql-parser)
- Modified `parse_identifier_expression()` in `identifiers.rs` to recognize hex/binary literal syntax
- Added hex decoding: `x'303132'` → `VARCHAR("012")` (bytes 0x30, 0x31, 0x32)
- Added binary decoding: `b'01010101'` → `VARCHAR("U")` (byte 0x55)
- Case-insensitive support: both `x'...'` and `X'...'` work
- Validation for malformed literals (odd hex length, invalid digits, binary not divisible by 8)

### Tests Added
**Parser tests** (`crates/vibesql-parser/src/tests/literals.rs`):
- ✅ Hex literal lowercase (`x'303132'` → "012")
- ✅ Hex literal uppercase (`X'48656C6C6F'` → "Hello")
- ✅ Empty hex literal (`x''` → "")
- ✅ Hex literal validation (odd length fails, invalid digits fail)
- ✅ Binary literal lowercase/uppercase
- ✅ Binary literal validation (invalid length, invalid digits)
- ✅ Hex literals in expressions (IN, comparisons)

**Executor tests** (`crates/vibesql-executor/src/tests/select_without_from.rs`):
- ✅ Hex literal in IN subquery without FROM clause
- ✅ Simple hex literal evaluation
- ✅ Binary literal in IN subquery without FROM clause

## Test Results
All parser and executor tests passing (11 new parser tests + 3 new executor tests).

## Fixes
Closes #1529

## Before
```sql
SELECT x'303132' IN (SELECT * FROM t1);
-- Error: Column reference requires FROM clause
```

## After
```sql
SELECT x'303132' IN (SELECT * FROM t1);
-- Returns: Boolean(false)

SELECT x'48656C6C6F';
-- Returns: Varchar("Hello")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)