### PR TITLE
Add inline hints to hot-path expression evaluation functions

### DIFF
--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -7,6 +7,7 @@ use crate::errors::ExecutorError;
 
 impl ExpressionEvaluator<'_> {
     /// Evaluate an expression in the context of a row
+    #[inline]
     pub fn eval(
         &self,
         expr: &vibesql_ast::Expression,
@@ -40,6 +41,7 @@ impl ExpressionEvaluator<'_> {
     }
 
     /// Internal implementation of eval with depth already incremented
+    #[inline]
     fn eval_impl(
         &self,
         expr: &vibesql_ast::Expression,
@@ -356,6 +358,7 @@ impl ExpressionEvaluator<'_> {
     }
 
     /// Evaluate column reference
+    #[inline]
     fn eval_column_ref(
         &self,
         table_qualifier: Option<&str>,

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -16,6 +16,7 @@ impl ExpressionEvaluator<'_> {
     /// - For NOT BETWEEN: (expr < low) OR (expr > high)
     ///   - If any comparison is NULL: NULL OR ... → TRUE or NULL (per three-valued OR)
     ///   - Example: 93 NOT BETWEEN NULL AND 10 = (NULL) OR (TRUE) = TRUE
+    #[inline]
     pub(super) fn eval_between(
         &self,
         expr: &vibesql_ast::Expression,
@@ -71,6 +72,7 @@ impl ExpressionEvaluator<'_> {
     }
 
     /// Evaluate CAST expression
+    #[inline]
     pub(super) fn eval_cast(
         &self,
         expr: &vibesql_ast::Expression,
@@ -82,6 +84,7 @@ impl ExpressionEvaluator<'_> {
     }
 
     /// Evaluate POSITION expression
+    #[inline]
     pub(super) fn eval_position(
         &self,
         substring: &vibesql_ast::Expression,
@@ -110,6 +113,7 @@ impl ExpressionEvaluator<'_> {
 
     /// Evaluate TRIM expression
     /// TRIM([position] [removal_char FROM] string)
+    #[inline]
     pub(super) fn eval_trim(
         &self,
         position: &Option<vibesql_ast::TrimPosition>,
@@ -197,6 +201,7 @@ impl ExpressionEvaluator<'_> {
     }
 
     /// Evaluate LIKE predicate
+    #[inline]
     pub(super) fn eval_like(
         &self,
         expr: &vibesql_ast::Expression,
@@ -238,6 +243,7 @@ impl ExpressionEvaluator<'_> {
     }
 
     /// Evaluate IN list predicate
+    #[inline]
     pub(super) fn eval_in_list(
         &self,
         expr: &vibesql_ast::Expression,


### PR DESCRIPTION
## Summary

Added `#[inline]` attributes to hot-path expression evaluation functions to reduce function call overhead. Analysis showed these functions were lacking inline hints despite being frequently called in tight loops during query execution.

## Changes

**Files Modified:**
- `evaluator/expressions/eval.rs`
  - Added `#[inline]` to `eval()` (main evaluation entry point)
  - Added `#[inline]` to `eval_impl()` (internal eval implementation)
  - Added `#[inline]` to `eval_column_ref()` (column lookup)

- `evaluator/expressions/predicates.rs`
  - Added `#[inline]` to all 6 predicate evaluation functions:
    - `eval_between()`
    - `eval_cast()`
    - `eval_position()`
    - `eval_trim()`
    - `eval_like()`
    - `eval_in_list()`

**Files Already Annotated:**
- `evaluator/operators/mod.rs` - Already had `#[inline]`
- `evaluator/operators/logical.rs` - Already had `#[inline]`  
- `evaluator/operators/arithmetic/mod.rs` - Already had `#[inline]`
- `evaluator/operators/comparison/mod.rs` - Already had `#[inline]`

## Test Plan

- ✅ All tests pass (`cargo test --lib --package vibesql-executor`)
- ✅ 988 tests passed, 0 failed
- ✅ No behavior changes (pure optimization)

## Expected Impact

- **Performance**: 2-5% speedup from reduced call overhead in expression evaluation
- **Code Size**: Minimal increase (only hot paths)
- **Risk**: Very low - inline hints are suggestions to the compiler, no functional changes

Closes #2072

🤖 Generated with [Claude Code](https://claude.com/claude-code)