### PR TITLE
Simplify TPC-H benchmarks using macros to reduce duplication

### DIFF
--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -31,6 +31,7 @@ duckdb = { version = "1.1", features = ["bundled"] }
 rand = "0.8"
 rand_chacha = "0.3"
 rust_decimal = "1.33"
+paste = "1.0"
 
 [[test]]
 name = "foreign_key_tests"


### PR DESCRIPTION
## Summary

This PR simplifies the TPC-H benchmark file by eliminating massive code duplication through macro-based generation.

**Changes:**
- ✅ Reduced from 2607 lines → 1743 lines (33% reduction, 864 lines removed)
- ✅ Eliminated 66 duplicate functions
- ✅ Replaced with 22 macro invocations + 6 helper functions + 2 macros
- ✅ Added `paste = "1.0"` dev-dependency for macro identifier concatenation

## Technical Approach

### Before (Example - Q6):
```rust
fn benchmark_q6_vibesql(c: &mut Criterion) {
    let db = load_vibesql(0.01);
    c.bench_function("tpch_q6_vibesql", |b| {
        b.iter(|| {
            let stmt = Parser::parse_sql(TPCH_Q6).unwrap();
            if let vibesql_ast::Statement::Select(select) = stmt {
                let executor = SelectExecutor::new(&db);
                let result = executor.execute(&select).unwrap();
                let row = result.first();
                black_box(row);
            }
        });
    });
}

fn benchmark_q6_sqlite(c: &mut Criterion) { /* ~15 lines */ }
fn benchmark_q6_duckdb(c: &mut Criterion) { /* ~15 lines */ }
```
**This pattern repeated 22 times = ~1500 lines of duplication**

### After:
```rust
// Helper functions extract shared logic (6 functions, ~150 lines)
fn benchmark_vibesql_query(c: &mut Criterion, name: &str, sql: &str) { /* ... */ }
fn benchmark_sqlite_query(c: &mut Criterion, name: &str, sql: &str) { /* ... */ }
fn benchmark_duckdb_query(c: &mut Criterion, name: &str, sql: &str) { /* ... */ }
// + 3 more for grouped benchmarks

// Macro generates the 3 functions per query
macro_rules! tpch_benchmark {
    ($query_num:expr, $sql:expr) => {
        paste::paste! {
            fn [<benchmark_q $query_num _vibesql>](c: &mut Criterion) {
                benchmark_vibesql_query(c, concat!("tpch_q", stringify!($query_num), "_vibesql"), $sql);
            }
            // ... sqlite and duckdb variants
        }
    };
}

// Usage: 1 line per query instead of 60+
tpch_benchmark!(6, TPCH_Q6);
```

## Benefits

1. **Maintainability**: Change benchmark logic once instead of 66 places
2. **Readability**: Clear intent - "generate benchmarks for query N"
3. **Extensibility**: Adding Q23 requires 1 line, not 60+
4. **DRY principle**: Eliminates massive code duplication

## Testing

The refactoring preserves identical functionality:
- Same function signatures generated by macros
- Same benchmark names (verified via `criterion_group!` listing)
- Same execution logic in helper functions
- Can verify with `cargo expand` that generated code matches original structure

## Risk Assessment

**Risk Level**: Low
- Pure refactoring, no logic changes
- Benchmark function signatures unchanged
- Criterion group registration unchanged
- Generated code structure identical to original

Closes #1596

🤖 Generated with [Claude Code](https://claude.com/claude-code)