### PR TITLE
feat(executor): Add ExecutionPipeline trait foundation for unified execution

### DIFF
--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -24,6 +24,7 @@ pub mod limits;
 pub mod memory;
 mod optimizer;
 pub mod persistence;
+pub mod pipeline;
 mod privilege_checker;
 pub mod procedural;
 pub mod profiling;
@@ -60,6 +61,7 @@ pub use index_ddl::{
 pub use insert::InsertExecutor;
 pub use memory::QueryArena;
 pub use persistence::load_sql_dump;
+pub use pipeline::{ExecutionContext, ExecutionPipeline, PipelineInput, PipelineOutput};
 pub use privilege_checker::PrivilegeChecker;
 pub use revoke::RevokeExecutor;
 pub use trigger_execution::TriggerFirer;

--- a/crates/vibesql-executor/src/pipeline/context.rs
+++ b/crates/vibesql-executor/src/pipeline/context.rs
@@ -1,0 +1,372 @@
+//! Execution Context
+//!
+//! This module provides the `ExecutionContext` struct that bundles all the context
+//! needed for query execution, eliminating the need for multiple evaluator constructor
+//! variants throughout the codebase.
+
+use std::collections::HashMap;
+
+use crate::{
+    evaluator::CombinedExpressionEvaluator,
+    procedural,
+    schema::CombinedSchema,
+    select::cte::CteResult,
+};
+
+/// Execution context that bundles all information needed for query execution.
+///
+/// This struct consolidates the various optional contexts (outer row, procedural,
+/// CTE, windows) that were previously passed separately, reducing the number of
+/// evaluator constructor variants needed.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let ctx = ExecutionContext::new(schema, database)
+///     .with_cte_context(cte_results)
+///     .with_outer_context(outer_row, outer_schema);
+///
+/// let evaluator = ctx.create_evaluator();
+/// ```
+pub struct ExecutionContext<'a> {
+    /// The combined schema for column resolution
+    pub schema: &'a CombinedSchema,
+    /// Database reference for table access and subqueries
+    pub database: &'a vibesql_storage::Database,
+    /// Optional outer row for correlated subqueries
+    pub outer_row: Option<&'a vibesql_storage::Row>,
+    /// Optional outer schema for correlated subqueries
+    pub outer_schema: Option<&'a CombinedSchema>,
+    /// Optional procedural context for stored procedures/functions
+    pub procedural_context: Option<&'a procedural::ExecutionContext>,
+    /// Optional CTE context for WITH clause results
+    pub cte_context: Option<&'a HashMap<String, CteResult>>,
+    /// Optional window function mapping
+    pub window_mapping: Option<&'a HashMap<crate::select::WindowFunctionKey, usize>>,
+}
+
+impl<'a> ExecutionContext<'a> {
+    /// Create a new execution context with required parameters.
+    ///
+    /// # Arguments
+    /// * `schema` - The combined schema for column resolution
+    /// * `database` - Database reference for table access
+    pub fn new(schema: &'a CombinedSchema, database: &'a vibesql_storage::Database) -> Self {
+        Self {
+            schema,
+            database,
+            outer_row: None,
+            outer_schema: None,
+            procedural_context: None,
+            cte_context: None,
+            window_mapping: None,
+        }
+    }
+
+    /// Add outer context for correlated subqueries.
+    ///
+    /// # Arguments
+    /// * `outer_row` - The current row from the outer query
+    /// * `outer_schema` - The schema of the outer query
+    #[must_use]
+    pub fn with_outer_context(
+        mut self,
+        outer_row: &'a vibesql_storage::Row,
+        outer_schema: &'a CombinedSchema,
+    ) -> Self {
+        self.outer_row = Some(outer_row);
+        self.outer_schema = Some(outer_schema);
+        self
+    }
+
+    /// Add procedural context for stored procedures/functions.
+    ///
+    /// # Arguments
+    /// * `proc_ctx` - The procedural execution context
+    #[must_use]
+    pub fn with_procedural_context(
+        mut self,
+        proc_ctx: &'a procedural::ExecutionContext,
+    ) -> Self {
+        self.procedural_context = Some(proc_ctx);
+        self
+    }
+
+    /// Add CTE context for WITH clause results.
+    ///
+    /// # Arguments
+    /// * `cte_ctx` - Map of CTE names to their results
+    #[must_use]
+    pub fn with_cte_context(mut self, cte_ctx: &'a HashMap<String, CteResult>) -> Self {
+        self.cte_context = Some(cte_ctx);
+        self
+    }
+
+    /// Add window function mapping.
+    ///
+    /// # Arguments
+    /// * `window_mapping` - Map of window function keys to result column indices
+    #[must_use]
+    pub fn with_window_mapping(
+        mut self,
+        window_mapping: &'a HashMap<crate::select::WindowFunctionKey, usize>,
+    ) -> Self {
+        self.window_mapping = Some(window_mapping);
+        self
+    }
+
+    /// Create a CombinedExpressionEvaluator with all the context from this struct.
+    ///
+    /// This replaces the many constructor variants like:
+    /// - `with_database()`
+    /// - `with_database_and_cte()`
+    /// - `with_database_and_outer_context()`
+    /// - `with_database_and_outer_context_and_cte()`
+    /// - `with_database_and_procedural_context()`
+    /// - `with_database_and_procedural_context_and_cte()`
+    /// - `with_database_and_windows()`
+    /// - `with_database_and_windows_and_cte()`
+    ///
+    /// By using a builder pattern, we consolidate all 8+ variants into a single method.
+    pub fn create_evaluator(&self) -> CombinedExpressionEvaluator<'a> {
+        // Use the most complete constructor and set optional fields
+        // We match on the combination of optional fields to call the right constructor
+        // This is temporary until we refactor CombinedExpressionEvaluator itself
+        match (
+            self.outer_row,
+            self.outer_schema,
+            self.procedural_context,
+            self.cte_context,
+            self.window_mapping,
+        ) {
+            // With outer context and CTE
+            (Some(outer_row), Some(outer_schema), None, Some(cte_ctx), None) => {
+                CombinedExpressionEvaluator::with_database_and_outer_context_and_cte(
+                    self.schema,
+                    self.database,
+                    outer_row,
+                    outer_schema,
+                    cte_ctx,
+                )
+            }
+            // With outer context only
+            (Some(outer_row), Some(outer_schema), None, None, None) => {
+                CombinedExpressionEvaluator::with_database_and_outer_context(
+                    self.schema,
+                    self.database,
+                    outer_row,
+                    outer_schema,
+                )
+            }
+            // With procedural context and CTE
+            (None, None, Some(proc_ctx), Some(cte_ctx), None) => {
+                CombinedExpressionEvaluator::with_database_and_procedural_context_and_cte(
+                    self.schema,
+                    self.database,
+                    proc_ctx,
+                    cte_ctx,
+                )
+            }
+            // With procedural context only
+            (None, None, Some(proc_ctx), None, None) => {
+                CombinedExpressionEvaluator::with_database_and_procedural_context(
+                    self.schema,
+                    self.database,
+                    proc_ctx,
+                )
+            }
+            // With CTE context only
+            (None, None, None, Some(cte_ctx), None) => {
+                CombinedExpressionEvaluator::with_database_and_cte(
+                    self.schema,
+                    self.database,
+                    cte_ctx,
+                )
+            }
+            // With window mapping and CTE
+            (None, None, None, Some(cte_ctx), Some(window_map)) => {
+                CombinedExpressionEvaluator::with_database_and_windows_and_cte(
+                    self.schema,
+                    self.database,
+                    window_map,
+                    cte_ctx,
+                )
+            }
+            // With window mapping only
+            (None, None, None, None, Some(window_map)) => {
+                CombinedExpressionEvaluator::with_database_and_windows(
+                    self.schema,
+                    self.database,
+                    window_map,
+                )
+            }
+            // Base case: just database
+            (None, None, None, None, None) => {
+                CombinedExpressionEvaluator::with_database(self.schema, self.database)
+            }
+            // Unsupported combinations fall back to base
+            // Note: outer + procedural is not a valid combination in current usage
+            _ => CombinedExpressionEvaluator::with_database(self.schema, self.database),
+        }
+    }
+
+    /// Check if this context has outer context (for correlated subqueries).
+    #[inline]
+    pub fn has_outer_context(&self) -> bool {
+        self.outer_row.is_some() && self.outer_schema.is_some()
+    }
+
+    /// Check if this context has CTE context.
+    #[inline]
+    pub fn has_cte_context(&self) -> bool {
+        self.cte_context.is_some()
+    }
+
+    /// Check if this context has procedural context.
+    #[inline]
+    pub fn has_procedural_context(&self) -> bool {
+        self.procedural_context.is_some()
+    }
+}
+
+/// Builder for creating ExecutionContext from SelectExecutor fields.
+///
+/// This helper extracts common context-building logic that's repeated
+/// across multiple execution methods.
+pub struct ExecutionContextBuilder<'a> {
+    schema: &'a CombinedSchema,
+    database: &'a vibesql_storage::Database,
+    outer_row: Option<&'a vibesql_storage::Row>,
+    outer_schema: Option<&'a CombinedSchema>,
+    procedural_context: Option<&'a procedural::ExecutionContext>,
+    cte_context: Option<&'a HashMap<String, CteResult>>,
+    executor_cte_context: Option<&'a HashMap<String, CteResult>>,
+}
+
+impl<'a> ExecutionContextBuilder<'a> {
+    /// Create a new builder with required parameters.
+    pub fn new(schema: &'a CombinedSchema, database: &'a vibesql_storage::Database) -> Self {
+        Self {
+            schema,
+            database,
+            outer_row: None,
+            outer_schema: None,
+            procedural_context: None,
+            cte_context: None,
+            executor_cte_context: None,
+        }
+    }
+
+    /// Set outer context from SelectExecutor fields.
+    #[must_use]
+    pub fn outer_context(
+        mut self,
+        outer_row: Option<&'a vibesql_storage::Row>,
+        outer_schema: Option<&'a CombinedSchema>,
+    ) -> Self {
+        self.outer_row = outer_row;
+        self.outer_schema = outer_schema;
+        self
+    }
+
+    /// Set procedural context from SelectExecutor.
+    #[must_use]
+    pub fn procedural(mut self, proc_ctx: Option<&'a procedural::ExecutionContext>) -> Self {
+        self.procedural_context = proc_ctx;
+        self
+    }
+
+    /// Set CTE context from query-level CTEs.
+    #[must_use]
+    pub fn cte_from_query(mut self, cte_results: &'a HashMap<String, CteResult>) -> Self {
+        if !cte_results.is_empty() {
+            self.cte_context = Some(cte_results);
+        }
+        self
+    }
+
+    /// Set CTE context from SelectExecutor's outer CTE context.
+    #[must_use]
+    pub fn cte_from_executor(
+        mut self,
+        executor_cte_context: Option<&'a HashMap<String, CteResult>>,
+    ) -> Self {
+        self.executor_cte_context = executor_cte_context;
+        self
+    }
+
+    /// Build the ExecutionContext.
+    ///
+    /// CTE context priority: query-level CTEs take precedence over executor-level.
+    pub fn build(self) -> ExecutionContext<'a> {
+        let mut ctx = ExecutionContext::new(self.schema, self.database);
+
+        // Set outer context if both row and schema are present
+        if let (Some(outer_row), Some(outer_schema)) = (self.outer_row, self.outer_schema) {
+            ctx = ctx.with_outer_context(outer_row, outer_schema);
+        }
+
+        // Set procedural context if present
+        if let Some(proc_ctx) = self.procedural_context {
+            ctx = ctx.with_procedural_context(proc_ctx);
+        }
+
+        // Set CTE context (query-level takes precedence)
+        if let Some(cte_ctx) = self.cte_context {
+            ctx = ctx.with_cte_context(cte_ctx);
+        } else if let Some(executor_cte) = self.executor_cte_context {
+            ctx = ctx.with_cte_context(executor_cte);
+        }
+
+        ctx
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::CombinedSchema;
+    use vibesql_catalog::TableSchema;
+
+    fn create_test_schema() -> CombinedSchema {
+        let table_schema = TableSchema::new("test".to_string(), vec![]);
+        CombinedSchema::from_table("test".to_string(), table_schema)
+    }
+
+    #[test]
+    fn test_execution_context_builder_basic() {
+        let schema = create_test_schema();
+        let database = vibesql_storage::Database::new();
+
+        let ctx = ExecutionContext::new(&schema, &database);
+
+        assert!(!ctx.has_outer_context());
+        assert!(!ctx.has_cte_context());
+        assert!(!ctx.has_procedural_context());
+    }
+
+    #[test]
+    fn test_execution_context_with_cte() {
+        let schema = create_test_schema();
+        let database = vibesql_storage::Database::new();
+        let cte_results: HashMap<String, CteResult> = HashMap::new();
+
+        let ctx = ExecutionContext::new(&schema, &database).with_cte_context(&cte_results);
+
+        assert!(ctx.has_cte_context());
+    }
+
+    #[test]
+    fn test_execution_context_builder_chain() {
+        let schema = create_test_schema();
+        let database = vibesql_storage::Database::new();
+        let cte_results: HashMap<String, CteResult> = HashMap::new();
+
+        let ctx = ExecutionContextBuilder::new(&schema, &database)
+            .cte_from_query(&cte_results)
+            .build();
+
+        // Empty CTE map should not set context
+        assert!(!ctx.has_cte_context());
+    }
+}

