### PR TITLE
feat(parser): Add EXTRACT(field FROM expr) SQL:1999 datetime function

### DIFF
--- a/crates/vibesql-ast/src/expression.rs
+++ b/crates/vibesql-ast/src/expression.rs
@@ -138,6 +138,17 @@ pub enum Expression {
         string: Box<Expression>,
     },
 
+    /// EXTRACT expression
+    /// Example: EXTRACT(YEAR FROM date_column)
+    /// Example: EXTRACT(MONTH FROM '2024-01-15')
+    /// Example: EXTRACT(DAY FROM order_date)
+    /// SQL:1999 Section 6.18: Datetime value function
+    /// Extracts a date/time field from a datetime or interval expression
+    Extract {
+        field: IntervalUnit,
+        expr: Box<Expression>,
+    },
+
     /// LIKE pattern matching
     /// Example: name LIKE 'John%'
     /// Example: email NOT LIKE '%spam%'

--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -501,6 +501,9 @@ impl TableSchema {
                     .is_some_and(|e| Self::expression_references_column(e, column_name))
                     || Self::expression_references_column(string, column_name)
             }
+            vibesql_ast::Expression::Extract { expr, .. } => {
+                Self::expression_references_column(expr, column_name)
+            }
             vibesql_ast::Expression::Like { expr, pattern, .. } => {
                 Self::expression_references_column(expr, column_name)
                     || Self::expression_references_column(pattern, column_name)

--- a/crates/vibesql-executor/src/cache/parameterized.rs
+++ b/crates/vibesql-executor/src/cache/parameterized.rs
@@ -400,6 +400,10 @@ impl LiteralExtractor {
                 Self::extract_from_expression(string, literals);
             }
 
+            Expression::Extract { expr, .. } => {
+                Self::extract_from_expression(expr, literals);
+            }
+
             Expression::Like { expr, pattern, .. } => {
                 Self::extract_from_expression(expr, literals);
                 Self::extract_from_expression(pattern, literals);

--- a/crates/vibesql-executor/src/cache/query_signature.rs
+++ b/crates/vibesql-executor/src/cache/query_signature.rs
@@ -403,6 +403,12 @@ impl QuerySignature {
                 Self::hash_expression(string, hasher);
             }
 
+            Expression::Extract { field, expr } => {
+                "EXTRACT".hash(hasher);
+                std::mem::discriminant(field).hash(hasher);
+                Self::hash_expression(expr, hasher);
+            }
+
             Expression::Like { expr, pattern, negated } => {
                 "LIKE".hash(hasher);
                 Self::hash_expression(expr, hasher);

--- a/crates/vibesql-executor/src/cache/table_extractor.rs
+++ b/crates/vibesql-executor/src/cache/table_extractor.rs
@@ -155,6 +155,9 @@ fn extract_from_expression(expr: &vibesql_ast::Expression, tables: &mut HashSet<
             }
             extract_from_expression(string, tables);
         }
+        vibesql_ast::Expression::Extract { expr, .. } => {
+            extract_from_expression(expr, tables);
+        }
         vibesql_ast::Expression::QuantifiedComparison { expr, subquery, .. } => {
             extract_from_expression(expr, tables);
             let subquery_tables = extract_tables_from_select(subquery);

--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -344,6 +344,10 @@ fn is_expression_correlated(
                 || is_expression_correlated(string, outer_schema, subquery_tables)
         }
 
+        Expression::Extract { expr, .. } => {
+            is_expression_correlated(expr, outer_schema, subquery_tables)
+        }
+
         Expression::WindowFunction { function, over } => {
             // Check window function arguments
             let func_correlated = match function {

--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -160,6 +160,11 @@ pub enum ExecutorError {
     FunctionReadOnlyViolation(String),
     /// Parse error
     ParseError(String),
+    /// Invalid EXTRACT field for the given value type
+    InvalidExtractField {
+        field: String,
+        value_type: String,
+    },
     Other(String),
 }
 
@@ -504,6 +509,13 @@ impl std::fmt::Display for ExecutorError {
             }
             ExecutorError::ParseError(msg) => {
                 write!(f, "Parse error: {}", msg)
+            }
+            ExecutorError::InvalidExtractField { field, value_type } => {
+                write!(
+                    f,
+                    "Cannot extract {} from {} value",
+                    field, value_type
+                )
             }
             ExecutorError::Other(msg) => write!(f, "{}", msg),
         }

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -214,6 +214,12 @@ impl CombinedExpressionEvaluator<'_> {
             vibesql_ast::Expression::Trim { position, removal_char, string } => {
                 self.eval_trim(position, removal_char, string, row)
             }
+
+            // EXTRACT expression: EXTRACT(field FROM expr)
+            vibesql_ast::Expression::Extract { field, expr } => {
+                self.eval_extract(field, expr, row)
+            }
+
             // LIKE pattern matching: expr LIKE pattern
             vibesql_ast::Expression::Like { expr, pattern, negated } => {
                 self.eval_like(expr, pattern, *negated, row)

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -1,10 +1,11 @@
-//! Predicate evaluation for combined expressions (BETWEEN, LIKE, IN)
+//! Predicate evaluation for combined expressions (BETWEEN, LIKE, IN, EXTRACT)
 
 use super::super::{
     core::{CombinedExpressionEvaluator, ExpressionEvaluator},
     pattern::like_match,
 };
 use crate::errors::ExecutorError;
+use chrono::{Datelike, Timelike};
 
 impl CombinedExpressionEvaluator<'_> {
     /// Evaluate BETWEEN predicate: expr BETWEEN low AND high
@@ -381,6 +382,146 @@ impl CombinedExpressionEvaluator<'_> {
                 left: substring_val.clone(),
                 op: "POSITION".to_string(),
                 right: string_val.clone(),
+            }),
+        }
+    }
+
+    /// Evaluate EXTRACT expression: EXTRACT(field FROM expr)
+    /// Extracts a date/time component from a datetime expression
+    pub(super) fn eval_extract(
+        &self,
+        field: &vibesql_ast::IntervalUnit,
+        expr: &vibesql_ast::Expression,
+        row: &vibesql_storage::Row,
+    ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        let datetime_val = self.eval(expr, row)?;
+
+        // Handle NULL
+        if matches!(datetime_val, vibesql_types::SqlValue::Null) {
+            return Ok(vibesql_types::SqlValue::Null);
+        }
+
+        // Extract component based on field type
+        use vibesql_ast::IntervalUnit;
+
+        match &datetime_val {
+            vibesql_types::SqlValue::Date(d) => {
+                let result = match field {
+                    IntervalUnit::Year => d.year as i64,
+                    IntervalUnit::Month => d.month as i64,
+                    IntervalUnit::Day => d.day as i64,
+                    IntervalUnit::Quarter => ((d.month - 1) / 3 + 1) as i64,
+                    IntervalUnit::Week => {
+                        // Calculate ISO week number using chrono
+                        let chrono_date = chrono::NaiveDate::from_ymd_opt(d.year, d.month as u32, d.day as u32)
+                            .unwrap_or_else(|| chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
+                        chrono_date.iso_week().week() as i64
+                    }
+                    _ => {
+                        return Err(ExecutorError::InvalidExtractField {
+                            field: format!("{:?}", field),
+                            value_type: "DATE".to_string(),
+                        })
+                    }
+                };
+                Ok(vibesql_types::SqlValue::Integer(result))
+            }
+
+            vibesql_types::SqlValue::Time(t) => {
+                let result = match field {
+                    IntervalUnit::Hour => t.hour as i64,
+                    IntervalUnit::Minute => t.minute as i64,
+                    IntervalUnit::Second => t.second as i64,
+                    IntervalUnit::Microsecond => (t.nanosecond / 1000) as i64,
+                    _ => {
+                        return Err(ExecutorError::InvalidExtractField {
+                            field: format!("{:?}", field),
+                            value_type: "TIME".to_string(),
+                        })
+                    }
+                };
+                Ok(vibesql_types::SqlValue::Integer(result))
+            }
+
+            vibesql_types::SqlValue::Timestamp(ts) => {
+                let result = match field {
+                    IntervalUnit::Year => ts.date.year as i64,
+                    IntervalUnit::Month => ts.date.month as i64,
+                    IntervalUnit::Day => ts.date.day as i64,
+                    IntervalUnit::Hour => ts.time.hour as i64,
+                    IntervalUnit::Minute => ts.time.minute as i64,
+                    IntervalUnit::Second => ts.time.second as i64,
+                    IntervalUnit::Microsecond => (ts.time.nanosecond / 1000) as i64,
+                    IntervalUnit::Quarter => ((ts.date.month - 1) / 3 + 1) as i64,
+                    IntervalUnit::Week => {
+                        // Calculate ISO week number using chrono
+                        let chrono_date = chrono::NaiveDate::from_ymd_opt(ts.date.year, ts.date.month as u32, ts.date.day as u32)
+                            .unwrap_or_else(|| chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
+                        chrono_date.iso_week().week() as i64
+                    }
+                    _ => {
+                        return Err(ExecutorError::InvalidExtractField {
+                            field: format!("{:?}", field),
+                            value_type: "TIMESTAMP".to_string(),
+                        })
+                    }
+                };
+                Ok(vibesql_types::SqlValue::Integer(result))
+            }
+
+            // For string values, try to parse as date/timestamp
+            vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
+                // Try to parse as date first
+                if let Ok(date) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+                    let result = match field {
+                        IntervalUnit::Year => date.year() as i64,
+                        IntervalUnit::Month => date.month() as i64,
+                        IntervalUnit::Day => date.day() as i64,
+                        IntervalUnit::Quarter => ((date.month() - 1) / 3 + 1) as i64,
+                        IntervalUnit::Week => date.iso_week().week() as i64,
+                        _ => {
+                            return Err(ExecutorError::InvalidExtractField {
+                                field: format!("{:?}", field),
+                                value_type: "DATE".to_string(),
+                            })
+                        }
+                    };
+                    return Ok(vibesql_types::SqlValue::Integer(result));
+                }
+
+                // Try to parse as timestamp
+                if let Ok(ts) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+                    let result = match field {
+                        IntervalUnit::Year => ts.year() as i64,
+                        IntervalUnit::Month => ts.month() as i64,
+                        IntervalUnit::Day => ts.day() as i64,
+                        IntervalUnit::Hour => ts.hour() as i64,
+                        IntervalUnit::Minute => ts.minute() as i64,
+                        IntervalUnit::Second => ts.second() as i64,
+                        IntervalUnit::Microsecond => ts.nanosecond() as i64 / 1000,
+                        IntervalUnit::Quarter => ((ts.month() - 1) / 3 + 1) as i64,
+                        IntervalUnit::Week => ts.iso_week().week() as i64,
+                        _ => {
+                            return Err(ExecutorError::InvalidExtractField {
+                                field: format!("{:?}", field),
+                                value_type: "TIMESTAMP".to_string(),
+                            })
+                        }
+                    };
+                    return Ok(vibesql_types::SqlValue::Integer(result));
+                }
+
+                Err(ExecutorError::TypeMismatch {
+                    left: datetime_val.clone(),
+                    op: "EXTRACT".to_string(),
+                    right: vibesql_types::SqlValue::Null,
+                })
+            }
+
+            _ => Err(ExecutorError::TypeMismatch {
+                left: datetime_val.clone(),
+                op: "EXTRACT".to_string(),
+                right: vibesql_types::SqlValue::Null,
             }),
         }
     }

