### PR TITLE
fix: Accumulate skipif directives with OR logic instead of overwriting

### DIFF
--- a/crates/vibesql-sqllogictest/src/parser/parser_core.rs
+++ b/crates/vibesql-sqllogictest/src/parser/parser_core.rs
@@ -301,6 +301,81 @@ fn parse_inner<T: ColumnType>(loc: &Location, script: &str) -> Result<Vec<Record
     Ok(records)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DefaultColumnType;
+    use crate::directive_parser::Condition;
+
+    #[test]
+    fn test_skipif_with_inline_comment() {
+        // Test that skipif mysql # comment is parsed correctly
+        let script = r#"skipif mysql # not compatible
+query I
+SELECT 1
+----
+1
+"#;
+        let records: Vec<Record<DefaultColumnType>> = parse(script).unwrap();
+
+        // Should have: Condition(SkipIf{mysql}), Query{...}
+        let mut found_skipif = false;
+        for record in &records {
+            if let Record::Condition(Condition::SkipIf { label }) = record {
+                assert_eq!(label, "mysql");
+                found_skipif = true;
+            }
+        }
+        assert!(found_skipif, "Should have parsed skipif mysql correctly");
+    }
+
+    #[test]
+    fn test_onlyif_with_inline_comment() {
+        // Test that onlyif mysql # comment is parsed correctly
+        let script = r#"onlyif mysql # MySQL-specific syntax
+statement ok
+SELECT 1
+"#;
+        let records: Vec<Record<DefaultColumnType>> = parse(script).unwrap();
+
+        let mut found_onlyif = false;
+        for record in &records {
+            if let Record::Condition(Condition::OnlyIf { label }) = record {
+                assert_eq!(label, "mysql");
+                found_onlyif = true;
+            }
+        }
+        assert!(found_onlyif, "Should have parsed onlyif mysql correctly");
+    }
+
+    #[test]
+    fn test_multiple_skipif_with_comments() {
+        // Test multiple skipif directives as found in real test files
+        let script = r#"skipif mysql # not compatible
+skipif postgresql # PostgreSQL requires AS
+query I
+SELECT 1
+----
+1
+"#;
+        let records: Vec<Record<DefaultColumnType>> = parse(script).unwrap();
+
+        let mut mysql_skipif = false;
+        let mut postgresql_skipif = false;
+        for record in &records {
+            if let Record::Condition(Condition::SkipIf { label }) = record {
+                match label.as_str() {
+                    "mysql" => mysql_skipif = true,
+                    "postgresql" => postgresql_skipif = true,
+                    _ => {}
+                }
+            }
+        }
+        assert!(mysql_skipif, "Should have parsed skipif mysql");
+        assert!(postgresql_skipif, "Should have parsed skipif postgresql");
+    }
+}
+
 /// Parse a sqllogictest file. The included scripts are inserted after the `include` record.
 pub fn parse_file<T: ColumnType>(filename: impl AsRef<Path>) -> Result<Vec<Record<T>>, ParseError> {
     let filename = filename.as_ref().to_str().unwrap();

--- a/tests/sqllogictest/preprocessing.rs
+++ b/tests/sqllogictest/preprocessing.rs
@@ -4,19 +4,40 @@
 pub fn preprocess_for_mysql(content: &str) -> String {
     let mut output_lines = Vec::new();
     let mut skip_next_record = false;
+    // Track if we've seen `onlyif mysql` for this record (separate from skip state)
+    let mut seen_onlyif_mysql = false;
+    // Track if we've seen ANY onlyif directive for this record
+    let mut in_onlyif_block = false;
 
     for line in content.lines() {
         // Check for dialect directives
         if line.starts_with("onlyif ") {
             let dialect =
                 line.trim_start_matches("onlyif ").split_whitespace().next().unwrap_or("");
-            skip_next_record = dialect != "mysql";
+            // Track that we're in an onlyif block
+            in_onlyif_block = true;
+            // For onlyif: run if ANY dialect matches mysql (OR logic for inclusion)
+            if dialect == "mysql" {
+                seen_onlyif_mysql = true;
+            }
+            // Don't set skip yet - wait until we've seen all consecutive onlyif directives
             continue; // Don't include the directive line
         } else if line.starts_with("skipif ") {
             let dialect =
                 line.trim_start_matches("skipif ").split_whitespace().next().unwrap_or("");
-            skip_next_record = dialect == "mysql";
+            // Accumulate skip conditions with OR - if ANY skipif matches mysql, skip the record
+            skip_next_record = skip_next_record || (dialect == "mysql");
             continue; // Don't include the directive line
+        }
+
+        // If we just finished processing onlyif directives, evaluate them
+        if in_onlyif_block {
+            // Skip if we saw onlyif directives but none matched mysql
+            if !seen_onlyif_mysql {
+                skip_next_record = true;
+            }
+            in_onlyif_block = false;
+            seen_onlyif_mysql = false;
         }
 
         // If we're not skipping, include the line
@@ -121,5 +142,62 @@ INSERT INTO t1 VALUES (3)
         // No directives should remain
         assert!(!output.contains("onlyif"));
         assert!(!output.contains("skipif"));
+    }
+
+    #[test]
+    fn test_preprocess_multiple_consecutive_skipif() {
+        // This is the bug from issue #2632 - multiple consecutive skipif directives
+        // should accumulate with OR logic, not overwrite each other
+        let input = r#"skipif mysql # not compatible
+skipif postgresql # PostgreSQL requires AS
+query I rowsort label-1665
+SELECT ( 41 ) / - 6 - - COUNT ( * ) col2 FROM tab0
+----
+4
+"#;
+        let output = preprocess_for_mysql(input);
+
+        // The query should be EXCLUDED because `skipif mysql` matches
+        // Even though `skipif postgresql` comes after, the mysql skip should still apply
+        assert!(
+            !output.contains("SELECT ( 41 )"),
+            "Query with skipif mysql should be excluded, even with subsequent skipif postgresql"
+        );
+        assert!(!output.contains("skipif"), "Directives should be removed");
+    }
+
+    #[test]
+    fn test_preprocess_multiple_consecutive_onlyif() {
+        // Multiple onlyif should use OR logic - run if ANY matches mysql
+        let input = r#"onlyif mysql # MySQL specific
+onlyif sqlite # also works on sqlite
+statement ok
+INSERT INTO t1 VALUES (1)
+"#;
+        let output = preprocess_for_mysql(input);
+
+        // Should INCLUDE because `onlyif mysql` matches
+        assert!(
+            output.contains("INSERT INTO t1 VALUES (1)"),
+            "Statement with onlyif mysql should be included, even with other onlyif directives"
+        );
+        assert!(!output.contains("onlyif"), "Directives should be removed");
+    }
+
+    #[test]
+    fn test_preprocess_multiple_onlyif_no_mysql() {
+        // Multiple onlyif with no mysql match should skip
+        let input = r#"onlyif postgresql
+onlyif sqlite
+statement ok
+INSERT INTO t1 VALUES (1)
+"#;
+        let output = preprocess_for_mysql(input);
+
+        // Should EXCLUDE because neither onlyif matches mysql
+        assert!(
+            !output.contains("INSERT INTO t1 VALUES (1)"),
+            "Statement with onlyif postgresql+sqlite should be excluded for MySQL"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Fix preprocessing logic to accumulate multiple consecutive `skipif` directives with OR semantics (if ANY matches mysql, skip the record)
- Fix `onlyif` handling to use OR semantics (if ANY matches mysql, run the record)
- Add comprehensive test coverage for multiple consecutive directives

## Problem
When test files contain patterns like:
```
skipif mysql # not compatible
skipif postgresql # PostgreSQL requires AS
query I rowsort label-1665
SELECT ( 41 ) / - 6 - - COUNT ( * ) col2 FROM tab0
```

The second `skipif postgresql` directive was overwriting the skip state set by `skipif mysql`, causing MySQL-incompatible tests to run.

## Test plan
- [x] Added unit tests for multiple consecutive skipif directives
- [x] Added unit tests for multiple consecutive onlyif directives  
- [x] Added tests for onlyif with no mysql match
- [x] All preprocessing tests pass

Closes #2632

🤖 Generated with [Claude Code](https://claude.com/claude-code)