### PR TITLE
fix(deps): Update API usage for rand 0.9 and wide 0.8 upgrades

### DIFF
--- a/crates/vibesql-executor/benches/tpch/data.rs
+++ b/crates/vibesql-executor/benches/tpch/data.rs
@@ -54,7 +54,7 @@ impl TPCHData {
     }
 
     pub fn random_varchar(&mut self, max_len: usize) -> String {
-        let len = self.rng.gen_range(10..max_len);
+        let len = self.rng.random_range(10..max_len);
         (0..len)
             .map(|_| self.rng.sample(rand::distributions::Alphanumeric) as char)
             .collect()
@@ -64,17 +64,17 @@ impl TPCHData {
         format!(
             "{:02}-{:03}-{:03}-{:04}",
             10 + nation_key,
-            self.rng.gen_range(100..1000),
-            self.rng.gen_range(100..1000),
-            self.rng.gen_range(1000..10000)
+            self.rng.random_range(100..1000),
+            self.rng.random_range(100..1000),
+            self.rng.random_range(1000..10000)
         )
     }
 
     pub fn random_date(&mut self, _start: &str, _end: &str) -> String {
         // Simple date generation between start and end
-        let year = self.rng.gen_range(1992..1999);
-        let month = self.rng.gen_range(1..13);
-        let day = self.rng.gen_range(1..29); // Simplified
+        let year = self.rng.random_range(1992..1999);
+        let month = self.rng.random_range(1..13);
+        let day = self.rng.random_range(1..29); // Simplified
         format!("{:04}-{:02}-{:02}", year, month, day)
     }
 }

--- a/crates/vibesql-executor/src/evaluator/functions/spatial/operations.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/spatial/operations.rs
@@ -207,22 +207,22 @@ pub fn st_simplify(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
 
             let simplified = match geom {
                 geo::Geometry::LineString(ls) => {
-                    let simplified_ls = ls.simplify(&tolerance);
+                    let simplified_ls = ls.simplify(tolerance);
                     geo::Geometry::LineString(simplified_ls)
                 }
                 geo::Geometry::MultiLineString(mls) => {
                     let simplified_mls = mls.0.iter()
-                        .map(|ls| ls.simplify(&tolerance))
+                        .map(|ls| ls.simplify(tolerance))
                         .collect();
                     geo::Geometry::MultiLineString(geo::MultiLineString(simplified_mls))
                 }
                 geo::Geometry::Polygon(poly) => {
-                    let simplified_poly = poly.simplify(&tolerance);
+                    let simplified_poly = poly.simplify(tolerance);
                     geo::Geometry::Polygon(simplified_poly)
                 }
                 geo::Geometry::MultiPolygon(mp) => {
                     let simplified_mp = mp.0.iter()
-                        .map(|p| p.simplify(&tolerance))
+                        .map(|p| p.simplify(tolerance))
                         .collect();
                     geo::Geometry::MultiPolygon(geo::MultiPolygon(simplified_mp))
                 }

--- a/crates/vibesql-executor/src/simd/comparison.rs
+++ b/crates/vibesql-executor/src/simd/comparison.rs
@@ -19,7 +19,7 @@ pub fn simd_gt_f64(column: &[f64], threshold: f64) -> Vec<bool> {
             column[offset + 3],
         ]);
         let thresh = f64x4::from([threshold; 4]);
-        let mask = values.cmp_gt(thresh);
+        let mask = values.simd_gt(thresh);
 
         // Extract individual boolean values from the mask
         let arr: [f64; 4] = mask.into();
@@ -53,7 +53,7 @@ pub fn simd_ge_f64(column: &[f64], threshold: f64) -> Vec<bool> {
             column[offset + 3],
         ]);
         let thresh = f64x4::from([threshold; 4]);
-        let mask = values.cmp_ge(thresh);
+        let mask = values.simd_ge(thresh);
 
         let arr: [f64; 4] = mask.into();
         for &val in &arr {
@@ -84,7 +84,7 @@ pub fn simd_lt_f64(column: &[f64], threshold: f64) -> Vec<bool> {
             column[offset + 3],
         ]);
         let thresh = f64x4::from([threshold; 4]);
-        let mask = values.cmp_lt(thresh);
+        let mask = values.simd_lt(thresh);
 
         let arr: [f64; 4] = mask.into();
         for &val in &arr {
@@ -115,7 +115,7 @@ pub fn simd_le_f64(column: &[f64], threshold: f64) -> Vec<bool> {
             column[offset + 3],
         ]);
         let thresh = f64x4::from([threshold; 4]);
