### PR TITLE
perf: Apply WHERE clause selectivity to join order optimizer

### DIFF
--- a/crates/vibesql-executor/src/select/join/search/cost.rs
+++ b/crates/vibesql-executor/src/select/join/search/cost.rs
@@ -4,12 +4,69 @@
 //! guide the search algorithm in selecting optimal join orders by predicting
 //! the expense of different join sequences.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use super::{JoinCost, JoinOrderContext};
 
 impl JoinOrderContext {
-    /// Extract table cardinalities from actual table statistics
+    /// Extract table cardinalities from actual table statistics, adjusted by WHERE clause selectivity
+    ///
+    /// Uses real row counts from database tables and applies selectivity estimation
+    /// for WHERE clause predicates that filter specific tables.
+    pub(super) fn extract_cardinalities_with_selectivity(
+        analyzer: &crate::select::join::reorder::JoinOrderAnalyzer,
+        database: &vibesql_storage::Database,
+        table_local_predicates: &HashMap<String, Vec<vibesql_ast::Expression>>,
+    ) -> std::collections::HashMap<String, usize> {
+        let mut cardinalities = std::collections::HashMap::new();
+
+        for table_name in analyzer.tables() {
+            // Get actual table row count from database
+            let base_rows = database
+                .get_table(table_name.as_str())
+                .map(|t| t.row_count())
+                .unwrap_or(10000); // Fallback for CTEs/subqueries
+
+            // Apply selectivity estimation for local predicates on this table
+            let estimated_rows = if let Some(predicates) = table_local_predicates.get(&table_name.to_lowercase()) {
+                // Get table statistics for selectivity estimation
+                let stats = database
+                    .get_table(table_name.as_str())
+                    .and_then(|t| t.get_statistics());
+
+                if let Some(stats) = stats {
+                    // Estimate combined selectivity of all local predicates
+                    let mut selectivity = 1.0;
+                    for pred in predicates {
+                        let pred_sel = crate::optimizer::selectivity::estimate_selectivity(pred, stats);
+                        selectivity *= pred_sel;
+                    }
+                    // Apply selectivity to base row count
+                    std::cmp::max(1, (base_rows as f64 * selectivity) as usize)
+                } else {
+                    // No stats available, use heuristic: assume each predicate filters ~30%
+                    let selectivity = 0.3_f64.powi(predicates.len() as i32);
+                    std::cmp::max(1, (base_rows as f64 * selectivity) as usize)
+                }
+            } else {
+                base_rows
+            };
+
+            // Debug logging
+            if std::env::var("JOIN_REORDER_VERBOSE").is_ok() && base_rows != estimated_rows {
+                eprintln!(
+                    "[JOIN_REORDER] Table {} cardinality: {} -> {} (after WHERE filter)",
+                    table_name, base_rows, estimated_rows
+                );
+            }
+
+            cardinalities.insert(table_name.clone(), estimated_rows);
+        }
+
+        cardinalities
+    }
+
+    /// Extract table cardinalities from actual table statistics (legacy, no selectivity)
     ///
     /// Uses real row counts from database tables instead of hardcoded estimates.
     /// This enables effective pruning in the search algorithm.
@@ -17,19 +74,7 @@ impl JoinOrderContext {
         analyzer: &crate::select::join::reorder::JoinOrderAnalyzer,
         database: &vibesql_storage::Database,
     ) -> std::collections::HashMap<String, usize> {
-        let mut cardinalities = std::collections::HashMap::new();
-
-        for table_name in analyzer.tables() {
-            // Get actual table row count from database
-            let actual_rows = database
-                .get_table(table_name.as_str())
-                .map(|t| t.row_count())
-                .unwrap_or(10000); // Fallback for CTEs/subqueries
-
-            cardinalities.insert(table_name.clone(), actual_rows);
-        }
-
-        cardinalities
+        Self::extract_cardinalities_with_selectivity(analyzer, database, &HashMap::new())
     }
 
     /// Estimate cost of joining next_table to already-joined tables


### PR DESCRIPTION
## Summary
- Apply WHERE clause selectivity estimation to join reorder cost model
- Extract table-local predicates from WHERE clause for cardinality adjustment
- Helps optimizer choose better join orders for queries like TPC-H Q3

## Test plan
- [ ] Verify compilation with `cargo build --release`
- [ ] Run TPC-H Q3 benchmark to measure improvement
- [ ] Test with verbose output: `JOIN_REORDER_VERBOSE=1`

Closes #2291

🤖 Generated with [Claude Code](https://claude.com/claude-code)