### PR TITLE
fix(parser): Allow interval unit keywords as column identifiers

### DIFF
--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -298,11 +298,16 @@ impl Keyword {
     /// These are "unreserved" keywords that are only treated as keywords in specific contexts.
     ///
     /// This follows SQLite's behavior where temporal type keywords (TIMESTAMP, DATE, TIME, INTERVAL)
-    /// can be used as identifiers without quoting.
+    /// and interval unit keywords (YEAR, MONTH, DAY, etc.) can be used as identifiers without quoting.
     pub fn can_be_identifier(&self) -> bool {
         matches!(
             self,
-            Keyword::Timestamp | Keyword::Date | Keyword::Time | Keyword::Interval
+            // Temporal type keywords
+            Keyword::Timestamp | Keyword::Date | Keyword::Time | Keyword::Interval |
+            // Interval unit keywords (used in EXTRACT, DATE_ADD, etc. but also valid as identifiers)
+            Keyword::Year | Keyword::Quarter | Keyword::Month | Keyword::Week |
+            Keyword::Day | Keyword::Hour | Keyword::Minute | Keyword::Second |
+            Keyword::Microsecond
         )
     }
 }

--- a/crates/vibesql-parser/src/parser/expressions/identifiers.rs
+++ b/crates/vibesql-parser/src/parser/expressions/identifiers.rs
@@ -5,122 +5,131 @@ impl Parser {
     pub(super) fn parse_identifier_expression(
         &mut self,
     ) -> Result<Option<vibesql_ast::Expression>, ParseError> {
-        match self.peek() {
+        // Extract identifier string from token (handles regular identifiers and keywords-as-identifiers)
+        let first = match self.peek() {
             Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                let first = id.clone();
+                let name = id.clone();
+                self.advance();
+                name
+            }
+            Token::Keyword(kw) if kw.can_be_identifier() => {
+                // Allow certain keywords (MONTH, YEAR, DAY, etc.) to be used as column names
+                let name = format!("{}", kw); // Uses Display impl, returns uppercase
+                self.advance();
+                name
+            }
+            _ => return Ok(None),
+        };
+
+        // Check for hex/binary literal (x'...' or b'...')
+        let first_upper = first.to_uppercase();
+        if (first_upper == "X" || first_upper == "B") && matches!(self.peek(), Token::String(_)) {
+            if let Token::String(s) = self.peek() {
+                let string_val = s.clone();
                 self.advance();
 
-                // Check for hex/binary literal (x'...' or b'...')
-                let first_upper = first.to_uppercase();
-                if (first_upper == "X" || first_upper == "B") && matches!(self.peek(), Token::String(_)) {
-                    if let Token::String(s) = self.peek() {
-                        let string_val = s.clone();
-                        self.advance();
+                if first_upper == "X" {
+                    // Parse hex literal: x'303132' -> "\x30\x31\x32"
+                    // Validate and decode hex string
+                    if string_val.len() % 2 != 0 {
+                        return Err(ParseError {
+                            message: format!("Hex literal must have even number of digits: x'{}'", string_val),
+                        });
+                    }
 
-                        if first_upper == "X" {
-                            // Parse hex literal: x'303132' -> "\x30\x31\x32"
-                            // Validate and decode hex string
-                            if string_val.len() % 2 != 0 {
+                    let mut bytes = Vec::new();
+                    for i in (0..string_val.len()).step_by(2) {
+                        let hex_byte = &string_val[i..i + 2];
+                        match u8::from_str_radix(hex_byte, 16) {
+                            Ok(byte) => bytes.push(byte),
+                            Err(_) => {
                                 return Err(ParseError {
-                                    message: format!("Hex literal must have even number of digits: x'{}'", string_val),
+                                    message: format!("Invalid hex digit in literal: x'{}'", string_val),
                                 });
                             }
-
-                            let mut bytes = Vec::new();
-                            for i in (0..string_val.len()).step_by(2) {
-                                let hex_byte = &string_val[i..i + 2];
-                                match u8::from_str_radix(hex_byte, 16) {
-                                    Ok(byte) => bytes.push(byte),
-                                    Err(_) => {
-                                        return Err(ParseError {
-                                            message: format!("Invalid hex digit in literal: x'{}'", string_val),
-                                        });
-                                    }
-                                }
-                            }
-
-                            // Convert bytes to string (UTF-8 lossy conversion for compatibility)
-                            let result = String::from_utf8_lossy(&bytes).to_string();
-                            return Ok(Some(vibesql_ast::Expression::Literal(
-                                vibesql_types::SqlValue::Varchar(result),
-                            )));
-                        } else {
-                            // Parse binary literal: b'01010101' -> "U"
-                            if !string_val.chars().all(|c| c == '0' || c == '1') {
-                                return Err(ParseError {
-                                    message: format!("Binary literal must contain only 0 and 1: b'{}'", string_val),
-                                });
-                            }
-
-                            if string_val.len() % 8 != 0 {
-                                return Err(ParseError {
-                                    message: format!("Binary literal must have length divisible by 8: b'{}'", string_val),
-                                });
-                            }
-
-                            let mut bytes = Vec::new();
-                            for i in (0..string_val.len()).step_by(8) {
-                                let binary_byte = &string_val[i..i + 8];
-                                match u8::from_str_radix(binary_byte, 2) {
-                                    Ok(byte) => bytes.push(byte),
-                                    Err(_) => {
-                                        return Err(ParseError {
-                                            message: format!("Invalid binary literal: b'{}'", string_val),
-                                        });
-                                    }
-                                }
-                            }
-
-                            // Convert bytes to string
-                            let result = String::from_utf8_lossy(&bytes).to_string();
-                            return Ok(Some(vibesql_ast::Expression::Literal(
-                                vibesql_types::SqlValue::Varchar(result),
-                            )));
                         }
                     }
-                }
 
-                // Check for function call (identifier followed by '(')
-                if matches!(self.peek(), Token::LParen) {
-                    // This is handled by parse_function_call, return None
-                    // We need to rewind
-                    self.position -= 1;
-                    return Ok(None);
-                }
-                // Check for qualified column reference (table.column)
-                if matches!(self.peek(), Token::Symbol('.')) {
-                    self.advance(); // consume '.'
-                    match self.peek() {
-                        Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
-                            let column = col.clone();
-                            self.advance();
-
-                            // Check for pseudo-variable (OLD.column or NEW.column)
-                            let first_upper = first.to_uppercase();
-                            if first_upper == "OLD" || first_upper == "NEW" {
-                                let pseudo_table = if first_upper == "OLD" {
-                                    vibesql_ast::PseudoTable::Old
-                                } else {
-                                    vibesql_ast::PseudoTable::New
-                                };
-                                Ok(Some(vibesql_ast::Expression::PseudoVariable {
-                                    pseudo_table,
-                                    column,
-                                }))
-                            } else {
-                                Ok(Some(vibesql_ast::Expression::ColumnRef { table: Some(first), column }))
-                            }
-                        }
-                        _ => Err(ParseError {
-                            message: "Expected column name after '.'".to_string(),
-                        }),
-                    }
+                    // Convert bytes to string (UTF-8 lossy conversion for compatibility)
+                    let result = String::from_utf8_lossy(&bytes).to_string();
+                    return Ok(Some(vibesql_ast::Expression::Literal(
+                        vibesql_types::SqlValue::Varchar(result),
+                    )));
                 } else {
-                    // Simple column reference
-                    Ok(Some(vibesql_ast::Expression::ColumnRef { table: None, column: first }))
+                    // Parse binary literal: b'01010101' -> "U"
+                    if !string_val.chars().all(|c| c == '0' || c == '1') {
+                        return Err(ParseError {
+                            message: format!("Binary literal must contain only 0 and 1: b'{}'", string_val),
+                        });
+                    }
+
+                    if string_val.len() % 8 != 0 {
+                        return Err(ParseError {
+                            message: format!("Binary literal must have length divisible by 8: b'{}'", string_val),
+                        });
+                    }
+
+                    let mut bytes = Vec::new();
+                    for i in (0..string_val.len()).step_by(8) {
+                        let binary_byte = &string_val[i..i + 8];
+                        match u8::from_str_radix(binary_byte, 2) {
+                            Ok(byte) => bytes.push(byte),
+                            Err(_) => {
+                                return Err(ParseError {
+                                    message: format!("Invalid binary literal: b'{}'", string_val),
+                                });
+                            }
+                        }
+                    }
+
+                    // Convert bytes to string
+                    let result = String::from_utf8_lossy(&bytes).to_string();
+                    return Ok(Some(vibesql_ast::Expression::Literal(
+                        vibesql_types::SqlValue::Varchar(result),
+                    )));
                 }
             }
-            _ => Ok(None),
+        }
+
+        // Check for function call (identifier followed by '(')
+        if matches!(self.peek(), Token::LParen) {
+            // This is handled by parse_function_call, return None
+            // We need to rewind
+            self.position -= 1;
+            return Ok(None);
+        }
+
+        // Check for qualified column reference (table.column)
+        if matches!(self.peek(), Token::Symbol('.')) {
+            self.advance(); // consume '.'
+            match self.peek() {
+                Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
+                    let column = col.clone();
+                    self.advance();
+
+                    // Check for pseudo-variable (OLD.column or NEW.column)
+                    let first_upper = first.to_uppercase();
+                    if first_upper == "OLD" || first_upper == "NEW" {
+                        let pseudo_table = if first_upper == "OLD" {
+                            vibesql_ast::PseudoTable::Old
+                        } else {
+                            vibesql_ast::PseudoTable::New
+                        };
+                        Ok(Some(vibesql_ast::Expression::PseudoVariable {
+                            pseudo_table,
+                            column,
+                        }))
+                    } else {
+                        Ok(Some(vibesql_ast::Expression::ColumnRef { table: Some(first), column }))
+                    }
+                }
+                _ => Err(ParseError {
+                    message: "Expected column name after '.'".to_string(),
+                }),
+            }
+        } else {
+            // Simple column reference
+            Ok(Some(vibesql_ast::Expression::ColumnRef { table: None, column: first }))
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes parsing failure when interval unit keywords (like `MONTH`, `YEAR`, `DAY`) are used as column names.

## Changes

1. **Extended `can_be_identifier()`** (`crates/vibesql-parser/src/keywords.rs`):
   - Added interval unit keywords: `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`, `HOUR`, `MINUTE`, `SECOND`, `MICROSECOND`
   - These keywords can now be used as unquoted identifiers

2. **Updated `parse_identifier_expression()`** (`crates/vibesql-parser/src/parser/expressions/identifiers.rs`):
   - Added handling for `Token::Keyword(kw)` when `kw.can_be_identifier()` returns true
   - Refactored to extract identifier name first, then process (cleaner structure)

## Test Plan

- [x] `test_window_lag_basic` passes
- [x] `test_window_lead_basic` passes
- [x] All 887 parser tests pass
- [x] All 8 window function tests pass

Closes #2685