### PR TITLE
refactor(errors): Replace ExecutorError::Other in vectorized module

### DIFF
--- a/crates/vibesql-executor/src/select/vectorized/aggregate.rs
+++ b/crates/vibesql-executor/src/select/vectorized/aggregate.rs
@@ -36,7 +36,10 @@ pub fn aggregate_column_simd(
     let schema = batch.schema();
     let (col_idx, _) = schema
         .column_with_name(column_name)
-        .ok_or_else(|| ExecutorError::Other(format!("Column not found: {}", column_name)))?;
+        .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: 0, // Column referenced by name
+            batch_columns: schema.fields().len(),
+        })?;
 
     let column = batch.column(col_idx);
 
@@ -59,26 +62,38 @@ fn aggregate_sum_simd(column: &ArrayRef) -> Result<SqlValue, ExecutorError> {
     match column.data_type() {
         arrow::datatypes::DataType::Int64 => {
             let array = column.as_any().downcast_ref::<Int64Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Int64Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Int64Array".to_string(),
+                    context: "aggregate_sum_simd".to_string(),
+                })?;
 
             let result = sum(array)
-                .ok_or_else(|| ExecutorError::Other("SUM returned None (all nulls?)".to_string()))?;
+                .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                    operation: "SUM".to_string(),
+                    reason: "returned None (all nulls?)".to_string(),
+                })?;
 
             Ok(SqlValue::Integer(result))
         }
         arrow::datatypes::DataType::Float64 => {
             let array = column.as_any().downcast_ref::<Float64Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Float64Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Float64Array".to_string(),
+                    context: "aggregate_sum_simd".to_string(),
+                })?;
 
             let result = sum(array)
-                .ok_or_else(|| ExecutorError::Other("SUM returned None (all nulls?)".to_string()))?;
+                .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                    operation: "SUM".to_string(),
+                    reason: "returned None (all nulls?)".to_string(),
+                })?;
 
             Ok(SqlValue::Double(result))
         }
-        _ => Err(ExecutorError::Other(format!(
-            "SUM not supported for type: {:?}",
-            column.data_type()
-        ))),
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: "SUM".to_string(),
+            array_type: format!("{:?}", column.data_type()),
+        }),
     }
 }
 
@@ -87,10 +102,16 @@ fn aggregate_avg_simd(column: &ArrayRef) -> Result<SqlValue, ExecutorError> {
     match column.data_type() {
         arrow::datatypes::DataType::Int64 => {
             let array = column.as_any().downcast_ref::<Int64Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Int64Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Int64Array".to_string(),
+                    context: "aggregate_avg_simd".to_string(),
+                })?;
 
             let sum_val = sum(array)
-                .ok_or_else(|| ExecutorError::Other("AVG: SUM returned None".to_string()))?;
+                .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                    operation: "AVG (SUM)".to_string(),
+                    reason: "returned None".to_string(),
+                })?;
 
             let count = (array.len() - array.null_count()) as f64;
             if count == 0.0 {
@@ -101,10 +122,16 @@ fn aggregate_avg_simd(column: &ArrayRef) -> Result<SqlValue, ExecutorError> {
         }
         arrow::datatypes::DataType::Float64 => {
             let array = column.as_any().downcast_ref::<Float64Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Float64Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Float64Array".to_string(),
+                    context: "aggregate_avg_simd".to_string(),
+                })?;
 
             let sum_val = sum(array)
-                .ok_or_else(|| ExecutorError::Other("AVG: SUM returned None".to_string()))?;
+                .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                    operation: "AVG (SUM)".to_string(),
+                    reason: "returned None".to_string(),
+                })?;
 
             let count = (array.len() - array.null_count()) as f64;
             if count == 0.0 {
@@ -113,10 +140,10 @@ fn aggregate_avg_simd(column: &ArrayRef) -> Result<SqlValue, ExecutorError> {
 
             Ok(SqlValue::Double(sum_val / count))
         }
-        _ => Err(ExecutorError::Other(format!(
-            "AVG not supported for type: {:?}",
-            column.data_type()
-        ))),
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: "AVG".to_string(),
+            array_type: format!("{:?}", column.data_type()),
+        }),
     }
 }
 
@@ -125,19 +152,31 @@ fn aggregate_min_simd(column: &ArrayRef) -> Result<SqlValue, ExecutorError> {
     match column.data_type() {
         arrow::datatypes::DataType::Int64 => {
             let array = column.as_any().downcast_ref::<Int64Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Int64Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Int64Array".to_string(),
+                    context: "aggregate_min_simd".to_string(),
+                })?;
 
             let result = min(array)
-                .ok_or_else(|| ExecutorError::Other("MIN returned None (all nulls?)".to_string()))?;
+                .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                    operation: "MIN".to_string(),
+                    reason: "returned None (all nulls?)".to_string(),
+                })?;
 
             Ok(SqlValue::Integer(result))
         }
         arrow::datatypes::DataType::Float64 => {
             let array = column.as_any().downcast_ref::<Float64Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Float64Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Float64Array".to_string(),
+                    context: "aggregate_min_simd".to_string(),
+                })?;
 
             let result = min(array)
-                .ok_or_else(|| ExecutorError::Other("MIN returned None (all nulls?)".to_string()))?;
+                .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                    operation: "MIN".to_string(),
+                    reason: "returned None (all nulls?)".to_string(),
+                })?;
 
             Ok(SqlValue::Double(result))
         }
@@ -145,10 +184,16 @@ fn aggregate_min_simd(column: &ArrayRef) -> Result<SqlValue, ExecutorError> {
             use super::batch::days_since_epoch_to_date;
 
             let array = column.as_any().downcast_ref::<Date32Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Date32Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Date32Array".to_string(),
+                    context: "aggregate_min_simd".to_string(),
+                })?;
 
             let result = min(array)
