### PR TITLE
refactor(evaluator): Remove deprecated _column_count parameter

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/scalar.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/scalar.rs
@@ -97,13 +97,13 @@ impl CombinedExpressionEvaluator<'_> {
                     )
                 };
                 let rows = select_executor.execute(subquery)?;
-                return crate::evaluator::subqueries_shared::eval_scalar_subquery_core(&rows, subquery.select_list.len());
+                return crate::evaluator::subqueries_shared::eval_scalar_subquery_core(&rows);
             }
         } else {
             // Correlated but no outer schema - skip caching
             let select_executor = crate::select::SelectExecutor::new(database);
             let rows = select_executor.execute(subquery)?;
-            return crate::evaluator::subqueries_shared::eval_scalar_subquery_core(&rows, subquery.select_list.len());
+            return crate::evaluator::subqueries_shared::eval_scalar_subquery_core(&rows);
         };
 
         // Try cache lookup
@@ -169,6 +169,6 @@ impl CombinedExpressionEvaluator<'_> {
         };
 
         // Delegate to shared logic
-        crate::evaluator::subqueries_shared::eval_scalar_subquery_core(&rows, subquery.select_list.len())
+        crate::evaluator::subqueries_shared::eval_scalar_subquery_core(&rows)
     }
 }

--- a/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
@@ -196,7 +196,7 @@ impl ExpressionEvaluator<'_> {
         };
 
         // Delegate to shared logic
-        super::super::subqueries_shared::eval_scalar_subquery_core(&rows, subquery.select_list.len())
+        super::super::subqueries_shared::eval_scalar_subquery_core(&rows)
     }
 
     /// Evaluate EXISTS predicate

--- a/crates/vibesql-executor/src/evaluator/subqueries_shared.rs
+++ b/crates/vibesql-executor/src/evaluator/subqueries_shared.rs
@@ -30,7 +30,6 @@ use vibesql_types::SqlValue;
 ///
 /// ## Parameters
 /// - `rows`: The result set from executing the subquery
-/// - `_column_count`: Deprecated parameter, kept for API compatibility. Use actual column count from rows instead.
 ///
 /// ## Returns
 /// - `Ok(SqlValue::Null)` if no rows returned
@@ -40,7 +39,6 @@ use vibesql_types::SqlValue;
 /// - `Err(ColumnIndexOutOfBounds)` if row doesn't have a value at index 0
 pub fn eval_scalar_subquery_core(
     rows: &[Row],
-    _column_count: usize,
 ) -> Result<SqlValue, ExecutorError> {
     // SQL:1999 Section 7.9: Scalar subquery must return exactly 1 row
     if rows.len() > 1 {


### PR DESCRIPTION
## Summary
- Remove unused `_column_count` parameter from `eval_scalar_subquery_core` function
- Update all 4 call sites to remove the redundant argument
- Clean up doc comment that described the deprecated parameter

## Why
The parameter was explicitly documented as deprecated and never used - the function already gets the actual column count from `rows[0].values.len()`.

## Impact
- **Files changed**: 3
- **Lines removed**: ~6 (including doc comment)
- **Risk**: Low - internal API only, no behavioral changes

Closes #2893

🤖 Generated with [Claude Code](https://claude.com/claude-code)