### PR TITLE
feat(sqllogictest): Complete runtime dialect switching (Phase 2)

### DIFF
--- a/crates/vibesql-sqllogictest/src/executor/core.rs
+++ b/crates/vibesql-sqllogictest/src/executor/core.rs
@@ -146,6 +146,26 @@ impl RunnerLocals {
     }
 }
 
+/// Supported SQL dialects for auto-switching.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum SqlDialect {
+    /// MySQL 8.0+ compatibility mode (default)
+    #[default]
+    MySQL,
+    /// SQLite 3 compatibility mode
+    SQLite,
+}
+
+impl SqlDialect {
+    /// Get the SQL mode string for SET SQL_MODE command.
+    pub fn as_sql_mode_str(&self) -> &'static str {
+        match self {
+            SqlDialect::MySQL => "mysql",
+            SqlDialect::SQLite => "sqlite",
+        }
+    }
+}
+
 /// Sqllogictest runner.
 pub struct Runner<D: AsyncDB, M: MakeConnection<Conn = D>> {
     pub(super) conn: Connections<D, M>,
@@ -164,6 +184,12 @@ pub struct Runner<D: AsyncDB, M: MakeConnection<Conn = D>> {
     pub(super) labels: HashSet<String>,
     /// Local variables/context for the runner.
     pub(super) locals: RunnerLocals,
+    /// Whether to automatically switch SQL dialect based on skipif/onlyif conditions.
+    /// When enabled, instead of skipping tests with `skipif mysql` or `skipif sqlite`,
+    /// the harness switches to the appropriate dialect and runs the test.
+    pub(super) auto_switch_dialect: bool,
+    /// Current SQL dialect being used.
+    pub(super) current_dialect: SqlDialect,
 }
 
 impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
@@ -183,12 +209,54 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
             labels: HashSet::new(),
             conn: Connections::new(make_conn),
             locals: RunnerLocals::default(),
+            auto_switch_dialect: false,
+            current_dialect: SqlDialect::default(),
         }
     }
 
     /// Add a label for condition `skipif` and `onlyif`.
     pub fn add_label(&mut self, label: &str) {
         self.labels.insert(label.to_string());
+    }
+
+    /// Enable automatic SQL dialect switching based on skipif/onlyif conditions.
+    ///
+    /// When enabled, instead of skipping tests with `skipif mysql` or `skipif sqlite`,
+    /// the harness automatically switches to the appropriate dialect and runs the test.
+    ///
+    /// This allows the test harness to run all tests regardless of dialect, maximizing
+    /// test coverage.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let mut tester = Runner::new(make_conn);
+    /// tester.enable_auto_switch_dialect();
+    ///
+    /// // Tests with `skipif mysql` will now run in sqlite mode
+    /// // Tests with `skipif sqlite` will now run in mysql mode
+    /// ```
+    pub fn enable_auto_switch_dialect(&mut self) {
+        self.auto_switch_dialect = true;
+    }
+
+    /// Disable automatic SQL dialect switching.
+    pub fn disable_auto_switch_dialect(&mut self) {
+        self.auto_switch_dialect = false;
+    }
+
+    /// Set the default SQL dialect for the runner.
+    pub fn with_default_dialect(&mut self, dialect: SqlDialect) {
+        self.current_dialect = dialect;
+    }
+
+    /// Get the current SQL dialect.
+    pub fn current_dialect(&self) -> &SqlDialect {
+        &self.current_dialect
+    }
+
+    /// Check if auto dialect switching is enabled.
+    pub fn is_auto_switch_dialect_enabled(&self) -> bool {
+        self.auto_switch_dialect
     }
 
     /// Set a local variable for substitution.
@@ -363,5 +431,35 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
     /// Shutdown all connections in the runner.
     pub fn shutdown(&mut self) {
         block_on(self.shutdown_async());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sql_dialect_default() {
+        assert_eq!(SqlDialect::default(), SqlDialect::MySQL);
+    }
+
+    #[test]
+    fn test_sql_dialect_as_sql_mode_str() {
+        assert_eq!(SqlDialect::MySQL.as_sql_mode_str(), "mysql");
+        assert_eq!(SqlDialect::SQLite.as_sql_mode_str(), "sqlite");
+    }
+
+    #[test]
+    fn test_sql_dialect_equality() {
+        assert_eq!(SqlDialect::MySQL, SqlDialect::MySQL);
+        assert_eq!(SqlDialect::SQLite, SqlDialect::SQLite);
+        assert_ne!(SqlDialect::MySQL, SqlDialect::SQLite);
+    }
+
+    #[test]
+    fn test_sql_dialect_clone() {
+        let dialect = SqlDialect::SQLite;
+        let cloned = dialect.clone();
+        assert_eq!(dialect, cloned);
     }
 }