--- a/crates/vibesql-executor/src/evaluator/expression_hash.rs
+++ b/crates/vibesql-executor/src/evaluator/expression_hash.rs
@@ -133,6 +133,8 @@ impl ExpressionHasher {
                     && removal_char.as_ref().is_none_or(|c| Self::is_deterministic(c))
             }
 
+            vibesql_ast::Expression::Extract { expr, .. } => Self::is_deterministic(expr),
+
             // Literals are deterministic, but column references, pseudo-variables, and session variables are NOT
             // Column references and pseudo-variables depend on the current row data, so they should not be cached
             // across multiple rows in row-iteration contexts
@@ -292,6 +294,12 @@ impl ExpressionHasher {
                     Self::hash_expression(ch, hasher);
                 }
                 Self::hash_expression(string, hasher);
+            }
+
+            vibesql_ast::Expression::Extract { field, expr } => {
+                "EXTRACT".hash(hasher);
+                std::mem::discriminant(field).hash(hasher);
+                Self::hash_expression(expr, hasher);
             }
 
             vibesql_ast::Expression::CurrentDate => {

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -158,6 +158,11 @@ impl ExpressionEvaluator<'_> {
                 self.eval_trim(position, removal_char, string, row)
             }
 
+            // EXTRACT expression
+            vibesql_ast::Expression::Extract { field, expr } => {
+                self.eval_extract(field, expr, row)
+            }
+
             // LIKE pattern matching
             vibesql_ast::Expression::Like { expr, pattern, negated } => {
                 self.eval_like(expr, pattern, *negated, row)

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -1,7 +1,8 @@
-//! Predicate evaluation methods (BETWEEN, LIKE, IN, POSITION)
+//! Predicate evaluation methods (BETWEEN, LIKE, IN, POSITION, EXTRACT)
 
 use super::super::{casting::cast_value, core::ExpressionEvaluator, pattern::like_match};
 use crate::errors::ExecutorError;
+use chrono::{Datelike, Timelike};
 
 impl ExpressionEvaluator<'_> {
     /// Evaluate BETWEEN predicate: expr BETWEEN low AND high
@@ -200,6 +201,147 @@ impl ExpressionEvaluator<'_> {
         };
 
         Ok(vibesql_types::SqlValue::Varchar(result))
