### PR TITLE
feat(executor): Implement SET SQL_MODE statement for runtime dialect switching

### DIFF
--- a/crates/vibesql-executor/src/schema_ddl.rs
+++ b/crates/vibesql-executor/src/schema_ddl.rs
@@ -173,6 +173,25 @@ impl SchemaExecutor {
         // Evaluate the value expression
         let value = evaluator.eval(&stmt.value, &empty_row)?;
 
+        // Special handling for sql_mode variable - update the SQL mode
+        if stmt.variable.eq_ignore_ascii_case("sql_mode") {
+            // Extract the mode string from the value
+            let mode_str = match &value {
+                vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => s.clone(),
+                other => other.to_string(),
+            };
+
+            // Parse the mode string into SqlMode
+            let mode: vibesql_types::SqlMode = mode_str.parse().map_err(|e: String| {
+                ExecutorError::StorageError(e)
+            })?;
+
+            // Set the SQL mode (this also updates the @@sql_mode session variable)
+            database.set_sql_mode(mode.clone());
+
+            return Ok(format!("SQL mode set to '{}'", mode));
+        }
+
         // Set the session variable in the database
         // Note: For now, we ignore the GLOBAL scope and always set session variables
         // Implementing true GLOBAL variables would require a separate storage mechanism

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -45,6 +45,7 @@
 //! - `alter_table_constraints`: ALTER TABLE ADD/DROP PRIMARY KEY and FOREIGN KEY tests (Phase 6 of issue #1388)
 //! - `non_unique_disk_index_tests`: Non-unique disk-backed index integration tests (issue #1575, PR #1571)
 //! - `monomorphic_integration_tests`: Generic monomorphic pattern integration tests (issue #2244)
+//! - `sql_mode_tests`: SET SQL_MODE tests for runtime dialect switching (issue #2658)
 
 mod common;
 mod aggregate_caching;
@@ -110,3 +111,4 @@ mod truncate_cascade_tests;
 mod truncate_table_tests;
 mod unique_index_tests;
 mod view_tests;
+mod sql_mode_tests;

--- a/crates/vibesql-executor/src/tests/sql_mode_tests.rs
+++ b/crates/vibesql-executor/src/tests/sql_mode_tests.rs
@@ -1,0 +1,159 @@
+//! Tests for SET SQL_MODE statement and runtime dialect switching
+//!
+//! Issue #2658: Implement SET SQL_MODE statement for runtime dialect switching
+
+#[cfg(test)]
+mod tests {
+    use vibesql_parser::Parser;
+    use vibesql_storage::Database;
+    use vibesql_types::SqlMode;
+    use crate::{SelectExecutor, SchemaExecutor};
+
+    /// Helper to execute a SET variable statement
+    fn execute_set_variable(db: &mut Database, sql: &str) -> Result<String, crate::errors::ExecutorError> {
+        let stmt = Parser::parse_sql(sql).expect("Failed to parse SET statement");
+        if let vibesql_ast::Statement::SetVariable(set_stmt) = stmt {
+            SchemaExecutor::execute_set_variable(&set_stmt, db)
+        } else {
+            panic!("Expected SetVariable statement, got {:?}", stmt);
+        }
+    }
+
+    /// Helper to execute a SELECT and return the first column of the first row
+    fn select_single_value(db: &Database, sql: &str) -> vibesql_types::SqlValue {
+        let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+        if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+            let executor = SelectExecutor::new(db);
+            let rows = executor.execute(&select_stmt).expect("Failed to execute SELECT");
+            rows[0].values[0].clone()
+        } else {
+            panic!("Expected Select statement");
+        }
+    }
+
+    #[test]
+    fn test_set_sql_mode_mysql() {
+        let mut db = Database::new();
+
+        // Default should be MySQL mode
+        assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
+
+        // Set to sqlite then back to mysql
+        execute_set_variable(&mut db, "SET sql_mode = 'sqlite'").unwrap();
+        assert!(matches!(db.sql_mode(), SqlMode::SQLite));
+
+        let result = execute_set_variable(&mut db, "SET sql_mode = 'mysql'").unwrap();
+        assert!(result.contains("mysql"));
+        assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
+    }
+
+    #[test]
+    fn test_set_sql_mode_sqlite() {
+        let mut db = Database::new();
+
+        let result = execute_set_variable(&mut db, "SET sql_mode = 'sqlite'").unwrap();
+        assert!(result.contains("sqlite"));
+        assert!(matches!(db.sql_mode(), SqlMode::SQLite));
+    }
+
+    #[test]
+    fn test_set_sql_mode_case_insensitive() {
+        let mut db = Database::new();
+
+        // Test uppercase
+        execute_set_variable(&mut db, "SET sql_mode = 'MYSQL'").unwrap();
+        assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
+
+        execute_set_variable(&mut db, "SET sql_mode = 'SQLITE'").unwrap();
+        assert!(matches!(db.sql_mode(), SqlMode::SQLite));
+
+        // Test mixed case
+        execute_set_variable(&mut db, "SET sql_mode = 'MySql'").unwrap();
+        assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
+    }
+
+    #[test]
+    fn test_set_sql_mode_invalid() {
+        let mut db = Database::new();
+
+        let result = execute_set_variable(&mut db, "SET sql_mode = 'invalid'");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_str = err.to_string();
+        assert!(err_str.contains("Unknown SQL mode"));
+    }
+
+    #[test]
+    fn test_select_session_variable_sql_mode() {
+        let mut db = Database::new();
+
+        // Set to SQLite mode
+        execute_set_variable(&mut db, "SET sql_mode = 'sqlite'").unwrap();
+
+        // Query the session variable
+        let value = select_single_value(&mut db, "SELECT @@sql_mode");
+
+        // The session variable should reflect the mode change
+        match value {
+            vibesql_types::SqlValue::Varchar(s) => {
+                // SQLite mode should be reflected in the session variable
+                assert!(s.to_lowercase().contains("sqlite"));
+            }
+            _ => panic!("Expected Varchar value, got {:?}", value),
+        }
+    }
+
+    #[test]
+    fn test_division_behavior_changes_with_mode() {
+        let mut db = Database::new();
+
+        // MySQL mode: 5 / 2 = 2.5 (decimal division)
+        execute_set_variable(&mut db, "SET sql_mode = 'mysql'").unwrap();
+        let mysql_result = select_single_value(&mut db, "SELECT 5 / 2");
+
+        // Should be a decimal value close to 2.5
+        match mysql_result {
+            vibesql_types::SqlValue::Numeric(n) => {
+                let f: f64 = n.to_string().parse().unwrap();
+                assert!((f - 2.5).abs() < 0.0001, "MySQL division 5/2 should be 2.5, got {}", f);
+            }
+            vibesql_types::SqlValue::Real(f) => {
+                assert!((f - 2.5).abs() < 0.0001, "MySQL division 5/2 should be 2.5, got {}", f);
+            }
+            other => {
+                // Accept any numeric-ish result
+                let s = other.to_string();
+                let f: f64 = s.parse().unwrap_or(0.0);
+                assert!((f - 2.5).abs() < 0.0001, "MySQL division 5/2 should be 2.5, got {}", s);
+            }
+        }
+
+        // SQLite mode: 5 / 2 = 2 (integer division)
+        execute_set_variable(&mut db, "SET sql_mode = 'sqlite'").unwrap();
+        let sqlite_result = select_single_value(&mut db, "SELECT 5 / 2");
+
+        // Should be an integer value of 2
+        match sqlite_result {
+            vibesql_types::SqlValue::Integer(i) => {
+                assert_eq!(i, 2, "SQLite division 5/2 should be 2, got {}", i);
+            }
+            other => {
+                let s = other.to_string();
+                let i: i64 = s.parse().unwrap_or(0);
+                assert_eq!(i, 2, "SQLite division 5/2 should be 2, got {}", s);
+            }
+        }
+    }
+
+    #[test]
+    fn test_set_sql_mode_variable_name_case_insensitive() {
+        let mut db = Database::new();
+
+        // Variable name should be case insensitive
+        execute_set_variable(&mut db, "SET SQL_MODE = 'sqlite'").unwrap();
+        assert!(matches!(db.sql_mode(), SqlMode::SQLite));
+
+        execute_set_variable(&mut db, "SET Sql_Mode = 'mysql'").unwrap();
+        assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
+    }
+}

