### PR TITLE
feat: Implement SQLite-compatible DATETIME function

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/datetime/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/datetime/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains all date/time manipulation and extraction functions including:
 //! - Current date/time functions (CURRENT_DATE/CURDATE, CURRENT_TIME/CURTIME,
-//!   CURRENT_TIMESTAMP/NOW)
+//!   CURRENT_TIMESTAMP/NOW, DATETIME)
 //! - Date/time extraction (YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, EXTRACT)
 //! - Date arithmetic (DATE_ADD/ADDDATE, DATE_SUB/SUBDATE, DATEDIFF)
 //! - Age calculation (AGE)
@@ -12,7 +12,7 @@
 //! # Module Organization
 //!
 //! The datetime functions are organized into logical modules:
-//! - `current` - Current date/time functions (CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP)
+//! - `current` - Current date/time functions (CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, DATETIME)
 //! - `extract` - Field extraction (YEAR, MONTH, DAY, HOUR, MINUTE, SECOND)
 //! - `arithmetic` - Date/time arithmetic (DATEDIFF, DATE_ADD, DATE_SUB, AGE, EXTRACT)
 
@@ -22,7 +22,7 @@ mod extract;
 
 // Re-export all public functions
 pub(super) use arithmetic::{age, date_add, date_sub, datediff, extract};
-pub(super) use current::{current_date, current_time, current_timestamp};
+pub(super) use current::{current_date, current_time, current_timestamp, datetime};
 pub(super) use extract::{day, hour, minute, month, second, year};
 
 // Re-export helper for use by arithmetic operators

