### PR TITLE
feat: Add parser support for indexed column prefix syntax

### DIFF
--- a/crates/vibesql-ast/src/ddl/schema.rs
+++ b/crates/vibesql-ast/src/ddl/schema.rs
@@ -172,6 +172,9 @@ pub enum IndexType {
 pub struct IndexColumn {
     pub column_name: String,
     pub direction: crate::select::OrderDirection,
+    /// Optional prefix length for indexed columns (MySQL/SQLite feature)
+    /// Example: UNIQUE (name(10)) creates index on first 10 characters of 'name'
+    pub prefix_length: Option<u64>,
 }
 
 /// DROP INDEX statement

--- a/crates/vibesql-ast/src/ddl/table.rs
+++ b/crates/vibesql-ast/src/ddl/table.rs
@@ -131,7 +131,7 @@ pub struct TableConstraint {
 #[derive(Debug, Clone, PartialEq)]
 pub enum TableConstraintKind {
     PrimaryKey {
-        columns: Vec<String>,
+        columns: Vec<crate::IndexColumn>,
     },
     ForeignKey {
         columns: Vec<String>,
@@ -141,7 +141,7 @@ pub enum TableConstraintKind {
         on_update: Option<ReferentialAction>,
     },
     Unique {
-        columns: Vec<String>,
+        columns: Vec<crate::IndexColumn>,
     },
     Check {
         expr: Box<Expression>,
@@ -150,7 +150,7 @@ pub enum TableConstraintKind {
     /// Example: FULLTEXT INDEX ft_search (title, body)
     Fulltext {
         index_name: Option<String>,
-        columns: Vec<String>,
+        columns: Vec<crate::IndexColumn>,
     },
 }
 

--- a/crates/vibesql-executor/src/alter.rs
+++ b/crates/vibesql-executor/src/alter.rs
@@ -278,8 +278,11 @@ impl AlterTableExecutor {
 
         match &stmt.constraint.kind {
             TableConstraintKind::PrimaryKey { columns } => {
+                // Extract column names from IndexColumn structs
+                let column_names: Vec<String> = columns.iter().map(|c| c.column_name.clone()).collect();
+
                 // Verify all columns exist
-                for col_name in columns {
+                for col_name in &column_names {
                     if !table.schema.has_column(col_name) {
                         return Err(ExecutorError::ColumnNotFound {
                             column_name: col_name.clone(),
@@ -303,7 +306,7 @@ impl AlterTableExecutor {
                 }
 
                 // Add primary key to table schema
-                table.schema_mut().primary_key = Some(columns.clone());
+                table.schema_mut().primary_key = Some(column_names);
 
                 // Rebuild table indexes to create the primary key index
                 table.rebuild_indexes();
@@ -319,7 +322,9 @@ impl AlterTableExecutor {
                 ))
             }
             TableConstraintKind::Unique { columns } => {
-                table.schema_mut().add_unique_constraint(columns.clone())?;
+                // Extract column names from IndexColumn structs
+                let column_names: Vec<String> = columns.iter().map(|c| c.column_name.clone()).collect();
+                table.schema_mut().add_unique_constraint(column_names)?;
 
                 // Rebuild table indexes to create the unique constraint index
                 table.rebuild_indexes();

--- a/crates/vibesql-executor/src/constraint_validator.rs
+++ b/crates/vibesql-executor/src/constraint_validator.rs
@@ -112,16 +112,20 @@ impl ConstraintValidator {
                     if result.primary_key.is_some() {
                         return Err(ExecutorError::MultiplePrimaryKeys);
                     }
-                    result.primary_key = Some(pk_cols.clone());
+                    // Extract column names from IndexColumn structs
+                    let column_names: Vec<String> = pk_cols.iter().map(|c| c.column_name.clone()).collect();
+                    result.primary_key = Some(column_names.clone());
                     // All PK columns must be NOT NULL
-                    for col_name in pk_cols {
+                    for col_name in &column_names {
                         if !result.not_null_columns.contains(col_name) {
                             result.not_null_columns.push(col_name.clone());
                         }
                     }
                 }
                 TableConstraintKind::Unique { columns } => {
-                    result.unique_constraints.push(columns.clone());
+                    // Extract column names from IndexColumn structs
+                    let column_names: Vec<String> = columns.iter().map(|c| c.column_name.clone()).collect();
+                    result.unique_constraints.push(column_names);
                 }
                 TableConstraintKind::Check { expr } => {
                     let constraint_name = format!("check_{}", constraint_counter);

--- a/crates/vibesql-parser/src/tests/alter_table.rs
+++ b/crates/vibesql-parser/src/tests/alter_table.rs
@@ -154,7 +154,7 @@ fn test_alter_table_add_unique_no_keyword() {
                 match &add.constraint.kind {
                     vibesql_ast::TableConstraintKind::Unique { columns } => {
                         assert_eq!(columns.len(), 1);
-                        assert_eq!(columns[0], "COL");
+                        assert_eq!(columns[0].column_name, "COL");
                     }
                     _ => panic!("Expected UNIQUE constraint"),
                 }
@@ -179,7 +179,7 @@ fn test_alter_table_add_primary_key_no_keyword() {
                 match &add.constraint.kind {
                     vibesql_ast::TableConstraintKind::PrimaryKey { columns } => {
                         assert_eq!(columns.len(), 1);
-                        assert_eq!(columns[0], "COL");
+                        assert_eq!(columns[0].column_name, "COL");
                     }
                     _ => panic!("Expected PRIMARY KEY constraint"),
                 }

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -243,7 +243,7 @@ pub fn read_catalog<R: Read>(reader: &mut R) -> Result<Database, StorageError> {
                 }
             };
 
-            columns.push(vibesql_ast::IndexColumn { column_name, direction });
+            columns.push(vibesql_ast::IndexColumn { column_name, direction, prefix_length: None });
         }
 
         index_specs.push((index_name, table_name, unique, columns));

--- a/crates/vibesql-storage/src/persistence/json.rs
+++ b/crates/vibesql-storage/src/persistence/json.rs
@@ -470,6 +470,7 @@ fn json_database_to_db(json_db: JsonDatabase) -> Result<Database, StorageError> 
                 } else {
                     OrderDirection::Asc
                 },
+                prefix_length: None,
             })
             .collect();
 


### PR DESCRIPTION
## Summary

Implements MySQL/SQLite indexed column prefix syntax to support constraints and indexes on column prefixes.

## Changes

- **AST Updates**: Added `prefix_length` field to `IndexColumn` to store optional column prefix length
- **Parser Support**: Updated parsers for CREATE INDEX and table constraints (PRIMARY KEY, UNIQUE, FULLTEXT) to parse the `column(n)` syntax
- **Executor Compatibility**: Modified constraint handling code to extract column names from IndexColumn structs
- **Tests**: Added comprehensive test cases covering UNIQUE, PRIMARY KEY, and CREATE INDEX with prefix syntax

## Example

```sql
-- Now supported:
CREATE TABLE t7(a TEXT, UNIQUE (a(1)))
CREATE INDEX idx1 ON users (email(50))
CREATE TABLE t8(name VARCHAR(100), PRIMARY KEY (name(50)))
```

## Implementation Approach

Following the recommendation in the issue, this implementation accepts the prefix syntax but **does not enforce prefix indexing behavior**. The parser recognizes and stores the prefix length, but the index operates on the full column value. This provides immediate test compatibility while leaving room for future optimization.

## Test Results

- ✅ All new parser tests pass
- ✅ Existing test suite passes with no regressions
- ✅ The failing test case `evidence/in1.test` now passes

Closes #1620

🤖 Generated with [Claude Code](https://claude.com/claude-code)