### PR TITLE
Add ANALYZE statement support to SQLLogicTest runner

### DIFF
--- a/tests/sqllogictest/db_adapter.rs
+++ b/tests/sqllogictest/db_adapter.rs
@@ -297,6 +297,11 @@ impl NistMemSqlDB {
                     .map_err(|e| TestError::Execution(format!("Execution error: {:?}", e)))?;
                 Ok(DBOutput::StatementComplete(0))
             }
+            vibesql_ast::Statement::Analyze(analyze_stmt) => {
+                vibesql_executor::AnalyzeExecutor::execute(&analyze_stmt, &mut self.db)
+                    .map_err(|e| TestError::Execution(format!("Execution error: {:?}", e)))?;
+                Ok(DBOutput::StatementComplete(0))
+            }
             vibesql_ast::Statement::Reindex(reindex_stmt) => {
                 vibesql_executor::IndexExecutor::execute_reindex(&reindex_stmt, &self.db)
                     .map_err(|e| TestError::Execution(format!("Execution error: {:?}", e)))?;

--- a/tests/sqllogictest_suite.rs
+++ b/tests/sqllogictest_suite.rs
@@ -36,7 +36,7 @@ fn run_test_suite() -> (HashMap<String, TestStats>, usize) {
         // Blocklist is now empty - select4.test and select5.test pass after fixes in #1036 and #1689
     ]
     .into_iter()
-    .map(|s| s.to_string())
+    .map(|s: &str| s.to_string())
     .collect();
 
     // Blocklist patterns for very large test files (10000+ rows)


### PR DESCRIPTION
## Summary

- Adds missing handler for `ANALYZE` statements in the SQLLogicTest database adapter
- Required after the ANALYZE command implementation in #2001
- Includes minor type annotation improvement in test suite

## Changes

1. **tests/sqllogictest/db_adapter.rs**: Added `Statement::Analyze` case to execute ANALYZE statements through `AnalyzeExecutor`
2. **tests/sqllogictest_suite.rs**: Added explicit type annotation for clarity

## Test Plan

- Verify SQLLogicTests can now execute ANALYZE statements without errors
- Existing test suite should continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)