### PR TITLE
fix: Support SQLite-compatible DROP VIEW behavior (allows dropping views with dependents)

### DIFF
--- a/crates/vibesql-ast/src/ddl/schema.rs
+++ b/crates/vibesql-ast/src/ddl/schema.rs
@@ -109,6 +109,11 @@ pub struct DropViewStmt {
     pub view_name: String,
     pub if_exists: bool,
     pub cascade: bool,
+    /// Whether RESTRICT was explicitly specified.
+    /// When neither CASCADE nor RESTRICT is specified, we use SQLite-compatible
+    /// behavior (allow dropping views even if dependents exist).
+    /// When RESTRICT is explicit, we enforce dependency checks.
+    pub restrict: bool,
 }
 
 /// CREATE TRIGGER statement

--- a/crates/vibesql-catalog/src/lib.rs
+++ b/crates/vibesql-catalog/src/lib.rs
@@ -28,7 +28,7 @@ pub use foreign_key::{ForeignKeyConstraint, ReferentialAction};
 pub use index::{IndexMetadata, IndexType, IndexedColumn, SortOrder};
 pub use privilege::PrivilegeGrant;
 pub use schema::Schema;
-pub use store::Catalog;
+pub use store::{Catalog, ViewDropBehavior};
 pub use table::TableSchema;
 pub use trigger::TriggerDefinition;
 pub use type_definition::{TypeAttribute, TypeDefinition, TypeDefinitionKind};

--- a/crates/vibesql-catalog/src/store/advanced/mod.rs
+++ b/crates/vibesql-catalog/src/store/advanced/mod.rs
@@ -34,3 +34,6 @@ mod views;
 // Note: All methods are defined as `impl Catalog` in each module,
 // so they are automatically available on the Catalog type.
 // No explicit re-exports are needed since the impls are applied directly.
+
+// Re-export ViewDropBehavior for use by external code
+pub use views::ViewDropBehavior;

--- a/crates/vibesql-catalog/src/store/advanced/views.rs
+++ b/crates/vibesql-catalog/src/store/advanced/views.rs
@@ -2,6 +2,17 @@
 
 use crate::{errors::CatalogError, view::ViewDefinition};
 
