### PR TITLE
feat: Replace eprintln! with proper logging framework in vibesql-storage

### DIFF
--- a/crates/vibesql-storage/Cargo.toml
+++ b/crates/vibesql-storage/Cargo.toml
@@ -20,6 +20,7 @@ zstd = "0.13"
 rstar = "0.12"
 lru = "0.12"
 parking_lot = "0.12"
+log = "0.4"
 
 # WASM-specific dependencies for browser storage
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/vibesql-storage/src/database/indexes.rs
+++ b/crates/vibesql-storage/src/database/indexes.rs
@@ -635,7 +635,7 @@ impl IndexManager {
                             // This is a known limitation that will need to be addressed.
                             if let Err(e) = btree.lock().unwrap().insert(key_values, row_index) {
                                 // Log error but don't fail - this may happen for non-unique indexes
-                                eprintln!("Warning: Failed to insert into disk-backed index '{}': {:?}", index_name, e);
+                                log::warn!("Failed to insert into disk-backed index '{}': {:?}", index_name, e);
                             }
                         }
                     }
@@ -703,7 +703,7 @@ impl IndexManager {
                                 let mut btree_guard = btree.lock().unwrap();
                                 let _ = btree_guard.delete(&old_key_values);
                                 if let Err(e) = btree_guard.insert(new_key_values, row_index) {
-                                    eprintln!("Warning: Failed to update disk-backed index '{}': {:?}", index_name, e);
+                                    log::warn!("Failed to update disk-backed index '{}': {:?}", index_name, e);
                                 }
                             }
                         }

--- a/crates/vibesql-storage/src/persistence/json.rs
+++ b/crates/vibesql-storage/src/persistence/json.rs
@@ -452,8 +452,8 @@ fn json_database_to_db(json_db: JsonDatabase) -> Result<Database, StorageError> 
     // Skip views for now - requires SQL parsing which we don't want to do during deserialization
     // Views will need to be recreated manually or via SQL execution
     if !json_db.views.is_empty() {
-        eprintln!(
-            "Warning: {} views found in JSON but skipped (not yet supported)",
+        log::warn!(
+            "{} views found in JSON but skipped (not yet supported)",
             json_db.views.len()
         );
     }

--- a/crates/vibesql-storage/src/table/normalization.rs
+++ b/crates/vibesql-storage/src/table/normalization.rs
@@ -343,8 +343,8 @@ impl<'a> RowNormalizer<'a> {
                 // Log a debug message for development
                 #[cfg(debug_assertions)]
                 {
-                    eprintln!(
-                        "Warning: Skipping validation for user-defined type '{}' in column '{}'",
+                    log::warn!(
+                        "Skipping validation for user-defined type '{}' in column '{}'",
                         type_name, column_name
                     );
                 }


### PR DESCRIPTION
## Summary

Replaces all `eprintln!` calls in the vibesql-storage library with proper logging using the `log` crate. This improves library ergonomics by allowing users to control log levels and filter messages, while also making warnings testable and observable.

## Changes

### Dependencies
- Added `log = "0.4"` to `crates/vibesql-storage/Cargo.toml`

### Code Changes
Replaced 4 `eprintln!` calls with `log::warn!`:

1. **`crates/vibesql-storage/src/database/indexes.rs:638`**
   - Warning for disk-backed index insert failures
   - Changed: `eprintln!("Warning: Failed to insert...")` → `log::warn!("Failed to insert...")`

2. **`crates/vibesql-storage/src/database/indexes.rs:706`**
   - Warning for disk-backed index update failures
   - Changed: `eprintln!("Warning: Failed to update...")` → `log::warn!("Failed to update...")`

3. **`crates/vibesql-storage/src/persistence/json.rs:455`**
   - Warning when views are found in JSON but not yet supported
   - Changed: `eprintln!("Warning: {} views found...")` → `log::warn!("{} views found...")`

4. **`crates/vibesql-storage/src/table/normalization.rs:346`**
   - Warning for user-defined type validation (debug builds only)
   - Changed: `eprintln!("Warning: Skipping validation...")` → `log::warn!("Skipping validation...")`

Note: Removed redundant "Warning:" prefix from messages since the log level already indicates this.

## Test Plan

- ✅ `cargo check -p vibesql-storage` - No compilation errors
- ✅ `cargo test -p vibesql-storage` - All 137 tests pass (0 failed, 4 ignored)
- ✅ No regressions introduced

## Impact

This is a low-risk change that:
- Maintains existing behavior (warnings still appear when logged)
- Makes vibesql-storage more professional and library-friendly
- Establishes logging pattern for future development
- Allows embedders to control logging via `env_logger` or similar

## Related

This is the **first introduction of structured logging** to the vibesql project. Future work could expand logging to other crates as needed.

Closes #1561

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>