### PR TITLE
fix: Make DROP VIEW default to CASCADE for SQLite compatibility

### DIFF
--- a/crates/vibesql-parser/src/parser/view.rs
+++ b/crates/vibesql-parser/src/parser/view.rs
@@ -108,6 +108,8 @@ impl Parser {
         let view_name = self.parse_qualified_identifier()?;
 
         // Check for optional CASCADE or RESTRICT
+        // Note: SQL standard defaults to RESTRICT, but SQLite (and SQLLogicTest suite)
+        // implicitly cascade drops. For compatibility, we default to CASCADE.
         let cascade = if self.peek_keyword(Keyword::Cascade) {
             self.consume_keyword(Keyword::Cascade)?;
             true
@@ -115,7 +117,7 @@ impl Parser {
             self.consume_keyword(Keyword::Restrict)?;
             false
         } else {
-            false // RESTRICT is the default
+            true // CASCADE is the default for SQLite compatibility
         };
 
         // Expect semicolon or EOF


### PR DESCRIPTION
## Summary

Fixes #1663 by making `DROP VIEW` default to CASCADE behavior for SQLite compatibility.

## Problem

The SQLLogicTest suite is based on SQLite behavior, which implicitly drops dependent views when dropping a base view. Our implementation was following the SQL standard (defaulting to RESTRICT), causing 4 test files to fail with "View still in use" errors:

```
third_party/sqllogictest/test/index/view/10/slt_good_1.test
third_party/sqllogictest/test/index/view/100/slt_good_2.test
third_party/sqllogictest/test/index/view/100/slt_good_4.test
third_party/sqllogictest/test/index/view/1000/slt_good_0.test
```

## Solution

Changed the `DROP VIEW` parser to default `cascade=true` instead of `cascade=false` when no CASCADE/RESTRICT keyword is specified. This matches SQLite's implicit cascading behavior.

## Changes

- **crates/vibesql-parser/src/parser/view.rs**: Modified `parse_drop_view_statement()` to default to CASCADE
- Added comment explaining the deviation from SQL standard for compatibility

## Testing

- Existing CASCADE operation tests remain unaffected (they explicitly use `RESTRICT` keyword)
- The 4 failing SQLLogicTest view files should now pass
- `DROP VIEW view_name` now behaves like `DROP VIEW view_name CASCADE`
- `DROP VIEW view_name RESTRICT` still works as expected

## Notes

This is a compatibility fix to match SQLite behavior. Users who need SQL-standard RESTRICT behavior can explicitly use `DROP VIEW view_name RESTRICT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)