### PR TITLE
Add BIT type support for MySQL compatibility

### DIFF
--- a/crates/vibesql-cli/src/executor/display.rs
+++ b/crates/vibesql-cli/src/executor/display.rs
@@ -179,6 +179,12 @@ fn format_data_type(data_type: &vibesql_types::DataType) -> String {
         }
         vibesql_types::DataType::Interval { .. } => "interval".to_string(),
         vibesql_types::DataType::BinaryLargeObject => "bytea".to_string(),
+        vibesql_types::DataType::Bit { length } => {
+            match length {
+                Some(len) => format!("bit({})", len),
+                None => "bit".to_string(),
+            }
+        }
         vibesql_types::DataType::UserDefined { type_name } => type_name.clone(),
         vibesql_types::DataType::Null => "null".to_string(),
     }

--- a/crates/vibesql-executor/src/evaluator/expression_hash.rs
+++ b/crates/vibesql-executor/src/evaluator/expression_hash.rs
@@ -439,6 +439,7 @@ impl ExpressionHasher {
                 }
             }
             vibesql_types::DataType::BinaryLargeObject => {}
+            vibesql_types::DataType::Bit { length } => length.hash(hasher),
             vibesql_types::DataType::UserDefined { type_name } => type_name.hash(hasher),
             vibesql_types::DataType::Null => {}
         }

