### PR TITLE
Fix DIV operator to return Numeric for SQLLogicTest compatibility

### DIFF
--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/division.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/division.rs
@@ -55,7 +55,7 @@ impl Division {
             if *b == 0 {
                 return Ok(SqlValue::Null);
             }
-            return Ok(Integer(a / b));
+            return Ok(Numeric((a / b) as f64));
         }
 
         // Use helper for type coercion
@@ -74,9 +74,9 @@ impl Division {
 
         // Integer division truncates toward zero
         match coerced {
-            super::CoercedValues::ExactNumeric(a, b) => Ok(Integer(a / b)),
-            super::CoercedValues::ApproximateNumeric(a, b) => Ok(Integer((a / b) as i64)),
-            super::CoercedValues::Numeric(a, b) => Ok(Integer((a / b) as i64)),
+            super::CoercedValues::ExactNumeric(a, b) => Ok(Numeric((a / b) as f64)),
+            super::CoercedValues::ApproximateNumeric(a, b) => Ok(Numeric((a / b).trunc())),
+            super::CoercedValues::Numeric(a, b) => Ok(Numeric((a / b).trunc())),
         }
     }
 }

--- a/crates/vibesql-executor/src/tests/operator_edge_cases/binary_arithmetic.rs
+++ b/crates/vibesql-executor/src/tests/operator_edge_cases/binary_arithmetic.rs
@@ -86,7 +86,7 @@ fn test_integer_division_basic() {
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 1);
     // 81 / 31 = 2.6129..., truncated to 2
-    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Integer(2));
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Numeric(2.0));
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn test_integer_division_with_floats() {
         &vibesql_types::SqlValue::Float(3.2),
     )
     .unwrap();
-    assert_eq!(result, vibesql_types::SqlValue::Integer(3));
+    assert_eq!(result, vibesql_types::SqlValue::Numeric(3.0));
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn test_integer_division_negative_operands() {
         &vibesql_types::SqlValue::Integer(-2),
     )
     .unwrap();
-    assert_eq!(result, vibesql_types::SqlValue::Integer(-48));
+    assert_eq!(result, vibesql_types::SqlValue::Numeric(-48.0));
 
     // -96 DIV 2 should return -48
     let result = OperatorRegistry::eval_binary_op(
@@ -123,7 +123,7 @@ fn test_integer_division_negative_operands() {
         &vibesql_types::SqlValue::Integer(2),
     )
     .unwrap();
-    assert_eq!(result, vibesql_types::SqlValue::Integer(-48));
+    assert_eq!(result, vibesql_types::SqlValue::Numeric(-48.0));
 
     // -96 DIV -2 should return 48
     let result = OperatorRegistry::eval_binary_op(
@@ -132,7 +132,7 @@ fn test_integer_division_negative_operands() {
         &vibesql_types::SqlValue::Integer(-2),
     )
     .unwrap();
-    assert_eq!(result, vibesql_types::SqlValue::Integer(48));
+    assert_eq!(result, vibesql_types::SqlValue::Numeric(48.0));
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn test_integer_division_equal_operands() {
         &vibesql_types::SqlValue::Integer(5),
     )
     .unwrap();
-    assert_eq!(result, vibesql_types::SqlValue::Integer(1));
+    assert_eq!(result, vibesql_types::SqlValue::Numeric(1.0));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fix DIV operator to return Numeric type instead of Integer for SQLLogicTest compatibility.

## Problem

The DIV operator (integer division) was producing functionally correct results but returning `SqlValue::Integer`, which displays as `8842` instead of the expected `8842.000` format. SQLLogicTest requires numeric operation results to display with 3 decimal places.

## Changes

1. **Modified `division.rs:58`**: Fast-path Integer DIV now returns `Numeric((a / b) as f64)`
2. **Modified `division.rs:77-79`**: All coercion paths now return Numeric with proper truncation:
   - `ExactNumeric`: Cast integer division result to f64
   - `ApproximateNumeric`: Use `.trunc()` to truncate toward zero
   - `Numeric`: Use `.trunc()` to truncate toward zero
3. **Updated unit tests**: Changed 4 test assertions from `Integer(...)` to `Numeric(...)`

## Test Plan

- ✅ All 7 binary_arithmetic unit tests pass
- ✅ Manual testing confirms:
  - `SELECT 81 DIV 10` returns `Numeric(8.0)` (displays as `8.000`)
  - `SELECT -96 DIV 2` returns `Numeric(-48.0)` (displays as `-48.000`)
  - `SELECT 10 DIV 0` returns `NULL` (division by zero)
- ✅ DIV still performs integer division (truncates fractional part)

## Impact

Resolves 12 SQLLogicTest failures in the test suite (#4 failure category from dogfooding analysis).

Closes #1711