### PR TITLE
perf(bench): Add configurable TPC-DS dimension table sizes

### DIFF
--- a/crates/vibesql-executor/benches/tpcds/data.rs
+++ b/crates/vibesql-executor/benches/tpcds/data.rs
@@ -313,12 +313,99 @@ pub const ITEM_UNITS: &[&str] = &[
 // Item containers
 pub const ITEM_CONTAINERS: &[&str] = &["Unknown", "Wrap", "Box"];
 
+/// Time granularity for time_dim table
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TimeGranularity {
+    /// One row per second (86,400 rows) - TPC-DS spec
+    Second,
+    /// One row per minute (1,440 rows) - recommended default
+    #[default]
+    Minute,
+    /// One row per hour (24 rows) - minimal for fast loading
+    Hour,
+}
+
+impl TimeGranularity {
+    /// Returns the number of seconds between each time_dim row
+    pub fn seconds_per_row(&self) -> usize {
+        match self {
+            TimeGranularity::Second => 1,
+            TimeGranularity::Minute => 60,
+            TimeGranularity::Hour => 3600,
+        }
+    }
+
+    /// Returns the number of rows in time_dim for this granularity
+    pub fn row_count(&self) -> usize {
+        86400 / self.seconds_per_row()
+    }
+}
+
+/// Configuration for TPC-DS dimension table sizes
+///
+/// By default, uses reduced sizes for faster data loading while maintaining
+/// meaningful benchmark results:
+/// - date_dim: 6 years (1998-2003) instead of 200 years
+/// - time_dim: minute granularity instead of second granularity
+#[derive(Debug, Clone)]
+pub struct TPCDSConfig {
+    /// Start year for date_dim (default: 1998)
+    pub date_start_year: i32,
+    /// End year for date_dim (default: 2003)
+    pub date_end_year: i32,
+    /// Time granularity for time_dim (default: Minute)
+    pub time_granularity: TimeGranularity,
+}
+
+impl Default for TPCDSConfig {
+    fn default() -> Self {
+        Self {
+            date_start_year: 1998,
+            date_end_year: 2003,
+            time_granularity: TimeGranularity::Minute,
+        }
+    }
+}
+
+impl TPCDSConfig {
+    /// Create a config with TPC-DS spec-compliant sizes (much larger)
+    pub fn spec_compliant() -> Self {
+        Self {
+            date_start_year: 1900,
+            date_end_year: 2100,
+            time_granularity: TimeGranularity::Second,
+        }
+    }
+
+    /// Create a minimal config for fastest loading (testing only)
+    pub fn minimal() -> Self {
+        Self {
+            date_start_year: 1998,
+            date_end_year: 2003,
+            time_granularity: TimeGranularity::Hour,
+        }
+    }
+
+    /// Calculate the number of days in the date range
+    /// Uses simplified calculation (365 days per year, ignoring leap years)
+    pub fn date_dim_count(&self) -> usize {
+        let years = (self.date_end_year - self.date_start_year + 1) as usize;
+        years * 365
+    }
+
+    /// Calculate the number of rows in time_dim
+    pub fn time_dim_count(&self) -> usize {
+        self.time_granularity.row_count()
+    }
+}
+
 pub struct TPCDSData {
     pub scale_factor: f64,
+    pub config: TPCDSConfig,
 
     // Dimension table counts (fixed or scaled)
-    pub date_dim_count: usize,       // ~73K days (200 years)
-    pub time_dim_count: usize,       // 86,400 seconds in a day
+    pub date_dim_count: usize,       // Configurable (default: ~2K days for 1998-2003)
+    pub time_dim_count: usize,       // Configurable (default: 1,440 minutes)
     pub item_count: usize,           // SF * 18,000
     pub customer_count: usize,       // SF * 100,000
     pub customer_address_count: usize,
@@ -348,10 +435,16 @@ pub struct TPCDSData {
 }
 
 impl TPCDSData {
+    /// Create a new TPCDSData with default configuration (reduced dimension sizes)
     pub fn new(scale_factor: f64) -> Self {
-        // Dimension table sizes based on TPC-DS spec
-        let date_dim_count = 73049; // Fixed: dates from 1900-01-01 to 2100-12-31
-        let time_dim_count = 86400; // Fixed: seconds in a day
+        Self::with_config(scale_factor, TPCDSConfig::default())
+    }
+
+    /// Create a new TPCDSData with custom configuration
+    pub fn with_config(scale_factor: f64, config: TPCDSConfig) -> Self {
+        // Dimension table sizes based on config
+        let date_dim_count = config.date_dim_count();
+        let time_dim_count = config.time_dim_count();
         let item_count = ((18_000.0 * scale_factor) as usize).max(1000);
         let customer_count = ((100_000.0 * scale_factor) as usize).max(1000);
         let customer_address_count = customer_count * 2; // ~2 addresses per customer
@@ -380,6 +473,7 @@ impl TPCDSData {
 
         Self {
             scale_factor,
+            config,
             date_dim_count,
             time_dim_count,
             item_count,

--- a/crates/vibesql-executor/benches/tpcds/mod.rs
+++ b/crates/vibesql-executor/benches/tpcds/mod.rs
@@ -20,7 +20,7 @@ pub mod queries;
 pub mod schema;
 
 // Re-export commonly used items for convenience
-pub use data::TPCDSData;
+pub use data::{TPCDSConfig, TPCDSData, TimeGranularity};
 pub use queries::*;
 pub use schema::load_vibesql;
 

--- a/crates/vibesql-executor/benches/tpcds/schema.rs
+++ b/crates/vibesql-executor/benches/tpcds/schema.rs
@@ -3463,15 +3463,15 @@ fn load_date_dim_vibesql(db: &mut VibeDB, data: &mut TPCDSData) {
         "Saturday",
     ];
 
-    // Generate dates from 1998-01-01 to 2003-12-31 (~2191 days)
-    // Using a reduced set for benchmarking
-    let num_dates = 2191.min(data.date_dim_count);
+    // Use configured date range
+    let start_year = data.config.date_start_year;
+    let num_dates = data.date_dim_count;
 
     for d_date_sk in 1..=num_dates {
         let days_since_base = d_date_sk as i64 - 1;
 
         // Calculate date components (simplified, ignoring leap years for benchmark)
-        let year = 1998 + (days_since_base / 365) as i32;
+        let year = start_year + (days_since_base / 365) as i32;
         let day_of_year = (days_since_base % 365) as i32;
         let month = (day_of_year / 30).min(11) + 1;
         let day = (day_of_year % 30) + 1;
@@ -3481,8 +3481,8 @@ fn load_date_dim_vibesql(db: &mut VibeDB, data: &mut TPCDSData) {
 
         let d_dow = (days_since_base % 7) as i32;
         let d_week_seq = (days_since_base / 7) as i32 + 1;
-        let d_month_seq = (year - 1998) * 12 + month;
-        let d_quarter_seq = (year - 1998) * 4 + ((month - 1) / 3) + 1;
+        let d_month_seq = (year - start_year) * 12 + month;
+        let d_quarter_seq = (year - start_year) * 4 + ((month - 1) / 3) + 1;
         let d_qoy = ((month - 1) / 3) + 1;
         let quarter_name = format!("{}Q{}", year, d_qoy);
 
@@ -3530,12 +3530,17 @@ fn load_time_dim_vibesql(db: &mut VibeDB, data: &mut TPCDSData) {
     use vibesql_storage::Row;
     use vibesql_types::SqlValue;
 
-    // Generate time dimension for every hour (24 entries for benchmark, full would be 86400)
-    let num_times = 24.min(data.time_dim_count / 3600).max(24);
+    // Use configured time granularity
+    let seconds_per_row = data.config.time_granularity.seconds_per_row();
+    let num_times = data.time_dim_count;
 
-    for hour in 0..num_times {
-        let t_time_sk = hour * 3600; // Seconds since midnight
+    for i in 0..num_times {
+        let t_time_sk = i * seconds_per_row; // Seconds since midnight
         let t_time_id = format!("AAAAAA{:010}", t_time_sk);
+
+        let hour = t_time_sk / 3600;
+        let minute = (t_time_sk % 3600) / 60;
+        let second = t_time_sk % 60;
 
         let am_pm = if hour < 12 { "AM" } else { "PM" };
         let shift = if hour < 8 {
@@ -3561,8 +3566,8 @@ fn load_time_dim_vibesql(db: &mut VibeDB, data: &mut TPCDSData) {
             SqlValue::Varchar(t_time_id),
             SqlValue::Integer(t_time_sk as i64),
             SqlValue::Integer(hour as i64),
-            SqlValue::Integer(0),  // t_minute
-            SqlValue::Integer(0),  // t_second
+            SqlValue::Integer(minute as i64),
+            SqlValue::Integer(second as i64),
             SqlValue::Varchar(am_pm.to_string()),
             SqlValue::Varchar(shift.to_string()),
             SqlValue::Varchar(sub_shift.to_string()),
@@ -4734,7 +4739,8 @@ fn create_tpcds_schema_sqlite(conn: &SqliteConn) {
 #[cfg(feature = "benchmark-comparison")]
 fn load_date_dim_sqlite(conn: &SqliteConn, data: &mut TPCDSData) {
     let day_names = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-    let num_dates = 2191.min(data.date_dim_count);
+    let start_year = data.config.date_start_year;
+    let num_dates = data.date_dim_count;
 
     let mut stmt = conn.prepare(
         "INSERT INTO date_dim VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
@@ -4742,7 +4748,7 @@ fn load_date_dim_sqlite(conn: &SqliteConn, data: &mut TPCDSData) {
 
     for d_date_sk in 1..=num_dates {
         let days_since_base = d_date_sk as i64 - 1;
-        let year = 1998 + (days_since_base / 365) as i32;
+        let year = start_year + (days_since_base / 365) as i32;
         let day_of_year = (days_since_base % 365) as i32;
         let month = (day_of_year / 30).min(11) + 1;
         let day = (day_of_year % 30) + 1;
@@ -4750,8 +4756,8 @@ fn load_date_dim_sqlite(conn: &SqliteConn, data: &mut TPCDSData) {
         let d_date_id = format!("AAAAAA{:010}", d_date_sk);
         let d_dow = (days_since_base % 7) as i32;
         let d_week_seq = (days_since_base / 7) as i32 + 1;
-        let d_month_seq = (year - 1998) * 12 + month;
-        let d_quarter_seq = (year - 1998) * 4 + ((month - 1) / 3) + 1;
+        let d_month_seq = (year - start_year) * 12 + month;
+        let d_quarter_seq = (year - start_year) * 4 + ((month - 1) / 3) + 1;
         let d_qoy = ((month - 1) / 3) + 1;
         let quarter_name = format!("{}Q{}", year, d_qoy);
         let is_weekend = d_dow == 0 || d_dow == 6;
@@ -4787,15 +4793,19 @@ fn load_date_dim_sqlite(conn: &SqliteConn, data: &mut TPCDSData) {
 
 #[cfg(feature = "benchmark-comparison")]
 fn load_time_dim_sqlite(conn: &SqliteConn, data: &mut TPCDSData) {
-    let num_times = 24.min(data.time_dim_count / 3600).max(24);
+    let seconds_per_row = data.config.time_granularity.seconds_per_row();
+    let num_times = data.time_dim_count;
 
     let mut stmt = conn.prepare(
         "INSERT INTO time_dim VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     ).unwrap();
 
-    for hour in 0..num_times {
-        let t_time_sk = hour * 3600;
+    for i in 0..num_times {
+        let t_time_sk = i * seconds_per_row;
         let t_time_id = format!("AAAAAA{:010}", t_time_sk);
+        let hour = t_time_sk / 3600;
+        let minute = (t_time_sk % 3600) / 60;
+        let second = t_time_sk % 60;
         let am_pm = if hour < 12 { "AM" } else { "PM" };
         let shift = if hour < 8 { "third" } else if hour < 16 { "first" } else { "second" };
         let sub_shift = if hour % 8 < 4 { "night" } else { "day" };
@@ -4805,7 +4815,7 @@ fn load_time_dim_sqlite(conn: &SqliteConn, data: &mut TPCDSData) {
             else { "" };
 
         stmt.execute(rusqlite::params![
-            t_time_sk, t_time_id, t_time_sk, hour, 0, 0, am_pm, shift, sub_shift, meal_time
+            t_time_sk, t_time_id, t_time_sk, hour, minute, second, am_pm, shift, sub_shift, meal_time
         ]).unwrap();
     }
 }
@@ -5206,7 +5216,8 @@ fn create_tpcds_schema_duckdb(conn: &DuckDBConn) {
 #[cfg(feature = "benchmark-comparison")]
 fn load_date_dim_duckdb(conn: &DuckDBConn, data: &mut TPCDSData) {
     let day_names = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-    let num_dates = 2191.min(data.date_dim_count);
+    let start_year = data.config.date_start_year;
+    let num_dates = data.date_dim_count;
 
     let mut stmt = conn.prepare(
         "INSERT INTO date_dim VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
@@ -5214,7 +5225,7 @@ fn load_date_dim_duckdb(conn: &DuckDBConn, data: &mut TPCDSData) {
 
     for d_date_sk in 1..=num_dates {
         let days_since_base = d_date_sk as i64 - 1;
-        let year = 1998 + (days_since_base / 365) as i32;
+        let year = start_year + (days_since_base / 365) as i32;
         let day_of_year = (days_since_base % 365) as i32;
         let month = (day_of_year / 30).min(11) + 1;
         let day = (day_of_year % 30) + 1;
@@ -5222,8 +5233,8 @@ fn load_date_dim_duckdb(conn: &DuckDBConn, data: &mut TPCDSData) {
         let d_date_id = format!("AAAAAA{:010}", d_date_sk);
         let d_dow = (days_since_base % 7) as i32;
         let d_week_seq = (days_since_base / 7) as i32 + 1;
-        let d_month_seq = (year - 1998) * 12 + month;
-        let d_quarter_seq = (year - 1998) * 4 + ((month - 1) / 3) + 1;
+        let d_month_seq = (year - start_year) * 12 + month;
+        let d_quarter_seq = (year - start_year) * 4 + ((month - 1) / 3) + 1;
         let d_qoy = ((month - 1) / 3) + 1;
         let quarter_name = format!("{}Q{}", year, d_qoy);
         let is_weekend = d_dow == 0 || d_dow == 6;
@@ -5259,15 +5270,19 @@ fn load_date_dim_duckdb(conn: &DuckDBConn, data: &mut TPCDSData) {
 
 #[cfg(feature = "benchmark-comparison")]
 fn load_time_dim_duckdb(conn: &DuckDBConn, data: &mut TPCDSData) {
-    let num_times = 24.min(data.time_dim_count / 3600).max(24);
+    let seconds_per_row = data.config.time_granularity.seconds_per_row();
+    let num_times = data.time_dim_count;
 
     let mut stmt = conn.prepare(
         "INSERT INTO time_dim VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     ).unwrap();
 
-    for hour in 0..num_times {
-        let t_time_sk = hour * 3600;
+    for i in 0..num_times {
+        let t_time_sk = i * seconds_per_row;
         let t_time_id = format!("AAAAAA{:010}", t_time_sk);
+        let hour = t_time_sk / 3600;
+        let minute = (t_time_sk % 3600) / 60;
+        let second = t_time_sk % 60;
         let am_pm = if hour < 12 { "AM" } else { "PM" };
         let shift = if hour < 8 { "third" } else if hour < 16 { "first" } else { "second" };
         let sub_shift = if hour % 8 < 4 { "night" } else { "day" };
@@ -5277,7 +5292,7 @@ fn load_time_dim_duckdb(conn: &DuckDBConn, data: &mut TPCDSData) {
             else { "" };
 
         stmt.execute(duckdb::params![
-            t_time_sk, t_time_id, t_time_sk, hour, 0, 0, am_pm, shift, sub_shift, meal_time
+            t_time_sk, t_time_id, t_time_sk, hour, minute, second, am_pm, shift, sub_shift, meal_time
         ]).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- Add `TPCDSConfig` struct for configuring dimension table sizes
- Add `TimeGranularity` enum (Second, Minute, Hour) for time_dim granularity
- Reduce default dimension table sizes by ~98% while maintaining valid results

## Changes

### New Configuration Options
```rust
pub struct TPCDSConfig {
    pub date_start_year: i32,    // default: 1998
    pub date_end_year: i32,      // default: 2003
    pub time_granularity: TimeGranularity, // default: Minute
}
```

### Impact Analysis
| Table     | TPC-DS Spec | Default Config | Reduction |
|-----------|-------------|----------------|-----------|
| date_dim  | 73,049      | 2,190          | 97%       |
| time_dim  | 86,400      | 1,440          | 98%       |
| **Total** | **159,449** | **3,630**      | **98%**   |

### Usage
```rust
// Default (reduced sizes for fast loading)
let data = TPCDSData::new(scale_factor);

// Custom configuration
let config = TPCDSConfig {
    date_start_year: 1998,
    date_end_year: 2018,  // 20 year range
    time_granularity: TimeGranularity::Minute,
};
let data = TPCDSData::with_config(scale_factor, config);

// TPC-DS spec compliant (full sizes)
let data = TPCDSData::with_config(scale_factor, TPCDSConfig::spec_compliant());
```

## Test plan
- [x] Build succeeds: `cargo build --bench tpcds_benchmark`
- [x] TPC-DS tests pass: `cargo test -p vibesql-executor tpcds`
- [x] Query validation tests pass: `cargo test --test tpcds_query_validation_tests`

Closes #2813

🤖 Generated with [Claude Code](https://claude.com/claude-code)