### PR TITLE
fix: Handle NULL values in comparisons per SQL standard

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/filter/comparison.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/comparison.rs
@@ -1,10 +1,45 @@
 use vibesql_types::SqlValue;
 
+/// Result of comparing two SqlValues, accounting for NULL semantics
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CompareResult {
+    /// Normal ordering result
+    Ordering(std::cmp::Ordering),
+    /// At least one value is NULL - comparison is UNKNOWN
+    Unknown,
+}
+
+impl CompareResult {
+    /// Check if comparison result equals a specific ordering
+    /// Returns false for Unknown (NULL comparisons always fail in WHERE)
+    pub fn equals(&self, expected: std::cmp::Ordering) -> bool {
+        match self {
+            CompareResult::Ordering(ord) => *ord == expected,
+            CompareResult::Unknown => false,
+        }
+    }
+
+    /// Check if comparison result matches any of the given orderings
+    /// Returns false for Unknown (NULL comparisons always fail in WHERE)
+    pub fn matches(&self, orderings: &[std::cmp::Ordering]) -> bool {
+        match self {
+            CompareResult::Ordering(ord) => orderings.contains(ord),
+            CompareResult::Unknown => false,
+        }
+    }
+}
+
 /// Compare two SqlValues for ordering
 ///
-/// Handles both same-type and mixed numeric type comparisons by coercing to f64
-pub(super) fn compare_values(a: &SqlValue, b: &SqlValue) -> std::cmp::Ordering {
+/// Handles both same-type and mixed numeric type comparisons by coercing to f64.
+/// Returns CompareResult::Unknown if either value is NULL (per SQL standard).
+pub(super) fn compare_values(a: &SqlValue, b: &SqlValue) -> CompareResult {
     use std::cmp::Ordering;
+
+    // NULL handling: any comparison involving NULL returns UNKNOWN
+    if matches!(a, SqlValue::Null) || matches!(b, SqlValue::Null) {
+        return CompareResult::Unknown;
+    }
 
     // Try to extract numeric value as f64 for cross-type comparison
     fn to_f64(v: &SqlValue) -> Option<f64> {
@@ -20,7 +55,7 @@ pub(super) fn compare_values(a: &SqlValue, b: &SqlValue) -> std::cmp::Ordering {
         }
     }
 
-    match (a, b) {
+    CompareResult::Ordering(match (a, b) {
         // Same-type comparisons (fast path)
         (SqlValue::Integer(a), SqlValue::Integer(b)) => a.cmp(b),
         (SqlValue::Bigint(a), SqlValue::Bigint(b)) => a.cmp(b),
@@ -72,5 +107,5 @@ pub(super) fn compare_values(a: &SqlValue, b: &SqlValue) -> std::cmp::Ordering {
                 Ordering::Equal
             }
         }
-    }
+    })
 }

--- a/crates/vibesql-executor/src/select/columnar/filter/evaluation.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/evaluation.rs
@@ -71,35 +71,31 @@ where
 
 /// Evaluate a column predicate on a specific value
 ///