-        let mask = values.cmp_le(thresh);
+        let mask = values.simd_le(thresh);
 
         let arr: [f64; 4] = mask.into();
         for &val in &arr {
@@ -146,7 +146,7 @@ pub fn simd_eq_f64(column: &[f64], value: f64) -> Vec<bool> {
             column[offset + 3],
         ]);
         let val = f64x4::from([value; 4]);
-        let mask = values.cmp_eq(val);
+        let mask = values.simd_eq(val);
 
         let arr: [f64; 4] = mask.into();
         for &v in &arr {
@@ -177,7 +177,7 @@ pub fn simd_ne_f64(column: &[f64], value: f64) -> Vec<bool> {
             column[offset + 3],
         ]);
         let val = f64x4::from([value; 4]);
-        let mask = values.cmp_ne(val);
+        let mask = values.simd_ne(val);
 
         let arr: [f64; 4] = mask.into();
         for &v in &arr {
@@ -208,7 +208,7 @@ pub fn simd_gt_i64(column: &[i64], threshold: i64) -> Vec<bool> {
             column[offset + 3],
         ]);
         let thresh = i64x4::from([threshold; 4]);
-        let mask = values.cmp_gt(thresh);
+        let mask = values.simd_gt(thresh);
 
         let arr: [i64; 4] = mask.into();
         for &val in &arr {
@@ -239,7 +239,7 @@ pub fn simd_lt_i64(column: &[i64], threshold: i64) -> Vec<bool> {
             column[offset + 3],
         ]);
         let thresh = i64x4::from([threshold; 4]);
-        let mask = values.cmp_lt(thresh);
+        let mask = values.simd_lt(thresh);
 
         let arr: [i64; 4] = mask.into();
         for &val in &arr {
@@ -271,7 +271,7 @@ pub fn simd_ge_i64(column: &[i64], threshold: i64) -> Vec<bool> {
         ]);
         let thresh = i64x4::from([threshold; 4]);
         // a >= b is equivalent to !(a < b)
-        let mask = !values.cmp_lt(thresh);
+        let mask = !values.simd_lt(thresh);
 
         let arr: [i64; 4] = mask.into();
         for &val in &arr {
@@ -303,7 +303,7 @@ pub fn simd_le_i64(column: &[i64], threshold: i64) -> Vec<bool> {
         ]);
         let thresh = i64x4::from([threshold; 4]);
         // a <= b is equivalent to !(a > b)
-        let mask = !values.cmp_gt(thresh);
+        let mask = !values.simd_gt(thresh);
 
         let arr: [i64; 4] = mask.into();
         for &val in &arr {
@@ -334,7 +334,7 @@ pub fn simd_eq_i64(column: &[i64], value: i64) -> Vec<bool> {
             column[offset + 3],
         ]);
         let val = i64x4::from([value; 4]);
-        let mask = values.cmp_eq(val);
+        let mask = values.simd_eq(val);
 
         let arr: [i64; 4] = mask.into();
         for &v in &arr {
@@ -366,7 +366,7 @@ pub fn simd_ne_i64(column: &[i64], value: i64) -> Vec<bool> {
         ]);
         let val = i64x4::from([value; 4]);
         // NE is equivalent to NOT(EQ)
-        let mask_eq = values.cmp_eq(val);
+        let mask_eq = values.simd_eq(val);
         let arr: [i64; 4] = mask_eq.into();
         for &v in &arr {
             result.push(v == 0); // NOT EQ
@@ -396,7 +396,7 @@ pub fn simd_gt_i32(column: &[i32], threshold: i32) -> Vec<bool> {
             column[offset + 3],
         ]);
         let thresh = i32x4::from([threshold; 4]);
-        let mask = values.cmp_gt(thresh);
+        let mask = values.simd_gt(thresh);
 
         let arr: [i32; 4] = mask.into();
         for &val in &arr {
@@ -428,7 +428,7 @@ pub fn simd_ge_i32(column: &[i32], threshold: i32) -> Vec<bool> {
         ]);
         let thresh = i32x4::from([threshold; 4]);
         // GE is equivalent to NOT(LT)
-        let mask_lt = values.cmp_lt(thresh);
+        let mask_lt = values.simd_lt(thresh);
         let arr: [i32; 4] = mask_lt.into();
         for &val in &arr {
             result.push(val == 0); // NOT LT
@@ -458,7 +458,7 @@ pub fn simd_lt_i32(column: &[i32], threshold: i32) -> Vec<bool> {
             column[offset + 3],
         ]);
         let thresh = i32x4::from([threshold; 4]);
