### PR TITLE
fix: Extract common equijoins from complex OR conditions to prevent memory explosion

### DIFF
--- a/crates/vibesql-executor/src/select/join/join_analyzer.rs
+++ b/crates/vibesql-executor/src/select/join/join_analyzer.rs
@@ -18,13 +18,14 @@ pub struct EquiJoinInfo {
 
 /// Analyze a join condition to detect if it's a simple equi-join
 ///
-/// Returns Some(EquiJoinInfo) if the condition is a simple equi-join like:
+/// Returns Some(EquiJoinInfo) if the condition is an equi-join like:
 /// - `t1.col = t2.col`
 /// - `t2.col = t1.col`
+/// - `(t1.col = t2.col AND ...) OR (t1.col = t2.col AND ...)`  (common equijoin in OR branches)
+/// - `t1.col = t2.col AND ...` (equijoin in AND expression)
 ///
 /// Returns None if:
-/// - The condition is more complex (AND/OR of multiple conditions)
-/// - The condition uses operators other than equality
+/// - The condition doesn't contain any equi-join
 /// - The condition doesn't reference columns from both sides
 pub fn analyze_equi_join(
     condition: &Expression,
@@ -54,9 +55,50 @@ pub fn analyze_equi_join(
             }
             None
         }
-        // For complex conditions (AND, OR, etc.), we could potentially optimize
-        // multiple equi-join conditions, but for now we fall back to nested loop
+        Expression::BinaryOp { op: BinaryOperator::And, left, right } => {
+            // For AND conditions, recursively check left side first, then right
+            // This allows us to find equijoin in expressions like: t1.id = t2.id AND t1.x > 5
+            analyze_equi_join(left, schema, left_column_count)
+                .or_else(|| analyze_equi_join(right, schema, left_column_count))
+        }
+        Expression::BinaryOp { op: BinaryOperator::Or, left, right } => {
+            // For OR conditions, check if there's a common equijoin in all branches
+            // This handles cases like: (t1.id = t2.id AND ...) OR (t1.id = t2.id AND ...)
+            let left_equijoin = analyze_equi_join(left, schema, left_column_count);
+            let right_equijoin = analyze_equi_join(right, schema, left_column_count);
+
+            // Only return the equijoin if both sides have the SAME equijoin
+            match (left_equijoin, right_equijoin) {
+                (Some(left_info), Some(right_info))
+                    if left_info.left_col_idx == right_info.left_col_idx
+                        && left_info.right_col_idx == right_info.right_col_idx =>
+                {
+                    Some(left_info)
+                }
+                _ => None,
+            }
+        }
         _ => None,
+    }
+}
+
+/// Check if a condition is a complex expression (contains AND/OR/other operators beyond simple equality)
+///
+/// Returns true if the expression is anything other than a simple `col1 = col2` equality.
+/// This is used to determine if a condition should still be applied as a post-join filter
+/// even after extracting an equijoin from it.
+pub fn is_complex_condition(expr: &Expression) -> bool {
+    match expr {
+        Expression::BinaryOp { op: BinaryOperator::Equal, left, right } => {
+            // Simple equality is only non-complex if both sides are column references
+            !matches!(left.as_ref(), Expression::ColumnRef { .. })
+                || !matches!(right.as_ref(), Expression::ColumnRef { .. })
+        }
+        Expression::BinaryOp { op: BinaryOperator::And, .. }
+        | Expression::BinaryOp { op: BinaryOperator::Or, .. } => true,
+        Expression::BinaryOp { .. } => true, // Other operators (>, <, LIKE, etc.)
+        Expression::ColumnRef { .. } => false,
+        _ => true, // Function calls, subqueries, etc. are complex
     }
 }
 
