### PR TITLE
fix: Add NULL handling to BETWEEN operator per SQL:1999 standard

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -24,6 +24,15 @@ impl CombinedExpressionEvaluator<'_> {
         let mut low_val = self.eval(low, row)?;
         let mut high_val = self.eval(high, row)?;
 
+        // Per SQL:1999 standard: any NULL operand makes entire predicate NULL
+        // NULL is treated as FALSE in WHERE clauses
+        if matches!(expr_val, vibesql_types::SqlValue::Null)
+            || matches!(low_val, vibesql_types::SqlValue::Null)
+            || matches!(high_val, vibesql_types::SqlValue::Null)
+        {
+            return Ok(vibesql_types::SqlValue::Null);
+        }
+
         // Check if bounds are reversed (low > high)
         let gt_result = ExpressionEvaluator::eval_binary_op_static(
             &low_val,


### PR DESCRIPTION
## Summary

Implements proper NULL handling for BETWEEN predicates according to SQL:1999 standard semantics.

## Changes

- Added NULL check in `eval_between()` function in `crates/vibesql-executor/src/evaluator/combined/predicates.rs:27-34`
- Any NULL operand (expr, low, or high) now causes the entire BETWEEN predicate to return NULL
- NULL results are treated as FALSE in WHERE clauses, matching SQL standard behavior

## SQL:1999 Semantics

Per SQL:1999 standard:
- `x BETWEEN NULL AND y` → NULL (treated as FALSE in WHERE)
- `x BETWEEN y AND NULL` → NULL (treated as FALSE in WHERE)
- `NULL BETWEEN x AND y` → NULL (treated as FALSE in WHERE)
- `x NOT BETWEEN NULL AND y` → NULL (treated as FALSE in WHERE)

## Testing

Manual verification:
```sql
-- All queries correctly return 0 rows
SELECT * FROM test WHERE val BETWEEN NULL AND 25;
SELECT * FROM test WHERE val BETWEEN 15 AND NULL;
SELECT * FROM test WHERE NULL BETWEEN 15 AND 25;
SELECT * FROM test WHERE val NOT BETWEEN NULL AND 25;
```

## Related Issues

Closes #1726

Fixes NULL comparison issues in BETWEEN predicates that were causing incorrect results in:
- index/random/10/slt_good_1.test
- index/random/10/slt_good_4.test
- random/expr/slt_good_75.test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>