### PR TITLE
perf: Optimize Q21 EXISTS subquery with compound join conditions

### DIFF
--- a/crates/vibesql-executor/src/select/join/hash_anti_join.rs
+++ b/crates/vibesql-executor/src/select/join/hash_anti_join.rs
@@ -5,6 +5,7 @@ use rayon::prelude::*;
 
 use super::FromResult;
 use crate::errors::ExecutorError;
+use crate::evaluator::CombinedExpressionEvaluator;
 
 #[cfg(feature = "parallel")]
 use crate::select::parallel::ParallelConfig;
@@ -141,6 +142,125 @@ pub(super) fn hash_anti_join(
     }
 
     // Return result with left schema only (we don't combine with right schema)
+    Ok(FromResult::from_rows(left.schema.clone(), result_rows))
+}
+
+/// Hash anti-join with additional filter conditions
+///
+/// This is an optimized version of hash_anti_join that supports additional filter predicates
+/// beyond the equi-join condition. This is essential for NOT EXISTS subqueries with complex WHERE clauses.
+///
+/// Example use case:
+/// ```sql
+/// NOT EXISTS (
+///     SELECT * FROM lineitem l2
+///     WHERE l2.l_orderkey = l1.l_orderkey    -- Equi-join (used for hash table)
+///       AND l2.l_suppkey <> l1.l_suppkey     -- Additional filter (checked during probe)
+/// )
+/// ```
+///
+/// Algorithm:
+/// 1. Build phase: Hash the RIGHT table on the equi-join column (O(n))
+/// 2. Probe phase: For each LEFT row:
+///    a. Check if hash table contains matching key
+///    b. If yes, verify additional filter conditions against ALL matching right rows
+///    c. If NO right row passes the filter, emit the left row (only once)
+///    d. If no matching key, emit the left row
+///
+/// Performance: Still O(n + m) average case, much faster than nested loop O(n*m)
+pub(super) fn hash_anti_join_with_filter(
+    mut left: FromResult,
+    mut right: FromResult,
+    left_col_idx: usize,
+    right_col_idx: usize,
+    additional_filter: Option<&vibesql_ast::Expression>,
+    combined_schema: &crate::schema::CombinedSchema,
+    database: &vibesql_storage::Database,
+) -> Result<FromResult, ExecutorError> {
+    // If no additional filter, use the simpler version
+    if additional_filter.is_none() {
+        return hash_anti_join(left, right, left_col_idx, right_col_idx);
+    }
+
+    let filter = additional_filter.unwrap();
+
+    // Get left and right row data
+    let left_rows = left.rows();
+    let right_rows = right.rows();
+
+    // Build phase: Create hash table from right side
+    // Unlike simple hash_anti_join, we need to store row indices to check the filter
+    let mut hash_table: HashMap<vibesql_types::SqlValue, Vec<usize>> = HashMap::new();
+
+    for (idx, row) in right_rows.iter().enumerate() {
+        let key = row.values[right_col_idx].clone();
+        // Skip NULL values - they never match in equi-joins
+        if key != vibesql_types::SqlValue::Null {
+            hash_table.entry(key).or_insert_with(Vec::new).push(idx);
+        }
+    }
+
+    // Probe phase: Check each left row for absence of a match that passes the filter
+    let estimated_capacity = left_rows.len().min(100_000);
+    let mut result_rows = Vec::with_capacity(estimated_capacity);
+
+    // Create evaluator for filter evaluation
+    let evaluator = CombinedExpressionEvaluator::with_database(combined_schema, database);
+
+    // Helper to create combined row (same as in hash_semi_join_with_filter)
+    let create_combined_row = |left_row: &vibesql_storage::Row, right_row: &vibesql_storage::Row| {
+        let mut combined_values = left_row.values.clone();
+        combined_values.extend_from_slice(&right_row.values);
+        vibesql_storage::Row::new(combined_values)
+    };
+
+    for left_row in left_rows.iter() {
+        let key = &left_row.values[left_col_idx];
+
+        // Skip NULL values - they never match in equi-joins, so they should be returned
+        // for anti-join (since they have "no match")
+        if key == &vibesql_types::SqlValue::Null {
+            result_rows.push(left_row.clone());
+            continue;
+        }
+
+        // Check if key exists in hash table
+        if let Some(right_indices) = hash_table.get(key) {
+            // Check if ANY matching right row passes the additional filter
+            let mut found_match = false;
+            for &right_idx in right_indices {
+                let right_row = &right_rows[right_idx];
+
+                // Create combined row for filter evaluation
+                let combined_row = create_combined_row(left_row, right_row);
+
+                // Clear CSE cache before evaluation
+                evaluator.clear_cse_cache();
+
+                // Evaluate the additional filter
+                match evaluator.eval(filter, &combined_row) {
+                    Ok(vibesql_types::SqlValue::Boolean(true)) => {
+                        found_match = true;
+                        break; // Anti-join: if we find one match, skip this left row
+                    }
+                    Ok(vibesql_types::SqlValue::Boolean(false))
+                    | Ok(vibesql_types::SqlValue::Null) => continue,
+                    Err(_) => continue, // Filter evaluation error, try next row
+                    Ok(_) => continue,  // Filter didn't return boolean, try next row
+                }
+            }
+
+            // If NO right row passed the filter, emit this left row
+            if !found_match {
+                result_rows.push(left_row.clone());
+            }
+        } else {
+            // No matching key in hash table, so emit this left row
+            result_rows.push(left_row.clone());
+        }
+    }
+
+    // Return result with left schema only
     Ok(FromResult::from_rows(left.schema.clone(), result_rows))
 }
 