@@ -68,5 +110,236 @@ fn extract_column_index(expr: &Expression, schema: &CombinedSchema) -> Option<us
             schema.get_column_index(table.as_deref(), column)
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibesql_catalog::{ColumnSchema, TableSchema};
+    use vibesql_types::DataType;
+    use crate::schema::CombinedSchema;
+
+    /// Helper to create a test schema with two tables
+    fn create_test_schema() -> CombinedSchema {
+        let t1 = TableSchema::new(
+            "t1".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, true),
+                ColumnSchema::new("value".to_string(), DataType::Integer, true),
+            ],
+        );
+
+        let t2 = TableSchema::new(
+            "t2".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, true),
+                ColumnSchema::new("data".to_string(), DataType::Integer, true),
+            ],
+        );
+
+        let mut schema = CombinedSchema::from_table("t1".to_string(), t1);
+        schema = CombinedSchema::combine(schema, "t2".to_string(), t2);
+        schema
+    }
+
+    #[test]
+    fn test_analyze_simple_equijoin() {
+        let schema = create_test_schema();
+
+        // t1.id = t2.id
+        let expr = Expression::BinaryOp {
+            op: BinaryOperator::Equal,
+            left: Box::new(Expression::ColumnRef {
+                table: Some("t1".to_string()),
+                column: "id".to_string(),
+            }),
+            right: Box::new(Expression::ColumnRef {
+                table: Some("t2".to_string()),
+                column: "id".to_string(),
+            }),
+        };
+
+        let result = analyze_equi_join(&expr, &schema, 2); // t1 has 2 columns
+        assert!(result.is_some());
+        let info = result.unwrap();
+        assert_eq!(info.left_col_idx, 0); // t1.id is column 0
+        assert_eq!(info.right_col_idx, 0); // t2.id is column 0
+    }
+
+    #[test]
+    fn test_analyze_equijoin_in_and() {
+        let schema = create_test_schema();
+
+        // t1.id = t2.id AND t1.value > 5
+        let expr = Expression::BinaryOp {
+            op: BinaryOperator::And,
+            left: Box::new(Expression::BinaryOp {
+                op: BinaryOperator::Equal,
+                left: Box::new(Expression::ColumnRef {
+                    table: Some("t1".to_string()),
+                    column: "id".to_string(),
+                }),
+                right: Box::new(Expression::ColumnRef {
+                    table: Some("t2".to_string()),
+                    column: "id".to_string(),
+                }),
+            }),
+            right: Box::new(Expression::BinaryOp {
+                op: BinaryOperator::GreaterThan,
+                left: Box::new(Expression::ColumnRef {
+                    table: Some("t1".to_string()),
+                    column: "value".to_string(),
+                }),
+                right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(5))),
+            }),
+        };
+
+        let result = analyze_equi_join(&expr, &schema, 2);
+        assert!(result.is_some());
+        let info = result.unwrap();
+        assert_eq!(info.left_col_idx, 0); // t1.id
+        assert_eq!(info.right_col_idx, 0); // t2.id
+    }
+
+    #[test]
+    fn test_analyze_equijoin_in_or_common() {
+        let schema = create_test_schema();
+
+        // (t1.id = t2.id AND t1.value > 5) OR (t1.id = t2.id AND t1.value < 10)
+        let expr = Expression::BinaryOp {
+            op: BinaryOperator::Or,
+            left: Box::new(Expression::BinaryOp {
+                op: BinaryOperator::And,
+                left: Box::new(Expression::BinaryOp {
+                    op: BinaryOperator::Equal,
+                    left: Box::new(Expression::ColumnRef {
+                        table: Some("t1".to_string()),
+                        column: "id".to_string(),
+                    }),
+                    right: Box::new(Expression::ColumnRef {
+                        table: Some("t2".to_string()),
+                        column: "id".to_string(),
+                    }),
+                }),
+                right: Box::new(Expression::BinaryOp {
+                    op: BinaryOperator::GreaterThan,
+                    left: Box::new(Expression::ColumnRef {
+                        table: Some("t1".to_string()),
+                        column: "value".to_string(),
+                    }),
+                    right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(5))),
+                }),
+            }),
+            right: Box::new(Expression::BinaryOp {
+                op: BinaryOperator::And,
+                left: Box::new(Expression::BinaryOp {
+                    op: BinaryOperator::Equal,
+                    left: Box::new(Expression::ColumnRef {
+                        table: Some("t1".to_string()),
+                        column: "id".to_string(),
+                    }),
+                    right: Box::new(Expression::ColumnRef {
+                        table: Some("t2".to_string()),
+                        column: "id".to_string(),
+                    }),
+                }),
+                right: Box::new(Expression::BinaryOp {
+                    op: BinaryOperator::LessThan,
+                    left: Box::new(Expression::ColumnRef {
+                        table: Some("t1".to_string()),
+                        column: "value".to_string(),
+                    }),
+                    right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(10))),
+                }),
+            }),
+        };
+
+        let result = analyze_equi_join(&expr, &schema, 2);
+        assert!(result.is_some());
+        let info = result.unwrap();
+        assert_eq!(info.left_col_idx, 0); // t1.id
+        assert_eq!(info.right_col_idx, 0); // t2.id
+    }
+
+    #[test]
+    fn test_analyze_equijoin_in_or_different() {
+        let schema = create_test_schema();
+
+        // (t1.id = t2.id) OR (t1.value = t2.data) - different equijoins
+        let expr = Expression::BinaryOp {
+            op: BinaryOperator::Or,
+            left: Box::new(Expression::BinaryOp {
+                op: BinaryOperator::Equal,
+                left: Box::new(Expression::ColumnRef {
+                    table: Some("t1".to_string()),
+                    column: "id".to_string(),
+                }),
+                right: Box::new(Expression::ColumnRef {
+                    table: Some("t2".to_string()),
+                    column: "id".to_string(),
+                }),
+            }),
+            right: Box::new(Expression::BinaryOp {
+                op: BinaryOperator::Equal,
+                left: Box::new(Expression::ColumnRef {
+                    table: Some("t1".to_string()),
+                    column: "value".to_string(),
+                }),
+                right: Box::new(Expression::ColumnRef {
+                    table: Some("t2".to_string()),
+                    column: "data".to_string(),
+                }),
+            }),
+        };
+
+        let result = analyze_equi_join(&expr, &schema, 2);
+        // Should return None because the equijoins are different
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_is_complex_condition_simple_equijoin() {
+        let expr = Expression::BinaryOp {
+            op: BinaryOperator::Equal,
+            left: Box::new(Expression::ColumnRef {
+                table: Some("t1".to_string()),
+                column: "id".to_string(),
+            }),
+            right: Box::new(Expression::ColumnRef {
+                table: Some("t2".to_string()),
+                column: "id".to_string(),
+            }),
+        };
+
+        assert!(!is_complex_condition(&expr));
+    }
+
+    #[test]
+    fn test_is_complex_condition_and() {
+        let expr = Expression::BinaryOp {
+            op: BinaryOperator::And,
+            left: Box::new(Expression::ColumnRef {
+                table: Some("t1".to_string()),
+                column: "id".to_string(),
+            }),
+            right: Box::new(Expression::ColumnRef {
+                table: Some("t2".to_string()),
+                column: "id".to_string(),
+            }),
+        };
+
+        assert!(is_complex_condition(&expr));
+    }
+
+    #[test]
+    fn test_is_complex_condition_or() {
+        let expr = Expression::BinaryOp {
+            op: BinaryOperator::Or,
+            left: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(1))),
+            right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(2))),
+        };
+
+        assert!(is_complex_condition(&expr));
     }
 }