--- a/crates/vibesql-sqllogictest/src/executor/mod.rs
+++ b/crates/vibesql-sqllogictest/src/executor/mod.rs
@@ -7,5 +7,5 @@ mod validator;
 
 // Re-export public types and traits
 pub use core::{
-    AsyncDB, DB, Partitioner, Runner, RunnerLocals, default_partitioner,
+    AsyncDB, DB, Partitioner, Runner, RunnerLocals, SqlDialect, default_partitioner,
 };

--- a/crates/vibesql-sqllogictest/src/executor/parallel.rs
+++ b/crates/vibesql-sqllogictest/src/executor/parallel.rs
@@ -59,6 +59,8 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                 hash_threshold: self.hash_threshold,
                 labels: self.labels.clone(),
                 locals,
+                auto_switch_dialect: self.auto_switch_dialect,
+                current_dialect: self.current_dialect.clone(),
             };
 
             tasks.push(async move {

--- a/crates/vibesql-sqllogictest/src/executor/record_processor.rs
+++ b/crates/vibesql-sqllogictest/src/executor/record_processor.rs
@@ -10,9 +10,74 @@ use crate::column_type::ColumnType;
 use crate::error_handling::AnyError;
 use crate::output::{RecordOutput, DBOutput};
 use crate::parser::*;
-use super::core::{AsyncDB, Runner};
+use super::core::{AsyncDB, Runner, SqlDialect};
 
 impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
+    /// Infer the required SQL dialect from skipif/onlyif conditions.
+    ///
+    /// Returns the dialect that should be used to run this test, or None if:
+    /// - No dialect-specific conditions are present
+    /// - The condition refers to an unsupported dialect (like postgresql)
+    fn infer_required_dialect(conditions: &[Condition]) -> Option<SqlDialect> {
+        for cond in conditions {
+            match cond {
+                // skipif mysql means "this test is for non-MySQL dialects" -> use sqlite
+                Condition::SkipIf { label } if label.eq_ignore_ascii_case("mysql") => {
+                    return Some(SqlDialect::SQLite);
+                }
+                // skipif sqlite means "this test is for non-SQLite dialects" -> use mysql
+                Condition::SkipIf { label } if label.eq_ignore_ascii_case("sqlite") => {
+                    return Some(SqlDialect::MySQL);
+                }
+                // onlyif mysql means "this test is MySQL-specific" -> use mysql
+                Condition::OnlyIf { label } if label.eq_ignore_ascii_case("mysql") => {
+                    return Some(SqlDialect::MySQL);
+                }
+                // onlyif sqlite means "this test is SQLite-specific" -> use sqlite
+                Condition::OnlyIf { label } if label.eq_ignore_ascii_case("sqlite") => {
+                    return Some(SqlDialect::SQLite);
+                }
+                // Other labels (postgresql, etc.) - not supported, return None to let normal skip logic handle
+                _ => {}
+            }
+        }
+        None
+    }
+
+    /// Switch to the specified dialect if different from current.
+    /// Returns an error output if the switch fails, or None on success.
+    async fn switch_dialect_if_needed(
+        &mut self,
+        required: &SqlDialect,
+    ) -> Option<RecordOutput<D::ColumnType>> {
+        if &self.current_dialect == required {
+            return None; // Already in the right dialect
+        }
+
+        let conn = match self.conn.get(Connection::Default).await {
+            Ok(conn) => conn,
+            Err(e) => {
+                return Some(RecordOutput::Statement {
+                    count: 0,
+                    error: Some(Arc::new(e)),
+                });
+            }
+        };
+
+        let sql = format!("SET SQL_MODE = '{}'", required.as_sql_mode_str());
+        match conn.run(&sql).await {
+            Ok(_) => {
+                tracing::debug!("Auto-switched dialect to: {:?}", required);
+                self.current_dialect = required.clone();
+                None // Success
+            }
+            Err(e) => Some(RecordOutput::Statement {
+                count: 0,
+                error: Some(Arc::new(e)),
+            }),
+        }
+    }
+
     pub async fn apply_record(
         &mut self,
         record: Record<D::ColumnType>,
@@ -56,6 +121,32 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                     }
                 };
 
+                let conn = match self.conn.get(connection.clone()).await {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        return RecordOutput::Statement {
+                            count: 0,
+                            error: Some(Arc::new(e)),
+                        }
+                    }
+                };
+
+                // Auto-switch dialect if enabled and conditions indicate a dialect requirement
+                if self.auto_switch_dialect {
+                    if let Some(required_dialect) = Self::infer_required_dialect(&conditions) {
+                        if let Some(error_output) = self.switch_dialect_if_needed(&required_dialect).await {
+                            return error_output;
+                        }
+                        // Don't skip - we've switched to the required dialect, now execute the test
+                    } else if should_skip(&self.labels, conn.engine_name(), &conditions) {
+                        // Non-dialect condition (e.g., postgresql) - use normal skip logic
+                        return RecordOutput::Nothing;
+                    }
+                } else if should_skip(&self.labels, conn.engine_name(), &conditions) {
+                    return RecordOutput::Nothing;
+                }
+
+                // Re-acquire connection since switch_dialect_if_needed may have used it
                 let conn = match self.conn.get(connection).await {
                     Ok(conn) => conn,
                     Err(e) => {
@@ -65,9 +156,6 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                         }
                     }
                 };
