### PR TITLE
fix(ci): Correct Python wheel filename pattern in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           uv pip install --system maturin
           cd crates/vibesql-python-bindings
           maturin build --release
-          uv pip install --system ../../target/wheels/vibesql_python_bindings-*.whl
+          uv pip install --system ../../target/wheels/vibesql-*.whl
 
       - name: Install benchmark dependencies
         run: |


### PR DESCRIPTION
## Summary

- Fix incorrect Python wheel filename pattern in CI benchmark workflow
- The `vibesql-python-bindings` crate has `lib.name = "vibesql"` in Cargo.toml, so maturin builds the wheel as `vibesql-*.whl`, not `vibesql_python_bindings-*.whl`

## Test plan

- [ ] CI benchmark job should now pass (was failing with "invalid wheel filename" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)