### PR TITLE
refactor(executor): Replace ExecutorError::Other with semantic spatial error types

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -197,6 +197,22 @@ pub enum ExecutorError {
         operation: String,
         array_type: String,
     },
+    /// Invalid or incompatible geometry type in spatial function
+    SpatialGeometryError {
+        function_name: String,
+        message: String,
+    },
+    /// Spatial operation failed (distance, intersection, etc.)
+    SpatialOperationFailed {
+        function_name: String,
+        message: String,
+    },
+    /// Spatial function argument count or type mismatch
+    SpatialArgumentError {
+        function_name: String,
+        expected: String,
+        actual: String,
+    },
     Other(String),
 }
 
@@ -594,6 +610,15 @@ impl std::fmt::Display for ExecutorError {
                     "Unsupported array type for {}: {}",
                     operation, array_type
                 )
+            }
+            ExecutorError::SpatialGeometryError { function_name, message } => {
+                write!(f, "{}: {}", function_name, message)
+            }
+            ExecutorError::SpatialOperationFailed { function_name, message } => {
+                write!(f, "{}: {}", function_name, message)
+            }
+            ExecutorError::SpatialArgumentError { function_name, expected, actual } => {
+                write!(f, "{} expects {}, got {}", function_name, expected, actual)
             }
             ExecutorError::Other(msg) => write!(f, "{}", msg),
         }

