### PR TITLE
refactor(executor): Replace ExecutorError::Other with structured variants in columnar module

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -165,6 +165,38 @@ pub enum ExecutorError {
         field: String,
         value_type: String,
     },
+    /// Arrow array downcast failed (columnar execution)
+    ArrowDowncastError {
+        expected_type: String,
+        context: String,
+    },
+    /// Type mismatch in columnar operations
+    ColumnarTypeMismatch {
+        operation: String,
+        left_type: String,
+        right_type: Option<String>,
+    },
+    /// SIMD operation failed (returned None or error)
+    SimdOperationFailed {
+        operation: String,
+        reason: String,
+    },
+    /// Column not found in batch by index
+    ColumnarColumnNotFound {
+        column_index: usize,
+        batch_columns: usize,
+    },
+    /// Column length mismatch in batch operations
+    ColumnarLengthMismatch {
+        context: String,
+        expected: usize,
+        actual: usize,
+    },
+    /// Unsupported array type for columnar operation
+    UnsupportedArrayType {
+        operation: String,
+        array_type: String,
+    },
     Other(String),
 }
 
@@ -515,6 +547,52 @@ impl std::fmt::Display for ExecutorError {
                     f,
                     "Cannot extract {} from {} value",
                     field, value_type
+                )
+            }
+            ExecutorError::ArrowDowncastError { expected_type, context } => {
+                write!(
+                    f,
+                    "Failed to downcast Arrow array to {} ({})",
+                    expected_type, context
+                )
+            }
+            ExecutorError::ColumnarTypeMismatch { operation, left_type, right_type } => {
+                if let Some(right) = right_type {
+                    write!(
+                        f,
+                        "Incompatible types for {}: {} vs {}",
+                        operation, left_type, right
+                    )
+                } else {
+                    write!(
+                        f,
+                        "Incompatible type for {}: {}",
+                        operation, left_type
+                    )
+                }
+            }
+            ExecutorError::SimdOperationFailed { operation, reason } => {
+                write!(f, "SIMD {} failed: {}", operation, reason)
+            }
+            ExecutorError::ColumnarColumnNotFound { column_index, batch_columns } => {
+                write!(
+                    f,
+                    "Column index {} out of bounds (batch has {} columns)",
+                    column_index, batch_columns
+                )
+            }
+            ExecutorError::ColumnarLengthMismatch { context, expected, actual } => {
+                write!(
+                    f,
+                    "Column length mismatch in {}: expected {}, got {}",
+                    context, expected, actual
+                )
+            }
+            ExecutorError::UnsupportedArrayType { operation, array_type } => {
+                write!(
+                    f,
+                    "Unsupported array type for {}: {}",
+                    operation, array_type
                 )
             }
             ExecutorError::Other(msg) => write!(f, "{}", msg),

--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/batch.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/batch.rs
@@ -78,9 +78,10 @@ fn evaluate_batch_expression(
 
             batch.column(col_idx)
                 .cloned()
-                .ok_or_else(|| ExecutorError::Other(format!(
-                    "Column index {} out of bounds in batch", col_idx
-                )))
+                .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+                    column_index: col_idx,
+                    batch_columns: batch.column_count(),
+                })
         }
         Expression::Literal(val) => {
             // Create an array filled with the literal value
@@ -227,9 +228,11 @@ fn apply_float64_binary_op(
     use vibesql_ast::BinaryOperator::*;
 
     if left.len() != right.len() {
-        return Err(ExecutorError::Other(format!(
-            "Array length mismatch: {} vs {}", left.len(), right.len()
-        )));
+        return Err(ExecutorError::ColumnarLengthMismatch {
+            context: "binary_op".to_string(),
+            expected: left.len(),
+            actual: right.len(),
+        });
     }
 
     // SIMD-friendly iteration (compiler will auto-vectorize)
@@ -255,9 +258,11 @@ fn apply_int64_binary_op(
     use vibesql_ast::BinaryOperator::*;
 
     if left.len() != right.len() {
-        return Err(ExecutorError::Other(format!(
-            "Array length mismatch: {} vs {}", left.len(), right.len()
-        )));
+        return Err(ExecutorError::ColumnarLengthMismatch {
+            context: "binary_op".to_string(),
+            expected: left.len(),
+            actual: right.len(),
+        });
     }
 
     // SIMD-friendly iteration (compiler will auto-vectorize)

--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/simd.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/simd.rs
@@ -41,7 +41,10 @@ pub fn try_simd_aggregate(
 
     // Convert rows to RecordBatch
     let batch = rows_to_record_batch(rows, &column_names)
-        .map_err(|_| ExecutorError::Other("Failed to convert to RecordBatch".to_string()))?;
+        .map_err(|e| ExecutorError::ArrowDowncastError {
+            expected_type: "RecordBatch".to_string(),
+            context: format!("rows_to_record_batch: {:?}", e),
+        })?;
 
     // Evaluate expression using SIMD
     let result_array = evaluate_arithmetic_simd(&batch, expr)?;
@@ -67,10 +70,16 @@ fn aggregate_sum(result_array: &arrow::array::ArrayRef) -> Result<SqlValue, Exec
                 .as_any()
                 .downcast_ref::<Int64Array>()
                 .ok_or_else(|| {
-                    ExecutorError::Other("Failed to downcast Int64Array".to_string())
+                    ExecutorError::ArrowDowncastError {
+                    expected_type: "Int64Array".to_string(),
+                    context: "SIMD aggregate".to_string(),
+                }
                 })?;
             let sum_val = sum(arr).ok_or_else(|| {
-                ExecutorError::Other("SIMD sum returned None".to_string())
+                ExecutorError::SimdOperationFailed {
+                operation: "SUM".to_string(),
+                reason: "returned None".to_string(),
+            }
             })?;
             Ok(SqlValue::Integer(sum_val))
         }
@@ -79,14 +88,23 @@ fn aggregate_sum(result_array: &arrow::array::ArrayRef) -> Result<SqlValue, Exec
                 .as_any()
                 .downcast_ref::<Float64Array>()
                 .ok_or_else(|| {
-                    ExecutorError::Other("Failed to downcast Float64Array".to_string())
+                    ExecutorError::ArrowDowncastError {
+                    expected_type: "Float64Array".to_string(),
+                    context: "SIMD aggregate".to_string(),
+                }
                 })?;
             let sum_val = sum(arr).ok_or_else(|| {
-                ExecutorError::Other("SIMD sum returned None".to_string())
+                ExecutorError::SimdOperationFailed {
+                operation: "SUM".to_string(),
+                reason: "returned None".to_string(),
+            }
             })?;
             Ok(SqlValue::Double(sum_val))
         }
-        _ => Err(ExecutorError::Other("Unsupported array type for SUM".to_string())),
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: "SUM".to_string(),
+            array_type: format!("{:?}", result_array.data_type()),
+        }),
     }
 }
 
