### PR TITLE
fix: Add NULL propagation to arithmetic operators

### DIFF
--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/addition.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/addition.rs
@@ -16,6 +16,11 @@ impl Addition {
     pub fn add(left: &SqlValue, right: &SqlValue) -> Result<SqlValue, ExecutorError> {
         use SqlValue::*;
 
+        // NULL propagation - SQL standard semantics
+        if matches!(left, Null) || matches!(right, Null) {
+            return Ok(Null);
+        }
+
         // Fast path for integers (both modes)
         if let (Integer(a), Integer(b)) = (left, right) {
             return Ok(Integer(a + b));

--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/division.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/division.rs
@@ -14,6 +14,11 @@ impl Division {
     pub fn divide(left: &SqlValue, right: &SqlValue) -> Result<SqlValue, ExecutorError> {
         use SqlValue::*;
 
+        // NULL propagation - SQL standard semantics
+        if matches!(left, Null) || matches!(right, Null) {
+            return Ok(Null);
+        }
+
         // Fast path for integers (both modes) - division always returns float
         if let (Integer(a), Integer(b)) = (left, right) {
             if *b == 0 {
@@ -49,6 +54,11 @@ impl Division {
     #[inline]
     pub fn integer_divide(left: &SqlValue, right: &SqlValue) -> Result<SqlValue, ExecutorError> {
         use SqlValue::*;
+
+        // NULL propagation - SQL standard semantics
+        if matches!(left, Null) || matches!(right, Null) {
+            return Ok(Null);
+        }
 
         // Fast path for integers (both modes)
         if let (Integer(a), Integer(b)) = (left, right) {

--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/mod.rs
@@ -439,4 +439,84 @@ mod tests {
         let mysql_result = ArithmeticOps::add(&int1, &int2).unwrap();
         assert_eq!(mysql_result, SqlValue::Integer(150));
     }
+
+    // NULL propagation tests for issue #1728
+    #[test]
+    fn test_null_addition() {
+        assert_eq!(
+            ArithmeticOps::add(&SqlValue::Null, &SqlValue::Integer(23)).unwrap(),
+            SqlValue::Null
+        );
+        assert_eq!(
+            ArithmeticOps::add(&SqlValue::Integer(23), &SqlValue::Null).unwrap(),
+            SqlValue::Null
+        );
+        assert_eq!(
+            ArithmeticOps::add(&SqlValue::Null, &SqlValue::Null).unwrap(),
+            SqlValue::Null
+        );
+    }
+
+    #[test]
+    fn test_null_subtraction() {
+        assert_eq!(
+            ArithmeticOps::subtract(&SqlValue::Null, &SqlValue::Integer(23)).unwrap(),
+            SqlValue::Null
+        );
+        assert_eq!(
+            ArithmeticOps::subtract(&SqlValue::Integer(23), &SqlValue::Null).unwrap(),
+            SqlValue::Null
+        );
+    }
+
+    #[test]
+    fn test_null_multiplication() {
+        assert_eq!(
+            ArithmeticOps::multiply(&SqlValue::Null, &SqlValue::Integer(23)).unwrap(),
+            SqlValue::Null
+        );
+        assert_eq!(
+            ArithmeticOps::multiply(&SqlValue::Integer(23), &SqlValue::Null).unwrap(),
+            SqlValue::Null
+        );
+    }
+
+    #[test]
+    fn test_null_division() {
+        assert_eq!(
+            ArithmeticOps::divide(&SqlValue::Null, &SqlValue::Integer(23)).unwrap(),
+            SqlValue::Null
+        );
+        assert_eq!(
+            ArithmeticOps::divide(&SqlValue::Integer(23), &SqlValue::Null).unwrap(),
+            SqlValue::Null
+        );
+    }
+
+    #[test]
+    fn test_null_modulo() {
+        assert_eq!(
+            ArithmeticOps::modulo(&SqlValue::Null, &SqlValue::Integer(23)).unwrap(),
+            SqlValue::Null
+        );
+        assert_eq!(
+            ArithmeticOps::modulo(&SqlValue::Integer(23), &SqlValue::Null).unwrap(),
+            SqlValue::Null
+        );
+    }
+
+    #[test]
+    fn test_cast_null_arithmetic() {
+        // Simulate CAST(NULL AS SIGNED) + 23
+        let null_bigint = SqlValue::Null; // Result of CAST(NULL AS SIGNED)
+        let result = ArithmeticOps::add(&null_bigint, &SqlValue::Integer(23)).unwrap();
+        assert_eq!(result, SqlValue::Null);
+
+        // Test chained operations with NULL
+        let step1 = ArithmeticOps::multiply(&SqlValue::Null, &SqlValue::Integer(100)).unwrap();
+        assert_eq!(step1, SqlValue::Null);
+
+        let step2 = ArithmeticOps::add(&step1, &SqlValue::Integer(-23)).unwrap();
+        assert_eq!(step2, SqlValue::Null);
+    }
 }

--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/modulo.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/modulo.rs
@@ -15,6 +15,11 @@ impl Modulo {
     pub fn modulo(left: &SqlValue, right: &SqlValue) -> Result<SqlValue, ExecutorError> {
         use SqlValue::*;
 
+        // NULL propagation - SQL standard semantics
+        if matches!(left, Null) || matches!(right, Null) {
+            return Ok(Null);
+        }
+
         // Fast path for integers (both modes)
         if let (Integer(a), Integer(b)) = (left, right) {
             if *b == 0 {

--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/multiplication.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/multiplication.rs
@@ -14,6 +14,11 @@ impl Multiplication {
     pub fn multiply(left: &SqlValue, right: &SqlValue) -> Result<SqlValue, ExecutorError> {
         use SqlValue::*;
 
+        // NULL propagation - SQL standard semantics
+        if matches!(left, Null) || matches!(right, Null) {
+            return Ok(Null);
+        }
+
         // Fast path for integers (both modes)
         if let (Integer(a), Integer(b)) = (left, right) {
             return Ok(Integer(a * b));

--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/subtraction.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/subtraction.rs
@@ -16,6 +16,11 @@ impl Subtraction {
     pub fn subtract(left: &SqlValue, right: &SqlValue) -> Result<SqlValue, ExecutorError> {
         use SqlValue::*;
 
+        // NULL propagation - SQL standard semantics
+        if matches!(left, Null) || matches!(right, Null) {
+            return Ok(Null);
+        }
+
         // Fast path for integers (both modes)
         if let (Integer(a), Integer(b)) = (left, right) {
             return Ok(Integer(a - b));


### PR DESCRIPTION
## Summary

Fixes NULL propagation in arithmetic operators to correctly handle CAST(NULL AS SIGNED) operations. Previously, arithmetic operations with NULL values would produce incorrect results instead of propagating NULL as required by SQL semantics.

## Problem

When `CAST(NULL AS SIGNED)` correctly returned NULL, subsequent arithmetic operations (like `NULL + 23`) would fail to check for NULL and produce incorrect results instead of NULL.

## Root Cause

The arithmetic operators (+, -, *, /, %) were missing NULL checks before performing operations. They would attempt to coerce NULL values to numeric types through `coerce_numeric_values()`, which is not NULL-safe.

## Solution

Added NULL propagation checks at the **beginning** of each arithmetic operator function (before the integer fast-path check):

### Files Modified

1. `crates/vibesql-executor/src/evaluator/operators/arithmetic/addition.rs`
2. `crates/vibesql-executor/src/evaluator/operators/arithmetic/subtraction.rs`
3. `crates/vibesql-executor/src/evaluator/operators/arithmetic/multiplication.rs`
4. `crates/vibesql-executor/src/evaluator/operators/arithmetic/division.rs` (both `divide()` and `integer_divide()`)
5. `crates/vibesql-executor/src/evaluator/operators/arithmetic/modulo.rs`

### Code Pattern Added

```rust
// NULL propagation - SQL standard semantics
if matches!(left, Null) || matches!(right, Null) {
    return Ok(Null);
}
```

## Changes

1. ✅ Added NULL check to all 5 arithmetic operator files
2. ✅ Added comprehensive unit tests for NULL propagation
3. ✅ All new tests pass (6 new test functions covering all operators)

## Test Results

**All new NULL propagation tests pass:**
- ✅ `test_null_addition` - NULL + value and value + NULL
- ✅ `test_null_subtraction` - NULL - value and value - NULL
- ✅ `test_null_multiplication` - NULL * value and value * NULL
- ✅ `test_null_division` - NULL / value and value / NULL
- ✅ `test_null_modulo` - NULL % value and value % NULL
- ✅ `test_cast_null_arithmetic` - Simulates CAST(NULL AS SIGNED) operations

**Test Command:**
```bash
cargo test -p vibesql-executor evaluator::operators::arithmetic
```

**Results:** 33 passed (including all 6 new NULL tests)

## Expected Impact

This fix will resolve the 2 failing test cases mentioned in the issue:
- `random/aggregates/slt_good_2.test`
- `index/random/1000/slt_good_0.test`

## SQL Semantics Verified

Per SQL standard, the following now correctly return NULL:
- `CAST(NULL AS SIGNED) + value` → NULL ✅
- `NULL * value` → NULL ✅
- `SUM(CAST(NULL AS SIGNED)) + value` → NULL ✅
- Any arithmetic operation with NULL operand → NULL ✅

## Note

Pre-existing test failure in `test_boolean_integer_divide` is **unrelated** to these changes (expects `Integer(10)` but gets `Numeric(10.0)` - issue with integer_divide return type).

Closes #1728