--- a/crates/vibesql-types/src/sql_mode/mod.rs
+++ b/crates/vibesql-types/src/sql_mode/mod.rs
@@ -59,6 +59,32 @@ impl Default for SqlMode {
     }
 }
 
+impl std::fmt::Display for SqlMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SqlMode::MySQL { .. } => write!(f, "mysql"),
+            SqlMode::SQLite => write!(f, "sqlite"),
+        }
+    }
+}
+
+impl std::str::FromStr for SqlMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "mysql" => Ok(SqlMode::MySQL {
+                flags: MySqlModeFlags::default(),
+            }),
+            "sqlite" => Ok(SqlMode::SQLite),
+            _ => Err(format!(
+                "Unknown SQL mode: '{}'. Valid modes: mysql, sqlite",
+                s
+            )),
+        }
+    }
+}
+
 impl SqlMode {
     /// Check if division should return floating-point (true) or integer (false)
     #[deprecated(
@@ -347,5 +373,71 @@ mod tests {
             sqlite_mode.string_concat_operator(),
             ConcatOperator::PipePipe
         );
+    }
+
+    // Tests for FromStr and Display implementations
+
+    #[test]
+    fn test_display_mysql() {
+        let mode = SqlMode::MySQL {
+            flags: MySqlModeFlags::default(),
+        };
+        assert_eq!(mode.to_string(), "mysql");
+    }
+
+    #[test]
+    fn test_display_sqlite() {
+        let mode = SqlMode::SQLite;
+        assert_eq!(mode.to_string(), "sqlite");
+    }
+
+    #[test]
+    fn test_from_str_mysql() {
+        let mode: SqlMode = "mysql".parse().unwrap();
+        assert!(matches!(mode, SqlMode::MySQL { .. }));
+    }
+
+    #[test]
+    fn test_from_str_sqlite() {
+        let mode: SqlMode = "sqlite".parse().unwrap();
+        assert!(matches!(mode, SqlMode::SQLite));
+    }
+
+    #[test]
+    fn test_from_str_case_insensitive() {
+        let mode1: SqlMode = "MYSQL".parse().unwrap();
+        assert!(matches!(mode1, SqlMode::MySQL { .. }));
+
+        let mode2: SqlMode = "SQLite".parse().unwrap();
+        assert!(matches!(mode2, SqlMode::SQLite));
+
+        let mode3: SqlMode = "MySql".parse().unwrap();
+        assert!(matches!(mode3, SqlMode::MySQL { .. }));
+    }
+
+    #[test]
+    fn test_from_str_invalid() {
+        let result: Result<SqlMode, _> = "invalid".parse();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Unknown SQL mode"));
+        assert!(err.contains("invalid"));
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        // MySQL roundtrip
+        let mysql = SqlMode::MySQL {
+            flags: MySqlModeFlags::default(),
+        };
+        let mysql_str = mysql.to_string();
+        let mysql_parsed: SqlMode = mysql_str.parse().unwrap();
+        assert!(matches!(mysql_parsed, SqlMode::MySQL { .. }));
+
+        // SQLite roundtrip
+        let sqlite = SqlMode::SQLite;
+        let sqlite_str = sqlite.to_string();
+        let sqlite_parsed: SqlMode = sqlite_str.parse().unwrap();
+        assert!(matches!(sqlite_parsed, SqlMode::SQLite));
     }
 }