@@ -127,10 +145,16 @@ fn aggregate_min(result_array: &arrow::array::ArrayRef) -> Result<SqlValue, Exec
                 .as_any()
                 .downcast_ref::<Int64Array>()
                 .ok_or_else(|| {
-                    ExecutorError::Other("Failed to downcast Int64Array".to_string())
+                    ExecutorError::ArrowDowncastError {
+                    expected_type: "Int64Array".to_string(),
+                    context: "SIMD aggregate".to_string(),
+                }
                 })?;
             let min_val = min(arr).ok_or_else(|| {
-                ExecutorError::Other("SIMD min returned None".to_string())
+                ExecutorError::SimdOperationFailed {
+                operation: "MIN".to_string(),
+                reason: "returned None".to_string(),
+            }
             })?;
             Ok(SqlValue::Integer(min_val))
         }
@@ -139,14 +163,23 @@ fn aggregate_min(result_array: &arrow::array::ArrayRef) -> Result<SqlValue, Exec
                 .as_any()
                 .downcast_ref::<Float64Array>()
                 .ok_or_else(|| {
-                    ExecutorError::Other("Failed to downcast Float64Array".to_string())
+                    ExecutorError::ArrowDowncastError {
+                    expected_type: "Float64Array".to_string(),
+                    context: "SIMD aggregate".to_string(),
+                }
                 })?;
             let min_val = min(arr).ok_or_else(|| {
-                ExecutorError::Other("SIMD min returned None".to_string())
+                ExecutorError::SimdOperationFailed {
+                operation: "MIN".to_string(),
+                reason: "returned None".to_string(),
+            }
             })?;
             Ok(SqlValue::Double(min_val))
         }
-        _ => Err(ExecutorError::Other("Unsupported array type for MIN".to_string())),
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: "MIN".to_string(),
+            array_type: format!("{:?}", result_array.data_type()),
+        }),
     }
 }
 
@@ -161,10 +194,16 @@ fn aggregate_max(result_array: &arrow::array::ArrayRef) -> Result<SqlValue, Exec
                 .as_any()
                 .downcast_ref::<Int64Array>()
                 .ok_or_else(|| {
-                    ExecutorError::Other("Failed to downcast Int64Array".to_string())
+                    ExecutorError::ArrowDowncastError {
+                    expected_type: "Int64Array".to_string(),
+                    context: "SIMD aggregate".to_string(),
+                }
                 })?;
             let max_val = max(arr).ok_or_else(|| {
-                ExecutorError::Other("SIMD max returned None".to_string())
+                ExecutorError::SimdOperationFailed {
+                operation: "MAX".to_string(),
+                reason: "returned None".to_string(),
+            }
             })?;
             Ok(SqlValue::Integer(max_val))
         }
@@ -173,13 +212,22 @@ fn aggregate_max(result_array: &arrow::array::ArrayRef) -> Result<SqlValue, Exec
                 .as_any()
                 .downcast_ref::<Float64Array>()
                 .ok_or_else(|| {
-                    ExecutorError::Other("Failed to downcast Float64Array".to_string())
+                    ExecutorError::ArrowDowncastError {
+                    expected_type: "Float64Array".to_string(),
+                    context: "SIMD aggregate".to_string(),
+                }
                 })?;
             let max_val = max(arr).ok_or_else(|| {
-                ExecutorError::Other("SIMD max returned None".to_string())
+                ExecutorError::SimdOperationFailed {
+                operation: "MAX".to_string(),
+                reason: "returned None".to_string(),
+            }
             })?;
             Ok(SqlValue::Double(max_val))
         }
-        _ => Err(ExecutorError::Other("Unsupported array type for MAX".to_string())),
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: "MAX".to_string(),
+            array_type: format!("{:?}", result_array.data_type()),
+        }),
     }
 }

