### PR TITLE
perf: Support 8-way joins for TPC-H Q8 national market share query

### DIFF
--- a/crates/vibesql-executor/benches/tpch/queries.rs
+++ b/crates/vibesql-executor/benches/tpch/queries.rs
@@ -127,23 +127,25 @@ GROUP BY supp_nation, cust_nation, l_year
 ORDER BY supp_nation, cust_nation, l_year
 "#;
 
-// TPC-H Q8: National Market Share
+// TPC-H Q8: National Market Share (8-way join)
 pub const TPCH_Q8: &str = r#"
 SELECT
     SUBSTR(o_orderdate, 1, 4) as o_year,
     SUM(CASE WHEN n2.n_name = 'BRAZIL'
         THEN l_extendedprice * (1 - l_discount)
-        ELSE 0 END) / SUM(l_extendprice * (1 - l_discount)) as mkt_share
-FROM lineitem, orders, customer, nation n1, nation n2, region, supplier
-WHERE l_orderkey = o_orderkey
+        ELSE 0 END) / SUM(l_extendedprice * (1 - l_discount)) as mkt_share
+FROM part, supplier, lineitem, orders, customer, nation n1, nation n2, region
+WHERE p_partkey = l_partkey
+    AND s_suppkey = l_suppkey
+    AND l_orderkey = o_orderkey
     AND o_custkey = c_custkey
     AND c_nationkey = n1.n_nationkey
     AND n1.n_regionkey = r_regionkey
     AND r_name = 'AMERICA'
-    AND l_suppkey = s_suppkey
     AND s_nationkey = n2.n_nationkey
     AND o_orderdate >= '1995-01-01'
     AND o_orderdate <= '1996-12-31'
+    AND p_type = 'ECONOMY ANODIZED STEEL'
 GROUP BY o_year
 ORDER BY o_year
 "#;

--- a/crates/vibesql-executor/src/select/join/search/mod.rs
+++ b/crates/vibesql-executor/src/select/join/search/mod.rs
@@ -83,7 +83,7 @@ impl Default for ParallelSearchConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            max_depth: 6,
+            max_depth: 8, // Support 8-way joins like TPC-H Q8
             max_states_per_layer: 1000,
             pruning_threshold: 1.5,
         }


### PR DESCRIPTION
## Summary
- Fix TPC-H Q8 query to include the `part` table and `p_type` filter (was missing from original)
- Fix typo: `l_extendprice` -> `l_extendedprice`
- Increase join optimizer `max_depth` from 6 to 8 to enable parallel BFS for 8-way joins

## Test plan
- [ ] Verify Q8 query compiles and runs correctly
- [ ] Run TPC-H benchmark to verify performance

Closes #2300

🤖 Generated with [Claude Code](https://claude.com/claude-code)