### PR TITLE
Fix NULL handling in BETWEEN predicates (#1762)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -20,6 +20,15 @@ impl ExpressionEvaluator<'_> {
         let mut low_val = self.eval(low, row)?;
         let mut high_val = self.eval(high, row)?;
 
+        // Per SQL:1999 standard: any NULL operand makes entire predicate NULL
+        // This applies to both BETWEEN and NOT BETWEEN
+        if matches!(expr_val, vibesql_types::SqlValue::Null)
+            || matches!(low_val, vibesql_types::SqlValue::Null)
+            || matches!(high_val, vibesql_types::SqlValue::Null)
+        {
+            return Ok(vibesql_types::SqlValue::Null);
+        }
+
         // Check if bounds are reversed (low > high)
         let gt_result =
             Self::eval_binary_op_static(&low_val, &vibesql_ast::BinaryOperator::GreaterThan, &high_val)?;


### PR DESCRIPTION
## Summary

Fixes #1762 by implementing proper NULL handling in BETWEEN and NOT BETWEEN predicates according to SQL three-valued logic.

## Problem

The `eval_between()` function was not checking for NULL operands before performing comparisons, violating SQL:1999 standard behavior. This caused incorrect results when BETWEEN expressions involved NULL values.

**Example failures**:
```sql
-- Before fix: incorrect results
SELECT * FROM tab WHERE col NOT BETWEEN 10 AND NULL
-- Expected: 0 rows (NULL predicate → excluded)
-- Actual: all rows or incorrect subset

-- After fix: correct behavior
SELECT * FROM tab WHERE col NOT BETWEEN 10 AND NULL
-- Returns: 0 rows (NULL predicate correctly excluded)
```

## Changes

1. **Core Fix** (`crates/vibesql-executor/src/evaluator/expressions/predicates.rs`):
   - Added NULL check at start of `eval_between()` method
   - Returns `SqlValue::Null` when any operand (expr, low, or high) is NULL
   - Applies to both `BETWEEN` and `NOT BETWEEN` predicates

2. **Test Coverage** (`crates/vibesql-executor/src/tests/predicate_tests/between_predicate.rs`):
   - Added `test_not_between_with_null_bound()` - validates NOT BETWEEN with NULL high bound
   - Added `test_between_with_null_bound()` - validates BETWEEN with NULL low bound
   - Both tests verify NULL predicates exclude rows from results

## SQL Three-Valued Logic

Per SQL:1999 standard:
- `x BETWEEN a AND b` → NULL if any of x, a, or b is NULL
- `x NOT BETWEEN a AND b` → NULL if any of x, a, or b is NULL
- NULL in WHERE clause is treated as FALSE (row excluded)

## Testing

### Unit Tests (✅ Passing)
```bash
$ cargo test -p vibesql-executor --lib test_between
running 10 tests
test_between_with_null_bound ... ok
test_not_between_with_null_bound ... ok
# All 10 BETWEEN tests pass
```

### Integration Tests (Expected Impact)
This fix should resolve 43 failing random/select SQLLogicTest files:
- All recent failures showed pattern: `NOT BETWEEN ... AND NULL`
- Fix aligns behavior with SQLite/MySQL/PostgreSQL

## Files Changed

- `crates/vibesql-executor/src/evaluator/expressions/predicates.rs` (+7 lines)
- `crates/vibesql-executor/src/tests/predicate_tests/between_predicate.rs` (+86 lines)

## Related Issues

- Issue #1762: SQLLogicTest random SELECT tests failing (91.5% fail rate)
- Global effort to achieve SQLLogicTest conformance

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)