--- a/crates/vibesql-executor/src/select/columnar/aggregate/functions.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/functions.rs
@@ -263,7 +263,10 @@ pub(super) fn compute_batch_sum(
     column_idx: usize,
 ) -> Result<SqlValue, ExecutorError> {
     let column = batch.column(column_idx)
-        .ok_or_else(|| ExecutorError::Other(format!("Column {} not found", column_idx)))?;
+        .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: column_idx,
+            batch_columns: batch.column_count(),
+        })?;
 
     match column {
         ColumnArray::Int64(values, nulls) => {
@@ -330,7 +333,10 @@ pub(super) fn compute_batch_avg(
     column_idx: usize,
 ) -> Result<SqlValue, ExecutorError> {
     let column = batch.column(column_idx)
-        .ok_or_else(|| ExecutorError::Other(format!("Column {} not found", column_idx)))?;
+        .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: column_idx,
+            batch_columns: batch.column_count(),
+        })?;
 
     match column {
         ColumnArray::Int64(values, nulls) => {
@@ -391,7 +397,10 @@ pub(super) fn compute_batch_min(
     column_idx: usize,
 ) -> Result<SqlValue, ExecutorError> {
     let column = batch.column(column_idx)
-        .ok_or_else(|| ExecutorError::Other(format!("Column {} not found", column_idx)))?;
+        .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: column_idx,
+            batch_columns: batch.column_count(),
+        })?;
 
     match column {
         ColumnArray::Int64(values, nulls) => {
@@ -444,7 +453,10 @@ pub(super) fn compute_batch_max(
     column_idx: usize,
 ) -> Result<SqlValue, ExecutorError> {
     let column = batch.column(column_idx)
-        .ok_or_else(|| ExecutorError::Other(format!("Column {} not found", column_idx)))?;
+        .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: column_idx,
+            batch_columns: batch.column_count(),
+        })?;
 
     match column {
         ColumnArray::Int64(values, nulls) => {

--- a/crates/vibesql-executor/src/select/columnar/batch.rs
+++ b/crates/vibesql-executor/src/select/columnar/batch.rs
@@ -128,10 +128,11 @@ impl ColumnarBatch {
         // Verify column has correct length
         let col_len = column.len();
         if self.row_count > 0 && col_len != self.row_count {
-            return Err(ExecutorError::Other(format!(
-                "Column length mismatch: expected {}, got {}",
-                self.row_count, col_len
-            )));
+            return Err(ExecutorError::ColumnarLengthMismatch {
+                context: "add_column".to_string(),
+                expected: self.row_count,
+                actual: col_len,
+            });
         }
 
         if self.row_count == 0 {
@@ -245,7 +246,10 @@ impl ColumnarBatch {
                 let arr = array
                     .as_any()
                     .downcast_ref::<Int64Array>()
-                    .ok_or_else(|| ExecutorError::Other("Failed to downcast Int64Array".to_string()))?;
+                    .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                        expected_type: "Int64Array".to_string(),
+                        context: "Arrow batch conversion".to_string(),
+                    })?;
 
                 let values: Vec<i64> = (0..arr.len()).map(|i| arr.value(i)).collect();
                 let nulls = if arr.null_count() > 0 {
@@ -261,7 +265,10 @@ impl ColumnarBatch {
                 let arr = array
                     .as_any()
                     .downcast_ref::<Int32Array>()
-                    .ok_or_else(|| ExecutorError::Other("Failed to downcast Int32Array".to_string()))?;
+                    .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                        expected_type: "Int32Array".to_string(),
+                        context: "Arrow batch conversion".to_string(),
+                    })?;
 
                 let values: Vec<i32> = (0..arr.len()).map(|i| arr.value(i)).collect();
                 let nulls = if arr.null_count() > 0 {
@@ -277,7 +284,10 @@ impl ColumnarBatch {
                 let arr = array
                     .as_any()
                     .downcast_ref::<Float64Array>()
-                    .ok_or_else(|| ExecutorError::Other("Failed to downcast Float64Array".to_string()))?;
+                    .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                        expected_type: "Float64Array".to_string(),
+                        context: "Arrow batch conversion".to_string(),
+                    })?;
 
                 let values: Vec<f64> = (0..arr.len()).map(|i| arr.value(i)).collect();
                 let nulls = if arr.null_count() > 0 {
@@ -293,7 +303,10 @@ impl ColumnarBatch {
                 let arr = array
                     .as_any()
                     .downcast_ref::<Float32Array>()
-                    .ok_or_else(|| ExecutorError::Other("Failed to downcast Float32Array".to_string()))?;
+                    .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                        expected_type: "Float32Array".to_string(),
+                        context: "Arrow batch conversion".to_string(),
+                    })?;
 
                 let values: Vec<f32> = (0..arr.len()).map(|i| arr.value(i)).collect();
                 let nulls = if arr.null_count() > 0 {
@@ -309,7 +322,10 @@ impl ColumnarBatch {
                 let arr = array
                     .as_any()
                     .downcast_ref::<StringArray>()
-                    .ok_or_else(|| ExecutorError::Other("Failed to downcast StringArray".to_string()))?;
+                    .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                        expected_type: "StringArray".to_string(),
+                        context: "Arrow batch conversion".to_string(),
+                    })?;
 
                 let values: Vec<String> = (0..arr.len()).map(|i| arr.value(i).to_string()).collect();
                 let nulls = if arr.null_count() > 0 {
@@ -325,7 +341,10 @@ impl ColumnarBatch {
                 let arr = array
                     .as_any()
                     .downcast_ref::<BooleanArray>()
-                    .ok_or_else(|| ExecutorError::Other("Failed to downcast BooleanArray".to_string()))?;
+                    .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                        expected_type: "BooleanArray".to_string(),
+                        context: "Arrow batch conversion".to_string(),
+                    })?;
 
                 let values: Vec<u8> = (0..arr.len())
                     .map(|i| if arr.value(i) { 1 } else { 0 })
@@ -343,7 +362,10 @@ impl ColumnarBatch {
                 let arr = array
                     .as_any()
                     .downcast_ref::<Date32Array>()
-                    .ok_or_else(|| ExecutorError::Other("Failed to downcast Date32Array".to_string()))?;
+                    .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                        expected_type: "Date32Array".to_string(),
+                        context: "Arrow batch conversion".to_string(),
+                    })?;
 
                 let values: Vec<i32> = (0..arr.len()).map(|i| arr.value(i)).collect();
                 let nulls = if arr.null_count() > 0 {
@@ -359,8 +381,9 @@ impl ColumnarBatch {
                 let arr = array
                     .as_any()
                     .downcast_ref::<TimestampMicrosecondArray>()
-                    .ok_or_else(|| {
-                        ExecutorError::Other("Failed to downcast TimestampMicrosecondArray".to_string())
+                    .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                        expected_type: "TimestampMicrosecondArray".to_string(),
+                        context: "Arrow batch conversion".to_string(),
                     })?;
 
                 let values: Vec<i64> = (0..arr.len()).map(|i| arr.value(i)).collect();
@@ -373,10 +396,10 @@ impl ColumnarBatch {
                 Ok(ColumnArray::Timestamp(values, nulls))
             }
 
-            _ => Err(ExecutorError::Other(format!(
-                "Unsupported Arrow data type for columnar conversion: {:?}",
-                data_type
-            ))),
+            _ => Err(ExecutorError::UnsupportedArrayType {
+                operation: "Arrow batch conversion".to_string(),
+                array_type: format!("{:?}", data_type),
+            }),
         }
     }
 
@@ -409,9 +432,12 @@ impl ColumnarBatch {
         let row_count = storage_columnar.row_count();
         let mut columns = Vec::with_capacity(column_names.len());
 
-        for col_name in &column_names {
+        for (col_idx, col_name) in column_names.iter().enumerate() {
             let storage_col = storage_columnar.get_column(col_name).ok_or_else(|| {
-                ExecutorError::Other(format!("Column '{}' not found in storage", col_name))
+                ExecutorError::ColumnarColumnNotFound {
+                    column_index: col_idx,
+                    batch_columns: column_names.len(),
+                }
             })?;
 
             let column_array = match storage_col {
@@ -541,7 +567,10 @@ impl ColumnarBatch {
     /// Get a value at a specific (row, column) position
     pub fn get_value(&self, row_idx: usize, col_idx: usize) -> Result<SqlValue, ExecutorError> {
         let column = self.column(col_idx)
-            .ok_or_else(|| ExecutorError::Other(format!("Column index {} out of bounds", col_idx).to_string()))?;
+            .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+                column_index: col_idx,
+                batch_columns: self.columns.len(),
+            })?;
         column.get_value(row_idx)
     }
 
@@ -571,12 +600,11 @@ impl ColumnarBatch {
         let row_count = columns[0].len();
         for (idx, column) in columns.iter().enumerate() {
             if column.len() != row_count {
-                return Err(ExecutorError::Other(format!(
-                    "Column {} length mismatch: expected {}, got {}",
-                    idx,
-                    row_count,
-                    column.len()
-                )));
+                return Err(ExecutorError::ColumnarLengthMismatch {
+                    context: format!("from_columns (column {})", idx),
+                    expected: row_count,
+                    actual: column.len(),
+                });
             }
         }
 
@@ -611,10 +639,11 @@ impl ColumnarBatch {
                             has_nulls = true;
                         }
                         Some(other) => {
-                            return Err(ExecutorError::Other(format!(
-                                "Type mismatch: expected Integer, got {:?}",
-                                other
-                            )));
+                            return Err(ExecutorError::ColumnarTypeMismatch {
+                                operation: "extract_column".to_string(),
+                                left_type: "Integer".to_string(),
+                                right_type: Some(format!("{:?}", other)),
+                            });
                         }
                         None => {
                             values.push(0);
@@ -644,10 +673,11 @@ impl ColumnarBatch {
                             has_nulls = true;
                         }
                         Some(other) => {
-                            return Err(ExecutorError::Other(format!(
-                                "Type mismatch: expected Double, got {:?}",
-                                other
-                            )));
+                            return Err(ExecutorError::ColumnarTypeMismatch {
+                                operation: "extract_column".to_string(),
+                                left_type: "Double".to_string(),
+                                right_type: Some(format!("{:?}", other)),
+                            });
                         }
                         None => {
                             values.push(0.0);
@@ -677,10 +707,11 @@ impl ColumnarBatch {
                             has_nulls = true;
                         }
                         Some(other) => {
-                            return Err(ExecutorError::Other(format!(
-                                "Type mismatch: expected Varchar, got {:?}",
-                                other
-                            )));
+                            return Err(ExecutorError::ColumnarTypeMismatch {
+                                operation: "extract_column".to_string(),
+                                left_type: "Varchar".to_string(),
+                                right_type: Some(format!("{:?}", other)),
+                            });
                         }
                         None => {
                             values.push(String::new());
@@ -722,10 +753,11 @@ impl ColumnarBatch {
                             has_nulls = true;
                         }
                         Some(other) => {
-                            return Err(ExecutorError::Other(format!(
-                                "Type mismatch: expected Boolean, got {:?}",
-                                other
-                            )));
+                            return Err(ExecutorError::ColumnarTypeMismatch {
+                                operation: "extract_column".to_string(),
+                                left_type: "Boolean".to_string(),
+                                right_type: Some(format!("{:?}", other)),
+                            });
                         }
                         None => {
                             values.push(0);
@@ -804,7 +836,7 @@ impl ColumnArray {
                 }
                 values.get(index)
                     .map(|v| SqlValue::Integer(*v))
-                    .ok_or_else(|| ExecutorError::Other("Index out of bounds".to_string()))
+                    .ok_or_else(|| ExecutorError::ColumnIndexOutOfBounds { index })
             }
 
             Self::Float64(values, nulls) => {
@@ -815,7 +847,7 @@ impl ColumnArray {
                 }
                 values.get(index)
                     .map(|v| SqlValue::Double(*v))
-                    .ok_or_else(|| ExecutorError::Other("Index out of bounds".to_string()))
+                    .ok_or_else(|| ExecutorError::ColumnIndexOutOfBounds { index })
             }
 
             Self::String(values, nulls) => {
@@ -826,7 +858,7 @@ impl ColumnArray {
                 }
                 values.get(index)
                     .map(|v| SqlValue::Varchar(v.clone()))
-                    .ok_or_else(|| ExecutorError::Other("Index out of bounds".to_string()))
+                    .ok_or_else(|| ExecutorError::ColumnIndexOutOfBounds { index })
             }
 
             Self::Boolean(values, nulls) => {
@@ -837,16 +869,19 @@ impl ColumnArray {
                 }
                 values.get(index)
                     .map(|v| SqlValue::Boolean(*v != 0))
-                    .ok_or_else(|| ExecutorError::Other("Index out of bounds".to_string()))
+                    .ok_or_else(|| ExecutorError::ColumnIndexOutOfBounds { index })
             }
 
             Self::Mixed(values) => {
                 values.get(index)
                     .cloned()
-                    .ok_or_else(|| ExecutorError::Other("Index out of bounds".to_string()))
+                    .ok_or_else(|| ExecutorError::ColumnIndexOutOfBounds { index })
             }
 
-            _ => Err(ExecutorError::Other("Unsupported column type".to_string())),
+            _ => Err(ExecutorError::UnsupportedArrayType {
+                operation: "get_value".to_string(),
+                array_type: format!("{:?}", std::mem::discriminant(self)),
+            }),
         }
     }
 

--- a/crates/vibesql-executor/src/select/columnar/executor.rs
+++ b/crates/vibesql-executor/src/select/columnar/executor.rs
@@ -151,7 +151,10 @@ fn compute_column_aggregate(
     op: AggregateOp,
 ) -> Result<SqlValue, ExecutorError> {
     let column = batch.column(col_idx).ok_or_else(|| {
-        ExecutorError::Other(format!("Column index {} out of bounds", col_idx))
+        ExecutorError::ColumnarColumnNotFound {
+            column_index: col_idx,
+            batch_columns: batch.column_count(),
+        }
     })?;
 
     match column {
@@ -213,12 +216,18 @@ fn compute_i64_aggregate(
             AggregateOp::Min => {
                 simd_min_i64(&valid_values)
                     .map(SqlValue::Integer)
-                    .ok_or_else(|| ExecutorError::Other("MIN on empty set".to_string()))
+                    .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                        operation: "MIN".to_string(),
+                        reason: "empty set".to_string(),
+                    })
             }
             AggregateOp::Max => {
                 simd_max_i64(&valid_values)
                     .map(SqlValue::Integer)
-                    .ok_or_else(|| ExecutorError::Other("MAX on empty set".to_string()))
+                    .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                        operation: "MAX".to_string(),
+                        reason: "empty set".to_string(),
+                    })
             }
         }
     }
@@ -235,12 +244,18 @@ fn compute_i64_aggregate(
             AggregateOp::Min => {
                 valid_values.iter().min().copied()
                     .map(SqlValue::Integer)
-                    .ok_or_else(|| ExecutorError::Other("MIN on empty set".to_string()))
+                    .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                        operation: "MIN".to_string(),
+                        reason: "empty set".to_string(),
+                    })
             }
             AggregateOp::Max => {
                 valid_values.iter().max().copied()
                     .map(SqlValue::Integer)
-                    .ok_or_else(|| ExecutorError::Other("MAX on empty set".to_string()))
+                    .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                        operation: "MAX".to_string(),
+                        reason: "empty set".to_string(),
+                    })
             }
         }
     }
@@ -291,12 +306,18 @@ fn compute_f64_aggregate(
             AggregateOp::Min => {
                 simd_min_f64(&valid_values)
                     .map(SqlValue::Double)
-                    .ok_or_else(|| ExecutorError::Other("MIN on empty set".to_string()))
+                    .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                        operation: "MIN".to_string(),
+                        reason: "empty set".to_string(),
+                    })
             }
             AggregateOp::Max => {
                 simd_max_f64(&valid_values)
                     .map(SqlValue::Double)
-                    .ok_or_else(|| ExecutorError::Other("MAX on empty set".to_string()))
+                    .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                        operation: "MAX".to_string(),
+                        reason: "empty set".to_string(),
+                    })
             }
         }
     }
