### PR TITLE
refactor: Organize grouping.rs into focused submodules

### DIFF
--- a/crates/vibesql-executor/src/select/grouping/hash.rs
+++ b/crates/vibesql-executor/src/select/grouping/hash.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+
+/// Grouped rows: (group key values, rows in group)
+pub type GroupedRows = Vec<(Vec<vibesql_types::SqlValue>, Vec<vibesql_storage::Row>)>;
+
+// NOTE: Parallel aggregation functions commented out for future implementation
+// The current evaluator architecture uses RefCell which is not Send, making it
+// incompatible with rayon's parallel iteration. To enable parallel aggregation,
+// we would need to:
+// 1. Refactor evaluator to be thread-safe (use Arc<Mutex> or thread-local evaluators)
+// 2. Or pre-evaluate all expressions sequentially, then parallelize only the accumulation
+// 3. Or use a different approach like the hash join (avoid evaluator in parallel sections)
+//
+// For now, the combine() method infrastructure is in place and tested, ready for
+// future parallelization when the evaluator architecture supports it.
+
+// /// Information about an aggregate function to compute
+// #[derive(Debug, Clone)]
+// pub struct AggregateInfo {
+//     pub function_name: String,
+//     pub expr: vibesql_ast::Expression,
+//     pub distinct: bool,
+// }
+//
+// /// Grouped aggregates: (group key values, aggregate accumulators)
+// pub type GroupedAggregates = Vec<(Vec<vibesql_types::SqlValue>, Vec<AggregateAccumulator>)>;
+
+/// Group rows by GROUP BY expressions (original implementation, kept for compatibility)
+///
+/// Optimized implementation using HashMap for O(1) group lookups instead of O(n) linear search.
+/// This significantly improves performance for queries with many groups.
+/// Timeout is checked every 1000 rows.
+pub fn group_rows<'a>(
+    rows: &[vibesql_storage::Row],
+    group_by_exprs: &[vibesql_ast::Expression],
+    evaluator: &crate::evaluator::CombinedExpressionEvaluator,
+    executor: &crate::SelectExecutor<'a>,
+) -> Result<GroupedRows, crate::errors::ExecutorError> {
+    // Use HashMap for O(1) group lookups
+    // Pre-allocate with reasonable capacity to reduce rehashing
+    // Most GROUP BY queries have < 1000 groups; estimate 10% of rows as groups
+    let estimated_groups = (rows.len() / 10).max(16);
+    let mut groups_map: HashMap<Vec<vibesql_types::SqlValue>, Vec<vibesql_storage::Row>> =
+        HashMap::with_capacity(estimated_groups);
+    let mut rows_processed = 0;
+    const CHECK_INTERVAL: usize = 1000;
+
+    for row in rows {
+        // Check timeout every 1000 rows
+        rows_processed += 1;
+        if rows_processed % CHECK_INTERVAL == 0 {
+            executor.check_timeout()?;
+        }
+
+        // Clear CSE cache before evaluating each row to prevent column values
+        // from being incorrectly cached across different rows
+        evaluator.clear_cse_cache();
+
+        // Evaluate GROUP BY expressions to get the group key
+        let mut key = Vec::new();
+        for expr in group_by_exprs {
+            let value = evaluator.eval(expr, row)?;
+            key.push(value);
+        }
+
+        // Insert or update group using HashMap (O(1) lookup)
+        groups_map.entry(key).or_default().push(row.clone());
+    }
+
+    // Convert HashMap back to Vec for compatibility with existing code
+    Ok(groups_map.into_iter().collect())
+}

--- a/crates/vibesql-executor/src/select/grouping/mod.rs
+++ b/crates/vibesql-executor/src/select/grouping/mod.rs
@@ -1,0 +1,13 @@
+//! GROUP BY operations and aggregate function evaluation
+//!
+//! This module provides:
+//! - Aggregate function accumulators (COUNT, SUM, AVG, MIN, MAX)
+//! - Hash-based grouping implementation
+//! - SQL value comparison and arithmetic helpers
+
+mod aggregates;
+mod hash;
+
+// Re-export public API
+pub(super) use aggregates::{AggregateAccumulator, compare_sql_values};
+pub(super) use hash::group_rows;


### PR DESCRIPTION
## Summary

Refactored the 752-line `grouping.rs` file into a well-organized module structure with focused responsibilities:

**New Structure:**
- `grouping/aggregates.rs` (681 lines): Complete aggregate function implementation
  - `AggregateAccumulator` enum with COUNT, SUM, AVG, MIN, MAX
  - Accumulation and finalization logic with DISTINCT support
  - SQL value arithmetic and comparison helpers  
  - Comprehensive unit tests (11 tests, all passing)

- `grouping/hash.rs` (72 lines): Hash-based grouping strategy
  - O(1) group lookup using HashMap
  - Timeout checking for long-running queries
  - CSE cache management per row

- `grouping/mod.rs` (13 lines): Clean public API
  - Re-exports for backward compatibility
  - Module documentation

**Benefits:**
✅ Clear separation of concerns (aggregation vs. grouping strategies)  
✅ All existing imports remain compatible via re-exports  
✅ All 11 grouping tests pass  
✅ No breaking changes to public API  
✅ Foundation for future enhancements (sorted grouping, etc.)

**Test Results:**
```
test select::grouping::aggregates::tests::test_combine_count ... ok
test select::grouping::aggregates::tests::test_combine_count_distinct ... ok
test select::grouping::aggregates::tests::test_combine_sum ... ok
test select::grouping::aggregates::tests::test_combine_avg ... ok
test select::grouping::aggregates::tests::test_combine_min ... ok
test select::grouping::aggregates::tests::test_combine_max ... ok
test select::grouping::aggregates::tests::test_combine_incompatible_types_fails ... ok
test select::grouping::aggregates::tests::test_combine_different_distinct_flags_fails ... ok
test select::grouping::aggregates::tests::test_sum_returns_null_for_empty_set ... ok
test select::grouping::aggregates::tests::test_sum_returns_null_for_all_nulls ... ok
test select::grouping::aggregates::tests::test_sum_returns_zero_when_values_sum_to_zero ... ok
```

Closes #2279

## Test plan

- [x] All grouping unit tests pass (11/11)
- [x] Build succeeds with no warnings
- [x] Existing imports remain functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)