### PR TITLE
Fix duplicate variable definition in index scan execution

### DIFF
--- a/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
@@ -66,9 +66,6 @@ pub(crate) fn execute_index_scan(
     // Determine if this is a multi-column index
     let is_multi_column_index = index_metadata.columns.len() > 1;
 
-    // Determine if this is a multi-column index
-    let is_multi_column_index = index_metadata.columns.len() > 1;
-
     // Get row indices using the appropriate index operation
     let matching_row_indices: Vec<usize> = match index_predicate {
         Some(IndexPredicate::Range(range)) => {


### PR DESCRIPTION
## Summary

Fixes a code quality issue introduced in PR #1950 where `is_multi_column_index` was accidentally defined twice in the index scan execution code.

## Changes Made

Removed duplicate definition of `is_multi_column_index` variable in:
- `crates/vibesql-executor/src/select/scan/index_scan/execution.rs`

**Before** (lines 66-70):
```rust
// Determine if this is a multi-column index
let is_multi_column_index = index_metadata.columns.len() > 1;

// Determine if this is a multi-column index
let is_multi_column_index = index_metadata.columns.len() > 1;
```

**After** (lines 66-67):
```rust
// Determine if this is a multi-column index
let is_multi_column_index = index_metadata.columns.len() > 1;
```

## Impact

- No functional changes
- Improves code quality by removing unnecessary duplication
- Found during Judge review of PR #1950

## Related

- Part of #1922 (multicolumn IN predicate fixes)
- Follow-up to PR #1950 which was already merged

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>