### PR TITLE
Fix: Case sensitivity bug in trigger tests for OLD/NEW pseudo-variables

### DIFF
--- a/crates/vibesql-executor/src/tests/trigger_tests.rs
+++ b/crates/vibesql-executor/src/tests/trigger_tests.rs
@@ -1015,12 +1015,11 @@ fn test_new_in_insert_trigger() {
     }
 
     // Create trigger that uses NEW to log inserted employee
-    // Manually construct the trigger since parser might not support NEW.name yet
     let trigger_stmt = CreateTriggerStmt {
         trigger_name: "log_new_employee".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
-        table_name: "employees".to_string(),
+        table_name: "EMPLOYEES".to_string(), // Use uppercase to match parser normalization
         granularity: TriggerGranularity::Row,
         when_condition: None,
         triggered_action: TriggerAction::RawSql(
@@ -1093,7 +1092,7 @@ fn test_old_and_new_in_update_trigger() {
         trigger_name: "log_salary_change".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Update(None), // No specific column list
-        table_name: "employees".to_string(),
+        table_name: "EMPLOYEES".to_string(), // Use uppercase to match parser normalization
         granularity: TriggerGranularity::Row,
         when_condition: None,
         triggered_action: TriggerAction::RawSql(
@@ -1167,7 +1166,7 @@ fn test_old_in_delete_trigger() {
         trigger_name: "log_deletion".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Delete,
-        table_name: "employees".to_string(),
+        table_name: "EMPLOYEES".to_string(), // Use uppercase to match parser normalization
         granularity: TriggerGranularity::Row,
         when_condition: None,
         triggered_action: TriggerAction::RawSql(


### PR DESCRIPTION
## Summary

Fixes #2172 by resolving a case sensitivity bug that was causing trigger tests to fail.

## Background

Issue #2172 requested parser support for OLD/NEW pseudo-variables in triggers. Upon investigation, I discovered that:
- Parser support was already implemented in PR #1458 (crates/vibesql-parser/src/parser/expressions/identifiers.rs:98-109)
- Executor support was already implemented in PR #2171 (merged from main)
- Both implementations were complete and correct

However, 3 trigger tests were still failing:
- `test_new_in_insert_trigger`
- `test_old_and_new_in_update_trigger`
- `test_old_in_delete_trigger`

## Root Cause

The SQL parser normalizes all identifiers to uppercase (e.g., `employees` → `EMPLOYEES`). When INSERT/UPDATE/DELETE statements execute, they look up triggers in the catalog using the normalized table name.

The failing tests were manually creating `TriggerDefinition` objects with lowercase table names (`"employees"`), while the parser normalized SQL table references to uppercase (`"EMPLOYEES"`). This caused catalog lookups to fail:

```rust
// Trigger created with lowercase name
table_name: "employees".to_string()

// Parser normalizes to uppercase
stmt.table_name => "EMPLOYEES"

// Catalog lookup fails - case mismatch!
db.catalog.get_triggers_for_table("EMPLOYEES", ...)  // Returns nothing
```

## Changes

- **crates/vibesql-executor/src/tests/trigger_tests.rs**
  - Changed trigger creation to use uppercase table names to match parser normalization
  - Fixed `test_new_in_insert_trigger` (line 1022)
  - Fixed `test_old_and_new_in_update_trigger` (line 1095)
  - Fixed `test_old_in_delete_trigger` (line 1169)
  - Removed obsolete comment about parser support

## Test Results

All 21 trigger tests now pass:
```
test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured
```

Specifically, the previously failing tests now pass:
- ✅ `test_new_in_insert_trigger ... ok`
- ✅ `test_old_and_new_in_update_trigger ... ok`
- ✅ `test_old_in_delete_trigger ... ok`

## Impact

This was purely a test bug - the actual parser and executor implementations were already correct. No production code changes were needed beyond the test fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)