### PR TITLE
Remove obsolete TODO for LIKE/IN operators (already implemented)

### DIFF
--- a/crates/vibesql-ast/src/operators.rs
+++ b/crates/vibesql-ast/src/operators.rs
@@ -26,7 +26,10 @@ pub enum BinaryOperator {
     // String
     Concat, /* || */
 
-            /* TODO: Add more (LIKE, IN, etc.) */
+    // Note: LIKE and IN are not simple binary operators. They are implemented
+    // as Expression variants in expression.rs due to their complex structure:
+    // - LIKE: Pattern matching with wildcards (%, _)
+    // - IN: Subquery or value list support
 }
 
 /// Unary operators for SQL expressions


### PR DESCRIPTION
## Summary

Removes misleading TODO comment from `BinaryOperator` enum suggesting LIKE and IN operators need to be added.

## Problem

The TODO at line 29 of `crates/vibesql-ast/src/operators.rs` said:
```rust
/* TODO: Add more (LIKE, IN, etc.) */
```

This was misleading because:
- ✅ LIKE is already implemented as `Expression::Like` (expression.rs:145)
- ✅ IN is already implemented as `Expression::In` (expression.rs:80)
- ✅ Both are actively used throughout the codebase (20+ files)
- ✅ They are correctly implemented as Expression variants, not BinaryOperators

## Solution

1. **Removed** the obsolete TODO comment
2. **Added** clarifying comment explaining why LIKE/IN are Expression variants:
   - They have complex structure (pattern matching, subqueries)
   - Not simple binary operations
   - Intentionally separate from BinaryOperator

This prevents:
- ❌ New contributors thinking these features are missing
- ❌ Wasted effort trying to "implement" already-implemented features
- ❌ This TODO being re-added in the future

## Testing

- ✅ `cargo check --workspace` - No compilation errors
- ✅ `cargo test --workspace -- like` - LIKE tests pass
- ✅ `cargo test --workspace -- in_operator` - IN tests pass
- ✅ All existing functionality unchanged (comment-only change)

## Files Changed

- `crates/vibesql-ast/src/operators.rs` - Removed TODO, added clarification

## Related Issues

Closes #1547

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>