### PR TITLE
fix: ON DELETE SET DEFAULT sets column to default value instead of NULL

### DIFF
--- a/tests/common/referential_integrity_fixtures.rs
+++ b/tests/common/referential_integrity_fixtures.rs
@@ -8,6 +8,7 @@
 
 #![allow(dead_code)]
 
+use vibesql_ast::Expression;
 use vibesql_catalog::{ColumnSchema, ForeignKeyConstraint, ReferentialAction, TableSchema};
 use vibesql_executor::{DeleteExecutor, UpdateExecutor};
 use vibesql_parser::Parser;
@@ -47,6 +48,47 @@ pub fn create_child_table(
     let columns = vec![
         ColumnSchema::new("ID".to_string(), DataType::Integer, false),
         ColumnSchema::new("PARENT_ID".to_string(), DataType::Integer, true),
+        ColumnSchema::new("DATA".to_string(), DataType::Varchar { max_length: Some(50) }, true),
+    ];
+
+    let fk = ForeignKeyConstraint {
+        name: Some(format!("FK_{}_{}", table_name, parent_table)),
+        column_names: vec!["PARENT_ID".to_string()],
+        column_indices: vec![1],
+        parent_table: parent_table.to_string(),
+        parent_column_names: vec!["ID".to_string()],
+        parent_column_indices: vec![0],
+        on_delete: on_delete.clone(),
+        on_update: on_update.clone(),
+    };
+
+    let mut schema =
+        TableSchema::with_primary_key(table_name.to_string(), columns, vec!["ID".to_string()]);
+    schema.foreign_keys.push(fk);
+
+    db.create_table(schema).unwrap();
+}
+
+/// Create a child table with a foreign key constraint and a default value for the FK column
+///
+/// Creates a table with columns: ID (INTEGER, PK), PARENT_ID (INTEGER, nullable, FK with default), DATA
+/// (VARCHAR(50), nullable)
+///
+/// This is specifically for testing SET DEFAULT referential action.
+pub fn create_child_table_with_default(
+    db: &mut Database,
+    table_name: &str,
+    parent_table: &str,
+    on_delete: ReferentialAction,
+    on_update: ReferentialAction,
+    default_value: i64,
+) {
+    let mut parent_id_column = ColumnSchema::new("PARENT_ID".to_string(), DataType::Integer, true);
+    parent_id_column.set_default(Expression::Literal(SqlValue::Integer(default_value)));
+
+    let columns = vec![
+        ColumnSchema::new("ID".to_string(), DataType::Integer, false),
+        parent_id_column,
         ColumnSchema::new("DATA".to_string(), DataType::Varchar { max_length: Some(50) }, true),
     ];
 

--- a/tests/storage/referential_integrity.rs
+++ b/tests/storage/referential_integrity.rs
@@ -200,15 +200,17 @@ fn test_on_delete_set_default() {
     // Create parent and child tables with SET DEFAULT
     create_parent_table(&mut db, "PARENT");
 
-    // Create a default parent row
+    // Create a default parent row (id=0 is the default FK value)
     insert_parent_row(&mut db, "PARENT", 0, "Default");
 
-    create_child_table(
+    // Use the helper that sets a default value for PARENT_ID column
+    create_child_table_with_default(
         &mut db,
         "CHILD",
         "PARENT",
         ReferentialAction::SetDefault,
         ReferentialAction::NoAction,
+        0, // default value for PARENT_ID
     );
 
     // Insert test data


### PR DESCRIPTION
## Summary
- Fixed the `test_on_delete_set_default` test by properly setting up a default value for the `PARENT_ID` column
- Added a new test fixture helper `create_child_table_with_default` that creates a child table with a default value for the FK column

## Root Cause
The test was failing because the `create_child_table` fixture didn't set a `default_value` on the `PARENT_ID` column. The `set_default` implementation in `integrity.rs` correctly looks for `column.default_value` but falls back to `NULL` when no default is defined (lines 220-238).

## Changes
- `tests/common/referential_integrity_fixtures.rs`: Added `create_child_table_with_default` helper function
- `tests/storage/referential_integrity.rs`: Updated `test_on_delete_set_default` to use the new helper with default value `0`

## Test plan
- [x] `test_on_delete_set_default` now passes
- [x] All 20 referential integrity tests pass (1 ignored)

Closes #2589

🤖 Generated with [Claude Code](https://claude.com/claude-code)