### PR TITLE
fix: Fix SQLite compatibility test data type handling

### DIFF
--- a/tests/compliance/sqllogictest_sqlite.rs
+++ b/tests/compliance/sqllogictest_sqlite.rs
@@ -51,21 +51,9 @@ impl SqliteDB {
                 rows: vec![vec![hash_string]],
             })
         } else {
-            // Flatten multi-column results: each value becomes its own row
-            let mut flattened_rows: Vec<Vec<String>> = Vec::new();
-            let mut flattened_types: Vec<DefaultColumnType> = Vec::new();
-
-            if !types.is_empty() {
-                flattened_types = vec![types[0].clone(); total_values];
-            }
-
-            for row in rows {
-                for val in row {
-                    flattened_rows.push(vec![val.clone()]);
-                }
-            }
-
-            Ok(DBOutput::Rows { types: flattened_types, rows: flattened_rows })
+            // Return rows as-is with one type per column
+            // The sqllogictest framework handles flattening for comparison
+            Ok(DBOutput::Rows { types, rows: rows.to_vec() })
         }
     }
 
@@ -237,7 +225,7 @@ CREATE TABLE types_test (id INTEGER, name TEXT, value REAL)
 statement ok
 INSERT INTO types_test VALUES (1, 'hello', 3.14)
 
-query IRT
+query ITR
 SELECT * FROM types_test
 ----
 1


### PR DESCRIPTION
## Summary
- Fix `format_result_rows` to return rows as-is with one type per column instead of incorrectly flattening and using only the first column's type for all values
- Correct the test's type annotation from `IRT` to `ITR` to match actual column order

## Test plan
- [x] Run `cargo test --release -p vibesql --test sqllogictest_sqlite` - all 3 tests pass
- [x] Verify `test_data_types` now correctly returns `1`, `hello`, `3.14` instead of `1`, `0`, `3`

Closes #2590

🤖 Generated with [Claude Code](https://claude.com/claude-code)