### PR TITLE
Deprecate division_returns_float() in favor of TypeBehavior trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+- Deprecated `SqlMode::division_returns_float()` method in favor of `TypeBehavior::division_result_type()`
+  - Migration: Use `mode.division_result_type(&left, &right)` instead of `mode.division_returns_float()`
+  - The new method provides more precise type information (returns `ValueType` enum instead of bool)
+  - Method will be removed in next major version
+
 ### Added
 - Added `--force` flag to `./scripts/sqllogictest` script to repopulate work queue with all 623 test files
   - Enables fresh test runs from scratch

--- a/crates/vibesql-types/src/sql_mode/mod.rs
+++ b/crates/vibesql-types/src/sql_mode/mod.rs
@@ -61,6 +61,10 @@ impl Default for SqlMode {
 
 impl SqlMode {
     /// Check if division should return floating-point (true) or integer (false)
+    #[deprecated(
+        since = "0.1.0",
+        note = "Use TypeBehavior::division_result_type() instead for more precise type information"
+    )]
     pub fn division_returns_float(&self) -> bool {
         match self {
             SqlMode::MySQL { .. } => true,
@@ -165,13 +169,24 @@ mod tests {
 
     #[test]
     fn test_division_behavior() {
+        use crate::sql_mode::types::{TypeBehavior, ValueType};
+        use crate::SqlValue;
+
         let mysql_mode = SqlMode::MySQL {
             flags: MySqlModeFlags::default(),
         };
-        assert!(mysql_mode.division_returns_float());
+        // MySQL returns Numeric for division
+        assert_eq!(
+            mysql_mode.division_result_type(&SqlValue::Integer(5), &SqlValue::Integer(2)),
+            ValueType::Numeric
+        );
 
         let sqlite_mode = SqlMode::SQLite;
-        assert!(!sqlite_mode.division_returns_float());
+        // SQLite returns Integer for int/int division
+        assert_eq!(
+            sqlite_mode.division_result_type(&SqlValue::Integer(5), &SqlValue::Integer(2)),
+            ValueType::Integer
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR deprecates the `SqlMode::division_returns_float()` method in favor of the more precise `TypeBehavior::division_result_type()` trait method introduced in #2016.

## Changes

- Added `#[deprecated]` attribute to `division_returns_float()` method
- Updated test assertions in `test_division_behavior` to use `TypeBehavior::division_result_type()`
- Added CHANGELOG entry documenting the deprecation

## Benefits

- **More expressive**: Returns `ValueType` enum (Integer, Numeric, Float) instead of simple boolean
- **Consistent**: Uses the trait-based architecture from the SqlMode redesign (#2016)
- **Future-proof**: Aligns with the new architectural patterns

## Migration Guide

**Before:**
```rust
if mode.division_returns_float() {
    // handle floating-point division
}
```

**After:**
```rust
use vibesql_types::sql_mode::types::{TypeBehavior, ValueType};

let result_type = mode.division_result_type(&left, &right);
match result_type {
    ValueType::Numeric => { /* MySQL-style decimal division */ }
    ValueType::Integer => { /* SQLite-style integer division */ }
    _ => { /* other cases */ }
}
```

## Testing

All tests pass, including the updated `test_division_behavior` test which now verifies:
- MySQL mode returns `ValueType::Numeric` for integer division
- SQLite mode returns `ValueType::Integer` for integer division

Closes #2032

🤖 Generated with [Claude Code](https://claude.com/claude-code)