### PR TITLE
Fix: Apply prefix truncation in unique constraint checking for indexes

### DIFF
--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -79,6 +79,7 @@ mod order_by_index_optimization_tests;
 mod phase3_join_optimization;
 mod predicate_pushdown;
 mod predicate_tests;
+mod prefix_index_tests;
 mod procedures;
 mod privilege_checker_tests;
 mod quantified_comparison_tests;

--- a/crates/vibesql-executor/src/tests/prefix_index_tests.rs
+++ b/crates/vibesql-executor/src/tests/prefix_index_tests.rs
@@ -1,0 +1,356 @@
+//! Tests for indexed column prefix functionality (MySQL/SQLite compatibility)
+//!
+//! Tests prefix indexing feature where indexes can be created on the first N
+//! characters of a string column, e.g., UNIQUE (email(50))
+
+use vibesql_ast::{IndexColumn, OrderDirection};
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+fn create_test_db() -> Database {
+    let mut db = Database::new();
+    db.catalog.set_case_sensitive_identifiers(false);
+
+    let users_schema = TableSchema::new(
+        "users".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new(
+                "email".to_string(),
+                DataType::Varchar { max_length: Some(255) },
+                false,
+            ),
+            ColumnSchema::new(
+                "name".to_string(),
+                DataType::Varchar { max_length: Some(100) },
+                true,
+            ),
+        ],
+    );
+
+    db.create_table(users_schema).unwrap();
+    db
+}
+
+#[test]
+fn test_create_index_with_prefix_length() {
+    let mut db = create_test_db();
+
+    // Create index on first 50 characters of email
+    db.create_index(
+        "idx_email_prefix".to_string(),
+        "users".to_string(),
+        false, // not unique
+        vec![IndexColumn {
+            column_name: "email".to_string(),
+            direction: OrderDirection::Asc,
+            prefix_length: Some(50),
+        }],
+    )
+    .unwrap();
+
+    assert!(db.index_exists("idx_email_prefix"));
+}
+
+#[test]
+fn test_create_unique_index_with_prefix_length() {
+    let mut db = create_test_db();
+
+    // Create UNIQUE index on first 50 characters of email
+    db.create_index(
+        "idx_email_unique_prefix".to_string(),
+        "users".to_string(),
+        true, // unique
+        vec![IndexColumn {
+            column_name: "email".to_string(),
+            direction: OrderDirection::Asc,
+            prefix_length: Some(50),
+        }],
+    )
+    .unwrap();
+
+    assert!(db.index_exists("idx_email_unique_prefix"));
+}
+
+#[test]
+fn test_unique_prefix_index_enforces_prefix_uniqueness() {
+    let mut db = create_test_db();
+
+    // Create UNIQUE index on first 10 characters
+    db.create_index(
+        "idx_email_prefix10".to_string(),
+        "users".to_string(),
+        true, // unique
+        vec![IndexColumn {
+            column_name: "email".to_string(),
+            direction: OrderDirection::Asc,
+            prefix_length: Some(10),
+        }],
+    )
+    .unwrap();
+
+    // Insert first row with email starting with "testuser12"
+    db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(1),
+            SqlValue::Varchar("testuser123@example.com".to_string()),
+            SqlValue::Varchar("Alice".to_string()),
+        ]),
+    )
+    .expect("First insert should succeed");
+
+    // Try to insert second row with email that has same 10-char prefix (should fail)
+    let result = db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(2),
+            SqlValue::Varchar("testuser124@example.com".to_string()),
+            SqlValue::Varchar("Bob".to_string()),
+        ]),
+    );
+
+    assert!(result.is_err(), "Should reject duplicate prefix");
+    assert!(result.unwrap_err().to_string().contains("UNIQUE constraint"));
+}
+
+#[test]
+fn test_unique_prefix_index_allows_different_prefixes() {
+    let mut db = create_test_db();
+
+    // Create UNIQUE index on first 10 characters
+    db.create_index(
+        "idx_email_prefix10".to_string(),
+        "users".to_string(),
+        true, // unique
+        vec![IndexColumn {
+            column_name: "email".to_string(),
+            direction: OrderDirection::Asc,
+            prefix_length: Some(10),
+        }],
+    )
+    .unwrap();
+
+    // Insert first row
+    db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(1),
+            SqlValue::Varchar("alice@example.com".to_string()),
+            SqlValue::Varchar("Alice".to_string()),
+        ]),
+    )
+    .expect("First insert should succeed");
+
+    // Insert second row with different 10-char prefix (should succeed)
+    let result = db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(2),
+            SqlValue::Varchar("bob123456@example.com".to_string()),
+            SqlValue::Varchar("Bob".to_string()),
+        ]),
+    );
+
+    assert!(result.is_ok(), "Should allow different prefixes: {:?}", result.err());
+}
+
+#[test]
+fn test_prefix_index_with_short_strings() {
+    let mut db = create_test_db();
+
+    // Create UNIQUE index on first 50 characters (longer than some test strings)
+    db.create_index(
+        "idx_email_prefix50".to_string(),
+        "users".to_string(),
+        true, // unique
+        vec![IndexColumn {
+            column_name: "email".to_string(),
+            direction: OrderDirection::Asc,
+            prefix_length: Some(50),
+        }],
+    )
+    .unwrap();
+
+    // Insert row with short email (< 50 chars)
+    db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(1),
+            SqlValue::Varchar("short@test.com".to_string()),
+            SqlValue::Varchar("Alice".to_string()),
+        ]),
+    )
+    .expect("First insert should succeed");
+
+    // Try to insert duplicate short string (should fail)
+    let result = db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(2),
+            SqlValue::Varchar("short@test.com".to_string()),
+            SqlValue::Varchar("Bob".to_string()),
+        ]),
+    );
+
+    assert!(result.is_err(), "Should reject duplicate short string");
+    assert!(result.unwrap_err().to_string().contains("UNIQUE constraint"));
+}
+
+#[test]
+fn test_composite_prefix_index() {
+    let mut db = create_test_db();
+
+    // Create composite UNIQUE index with prefix on both email and name
+    db.create_index(
+        "idx_composite_prefix".to_string(),
+        "users".to_string(),
+        true, // unique
+        vec![
+            IndexColumn {
+                column_name: "email".to_string(),
+                direction: OrderDirection::Asc,
+                prefix_length: Some(10),
+            },
+            IndexColumn {
+                column_name: "name".to_string(),
+                direction: OrderDirection::Asc,
+                prefix_length: Some(5),
+            },
+        ],
+    )
+    .unwrap();
+
+    // Insert first row with email="alice@exam..." (10 chars) and name="Alice..." (5 chars)
+    db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(1),
+            SqlValue::Varchar("alice@example.com".to_string()), // email: "alice@exam" prefix
+            SqlValue::Varchar("Alice Smith".to_string()), // name: "Alice" prefix
+        ]),
+    )
+    .expect("First insert should succeed");
+
+    // Try to insert row with same email(10) + name(5) prefix combination (should fail)
+    let result = db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(2),
+            SqlValue::Varchar("alice@example.org".to_string()), // Same "alice@exam" prefix
+            SqlValue::Varchar("Alice Jones".to_string()), // Same "Alice" prefix
+        ]),
+    );
+
+    assert!(result.is_err(), "Should reject duplicate composite prefix: {:?}", result);
+    assert!(result.unwrap_err().to_string().contains("UNIQUE constraint"));
+
+    // Insert row with different email prefix (should succeed)
+    let result = db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(3),
+            SqlValue::Varchar("bob@example.com".to_string()), // Different "bob@exampl" prefix
+            SqlValue::Varchar("Alice Smith".to_string()), // Same "Alice" prefix is OK
+        ]),
+    );
+
+    assert!(result.is_ok(), "Should allow different email prefix: {:?}", result.err());
+}
+
+#[test]
+fn test_prefix_index_with_utf8_strings() {
+    let mut db = create_test_db();
+
+    // Create UNIQUE index on first 6 characters (UTF-8 aware)
+    db.create_index(
+        "idx_email_utf8".to_string(),
+        "users".to_string(),
+        true, // unique
+        vec![IndexColumn {
+            column_name: "email".to_string(),
+            direction: OrderDirection::Asc,
+            prefix_length: Some(6),
+        }],
+    )
+    .unwrap();
+
+    // Insert with UTF-8 characters - "josé@e" is the 6-char prefix
+    db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(1),
+            SqlValue::Varchar("josé@example.com".to_string()),
+            SqlValue::Varchar("José".to_string()),
+        ]),
+    )
+    .expect("First insert should succeed");
+
+    // Try to insert with same UTF-8 prefix "josé@e" (should fail)
+    let result = db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(2),
+            SqlValue::Varchar("josé@email.com".to_string()),
+            SqlValue::Varchar("José Jr.".to_string()),
+        ]),
+    );
+
+    assert!(result.is_err(), "Should reject duplicate UTF-8 prefix: {:?}", result);
+    assert!(result.unwrap_err().to_string().contains("UNIQUE constraint"));
+
+    // Insert with different UTF-8 prefix (should succeed)
+    let result = db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(3),
+            SqlValue::Varchar("maria@example.com".to_string()),
+            SqlValue::Varchar("Maria".to_string()),
+        ]),
+    );
+
+    assert!(result.is_ok(), "Should allow different UTF-8 prefix: {:?}", result.err());
+}
+
+#[test]
+fn test_non_unique_prefix_index_allows_duplicates() {
+    let mut db = create_test_db();
+
+    // Create non-unique index on first 10 characters
+    db.create_index(
+        "idx_email_prefix10".to_string(),
+        "users".to_string(),
+        false, // NOT unique
+        vec![IndexColumn {
+            column_name: "email".to_string(),
+            direction: OrderDirection::Asc,
+            prefix_length: Some(10),
+        }],
+    )
+    .unwrap();
+
+    // Insert first row
+    db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(1),
+            SqlValue::Varchar("testuser123@example.com".to_string()),
+            SqlValue::Varchar("Alice".to_string()),
+        ]),
+    )
+    .expect("First insert should succeed");
+
+    // Insert second row with same 10-char prefix (should succeed for non-unique index)
+    let result = db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(2),
+            SqlValue::Varchar("testuser124@example.com".to_string()),
+            SqlValue::Varchar("Bob".to_string()),
+        ]),
+    );
+
+    assert!(result.is_ok(), "Non-unique index should allow duplicate prefixes: {:?}", result.err());
+}
+

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance.rs
@@ -24,7 +24,7 @@ use crate::{Row, StorageError};
 ///
 /// # Returns
 /// Truncated value if applicable, otherwise the original value
