### PR TITLE
Add comprehensive test coverage for NOT operator in WHERE clauses

### DIFF
--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -73,6 +73,7 @@ mod lazy_evaluation_tests;
 mod limit_offset;
 mod natural_join;
 mod non_unique_disk_index_tests;
+mod not_operator_tests;
 mod operator_edge_cases;
 mod order_by_index_optimization_tests;
 mod phase3_join_optimization;

--- a/crates/vibesql-executor/src/tests/not_operator_tests.rs
+++ b/crates/vibesql-executor/src/tests/not_operator_tests.rs
@@ -1,0 +1,249 @@
+//! Tests for NOT operator in WHERE clauses (issue #2010)
+//!
+//! This module tests the NOT unary operator in various contexts:
+//! - SELECT WHERE with NOT
+//! - DELETE WHERE with NOT
+//! - NOT with complex expressions
+
+use super::super::*;
+
+#[test]
+fn test_not_in_select_where() {
+    // Test: SELECT pk FROM tab0 WHERE NOT (col0 < 542)
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "tab0".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new("pk".to_string(), vibesql_types::DataType::Integer, false),
+            vibesql_catalog::ColumnSchema::new("col0".to_string(), vibesql_types::DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    // Insert test data
+    db.insert_row("tab0", vibesql_storage::Row::new(vec![
+        vibesql_types::SqlValue::Integer(1),
+        vibesql_types::SqlValue::Integer(100),
+    ])).unwrap();
+    db.insert_row("tab0", vibesql_storage::Row::new(vec![
+        vibesql_types::SqlValue::Integer(2),
+        vibesql_types::SqlValue::Integer(542),
+    ])).unwrap();
+    db.insert_row("tab0", vibesql_storage::Row::new(vec![
+        vibesql_types::SqlValue::Integer(3),
+        vibesql_types::SqlValue::Integer(600),
+    ])).unwrap();
+
+    let executor = select::SelectExecutor::new(&db);
+
+    // SELECT pk FROM tab0 WHERE NOT (col0 < 542)
+    // Should return rows where col0 >= 542 (pk=2 and pk=3)
+    let stmt = vibesql_ast::SelectStmt {
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Expression {
+            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "pk".to_string() },
+            alias: None,
+        }],
+        from: Some(vibesql_ast::FromClause::Table { name: "tab0".to_string(), alias: None }),
+        where_clause: Some(vibesql_ast::Expression::UnaryOp {
+            op: vibesql_ast::UnaryOperator::Not,
+            expr: Box::new(vibesql_ast::Expression::BinaryOp {
+                left: Box::new(vibesql_ast::Expression::ColumnRef { table: None, column: "col0".to_string() }),
+                op: vibesql_ast::BinaryOperator::LessThan,
+                right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(542))),
+            }),
+        }),
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+        into_table: None,
+        into_variables: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 2); // Should return 2 rows (pk=2 and pk=3)
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Integer(2));
+    assert_eq!(result[1].values[0], vibesql_types::SqlValue::Integer(3));
+}
+
+#[test]
+fn test_not_with_equality() {
+    // Test: SELECT pk FROM tab0 WHERE NOT col0 = 100
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "tab0".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new("pk".to_string(), vibesql_types::DataType::Integer, false),
+            vibesql_catalog::ColumnSchema::new("col0".to_string(), vibesql_types::DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    db.insert_row("tab0", vibesql_storage::Row::new(vec![
+        vibesql_types::SqlValue::Integer(1),
+        vibesql_types::SqlValue::Integer(100),
+    ])).unwrap();
+    db.insert_row("tab0", vibesql_storage::Row::new(vec![
+        vibesql_types::SqlValue::Integer(2),
+        vibesql_types::SqlValue::Integer(200),
+    ])).unwrap();
+
+    let executor = select::SelectExecutor::new(&db);
+
+    let stmt = vibesql_ast::SelectStmt {
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Expression {
+            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "pk".to_string() },
+            alias: None,
+        }],
+        from: Some(vibesql_ast::FromClause::Table { name: "tab0".to_string(), alias: None }),
+        where_clause: Some(vibesql_ast::Expression::UnaryOp {
+            op: vibesql_ast::UnaryOperator::Not,
+            expr: Box::new(vibesql_ast::Expression::BinaryOp {
+                left: Box::new(vibesql_ast::Expression::ColumnRef { table: None, column: "col0".to_string() }),
+                op: vibesql_ast::BinaryOperator::Equal,
+                right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(100))),
+            }),
+        }),
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+        into_table: None,
+        into_variables: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 1); // Should return 1 row (pk=2)
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Integer(2));
+}
+
+#[test]
+fn test_not_in_delete_where() {
+    // Test: DELETE FROM tab0 WHERE NOT (col0 < 542)
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "tab0".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new("pk".to_string(), vibesql_types::DataType::Integer, false),
+            vibesql_catalog::ColumnSchema::new("col0".to_string(), vibesql_types::DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    // Insert test data
+    db.insert_row("tab0", vibesql_storage::Row::new(vec![
+        vibesql_types::SqlValue::Integer(1),
+        vibesql_types::SqlValue::Integer(100),
+    ])).unwrap();
+    db.insert_row("tab0", vibesql_storage::Row::new(vec![
+        vibesql_types::SqlValue::Integer(2),
+        vibesql_types::SqlValue::Integer(542),
+    ])).unwrap();
+    db.insert_row("tab0", vibesql_storage::Row::new(vec![
+        vibesql_types::SqlValue::Integer(3),
+        vibesql_types::SqlValue::Integer(600),
+    ])).unwrap();
+
+    // DELETE FROM tab0 WHERE NOT (col0 < 542)
+    let stmt = vibesql_ast::DeleteStmt {
+        only: false,
+        table_name: "tab0".to_string(),
+        where_clause: Some(vibesql_ast::WhereClause::Condition(vibesql_ast::Expression::UnaryOp {
+            op: vibesql_ast::UnaryOperator::Not,
+            expr: Box::new(vibesql_ast::Expression::BinaryOp {
+                left: Box::new(vibesql_ast::Expression::ColumnRef { table: None, column: "col0".to_string() }),
+                op: vibesql_ast::BinaryOperator::LessThan,
+                right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(542))),
+            }),
+        })),
+    };
+
+    let deleted_count = delete::DeleteExecutor::execute(&stmt, &mut db).unwrap();
+    assert_eq!(deleted_count, 2); // Should delete 2 rows (pk=2 and pk=3)
+
+    // Verify only row with pk=1 remains by selecting all rows
+    let executor = select::SelectExecutor::new(&db);
+    let verify_stmt = vibesql_ast::SelectStmt {
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+        from: Some(vibesql_ast::FromClause::Table { name: "tab0".to_string(), alias: None }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+        into_table: None,
+        into_variables: None,
+    };
+    let remaining_rows = executor.execute(&verify_stmt).unwrap();
+    assert_eq!(remaining_rows.len(), 1);
+    assert_eq!(remaining_rows[0].values[0], vibesql_types::SqlValue::Integer(1)); // pk=1
+    assert_eq!(remaining_rows[0].values[1], vibesql_types::SqlValue::Integer(100)); // col0=100
+}
+
+#[test]
+fn test_not_with_null() {
+    // Test NOT with NULL value (should return NULL per SQL three-valued logic)
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "tab0".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new("pk".to_string(), vibesql_types::DataType::Integer, false),
+            vibesql_catalog::ColumnSchema::new("col0".to_string(), vibesql_types::DataType::Integer, true), // nullable
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    db.insert_row("tab0", vibesql_storage::Row::new(vec![
+        vibesql_types::SqlValue::Integer(1),
+        vibesql_types::SqlValue::Null,
+    ])).unwrap();
+    db.insert_row("tab0", vibesql_storage::Row::new(vec![
+        vibesql_types::SqlValue::Integer(2),
+        vibesql_types::SqlValue::Integer(100),
+    ])).unwrap();
+
+    let executor = select::SelectExecutor::new(&db);
+
+    // SELECT pk FROM tab0 WHERE NOT (col0 < 542)
+    // Row with NULL should be filtered out (NULL propagates)
+    let stmt = vibesql_ast::SelectStmt {
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Expression {
+            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "pk".to_string() },
+            alias: None,
+        }],
+        from: Some(vibesql_ast::FromClause::Table { name: "tab0".to_string(), alias: None }),
+        where_clause: Some(vibesql_ast::Expression::UnaryOp {
+            op: vibesql_ast::UnaryOperator::Not,
+            expr: Box::new(vibesql_ast::Expression::BinaryOp {
+                left: Box::new(vibesql_ast::Expression::ColumnRef { table: None, column: "col0".to_string() }),
+                op: vibesql_ast::BinaryOperator::LessThan,
+                right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(542))),
+            }),
+        }),
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+        into_table: None,
+        into_variables: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 0); // NOT (NULL < 542) = NOT NULL = NULL, which filters out the row
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive test coverage for the NOT unary operator in WHERE clauses for both SELECT and DELETE statements, and provides evidence that issue #2010 is outdated.

