### PR TITLE
Remove select4.test and select5.test from blocklist

### DIFF
--- a/tests/sqllogictest_suite.rs
+++ b/tests/sqllogictest_suite.rs
@@ -33,9 +33,7 @@ fn run_test_suite() -> (HashMap<String, TestStats>, usize) {
 
     // Blocklist of test files to skip (typically due to memory issues)
     let blocklist: HashSet<String> = vec![
-        // Large select test files (memory intensive)
-        "select4.test",
-        "select5.test",
+        // Blocklist is now empty - select4.test and select5.test pass after fixes in #1036 and #1689
     ]
     .into_iter()
     .map(|s| s.to_string())


### PR DESCRIPTION
## Summary

Remove `select4.test` and `select5.test` from the SQLLogicTest blocklist as both tests now pass after recent fixes.

## Background

These two test files were previously blocklisted due to:
- **select5.test**: Memory exhaustion (6.48 GB) from lack of predicate pushdown
- **select4.test**: Complex SQL feature bugs (set operations, subqueries, etc.)

## Changes

- Removed `select4.test` and `select5.test` from the blocklist in `tests/sqllogictest_suite.rs`
- Added comment referencing the issues that fixed the underlying problems

## Testing

Verified both tests pass individually:
- ✅ **select4.test**: PASSED (48,300 lines, tests set operations: UNION, EXCEPT, INTERSECT)
- ✅ **select5.test**: PASSED (31,948 lines, tests complex joins and aggregations)

## Related Issues

- Closes #1985
- Related to #1036 (Predicate pushdown fix for select5.test)
- Related to #1689 (Core SELECT test fixes for select1-4.test)

## Impact

- **Test Coverage**: Adds 2 major test files back to the active test suite
- **Lines of Test Coverage**: +80,248 lines of SQLLogicTest coverage
- **Pass Rate**: Should improve overall conformance test pass rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)