+    }
+
+    /// Evaluate EXTRACT expression
+    /// EXTRACT(field FROM expr) - extracts date/time component from datetime expression
+    #[inline]
+    pub(super) fn eval_extract(
+        &self,
+        field: &vibesql_ast::IntervalUnit,
+        expr: &vibesql_ast::Expression,
+        row: &vibesql_storage::Row,
+    ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        let datetime_val = self.eval(expr, row)?;
+
+        // Handle NULL
+        if matches!(datetime_val, vibesql_types::SqlValue::Null) {
+            return Ok(vibesql_types::SqlValue::Null);
+        }
+
+        // Extract component based on field type
+        use vibesql_ast::IntervalUnit;
+
+        match &datetime_val {
+            vibesql_types::SqlValue::Date(d) => {
+                let result = match field {
+                    IntervalUnit::Year => d.year as i64,
+                    IntervalUnit::Month => d.month as i64,
+                    IntervalUnit::Day => d.day as i64,
+                    IntervalUnit::Quarter => ((d.month - 1) / 3 + 1) as i64,
+                    IntervalUnit::Week => {
+                        // Calculate ISO week number using chrono
+                        let chrono_date = chrono::NaiveDate::from_ymd_opt(d.year, d.month as u32, d.day as u32)
+                            .unwrap_or_else(|| chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
+                        chrono_date.iso_week().week() as i64
+                    }
+                    _ => {
+                        return Err(ExecutorError::InvalidExtractField {
+                            field: format!("{:?}", field),
+                            value_type: "DATE".to_string(),
+                        })
+                    }
+                };
+                Ok(vibesql_types::SqlValue::Integer(result))
+            }
+
+            vibesql_types::SqlValue::Time(t) => {
+                let result = match field {
+                    IntervalUnit::Hour => t.hour as i64,
+                    IntervalUnit::Minute => t.minute as i64,
+                    IntervalUnit::Second => t.second as i64,
+                    IntervalUnit::Microsecond => (t.nanosecond / 1000) as i64,
+                    _ => {
+                        return Err(ExecutorError::InvalidExtractField {
+                            field: format!("{:?}", field),
+                            value_type: "TIME".to_string(),
+                        })
+                    }
+                };
+                Ok(vibesql_types::SqlValue::Integer(result))
+            }
+
+            vibesql_types::SqlValue::Timestamp(ts) => {
+                let result = match field {
+                    IntervalUnit::Year => ts.date.year as i64,
+                    IntervalUnit::Month => ts.date.month as i64,
+                    IntervalUnit::Day => ts.date.day as i64,
+                    IntervalUnit::Hour => ts.time.hour as i64,
+                    IntervalUnit::Minute => ts.time.minute as i64,
+                    IntervalUnit::Second => ts.time.second as i64,
+                    IntervalUnit::Microsecond => (ts.time.nanosecond / 1000) as i64,
+                    IntervalUnit::Quarter => ((ts.date.month - 1) / 3 + 1) as i64,
+                    IntervalUnit::Week => {
+                        // Calculate ISO week number using chrono
+                        let chrono_date = chrono::NaiveDate::from_ymd_opt(ts.date.year, ts.date.month as u32, ts.date.day as u32)
+                            .unwrap_or_else(|| chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
+                        chrono_date.iso_week().week() as i64
+                    }
+                    _ => {
+                        return Err(ExecutorError::InvalidExtractField {
+                            field: format!("{:?}", field),
+                            value_type: "TIMESTAMP".to_string(),
+                        })
+                    }
+                };
+                Ok(vibesql_types::SqlValue::Integer(result))
+            }
+
+            // For string values, try to parse as date/timestamp
+            vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
+                // Try to parse as date first
+                if let Ok(date) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+                    let result = match field {
+                        IntervalUnit::Year => date.year() as i64,
+                        IntervalUnit::Month => date.month() as i64,
+                        IntervalUnit::Day => date.day() as i64,
+                        IntervalUnit::Quarter => ((date.month() - 1) / 3 + 1) as i64,
+                        IntervalUnit::Week => date.iso_week().week() as i64,
+                        _ => {
+                            return Err(ExecutorError::InvalidExtractField {
+                                field: format!("{:?}", field),
+                                value_type: "DATE".to_string(),
+                            })
+                        }
+                    };
+                    return Ok(vibesql_types::SqlValue::Integer(result));
+                }
+
+                // Try to parse as timestamp
+                if let Ok(ts) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+                    let result = match field {
+                        IntervalUnit::Year => ts.year() as i64,
+                        IntervalUnit::Month => ts.month() as i64,
+                        IntervalUnit::Day => ts.day() as i64,
+                        IntervalUnit::Hour => ts.hour() as i64,
+                        IntervalUnit::Minute => ts.minute() as i64,
+                        IntervalUnit::Second => ts.second() as i64,
+                        IntervalUnit::Microsecond => ts.nanosecond() as i64 / 1000,
+                        IntervalUnit::Quarter => ((ts.month() - 1) / 3 + 1) as i64,
+                        IntervalUnit::Week => ts.iso_week().week() as i64,
+                        _ => {
+                            return Err(ExecutorError::InvalidExtractField {
+                                field: format!("{:?}", field),
+                                value_type: "TIMESTAMP".to_string(),
+                            })
+                        }
+                    };
+                    return Ok(vibesql_types::SqlValue::Integer(result));
+                }
+
+                Err(ExecutorError::TypeMismatch {
+                    left: datetime_val.clone(),
+                    op: "EXTRACT".to_string(),
+                    right: vibesql_types::SqlValue::Null,
+                })
+            }
+
+            _ => Err(ExecutorError::TypeMismatch {
+                left: datetime_val.clone(),
+                op: "EXTRACT".to_string(),
+                right: vibesql_types::SqlValue::Null,
+            }),
+        }
     }
 
     /// Evaluate LIKE predicate

