### PR TITLE
Fix integer division to return Integer instead of Float

### DIFF
--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/mod.rs
@@ -175,9 +175,9 @@ mod tests {
 
     #[test]
     fn test_integer_division() {
-        // Division returns Float for integer operands (SQLLogicTest behavior)
+        // Division returns Integer for integer operands (SQLite/SQLLogicTest behavior)
         let result = ArithmeticOps::divide(&SqlValue::Integer(15), &SqlValue::Integer(3)).unwrap();
-        assert_eq!(result, SqlValue::Float(5.0));
+        assert_eq!(result, SqlValue::Integer(5));
     }
 
     #[test]
@@ -261,15 +261,15 @@ mod tests {
 
     #[test]
     fn test_boolean_division() {
-        // 10 / TRUE = 10.0 (booleans coerce to integers, then division returns float)
+        // 10 / TRUE = 10 (booleans coerce to integers, then division returns integer)
         let result =
             ArithmeticOps::divide(&SqlValue::Integer(10), &SqlValue::Boolean(true)).unwrap();
-        assert_eq!(result, SqlValue::Float(10.0));
+        assert_eq!(result, SqlValue::Integer(10));
 
-        // TRUE / TRUE = 1.0
+        // TRUE / TRUE = 1
         let result =
             ArithmeticOps::divide(&SqlValue::Boolean(true), &SqlValue::Boolean(true)).unwrap();
-        assert_eq!(result, SqlValue::Float(1.0));
+        assert_eq!(result, SqlValue::Integer(1));
     }
 
     #[test]

--- a/crates/vibesql-executor/src/tests/operator_edge_cases/binary_arithmetic.rs
+++ b/crates/vibesql-executor/src/tests/operator_edge_cases/binary_arithmetic.rs
@@ -47,12 +47,11 @@ fn test_nested_arithmetic() {
 
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 1);
-    // Division returns Float, so the result is Float(11.0)
-    // (8 * 2) = Integer(16), 10 / 2 = Float(5.0), 16 - 5.0 = Float(11.0)
-    assert!(matches!(result[0].values[0], vibesql_types::SqlValue::Float(_)));
-    if let vibesql_types::SqlValue::Float(f) = result[0].values[0] {
-        assert!((f - 11.0).abs() < 0.001); // (8 * 2) - (10 / 2) = 11.0
-    }
+    // Division now returns Integer for integer operands
+    // (5 + 3) * 2 = 8 * 2 = 16
+    // 10 / 2 = 5 (integer division)
+    // 16 - 5 = 11
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Integer(11));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Fixes #2007 where integer division was incorrectly returning `Float` instead of `Integer`, causing type mismatches in SQLLogicTest expectations.

## Problem
The division operator (`/`) was returning `Float` for integer operands, e.g., `9 / 99 = Float(0.0909...)`. This caused expressions like `- col1 + - 9 / - col2` to return floating-point values instead of integers, failing 243 tests in the `random/aggregates` category.

## Root Cause  
In `crates/vibesql-executor/src/evaluator/operators/arithmetic/division.rs:31`, division always returned `Float` for integer operands, even though SQLite and SQLLogicTest expect integer division (truncating toward zero).

## Changes
- Modified division operator to return `Integer` for integer operands
- Division now truncates toward zero (matching SQLite behavior)
- Updated related tests to expect `Integer` results instead of `Float`

## Files Changed
- `crates/vibesql-executor/src/evaluator/operators/arithmetic/division.rs` - Core fix
- `crates/vibesql-executor/src/evaluator/operators/arithmetic/mod.rs` - Updated tests  
- `crates/vibesql-executor/src/tests/operator_edge_cases/binary_arithmetic.rs` - Updated test expectations

## Test Results
All integer division tests pass:
- `test_integer_division` ✓
- `test_integer_division_basic` ✓
- `test_integer_division_with_floats` ✓
- `test_integer_division_negative_operands` ✓
- `test_integer_division_equal_operands` ✓
- `test_integer_division_by_zero` ✓

## Impact
This fix should resolve the 243 failing tests in `random/aggregates` and significantly improve the SQLLogicTest pass rate from the current 52.4% baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
