### PR TITLE
fix: Use schema-based column resolution in join reorder optimizer

### DIFF
--- a/crates/vibesql-executor/src/select/join/reorder.rs
+++ b/crates/vibesql-executor/src/select/join/reorder.rs
@@ -121,6 +121,8 @@ pub struct JoinOrderAnalyzer {
     edges: Vec<JoinEdge>,
     /// Selectivity information for each predicate
     selectivity: HashMap<String, Selectivity>,
+    /// Schema-based column-to-table mapping for resolving unqualified columns
+    column_to_table: HashMap<String, String>,
 }
 
 impl Default for JoinOrderAnalyzer {
@@ -132,7 +134,27 @@ impl Default for JoinOrderAnalyzer {
 impl JoinOrderAnalyzer {
     /// Create a new join order analyzer
     pub fn new() -> Self {
-        Self { tables: HashMap::new(), edges: Vec::new(), selectivity: HashMap::new() }
+        Self {
+            tables: HashMap::new(),
+            edges: Vec::new(),
+            selectivity: HashMap::new(),
+            column_to_table: HashMap::new(),
+        }
+    }
+
+    /// Create a new join order analyzer with schema-based column resolution
+    pub fn with_column_map(column_to_table: HashMap<String, String>) -> Self {
+        Self {
+            tables: HashMap::new(),
+            edges: Vec::new(),
+            selectivity: HashMap::new(),
+            column_to_table,
+        }
+    }
+
+    /// Set the column-to-table mapping for schema-based resolution
+    pub fn set_column_map(&mut self, column_to_table: HashMap<String, String>) {
+        self.column_to_table = column_to_table;
     }
 
     /// Register all tables involved in the query
@@ -338,9 +360,38 @@ impl JoinOrderAnalyzer {
         }
     }
 
-    /// Infer table name from column name using prefix matching and abbreviations
-    /// This mirrors the logic in scan/reorder.rs for consistency
+    /// Infer table name from column name using schema-based lookup with TPC-H prefix fallback
+    ///
+    /// Primary resolution uses the schema-based column-to-table map (if populated).
+    /// Falls back to TPC-H prefix matching only if schema lookup fails.
     fn infer_table_from_column(&self, column: &str, tables: &HashSet<String>) -> Option<String> {
+        // Primary: Schema-based lookup (uses actual database schema)
+        if !self.column_to_table.is_empty() {
+            let col_lower = column.to_lowercase();
+            if let Some(table) = self.column_to_table.get(&col_lower) {
+                if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+                    eprintln!("[ANALYZER] Schema lookup: {} -> {}", column, table);
+                }
+                // Verify the table is in our set (could be aliased)
+                if tables.contains(table) {
+                    return Some(table.clone());
+                }
+                // Try case-insensitive match
+                for t in tables {
+                    if t.eq_ignore_ascii_case(table) {
+                        return Some(t.clone());
+                    }
+                }
+                if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+                    eprintln!("[ANALYZER] Warning: Table {} not in tables set {:?}", table, tables);
+                }
+            } else if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+                eprintln!("[ANALYZER] Warning: Column {} not found in schema map (available: {:?})",
+                    col_lower, self.column_to_table.keys().take(10).collect::<Vec<_>>());
+            }
+        }
+
+        // Fallback: TPC-H prefix pattern (kept for compatibility with TPC-H queries)
         let col_upper = column.to_uppercase();
 
         // Extract prefix before first underscore (e.g., "L_SUPPKEY" -> "L")

--- a/crates/vibesql-executor/src/select/scan/reorder/graph.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/graph.rs
@@ -1,6 +1,6 @@
 //! Join graph construction and table reference analysis
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use vibesql_ast::{Expression, FromClause, JoinType};
 
 /// Information about a table extracted from a FROM clause