--- a/crates/vibesql-executor/src/optimizer/expressions.rs
+++ b/crates/vibesql-executor/src/optimizer/expressions.rs
@@ -270,7 +270,7 @@ pub fn optimize_expression(
         }
 
         // String functions - cannot optimize generally
-        Expression::Position { .. } | Expression::Trim { .. } => Ok(expr.clone()),
+        Expression::Position { .. } | Expression::Trim { .. } | Expression::Extract { .. } => Ok(expr.clone()),
 
         // LIKE - cannot optimize generally
         Expression::Like { .. } => Ok(expr.clone()),

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
@@ -184,6 +184,8 @@ pub(super) fn has_external_column_refs(expr: &Expression, subquery: &SelectStmt)
                 || has_external_column_refs(string, subquery)
         }
 
+        Expression::Extract { expr, .. } => has_external_column_refs(expr, subquery),
+
         Expression::Like { expr, pattern, .. } => {
             has_external_column_refs(expr, subquery) || has_external_column_refs(pattern, subquery)
         }

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
@@ -224,6 +224,11 @@ pub(super) fn rewrite_expression_with_context(
             string: Box::new(rewrite_expression_with_context(string, rewrite_subquery_fn, outer_tables)),
         },
 
+        Expression::Extract { field, expr } => Expression::Extract {
+            field: field.clone(),
+            expr: Box::new(rewrite_expression_with_context(expr, rewrite_subquery_fn, outer_tables)),
+        },
+
         Expression::Like {
             expr,
             pattern,

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -80,6 +80,7 @@ impl SelectExecutor<'_> {
             | vibesql_ast::Expression::IsNull { .. }
             | vibesql_ast::Expression::Position { .. }
             | vibesql_ast::Expression::Trim { .. }
+            | vibesql_ast::Expression::Extract { .. }
             | vibesql_ast::Expression::Interval { .. } => {
                 simple::evaluate(self, expr, group_rows, group_key, evaluator)
             }

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -427,6 +427,11 @@ fn validate_expression_column_refs(
             validate_expression_column_refs(string, schema, outer_schema, allowed_aliases)
         }
 
+        // EXTRACT - extract field from expression
+        Expression::Extract { expr, .. } => {
+            validate_expression_column_refs(expr, schema, outer_schema, allowed_aliases)
+        }
+
         // MATCH AGAINST - column names are strings, not expressions
         Expression::MatchAgainst { search_modifier, .. } => {
             validate_expression_column_refs(search_modifier, schema, outer_schema, allowed_aliases)

--- a/crates/vibesql-executor/src/select/executor/utils.rs
+++ b/crates/vibesql-executor/src/select/executor/utils.rs
@@ -47,6 +47,8 @@ fn expression_references_column(expr: &vibesql_ast::Expression) -> bool {
                 || expression_references_column(string)
         }
 
+        vibesql_ast::Expression::Extract { expr, .. } => expression_references_column(expr),
+
         vibesql_ast::Expression::Like { expr, pattern, .. } => {
             expression_references_column(expr) || expression_references_column(pattern)
         }

--- a/crates/vibesql-executor/src/select/executor/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/validation.rs
@@ -101,6 +101,9 @@ fn extract_column_refs(expr: &Expression, refs: &mut Vec<ColumnReference>) {
             }
             extract_column_refs(string, refs);
         }
+        Expression::Extract { expr, .. } => {
+            extract_column_refs(expr, refs);
+        }
         Expression::ScalarSubquery(_) => {
             // Scalar subquery columns are validated when executing the subquery
         }

--- a/crates/vibesql-executor/src/select/join/expression_mapper.rs
+++ b/crates/vibesql-executor/src/select/join/expression_mapper.rs
@@ -235,6 +235,9 @@ impl ExpressionMapper {
                 }
                 self.walk_expression(string, tables, columns, resolvable);
             }