-                .ok_or_else(|| ExecutorError::Other("MIN returned None (all nulls?)".to_string()))?;
+                .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                    operation: "MIN".to_string(),
+                    reason: "returned None (all nulls?)".to_string(),
+                })?;
 
             Ok(SqlValue::Date(days_since_epoch_to_date(result)))
         }
@@ -156,17 +201,23 @@ fn aggregate_min_simd(column: &ArrayRef) -> Result<SqlValue, ExecutorError> {
             use super::batch::microseconds_to_timestamp;
 
             let array = column.as_any().downcast_ref::<TimestampMicrosecondArray>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast TimestampMicrosecondArray".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "TimestampMicrosecondArray".to_string(),
+                    context: "aggregate_min_simd".to_string(),
+                })?;
 
             let result = min(array)
-                .ok_or_else(|| ExecutorError::Other("MIN returned None (all nulls?)".to_string()))?;
+                .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                    operation: "MIN".to_string(),
+                    reason: "returned None (all nulls?)".to_string(),
+                })?;
 
             Ok(SqlValue::Timestamp(microseconds_to_timestamp(result)))
         }
-        _ => Err(ExecutorError::Other(format!(
-            "MIN not supported for type: {:?}",
-            column.data_type()
-        ))),
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: "MIN".to_string(),
+            array_type: format!("{:?}", column.data_type()),
+        }),
     }
 }
 
@@ -175,19 +226,31 @@ fn aggregate_max_simd(column: &ArrayRef) -> Result<SqlValue, ExecutorError> {
     match column.data_type() {
         arrow::datatypes::DataType::Int64 => {
             let array = column.as_any().downcast_ref::<Int64Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Int64Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Int64Array".to_string(),
+                    context: "aggregate_max_simd".to_string(),
+                })?;
 
             let result = max(array)
-                .ok_or_else(|| ExecutorError::Other("MAX returned None (all nulls?)".to_string()))?;
+                .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                    operation: "MAX".to_string(),
+                    reason: "returned None (all nulls?)".to_string(),
+                })?;
 
             Ok(SqlValue::Integer(result))
         }
         arrow::datatypes::DataType::Float64 => {
             let array = column.as_any().downcast_ref::<Float64Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Float64Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Float64Array".to_string(),
+                    context: "aggregate_max_simd".to_string(),
+                })?;
 
             let result = max(array)
-                .ok_or_else(|| ExecutorError::Other("MAX returned None (all nulls?)".to_string()))?;
+                .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                    operation: "MAX".to_string(),
+                    reason: "returned None (all nulls?)".to_string(),
+                })?;
 
             Ok(SqlValue::Double(result))
         }
@@ -195,10 +258,16 @@ fn aggregate_max_simd(column: &ArrayRef) -> Result<SqlValue, ExecutorError> {
             use super::batch::days_since_epoch_to_date;
 
             let array = column.as_any().downcast_ref::<Date32Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Date32Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Date32Array".to_string(),
+                    context: "aggregate_max_simd".to_string(),
+                })?;
 
             let result = max(array)
-                .ok_or_else(|| ExecutorError::Other("MAX returned None (all nulls?)".to_string()))?;
+                .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                    operation: "MAX".to_string(),
+                    reason: "returned None (all nulls?)".to_string(),
+                })?;
 
             Ok(SqlValue::Date(days_since_epoch_to_date(result)))
         }
@@ -206,17 +275,23 @@ fn aggregate_max_simd(column: &ArrayRef) -> Result<SqlValue, ExecutorError> {
             use super::batch::microseconds_to_timestamp;
 
             let array = column.as_any().downcast_ref::<TimestampMicrosecondArray>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast TimestampMicrosecondArray".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "TimestampMicrosecondArray".to_string(),
+                    context: "aggregate_max_simd".to_string(),
+                })?;
 
             let result = max(array)
-                .ok_or_else(|| ExecutorError::Other("MAX returned None (all nulls?)".to_string()))?;
+                .ok_or_else(|| ExecutorError::SimdOperationFailed {
+                    operation: "MAX".to_string(),
+                    reason: "returned None (all nulls?)".to_string(),
+                })?;
 
             Ok(SqlValue::Timestamp(microseconds_to_timestamp(result)))
         }
-        _ => Err(ExecutorError::Other(format!(
-            "MAX not supported for type: {:?}",
-            column.data_type()
-        ))),
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: "MAX".to_string(),
+            array_type: format!("{:?}", column.data_type()),
+        }),
     }
 }
 

--- a/crates/vibesql-executor/src/select/vectorized/arithmetic.rs
+++ b/crates/vibesql-executor/src/select/vectorized/arithmetic.rs
@@ -41,8 +41,8 @@ pub fn evaluate_arithmetic_simd(
             // Create array filled with literal value
             create_literal_array(value, batch.num_rows())
         }
