### PR TITLE
fix: Recognize IN and BETWEEN predicates for index selection

### DIFF
--- a/crates/vibesql-executor/src/select/scan/index_scan.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan.rs
@@ -90,6 +90,12 @@ fn expression_filters_column(expr: &Expression, column_name: &str) -> bool {
             }
             false
         }
+        // IN with value list: col IN (1, 2, 3)
+        Expression::InList { expr, .. } => is_column_reference(expr, column_name),
+        // IN with subquery: col IN (SELECT ...)
+        Expression::In { expr, .. } => is_column_reference(expr, column_name),
+        // BETWEEN: col BETWEEN low AND high
+        Expression::Between { expr, .. } => is_column_reference(expr, column_name),
         _ => false,
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1644 by improving index selection for queries with IN and BETWEEN predicates.

## Problem

The index scan optimizer (`should_use_index_scan`) failed to recognize when IN and BETWEEN predicates filtered indexed columns. This caused queries like `WHERE col IN (1, 2, 3)` or `WHERE col BETWEEN 10 AND 20` to skip indexes even when they would be beneficial, falling back to full table scans instead.

The root cause was in the `expression_filters_column()` function (crates/vibesql-executor/src/select/scan/index_scan.rs:68-101), which only recognized simple binary comparisons (=, <, >, <=, >=) and missed IN/BETWEEN expressions.

## Solution

Extended `expression_filters_column()` to handle:
- `Expression::InList` - col IN (val1, val2, ...)  
- `Expression::In` - col IN (SELECT ...)
- `Expression::Between` - col BETWEEN low AND high

This allows the query planner to choose appropriate indexes for these predicates.

## Changes

- Updated `crates/vibesql-executor/src/select/scan/index_scan.rs`
  - Added 3 new match arms to `expression_filters_column()` (lines 93-98)
  - Each checks if the expression's subject is a reference to the indexed column

## Impact

- **Improved**: Index selection for queries with IN and BETWEEN predicates
- **No regressions**: Change is purely additive - only affects index selection heuristics
- **Performance**: Queries with IN/BETWEEN on indexed columns may now use indexes instead of full scans

## Testing

- ✅ Built successfully with `cargo build --release`
- ⏳ Running full SQLLogicTest suite to verify improvement on index tests

## Notes

This fix addresses the index **selection** issue. If there are still test failures after this change, they may be due to other issues in the WHERE clause evaluation or range predicate extraction logic, which would require separate investigation.

The fix is conservative and correct:
- IN and BETWEEN expressions do filter columns
- Recognizing them allows the optimizer to consider using indexes
- The actual query execution still applies the full WHERE clause correctly

## Related

- Issue #1644 - 73 remaining index test failures
- PR #1641 - Previously fixed 124 tests related to bulk transfer index maintenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>