### PR TITLE
feat: Add validation for indexed column prefix length values

### DIFF
--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -19,6 +19,19 @@ impl Parser {
                         message: "Invalid integer for column prefix length".to_string(),
                     })?;
                     self.advance();
+
+                    // Validate prefix length range
+                    if value < 1 {
+                        return Err(ParseError {
+                            message: "Prefix length must be at least 1".to_string(),
+                        });
+                    }
+                    if value > 10000 {
+                        return Err(ParseError {
+                            message: "Prefix length must not exceed 10000".to_string(),
+                        });
+                    }
+
                     value
                 }
                 _ => {

--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -96,6 +96,19 @@ impl Parser {
                             message: "Invalid integer for column prefix length".to_string(),
                         })?;
                         self.advance();
+
+                        // Validate prefix length range
+                        if value < 1 {
+                            return Err(ParseError {
+                                message: "Prefix length must be at least 1".to_string(),
+                            });
+                        }
+                        if value > 10000 {
+                            return Err(ParseError {
+                                message: "Prefix length must not exceed 10000".to_string(),
+                            });
+                        }
+
                         value
                     }
                     _ => {


### PR DESCRIPTION
## Summary

Adds parser-level validation for indexed column prefix lengths to provide better error messages when users specify invalid values.

## Changes

- **Minimum validation**: Prefix length must be at least 1 (rejects meaningless zero-length prefixes)
- **Maximum validation**: Prefix length must not exceed 10000 (prevents extremely large impractical values)
- **Clear error messages**: Users get helpful feedback like "Prefix length must be at least 1" instead of silent acceptance or runtime errors

Validation is applied to:
- `CREATE INDEX` statements with column prefixes: `CREATE INDEX idx ON t (col(n))`
- Table-level `PRIMARY KEY` constraints: `PRIMARY KEY (col(n))`
- Table-level `UNIQUE` constraints: `UNIQUE (col(n))`

## Test Coverage

Added 7 new tests:
- Zero prefix rejection for UNIQUE, PRIMARY KEY, and CREATE INDEX
- Excessive prefix rejection (> 10000) for all three cases  
- Boundary value acceptance (1 and 10000 are valid)

All tests pass:
```
running 10 tests
test tests::create_table::constraints_table::test_parse_create_index_prefix_zero_fails ... ok
test tests::create_table::constraints_table::test_parse_create_index_prefix_too_large_fails ... ok
test tests::create_table::constraints_table::test_parse_create_index_with_column_prefix ... ok
test tests::create_table::constraints_table::test_parse_create_table_with_primary_key_prefix ... ok
test tests::create_table::constraints_table::test_parse_primary_key_prefix_too_large_fails ... ok
test tests::create_table::constraints_table::test_parse_create_table_with_indexed_column_prefix ... ok
test tests::create_table::constraints_table::test_parse_primary_key_prefix_zero_fails ... ok
test tests::create_table::constraints_table::test_parse_unique_constraint_prefix_too_large_fails ... ok
test tests::create_table::constraints_table::test_parse_unique_constraint_prefix_zero_fails ... ok
test tests::create_table::constraints_table::test_parse_unique_constraint_prefix_boundary_values ... ok
```

## Examples

**Before** (accepted silently):
```sql
CREATE TABLE t1(a TEXT, UNIQUE (a(0)));  -- Zero-length prefix
CREATE TABLE t2(a TEXT, UNIQUE (a(999999999)));  -- Impractically large
```

**After** (helpful errors):
```sql
CREATE TABLE t1(a TEXT, UNIQUE (a(0)));
-- Error: Prefix length must be at least 1

CREATE TABLE t2(a TEXT, UNIQUE (a(10001)));
-- Error: Prefix length must not exceed 10000
```

Closes #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)