### PR TITLE
Fix ORDER BY index scan incorrectly filtering rows

### DIFF
--- a/crates/vibesql-executor/src/select/scan/index_scan.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan.rs
@@ -202,6 +202,32 @@ fn extract_range_predicate(expr: &Expression, column_name: &str) -> Option<Range
     match expr {
         Expression::BinaryOp { left, op, right } => {
             match op {
+                // Handle equality: col = value
+                BinaryOperator::Equal => {
+                    // Check if left side is our column and right side is a literal
+                    if is_column_reference(left, column_name) {
+                        if let Expression::Literal(value) = right.as_ref() {
+                            // Equal is a range with same start and end, both inclusive
+                            return Some(RangePredicate {
+                                start: Some(value.clone()),
+                                end: Some(value.clone()),
+                                inclusive_start: true,
+                                inclusive_end: true,
+                            });
+                        }
+                    }
+                    // Also handle reverse: value = col
+                    if is_column_reference(right, column_name) {
+                        if let Expression::Literal(value) = left.as_ref() {
+                            return Some(RangePredicate {
+                                start: Some(value.clone()),
+                                end: Some(value.clone()),
+                                inclusive_start: true,
+                                inclusive_end: true,
+                            });
+                        }
+                    }
+                }
                 // Handle simple comparisons: col > value, col < value, etc.
                 BinaryOperator::GreaterThan
                 | BinaryOperator::GreaterThanOrEqual
@@ -589,7 +615,8 @@ pub(crate) fn execute_index_scan(
                 // Clear CSE cache before evaluating each row
                 evaluator.clear_cse_cache();
 
-                let include_row = match evaluator.eval(where_expr, &row)? {
+                let eval_result = evaluator.eval(where_expr, &row)?;
+                let include_row = match eval_result {
                     vibesql_types::SqlValue::Boolean(true) => true,
                     vibesql_types::SqlValue::Boolean(false) | vibesql_types::SqlValue::Null => false,
                     // SQLLogicTest compatibility: treat integers as truthy/falsy (C-like behavior)
@@ -622,9 +649,15 @@ pub(crate) fn execute_index_scan(
     }
 
     // Return results with sorting metadata if available
-    match sorted_columns {
-        Some(sorted) => Ok(super::FromResult::from_rows_sorted(schema, rows, sorted)),
-        None => Ok(super::FromResult::from_rows(schema, rows)),
+    // If WHERE clause was fully handled by index (!need_where_filter), indicate this
+    // so the executor doesn't redundantly re-apply WHERE filtering
+    if !need_where_filter {
+        Ok(super::FromResult::from_rows_where_filtered(schema, rows, sorted_columns))
+    } else {
+        match sorted_columns {
+            Some(sorted) => Ok(super::FromResult::from_rows_sorted(schema, rows, sorted)),
+            None => Ok(super::FromResult::from_rows(schema, rows)),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #1879 - Query with ORDER BY and index scan incorrectly drops rows from results

This PR fixes a critical bug where queries using index scans with ORDER BY optimization were incorrectly filtering out rows that should have been included in the results.

## Root Cause

Two issues were identified:

1. **Missing Equal operator support**: The index scan's range predicate extraction (`extract_range_predicate()`) didn't handle the `=` operator, only supporting `>`, `>=`, `<`, `<=`, and `BETWEEN`.

2. **Redundant WHERE re-evaluation**: After the index scan applied WHERE filtering during the scan (via predicate pushdown), the nonagg executor was redundantly re-applying the same WHERE clause. This double-filtering incorrectly dropped rows that had already been correctly filtered by the index scan.

## Solution

### 1. Added Equal operator support

Added handling for `BinaryOperator::Equal` in `extract_range_predicate()`:
- Treats `col = value` as a range predicate with identical start and end bounds (both inclusive)
- Handles both `col = value` and `value = col` patterns

### 2. Prevented redundant WHERE filtering

Added `where_filtered` metadata to communicate between index scan and executor:
- Added `where_filtered: bool` field to `FromResult` struct in `join/mod.rs`
- Created new constructor `from_rows_where_filtered()` for index scan results
- Index scan sets this flag when WHERE clause was fully handled during the scan
- Nonagg executor checks this flag and skips redundant WHERE re-evaluation when true

## Files Modified

- `crates/vibesql-executor/src/select/scan/index_scan.rs` - Added Equal operator support and where_filtered flag
- `crates/vibesql-executor/src/select/join/mod.rs` - Added where_filtered field and constructor
- `crates/vibesql-executor/src/select/executor/nonagg.rs` - Skip WHERE re-evaluation when already filtered

## Testing

- Created minimal test case demonstrating the bug (8 rows expected, only 7 returned)
- Verified fix resolves the issue (all 8 rows now returned)
- Confirmed no regressions in passing ORDER BY tests
- Pre-existing test failures remain unchanged

## Test Plan

- [x] Build succeeds without warnings
- [x] Test case for issue #1879 passes
- [x] Existing ORDER BY tests (slt_good_0) still pass
- [x] No new test regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)