### PR TITLE
fix: Use SQLite mode for SQLLogicTest suite

### DIFF
--- a/tests/sqllogictest/db_adapter/pool.rs
+++ b/tests/sqllogictest/db_adapter/pool.rs
@@ -6,7 +6,8 @@
 //! that is reset between files.
 
 use std::cell::RefCell;
-use vibesql_storage::Database;
+use vibesql_storage::{Database, DatabaseConfig};
+use vibesql_types::SqlMode;
 
 // Thread-local Database pool for reuse across test files within the same worker thread.
 // This avoids the overhead of creating a new Database for each test file (622 files in full suite).
@@ -28,10 +29,13 @@ pub fn get_pooled_database() -> Database {
                 db
             }
             None => {
-                // First use - create new database with MySQL mode (default)
-                // The SQLLogicTest suite was generated from MySQL 8 and expects MySQL semantics
-                // including decimal division (INTEGER / INTEGER → DECIMAL)
-                vibesql_storage::Database::new()
+                // First use - create new database with SQLite mode
+                // The SQLLogicTest suite is from SQLite and expects SQLite semantics
+                // including integer division (INTEGER / INTEGER → INTEGER, truncated)
+                // Tests with `skipif mysql` handle MySQL-incompatible queries
+                let mut config = DatabaseConfig::test_default();
+                config.sql_mode = SqlMode::SQLite;
+                Database::with_config(config)
             }
         }
     })


### PR DESCRIPTION
## Summary

- Configure SQLLogicTest database pool to use SQLite mode instead of MySQL mode
- The SQLLogicTest suite originates from SQLite and expects SQLite semantics (e.g., integer division returns truncated integers)
- This fixes test failures in queries like `SELECT * FROM tab2 WHERE -col2 + col0/col1*col1 NOT IN (+col2)` where division behavior differs

## Root Cause

The test file `random/aggregates/slt_good_115.test` was failing because:
- SQLite integer division: `46/51 = 0` (truncated)
- MySQL integer division: `46/51 = 0.9019...` (returns float/Numeric)

This caused different `NOT IN` evaluation results, excluding rows incorrectly.

## Changes

- `tests/sqllogictest/db_adapter/pool.rs`: Set `SqlMode::SQLite` in `DatabaseConfig` when creating the test database pool
- Updated comments to accurately document that the test suite is from SQLite (not MySQL as previously stated)

## Test plan

- [x] Verified failing test `slt_good_115.test` now passes
- [x] Running broader SQLLogicTest suite to check for regressions (in progress)

Closes #2652

🤖 Generated with [Claude Code](https://claude.com/claude-code)