### PR TITLE
Fix parallel test runner false positive reporting

### DIFF
--- a/tests/sqllogictest_suite.rs
+++ b/tests/sqllogictest_suite.rs
@@ -125,16 +125,16 @@ fn run_test_suite() -> (HashMap<String, TestStats>, usize) {
             Err(TestError::Timeout { file, timeout_seconds }) => {
                 eprintln!("⏱️  TIMEOUT: {} exceeded {}s", file, timeout_seconds);
                 stats.failed += 1;
-                if !detailed_failures.is_empty() {
-                    stats.detailed_failures.push((relative_path.clone(), detailed_failures));
-                }
+                // Always track failed files, even if detailed_failures is empty
+                // This ensures accurate pass/fail reporting in JSON output
+                stats.detailed_failures.push((relative_path.clone(), detailed_failures));
             }
             Err(TestError::Execution(e)) => {
                 eprintln!("✗ {} - {}", relative_path, e);
                 stats.failed += 1;
-                if !detailed_failures.is_empty() {
-                    stats.detailed_failures.push((relative_path.clone(), detailed_failures));
-                }
+                // Always track failed files, even if detailed_failures is empty
+                // This ensures accurate pass/fail reporting in JSON output
+                stats.detailed_failures.push((relative_path.clone(), detailed_failures));
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #1825 - Parallel test runner was reporting 100% pass rate when only 5.5% of tests actually passed.

## Problem

The parallel SQLLogicTest runner had a critical bug causing false positive reporting:
- **Reported**: 623/623 tests passed (100%)
- **Actual**: 34/623 tests passed (5.5%)

This prevented trusting parallel test results and forced use of slower serial execution.

## Root Cause

In `tests/sqllogictest_suite.rs`, failed tests were only added to `detailed_failures` if they had detailed failure information:

```rust
// BEFORE (buggy):
stats.failed += 1;
if !detailed_failures.is_empty() {
    stats.detailed_failures.push((relative_path.clone(), detailed_failures));
}
```

The JSON generation logic (lines 261-268) determines pass/fail by checking if files are in `all_detailed_failures`. Files not in this list are counted as "passed".

**Result**: Tests that failed without detailed failures (timeouts, crashes, errors) were not tracked in `detailed_failures`, causing them to be incorrectly counted as passed.

## Solution

Remove the conditional check and always track failed files:

```rust
// AFTER (correct):
stats.failed += 1;
// Always track failed files, even if detailed_failures is empty
// This ensures accurate pass/fail reporting in JSON output
stats.detailed_failures.push((relative_path.clone(), detailed_failures));
```

This ensures:
- All failed files are tracked in `detailed_failures`
- JSON output correctly identifies passed vs failed files
- Maintains backward compatibility with detailed failure information

## Changes

- `tests/sqllogictest_suite.rs`: Removed conditional checks on lines 128-130 and 135-137
- Added explanatory comments documenting the fix

## Testing

- ✅ Code compiles successfully
- ✅ Fix addresses the root cause identified in issue analysis
- 🔄 Parallel test suite validation needed (requires Judge review)

## Verification Steps

To verify this fix works:

```bash
# Run parallel test suite
./scripts/sqllogictest run --parallel --workers 8 --time 60

# Check results match actual pass/fail counts
./scripts/sqllogictest query --preset by-category

# Results should now show ~5.5% pass rate, not 100%
```

## Impact

This fix unblocks:
- Fast CI/CD pipelines with parallel testing
- Accurate test progress tracking
- Issues #1826, #1827, #1828 (all depend on accurate test reporting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>