### PR TITLE
fix(storage): Implement CASCADE behavior for DROP TABLE to clean up indexes

### DIFF
--- a/crates/vibesql-storage/src/database/indexes/index_maintenance.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance.rs
@@ -509,17 +509,40 @@ impl IndexManager {
     ///
     /// # Arguments
     ///
-    /// * `table_name` - The qualified name of the table (e.g., "public.users")
+    /// * `table_name` - The table name, which may be qualified (e.g., "public.users") or
+    ///                  unqualified (e.g., "users"). Matching is case-insensitive and handles
+    ///                  both qualified and unqualified names.
     ///
     /// # Returns
     ///
     /// Vector of index names that were dropped (for logging/debugging)
     pub fn drop_indexes_for_table(&mut self, table_name: &str) -> Vec<String> {
+        // Normalize for case-insensitive comparison
+        let search_name_upper = table_name.to_uppercase();
+
+        // Extract just the table name part if qualified (e.g., "public.users" -> "users")
+        let search_table_only = search_name_upper
+            .rsplit('.')
+            .next()
+            .unwrap_or(&search_name_upper);
+
         // Collect index names to drop (can't modify while iterating)
+        // Match if:
+        // 1. Exact match (case-insensitive), OR
+        // 2. Index's unqualified table name matches our unqualified search name
         let indexes_to_drop: Vec<String> = self
             .indexes
             .iter()
-            .filter(|(_, metadata)| metadata.table_name == table_name)
+            .filter(|(_, metadata)| {
+                let stored_upper = metadata.table_name.to_uppercase();
+                let stored_table_only = stored_upper
+                    .rsplit('.')
+                    .next()
+                    .unwrap_or(&stored_upper);
+
+                // Match if full names match OR unqualified parts match
+                stored_upper == search_name_upper || stored_table_only == search_table_only
+            })
             .map(|(name, _)| name.clone())
             .collect();
 

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -542,11 +542,32 @@ impl Operations {
     }
 
     /// Drop all spatial indexes associated with a table (CASCADE behavior)
+    ///
+    /// Matching is case-insensitive and handles both qualified ("schema.table")
+    /// and unqualified ("table") names.
     pub fn drop_spatial_indexes_for_table(&mut self, table_name: &str) -> Vec<String> {
+        // Normalize for case-insensitive comparison
+        let search_name_upper = table_name.to_uppercase();
+
+        // Extract just the table name part if qualified (e.g., "public.users" -> "users")
+        let search_table_only = search_name_upper
+            .rsplit('.')
+            .next()
+            .unwrap_or(&search_name_upper);
+
         let indexes_to_drop: Vec<String> = self
             .spatial_indexes
             .iter()
-            .filter(|(_, (metadata, _))| metadata.table_name == table_name)
+            .filter(|(_, (metadata, _))| {
+                let stored_upper = metadata.table_name.to_uppercase();
+                let stored_table_only = stored_upper
+                    .rsplit('.')
+                    .next()
+                    .unwrap_or(&stored_upper);
+
+                // Match if full names match OR unqualified parts match
+                stored_upper == search_name_upper || stored_table_only == search_table_only
+            })
             .map(|(name, _)| name.clone())
             .collect();
 

--- a/crates/vibesql-storage/tests/index_validation.rs
+++ b/crates/vibesql-storage/tests/index_validation.rs
@@ -445,7 +445,6 @@ mod index_operations_tests {
     }
 
     #[test]
-    #[ignore] // TODO: CASCADE behavior not yet implemented - indexes persist after table drop
     fn test_cascade_drop_indexes_with_table() {
         let mut db = Database::new();
 


### PR DESCRIPTION
## Summary

- Fixed `drop_indexes_for_table()` in `IndexManager` to use case-insensitive matching and handle both qualified ("schema.table") and unqualified ("table") names
- Applied the same fix to `drop_spatial_indexes_for_table()` for consistency
- Enabled the previously ignored `test_cascade_drop_indexes_with_table` test which now passes

## Test plan

- [x] Run `cargo test --package vibesql-storage test_cascade_drop_indexes_with_table` - passes
- [x] Run `cargo test --package vibesql-storage` - all 253 tests pass
- [x] Build the package successfully

Closes #2653

🤖 Generated with [Claude Code](https://claude.com/claude-code)