### PR TITLE
Re-enable IN clause index optimization

### DIFF
--- a/crates/vibesql-executor/src/select/executor/index_optimization/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/index_optimization/mod.rs
@@ -13,5 +13,5 @@ mod where_filter;
 mod spatial;
 
 pub(in crate::select::executor) use order_by::try_index_based_ordering;
-pub(in crate::select::executor) use where_filter::try_index_based_where_filtering;
+pub(in crate::select::executor) use where_filter::{try_index_based_where_filtering, try_index_for_in_clause};
 pub(in crate::select::executor) use spatial::try_spatial_index_optimization;


### PR DESCRIPTION
## Summary

Re-enables IN clause index optimization using a focused, phased approach to avoid reintroducing row loss bugs from #1744.

This implements **Option 1: Phased Re-enablement** from the Curator's analysis - specifically targeting IN clauses while keeping general WHERE filtering disabled for safety.

## Changes

**New function: `try_index_for_in_clause()`** (`where_filter.rs:21-55`)
- Dedicated entry point for IN clause optimization
- Handles both simple `col IN (...)` and combined `col IN (...) AND comparison` patterns
- Bypasses the disabled `try_index_based_where_filtering()` 
- Calls existing (previously unreachable) functions:
  - `try_index_for_in_expr()` - handles simple IN clauses
  - `try_index_for_in_and_comparison()` - handles IN + comparison combinations

**Integration into query execution** (`nonagg.rs:364-381`)
- Added IN clause optimization step in the WHERE filter pipeline
- Runs after spatial index optimization, before general WHERE filtering
- Falls back to standard evaluation if no index can be used

**Module exports** (`mod.rs:16`)
- Exported new function for use by query executor

## Test Plan

### Required Test Files (from issue acceptance criteria)

All 4 IN clause test files must pass:
- `index/in/10/slt_good_1.test`
- `index/in/100/slt_good_0.test`
- `index/in/100/slt_good_1.test` 
- `index/in/100/slt_good_3.test`

Test locally with:
```bash
./scripts/sqllogictest test index/in/10/slt_good_1.test
```

### Edge Cases Handled

- ✅ Simple IN clauses: `WHERE col IN (1, 2, 3)`
- ✅ IN with AND: `WHERE col IN (...) AND col2 > value`
- ✅ Graceful fallback when no index exists
- ✅ NULL values in IN list
- ✅ Empty IN list (returns no rows)

## Safety Considerations

**Why this is safe:**
- Focused scope: Only IN clauses, not all WHERE filtering
- Reuses battle-tested functions (`try_index_for_in_expr`, etc.)
- No changes to index data structures or row conversion logic
- Existing WHERE evaluation as fallback

**What remains disabled:**
- General WHERE filtering (still returns `Ok(None)` due to #1744)
- Index-based ORDER BY (disabled separately)
- Binary operation optimizations outside of IN context

## Related Issues

- Closes #1764 (IN clause test failures)
- Related to #1744 (parent issue that caused disablement)
- Implements Curator's recommended Option 1 approach

## Next Steps

If this PR succeeds:
1. Monitor for any row loss issues
2. Consider expanding to other WHERE optimizations incrementally
3. Eventually re-enable full `try_index_based_where_filtering()` with proper fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>