--- a/crates/vibesql-executor/src/evaluator/functions/spatial/measurements.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/spatial/measurements.rs
@@ -36,7 +36,10 @@ fn to_geo_geometry(geom: &Geometry) -> Result<geo::Geometry<f64>, ExecutorError>
         }
         Geometry::Polygon { rings } => {
             if rings.is_empty() {
-                return Err(ExecutorError::Other("Empty polygon".to_string()));
+                return Err(ExecutorError::SpatialGeometryError {
+                    function_name: "to_geo_geometry".to_string(),
+                    message: "Empty polygon".to_string(),
+                });
             }
             
             let exterior: Vec<geo::Coord<f64>> = rings[0]
@@ -83,7 +86,10 @@ fn to_geo_geometry(geom: &Geometry) -> Result<geo::Geometry<f64>, ExecutorError>
                 .iter()
                 .map(|poly_rings| {
                     if poly_rings.is_empty() {
-                        Err(ExecutorError::Other("Empty polygon in multipolygon".to_string()))
+                        Err(ExecutorError::SpatialGeometryError {
+                            function_name: "to_geo_geometry".to_string(),
+                            message: "Empty polygon in multipolygon".to_string(),
+                        })
                     } else {
                         let exterior: Vec<geo::Coord<f64>> = poly_rings[0]
                             .iter()
@@ -182,9 +188,11 @@ fn from_geo_geometry(geom: &geo::Geometry<f64>) -> Result<Geometry, ExecutorErro
 /// ST_Distance(geom1, geom2) - Calculate Euclidean distance between geometries
 pub fn st_distance(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Distance expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Distance".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match (&args[0], &args[1]) {
@@ -222,9 +230,10 @@ pub fn st_distance(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                                 .fold(f64::INFINITY, f64::min)
                         }
                         _ => {
-                            return Err(ExecutorError::Other(
-                                "ST_Distance not fully supported between these geometry types".to_string()
-                            ));
+                            return Err(ExecutorError::SpatialOperationFailed {
+                                function_name: "ST_Distance".to_string(),
+                                message: "not fully supported between these geometry types".to_string(),
+                            });
                         }
                     }
                 }
@@ -232,18 +241,22 @@ pub fn st_distance(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
 
             Ok(SqlValue::Double(distance))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Distance requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Distance".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }
 
 /// ST_Length(geom) - Calculate length of LineString
 pub fn st_length(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
-        return Err(ExecutorError::Other(
-            "ST_Length expects exactly 1 argument".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Length".to_string(),
+            expected: "exactly 1 argument".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match &args[0] {
@@ -275,23 +288,28 @@ pub fn st_length(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                     }
                     Ok(SqlValue::Double(total_length))
                 }
-                _ => Err(ExecutorError::Other(
-                    "ST_Length only works on LineString and MultiLineString".to_string(),
-                )),
+                _ => Err(ExecutorError::SpatialGeometryError {
+                    function_name: "ST_Length".to_string(),
+                    message: "only works on LineString and MultiLineString".to_string(),
+                }),
             }
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Length requires a VARCHAR geometry argument".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Length".to_string(),
+            expected: "VARCHAR geometry argument".to_string(),
+            actual: format!("{:?}", args[0].type_name()),
+        }),
     }
 }
 
 /// ST_Perimeter(geom) - Calculate perimeter of Polygon
 pub fn st_perimeter(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
-        return Err(ExecutorError::Other(
-            "ST_Perimeter expects exactly 1 argument".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Perimeter".to_string(),
+            expected: "exactly 1 argument".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match &args[0] {
@@ -330,23 +348,28 @@ pub fn st_perimeter(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                     }
                     Ok(SqlValue::Double(total_perimeter))
                 }
-                _ => Err(ExecutorError::Other(
-                    "ST_Perimeter only works on Polygon and MultiPolygon".to_string(),
-                )),
+                _ => Err(ExecutorError::SpatialGeometryError {
+                    function_name: "ST_Perimeter".to_string(),
+                    message: "only works on Polygon and MultiPolygon".to_string(),
+                }),
             }
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Perimeter requires a VARCHAR geometry argument".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Perimeter".to_string(),
+            expected: "VARCHAR geometry argument".to_string(),
+            actual: format!("{:?}", args[0].type_name()),
+        }),
     }
 }
 
 /// ST_Area(geom) - Calculate area of Polygon
 pub fn st_area(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
-        return Err(ExecutorError::Other(
-            "ST_Area expects exactly 1 argument".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Area".to_string(),
+            expected: "exactly 1 argument".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match &args[0] {
@@ -363,23 +386,28 @@ pub fn st_area(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                     let area = mp.unsigned_area();
                     Ok(SqlValue::Double(area))
                 }
-                _ => Err(ExecutorError::Other(
-                    "ST_Area only works on Polygon and MultiPolygon".to_string(),
-                )),
+                _ => Err(ExecutorError::SpatialGeometryError {
+                    function_name: "ST_Area".to_string(),
+                    message: "only works on Polygon and MultiPolygon".to_string(),
+                }),
             }
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Area requires a VARCHAR geometry argument".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Area".to_string(),
+            expected: "VARCHAR geometry argument".to_string(),
+            actual: format!("{:?}", args[0].type_name()),
+        }),
     }
 }
 
 /// ST_Centroid(geom) - Find center point (geometric center of mass)
 pub fn st_centroid(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
-        return Err(ExecutorError::Other(
-            "ST_Centroid expects exactly 1 argument".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Centroid".to_string(),
+            expected: "exactly 1 argument".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match &args[0] {
@@ -389,7 +417,7 @@ pub fn st_centroid(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
 
             match geom.centroid() {
                 Some(centroid) => {
-                    let result_geom = Geometry::Point { 
+                    let result_geom = Geometry::Point {
                         x: centroid.x(),
                         y: centroid.y(),
                     };
@@ -402,18 +430,22 @@ pub fn st_centroid(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                 }
             }
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Centroid requires a VARCHAR geometry argument".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Centroid".to_string(),
+            expected: "VARCHAR geometry argument".to_string(),
+            actual: format!("{:?}", args[0].type_name()),
+        }),
     }
 }
 
 /// ST_Envelope(geom) - Get bounding box as a Polygon
 pub fn st_envelope(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
-        return Err(ExecutorError::Other(
-            "ST_Envelope expects exactly 1 argument".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Envelope".to_string(),
+            expected: "exactly 1 argument".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match &args[0] {
@@ -444,18 +476,22 @@ pub fn st_envelope(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                 None => Ok(SqlValue::Null),
             }
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Envelope requires a VARCHAR geometry argument".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Envelope".to_string(),
+            expected: "VARCHAR geometry argument".to_string(),
+            actual: format!("{:?}", args[0].type_name()),
+        }),
     }
 }
 
 /// ST_ConvexHull(geom) - Find smallest convex polygon containing geometry
 pub fn st_convex_hull(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
-        return Err(ExecutorError::Other(
-            "ST_ConvexHull expects exactly 1 argument".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_ConvexHull".to_string(),
+            expected: "exactly 1 argument".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match &args[0] {
@@ -486,22 +522,26 @@ pub fn st_convex_hull(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                 }
                 Geometry::Polygon { rings }
             };
-            
+
             let result_value = super::geometry_to_sql_value(result_geom, 0);
             Ok(result_value)
         }
-        _ => Err(ExecutorError::Other(
-            "ST_ConvexHull requires a VARCHAR geometry argument".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_ConvexHull".to_string(),
+            expected: "VARCHAR geometry argument".to_string(),
+            actual: format!("{:?}", args[0].type_name()),
+        }),
     }
 }
 
 /// ST_PointOnSurface(geom) - Get a point guaranteed to be on the geometry
 pub fn st_point_on_surface(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
-        return Err(ExecutorError::Other(
-            "ST_PointOnSurface expects exactly 1 argument".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_PointOnSurface".to_string(),
+            expected: "exactly 1 argument".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match &args[0] {
@@ -540,23 +580,28 @@ pub fn st_point_on_surface(args: &[SqlValue]) -> Result<SqlValue, ExecutorError>
                         None => Ok(SqlValue::Null),
                     }
                 }
-                _ => Err(ExecutorError::Other(
-                    "ST_PointOnSurface not fully supported for this geometry type".to_string(),
-                )),
+                _ => Err(ExecutorError::SpatialGeometryError {
+                    function_name: "ST_PointOnSurface".to_string(),
+                    message: "not fully supported for this geometry type".to_string(),
+                }),
             }
         }
-        _ => Err(ExecutorError::Other(
-            "ST_PointOnSurface requires a VARCHAR geometry argument".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_PointOnSurface".to_string(),
+            expected: "VARCHAR geometry argument".to_string(),
+            actual: format!("{:?}", args[0].type_name()),
+        }),
     }
 }
 
 /// ST_Boundary(geom) - Get boundary of geometry (exterior ring for polygons, endpoints for lines)
 pub fn st_boundary(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
-        return Err(ExecutorError::Other(
-            "ST_Boundary expects exactly 1 argument".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Boundary".to_string(),
+            expected: "exactly 1 argument".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match &args[0] {
@@ -614,18 +659,22 @@ pub fn st_boundary(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
 
             Ok(super::geometry_to_sql_value(boundary_geom, geom_with_srid.srid))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Boundary requires a VARCHAR geometry argument".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Boundary".to_string(),
+            expected: "VARCHAR geometry argument".to_string(),
+            actual: format!("{:?}", args[0].type_name()),
+        }),
     }
 }
 
 /// ST_HausdorffDistance(geom1, geom2) - Maximum distance between any point in geom1 to nearest point in geom2
 pub fn st_hausdorff_distance(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_HausdorffDistance expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_HausdorffDistance".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match (&args[0], &args[1]) {
@@ -642,9 +691,11 @@ pub fn st_hausdorff_distance(args: &[SqlValue]) -> Result<SqlValue, ExecutorErro
             let distance = calculate_hausdorff_distance(&geom1, &geom2)?;
             Ok(SqlValue::Double(distance))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_HausdorffDistance requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_HausdorffDistance".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }
 

--- a/crates/vibesql-executor/src/evaluator/functions/spatial/operations.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/spatial/operations.rs
@@ -35,7 +35,10 @@ fn to_geo_geometry(geom: &Geometry) -> Result<geo::Geometry<f64>, ExecutorError>
         }
         Geometry::Polygon { rings } => {
             if rings.is_empty() {
-                return Err(ExecutorError::Other("Empty polygon".to_string()));
+                return Err(ExecutorError::SpatialGeometryError {
+                    function_name: "to_geo_geometry".to_string(),
+                    message: "empty polygon has no rings".to_string(),
+                });
             }
             
             let exterior: Vec<geo::Coord<f64>> = rings[0]
@@ -82,7 +85,10 @@ fn to_geo_geometry(geom: &Geometry) -> Result<geo::Geometry<f64>, ExecutorError>
                 .iter()
                 .map(|poly_rings| {
                     if poly_rings.is_empty() {
-                        Err(ExecutorError::Other("Empty polygon in multipolygon".to_string()))
+                        Err(ExecutorError::SpatialGeometryError {
+                            function_name: "to_geo_geometry".to_string(),
+                            message: "empty polygon in multipolygon".to_string(),
+                        })
                     } else {
                         let exterior: Vec<geo::Coord<f64>> = poly_rings[0]
                             .iter()
@@ -181,9 +187,11 @@ fn from_geo_geometry(geom: &geo::Geometry<f64>) -> Result<Geometry, ExecutorErro
 /// ST_Simplify(geom, tolerance) - Simplify geometry using Douglas-Peucker algorithm
 pub fn st_simplify(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Simplify expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Simplify".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match (&args[0], &args[1]) {
@@ -192,15 +200,18 @@ pub fn st_simplify(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             let tolerance = match tol {
                 SqlValue::Double(d) => *d,
                 SqlValue::Integer(i) => *i as f64,
-                _ => return Err(ExecutorError::Other(
-                    "ST_Simplify requires DOUBLE tolerance".to_string(),
-                )),
+                _ => return Err(ExecutorError::SpatialArgumentError {
+                    function_name: "ST_Simplify".to_string(),
+                    expected: "DOUBLE tolerance".to_string(),
+                    actual: format!("{:?}", tol),
+                }),
             };
 
             if tolerance < 0.0 {
-                return Err(ExecutorError::Other(
-                    "Tolerance must be non-negative".to_string(),
-                ));
+                return Err(ExecutorError::SpatialGeometryError {
+                    function_name: "ST_Simplify".to_string(),
+                    message: "tolerance must be non-negative".to_string(),
+                });
             }
 
             let geom = wkt_to_geo(wkt)?;
@@ -236,18 +247,22 @@ pub fn st_simplify(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             let result_value = geometry_to_sql_value(result_geom, 0);
             Ok(result_value)
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Simplify requires VARCHAR geometry and DOUBLE tolerance arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Simplify".to_string(),
+            expected: "VARCHAR geometry and DOUBLE tolerance".to_string(),
+            actual: format!("{:?}, {:?}", args[0], args[1]),
+        }),
     }
 }
 
 /// ST_Union(geom1, geom2) - Combine two geometries
 pub fn st_union(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Union expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Union".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match (&args[0], &args[1]) {
@@ -274,18 +289,22 @@ pub fn st_union(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             let result_value = geometry_to_sql_value(result_geom, 0);
             Ok(result_value)
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Union requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Union".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0], args[1]),
+        }),
     }
 }
 
 /// ST_Intersection(geom1, geom2) - Find intersection of two geometries
 pub fn st_intersection(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Intersection expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Intersection".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match (&args[0], &args[1]) {
@@ -303,9 +322,10 @@ pub fn st_intersection(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                     int_result.into()
                 }
                 _ => {
-                    return Err(ExecutorError::Other(
-                        "ST_Intersection currently only supports polygon-polygon intersection".to_string(),
-                    ));
+                    return Err(ExecutorError::SpatialGeometryError {
+                        function_name: "ST_Intersection".to_string(),
+                        message: "currently only supports polygon-polygon intersection".to_string(),
+                    });
                 }
             };
 
@@ -313,18 +333,22 @@ pub fn st_intersection(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             let result_value = geometry_to_sql_value(result_geom, 0);
             Ok(result_value)
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Intersection requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Intersection".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0], args[1]),
+        }),
     }
 }
 
 /// ST_Difference(geom1, geom2) - Subtract geom2 from geom1
 pub fn st_difference(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Difference expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Difference".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match (&args[0], &args[1]) {
@@ -342,9 +366,10 @@ pub fn st_difference(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                     diff_result.into()
                 }
                 _ => {
-                    return Err(ExecutorError::Other(
-                        "ST_Difference currently only supports polygon-polygon difference".to_string(),
-                    ));
+                    return Err(ExecutorError::SpatialGeometryError {
+                        function_name: "ST_Difference".to_string(),
+                        message: "currently only supports polygon-polygon difference".to_string(),
+                    });
                 }
             };
 
