### PR TITLE
chore: Remove broken playwright testing scripts from web-demo

### DIFF
--- a/web-demo/README.md
+++ b/web-demo/README.md
@@ -128,7 +128,7 @@ pnpm format:check # Check formatting
 - **Frontend**: TypeScript, Vite, Tailwind CSS
 - **Editor**: Monaco Editor (VS Code engine)
 - **Database**: Rust compiled to WebAssembly via wasm-pack
-- **Testing**: Vitest, Playwright
+- **Testing**: Vitest
 - **CI/CD**: GitHub Actions
 
 ### Project Structure

--- a/web-demo/package.json
+++ b/web-demo/package.json
@@ -15,14 +15,7 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
-    "prepare": "husky",
-    "debug:site": "npx tsx debug-credentials-error.ts",
-    "inspect:site": "npx tsx inspect-site.ts",
-    "inspect:firefox": "npx tsx inspect-firefox.ts",
-    "find:credentials": "npx tsx find-credentials-usage.ts",
-    "test:execution": "npx tsx test-execution.ts",
-    "diagnose:data": "npx tsx diagnose-data-format.ts",
-    "test:local": "npx tsx test-local.ts"
+    "prepare": "husky"
   },
   "lint-staged": {
     "*.ts": [


### PR DESCRIPTION
## Summary

This PR simplifies the web-demo testing infrastructure by removing broken references to non-existent playwright testing scripts.

**Changes:**
- ✅ Removed 7 broken npm scripts from `package.json` that referenced non-existent files
- ✅ Updated `README.md` to accurately reflect that only Vitest is used for testing (removed Playwright)

**Scripts Removed:**
- `debug:site` → `debug-credentials-error.ts` (file doesn't exist)
- `inspect:site` → `inspect-site.ts` (file doesn't exist)
- `inspect:firefox` → `inspect-firefox.ts` (file doesn't exist)
- `find:credentials` → `find-credentials-usage.ts` (file doesn't exist)
- `test:execution` → `test-execution.ts` (file doesn't exist)
- `diagnose:data` → `diagnose-data-format.ts` (file doesn't exist)
- `test:local` → `test-local.ts` (file doesn't exist)

**Impact:**
- Developers will no longer encounter errors when running these scripts
- Documentation now accurately represents the testing infrastructure
- Reduced confusion about which testing tools are actually used
- No functional impact - these scripts were already broken

**Files Changed:**
- `web-demo/package.json` - Removed 7 broken script entries
- `web-demo/README.md` - Removed Playwright from tech stack listing

Closes #1572

🤖 Generated with [Claude Code](https://claude.com/claude-code)