### PR TITLE
fix: Handle ApproximateNumeric + Numeric division result type combination

### DIFF
--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/division.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/division.rs
@@ -105,6 +105,11 @@ impl Division {
             (super::CoercedValues::Numeric(a, b), ValueType::Float) => {
                 Ok(Numeric(a / b))
             }
+            // ApproximateNumeric with Numeric result type (MySQL mode with Float operands)
+            // MySQL always returns Numeric for division even with Float inputs
+            (super::CoercedValues::ApproximateNumeric(a, b), ValueType::Numeric) => {
+                Ok(Numeric(a / b))
+            }
             // All other combinations should be unreachable due to type coercion rules
             _ => unreachable!("Unexpected combination of coerced type and result type"),
         }


### PR DESCRIPTION
## Summary
- Fixes division operator panic when dividing Float operands in MySQL mode
- The panic occurred because MySQL always returns `Numeric` for division results, but the match arm for `(ApproximateNumeric, Numeric)` was missing in the division operator implementation

## Root Cause
The `Division::divide()` function in `division.rs` matches on `(coerced_values, result_type)` to determine how to perform the division. When Float operands are coerced to `ApproximateNumeric(f64, f64)` and MySQL mode requests `ValueType::Numeric` as the result type, there was no match arm to handle this combination, causing an `unreachable!` panic.

## Fix
Added the missing match arm at line 108-112:
```rust
// ApproximateNumeric with Numeric result type (MySQL mode with Float operands)
// MySQL always returns Numeric for division even with Float inputs
(super::CoercedValues::ApproximateNumeric(a, b), ValueType::Numeric) => {
    Ok(Numeric(a / b))
}
```

## Test plan
- [x] Verified fix builds successfully
- [x] Ran `index/random/10/slt_good_0` test (one of the affected tests) - no more panics
- [ ] CI will run full test suite

Closes #2600

🤖 Generated with [Claude Code](https://claude.com/claude-code)