### PR TITLE
fix: Correct TPC-H Q14 to include lineitem-part join

### DIFF
--- a/crates/vibesql-executor/benches/tpch/queries.rs
+++ b/crates/vibesql-executor/benches/tpch/queries.rs
@@ -241,13 +241,16 @@ ORDER BY custdist DESC, c_count DESC
 "#;
 
 // TPC-H Q14: Promotion Effect
+// 2-way JOIN between lineitem and part with date range filter.
+// Uses CASE in aggregate to calculate promotional percentage.
 pub const TPCH_Q14: &str = r#"
 SELECT
-    100.00 * SUM(CASE WHEN l_shipdate >= '1995-09-01' AND l_shipdate < '1995-10-01'
+    100.00 * SUM(CASE WHEN p_type LIKE 'PROMO%'
         THEN l_extendedprice * (1 - l_discount)
         ELSE 0 END) / SUM(l_extendedprice * (1 - l_discount)) as promo_revenue
-FROM lineitem
-WHERE l_shipdate >= '1995-09-01'
+FROM lineitem, part
+WHERE l_partkey = p_partkey
+    AND l_shipdate >= '1995-09-01'
     AND l_shipdate < '1995-10-01'
 "#;
 


### PR DESCRIPTION
## Summary
- Fixes TPC-H Q14 (Promotion Effect) to match the official specification
- Adds the missing JOIN between lineitem and part tables  
- Uses `p_type LIKE 'PROMO%'` in CASE expression for promotional revenue calculation

## Test plan
- [x] Verify build passes with `cargo check`
- [ ] Run TPC-H benchmark suite to verify Q14 executes correctly

Closes #2309

🤖 Generated with [Claude Code](https://claude.com/claude-code)