+            Expression::Extract { expr, .. } => {
+                self.walk_expression(expr, tables, columns, resolvable);
+            }
             Expression::Like { expr: e, pattern, .. } => {
                 self.walk_expression(e, tables, columns, resolvable);
                 self.walk_expression(pattern, tables, columns, resolvable);

--- a/crates/vibesql-executor/src/select/window/order_by.rs
+++ b/crates/vibesql-executor/src/select/window/order_by.rs
@@ -92,6 +92,9 @@ fn collect_window_functions_from_expression(
             }
             collect_window_functions_from_expression(string, window_functions);
         }
+        Expression::Extract { expr, .. } => {
+            collect_window_functions_from_expression(expr, window_functions);
+        }
         Expression::Exists { .. }
         | Expression::ScalarSubquery(_)
         | Expression::QuantifiedComparison { .. } => {

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -105,6 +105,12 @@ impl Parser {
             return Ok(Some(self.parse_substring_function(first)?));
         }
 
+        // Special case for EXTRACT(field FROM expr)
+        // SQL:1999 standard syntax for date/time extraction
+        if first.to_uppercase() == "EXTRACT" {
+            return Ok(Some(self.parse_extract_function()?));
+        }
+
         // Check if this is an aggregate function
         let function_name_upper = first.to_uppercase();
         let is_aggregate =

--- a/crates/vibesql-parser/src/parser/expressions/functions/string_special.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/string_special.rs
@@ -5,6 +5,7 @@
 //! - POSITION(substring IN string [USING unit])
 //! - TRIM([position] [removal_char FROM] string)
 //! - SUBSTRING(string FROM start [FOR length] [USING unit])
+//! - EXTRACT(field FROM expr)
 
 use super::super::*;
 
@@ -37,6 +38,33 @@ impl Parser {
             substring: Box::new(substring),
             string: Box::new(string),
             character_unit,
+        })
+    }
+
+    /// Parse EXTRACT(field FROM expr)
+    /// SQL:1999 standard syntax for extracting date/time components
+    ///
+    /// Forms:
+    /// - EXTRACT(YEAR FROM date_column)
+    /// - EXTRACT(MONTH FROM timestamp_column)
+    /// - EXTRACT(DAY FROM '2024-01-15')
+    /// - EXTRACT(HOUR FROM current_timestamp)
+    pub(super) fn parse_extract_function(&mut self) -> Result<vibesql_ast::Expression, ParseError> {
+        // Parse the field (date/time unit) - reuse the interval unit parser
+        let field = self.parse_interval_unit()?;
+
+        // Expect FROM keyword
+        self.expect_keyword(Keyword::From)?;
+
+        // Parse the expression at primary level to avoid operator conflicts
+        let expr = self.parse_primary_expression()?;
+
+        // Expect closing parenthesis
+        self.expect_token(Token::RParen)?;
+
+        Ok(vibesql_ast::Expression::Extract {
+            field,
+            expr: Box::new(expr),
         })
     }
 

