### PR TITLE
Optimize TpchQ1Plan: Remove redundant String clones in result mapping

### DIFF
--- a/crates/vibesql-executor/src/select/monomorphic/tpch.rs
+++ b/crates/vibesql-executor/src/select/monomorphic/tpch.rs
@@ -251,8 +251,8 @@ impl MonomorphicPlan for TpchQ1Plan {
 
                 Row {
                     values: vec![
-                        SqlValue::Varchar(returnflag.clone()),
-                        SqlValue::Varchar(linestatus.clone()),
+                        SqlValue::Varchar(returnflag),
+                        SqlValue::Varchar(linestatus),
                         SqlValue::Double(agg.sum_qty),
                         SqlValue::Double(agg.sum_base_price),
                         SqlValue::Double(agg.sum_disc_price),


### PR DESCRIPTION
## Summary

Removes unnecessary `.clone()` calls on `returnflag` and `linestatus` in the TpchQ1Plan result mapping (lines 254-255).

## Changes

Since `groups.into_iter()` consumes the HashMap and provides **owned** `String` values, the `.clone()` calls create unnecessary heap allocations.

**Before:**
```rust
SqlValue::Varchar(returnflag.clone()),
SqlValue::Varchar(linestatus.clone()),
```

**After:**
```rust
SqlValue::Varchar(returnflag),
SqlValue::Varchar(linestatus),
```

## Performance Impact

- Saves 2 String clones per result row
- ~8 fewer heap allocations per typical Q1 query (4 result groups)
- More idiomatic Rust (takes ownership rather than clones)

## Testing

✅ All tests pass, including `test_q1_pattern_matching`

Closes #2235

🤖 Generated with [Claude Code](https://claude.com/claude-code)