### PR TITLE
fix(ci): Install sccache in GitHub Actions

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -17,6 +17,9 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.6
+
     - name: Setup Rust toolchain
       uses: dtolnay/rust-toolchain@stable
       with:


### PR DESCRIPTION
## Summary
- Adds mozilla-actions/sccache-action to setup-rust composite action
- Fixes CI failures caused by missing sccache binary

## Root Cause
Commit 1a0d6b8d added `rustc-wrapper = "sccache"` to `.cargo/config.toml` but didn't install sccache in CI.

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)