-/// Returns true if the value satisfies the predicate
+/// Returns true if the value satisfies the predicate.
+/// Returns false if either the value or predicate threshold is NULL (per SQL standard).
 pub fn evaluate_predicate(predicate: &ColumnPredicate, value: &SqlValue) -> bool {
+    use std::cmp::Ordering;
+
     match predicate {
         ColumnPredicate::LessThan { value: threshold, .. } => {
-            compare_values(value, threshold) == std::cmp::Ordering::Less
+            compare_values(value, threshold).equals(Ordering::Less)
         }
         ColumnPredicate::GreaterThan { value: threshold, .. } => {
-            compare_values(value, threshold) == std::cmp::Ordering::Greater
+            compare_values(value, threshold).equals(Ordering::Greater)
         }
         ColumnPredicate::GreaterThanOrEqual { value: threshold, .. } => {
-            matches!(
-                compare_values(value, threshold),
-                std::cmp::Ordering::Greater | std::cmp::Ordering::Equal
-            )
+            compare_values(value, threshold).matches(&[Ordering::Greater, Ordering::Equal])
         }
         ColumnPredicate::LessThanOrEqual { value: threshold, .. } => {
-            matches!(
-                compare_values(value, threshold),
-                std::cmp::Ordering::Less | std::cmp::Ordering::Equal
-            )
+            compare_values(value, threshold).matches(&[Ordering::Less, Ordering::Equal])
         }
         ColumnPredicate::Equal { value: target, .. } => {
-            compare_values(value, target) == std::cmp::Ordering::Equal
+            compare_values(value, target).equals(Ordering::Equal)
         }
         ColumnPredicate::Between { low, high, .. } => {
-            let cmp_low = compare_values(value, low);
-            let cmp_high = compare_values(value, high);
-            let passes_low = matches!(cmp_low, std::cmp::Ordering::Greater | std::cmp::Ordering::Equal);
-            let passes_high = matches!(cmp_high, std::cmp::Ordering::Less | std::cmp::Ordering::Equal);
+            // Both bounds must pass - if either comparison involves NULL, it returns false
+            let passes_low = compare_values(value, low).matches(&[Ordering::Greater, Ordering::Equal]);
+            let passes_high = compare_values(value, high).matches(&[Ordering::Less, Ordering::Equal]);
             passes_low && passes_high
         }
     }

--- a/crates/vibesql-executor/src/select/columnar/simd_filter.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter.rs
@@ -13,6 +13,21 @@ use crate::simd::comparison::{
 
 use vibesql_types::SqlValue;
 
+/// Check if any value in a predicate is NULL
+/// Per SQL standard, any comparison with NULL returns UNKNOWN (treated as false in WHERE)
+fn predicate_contains_null(predicate: &ColumnPredicate) -> bool {
+    match predicate {
+        ColumnPredicate::LessThan { value, .. }
+        | ColumnPredicate::GreaterThan { value, .. }
+        | ColumnPredicate::GreaterThanOrEqual { value, .. }
+        | ColumnPredicate::LessThanOrEqual { value, .. }
+        | ColumnPredicate::Equal { value, .. } => matches!(value, SqlValue::Null),
+        ColumnPredicate::Between { low, high, .. } => {
+            matches!(low, SqlValue::Null) || matches!(high, SqlValue::Null)
+        }
+    }
+}
+
 /// Apply SIMD-accelerated filtering to a columnar batch
 ///
 /// Returns a new batch containing only the rows that pass all predicates.
@@ -75,6 +90,12 @@ fn evaluate_predicate_simd(
     batch: &ColumnarBatch,
     predicate: &ColumnPredicate,
 ) -> Result<Vec<bool>, ExecutorError> {
+    // NULL handling: any comparison with NULL returns false (UNKNOWN in SQL)
+    // Return all-false mask immediately if predicate contains NULL literal
+    if predicate_contains_null(predicate) {
+        return Ok(vec![false; batch.row_count()]);
+    }
+
     let column_idx = match predicate {
         ColumnPredicate::LessThan { column_idx, .. }
         | ColumnPredicate::GreaterThan { column_idx, .. }


### PR DESCRIPTION
## Summary

- Fix NULL comparisons returning incorrect results (all rows instead of no rows)
- Fix NULL comparisons throwing "Incompatible types for comparison" error
- Implement proper SQL standard NULL handling (UNKNOWN treated as FALSE in WHERE)

## Changes

1. **comparison.rs**: Add `CompareResult` enum with `Unknown` variant for NULL handling
2. **evaluation.rs**: Update `evaluate_predicate()` to use `CompareResult.equals/matches` methods
3. **simd_filter.rs**: Add `predicate_contains_null()` check to return all-false mask when predicate literal is NULL

## Test plan

- [x] Verify `WHERE NULL = col` returns 0 rows (was returning all rows)
- [x] Verify `WHERE NULL >= col0` returns 0 rows without error (was throwing error)
- [x] Verify `WHERE col < NULL` returns 0 rows without error
- [x] Run executor lib tests (1439 passed)

Closes #2610

🤖 Generated with [Claude Code](https://claude.com/claude-code)