--- a/crates/vibesql-executor/src/evaluator/functions/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/mod.rs
@@ -89,6 +89,7 @@ pub(super) fn eval_scalar_function(
         "CURRENT_DATE" | "CURDATE" => datetime::current_date(args),
         "CURRENT_TIME" | "CURTIME" => datetime::current_time(args),
         "CURRENT_TIMESTAMP" | "NOW" => datetime::current_timestamp(args),
+        "DATETIME" => datetime::datetime(args),
         "YEAR" => datetime::year(args),
         "MONTH" => datetime::month(args),
         "DAY" => datetime::day(args),

--- a/crates/vibesql-executor/tests/date_time_function_tests/current_datetime.rs
+++ b/crates/vibesql-executor/tests/date_time_function_tests/current_datetime.rs
@@ -1,9 +1,10 @@
-//! Tests for current date/time functions (CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP)
+//! Tests for current date/time functions (CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, DATETIME)
 //!
 //! This module tests the SQL standard CURRENT_* functions and their aliases:
 //! - CURRENT_DATE / CURDATE
 //! - CURRENT_TIME / CURTIME
 //! - CURRENT_TIMESTAMP / NOW
+//! - DATETIME (SQLite-compatible datetime function)
 
 use super::fixtures::*;
 
@@ -92,4 +93,206 @@ fn test_now_alias() {
 
     // Verify NOW is an alias for CURRENT_TIMESTAMP
     assert!(matches!(result, vibesql_types::SqlValue::Timestamp(_)));
+}
+
+// ==================== DATETIME ====================
+
+#[test]
+fn test_datetime_now() {
+    let (evaluator, row) = setup_test();
+
+    let expr = create_datetime_function(
+        "DATETIME",
+        vec![create_literal(vibesql_types::SqlValue::Varchar("now".to_string()))],
+    );
+    let result = evaluator.eval(&expr, &row).unwrap();
+
+    // Verify it returns a Timestamp type with YYYY-MM-DD HH:MM:SS format
+    match result {
+        vibesql_types::SqlValue::Timestamp(s) => {
+            validate_timestamp_format(&s.to_string());
+        }
+        _ => panic!("DATETIME('now') should return Timestamp type"),
+    }
+}
+
+#[test]
+fn test_datetime_now_case_insensitive() {
+    let (evaluator, row) = setup_test();
+
+    let expr = create_datetime_function(
+        "DATETIME",
+        vec![create_literal(vibesql_types::SqlValue::Varchar("NOW".to_string()))],
+    );
+    let result = evaluator.eval(&expr, &row).unwrap();
+
+    // Verify case-insensitive 'NOW' works
+    assert!(matches!(result, vibesql_types::SqlValue::Timestamp(_)));
+}
+
+#[test]
+fn test_datetime_with_timestamp_string() {
+    let (evaluator, row) = setup_test();
+
+    let expr = create_datetime_function(
+        "DATETIME",
+        vec![create_literal(vibesql_types::SqlValue::Varchar(
+            "2024-03-15 14:30:45".to_string(),
+        ))],
+    );
+    let result = evaluator.eval(&expr, &row).unwrap();
+
+    match result {
+        vibesql_types::SqlValue::Timestamp(ts) => {
+            assert_eq!(ts.to_string(), "2024-03-15 14:30:45");
+        }
+        _ => panic!("DATETIME with timestamp string should return Timestamp type"),
+    }
+}
+
+#[test]
+fn test_datetime_with_date_string() {
+    let (evaluator, row) = setup_test();
+
+    let expr = create_datetime_function(
+        "DATETIME",
+        vec![create_literal(vibesql_types::SqlValue::Varchar(
+            "2024-03-15".to_string(),
+        ))],
+    );
+    let result = evaluator.eval(&expr, &row).unwrap();
+
+    match result {
+        vibesql_types::SqlValue::Timestamp(ts) => {
+            // Should add 00:00:00 time
+            assert_eq!(ts.to_string(), "2024-03-15 00:00:00");
+        }
+        _ => panic!("DATETIME with date string should return Timestamp type"),
+    }
+}
+
+#[test]
+fn test_datetime_with_iso_format() {
+    let (evaluator, row) = setup_test();
+
+    let expr = create_datetime_function(
+        "DATETIME",
+        vec![create_literal(vibesql_types::SqlValue::Varchar(
+            "2024-03-15T14:30:45".to_string(),
+        ))],
+    );
+    let result = evaluator.eval(&expr, &row).unwrap();
+
+    match result {
+        vibesql_types::SqlValue::Timestamp(ts) => {
+            assert_eq!(ts.to_string(), "2024-03-15 14:30:45");
+        }
+        _ => panic!("DATETIME with ISO format should return Timestamp type"),
+    }
+}
+
+#[test]
+fn test_datetime_with_null() {
+    let (evaluator, row) = setup_test();
+
+    let expr = create_datetime_function(
+        "DATETIME",
+        vec![create_literal(vibesql_types::SqlValue::Null)],
+    );
+    let result = evaluator.eval(&expr, &row).unwrap();
+
+    assert!(matches!(result, vibesql_types::SqlValue::Null));
+}
+
+#[test]
+fn test_datetime_with_date_value() {
+    let (evaluator, row) = setup_test();
+
+    let date = vibesql_types::Date::new(2024, 3, 15).unwrap();
+    let expr = create_datetime_function(
+        "DATETIME",
+        vec![create_literal(vibesql_types::SqlValue::Date(date))],
+    );
+    let result = evaluator.eval(&expr, &row).unwrap();
+
+    match result {
+        vibesql_types::SqlValue::Timestamp(ts) => {
+            assert_eq!(ts.to_string(), "2024-03-15 00:00:00");
+        }
+        _ => panic!("DATETIME with Date value should return Timestamp type"),
+    }
+}
+
+#[test]
+fn test_datetime_with_timestamp_value() {
+    let (evaluator, row) = setup_test();
+
+    let date = vibesql_types::Date::new(2024, 3, 15).unwrap();
+    let time = vibesql_types::Time::new(14, 30, 45, 0).unwrap();
+    let timestamp = vibesql_types::Timestamp::new(date, time);
+    let expr = create_datetime_function(
+        "DATETIME",
+        vec![create_literal(vibesql_types::SqlValue::Timestamp(timestamp))],
+    );
+    let result = evaluator.eval(&expr, &row).unwrap();
+
+    match result {
+        vibesql_types::SqlValue::Timestamp(ts) => {
+            assert_eq!(ts.to_string(), "2024-03-15 14:30:45");
+        }
+        _ => panic!("DATETIME with Timestamp value should return Timestamp type"),
+    }
+}
+
+#[test]
+fn test_datetime_no_arguments_error() {
+    let (evaluator, row) = setup_test();
+
+    let expr = create_datetime_function("DATETIME", vec![]);
+    let result = evaluator.eval(&expr, &row);
+
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("requires at least 1 argument"));
+}
+
+#[test]
+fn test_datetime_invalid_string_error() {
+    let (evaluator, row) = setup_test();
+
+    let expr = create_datetime_function(
+        "DATETIME",
+        vec![create_literal(vibesql_types::SqlValue::Varchar(
+            "invalid-date".to_string(),
+        ))],
+    );
+    let result = evaluator.eval(&expr, &row);
+
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Unable to parse datetime string"));
+}
+
+#[test]
+fn test_datetime_modifiers_not_supported() {
+    let (evaluator, row) = setup_test();
+
+    let expr = create_datetime_function(
+        "DATETIME",
+        vec![
+            create_literal(vibesql_types::SqlValue::Varchar("now".to_string())),
+            create_literal(vibesql_types::SqlValue::Varchar("+1 day".to_string())),
+        ],
+    );
+    let result = evaluator.eval(&expr, &row);
+
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("modifiers not yet supported"));
 }