@@ -92,163 +92,111 @@ pub(super) fn extract_conditions_with_types(from: &FromClause, conditions: &mut 
 ///
 /// This function recursively walks an expression tree and collects all table names
 /// mentioned in column references. Used to determine which tables a join condition connects.
-/// Handles both explicit table qualifiers and infers tables from column name prefixes.
+///
+/// Uses schema-based column resolution when a column_to_table map is provided,
+/// falling back to TPC-H prefix heuristics for unresolved columns.
 ///
 /// # Parameters
 /// - `expr`: The expression to analyze
 /// - `output`: HashSet to populate with referenced table names
-/// - `available_tables`: Set of FROM clause tables (for inferring unqualified columns)
+/// - `available_tables`: Set of FROM clause tables
+/// - `column_to_table`: Optional schema-based column-to-table mapping
 pub(super) fn extract_referenced_tables(
     expr: &Expression,
     output: &mut HashSet<String>,
     available_tables: &HashSet<String>,
+) {
+    // Use empty map for legacy compatibility - new code should use extract_referenced_tables_with_schema
+    let empty_map = HashMap::new();
+    extract_referenced_tables_with_schema(expr, output, available_tables, &empty_map);
+}
+
+/// Extract all table names referenced in an expression using schema-based column resolution
+///
+/// This is the preferred method that uses actual database schema to resolve unqualified columns.
+/// Falls back to TPC-H prefix heuristics only when schema lookup fails.
+///
+/// # Parameters
+/// - `expr`: The expression to analyze
+/// - `output`: HashSet to populate with referenced table names
+/// - `available_tables`: Set of FROM clause tables
+/// - `column_to_table`: Schema-based column-to-table mapping
+pub(super) fn extract_referenced_tables_with_schema(
+    expr: &Expression,
+    output: &mut HashSet<String>,
+    available_tables: &HashSet<String>,
+    column_to_table: &HashMap<String, String>,
 ) {
     match expr {
         Expression::ColumnRef { table: Some(table), .. } => {
             output.insert(table.to_lowercase());
         }
         Expression::ColumnRef { table: None, column } => {
-            // Infer table from column name using multiple matching strategies
-            // This handles different naming conventions:
-            // 1. SQLLogicTest suffix pattern: column "a1" → table "t1" (numeric suffix)
-            // 2. TPC-H prefix pattern: column "l_orderkey" → table "lineitem" (prefix before underscore)
-            // 3. Abbreviation match: column "ps_suppkey" → table "partsupp"
-
-            // --- Tier 1: SQLLogicTest suffix pattern ---
-            // Columns like "a1", "b2", "x9" where the trailing digit indicates the table
-            // This is common in SQLLogicTest files with tables t1, t2, ..., t9
-            let mut found = false;
-            if let Some(last_char) = column.chars().last() {
-                if last_char.is_ascii_digit() {
-                    let table_candidate = format!("t{}", last_char);
-                    for table in available_tables {
-                        if table.eq_ignore_ascii_case(&table_candidate) {
-                            output.insert(table.clone());
-                            found = true;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if found {
-                return; // Found via suffix pattern, no need for other strategies
-            }
-
-            // --- Tier 2: TPC-H prefix pattern ---
-            // Extract prefix: everything before the first underscore
-            let prefix = column
-                .split('_')
-                .next()
-                .unwrap_or("");
-
-            if !prefix.is_empty() {
-                // Try to find a FROM clause table that starts with this prefix (case-insensitive)
-                let prefix_upper = prefix.to_uppercase();
-
-                // Try three matching strategies in order of specificity:
-                // 1. Exact match (e.g., "P" == "P")
-                // 2. Prefix match (e.g., "P" matches "PART")
-                // 3. Abbreviation match (e.g., "PS" matches "partsupp")
-                let mut exact_match: Option<String> = None;
-                let mut prefix_matches = Vec::new();
-                let mut abbrev_matches = Vec::new();
-
-                for table in available_tables {
-                    let table_upper = table.to_uppercase();
-                    if table_upper == prefix_upper {
-                        exact_match = Some(table.clone());
-                        break;  // Exact match takes priority
-                    } else if table_upper.starts_with(&prefix_upper) {
-                        prefix_matches.push(table.clone());
-                    } else {
-                        // Check abbreviation match (e.g., "ps" → "partsupp")
-                        let abbrev = super::utils::get_table_abbreviation(table);
-                        if abbrev.to_uppercase() == prefix_upper {
-                            abbrev_matches.push(table.clone());
-                        }
-                    }
-                }
-
-                if let Some(table) = exact_match {
-                    output.insert(table);
-                } else if !prefix_matches.is_empty() {
-                    // Sort by length ascending to prefer shorter, more specific matches
-                    // This ensures "PART" matches before "PARTSUPP" for prefix "P"
-                    prefix_matches.sort_by_key(|t| t.len());
-                    if let Some(table) = prefix_matches.into_iter().next() {
-                        output.insert(table);
-                    }
-                } else if !abbrev_matches.is_empty() {
-                    // Use abbreviation match as last resort
-                    // Sort by length to prefer shorter names if multiple match
-                    abbrev_matches.sort_by_key(|t| t.len());
-                    if let Some(table) = abbrev_matches.into_iter().next() {
-                        output.insert(table);
-                    }
-                }
+            // Use schema-based lookup with TPC-H fallback
+            if let Some(table) = super::utils::resolve_column_with_fallback(column, column_to_table, available_tables) {
+                output.insert(table.to_lowercase());
             }
         }
         Expression::BinaryOp { left, right, .. } => {
-            extract_referenced_tables(left, output, available_tables);
-            extract_referenced_tables(right, output, available_tables);
+            extract_referenced_tables_with_schema(left, output, available_tables, column_to_table);
+            extract_referenced_tables_with_schema(right, output, available_tables, column_to_table);
         }
         Expression::UnaryOp { expr, .. } => {
-            extract_referenced_tables(expr, output, available_tables);
+            extract_referenced_tables_with_schema(expr, output, available_tables, column_to_table);
         }
         Expression::Function { args, .. } | Expression::AggregateFunction { args, .. } => {
             for arg in args {
-                extract_referenced_tables(arg, output, available_tables);
+                extract_referenced_tables_with_schema(arg, output, available_tables, column_to_table);
             }
         }
         Expression::InList { expr, values, .. } => {
-            extract_referenced_tables(expr, output, available_tables);
+            extract_referenced_tables_with_schema(expr, output, available_tables, column_to_table);
             for item in values {
-                extract_referenced_tables(item, output, available_tables);
+                extract_referenced_tables_with_schema(item, output, available_tables, column_to_table);
             }
         }
         Expression::Between { expr, low, high, .. } => {
-            extract_referenced_tables(expr, output, available_tables);
-            extract_referenced_tables(low, output, available_tables);
-            extract_referenced_tables(high, output, available_tables);
+            extract_referenced_tables_with_schema(expr, output, available_tables, column_to_table);
+            extract_referenced_tables_with_schema(low, output, available_tables, column_to_table);
+            extract_referenced_tables_with_schema(high, output, available_tables, column_to_table);
         }
         Expression::Case { operand, when_clauses, else_result } => {
             if let Some(op) = operand {
-                extract_referenced_tables(op, output, available_tables);
+                extract_referenced_tables_with_schema(op, output, available_tables, column_to_table);
             }
             for clause in when_clauses {
                 for condition in &clause.conditions {
-                    extract_referenced_tables(condition, output, available_tables);
+                    extract_referenced_tables_with_schema(condition, output, available_tables, column_to_table);
                 }
-                extract_referenced_tables(&clause.result, output, available_tables);
+                extract_referenced_tables_with_schema(&clause.result, output, available_tables, column_to_table);
             }
             if let Some(else_res) = else_result {
-                extract_referenced_tables(else_res, output, available_tables);
+                extract_referenced_tables_with_schema(else_res, output, available_tables, column_to_table);
             }
         }
         Expression::IsNull { expr, .. } => {
-            extract_referenced_tables(expr, output, available_tables);
+            extract_referenced_tables_with_schema(expr, output, available_tables, column_to_table);
         }
         Expression::Cast { expr, .. } => {
-            extract_referenced_tables(expr, output, available_tables);
+            extract_referenced_tables_with_schema(expr, output, available_tables, column_to_table);
         }
         Expression::In { expr, .. } => {
-            extract_referenced_tables(expr, output, available_tables);
+            extract_referenced_tables_with_schema(expr, output, available_tables, column_to_table);
             // Note: We don't traverse into subqueries as they reference different tables
         }
         Expression::Position { substring, string, .. } => {
-            extract_referenced_tables(substring, output, available_tables);
-            extract_referenced_tables(string, output, available_tables);
+            extract_referenced_tables_with_schema(substring, output, available_tables, column_to_table);
+            extract_referenced_tables_with_schema(string, output, available_tables, column_to_table);
         }
         Expression::Trim { removal_char, string, .. } => {
             if let Some(char_expr) = removal_char {
-                extract_referenced_tables(char_expr, output, available_tables);
+                extract_referenced_tables_with_schema(char_expr, output, available_tables, column_to_table);
             }
-            extract_referenced_tables(string, output, available_tables);
+            extract_referenced_tables_with_schema(string, output, available_tables, column_to_table);
         }
         Expression::Like { expr, pattern, .. } => {
-            extract_referenced_tables(expr, output, available_tables);
-            extract_referenced_tables(pattern, output, available_tables);
+            extract_referenced_tables_with_schema(expr, output, available_tables, column_to_table);
+            extract_referenced_tables_with_schema(pattern, output, available_tables, column_to_table);
         }
         // For other expressions (literals, wildcards, subqueries, etc.), no direct column refs to extract
         _ => {}

--- a/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
@@ -48,11 +48,24 @@ where
     let table_names: Vec<String> =
         table_refs.iter().map(|t| t.alias.clone().unwrap_or_else(|| t.name.clone())).collect();
 
-    let mut analyzer = JoinOrderAnalyzer::new();
+    // Step 3.5: Build schema-based column-to-table mapping
+    // This uses actual database schema to resolve unqualified column references
+    let column_to_table = utils::build_column_to_table_map(database, &table_names, &table_refs, cte_results);
+
+    // Create analyzer with schema-based column resolution
+    let mut analyzer = JoinOrderAnalyzer::with_column_map(column_to_table.clone());
     analyzer.register_tables(table_names.clone());
 
     // Combine table names into a set for predicate analysis (normalize to lowercase)
     let table_set: HashSet<String> = table_names.iter().map(|t| t.to_lowercase()).collect();
+
+    if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+        eprintln!("[JOIN_REORDER] Schema-based column mapping: {} columns resolved from {} tables",
+            column_to_table.len(), table_names.len());
+        if column_to_table.is_empty() && !table_names.is_empty() {
+            eprintln!("[JOIN_REORDER] Warning: No schema columns found for tables: {:?}", table_names);
+        }
+    }
 
     // Step 4: Analyze join conditions to extract edges with their join types
     for condition_with_type in &join_conditions_with_types {
@@ -70,10 +83,8 @@ where
             eprintln!("[JOIN_REORDER] Table set: {:?}", table_set);
         }
 
-        // Extract equijoin conditions from WHERE clause manually
-        // This is simpler and more reliable than using decompose_where_clause,
-        // which requires a full schema with column information
-        let equijoins = predicates::extract_where_equijoins(where_expr, &table_set);
+        // Extract equijoin conditions from WHERE clause using schema-based column resolution
+        let equijoins = predicates::extract_where_equijoins_with_schema(where_expr, &table_set, &column_to_table);
 
         if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
             eprintln!("[JOIN_REORDER] Extracted {} WHERE equijoins", equijoins.len());
@@ -176,9 +187,9 @@ where
                     continue;
                 }
 
-                // Extract tables referenced in this condition
+                // Extract tables referenced in this condition using schema-based column resolution
                 let mut referenced_tables = HashSet::new();
-                graph::extract_referenced_tables(condition, &mut referenced_tables, &table_set);
+                graph::extract_referenced_tables_with_schema(condition, &mut referenced_tables, &table_set, &column_to_table);
 
                 // Check if condition connects the new table with any already-joined table
                 // Condition is applicable if it references the new table AND at least one joined table
@@ -195,6 +206,17 @@ where
             if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
                 eprintln!("[JOIN_REORDER] Joining {} to {:?}, found {} applicable conditions",
                     table_name, joined_tables, applicable_conditions.len());
+                eprintln!("[JOIN_REORDER]   join_conditions total: {}", join_conditions.len());
+                for (idx, cond) in join_conditions.iter().enumerate() {
+                    if !applied_conditions.contains(&idx) {
+                        let mut refs = HashSet::new();
+                        graph::extract_referenced_tables_with_schema(cond, &mut refs, &table_set, &column_to_table);
+                        eprintln!("[JOIN_REORDER]   cond[{}] refs: {:?}, new_table: {}, matches_new: {}, matches_joined: {}",
+                            idx, refs, table_name.to_lowercase(),
+                            refs.contains(&table_name.to_lowercase()),
+                            refs.iter().any(|t| joined_tables.contains(t)));
+                    }
+                }
             }
 
             // Always use INNER join for comma-list joins, even when applicable_conditions is empty.

--- a/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 use vibesql_ast::{BinaryOperator, Expression};
+use super::utils::resolve_column_with_fallback;
 
 /// Extract table-local predicates from a WHERE clause expression
 ///
@@ -111,11 +112,14 @@ pub(super) fn extract_in_predicates_from_or(
     result
 }
 
-/// Extract equijoin conditions from a WHERE clause expression
+/// Extract equijoin conditions from a WHERE clause expression using schema-based column resolution
 ///
-/// Recursively walks the expression tree looking for binary equality operations
-/// that reference columns from two different tables.
-pub(super) fn extract_where_equijoins(expr: &Expression, tables: &HashSet<String>) -> Vec<Expression> {
+/// This is the preferred method that uses actual database schema to resolve unqualified columns.
+pub(super) fn extract_where_equijoins_with_schema(
+    expr: &Expression,
+    tables: &HashSet<String>,
+    column_to_table: &HashMap<String, String>,
+) -> Vec<Expression> {
     let mut equijoins = Vec::new();
 
     // Helper function to collect all branches of an OR expression into a flat list
@@ -164,13 +168,14 @@ pub(super) fn extract_where_equijoins(expr: &Expression, tables: &HashSet<String
     fn extract_recursive(
         expr: &Expression,
         tables: &HashSet<String>,
+        column_to_table: &HashMap<String, String>,
         equijoins: &mut Vec<Expression>,
     ) {
         match expr {
             // Binary AND: recurse into both sides
             Expression::BinaryOp { op: BinaryOperator::And, left, right } => {
-                extract_recursive(left, tables, equijoins);
-                extract_recursive(right, tables, equijoins);
+                extract_recursive(left, tables, column_to_table, equijoins);
+                extract_recursive(right, tables, column_to_table, equijoins);
             }
             // Binary OR: extract common equijoins from all branches
             Expression::BinaryOp { op: BinaryOperator::Or, .. } => {
@@ -190,7 +195,7 @@ pub(super) fn extract_where_equijoins(expr: &Expression, tables: &HashSet<String
                 let mut branch_equijoins: Vec<Vec<Expression>> = Vec::new();
                 for branch in &branches {
                     let mut branch_eqs = Vec::new();
-                    extract_recursive(branch, tables, &mut branch_eqs);
+                    extract_recursive(branch, tables, column_to_table, &mut branch_eqs);
                     branch_equijoins.push(branch_eqs);
                 }
 
@@ -210,86 +215,20 @@ pub(super) fn extract_where_equijoins(expr: &Expression, tables: &HashSet<String
             // Binary EQUAL: check if it's an equijoin
             Expression::BinaryOp { op: BinaryOperator::Equal, left, right } => {
                 // Check if both sides are column references
-                // Handle both explicit table qualifiers and implicit (prefix-based) references
-
-                // Helper closure to infer table from column name
-                // Uses multi-tier matching for different naming conventions:
-                // 1) SQLLogicTest suffix pattern: column "a1" → table "t1" (numeric suffix)
-                // 2) TPC-H prefix pattern: column "l_orderkey" → table "lineitem" (prefix before underscore)
-                // 3) Abbreviation match: column "ps_suppkey" → table "partsupp"
-                let infer_table = |column: &str| -> Option<String> {
-                    // --- Tier 1: SQLLogicTest suffix pattern ---
-                    // Columns like "a1", "b2", "x9" where the trailing digit indicates the table
-                    // This is common in SQLLogicTest files with tables t1, t2, ..., t9
-                    if let Some(last_char) = column.chars().last() {
-                        if last_char.is_ascii_digit() {
-                            let table_candidate = format!("t{}", last_char);
-                            if tables.contains(&table_candidate) || tables.contains(&table_candidate.to_uppercase()) {
-                                // Found a table matching the suffix pattern
-                                for table in tables {
-                                    if table.eq_ignore_ascii_case(&table_candidate) {
-                                        return Some(table.clone());
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // --- Tier 2: TPC-H prefix pattern ---
-                    let prefix = column.split('_').next().unwrap_or("").to_uppercase();
-                    if prefix.is_empty() {
-                        return None;
-                    }
-
-                    // Collect all matching tables (exact, prefix, and abbreviation matches)
-                    let mut exact_matches = Vec::new();
-                    let mut prefix_matches = Vec::new();
-                    let mut abbrev_matches = Vec::new();
-
-                    for table in tables {
-                        let table_upper = table.to_uppercase();
-                        if table_upper == prefix {
-                            exact_matches.push(table.clone());
-                        } else if table_upper.starts_with(&prefix) {
-                            prefix_matches.push(table.clone());
-                        } else {
-                            // Check abbreviation match (e.g., "ps" → "partsupp")
-                            let abbrev = super::utils::get_table_abbreviation(table);
-                            if abbrev.to_uppercase() == prefix {
-                                abbrev_matches.push(table.clone());
-                            }
-                        }
-                    }
-
-                    // Prefer exact match (e.g., "P" -> "P" table if it exists)
-                    if !exact_matches.is_empty() {
-                        return exact_matches.into_iter().next();
-                    }
-
-                    // For prefix matches, prefer shorter (more specific) tables
-                    // This ensures "PART" matches before "PARTSUPP" for prefix "P"
-                    if !prefix_matches.is_empty() {
-                        prefix_matches.sort_by_key(|t| t.len());
-                        return prefix_matches.into_iter().next();
-                    }
-
-                    // Use abbreviation match as last resort (e.g., "PS" -> "partsupp")
-                    if !abbrev_matches.is_empty() {
-                        abbrev_matches.sort_by_key(|t| t.len());
-                        return abbrev_matches.into_iter().next();
-                    }
-
-                    None
-                };
+                // Use schema-based lookup with TPC-H fallback
 
                 let left_table = match left.as_ref() {
                     Expression::ColumnRef { table: Some(t), .. } => Some(t.to_lowercase()),
-                    Expression::ColumnRef { table: None, column } => infer_table(column),
+                    Expression::ColumnRef { table: None, column } => {
+                        resolve_column_with_fallback(column, column_to_table, tables)
+                    }
                     _ => None,
                 };
                 let right_table = match right.as_ref() {
                     Expression::ColumnRef { table: Some(t), .. } => Some(t.to_lowercase()),
-                    Expression::ColumnRef { table: None, column } => infer_table(column),
+                    Expression::ColumnRef { table: None, column } => {
+                        resolve_column_with_fallback(column, column_to_table, tables)
+                    }
                     _ => None,
                 };
 
@@ -316,6 +255,6 @@ pub(super) fn extract_where_equijoins(expr: &Expression, tables: &HashSet<String
         }
     }
 
-    extract_recursive(expr, tables, &mut equijoins);
+    extract_recursive(expr, tables, column_to_table, &mut equijoins);
     equijoins
 }

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -1,8 +1,9 @@
 //! Utility functions for join reordering
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use vibesql_ast::FromClause;
 use crate::schema::CombinedSchema;
+use crate::select::cte::CteResult;
 
 /// Check if join reordering optimization should be applied
 ///
@@ -171,4 +172,195 @@ pub(super) fn build_column_permutation(
     }
 
     permutation
+}
+
+/// Build a column-to-table mapping using actual database schema
+///
+/// This is the proper schema-based column resolution that replaces heuristic
+/// pattern matching. For each unqualified column reference, we look up which
+/// table(s) contain that column using the actual database schema.
+///
+/// # Parameters
+/// - `database`: The database to query for table schemas
+/// - `table_names`: The tables in the FROM clause (may be aliases)
+/// - `table_refs`: Table references with name/alias info for resolving CTEs and subqueries
+/// - `cte_results`: CTE results for looking up CTE schemas
+///
+/// # Returns
+/// A HashMap mapping column names (lowercase) to the table name that contains them.
+/// If a column exists in multiple tables, it's ambiguous and not included (user must qualify it).
+pub(super) fn build_column_to_table_map(
+    database: &vibesql_storage::Database,
+    table_names: &[String],
+    table_refs: &[super::graph::TableRef],
+    cte_results: &HashMap<String, CteResult>,
+) -> HashMap<String, String> {
+    let mut column_to_table: HashMap<String, Vec<String>> = HashMap::new();
+
+    if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+        eprintln!("[JOIN_REORDER] build_column_to_table_map: database.tables.keys(): {:?}",
+            database.tables.keys().collect::<Vec<_>>());
+        eprintln!("[JOIN_REORDER] build_column_to_table_map: table_refs: {:?}",
+            table_refs.iter().map(|r| (&r.name, &r.alias)).collect::<Vec<_>>());
+    }
+
+    for table_name in table_names {
+        let table_lower = table_name.to_lowercase();
+
+        // Find the corresponding TableRef to check if it's a subquery/CTE
+        let table_ref = table_refs.iter().find(|r| {
+            r.alias.as_ref().map(|a| a.to_lowercase()) == Some(table_lower.clone())
+                || r.name.to_lowercase() == table_lower
+        });
+
+        // Get column names for this table
+        let column_names: Vec<String> = if let Some(tr) = table_ref {
+            if tr.is_subquery {
+                // For subqueries, we don't have schema info readily available
+                // Skip for now - subqueries need explicit qualification anyway
+                continue;
+            } else if let Some(cte_result) = cte_results.get(&tr.name) {
+                // CTE: get columns from CTE result schema (CteResult is a tuple: (TableSchema, Vec<Row>))
+                cte_result.0.columns.iter().map(|c| c.name.to_lowercase()).collect()
+            } else {
+                // Regular table: get columns from database
+                // Try multiple case variations and schema prefixes since database keys may vary
+                let actual_table_name = &tr.name;
+                let public_prefixed = format!("public.{}", actual_table_name);
+                let table = database.tables.get(actual_table_name)
+                    .or_else(|| database.tables.get(&actual_table_name.to_lowercase()))
+                    .or_else(|| database.tables.get(&actual_table_name.to_uppercase()))
+                    .or_else(|| database.tables.get(&public_prefixed))
+                    .or_else(|| database.tables.get(&public_prefixed.to_lowercase()))
+                    .or_else(|| database.tables.get(&public_prefixed.to_uppercase()))
+                    .or_else(|| {
+                        // Case-insensitive search through all tables (handles schema.table format)
+                        let target = actual_table_name.to_lowercase();
+                        database.tables.iter().find(|(k, _)| {
+                            let key_lower = k.to_lowercase();
+                            key_lower == target || key_lower.ends_with(&format!(".{}", target))
+                        }).map(|(_, v)| v)
+                    });
+
+                if let Some(t) = table {
+                    t.schema.columns.iter().map(|c| c.name.to_lowercase()).collect()
+                } else {
+                    // Table not found in database - might be an alias or CTE
+                    continue;
+                }
+            }
+        } else {
+            // Direct table lookup without TableRef
+            let public_prefixed = format!("public.{}", table_name);
+            let table = database.tables.get(table_name)
+                .or_else(|| database.tables.get(&table_lower))
+                .or_else(|| database.tables.get(&table_name.to_uppercase()))
+                .or_else(|| database.tables.get(&public_prefixed))
+                .or_else(|| database.tables.get(&public_prefixed.to_lowercase()))
+                .or_else(|| database.tables.get(&public_prefixed.to_uppercase()))
+                .or_else(|| {
+                    // Case-insensitive search through all tables (handles schema.table format)
+                    database.tables.iter().find(|(k, _)| {
+                        let key_lower = k.to_lowercase();
+                        key_lower == table_lower || key_lower.ends_with(&format!(".{}", table_lower))
+                    }).map(|(_, v)| v)
+                });
+
+            if let Some(t) = table {
+                t.schema.columns.iter().map(|c| c.name.to_lowercase()).collect()
+            } else {
+                continue;
+            }
+        };
+
+        // Add columns to the mapping
+        for col_name in column_names {
+            column_to_table.entry(col_name).or_default().push(table_lower.clone());
+        }
+    }
+
+    // Convert to single-table mapping, excluding ambiguous columns
+    let mut result: HashMap<String, String> = HashMap::new();
+    for (col, tables) in column_to_table {
+        if tables.len() == 1 {
+            result.insert(col, tables.into_iter().next().unwrap());
+        }
+        // Ambiguous columns (in multiple tables) are not included
+        // This forces the user to qualify them explicitly
+    }
+
+    result
+}
+
+/// Resolve an unqualified column to its table using schema-based lookup
+///
+/// Returns the table name if the column is found in exactly one table,
+/// None otherwise (column not found or ambiguous).
+pub(super) fn resolve_column_to_table(
+    column: &str,
+    column_to_table: &HashMap<String, String>,
+) -> Option<String> {
+    column_to_table.get(&column.to_lowercase()).cloned()
+}
+
+/// Resolve an unqualified column using schema-based lookup with TPC-H heuristic fallback
+///
+/// Primary resolution uses the schema-based column-to-table map.
+/// Falls back to TPC-H prefix matching ONLY if schema lookup fails.
+/// The SQLLogicTest suffix pattern has been removed as it was test-specific.
+///
+/// # Parameters
+/// - `column`: The unqualified column name
+/// - `column_to_table`: Schema-based column-to-table mapping
+/// - `available_tables`: Set of FROM clause tables (for fallback heuristics)
+pub(super) fn resolve_column_with_fallback(
+    column: &str,
+    column_to_table: &HashMap<String, String>,
+    available_tables: &HashSet<String>,
+) -> Option<String> {
+    // Primary: Schema-based lookup
+    if let Some(table) = resolve_column_to_table(column, column_to_table) {
+        return Some(table);
+    }
+
+    // Fallback: TPC-H prefix pattern only (test-specific heuristics removed)
+    // This handles TPC-H queries where columns like l_orderkey → lineitem
+    let prefix = column.split('_').next().unwrap_or("").to_uppercase();
+    if prefix.is_empty() {
+        return None;
+    }
+
+    // Try exact match, prefix match, then abbreviation match
+    let mut exact_match: Option<String> = None;
+    let mut prefix_matches = Vec::new();
+    let mut abbrev_matches = Vec::new();
+
+    for table in available_tables {
+        let table_upper = table.to_uppercase();
+        if table_upper == prefix {
+            exact_match = Some(table.clone());
+            break;
+        } else if table_upper.starts_with(&prefix) {
+            prefix_matches.push(table.clone());
+        } else {
+            let abbrev = get_table_abbreviation(table);
+            if abbrev.to_uppercase() == prefix {
+                abbrev_matches.push(table.clone());
+            }
+        }
+    }
+
+    if let Some(table) = exact_match {
+        return Some(table);
+    }
+    if !prefix_matches.is_empty() {
+        prefix_matches.sort_by_key(|t| t.len());
+        return prefix_matches.into_iter().next();
+    }
+    if !abbrev_matches.is_empty() {
+        abbrev_matches.sort_by_key(|t| t.len());
+        return abbrev_matches.into_iter().next();
+    }
+
+    None
 }


### PR DESCRIPTION
## Summary

- Fixes `select4.test` hanging indefinitely by properly resolving unqualified column references
- Uses actual database schema metadata to build column-to-table mapping instead of heuristic pattern matching
- Key fix: Use `extract_referenced_tables_with_schema` instead of `extract_referenced_tables` in optimizer.rs:192

## Root Cause

The join reorder optimizer was using heuristic pattern matching to resolve unqualified column references (e.g., inferring `l_orderkey` belongs to `lineitem` based on the `l_` prefix). This failed for SQLLogicTest naming conventions where columns are named `A1`, `E1`, etc. without any table-identifying prefix.

When equijoin conditions couldn't be properly attributed to tables, the optimizer couldn't find applicable conditions when joining tables, leading to Cartesian products and memory exhaustion.

## Solution

Build a `column_to_table` mapping from actual database schema at the start of join reordering. This mapping is then used throughout the optimizer to resolve unqualified column references:

1. `build_column_to_table_map()` in utils.rs queries database schema for each table
2. `extract_referenced_tables_with_schema()` uses the mapping to resolve column references
3. `extract_where_equijoins_with_schema()` properly identifies equijoin conditions

## Test plan

- [x] `select4.test` completes in ~224 seconds instead of hanging
- [x] All 4 SQLLogicTest files pass: select1.test, select3.test, select4.test, slt_good_29.test
- [x] No compiler warnings

Closes #2597

🤖 Generated with [Claude Code](https://claude.com/claude-code)