### PR TITLE
feat(tests): Add per-dialect tracking to SQLLogicTest results

### DIFF
--- a/crates/vibesql-sqllogictest/src/executor/core.rs
+++ b/crates/vibesql-sqllogictest/src/executor/core.rs
@@ -166,6 +166,59 @@ impl SqlDialect {
     }
 }
 
+/// Statistics tracking tests executed per SQL dialect.
+#[derive(Debug, Clone, Default)]
+pub struct DialectStats {
+    /// Number of tests that passed in MySQL mode.
+    pub mysql_passed: usize,
+    /// Number of tests that failed in MySQL mode.
+    pub mysql_failed: usize,
+    /// Number of tests that passed in SQLite mode.
+    pub sqlite_passed: usize,
+    /// Number of tests that failed in SQLite mode.
+    pub sqlite_failed: usize,
+}
+
+impl DialectStats {
+    /// Create new empty dialect stats.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a test result for the given dialect.
+    pub fn record(&mut self, dialect: &SqlDialect, passed: bool) {
+        match (dialect, passed) {
+            (SqlDialect::MySQL, true) => self.mysql_passed += 1,
+            (SqlDialect::MySQL, false) => self.mysql_failed += 1,
+            (SqlDialect::SQLite, true) => self.sqlite_passed += 1,
+            (SqlDialect::SQLite, false) => self.sqlite_failed += 1,
+        }
+    }
+
+    /// Total tests run in MySQL mode.
+    pub fn mysql_total(&self) -> usize {
+        self.mysql_passed + self.mysql_failed
+    }
+
+    /// Total tests run in SQLite mode.
+    pub fn sqlite_total(&self) -> usize {
+        self.sqlite_passed + self.sqlite_failed
+    }
+
+    /// Total tests run across all dialects.
+    pub fn total(&self) -> usize {
+        self.mysql_total() + self.sqlite_total()
+    }
+
+    /// Merge another DialectStats into this one.
+    pub fn merge(&mut self, other: &DialectStats) {
+        self.mysql_passed += other.mysql_passed;
+        self.mysql_failed += other.mysql_failed;
+        self.sqlite_passed += other.sqlite_passed;
+        self.sqlite_failed += other.sqlite_failed;
+    }
+}
+
 /// Sqllogictest runner.
 pub struct Runner<D: AsyncDB, M: MakeConnection<Conn = D>> {
     pub(super) conn: Connections<D, M>,
@@ -190,6 +243,8 @@ pub struct Runner<D: AsyncDB, M: MakeConnection<Conn = D>> {
     pub(super) auto_switch_dialect: bool,
     /// Current SQL dialect being used.
     pub(super) current_dialect: SqlDialect,
+    /// Statistics tracking tests executed per dialect.
+    pub(super) dialect_stats: DialectStats,
 }
 
 impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
@@ -211,6 +266,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
             locals: RunnerLocals::default(),
             auto_switch_dialect: false,
             current_dialect: SqlDialect::default(),
+            dialect_stats: DialectStats::default(),
         }
     }
 
@@ -257,6 +313,21 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
     /// Check if auto dialect switching is enabled.
     pub fn is_auto_switch_dialect_enabled(&self) -> bool {
         self.auto_switch_dialect
+    }
+
+    /// Get the dialect statistics (tests run per dialect).
+    pub fn dialect_stats(&self) -> &DialectStats {
+        &self.dialect_stats
+    }
+
+    /// Get a mutable reference to dialect statistics.
+    pub fn dialect_stats_mut(&mut self) -> &mut DialectStats {
+        &mut self.dialect_stats
+    }
+
+    /// Reset dialect statistics to zero.
+    pub fn reset_dialect_stats(&mut self) {
+        self.dialect_stats = DialectStats::default();
     }
 
     /// Set a local variable for substitution.

--- a/crates/vibesql-sqllogictest/src/executor/mod.rs
+++ b/crates/vibesql-sqllogictest/src/executor/mod.rs
@@ -7,5 +7,5 @@ mod validator;
 
 // Re-export public types and traits
 pub use core::{
-    AsyncDB, DB, Partitioner, Runner, RunnerLocals, SqlDialect, default_partitioner,
+    AsyncDB, DB, DialectStats, Partitioner, Runner, RunnerLocals, SqlDialect, default_partitioner,
 };

