### PR TITLE
fix: Correct Q18 to match official TPC-H specification

### DIFF
--- a/crates/vibesql-executor/benches/tpch/queries.rs
+++ b/crates/vibesql-executor/benches/tpch/queries.rs
@@ -349,10 +349,15 @@ SELECT
     o_totalprice,
     SUM(l_quantity) as total_qty
 FROM customer, orders, lineitem
-WHERE c_custkey = o_custkey
+WHERE o_orderkey IN (
+        SELECT l_orderkey
+        FROM lineitem
+        GROUP BY l_orderkey
+        HAVING SUM(l_quantity) > 300
+    )
+    AND c_custkey = o_custkey
     AND o_orderkey = l_orderkey
 GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
-HAVING SUM(l_quantity) > 300
 ORDER BY o_totalprice DESC, o_orderdate
 LIMIT 100
 "#;


### PR DESCRIPTION
## Summary

- Fixed TPC-H Q18 query to match official specification
- Added missing subquery with GROUP BY and HAVING clause
- Identified actual performance bottlenecks requiring further optimization

## Problem

Issue #2492 reported Q18 had poor performance (723ms vs 3ms DuckDB). Investigation revealed the query implementation was **incorrect** - it was missing the correlated subquery specified in the official TPC-H benchmark.

## Changes

### Query Structure Fix

**Before** (incorrect):
```sql
SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, SUM(l_quantity)
FROM customer, orders, lineitem
WHERE c_custkey = o_custkey AND o_orderkey = l_orderkey
GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
HAVING SUM(l_quantity) > 300  -- Wrong: HAVING in outer query
```

**After** (correct per TPC-H spec):
```sql
SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, SUM(l_quantity)
FROM customer, orders, lineitem
WHERE o_orderkey IN (
        SELECT l_orderkey
        FROM lineitem
        GROUP BY l_orderkey
        HAVING SUM(l_quantity) > 300  -- Correct: HAVING in subquery
    )
    AND c_custkey = o_custkey
    AND o_orderkey = l_orderkey
GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
```

## Performance Impact

- **Before fix**: 622ms, 0 rows returned (incorrect filtering)
- **After fix**: >60s, times out (reveals actual performance issues)

The "235x performance gap" was comparing an incorrect query. With the correct implementation, actual issues are:

1. Subquery execution is very slow (>60s for SF 0.01 data)
2. Timeout mechanism doesn't apply to subqueries
3. Need optimizations:
   - Subquery materialization/caching
   - Semi-join conversion for `IN (subquery)`  
   - Aggregate pushdown into join planning

## Test Plan

- [x] Query now matches official TPC-H Q18 specification
- [x] Profiling reveals actual bottlenecks for optimization
- [ ] Follow-up work needed for performance optimization
- [ ] Follow-up work needed to fix timeout propagation

## Related

- Closes #2492 (partially - identifies root cause)
- Follow-up issues needed for:
  - Subquery performance optimization
  - Timeout mechanism for subqueries

## References

- [Official TPC-H Q18](https://github.com/dragansah/tpch-dbgen/blob/master/tpch-queries/18.sql)
- [TPC-H Specification](https://www.tpc.org/tpc_documents_current_versions/pdf/tpc-h_v2.17.1.pdf)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)