### PR TITLE
Partial fix for #1689: Enable hash threshold in SQLLogicTest runner

### DIFF
--- a/tests/sqllogictest_runner.rs
+++ b/tests/sqllogictest_runner.rs
@@ -682,6 +682,9 @@ async fn run_single_test_file() {
 
     let mut tester = sqllogictest::Runner::new(|| async { Ok(NistMemSqlDB::new()) });
 
+    // Set hash threshold to 8 (SQLLogicTest default) - results with more than 8 values will be hashed
+    tester.with_hash_threshold(8);
+
     tester.run_script(&contents)
         .unwrap_or_else(|e| panic!("Test failed for {}: {}", test_file, e));
 }


### PR DESCRIPTION
## Summary

Partial fix for #1689 - Addresses hash threshold configuration issue in select1-4.test failures.

**Status:** Tests still fail with hash mismatches, but now using correct result format.

## Problem Found

The select1-4.test files were failing due to TWO distinct issues:

### Issue 1: Hash Threshold Not Set (✅ FIXED)

The single file test runner (`tests/sqllogictest_runner.rs`) wasn't setting `hash_threshold`, causing it to default to 0 (disabled). This meant results weren't being hashed when they should be.

**Expected format:** `30 values hashing to 3c13dee48d9356ae19af2515e05e6b54`  
**Actual (before fix):** Individual values listed (358, 364, 376, ...)

**Note:** The test suite runner (`tests/sqllogictest/execution.rs`) already had the fix (line 37), but the single file runner was missing it.

### Issue 2: SQL Execution Bugs (❌ NOT FIXED - Needs Investigation)

After fixing hash threshold, tests now hash results correctly, but the **hash values don't match expected values**.

**Example failure:**
```sql
SELECT a+b*2+c*3+d*4+e*5, (a+b+c+d+e)/5
  FROM t1 ORDER BY 1,2
```
Expected hash: `010239dc0b8e04fa7aa927551a6a231f`  
Actual hash: `c2ae0191f0fdd8db6bd7e78cf722a6b4`

This indicates incorrect SQL query results, likely related to recent arithmetic operator changes.

## Changes

- Set `hash_threshold = 8` in `run_single_test_file` test (line 686)
- Matches SQLLogicTest standard behavior (hash results with >8 values)
- Merged latest main branch (31 commits) including recent arithmetic fixes

## Testing

```bash
export SQLLOGICTEST_FILE="select1.test"
cargo test --release -p vibesql --test sqllogictest_runner run_single_test_file
```

**Before fix:** Format mismatch (raw values instead of hash)  
**After fix:** Hash format correct, but values mismatch (incorrect SQL execution)

## Next Steps for #1689

The select1-4.test failures require additional investigation:

1. **Identify which arithmetic operations produce wrong results**
   - Division operator `/` vs `DIV`  
   - NULL handling in arithmetic (commit 0c0b3ba7)
   - Type conversions (Integer vs Numeric)

2. **Recent conflicting commits to investigate:**
   - `0c0b3ba7` - Add NULL propagation to arithmetic operators
   - `fa90644f` - Change DIV to return Integer
   - `f53a9c57` - Change DIV to return Numeric (conflicts with above)

3. **Debug specific failing queries** to isolate root cause

## Related

- Partially addresses #1689 (hash threshold fixed)
- Blocks #1674 (100% test suite pass rate)
- Related to #1690 (random test failures)

## Review Notes

This PR improves the situation by fixing the hash threshold issue, but doesn't fully resolve #1689. The tests now fail with **correct error messages** (hash mismatches) instead of format errors, making it easier to debug the underlying SQL execution bugs.

Recommend merging this fix and keeping #1689 open with updated description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>