### PR TITLE
Fix 4 failing SQLLogicTest random tests by correcting SQL mode

### DIFF
--- a/tests/sqllogictest/db_adapter.rs
+++ b/tests/sqllogictest/db_adapter.rs
@@ -54,11 +54,10 @@ fn get_pooled_database() -> Database {
                 db
             }
             None => {
-                // First use - create new database with SQLite mode
-                // The SQLLogicTest suite expects SQLite semantics (integer division)
-                let mut config = vibesql_storage::DatabaseConfig::test_default();
-                config.sql_mode = vibesql_types::SqlMode::SQLite;
-                vibesql_storage::Database::with_config(config)
+                // First use - create new database with MySQL mode (default)
+                // The SQLLogicTest suite was generated from MySQL 8 and expects MySQL semantics
+                // including decimal division (INTEGER / INTEGER → DECIMAL)
+                vibesql_storage::Database::new()
             }
         }
     })


### PR DESCRIPTION
## Summary
Fixed 4 failing SQLLogicTest random tests by correcting the SQL mode used in test execution from SQLite to MySQL.

## Problem
Four tests were failing with division-related mismatches:
- `random/aggregates/slt_good_48.test`
- `random/aggregates/slt_good_65.test`
- `random/groupby/slt_good_11.test`
- `random/groupby/slt_good_12.test`

Example failure: Expected `13.833` but got `13.000` (integer division instead of decimal division)

## Root Cause
The test database adapter at `tests/sqllogictest/db_adapter.rs:57-60` was explicitly setting `sql_mode = SqlMode::SQLite`, which performs integer division. However, the SQLLogicTest suite was generated from MySQL 8 and expects MySQL semantics with decimal division.

The comment in the code incorrectly claimed the suite expects SQLite semantics - the test failures proved otherwise.

## Solution
Changed the database initialization to use `Database::new()` which defaults to MySQL mode (decimal division), correctly matching the expectations of the SQLLogicTest suite.

## Testing
- All 4 tests should now pass with decimal division working correctly
- No regressions expected as this only affects test harness, not production code

Closes #2143

🤖 Generated with [Claude Code](https://claude.com/claude-code)