### PR TITLE
feat: Add sysbench OLTP write-only mixed benchmark

### DIFF
--- a/crates/vibesql-executor/benches/sysbench_oltp.rs
+++ b/crates/vibesql-executor/benches/sysbench_oltp.rs
@@ -15,6 +15,7 @@
 //!
 //! **Write Tests:**
 //! - `oltp_insert` - Single row inserts
+//! - `oltp_write_only` - Write-only workload (1 index update, 1 non-index update, 1 delete, 1 insert)
 //!
 //! **Mixed Tests:**
 //! - `oltp_read_write` - Mixed read/write workload (10 reads, 4 writes per transaction)
@@ -30,6 +31,9 @@
 //!
 //! # Run only insert benchmarks
 //! cargo bench --bench sysbench_oltp --features benchmark-comparison -- insert
+//!
+//! # Run only write_only benchmarks
+//! cargo bench --bench sysbench_oltp --features benchmark-comparison -- write_only
 //!
 //! # Run only VibeSQL benchmarks
 //! cargo bench --bench sysbench_oltp --features benchmark-comparison -- vibesql
@@ -105,6 +109,24 @@ fn vibesql_update_non_index(db: &mut VibeDB, id: i64, c: &str) {
     }
 }
 
+/// Execute an update query on VibeSQL (update indexed column k)
+fn vibesql_update_index(db: &mut VibeDB, id: i64) {
+    let sql = format!("UPDATE sbtest1 SET k = k + 1 WHERE id = {}", id);
+    let stmt = Parser::parse_sql(&sql).unwrap();
+    if let vibesql_ast::Statement::Update(update) = stmt {
+        vibesql_executor::UpdateExecutor::execute(&update, db).unwrap();
+    }
+}
+
+/// Execute a delete query on VibeSQL
+fn vibesql_delete(db: &mut VibeDB, id: i64) {
+    let sql = format!("DELETE FROM sbtest1 WHERE id = {}", id);
+    let stmt = Parser::parse_sql(&sql).unwrap();
+    if let vibesql_ast::Statement::Delete(delete) = stmt {
+        vibesql_executor::DeleteExecutor::execute(&delete, db).unwrap();
+    }
+}
+
 // =============================================================================
 // Helper Functions - SQLite
 // =============================================================================
@@ -138,6 +160,22 @@ fn sqlite_update_non_index(conn: &SqliteConn, id: i64, c: &str) {
     stmt.execute(rusqlite::params![c, id]).unwrap();
 }
 
