### PR TITLE
fix(types): Change default SqlMode from MySQL to SQLite for correct integer division

### DIFF
--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/mod.rs
@@ -178,10 +178,25 @@ mod tests {
     }
 
     #[test]
-    fn test_integer_division() {
-        // Division returns Numeric for integer operands in MySQL mode (exact decimal arithmetic)
+    fn test_integer_division_sqlite() {
+        // SQLite mode (default): Division returns Integer for integer operands (truncated)
         let result = ArithmeticOps::divide(&SqlValue::Integer(15), &SqlValue::Integer(3), vibesql_types::SqlMode::default()).unwrap();
+        assert_eq!(result, SqlValue::Integer(5));
+
+        // Test truncation behavior
+        let result = ArithmeticOps::divide(&SqlValue::Integer(15), &SqlValue::Integer(4), vibesql_types::SqlMode::default()).unwrap();
+        assert_eq!(result, SqlValue::Integer(3)); // 15/4 = 3.75 truncates to 3
+    }
+
+    #[test]
+    fn test_integer_division_mysql() {
+        // MySQL mode: Division returns Numeric for integer operands (exact decimal arithmetic)
+        let mysql_mode = vibesql_types::SqlMode::MySQL { flags: Default::default() };
+        let result = ArithmeticOps::divide(&SqlValue::Integer(15), &SqlValue::Integer(3), mysql_mode.clone()).unwrap();
         assert_eq!(result, SqlValue::Numeric(5.0));
+
+        let result = ArithmeticOps::divide(&SqlValue::Integer(15), &SqlValue::Integer(4), mysql_mode).unwrap();
+        assert_eq!(result, SqlValue::Numeric(3.75));
     }
 
     #[test]
@@ -265,14 +280,28 @@ mod tests {
 
     #[test]
     fn test_boolean_division() {
-        // 10 / TRUE = 10.0 (booleans coerce to integers, then division returns exact decimal)
+        // SQLite mode (default): 10 / TRUE = 10 (integer division)
         let result =
             ArithmeticOps::divide(&SqlValue::Integer(10), &SqlValue::Boolean(true), vibesql_types::SqlMode::default()).unwrap();
+        assert_eq!(result, SqlValue::Integer(10));
+
+        // TRUE / TRUE = 1
+        let result =
+            ArithmeticOps::divide(&SqlValue::Boolean(true), &SqlValue::Boolean(true), vibesql_types::SqlMode::default()).unwrap();
+        assert_eq!(result, SqlValue::Integer(1));
+    }
+
+    #[test]
+    fn test_boolean_division_mysql() {
+        // MySQL mode: 10 / TRUE = 10.0 (exact decimal division)
+        let mysql_mode = vibesql_types::SqlMode::MySQL { flags: Default::default() };
+        let result =
+            ArithmeticOps::divide(&SqlValue::Integer(10), &SqlValue::Boolean(true), mysql_mode.clone()).unwrap();
         assert_eq!(result, SqlValue::Numeric(10.0));
 
         // TRUE / TRUE = 1.0
         let result =
-            ArithmeticOps::divide(&SqlValue::Boolean(true), &SqlValue::Boolean(true), vibesql_types::SqlMode::default()).unwrap();
+            ArithmeticOps::divide(&SqlValue::Boolean(true), &SqlValue::Boolean(true), mysql_mode).unwrap();
         assert_eq!(result, SqlValue::Numeric(1.0));
     }
 

--- a/crates/vibesql-types/src/lib.rs
+++ b/crates/vibesql-types/src/lib.rs
@@ -15,5 +15,6 @@ mod temporal;
 pub use data_type::DataType;
 pub use sql_mode::{MySqlModeFlags, SqlMode};
 pub use sql_mode::types::{TypeBehavior, ValueType};
+pub use sql_mode::{OperatorBehavior, DivisionBehavior, ConcatOperator};
 pub use sql_value::SqlValue;
 pub use temporal::{Date, Interval, IntervalField, Time, Timestamp};

--- a/crates/vibesql-types/src/sql_mode/mod.rs
+++ b/crates/vibesql-types/src/sql_mode/mod.rs
@@ -52,10 +52,10 @@ pub enum SqlMode {
 
 impl Default for SqlMode {
     fn default() -> Self {
-        // Default to MySQL mode for SQLLogicTest compatibility
-        SqlMode::MySQL {
-            flags: MySqlModeFlags::default(),
-        }
+        // Default to SQLite mode for SQLLogicTest compatibility
+        // The SQLLogicTest suite is derived from SQLite and expects SQLite semantics
+        // including integer division (INTEGER / INTEGER → INTEGER, truncated)
+        SqlMode::SQLite
     }
 }
 
@@ -180,14 +180,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_default_is_mysql() {
+    fn test_default_is_sqlite() {
+        // Default is SQLite for SQLLogicTest compatibility (SQLite-derived test suite)
         let mode = SqlMode::default();
-        assert!(matches!(mode, SqlMode::MySQL { .. }));
+        assert!(matches!(mode, SqlMode::SQLite));
     }
 
     #[test]
-    fn test_default_mysql_has_default_flags() {
-        let mode = SqlMode::default();
+    fn test_mysql_mode_has_default_flags() {
+        // Test that MySQL mode can be constructed with default flags
+        let mode = SqlMode::MySQL { flags: MySqlModeFlags::default() };
         if let SqlMode::MySQL { flags } = mode {
             assert_eq!(flags, MySqlModeFlags::default());
         } else {

--- a/crates/vibesql-types/src/sql_mode/operators.rs
+++ b/crates/vibesql-types/src/sql_mode/operators.rs
@@ -40,9 +40,9 @@ pub enum ConcatOperator {
 /// ## Example
 ///
 /// ```rust
-/// use vibesql_types::sql_mode::{SqlMode, OperatorBehavior, DivisionBehavior};
+/// use vibesql_types::{SqlMode, MySqlModeFlags, OperatorBehavior, DivisionBehavior};
 ///
-/// let mode = SqlMode::MySQL;
+/// let mode = SqlMode::MySQL { flags: MySqlModeFlags::default() };
 /// assert_eq!(mode.integer_division_behavior(), DivisionBehavior::Decimal);
 /// assert!(mode.supports_xor());
 /// ```

--- a/crates/vibesql-types/src/sql_mode/types.rs
+++ b/crates/vibesql-types/src/sql_mode/types.rs
@@ -39,10 +39,9 @@ pub enum ValueType {
 /// # Examples
 ///
 /// ```
-/// use vibesql_types::{SqlMode, SqlValue};
-/// use vibesql_types::sql_mode::types::{TypeBehavior, ValueType};
+/// use vibesql_types::{SqlMode, SqlValue, MySqlModeFlags, TypeBehavior, ValueType};
 ///
-/// let mysql_mode = SqlMode::MySQL;
+/// let mysql_mode = SqlMode::MySQL { flags: MySqlModeFlags::default() };
 /// let sqlite_mode = SqlMode::SQLite;
 ///
 /// // MySQL always returns Numeric for division
@@ -189,25 +188,29 @@ mod tests {
 
     #[test]
     fn test_has_decimal_type() {
-        assert!(SqlMode::default().has_decimal_type());
+        assert!(SqlMode::MySQL { flags: Default::default() }.has_decimal_type());
         assert!(!SqlMode::SQLite.has_decimal_type());
+        // Default is now SQLite
+        assert!(!SqlMode::default().has_decimal_type());
     }
 
     #[test]
     fn test_uses_dynamic_typing() {
-        assert!(!SqlMode::default().uses_dynamic_typing());
+        assert!(!SqlMode::MySQL { flags: Default::default() }.uses_dynamic_typing());
         assert!(SqlMode::SQLite.uses_dynamic_typing());
+        // Default is now SQLite
+        assert!(SqlMode::default().uses_dynamic_typing());
     }
 
     #[test]
     fn test_permissive_type_coercion() {
-        assert!(SqlMode::default().permissive_type_coercion());
+        assert!(SqlMode::MySQL { flags: Default::default() }.permissive_type_coercion());
         assert!(SqlMode::SQLite.permissive_type_coercion());
     }
 
     #[test]
     fn test_mysql_division_result_type() {
-        let mode = SqlMode::default();
+        let mode = SqlMode::MySQL { flags: Default::default() };
 
         // MySQL always returns Numeric for division
         assert_eq!(

--- a/tests/sqllogictest/db_adapter/pool.rs
+++ b/tests/sqllogictest/db_adapter/pool.rs
@@ -28,9 +28,9 @@ pub fn get_pooled_database() -> Database {
                 db
             }
             None => {
-                // First use - create new database with MySQL mode (default)
-                // The SQLLogicTest suite was generated from MySQL 8 and expects MySQL semantics
-                // including decimal division (INTEGER / INTEGER → DECIMAL)
+                // First use - create new database with SQLite mode (default)
+                // The SQLLogicTest suite is derived from SQLite and expects SQLite semantics
+                // including integer division (INTEGER / INTEGER → INTEGER, truncated)
                 vibesql_storage::Database::new()
             }
         }


### PR DESCRIPTION
## Summary

- Changed default `SqlMode` from MySQL to SQLite to fix integer division behavior
- The SQLLogicTest suite expects SQLite semantics (integer division truncates)
- Updated tests to explicitly use MySQL mode where needed

## Root Cause

The failing test `random/aggregates/slt_good_121.test` had a query:

```sql
SELECT ALL - + col0 * - col2 AS col2 
FROM tab0 
WHERE NOT - col0 NOT IN ( col2, - col0 / - col1 * - col1 )
```

The expression `- col0 / - col1 * - col1` was returning floating-point results (e.g., `-15.0`) instead of integer results (e.g., `0`), causing incorrect row filtering.

**SQLite (expected)**: `15 / 81 = 0` (integer division, truncated)
**MySQL (previous default)**: `15 / 81 = 0.185...` (decimal division)

## Test plan

- [x] `./scripts/sqllogictest test random/aggregates/slt_good_121.test` passes
- [x] Verified `SELECT 15 / 81` returns `Integer(0)` (not `Numeric(0.185...)`)
- [x] `cargo test --package vibesql-types` passes (69 tests)
- [x] Release build succeeds

Closes #2683

🤖 Generated with [Claude Code](https://claude.com/claude-code)