### PR DESCRIPTION
## Summary

Implements the `DATETIME()` function to resolve issue #1707 and fix dogfooding query failures.

## Changes

- ✅ Implemented `DATETIME('now')` - returns current timestamp
- ✅ Implemented `DATETIME(timestring)` - parses date/time strings in multiple formats
- ✅ Added support for Date and Timestamp value inputs
- ✅ Comprehensive error handling for invalid inputs
- ✅ 11 new unit tests covering all use cases

## Implementation Details

**Supported formats:**
- `DATETIME('now')` - returns current timestamp (case-insensitive)
- `DATETIME('YYYY-MM-DD HH:MM:SS')` - standard timestamp format
- `DATETIME('YYYY-MM-DD')` - date only (adds 00:00:00 time)
- `DATETIME('YYYY-MM-DDTHH:MM:SS')` - ISO 8601 format
- `DATETIME(Date)` - converts Date to Timestamp with 00:00:00 time
- `DATETIME(Timestamp)` - returns Timestamp as-is
- `DATETIME(NULL)` - returns NULL

**Files modified:**
- `crates/vibesql-executor/src/evaluator/functions/datetime/current.rs:148-250` - Implementation
- `crates/vibesql-executor/src/evaluator/functions/datetime/mod.rs:25` - Export
- `crates/vibesql-executor/src/evaluator/functions/mod.rs:92` - Dispatch
- `crates/vibesql-executor/tests/date_time_function_tests/current_datetime.rs:98-299` - Tests

## Test Results

All 45 datetime function tests pass:
```
test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured
```

New DATETIME tests (11):
- ✅ test_datetime_now
- ✅ test_datetime_now_case_insensitive
- ✅ test_datetime_with_timestamp_string
- ✅ test_datetime_with_date_string
- ✅ test_datetime_with_iso_format
- ✅ test_datetime_with_null
- ✅ test_datetime_with_date_value
- ✅ test_datetime_with_timestamp_value
- ✅ test_datetime_no_arguments_error
- ✅ test_datetime_invalid_string_error
- ✅ test_datetime_modifiers_not_supported

## Manual Testing

```sql
SELECT DATETIME('now');
-- Returns: Timestamp(Timestamp { date: Date { year: 2025, month: 11, day: 14 }, ... })

SELECT DATETIME('2024-03-15 14:30:45');
-- Returns: Timestamp(Timestamp { date: Date { year: 2024, month: 3, day: 15 }, time: Time { hour: 14, minute: 30, second: 45, ... } })

SELECT DATETIME('2024-12-25');
-- Returns: Timestamp(Timestamp { date: Date { year: 2024, month: 12, day: 25 }, time: Time { hour: 0, minute: 0, second: 0, ... } })
```

## Acceptance Criteria

- [x] `DATETIME('now')` returns current timestamp in 'YYYY-MM-DD HH:MM:SS' format
- [x] `DATETIME(date_string)` parses and formats valid date/time strings
- [x] Function returns SqlValue::Timestamp type
- [x] Comprehensive tests added to `date_time_function_tests/`
- [x] Error handling for invalid arguments and malformed strings
- [x] Documentation comments follow existing datetime function style
- [ ] The dogfooding query (`./scripts/query_test_results.py --preset progress`) works without errors (needs database setup to verify)

## Notes

- SQLite modifier support (e.g., '+1 day', 'start of month') is explicitly not included in this implementation. An informative error message is provided for such cases.
- This implementation focuses on the core DATETIME functionality needed for the dogfooding use case.

Closes #1707

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>