### PR TITLE
fix: Mark slow test_issue_898_files test as ignored

### DIFF
--- a/tests/regression/issue_898.rs
+++ b/tests/regression/issue_898.rs
@@ -211,6 +211,7 @@ async fn test_file(path: &str) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[tokio::test]
+#[ignore] // Slow test (~60s+): Run manually with `cargo test test_issue_898_files -- --ignored`
 async fn test_issue_898_files() {
     let files = vec![
         "third_party/sqllogictest/test/select1.test",


### PR DESCRIPTION
## Summary
- Mark `test_issue_898_files` test with `#[ignore]` attribute to prevent CI timeout
- The test processes 145,000+ lines of SQLLogicTest files and takes >60 seconds
- Test can still be run manually with: `cargo test test_issue_898_files -- --ignored`

## Test plan
- [x] Verified test now shows as "ignored" instead of timing out
- [x] Test result: `ok. 0 passed; 0 failed; 1 ignored` (finished in 0.00s)

Closes #2585

🤖 Generated with [Claude Code](https://claude.com/claude-code)