### PR TITLE
Remove commented-out test waiting for Phase 3.2

### DIFF
--- a/crates/vibesql-executor/tests/predicate_pushdown_tests.rs
+++ b/crates/vibesql-executor/tests/predicate_pushdown_tests.rs
@@ -251,36 +251,6 @@ fn test_large_multi_table_join_with_predicate_pushdown() {
 // Solution requires Phase 3: Build smart join plans that use hash joins for equijoins
 // or reorder the join tree to apply selectivity early.
 
-// DISABLED: Requires Phase 3.2 integration
-// This test demonstrates the cascading join problem that Phase 3.2 solves
-// With 15 tables and recursive binary joins, we still build large intermediate results
-// Phase 3.2 needs integration into scan.rs to apply join reordering
-// #[test]
-// fn test_select5_style_multi_table_with_equijoins() {
-//     // Simulate select5.test style query: many tables with equijoin conditions
-// // This mirrors the pathological queries in select5.test with smaller scale
-//     let db = setup_test_db_with_tables(15, 10);
-//     let executor = SelectExecutor::new(&db);
-//
-//     // Build a query similar to select5.test with 15 tables
-//     // Each table is filtered locally, then joined with equijoin conditions
-//     let sql = "SELECT COUNT(*) FROM T1, t2, t3, t4, t5, t6, t7, t8, t9, t10, \
-//                                t11, t12, t13, t14, t15 \
-//                 WHERE a1 > 1 AND a2 > 1 AND a3 > 1 AND a4 > 1 AND a5 > 1 \
-//                 AND a6 > 1 AND a7 > 1 AND a8 > 1 AND a9 > 1 AND a10 > 1 \
-//                 AND a11 > 1 AND a12 > 1 AND a13 > 1 AND a14 > 1 AND a15 > 1 \
-//                 AND a1 = b2 AND a2 = b3 AND a3 = b4 AND a4 = b5 AND a5 = b6 \
-//                 AND a6 = b7 AND a7 = b8 AND a8 = b9 AND a9 = b10 AND a10 = b11 \
-//                 AND a11 = b12 AND a12 = b13 AND a13 = b14 AND a14 = b15";
-//     let stmt = parse_select(sql);
-//
-//     // This should execute successfully with predicate pushdown
-//     let result = executor.execute(&stmt).unwrap();
-//
-//     // Should successfully execute
-//     assert_eq!(result.len(), 1);
-// }
-
 // ============================================================================
 // Phase 3.1: Hash Join Selection from WHERE Clause Equijoins
 // ============================================================================


### PR DESCRIPTION
## Summary

Removes 29 lines of commented-out test code that was disabled awaiting Phase 3.2 join tree reordering functionality. This is a code hygiene improvement that eliminates dead code without functional impact.

## Changes

- ✅ Removed lines 254-282 from `crates/vibesql-executor/tests/predicate_pushdown_tests.rs`
- ✅ Preserved explanatory comments about Phase 3 (lines 234-252)
- ✅ File compiles without errors
- ✅ All 20 predicate pushdown tests pass

## Test Results

```
running 20 tests
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured
```

## Risk Assessment

**Risk Level**: Very Low
- Commented-out code has no functionality
- Test is clearly marked as disabled
- Can be restored from git history (commit 416406f93) if needed
- No other code depends on this test

Closes #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)