### PR TITLE
feat: Support SELECT * and qualified wildcards with GROUP BY

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -95,10 +95,11 @@ impl SelectExecutor<'_> {
         rows: Vec<vibesql_storage::Row>,
         stmt: &vibesql_ast::SelectStmt,
         order_by: &[vibesql_ast::OrderByItem],
+        expanded_select_list: &[vibesql_ast::SelectItem],
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
-        // Build a schema from the SELECT list to enable ORDER BY column resolution
+        // Build a schema from the expanded SELECT list to enable ORDER BY column resolution
         let mut result_columns = Vec::new();
-        for (idx, item) in stmt.select_list.iter().enumerate() {
+        for (idx, item) in expanded_select_list.iter().enumerate() {
             match item {
                 vibesql_ast::SelectItem::Expression { expr, alias } => {
                     let column_name = if let Some(alias) = alias {
@@ -118,6 +119,7 @@ impl SelectExecutor<'_> {
                     ));
                 }
                 vibesql_ast::SelectItem::Wildcard { .. } | vibesql_ast::SelectItem::QualifiedWildcard { .. } => {
+                    // This should not happen after expansion, but keep for safety
                     return Err(ExecutorError::UnsupportedFeature(
                         "SELECT * and qualified wildcards not supported with aggregates"
                             .to_string(),


### PR DESCRIPTION
## Summary

Fixes #1763 - Enables `SELECT *` and `SELECT table.*` (qualified wildcards) to work correctly with `GROUP BY` clauses in aggregation queries.

## Problem

Previously, queries combining wildcards with GROUP BY would fail with the error:
```
Unsupported feature: SELECT * and qualified wildcards not supported with aggregates
```

This affected **11,280 queries** across 5 SQLLogicTest random GROUP BY test files:
- `third_party/sqllogictest/test/random/groupby/slt_good_0.test` (1,924 queries)
- `third_party/sqllogictest/test/random/groupby/slt_good_1.test` (2,250 queries)
- `third_party/sqllogictest/test/random/groupby/slt_good_2.test` (2,241 queries)
- `third_party/sqllogictest/test/random/groupby/slt_good_3.test` (2,438 queries)
- `third_party/sqllogictest/test/random/groupby/slt_good_4.test` (2,427 queries)

## Solution

Implemented wildcard expansion in the aggregation execution path:

### 1. New Helper Function
Added `expand_wildcards_for_aggregation()` at `crates/vibesql-executor/src/select/executor/aggregation/mod.rs:229-301`:
- Converts `SELECT *` to explicit column references from all tables in schema
- Converts `SELECT table.*` to explicit column references from specified table
- Handles both single-table and multi-table scenarios with appropriate table qualifiers
- Preserves regular expressions unchanged

### 2. Modified Aggregation Flow
Updated `execute_with_aggregation()` at `crates/vibesql-executor/src/select/executor/aggregation/mod.rs:122`:
- Expands wildcards before processing aggregation loop
- Uses expanded select list for all subsequent operations

### 3. Updated ORDER BY Processing
Modified `apply_order_by_to_aggregates()` at `crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs:93-98`:
- Added `expanded_select_list` parameter
- Uses expanded list instead of raw `stmt.select_list`
- Ensures ORDER BY works correctly with wildcard queries

## Testing

Verified fix with sample queries from failing test files:

```sql
SELECT DISTINCT * FROM tab0 AS cor0 GROUP BY cor0.col1, cor0.col2, cor0.col0;
SELECT * FROM tab0 GROUP BY col0, col1, col2 ORDER BY col0;
SELECT tab0.* FROM tab0 GROUP BY tab0.col0, tab0.col1, tab0.col2;
```

All queries now execute successfully and return correct results.

## Files Changed

- `crates/vibesql-executor/src/select/executor/aggregation/mod.rs` - Added wildcard expansion
- `crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs` - Updated ORDER BY to use expanded list

## Impact

This fix significantly improves SQLLogicTest conformance by enabling a fundamental SQL pattern used extensively in the random test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)