### PR TITLE
fix(ci): Use x86-64-v2 baseline CPU for Linux CI compatibility

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,12 @@
 [build]
 rustc-wrapper = "sccache"
 
+# Use baseline x86-64-v2 (SSE4.2) for Linux CI compatibility
+# GitHub Actions runners may not support AVX/AVX2 instructions
+# This ensures SIMD code uses only SSE instructions on Linux
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=x86-64-v2"]
+
 [alias]
 # Coverage commands using cargo-llvm-cov
 coverage = "llvm-cov --workspace --html"


### PR DESCRIPTION
## Summary

- Set x86-64-v2 (SSE4.2) as the target CPU baseline for Linux builds

## Why This Matters

GitHub Actions runners may not support AVX/AVX2 instructions that the compiler might auto-vectorize to when targeting the native CPU. This causes illegal instruction crashes in CI when SIMD code is compiled with higher instruction set assumptions than the runner supports.

Setting x86-64-v2 ensures:
- SIMD code uses only SSE/SSE2/SSE3/SSSE3/SSE4.1/SSE4.2 instructions
- Consistent behavior across different CI runner hardware
- No illegal instruction errors from unsupported AVX instructions

## Test plan

- [x] Build compiles successfully
- [ ] CI tests pass on Linux runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)