### PR TITLE
Add support for FIXED data type in MySQL DDL compatibility

### DIFF
--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -16,6 +16,7 @@ impl Parser {
             // MySQL-specific types that are keywords
             Token::Keyword(Keyword::Set) => "SET".to_string(),
             Token::Keyword(Keyword::Year) => "YEAR".to_string(),
+            Token::Keyword(Keyword::Fixed) => "FIXED".to_string(),
             _ => return Err(ParseError { message: "Expected data type".to_string() }),
         };
         self.advance();
@@ -626,7 +627,7 @@ impl Parser {
             // Collection types (SQL/MM standard)
             "GEOMETRY" | "GEOMETRYCOLLECTION" |
             // MySQL numeric types
-            "TINYINT" | "MEDIUMINT" | "SERIAL" |
+            "TINYINT" | "MEDIUMINT" | "SERIAL" | "FIXED" |
             // MySQL temporal types
             "YEAR" |
             // MySQL string types


### PR DESCRIPTION
## Summary

This PR adds support for the `FIXED` MySQL data type to enable full parsing compatibility with the `ddl/createtable/createtable1.test` SQLLogicTest file.

## Changes

- Added `Keyword::Fixed` to the data type parser's keyword handling in `types.rs`
- Added `"FIXED"` to the list of supported MySQL extension types
- The FIXED type is now parsed as a `UserDefined` data type, allowing graceful handling of MySQL-specific DDL syntax

## Background

The FIXED keyword was already recognized for `ROW_FORMAT` table options, but wasn't handled when used as a column data type. This caused parse errors in the createtable1.test file.

Note: All MySQL table options mentioned in the issue (KEY_BLOCK_SIZE, ROW_FORMAT, CONNECTION, INSERT_METHOD, UNION, etc.) were already implemented. The only missing piece was the FIXED data type support.

## Testing

- ✅ `ddl/createtable/createtable1.test` now passes
- ✅ Brings DDL test category closer to 100% compatibility

Closes #1857

🤖 Generated with [Claude Code](https://claude.com/claude-code)