-                if should_skip(&self.labels, conn.engine_name(), &conditions) {
-                    return RecordOutput::Nothing;
-                }
 
                 let ret = conn.run(&sql).await;
                 match ret {
@@ -206,6 +294,33 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                     }
                 };
 
+                let conn = match self.conn.get(connection.clone()).await {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        return RecordOutput::Query {
+                            error: Some(Arc::new(e)),
+                            types: vec![],
+                            rows: vec![],
+                        }
+                    }
+                };
+
+                // Auto-switch dialect if enabled and conditions indicate a dialect requirement
+                if self.auto_switch_dialect {
+                    if let Some(required_dialect) = Self::infer_required_dialect(&conditions) {
+                        if let Some(error_output) = self.switch_dialect_if_needed(&required_dialect).await {
+                            return error_output;
+                        }
+                        // Don't skip - we've switched to the required dialect, now execute the test
+                    } else if should_skip(&self.labels, conn.engine_name(), &conditions) {
+                        // Non-dialect condition (e.g., postgresql) - use normal skip logic
+                        return RecordOutput::Nothing;
+                    }
+                } else if should_skip(&self.labels, conn.engine_name(), &conditions) {
+                    return RecordOutput::Nothing;
+                }
+
+                // Re-acquire connection since switch_dialect_if_needed may have used it
                 let conn = match self.conn.get(connection).await {
                     Ok(conn) => conn,
                     Err(e) => {
@@ -216,9 +331,6 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                         }
                     }
                 };
