### PR TITLE
perf: Push down non-correlated IN subquery predicates for Q18

### DIFF
--- a/crates/vibesql-executor/src/optimizer/where_pushdown/table_refs.rs
+++ b/crates/vibesql-executor/src/optimizer/where_pushdown/table_refs.rs
@@ -96,9 +96,24 @@ fn extract_tables_recursive_branch(
             let else_ok = else_result.as_ref().is_none_or(|else_res| extract_tables_recursive_branch(else_res, schema, tables));
             op_ok && when_ok && else_ok
         }
-        vibesql_ast::Expression::In { .. } => {
-            // IN with subquery: may be correlated, treat as complex
-            false
+        vibesql_ast::Expression::In { expr, subquery, .. } => {
+            // IN with subquery: check if non-correlated
+            // Non-correlated subqueries can be pushed down as table-local predicates
+            // because they can be evaluated independently (and cached)
+            //
+            // For example, in Q18:
+            //   WHERE o_orderkey IN (SELECT l_orderkey FROM lineitem GROUP BY l_orderkey HAVING SUM(l_quantity) > 300)
+            // The subquery is non-correlated, so this can be pushed down to filter the orders table
+            // during the scan phase, significantly reducing the join input size.
+            if !crate::correlation::is_correlated(subquery, schema) {
+                // Non-correlated subquery: the predicate can be pushed down
+                // Extract table references from the left-hand expression only
+                // (the subquery is evaluated independently, so it doesn't add table references)
+                extract_tables_recursive_branch(expr, schema, tables)
+            } else {
+                // Correlated subquery: treat as complex (must be evaluated after joins)
+                false
+            }
         }
         vibesql_ast::Expression::ScalarSubquery(_) => {
             // Scalar subqueries may reference columns from outer scope (correlated subqueries)


### PR DESCRIPTION
## Summary

- Fix TPC-H Q18 timeout by enabling predicate pushdown for non-correlated IN subqueries
- Q18 execution time reduced from ~2.9s to ~150ms (~19x improvement)
- Non-correlated IN predicates are now classified as table-local predicates

## Problem

TPC-H Query 18 was timing out during benchmark because the `WHERE o_orderkey IN (SELECT ...)` predicate was being evaluated after the full 3-way join (customer × orders × lineitem) instead of being pushed down to filter the orders table during the scan phase.

The IN subquery was always treated as a "complex" predicate regardless of whether it was correlated or non-correlated, which prevented early filtering.

## Solution

Modified `extract_tables_recursive_branch` in `where_pushdown/table_refs.rs` to:
1. Check if the IN subquery is non-correlated using `is_correlated()`
2. If non-correlated, extract table references only from the left-hand expression
3. This allows the predicate to be classified as table-local for the referenced table

## Test plan

- [x] All existing tests pass (`cargo test -p vibesql-executor --release`)
- [x] TPC-H Q18 completes in ~150ms (was ~2.9s)
- [x] No regression in other TPC-H queries
- [x] All 21 subquery tests pass
- [x] Isolated benchmark: 19/22 queries pass, 0 timeouts

## Benchmark Results

```
Q18: 158.62ms (was ~2890ms - 18x improvement)
Total: 19/22 passed, 0 timeouts
(Q7, Q8, Q9 crash due to unrelated parse errors)
```

Fixes #2791

🤖 Generated with [Claude Code](https://claude.com/claude-code)