### PR TITLE
fix(executor): Move ExecutionContextBuilder inside #[cfg(test)]

### DIFF
--- a/crates/vibesql-executor/src/pipeline/context.rs
+++ b/crates/vibesql-executor/src/pipeline/context.rs
@@ -229,104 +229,75 @@ impl<'a> ExecutionContext<'a> {
     }
 }
 
-/// Builder for creating ExecutionContext from SelectExecutor fields.
-///
-/// This helper extracts common context-building logic that's repeated
-/// across multiple execution methods.
-pub struct ExecutionContextBuilder<'a> {
-    schema: &'a CombinedSchema,
-    database: &'a vibesql_storage::Database,
-    outer_row: Option<&'a vibesql_storage::Row>,
-    outer_schema: Option<&'a CombinedSchema>,
-    procedural_context: Option<&'a procedural::ExecutionContext>,
-    cte_context: Option<&'a HashMap<String, CteResult>>,
-    executor_cte_context: Option<&'a HashMap<String, CteResult>>,
-}
-
-impl<'a> ExecutionContextBuilder<'a> {
-    /// Create a new builder with required parameters.
-    pub fn new(schema: &'a CombinedSchema, database: &'a vibesql_storage::Database) -> Self {
-        Self {
-            schema,
-            database,
-            outer_row: None,
-            outer_schema: None,
-            procedural_context: None,
-            cte_context: None,
-            executor_cte_context: None,
-        }
-    }
-
-    /// Set outer context from SelectExecutor fields.
-    #[must_use]
-    pub fn outer_context(
-        mut self,
-        outer_row: Option<&'a vibesql_storage::Row>,
-        outer_schema: Option<&'a CombinedSchema>,
-    ) -> Self {
-        self.outer_row = outer_row;
-        self.outer_schema = outer_schema;
-        self
-    }
-
-    /// Set procedural context from SelectExecutor.
-    #[must_use]
-    pub fn procedural(mut self, proc_ctx: Option<&'a procedural::ExecutionContext>) -> Self {
-        self.procedural_context = proc_ctx;
-        self
-    }
-
-    /// Set CTE context from query-level CTEs.
-    #[must_use]
-    pub fn cte_from_query(mut self, cte_results: &'a HashMap<String, CteResult>) -> Self {
-        if !cte_results.is_empty() {
-            self.cte_context = Some(cte_results);
-        }
-        self
-    }
-
-    /// Set CTE context from SelectExecutor's outer CTE context.
-    #[must_use]
-    pub fn cte_from_executor(
-        mut self,
-        executor_cte_context: Option<&'a HashMap<String, CteResult>>,
-    ) -> Self {
-        self.executor_cte_context = executor_cte_context;
-        self
-    }
-
-    /// Build the ExecutionContext.
-    ///
-    /// CTE context priority: query-level CTEs take precedence over executor-level.
-    pub fn build(self) -> ExecutionContext<'a> {
-        let mut ctx = ExecutionContext::new(self.schema, self.database);
-
-        // Set outer context if both row and schema are present
-        if let (Some(outer_row), Some(outer_schema)) = (self.outer_row, self.outer_schema) {
-            ctx = ctx.with_outer_context(outer_row, outer_schema);
-        }
-
-        // Set procedural context if present
-        if let Some(proc_ctx) = self.procedural_context {
-            ctx = ctx.with_procedural_context(proc_ctx);
-        }
-
-        // Set CTE context (query-level takes precedence)
-        if let Some(cte_ctx) = self.cte_context {
-            ctx = ctx.with_cte_context(cte_ctx);
-        } else if let Some(executor_cte) = self.executor_cte_context {
-            ctx = ctx.with_cte_context(executor_cte);
-        }
-
-        ctx
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::schema::CombinedSchema;
     use vibesql_catalog::TableSchema;
+
+    /// Builder for creating ExecutionContext from SelectExecutor fields.
+    ///
+    /// This helper extracts common context-building logic that's repeated
+    /// across multiple execution methods.
+    struct ExecutionContextBuilder<'a> {
+        schema: &'a CombinedSchema,
+        database: &'a vibesql_storage::Database,
+        outer_row: Option<&'a vibesql_storage::Row>,
+        outer_schema: Option<&'a CombinedSchema>,
+        procedural_context: Option<&'a procedural::ExecutionContext>,
+        cte_context: Option<&'a HashMap<String, CteResult>>,
+        executor_cte_context: Option<&'a HashMap<String, CteResult>>,
+    }
+
+    impl<'a> ExecutionContextBuilder<'a> {
+        /// Create a new builder with required parameters.
+        fn new(schema: &'a CombinedSchema, database: &'a vibesql_storage::Database) -> Self {
+            Self {
+                schema,
+                database,
+                outer_row: None,
+                outer_schema: None,
+                procedural_context: None,
+                cte_context: None,
+                executor_cte_context: None,
+            }
+        }
+
+        /// Set CTE context from query-level CTEs.
+        #[must_use]
+        fn cte_from_query(mut self, cte_results: &'a HashMap<String, CteResult>) -> Self {
+            if !cte_results.is_empty() {
+                self.cte_context = Some(cte_results);
+            }
+            self
+        }
+
+        /// Build the ExecutionContext.
+        ///
+        /// CTE context priority: query-level CTEs take precedence over executor-level.
+        fn build(self) -> ExecutionContext<'a> {
+            let mut ctx = ExecutionContext::new(self.schema, self.database);
+
+            // Set outer context if both row and schema are present
+            if let (Some(outer_row), Some(outer_schema)) = (self.outer_row, self.outer_schema) {
+                ctx = ctx.with_outer_context(outer_row, outer_schema);
+            }
+
+            // Set procedural context if present
+            if let Some(proc_ctx) = self.procedural_context {
+                ctx = ctx.with_procedural_context(proc_ctx);
+            }
+
+            // Set CTE context (query-level takes precedence)
+            if let Some(cte_ctx) = self.cte_context {
+                ctx = ctx.with_cte_context(cte_ctx);
+            } else if let Some(executor_cte) = self.executor_cte_context {
+                ctx = ctx.with_cte_context(executor_cte);
+            }
+
+            ctx
+        }
+    }
 
     fn create_test_schema() -> CombinedSchema {
         let table_schema = TableSchema::new("test".to_string(), vec![]);


### PR DESCRIPTION
## Summary

- Moved `ExecutionContextBuilder` struct and its impl block inside the `#[cfg(test)]` module
- The struct was only used in tests but was defined in the main module, causing dead code warnings

## Root Cause

The `ExecutionContextBuilder` struct (lines 236-322 in the original file) was defined in the main module but was only used within the `#[cfg(test)]` module tests. This caused compiler warnings about unused code in release builds.

## Fix

Moved the struct and its implementation inside the `#[cfg(test)]` module where it's actually used. Also simplified the struct to only include methods that are actually called by the tests.

## Test plan

- [x] `cargo build --package vibesql-executor` - no warnings
- [x] `cargo test --package vibesql-executor pipeline::context` - all 3 tests pass
- [x] `make all` - no warnings about ExecutionContextBuilder

Closes #2886

🤖 Generated with [Claude Code](https://claude.com/claude-code)