### PR TITLE
fix: Populate user-defined indexes during bulk INSERT...SELECT transfers

### DIFF
--- a/crates/vibesql-executor/src/insert/bulk_transfer.rs
+++ b/crates/vibesql-executor/src/insert/bulk_transfer.rs
@@ -244,14 +244,11 @@ fn execute_bulk_transfer(
             }
         }
 
-        // Insert row directly without re-validation of type and NOT NULL
-        // (already validated by schema compatibility check)
-        let dest_table_mut = db
-            .get_table_mut(dest_table)
-            .ok_or_else(|| ExecutorError::TableNotFound(dest_table.to_string()))?;
-
+        // Insert row using db.insert_row() to ensure indexes are properly populated
+        // Even though type and NOT NULL are already validated by schema compatibility,
+        // we need db.insert_row() to update user-defined B-tree indexes
         let row = vibesql_storage::Row::new(row_values);
-        dest_table_mut.insert(row)?;
+        db.insert_row(dest_table, row)?;
         inserted_count += 1;
     }
 


### PR DESCRIPTION
## Summary

Fixes #1642 - Index scans were returning 0 rows due to indexes not being populated during bulk INSERT...SELECT operations.

## Problem

Index-based queries were returning 0 rows when they should return data, causing 593 out of 623 SQLLogicTest tests to fail (4.8% pass rate).

The bulk_transfer optimization for INSERT INTO...SELECT was calling `table.insert()` directly instead of `db.insert_row()`, which bypassed the index population logic. This meant that user-defined B-tree indexes (created with CREATE INDEX) were never populated during bulk transfers.

## Root Cause Location

**File**: `crates/vibesql-executor/src/insert/bulk_transfer.rs:254`

**Before**:
```rust
let dest_table_mut = db
    .get_table_mut(dest_table)
    .ok_or_else(|| ExecutorError::TableNotFound(dest_table.to_string()))?;

let row = vibesql_storage::Row::new(row_values);
dest_table_mut.insert(row)?;  // ❌ Bypasses index population
```

**After**:
```rust
let row = vibesql_storage::Row::new(row_values);
db.insert_row(dest_table, row)?;  // ✅ Populates indexes correctly
```

## Solution

Changed `bulk_transfer.rs` to use `db.insert_row()` instead of `table.insert()` directly. This ensures:

1. ✅ Rows are inserted into table storage
2. ✅ User-defined B-tree indexes are properly updated via `IndexManager::add_to_indexes_for_insert()`
3. ✅ Row indices in indexes match actual row positions in table

## Testing

### Minimal Test Case

```sql
CREATE TABLE tab0(col0 INTEGER, col1 INTEGER, col2 INTEGER, PRIMARY KEY(col0));
CREATE TABLE tab1(col0 INTEGER, col1 INTEGER, col2 INTEGER, PRIMARY KEY(col0));

INSERT INTO tab0 VALUES(0, 1, 2);
INSERT INTO tab0 VALUES(6, 7, 8);
INSERT INTO tab0 VALUES(7, 8, 9);

CREATE INDEX idx_tab1_0 ON tab1(col0);

-- This is where the bug manifested
INSERT INTO tab1 SELECT * FROM tab0;

-- Expected: 2 rows, Got: 2 rows ✅
SELECT col0 FROM tab1 WHERE col0 >= 6;
```

**Before fix**: Returned 0 rows
**After fix**: Returned 2 rows (correct!)

### Build Status

✅ Release build successful
⚠️ Test compilation fails due to pre-existing issues with `IndexColumn` schema changes (unrelated to this fix)

## Impact

This fix should dramatically improve SQLLogicTest pass rates, especially for:
- **index category**: Was at 7.9% pass rate (197/214 failures)
- **random category**: Was at 0.5% pass rate (389/391 failures)

These categories heavily use INSERT...SELECT with indexes, which is exactly what this bug affected.

## Technical Details

The issue description incorrectly stated that PR #1633 had already fixed this by using `db.insert_row()`, but reviewing the code showed that `bulk_transfer.rs` was still using the direct `table.insert()` call, bypassing index population.

The fix is a simple but critical change: routing through `db.insert_row()` ensures that `operations.rs::insert_row()` is called, which in turn calls `IndexManager::add_to_indexes_for_insert()` to populate the B-tree indexes with correct row indices.

## Related

- Closes #1642
- Related to #1618 (original bug report)
- Related to PR #1633 (partial fix attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>