### PR TITLE
Remove deprecated division_returns_float() method

### DIFF
--- a/crates/vibesql-types/src/sql_mode/mod.rs
+++ b/crates/vibesql-types/src/sql_mode/mod.rs
@@ -97,18 +97,6 @@ impl std::str::FromStr for SqlMode {
 }
 
 impl SqlMode {
-    /// Check if division should return floating-point (true) or integer (false)
-    #[deprecated(
-        since = "0.1.0",
-        note = "Use TypeBehavior::division_result_type() instead for more precise type information"
-    )]
-    pub fn division_returns_float(&self) -> bool {
-        match self {
-            SqlMode::MySQL { .. } => true,
-            SqlMode::SQLite => false,
-        }
-    }
-
     /// Get the MySQL mode flags, if in MySQL mode
     pub fn mysql_flags(&self) -> Option<&MySqlModeFlags> {
         match self {


### PR DESCRIPTION
## Summary

- Remove the deprecated `division_returns_float()` method from `SqlMode` that was deprecated in PR #2035
- The function has **zero usages** in the codebase and the replacement `TypeBehavior::division_result_type()` is already in use (17 usages)
- Removes ~11 lines of dead code

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes

Closes #2827

🤖 Generated with [Claude Code](https://claude.com/claude-code)