-        _ => Err(ExecutorError::Other(format!(
-            "Unsupported SIMD arithmetic expression: {:?}",
+        _ => Err(ExecutorError::UnsupportedFeature(format!(
+            "SIMD arithmetic expression: {:?}",
             expr
         ))),
     }
@@ -85,29 +85,35 @@ fn apply_int64_op(
     let left_arr = left
         .as_any()
         .downcast_ref::<Int64Array>()
-        .ok_or_else(|| ExecutorError::Other("Failed to downcast Int64Array".to_string()))?;
+        .ok_or_else(|| ExecutorError::ArrowDowncastError {
+            expected_type: "Int64Array".to_string(),
+            context: "apply_int64_op (left)".to_string(),
+        })?;
     let right_arr = right
         .as_any()
         .downcast_ref::<Int64Array>()
-        .ok_or_else(|| ExecutorError::Other("Failed to downcast Int64Array".to_string()))?;
+        .ok_or_else(|| ExecutorError::ArrowDowncastError {
+            expected_type: "Int64Array".to_string(),
+            context: "apply_int64_op (right)".to_string(),
+        })?;
 
     let result: ArrayRef = match op {
         BinaryOperator::Plus => add(left_arr, right_arr)
-            .map_err(|e| ExecutorError::Other(format!("SIMD add failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "add".to_string(), reason: e.to_string() })?,
         BinaryOperator::Minus => sub(left_arr, right_arr)
-            .map_err(|e| ExecutorError::Other(format!("SIMD subtract failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "subtract".to_string(), reason: e.to_string() })?,
         BinaryOperator::Multiply => mul(left_arr, right_arr)
-            .map_err(|e| ExecutorError::Other(format!("SIMD multiply failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "multiply".to_string(), reason: e.to_string() })?,
         BinaryOperator::Divide => {
             // For integer division, cast to float64 first
             let left_f64 = cast_int64_to_float64(left_arr)?;
             let right_f64 = cast_int64_to_float64(right_arr)?;
             div(&left_f64, &right_f64)
-                .map_err(|e| ExecutorError::Other(format!("SIMD divide failed: {}", e)))?
+                .map_err(|e| ExecutorError::SimdOperationFailed { operation: "divide".to_string(), reason: e.to_string() })?
         }
         _ => {
-            return Err(ExecutorError::Other(format!(
-                "Unsupported arithmetic operator: {:?}",
+            return Err(ExecutorError::UnsupportedFeature(format!(
+                "arithmetic operator {:?}",
                 op
             )))
         }
@@ -125,28 +131,34 @@ fn apply_float64_op(
     let left_arr = left
         .as_any()
         .downcast_ref::<Float64Array>()
-        .ok_or_else(|| ExecutorError::Other("Failed to downcast Float64Array".to_string()))?;
+        .ok_or_else(|| ExecutorError::ArrowDowncastError {
+            expected_type: "Float64Array".to_string(),
+            context: "apply_float64_op (left)".to_string(),
+        })?;
     let right_arr = right
         .as_any()
         .downcast_ref::<Float64Array>()
-        .ok_or_else(|| ExecutorError::Other("Failed to downcast Float64Array".to_string()))?;
+        .ok_or_else(|| ExecutorError::ArrowDowncastError {
+            expected_type: "Float64Array".to_string(),
+            context: "apply_float64_op (right)".to_string(),
+        })?;
 
     let result: ArrayRef = match op {
         BinaryOperator::Plus => add(left_arr, right_arr)
-            .map_err(|e| ExecutorError::Other(format!("SIMD add failed: {}", e)))?
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "add".to_string(), reason: e.to_string() })?
             .into(),
         BinaryOperator::Minus => sub(left_arr, right_arr)
-            .map_err(|e| ExecutorError::Other(format!("SIMD subtract failed: {}", e)))?
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "subtract".to_string(), reason: e.to_string() })?
             .into(),
         BinaryOperator::Multiply => mul(left_arr, right_arr)
-            .map_err(|e| ExecutorError::Other(format!("SIMD multiply failed: {}", e)))?
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "multiply".to_string(), reason: e.to_string() })?
             .into(),
         BinaryOperator::Divide => div(left_arr, right_arr)
-            .map_err(|e| ExecutorError::Other(format!("SIMD divide failed: {}", e)))?
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "divide".to_string(), reason: e.to_string() })?
             .into(),
         _ => {
-            return Err(ExecutorError::Other(format!(
-                "Unsupported arithmetic operator: {:?}",
+            return Err(ExecutorError::UnsupportedFeature(format!(
+                "arithmetic operator {:?}",
                 op
             )))
         }
@@ -160,7 +172,10 @@ fn get_numeric_column(batch: &RecordBatch, col_name: &str) -> Result<ArrayRef, E
     let schema = batch.schema();
     let (col_idx, _) = schema
         .column_with_name(col_name)
-        .ok_or_else(|| ExecutorError::Other(format!("Column not found: {}", col_name)))?;
+        .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: 0, // Column referenced by name
+            batch_columns: schema.fields().len(),
+        })?;
     let column = batch.column(col_idx);
 
     // Verify it's a numeric type
@@ -169,11 +184,10 @@ fn get_numeric_column(batch: &RecordBatch, col_name: &str) -> Result<ArrayRef, E
         | arrow::datatypes::DataType::Float64
         | arrow::datatypes::DataType::Int32
         | arrow::datatypes::DataType::Float32 => Ok(column.clone()),
-        _ => Err(ExecutorError::Other(format!(
-            "Column {} is not numeric: {:?}",
-            col_name,
-            column.data_type()
-        ))),
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: format!("arithmetic on column {}", col_name),
+            array_type: format!("{:?}", column.data_type()),
+        }),
     }
 }
 
@@ -196,10 +210,11 @@ fn create_literal_array(value: &SqlValue, len: usize) -> Result<ArrayRef, Execut
             // Create array of nulls
             Ok(Arc::new(Int64Array::from(vec![None; len])) as ArrayRef)
         }
-        _ => Err(ExecutorError::Other(format!(
-            "Cannot create literal array for {:?}",
-            value
-        ))),
+        _ => Err(ExecutorError::ColumnarTypeMismatch {
+            operation: "literal array creation".to_string(),
+            left_type: format!("{:?}", value),
+            right_type: Some("numeric".to_string()),
+        }),
     }
 }
 
@@ -210,14 +225,17 @@ fn cast_to_float64(array: &ArrayRef) -> Result<ArrayRef, ExecutorError> {
             let int_arr = array
                 .as_any()
                 .downcast_ref::<Int64Array>()
-                .ok_or_else(|| ExecutorError::Other("Downcast failed".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Int64Array".to_string(),
+                    context: "cast_to_float64".to_string(),
+                })?;
             Ok(Arc::new(cast_int64_to_float64(int_arr)?) as ArrayRef)
         }
         arrow::datatypes::DataType::Float64 => Ok(array.clone()),
-        _ => Err(ExecutorError::Other(format!(
-            "Unsupported type for float64 cast: {:?}",
-            array.data_type()
-        ))),
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: "float64 cast".to_string(),
+            array_type: format!("{:?}", array.data_type()),
+        }),
     }
 }
 

