### PR TITLE
fix: Preserve column names in derived table wildcard expansion

### DIFF
--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -109,7 +109,7 @@ impl SelectExecutor<'_> {
         cte_results: &HashMap<String, CteResult>,
     ) -> Result<FromResult, ExecutorError> {
         use crate::select::scan::execute_from_clause;
-        execute_from_clause(from, cte_results, self.database, None, |query| self.execute(query))
+        execute_from_clause(from, cte_results, self.database, None, |query| self.execute_with_columns(query))
     }
 
     /// Execute a FROM clause with WHERE clause for predicate pushdown
@@ -121,7 +121,7 @@ impl SelectExecutor<'_> {
     ) -> Result<FromResult, ExecutorError> {
         use crate::select::scan::execute_from_clause;
         execute_from_clause(from, cte_results, self.database, where_clause, |query| {
-            self.execute(query)
+            self.execute_with_columns(query)
         })
     }
 }

--- a/crates/vibesql-executor/src/select/scan/join_scan.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan.rs
@@ -25,7 +25,7 @@ pub(crate) fn execute_join<F>(
     execute_subquery: F,
 ) -> Result<super::FromResult, ExecutorError>
 where
-    F: Fn(&vibesql_ast::SelectStmt) -> Result<Vec<vibesql_storage::Row>, ExecutorError> + Copy,
+    F: Fn(&vibesql_ast::SelectStmt) -> Result<crate::select::SelectResult, ExecutorError> + Copy,
 {
     // Execute left and right sides with WHERE clause for predicate pushdown
     let left_result = super::execute_from_clause(left, cte_results, database, where_clause, execute_subquery)?;

--- a/crates/vibesql-executor/src/select/scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/mod.rs
@@ -45,7 +45,7 @@ pub(super) fn execute_from_clause<F>(
     execute_subquery: F,
 ) -> Result<FromResult, ExecutorError>
 where
-    F: Fn(&vibesql_ast::SelectStmt) -> Result<Vec<vibesql_storage::Row>, ExecutorError> + Copy,
+    F: Fn(&vibesql_ast::SelectStmt) -> Result<super::SelectResult, ExecutorError> + Copy,
 {
     // Check if this is a multi-table join that could benefit from reordering
     if matches!(from, vibesql_ast::FromClause::Join { .. }) {

--- a/crates/vibesql-executor/src/select/scan/reorder.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder.rs
@@ -15,6 +15,7 @@ use crate::{
     select::{
         cte::CteResult,
         join::{nested_loop_join, JoinOrderAnalyzer, JoinOrderSearch},
+        SelectResult,
     },
 };
 
@@ -130,7 +131,7 @@ pub(crate) fn execute_with_join_reordering<F>(
     execute_subquery: F,
 ) -> Result<super::FromResult, ExecutorError>
 where
-    F: Fn(&vibesql_ast::SelectStmt) -> Result<Vec<vibesql_storage::Row>, ExecutorError> + Copy,
+    F: Fn(&vibesql_ast::SelectStmt) -> Result<SelectResult, ExecutorError> + Copy,
 {
     // Step 1: Flatten join tree to extract all tables
     let mut table_refs = Vec::new();


### PR DESCRIPTION
Fixes #1636 (partial)

This PR fixes the ColumnNotFound errors in SQLLogicTest by preserving column names through derived table (subquery in FROM clause) execution.

## Problem

When using  from a derived table, the executor was generating generic column names like ,  instead of preserving the actual column names from the subquery. This caused queries like:

```sql
SELECT pk FROM ( SELECT pk, col0 FROM tab0 ) AS derived_table
```

to fail with `ColumnNotFound` errors because the outer query expected `pk` but found `column1`.

## Solution

Modified the derived table execution pipeline to use `SelectResult` (which includes both rows and column metadata) instead of just `Vec<Row>`. Updated 5 files:

- `crates/vibesql-executor/src/select/scan/derived.rs` - Core fix to preserve column names
- `crates/vibesql-executor/src/select/scan/mod.rs` - Updated function signature
- `crates/vibesql-executor/src/select/scan/reorder.rs` - Updated function signature
- `crates/vibesql-executor/src/select/scan/join_scan.rs` - Updated function signature
- `crates/vibesql-executor/src/select/executor/execute.rs` - Use `execute_with_columns`

## Impact

This should resolve 11 of the 18 remaining SQLLogicTest failures in issue #1636 (all the ColumnNotFound errors in view index tests).

## Testing

- [x] Build successful
- [x] Manual test of derived table column preservation
- [ ] Full SQLLogicTest suite running (in progress)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>