@@ -314,13 +335,19 @@ fn compute_f64_aggregate(
                 valid_values.iter().cloned()
                     .min_by(|a, b| a.partial_cmp(b).unwrap())
                     .map(SqlValue::Double)
-                    .ok_or_else(|| ExecutorError::Other("MIN on empty set".to_string()))
+                    .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                        operation: "MIN".to_string(),
+                        reason: "empty set".to_string(),
+                    })
             }
             AggregateOp::Max => {
                 valid_values.iter().cloned()
                     .max_by(|a, b| a.partial_cmp(b).unwrap())
                     .map(SqlValue::Double)
-                    .ok_or_else(|| ExecutorError::Other("MAX on empty set".to_string()))
+                    .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                        operation: "MAX".to_string(),
+                        reason: "empty set".to_string(),
+                    })
             }
         }
     }
@@ -540,10 +567,16 @@ fn compute_multiply_aggregate(
     op: AggregateOp,
 ) -> Result<SqlValue, ExecutorError> {
     let left_col = batch.column(left_idx).ok_or_else(|| {
-        ExecutorError::Other(format!("Column {} not found", left_idx))
+        ExecutorError::ColumnarColumnNotFound {
+            column_index: left_idx,
+            batch_columns: batch.column_count(),
+        }
     })?;
     let right_col = batch.column(right_idx).ok_or_else(|| {
-        ExecutorError::Other(format!("Column {} not found", right_idx))
+        ExecutorError::ColumnarColumnNotFound {
+            column_index: right_idx,
+            batch_columns: batch.column_count(),
+        }
     })?;
 
     // Extract f64 arrays from both columns
@@ -551,7 +584,11 @@ fn compute_multiply_aggregate(
     let right_f64 = column_to_f64_vec(right_col)?;
 
     if left_f64.len() != right_f64.len() {
-        return Err(ExecutorError::Other("Column length mismatch".to_string()));
+        return Err(ExecutorError::ColumnarLengthMismatch {
+            context: "multiply_aggregate".to_string(),
+            expected: left_f64.len(),
+            actual: right_f64.len(),
+        });
     }
 
     // Vectorized multiply and aggregate
@@ -609,7 +646,10 @@ fn column_to_f64_vec(column: &ColumnArray) -> Result<Vec<Option<f64>>, ExecutorE
                 }
             }).collect())
         }