--- a/crates/vibesql-executor/src/select/vectorized/batch.rs
+++ b/crates/vibesql-executor/src/select/vectorized/batch.rs
@@ -92,9 +92,11 @@ pub fn rows_to_record_batch_with_columns(
     column_indices: Option<&[usize]>,
 ) -> Result<RecordBatch, ExecutorError> {
     if rows.is_empty() {
-        return Err(ExecutorError::Other(
-            "Cannot create RecordBatch from empty rows".to_string(),
-        ));
+        return Err(ExecutorError::ColumnarLengthMismatch {
+            expected: 1,
+            actual: 0,
+            context: "Cannot create RecordBatch from empty rows".to_string(),
+        });
     }
 
     // Determine which columns to convert
@@ -104,9 +106,10 @@ pub fn rows_to_record_batch_with_columns(
     };
 
     if indices.is_empty() {
-        return Err(ExecutorError::Other(
-            "Must specify at least one column".to_string(),
-        ));
+        return Err(ExecutorError::ColumnarColumnNotFound {
+            column_index: 0,
+            batch_columns: 0,
+        });
     }
 
     // Build schema for selected columns only
@@ -124,9 +127,10 @@ pub fn rows_to_record_batch_with_columns(
             Some(SqlValue::Date(_)) => DataType::Date32,
             Some(SqlValue::Timestamp(_)) => DataType::Timestamp(TimeUnit::Microsecond, None),
             Some(SqlValue::Null) => DataType::Int64,
-            _ => return Err(ExecutorError::Other(format!(
-                "Unsupported type for SIMD at column {}", col_idx
-            ))),
+            _ => return Err(ExecutorError::UnsupportedArrayType {
+                operation: format!("SIMD conversion at column {}", col_idx),
+                array_type: format!("{:?}", rows[0].values.get(col_idx)),
+            }),
         };
 
         schema_fields.push(Field::new(name, data_type, true));
@@ -142,7 +146,10 @@ pub fn rows_to_record_batch_with_columns(
     }
 
     RecordBatch::try_new(Arc::new(schema), columns)
-        .map_err(|e| ExecutorError::Other(format!("Failed to create RecordBatch: {}", e)))
+        .map_err(|e| ExecutorError::SimdOperationFailed {
+            operation: "RecordBatch creation".to_string(),
+            reason: e.to_string(),
+        })
 }
 
 /// Convert RecordBatch back to row format
@@ -279,9 +286,10 @@ fn infer_schema_from_row(row: &Row, column_names: &[String]) -> Result<Schema, E
             SqlValue::Date(_) => DataType::Date32,
             SqlValue::Timestamp(_) => DataType::Timestamp(TimeUnit::Microsecond, None),
             SqlValue::Null => DataType::Int64, // Default to Int64 for nulls
-            _ => return Err(ExecutorError::Other(format!(
-                "Unsupported type for SIMD: {:?}", value
-            ))),
+            _ => return Err(ExecutorError::UnsupportedArrayType {
+                operation: "SIMD schema inference".to_string(),
+                array_type: format!("{:?}", value),
+            }),
         };
 
         Ok(Field::new(name, data_type, true))
@@ -369,10 +377,10 @@ fn build_column_array(
             }
             Ok(Arc::new(builder.finish()))
         }
-        _ => Err(ExecutorError::Other(format!(
-            "Unsupported Arrow data type: {:?}",
-            data_type
-        ))),
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: "build_column_array".to_string(),
+            array_type: format!("{:?}", data_type),
+        }),
     }
 }
 
@@ -385,40 +393,58 @@ fn arrow_value_to_sql(array: &dyn Array, idx: usize) -> Result<SqlValue, Executo
     match array.data_type() {
         DataType::Int64 => {
             let arr = array.as_any().downcast_ref::<Int64Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Int64Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Int64Array".to_string(),
+                    context: "arrow_value_to_sql".to_string(),
+                })?;
             Ok(SqlValue::Integer(arr.value(idx)))
         }
         DataType::Float64 => {
             let arr = array.as_any().downcast_ref::<Float64Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Float64Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Float64Array".to_string(),
+                    context: "arrow_value_to_sql".to_string(),
+                })?;
             Ok(SqlValue::Double(arr.value(idx)))
         }
         DataType::Utf8 => {
             let arr = array.as_any().downcast_ref::<StringArray>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast StringArray".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "StringArray".to_string(),
+                    context: "arrow_value_to_sql".to_string(),
+                })?;
             Ok(SqlValue::Varchar(arr.value(idx).to_string()))
         }
         DataType::Boolean => {
             let arr = array.as_any().downcast_ref::<BooleanArray>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast BooleanArray".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "BooleanArray".to_string(),
+                    context: "arrow_value_to_sql".to_string(),
+                })?;
             Ok(SqlValue::Boolean(arr.value(idx)))
         }
         DataType::Date32 => {
             let arr = array.as_any().downcast_ref::<Date32Array>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast Date32Array".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "Date32Array".to_string(),
+                    context: "arrow_value_to_sql".to_string(),
+                })?;
             let days = arr.value(idx);
             Ok(SqlValue::Date(days_since_epoch_to_date(days)))
         }
         DataType::Timestamp(TimeUnit::Microsecond, None) => {
             let arr = array.as_any().downcast_ref::<TimestampMicrosecondArray>()
-                .ok_or_else(|| ExecutorError::Other("Failed to downcast TimestampMicrosecondArray".to_string()))?;
+                .ok_or_else(|| ExecutorError::ArrowDowncastError {
+                    expected_type: "TimestampMicrosecondArray".to_string(),
+                    context: "arrow_value_to_sql".to_string(),
+                })?;
             let micros = arr.value(idx);
             Ok(SqlValue::Timestamp(microseconds_to_timestamp(micros)))
         }