+#[cfg(feature = "benchmark-comparison")]
+fn sqlite_update_index(conn: &SqliteConn, id: i64) {
+    let mut stmt = conn
+        .prepare_cached("UPDATE sbtest1 SET k = k + 1 WHERE id = ?1")
+        .unwrap();
+    stmt.execute(rusqlite::params![id]).unwrap();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn sqlite_delete(conn: &SqliteConn, id: i64) {
+    let mut stmt = conn
+        .prepare_cached("DELETE FROM sbtest1 WHERE id = ?1")
+        .unwrap();
+    stmt.execute(rusqlite::params![id]).unwrap();
+}
+
 // =============================================================================
 // Helper Functions - DuckDB
 // =============================================================================
@@ -169,6 +207,22 @@ fn duckdb_update_non_index(conn: &DuckDBConn, id: i64, c: &str) {
         .prepare_cached("UPDATE sbtest1 SET c = ?1 WHERE id = ?2")
         .unwrap();
     stmt.execute(duckdb::params![c, id]).unwrap();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn duckdb_update_index(conn: &DuckDBConn, id: i64) {
+    let mut stmt = conn
+        .prepare_cached("UPDATE sbtest1 SET k = k + 1 WHERE id = ?1")
+        .unwrap();
+    stmt.execute(duckdb::params![id]).unwrap();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn duckdb_delete(conn: &DuckDBConn, id: i64) {
+    let mut stmt = conn
+        .prepare_cached("DELETE FROM sbtest1 WHERE id = ?1")
+        .unwrap();
+    stmt.execute(duckdb::params![id]).unwrap();
 }
 
 // =============================================================================
@@ -310,6 +364,145 @@ fn benchmark_insert_duckdb(c: &mut Criterion) {
                 let c = generate_c_string();
                 let pad = generate_pad_string();
                 duckdb_insert(&conn, next_id, k, &c, &pad);
+                next_id += 1;
+            }
+            start.elapsed()
+        })
+    });
+
+    group.finish();
+}
+
+// =============================================================================
+// Write-Only Benchmarks
+// =============================================================================
+
+/// Benchmark oltp_write_only on VibeSQL
+///
+/// This test simulates a write-heavy OLTP workload per transaction:
+/// - 1 index update (UPDATE sbtest1 SET k = k + 1 WHERE id = ?)
+/// - 1 non-index update (UPDATE sbtest1 SET c = ? WHERE id = ?)
+/// - 1 delete (DELETE FROM sbtest1 WHERE id = ?)
+/// - 1 insert (INSERT INTO sbtest1 (id, k, c, pad) VALUES (?, ?, ?, ?))
+///
+/// The delete uses a random existing ID, the insert uses a new ID.
+/// This measures write throughput without read operations.
+fn benchmark_write_only_vibesql(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sysbench_write_only");
+    group.measurement_time(Duration::from_secs(10));
+
+    group.bench_function(BenchmarkId::new("vibesql", TABLE_SIZE), |b| {
+        b.iter_custom(|iters| {
+            let mut db = load_vibesql(TABLE_SIZE);
+            let mut rng = ChaCha8Rng::seed_from_u64(42);
+            let mut data_gen = SysbenchData::new(TABLE_SIZE);
+            let mut next_id = (TABLE_SIZE + 1) as i64;
+
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                // Pick a random ID for updates
+                let update_id = rng.random_range(1..=TABLE_SIZE as i64);
+
+                // 1 index update (SET k = k + 1)
+                vibesql_update_index(&mut db, update_id);
+
+                // 1 non-index update (SET c = ?)
+                let c = generate_c_string();
+                vibesql_update_non_index(&mut db, update_id, &c);
+
+                // 1 delete (random existing row)
+                let delete_id = rng.random_range(1..=next_id - 1);
+                vibesql_delete(&mut db, delete_id);
+
+                // 1 insert (new row with new ID)
+                let k = data_gen.random_k();
+                let new_c = generate_c_string();
+                let pad = generate_pad_string();
+                vibesql_insert(&mut db, next_id, k, &new_c, &pad);
+                next_id += 1;
+            }
+            start.elapsed()
+        })
+    });
+
+    group.finish();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn benchmark_write_only_sqlite(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sysbench_write_only");
+    group.measurement_time(Duration::from_secs(10));
+
+    group.bench_function(BenchmarkId::new("sqlite", TABLE_SIZE), |b| {
+        b.iter_custom(|iters| {
+            let conn = load_sqlite(TABLE_SIZE);
+            let mut rng = ChaCha8Rng::seed_from_u64(42);
+            let mut data_gen = SysbenchData::new(TABLE_SIZE);
+            let mut next_id = (TABLE_SIZE + 1) as i64;
+
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                // Pick a random ID for updates
+                let update_id = rng.random_range(1..=TABLE_SIZE as i64);
+
+                // 1 index update (SET k = k + 1)
+                sqlite_update_index(&conn, update_id);
+
+                // 1 non-index update (SET c = ?)
+                let c = generate_c_string();
+                sqlite_update_non_index(&conn, update_id, &c);
+
+                // 1 delete (random existing row)
+                let delete_id = rng.random_range(1..=next_id - 1);
+                sqlite_delete(&conn, delete_id);
+
+                // 1 insert (new row with new ID)
+                let k = data_gen.random_k();
+                let new_c = generate_c_string();
+                let pad = generate_pad_string();
+                sqlite_insert(&conn, next_id, k, &new_c, &pad);
+                next_id += 1;
+            }
+            start.elapsed()
+        })
+    });
+
+    group.finish();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn benchmark_write_only_duckdb(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sysbench_write_only");
+    group.measurement_time(Duration::from_secs(10));
+
+    group.bench_function(BenchmarkId::new("duckdb", TABLE_SIZE), |b| {
+        b.iter_custom(|iters| {
+            let conn = load_duckdb(TABLE_SIZE);
+            let mut rng = ChaCha8Rng::seed_from_u64(42);
+            let mut data_gen = SysbenchData::new(TABLE_SIZE);
+            let mut next_id = (TABLE_SIZE + 1) as i64;
+
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                // Pick a random ID for updates
+                let update_id = rng.random_range(1..=TABLE_SIZE as i64);
+
+                // 1 index update (SET k = k + 1)
+                duckdb_update_index(&conn, update_id);
+
+                // 1 non-index update (SET c = ?)
+                let c = generate_c_string();
+                duckdb_update_non_index(&conn, update_id, &c);
+
+                // 1 delete (random existing row)
+                let delete_id = rng.random_range(1..=next_id - 1);
+                duckdb_delete(&conn, delete_id);
+
+                // 1 insert (new row with new ID)
+                let k = data_gen.random_k();
+                let new_c = generate_c_string();
+                let pad = generate_pad_string();
+                duckdb_insert(&conn, next_id, k, &new_c, &pad);
                 next_id += 1;
             }
             start.elapsed()
@@ -465,6 +658,7 @@ criterion_group!(
     benches,
     benchmark_point_select_vibesql,
     benchmark_insert_vibesql,
+    benchmark_write_only_vibesql,
     benchmark_read_write_vibesql
 );
 
@@ -477,6 +671,9 @@ criterion_group!(
     benchmark_insert_vibesql,
     benchmark_insert_sqlite,
     benchmark_insert_duckdb,
+    benchmark_write_only_vibesql,
+    benchmark_write_only_sqlite,
+    benchmark_write_only_duckdb,
     benchmark_read_write_vibesql,
     benchmark_read_write_sqlite,
     benchmark_read_write_duckdb


### PR DESCRIPTION
## Summary

- Adds the `oltp_write_only` benchmark to complete the sysbench OLTP suite
- Measures write-heavy workload performance without read operations
- Implements benchmarks for VibeSQL, SQLite, and DuckDB

## Benchmark Operations Per Transaction

| Operation | Query |
|-----------|-------|
| Index update | `UPDATE sbtest1 SET k = k + 1 WHERE id = ?` |
| Non-index update | `UPDATE sbtest1 SET c = ? WHERE id = ?` |
| Delete | `DELETE FROM sbtest1 WHERE id = ?` |
| Insert | `INSERT INTO sbtest1 (id, k, c, pad) VALUES (?, ?, ?, ?)` |

## Test Plan

- [x] Benchmark compiles: `cargo check --bench sysbench_oltp --features benchmark-comparison`
- [x] Benchmark runs: `cargo bench --bench sysbench_oltp --features benchmark-comparison -- write_only`
- [x] All three engines complete successfully (VibeSQL, SQLite, DuckDB)

## Sample Output

```
sysbench_write_only/vibesql/10000   time: [7.3425 ms 7.6480 ms 7.8970 ms]
sysbench_write_only/sqlite/10000    time: [7.4897 µs 8.7497 µs 10.575 µs]
sysbench_write_only/duckdb/10000    time: [1.1212 ms 1.2387 ms 1.3695 ms]
```

## Usage

```bash
# Run all write-only benchmarks
cargo bench --bench sysbench_oltp --features benchmark-comparison -- write_only

# Run only VibeSQL
cargo bench --bench sysbench_oltp --features benchmark-comparison -- write_only/vibesql
```

Closes #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)