### PR TITLE
Fix benchmark script test command to use correct test binary

### DIFF
--- a/scripts/sqllogictest
+++ b/scripts/sqllogictest
@@ -156,7 +156,7 @@ EOF
     local start_time=$(date +%s)
     local output_log="/tmp/sqllogictest_test_output_$$.log"
 
-    if SQLLOGICTEST_FILES="$full_path" cargo test --release run_sqllogictest_file 2>&1 | tee "$output_log" | grep -q "test result: ok"; then
+    if SQLLOGICTEST_FILES="$test_file" cargo test --release --package vibesql --test sqllogictest_suite 2>&1 | tee "$output_log"; then
         local end_time=$(date +%s)
         local elapsed=$((end_time - start_time))
         print_success "Passed (${elapsed}s)"


### PR DESCRIPTION
## Summary

Fixes the `./scripts/sqllogictest test` command which was running the wrong test binary, causing all benchmark tests to fail.

## Problem

The benchmark script was using `cargo test --release run_sqllogictest_file` which:
- Ran the vibesql unittests binary instead of sqllogictest suite binary
- Always showed "running 0 tests" and failed
- Made the benchmark suite unusable

## Changes

Updated `scripts/sqllogictest` cmd_test function to:
1. Specify correct test binary: `--package vibesql --test sqllogictest_suite`
2. Pass relative path in `SQLLOGICTEST_FILES` environment variable
3. Remove incorrect test function name (binary uses `main()`, not test functions)
4. Simplify success detection to rely on exit code

## Testing

Verified the fix by running:
```bash
./scripts/sqllogictest test evidence/slt_lang_createview.test
```

Output:
```
✓ Passed (1s)
Pass Rate: 100.0%
```

## Impact

- Benchmark suite `benchmarks/suite/suite.sh` can now run individual test files
- Performance benchmarking is now functional
- Individual file testing works as documented

Closes #2151

🤖 Generated with [Claude Code](https://claude.com/claude-code)