### PR TITLE
Fix index optimization: restrict find_index_for_where to single-column indexes

### DIFF
--- a/crates/vibesql-executor/src/select/executor/index_optimization/where_filter.rs
+++ b/crates/vibesql-executor/src/select/executor/index_optimization/where_filter.rs
@@ -555,8 +555,10 @@ pub(in crate::select::executor) fn try_index_for_in_expr(
         return Ok(None);
     }
 
-    // Find an index on this table and column
-    let index_name = find_index_for_where(database, &table_name, column_name)?;
+    // Find an index on this table and column (supports multi-column indexes)
+    // Use find_index_with_prefix because this function can handle both single-column
+    // and multi-column indexes correctly via range scans
+    let index_name = find_index_with_prefix(database, &table_name, column_name)?;
     if index_name.is_none() {
         return Ok(None);
     }
@@ -614,15 +616,40 @@ pub(in crate::select::executor) fn try_index_for_in_expr(
     Ok(Some(result_rows))
 }
 
-/// Find an index that can be used for WHERE clause filtering
+/// Find a SINGLE-COLUMN index that can be used for WHERE clause filtering
+/// For multi-column index support, use find_index_with_prefix() instead
 pub(in crate::select::executor) fn find_index_for_where(
     database: &Database,
     table_name: &str,
     column_name: &str,
 ) -> Result<Option<String>, ExecutorError> {
-    // Look through all indexes for one on this table and column
-    // We support both single-column indexes and multi-column indexes
-    // where the target column is the FIRST column (prefix matching)
+    // Look through all indexes for a SINGLE-COLUMN index on this table and column
+    // Multi-column indexes are intentionally excluded because most index operations
+    // (equality lookups, range scans) expect single-element keys
+    let all_indexes = database.list_indexes();
+    for index_name in all_indexes {
+        if let Some(metadata) = database.get_index(&index_name) {
+            if metadata.table_name == table_name
+                && metadata.columns.len() == 1
+                && metadata.columns[0].column_name == column_name
+            {
+                // Found a single-column index
+                return Ok(Some(index_name));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Find an index (single or multi-column) where the target column is the first column
+/// This supports prefix matching on composite indexes
+fn find_index_with_prefix(
+    database: &Database,
+    table_name: &str,
+    column_name: &str,
+) -> Result<Option<String>, ExecutorError> {
+    // Look through all indexes for one where the target column is the FIRST column
+    // This works for both single-column and multi-column indexes
     let all_indexes = database.list_indexes();
     for index_name in all_indexes {
         if let Some(metadata) = database.get_index(&index_name) {
@@ -631,7 +658,6 @@ pub(in crate::select::executor) fn find_index_for_where(
                 && metadata.columns[0].column_name == column_name
             {
                 // Found an index where our column is the first column
-                // This works for both single-column and multi-column indexes
                 return Ok(Some(index_name));
             }
         }


### PR DESCRIPTION
## Summary

Fixes critical bug in index optimization that caused 205/214 index tests to fail.

## Problem

Commit `8e65cb8b` modified `find_index_for_where()` to return multi-column indexes, but this broke ALL binary operator optimizations (=, <, >, <=, >=) because the code expected single-element keys but was getting composite keys from multi-column indexes.

**Test Results**:
- Before `8e65cb8b` (commit `ce59dee5`): 140/623 tests passing (22.5%)
- After `8e65cb8b` (commit `573a0fbb`): 34/622 tests passing (5.5%) ← **106 test regression**
- Index category specifically: 9/214 passing (4.2%), 205 failing

## Root Cause

In `try_index_for_binary_op()` (where_filter.rs:153-154):
```rust
let search_key = vec![value];  // Single-element key
index_data.get(&search_key)     // Lookup fails for multi-column indexes
```

Multi-column indexes have composite keys like `vec![val1, val2, val3]`, so looking up `vec![single_val]` never matches.

## Solution

1. **Reverted `find_index_for_where()`** - Now only returns single-column indexes
   - Changed check from `!metadata.columns.is_empty()` to `metadata.columns.len() == 1`
   - This fixes binary operators, BETWEEN, commutative optimization, etc.

2. **Created `find_index_with_prefix()`** - New helper for multi-column index support
   - Can return multi-column indexes where target column is first column
   - Used specifically by `try_index_for_in_expr()` which handles multi-column indexes correctly

3. **Updated `try_index_for_in_expr()`** - Uses new `find_index_with_prefix()` function
   - Maintains multi-column index support for IN clauses via range scans
   - Ensures other optimizations don't accidentally get multi-column indexes

## Files Changed

- `crates/vibesql-executor/src/select/executor/index_optimization/where_filter.rs`
  - Modified `find_index_for_where()` to only return single-column indexes  
  - Added `find_index_with_prefix()` for multi-column index support
  - Updated `try_index_for_in_expr()` to use new function

## Testing

- ✅ Code compiles successfully  
- ✅ Fix targets the specific bug introduced in 8e65cb8b
- ✅ Maintains backward compatibility with existing optimizations
- 🔄 Full test suite run needed to measure improvement

## Expected Impact

This should significantly improve the index test pass rate by restoring correct behavior for:
- Binary operators (=, <, >, <=, >=) with indexes
- BETWEEN operations  
- Commutative query optimization
- Other single-column index optimizations

## Related Issues

- Closes #1832
- Related to #1830
- Related to #1807

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>