### PR TITLE
fix(ci): Add x86-64-v2 suffix to rust-cache key to bust stale binaries

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -29,7 +29,8 @@ runs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        shared-key: rust-${{ inputs.cache-key-suffix }}
+        # x86-64-v2 suffix busts cache after target-cpu change (see .cargo/config.toml)
+        shared-key: rust-${{ inputs.cache-key-suffix }}-x86-64-v2
         # Automatically handles:
         # - ~/.cargo/bin/
         # - ~/.cargo/registry/index/


### PR DESCRIPTION
## Summary

- Adds `-x86-64-v2` suffix to the rust-cache shared-key to invalidate stale cached binaries
- Fixes SIGILL crashes caused by cached binaries compiled with AVX/AVX2 instructions before the target-cpu fix

## Root Cause

The `.cargo/config.toml` fix (commit bd089ef0) set `target-cpu=x86-64-v2` for Linux builds, but `Swatinem/rust-cache` was restoring binaries compiled **before** this change. Since the cache key didn't include the target-cpu setting, stale binaries with AVX/AVX2 instructions were being reused on runners that don't support them.

## Test plan

- [ ] CI passes without SIGILL crash
- [ ] Verify rust-cache shows cache miss (fresh build) on first run after merge

Closes #2668

🤖 Generated with [Claude Code](https://claude.com/claude-code)