--- a/crates/vibesql-executor/src/select/join/hash_semi_join.rs
+++ b/crates/vibesql-executor/src/select/join/hash_semi_join.rs
@@ -5,6 +5,7 @@ use rayon::prelude::*;
 
 use super::FromResult;
 use crate::errors::ExecutorError;
+use crate::evaluator::CombinedExpressionEvaluator;
 
 #[cfg(feature = "parallel")]
 use crate::select::parallel::ParallelConfig;
@@ -141,6 +142,122 @@ pub(super) fn hash_semi_join(
 
     // Return result with left schema only (we don't combine with right schema)
     Ok(FromResult::from_rows(left.schema.clone(), result_rows))
+}
+
+/// Hash semi-join with additional filter conditions
+///
+/// This is an optimized version of hash_semi_join that supports additional filter predicates
+/// beyond the equi-join condition. This is essential for EXISTS subqueries with complex WHERE clauses.
+///
+/// Example use case (TPC-H Q21):
+/// ```sql
+/// EXISTS (
+///     SELECT * FROM lineitem l2
+///     WHERE l2.l_orderkey = l1.l_orderkey    -- Equi-join (used for hash table)
+///       AND l2.l_suppkey <> l1.l_suppkey     -- Additional filter (checked during probe)
+/// )
+/// ```
+///
+/// Algorithm:
+/// 1. Build phase: Hash the RIGHT table on the equi-join column (O(n))
+/// 2. Probe phase: For each LEFT row:
+///    a. Check if hash table contains matching key
+///    b. If yes, verify additional filter conditions against ALL matching right rows
+///    c. If any right row passes the filter, emit the left row (only once)
+///
+/// Performance: Still O(n + m) average case, much faster than nested loop O(n*m)
+pub(super) fn hash_semi_join_with_filter(
+    mut left: FromResult,
+    mut right: FromResult,
+    left_col_idx: usize,
+    right_col_idx: usize,
+    additional_filter: Option<&vibesql_ast::Expression>,
+    combined_schema: &crate::schema::CombinedSchema,
+    database: &vibesql_storage::Database,
+) -> Result<FromResult, ExecutorError> {
+    // If no additional filter, use the simpler version
+    if additional_filter.is_none() {
+        return hash_semi_join(left, right, left_col_idx, right_col_idx);
+    }
+
+    let filter = additional_filter.unwrap();
+
+    // Get left and right row data
+    let left_rows = left.rows();
+    let right_rows = right.rows();
+
+    // Build phase: Create hash table from right side
+    // Unlike simple hash_semi_join, we need to store row indices to check the filter
+    use std::collections::HashMap;
+    let mut hash_table: HashMap<vibesql_types::SqlValue, Vec<usize>> = HashMap::new();
+
+    for (idx, row) in right_rows.iter().enumerate() {
+        let key = row.values[right_col_idx].clone();
+        // Skip NULL values - they never match in equi-joins
+        if key != vibesql_types::SqlValue::Null {
+            hash_table.entry(key).or_insert_with(Vec::new).push(idx);
+        }
+    }
+
+    // Probe phase: Check each left row for a match that passes the filter
+    let estimated_capacity = left_rows.len().min(100_000);
+    let mut result_rows = Vec::with_capacity(estimated_capacity);
+
+    // Create evaluator for filter evaluation
+    let evaluator = CombinedExpressionEvaluator::with_database(combined_schema, database);
+
+    for left_row in left_rows.iter() {
+        let key = &left_row.values[left_col_idx];
+
+        // Skip NULL values - they never match in equi-joins
+        if key == &vibesql_types::SqlValue::Null {
+            continue;
+        }
+
+        // Check if key exists in hash table
+        if let Some(right_indices) = hash_table.get(key) {
+            // Check if any matching right row passes the additional filter
+            let mut found_match = false;
+            for &right_idx in right_indices {
+                let right_row = &right_rows[right_idx];
+
+                // Create combined row for filter evaluation
+                let combined_row = create_combined_row(left_row, right_row);
+
+                // Clear CSE cache before evaluation
+                evaluator.clear_cse_cache();
+
+                // Evaluate the additional filter
+                match evaluator.eval(filter, &combined_row) {
+                    Ok(vibesql_types::SqlValue::Boolean(true)) => {
+                        found_match = true;
+                        break; // Semi-join: we only need one match
+                    }
+                    Ok(vibesql_types::SqlValue::Boolean(false))
+                    | Ok(vibesql_types::SqlValue::Null) => continue,
+                    Err(_) => continue, // Filter evaluation error, skip this row
+                    Ok(_) => continue,  // Filter didn't return boolean, skip this row
+                }
+            }
+
+            if found_match {
+                result_rows.push(left_row.clone());
+            }
+        }
+    }
+
+    // Return result with left schema only
+    Ok(FromResult::from_rows(left.schema.clone(), result_rows))
+}
+
+/// Helper function to create a combined row from left and right rows
+fn create_combined_row(
+    left_row: &vibesql_storage::Row,
+    right_row: &vibesql_storage::Row,
+) -> vibesql_storage::Row {
+    let mut combined_values = left_row.values.clone();
+    combined_values.extend_from_slice(&right_row.values);
+    vibesql_storage::Row::new(combined_values)
 }
 
 #[cfg(test)]

