### PR TITLE
perf: Add debug logging to verify SIMD aggregation paths

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/batch.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/batch.rs
@@ -45,8 +45,15 @@ pub fn compute_batch_expression_aggregate(
     op: AggregateOp,
     schema: &CombinedSchema,
 ) -> Result<SqlValue, ExecutorError> {
+    log::debug!(
+        "[BatchExpr] compute_batch_expression_aggregate: {} rows, op={:?}",
+        batch.row_count(),
+        op
+    );
+
     // Empty batch handling
     if batch.row_count() == 0 {
+        log::debug!("[BatchExpr] Empty batch, returning default");
         return Ok(match op {
             AggregateOp::Count => SqlValue::Integer(0),
             _ => SqlValue::Null,
@@ -54,9 +61,11 @@ pub fn compute_batch_expression_aggregate(
     }
 
     // Evaluate expression on batch columns using SIMD
+    log::debug!("[BatchExpr] Evaluating expression on batch columns (SIMD-enabled)");
     let result_array = evaluate_batch_expression(batch, expr, schema)?;
 
     // Aggregate the result array using SIMD
+    log::debug!("[BatchExpr] Aggregating result array with SIMD");
     aggregate_column_array(&result_array, op)
 }
 

--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/simd.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/simd.rs
@@ -27,6 +27,7 @@ pub fn try_simd_aggregate(
     op: AggregateOp,
     schema: &CombinedSchema,
 ) -> Result<SqlValue, ExecutorError> {
+    log::debug!("[SIMD-Arrow] try_simd_aggregate called: {} rows, op={:?}", rows.len(), op);
     use crate::select::vectorized::{
         evaluate_arithmetic_simd, rows_to_record_batch,
     };

--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/vectorized.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/vectorized.rs
@@ -31,8 +31,11 @@ fn try_vectorized_binary_aggregate(
     filter_bitmap: Option<&[bool]>,
     schema: &CombinedSchema,
 ) -> Result<Option<SqlValue>, ExecutorError> {
+    log::trace!("[VecBinary] Checking vectorized binary aggregate for {} rows, op={:?}", rows.len(), op);
+
     // Only optimize SUM and AVG for now
     if !matches!(op, AggregateOp::Sum | AggregateOp::Avg) {
+        log::trace!("[VecBinary] Op {:?} not supported for vectorized binary", op);
         return Ok(None);
     }
 
@@ -134,22 +137,37 @@ pub fn compute_expression_aggregate(
     filter_bitmap: Option<&[bool]>,
     schema: &CombinedSchema,
 ) -> Result<SqlValue, ExecutorError> {
+    log::debug!(
+        "[ExprAgg] compute_expression_aggregate: {} rows, op={:?}, has_filter={}, threshold={}",
+        rows.len(),
+        op,
+        filter_bitmap.is_some(),
+        SIMD_THRESHOLD
+    );
+
     // Try main branch's vectorized path first for simple binary operations
     // This is optimized for column × column multiplication with optional filtering
     if let Some(result) = try_vectorized_binary_aggregate(rows, expr, op, filter_bitmap, schema)? {
+        log::debug!("[ExprAgg] Used vectorized binary aggregate path");
         return Ok(result);
     }
 
     // Try SIMD path for large datasets (more general than vectorized binary)
     // Only when no filter bitmap (vectorized binary handles filtered case)
     if rows.len() >= SIMD_THRESHOLD && filter_bitmap.is_none() {
+        log::debug!("[ExprAgg] Attempting Arrow SIMD path ({} >= {} rows)", rows.len(), SIMD_THRESHOLD);
         if let Ok(result) = try_simd_aggregate(rows, expr, op, schema) {
+            log::debug!("[ExprAgg] Arrow SIMD path succeeded");
             return Ok(result);
         }
+        log::debug!("[ExprAgg] Arrow SIMD path failed, falling back to scalar");
         // Fall through to scalar path if SIMD fails
+    } else if rows.len() < SIMD_THRESHOLD {
+        log::debug!("[ExprAgg] Below SIMD threshold ({} < {}), using vectorized/scalar path", rows.len(), SIMD_THRESHOLD);
     }
 
     // Scalar path (for small datasets, complex expressions, or when SIMD not applicable)
+    log::debug!("[ExprAgg] Using scalar aggregate path");
     compute_scalar_aggregate(rows, expr, op, filter_bitmap, schema)
 }
 

--- a/crates/vibesql-executor/src/select/columnar/executor.rs
+++ b/crates/vibesql-executor/src/select/columnar/executor.rs
@@ -174,6 +174,7 @@ fn compute_i64_aggregate(
     nulls: Option<&Vec<bool>>,
     op: AggregateOp,
 ) -> Result<SqlValue, ExecutorError> {
+    log::debug!("[SIMD] compute_i64_aggregate: {} values, op={:?}", values.len(), op);
     if values.is_empty() {
         return Ok(match op {
             AggregateOp::Count => SqlValue::Integer(0),
@@ -201,6 +202,7 @@ fn compute_i64_aggregate(
 
     #[cfg(feature = "simd")]
     {
+        log::debug!("[SIMD] Using SIMD path for i64 aggregate with {} valid values", valid_values.len());
         use crate::simd::aggregation::{simd_sum_i64, simd_min_i64, simd_max_i64};
 
         match op {
@@ -252,6 +254,7 @@ fn compute_f64_aggregate(
     nulls: Option<&Vec<bool>>,
     op: AggregateOp,
 ) -> Result<SqlValue, ExecutorError> {
+    log::debug!("[SIMD] compute_f64_aggregate: {} values, op={:?}", values.len(), op);
     if values.is_empty() {
         return Ok(match op {
             AggregateOp::Count => SqlValue::Integer(0),
@@ -279,6 +282,7 @@ fn compute_f64_aggregate(
 
     #[cfg(feature = "simd")]
     {
+        log::debug!("[SIMD] Using SIMD path for f64 aggregate with {} valid values", valid_values.len());
         use crate::simd::aggregation::{simd_sum_f64, simd_min_f64, simd_max_f64};
 
         match op {

--- a/crates/vibesql-executor/src/simd/aggregation.rs
+++ b/crates/vibesql-executor/src/simd/aggregation.rs
@@ -10,6 +10,7 @@ use wide::*;
 /// SIMD sum for f64 columns
 #[cfg(feature = "simd")]
 pub fn simd_sum_f64(column: &[f64]) -> f64 {
+    log::debug!("[SIMD] simd_sum_f64 called with {} elements", column.len());
     let mut sum = 0.0;
 
     // Process chunks of 4 elements with SIMD
@@ -127,6 +128,7 @@ pub fn simd_count(len: usize) -> usize {
 /// SIMD sum for i64 columns
 #[cfg(feature = "simd")]
 pub fn simd_sum_i64(column: &[i64]) -> i64 {
+    log::debug!("[SIMD] simd_sum_i64 called with {} elements", column.len());
     let mut sum = 0i64;
 
     // Process chunks of 4 elements with SIMD


### PR DESCRIPTION
## Summary

- Add debug logging throughout SIMD aggregation code paths to verify SIMD acceleration is being used
- Document the three SIMD paths available in the codebase (batch-native, Arrow, wide crate)
- All TPC-H columnar tests pass with no regression

## SIMD Architecture Findings

Investigation revealed the codebase has three SIMD execution paths:

1. **Batch-native path** (`batch.rs`): Used for expression aggregates like `SUM(a*b)` when columnar execution is selected. Uses auto-vectorized Rust iterators on ColumnArray types.

2. **Arrow SIMD path** (`simd.rs`): Uses Apache Arrow compute kernels for SIMD. Activated for datasets >= 100 rows on the row-based path.

3. **Wide crate SIMD path** (`aggregation.rs`): Uses the `wide` crate for explicit SIMD on simple column aggregates via f64x4/i64x4 vectors.

## Verification

Running with `RUST_LOG=vibesql_executor=debug` shows the execution path:

```
[BatchExpr] compute_batch_expression_aggregate: 3 rows, op=Sum
[BatchExpr] Evaluating expression on batch columns (SIMD-enabled)
[BatchExpr] Aggregating result array with SIMD
```

## Test plan

- [x] All TPC-H Q6 columnar tests pass (6 tests)
- [x] All TPC-H Q1 columnar tests pass (2 tests)
- [x] Debug logging verified with `RUST_LOG=vibesql_executor=debug`

Closes #2843

🤖 Generated with [Claude Code](https://claude.com/claude-code)