### PR TITLE
feat(parser): Add DATETIME data type support

### DIFF
--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -130,6 +130,12 @@ impl Parser {
                 let with_timezone = self.parse_timezone_modifier()?;
                 Ok(vibesql_types::DataType::Timestamp { with_timezone })
             }
+            "DATETIME" => {
+                // MySQL/SQLite DATETIME type - treated as alias for TIMESTAMP
+                // Parse optional WITH TIME ZONE or WITHOUT TIME ZONE
+                let with_timezone = self.parse_timezone_modifier()?;
+                Ok(vibesql_types::DataType::Timestamp { with_timezone })
+            }
             "INTERVAL" => {
                 // Parse INTERVAL start_field [TO end_field]
                 let start_field = self.parse_interval_field()?;


### PR DESCRIPTION
## Summary

- Add DATETIME data type support to the parser
- Treat DATETIME as an alias for TIMESTAMP (MySQL/SQLite compatibility)
- Add comprehensive tests for DATETIME parsing

## Changes

**Parser (`types.rs`)**:
- Added DATETIME case in `parse_data_type()` method
- Maps DATETIME to `DataType::Timestamp`
- Supports optional WITH/WITHOUT TIME ZONE modifiers

**Tests (`temporal_types.rs`)**:
- Added `test_parse_create_table_datetime()` for basic DATETIME parsing
- Added `test_parse_create_table_datetime_with_constraints()` for the exact statement from issue #1619

## Test Results

All parser tests pass, including the new DATETIME tests:
```
test tests::create_table::temporal_types::test_parse_create_table_datetime ... ok
test tests::create_table::temporal_types::test_parse_create_table_datetime_with_constraints ... ok
```

## Related

Closes #1619

## Impact

- Fixes parsing errors in `ddl/createtable/createtable1.test`
- Improves SQL compatibility with MySQL and SQLite
- No breaking changes - DATETIME is a new recognized type

🤖 Generated with [Claude Code](https://claude.com/claude-code)