-        _ => Err(ExecutorError::Other("Cannot convert column to f64".to_string()))
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: "column_to_f64".to_string(),
+            array_type: format!("{:?}", std::mem::discriminant(column)),
+        })
     }
 }
 
@@ -637,10 +677,18 @@ fn eval_expr_on_batch(
                 (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
                 (l, r) => {
                     let l_f64 = sql_value_to_f64(&l).ok_or_else(|| {
-                        ExecutorError::Other("Cannot convert to f64".to_string())
+                        ExecutorError::ColumnarTypeMismatch {
+                            operation: "binary_op".to_string(),
+                            left_type: format!("{:?}", l),
+                            right_type: None,
+                        }
                     })?;
                     let r_f64 = sql_value_to_f64(&r).ok_or_else(|| {
-                        ExecutorError::Other("Cannot convert to f64".to_string())
+                        ExecutorError::ColumnarTypeMismatch {
+                            operation: "binary_op".to_string(),
+                            left_type: format!("{:?}", r),
+                            right_type: None,
+                        }
                     })?;
 
                     let result = match op {
@@ -648,7 +696,9 @@ fn eval_expr_on_batch(
                         BinaryOperator::Minus => l_f64 - r_f64,
                         BinaryOperator::Multiply => l_f64 * r_f64,
                         BinaryOperator::Divide => l_f64 / r_f64,
-                        _ => return Err(ExecutorError::Other("Unsupported operator".to_string()))
+                        _ => return Err(ExecutorError::UnsupportedExpression(
+                            format!("Unsupported binary operator: {:?}", op)
+                        ))
                     };
                     Ok(SqlValue::Double(result))
                 }

--- a/crates/vibesql-executor/src/select/columnar/simd_filter.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter.rs
@@ -107,7 +107,10 @@ fn evaluate_predicate_simd(
 
     let column = batch
         .column(column_idx)
-        .ok_or_else(|| ExecutorError::Other(format!("Column index {} out of bounds", column_idx).to_string()))?;
+        .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: column_idx,
+            batch_columns: batch.column_count(),
+        })?;
 
     match column {
         // SIMD path for i64 columns
@@ -152,7 +155,11 @@ fn evaluate_predicate_i64_simd(
             } else {
                 // Type mismatch: convert to f64 and use f64 SIMD
                 let threshold = value_to_f64(value)
-                    .ok_or_else(|| ExecutorError::Other("Incompatible types for comparison".to_string()))?;
+                    .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                        operation: "comparison".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: Some(format!("{:?}", value)),
+                    })?;
                 let f64_values: Vec<f64> = values.iter().map(|&v| v as f64).collect();
                 simd_lt_f64(&f64_values, threshold)
             }
@@ -165,7 +172,11 @@ fn evaluate_predicate_i64_simd(
                 simd_gt_i64(values, *threshold)
             } else {
                 let threshold = value_to_f64(value)
-                    .ok_or_else(|| ExecutorError::Other("Incompatible types for comparison".to_string()))?;
+                    .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                        operation: "comparison".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: Some(format!("{:?}", value)),
+                    })?;
                 let f64_values: Vec<f64> = values.iter().map(|&v| v as f64).collect();
                 simd_gt_f64(&f64_values, threshold)
             }
