### PR TITLE
fix: Preserve database_path on Database::reset() (#1610)

### DIFF
--- a/crates/vibesql-storage/src/database/core.rs
+++ b/crates/vibesql-storage/src/database/core.rs
@@ -103,20 +103,14 @@ impl Database {
     ///
     /// Clears all tables, resets catalog to default state, and clears all indexes and transactions.
     /// Useful for test scenarios where you need to reuse a Database instance.
-    /// Preserves database path to ensure disk-backed indexes continue to work after reset.
+    /// Preserves database configuration (path, storage backend, memory budgets) across resets.
     pub fn reset(&mut self) {
-        // Save database path before reset (fixes issue #1610)
-        let db_path = self.operations.get_database_path();
-
         self.catalog = vibesql_catalog::Catalog::new();
         self.lifecycle.reset();
         self.metadata = Metadata::new();
-        self.operations = Operations::new();
 
-        // Restore database path after reset
-        if let Some(path) = db_path {
-            self.operations.set_database_path(path);
-        }
+        // Reset operations in place to preserve database_path, storage backend, and config
+        self.operations.reset();
 
         self.tables.clear();
     }

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -110,14 +110,21 @@ impl IndexManager {
         self.database_path = Some(path);
     }
 
-    /// Get the database directory path for index file storage
-    pub fn get_database_path(&self) -> Option<PathBuf> {
-        self.database_path.clone()
-    }
-
     /// Set the resource budget configuration
     pub fn set_config(&mut self, config: DatabaseConfig) {
         self.config = config;
+    }
+
+    /// Reset the index manager to empty state (clears all indexes).
+    ///
+    /// Clears all index metadata and data but preserves configuration
+    /// (database path, storage backend, and resource budgets).
+    /// This is more efficient than creating a new instance and ensures
+    /// disk-backed indexes continue to work after reset.
+    pub fn reset(&mut self) {
+        self.indexes.clear();
+        self.index_data.clear();
+        self.resource_tracker = ResourceTracker::new();
     }
 
     /// Check if an index exists

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -42,11 +42,6 @@ impl Operations {
         self.index_manager.set_database_path(path);
     }
 
-    /// Get the database path for index storage
-    pub fn get_database_path(&self) -> Option<std::path::PathBuf> {
-        self.index_manager.get_database_path()
-    }
-
     /// Set the database configuration (memory budgets, spill policy)
     pub fn set_config(&mut self, config: super::DatabaseConfig) {
         self.index_manager.set_config(config);
@@ -534,6 +529,18 @@ impl Operations {
                 }
             }
         }
+    }
+
+    /// Reset the operations manager to empty state (clears all indexes).
+    ///
+    /// Clears all index data but preserves configuration (database path, storage backend, config).
+    /// This is more efficient than creating a new instance and ensures indexes work after reset.
+    pub fn reset(&mut self) {
+        // Clear all user-defined indexes (preserves database_path, storage, config)
+        self.index_manager.reset();
+
+        // Clear all spatial indexes
+        self.spatial_indexes.clear();
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes #1610 - Complete fix for SQLLogicTest regression where 595/623 tests fail.

## Root Cause Analysis  
The original fix preserved `database_path` but was incomplete. The real issue was that `Database::reset()` created a new `Operations` instance, which created a new `IndexManager` with:
- Empty `indexes` HashMap (all index metadata lost)
- Empty `index_data` HashMap (all index data structures lost)  
- New storage backend (even after restoring path)

The test runner uses database pooling (`get_pooled_database()` in `db_adapter.rs`) to reuse Database instances between test files, calling `reset()` between each file. When `reset()` lost the index infrastructure, newly created indexes in subsequent test files had no working storage backend, even though `database_path` was preserved.

## Complete Solution
Instead of replacing `Operations` with a new instance and trying to restore state, we now reset it in place:

### Changes Made

**1. Added `IndexManager::reset()` method** (crates/vibesql-storage/src/database/indexes/index_manager.rs:118-128)
   - Clears `indexes` and `index_data` HashMaps
   - Resets `resource_tracker`
   - **Preserves**: `database_path`, `storage` backend, `config` (memory budgets)

**2. Added `Operations::reset()` method** (crates/vibesql-storage/src/database/operations.rs:535-545)
   - Delegates to `IndexManager::reset()`
   - Clears `spatial_indexes` HashMap

**3. Updated `Database::reset()` method** (crates/vibesql-storage/src/database/core.rs:107-116)
   - Calls `self.operations.reset()` instead of `self.operations = Operations::new()`
   - Removed manual save/restore of `database_path`
   - All infrastructure now preserved automatically

## Why This Works
- **Preserves complete infrastructure**: Storage backend, database_path, and config all remain intact
- **More efficient**: No reallocating storage backends or recreating structures
- **Cleaner design**: Reset-in-place pattern instead of replace-and-restore
- **Fixes test runner**: Database instances can be safely reused across test files

## Testing
- Manual CLI tests confirm indexes work correctly
- Code compiles cleanly with proper encapsulation
- All configuration state preserved automatically
- CI tests running...

## Files Changed
- `crates/vibesql-storage/src/database/core.rs` - Updated reset() method
- `crates/vibesql-storage/src/database/operations.rs` - Added Operations::reset()
- `crates/vibesql-storage/src/database/indexes/index_manager.rs` - Added IndexManager::reset()

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>