### PR TITLE
fix: BETWEEN SYMMETRIC now correctly swaps bounds when low > high

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -221,12 +221,14 @@ fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<
         }
 
         // BETWEEN: column BETWEEN low AND high
+        // Only support ASYMMETRIC (default) BETWEEN for columnar optimization
+        // SYMMETRIC BETWEEN falls through to general evaluator which handles bounds swapping
         Expression::Between {
             expr: inner,
             low,
             high,
             negated: false,
-            symmetric: _,
+            symmetric: false,
         } => {
             if let Expression::ColumnRef { table, column } = inner.as_ref() {
                 if let (Expression::Literal(low_val), Expression::Literal(high_val)) =
@@ -336,12 +338,13 @@ fn extract_predicates_recursive(
         }
 
         // BETWEEN: column BETWEEN low AND high
+        // Only support ASYMMETRIC (default) BETWEEN for columnar optimization
         Expression::Between {
             expr: inner,
             low,
             high,
             negated: false,
-            symmetric: _,
+            symmetric: false,
         } => {
             if let Expression::ColumnRef { table, column } = inner.as_ref() {
                 if let (Expression::Literal(low_val), Expression::Literal(high_val)) =

--- a/crates/vibesql-executor/src/select/scan/index_scan/predicate.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/predicate.rs
@@ -176,7 +176,8 @@ fn extract_range_predicate(expr: &Expression, column_name: &str) -> Option<Range
             }
         }
         // Handle BETWEEN: col BETWEEN low AND high
-        Expression::Between { expr: col_expr, low, high, negated, .. } => {
+        // For SYMMETRIC: swap bounds if low > high
+        Expression::Between { expr: col_expr, low, high, negated, symmetric } => {
             if !negated && is_column_reference(col_expr, column_name) {
                 if let (Expression::Literal(low_val), Expression::Literal(high_val)) =
                     (low.as_ref(), high.as_ref())
@@ -185,9 +186,17 @@ fn extract_range_predicate(expr: &Expression, column_name: &str) -> Option<Range
                     if matches!(low_val, SqlValue::Null) || matches!(high_val, SqlValue::Null) {
                         return None;
                     }
+
+                    // Handle SYMMETRIC: swap bounds if low > high
+                    let (effective_low, effective_high) = if *symmetric && low_val > high_val {
+                        (high_val.clone(), low_val.clone())
+                    } else {
+                        (low_val.clone(), high_val.clone())
+                    };
+
                     return Some(RangePredicate {
-                        start: Some(low_val.clone()),
-                        end: Some(high_val.clone()),
+                        start: Some(effective_low),
+                        end: Some(effective_high),
                         inclusive_start: true,
                         inclusive_end: true,
                     });
@@ -308,8 +317,11 @@ pub(crate) fn where_clause_fully_satisfied_by_index(
             }
         }
         // BETWEEN on indexed column: col BETWEEN low AND high
-        Expression::Between { expr: col_expr, low, high, negated, .. } => {
+        // Only ASYMMETRIC BETWEEN (symmetric: false) can be fully satisfied by index
+        // SYMMETRIC BETWEEN needs bounds swapping handled by evaluator
+        Expression::Between { expr: col_expr, low, high, negated, symmetric } => {
             !negated
+                && !symmetric
                 && is_column_reference(col_expr, indexed_column)
                 && matches!(low.as_ref(), Expression::Literal(_))
                 && matches!(high.as_ref(), Expression::Literal(_))

--- a/crates/vibesql-executor/src/select/vectorized/compiled_predicate.rs
+++ b/crates/vibesql-executor/src/select/vectorized/compiled_predicate.rs
@@ -33,6 +33,7 @@ enum CompiledPredicate {
         low: SqlValue,
         high: SqlValue,
         negated: bool,
+        symmetric: bool,
     },
 }
 
@@ -191,9 +192,9 @@ impl CompiledWhereClause {
                 Self::extract_and_predicates(left, schema, predicates) &&
                 Self::extract_and_predicates(right, schema, predicates)
             }
-            Expression::Between { expr: col_expr, low, high, negated, symmetric: _ } => {
+            Expression::Between { expr: col_expr, low, high, negated, symmetric } => {
                 // Try to compile BETWEEN predicate
-                Self::try_compile_between(col_expr, low, high, *negated, schema, predicates)
+                Self::try_compile_between(col_expr, low, high, *negated, *symmetric, schema, predicates)
             }
             _ => {
                 // Try to compile as simple binary comparison
@@ -208,6 +209,7 @@ impl CompiledWhereClause {
         low_expr: &Expression,
         high_expr: &Expression,
         negated: bool,
+        symmetric: bool,
         schema: &CombinedSchema,
         predicates: &mut Vec<CompiledPredicate>,
     ) -> bool {
@@ -240,6 +242,7 @@ impl CompiledWhereClause {
             low,
             high,
             negated,
+            symmetric,
         });
 
         true
@@ -347,9 +350,9 @@ impl CompiledWhereClause {
                 let column_value = &row.values[*column_idx];
                 self.compare_values(column_value, literal, *op)
             }
-            CompiledPredicate::Between { column_idx, low, high, negated } => {
+            CompiledPredicate::Between { column_idx, low, high, negated, symmetric } => {
                 let column_value = &row.values[*column_idx];
-                let result = self.is_between(column_value, low, high)?;
+                let result = self.is_between(column_value, low, high, *symmetric)?;
                 Ok(if *negated { !result } else { result })
             }
         }
@@ -441,11 +444,25 @@ impl CompiledWhereClause {
     }
 
     /// Check if value is between low and high (inclusive)
+    /// For SYMMETRIC: swap bounds if low > high before comparison
     #[inline(always)]
-    fn is_between(&self, value: &SqlValue, low: &SqlValue, high: &SqlValue) -> Result<bool, ExecutorError> {
+    fn is_between(&self, value: &SqlValue, low: &SqlValue, high: &SqlValue, symmetric: bool) -> Result<bool, ExecutorError> {
+        // Handle SYMMETRIC: swap bounds if low > high
+        let (effective_low, effective_high) = if symmetric {
+            // Check if bounds need swapping
+            let low_gt_high = self.compare_values(low, high, ComparisonOp::GreaterThan)?;
+            if low_gt_high {
+                (high, low)
+            } else {
+                (low, high)
+            }
+        } else {
+            (low, high)
+        };
+
         // BETWEEN is inclusive on both ends: value >= low AND value <= high
-        let ge_low = self.compare_values(value, low, ComparisonOp::GreaterThanOrEqual)?;
-        let le_high = self.compare_values(value, high, ComparisonOp::LessThanOrEqual)?;
+        let ge_low = self.compare_values(value, effective_low, ComparisonOp::GreaterThanOrEqual)?;
+        let le_high = self.compare_values(value, effective_high, ComparisonOp::LessThanOrEqual)?;
         Ok(ge_low && le_high)
     }
 }
@@ -636,6 +653,7 @@ mod tests {
             low: SqlValue::Integer(1),
             high: SqlValue::Integer(10),
             negated: false,
+            symmetric: false,
         };
         assert_eq!(between_pred.estimate_selectivity(), 0.10);
     }


### PR DESCRIPTION
## Summary
- Fixed BETWEEN SYMMETRIC predicate to correctly swap bounds when low > high
- The `symmetric` flag was being ignored in multiple execution paths:
  - Columnar filter predicates now only optimize asymmetric BETWEEN
  - Vectorized compiled predicates now include and handle symmetric flag
  - Index scan range extraction now swaps bounds for SYMMETRIC
  - Index satisfaction check no longer reports SYMMETRIC as fully satisfied

## Test plan
- [x] `test_between_symmetric_swaps_bounds` now passes
- [x] All 32 BETWEEN-related tests pass
- [x] 1430+ executor tests pass (2 pre-existing failures unrelated to this change)

Closes #2586

🤖 Generated with [Claude Code](https://claude.com/claude-code)