### PR TITLE
perf: Fix TPC-H Q9 slow performance (100x improvement)

### DIFF
--- a/crates/vibesql-executor/src/optimizer/where_pushdown/table_refs.rs
+++ b/crates/vibesql-executor/src/optimizer/where_pushdown/table_refs.rs
@@ -114,8 +114,18 @@ fn extract_tables_recursive_branch(
             // Quantified comparisons (ANY/ALL/SOME) may be correlated, treat as complex
             false
         }
+        vibesql_ast::Expression::Like { expr, pattern, .. } => {
+            // LIKE predicate: extract table references from both the expression and pattern
+            // Example: p_name LIKE '%green%' references the table containing p_name
+            extract_tables_recursive_branch(expr, schema, tables)
+                && extract_tables_recursive_branch(pattern, schema, tables)
+        }
+        vibesql_ast::Expression::IsNull { expr, .. } => {
+            // IS NULL / IS NOT NULL: extract table references from the expression
+            extract_tables_recursive_branch(expr, schema, tables)
+        }
         _ => {
-            // Other expression types: Literal, Wildcard, IsNull, Like, etc.
+            // Other expression types: Literal, Wildcard, etc.
             true
         }
     }

--- a/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
@@ -104,8 +104,9 @@ where
     join_conditions.extend(where_equijoins);
 
     // Step 6.5: Extract table-local predicates for cardinality estimation
+    // Use schema-based column resolution to handle unqualified columns like `p_name LIKE '%green%'`
     let mut table_local_predicates = if let Some(where_expr) = where_clause {
-        predicates::extract_table_local_predicates(where_expr, &table_set)
+        predicates::extract_table_local_predicates_with_schema(where_expr, &table_set, &column_to_table)
     } else {
         HashMap::new()
     };

--- a/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
@@ -8,9 +8,24 @@ use super::utils::resolve_column_with_fallback;
 ///
 /// A table-local predicate is one that references only a single table,
 /// e.g., `c_mktsegment = 'BUILDING'` references only `customer`.
+///
+/// Uses schema-based column resolution to handle unqualified column names like
+/// `p_name LIKE '%green%'` which should be recognized as a `part` table predicate.
 pub(super) fn extract_table_local_predicates(
     where_expr: &Expression,
     table_set: &HashSet<String>,
+) -> HashMap<String, Vec<Expression>> {
+    // Use default empty column map for backward compatibility
+    extract_table_local_predicates_with_schema(where_expr, table_set, &HashMap::new())
+}
+
+/// Extract table-local predicates using schema-based column resolution
+///
+/// This version accepts a column_to_table map for resolving unqualified column names.
+pub(super) fn extract_table_local_predicates_with_schema(
+    where_expr: &Expression,
+    table_set: &HashSet<String>,
+    column_to_table: &HashMap<String, String>,
 ) -> HashMap<String, Vec<Expression>> {
     let mut local_predicates: HashMap<String, Vec<Expression>> = HashMap::new();
 
@@ -18,9 +33,9 @@ pub(super) fn extract_table_local_predicates(
     let predicates = flatten_and_chain(where_expr);
 
     for pred in predicates {
-        // Get tables referenced by this predicate
+        // Get tables referenced by this predicate using schema-based resolution
         let mut referenced_tables = HashSet::new();
-        super::graph::extract_referenced_tables(&pred, &mut referenced_tables, table_set);
+        super::graph::extract_referenced_tables_with_schema(&pred, &mut referenced_tables, table_set, column_to_table);
 
         // If predicate references exactly one table, it's table-local
         if referenced_tables.len() == 1 {


### PR DESCRIPTION
## Summary
- Fix TPC-H Q9 slow performance by enabling LIKE predicate pushdown
- Add schema-based column resolution for table-local predicate detection
- Q9 execution time: 3.94s → 34ms (100x improvement)

## Problem
Q9 was taking 3.94s on SF 0.01 due to LIKE predicates not being pushed down:

```sql
SELECT ... FROM part, supplier, lineitem, partsupp, orders, nation
WHERE ... AND p_name LIKE '%green%'
```

The `p_name LIKE '%green%'` predicate wasn't being recognized as a `part` table predicate because:
1. The column name was unqualified (no `part.` prefix)
2. The `extract_tables_recursive_branch` function in `table_refs.rs` had a catch-all that didn't extract table references from LIKE expressions
3. The join reordering code wasn't using schema-based column resolution for table-local predicate detection

## Solution
1. Add explicit LIKE and IsNull handling in `extract_tables_recursive_branch`
2. Add `extract_table_local_predicates_with_schema` function that accepts a column_to_table map
3. Use schema-based column resolution in join reordering to properly detect table-local predicates

## Testing
- Q9 execution time drops from 3.94s to ~34ms (100x improvement)
- All other TPC-H queries (Q1-Q17) continue to pass
- Q18 and Q21 issues are pre-existing and separate from this fix

## Related Issues
Closes #2718 (partial - Q9 only; Q18 and Q21 require separate investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)