### PR TITLE
Enable subquery validation test for issue #2069

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,5 +82,9 @@ path = "tests/test_issue_1618.rs"
 name = "aggregate_random_patterns"
 path = "tests/aggregate_random_patterns.rs"
 
+[[test]]
+name = "test_error_handling"
+path = "tests/test_error_handling.rs"
+
 [patch.crates-io]
 sqllogictest = { path = "crates/sqllogictest" }

--- a/tests/sqllogictest/execution.rs
+++ b/tests/sqllogictest/execution.rs
@@ -126,6 +126,7 @@ mod tests {
     use super::*;
     #[allow(unused_imports)]
     use std::env;
+    use crate::sqllogictest::scheduler::get_test_file_timeout;
 
     #[test]
     fn test_timeout_wraps_execution() {

--- a/tests/sqltest_conformance.rs
+++ b/tests/sqltest_conformance.rs
@@ -378,7 +378,8 @@ impl SqltestRunner {
             | vibesql_ast::Statement::ShowColumns(_)
             | vibesql_ast::Statement::ShowIndex(_)
             | vibesql_ast::Statement::ShowCreateTable(_)
-            | vibesql_ast::Statement::Describe(_) => {
+            | vibesql_ast::Statement::Describe(_)
+            | vibesql_ast::Statement::Analyze(_) => {
                 // Transactions, cursors, triggers, assertions, procedures, functions, and advanced SQL objects are no-ops
                 // for validation
                 Ok(true)

--- a/tests/test_error_handling/executor_errors.rs
+++ b/tests/test_error_handling/executor_errors.rs
@@ -46,7 +46,6 @@ fn test_division_by_zero_error() {
 }
 
 #[test]
-#[ignore] // TODO: Implement subquery execution and scalar subquery validation
 fn test_subquery_returned_multiple_rows_error() {
     let mut db = Database::new();
 


### PR DESCRIPTION
## Summary
- Removed `#[ignore]` attribute from `test_subquery_returned_multiple_rows_error` test
- Added `test_error_handling` to Cargo.toml test targets to make the test discoverable
- Fixed missing import in `tests/sqllogictest/execution.rs` 
- Added missing `Analyze` statement pattern match in `tests/sqltest_conformance.rs`

## Background
The scalar subquery validation logic was already fully implemented in `crates/vibesql-executor/src/evaluator/subqueries_shared.rs:45-51`. The `SubqueryReturnedMultipleRows` error variant and its display implementation also already existed. This PR simply enables the test that validates this existing functionality.

## Test Plan
- [x] Ran `cargo test -p vibesql --test test_error_handling test_subquery_returned_multiple_rows_error`
- [x] Test passes successfully

## File References
- Test removed `#[ignore]` from: tests/test_error_handling/executor_errors.rs:48
- Existing validation logic: crates/vibesql-executor/src/evaluator/subqueries_shared.rs:45-51
- Error variant definition: crates/vibesql-executor/src/errors.rs:48-51

Closes #2069

🤖 Generated with [Claude Code](https://claude.com/claude-code)