@@ -352,18 +377,22 @@ pub fn st_difference(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             let result_value = geometry_to_sql_value(result_geom, 0);
             Ok(result_value)
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Difference requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Difference".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0], args[1]),
+        }),
     }
 }
 
 /// ST_SymDifference(geom1, geom2) - Parts in either but not both (symmetric difference / XOR)
 pub fn st_sym_difference(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_SymDifference expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_SymDifference".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
 
     match (&args[0], &args[1]) {
@@ -386,9 +415,10 @@ pub fn st_sym_difference(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                     geo::Geometry::MultiPolygon(union_result)
                 }
                 _ => {
-                    return Err(ExecutorError::Other(
-                        "ST_SymDifference currently only supports polygon-polygon symmetric difference".to_string(),
-                    ));
+                    return Err(ExecutorError::SpatialGeometryError {
+                        function_name: "ST_SymDifference".to_string(),
+                        message: "currently only supports polygon-polygon symmetric difference".to_string(),
+                    });
                 }
             };
 
@@ -396,9 +426,11 @@ pub fn st_sym_difference(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             let result_value = geometry_to_sql_value(result_geom, 0);
             Ok(result_value)
         }
-        _ => Err(ExecutorError::Other(
-            "ST_SymDifference requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_SymDifference".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0], args[1]),
+        }),
     }
 }
 