@@ -178,7 +189,11 @@ fn evaluate_predicate_i64_simd(
                 simd_eq_i64(values, *target)
             } else {
                 let target = value_to_f64(value)
-                    .ok_or_else(|| ExecutorError::Other("Incompatible types for comparison".to_string()))?;
+                    .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                        operation: "comparison".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: Some(format!("{:?}", value)),
+                    })?;
                 let f64_values: Vec<f64> = values.iter().map(|&v| v as f64).collect();
                 simd_eq_f64(&f64_values, target)
             }
@@ -191,18 +206,22 @@ fn evaluate_predicate_i64_simd(
                 SqlValue::Integer(v) => *v,
                 SqlValue::Bigint(v) => *v,
                 _ => {
-                    return Err(ExecutorError::Other(
-                        "Incompatible types for BETWEEN".to_string(),
-                    ))
+                    return Err(ExecutorError::ColumnarTypeMismatch {
+                        operation: "BETWEEN".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: None,
+                    })
                 }
             };
             let high_i64 = match high {
                 SqlValue::Integer(v) => *v,
                 SqlValue::Bigint(v) => *v,
                 _ => {
-                    return Err(ExecutorError::Other(
-                        "Incompatible types for BETWEEN".to_string(),
-                    ))
+                    return Err(ExecutorError::ColumnarTypeMismatch {
+                        operation: "BETWEEN".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: None,
+                    })
                 }
             };
 
