### PR TITLE
refactor: Remove TPC-H specific heuristics from join reorder optimizer

### DIFF
--- a/crates/vibesql-executor/src/select/join/reorder.rs
+++ b/crates/vibesql-executor/src/select/join/reorder.rs
@@ -37,20 +37,6 @@ use std::{
 
 use vibesql_ast::{BinaryOperator, Expression};
 
-/// Get standard table abbreviation for TPC-H tables
-/// This mirrors the abbreviation logic in scan/reorder.rs
-fn get_table_abbreviation(table_name: &str) -> String {
-    let table_lower = table_name.to_lowercase();
-    // Known TPC-H table abbreviations
-    match table_lower.as_str() {
-        "partsupp" => "ps".to_string(), // Special case: compound abbreviation
-        _ => {
-            // Default: use first letter as abbreviation
-            table_name.chars().next().map(|c| c.to_lowercase().to_string()).unwrap_or_default()
-        }
-    }
-}
-
 /// Information about a table and its predicates
 #[derive(Debug, Clone)]
 struct TableInfo {
@@ -360,73 +346,34 @@ impl JoinOrderAnalyzer {
         }
     }
 
-    /// Infer table name from column name using schema-based lookup with TPC-H prefix fallback
+    /// Infer table name from column name using schema-based lookup
     ///
-    /// Primary resolution uses the schema-based column-to-table map (if populated).
-    /// Falls back to TPC-H prefix matching only if schema lookup fails.
+    /// Uses the schema-based column-to-table map to resolve column references.
+    /// TPC-H prefix heuristics have been removed - all column resolution now
+    /// relies solely on actual database schema metadata.
     fn infer_table_from_column(&self, column: &str, tables: &HashSet<String>) -> Option<String> {
-        // Primary: Schema-based lookup (uses actual database schema)
-        if !self.column_to_table.is_empty() {
-            let col_lower = column.to_lowercase();
-            if let Some(table) = self.column_to_table.get(&col_lower) {
-                if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
-                    eprintln!("[ANALYZER] Schema lookup: {} -> {}", column, table);
-                }
-                // Verify the table is in our set (could be aliased)
-                if tables.contains(table) {
-                    return Some(table.clone());
-                }
-                // Try case-insensitive match
-                for t in tables {
-                    if t.eq_ignore_ascii_case(table) {
-                        return Some(t.clone());
-                    }
-                }
-                if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
-                    eprintln!("[ANALYZER] Warning: Table {} not in tables set {:?}", table, tables);
-                }
-            } else if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
-                eprintln!("[ANALYZER] Warning: Column {} not found in schema map (available: {:?})",
-                    col_lower, self.column_to_table.keys().take(10).collect::<Vec<_>>());
+        // Schema-based lookup only - no heuristic fallbacks
+        let col_lower = column.to_lowercase();
+        if let Some(table) = self.column_to_table.get(&col_lower) {
+            if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+                eprintln!("[ANALYZER] Schema lookup: {} -> {}", column, table);
             }
-        }
-
-        // Fallback: TPC-H prefix pattern (kept for compatibility with TPC-H queries)
-        let col_upper = column.to_uppercase();
-
-        // Extract prefix before first underscore (e.g., "L_SUPPKEY" -> "L")
-        let prefix = col_upper.split('_').next()?;
-
-        // Try exact match first
-        if tables.contains(&prefix.to_lowercase()) {
-            return Some(prefix.to_lowercase());
-        }
-
-        // Try prefix matching (prefer shorter names for specificity)
-        let mut prefix_matches: Vec<String> = tables
-            .iter()
-            .filter(|t| t.to_uppercase().starts_with(prefix))
-            .cloned()
-            .collect();
-
-        if !prefix_matches.is_empty() {
-            prefix_matches.sort_by_key(|t| t.len()); // Ascending: prefer shorter matches
-            return prefix_matches.into_iter().next();
-        }
-
-        // Try abbreviation match (e.g., "PS" -> "partsupp")
-        let mut abbrev_matches: Vec<String> = tables
-            .iter()
-            .filter(|t| {
-                let abbrev = get_table_abbreviation(t);
-                abbrev.eq_ignore_ascii_case(prefix)
-            })
-            .cloned()
-            .collect();
-
-        if !abbrev_matches.is_empty() {
-            abbrev_matches.sort_by_key(|t| t.len());
-            return abbrev_matches.into_iter().next();
+            // Verify the table is in our set (could be aliased)
+            if tables.contains(table) {
+                return Some(table.clone());
+            }
+            // Try case-insensitive match
+            for t in tables {
+                if t.eq_ignore_ascii_case(table) {
+                    return Some(t.clone());
+                }
+            }
+            if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+                eprintln!("[ANALYZER] Warning: Table {} not in tables set {:?}", table, tables);
+            }
+        } else if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+            eprintln!("[ANALYZER] Warning: Column {} not found in schema map (available: {:?})",
+                col_lower, self.column_to_table.keys().take(10).collect::<Vec<_>>());
         }
 
         None

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -70,28 +70,6 @@ pub(crate) fn all_joins_are_cross(from: &FromClause) -> bool {
     }
 }
 
