### PR TITLE
fix(deps): Update rand::distributions to rand::distr for rand 0.9

### DIFF
--- a/crates/vibesql-executor/benches/tpch/data.rs
+++ b/crates/vibesql-executor/benches/tpch/data.rs
@@ -56,7 +56,7 @@ impl TPCHData {
     pub fn random_varchar(&mut self, max_len: usize) -> String {
         let len = self.rng.random_range(10..max_len);
         (0..len)
-            .map(|_| self.rng.sample(rand::distributions::Alphanumeric) as char)
+            .map(|_| self.rng.sample(rand::distr::Alphanumeric) as char)
             .collect()
     }
 


### PR DESCRIPTION
## Summary
- Updates `rand::distributions::Alphanumeric` to `rand::distr::Alphanumeric` for compatibility with rand 0.9
- The `distributions` module was renamed to `distr` in rand 0.9

This fixes the CI test compilation failure on main.

## Context
Split from #2648 per Judge review feedback - this PR now contains only the rand API fix.

## Test plan
- [x] `cargo check --release --all-targets` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)