### PR TITLE
fix(bench): Restore Q7, Q8, Q9 TPC-H query execution

### DIFF
--- a/crates/vibesql-executor/benches/tpch/queries.rs
+++ b/crates/vibesql-executor/benches/tpch/queries.rs
@@ -126,7 +126,7 @@ pub const TPCH_Q7: &str = r#"
 SELECT
     n1.n_name as supp_nation,
     n2.n_name as cust_nation,
-    EXTRACT(YEAR FROM l_shipdate) as l_year,
+    SUBSTR(l_shipdate, 1, 4) as l_year,
     SUM(l_extendedprice * (1 - l_discount)) as revenue
 FROM supplier, lineitem, orders, customer, nation n1, nation n2
 WHERE s_suppkey = l_suppkey
@@ -138,14 +138,14 @@ WHERE s_suppkey = l_suppkey
          OR (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE'))
     AND l_shipdate >= '1995-01-01'
     AND l_shipdate <= '1996-12-31'
-GROUP BY n1.n_name, n2.n_name, EXTRACT(YEAR FROM l_shipdate)
+GROUP BY supp_nation, cust_nation, l_year
 ORDER BY supp_nation, cust_nation, l_year
 "#;
 
 // TPC-H Q8: National Market Share (8-way join)
 pub const TPCH_Q8: &str = r#"
 SELECT
-    EXTRACT(YEAR FROM o_orderdate) as o_year,
+    SUBSTR(o_orderdate, 1, 4) as o_year,
     SUM(CASE WHEN n2.n_name = 'BRAZIL'
         THEN l_extendedprice * (1 - l_discount)
         ELSE 0 END) / SUM(l_extendedprice * (1 - l_discount)) as mkt_share
@@ -161,7 +161,7 @@ WHERE p_partkey = l_partkey
     AND o_orderdate >= '1995-01-01'
     AND o_orderdate <= '1996-12-31'
     AND p_type = 'ECONOMY ANODIZED STEEL'
-GROUP BY EXTRACT(YEAR FROM o_orderdate)
+GROUP BY o_year
 ORDER BY o_year
 "#;
 
@@ -170,7 +170,7 @@ ORDER BY o_year
 pub const TPCH_Q9: &str = r#"
 SELECT
     n_name as nation,
-    EXTRACT(YEAR FROM o_orderdate) as o_year,
+    SUBSTR(o_orderdate, 1, 4) as o_year,
     SUM(l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity) as sum_profit
 FROM part, supplier, lineitem, partsupp, orders, nation
 WHERE s_suppkey = l_suppkey
@@ -180,7 +180,7 @@ WHERE s_suppkey = l_suppkey
     AND o_orderkey = l_orderkey
     AND s_nationkey = n_nationkey
     AND p_name LIKE '%green%'
-GROUP BY n_name, EXTRACT(YEAR FROM o_orderdate)
+GROUP BY nation, o_year
 ORDER BY nation, o_year DESC
 "#;
 


### PR DESCRIPTION
## Summary

- Fixes TPC-H Q7, Q8, and Q9 query execution by reverting `EXTRACT(YEAR FROM date)` syntax back to `SUBSTR(date, 1, 4)` 
- The VibeSQL parser doesn't support the standard SQL EXTRACT syntax, causing parse errors
- This restores the queries to their original working state before commit b3f94934

**Root cause**: Commit b3f94934 changed these queries to use `EXTRACT(YEAR FROM date)` for DuckDB compatibility in benchmark comparisons, but broke them for VibeSQL's native execution since the parser doesn't support this syntax.

## Test plan

- [x] Verified Q7, Q8, Q9 parse and execute successfully
- [x] Verified all 22 TPC-H queries execute without errors
- [x] No regressions in other queries

Closes #2805

🤖 Generated with [Claude Code](https://claude.com/claude-code)