-        _ => Err(ExecutorError::Other(format!(
-            "Unsupported Arrow data type for conversion: {:?}",
-            array.data_type()
-        ))),
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: "arrow_value_to_sql conversion".to_string(),
+            array_type: format!("{:?}", array.data_type()),
+        }),
     }
 }
 

--- a/crates/vibesql-executor/src/select/vectorized/filter.rs
+++ b/crates/vibesql-executor/src/select/vectorized/filter.rs
@@ -18,7 +18,10 @@ pub fn filter_record_batch_simd(
 ) -> Result<RecordBatch, ExecutorError> {
     let mask = evaluate_predicate_simd(batch, predicate)?;
     filter_record_batch(batch, &mask)
-        .map_err(|e| ExecutorError::Other(format!("SIMD filter failed: {}", e)))
+        .map_err(|e| ExecutorError::SimdOperationFailed {
+            operation: "filter".to_string(),
+            reason: e.to_string(),
+        })
 }
 
 /// Evaluate a predicate expression on a RecordBatch
@@ -33,7 +36,11 @@ fn evaluate_predicate_simd(
         Expression::Literal(value) => {
             match value {
                 SqlValue::Boolean(b) => Ok(BooleanArray::from(vec![*b; batch.num_rows()])),
-                _ => Err(ExecutorError::Other("Non-boolean literal in WHERE clause".to_string())),
+                _ => Err(ExecutorError::ColumnarTypeMismatch {
+                    operation: "WHERE clause literal".to_string(),
+                    left_type: format!("{:?}", value),
+                    right_type: Some("Boolean".to_string()),
+                }),
             }
         }
         Expression::ColumnRef { column, .. } => {
@@ -43,15 +50,18 @@ fn evaluate_predicate_simd(
             match op {
                 vibesql_ast::UnaryOperator::Not => {
                     let expr_mask = evaluate_predicate_simd(batch, expr)?;
-                    not_op(&expr_mask).map_err(|e| ExecutorError::Other(format!("SIMD NOT failed: {}", e)))
+                    not_op(&expr_mask).map_err(|e| ExecutorError::SimdOperationFailed {
+                        operation: "NOT".to_string(),
+                        reason: e.to_string(),
+                    })
                 }
-                _ => Err(ExecutorError::Other(format!("Unsupported unary operator: {:?}", op))),
+                _ => Err(ExecutorError::UnsupportedFeature(format!("unary operator {:?} in SIMD predicate", op))),
             }
         }
         Expression::Like { expr, pattern, negated } => {
             evaluate_like_simd(batch, expr, pattern, *negated)
         }
-        _ => Err(ExecutorError::Other(format!("Unsupported SIMD predicate: {:?}", expr))),
+        _ => Err(ExecutorError::UnsupportedFeature(format!("SIMD predicate expression: {:?}", expr))),
     }
 }
 
@@ -74,7 +84,10 @@ fn evaluate_binary_op_simd(
 
             // Evaluate right side
             let right_mask = evaluate_predicate_simd(batch, right)?;
-            and_op(&left_mask, &right_mask).map_err(|e| ExecutorError::Other(format!("SIMD AND failed: {}", e)))
+            and_op(&left_mask, &right_mask).map_err(|e| ExecutorError::SimdOperationFailed {
+                operation: "AND".to_string(),
+                reason: e.to_string(),
+            })
         }
         BinaryOperator::Or => {
             // Evaluate left side first
@@ -87,13 +100,16 @@ fn evaluate_binary_op_simd(
 
             // Evaluate right side
             let right_mask = evaluate_predicate_simd(batch, right)?;
-            or_op(&left_mask, &right_mask).map_err(|e| ExecutorError::Other(format!("SIMD OR failed: {}", e)))
+            or_op(&left_mask, &right_mask).map_err(|e| ExecutorError::SimdOperationFailed {
+                operation: "OR".to_string(),
+                reason: e.to_string(),
+            })
         }
         BinaryOperator::Equal | BinaryOperator::NotEqual | BinaryOperator::LessThan
         | BinaryOperator::LessThanOrEqual | BinaryOperator::GreaterThan | BinaryOperator::GreaterThanOrEqual => {
             evaluate_comparison_simd(batch, left, op, right)
         }
-        _ => Err(ExecutorError::Other(format!("Unsupported SIMD binary operator: {:?}", op))),
+        _ => Err(ExecutorError::UnsupportedFeature(format!("SIMD binary operator: {:?}", op))),
     }
 }
 
