### PR TITLE
Fix NOT BETWEEN with NULL boundaries using three-valued logic

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -12,9 +12,13 @@ impl CombinedExpressionEvaluator<'_> {
     /// BETWEEN SYMMETRIC: swaps low and high if low > high before evaluation
     /// If negated: expr < low OR expr > high
     ///
-    /// NULL handling (standard SQL:1999 three-valued logic):
-    /// - Any NULL operand (expr, low, or high) makes entire predicate NULL
-    /// - This applies to both BETWEEN and NOT BETWEEN
+    /// NULL handling (SQLite/SQL:1999 three-valued logic):
+    /// - NULL propagates through comparisons naturally (x < NULL → NULL, x > NULL → NULL)
+    /// - For BETWEEN: (expr >= low) AND (expr <= high)
+    ///   - If any comparison is NULL: NULL AND ... → NULL or FALSE (per three-valued AND)
+    /// - For NOT BETWEEN: (expr < low) OR (expr > high)
+    ///   - If any comparison is NULL: NULL OR ... → TRUE or NULL (per three-valued OR)
+    ///   - Example: 93 NOT BETWEEN NULL AND 10 = (NULL) OR (TRUE) = TRUE
     pub(super) fn eval_between(
         &self,
         expr: &vibesql_ast::Expression,
@@ -27,17 +31,6 @@ impl CombinedExpressionEvaluator<'_> {
         let expr_val = self.eval(expr, row)?;
         let mut low_val = self.eval(low, row)?;
         let mut high_val = self.eval(high, row)?;
-
-        // NULL handling: Per SQL standard, if ANY operand (expr, low, or high) is NULL,
-        // BETWEEN returns NULL. This must be checked explicitly because three-valued logic
-        // doesn't correctly handle: NOT (FALSE AND NULL) which evaluates to TRUE instead of NULL.
-        // SQL:1999 standard: val BETWEEN NULL AND x → NULL, val BETWEEN x AND NULL → NULL
-        if matches!(expr_val, vibesql_types::SqlValue::Null)
-            || matches!(low_val, vibesql_types::SqlValue::Null)
-            || matches!(high_val, vibesql_types::SqlValue::Null)
-        {
-            return Ok(vibesql_types::SqlValue::Null);
-        }
 
         // Check if bounds are reversed (low > high)
         let gt_result = ExpressionEvaluator::eval_binary_op_static(


### PR DESCRIPTION
## Summary
Fixed `NOT BETWEEN` with NULL boundaries to use three-valued logic instead of early NULL check.

- **Problem**: `expr NOT BETWEEN NULL AND high` incorrectly filtered out all rows
- **Root Cause**: Commit b36e8dca added early NULL check that broke three-valued OR logic
- **Solution**: Removed early NULL checks, let three-valued logic work naturally

## Changes
- Removed early NULL checks from `ExpressionEvaluator::eval_between()` 
- Removed early NULL checks from `CombinedExpressionEvaluator::eval_between()`
- Updated documentation to explain three-valued logic behavior

## Test Cases
**NOT BETWEEN with NULL:**
- `93 NOT BETWEEN NULL AND 10` = `(93 < NULL) OR (93 > 10)` = `NULL OR TRUE` = `TRUE` ✅
- `5 NOT BETWEEN NULL AND 10` = `(5 < NULL) OR (5 > 10)` = `NULL OR FALSE` = `NULL` (filtered) ✅

**BETWEEN with NULL:**
- `5 BETWEEN NULL AND 10` = `(5 >= NULL) AND (5 <= 10)` = `NULL AND TRUE` = `NULL` (filtered) ✅

## Impact
- Fixes 14 test files in `index/random/10` pattern
- Example query now works: `SELECT 79 FROM tab0 WHERE 93 NOT BETWEEN NULL AND 43`

Closes #2006

🤖 Generated with [Claude Code](https://claude.com/claude-code)