@@ -225,7 +244,11 @@ fn evaluate_predicate_i64_simd(
                 simd_ge_i64(values, *threshold)
             } else {
                 let threshold = value_to_f64(value)
-                    .ok_or_else(|| ExecutorError::Other("Incompatible types for comparison".to_string()))?;
+                    .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                        operation: "comparison".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: Some(format!("{:?}", value)),
+                    })?;
                 let f64_values: Vec<f64> = values.iter().map(|&v| v as f64).collect();
                 simd_ge_f64(&f64_values, threshold)
             }
@@ -238,7 +261,11 @@ fn evaluate_predicate_i64_simd(
                 simd_le_i64(values, *threshold)
             } else {
                 let threshold = value_to_f64(value)
-                    .ok_or_else(|| ExecutorError::Other("Incompatible types for comparison".to_string()))?;
+                    .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                        operation: "comparison".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: Some(format!("{:?}", value)),
+                    })?;
                 let f64_values: Vec<f64> = values.iter().map(|&v| v as f64).collect();
                 simd_le_f64(&f64_values, threshold)
             }
@@ -266,39 +293,67 @@ fn evaluate_predicate_i32_simd(
     let mut result = match predicate {
         ColumnPredicate::LessThan { value, .. } => {
             let threshold = value_to_date_i32(value)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for date comparison".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "date comparison".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: None,
+                })?;
             simd_lt_i32(values, threshold)
         }
 
         ColumnPredicate::GreaterThan { value, .. } => {
             let threshold = value_to_date_i32(value)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for date comparison".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "date comparison".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: None,
+                })?;
             simd_gt_i32(values, threshold)
         }
 
         ColumnPredicate::GreaterThanOrEqual { value, .. } => {
             let threshold = value_to_date_i32(value)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for date comparison".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "date comparison".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: None,
+                })?;
             simd_ge_i32(values, threshold)
         }
 
         ColumnPredicate::LessThanOrEqual { value, .. } => {
             let threshold = value_to_date_i32(value)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for date comparison".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "date comparison".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: None,
+                })?;
             simd_le_i32(values, threshold)
         }
 
         ColumnPredicate::Equal { value, .. } => {
             let target = value_to_date_i32(value)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for date comparison".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "date comparison".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: None,
+                })?;
             simd_eq_i32(values, target)
         }
 
         ColumnPredicate::Between { low, high, ..} => {
             let low_i32 = value_to_date_i32(low)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for BETWEEN".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "BETWEEN".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: Some(format!("{:?}", low)),
+                })?;
             let high_i32 = value_to_date_i32(high)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for BETWEEN".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "BETWEEN".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: Some(format!("{:?}", high)),
+                })?;
 
             let ge_low = simd_ge_i32(values, low_i32);
             let le_high = simd_le_i32(values, high_i32);
@@ -333,39 +388,67 @@ fn evaluate_predicate_f64_simd(
     let mut result = match predicate {
         ColumnPredicate::LessThan { value, .. } => {
             let threshold = value_to_f64(value)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for comparison".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "comparison".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", value)),
+                })?;
             simd_lt_f64(values, threshold)
         }
 
         ColumnPredicate::GreaterThan { value, .. } => {
             let threshold = value_to_f64(value)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for comparison".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "comparison".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", value)),
+                })?;
             simd_gt_f64(values, threshold)
         }
 
         ColumnPredicate::GreaterThanOrEqual { value, .. } => {
             let threshold = value_to_f64(value)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for comparison".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "comparison".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", value)),
+                })?;
             simd_ge_f64(values, threshold)
         }
 
         ColumnPredicate::LessThanOrEqual { value, .. } => {
             let threshold = value_to_f64(value)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for comparison".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "comparison".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", value)),
+                })?;
             simd_le_f64(values, threshold)
         }
 
         ColumnPredicate::Equal { value, .. } => {
             let target = value_to_f64(value)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for comparison".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "comparison".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", value)),
+                })?;
             simd_eq_f64(values, target)
         }
 
         ColumnPredicate::Between { low, high, .. } => {
             let low_f64 = value_to_f64(low)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for BETWEEN".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "BETWEEN".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", low)),
