### PR TITLE
fix: Add SetVariable to sqllogictest adapter

### DIFF
--- a/tests/sqllogictest/db_adapter.rs
+++ b/tests/sqllogictest/db_adapter.rs
@@ -339,7 +339,8 @@ impl NistMemSqlDB {
             | vibesql_ast::Statement::ShowColumns(_)
             | vibesql_ast::Statement::ShowIndex(_)
             | vibesql_ast::Statement::ShowCreateTable(_)
-            | vibesql_ast::Statement::Describe(_) => Ok(DBOutput::StatementComplete(0)),
+            | vibesql_ast::Statement::Describe(_)
+            | vibesql_ast::Statement::SetVariable(_) => Ok(DBOutput::StatementComplete(0)),
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a compilation error in the sqllogictest adapter that was introduced when PR #1639 added SetVariable statement support but didn't update the test adapter.

## Problem

PR #1639 added `SetVariable` statement support to the parser and AST, but the sqllogictest test adapter wasn't updated to handle this new statement type. This caused a compilation error:

```
error[E0004]: non-exhaustive patterns: `vibesql_ast::Statement::SetVariable(_)` not covered
   --> tests/sqllogictest/db_adapter.rs:148:15
```

This blocked anyone from running the sqllogictest suite.

## Solution

Added `SetVariable` to the list of unimplemented statements in the sqllogictest adapter that return `StatementComplete(0)`.

**Location**: `tests/sqllogictest/db_adapter.rs:343`

## Testing

- ✅ Compilation now succeeds
- ✅ sqllogictest suite can run (though other issues may remain)

## Related Issues

- Fixes compilation blocker preventing investigation of #1636
- Enables sqllogictest suite to run after #1639 was merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>