### PR TITLE
fix: Handle nested IN/EXISTS subqueries in self-join column rewriting

### DIFF
--- a/crates/vibesql-executor/src/optimizer/subquery_to_join.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join.rs
@@ -340,6 +340,18 @@ fn rewrite_column_refs_with_alias(expr: &Expression, old_table: &str, new_alias:
             expr: Box::new(rewrite_column_refs_with_alias(inner, old_table, new_alias)),
             data_type: data_type.clone(),
         },
+        // Handle nested IN subqueries: rewrite the outer expression but NOT the subquery
+        // (the subquery has its own scope and column references shouldn't be changed)
+        Expression::In { expr: inner, subquery, negated } => Expression::In {
+            expr: Box::new(rewrite_column_refs_with_alias(inner, old_table, new_alias)),
+            subquery: subquery.clone(), // Don't rewrite inside subquery - different scope
+            negated: *negated,
+        },
+        // Handle EXISTS subqueries similarly - don't rewrite inside the subquery
+        Expression::Exists { subquery, negated } => Expression::Exists {
+            subquery: subquery.clone(), // Don't rewrite inside subquery - different scope
+            negated: *negated,
+        },
         // For other expression types, just clone (they don't contain column refs that need rewriting)
         _ => expr.clone(),
     }
@@ -726,5 +738,94 @@ mod tests {
 
         // WHERE should only have the simple predicate left
         assert!(transformed.where_clause.is_some(), "Simple predicate should remain in WHERE");
+    }
+
+    #[test]
+    fn test_nested_in_subquery_self_join_column_qualification() {
+        // Test that nested IN subqueries in self-joins properly qualify the outer expression
+        // This is the bug from issue #2630:
+        // SELECT pk FROM tab0 WHERE col3 IN (SELECT col0 FROM tab0 WHERE col0 IN (...) AND col4 >= 7680.91)
+        //
+        // When the outer IN is transformed to a SEMI JOIN, the nested IN's outer column (col0)
+        // should be qualified with the subquery alias (__subquery_TAB0), not left unqualified.
+
+        // Create a nested IN subquery pattern
+        let innermost_subquery = simple_select("tab0", "col3"); // SELECT col3 FROM tab0
+
+        // Middle subquery: SELECT col0 FROM tab0 WHERE col0 IN (innermost) AND col4 >= 7680
+        let mut middle_subquery = simple_select("tab0", "col0");
+        middle_subquery.where_clause = Some(Expression::BinaryOp {
+            op: BinaryOperator::And,
+            left: Box::new(Expression::In {
+                expr: Box::new(column_ref("col0")), // This should get qualified!
+                subquery: Box::new(innermost_subquery),
+                negated: false,
+            }),
+            right: Box::new(Expression::BinaryOp {
+                op: BinaryOperator::GreaterThanOrEqual,
+                left: Box::new(column_ref("col4")),
+                right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(7680))),
+            }),
+        });
+
+        // Outer query: SELECT pk FROM tab0 WHERE col3 IN (middle_subquery)
+        let mut stmt = simple_select("tab0", "pk");
+        stmt.where_clause = Some(Expression::In {
+            expr: Box::new(column_ref("col3")),
+            subquery: Box::new(middle_subquery),
+            negated: false,
+        });
+
+        let transformed = transform_subqueries_to_joins(&stmt);
+
+        // Should have transformed to a SEMI JOIN
+        match &transformed.from {
+            Some(FromClause::Join {
+                join_type,
+                condition,
+                right,
+                ..
+            }) => {
+                assert!(matches!(join_type, JoinType::Semi), "Should be SEMI join");
+
+                // Check that the right side has the alias
+                match right.as_ref() {
+                    FromClause::Table { alias: Some(alias), .. } => {
+                        assert!(alias.starts_with("__subquery_"), "Should have subquery alias");
+                    }
+                    _ => panic!("Expected aliased table on right side"),
+                }
+
+                // Check the join condition - nested IN's outer column should be qualified
+                if let Some(cond) = condition {
+                    // The condition should contain a nested IN expression
+                    // with a qualified column reference for col0
+                    fn check_nested_in_qualification(expr: &Expression) -> bool {
+                        match expr {
+                            Expression::In { expr: inner_expr, .. } => {
+                                // The outer expression of the nested IN should be qualified
+                                match inner_expr.as_ref() {
+                                    Expression::ColumnRef { table: Some(t), column: c } => {
+                                        t.starts_with("__subquery_") && c.eq_ignore_ascii_case("col0")
+                                    }
+                                    _ => false,
+                                }
+                            }
+                            Expression::BinaryOp { left, right, .. } => {
+                                check_nested_in_qualification(left) || check_nested_in_qualification(right)
+                            }
+                            _ => false,
+                        }
+                    }
+
+                    assert!(
+                        check_nested_in_qualification(cond),
+                        "Nested IN subquery's outer column should be qualified with subquery alias. Condition: {:?}",
+                        cond
+                    );
+                }
+            }
+            _ => panic!("Expected SEMI JOIN in FROM clause"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

When transforming an IN subquery to a SEMI JOIN for self-joins, the `rewrite_column_refs_with_alias` function now properly handles nested `Expression::In` and `Expression::Exists` subqueries.

## Changes

- Added handling for `Expression::In` in `rewrite_column_refs_with_alias`: only the outer expression is rewritten, the inner subquery is left unchanged (it has its own scope)
- Added handling for `Expression::Exists` similarly
- Added unit test `test_nested_in_subquery_self_join_column_qualification` to verify the fix

## Root Cause

The `rewrite_column_refs_with_alias` function had a catch-all clause that simply cloned expressions it didn't explicitly handle. This caused nested `Expression::In` subqueries to pass through without having their outer column references qualified with the subquery alias.

For example, in:
```sql
SELECT pk FROM tab0 WHERE col3 IN (
  SELECT col0 FROM tab0 WHERE col0 IN (SELECT col3 FROM tab0 WHERE col1 < 444.10) AND col4 >= 7680.91
)
```

When the outer IN is transformed to a SEMI JOIN with alias `__subquery_TAB0`, the nested `col0 IN (...)` expression's outer column reference (`col0`) was left unqualified instead of being rewritten to `__subquery_TAB0.col0`.

## Test Plan

- [x] Unit test `test_nested_in_subquery_self_join_column_qualification` passes
- [x] SQLLogicTest `index/commute/1000/slt_good_2.test` now passes (100%)

Closes #2630

🤖 Generated with [Claude Code](https://claude.com/claude-code)