### PR TITLE
fix(types): Change default SqlMode from SQLite to MySQL for SQLLogicTest compatibility

### DIFF
--- a/crates/vibesql-executor/src/tests/sql_mode_tests.rs
+++ b/crates/vibesql-executor/src/tests/sql_mode_tests.rs
@@ -35,17 +35,17 @@ mod tests {
     fn test_set_sql_mode_mysql() {
         let mut db = Database::new();
 
-        // Default is SQLite mode (for SQLLogicTest compatibility)
+        // Default is MySQL mode (for SQLLogicTest compatibility - dolthub corpus was regenerated against MySQL 8.x)
+        assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
+
+        // Set to sqlite
+        execute_set_variable(&mut db, "SET sql_mode = 'sqlite'").unwrap();
         assert!(matches!(db.sql_mode(), SqlMode::SQLite));
 
-        // Set to mysql
+        // Set back to mysql
         let result = execute_set_variable(&mut db, "SET sql_mode = 'mysql'").unwrap();
         assert!(result.contains("mysql"));
         assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
-
-        // Set back to sqlite
-        execute_set_variable(&mut db, "SET sql_mode = 'sqlite'").unwrap();
-        assert!(matches!(db.sql_mode(), SqlMode::SQLite));
     }
 
     #[test]

--- a/crates/vibesql-sqllogictest/src/executor/core.rs
+++ b/crates/vibesql-sqllogictest/src/executor/core.rs
@@ -159,15 +159,12 @@ pub enum SqlDialect {
 impl SqlDialect {
     /// Get the SQL mode string for SET SQL_MODE command.
     ///
-    /// For MySQL mode, returns "mysql_slt" which enables MySQL syntax
-    /// (e.g., `CAST...AS SIGNED`) but uses SQLite division semantics
-    /// (INTEGER / INTEGER → INTEGER). This is because SQLLogicTest expected
-    /// results were generated using SQLite, so all tests expect SQLite
-    /// division behavior regardless of the `onlyif mysql` directive.
+    /// The dolthub/sqllogictest test corpus was regenerated against MySQL 8.x
+    /// (see third_party/sqllogictest/README.md), so MySQL mode uses full MySQL
+    /// semantics including decimal division (INTEGER / INTEGER → DECIMAL).
     pub fn as_sql_mode_str(&self) -> &'static str {
         match self {
-            // Use mysql_slt for SQLLogicTest context - MySQL syntax with SQLite division
-            SqlDialect::MySQL => "mysql_slt",
+            SqlDialect::MySQL => "mysql",
             SqlDialect::SQLite => "sqlite",
         }
     }
@@ -523,8 +520,9 @@ mod tests {
 
     #[test]
     fn test_sql_dialect_as_sql_mode_str() {
-        // MySQL uses mysql_slt for SQLLogicTest - MySQL syntax with SQLite division semantics
-        assert_eq!(SqlDialect::MySQL.as_sql_mode_str(), "mysql_slt");
+        // MySQL uses full MySQL mode (decimal division) since dolthub/sqllogictest
+        // was regenerated against MySQL 8.x
+        assert_eq!(SqlDialect::MySQL.as_sql_mode_str(), "mysql");
         assert_eq!(SqlDialect::SQLite.as_sql_mode_str(), "sqlite");
     }
 

--- a/crates/vibesql-storage/src/database/core.rs
+++ b/crates/vibesql-storage/src/database/core.rs
@@ -417,18 +417,18 @@ mod tests {
     fn test_set_sql_mode_changes_mode() {
         let mut db = Database::new();
 
-        // Default is SQLite (for SQLLogicTest compatibility)
+        // Default is MySQL (for SQLLogicTest compatibility - dolthub corpus was regenerated against MySQL 8.x)
+        assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
+
+        // Change to SQLite
+        db.set_sql_mode(SqlMode::SQLite);
         assert!(matches!(db.sql_mode(), SqlMode::SQLite));
 
-        // Change to MySQL
+        // Change back to MySQL
         db.set_sql_mode(SqlMode::MySQL {
             flags: MySqlModeFlags::default(),
         });
         assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
-
-        // Change back to SQLite
-        db.set_sql_mode(SqlMode::SQLite);
-        assert!(matches!(db.sql_mode(), SqlMode::SQLite));
     }
 
     #[test]
@@ -498,16 +498,14 @@ mod tests {
     fn test_sql_mode_affects_subsequent_queries() {
         let mut db = Database::new();
 
-        // Start in SQLite mode (default for SQLLogicTest compatibility)
-        assert!(matches!(db.sql_mode(), SqlMode::SQLite));
+        // Start in MySQL mode (default for SQLLogicTest compatibility)
+        assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
 
-        // Switch to MySQL
-        db.set_sql_mode(SqlMode::MySQL {
-            flags: MySqlModeFlags::default(),
-        });
+        // Switch to SQLite
+        db.set_sql_mode(SqlMode::SQLite);
 
-        // Verify the mode is available for query execution
+        // Verify the mode changed
         let mode = db.sql_mode();
-        assert!(matches!(mode, SqlMode::MySQL { .. }));
+        assert!(matches!(mode, SqlMode::SQLite));
     }
 }

--- a/crates/vibesql-storage/src/database/session.rs
+++ b/crates/vibesql-storage/src/database/session.rs
@@ -76,11 +76,11 @@ impl Database {
     /// use vibesql_types::{MySqlModeFlags, SqlMode};
     ///
     /// let mut db = Database::new();
-    /// // Default is SQLite (for SQLLogicTest compatibility)
-    /// assert!(matches!(db.sql_mode(), SqlMode::SQLite));
-    ///
-    /// db.set_sql_mode(SqlMode::MySQL { flags: MySqlModeFlags::default() });
+    /// // Default is MySQL (for SQLLogicTest compatibility)
     /// assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
+    ///
+    /// db.set_sql_mode(SqlMode::SQLite);
+    /// assert!(matches!(db.sql_mode(), SqlMode::SQLite));
     /// ```
     pub fn set_sql_mode(&mut self, mode: vibesql_types::SqlMode) {
         self.sql_mode = mode.clone();
@@ -125,18 +125,18 @@ mod tests {
     fn test_set_sql_mode_changes_mode() {
         let mut db = Database::new();
 
-        // Default is SQLite (for SQLLogicTest compatibility)
+        // Default is MySQL (for SQLLogicTest compatibility - dolthub corpus was regenerated against MySQL 8.x)
+        assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
+
+        // Change to SQLite
+        db.set_sql_mode(SqlMode::SQLite);
         assert!(matches!(db.sql_mode(), SqlMode::SQLite));
 
-        // Change to MySQL
+        // Change back to MySQL
         db.set_sql_mode(SqlMode::MySQL {
             flags: MySqlModeFlags::default(),
         });
         assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
-
-        // Change back to SQLite
-        db.set_sql_mode(SqlMode::SQLite);
-        assert!(matches!(db.sql_mode(), SqlMode::SQLite));
     }
 
     #[test]
@@ -209,16 +209,14 @@ mod tests {
     fn test_sql_mode_affects_subsequent_queries() {
         let mut db = Database::new();
 
-        // Start in SQLite mode (default)
-        assert!(matches!(db.sql_mode(), SqlMode::SQLite));
+        // Start in MySQL mode (default)
+        assert!(matches!(db.sql_mode(), SqlMode::MySQL { .. }));
 
-        // Switch to MySQL
-        db.set_sql_mode(SqlMode::MySQL {
-            flags: MySqlModeFlags::default(),
-        });
+        // Switch to SQLite
+        db.set_sql_mode(SqlMode::SQLite);
 
-        // Verify the mode is available for query execution
+        // Verify the mode changed
         let mode = db.sql_mode();
-        assert!(matches!(mode, SqlMode::MySQL { .. }));
+        assert!(matches!(mode, SqlMode::SQLite));
     }
 }

--- a/crates/vibesql-types/src/sql_mode/mod.rs
+++ b/crates/vibesql-types/src/sql_mode/mod.rs
@@ -56,10 +56,13 @@ pub enum SqlMode {
 
 impl Default for SqlMode {
     fn default() -> Self {
-        // Default to SQLite mode for SQLLogicTest compatibility
-        // The SQLLogicTest suite is derived from SQLite and expects SQLite semantics
-        // including integer division (INTEGER / INTEGER → INTEGER, truncated)
-        SqlMode::SQLite
+        // Default to MySQL mode for SQLLogicTest compatibility
+        // The dolthub/sqllogictest corpus was regenerated against MySQL 8.x
+        // and expects MySQL semantics including decimal division
+        // (INTEGER / INTEGER → DECIMAL)
+        SqlMode::MySQL {
+            flags: MySqlModeFlags::default(),
+        }
     }
 }
 

--- a/tests/sqllogictest/db_adapter/pool.rs
+++ b/tests/sqllogictest/db_adapter/pool.rs
@@ -28,9 +28,9 @@ pub fn get_pooled_database() -> Database {
                 db
             }
             None => {
-                // First use - create new database with SQLite mode (default)
-                // The SQLLogicTest suite is derived from SQLite and expects SQLite semantics
-                // including integer division (INTEGER / INTEGER → INTEGER, truncated)
+                // First use - create new database with MySQL mode (default)
+                // The dolthub/sqllogictest corpus was regenerated against MySQL 8.x
+                // and expects MySQL semantics including decimal division
                 vibesql_storage::Database::new()
             }
         }

--- a/tests/sqllogictest/execution.rs
+++ b/tests/sqllogictest/execution.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use sqllogictest::{Runner, SqlDialect};
+use sqllogictest::Runner;
 use tokio::time::timeout;
 
 use super::{
@@ -49,24 +49,14 @@ async fn run_test_file_async(contents: &str, file_name: &str) -> TestFileResult 
     // VibeSQL uses MySQL-compatible division (returns REAL/DECIMAL for integer division)
     tester.add_label("mysql");
 
-    // The random/ tests are from SQLite's official test suite and assume SQLite semantics
-    // (e.g., integer division). The `onlyif mysql` directives in these tests are for
-    // MySQL-specific SYNTAX (like CAST AS SIGNED), not MySQL division semantics.
-    // Therefore, we:
-    // 1. Set SQLite mode for random/ tests
-    // 2. Do NOT enable auto-dialect switching for random/ tests (they should stay in SQLite mode)
-    // 3. Enable auto-dialect switching only for non-random tests
-    let script = if file_name.starts_with("random/") {
-        // Set SQLite mode and update internal tracking
-        // Do NOT enable auto-dialect switching - these tests expect SQLite division semantics
-        // even when using MySQL-specific syntax like CAST AS SIGNED (issue #2783)
-        tester.with_default_dialect(SqlDialect::SQLite);
-        format!("statement ok\nSET SQL_MODE = 'sqlite'\n\n{}", contents)
-    } else {
-        // Enable auto-dialect switching for non-random tests to maximize coverage
-        tester.enable_auto_switch_dialect();
-        contents.to_string()
-    };
+    // The dolthub/sqllogictest corpus was regenerated against MySQL 8.x
+    // (see third_party/sqllogictest/README.md), so all tests expect MySQL semantics
+    // including decimal division (INTEGER / INTEGER → DECIMAL).
+    // The `onlyif mysql` directives are for MySQL-specific SYNTAX (like CAST AS SIGNED).
+    // The Database default is now MySQL mode, so tests use MySQL division semantics.
+    // Enable auto-dialect switching to handle tests with skipif/onlyif conditions.
+    tester.enable_auto_switch_dialect();
+    let script = contents.to_string();
 
     let result = tester.run_script(&script);
 


### PR DESCRIPTION
## Summary
- Changes the default SqlMode from SQLite to MySQL for SQLLogicTest compatibility
- The dolthub/sqllogictest test corpus was regenerated against MySQL 8.x, so all tests expect MySQL semantics including decimal division (INTEGER / INTEGER → DECIMAL)
- Fixes failing test at `random/groupby/slt_good_11.test:35661` which expected `13.833` but got `13.000`

## Changes
- Changed `SqlMode::default()` from `SQLite` to `MySQL { flags: MySqlModeFlags::default() }` in `crates/vibesql-types/src/sql_mode/mod.rs`
- Updated `SqlDialect::as_sql_mode_str()` to return `"mysql"` instead of `"mysql_slt"` in `crates/vibesql-sqllogictest/src/executor/core.rs`
- Removed SQLite mode prepending from test execution (default is now MySQL)
- Updated all tests that checked for SQLite as default
- Updated comments to reflect accurate test corpus origin (MySQL 8.x, not SQLite)

## Test plan
- [x] Run the specific failing test: `SQLLOGICTEST_FILE=random/groupby/slt_good_11.test cargo test run_single_test_file`
- [x] Run `vibesql-storage` tests
- [x] Run `vibesql-executor` sql_mode tests
- [x] Run `sqllogictest` crate tests

Closes #2851

🤖 Generated with [Claude Code](https://claude.com/claude-code)