### PR TITLE
test: Enable previously-ignored generic filter tests

### DIFF
--- a/crates/vibesql-executor/src/select/monomorphic/generic/aggregation.rs
+++ b/crates/vibesql-executor/src/select/monomorphic/generic/aggregation.rs
@@ -316,7 +316,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO: Fix generic filter tests (broken on main)
     fn test_generic_pattern_q6_like() {
         // Create lineitem-like schema
         let table = TableSchema::new(
@@ -360,7 +359,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO: Fix generic filter tests (broken on main)
     fn test_generic_pattern_different_table() {
         // Create a sales table with similar structure
         let table = TableSchema::new(

--- a/crates/vibesql-executor/src/select/monomorphic/generic/filter.rs
+++ b/crates/vibesql-executor/src/select/monomorphic/generic/filter.rs
@@ -429,7 +429,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO: Fix generic filter tests (broken on main)
     fn test_filter_extraction_simple_comparison() {
         // Create schema with a sales table
         let table = TableSchema::new(

--- a/crates/vibesql-executor/src/tests/monomorphic_integration_tests.rs
+++ b/crates/vibesql-executor/src/tests/monomorphic_integration_tests.rs
@@ -421,13 +421,8 @@ fn test_generic_pattern_no_matching_rows() {
     );
 }
 
-// TODO: Test for SUM with simple numeric filters (currently failing - needs investigation)
-// This test is temporarily disabled while we investigate why simple numeric comparisons
-// on DoublePrecision columns aren't matching the generic pattern correctly.
-// The other 6 tests provide good coverage of the generic monomorphic pattern system.
 #[test]
-#[ignore]
-fn test_generic_pattern_mixed_types_disabled() {
+fn test_generic_pattern_mixed_types() {
     let mut db = vibesql_storage::Database::new();
 
     let schema = vibesql_catalog::TableSchema::new(


### PR DESCRIPTION
## Summary

- Remove `#[ignore]` annotations from 4 tests that were marked as broken but now pass
- Rename `test_generic_pattern_mixed_types_disabled` to `test_generic_pattern_mixed_types`
- Remove associated TODO comments about fixing tests

## Changes

| File | Test | Change |
|------|------|--------|
| `monomorphic_integration_tests.rs` | `test_generic_pattern_mixed_types` | Removed ignore + TODO comments, renamed |
| `aggregation.rs` | `test_generic_pattern_q6_like` | Removed ignore annotation |
| `aggregation.rs` | `test_generic_pattern_different_table` | Removed ignore annotation |
| `filter.rs` | `test_filter_extraction_simple_comparison` | Removed ignore annotation |

## Test plan

- [x] Verified all 4 tests pass individually with `cargo test --package vibesql-executor`
- [x] Tests cover: DoublePrecision comparisons, filter extraction, Q6-like patterns

Closes #2655

🤖 Generated with [Claude Code](https://claude.com/claude-code)