### PR TITLE
Add views persistence support to JSON serialization

### DIFF
--- a/crates/vibesql-catalog/src/store/advanced/views.rs
+++ b/crates/vibesql-catalog/src/store/advanced/views.rs
@@ -39,6 +39,11 @@ impl super::super::Catalog {
         self.views.get(&key)
     }
 
+    /// List all VIEW names
+    pub fn list_views(&self) -> Vec<String> {
+        self.views.keys().cloned().collect()
+    }
+
     /// Drop a VIEW
     pub fn drop_view(&mut self, name: &str, cascade: bool) -> Result<(), CatalogError> {
         // Normalize the key for case-insensitive lookup

--- a/crates/vibesql-catalog/src/view.rs
+++ b/crates/vibesql-catalog/src/view.rs
@@ -13,6 +13,9 @@ pub struct ViewDefinition {
     pub query: SelectStmt,
     /// Whether WITH CHECK OPTION is enabled
     pub with_check_option: bool,
+    /// Optional SQL definition string (for persistence/serialization)
+    /// When None, we can fallback to Debug format of the query AST
+    pub sql_definition: Option<String>,
 }
 
 impl ViewDefinition {
@@ -23,6 +26,17 @@ impl ViewDefinition {
         query: SelectStmt,
         with_check_option: bool,
     ) -> Self {
-        ViewDefinition { name, columns, query, with_check_option }
+        ViewDefinition { name, columns, query, with_check_option, sql_definition: None }
+    }
+
+    /// Create a new view definition with SQL definition string
+    pub fn new_with_sql(
+        name: String,
+        columns: Option<Vec<String>>,
+        query: SelectStmt,
+        with_check_option: bool,
+        sql_definition: String,
+    ) -> Self {
+        ViewDefinition { name, columns, query, with_check_option, sql_definition: Some(sql_definition) }
     }
 }


### PR DESCRIPTION
## Summary

Implements view persistence for JSON export/import operations to resolve #2257.

## Changes Made

- ✅ **Added `list_views()` method to catalog** - Allows enumeration of all views in the database
- ✅ **Added `sql_definition` field to ViewDefinition** - Optional field to store original SQL definition string for persistence
- ✅ **Updated JSON serialization** - Views are now exported to JSON with their definitions (uses SQL string if available, falls back to Debug format)
- ✅ **Updated JSON deserialization** - View metadata is preserved in JSON but views are intentionally not automatically recreated (with warning log)
- ✅ **Added comprehensive tests** - Two test cases covering view persistence with and without SQL definitions

## Implementation Details

### Catalog API Enhancement
Added `list_views()` method in `crates/vibesql-catalog/src/store/advanced/views.rs:43-45`:
```rust
pub fn list_views(&self) -> Vec<String> {
    self.views.keys().cloned().collect()
}
```

### ViewDefinition Enhancement
Added optional `sql_definition` field to preserve original SQL:
- New field: `pub sql_definition: Option<String>`
- New constructor: `new_with_sql()` for creating views with SQL definition
- Backward compatible: existing `new()` constructor sets `sql_definition` to `None`

### JSON Serialization
Views are now serialized using:
1. SQL definition string if available (`sql_definition` field)
2. Debug format of AST as fallback (preserves structure even without original SQL)

### JSON Deserialization
Views are **intentionally not automatically recreated** during import because:
- Requires SQL parsing and execution during deserialization
- Could fail or have side effects
- Better handled explicitly by user after import

A warning is logged to inform users that views need manual recreation.

## Test Results

```
running 2 tests
test persistence::tests::json_persistence::test_json_view_preservation ... ok
test persistence::tests::json_persistence::test_json_view_preservation_without_sql_definition ... ok
```

## Acceptance Criteria Status

- [x] Implement `list_views()` in catalog
- [x] Serialize views to JSON format
- [x] Deserialize views from JSON format (preserve metadata, warn about manual recreation)
- [x] Add tests for view persistence round-trip
- [x] Verify view definitions are preserved correctly

## Future Work

- Implement Display/ToString for SelectStmt AST to generate proper SQL from AST
- Update CREATE VIEW execution to capture and store original SQL definition
- Consider automatic view recreation during import (would require SQL parser integration)

Closes #2257