## Key Finding: Issue Already Resolved

After investigation requested by Judge review, I discovered that **the NOT operator was implemented on November 6, 2025** - 11 days BEFORE issue #2010 was created (November 17, 2025).

## SQLLogicTest Verification

Tested all three SQLLogicTest files mentioned in issue #2010:
- ✅ `index/delete/10/slt_good_0.test` - **100% PASS**
- ✅ `index/delete/100/slt_good_0.test` - **100% PASS**  
- ✅ `index/delete/100/slt_good_1.test` - **100% PASS**

The 192 failures claimed in the issue **do not exist**. All tests pass successfully.

## Implementation Timeline

- **Nov 6, 2025** (commit a2bdf969): NOT operator implemented  
- **Nov 8, 2025** (commit b714c8e5): NULL handling fixed
- **Nov 17, 2025**: Issue #2010 created (11 days after implementation)
- **Today**: Verified SQLLogicTests pass with 100% success rate

## Changes Made

- Added `not_operator_tests.rs` module with 4 comprehensive unit tests:
  - `test_not_in_select_where`: Tests NOT with comparison operators in SELECT 
  - `test_not_with_equality`: Tests NOT with equality operator
  - `test_not_in_delete_where`: Tests NOT in DELETE WHERE clauses
  - `test_not_with_null`: Tests NULL handling per SQL three-valued logic

