### PR TITLE
fix: Correct correlation detection for aliased tables in subqueries

### DIFF
--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
@@ -241,10 +241,21 @@ fn extract_table_prefixes(from: &vibesql_ast::FromClause) -> Vec<char> {
 }
 
 /// Recursively check if FROM clause contains a table reference
+///
+/// When a table has an alias, only the alias is valid for referencing that table
+/// in the current scope. The original table name is "shadowed" by the alias.
+/// This matches SQL standard behavior where `FROM t1 AS x` means only `x.col`
+/// is valid, not `t1.col`.
 fn from_clause_contains_table(from: &vibesql_ast::FromClause, table_name: &str) -> bool {
     match from {
         vibesql_ast::FromClause::Table { name, alias } => {
-            name == table_name || alias.as_ref().is_some_and(|a| a == table_name)
+            // If table has an alias, only the alias is valid for column references
+            // in this scope. The original table name is shadowed.
+            if let Some(a) = alias {
+                a.eq_ignore_ascii_case(table_name)
+            } else {
+                name.eq_ignore_ascii_case(table_name)
+            }
         }
         vibesql_ast::FromClause::Join { left, right, .. } => {
             from_clause_contains_table(left, table_name)


### PR DESCRIPTION
## Summary

- Fixed incorrect correlation detection for subqueries with aliased tables
- When a table has an alias (e.g., `FROM t1 AS x`), the original table name is now correctly shadowed
- References to the outer table by its original name (e.g., `t1.c`) are now properly recognized as external

## Problem

Correlated subqueries that reference outer table columns were failing when the subquery used a table alias:

```sql
SELECT (SELECT count(*) FROM t1 AS x WHERE x.c > t1.c) FROM t1
                                           ^^^^
                                     -- Error: Column not found
```

The `t1.c` reference should resolve to the outer query's `t1` table, but the correlation detection incorrectly matched `t1` against the aliased table in the subquery's FROM clause.

## Fix

Modified `from_clause_contains_table()` in `correlation.rs` to follow SQL standard aliasing behavior:
- If a table has an alias, only the alias is valid for column references in that scope
- The original table name is "shadowed" and should not match

## Test plan

- [x] Reproduce bug with test query from issue
- [x] Verify fix resolves the issue
- [x] Run correlation unit tests (5 passed)
- [x] Run subquery unit tests (57 passed)
- [x] Run `select1.test` SQLLogicTest (100% pass)
- [x] Run `select3.test` SQLLogicTest (100% pass)

Closes #2596

🤖 Generated with [Claude Code](https://claude.com/claude-code)