@@ -118,12 +134,15 @@ fn evaluate_comparison_simd(
 ) -> Result<BooleanArray, ExecutorError> {
     let (col_name, literal_value) = match (left, right) {
         (Expression::ColumnRef { column, .. }, Expression::Literal(val)) => (column, val),
-        _ => return Err(ExecutorError::Other("SIMD comparison requires: column <op> literal".to_string())),
+        _ => return Err(ExecutorError::UnsupportedFeature("SIMD comparison requires: column <op> literal".to_string())),
     };
 
     let schema = batch.schema();
     let (col_idx, _) = schema.column_with_name(col_name)
-        .ok_or_else(|| ExecutorError::Other(format!("Column not found: {}", col_name)))?;
+        .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: 0, // Column referenced by name, not index
+            batch_columns: schema.fields().len(),
+        })?;
     let column = batch.column(col_idx);
 
     match column.data_type() {
@@ -132,18 +151,28 @@ fn evaluate_comparison_simd(
         arrow::datatypes::DataType::Utf8 => compare_string(column, literal_value, op),
         arrow::datatypes::DataType::Date32 => compare_date32(column, literal_value, op),
         arrow::datatypes::DataType::Timestamp(TimeUnit::Microsecond, None) => compare_timestamp(column, literal_value, op),
-        _ => Err(ExecutorError::Other(format!("Unsupported column type: {:?}", column.data_type()))),
+        _ => Err(ExecutorError::UnsupportedArrayType {
+            operation: "comparison".to_string(),
+            array_type: format!("{:?}", column.data_type()),
+        }),
     }
 }
 
 fn compare_int64(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator) -> Result<BooleanArray, ExecutorError> {
     let array = column.as_any().downcast_ref::<Int64Array>()
-        .ok_or_else(|| ExecutorError::Other("Failed to downcast Int64Array".to_string()))?;
+        .ok_or_else(|| ExecutorError::ArrowDowncastError {
+            expected_type: "Int64Array".to_string(),
+            context: "compare_int64".to_string(),
+        })?;
 
     let val = match literal {
         SqlValue::Integer(i) | SqlValue::Bigint(i) => *i,
         SqlValue::Smallint(i) => *i as i64,
-        _ => return Err(ExecutorError::Other("Type mismatch".to_string())),
+        _ => return Err(ExecutorError::ColumnarTypeMismatch {
+            operation: "Int64 comparison".to_string(),
+            left_type: "Int64".to_string(),
+            right_type: Some(format!("{:?}", literal)),
+        }),
     };
 
     // Create scalar array for comparison
@@ -151,18 +180,18 @@ fn compare_int64(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator) -> 
 
     let result = match op {
         BinaryOperator::Equal => eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD eq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "eq".to_string(), reason: e.to_string() })?,
         BinaryOperator::NotEqual => neq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD neq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "neq".to_string(), reason: e.to_string() })?,
         BinaryOperator::LessThan => lt(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD lt failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "lt".to_string(), reason: e.to_string() })?,
         BinaryOperator::LessThanOrEqual => lt_eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD lt_eq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "lt_eq".to_string(), reason: e.to_string() })?,
         BinaryOperator::GreaterThan => gt(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD gt failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "gt".to_string(), reason: e.to_string() })?,
         BinaryOperator::GreaterThanOrEqual => gt_eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD gt_eq failed: {}", e)))?,
-        _ => return Err(ExecutorError::Other("Unsupported operator".to_string())),
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "gt_eq".to_string(), reason: e.to_string() })?,
+        _ => return Err(ExecutorError::UnsupportedFeature(format!("comparison operator {:?}", op))),
     };
 
     Ok(result)
@@ -170,13 +199,20 @@ fn compare_int64(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator) -> 
 
 fn compare_float64(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator) -> Result<BooleanArray, ExecutorError> {
     let array = column.as_any().downcast_ref::<Float64Array>()
-        .ok_or_else(|| ExecutorError::Other("Failed to downcast Float64Array".to_string()))?;
+        .ok_or_else(|| ExecutorError::ArrowDowncastError {
+            expected_type: "Float64Array".to_string(),
+            context: "compare_float64".to_string(),
+        })?;
 
     let val = match literal {
         SqlValue::Double(f) | SqlValue::Numeric(f) => *f,
         SqlValue::Float(f) | SqlValue::Real(f) => *f as f64,
         SqlValue::Integer(i) => *i as f64,
-        _ => return Err(ExecutorError::Other("Type mismatch".to_string())),
+        _ => return Err(ExecutorError::ColumnarTypeMismatch {
+            operation: "Float64 comparison".to_string(),
+            left_type: "Float64".to_string(),
+            right_type: Some(format!("{:?}", literal)),
+        }),
     };
 
     // Create scalar array for comparison
@@ -184,18 +220,18 @@ fn compare_float64(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator) -
 
     let result = match op {
         BinaryOperator::Equal => eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD eq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "eq".to_string(), reason: e.to_string() })?,
         BinaryOperator::NotEqual => neq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD neq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "neq".to_string(), reason: e.to_string() })?,
         BinaryOperator::LessThan => lt(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD lt failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "lt".to_string(), reason: e.to_string() })?,
         BinaryOperator::LessThanOrEqual => lt_eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD lt_eq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "lt_eq".to_string(), reason: e.to_string() })?,
         BinaryOperator::GreaterThan => gt(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD gt failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "gt".to_string(), reason: e.to_string() })?,
         BinaryOperator::GreaterThanOrEqual => gt_eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD gt_eq failed: {}", e)))?,
-        _ => return Err(ExecutorError::Other("Unsupported operator".to_string())),
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "gt_eq".to_string(), reason: e.to_string() })?,
+        _ => return Err(ExecutorError::UnsupportedFeature(format!("comparison operator {:?}", op))),
     };
 
     Ok(result)
