### PR TITLE
chore: Add perf-test files to .gitignore

### DIFF
--- a/web-demo/.gitignore
+++ b/web-demo/.gitignore
@@ -25,6 +25,7 @@ inspect-*.ts
 test-*.ts
 diagnose-*.ts
 find-*.ts
+perf-*.ts
 debug-screenshot-*.png
 
 # Compiled debug/test scripts (should not be committed)
@@ -34,3 +35,5 @@ test-*.js
 diagnose-*.js
 find-*.js
 check-*.js
+perf-*.js
+perf-*.cjs


### PR DESCRIPTION
## Summary

Prevents accidental commits of temporary performance testing scripts by adding `perf-*` patterns to `.gitignore`.

## Changes

- Added `perf-*.ts` to source scripts section of `.gitignore`
- Added `perf-*.js` and `perf-*.cjs` to compiled scripts section of `.gitignore`

## Context

Currently, there are untracked performance test files in the repository:
- `web-demo/perf-test.js` (162 lines, 5.5KB)
- `web-demo/perf-test.cjs` (162 lines, 5.6KB)

These files are duplicate implementations (ES module vs CommonJS) of the same performance testing logic and should be removed manually from the main workspace after this PR is merged.

## Manual Cleanup Required

After merging this PR, the following untracked files should be manually deleted from your local workspace:

```bash
rm web-demo/perf-test.js web-demo/perf-test.cjs
```

These files are not tracked by git, so they cannot be removed via a commit. The `.gitignore` changes in this PR will prevent similar files from being accidentally committed in the future.

## Test Plan

- [x] Verified `.gitignore` patterns are correct
- [x] Confirmed no references to perf-test files exist in the codebase
- [x] Patterns follow existing conventions in `.gitignore`

Closes #1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)