--- a/crates/vibesql-sqllogictest/src/executor/parallel.rs
+++ b/crates/vibesql-sqllogictest/src/executor/parallel.rs
@@ -61,6 +61,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                 locals,
                 auto_switch_dialect: self.auto_switch_dialect,
                 current_dialect: self.current_dialect.clone(),
+                dialect_stats: Default::default(),
             };
 
             tasks.push(async move {

--- a/crates/vibesql-sqllogictest/src/executor/validator.rs
+++ b/crates/vibesql-sqllogictest/src/executor/validator.rs
@@ -18,8 +18,20 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
     ) -> Result<RecordOutput<D::ColumnType>, TestError> {
         let result = self.apply_record(record.clone()).await;
 
+        // Helper to check if this record type should be tracked for dialect stats
+        let is_testable_record = matches!(
+            &record,
+            Record::Statement { .. } | Record::Query { .. }
+        );
+
+        // Track dialect statistics for Statement and Query records
+        // We capture the current dialect before validation since it may have been switched
+        let current_dialect = self.current_dialect.clone();
+
         match (record, &result) {
-            (_, RecordOutput::Nothing) => {}
+            (_, RecordOutput::Nothing) => {
+                // Skipped or control records - don't track
+            }
             // Tolerate the mismatched return type...
             (
                 Record::Statement {
@@ -30,6 +42,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                 },
             ) => {
                 if let StatementExpect::Error(_) = expected {
+                    self.dialect_stats.record(&current_dialect, false);
                     return Err(TestErrorKind::Ok {
                         sql,
                         kind: RecordKind::Query,
@@ -38,6 +51,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                 }
                 if let StatementExpect::Count(expected_count) = expected {
                     if expected_count != rows.len() as u64 {
+                        self.dialect_stats.record(&current_dialect, false);
                         return Err(TestErrorKind::StatementResultMismatch {
                             sql,
                             expected: expected_count,
@@ -54,6 +68,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                 RecordOutput::Statement { error: None, .. },
             ) => match expected {
                 QueryExpect::Error(_) => {
+                    self.dialect_stats.record(&current_dialect, false);
                     return Err(TestErrorKind::Ok {
                         sql,
                         kind: RecordKind::Query,
@@ -61,6 +76,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                     .at(loc))
                 }
                 QueryExpect::Results { results, .. } if !results.is_empty() => {
+                    self.dialect_stats.record(&current_dialect, false);
                     return Err(TestErrorKind::QueryResultMismatch {
                         sql,
                         expected: results.join("\n"),
@@ -82,6 +98,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                 RecordOutput::Statement { count, error },
             ) => match (error, expected) {
                 (None, StatementExpect::Error(_)) => {
+                    self.dialect_stats.record(&current_dialect, false);
                     return Err(TestErrorKind::Ok {
                         sql,
                         kind: RecordKind::Statement,
@@ -90,6 +107,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                 }
                 (None, StatementExpect::Count(expected_count)) => {
                     if expected_count != *count {
+                        self.dialect_stats.record(&current_dialect, false);
                         return Err(TestErrorKind::StatementResultMismatch {
                             sql,
                             expected: expected_count,
@@ -101,6 +119,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                 (None, StatementExpect::Ok) => {}
                 (Some(e), StatementExpect::Error(expected_error)) => {
                     if !expected_error.is_match(&e.to_string()) {
+                        self.dialect_stats.record(&current_dialect, false);
                         return Err(TestErrorKind::ErrorMismatch {
                             sql,
                             err: Arc::clone(e),
@@ -111,6 +130,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                     }
                 }
                 (Some(e), StatementExpect::Count(_) | StatementExpect::Ok) => {
+                    self.dialect_stats.record(&current_dialect, false);
                     return Err(TestErrorKind::Fail {
                         sql,
                         err: Arc::clone(e),
@@ -132,6 +152,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
             ) => {
                 match (error, expected) {
                     (None, QueryExpect::Error(_)) => {
+                        self.dialect_stats.record(&current_dialect, false);
                         return Err(TestErrorKind::Ok {
                             sql,
                             kind: RecordKind::Query,
@@ -140,6 +161,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                     }
                     (Some(e), QueryExpect::Error(expected_error)) => {
                         if !expected_error.is_match(&e.to_string()) {
+                            self.dialect_stats.record(&current_dialect, false);
                             return Err(TestErrorKind::ErrorMismatch {
                                 sql,
                                 err: Arc::clone(e),
@@ -150,6 +172,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                         }
                     }
                     (Some(e), QueryExpect::Results { .. }) => {
+                        self.dialect_stats.record(&current_dialect, false);
                         return Err(TestErrorKind::Fail {
                             sql,
                             err: Arc::clone(e),
@@ -166,6 +189,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                         },
                     ) => {
                         if !(self.column_type_validator)(types, &expected_types) {
+                            self.dialect_stats.record(&current_dialect, false);
                             return Err(TestErrorKind::QueryResultColumnsMismatch {
                                 sql,
                                 expected: expected_types.iter().map(|c| c.to_char()).join(""),
@@ -188,6 +212,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                             // Flatten the rows so each column value is on its own line for error reporting
                             let output_rows: Vec<String> =
                                 rows.iter().flat_map(|strs| strs.iter().cloned()).collect_vec();
+                            self.dialect_stats.record(&current_dialect, false);
                             return Err(TestErrorKind::QueryResultMismatch {
                                 sql,
                                 expected: expected_results.join("\n"),
@@ -235,6 +260,13 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                 }
             }
             _ => unreachable!(),
+        }
+
+        // Record successful test execution in dialect stats
+        // Only track Statement and Query records (is_testable_record is true for those)
+        // RecordOutput::Nothing means the record was skipped, so we don't track it
+        if is_testable_record && !matches!(result, RecordOutput::Nothing) {
+            self.dialect_stats.record(&current_dialect, true);
         }
 
         Ok(result)

--- a/tests/compliance/sqllogictest_suite.rs
+++ b/tests/compliance/sqllogictest_suite.rs
@@ -164,10 +164,12 @@ fn run_test_suite() -> (HashMap<String, TestStats>, usize) {
         let _test_start = Instant::now();
 
         // Create a new database for each test file and run with detailed failure capture
-        let (test_result, detailed_failures) =
-            run_test_file_with_details(&contents, &relative_path);
+        let test_file_result = run_test_file_with_details(&contents, &relative_path);
 
-        match test_result {
+        // Merge dialect stats from this test file
+        stats.merge_dialect_stats(&test_file_result.dialect_stats);
+
+        match test_file_result.result {
             Ok(_) => {
                 stats.passed += 1;
             }
@@ -182,7 +184,7 @@ fn run_test_suite() -> (HashMap<String, TestStats>, usize) {
                 stats.failed += 1;
                 // Always track failed files, even if detailed_failures is empty
                 // This ensures accurate pass/fail reporting in JSON output
-                stats.detailed_failures.push((relative_path.clone(), detailed_failures));
+                stats.detailed_failures.push((relative_path.clone(), test_file_result.failures));
             }
         }
     }
@@ -202,16 +204,15 @@ fn main() {
     if env::var("SELECT1_ONLY").is_ok() {
         let test_file = PathBuf::from("third_party/sqllogictest/test/select1.test");
         let contents = std::fs::read_to_string(&test_file).expect("Failed to read select1.test");
-        let (test_result, detailed_failures) =
-            run_test_file_with_details(&contents, "select1.test");
+        let test_file_result = run_test_file_with_details(&contents, "select1.test");
 
-        match test_result {
+        match test_file_result.result {
             Ok(_) => {
                 // Success message already printed
             }
             Err(_) => {
                 // Error message already printed
-                for failure in detailed_failures {
+                for failure in test_file_result.failures {
                     println!("  SQL: {}", failure.sql_statement);
                     println!("  Expected: {:?}", failure.expected_result);
                     println!("  Actual: {:?}", failure.actual_result);
@@ -265,6 +266,7 @@ fn main() {
             grand_total.timed_out += stats.timed_out;
             grand_total.errors += stats.errors;
             grand_total.skipped += stats.skipped;
+            grand_total.merge_dialect_stats(&stats.dialect_stats);
             all_tested_files.extend(stats.tested_files.clone());
         }
     }
@@ -280,6 +282,51 @@ fn main() {
         grand_total.errors,
         grand_total.skipped,
         grand_total.pass_rate()
+    );
+
+    // Print dialect breakdown
+    println!("\n=== Dialect Breakdown ===");
+    let ds = &grand_total.dialect_stats;
+    let mysql_total = ds.mysql_total();
+    let sqlite_total = ds.sqlite_total();
+    let mysql_pass_rate = if mysql_total > 0 {
+        (ds.mysql_passed as f64 / mysql_total as f64) * 100.0
+    } else {
+        0.0
+    };
+    let sqlite_pass_rate = if sqlite_total > 0 {
+        (ds.sqlite_passed as f64 / sqlite_total as f64) * 100.0
+    } else {
+        0.0
+    };
+    println!(
+        "{:<20} {:>12} {:>12} {:>12} {:>10}",
+        "Dialect", "Total", "Passed", "Failed", "Pass Rate"
+    );
+    println!("{}", "-".repeat(70));
+    println!(
+        "{:<20} {:>12} {:>12} {:>12} {:>9.1}%",
+        "MySQL mode",
+        mysql_total,
+        ds.mysql_passed,
+        ds.mysql_failed,
+        mysql_pass_rate
+    );
+    println!(
+        "{:<20} {:>12} {:>12} {:>12} {:>9.1}%",
+        "SQLite mode",
+        sqlite_total,
+        ds.sqlite_passed,
+        ds.sqlite_failed,
+        sqlite_pass_rate
+    );
+    println!("{}", "-".repeat(70));
+    println!(
+        "{:<20} {:>12} {:>12} {:>12}",
+        "TOTAL (records)",
+        ds.total(),
+        ds.mysql_passed + ds.sqlite_passed,
+        ds.mysql_failed + ds.sqlite_failed
     );
 
     println!(
@@ -314,6 +361,21 @@ fn main() {
             "pass_rate": grand_total.pass_rate(),
             "total_available_files": total_available_files,
             "tested_files": tested_files_vec.len(),
+        },
+        "dialect_stats": {
+            "mysql": {
+                "total": mysql_total,
+                "passed": ds.mysql_passed,
+                "failed": ds.mysql_failed,
+                "pass_rate": mysql_pass_rate
+            },
+            "sqlite": {
+                "total": sqlite_total,
+                "passed": ds.sqlite_passed,
+                "failed": ds.sqlite_failed,
+                "pass_rate": sqlite_pass_rate
+            },
+            "total_records": ds.total()
         },
         "tested_files": {
             "passed": results.values().flat_map(|s| &s.tested_files).filter(|f| {

--- a/tests/sqllogictest/execution.rs
+++ b/tests/sqllogictest/execution.rs
@@ -10,6 +10,9 @@ use super::{
     scheduler, stats::TestFailure,
 };
 
+// Re-export DialectStats for use by the test suite
+pub use sqllogictest::DialectStats;
+
 #[derive(Debug)]
 pub enum TestError {
     Execution(String),
@@ -29,8 +32,15 @@ impl std::fmt::Display for TestError {
 
 impl std::error::Error for TestError {}
 
+/// Result of running a test file, including dialect statistics
+pub struct TestFileResult {
+    pub result: Result<(), TestError>,
+    pub failures: Vec<TestFailure>,
+    pub dialect_stats: DialectStats,
+}
+
 /// Run a test file asynchronously and capture detailed failure information
-async fn run_test_file_async(contents: &str, file_name: &str) -> (Result<(), TestError>, Vec<TestFailure>) {
+async fn run_test_file_async(contents: &str, file_name: &str) -> TestFileResult {
     let mut tester = Runner::new(|| async { Ok(VibeSqlDB::new()) });
     // Enable hash mode with threshold of 8 (standard SQLLogicTest behavior)
     tester.with_hash_threshold(8);
@@ -51,8 +61,17 @@ async fn run_test_file_async(contents: &str, file_name: &str) -> (Result<(), Tes
         contents.to_string()
     };
 
-    match tester.run_script(&script) {
-        Ok(_) => (Ok(()), vec![]),
+    let result = tester.run_script(&script);
+
+    // Capture dialect stats before returning (stats are accumulated in the runner)
+    let dialect_stats = tester.dialect_stats().clone();
+
+    match result {
+        Ok(_) => TestFileResult {
+            result: Ok(()),
+            failures: vec![],
+            dialect_stats,
+        },
         Err(e) => {
             // Capture error information
             let failure = TestFailure {
@@ -62,7 +81,11 @@ async fn run_test_file_async(contents: &str, file_name: &str) -> (Result<(), Tes
                 error_message: e.to_string(),
                 line_number: None,
             };
-            (Err(TestError::Execution(e.to_string())), vec![failure])
+            TestFileResult {
+                result: Err(TestError::Execution(e.to_string())),
+                failures: vec![failure],
+                dialect_stats,
+            }
         }
     }
 }
@@ -72,7 +95,7 @@ async fn run_test_file_with_timeout_impl(
     contents: &str,
     file_name: &str,
     timeout_secs: u64,
-) -> (Result<(), TestError>, Vec<TestFailure>) {
+) -> TestFileResult {
     // Create a future that runs the test with a timeout
     let test_future = run_test_file_async(contents, file_name);
 
@@ -87,13 +110,14 @@ async fn run_test_file_with_timeout_impl(
                 error_message: format!("Test file exceeded {}s timeout limit", timeout_secs),
                 line_number: None,
             };
-            (
-                Err(TestError::Timeout {
+            TestFileResult {
+                result: Err(TestError::Timeout {
                     file: file_name.to_string(),
                     timeout_seconds: timeout_secs,
                 }),
-                vec![failure],
-            )
+                failures: vec![failure],
+                dialect_stats: DialectStats::default(),
+            }
         }
     }
 }
@@ -103,7 +127,7 @@ async fn run_test_file_with_timeout_impl(
 pub fn run_test_file_with_details(
     contents: &str,
     file_name: &str,
-) -> (Result<(), TestError>, Vec<TestFailure>) {
+) -> TestFileResult {
     let timeout_secs = scheduler::get_test_file_timeout_for(file_name);
 
     let result = std::panic::catch_unwind(|| {
@@ -127,10 +151,11 @@ pub fn run_test_file_with_details(
                 error_message: format!("Test harness panicked: {}", error_msg),
                 line_number: None,
             };
-            (
-                Err(TestError::Execution(format!("Test harness panicked: {}", error_msg))),
-                vec![failure],
-            )
+            TestFileResult {
+                result: Err(TestError::Execution(format!("Test harness panicked: {}", error_msg))),
+                failures: vec![failure],
+                dialect_stats: DialectStats::default(),
+            }
         }
     }
 }
@@ -173,10 +198,10 @@ SELECT 1
 
         // Set very short timeout of 1 second
         let file_name = "test_timeout.test";
-        let result = run_test_file_with_timeout_impl(slow_test, file_name, 1).await;
+        let test_result = run_test_file_with_timeout_impl(slow_test, file_name, 1).await;
 
         // Check if result is ok or timeout
-        match result.0 {
+        match test_result.result {
             Ok(()) => {
                 // Test completed successfully within timeout
                 assert!(true, "Test completed within timeout");

--- a/tests/sqllogictest/stats.rs
+++ b/tests/sqllogictest/stats.rs
@@ -1,6 +1,7 @@
 //! Test result statistics and failure information tracking.
 
 use std::collections::HashSet;
+use sqllogictest::DialectStats;
 
 /// Detailed failure information for a single test file
 #[allow(dead_code)]
@@ -26,6 +27,8 @@ pub struct TestStats {
     pub tested_files: HashSet<String>, // Files that were actually tested this run
     pub detailed_failures: Vec<(String, Vec<TestFailure>)>, // (file_path, failures) pairs
     pub timed_out_files: Vec<String>, // Files that timed out
+    /// Per-dialect statistics (MySQL vs SQLite mode)
+    pub dialect_stats: DialectStats,
 }
 
 impl TestStats {
@@ -37,5 +40,11 @@ impl TestStats {
         } else {
             (self.passed as f64 / relevant_total as f64) * 100.0
         }
+    }
+
+    /// Merge dialect stats from another DialectStats into this TestStats
+    #[allow(dead_code)]
+    pub fn merge_dialect_stats(&mut self, other: &DialectStats) {
+        self.dialect_stats.merge(other);
     }
 }


### PR DESCRIPTION
## Summary

- Track MySQL mode pass/fail counts separately from SQLite mode
- Report both in JSON results and console output after #2689 auto-dialect switching
- Add `DialectStats` struct with per-dialect counters to vendored sqllogictest crate

## Test plan

- [x] Verify compile with `cargo check -p vibesql --test sqllogictest_suite`
- [x] Run single test file: `SQLLOGICTEST_FILES="random/aggregates/slt_good_0.test" cargo test --release -p vibesql --test sqllogictest_suite`
- [x] Verify dialect breakdown appears in console output
- [x] Verify `dialect_stats` object appears in JSON output (`target/sqllogictest_results.json`)

Example output:
```
=== Dialect Breakdown ===
Dialect                     Total       Passed       Failed  Pass Rate
----------------------------------------------------------------------
MySQL mode                   3910         3910            0     100.0%
SQLite mode                 10013        10013            0     100.0%
----------------------------------------------------------------------
TOTAL (records)             13923        13923            0
```

Closes #2691

🤖 Generated with [Claude Code](https://claude.com/claude-code)