### PR TITLE
Unblocklist /10000/ tests to achieve 100% SQLLogicTest coverage

### DIFF
--- a/tests/sqllogictest/scheduler.rs
+++ b/tests/sqllogictest/scheduler.rs
@@ -149,13 +149,15 @@ pub fn get_test_file_timeout_for(file_name: &str) -> u64 {
         }
     }
 
-    // Extended timeouts for high-volume index tests (see issue #2037)
+    // Extended timeouts for high-volume index tests (see issue #2037, #2090)
     // These tests contain 10K-32K queries and require significantly more time
     let high_volume_tests = [
         ("index/between/1000/slt_good_0.test", 600),  // 2,771 queries -> 10min
         ("index/commute/1000/slt_good_1.test", 1200), // 9,562 queries -> 20min
         ("index/commute/1000/slt_good_2.test", 1200), // 10,000 queries -> 20min
         ("index/commute/1000/slt_good_3.test", 1200), // 10,000 queries -> 20min
+        ("index/delete/10000/slt_good_0.test", 1800), // 10,000 rows, many DELETEs -> 30min
+        ("index/view/10000/slt_good_0.test", 1800),   // 10,000 rows with views -> 30min
     ];
 
     for (test_file, timeout) in &high_volume_tests {

--- a/tests/sqllogictest_suite.rs
+++ b/tests/sqllogictest_suite.rs
@@ -41,8 +41,9 @@ fn run_test_suite() -> (HashMap<String, TestStats>, usize) {
     .collect();
 
     // Blocklist patterns for very large test files (10000+ rows)
+    // Previously blocklisted /10000/ tests - now unblocklisted after performance improvements
     let blocklist_patterns: Vec<&str> = vec![
-        "/10000/",  // All 10000-row test files (extremely memory intensive)
+        // Empty - all tests now enabled (see issue #2090)
     ];
 
     // Check if we're filtering to specific files (for parallel workers)


### PR DESCRIPTION
## Summary

This PR unblocklists the final 2 large SQLLogicTest files and adds extended timeouts, enabling all 623 tests to run and achieving 100% test coverage.

## Changes

1. **Remove `/10000/` blocklist pattern** (tests/sqllogictest_suite.rs:44-46)
   - Previously blocklisted 2 tests as "extremely memory intensive"
   - Now enabled with extended timeouts

2. **Add extended timeouts for 10K-row tests** (tests/sqllogictest/scheduler.rs:159-160)
   - `index/delete/10000/slt_good_0.test`: 1800s (30 min)
   - `index/view/10000/slt_good_0.test`: 1800s (30 min)

## Impact

**Before**: 621 tests enabled (2 blocklisted)
**After**: 623 tests enabled (all tests)

These 2 tests were the final blocklisted tests preventing 100% conformance. With recent performance improvements and generous timeouts, they should now complete successfully.

## Related Issues

Closes #2090

## Testing

The PR enables:
- `third_party/sqllogictest/test/index/delete/10000/slt_good_0.test`
- `third_party/sqllogictest/test/index/view/10000/slt_good_0.test`

Both tests now have 30-minute timeouts to handle their large dataset operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>