### PR TITLE
refactor(executor): Unify execution path selection into single adaptive framework

### DIFF
--- a/crates/vibesql-executor/src/optimizer/adaptive/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/adaptive/mod.rs
@@ -53,9 +53,13 @@ mod expression;
 mod hints;
 mod patterns;
 mod query;
+pub mod strategy;
 
 use hints::extract_query_hint;
 use patterns::has_analytical_pattern;
+
+// Re-export strategy types for external use
+pub use strategy::{choose_execution_strategy, ExecutionStrategy, StrategyContext};
 
 /// Execution model for query processing
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/vibesql-executor/src/optimizer/adaptive/strategy.rs
+++ b/crates/vibesql-executor/src/optimizer/adaptive/strategy.rs
@@ -1,0 +1,531 @@
+//! Unified Execution Strategy Selection
+//!
+//! This module provides a comprehensive `ExecutionStrategy` enum that encapsulates
+//! all execution path selection logic in a single decision point. This replaces the
+//! previous scattered eligibility checks across multiple execution methods.
+//!
+//! ## Execution Strategies
+//!
+//! - **NativeColumnar**: Zero-copy SIMD execution directly from columnar storage
+//! - **StandardColumnar**: SIMD execution with row-to-batch conversion
+//! - **RowOriented**: Traditional row-by-row execution (with or without aggregation)
+//! - **ExpressionOnly**: SELECT without FROM clause
+//!
+//! ## Benefits
+//!
+//! - Single decision point for observability and debugging
+//! - Clear reasoning captured in `StrategyScore`
+//! - Extensible for future strategies (JIT, GPU, distributed)
+//! - Preserves existing hint mechanism
+
+use std::collections::HashMap;
+
+use vibesql_ast::{FromClause, SelectStmt};
+
+use super::patterns::has_analytical_pattern;
+use super::query::{has_aggregate_functions, has_group_by, is_single_table};
+use crate::select::cte::CteResult;
+
+/// Comprehensive execution strategy selection
+///
+/// Each variant represents a distinct execution path with its selection rationale.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecutionStrategy {
+    /// Zero-copy SIMD execution directly from columnar storage (fastest for eligible queries)
+    ///
+    /// Requirements:
+    /// - Single table scan (no JOINs)
+    /// - No CTEs or set operations
+    /// - Analytical pattern detected
+    /// - native-columnar feature enabled or VIBESQL_NATIVE_COLUMNAR env var set
+    NativeColumnar {
+        /// Table name for columnar access
+        table: String,
+        /// Explains why this strategy was chosen
+        score: StrategyScore,
+    },
+
+    /// SIMD execution with row-to-batch conversion
+    ///
+    /// Requirements:
+    /// - No GROUP BY (handled by NativeColumnar path)
+    /// - No CTEs or set operations
+    /// - Has FROM clause
+    /// - Analytical pattern detected
+    StandardColumnar {
+        /// Explains why this strategy was chosen
+        score: StrategyScore,
+    },
+
+    /// Traditional row-oriented execution
+    ///
+    /// Used when:
+    /// - Query doesn't benefit from columnar execution
+    /// - Has features not yet supported by columnar paths
+    /// - Explicit ROW_ORIENTED hint
+    RowOriented {
+        /// Whether the query has aggregation
+        has_aggregation: bool,
+        /// Whether the query has GROUP BY
+        has_group_by: bool,
+        /// Explains why this strategy was chosen
+        score: StrategyScore,
+    },
+
+    /// SELECT without FROM clause (expression evaluation only)
+    ///
+    /// For queries like: SELECT 1 + 1, CURRENT_DATE
+    ExpressionOnly {
+        /// Explains why this strategy was chosen
+        score: StrategyScore,
+    },
+}
+
+impl ExecutionStrategy {
+    /// Get the strategy score for debugging/observability
+    pub fn score(&self) -> &StrategyScore {
+        match self {
+            ExecutionStrategy::NativeColumnar { score, .. } => score,
+            ExecutionStrategy::StandardColumnar { score } => score,
+            ExecutionStrategy::RowOriented { score, .. } => score,
+            ExecutionStrategy::ExpressionOnly { score } => score,
+        }
+    }
+
+    /// Get a human-readable name for the strategy
+    pub fn name(&self) -> &'static str {
+        match self {
+            ExecutionStrategy::NativeColumnar { .. } => "NativeColumnar",
+            ExecutionStrategy::StandardColumnar { .. } => "StandardColumnar",
+            ExecutionStrategy::RowOriented { .. } => "RowOriented",
+            ExecutionStrategy::ExpressionOnly { .. } => "ExpressionOnly",
+        }
+    }
+}
+
+/// Explains why a strategy was chosen
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StrategyScore {
+    /// Primary reason for the strategy selection
+    pub reason: StrategyReason,
+    /// Additional context for debugging
+    pub details: Option<String>,
+}
+
+impl StrategyScore {
+    /// Create a new strategy score
+    pub fn new(reason: StrategyReason) -> Self {
+        Self {
+            reason,
+            details: None,
+        }
+    }
+
+    /// Add details to the score
+    pub fn with_details(mut self, details: impl Into<String>) -> Self {
+        self.details = Some(details.into());
+        self
+    }
+}
+
+/// Primary reason for strategy selection
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // Some variants are for future use (query hints, etc.)
+pub enum StrategyReason {
+    /// User override via query hint (/* COLUMNAR */, /* ROW_ORIENTED */)
+    QueryHint(String),
+    /// Table has columnar storage available
+    ColumnarStorageAvailable,
+    /// Query matches analytical pattern (aggregates, arithmetic, selective projection)
+    AnalyticalPattern,
+    /// Simple single-table scan detected
+    SingleTableScan,
+    /// No FROM clause - expression-only query
+    NoFromClause,
+    /// Feature not supported by columnar paths
+    UnsupportedFeature(String),
+    /// Default fallback when no specific reason applies
+    Fallback,
+}
+
+impl std::fmt::Display for StrategyReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StrategyReason::QueryHint(hint) => write!(f, "Query hint: {}", hint),
+            StrategyReason::ColumnarStorageAvailable => write!(f, "Columnar storage available"),
+            StrategyReason::AnalyticalPattern => write!(f, "Analytical pattern detected"),
+            StrategyReason::SingleTableScan => write!(f, "Single table scan"),
+            StrategyReason::NoFromClause => write!(f, "No FROM clause"),
+            StrategyReason::UnsupportedFeature(feature) => {
+                write!(f, "Unsupported feature: {}", feature)
+            }
+            StrategyReason::Fallback => write!(f, "Default fallback"),
+        }
+    }
+}
+
+/// Context required for strategy selection
+///
+/// This bundles all the information needed to make an execution strategy decision.
+pub struct StrategyContext<'a> {
+    /// The SELECT statement to analyze
+    pub stmt: &'a SelectStmt,
+    /// CTE results from outer query (if any)
+    pub cte_results: &'a HashMap<String, CteResult>,
+    /// Whether native-columnar feature is enabled
+    pub native_columnar_enabled: bool,
+}
+
+impl<'a> StrategyContext<'a> {
+    /// Create a new strategy context
+    pub fn new(
+        stmt: &'a SelectStmt,
+        cte_results: &'a HashMap<String, CteResult>,
+        native_columnar_enabled: bool,
+    ) -> Self {
+        Self {
+            stmt,
+            cte_results,
+            native_columnar_enabled,
+        }
+    }
+}
+
+/// Choose the optimal execution strategy for a query
+///
+/// This is the single decision point for execution path selection. It encapsulates
+/// all eligibility checks that were previously scattered across multiple methods.
+///
+/// # Arguments
+/// * `ctx` - The strategy context containing the query and execution environment
+///
+/// # Returns
+/// The recommended execution strategy with its selection rationale
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let ctx = StrategyContext::new(&stmt, &cte_results, true);
+/// let strategy = choose_execution_strategy(&ctx);
+///
+/// match strategy {
+///     ExecutionStrategy::NativeColumnar { table, .. } => {
+///         // Execute using zero-copy columnar path
+///     }
+///     ExecutionStrategy::StandardColumnar { .. } => {
+///         // Execute using row-to-batch columnar path
+///     }
+///     ExecutionStrategy::RowOriented { has_aggregation, .. } => {
+///         // Execute using traditional row-by-row path
+///     }
+///     ExecutionStrategy::ExpressionOnly { .. } => {
+///         // Evaluate expressions without FROM
+///     }
+/// }
+/// ```
+pub fn choose_execution_strategy(ctx: &StrategyContext<'_>) -> ExecutionStrategy {
+    let stmt = ctx.stmt;
+
+    // Check 1: No FROM clause → ExpressionOnly
+    if stmt.from.is_none() {
+        return ExecutionStrategy::ExpressionOnly {
+            score: StrategyScore::new(StrategyReason::NoFromClause),
+        };
+    }
+
+    // Check 2: Has CTEs or set operations → Row-oriented (columnar paths don't support these yet)
+    if !ctx.cte_results.is_empty() || stmt.set_operation.is_some() {
+        let reason = if !ctx.cte_results.is_empty() {
+            "CTEs"
+        } else {
+            "set operations"
+        };
+        return make_row_oriented(
+            stmt,
+            StrategyReason::UnsupportedFeature(reason.to_string()),
+        );
+    }
+
+    // Check 3: Try NativeColumnar (highest priority columnar path)
+    if let Some(strategy) = try_native_columnar_strategy(ctx) {
+        return strategy;
+    }
+
+    // Check 4: Try StandardColumnar (lower priority, has more restrictions)
+    if let Some(strategy) = try_standard_columnar_strategy(ctx) {
+        return strategy;
+    }
+
+    // Check 5: Default to row-oriented
+    make_row_oriented(stmt, StrategyReason::Fallback)
+}
+
+/// Try to select NativeColumnar strategy
+///
+/// Requirements:
+/// - native-columnar feature enabled
+/// - Single table (no JOINs)
+/// - Analytical pattern detected
+fn try_native_columnar_strategy(ctx: &StrategyContext<'_>) -> Option<ExecutionStrategy> {
+    // Native columnar must be enabled
+    if !ctx.native_columnar_enabled {
+        return None;
+    }
+
+    // Must be a single table scan
+    if !is_single_table(ctx.stmt) {
+        return None;
+    }
+
+    // Must have analytical pattern
+    if !has_analytical_pattern(ctx.stmt) {
+        return None;
+    }
+
+    // Extract table name
+    let table_name = match &ctx.stmt.from {
+        Some(FromClause::Table { name, .. }) => name.clone(),
+        _ => return None,
+    };
+
+    Some(ExecutionStrategy::NativeColumnar {
+        table: table_name,
+        score: StrategyScore::new(StrategyReason::ColumnarStorageAvailable)
+            .with_details("Zero-copy SIMD execution from columnar storage"),
+    })
+}
+
+/// Try to select StandardColumnar strategy
+///
+/// Requirements:
+/// - No GROUP BY (GROUP BY goes through NativeColumnar or RowOriented)
+/// - Single table (no JOINs)
+/// - Analytical pattern detected
+fn try_standard_columnar_strategy(ctx: &StrategyContext<'_>) -> Option<ExecutionStrategy> {
+    // GROUP BY is NOT supported in StandardColumnar path
+    // It should use NativeColumnar or fall back to RowOriented
+    if ctx.stmt.group_by.is_some() {
+        return None;
+    }
+
+    // Must be a single table scan
+    if !is_single_table(ctx.stmt) {
+        return None;
+    }
+
+    // Must have analytical pattern
+    if !has_analytical_pattern(ctx.stmt) {
+        return None;
+    }
+
+    Some(ExecutionStrategy::StandardColumnar {
+        score: StrategyScore::new(StrategyReason::AnalyticalPattern)
+            .with_details("SIMD execution with row-to-batch conversion"),
+    })
+}
+
+/// Create a RowOriented strategy with the given reason
+fn make_row_oriented(stmt: &SelectStmt, reason: StrategyReason) -> ExecutionStrategy {
+    let has_agg = has_aggregate_functions(stmt) || stmt.having.is_some();
+    let has_gb = has_group_by(stmt);
+
+    ExecutionStrategy::RowOriented {
+        has_aggregation: has_agg,
+        has_group_by: has_gb,
+        score: StrategyScore::new(reason),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibesql_ast::{BinaryOperator, Expression, GroupByClause, SelectItem};
+    use vibesql_types::SqlValue;
+
+    fn make_simple_table_query(table: &str) -> SelectStmt {
+        SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Wildcard { alias: None }],
+            into_table: None,
+            into_variables: None,
+            from: Some(FromClause::Table {
+                name: table.to_string(),
+                alias: None,
+            }),
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+        }
+    }
+
+    fn make_aggregate_query(table: &str) -> SelectStmt {
+        SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Expression {
+                expr: Expression::AggregateFunction {
+                    name: "SUM".to_string(),
+                    distinct: false,
+                    args: vec![Expression::BinaryOp {
+                        left: Box::new(Expression::ColumnRef {
+                            table: None,
+                            column: "price".to_string(),
+                        }),
+                        op: BinaryOperator::Multiply,
+                        right: Box::new(Expression::ColumnRef {
+                            table: None,
+                            column: "quantity".to_string(),
+                        }),
+                    }],
+                },
+                alias: None,
+            }],
+            into_table: None,
+            into_variables: None,
+            from: Some(FromClause::Table {
+                name: table.to_string(),
+                alias: None,
+            }),
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+        }
+    }
+
+    #[test]
+    fn test_expression_only_for_no_from() {
+        let stmt = SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Expression {
+                expr: Expression::Literal(SqlValue::Integer(42)),
+                alias: None,
+            }],
+            into_table: None,
+            into_variables: None,
+            from: None,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+        };
+
+        let cte_results = HashMap::new();
+        let ctx = StrategyContext::new(&stmt, &cte_results, true);
+        let strategy = choose_execution_strategy(&ctx);
+
+        assert!(matches!(strategy, ExecutionStrategy::ExpressionOnly { .. }));
+    }
+
+    #[test]
+    fn test_row_oriented_for_simple_select() {
+        let stmt = make_simple_table_query("users");
+        let cte_results = HashMap::new();
+        let ctx = StrategyContext::new(&stmt, &cte_results, true);
+        let strategy = choose_execution_strategy(&ctx);
+
+        assert!(matches!(strategy, ExecutionStrategy::RowOriented { .. }));
+    }
+
+    #[test]
+    fn test_native_columnar_for_aggregate_when_enabled() {
+        let stmt = make_aggregate_query("orders");
+        let cte_results = HashMap::new();
+        let ctx = StrategyContext::new(&stmt, &cte_results, true);
+        let strategy = choose_execution_strategy(&ctx);
+
+        // Should choose NativeColumnar when feature is enabled and query has analytical pattern
+        assert!(matches!(
+            strategy,
+            ExecutionStrategy::NativeColumnar { .. }
+        ));
+    }
+
+    #[test]
+    fn test_standard_columnar_for_aggregate_when_native_disabled() {
+        let stmt = make_aggregate_query("orders");
+        let cte_results = HashMap::new();
+        let ctx = StrategyContext::new(&stmt, &cte_results, false);
+        let strategy = choose_execution_strategy(&ctx);
+
+        // Should choose StandardColumnar when native is disabled but query has analytical pattern
+        assert!(matches!(
+            strategy,
+            ExecutionStrategy::StandardColumnar { .. }
+        ));
+    }
+
+    #[test]
+    fn test_row_oriented_for_group_by_when_native_disabled() {
+        let mut stmt = make_aggregate_query("orders");
+        stmt.group_by = Some(GroupByClause::Simple(vec![Expression::ColumnRef {
+            table: None,
+            column: "region".to_string(),
+        }]));
+
+        // With native disabled, GROUP BY queries fall back to row-oriented
+        // (StandardColumnar doesn't support GROUP BY)
+        let cte_results = HashMap::new();
+        let ctx = StrategyContext::new(&stmt, &cte_results, false);
+        let strategy = choose_execution_strategy(&ctx);
+
+        assert!(matches!(strategy, ExecutionStrategy::RowOriented { .. }));
+    }
+
+    #[test]
+    fn test_native_columnar_for_group_by_when_enabled() {
+        let mut stmt = make_aggregate_query("orders");
+        stmt.group_by = Some(GroupByClause::Simple(vec![Expression::ColumnRef {
+            table: None,
+            column: "region".to_string(),
+        }]));
+
+        // With native enabled, GROUP BY queries can use NativeColumnar
+        let cte_results = HashMap::new();
+        let ctx = StrategyContext::new(&stmt, &cte_results, true);
+        let strategy = choose_execution_strategy(&ctx);
+
+        assert!(matches!(
+            strategy,
+            ExecutionStrategy::NativeColumnar { .. }
+        ));
+    }
+
+    #[test]
+    fn test_strategy_name() {
+        let native = ExecutionStrategy::NativeColumnar {
+            table: "test".to_string(),
+            score: StrategyScore::new(StrategyReason::ColumnarStorageAvailable),
+        };
+        assert_eq!(native.name(), "NativeColumnar");
+
+        let standard = ExecutionStrategy::StandardColumnar {
+            score: StrategyScore::new(StrategyReason::AnalyticalPattern),
+        };
+        assert_eq!(standard.name(), "StandardColumnar");
+
+        let row = ExecutionStrategy::RowOriented {
+            has_aggregation: true,
+            has_group_by: false,
+            score: StrategyScore::new(StrategyReason::Fallback),
+        };
+        assert_eq!(row.name(), "RowOriented");
+
+        let expr = ExecutionStrategy::ExpressionOnly {
+            score: StrategyScore::new(StrategyReason::NoFromClause),
+        };
+        assert_eq!(expr.name(), "ExpressionOnly");
+    }
+}

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -5,6 +5,9 @@ use std::collections::HashMap;
 use super::builder::SelectExecutor;
 use crate::{
     errors::ExecutorError,
+    optimizer::adaptive::{
+        choose_execution_strategy, ExecutionStrategy, StrategyContext,
+    },
     select::{
         cte::{execute_ctes, CteResult},
         helpers::apply_limit_offset,
@@ -144,6 +147,12 @@ impl SelectExecutor<'_> {
     }
 
     /// Execute SELECT statement with CTE context
+    ///
+    /// Uses unified strategy selection to determine the optimal execution path:
+    /// - NativeColumnar: Zero-copy SIMD execution from columnar storage
+    /// - StandardColumnar: SIMD execution with row-to-batch conversion
+    /// - RowOriented: Traditional row-by-row execution
+    /// - ExpressionOnly: SELECT without FROM clause
     pub(super) fn execute_with_ctes(
         &self,
         stmt: &vibesql_ast::SelectStmt,
@@ -152,117 +161,99 @@ impl SelectExecutor<'_> {
         #[cfg(feature = "profile-q6")]
         let execute_ctes_start = std::time::Instant::now();
 
-        // Try NATIVE columnar execution path FIRST (Phase 2b - zero row materialization)
-        // This path operates on ColumnarBatch from storage directly without row conversion
-        #[cfg(feature = "profile-q6")]
-        let native_columnar_start = std::time::Instant::now();
+        // Check if native columnar is enabled via feature flag or env var
+        let native_columnar_enabled =
+            cfg!(feature = "native-columnar") || std::env::var("VIBESQL_NATIVE_COLUMNAR").is_ok();
 
-        log::debug!("Checking if native columnar execution is possible...");
-        #[cfg(feature = "profile-q6")]
-        eprintln!("[PROFILE-Q6] Checking native columnar execution eligibility...");
+        // Use unified strategy selection for the execution path
+        let ctx = StrategyContext::new(stmt, cte_results, native_columnar_enabled);
+        let strategy = choose_execution_strategy(&ctx);
 
-        if let Some(result) = self.try_native_columnar_execution(stmt, cte_results)? {
-            log::debug!("✓ Using NATIVE COLUMNAR execution path (zero-copy, SIMD-accelerated)");
-            #[cfg(feature = "profile-q6")]
-            {
-                let total_execute_ctes = execute_ctes_start.elapsed();
-                let native_columnar_time = native_columnar_start.elapsed();
-                eprintln!("[PROFILE-Q6] ✓ USING NATIVE COLUMNAR EXECUTION (zero-copy)");
-                eprintln!("[PROFILE-Q6]   Native columnar check time: {:?}", native_columnar_time);
-                eprintln!("[PROFILE-Q6]   Total execution time: {:?}", total_execute_ctes);
+        log::debug!(
+            "Execution strategy selected: {} (reason: {})",
+            strategy.name(),
+            strategy.score().reason
+        );
+
+        #[cfg(feature = "profile-q6")]
+        eprintln!(
+            "[PROFILE-Q6] Execution strategy: {} ({})",
+            strategy.name(),
+            strategy.score().reason
+        );
+
+        // Dispatch based on selected strategy
+        let mut results = match strategy {
+            ExecutionStrategy::NativeColumnar { .. } => {
+                // Try native columnar execution path (zero-copy, SIMD-accelerated)
+                #[cfg(feature = "profile-q6")]
+                let native_start = std::time::Instant::now();
+
+                if let Some(result) = self.try_native_columnar_execution(stmt, cte_results)? {
+                    log::debug!("✓ Native columnar execution succeeded");
+                    #[cfg(feature = "profile-q6")]
+                    {
+                        eprintln!(
+                            "[PROFILE-Q6] ✓ NATIVE COLUMNAR execution: {:?}",
+                            native_start.elapsed()
+                        );
+                    }
+                    return Ok(result);
+                }
+
+                // Fall back to row-oriented if native columnar fails at runtime
+                // (e.g., table not in columnar cache, unsupported predicate)
+                log::debug!("Native columnar runtime fallback to row-oriented");
+                #[cfg(feature = "profile-q6")]
+                eprintln!("[PROFILE-Q6] Native columnar fallback to row-oriented");
+
+                self.execute_row_oriented(stmt, cte_results)?
             }
-            return Ok(result);
-        }
-        log::debug!("✗ Native columnar execution not used, trying standard columnar path");
-        #[cfg(feature = "profile-q6")]
-        eprintln!("[PROFILE-Q6] ✗ NATIVE COLUMNAR NOT USED - Trying standard columnar path");
 
-        // Try columnar execution path for compatible queries
-        // Phase 5: SIMD-accelerated columnar execution provides 6-10x speedup
-        // This path converts rows to batch format before processing
-        #[cfg(feature = "profile-q6")]
-        let columnar_check_start = std::time::Instant::now();
+            ExecutionStrategy::StandardColumnar { .. } => {
+                // Try standard columnar execution path (row-to-batch conversion)
+                #[cfg(feature = "profile-q6")]
+                let columnar_start = std::time::Instant::now();
 
-        log::debug!("Checking if columnar execution is possible...");
-        #[cfg(feature = "profile-q6")]
-        eprintln!("[PROFILE-Q6] Checking columnar execution eligibility...");
+                if let Some(result) = self.try_columnar_execution(stmt, cte_results)? {
+                    log::debug!("✓ Standard columnar execution succeeded");
+                    #[cfg(feature = "profile-q6")]
+                    {
+                        eprintln!(
+                            "[PROFILE-Q6] ✓ STANDARD COLUMNAR execution: {:?}",
+                            columnar_start.elapsed()
+                        );
+                    }
+                    return Ok(result);
+                }
 
-        if let Some(result) = self.try_columnar_execution(stmt, cte_results)? {
-            log::debug!("✓ Using COLUMNAR execution path (SIMD-accelerated)");
-            #[cfg(feature = "profile-q6")]
-            {
-                let total_execute_ctes = execute_ctes_start.elapsed();
-                let columnar_check_time = columnar_check_start.elapsed();
-                eprintln!("[PROFILE-Q6] ✓ USING COLUMNAR EXECUTION (SIMD-accelerated)");
-                eprintln!("[PROFILE-Q6]   Columnar check time: {:?}", columnar_check_time);
-                eprintln!("[PROFILE-Q6]   Total execution time: {:?}", total_execute_ctes);
+                // Fall back to row-oriented if columnar fails at runtime
+                log::debug!("Standard columnar runtime fallback to row-oriented");
+                #[cfg(feature = "profile-q6")]
+                eprintln!("[PROFILE-Q6] Standard columnar fallback to row-oriented");
+
+                self.execute_row_oriented(stmt, cte_results)?
             }
-            return Ok(result);
-        }
-        log::debug!("✗ Columnar execution not used, falling back to row-based execution");
-        #[cfg(feature = "profile-q6")]
-        eprintln!("[PROFILE-Q6] ✗ COLUMNAR NOT USED - Falling back to row-based execution");
 
-        // Try monomorphic execution path for known query patterns (TEMPORARILY DISABLED)
-        // NOTE: Monomorphic execution currently has issues with complex aggregate expressions
-        // For Phase 5, we're prioritizing columnar execution over monomorphic
-        // TODO: Re-enable monomorphic execution after fixing complex aggregate handling
-        let mono_result: Option<Vec<vibesql_storage::Row>> = None; // Disabled
-
-        #[cfg(feature = "profile-q6")]
-        let mono_check_start = std::time::Instant::now();
-
-        if let Some(result) = mono_result {
-            #[cfg(feature = "profile-q6")]
-            {
-                let total_execute_ctes = execute_ctes_start.elapsed();
-                let mono_check_time = mono_check_start.elapsed();
+            ExecutionStrategy::RowOriented { .. } => {
+                // Use traditional row-by-row execution
+                self.execute_row_oriented(stmt, cte_results)?
             }
-            return Ok(result);
-        }
 
-        // Execute the left-hand side query
-        let has_aggregates = self.has_aggregates(&stmt.select_list) || stmt.having.is_some();
-        let has_group_by = stmt.group_by.is_some();
+            ExecutionStrategy::ExpressionOnly { .. } => {
+                // SELECT without FROM - but may still have aggregates
+                // (e.g., SELECT COUNT(*), SELECT MAX(1))
+                let has_aggregates =
+                    self.has_aggregates(&stmt.select_list) || stmt.having.is_some();
 
-        let mut results = if has_aggregates || has_group_by {
-            self.execute_with_aggregation(stmt, cte_results)?
-        } else if let Some(from_clause) = &stmt.from {
-
-
-            // Re-enabled predicate pushdown for all queries (issue #1902)
-            //
-            // Previously, predicate pushdown was selectively disabled for multi-column IN clauses
-            // because index optimization happened in execute_without_aggregation() on row indices
-            // from the FROM result. When predicate pushdown filtered rows early, the indices no
-            // longer matched the original table, causing incorrect results.
-            //
-            // Now that all index optimization has been moved to the scan level (execute_index_scan),
-            // it happens BEFORE predicate pushdown, avoiding the row-index mismatch problem.
-            // This allows predicate pushdown to work correctly for all queries, improving performance.
-            //
-            // Fixes issues #1807, #1895, #1896, and #1902.
-
-            // Pass WHERE and ORDER BY to execute_from for optimization
-            let from_result =
-                self.execute_from_with_where(from_clause, cte_results, stmt.where_clause.as_ref(), stmt.order_by.as_deref())?;
-
-            // Validate column references BEFORE processing rows (issue #2654)
-            // This ensures column errors are caught even when tables are empty
-            // Pass procedural context to allow procedure variables in WHERE clause
-            // Pass outer_schema for correlated subqueries (#2694)
-            super::validation::validate_select_columns_with_context(
-                &stmt.select_list,
-                stmt.where_clause.as_ref(),
-                &from_result.schema,
-                self.procedural_context,
-                self.outer_schema,
-            )?;
-
-            self.execute_without_aggregation(stmt, from_result, cte_results)?
-        } else {
-            // SELECT without FROM - evaluate expressions as a single row
-            self.execute_select_without_from(stmt)?
+                if has_aggregates {
+                    // Aggregates without FROM need the aggregation path
+                    self.execute_with_aggregation(stmt, cte_results)?
+                } else {
+                    // Simple expression evaluation (e.g., SELECT 1 + 1)
+                    self.execute_select_without_from(stmt)?
+                }
+            }
         };
 
         // Handle set operations (UNION, INTERSECT, EXCEPT)
@@ -277,6 +268,60 @@ impl SelectExecutor<'_> {
         }
 
         Ok(results)
+    }
+
+    /// Execute using traditional row-oriented path
+    ///
+    /// This is the fallback path when columnar execution is not available or not beneficial.
+    fn execute_row_oriented(
+        &self,
+        stmt: &vibesql_ast::SelectStmt,
+        cte_results: &HashMap<String, CteResult>,
+    ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
+        let has_aggregates = self.has_aggregates(&stmt.select_list) || stmt.having.is_some();
+        let has_group_by = stmt.group_by.is_some();
+
+        if has_aggregates || has_group_by {
+            self.execute_with_aggregation(stmt, cte_results)
+        } else if let Some(from_clause) = &stmt.from {
+            // Re-enabled predicate pushdown for all queries (issue #1902)
+            //
+            // Previously, predicate pushdown was selectively disabled for multi-column IN clauses
+            // because index optimization happened in execute_without_aggregation() on row indices
+            // from the FROM result. When predicate pushdown filtered rows early, the indices no
+            // longer matched the original table, causing incorrect results.
+            //
+            // Now that all index optimization has been moved to the scan level (execute_index_scan),
+            // it happens BEFORE predicate pushdown, avoiding the row-index mismatch problem.
+            // This allows predicate pushdown to work correctly for all queries, improving performance.
+            //
+            // Fixes issues #1807, #1895, #1896, and #1902.
+
+            // Pass WHERE and ORDER BY to execute_from for optimization
+            let from_result = self.execute_from_with_where(
+                from_clause,
+                cte_results,
+                stmt.where_clause.as_ref(),
+                stmt.order_by.as_deref(),
+            )?;
+
+            // Validate column references BEFORE processing rows (issue #2654)
+            // This ensures column errors are caught even when tables are empty
+            // Pass procedural context to allow procedure variables in WHERE clause
+            // Pass outer_schema for correlated subqueries (#2694)
+            super::validation::validate_select_columns_with_context(
+                &stmt.select_list,
+                stmt.where_clause.as_ref(),
+                &from_result.schema,
+                self.procedural_context,
+                self.outer_schema,
+            )?;
+
+            self.execute_without_aggregation(stmt, from_result, cte_results)
+        } else {
+            // SELECT without FROM - evaluate expressions as a single row
+            self.execute_select_without_from(stmt)
+        }
     }
 
     /// Execute a chain of set operations left-to-right


### PR DESCRIPTION
## Summary

- Implement Phase 1 of the unified execution strategy selection framework (#2828)
- Create comprehensive `ExecutionStrategy` enum with variants for all execution paths
- Add `StrategyScore` and `StrategyReason` for debugging and observability
- Refactor `execute_with_ctes()` to use centralized `choose_execution_strategy()`
- Extract `execute_row_oriented()` helper for cleaner code organization

## Changes

### New Files
- `crates/vibesql-executor/src/optimizer/adaptive/strategy.rs` - New strategy selection module

### Modified Files
- `crates/vibesql-executor/src/optimizer/adaptive/mod.rs` - Export strategy types
- `crates/vibesql-executor/src/select/executor/execute.rs` - Refactor to use unified strategy

## Test plan

- [x] All 1515+ executor unit tests pass
- [x] All strategy module tests pass (7 new tests)
- [x] TPC-H columnar tests pass (Q1, Q6)
- [x] CTE and subquery tests pass
- [x] Grouping sets and HAVING tests pass
- [x] Aggregate without FROM tests pass

## Architecture

The new `ExecutionStrategy` enum provides a single decision point for execution path selection:

```rust
pub enum ExecutionStrategy {
    NativeColumnar { table: String, score: StrategyScore },
    StandardColumnar { score: StrategyScore },
    RowOriented { has_aggregation: bool, has_group_by: bool, score: StrategyScore },
    ExpressionOnly { score: StrategyScore },
}
```

Each strategy includes a `StrategyScore` explaining why it was chosen, enabling better debugging and observability.

Closes #2828

🤖 Generated with [Claude Code](https://claude.com/claude-code)