-fn apply_prefix_truncation(value: &SqlValue, prefix_length: Option<u64>) -> SqlValue {
+pub(super) fn apply_prefix_truncation(value: &SqlValue, prefix_length: Option<u64>) -> SqlValue {
     // If no prefix length specified, return value as-is
     let Some(prefix_len) = prefix_length else {
         return value.clone();

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -181,7 +181,7 @@ impl IndexManager {
             if metadata.table_name == table_name && metadata.unique {
                 if let Some(index_data) = self.index_data.get(index_name) {
                     // Build composite key from the indexed columns
-                    // Normalize numeric types to ensure consistent comparison
+                    // Apply prefix truncation and normalize numeric types to ensure consistent comparison
                     let key_values: Vec<SqlValue> = metadata
                         .columns
                         .iter()
@@ -190,7 +190,8 @@ impl IndexManager {
                                 .get_column_index(&col.column_name)
                                 .expect("Index column should exist");
                             let value = &row.values[col_idx];
-                            crate::database::indexes::index_operations::normalize_for_comparison(value)
+                            let truncated = super::index_maintenance::apply_prefix_truncation(value, col.prefix_length);
+                            crate::database::indexes::index_operations::normalize_for_comparison(&truncated)
                         })
                         .collect();
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where UNIQUE constraint checking for indexed columns with `prefix_length` was not applying prefix truncation, leading to inconsistent behavior between index creation and constraint validation.

## Changes

1. **index_manager.rs:193**: Updated `check_unique_constraints_for_insert` to apply prefix truncation when building composite keys for uniqueness checking
2. **index_maintenance.rs:27**: Made `apply_prefix_truncation` function public within the module (`pub(super)`)
3. **prefix_index_tests.rs**: Added comprehensive test suite with 8 tests covering various prefix indexing scenarios

## Test Plan

- ✅ All 8 new prefix indexing tests pass
- ✅ All 1220 existing tests pass
- ✅ Tests cover:
  - Basic prefix index creation
  - UNIQUE prefix index enforcement
  - Different/same prefixes
  - Short strings (< prefix length)
  - Composite prefix indexes
  - UTF-8 aware prefix handling
  - Non-unique prefix indexes

## Related Issue

Closes #2152

🤖 Generated with [Claude Code](https://claude.com/claude-code)