--- a/crates/vibesql-executor/src/select/join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/mod.rs
@@ -316,10 +316,16 @@ pub(super) fn nested_loop_join(
                 )?;
 
                 // Apply remaining equijoins and conditions as post-join filters
+                // IMPORTANT: For complex conditions (AND/OR), we must keep the entire condition
+                // even though we extracted an equijoin from it. For example:
+                //   (t1.id = t2.id AND t1.x > 5) OR (t1.id = t2.id AND t1.y < 10)
+                // We use t1.id = t2.id for hash join, but still need the full condition
+                // to filter by the x > 5 and y < 10 predicates.
+                let is_current_complex = join_analyzer::is_complex_condition(equijoin);
                 let remaining_conditions: Vec<_> = additional_equijoins
                     .iter()
                     .enumerate()
-                    .filter(|(i, _)| *i != idx)
+                    .filter(|(i, _)| *i != idx || is_current_complex)
                     .map(|(_, e)| e.clone())
                     .collect();
 


### PR DESCRIPTION
Closes #2349

## Problem

TPC-H Q19 (Discounted Revenue) was experiencing a memory explosion (11.18 GB on SF 0.01) due to inefficient join execution with complex OR conditions.

The query has a WHERE clause with three OR branches, each containing the same equijoin condition:

```sql
WHERE
    (p_partkey = l_partkey AND p_brand = 'Brand#12' AND ...)
    OR
    (p_partkey = l_partkey AND p_brand = 'Brand#23' AND ...)
    OR
    (p_partkey = l_partkey AND p_brand = 'Brand#34' AND ...)
```

The join analyzer couldn't detect the common `p_partkey = l_partkey` equijoin across all OR branches, causing fallback to nested loop join which produced a massive cartesian product (60K × 20K = 1.2B rows) before filtering.

## Solution

Enhanced the join analyzer to intelligently extract equijoin conditions from complex expressions:

### Changes to `join_analyzer.rs`

1. **AND condition support**: Recursively searches for equijoins in AND expressions
   - Example: `t1.id = t2.id AND t1.value > 5` → extracts `t1.id = t2.id`

2. **OR condition support**: Detects common equijoins across all OR branches
   - Example: `(t1.id = t2.id AND ...) OR (t1.id = t2.id AND ...)` → extracts `t1.id = t2.id`
   - Only returns equijoin if it's identical across ALL branches

3. **Complex condition detection**: New `is_complex_condition` function
   - Identifies conditions that have more than just a simple equijoin
   - Used to determine post-join filter requirements

### Changes to `mod.rs`

Updated join logic to keep complex conditions in post-join filters even after extracting an equijoin:

- For simple equijoin: `t1.id = t2.id` → remove from filter list after using for hash join
- For complex condition: `(t1.id = t2.id AND ...) OR (...)` → keep in filter list to evaluate remaining predicates

This ensures correct query semantics while still enabling hash join optimization.

## Impact

- **Q19 performance**: Uses hash join (O(n+m)) instead of nested loop (O(n×m))
- **Memory usage**: Expected <50MB vs 11.18GB
- **Broader benefit**: Any query with common equijoins in OR conditions will benefit

## Testing

Added comprehensive test coverage:

- ✅ 7 new unit tests for join analyzer functionality
- ✅ All 12 existing hash join tests pass
- ✅ Verified correct handling of:
  - Simple equijoins: `t1.id = t2.id`
  - Equijoins in AND: `t1.id = t2.id AND t1.x > 5`
  - Common equijoins in OR: `(t1.id = t2.id AND ...) OR (t1.id = t2.id AND ...)`
  - Different equijoins in OR: properly rejected to avoid incorrect optimization

## Related Issues

- #2298 - TPC-H Performance Tracking
- #2313 - Q19 performance issue (may need to merge/close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>