+                })?;
             let high_f64 = value_to_f64(high)
-                .ok_or_else(|| ExecutorError::Other("Incompatible types for BETWEEN".to_string()))?;
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "BETWEEN".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", high)),
+                })?;
 
             let ge_low = simd_ge_f64(values, low_f64);
             let le_high = simd_le_f64(values, high_f64);
@@ -422,9 +505,11 @@ fn apply_filter_mask(
     mask: &[bool],
 ) -> Result<ColumnarBatch, ExecutorError> {
     if mask.len() != batch.row_count() {
-        return Err(ExecutorError::Other(
-            "Filter mask length does not match batch row count".to_string(),
-        ));
+        return Err(ExecutorError::ColumnarLengthMismatch {
+            context: "filter mask".to_string(),
+            expected: batch.row_count(),
+            actual: mask.len(),
+        });
     }
 
     // Count how many rows will pass
@@ -441,7 +526,10 @@ fn apply_filter_mask(
     for col_idx in 0..batch.column_count() {
         let column = batch
             .column(col_idx)
-            .ok_or_else(|| ExecutorError::Other(format!("Column {} not found", col_idx).to_string()))?;
+            .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+                column_index: col_idx,
+                batch_columns: batch.column_count(),
+            })?;
 
         let new_column = filter_column(column, mask)?;
         new_columns.push(new_column);

--- a/crates/vibesql-executor/src/select/columnar/simd_join.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_join.rs
@@ -54,7 +54,10 @@ impl HashTable {
     fn build(right: &ColumnarBatch, right_key_col: usize) -> Result<Self, ExecutorError> {
         let key_column = right
             .column(right_key_col)
-            .ok_or_else(|| ExecutorError::Other("Right key column not found".to_string()))?;
+            .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+                column_index: right_key_col,
+                batch_columns: right.column_count(),
+            })?;
 
         match key_column {
             ColumnArray::Int64(values, nulls) => {
@@ -95,10 +98,10 @@ impl HashTable {
 
                 Ok(HashTable::Float64(table))
             }
-            _ => Err(ExecutorError::Other(
-                "Unsupported key type for columnar join (only Int64 and Float64 supported)"
-                    .to_string(),
-            )),
+            _ => Err(ExecutorError::UnsupportedArrayType {
+                operation: "columnar hash join".to_string(),
+                array_type: format!("{:?}", std::mem::discriminant(key_column)),
+            }),
         }
     }
 
@@ -112,7 +115,10 @@ impl HashTable {
     ) -> Result<Vec<(usize, usize)>, ExecutorError> {
         let key_column = left
             .column(left_key_col)
-            .ok_or_else(|| ExecutorError::Other("Left key column not found".to_string()))?;
+            .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+                column_index: left_key_col,
+                batch_columns: left.column_count(),
+            })?;
 
         match (self, key_column) {
             (HashTable::Int64(table), ColumnArray::Int64(left_values, left_nulls)) => {
@@ -121,9 +127,11 @@ impl HashTable {
             (HashTable::Float64(table), ColumnArray::Float64(left_values, left_nulls)) => {
                 Self::probe_f64_simd(table, left_values, left_nulls)
             }
-            _ => Err(ExecutorError::Other(
-                "Type mismatch between left and right key columns".to_string(),
-            )),
+            _ => Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "hash join probe".to_string(),
+                left_type: format!("{:?}", std::mem::discriminant(key_column)),
+                right_type: None,
+            }),
         }
     }
 
@@ -226,7 +234,10 @@ fn materialize_join_results(
     // Process left columns
     for col_idx in 0..left.column_count() {
         let left_col = left.column(col_idx)
-            .ok_or_else(|| ExecutorError::Other("Left column missing".to_string()))?;
+            .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+                column_index: col_idx,
+                batch_columns: left.column_count(),
+            })?;
 
         let output_col = gather_column(left_col, &matches, |&(left_row, _)| left_row)?;
         output.add_column(output_col)?;
@@ -235,7 +246,10 @@ fn materialize_join_results(
     // Process right columns
     for col_idx in 0..right.column_count() {
         let right_col = right.column(col_idx)
-            .ok_or_else(|| ExecutorError::Other("Right column missing".to_string()))?;
+            .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+                column_index: col_idx,
+                batch_columns: right.column_count(),
+            })?;
 
         let output_col = gather_column(right_col, &matches, |&(_, right_row)| right_row)?;
         output.add_column(output_col)?;


### PR DESCRIPTION
## Summary

- Replace ~92 instances of generic `ExecutorError::Other(String)` with type-safe structured error variants in the columnar execution module
- Add 6 new error variants to `ExecutorError` for better error handling, pattern matching, and debugging:
  - `ArrowDowncastError`: Arrow array downcast failures
  - `ColumnarTypeMismatch`: Type mismatches in columnar operations  
  - `SimdOperationFailed`: SIMD operations that return None or fail
  - `ColumnarColumnNotFound`: Column index out of bounds errors
  - `ColumnarLengthMismatch`: Array/column length mismatches
  - `UnsupportedArrayType`: Unsupported Arrow data types

## Test plan

- [x] Build passes (`cargo build --release`)
- [x] SIMD tests pass (204 tests in `cargo test --release -p vibesql-executor simd`)
- [x] No remaining `ExecutorError::Other` in columnar module (verified via grep)

Closes #2899

🤖 Generated with [Claude Code](https://claude.com/claude-code)