### PR TITLE
feat: Implement DiskBacked index operations for scalability

### DIFF
--- a/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
@@ -94,10 +94,10 @@ pub(crate) fn execute_index_scan(
         None => {
             // Full index scan - collect all row indices from the index in index key order
             // (Will be sorted by row index later if needed, see lines 425-427)
+            // Note: values() now returns owned Vec<usize>, so no need for .copied()
             index_data
                 .values()
                 .flatten()
-                .copied()
                 .collect()
         }
     };


### PR DESCRIPTION
## Summary

Implements the missing DiskBacked index operations to enable database scaling beyond memory constraints.

## Changes

### API Updates (Breaking Changes)
- `IndexData::get()`: Changed return type from `Option<&Vec<usize>>` to `Option<Vec<usize>>` (owned data) to support disk I/O
- `IndexData::values()`: Changed return type from `Iterator<Item = &Vec<usize>>` to `Iterator<Item = Vec<usize>>`
- `IndexData::iter()`: Changed return type from `Iterator<Item = (&Vec<SqlValue>, &Vec<usize>)>` to `Iterator<Item = (Vec<SqlValue>, Vec<usize>)>`

### DiskBacked Implementations
- **`get()`**: Uses `BTreeIndex::lookup()` for point queries
- **`contains_key()`**: Uses `BTreeIndex::lookup()` and checks for non-empty results (used for UNIQUE constraint validation)
- **`values()`**: Uses `BTreeIndex::range_scan()` for full index scans
- **`iter()`**: Returns empty iterator with warning (requires future B+tree API enhancement for key-grouped iteration)

### Caller Updates
- Updated `select/scan/index_scan/execution.rs` to remove `.copied()` call since `values()` now returns owned data

## Performance Impact

**Minimal** - the one active caller of `values()` already copies all data via `.flatten().copied().collect()`. Now the copy happens during iteration instead of after, with no net difference. For large tables (100K+ rows), disk I/O dominates any clone cost.

## Testing

- All index-related tests pass (33 passed in vibesql-storage)
- DiskBacked operations use existing BTreeIndex infrastructure which has comprehensive test coverage
- Full workspace compiles successfully

## Notes

- The `iter()` method for DiskBacked indexes is currently unimplemented (returns empty iterator) as BTreeIndex doesn't expose an API for key-grouped iteration. This is acceptable since `iter()` has no callers in the codebase. Callers should use `values()` for full scans or `lookup()`/`multi_lookup()` for point queries.

Closes #2260

🤖 Generated with [Claude Code](https://claude.com/claude-code)