### PR TITLE
Fix test_unary_plus_invalid_type to align with SQLite behavior

### DIFF
--- a/crates/vibesql-executor/src/tests/operator_edge_cases/unary_operators.rs
+++ b/crates/vibesql-executor/src/tests/operator_edge_cases/unary_operators.rs
@@ -86,13 +86,14 @@ fn test_unary_minus_null() {
 }
 
 #[test]
-fn test_unary_plus_invalid_type() {
+fn test_unary_plus_text() {
+    // SQLite behavior: unary + on text returns text unchanged (identity operation)
     let db = vibesql_storage::Database::new();
     let expr = vibesql_ast::Expression::UnaryOp {
         op: vibesql_ast::UnaryOperator::Plus,
         expr: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar("hello".to_string()))),
     };
-    assert_type_mismatch(&db, expr);
+    assert_expression_result(&db, expr, vibesql_types::SqlValue::Varchar("hello".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes the failing `test_unary_plus_invalid_type` test by aligning it with the implementation's SQLite-compatible behavior.

## Changes

- **Renamed test**: `test_unary_plus_invalid_type` → `test_unary_plus_text`
- **Updated assertion**: Changed from `assert_type_mismatch` to `assert_expression_result` expecting varchar unchanged
- **Added documentation**: Comment explaining SQLite behavior (unary + on text is identity operation)

## Problem

The test suite had an internal contradiction:
- `test_unary_plus_invalid_type` expected unary plus on strings to **FAIL** with TypeMismatch
- Implementation at `operators.rs:42-45` intentionally **SUCCEEDS** following SQLite behavior
- Unit test `test_unary_plus_on_text` at `operators.rs:216-231` validated this SQLite behavior

## Solution

Aligned the test with the implementation by:
1. Recognizing that unary `+` on text types is valid in SQLite (identity operation)
2. Renaming the test to reflect its actual behavior
3. Updating assertion to expect success instead of error

## Technical Details

**Files modified:**
- `crates/vibesql-executor/src/tests/operator_edge_cases/unary_operators.rs:89-96`

**SQLite behavior reference:**
In SQLite, `+text` returns `text` unchanged (identity operation), which differs from strict SQL standard but provides compatibility.

**Note:** The similar test `test_unary_minus_invalid_type` correctly expects an error and continues to pass, as unary minus on text is NOT supported (no SQLite exception).

## Test Plan

- [x] Renamed test `test_unary_plus_text` passes
- [x] All 10 unary operator tests pass (verified locally)
- [x] No changes to runtime behavior (test-only fix)
- [x] Test suite now internally consistent

## Verification

```bash
cargo test -p vibesql-executor --lib tests::operator_edge_cases::unary_operators
# Result: ok. 10 passed; 0 failed
```

## Impact

- ✅ Fixes failing test on main branch
- ✅ Makes test suite internally consistent
- ✅ Maintains SQLite compatibility
- ✅ No runtime behavior changes
- ✅ Zero risk (test-only modification)

Closes #1776

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>