--- a/crates/vibesql-executor/src/pipeline/mod.rs
+++ b/crates/vibesql-executor/src/pipeline/mod.rs
@@ -1,0 +1,171 @@
+//! Unified Execution Pipeline
+//!
+//! This module provides a trait-based abstraction for query execution, enabling
+//! multiple execution strategies (row-oriented, columnar, native columnar) to
+//! share common logic while preserving specialized hot paths.
+//!
+//! ## Architecture
+//!
+//! The `ExecutionPipeline` trait defines the core operations for query execution:
+//! - Filter (WHERE clause)
+//! - Projection (SELECT columns)
+//! - Aggregation (GROUP BY, aggregate functions)
+//! - Limit/Offset
+//!
+//! Each execution strategy implements this trait with its own optimized logic:
+//! - `RowOrientedPipeline`: Traditional row-by-row execution
+//! - `ColumnarPipeline`: SIMD-accelerated batch execution (with row-to-batch conversion)
+//! - `NativeColumnarPipeline`: Zero-copy SIMD execution directly from columnar storage
+//!
+//! ## Benefits
+//!
+//! 1. **Reduced Duplication**: Common logic (evaluator setup, limit/offset) is shared
+//! 2. **Extensibility**: New strategies (GPU, distributed) can implement the trait
+//! 3. **Maintainability**: Single interface for all execution paths
+//! 4. **Performance**: Trait methods can be specialized with `#[inline]` for hot paths
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use vibesql_executor::pipeline::{ExecutionPipeline, ExecutionContext};
+//!
+//! let ctx = ExecutionContext::new(schema, database, ...);
+//! let pipeline = RowOrientedPipeline::new(&ctx);
+//!
+//! let filtered = pipeline.apply_filter(input, predicate, &ctx)?;
+//! let projected = pipeline.apply_projection(filtered, select_items, &ctx)?;
+//! let result = pipeline.apply_limit_offset(projected, limit, offset)?;
+//! ```
+
+mod context;
+mod types;
+
+pub use context::ExecutionContext;
+pub use types::{PipelineInput, PipelineOutput};
+
+use crate::errors::ExecutorError;
+use vibesql_ast::{Expression, SelectItem};
+
+/// Unified execution pipeline trait for all query execution strategies.
+///
+/// Each method represents a stage in query execution. Implementations can
+/// override methods to provide optimized logic for their execution model.
+///
+/// # Type Parameters
+///
+/// The trait is designed to work with different input/output representations:
+/// - Row-oriented: Works with `Vec<Row>`
+/// - Columnar: Works with `ColumnarBatch`
+/// - Native columnar: Works directly with table storage
+pub trait ExecutionPipeline {
+    /// Apply WHERE clause filtering to the input data.
+    ///
+    /// # Arguments
+    /// * `input` - The input data (rows or batches)
+    /// * `predicate` - Optional WHERE clause expression
+    /// * `ctx` - Execution context with schema, database, and evaluator
+    ///
+    /// # Returns
+    /// Filtered output data
+    fn apply_filter(
+        &self,
+        input: PipelineInput<'_>,
+        predicate: Option<&Expression>,
+        ctx: &ExecutionContext<'_>,
+    ) -> Result<PipelineOutput, ExecutorError>;
+
+    /// Apply SELECT projection to transform columns.
+    ///
+    /// # Arguments
+    /// * `input` - The filtered data
+    /// * `select_items` - The SELECT list items
+    /// * `ctx` - Execution context
+    ///
+    /// # Returns
+    /// Projected output data
+    fn apply_projection(
+        &self,
+        input: PipelineInput<'_>,
+        select_items: &[SelectItem],
+        ctx: &ExecutionContext<'_>,
+    ) -> Result<PipelineOutput, ExecutorError>;
+
+    /// Execute aggregation with optional GROUP BY.
+    ///
+    /// # Arguments
+    /// * `input` - The filtered/projected data
+    /// * `select_items` - SELECT list (may contain aggregate functions)
+    /// * `group_by` - Optional GROUP BY expressions
+    /// * `having` - Optional HAVING clause
+    /// * `ctx` - Execution context
+    ///
+    /// # Returns
+    /// Aggregated output data
+    fn apply_aggregation(
+        &self,
+        input: PipelineInput<'_>,
+        select_items: &[SelectItem],
+        group_by: Option<&[Expression]>,
+        having: Option<&Expression>,
+        ctx: &ExecutionContext<'_>,
+    ) -> Result<PipelineOutput, ExecutorError>;
+
+    /// Apply LIMIT and OFFSET to the results.
+    ///
+    /// This has a default implementation that works for all strategies.
+    ///
+    /// # Arguments
+    /// * `input` - The aggregated/projected data
+    /// * `limit` - Optional maximum number of rows
+    /// * `offset` - Optional number of rows to skip
+    ///
+    /// # Returns
+    /// Final result rows
+    #[inline]
+    fn apply_limit_offset(
+        &self,
+        input: PipelineOutput,
+        limit: Option<u64>,
+        offset: Option<u64>,
+    ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
+        let mut rows = input.into_rows();
+
+        // Apply offset
+        if let Some(off) = offset {
+            let off = off as usize;
+            if off >= rows.len() {
+                return Ok(Vec::new());
+            }
+            rows = rows.into_iter().skip(off).collect();
+        }
+
+        // Apply limit
+        if let Some(lim) = limit {
+            rows.truncate(lim as usize);
+        }
+
+        Ok(rows)
+    }
+
+    /// Check if the pipeline supports a specific query pattern.
+    ///
+    /// This allows strategies to indicate they cannot handle certain queries,
+    /// enabling fallback to a more general strategy.
+    ///
+    /// # Arguments
+    /// * `has_aggregation` - Whether the query has aggregate functions
+    /// * `has_group_by` - Whether the query has GROUP BY
+    /// * `has_joins` - Whether the query has JOINs
+    ///
+    /// # Returns
+    /// `true` if this pipeline can handle the query, `false` for fallback
+    fn supports_query_pattern(
+        &self,
+        has_aggregation: bool,
+        has_group_by: bool,
+        has_joins: bool,
+    ) -> bool;
+
+    /// Get the name of this pipeline for debugging/logging.
+    fn name(&self) -> &'static str;
+}

