### PR TITLE
feat(parser): Support CREATE TEMP VIEW syntax

### DIFF
--- a/crates/vibesql-ast/src/ddl/schema.rs
+++ b/crates/vibesql-ast/src/ddl/schema.rs
@@ -101,6 +101,8 @@ pub struct CreateViewStmt {
     pub query: Box<crate::SelectStmt>,
     pub with_check_option: bool,
     pub or_replace: bool,
+    /// Whether this is a temporary view (CREATE TEMP VIEW or CREATE TEMPORARY VIEW)
+    pub temporary: bool,
 }
 
 /// DROP VIEW statement

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -291,6 +291,9 @@ pub enum Keyword {
     Keys,
     // Auto-increment keywords (MySQL and SQLite)
     AutoIncrement,
+    // Temporary object keywords (SQLite)
+    Temp,
+    Temporary,
 }
 
 impl Keyword {
@@ -573,6 +576,9 @@ impl fmt::Display for Keyword {
             Keyword::Keys => "KEYS",
             // Auto-increment keywords
             Keyword::AutoIncrement => "AUTO_INCREMENT",
+            // Temporary object keywords
+            Keyword::Temp => "TEMP",
+            Keyword::Temporary => "TEMPORARY",
         };
         write!(f, "{}", keyword_str)
     }

