### PR TITLE
feat(parser): Add YEAR type support for MySQL compatibility

### DIFF
--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -15,6 +15,7 @@ impl Parser {
             Token::Keyword(Keyword::Boolean) => "BOOLEAN".to_string(),
             // MySQL-specific types that are keywords
             Token::Keyword(Keyword::Set) => "SET".to_string(),
+            Token::Keyword(Keyword::Year) => "YEAR".to_string(),
             _ => return Err(ParseError { message: "Expected data type".to_string() }),
         };
         self.advance();
@@ -135,6 +136,11 @@ impl Parser {
                 // Parse optional WITH TIME ZONE or WITHOUT TIME ZONE
                 let with_timezone = self.parse_timezone_modifier()?;
                 Ok(vibesql_types::DataType::Timestamp { with_timezone })
+            }
+            "YEAR" => {
+                // MySQL YEAR type - stores years from 1901-2155
+                // Treated as a user-defined type for compatibility
+                Ok(vibesql_types::DataType::UserDefined { type_name: "YEAR".to_string() })
             }
             "INTERVAL" => {
                 // Parse INTERVAL start_field [TO end_field]
@@ -346,6 +352,8 @@ impl Parser {
             "GEOMETRY" | "GEOMETRYCOLLECTION" |
             // MySQL numeric types
             "TINYINT" | "MEDIUMINT" | "SERIAL" |
+            // MySQL temporal types
+            "YEAR" |
             // MySQL string types
             "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT" |
             "BLOB" | "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" |


### PR DESCRIPTION
## Summary

Adds support for the MySQL YEAR data type to the parser.

## Background

Issue #1627 identified that the YEAR type appears 101 times in the SQLLogicTest suite (createtable1.test) but was not supported by the parser.

## Changes

- Added YEAR keyword handling in `parse_data_type()`
- Added YEAR case to map it to `UserDefined` type (following the pattern of other MySQL-specific types like TINYINT, MEDIUMINT)
- Added YEAR to `is_supported_extension_type()` list
- Added comprehensive tests for YEAR type parsing

## Implementation Details

YEAR is a MySQL-specific temporal type that stores years from 1901-2155 in a single byte. Following the existing pattern for MySQL extension types (like TINYINT, MEDIUMINT), YEAR is mapped to `DataType::UserDefined { type_name: "YEAR" }` for compatibility.

## Testing

- Added `test_parse_create_table_year` - basic YEAR column parsing
- Added `test_parse_create_table_year_with_constraints` - YEAR with KEY and NULL constraints (from createtable1.test)
- All 842 parser tests pass

Closes #1627

🤖 Generated with [Claude Code](https://claude.com/claude-code)