-/// Get table abbreviation for matching column prefixes
-///
-/// TPC-H uses abbreviations for compound table names:
-/// - "ps" → "partsupp" (partsupp is "part" + "supplier" abbreviated)
-/// - "c" → "customer", "l" → "lineitem", etc. (standard prefixes)
-///
-/// This enables matching abbreviation-style column prefixes (e.g., ps_partkey → partsupp)
-pub(super) fn get_table_abbreviation(table_name: &str) -> String {
-    let table_lower = table_name.to_lowercase();
-
-    // Known TPC-H table abbreviations
-    match table_lower.as_str() {
-        "partsupp" => "ps".to_string(),  // Special case: compound abbreviation
-        _ => {
-            // Default: use first letter as abbreviation
-            table_name.chars().next()
-                .map(|c| c.to_lowercase().to_string())
-                .unwrap_or_default()
-        }
-    }
-}
-
 /// Build a reordered combined schema with tables in original order
 ///
 /// Takes the current schema (with tables in optimal order) and reconstructs it
@@ -303,64 +281,21 @@ pub(super) fn resolve_column_to_table(
     column_to_table.get(&column.to_lowercase()).cloned()
 }
 
-/// Resolve an unqualified column using schema-based lookup with TPC-H heuristic fallback
+/// Resolve an unqualified column using schema-based lookup
 ///
-/// Primary resolution uses the schema-based column-to-table map.
-/// Falls back to TPC-H prefix matching ONLY if schema lookup fails.
-/// The SQLLogicTest suffix pattern has been removed as it was test-specific.
+/// Uses the schema-based column-to-table map to resolve column references.
+/// TPC-H prefix heuristics have been removed - all column resolution now
+/// relies solely on actual database schema metadata.
 ///
 /// # Parameters
 /// - `column`: The unqualified column name
 /// - `column_to_table`: Schema-based column-to-table mapping
-/// - `available_tables`: Set of FROM clause tables (for fallback heuristics)
+/// - `_available_tables`: Unused, kept for API compatibility
 pub(super) fn resolve_column_with_fallback(
     column: &str,
     column_to_table: &HashMap<String, String>,
-    available_tables: &HashSet<String>,
+    _available_tables: &HashSet<String>,
 ) -> Option<String> {
-    // Primary: Schema-based lookup
-    if let Some(table) = resolve_column_to_table(column, column_to_table) {
-        return Some(table);
-    }
-
-    // Fallback: TPC-H prefix pattern only (test-specific heuristics removed)
-    // This handles TPC-H queries where columns like l_orderkey → lineitem
-    let prefix = column.split('_').next().unwrap_or("").to_uppercase();
-    if prefix.is_empty() {
-        return None;
-    }
-
-    // Try exact match, prefix match, then abbreviation match
-    let mut exact_match: Option<String> = None;
-    let mut prefix_matches = Vec::new();
-    let mut abbrev_matches = Vec::new();
-
-    for table in available_tables {
-        let table_upper = table.to_uppercase();
-        if table_upper == prefix {
-            exact_match = Some(table.clone());
-            break;
-        } else if table_upper.starts_with(&prefix) {
-            prefix_matches.push(table.clone());
-        } else {
-            let abbrev = get_table_abbreviation(table);
-            if abbrev.to_uppercase() == prefix {
-                abbrev_matches.push(table.clone());
-            }
-        }
-    }
-
-    if let Some(table) = exact_match {
-        return Some(table);
-    }
-    if !prefix_matches.is_empty() {
-        prefix_matches.sort_by_key(|t| t.len());
-        return prefix_matches.into_iter().next();
-    }
-    if !abbrev_matches.is_empty() {
-        abbrev_matches.sort_by_key(|t| t.len());
-        return abbrev_matches.into_iter().next();
-    }
-
-    None
+    // Schema-based lookup only - no heuristic fallbacks
+    resolve_column_to_table(column, column_to_table)
 }


### PR DESCRIPTION
## Summary

Removes TPC-H-specific prefix matching heuristics from the join reorder optimizer that amounted to "teaching to the test". The optimizer now relies solely on schema-based column resolution.

- Removed `get_table_abbreviation()` from `utils.rs` and `join/reorder.rs`
- Removed TPC-H prefix pattern matching (e.g., `l_orderkey` → `lineitem`)
- Removed TPC-H abbreviation matching (e.g., `ps_partkey` → `partsupp`)
- Simplified `resolve_column_with_fallback()` to use schema-based lookup only

## Why This Matters

1. **Teaching to the test** - The optimizer had special knowledge of TPC-H naming conventions that won't help real-world queries
2. **Fragile** - Real databases don't follow `l_` = lineitem, `o_` = orders conventions
3. **Misleading benchmarks** - Performance numbers don't reflect general query optimization capability
4. **Maintenance burden** - Heuristic code paths that only benefit synthetic benchmarks

## Test plan

- [x] Code compiles without warnings
- [x] TPC-H tests pass (5/6 - Q21 failure is pre-existing on base branch)
- [x] SQLLogicTest individual tests pass (slt_good_29.test, view tests, evidence tests)
- [x] Schema-based resolution handles column lookups correctly

## Dependencies

- Stacked on #2619 (schema-based column resolution)

Closes #2621

🤖 Generated with [Claude Code](https://claude.com/claude-code)