-        let mask = values.cmp_lt(thresh);
+        let mask = values.simd_lt(thresh);
 
         let arr: [i32; 4] = mask.into();
         for &val in &arr {
@@ -490,7 +490,7 @@ pub fn simd_le_i32(column: &[i32], threshold: i32) -> Vec<bool> {
         ]);
         let thresh = i32x4::from([threshold; 4]);
         // LE is equivalent to NOT(GT)
-        let mask_gt = values.cmp_gt(thresh);
+        let mask_gt = values.simd_gt(thresh);
         let arr: [i32; 4] = mask_gt.into();
         for &val in &arr {
             result.push(val == 0); // NOT GT
@@ -520,7 +520,7 @@ pub fn simd_eq_i32(column: &[i32], value: i32) -> Vec<bool> {
             column[offset + 3],
         ]);
         let val = i32x4::from([value; 4]);
-        let mask = values.cmp_eq(val);
+        let mask = values.simd_eq(val);
 
         let arr: [i32; 4] = mask.into();
         for &v in &arr {
@@ -552,7 +552,7 @@ pub fn simd_ne_i32(column: &[i32], value: i32) -> Vec<bool> {
         ]);
         let val = i32x4::from([value; 4]);
         // NE is equivalent to NOT(EQ)
-        let mask_eq = values.cmp_eq(val);
+        let mask_eq = values.simd_eq(val);
         let arr: [i32; 4] = mask_eq.into();
         for &v in &arr {
             result.push(v == 0); // NOT EQ

--- a/crates/vibesql-executor/src/simd/hashing.rs
+++ b/crates/vibesql-executor/src/simd/hashing.rs
@@ -67,7 +67,7 @@ pub fn simd_hash_i64_batch(keys: &[i64], output: &mut [u64]) {
         let hashed = xored * mult_vec;
 
         // Additional mixing for better distribution
-        let rotated = (hashed ^ (hashed >> 32)) * mult_vec;
+        let rotated: i64x4 = (hashed ^ (hashed >> 32)) * mult_vec;
 
         // Store results
         let result = rotated.to_array();
@@ -116,7 +116,7 @@ pub fn simd_hash_f64_batch(keys: &[f64], output: &mut [u64]) {
 
         let xored = keys_vec ^ seed_vec;
         let hashed = xored * mult_vec;
-        let rotated = (hashed ^ (hashed >> 32)) * mult_vec;
+        let rotated: i64x4 = (hashed ^ (hashed >> 32)) * mult_vec;
 
         // Store results
         let result = rotated.to_array();

--- a/crates/vibesql-server/Cargo.toml
+++ b/crates/vibesql-server/Cargo.toml
@@ -33,7 +33,7 @@ rustls = "0.23"
 rustls-pemfile = "2.0"
 
 # Authentication
-argon2 = "0.5"
+argon2 = { version = "0.5", features = ["std"] }
 md-5 = "0.10"
 sha2 = "0.10"
 base64 = "0.22"

--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -185,7 +185,7 @@ impl ConnectionHandler {
 
                 // Generate random salt
                 use rand::Rng;
-                let salt: [u8; 4] = rand::thread_rng().gen();
+                let salt: [u8; 4] = rand::rng().random();
 
                 self.send_md5_password_request(&salt).await?;
 

--- a/crates/vibesql-server/src/observability/provider.rs
+++ b/crates/vibesql-server/src/observability/provider.rs
@@ -6,8 +6,7 @@ use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::KeyValue;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
-use opentelemetry_sdk::runtime;
-use opentelemetry_sdk::trace::{Sampler, TracerProvider};
+use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
 use opentelemetry_sdk::Resource;
 use std::time::Duration;
 use tracing_subscriber::layer::SubscriberExt;
@@ -18,7 +17,7 @@ pub struct ObservabilityProvider {
     #[allow(dead_code)]
     meter_provider: Option<SdkMeterProvider>,
     #[allow(dead_code)]
-    tracer_provider: Option<TracerProvider>,
+    tracer_provider: Option<SdkTracerProvider>,
     metrics: Option<ServerMetrics>,
 }
 
@@ -33,10 +32,10 @@ impl ObservabilityProvider {
             });
         }
 
-        let resource = Resource::new(vec![
-            KeyValue::new("service.name", "vibesql-server"),
-            KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
-        ]);
+        let resource = Resource::builder()
+            .with_service_name("vibesql-server")
+            .with_attribute(KeyValue::new("service.version", env!("CARGO_PKG_VERSION")))
+            .build();
 
         // Initialize metrics if enabled
         let (meter_provider, metrics) = if config.metrics.enabled {
@@ -47,12 +46,9 @@ impl ObservabilityProvider {
                 .build()
                 .context("Failed to create OTLP metrics exporter")?;
 
-            let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(
-                exporter,
-                runtime::Tokio,
-            )
-            .with_interval(Duration::from_secs(config.metrics.export_interval_seconds))
-            .build();
+            let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter)
+                .with_interval(Duration::from_secs(config.metrics.export_interval_seconds))
+                .build();
 
             let provider = SdkMeterProvider::builder()
                 .with_reader(reader)
@@ -94,8 +90,8 @@ impl ObservabilityProvider {
                 .build()
                 .context("Failed to create OTLP trace exporter")?;
 
-            let provider = TracerProvider::builder()
-                .with_batch_exporter(exporter, runtime::Tokio)
+            let provider = SdkTracerProvider::builder()
+                .with_batch_exporter(exporter)
                 .with_sampler(sampler)
                 .with_resource(resource.clone())
                 .build();

--- a/crates/vibesql-sqllogictest/src/result_updater.rs
+++ b/crates/vibesql-sqllogictest/src/result_updater.rs
@@ -269,7 +269,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
             let outfilename = format!(
                 "{}{:010}{}",
                 filename.file_name().unwrap().to_str().unwrap().to_owned(),
-                rand::thread_rng().gen_range(0..10_000_000),
+                rand::rng().random_range(0..10_000_000),
                 ".temp"
             );
             let outfilename = filename.parent().unwrap().join(outfilename);

--- a/crates/vibesql-storage/src/statistics/sampling.rs
+++ b/crates/vibesql-storage/src/statistics/sampling.rs
@@ -7,7 +7,7 @@
 //! - Reservoir sampling: Single-pass streaming sample
 //! - Adaptive sampling: Choose sample size based on table size
 
-use rand::seq::SliceRandom;
+use rand::prelude::IndexedRandom;
 use rand::Rng;
 
 /// Configuration for statistical sampling
@@ -193,7 +193,7 @@ fn reservoir_sample<T: Clone>(rows: &[T], k: usize, rng: &mut impl Rng) -> Vec<T
 
     for (i, row) in rows.iter().enumerate().skip(k) {
         // Randomly decide whether to include this element
-        let j = rng.gen_range(0..=i);
+        let j = rng.random_range(0..=i);
         if j < k {
             reservoir[j] = row.clone();
         }

--- a/crates/vibesql-storage/src/statistics/table.rs
+++ b/crates/vibesql-storage/src/statistics/table.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use instant::SystemTime;
+use rand::SeedableRng;
 use super::{ColumnStatistics, SamplingConfig, SampleMetadata};
 use super::histogram::BucketStrategy;
 
@@ -52,8 +53,6 @@ impl TableStatistics {
         bucket_strategy: BucketStrategy,
     ) -> Self {
         use super::sampling::{sample_rows};
-        use rand::SeedableRng;
-
         let total_rows = rows.len();
         let config = sampling_config.unwrap_or_else(SamplingConfig::adaptive);
 
@@ -61,7 +60,7 @@ impl TableStatistics {
         let (sample_size, should_sample) = config.determine_sample_size(total_rows);
 
         // Sample rows if needed (Phase 5.2)
-        let mut rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = rand::rngs::StdRng::from_os_rng();
         let sampled_rows = if should_sample {
             sample_rows(rows, &config, &mut rng)
         } else {


### PR DESCRIPTION
## Summary

Fixes build failures caused by breaking API changes in the dependency upgrades from #2627.

## Changes

**rand 0.9:**
- `gen_range` → `random_range` (deprecated method renamed)
- `thread_rng()` → `rng()` (function renamed)
- `StdRng::from_entropy()` → `StdRng::from_os_rng()` (method renamed)
- `rand::seq::SliceRandom` → `rand::prelude::IndexedRandom` (trait moved)

**wide 0.8:**
- `cmp_gt` → `simd_gt` (method renamed)
- `cmp_lt` → `simd_lt` (method renamed)
- `cmp_eq` → `simd_eq` (method renamed)
- `cmp_ge` → `simd_ge` (method renamed)
- `cmp_le` → `simd_le` (method renamed)

## Test Plan

- [x] `cargo check -p vibesql-storage` passes
- [x] `cargo test -p vibesql-storage --lib -- sampling` passes (9 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)