--- a/crates/vibesql-parser/src/lexer/keywords.rs
+++ b/crates/vibesql-parser/src/lexer/keywords.rs
@@ -289,6 +289,9 @@ pub(super) fn map_keyword(upper_text: String) -> Token {
         // Auto-increment keywords (MySQL and SQLite)
         "AUTO_INCREMENT" => Token::Keyword(Keyword::AutoIncrement),
         "AUTOINCREMENT" => Token::Keyword(Keyword::AutoIncrement),
+        // Temporary object keywords (SQLite)
+        "TEMP" => Token::Keyword(Keyword::Temp),
+        "TEMPORARY" => Token::Keyword(Keyword::Temporary),
         _ => Token::Identifier(upper_text), // Regular identifiers are normalized to uppercase
     }
 }

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -123,10 +123,17 @@ impl Parser {
                 Ok(vibesql_ast::Statement::Delete(delete_stmt))
             }
             Token::Keyword(Keyword::Create) => {
-                // Check for CREATE OR REPLACE VIEW
-                if self.peek_next_keyword(Keyword::Or) && matches!(self.peek_at_offset(2), Token::Keyword(Keyword::Replace)) && matches!(self.peek_at_offset(3), Token::Keyword(Keyword::View)) {
-                    Ok(vibesql_ast::Statement::CreateView(self.parse_create_view_statement()?))
-                } else if self.peek_next_keyword(Keyword::Table) {
+                // Check for CREATE OR REPLACE VIEW and CREATE OR REPLACE TEMP/TEMPORARY VIEW
+                if self.peek_next_keyword(Keyword::Or) && matches!(self.peek_at_offset(2), Token::Keyword(Keyword::Replace)) {
+                    // Could be CREATE OR REPLACE VIEW or CREATE OR REPLACE TEMP/TEMPORARY VIEW
+                    if matches!(self.peek_at_offset(3), Token::Keyword(Keyword::View))
+                        || matches!(self.peek_at_offset(3), Token::Keyword(Keyword::Temp))
+                        || matches!(self.peek_at_offset(3), Token::Keyword(Keyword::Temporary))
+                    {
+                        return Ok(vibesql_ast::Statement::CreateView(self.parse_create_view_statement()?));
+                    }
+                }
+                if self.peek_next_keyword(Keyword::Table) {
                     Ok(vibesql_ast::Statement::CreateTable(self.parse_create_table_statement()?))
                 } else if self.peek_next_keyword(Keyword::Schema) {
                     Ok(vibesql_ast::Statement::CreateSchema(self.parse_create_schema_statement()?))
@@ -149,6 +156,9 @@ impl Parser {
                         self.parse_create_translation_statement()?,
                     ))
                 } else if self.peek_next_keyword(Keyword::View) {
+                    Ok(vibesql_ast::Statement::CreateView(self.parse_create_view_statement()?))
+                } else if self.peek_next_keyword(Keyword::Temp) || self.peek_next_keyword(Keyword::Temporary) {
+                    // CREATE TEMP VIEW or CREATE TEMPORARY VIEW
                     Ok(vibesql_ast::Statement::CreateView(self.parse_create_view_statement()?))
                 } else if self.peek_next_keyword(Keyword::Trigger) {
                     Ok(vibesql_ast::Statement::CreateTrigger(self.parse_create_trigger_statement()?))

--- a/crates/vibesql-parser/src/parser/view.rs
+++ b/crates/vibesql-parser/src/parser/view.rs
@@ -7,7 +7,8 @@ impl Parser {
     /// Parse CREATE VIEW statement
     ///
     /// Syntax:
-    ///   CREATE [OR REPLACE] VIEW view_name [(column_list)] AS select_statement [WITH CHECK OPTION]
+    ///   CREATE [OR REPLACE] [TEMP | TEMPORARY] VIEW view_name [(column_list)] AS select_statement [WITH CHECK OPTION]
+    ///   CREATE [TEMP | TEMPORARY] VIEW view_name [(column_list)] AS select_statement [WITH CHECK OPTION]
     pub(super) fn parse_create_view_statement(
         &mut self,
     ) -> Result<vibesql_ast::CreateViewStmt, ParseError> {
@@ -18,6 +19,17 @@ impl Parser {
         let or_replace = if self.peek_keyword(Keyword::Or) {
             self.consume_keyword(Keyword::Or)?;
             self.expect_keyword(Keyword::Replace)?;
+            true
+        } else {
+            false
+        };
+
+        // Check for optional TEMP or TEMPORARY
+        let temporary = if self.peek_keyword(Keyword::Temp) {
+            self.consume_keyword(Keyword::Temp)?;
+            true
+        } else if self.peek_keyword(Keyword::Temporary) {
+            self.consume_keyword(Keyword::Temporary)?;
             true
         } else {
             false
@@ -81,7 +93,7 @@ impl Parser {
             self.advance();
         }
 
-        Ok(vibesql_ast::CreateViewStmt { view_name, columns, query, with_check_option, or_replace })
+        Ok(vibesql_ast::CreateViewStmt { view_name, columns, query, with_check_option, or_replace, temporary })
     }
 
     /// Parse DROP VIEW statement

--- a/crates/vibesql-parser/src/tests/view.rs
+++ b/crates/vibesql-parser/src/tests/view.rs
@@ -205,3 +205,48 @@ fn test_drop_view_qualified_name() {
         panic!("Expected DropView statement");
     }
 }
+
+#[test]
+fn test_create_temp_view() {
+    let sql = "CREATE TEMP VIEW view2 AS SELECT x FROM t1 WHERE x>0";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    if let Ok(vibesql_ast::Statement::CreateView(stmt)) = result {
+        assert_eq!(stmt.view_name, "VIEW2");
+        assert!(stmt.temporary);
+        assert!(!stmt.or_replace);
+    } else {
+        panic!("Expected CreateView statement");
+    }
+}
+
+#[test]
+fn test_create_temporary_view() {
+    let sql = "CREATE TEMPORARY VIEW view3 AS SELECT x FROM t1 WHERE x>0";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    if let Ok(vibesql_ast::Statement::CreateView(stmt)) = result {
+        assert_eq!(stmt.view_name, "VIEW3");
+        assert!(stmt.temporary);
+        assert!(!stmt.or_replace);
+    } else {
+        panic!("Expected CreateView statement");
+    }
+}
+
+#[test]
+fn test_create_or_replace_temp_view() {
+    let sql = "CREATE OR REPLACE TEMP VIEW my_view AS SELECT * FROM users";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    if let Ok(vibesql_ast::Statement::CreateView(stmt)) = result {
+        assert_eq!(stmt.view_name, "MY_VIEW");
+        assert!(stmt.temporary);
+        assert!(stmt.or_replace);
+    } else {
+        panic!("Expected CreateView statement");
+    }
+}


### PR DESCRIPTION
## Summary
- Add support for SQLite's `CREATE TEMP VIEW` and `CREATE TEMPORARY VIEW` syntax
- Add `Temp` and `Temporary` keywords to the parser lexer
- Add `temporary` field to `CreateViewStmt` AST node to track temporary view status
- Support combinations like `CREATE OR REPLACE TEMP VIEW`

## Test plan
- [x] Unit tests for `CREATE TEMP VIEW`, `CREATE TEMPORARY VIEW`, and `CREATE OR REPLACE TEMP VIEW`
- [x] SQLLogicTest `evidence/slt_lang_createview.test` passes (100% pass rate)

Closes #2695

🤖 Generated with [Claude Code](https://claude.com/claude-code)