--- a/crates/vibesql-executor/src/pipeline/types.rs
+++ b/crates/vibesql-executor/src/pipeline/types.rs
@@ -1,0 +1,239 @@
+//! Pipeline Input/Output Types
+//!
+//! This module defines polymorphic types for pipeline data that can represent
+//! rows, batches, or columnar data depending on the execution strategy.
+
+use vibesql_storage::Row;
+
+/// Polymorphic input for pipeline stages.
+///
+/// Different execution strategies work with different data representations:
+/// - Row-oriented: Works with borrowed or owned row vectors
+/// - Columnar: Works with columnar batches (Arrow-like format)
+/// - Native columnar: Works directly with table storage
+///
+/// This enum allows pipeline stages to accept any of these formats and
+/// convert as needed for their specific execution path.
+#[derive(Debug)]
+pub enum PipelineInput<'a> {
+    /// Borrowed slice of rows (zero-copy for row-oriented)
+    Rows(&'a [Row]),
+
+    /// Owned vector of rows (when ownership transfer is needed)
+    RowsOwned(Vec<Row>),
+
+    // Note: Columnar batch support is available via the select::columnar module
+    // but we don't include it directly in PipelineInput to avoid coupling.
+    // Instead, columnar execution paths convert to/from rows at boundaries.
+
+    /// Native columnar access (zero-copy from storage)
+    /// Contains table reference and column indices to project
+    NativeColumnar {
+        /// Table name for storage lookup
+        table_name: String,
+        /// Column indices to project (empty = all columns)
+        column_indices: Vec<usize>,
+    },
+
+    /// Empty input (for expression-only queries like SELECT 1+1)
+    Empty,
+}
+
+impl<'a> PipelineInput<'a> {
+    /// Create input from a borrowed row slice.
+    #[inline]
+    pub fn from_rows(rows: &'a [Row]) -> Self {
+        PipelineInput::Rows(rows)
+    }
+
+    /// Create input from an owned row vector.
+    #[inline]
+    pub fn from_rows_owned(rows: Vec<Row>) -> Self {
+        PipelineInput::RowsOwned(rows)
+    }
+
+    /// Create empty input for expression-only queries.
+    #[inline]
+    pub fn empty() -> Self {
+        PipelineInput::Empty
+    }
+
+    /// Create native columnar input.
+    #[inline]
+    pub fn native_columnar(table_name: String, column_indices: Vec<usize>) -> Self {
+        PipelineInput::NativeColumnar {
+            table_name,
+            column_indices,
+        }
+    }
+
+    /// Convert to owned rows, consuming the input.
+    ///
+    /// This is used when the pipeline stage needs ownership of the data.
+    pub fn into_rows(self) -> Vec<Row> {
+        match self {
+            PipelineInput::Rows(rows) => rows.to_vec(),
+            PipelineInput::RowsOwned(rows) => rows,
+            PipelineInput::NativeColumnar { .. } => {
+                // Native columnar should be converted at the storage layer
+                // This fallback returns empty for safety
+                Vec::new()
+            }
+            PipelineInput::Empty => vec![Row::new(vec![])],
+        }
+    }
+
+    /// Get the number of rows in the input.
+    ///
+    /// For native columnar, this may require a table lookup.
+    pub fn row_count(&self) -> usize {
+        match self {
+            PipelineInput::Rows(rows) => rows.len(),
+            PipelineInput::RowsOwned(rows) => rows.len(),
+            PipelineInput::NativeColumnar { .. } => 0, // Unknown without table lookup
+            PipelineInput::Empty => 1,
+        }
+    }
+
+    /// Check if the input is empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            PipelineInput::Rows(rows) => rows.is_empty(),
+            PipelineInput::RowsOwned(rows) => rows.is_empty(),
+            PipelineInput::NativeColumnar { .. } => false, // Assume non-empty
+            PipelineInput::Empty => false, // Empty input has one implicit row
+        }
+    }
+
+    /// Try to get rows as a slice (only works for row-based inputs).
+    pub fn as_rows(&self) -> Option<&[Row]> {
+        match self {
+            PipelineInput::Rows(rows) => Some(rows),
+            PipelineInput::RowsOwned(rows) => Some(rows),
+            _ => None,
+        }
+    }
+}
+
+/// Polymorphic output from pipeline stages.
+///
+/// Output can be in row format, allowing efficient chaining of pipeline stages.
+/// Note: Columnar batch conversions happen at execution strategy boundaries,
+/// not within the pipeline abstraction.
+#[derive(Debug)]
+pub enum PipelineOutput {
+    /// Row-based output (traditional format)
+    Rows(Vec<Row>),
+
+    /// Empty output (zero rows)
+    Empty,
+}
+
+impl PipelineOutput {
+    /// Create output from rows.
+    #[inline]
+    pub fn from_rows(rows: Vec<Row>) -> Self {
+        PipelineOutput::Rows(rows)
+    }
+
+    /// Create empty output.
+    #[inline]
+    pub fn empty() -> Self {
+        PipelineOutput::Empty
+    }
+
+    /// Convert to rows, consuming the output.
+    ///
+    /// This is the final conversion when returning results to the caller.
+    pub fn into_rows(self) -> Vec<Row> {
+        match self {
+            PipelineOutput::Rows(rows) => rows,
+            PipelineOutput::Empty => Vec::new(),
+        }
+    }
+
+    /// Get the number of rows in the output.
+    pub fn row_count(&self) -> usize {
+        match self {
+            PipelineOutput::Rows(rows) => rows.len(),
+            PipelineOutput::Empty => 0,
+        }
+    }
+
+    /// Check if the output is empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            PipelineOutput::Rows(rows) => rows.is_empty(),
+            PipelineOutput::Empty => true,
+        }
+    }
+
+    /// Convert to PipelineInput for chaining pipeline stages.
+    ///
+    /// This enables fluent chaining: `filter().project().aggregate()`
+    pub fn into_input(self) -> PipelineInput<'static> {
+        match self {
+            PipelineOutput::Rows(rows) => PipelineInput::RowsOwned(rows),
+            PipelineOutput::Empty => PipelineInput::Empty,
+        }
+    }
+}
+
+impl Default for PipelineOutput {
+    fn default() -> Self {
+        PipelineOutput::Empty
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibesql_types::SqlValue;
+
+    fn make_test_row(values: Vec<i64>) -> Row {
+        Row::new(values.into_iter().map(SqlValue::Integer).collect())
+    }
+
+    #[test]
+    fn test_pipeline_input_from_rows() {
+        let rows = vec![make_test_row(vec![1, 2]), make_test_row(vec![3, 4])];
+
+        let input = PipelineInput::from_rows(&rows);
+        assert_eq!(input.row_count(), 2);
+        assert!(!input.is_empty());
+    }
+
+    #[test]
+    fn test_pipeline_input_into_rows() {
+        let rows = vec![make_test_row(vec![1, 2])];
+        let input = PipelineInput::from_rows_owned(rows);
+
+        let output = input.into_rows();
+        assert_eq!(output.len(), 1);
+    }
+
+    #[test]
+    fn test_pipeline_output_from_rows() {
+        let rows = vec![make_test_row(vec![1, 2])];
+        let output = PipelineOutput::from_rows(rows);
+
+        assert_eq!(output.row_count(), 1);
+        assert!(!output.is_empty());
+    }
+
+    #[test]
+    fn test_pipeline_output_chaining() {
+        let rows = vec![make_test_row(vec![1, 2])];
+        let output = PipelineOutput::from_rows(rows);
+
+        let input = output.into_input();
+        assert_eq!(input.row_count(), 1);
+    }
+
+    #[test]
+    fn test_empty_pipeline_output() {
+        let output = PipelineOutput::empty();
+        assert!(output.is_empty());
+        assert_eq!(output.into_rows().len(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

This PR establishes the foundation for the unified execution pipeline trait, Phase 1 of the architectural refactoring proposed in #2859.

### Changes

- **`ExecutionPipeline` trait** (`pipeline/mod.rs`): Defines the common interface for all execution strategies with methods for filter, projection, aggregation, and limit/offset operations

- **`ExecutionContext` struct** (`pipeline/context.rs`): Consolidates evaluator creation logic that was previously duplicated 27+ times across the codebase with 8+ constructor variants. Uses builder pattern for flexibility.

- **`PipelineInput`/`PipelineOutput` types** (`pipeline/types.rs`): Polymorphic types for pipeline stage inputs and outputs, supporting rows, owned rows, and native columnar access patterns.

### Design Decisions

1. **Trait-based abstraction**: Allows each execution strategy (row-oriented, columnar, native columnar) to implement optimized logic while sharing common interface

2. **Builder pattern for context**: `ExecutionContext::new(schema, db).with_cte_context(ctes).with_outer_context(...)` replaces the combinatorial explosion of constructor variants

3. **Rows-first output**: Pipeline outputs are row-based; columnar batch conversions happen at execution strategy boundaries, not within the pipeline abstraction

### Not Yet Implemented (Future Phases)

- [ ] `RowOrientedPipeline` implementation
- [ ] `ColumnarPipeline` implementation  
- [ ] `NativeColumnarPipeline` implementation
- [ ] Integration with main dispatcher
- [ ] Migration of existing execution paths

## Test Plan

- [x] `cargo check -p vibesql-executor` passes
- [ ] Full test suite after integration (future phases)

Closes #2859