### PR TITLE
docs: Reconcile conflicting TPC-H Q6 performance targets

### DIFF
--- a/BENCHMARK_STATUS.md
+++ b/BENCHMARK_STATUS.md
@@ -58,13 +58,30 @@ Status: Compiling dependencies (in progress)
 
 ## Performance Targets (SF 0.01)
 
-Per issue #2414 and `IMPLEMENTATION_STATUS.md`:
+### TPC-H Q6 Performance Evolution
 
-| Query | Baseline | Target | Expected Speedup | Status |
-|-------|----------|--------|------------------|---------|
-| Q6 | ~600ms | <100ms | 6-10x | Ready to test |
-| Q1 | ~600ms | <100ms | 6-10x | Ready to test |
-| Q3 | 724ms | <180ms | 4x | Ready to test |
+**Historical Baselines** (different optimization stages):
+- **Initial row-by-row**: ~600ms (naive implementation, pre-monomorphic)
+- **Monomorphic execution**: 35ms (type-specialized paths, commit 55713f6c)
+- **With lazy filtering**: 1.54ms (deferred row materialization)
+
+**Reference Implementations** (from issue #2220):
+- **DuckDB**: 646µs (0.646ms) - Gold standard target
+- **SQLite**: 6.51ms - Comparison baseline
+
+**Current Columnar Target**:
+- **Goal**: <1ms (approach DuckDB performance)
+- **Stretch**: 646µs (match DuckDB exactly)
+
+**Note**: The ~600ms baseline represents the initial naive implementation. The relevant starting point for columnar optimization is the 35ms monomorphic baseline. Achieving <1ms requires a ~35x improvement from the monomorphic baseline, which columnar + SIMD execution should provide.
+
+### Performance Targets Summary
+
+| Query | Pre-Monomorphic | Monomorphic Baseline | Columnar Target | Expected Speedup | Status |
+|-------|----------------|---------------------|----------------|------------------|---------|
+| Q6 | ~600ms | ~35ms | <1ms | 35-50x | Ready to test |
+| Q1 | ~600ms | (not measured) | <100ms | 6-10x | Ready to test |
+| Q3 | (not measured) | 724ms | <180ms | 4x | Ready to test |
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Resolves conflicting TPC-H Q6 baseline numbers found across multiple documents by documenting the full performance evolution with proper historical context.

## Problem

Multiple documents contained conflicting Q6 performance numbers:
- **BENCHMARK_STATUS.md**: ~600ms baseline
- **Issue #2430**: 35.2ms starting point  
- **17x difference** causing confusion about actual targets

## Root Cause

Both numbers are correct - they represent different optimization stages:
1. **~600ms**: Initial naive row-by-row implementation
2. **~35ms**: After monomorphic execution optimization (commit 55713f6c)
3. **1.54ms**: After lazy filtering optimization
4. **646µs**: DuckDB target to match

## Changes

Updated `BENCHMARK_STATUS.md` to:
- Document Q6 performance evolution across all optimization stages
- Clarify which baseline is relevant for columnar work (35ms, not 600ms)
- Add reference implementations (DuckDB: 646µs, SQLite: 6.51ms)
- Set clear columnar targets: <1ms goal, 646µs stretch
- Show expected speedup: 35-50x from monomorphic baseline

## Key Insight

The monomorphic baseline (35ms) is the relevant starting point for columnar optimization. The 600ms baseline is historical context showing how far we've already come through type specialization.

## Testing

Documentation-only change, no code modifications.

## Related Issues

- Closes #2441
- Related to #2430 (Q6 benchmarking)
- Related to #2220 (DuckDB performance targets EPIC)
- Related to #2414 (TPC-H benchmark validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)