### PR TITLE
fix: Correct test expectation for SUM with no matching rows

### DIFF
--- a/crates/vibesql-executor/src/tests/monomorphic_integration_tests.rs
+++ b/crates/vibesql-executor/src/tests/monomorphic_integration_tests.rs
@@ -371,6 +371,7 @@ fn test_generic_pattern_not_tpch_fallback() {
 }
 
 /// Test 6: Edge case - query with no matching rows
+/// Per SQL standard, SUM of an empty set returns NULL (not 0)
 #[test]
 fn test_generic_pattern_no_matching_rows() {
     let mut db = vibesql_storage::Database::new();
@@ -410,15 +411,14 @@ fn test_generic_pattern_no_matching_rows() {
     let executor = SelectExecutor::new(&db);
     let result = executor.execute(&select_stmt).unwrap();
 
+    // Aggregation without GROUP BY should still return 1 row
     assert_eq!(result.len(), 1);
-    let total = match &result[0].values[0] {
-        SqlValue::Double(v) => *v,
-        SqlValue::Float(v) => *v as f64,
-        SqlValue::Integer(v) => *v as f64,
-        SqlValue::Numeric(v) => *v,
-        other => panic!("Expected numeric result, got {:?}", other),
-    };
-    assert_eq!(total, 0.0, "Expected 0.0 for no matching rows, got {}", total);
+    // Per SQL standard, SUM over empty set returns NULL
+    assert_eq!(
+        result[0].values[0],
+        SqlValue::Null,
+        "SUM of no matching rows should return NULL (SQL standard)"
+    );
 }
 
 // TODO: Test for SUM with simple numeric filters (currently failing - needs investigation)


### PR DESCRIPTION
## Summary
- Fixed `test_generic_pattern_no_matching_rows` test which expected `0.0` for SUM over empty set
- Per SQL standard, SUM of an empty set returns NULL (not 0) - COUNT is the only aggregate that returns 0 for empty sets
- Updated test assertion to expect `SqlValue::Null`, consistent with existing `test_distinct_empty_table` behavior

## Test plan
- [x] Verified the specific test passes: `cargo test --package vibesql-executor test_generic_pattern_no_matching_rows`
- [ ] Run full test suite to ensure no regressions

Closes #2587

🤖 Generated with [Claude Code](https://claude.com/claude-code)