--- a/crates/vibesql-parser/src/tests/select/extract.rs
+++ b/crates/vibesql-parser/src/tests/select/extract.rs
@@ -1,0 +1,288 @@
+//! Parser tests for EXTRACT(field FROM expr) syntax
+//! SQL:1999 Section 6.18: Datetime value function
+
+use super::super::*;
+
+/// Test parsing: SELECT EXTRACT(YEAR FROM '2024-01-15')
+#[test]
+fn test_parse_extract_year_from_literal() {
+    let result = Parser::parse_sql("SELECT EXTRACT(YEAR FROM '2024-01-15');");
+    if result.is_err() {
+        eprintln!("Parse error: {:?}", result.as_ref().err());
+    }
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select_stmt) => {
+            assert_eq!(select_stmt.select_list.len(), 1);
+            match &select_stmt.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                    vibesql_ast::Expression::Extract { field, expr } => {
+                        assert_eq!(*field, vibesql_ast::IntervalUnit::Year);
+                        assert_eq!(
+                            **expr,
+                            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                                "2024-01-15".to_string()
+                            ))
+                        );
+                    }
+                    _ => panic!("Expected Extract expression, got {:?}", expr),
+                },
+                _ => panic!("Expected Expression select item"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+/// Test parsing: SELECT EXTRACT(MONTH FROM order_date) FROM orders
+#[test]
+fn test_parse_extract_month_from_column() {
+    let result = Parser::parse_sql("SELECT EXTRACT(MONTH FROM order_date) FROM orders;");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select_stmt) => {
+            assert_eq!(select_stmt.select_list.len(), 1);
+            match &select_stmt.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                    vibesql_ast::Expression::Extract { field, expr } => {
+                        assert_eq!(*field, vibesql_ast::IntervalUnit::Month);
+                        match &**expr {
+                            vibesql_ast::Expression::ColumnRef { column, .. } => {
+                                assert_eq!(column, "ORDER_DATE");
+                            }
+                            _ => panic!("Expected column reference in Extract"),
+                        }
+                    }
+                    _ => panic!("Expected Extract expression"),
+                },
+                _ => panic!("Expected Expression select item"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+/// Test parsing: SELECT EXTRACT(DAY FROM '2024-01-15')
+#[test]
+fn test_parse_extract_day() {
+    let result = Parser::parse_sql("SELECT EXTRACT(DAY FROM '2024-01-15');");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select_stmt) => {
+            match &select_stmt.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                    vibesql_ast::Expression::Extract { field, .. } => {
+                        assert_eq!(*field, vibesql_ast::IntervalUnit::Day);
+                    }
+                    _ => panic!("Expected Extract expression"),
+                },
+                _ => panic!("Expected Expression select item"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+/// Test parsing: SELECT EXTRACT(HOUR FROM timestamp_column)
+#[test]
+fn test_parse_extract_hour() {
+    let result = Parser::parse_sql("SELECT EXTRACT(HOUR FROM timestamp_column);");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select_stmt) => {
+            match &select_stmt.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                    vibesql_ast::Expression::Extract { field, .. } => {
+                        assert_eq!(*field, vibesql_ast::IntervalUnit::Hour);
+                    }
+                    _ => panic!("Expected Extract expression"),
+                },
+                _ => panic!("Expected Expression select item"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+/// Test parsing: SELECT EXTRACT(MINUTE FROM time_col)
+#[test]
+fn test_parse_extract_minute() {
+    let result = Parser::parse_sql("SELECT EXTRACT(MINUTE FROM time_col);");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select_stmt) => {
+            match &select_stmt.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                    vibesql_ast::Expression::Extract { field, .. } => {
+                        assert_eq!(*field, vibesql_ast::IntervalUnit::Minute);
+                    }
+                    _ => panic!("Expected Extract expression"),
+                },
+                _ => panic!("Expected Expression select item"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+/// Test parsing: SELECT EXTRACT(SECOND FROM time_col)
+#[test]
+fn test_parse_extract_second() {
+    let result = Parser::parse_sql("SELECT EXTRACT(SECOND FROM time_col);");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select_stmt) => {
+            match &select_stmt.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                    vibesql_ast::Expression::Extract { field, .. } => {
+                        assert_eq!(*field, vibesql_ast::IntervalUnit::Second);
+                    }
+                    _ => panic!("Expected Extract expression"),
+                },
+                _ => panic!("Expected Expression select item"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+/// Test parsing: EXTRACT with nested function call
+/// SELECT EXTRACT(YEAR FROM CURRENT_DATE)
+#[test]
+fn test_parse_extract_from_current_date() {
+    let result = Parser::parse_sql("SELECT EXTRACT(YEAR FROM CURRENT_DATE);");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select_stmt) => {
+            match &select_stmt.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                    vibesql_ast::Expression::Extract { field, expr } => {
+                        assert_eq!(*field, vibesql_ast::IntervalUnit::Year);
+                        assert!(matches!(**expr, vibesql_ast::Expression::CurrentDate));
+                    }
+                    _ => panic!("Expected Extract expression"),
+                },
+                _ => panic!("Expected Expression select item"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+/// Test case-insensitivity of EXTRACT and field names
+#[test]
+fn test_parse_extract_case_insensitive() {
+    let result = Parser::parse_sql("SELECT extract(year FROM date_col);");
+    assert!(result.is_ok());
+
+    let result2 = Parser::parse_sql("SELECT EXTRACT(Year FROM date_col);");
+    assert!(result2.is_ok());
+}
+
+/// Test EXTRACT with table-qualified column
+#[test]
+fn test_parse_extract_with_qualified_column() {
+    let result = Parser::parse_sql("SELECT EXTRACT(MONTH FROM orders.order_date) FROM orders;");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select_stmt) => {
+            match &select_stmt.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                    vibesql_ast::Expression::Extract { field, expr } => {
+                        assert_eq!(*field, vibesql_ast::IntervalUnit::Month);
+                        match &**expr {
+                            vibesql_ast::Expression::ColumnRef { table, column } => {
+                                assert_eq!(table.as_deref(), Some("ORDERS"));
+                                assert_eq!(column, "ORDER_DATE");
+                            }
+                            _ => panic!("Expected qualified column reference"),
+                        }
+                    }
+                    _ => panic!("Expected Extract expression"),
+                },
+                _ => panic!("Expected Expression select item"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+/// Test TPC-H Q7 style query with EXTRACT in SELECT and GROUP BY
+/// This tests the exact pattern used in TPC-H queries Q7, Q8, Q9
+#[test]
+fn test_parse_tpch_q7_style_extract() {
+    let query = r#"
+        SELECT
+            n1.n_name as supp_nation,
+            n2.n_name as cust_nation,
+            EXTRACT(YEAR FROM l_shipdate) as l_year,
+            SUM(l_extendedprice * (1 - l_discount)) as revenue
+        FROM supplier, lineitem, orders, customer, nation n1, nation n2
+        WHERE s_suppkey = l_suppkey
+        GROUP BY n1.n_name, n2.n_name, EXTRACT(YEAR FROM l_shipdate)
+        ORDER BY supp_nation, cust_nation, l_year
+    "#;
+
+    let result = Parser::parse_sql(query);
+    if result.is_err() {
+        eprintln!("Parse error: {:?}", result.as_ref().err());
+    }
+    assert!(result.is_ok(), "TPC-H Q7 style query should parse successfully");
+}
+
+/// Test TPC-H Q8 style query with EXTRACT in SELECT and GROUP BY
+#[test]
+fn test_parse_tpch_q8_style_extract() {
+    let query = r#"
+        SELECT
+            EXTRACT(YEAR FROM o_orderdate) as o_year,
+            SUM(l_extendedprice * (1 - l_discount)) as mkt_share
+        FROM part, supplier, lineitem, orders
+        WHERE p_partkey = l_partkey
+        GROUP BY EXTRACT(YEAR FROM o_orderdate)
+        ORDER BY o_year
+    "#;
+
+    let result = Parser::parse_sql(query);
+    if result.is_err() {
+        eprintln!("Parse error: {:?}", result.as_ref().err());
+    }
+    assert!(result.is_ok(), "TPC-H Q8 style query should parse successfully");
+}
+
+/// Test TPC-H Q9 style query with EXTRACT in SELECT and GROUP BY
+#[test]
+fn test_parse_tpch_q9_style_extract() {
+    let query = r#"
+        SELECT
+            n_name as nation,
+            EXTRACT(YEAR FROM o_orderdate) as o_year,
+            SUM(l_extendedprice * (1 - l_discount)) as sum_profit
+        FROM part, supplier, lineitem, orders, nation
+        WHERE s_suppkey = l_suppkey
+        GROUP BY n_name, EXTRACT(YEAR FROM o_orderdate)
+        ORDER BY nation, o_year DESC
+    "#;
+
+    let result = Parser::parse_sql(query);
+    if result.is_err() {
+        eprintln!("Parse error: {:?}", result.as_ref().err());
+    }
+    assert!(result.is_ok(), "TPC-H Q9 style query should parse successfully");
+}

--- a/crates/vibesql-parser/src/tests/select/mod.rs
+++ b/crates/vibesql-parser/src/tests/select/mod.rs
@@ -3,5 +3,6 @@ mod backtick_identifiers;
 mod basic_expressions;
 mod concat;
 mod derived_columns;
+mod extract;
 mod filters;
 mod position;

--- a/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
+++ b/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
@@ -65,6 +65,7 @@ enum ExprTag {
     MatchAgainst = 0x1B,
     PseudoVariable = 0x1C,
     SessionVariable = 0x1D,
+    Extract = 0x1E,
 }
 
 impl ExprTag {
@@ -100,6 +101,7 @@ impl ExprTag {
             0x1B => Ok(ExprTag::MatchAgainst),
             0x1C => Ok(ExprTag::PseudoVariable),
             0x1D => Ok(ExprTag::SessionVariable),
+            0x1E => Ok(ExprTag::Extract),
             _ => Err(StorageError::NotImplemented(format!(
                 "Unknown expression tag: 0x{:02X}",
                 tag
@@ -365,6 +367,11 @@ pub fn write_expression<W: Write>(writer: &mut W, expr: &Expression) -> Result<(
         Expression::SessionVariable { name } => {
             write_tag!(writer, ExprTag::SessionVariable);
             write_string(writer, name)?;
+        }
+        Expression::Extract { field, expr } => {
+            write_tag!(writer, ExprTag::Extract);
+            write_interval_unit(writer, field)?;
+            write_expression(writer, expr)?;
         }
     }
     Ok(())
@@ -634,6 +641,11 @@ pub fn read_expression<R: Read>(reader: &mut R) -> Result<Expression, StorageErr
         ExprTag::SessionVariable => {
             let name = read_string(reader)?;
             Ok(Expression::SessionVariable { name })
+        }
+        ExprTag::Extract => {
+            let field = read_interval_unit(reader)?;
+            let expr = Box::new(read_expression(reader)?);
+            Ok(Expression::Extract { field, expr })
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements the SQL:1999 standard EXTRACT function for extracting date/time components from datetime expressions. This enables TPC-H queries Q7, Q8, and Q9 which use `EXTRACT(YEAR FROM ...)` syntax.

**Changes:**
- Add `Extract` variant to Expression AST
- Parse `EXTRACT(field FROM expr)` syntax in parser  
- Implement `eval_extract` in both evaluators
- Add binary serialization support for Extract
- Add `InvalidExtractField` error type
- Update all expression pattern matches across codebase
- Add comprehensive parser tests including TPC-H style queries

**Supported fields:** YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MICROSECOND, QUARTER, WEEK

**Example usage:**
```sql
-- TPC-H Q7 style query
SELECT
    EXTRACT(YEAR FROM l_shipdate) as l_year,
    SUM(l_extendedprice) as revenue
FROM lineitem
GROUP BY EXTRACT(YEAR FROM l_shipdate)
ORDER BY l_year
```

Closes #2802

## Test plan

- [x] All 916 parser tests pass
- [x] All executor tests pass  
- [x] New EXTRACT parser tests (12 tests) pass
- [x] TPC-H Q7, Q8, Q9 style queries parse successfully
- [x] Build completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)