@@ -203,11 +239,18 @@ fn compare_float64(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator) -
 
 fn compare_string(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator) -> Result<BooleanArray, ExecutorError> {
     let array = column.as_any().downcast_ref::<StringArray>()
-        .ok_or_else(|| ExecutorError::Other("Failed to downcast StringArray".to_string()))?;
+        .ok_or_else(|| ExecutorError::ArrowDowncastError {
+            expected_type: "StringArray".to_string(),
+            context: "compare_string".to_string(),
+        })?;
 
     let val = match literal {
         SqlValue::Varchar(s) | SqlValue::Character(s) => s.as_str(),
-        _ => return Err(ExecutorError::Other("Type mismatch".to_string())),
+        _ => return Err(ExecutorError::ColumnarTypeMismatch {
+            operation: "String comparison".to_string(),
+            left_type: "String".to_string(),
+            right_type: Some(format!("{:?}", literal)),
+        }),
     };
 
     // Create scalar array for comparison
@@ -215,18 +258,18 @@ fn compare_string(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator) ->
 
     let result = match op {
         BinaryOperator::Equal => eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD eq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "eq".to_string(), reason: e.to_string() })?,
         BinaryOperator::NotEqual => neq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD neq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "neq".to_string(), reason: e.to_string() })?,
         BinaryOperator::LessThan => lt(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD lt failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "lt".to_string(), reason: e.to_string() })?,
         BinaryOperator::LessThanOrEqual => lt_eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD lt_eq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "lt_eq".to_string(), reason: e.to_string() })?,
         BinaryOperator::GreaterThan => gt(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD gt failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "gt".to_string(), reason: e.to_string() })?,
         BinaryOperator::GreaterThanOrEqual => gt_eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD gt_eq failed: {}", e)))?,
-        _ => return Err(ExecutorError::Other("Unsupported operator".to_string())),
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "gt_eq".to_string(), reason: e.to_string() })?,
+        _ => return Err(ExecutorError::UnsupportedFeature(format!("comparison operator {:?}", op))),
     };
 
     Ok(result)
@@ -236,11 +279,18 @@ fn compare_date32(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator) ->
     use super::batch::date_to_days_since_epoch;
 
     let array = column.as_any().downcast_ref::<Date32Array>()
-        .ok_or_else(|| ExecutorError::Other("Failed to downcast Date32Array".to_string()))?;
+        .ok_or_else(|| ExecutorError::ArrowDowncastError {
+            expected_type: "Date32Array".to_string(),
+            context: "compare_date32".to_string(),
+        })?;
 
     let val = match literal {
         SqlValue::Date(d) => date_to_days_since_epoch(d),
-        _ => return Err(ExecutorError::Other("Type mismatch: expected Date".to_string())),
+        _ => return Err(ExecutorError::ColumnarTypeMismatch {
+            operation: "Date comparison".to_string(),
+            left_type: "Date32".to_string(),
+            right_type: Some(format!("{:?}", literal)),
+        }),
     };
 
     // Create scalar array for comparison
@@ -248,18 +298,18 @@ fn compare_date32(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator) ->
 
     let result = match op {
         BinaryOperator::Equal => eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD eq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "eq".to_string(), reason: e.to_string() })?,
         BinaryOperator::NotEqual => neq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD neq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "neq".to_string(), reason: e.to_string() })?,
         BinaryOperator::LessThan => lt(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD lt failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "lt".to_string(), reason: e.to_string() })?,
         BinaryOperator::LessThanOrEqual => lt_eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD lt_eq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "lt_eq".to_string(), reason: e.to_string() })?,
         BinaryOperator::GreaterThan => gt(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD gt failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "gt".to_string(), reason: e.to_string() })?,
         BinaryOperator::GreaterThanOrEqual => gt_eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD gt_eq failed: {}", e)))?,
-        _ => return Err(ExecutorError::Other("Unsupported operator".to_string())),
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "gt_eq".to_string(), reason: e.to_string() })?,
+        _ => return Err(ExecutorError::UnsupportedFeature(format!("comparison operator {:?}", op))),
     };
 
     Ok(result)
@@ -269,11 +319,18 @@ fn compare_timestamp(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator)
     use super::batch::timestamp_to_microseconds;
 
     let array = column.as_any().downcast_ref::<TimestampMicrosecondArray>()
-        .ok_or_else(|| ExecutorError::Other("Failed to downcast TimestampMicrosecondArray".to_string()))?;
+        .ok_or_else(|| ExecutorError::ArrowDowncastError {
+            expected_type: "TimestampMicrosecondArray".to_string(),
+            context: "compare_timestamp".to_string(),
+        })?;
 
     let val = match literal {
         SqlValue::Timestamp(ts) => timestamp_to_microseconds(ts),
-        _ => return Err(ExecutorError::Other("Type mismatch: expected Timestamp".to_string())),
+        _ => return Err(ExecutorError::ColumnarTypeMismatch {
+            operation: "Timestamp comparison".to_string(),
+            left_type: "Timestamp".to_string(),
+            right_type: Some(format!("{:?}", literal)),
+        }),
     };
 
     // Create scalar array for comparison
@@ -281,18 +338,18 @@ fn compare_timestamp(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator)
 
     let result = match op {
         BinaryOperator::Equal => eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD eq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "eq".to_string(), reason: e.to_string() })?,
         BinaryOperator::NotEqual => neq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD neq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "neq".to_string(), reason: e.to_string() })?,
         BinaryOperator::LessThan => lt(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD lt failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "lt".to_string(), reason: e.to_string() })?,
         BinaryOperator::LessThanOrEqual => lt_eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD lt_eq failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "lt_eq".to_string(), reason: e.to_string() })?,
         BinaryOperator::GreaterThan => gt(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD gt failed: {}", e)))?,
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "gt".to_string(), reason: e.to_string() })?,
         BinaryOperator::GreaterThanOrEqual => gt_eq(array, &scalar_array)