### Test Results  

**Unit tests:** All 4 new tests pass successfully  
**SQLLogicTests:** 3/3 files pass with 100% success rate

## Implementation Details

The codebase already supports the NOT operator through:
1. `eval_unary_op()` handles NOT for all SQL types (crates/vibesql-executor/src/evaluator/expressions/operators.rs:47-75)
2. `ExpressionEvaluator` calls `eval_unary_op` for UnaryOp expressions (crates/vibesql-executor/src/evaluator/expressions/eval.rs:226-229)
3. `CombinedExpressionEvaluator` delegates to the same implementation (crates/vibesql-executor/src/evaluator/combined/eval.rs:252)  
4. Aggregation contexts properly handle NOT through `binary_op::evaluate_unary` (crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs:47-49)

## Test Plan

- ✅ All new unit tests pass
- ✅ All existing tests continue to pass
- ✅ **SQLLogicTests verified** - all files mentioned in issue pass with 100% success
- ✅ Tests cover SELECT, DELETE, NULL handling, and various operators

## Recommendation

This PR provides valuable test coverage for the NOT operator. Issue #2010 should be closed as "already resolved" or "not reproducible" since the feature was implemented before the issue was created.

Closes #2010

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Doctor's Note**: Updated PR based on Judge feedback to verify SQLLogicTest results and provide timeline analysis.