### PR TITLE
fix: Disable buggy index optimizations that cause row loss

### DIFF
--- a/crates/vibesql-executor/src/select/executor/index_optimization/order_by.rs
+++ b/crates/vibesql-executor/src/select/executor/index_optimization/order_by.rs
@@ -5,9 +5,7 @@
 //! - Reverse index traversal (ASC index used for DESC ordering)
 //! - Mixed ASC/DESC directions when index supports them
 
-use std::collections::{BTreeMap, HashMap};
-
-use vibesql_storage::database::{Database, IndexData};
+use vibesql_storage::database::Database;
 use vibesql_types::SqlValue;
 
 use crate::{
@@ -19,165 +17,17 @@ use crate::{
 /// Try to use an index for ORDER BY optimization
 /// Returns ordered rows if an index can be used, None otherwise
 pub(in crate::select::executor) fn try_index_based_ordering(
-    database: &Database,
-    rows: &[RowWithSortKeys],
-    order_by: &[vibesql_ast::OrderByItem],
-    schema: &CombinedSchema,
+    _database: &Database,
+    _rows: &[RowWithSortKeys],
+    _order_by: &[vibesql_ast::OrderByItem],
+    _schema: &CombinedSchema,
     _from_clause: &Option<vibesql_ast::FromClause>,
-    select_list: &[vibesql_ast::SelectItem],
+    _select_list: &[vibesql_ast::SelectItem],
 ) -> Result<Option<Vec<RowWithSortKeys>>, ExecutorError> {
-    // Empty ORDER BY - nothing to optimize
-    if order_by.is_empty() {
-        return Ok(None);
-    }
-
-    // Extract column names and directions from ORDER BY
-    let mut order_columns = Vec::new();
-    let mut order_directions = Vec::new();
-
-    for order_item in order_by {
-        // Resolve ORDER BY expression (handle positional references and aliases)
-        let resolved_expr = resolve_order_by_expression(&order_item.expr, select_list)?;
-
-        // Check if resolved expression is a simple column reference
-        let column_name = match resolved_expr {
-            vibesql_ast::Expression::ColumnRef { table: None, column } => column,
-            _ => return Ok(None), // Complex expressions can't use index
-        };
-        order_columns.push(column_name.clone());
-        order_directions.push(order_item.direction.clone());
-    }
-
-    // Find the table that has the first ORDER BY column
-    let first_column = &order_columns[0];
-    let mut found_table = None;
-    for (table_name, (_start_idx, table_schema)) in &schema.table_schemas {
-        if table_schema.get_column_index(first_column).is_some() {
-            found_table = Some(table_name.clone());
-            break;
-        }
-    }
-
-    let table_name = match found_table {
-        Some(name) => name,
-        None => return Ok(None),
-    };
-
-    // Find an index that can be used for this ORDER BY
-    let result =
-        find_index_for_multi_column_ordering(database, &table_name, &order_columns, &order_directions)?;
-    let (index_name, _needs_reverse) = match result {
-        Some(r) => r,
-        None => return Ok(None),
-    };
-    // Note: We ignore needs_reverse and always sort according to target directions.
-    // This is simpler and more correct than trying to use index order with reversal.
-
-    // Get the index data
-    let index_data = if let Some(table_name) = index_name.strip_prefix("__pk_") {
-        // Primary key index
-        // Remove "__pk_" prefix
-        let qualified_table_name = format!("public.{}", table_name);
-        if let Some(table) = database.get_table(&qualified_table_name) {
-            if let Some(pk_index) = table.primary_key_index() {
-                // Convert to IndexData format (BTreeMap)
-                let data: BTreeMap<Vec<SqlValue>, Vec<usize>> =
-                    pk_index.iter().map(|(key, &row_idx)| (key.clone(), vec![row_idx])).collect();
-                IndexData::InMemory { data }
-            } else {
-                return Ok(None);
-            }
-        } else {
-            return Ok(None);
-        }
-    } else {
-        match database.get_index_data(&index_name) {
-            Some(data) => data.clone(),
-            None => return Ok(None),
-        }
-    };
-
-    // Extract ORDER BY column values from filtered rows
-    // Build a map: ORDER BY value(s) -> Vec<row position in filtered set>
-    let mut value_to_row_positions: HashMap<Vec<SqlValue>, Vec<usize>> = HashMap::new();
-
-    for (row_idx, (row, _)) in rows.iter().enumerate() {
-        // Extract the ORDER BY column values from this row
-        let mut order_values = Vec::new();
-        for col_name in &order_columns {
-            // Get column value from the row
-            // Find which table this row belongs to
-            let mut found_value = None;
-            for (start_idx, tbl_schema) in schema.table_schemas.values() {
-                if let Some(col_idx) = tbl_schema.get_column_index(col_name) {
-                    let global_col_idx = start_idx + col_idx;
-                    if global_col_idx < row.len() {
-                        found_value = Some(row.values[global_col_idx].clone());
-                        break;
-                    }
-                }
-            }
-
-            if let Some(value) = found_value {
-                order_values.push(value);
-            } else {
-                // Column not found in row, can't use index
-                return Ok(None);
-            }
-        }
-
-        value_to_row_positions.entry(order_values).or_default().push(row_idx);
-    }
-
-    // Convert index HashMap to Vec and sort for consistent ordering
-    let mut data_vec: Vec<(Vec<SqlValue>, Vec<usize>)> =
-        index_data.iter().map(|(k, v): (&Vec<SqlValue>, &Vec<usize>)| (k.clone(), v.clone())).collect();
-
-    // Sort by key, always respecting the desired ORDER BY directions
-    // This is simpler and more correct than trying to use vector reversal
-    data_vec.sort_by(|(a, _): &(Vec<SqlValue>, Vec<usize>), (b, _): &(Vec<SqlValue>, Vec<usize>)| {
-        for (i, (val_a, val_b)) in a.iter().zip(b.iter()).enumerate() {
-            // Get the desired direction for this column
-            let target_direction = order_directions.get(i)
-                .cloned()
-                .unwrap_or(vibesql_ast::OrderDirection::Asc);
-
-            // Handle NULLs: always sort last regardless of ASC/DESC (SQL standard behavior)
-            let ord = match (val_a.is_null(), val_b.is_null()) {
-                (true, true) => std::cmp::Ordering::Equal,
-                (true, false) => std::cmp::Ordering::Greater, // NULL always sorts last
-                (false, true) => std::cmp::Ordering::Less,    // non-NULL always sorts first
-                (false, false) => {
-                    // Compare non-NULL values according to the target direction
-                    let comparison = compare_sql_values(val_a, val_b);
-
-                    match target_direction {
-                        vibesql_ast::OrderDirection::Asc => comparison,
-                        vibesql_ast::OrderDirection::Desc => comparison.reverse(),
-                    }
-                }
-            };
-
-            if ord != std::cmp::Ordering::Equal {
-                return ord;
-            }
-        }
-        std::cmp::Ordering::Equal
-    });
-
-    // Build ordered rows by traversing index and looking up filtered rows
-    let mut ordered_rows: Vec<RowWithSortKeys> = Vec::new();
-    for (index_key, _) in data_vec {
-        // Check if we have any filtered rows with this index key value
-        if let Some(row_positions) = value_to_row_positions.get(&index_key) {
-            // Add all rows with this key value (handles duplicates)
-            for &row_pos in row_positions {
-                ordered_rows.push(rows[row_pos].clone());
-            }
-        }
-    }
-
-    Ok(Some(ordered_rows))
+    // TEMPORARILY DISABLED: Index-based ORDER BY optimization has bugs that cause
+    // rows to be dropped and incorrect ordering. Falling back to regular sorting.
+    // See issue #1744
+    Ok(None)
 }
 
 /// Find an index that can be used for multi-column ordering

--- a/crates/vibesql-executor/src/select/executor/index_optimization/where_filter.rs
+++ b/crates/vibesql-executor/src/select/executor/index_optimization/where_filter.rs
@@ -7,33 +7,15 @@ use crate::{errors::ExecutorError, schema::CombinedSchema};
 /// Try to use indexes for WHERE clause filtering
 /// Returns Some(rows) if index optimization was applied, None if not applicable
 pub(in crate::select::executor) fn try_index_based_where_filtering(
-    database: &Database,
-    where_expr: Option<&vibesql_ast::Expression>,
-    all_rows: &[vibesql_storage::Row],
-    schema: &CombinedSchema,
+    _database: &Database,
+    _where_expr: Option<&vibesql_ast::Expression>,
+    _all_rows: &[vibesql_storage::Row],
+    _schema: &CombinedSchema,
 ) -> Result<Option<Vec<vibesql_storage::Row>>, ExecutorError> {
-    let where_expr = match where_expr {
-        Some(expr) => expr,
-        None => return Ok(None), // No WHERE clause
-    };
-
-    // Try to match different predicate patterns
-    match where_expr {
-        // AND expressions (for BETWEEN pattern) - check first before binary op
-        vibesql_ast::Expression::BinaryOp { op: vibesql_ast::BinaryOperator::And, left, right } => {
-            try_index_for_and_expr(database, left, right, all_rows, schema)
-        }
-        // Simple binary operations: column OP value
-        vibesql_ast::Expression::BinaryOp { left, op, right } => {
-            try_index_for_binary_op(database, left, op, right, all_rows, schema)
-        }
-        // IN expressions: column IN (val1, val2, ...)
-        vibesql_ast::Expression::InList { expr, values, negated: false } => {
-            try_index_for_in_expr(database, expr, values, all_rows, schema)
-        }
-        // Other expressions not supported for index optimization
-        _ => Ok(None),
-    }
+    // TEMPORARILY DISABLED: Index-based WHERE filtering has bugs that cause
+    // rows to be dropped. Falling back to regular filtering.
+    // See issue #1744
+    Ok(None)
 }
 
 /// Try to use index for binary operation predicates (=, <, >, <=, >=)


### PR DESCRIPTION
## Summary

Fixes issue #1744 by temporarily disabling two buggy index optimizations that were causing rows to be silently dropped from query results.

## Root Causes Identified

### 1. Index-based ORDER BY Optimization  
The `try_index_based_ordering` function was using index data directly to determine row order. This caused rows to be dropped when:
- Filtered rows weren't present in the index  
- Index data was incomplete or stale

### 2. Index-based WHERE Filtering  
The `try_index_based_where_filtering` function had bugs causing incorrect filtering when using indexed columns.

## Changes Made

- Disabled `try_index_based_ordering()` - returns `Ok(None)` to fall back to regular sorting
- Disabled `try_index_based_where_filtering()` - returns `Ok(None)` to fall back to regular filtering
- Added comments explaining the temporary disablement

## Test Results

**Before fix:**
- `index/orderby/10/slt_good_1.test`: ❌ FAILED (missing rows 7 and 9)
- `index/orderby/10/slt_good_2.test`: ❌ FAILED

**After fix:**
- `index/orderby/10/slt_good_1.test`: ✅ PASSED
- `index/orderby/10/slt_good_2.test`: ✅ PASSED

Manual testing confirmed:
```sql
SELECT pk FROM tab1 WHERE col0 > 309 ORDER BY 1 DESC;
-- Returns all 8 expected rows in correct descending order
```

## Impact

- ✅ Fixes critical bug where query results were missing rows
- ✅ Ensures correctness by using proven non-optimized code paths  
- ⚠️  Performance: These optimizations provided speed benefits but correctness is more important
- 📝 Future work: Re-implement these optimizations correctly

## Next Steps

These index optimizations should be re-designed and re-implemented with:
1. Comprehensive test coverage
2. Proper handling of filtered row sets
3. Validation that index data is complete and current

Closes #1744

🤖 Generated with [Claude Code](https://claude.com/claude-code)