### PR TITLE
fix: Fix failing tests in generic monomorphic patterns

### DIFF
--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -141,8 +141,16 @@ impl TableSchema {
     }
 
     /// Get column by name.
+    /// Uses case-insensitive matching for column names.
     pub fn get_column(&self, name: &str) -> Option<&ColumnSchema> {
-        self.columns.iter().find(|col| col.name == name)
+        // First try exact match for performance
+        if let Some(col) = self.columns.iter().find(|col| col.name == name) {
+            return Some(col);
+        }
+
+        // Fall back to case-insensitive search
+        let name_lower = name.to_lowercase();
+        self.columns.iter().find(|col| col.name.to_lowercase() == name_lower)
     }
 
     /// Get column index by name.


### PR DESCRIPTION
## Summary
Fixes three failing tests introduced in PR #2242:
- `test_filter_extraction_simple_comparison`
- `test_generic_pattern_q6_like`
- `test_generic_pattern_different_table`

## Root Causes

### 1. Case-insensitive column lookup issue
The parser uppercases column names (e.g., `QUANTITY`) but tests created schemas with lowercase names (e.g., `quantity`). The `get_column()` method performed exact string matching, causing lookups to fail.

**Fix**: Updated `TableSchema::get_column()` to perform case-insensitive matching, consistent with `get_column_index()`.

### 2. Numeric literal support
The parser creates `SqlValue::Numeric` for decimal literals like `0.05`, but `extract_f64_literal()` only handled `Double` and `Integer` types, causing BETWEEN predicates to fail.

**Fix**: Added support for `SqlValue::Numeric` in `extract_f64_literal()`.

### 3. Test issues
- Used reserved keyword `date` as column name, causing parser errors
- Expected case-sensitive table name matching in plan descriptions

**Fix**: Renamed column to `sale_date` and made description assertions case-insensitive.

## Test Results
All three originally failing tests now pass:
```
test select::monomorphic::generic::tests::test_filter_extraction_simple_comparison ... ok
test select::monomorphic::generic::tests::test_generic_pattern_q6_like ... ok  
test select::monomorphic::generic::tests::test_generic_pattern_different_table ... ok
```

No regressions in generic monomorphic pattern tests.

## Files Changed
- `crates/vibesql-catalog/src/table.rs` - Case-insensitive column lookup
- `crates/vibesql-executor/src/select/monomorphic/generic.rs` - Numeric literal support and test fixes

Closes #2243

🤖 Generated with [Claude Code](https://claude.com/claude-code)