### PR TITLE
fix: Extract common equi-join predicates from OR conditions

### DIFF
--- a/crates/vibesql-executor/src/select/join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/mod.rs
@@ -302,6 +302,60 @@ pub(super) fn nested_loop_join(
             }
         }
 
+        // Phase 3.2: Try OR conditions with common equi-join (TPC-H Q19 optimization)
+        // For expressions like `(a.x = b.x AND ...) OR (a.x = b.x AND ...) OR (a.x = b.x AND ...)`,
+        // extract the common equi-join `a.x = b.x` for hash join
+        if let Some(cond) = condition {
+            if let Some(or_result) =
+                join_analyzer::analyze_or_equi_join(cond, &temp_schema, left_col_count)
+            {
+                // Save schemas for NATURAL JOIN processing before moving left/right
+                let (left_schema_for_natural, right_schema_for_natural) = if natural {
+                    (Some(left.schema.clone()), Some(right.schema.clone()))
+                } else {
+                    (None, None)
+                };
+
+                let mut result = hash_join_inner(
+                    left,
+                    right,
+                    or_result.equi_join.left_col_idx,
+                    or_result.equi_join.right_col_idx,
+                )?;
+
+                // Apply remaining OR conditions as post-join filter
+                if !or_result.remaining_conditions.is_empty() {
+                    if let Some(filter_expr) = combine_with_and(or_result.remaining_conditions) {
+                        result = apply_post_join_filter(result, &filter_expr, database)?;
+                    }
+                }
+
+                // For NATURAL JOIN, remove duplicate columns from the result
+                if natural {
+                    if let (Some(left_schema), Some(right_schema_orig)) =
+                        (left_schema_for_natural, right_schema_for_natural)
+                    {
+                        let right_schema_for_removal = CombinedSchema {
+                            table_schemas: vec![(
+                                right_table_name_for_natural.clone(),
+                                (0, right_schema_orig.table_schemas.values().next().unwrap().1.clone()),
+                            )]
+                            .into_iter()
+                            .collect(),
+                            total_columns: right_schema_orig.total_columns,
+                        };
+                        result = remove_duplicate_columns_for_natural_join(
+                            result,
+                            &left_schema,
+                            &right_schema_for_removal,
+                        )?;
+                    }
+                }
+
+                return Ok(result);
+            }
+        }
+
         // Phase 3.1: If no ON condition hash join, try WHERE clause equijoins
         // Iterate through all additional equijoins to find one suitable for hash join
         for (idx, equijoin) in additional_equijoins.iter().enumerate() {


### PR DESCRIPTION
## Summary

Fixes #2369 by enabling hash join for queries with complex OR conditions.

This PR extracts common equi-join predicates from OR expressions to enable hash join optimization, preventing memory explosion in TPC-H Q19 and similar queries.

## Problem

TPC-H Q19 (Discounted Revenue) exhausted memory (11.18 GB on SF 0.01) due to complex OR conditions:

```sql
WHERE
    (p_partkey = l_partkey AND p_brand = 'Brand#12' AND ...)
    OR
    (p_partkey = l_partkey AND p_brand = 'Brand#23' AND ...)
    OR
    (p_partkey = l_partkey AND p_brand = 'Brand#34' AND ...)
```

**Root cause:**
- The join analyzer only handled AND conditions
- OR conditions returned None, causing fallback to nested loop join  
- Nested loop created cartesian product: ~60K lineitem × ~200K part = 12B rows
- Memory explosion before filtering could be applied

## Solution

1. **New `analyze_or_equi_join()` function** (`join_analyzer.rs`):
   - Flattens OR branches and extracts all equi-joins from each branch
   - Finds equi-joins that appear in **all** branches (common predicates)
   - Returns common predicate for hash join + original OR as post-filter

2. **Phase 3.2 in `nested_loop_join()`** (`mod.rs`):
   - Try OR analysis after AND analysis
   - Use extracted equi-join for hash join
   - Apply remaining OR conditions as post-join filter

## Changes

- `crates/vibesql-executor/src/select/join/join_analyzer.rs`: +124 lines
  - Added `flatten_or_conditions()` helper
  - Added `analyze_or_equi_join()` function
- `crates/vibesql-executor/src/select/join/mod.rs`: +54 lines
  - Added Phase 3.2 OR analysis before fallback

## Impact

- **Fixes #2369**: Q19 should now execute without memory error
- **General improvement**: Any query with OR conditions containing common equi-joins will benefit
- **No breaking changes**: Existing AND/simple equi-join logic unchanged

## Test Plan

- [x] Code compiles successfully
- [ ] Verify Q19 executes on SF 0.01 without memory error
- [ ] Verify memory usage < 100MB  
- [ ] Existing join tests pass
- [ ] Q19 produces correct results
- [ ] Execution time < 5s

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)