### PR DESCRIPTION
## Summary

- Implement SET SQL_MODE statement for runtime dialect switching
- Add FromStr and Display implementations for SqlMode type
- Intercept sql_mode variable in executor to update database mode
- Add comprehensive integration tests

## Changes

### `crates/vibesql-types/src/sql_mode/mod.rs`
- Add `Display` impl for SqlMode (formats as "mysql" or "sqlite")
- Add `FromStr` impl for SqlMode (parses "mysql", "sqlite", case-insensitive)
- Add unit tests for Display, FromStr, and roundtrip parsing

### `crates/vibesql-executor/src/schema_ddl.rs`
- Intercept `sql_mode` variable in `execute_set_variable()`
- Parse mode string using SqlMode::from_str()
- Call database.set_sql_mode() to update the mode

### `crates/vibesql-executor/src/tests/sql_mode_tests.rs`
- Add integration tests for SET SQL_MODE functionality
- Test mode switching, case insensitivity, invalid modes
- Test division behavior changes with mode
- Test SELECT @@sql_mode query

## Test plan

- [x] `cargo test -p vibesql-types` - All SqlMode tests pass (7 new tests)
- [x] `cargo test -p vibesql-executor sql_mode_tests` - All integration tests pass (7 tests)

## Usage

```sql
SET SQL_MODE = 'mysql';    -- Switch to MySQL mode (decimal division)
SET SQL_MODE = 'sqlite';   -- Switch to SQLite mode (integer division)
SELECT @@sql_mode;         -- Query current mode

-- Division behavior example:
SET SQL_MODE = 'mysql';
SELECT 5 / 2;  -- Returns 2.5 (decimal)

SET SQL_MODE = 'sqlite';
SELECT 5 / 2;  -- Returns 2 (integer)
```

Closes #2658

🤖 Generated with [Claude Code](https://claude.com/claude-code)