### PR TITLE
feat: Add NVARCHAR type alias support in parser

### DIFF
--- a/crates/vibesql-parser/src/tests/create_table/string_types.rs
+++ b/crates/vibesql-parser/src/tests/create_table/string_types.rs
@@ -622,3 +622,169 @@ fn test_parse_nchar_varying_with_octets_modifier() {
         _ => panic!("Expected CREATE TABLE statement"),
     }
 }
+
+// ========================================================================
+// NVARCHAR Tests (SQL Server/MySQL alias for NCHAR VARYING)
+// ========================================================================
+
+#[test]
+fn test_parse_nvarchar_with_length() {
+    let result = Parser::parse_sql("CREATE TABLE t (x NVARCHAR(13));");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "T");
+            assert_eq!(create.columns.len(), 1);
+            assert_eq!(create.columns[0].name, "X");
+            match create.columns[0].data_type {
+                vibesql_types::DataType::Varchar { max_length: Some(13) } => {} // Success
+                _ => panic!("Expected VARCHAR(13) data type"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_nvarchar_with_space_before_paren() {
+    // NVARCHAR (13) with space before parenthesis
+    let result = Parser::parse_sql("CREATE TABLE t (x NVARCHAR (13));");
+    assert!(result.is_ok(), "Failed to parse NVARCHAR with space: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "T");
+            assert_eq!(create.columns.len(), 1);
+            assert_eq!(create.columns[0].name, "X");
+            match create.columns[0].data_type {
+                vibesql_types::DataType::Varchar { max_length: Some(13) } => {} // Success
+                _ => panic!("Expected VARCHAR(13) data type"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_nvarchar_without_length() {
+    let result = Parser::parse_sql("CREATE TABLE t (x NVARCHAR);");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "T");
+            assert_eq!(create.columns.len(), 1);
+            assert_eq!(create.columns[0].name, "X");
+            match create.columns[0].data_type {
+                vibesql_types::DataType::Varchar { max_length: None } => {} // Success
+                _ => panic!("Expected VARCHAR data type without length"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_nvarchar_with_constraint() {
+    // This is the actual failing test case from SQLLogicTest: NVARCHAR with UNIQUE
+    let result = Parser::parse_sql("CREATE TABLE `t21291` (`c1` NVARCHAR (13) UNIQUE, `c2` NVARCHAR (11) KEY);");
+    assert!(result.is_ok(), "Failed to parse NVARCHAR with constraints: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            // Backtick-quoted identifiers preserve case (lowercase in this case)
+            assert_eq!(create.table_name, "t21291");
+            assert_eq!(create.columns.len(), 2);
+
+            // Check first column (backtick-quoted, preserves case)
+            assert_eq!(create.columns[0].name, "c1");
+            match create.columns[0].data_type {
+                vibesql_types::DataType::Varchar { max_length: Some(13) } => {} // Success
+                _ => panic!("Expected VARCHAR(13) for c1"),
+            }
+            // Verify UNIQUE constraint
+            assert!(create.columns[0].constraints.iter().any(|c| matches!(
+                &c.kind,
+                vibesql_ast::ColumnConstraintKind::Unique
+            )));
+
+            // Check second column (backtick-quoted, preserves case)
+            assert_eq!(create.columns[1].name, "c2");
+            match create.columns[1].data_type {
+                vibesql_types::DataType::Varchar { max_length: Some(11) } => {} // Success
+                _ => panic!("Expected VARCHAR(11) for c2"),
+            }
+            // Verify KEY constraint
+            assert!(create.columns[1].constraints.iter().any(|c| matches!(
+                &c.kind,
+                vibesql_ast::ColumnConstraintKind::Key
+            )));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_nvarchar_equivalence() {
+    // NVARCHAR should be identical to NCHAR VARYING
+    let nvarchar_result = Parser::parse_sql("CREATE TABLE t1 (x NVARCHAR(50));");
+    let nchar_varying_result = Parser::parse_sql("CREATE TABLE t2 (x NCHAR VARYING(50));");
+
+    assert!(nvarchar_result.is_ok());
+    assert!(nchar_varying_result.is_ok());
+
+    let nvarchar_stmt = nvarchar_result.unwrap();
+    let nchar_varying_stmt = nchar_varying_result.unwrap();
+
+    match (nvarchar_stmt, nchar_varying_stmt) {
+        (
+            vibesql_ast::Statement::CreateTable(nvarchar_create),
+            vibesql_ast::Statement::CreateTable(nchar_varying_create),
+        ) => {
+            // Both should produce the same data type
+            assert_eq!(nvarchar_create.columns[0].data_type, nchar_varying_create.columns[0].data_type);
+        }
+        _ => panic!("Expected CREATE TABLE statements"),
+    }
+}
+
+#[test]
+fn test_parse_nvarchar_with_characters_modifier() {
+    let result = Parser::parse_sql("CREATE TABLE t (x NVARCHAR(25 CHARACTERS));");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].name, "X");
+            match create.columns[0].data_type {
+                vibesql_types::DataType::Varchar { max_length: Some(25) } => {} // Success
+                _ => panic!("Expected VARCHAR(25) data type"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_nvarchar_with_octets_modifier() {
+    let result = Parser::parse_sql("CREATE TABLE t (x NVARCHAR(30 OCTETS));");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].name, "X");
+            match create.columns[0].data_type {
+                vibesql_types::DataType::Varchar { max_length: Some(30) } => {} // Success
+                _ => panic!("Expected VARCHAR(30) data type"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for `NVARCHAR` as a SQL Server/MySQL alias for `NCHAR VARYING` in the parser. This enables the parser to handle table definitions using `NVARCHAR` syntax, which is common in SQL Server and MySQL codebases.

## Changes

### Parser Implementation
- **File**: `crates/vibesql-parser/src/parser/create/types.rs`
- Added `NVARCHAR` case (lines 371-405) that maps to `DataType::Varchar`
- Supports all standard syntax variants:
  - `NVARCHAR` (no length, defaults to unlimited)
  - `NVARCHAR(n)` (with max length)
  - `NVARCHAR (n)` (with space before paren)
  - `NVARCHAR(n CHARACTERS)` / `NVARCHAR(n OCTETS)` (with modifiers)

### Parser Tests
- **File**: `crates/vibesql-parser/src/tests/create_table/string_types.rs`
- Added 7 comprehensive test cases:
  - `test_parse_nvarchar_with_length` - Basic length syntax
  - `test_parse_nvarchar_with_space_before_paren` - Space before paren
  - `test_parse_nvarchar_without_length` - No length specified
  - `test_parse_nvarchar_with_constraint` - With UNIQUE/KEY constraints (from failing SQLLogicTest)
  - `test_parse_nvarchar_equivalence` - Verify NVARCHAR ≡ NCHAR VARYING
  - `test_parse_nvarchar_with_characters_modifier` - CHARACTERS modifier
  - `test_parse_nvarchar_with_octets_modifier` - OCTETS modifier

## Testing

✅ **All parser tests pass** (35/35 tests in `string_types` module)

✅ **Manual verification** with the exact failing SQLLogicTest case:
```sql
CREATE TABLE `t21291` (`c1` NVARCHAR (13) UNIQUE, `c2` NVARCHAR (11) KEY);
```
Output: Successfully parsed and executed (0 rows)

## SQLLogicTest Impact

This PR fixes the failing test at line 8482 in `createtable1.test`:
```sql
CREATE TABLE `t21291` (`c1` NVARCHAR (13) UNIQUE, `c2` NVARCHAR (11) KEY);
```

## Implementation Notes

- Follows the exact same pattern as existing `NCHAR VARYING` implementation
- Maintains backward compatibility with `NCHAR VARYING` syntax
- No changes to the AST or type system—`NVARCHAR` is purely a parser-level alias
- Consistent with how other type aliases are handled (e.g., `VARBINARY`, `DATETIME`)

## Related Issues

Closes #1691

Similar to:
- #1681 (NCHAR/NCHAR VARYING support)
- #1687 (VARBINARY support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)