### PR TITLE
fix: Update test_having_with_scalar_subquery expectations for INTEGER SUM

### DIFF
--- a/crates/vibesql-executor/tests/having_subquery_tests.rs
+++ b/crates/vibesql-executor/tests/having_subquery_tests.rs
@@ -119,11 +119,11 @@ fn test_having_with_scalar_subquery() {
 
     // Check dept 1
     assert_eq!(rows[0].get(0), Some(&vibesql_types::SqlValue::Integer(1)));
-    assert_eq!(rows[0].get(1), Some(&vibesql_types::SqlValue::Numeric(300.0)));
+    assert_eq!(rows[0].get(1), Some(&vibesql_types::SqlValue::Integer(300)));
 
     // Check dept 3
     assert_eq!(rows[1].get(0), Some(&vibesql_types::SqlValue::Integer(3)));
-    assert_eq!(rows[1].get(1), Some(&vibesql_types::SqlValue::Numeric(500.0)))
+    assert_eq!(rows[1].get(1), Some(&vibesql_types::SqlValue::Integer(500)))
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes test expectations in `test_having_with_scalar_subquery` to correctly expect `Integer` type for `SUM(INTEGER)` instead of `Numeric`.

## Changes

- Updated test expectations at lines 122 and 126 in `crates/vibesql-executor/tests/having_subquery_tests.rs`
- Changed from `Numeric(300.0)` and `Numeric(500.0)` to `Integer(300)` and `Integer(500)`

## Rationale

The `amount` column is defined as `INTEGER` type, so `SUM(amount)` should preserve the integer type and return `Integer(300)` rather than `Numeric(300.0)`. This fix aligns test expectations with the correct implementation behavior.

## Test plan

- [x] Verified test `test_having_with_scalar_subquery` now passes
- [x] Checked for similar issues in other tests in the same file (none found)

Closes #2434

🤖 Generated with [Claude Code](https://claude.com/claude-code)