### PR TITLE
Fix test_unary_plus_invalid_type to align with SQLite behavior

### DIFF
--- a/crates/vibesql-executor/src/tests/operator_edge_cases/unary_operators.rs
+++ b/crates/vibesql-executor/src/tests/operator_edge_cases/unary_operators.rs
@@ -86,13 +86,14 @@ fn test_unary_minus_null() {
 }
 
 #[test]
-fn test_unary_plus_invalid_type() {
+fn test_unary_plus_text() {
+    // SQLite behavior: unary + on text returns text unchanged (identity operation)
     let db = vibesql_storage::Database::new();
     let expr = vibesql_ast::Expression::UnaryOp {
         op: vibesql_ast::UnaryOperator::Plus,
         expr: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar("hello".to_string()))),
     };
-    assert_type_mismatch(&db, expr);
+    assert_expression_result(&db, expr, vibesql_types::SqlValue::Varchar("hello".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #1757 - Resolves the conflict between `test_unary_plus_invalid_type` and the SQLite-compatible implementation of unary plus operator.

## Problem

The test `test_unary_plus_invalid_type` was failing because it expected unary `+` on text types to return a `TypeMismatch` error. However, the implementation (in `crates/vibesql-executor/src/evaluator/expressions/operators.rs:42-45`) correctly follows SQLite behavior where unary `+` on text is an identity operation that returns the text unchanged.

This created an internal contradiction in the test suite:
- `test_unary_plus_on_text` (line 216 in operators.rs) expected unary `+` on text to succeed
- `test_unary_plus_invalid_type` (line 88) expected it to fail

## Solution

Updated the test to align with SQLite behavior:
- Renamed `test_unary_plus_invalid_type` → `test_unary_plus_text`
- Changed expectation from error to success (identity operation)
- Added comment explaining SQLite behavior
- `test_unary_minus_invalid_type` remains unchanged (correctly expects error for unary `-` on text)

## Testing

All unary operator tests now pass:
```bash
cargo test --package vibesql-executor --lib tests::operator_edge_cases::unary_operators
```

**Result**: `ok. 10 passed; 0 failed`

## Behavior

- ✅ Unary `+` on text: Returns text unchanged (SQLite compatibility)
- ✅ Unary `-` on text: Returns TypeMismatch error (as expected)
- ✅ Unary `+` on NULL: Returns NULL (NULL propagation)
- ✅ Unary `-` on NULL: Returns NULL (NULL propagation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)