--- a/crates/vibesql-executor/src/select/join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/mod.rs
@@ -20,8 +20,8 @@ mod tests;
 // Re-export join reorder analyzer for public tests
 // Re-export hash_join functions for internal use
 use hash_join::hash_join_inner;
-use hash_semi_join::hash_semi_join;
-use hash_anti_join::hash_anti_join;
+use hash_semi_join::{hash_semi_join, hash_semi_join_with_filter};
+use hash_anti_join::{hash_anti_join, hash_anti_join_with_filter};
 // Re-export hash join iterator for public use
 pub use hash_join_iterator::HashJoinIterator;
 // Re-export nested loop join variants for internal use
@@ -448,24 +448,36 @@ pub(super) fn nested_loop_join(
         let temp_schema =
             CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
 
-        // Try ON condition first
+        // Try ON condition first - use analyze_compound_equi_join to handle complex conditions
+        // This enables hash join optimization for EXISTS subqueries with additional predicates
+        // Example: EXISTS (SELECT * FROM t WHERE t.x = outer.x AND t.y <> outer.y)
+        // The equi-join (t.x = outer.x) is used for hash join, and the inequality is a post-filter
         if let Some(cond) = condition {
-            if let Some(equi_join_info) =
-                join_analyzer::analyze_equi_join(cond, &temp_schema, left_col_count)
+            if let Some(compound_result) =
+                join_analyzer::analyze_compound_equi_join(cond, &temp_schema, left_col_count)
             {
+                // Build the combined remaining condition (if any)
+                let remaining_filter = combine_with_and(compound_result.remaining_conditions);
+
                 let result = if matches!(join_type, vibesql_ast::JoinType::Semi) {
-                    hash_semi_join(
+                    hash_semi_join_with_filter(
                         left,
                         right,
-                        equi_join_info.left_col_idx,
-                        equi_join_info.right_col_idx,
+                        compound_result.equi_join.left_col_idx,
+                        compound_result.equi_join.right_col_idx,
+                        remaining_filter.as_ref(),
+                        &temp_schema,
+                        database,
                     )?
                 } else {
-                    hash_anti_join(
+                    hash_anti_join_with_filter(
                         left,
                         right,
-                        equi_join_info.left_col_idx,
-                        equi_join_info.right_col_idx,
+                        compound_result.equi_join.left_col_idx,
+                        compound_result.equi_join.right_col_idx,
+                        remaining_filter.as_ref(),
+                        &temp_schema,
+                        database,
                     )?
                 };
 


### PR DESCRIPTION
## Summary
Fix TPC-H Q21 timeout by optimizing EXISTS subqueries with compound join conditions.

## Problem
Q21 was timing out (>120s) on SF 0.01 (60K row) dataset despite semi-join operators being implemented (#2405, #2427). The query uses an EXISTS subquery with both an equi-join and an inequality filter:
```sql
EXISTS (
    SELECT * FROM lineitem l2
    WHERE l2.l_orderkey = l1.l_orderkey    -- Equi-join predicate
      AND l2.l_suppkey <> l1.l_suppkey     -- Additional filter
)
```

The existing code only used `analyze_equi_join` which returns `None` for compound AND conditions, causing fallback to nested loop semi-join with O(n*m) complexity.

## Solution
1. **Use `analyze_compound_equi_join` for SEMI/ANTI joins** - This function extracts the equi-join predicate from compound conditions and returns remaining predicates separately
2. **Add filtered hash join variants**:
   - `hash_semi_join_with_filter` - Hash on equi-join, check additional filters during probe
   - `hash_anti_join_with_filter` - Hash on equi-join, check additional filters during probe
3. **Maintain O(n+m) complexity** - Hash table build is O(n), probe with filter check is O(m * matches), which is much better than nested loop O(n*m)

## Performance Impact
- **Before**: >120s timeout on SF 0.01
- **After**: 1.95s on SF 0.01
- **Speedup**: **60x+ improvement**

## Test Results
```
test test_q21_correlated_exists ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 1.95s
```

## Files Changed
- `hash_semi_join.rs`: Added `hash_semi_join_with_filter` function
- `hash_anti_join.rs`: Added `hash_anti_join_with_filter` function  
- `mod.rs`: Modified semi/anti join execution to use `analyze_compound_equi_join`

## Acceptance Criteria
- [x] Q21 executes in <10s on SF 0.01 (actual: 1.95s)
- [x] EXISTS is transformed to semi-join in query plan
- [x] Hash semi-join is used (not nested loop)
- [x] Test `test_q21_correlated_exists` passes without timeout
- [x] Query produces correct results (4 rows returned)

Closes #2467

🤖 Generated with [Claude Code](https://claude.com/claude-code)