### PR TITLE
fix: Fix test_cross_join_with_condition_fails expects panic that doesn't occur

### DIFF
--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -51,11 +51,18 @@ pub(crate) fn count_tables_in_from(from: &FromClause) -> usize {
 /// Join reordering changes column ordering, so we only apply it to implicit CROSS joins
 /// from comma-list syntax (FROM t1, t2, t3). Explicit INNER/LEFT/RIGHT joins must
 /// preserve their declared ordering.
+///
+/// Note: CROSS JOINs with ON conditions are NOT valid comma-list syntax and should
+/// not be reordered. This ensures `CROSS JOIN ... ON` goes through the normal path
+/// where the appropriate error is raised (CROSS JOIN does not support ON clause).
 pub(crate) fn all_joins_are_cross(from: &FromClause) -> bool {
     match from {
         FromClause::Table { .. } | FromClause::Subquery { .. } => true,
-        FromClause::Join { left, right, join_type, .. } => {
+        FromClause::Join { left, right, join_type, condition, .. } => {
+            // Must be CROSS join type AND have no ON condition
+            // CROSS JOIN with ON clause is invalid and should not be reordered
             matches!(join_type, vibesql_ast::JoinType::Cross)
+                && condition.is_none()
                 && all_joins_are_cross(left)
                 && all_joins_are_cross(right)
         }

--- a/crates/vibesql-executor/src/tests/select_joins.rs
+++ b/crates/vibesql-executor/src/tests/select_joins.rs
@@ -420,33 +420,47 @@ fn test_cross_join() {
 }
 
 #[test]
-#[should_panic(expected = "CROSS JOIN does not support ON clause")]
 fn test_cross_join_with_condition_fails() {
     let mut db = vibesql_storage::Database::new();
 
     let users_schema = vibesql_catalog::TableSchema::new(
         "users".to_string(),
-        vec![vibesql_catalog::ColumnSchema::new("id".to_string(), vibesql_types::DataType::Integer, false)],
+        vec![vibesql_catalog::ColumnSchema::new(
+            "id".to_string(),
+            vibesql_types::DataType::Integer,
+            false,
+        )],
     );
     db.create_table(users_schema).unwrap();
 
     let products_schema = vibesql_catalog::TableSchema::new(
         "products".to_string(),
-        vec![vibesql_catalog::ColumnSchema::new("id".to_string(), vibesql_types::DataType::Integer, false)],
+        vec![vibesql_catalog::ColumnSchema::new(
+            "id".to_string(),
+            vibesql_types::DataType::Integer,
+            false,
+        )],
     );
     db.create_table(products_schema).unwrap();
 
-    // CROSS JOIN with condition should fail
+    // CROSS JOIN with condition should return an error
     let executor = SelectExecutor::new(&db);
     let stmt = vibesql_ast::SelectStmt {
         into_table: None,
-        into_variables: None,        with_clause: None,
+        into_variables: None,
+        with_clause: None,
         set_operation: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
-            left: Box::new(vibesql_ast::FromClause::Table { name: "users".to_string(), alias: None }),
-            right: Box::new(vibesql_ast::FromClause::Table { name: "products".to_string(), alias: None }),
+            left: Box::new(vibesql_ast::FromClause::Table {
+                name: "users".to_string(),
+                alias: None,
+            }),
+            right: Box::new(vibesql_ast::FromClause::Table {
+                name: "products".to_string(),
+                alias: None,
+            }),
             join_type: vibesql_ast::JoinType::Cross,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
@@ -469,7 +483,14 @@ fn test_cross_join_with_condition_fails() {
         offset: None,
     };
 
-    let _ = executor.execute(&stmt).unwrap(); // Should panic
+    let result = executor.execute(&stmt);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("CROSS JOIN does not support ON clause"),
+        "Expected error about CROSS JOIN ON clause, got: {}",
+        err
+    );
 }
 
 /// Test that NULL values in join columns do NOT match each other (issue #1877)


### PR DESCRIPTION
## Summary

- Fix `test_cross_join_with_condition_fails` to check for `Result::Err` instead of expecting a panic
- Fix `all_joins_are_cross()` to exclude CROSS JOINs with ON conditions from join reordering

## Root Cause

The test was failing because:
1. The test used `#[should_panic]` but the code returns `Result::Err` instead of panicking
2. CROSS JOINs with ON conditions were being silently converted to INNER JOINs by the join reordering optimizer, bypassing the error check in `nested_loop_cross_join()`

## Changes

1. **Test fix** (`select_joins.rs`): Updated to properly assert `result.is_err()` and verify the error message contains "CROSS JOIN does not support ON clause"

2. **Join reordering fix** (`reorder/utils.rs`): Modified `all_joins_are_cross()` to return `false` when a CROSS JOIN has an ON condition. This ensures such invalid constructs go through the normal execution path where the appropriate error is raised.

## Test plan

- [x] `test_cross_join_with_condition_fails` now passes
- [x] All other cross join tests pass
- [x] All join reorder tests pass
- [x] No regressions in executor tests (2 pre-existing failures unrelated to this change)

Closes #2588

🤖 Generated with [Claude Code](https://claude.com/claude-code)