### PR TITLE
fix(bench): Use DATE values for DATE columns in TPC-DS web tables

### DIFF
--- a/crates/vibesql-executor/benches/tpcds/schema.rs
+++ b/crates/vibesql-executor/benches/tpcds/schema.rs
@@ -3557,8 +3557,8 @@ fn load_web_page_vibesql(db: &mut VibeDB, data: &mut TPCDSData) {
         let row = Row::new(vec![
             SqlValue::Integer(i as i64),
             SqlValue::Varchar(wp_web_page_id),
-            SqlValue::Integer(((i - 1) / 100 + 1) as i64),  // wp_rec_start_date_sk (date_sk)
-            SqlValue::Null,  // wp_rec_end_date_sk
+            SqlValue::Date(Date::from_str("1998-01-01").unwrap()),  // wp_rec_start_date
+            SqlValue::Null,  // wp_rec_end_date
             SqlValue::Integer(((i - 1) / 20 + 1) as i64),  // wp_creation_date_sk
             SqlValue::Integer(((i - 1) / 10 + 1) as i64),  // wp_access_date_sk
             SqlValue::Varchar("N".to_string()),  // wp_autogen_flag
@@ -3587,8 +3587,8 @@ fn load_web_site_vibesql(db: &mut VibeDB, data: &mut TPCDSData) {
         let row = Row::new(vec![
             SqlValue::Integer(i as i64),
             SqlValue::Varchar(web_site_id),
-            SqlValue::Integer(((i - 1) / 10 + 1) as i64),  // web_rec_start_date_sk
-            SqlValue::Null,  // web_rec_end_date_sk
+            SqlValue::Date(Date::from_str("1998-01-01").unwrap()),  // web_rec_start_date
+            SqlValue::Null,  // web_rec_end_date
             SqlValue::Varchar(format!("site_{}", i)),  // web_name
             SqlValue::Integer(((i - 1) / 5 + 1) as i64),  // web_open_date_sk
             SqlValue::Null,  // web_close_date_sk


### PR DESCRIPTION
## Summary
- Fixed TypeMismatch error when loading `web_page` table by using `SqlValue::Date` instead of `SqlValue::Integer` for `wp_rec_start_date` column
- Fixed same issue in `web_site` table for `web_rec_start_date` column
- Data generation now matches the schema definition (DATE type columns)

## Test plan
- [x] Build the TPC-DS benchmark: `cargo bench --package vibesql-executor --bench tpcds_benchmark --features benchmark-comparison --no-run`
- [x] Verified no TypeMismatch errors remain for web_page and web_site tables
- [ ] Run full benchmark suite when other issues are resolved (currently blocked by unrelated case-sensitivity issue in table lookup)

Closes #2762

🤖 Generated with [Claude Code](https://claude.com/claude-code)