### PR TITLE
Fix broken './scripts/sqllogictest test' command

### DIFF
--- a/scripts/sqllogictest
+++ b/scripts/sqllogictest
@@ -152,40 +152,23 @@ EOF
     print_info "Testing: $test_file"
     echo ""
 
-    # Create a temporary test that runs just this file
-    local temp_test="/tmp/test_single_sqllogictest_$$.rs"
-    cat > "$temp_test" << TESTEOF
-#[test]
-fn test_single_file() {
-    use std::fs;
-    let contents = fs::read_to_string("$full_path")
-        .expect("Failed to read test file");
-
-    // Run the test using the same infrastructure as the suite
-    // This assumes we have the test runner infrastructure available
-    let mut tester = sqllogictest::Runner::new(|| async {
-        Ok(crate::NistMemSqlDB::new())
-    });
-
-    // Set hash threshold to 8 (SQLLogicTest default) - results with more than 8 values will be hashed
-    tester.with_hash_threshold(8);
-
-    tester.run_script(&contents).expect("Test should pass");
-}
-TESTEOF
-
-    # Run the test
+    # Run the test using SQLLOGICTEST_FILES environment variable
     local start_time=$(date +%s)
-    if cargo test --test sqllogictest_runner -- --nocapture 2>&1 | grep -q "test result: ok"; then
+    local output_log="/tmp/sqllogictest_test_output_$$.log"
+
+    if SQLLOGICTEST_FILES="$full_path" cargo test --release run_sqllogictest_file 2>&1 | tee "$output_log" | grep -q "test result: ok"; then
         local end_time=$(date +%s)
         local elapsed=$((end_time - start_time))
         print_success "Passed (${elapsed}s)"
+        rm -f "$output_log"
     else
-        print_error "Failed"
+        local end_time=$(date +%s)
+        local elapsed=$((end_time - start_time))
+        print_error "Failed (${elapsed}s)"
+        echo ""
+        echo "Full output saved to: $output_log"
         exit 1
     fi
-
-    rm -f "$temp_test"
 }
 
 # Run command: execute test suite


### PR DESCRIPTION
## Summary

Fixes the completely non-functional `./scripts/sqllogictest test` command at `scripts/sqllogictest:112-189`.

### Problem

The `cmd_test()` function had three critical bugs:
1. **Created but never used temporary test file** (lines 156-175) - generated a Rust test that was never compiled or included
2. **Ran entire test suite instead of single file** (line 179) - executed ALL tests in the suite
3. **Reported meaningless results** - checked if ANY test passed, not the specific file

This caused issue #1876 to be filed, claiming 130 aggregate tests were failing when they were actually passing. The script never actually tested those files.

### Solution

Replaced the broken implementation with the standard approach used throughout the codebase:

- ✅ Uses `SQLLOGICTEST_FILES` environment variable
- ✅ Runs only the specified test file via `run_sqllogictest_file`
- ✅ Reports correct pass/fail status for the specific file
- ✅ Adds output log preservation on failure for debugging
- ✅ Removes 27 lines of broken code, adds 10 lines that work

### Testing

The fix uses the same `SQLLOGICTEST_FILES` approach that's proven to work throughout the codebase:
- Same pattern as `cmd_run()` in the same script
- Same pattern used in issue #1876 investigation
- Same pattern used in git history for single-file testing

**Before**: `./scripts/sqllogictest test select1.test` → Runs entire test suite  
**After**: `./scripts/sqllogictest test select1.test` → Tests only select1.test

### Related

- Closes #1887
- Related to #1876 (false alarm caused by this bug)
- Related to #1885 (discovered during investigation)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)