+/// Drop behavior for views
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ViewDropBehavior {
+    /// CASCADE: drop dependent views recursively
+    Cascade,
+    /// RESTRICT: fail if dependents exist
+    Restrict,
+    /// Silent: drop the view, ignore dependents (SQLite-compatible)
+    Silent,
+}
+
 impl super::super::Catalog {
     // ============================================================================
     // View Management Methods
@@ -44,8 +55,16 @@ impl super::super::Catalog {
         self.views.keys().cloned().collect()
     }
 
-    /// Drop a VIEW
-    pub fn drop_view(&mut self, name: &str, cascade: bool) -> Result<(), CatalogError> {
+    /// Drop a VIEW with specified behavior
+    ///
+    /// - `Cascade`: Drop dependent views recursively
+    /// - `Restrict`: Fail if dependents exist
+    /// - `Silent`: Drop the view, ignore dependents (SQLite-compatible)
+    pub fn drop_view_with_behavior(
+        &mut self,
+        name: &str,
+        behavior: ViewDropBehavior,
+    ) -> Result<(), CatalogError> {
         // Normalize the key for case-insensitive lookup
         let key = if self.case_sensitive_identifiers {
             name.to_string()
@@ -58,30 +77,49 @@ impl super::super::Catalog {
             return Err(CatalogError::ViewNotFound(name.to_string()));
         }
 
-        // If CASCADE, drop all dependent views recursively
-        if cascade {
-            // Find all views that depend on this view or table
-            // Use the original name for dependency checking (not the normalized key)
-            let dependent_views = self.find_dependent_views(name);
-            let views_to_drop = dependent_views.clone();
-            for dependent_view in views_to_drop {
-                // Recursively drop dependent views (they might have their own dependents)
-                self.drop_view(&dependent_view, true)?;
+        match behavior {
+            ViewDropBehavior::Cascade => {
+                // Find all views that depend on this view or table
+                // Use the original name for dependency checking (not the normalized key)
+                let dependent_views = self.find_dependent_views(name);
+                let views_to_drop = dependent_views.clone();
+                for dependent_view in views_to_drop {
+                    // Recursively drop dependent views (they might have their own dependents)
+                    self.drop_view_with_behavior(&dependent_view, ViewDropBehavior::Cascade)?;
+                }
             }
-        } else {
-            // If RESTRICT (not CASCADE): Check for dependent views and fail if any exist
-            let dependent_views = self.find_dependent_views(name);
-            if !dependent_views.is_empty() {
-                return Err(CatalogError::ViewInUse {
-                    view_name: name.to_string(),
-                    dependent_views,
-                });
+            ViewDropBehavior::Restrict => {
+                // Check for dependent views and fail if any exist
+                let dependent_views = self.find_dependent_views(name);
+                if !dependent_views.is_empty() {
+                    return Err(CatalogError::ViewInUse {
+                        view_name: name.to_string(),
+                        dependent_views,
+                    });
+                }
+            }
+            ViewDropBehavior::Silent => {
+                // SQLite-compatible behavior: just drop the view, don't check dependents
+                // Dependent views will fail at query time if they reference this view
             }
         }
 
         // Finally, drop the view itself using the normalized key
         self.views.remove(&key);
         Ok(())
+    }
+
+    /// Drop a VIEW (legacy method, defaults to RESTRICT behavior)
+    ///
+    /// This maintains backward compatibility with existing code.
+    /// Use `drop_view_with_behavior` for explicit control.
+    pub fn drop_view(&mut self, name: &str, cascade: bool) -> Result<(), CatalogError> {
+        let behavior = if cascade {
+            ViewDropBehavior::Cascade
+        } else {
+            ViewDropBehavior::Restrict
+        };
+        self.drop_view_with_behavior(name, behavior)
     }
 
     /// Find all views that depend on a given view or table

--- a/crates/vibesql-catalog/src/store/mod.rs
+++ b/crates/vibesql-catalog/src/store/mod.rs
@@ -32,6 +32,9 @@ mod schemas;
 mod session;
 mod tables;
 
+// Re-export types from submodules
+pub use advanced::ViewDropBehavior;
+
 /// Database catalog - manages all schemas and their objects.
 #[derive(Debug, Clone)]
 pub struct Catalog {

--- a/crates/vibesql-executor/src/advanced_objects/views.rs
+++ b/crates/vibesql-executor/src/advanced_objects/views.rs
@@ -1,6 +1,7 @@
 //! Executor for VIEW objects (SQL:1999)
 
 use vibesql_ast::*;
+use vibesql_catalog::ViewDropBehavior;
 use vibesql_storage::Database;
 
 use crate::errors::ExecutorError;
@@ -49,7 +50,19 @@ pub fn execute_drop_view(stmt: &DropViewStmt, db: &mut Database) -> Result<(), E
         return Ok(());
     }
 
-    // Handle CASCADE to drop dependent views
-    db.catalog.drop_view(&stmt.view_name, stmt.cascade)?;
+    // Determine drop behavior:
+    // - CASCADE: drop dependent views recursively
+    // - RESTRICT (explicit): fail if dependents exist
+    // - Neither: SQLite-compatible behavior (just drop, ignore dependents)
+    let drop_behavior = if stmt.cascade {
+        ViewDropBehavior::Cascade
+    } else if stmt.restrict {
+        ViewDropBehavior::Restrict
+    } else {
+        ViewDropBehavior::Silent // SQLite-compatible: allow dropping even with dependents
+    };
+
+    db.catalog
+        .drop_view_with_behavior(&stmt.view_name, drop_behavior)?;
     Ok(())
 }

--- a/crates/vibesql-executor/src/view_ddl.rs
+++ b/crates/vibesql-executor/src/view_ddl.rs
@@ -1,7 +1,7 @@
 //! View DDL executor
 
 use vibesql_ast::{CreateViewStmt, DropViewStmt};
-use vibesql_catalog::ViewDefinition;
+use vibesql_catalog::{ViewDefinition, ViewDropBehavior};
 use vibesql_storage::Database;
 
 use crate::errors::ExecutorError;
@@ -53,10 +53,22 @@ impl ViewExecutor {
         stmt: &DropViewStmt,
         database: &mut Database,
     ) -> Result<String, ExecutorError> {
+        // Determine drop behavior:
+        // - CASCADE: drop dependent views recursively
+        // - RESTRICT (explicit): fail if dependents exist
+        // - Neither: SQLite-compatible behavior (just drop, ignore dependents)
+        let drop_behavior = if stmt.cascade {
+            ViewDropBehavior::Cascade
+        } else if stmt.restrict {
+            ViewDropBehavior::Restrict
+        } else {
+            ViewDropBehavior::Silent // SQLite-compatible: allow dropping even with dependents
+        };
+
         // Drop the view
         let result = database
             .catalog
-            .drop_view(&stmt.view_name, stmt.cascade);
+            .drop_view_with_behavior(&stmt.view_name, drop_behavior);
 
         match result {
             Ok(()) => Ok(format!("View '{}' dropped", stmt.view_name)),

--- a/crates/vibesql-parser/src/parser/view.rs
+++ b/crates/vibesql-parser/src/parser/view.rs
@@ -108,15 +108,16 @@ impl Parser {
         let view_name = self.parse_qualified_identifier()?;
 
         // Check for optional CASCADE or RESTRICT
-        // SQL standard defaults to RESTRICT (do not drop dependent objects)
-        let cascade = if self.peek_keyword(Keyword::Cascade) {
+        // When neither is specified, we use SQLite-compatible behavior
+        // (allow dropping views even if dependents exist)
+        let (cascade, restrict) = if self.peek_keyword(Keyword::Cascade) {
             self.consume_keyword(Keyword::Cascade)?;
-            true
+            (true, false)
         } else if self.peek_keyword(Keyword::Restrict) {
             self.consume_keyword(Keyword::Restrict)?;
-            false
+            (false, true)
         } else {
-            false // RESTRICT is the SQL standard default
+            (false, false) // Neither specified - SQLite-compatible behavior
         };
 
         // Expect semicolon or EOF
@@ -124,6 +125,6 @@ impl Parser {
             self.advance();
         }
 
-        Ok(vibesql_ast::DropViewStmt { view_name, if_exists, cascade })
+        Ok(vibesql_ast::DropViewStmt { view_name, if_exists, cascade, restrict })
     }
 }

--- a/crates/vibesql-parser/src/tests/view.rs
+++ b/crates/vibesql-parser/src/tests/view.rs
@@ -123,6 +123,7 @@ fn test_drop_view_simple() {
         assert_eq!(stmt.view_name, "MY_VIEW");
         assert!(!stmt.if_exists);
         assert!(!stmt.cascade);
+        assert!(!stmt.restrict); // Neither CASCADE nor RESTRICT specified
     } else {
         panic!("Expected DropView statement");
     }
@@ -138,6 +139,7 @@ fn test_drop_view_if_exists() {
         assert_eq!(stmt.view_name, "MY_VIEW");
         assert!(stmt.if_exists);
         assert!(!stmt.cascade);
+        assert!(!stmt.restrict);
     } else {
         panic!("Expected DropView statement");
     }
@@ -153,6 +155,7 @@ fn test_drop_view_cascade() {
         assert_eq!(stmt.view_name, "MY_VIEW");
         assert!(!stmt.if_exists);
         assert!(stmt.cascade);
+        assert!(!stmt.restrict);
     } else {
         panic!("Expected DropView statement");
     }
@@ -167,7 +170,8 @@ fn test_drop_view_restrict() {
     if let Ok(vibesql_ast::Statement::DropView(stmt)) = result {
         assert_eq!(stmt.view_name, "MY_VIEW");
         assert!(!stmt.if_exists);
-        assert!(!stmt.cascade); // RESTRICT means cascade is false
+        assert!(!stmt.cascade);
+        assert!(stmt.restrict); // RESTRICT explicitly specified
     } else {
         panic!("Expected DropView statement");
     }
@@ -183,6 +187,7 @@ fn test_drop_view_if_exists_cascade() {
         assert_eq!(stmt.view_name, "MY_VIEW");
         assert!(stmt.if_exists);
         assert!(stmt.cascade);
+        assert!(!stmt.restrict);
     } else {
         panic!("Expected DropView statement");
     }


### PR DESCRIPTION
## Summary
- Implements SQLite-compatible late-binding semantics for DROP VIEW
- When neither CASCADE nor RESTRICT is explicitly specified, DROP VIEW now succeeds even if dependent views exist
- This matches SQLite's behavior where views can be dropped regardless of dependents

## Changes
- Added `restrict` field to `DropViewStmt` AST to distinguish between explicit RESTRICT and no option specified
- Created `ViewDropBehavior` enum with `Cascade`, `Restrict`, and `Silent` variants
- Updated parser to set restrict flag when RESTRICT keyword is explicit
- Updated catalog with `drop_view_with_behavior` method
- Updated both executor paths (`view_ddl.rs` and `advanced_objects/views.rs`)

## Behavior
| Command | Behavior |
|---------|----------|
| `DROP VIEW name CASCADE` | Drop dependent views recursively (unchanged) |
| `DROP VIEW name RESTRICT` | Fail if dependents exist (SQL standard) |
| `DROP VIEW name` | Allow dropping even with dependents (SQLite-compatible) |

## Test plan
- [x] SQLLogicTest `index/view/10/slt_good_1.test` passes
- [x] SQLLogicTest `index/view/10/slt_good_2.test` passes
- [x] SQLLogicTest `index/view/10/slt_good_3.test` passes
- [x] Parser tests for DROP VIEW pass (6 tests)
- [x] Cascade operations tests pass (5 tests)

Closes #2611

🤖 Generated with [Claude Code](https://claude.com/claude-code)