--- a/crates/vibesql-parser/src/tests/create_table/bit_type.rs
+++ b/crates/vibesql-parser/src/tests/create_table/bit_type.rs
@@ -1,0 +1,138 @@
+use super::super::*;
+
+// ========================================================================
+// BIT Data Type - MySQL Binary Bit String Type
+// ========================================================================
+
+#[test]
+fn test_parse_create_table_bit_no_length() {
+    // BIT without length defaults to BIT(1)
+    let result = Parser::parse_sql("CREATE TABLE test (flags BIT);");
+    assert!(result.is_ok(), "Should parse BIT without length");
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 1);
+
+            match &create.columns[0].data_type {
+                vibesql_types::DataType::Bit { length } => {
+                    assert_eq!(*length, None, "Expected BIT without length (defaults to 1)");
+                }
+                _ => panic!("Expected BIT, got {:?}", create.columns[0].data_type),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_bit_with_length() {
+    // BIT(n) with explicit length
+    let result = Parser::parse_sql("CREATE TABLE test (flags BIT(8));");
+    assert!(result.is_ok(), "Should parse BIT(8)");
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 1);
+
+            match &create.columns[0].data_type {
+                vibesql_types::DataType::Bit { length } => {
+                    assert_eq!(*length, Some(8), "Expected BIT(8)");
+                }
+                _ => panic!("Expected BIT(8), got {:?}", create.columns[0].data_type),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_bit_multiple_columns() {
+    // Multiple BIT columns with different lengths
+    let result = Parser::parse_sql(
+        "CREATE TABLE test (flags1 BIT, flags2 BIT(16), flags3 BIT(64));",
+    );
+    assert!(result.is_ok(), "Should parse multiple BIT columns");
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 3);
+
+            match &create.columns[0].data_type {
+                vibesql_types::DataType::Bit { length } => {
+                    assert_eq!(*length, None, "Expected BIT");
+                }
+                _ => panic!("Expected BIT, got {:?}", create.columns[0].data_type),
+            }
+
+            match &create.columns[1].data_type {
+                vibesql_types::DataType::Bit { length } => {
+                    assert_eq!(*length, Some(16), "Expected BIT(16)");
+                }
+                _ => panic!("Expected BIT(16), got {:?}", create.columns[1].data_type),
+            }
+
+            match &create.columns[2].data_type {
+                vibesql_types::DataType::Bit { length } => {
+                    assert_eq!(*length, Some(64), "Expected BIT(64)");
+                }
+                _ => panic!("Expected BIT(64), got {:?}", create.columns[2].data_type),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_bit_with_comment() {
+    // BIT with COMMENT clause (from the failing test case)
+    let result = Parser::parse_sql("CREATE TABLE t (c1 BIT COMMENT 'test', c2 BIT COMMENT 'test2');");
+    assert!(result.is_ok(), "Should parse BIT with COMMENT");
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 2);
+
+            match &create.columns[0].data_type {
+                vibesql_types::DataType::Bit { length } => {
+                    assert_eq!(*length, None, "Expected BIT");
+                }
+                _ => panic!("Expected BIT, got {:?}", create.columns[0].data_type),
+            }
+
+            match &create.columns[1].data_type {
+                vibesql_types::DataType::Bit { length } => {
+                    assert_eq!(*length, None, "Expected BIT");
+                }
+                _ => panic!("Expected BIT, got {:?}", create.columns[1].data_type),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_bit_max_length() {
+    // MySQL BIT supports up to 64 bits
+    let result = Parser::parse_sql("CREATE TABLE test (flags BIT(64));");
+    assert!(result.is_ok(), "Should parse BIT(64)");
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 1);
+
+            match &create.columns[0].data_type {
+                vibesql_types::DataType::Bit { length } => {
+                    assert_eq!(*length, Some(64), "Expected BIT(64)");
+                }
+                _ => panic!("Expected BIT(64), got {:?}", create.columns[0].data_type),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}

--- a/crates/vibesql-parser/src/tests/create_table/mod.rs
+++ b/crates/vibesql-parser/src/tests/create_table/mod.rs
@@ -1,5 +1,6 @@
 mod auto_increment;
 mod basic;
+mod bit_type;
 mod constraints_column;
 mod constraints_table;
 mod mysql_table_options;

--- a/crates/vibesql-storage/src/btree/mod.rs
+++ b/crates/vibesql-storage/src/btree/mod.rs
@@ -174,6 +174,13 @@ fn estimate_max_key_size(key_schema: &[DataType]) -> usize {
                 // Conservative estimate for BLOB
                 1 + 8 + 1024
             }
+            DataType::Bit { length } => {
+                // BIT type: tag + length + bits (rounded up to bytes)
+                // MySQL BIT can be 1-64 bits
+                let bit_length = length.unwrap_or(1);
+                let byte_length = (bit_length + 7) / 8;  // Round up to nearest byte
+                1 + 8 + byte_length
+            }
             DataType::UserDefined { .. } => {
                 // Unknown type, use conservative estimate
                 1 + 8 + 256

--- a/crates/vibesql-storage/src/persistence/json.rs
+++ b/crates/vibesql-storage/src/persistence/json.rs
@@ -381,6 +381,7 @@ fn column_to_json(col: &ColumnSchema) -> JsonColumn {
         }
         DataType::Interval { .. } => ("INTERVAL".to_string(), None, None, None),
         DataType::BinaryLargeObject => ("BLOB".to_string(), None, None, None),
+        DataType::Bit { length } => ("BIT".to_string(), *length, None, None),
         DataType::UserDefined { type_name } => (type_name.clone(), None, None, None),
         DataType::Null => ("NULL".to_string(), None, None, None),
     };

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -213,6 +213,13 @@ pub(super) fn format_data_type(data_type: &vibesql_types::DataType) -> String {
         DataType::CharacterLargeObject => "CLOB".to_string(),
         DataType::Name => "VARCHAR(128)".to_string(),
         DataType::BinaryLargeObject => "BLOB".to_string(),
+        DataType::Bit { length } => {
+            if let Some(len) = length {
+                format!("BIT({})", len)
+            } else {
+                "BIT".to_string()
+            }
+        }
         DataType::UserDefined { type_name } => type_name.clone(),
         DataType::Null => "NULL".to_string(),
     }

--- a/crates/vibesql-storage/src/table/normalization.rs
+++ b/crates/vibesql-storage/src/table/normalization.rs
@@ -317,6 +317,17 @@ impl<'a> RowNormalizer<'a> {
                     });
                 }
             }
+            DataType::Bit { .. } => {
+                // BIT type: For now, accept Varchar or Integer as placeholder until proper BIT type is fully implemented
+                // VARCHAR can hold binary literals like b'1010', INTEGER can hold numeric values
+                if !matches!(value, SqlValue::Varchar(_) | SqlValue::Integer(_) | SqlValue::Bigint(_) | SqlValue::Unsigned(_)) {
+                    return Err(StorageError::TypeMismatch {
+                        column: column_name.to_string(),
+                        expected: "BIT".to_string(),
+                        actual: value.type_name().to_string(),
+                    });
+                }
+            }
             // User-defined types
             #[cfg_attr(not(debug_assertions), allow(unused_variables))]
             DataType::UserDefined { type_name } => {


### PR DESCRIPTION
## Summary

Adds comprehensive support for the MySQL BIT data type to resolve parsing errors in `ddl/createtable/createtable1.test`.

## What Changed

### Core Type System
- Added `DataType::Bit { length: Option<usize> }` variant to support BIT and BIT(n) syntax
- Default length is 1 when not specified (MySQL standard)
- Supports up to 64 bits per MySQL specification

### Parser
- Added BIT type parsing in `crates/vibesql-parser/src/parser/create/types.rs`
- Handles both `BIT` and `BIT(n)` syntax
- Properly parses tables like: `CREATE TABLE t (c BIT COMMENT 'test');`

### Type System
- Implemented type precedence (11, between BLOB and Interval)
- Added coercion rules: BIT ↔ BIT, BIT ↔ Integer types, BIT ↔ BLOB
- Proper common type resolution for BIT types with different lengths

### Storage Layer
- Added serialization/deserialization (type ID 22)
- Proper size estimation for B+ tree keys
- JSON persistence support
- SQL formatting for CREATE TABLE statements

### Testing
- 5 comprehensive unit tests in `crates/vibesql-parser/src/tests/create_table/bit_type.rs`
- Tests cover: no length, explicit length, multiple columns, with COMMENT, max length (64)
- All tests passing ✅

## Testing

### Unit Tests
```bash
cargo test test_parse_create_table_bit
```
**Result:** All 5 tests pass ✅

### Impact on SQLLogicTest  
This change fixes the parsing errors in `ddl/createtable/createtable1.test` that were blocking progress on issue #1831.

## Related Issues

Closes #1831

## Notes

- BIT values are accepted as VARCHAR or Integer placeholders in the storage layer (similar to BLOB)
- Full BIT value operations can be added in future work
- This implementation focuses on parsing and type system support

🤖 Generated with [Claude Code](https://claude.com/claude-code)