-            .map_err(|e| ExecutorError::Other(format!("SIMD gt_eq failed: {}", e)))?,
-        _ => return Err(ExecutorError::Other("Unsupported operator".to_string())),
+            .map_err(|e| ExecutorError::SimdOperationFailed { operation: "gt_eq".to_string(), reason: e.to_string() })?,
+        _ => return Err(ExecutorError::UnsupportedFeature(format!("comparison operator {:?}", op))),
     };
 
     Ok(result)
@@ -301,10 +358,16 @@ fn compare_timestamp(column: &ArrayRef, literal: &SqlValue, op: &BinaryOperator)
 fn get_boolean_column(batch: &RecordBatch, col_name: &str) -> Result<BooleanArray, ExecutorError> {
     let schema = batch.schema();
     let (col_idx, _) = schema.column_with_name(col_name)
-        .ok_or_else(|| ExecutorError::Other(format!("Column not found: {}", col_name)))?;
+        .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: 0, // Column referenced by name
+            batch_columns: schema.fields().len(),
+        })?;
     let column = batch.column(col_idx);
     let array = column.as_any().downcast_ref::<BooleanArray>()
-        .ok_or_else(|| ExecutorError::Other("Column is not boolean type".to_string()))?;
+        .ok_or_else(|| ExecutorError::ArrowDowncastError {
+            expected_type: "BooleanArray".to_string(),
+            context: "get_boolean_column".to_string(),
+        })?;
     Ok(array.clone())
 }
 
@@ -318,7 +381,7 @@ fn evaluate_like_simd(
     // Extract column name from expression
     let col_name = match expr {
         Expression::ColumnRef { column, .. } => column,
-        _ => return Err(ExecutorError::Other("SIMD LIKE requires: column LIKE literal".to_string())),
+        _ => return Err(ExecutorError::UnsupportedFeature("SIMD LIKE requires: column LIKE literal".to_string())),
     };
 
     // Extract pattern string from literal
@@ -328,31 +391,50 @@ fn evaluate_like_simd(
             // NULL pattern matches nothing - return all false
             return Ok(BooleanArray::from(vec![false; batch.num_rows()]));
         }
-        _ => return Err(ExecutorError::Other("SIMD LIKE pattern must be a string literal".to_string())),
+        _ => return Err(ExecutorError::ColumnarTypeMismatch {
+            operation: "LIKE pattern".to_string(),
+            left_type: "String".to_string(),
+            right_type: Some(format!("{:?}", pattern)),
+        }),
     };
 
     // Get the string column
     let schema = batch.schema();
     let (col_idx, _) = schema.column_with_name(col_name)
-        .ok_or_else(|| ExecutorError::Other(format!("Column not found: {}", col_name)))?;
+        .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: 0, // Column referenced by name
+            batch_columns: schema.fields().len(),
+        })?;
     let column = batch.column(col_idx);
 
     // Ensure column is string type
     if !matches!(column.data_type(), arrow::datatypes::DataType::Utf8) {
-        return Err(ExecutorError::Other(format!("LIKE requires string column, got: {:?}", column.data_type())));
+        return Err(ExecutorError::UnsupportedArrayType {
+            operation: "LIKE".to_string(),
+            array_type: format!("{:?}", column.data_type()),
+        });
     }
 
     let string_array = column.as_any().downcast_ref::<StringArray>()
-        .ok_or_else(|| ExecutorError::Other("Failed to downcast StringArray".to_string()))?;
+        .ok_or_else(|| ExecutorError::ArrowDowncastError {
+            expected_type: "StringArray".to_string(),
+            context: "evaluate_like_simd".to_string(),
+        })?;
 
     // Use Arrow's SIMD-accelerated like kernel
     let pattern_scalar = Scalar::new(StringArray::from(vec![pattern_str]));
     let result = like(string_array, &pattern_scalar)
-        .map_err(|e| ExecutorError::Other(format!("SIMD LIKE failed: {}", e)))?;
+        .map_err(|e| ExecutorError::SimdOperationFailed {
+            operation: "LIKE".to_string(),
+            reason: e.to_string(),
+        })?;
 
     // Apply negation if needed
     if negated {
-        not_op(&result).map_err(|e| ExecutorError::Other(format!("SIMD NOT failed: {}", e)))
+        not_op(&result).map_err(|e| ExecutorError::SimdOperationFailed {
+            operation: "NOT".to_string(),
+            reason: e.to_string(),
+        })
     } else {
         Ok(result)
     }


### PR DESCRIPTION
## Summary

- Replace generic `ExecutorError::Other` with type-specific error variants in the vectorized execution module
- Affected files: `filter.rs`, `aggregate.rs`, `arithmetic.rs`, `batch.rs`
- Follows the structured error types from PR #2903:
  - `ArrowDowncastError`: for array type downcast failures
  - `SimdOperationFailed`: for SIMD operation failures
  - `ColumnarTypeMismatch`: for type comparison mismatches
  - `ColumnarColumnNotFound`: for missing column references
  - `UnsupportedArrayType`: for unsupported data types
  - `UnsupportedFeature`: for unsupported operations
  - `ColumnarLengthMismatch`: for empty input validation

## Test plan

- [x] All 59 vectorized module tests pass
- [x] `cargo check --package vibesql-executor` compiles without errors
- [x] No regression in filter, aggregate, arithmetic, and batch tests

Closes #2905

🤖 Generated with [Claude Code](https://claude.com/claude-code)