### PR TITLE
fix: Silence unused variable warning for file_name parameter

### DIFF
--- a/tests/sqllogictest/execution.rs
+++ b/tests/sqllogictest/execution.rs
@@ -41,7 +41,7 @@ pub struct TestFileResult {
 }
 
 /// Run a test file asynchronously and capture detailed failure information
-async fn run_test_file_async(contents: &str, file_name: &str) -> TestFileResult {
+async fn run_test_file_async(contents: &str, _file_name: &str) -> TestFileResult {
     let mut tester = Runner::new(|| async { Ok(VibeSqlDB::new()) });
     // Enable hash mode with threshold of 8 (standard SQLLogicTest behavior)
     tester.with_hash_threshold(8);


### PR DESCRIPTION
## Summary

- Prefix the `file_name` parameter in `run_test_file_async` with underscore to indicate it is intentionally unused
- Eliminates 4 compiler warnings that appeared during `make all` across tests/integration, tests/compliance, tests/executor, and tests/dialect

## Test plan

- [x] Verify `cargo check --tests` no longer shows `file_name` unused variable warnings
- [x] Change is a single character - no functional impact

Closes #2871

🤖 Generated with [Claude Code](https://claude.com/claude-code)