### PR TITLE
Implement StringBehavior trait and collation support

### DIFF
--- a/crates/vibesql-types/src/sql_mode/strings.rs
+++ b/crates/vibesql-types/src/sql_mode/strings.rs
@@ -1,0 +1,99 @@
+/// String comparison and collation behavior
+///
+/// This module defines how string comparisons and collations work across
+/// different SQL modes.
+
+/// Collation type for string comparisons
+///
+/// Different SQL dialects support different collation strategies for comparing
+/// strings and determining sort order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Collation {
+    /// Case-sensitive, byte-by-byte comparison
+    ///
+    /// Used by both MySQL (BINARY) and SQLite (BINARY).
+    /// Compares strings byte-by-byte without any transformations.
+    Binary,
+
+    /// Case-insensitive comparison (SQLite NOCASE)
+    ///
+    /// SQLite-specific collation that treats ASCII uppercase letters
+    /// as equal to their lowercase counterparts.
+    NoCase,
+
+    /// Ignore trailing spaces (SQLite RTRIM)
+    ///
+    /// SQLite-specific collation that ignores trailing whitespace
+    /// when comparing strings.
+    Rtrim,
+
+    /// MySQL utf8mb4_bin - case-sensitive binary UTF-8 comparison
+    ///
+    /// Binary comparison for UTF-8 encoded strings.
+    /// Character values are compared directly without case folding.
+    Utf8Binary,
+
+    /// MySQL utf8mb4_general_ci - case-insensitive general UTF-8 comparison
+    ///
+    /// Case-insensitive comparison for UTF-8 encoded strings.
+    /// This is the most common default collation for MySQL.
+    Utf8GeneralCi,
+}
+
+/// Trait defining string comparison and collation behavior for SQL modes
+///
+/// Different SQL dialects have different defaults and supported options
+/// for string comparison:
+///
+/// - **MySQL**: Defaults to case-insensitive (`utf8mb4_general_ci`)
+/// - **SQLite**: Defaults to case-sensitive (Binary collation)
+pub trait StringBehavior {
+    /// Returns whether string comparisons are case-sensitive by default
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// assert!(!SqlMode::MySQL.default_string_comparison_case_sensitive());
+    /// assert!(SqlMode::SQLite.default_string_comparison_case_sensitive());
+    /// ```
+    fn default_string_comparison_case_sensitive(&self) -> bool;
+
+    /// Returns the default collation for this SQL mode
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// assert_eq!(SqlMode::MySQL.default_collation(), Collation::Utf8GeneralCi);
+    /// assert_eq!(SqlMode::SQLite.default_collation(), Collation::Binary);
+    /// ```
+    fn default_collation(&self) -> Collation;
+
+    /// Returns the list of collations supported by this SQL mode
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let mysql_collations = SqlMode::MySQL.supported_collations();
+    /// assert!(mysql_collations.contains(&Collation::Utf8Binary));
+    /// assert!(mysql_collations.contains(&Collation::Utf8GeneralCi));
+    /// ```
+    fn supported_collations(&self) -> &[Collation];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collation_equality() {
+        assert_eq!(Collation::Binary, Collation::Binary);
+        assert_ne!(Collation::Binary, Collation::NoCase);
+    }
+
+    #[test]
+    fn test_collation_debug() {
+        let collation = Collation::Utf8GeneralCi;
+        let debug_str = format!("{:?}", collation);
+        assert!(debug_str.contains("Utf8GeneralCi"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `StringBehavior` trait and `Collation` enum to handle mode-specific string comparison and collation behaviors as part of the SqlMode architecture redesign (#2016).

## Changes

- **Refactored module structure**: Converted `sql_mode.rs` to a module directory (`sql_mode/`)
- **New file**: `crates/vibesql-types/src/sql_mode/strings.rs`
  - `Collation` enum with 5 variants:
    - `Binary` - case-sensitive byte comparison (both MySQL and SQLite)
    - `NoCase` - case-insensitive (SQLite)
    - `Rtrim` - ignore trailing spaces (SQLite)
    - `Utf8Binary` - case-sensitive UTF-8 (MySQL)
    - `Utf8GeneralCi` - case-insensitive UTF-8 (MySQL, default)
  - `StringBehavior` trait with 3 methods:
    - `default_string_comparison_case_sensitive()` - whether comparisons are case-sensitive by default
    - `default_collation()` - the default collation for the mode
    - `supported_collations()` - list of supported collations

## Implementations

**MySQL mode:**
- Default: case-insensitive (Utf8GeneralCi)
- Supported: Binary, Utf8Binary, Utf8GeneralCi

**SQLite mode:**
- Default: case-sensitive (Binary)
- Supported: Binary, NoCase, Rtrim

## Testing

All tests passing (9 tests):
- Collation enum tests
- StringBehavior implementation tests for both MySQL and SQLite
- Case sensitivity consistency tests

## Test Plan

- [x] Unit tests for Collation enum
- [x] Unit tests for StringBehavior implementations
- [x] Tests verify default behaviors match spec
- [x] Tests verify supported collations for each mode
- [x] All existing tests still pass

Closes #2019

Generated with [Claude Code](https://claude.com/claude-code)