### PR TITLE
Fix type_display_tests to match 3-decimal formatting

### DIFF
--- a/crates/vibesql-types/tests/type_display_tests.rs
+++ b/crates/vibesql-types/tests/type_display_tests.rs
@@ -66,13 +66,13 @@ fn test_numeric_whole_number_display() {
 #[test]
 fn test_float_display() {
     let value = SqlValue::Float(2.5);
-    assert_eq!(format!("{}", value), "2.5");
+    assert_eq!(format!("{}", value), "2.500");
 }
 
 #[test]
 fn test_real_display() {
     let value = SqlValue::Real(2.71);
-    assert_eq!(format!("{}", value), "2.71");
+    assert_eq!(format!("{}", value), "2.710");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fixed `test_float_display` to expect `"2.500"` instead of `"2.5"`
- Fixed `test_real_display` to expect `"2.710"` instead of `"2.71"`
- All tests in `type_display_tests.rs` now pass

## Test Plan

- [x] Ran `cargo test --package vibesql-types --test type_display_tests`
- [x] All 16 tests passed

Closes #2029

🤖 Generated with [Claude Code](https://claude.com/claude-code)