-                if should_skip(&self.labels, conn.engine_name(), &conditions) {
-                    return RecordOutput::Nothing;
-                }
 
                 let (mut types, mut rows) = match conn.run(&sql).await {
                     Ok(out) => match out {
@@ -370,6 +482,11 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                 match conn.run(&sql).await {
                     Ok(_) => {
                         tracing::debug!("Switched dialect to: {}", mode);
+                        // Update current dialect tracking
+                        self.current_dialect = match mode.to_lowercase().as_str() {
+                            "sqlite" => SqlDialect::SQLite,
+                            _ => SqlDialect::MySQL,
+                        };
                         RecordOutput::Nothing
                     }
                     Err(e) => RecordOutput::Statement {
@@ -386,5 +503,89 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
             | Record::Condition(_)
             | Record::Connection(_) => RecordOutput::Nothing,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::Condition;
+
+    // Helper trait to allow testing infer_required_dialect without a full Runner
+    fn test_infer_dialect(conditions: &[Condition]) -> Option<SqlDialect> {
+        // Copy the logic from Runner::infer_required_dialect
+        for cond in conditions {
+            match cond {
+                Condition::SkipIf { label } if label.eq_ignore_ascii_case("mysql") => {
+                    return Some(SqlDialect::SQLite);
+                }
+                Condition::SkipIf { label } if label.eq_ignore_ascii_case("sqlite") => {
+                    return Some(SqlDialect::MySQL);
+                }
+                Condition::OnlyIf { label } if label.eq_ignore_ascii_case("mysql") => {
+                    return Some(SqlDialect::MySQL);
+                }
+                Condition::OnlyIf { label } if label.eq_ignore_ascii_case("sqlite") => {
+                    return Some(SqlDialect::SQLite);
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_infer_dialect_skipif_mysql() {
+        let conditions = vec![Condition::SkipIf { label: "mysql".to_string() }];
+        assert_eq!(test_infer_dialect(&conditions), Some(SqlDialect::SQLite));
+    }
+
+    #[test]
+    fn test_infer_dialect_skipif_sqlite() {
+        let conditions = vec![Condition::SkipIf { label: "sqlite".to_string() }];
+        assert_eq!(test_infer_dialect(&conditions), Some(SqlDialect::MySQL));
+    }
+
+    #[test]
+    fn test_infer_dialect_onlyif_mysql() {
+        let conditions = vec![Condition::OnlyIf { label: "mysql".to_string() }];
+        assert_eq!(test_infer_dialect(&conditions), Some(SqlDialect::MySQL));
+    }
+
+    #[test]
+    fn test_infer_dialect_onlyif_sqlite() {
+        let conditions = vec![Condition::OnlyIf { label: "sqlite".to_string() }];
+        assert_eq!(test_infer_dialect(&conditions), Some(SqlDialect::SQLite));
+    }
+
+    #[test]
+    fn test_infer_dialect_case_insensitive() {
+        let conditions = vec![Condition::SkipIf { label: "MySQL".to_string() }];
+        assert_eq!(test_infer_dialect(&conditions), Some(SqlDialect::SQLite));
+
+        let conditions = vec![Condition::OnlyIf { label: "SQLITE".to_string() }];
+        assert_eq!(test_infer_dialect(&conditions), Some(SqlDialect::SQLite));
+    }
+
+    #[test]
+    fn test_infer_dialect_postgresql_not_supported() {
+        let conditions = vec![Condition::SkipIf { label: "postgresql".to_string() }];
+        assert_eq!(test_infer_dialect(&conditions), None);
+    }
+
+    #[test]
+    fn test_infer_dialect_no_conditions() {
+        let conditions: Vec<Condition> = vec![];
+        assert_eq!(test_infer_dialect(&conditions), None);
+    }
+
+    #[test]
+    fn test_infer_dialect_multiple_conditions() {
+        // First matching condition wins
+        let conditions = vec![
+            Condition::SkipIf { label: "postgresql".to_string() },
+            Condition::SkipIf { label: "mysql".to_string() },
+        ];
+        assert_eq!(test_infer_dialect(&conditions), Some(SqlDialect::SQLite));
     }
 }

--- a/crates/vibesql-sqllogictest/src/harness.rs
+++ b/crates/vibesql-sqllogictest/src/harness.rs
@@ -37,6 +37,21 @@ pub fn test(filename: impl AsRef<Path>, make_conn: impl MakeConnection) -> Resul
     // Add "mysql" label for skipif/onlyif directives
     // VibeSQL uses MySQL-compatible division (returns REAL/DECIMAL for integer division)
     tester.add_label("mysql");
+    // Enable auto-switching of SQL dialect based on skipif/onlyif conditions.
+    // This allows tests with `skipif mysql` to run in sqlite mode and vice versa,
+    // maximizing test coverage instead of skipping tests.
+    tester.enable_auto_switch_dialect();
+    tester.run_file(filename)?;
+    tester.shutdown();
+    Ok(())
+}
+
+/// Test with auto-dialect switching disabled.
+/// Use this when you want the original skip behavior based on labels.
+pub fn test_no_auto_switch(filename: impl AsRef<Path>, make_conn: impl MakeConnection) -> Result<(), Failed> {
+    let mut tester = Runner::new(make_conn);
+    tester.add_label("mysql");
+    // Auto-switch is disabled by default, but we explicitly note it here
     tester.run_file(filename)?;
     tester.shutdown();
     Ok(())


### PR DESCRIPTION
## Summary

This PR completes Phase 2 of the Runtime SQL Dialect Switching epic (#2656) by merging the remaining features from the feature branch into main.

## Changes Included

- **SET SQL_MODE statement** - Runtime dialect switching via `SET SQL_MODE = 'mysql'` or `SET SQL_MODE = 'sqlite'`
- **`dialect` directive** - New sqllogictest directive for switching SQL mode within test files
- **Auto-switch from skipif/onlyif** - Test harness automatically switches dialect based on `skipif`/`onlyif` conditions instead of skipping tests

## Related Issues

Closes #2659 (dialect directive - already closed but this merges to main)

Part of Epic #2656

## PRs Included

- PR #2674 - Auto-switch dialect from skipif/onlyif conditions
- Commits from issues #2658, #2659

## Test plan

- [ ] All existing tests continue to pass
- [ ] New dialect switching functionality works as expected
- [ ] No regressions in sqllogictest behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)