--- a/crates/vibesql-executor/src/evaluator/functions/spatial/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/spatial/predicates.rs
@@ -39,15 +39,18 @@ fn to_geo_geometry(geom: &Geometry) -> Result<geo::Geometry<f64>, ExecutorError>
         }
         Geometry::Polygon { rings } => {
             if rings.is_empty() {
-                return Err(ExecutorError::Other("Empty polygon".to_string()));
+                return Err(ExecutorError::SpatialGeometryError {
+                    function_name: "to_geo_geometry".to_string(),
+                    message: "Empty polygon".to_string(),
+                });
             }
-            
+
             let exterior: Vec<geo::Coord<f64>> = rings[0]
                 .iter()
                 .map(|(x, y)| geo::Coord { x: *x, y: *y })
                 .collect();
             let exterior_ring = geo::LineString(exterior);
-            
+
             let interiors: Vec<geo::LineString<f64>> = rings[1..]
                 .iter()
                 .map(|ring| {
@@ -58,7 +61,7 @@ fn to_geo_geometry(geom: &Geometry) -> Result<geo::Geometry<f64>, ExecutorError>
                     geo::LineString(coords)
                 })
                 .collect();
-            
+
             Ok(geo::Geometry::Polygon(geo::Polygon::new(exterior_ring, interiors)))
         }
         _ => Err(ExecutorError::UnsupportedFeature(format!(
@@ -72,227 +75,261 @@ fn to_geo_geometry(geom: &Geometry) -> Result<geo::Geometry<f64>, ExecutorError>
 /// ST_Contains(geom1, geom2) - Does geom1 completely contain geom2?
 pub fn st_contains(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Contains expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Contains".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
-    
+
     match (&args[0], &args[1]) {
         (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
         (SqlValue::Varchar(wkt1) | SqlValue::Character(wkt1),
          SqlValue::Varchar(wkt2) | SqlValue::Character(wkt2)) => {
             let geom1 = wkt_to_geo(wkt1)?;
             let geom2 = wkt_to_geo(wkt2)?;
-            
+
             let result = geom1.contains(&geom2);
             Ok(SqlValue::Boolean(result))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Contains requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Contains".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }
 
 /// ST_Within(geom1, geom2) - Is geom1 completely within geom2?
 pub fn st_within(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Within expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Within".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
-    
+
     match (&args[0], &args[1]) {
         (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
         (SqlValue::Varchar(wkt1) | SqlValue::Character(wkt1),
          SqlValue::Varchar(wkt2) | SqlValue::Character(wkt2)) => {
             let geom1 = wkt_to_geo(wkt1)?;
             let geom2 = wkt_to_geo(wkt2)?;
-            
+
             let result = geom2.contains(&geom1);
             Ok(SqlValue::Boolean(result))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Within requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Within".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }
 
 /// ST_Intersects(geom1, geom2) - Do geom1 and geom2 share any space?
 pub fn st_intersects(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Intersects expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Intersects".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
-    
+
     match (&args[0], &args[1]) {
         (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
         (SqlValue::Varchar(wkt1) | SqlValue::Character(wkt1),
          SqlValue::Varchar(wkt2) | SqlValue::Character(wkt2)) => {
             let geom1 = wkt_to_geo(wkt1)?;
             let geom2 = wkt_to_geo(wkt2)?;
-            
+
             let result = geom1.intersects(&geom2);
             Ok(SqlValue::Boolean(result))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Intersects requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Intersects".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }
 
 /// ST_Disjoint(geom1, geom2) - Do geom1 and geom2 share no space?
 pub fn st_disjoint(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Disjoint expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Disjoint".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
-    
+
     match (&args[0], &args[1]) {
         (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
         (SqlValue::Varchar(wkt1) | SqlValue::Character(wkt1),
          SqlValue::Varchar(wkt2) | SqlValue::Character(wkt2)) => {
             let geom1 = wkt_to_geo(wkt1)?;
             let geom2 = wkt_to_geo(wkt2)?;
-            
+
             // Disjoint = NOT Intersects
             let result = !geom1.intersects(&geom2);
             Ok(SqlValue::Boolean(result))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Disjoint requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Disjoint".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }
 
 /// ST_Equals(geom1, geom2) - Are geom1 and geom2 spatially equal?
 pub fn st_equals(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Equals expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Equals".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
-    
+
     match (&args[0], &args[1]) {
         (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
         (SqlValue::Varchar(wkt1) | SqlValue::Character(wkt1),
          SqlValue::Varchar(wkt2) | SqlValue::Character(wkt2)) => {
             let geom1 = wkt_to_geo(wkt1)?;
             let geom2 = wkt_to_geo(wkt2)?;
-            
+
             let result = geom1 == geom2;
             Ok(SqlValue::Boolean(result))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Equals requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Equals".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }
 
 /// ST_Touches(geom1, geom2) - DE-9IM: Boundaries touch but interiors don't intersect
 /// Pattern: FT******* or F**T***** or F***T****
-/// 
+///
 /// True when: Boundaries intersect, and at least one interior is disjoint from the other
 pub fn st_touches(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Touches expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Touches".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
-    
+
     match (&args[0], &args[1]) {
         (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
         (SqlValue::Varchar(wkt1) | SqlValue::Character(wkt1),
          SqlValue::Varchar(wkt2) | SqlValue::Character(wkt2)) => {
             let geom1 = wkt_to_geo(wkt1)?;
             let geom2 = wkt_to_geo(wkt2)?;
-            
+
             // Use DE-9IM Relate for proper Touches predicate
             let relate_matrix = geom1.relate(&geom2);
             let result = relate_matrix.is_touches();
-            
+
             Ok(SqlValue::Boolean(result))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Touches requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Touches".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }
 
 /// ST_Crosses(geom1, geom2) - DE-9IM: Geometries cross
-/// 
+///
 /// True when:
 /// - For point/line: geometries intersect, and their dimensions don't match (dimension mismatch)
 /// - For line/polygon: geometries share some interior points but not all
 /// - For other combos: topological crossing exists (dimension-dependent)
 pub fn st_crosses(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Crosses expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Crosses".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
-    
+
     match (&args[0], &args[1]) {
         (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
         (SqlValue::Varchar(wkt1) | SqlValue::Character(wkt1),
          SqlValue::Varchar(wkt2) | SqlValue::Character(wkt2)) => {
             let geom1 = wkt_to_geo(wkt1)?;
             let geom2 = wkt_to_geo(wkt2)?;
-            
+
             // Use DE-9IM Relate for proper Crosses predicate
             let relate_matrix = geom1.relate(&geom2);
             let result = relate_matrix.is_crosses();
-            
+
             Ok(SqlValue::Boolean(result))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Crosses requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Crosses".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }
 
 /// ST_Overlaps(geom1, geom2) - DE-9IM: Same-dimension geometries with overlapping interiors
 /// Pattern: T*T***T** (for same-dimension geometries)
-/// 
+///
 /// True when:
 /// - Geometries have the same dimension
 /// - Their interiors intersect (have points in common)
 /// - Neither geometry is completely contained in the other
 pub fn st_overlaps(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Overlaps expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Overlaps".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
-    
+
     match (&args[0], &args[1]) {
         (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
         (SqlValue::Varchar(wkt1) | SqlValue::Character(wkt1),
          SqlValue::Varchar(wkt2) | SqlValue::Character(wkt2)) => {
             let geom1 = wkt_to_geo(wkt1)?;
             let geom2 = wkt_to_geo(wkt2)?;
-            
+
             // Use DE-9IM Relate for proper Overlaps predicate
             let relate_matrix = geom1.relate(&geom2);
             let result = relate_matrix.is_overlaps();
-            
+
             Ok(SqlValue::Boolean(result))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Overlaps requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Overlaps".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }
 
 /// ST_Covers(geom1, geom2) - Does geom1 cover geom2? (includes boundary)
 pub fn st_covers(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_Covers expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Covers".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
-    
+
     match (&args[0], &args[1]) {
         (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
         (SqlValue::Varchar(wkt1) | SqlValue::Character(wkt1),
@@ -300,46 +337,52 @@ pub fn st_covers(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             // Covers is similar to Contains but includes boundaries
             let geom1 = wkt_to_geo(wkt1)?;
             let geom2 = wkt_to_geo(wkt2)?;
-            
+
             // For now, use Contains as approximation
             let result = geom1.contains(&geom2);
             Ok(SqlValue::Boolean(result))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Covers requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Covers".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }
 
 /// ST_CoveredBy(geom1, geom2) - Is geom1 covered by geom2?
 pub fn st_coveredby(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
-        return Err(ExecutorError::Other(
-            "ST_CoveredBy expects exactly 2 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_CoveredBy".to_string(),
+            expected: "exactly 2 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
-    
+
     match (&args[0], &args[1]) {
         (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
         (SqlValue::Varchar(wkt1) | SqlValue::Character(wkt1),
          SqlValue::Varchar(wkt2) | SqlValue::Character(wkt2)) => {
             let geom1 = wkt_to_geo(wkt1)?;
             let geom2 = wkt_to_geo(wkt2)?;
-            
+
             let result = geom2.contains(&geom1);
             Ok(SqlValue::Boolean(result))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_CoveredBy requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_CoveredBy".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }
 
 /// ST_DWithin(geom1, geom2, distance) - Are geometries within distance of each other?
-/// 
+///
 /// Calculates Euclidean distance for all geometry type combinations.
 /// Returns TRUE if distance(geom1, geom2) <= distance parameter.
-/// 
+///
 /// Supported combinations:
 /// - Point to Point: haversine distance (great-circle distance on sphere)
 /// - Point to LineString: minimum distance to any point on the line
@@ -350,11 +393,13 @@ pub fn st_coveredby(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
 /// - All combinations using EuclideanDistance trait
 pub fn st_dwithin(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 3 {
-        return Err(ExecutorError::Other(
-            "ST_DWithin expects exactly 3 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_DWithin".to_string(),
+            expected: "exactly 3 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
-    
+
     // Extract distance value as f64
     let distance = match &args[2] {
         SqlValue::Double(d) => *d,
@@ -362,23 +407,25 @@ pub fn st_dwithin(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         SqlValue::Integer(i) => *i as f64,
         SqlValue::Float(f) => *f as f64,
         SqlValue::Null => return Ok(SqlValue::Null),
-        _ => return Err(ExecutorError::Other(
-            "ST_DWithin distance must be numeric".to_string(),
-        )),
+        _ => return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_DWithin".to_string(),
+            expected: "numeric distance".to_string(),
+            actual: format!("{:?}", args[2].type_name()),
+        }),
     };
-    
+
     // Reject negative distances
     if distance < 0.0 {
         return Ok(SqlValue::Boolean(false));
     }
-    
+
     match (&args[0], &args[1]) {
         (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
         (SqlValue::Varchar(wkt1) | SqlValue::Character(wkt1),
          SqlValue::Varchar(wkt2) | SqlValue::Character(wkt2)) => {
             let geom1 = wkt_to_geo(wkt1)?;
             let geom2 = wkt_to_geo(wkt2)?;
-            
+
             // Use Distance trait for all geometry combinations
             let dist = match (&geom1, &geom2) {
                 (geo::Geometry::Point(p1), geo::Geometry::Point(p2)) => {
@@ -390,34 +437,38 @@ pub fn st_dwithin(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                     Euclidean.distance(&geom1, &geom2)
                 }
             };
-            
+
             let result = dist <= distance;
             Ok(SqlValue::Boolean(result))
         }
-        _ => Err(ExecutorError::Other(
-            "ST_DWithin requires (VARCHAR, VARCHAR, NUMERIC) arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_DWithin".to_string(),
+            expected: "(VARCHAR, VARCHAR, NUMERIC) arguments".to_string(),
+            actual: format!("{:?}, {:?}, {:?}", args[0].type_name(), args[1].type_name(), args[2].type_name()),
+        }),
     }
 }
 
 /// ST_Relate(geom1, geom2) - Return DE-9IM relationship (simplified version)
 /// ST_Relate(geom1, geom2, pattern) - Test DE-9IM relationship against a pattern
-/// 
+///
 /// Note: Simplified implementation - full DE-9IM computation is deferred to Phase 4
 pub fn st_relate(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() < 2 || args.len() > 3 {
-        return Err(ExecutorError::Other(
-            "ST_Relate expects 2 or 3 arguments".to_string(),
-        ));
+        return Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Relate".to_string(),
+            expected: "2 or 3 arguments".to_string(),
+            actual: format!("{} arguments", args.len()),
+        });
     }
-    
+
     match (&args[0], &args[1]) {
         (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
         (SqlValue::Varchar(wkt1) | SqlValue::Character(wkt1),
          SqlValue::Varchar(wkt2) | SqlValue::Character(wkt2)) => {
             let geom1 = wkt_to_geo(wkt1)?;
             let geom2 = wkt_to_geo(wkt2)?;
-            
+
             if args.len() == 2 {
                 // ST_Relate(geom1, geom2) - return DE-9IM string
                 // Simplified: return a basic relationship indicator
@@ -446,8 +497,10 @@ pub fn st_relate(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                 ))
             }
         }
-        _ => Err(ExecutorError::Other(
-            "ST_Relate requires VARCHAR geometry arguments".to_string(),
-        )),
+        _ => Err(ExecutorError::SpatialArgumentError {
+            function_name: "ST_Relate".to_string(),
+            expected: "VARCHAR geometry arguments".to_string(),
+            actual: format!("{:?}, {:?}", args[0].type_name(), args[1].type_name()),
+        }),
     }
 }


### PR DESCRIPTION
## Summary

- Add three new spatial-specific error variants to ExecutorError:
  - `SpatialGeometryError`: for invalid/incompatible geometry types  
  - `SpatialOperationFailed`: for spatial operation failures
  - `SpatialArgumentError`: for argument count/type mismatches
- Replace all `ExecutorError::Other` usages in spatial functions with appropriate semantic variants
- Error messages now include function name and specific error details

## Files Changed

- `errors.rs`: Added new error variants and Display implementations
- `measurements.rs`: Updated ST_Distance, ST_Length, ST_Perimeter, ST_Area, ST_Centroid, ST_Envelope, ST_ConvexHull, ST_PointOnSurface, ST_Boundary, ST_HausdorffDistance
- `predicates.rs`: Updated ST_Contains, ST_Within, ST_Intersects, ST_Disjoint, ST_Equals, ST_Touches, ST_Crosses, ST_Overlaps, ST_Covers, ST_CoveredBy, ST_DWithin, ST_Relate
- `operations.rs`: Updated ST_Simplify, ST_Union, ST_Intersection, ST_Difference, ST_SymDifference

## Test plan

- [x] Build succeeds with `cargo build -p vibesql-executor --features spatial`
- [x] All 13 error_display tests pass
- [x] All 43 spatial tests pass (spatial_function_tests, spatial_measurements_tests, spatial_operations_tests)

Closes #2906

🤖 Generated with [Claude Code](https://claude.com/claude-code)