### PR TITLE
Add BLOB data type support to parser

### DIFF
--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -342,7 +342,7 @@ impl Parser {
             "TINYINT" | "MEDIUMINT" | "SERIAL" |
             // MySQL string types
             "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT" |
-            "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" |
+            "BLOB" | "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" |
             "BINARY" | "VARBINARY" |
             // MySQL JSON type
             "JSON" |


### PR DESCRIPTION
## Summary
Adds BLOB data type keyword recognition to the parser. This is a minimal 1-line fix that enables parsing of CREATE TABLE statements with BLOB columns.

## Problem
The parser recognized MySQL BLOB variants (TINYBLOB, MEDIUMBLOB, LONGBLOB) but not the base BLOB keyword, causing DDL tests to fail with "Unknown data type: BLOB" errors.

## Solution
Added "BLOB" to the list of supported extension types in `crates/vibesql-parser/src/parser/create/types.rs:345`.

All the infrastructure for BLOB support already exists:
- BinaryLargeObject type enum variant
- B-tree serialization/deserialization  
- JSON persistence
- Table normalization
- CLI display

Only parser keyword recognition was missing.

## Changes
- **Modified**: `crates/vibesql-parser/src/parser/create/types.rs`
  - Added "BLOB" to supported extension types matcher

## Testing
- ✅ Parser compiles successfully
- ✅ `CREATE TABLE t1 (c1 BLOB NULL, c2 BLOB NULL)` parses without error
- ✅ All 833 parser tests pass (no regressions)
- ✅ Tested with example from issue #1611

## Impact
- Enables parsing of 101+ BLOB occurrences in SQLLogicTest suite
- Fixes createtable1.test failures
- No breaking changes

Closes #1611

Generated with [Claude Code](https://claude.com/claude-code)