### PR TITLE
fix(tests): Update tests to explicitly use SQLite mode after default change

### DIFF
--- a/tests/regression/issue_2783.rs
+++ b/tests/regression/issue_2783.rs
@@ -11,7 +11,7 @@
 use vibesql_executor::SelectExecutor;
 use vibesql_parser::Parser;
 use vibesql_storage::Database;
-use vibesql_types::SqlValue;
+use vibesql_types::{SqlMode, SqlValue};
 
 /// Helper to execute SQL and return results
 fn execute_select(db: &mut Database, sql: &str) -> Vec<vibesql_storage::Row> {
@@ -29,7 +29,8 @@ fn execute_select(db: &mut Database, sql: &str) -> Vec<vibesql_storage::Row> {
 fn test_issue_2783_sqlite_mode_division_with_cast_signed() {
     // This is the exact query from slt_good_6.test that was failing
     let mut db = Database::new();
-    // Default mode is SQLite (integer division)
+    // Explicitly set SQLite mode (integer division)
+    db.set_sql_mode(SqlMode::SQLite);
 
     let sql = r#"
         SELECT DISTINCT + 54 AS col0,
@@ -65,7 +66,8 @@ fn test_issue_2783_sqlite_mode_division_with_cast_signed() {
 fn test_issue_2783_integer_division_with_avg() {
     // Simpler test case isolating the division behavior
     let mut db = Database::new();
-    // Default mode is SQLite (integer division)
+    // Explicitly set SQLite mode (integer division)
+    db.set_sql_mode(SqlMode::SQLite);
 
     // In SQLite mode: 82 / -42 = -1 (truncated integer division)
     // In MySQL mode: 82 / -42 = -1.952... (decimal division)
@@ -85,6 +87,8 @@ fn test_issue_2783_integer_division_with_avg() {
 fn test_issue_2783_division_by_avg_preserves_sqlite_semantics() {
     // Test that division by AVG() works correctly in SQLite mode
     let mut db = Database::new();
+    // Explicitly set SQLite mode (integer division)
+    db.set_sql_mode(SqlMode::SQLite);
 
     // AVG(97) returns 97.0 (Numeric), but the whole expression should
     // still respect SQLite semantics for the final CAST
@@ -113,6 +117,8 @@ fn test_issue_2783_division_by_avg_preserves_sqlite_semantics() {
 fn test_issue_2783_cast_as_signed_works_in_sqlite_mode() {
     // Verify that CAST AS SIGNED (MySQL syntax) works in SQLite mode
     let mut db = Database::new();
+    // Explicitly set SQLite mode (truncation toward zero)
+    db.set_sql_mode(SqlMode::SQLite);
 
     let sql = "SELECT CAST(151.99 AS SIGNED) AS result";
     let rows = execute_select(&mut db, sql);

--- a/tests/regression/issue_2852.rs
+++ b/tests/regression/issue_2852.rs
@@ -31,7 +31,8 @@ fn execute_select(db: &mut Database, sql: &str) -> Vec<vibesql_storage::Row> {
 fn test_issue_2852_sqlite_integer_division() {
     // Verify SQLite mode returns integer division
     let mut db = Database::new();
-    // Default mode is SQLite (integer division)
+    // Explicitly set SQLite mode (integer division)
+    db.set_sql_mode(SqlMode::SQLite);
 
     // In SQLite: 22 / 49 = 0 (integer division)
     let sql = "SELECT 22 / 49";
@@ -74,6 +75,8 @@ fn test_issue_2852_mysql_floating_division() {
 fn test_issue_2852_negative_division_sqlite() {
     // Test negative division in SQLite mode
     let mut db = Database::new();
+    // Explicitly set SQLite mode (integer division)
+    db.set_sql_mode(SqlMode::SQLite);
 
     // In SQLite: -22 / 49 = 0 (truncated toward zero)
     let sql = "SELECT -22 / 49";


### PR DESCRIPTION
## Summary

- Fixed failing tests that expected SQLite mode as the default after commit f2e4b9a9 changed the default to MySQL
- Updated regression tests (issue_2783.rs, issue_2852.rs) to explicitly set `SqlMode::SQLite`
- Fixed unit tests in sql_mode/mod.rs and types.rs to reflect MySQL as the new default
- Fixed arithmetic operator tests to use explicit SQLite mode

## Test plan

- [x] `cargo test --release -p vibesql --test issue_2783` passes
- [x] `cargo test --release -p vibesql --test issue_2852` passes
- [x] `cargo test --release -p vibesql-types` passes
- [x] `cargo test --release -p vibesql-executor --lib` passes

Closes #2887

🤖 Generated with [Claude Code](https://claude.com/claude-code)