### PR TITLE
perf(subquery): Fix EXISTS/NOT EXISTS self-join aliasing for TPC-H Q21

### DIFF
--- a/crates/vibesql-executor/src/optimizer/subquery_to_join.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join.rs
@@ -562,10 +562,40 @@ fn try_convert_exists_to_join(
         return None;
     }
 
+    // Detect self-join: check if subquery table name conflicts with outer query tables
+    let needs_alias = is_self_join(from, &table_name, &table_alias);
+
+    // Handle self-join case: generate unique alias and rewrite column references
+    let (effective_alias, rewritten_where) = if needs_alias {
+        // Create a unique alias for the right side of the self-join
+        let new_alias = format!("__subquery_{}", table_alias.as_ref().unwrap_or(&table_name));
+
+        if std::env::var("SUBQUERY_TRANSFORM_VERBOSE").is_ok() {
+            eprintln!("[SUBQUERY_TRANSFORM] EXISTS self-join detected: table={}, alias={:?}, new_alias={}",
+                     table_name, table_alias, new_alias);
+        }
+
+        // Use the table alias (if present) for matching column references, not just the table name
+        // This is critical for Q21 where the subquery uses an alias like "l2" or "l3"
+        // Column references like "l2.l_orderkey" need to match against "l2", not "LINEITEM"
+        let old_table_ref = table_alias.as_ref().unwrap_or(&table_name);
+
+        // Rewrite column references in the WHERE clause to use the new alias
+        let rewritten = rewrite_column_refs_with_alias(where_clause, old_table_ref, &new_alias);
+
+        if std::env::var("SUBQUERY_TRANSFORM_VERBOSE").is_ok() {
+            eprintln!("[SUBQUERY_TRANSFORM] EXISTS rewritten_where={:?}", rewritten);
+        }
+
+        (Some(new_alias), rewritten)
+    } else {
+        (table_alias.clone(), where_clause.clone())
+    };
+
     // Create the right side of the join
     let right_from = FromClause::Table {
         name: table_name,
-        alias: table_alias,
+        alias: effective_alias,
     };
 
     // Create SEMI or ANTI join based on negation
@@ -580,9 +610,13 @@ fn try_convert_exists_to_join(
         left: Box::new(from.clone()),
         right: Box::new(right_from),
         join_type,
-        condition: Some(where_clause.clone()),
+        condition: Some(rewritten_where),
         natural: false,
     };
+
+    if std::env::var("SUBQUERY_TRANSFORM_VERBOSE").is_ok() {
+        eprintln!("[SUBQUERY_TRANSFORM] EXISTS new_from={:?}", new_from);
+    }
 
     // EXISTS doesn't leave any residual WHERE clause
     Some((new_from, None))


### PR DESCRIPTION
## Summary
- Fix EXISTS/NOT EXISTS subquery transformation to properly handle self-joins
- Add unique aliasing (`__subquery_<alias>`) for self-join scenarios
- Rewrite column references in WHERE clauses to use new aliases
- Resolves TPC-H Q21 memory explosion (83.82 GB → <1 GB)

## Root Cause
TPC-H Q21 uses EXISTS and NOT EXISTS subqueries with self-joins on `lineitem`:
```sql
EXISTS (SELECT * FROM lineitem l2 WHERE l2.l_orderkey = l1.l_orderkey ...)
NOT EXISTS (SELECT * FROM lineitem l3 WHERE l3.l_orderkey = l1.l_orderkey ...)
```

The existing `try_convert_exists_to_join` function wasn't detecting self-joins or generating unique aliases for the right side of the join, causing column reference conflicts that led to cartesian product execution.

## Changes
- Added self-join detection using `is_self_join()` 
- Generate unique alias for EXISTS/NOT EXISTS self-join right-hand side
- Rewrite column references with `rewrite_column_refs_with_alias()`
- Match existing pattern from IN subquery handling

## Test Plan
- [x] Q21 benchmark: 312ms, 4 rows (was: memory limit exceeded at 83.82 GB)
- [x] All 63 subquery tests pass
- [x] No regressions in TPC-H query suite

## Benchmark Results
```
=== Q21 ===
  Parse:        1.43ms
  Executor:   173.96µs
  Execute:    310.80ms (4 rows)
  TOTAL:      312.40ms
```

Closes #2749

🤖 Generated with [Claude Code](https://claude.com/claude-code)