### PR TITLE
feat(executor): Support SELECT aliases in GROUP BY clause

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -15,7 +15,10 @@ use crate::{
     select::{
         cte::CteResult,
         filter::apply_where_filter_combined_auto,
-        grouping::{expand_group_by_clause, get_base_expressions, group_rows, GroupingContext},
+        grouping::{
+            expand_group_by_clause, get_base_expressions, group_rows,
+            resolve_base_expressions_aliases, resolve_grouping_set_aliases, GroupingContext,
+        },
         helpers::{apply_distinct, apply_limit_offset},
     },
 };
@@ -136,14 +139,22 @@ impl SelectExecutor<'_> {
             let grouping_sets = expand_group_by_clause(group_by_clause);
             let base_expressions = get_base_expressions(group_by_clause);
 
+            // Resolve aliases in base expressions for GROUPING() function support
+            let resolved_base_expressions =
+                resolve_base_expressions_aliases(&base_expressions, &expanded_select_list);
+
             // For each grouping set, group rows and compute aggregates
             for resolved_set in grouping_sets {
+                // Resolve SELECT list aliases in GROUP BY expressions
+                // This allows: SELECT n_name AS nation ... GROUP BY nation
+                let resolved_set = resolve_grouping_set_aliases(&resolved_set, &expanded_select_list);
+
                 let grouping_context = GroupingContext {
-                    base_expressions: base_expressions.clone(),
+                    base_expressions: resolved_base_expressions.clone(),
                     rolled_up: resolved_set.rolled_up.clone(),
                 };
 
-                // Group rows by this grouping set's expressions
+                // Group rows by this grouping set's expressions (now with aliases resolved)
                 let groups = if resolved_set.group_by_exprs.is_empty() {
                     // Empty grouping set (grand total) - all rows in one group
                     vec![(Vec::new(), filtered_rows.clone())]

--- a/crates/vibesql-executor/src/select/grouping/grouping_sets.rs
+++ b/crates/vibesql-executor/src/select/grouping/grouping_sets.rs
@@ -608,6 +608,77 @@ fn window_spec_equal(a: &WindowSpec, b: &WindowSpec) -> bool {
     partition_equal && order_equal && frame_equal
 }
 
+/// Resolve GROUP BY expression that might be a SELECT list alias or column position
+///
+/// Similar to ORDER BY alias resolution, handles three cases:
+/// 1. Numeric literal (e.g., GROUP BY 1, 2, 3) - returns the expression from that position in SELECT list
+/// 2. Simple column reference that matches a SELECT list alias - returns the SELECT list expression
+/// 3. Otherwise - returns the original GROUP BY expression
+///
+/// This enables standard SQL behavior where GROUP BY can reference SELECT aliases:
+/// ```sql
+/// SELECT n_name as nation, COUNT(*) FROM ... GROUP BY nation
+/// ```
+pub fn resolve_group_by_alias(
+    group_expr: &Expression,
+    select_list: &[vibesql_ast::SelectItem],
+) -> Expression {
+    // Check for numeric column position (GROUP BY 1, 2, 3, etc.)
+    if let Expression::Literal(vibesql_types::SqlValue::Integer(pos)) = group_expr {
+        if *pos > 0 && (*pos as usize) <= select_list.len() {
+            // Valid column position, return the expression at that position
+            let idx = (*pos as usize) - 1;
+            if let vibesql_ast::SelectItem::Expression { expr, .. } = &select_list[idx] {
+                return expr.clone();
+            }
+        }
+    }
+
+    // Check if GROUP BY expression is a simple column reference (no table qualifier)
+    if let Expression::ColumnRef { table: None, column } = group_expr {
+        // Search for matching alias in SELECT list (case-insensitive)
+        for item in select_list {
+            if let vibesql_ast::SelectItem::Expression { expr, alias: Some(alias_name) } = item {
+                if alias_name.eq_ignore_ascii_case(column) {
+                    // Found matching alias, use the SELECT list expression
+                    return expr.clone();
+                }
+            }
+        }
+    }
+
+    // Not an alias or column position, use the original expression
+    group_expr.clone()
+}
+
+/// Resolve all aliases in a ResolvedGroupingSet against SELECT list
+///
+/// Processes each GROUP BY expression, resolving any aliases to their
+/// underlying expressions from the SELECT list.
+pub fn resolve_grouping_set_aliases(
+    set: &ResolvedGroupingSet,
+    select_list: &[vibesql_ast::SelectItem],
+) -> ResolvedGroupingSet {
+    ResolvedGroupingSet {
+        group_by_exprs: set.group_by_exprs.iter()
+            .map(|expr| resolve_group_by_alias(expr, select_list))
+            .collect(),
+        rolled_up: set.rolled_up.clone(),
+    }
+}
+
+/// Resolve aliases in base expressions for GroupingContext
+///
+/// Used to ensure GROUPING() function can properly match aliased columns
+pub fn resolve_base_expressions_aliases(
+    base_exprs: &[Expression],
+    select_list: &[vibesql_ast::SelectItem],
+) -> Vec<Expression> {
+    base_exprs.iter()
+        .map(|expr| resolve_group_by_alias(expr, select_list))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1333,5 +1404,158 @@ mod tests {
         // Same expression with different case
         let expr_upper = binary_op(BinaryOperator::Plus, col("A"), lit_int(1));
         assert_eq!(ctx.is_rolled_up(&expr_upper), 1);
+    }
+
+    // ============================================================
+    // Unit tests for GROUP BY alias resolution - issue #2910
+    // ============================================================
+
+    fn select_item(expr: Expression, alias: Option<&str>) -> vibesql_ast::SelectItem {
+        vibesql_ast::SelectItem::Expression {
+            expr,
+            alias: alias.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_resolve_group_by_alias_simple() {
+        // SELECT n_name AS nation, COUNT(*) FROM ... GROUP BY nation
+        let select_list = vec![
+            select_item(col("n_name"), Some("nation")),
+            select_item(
+                Expression::AggregateFunction {
+                    name: "COUNT".to_string(),
+                    distinct: false,
+                    args: vec![Expression::Wildcard],
+                },
+                None,
+            ),
+        ];
+
+        // GROUP BY nation should resolve to n_name
+        let group_expr = col("nation");
+        let resolved = resolve_group_by_alias(&group_expr, &select_list);
+
+        assert!(matches!(resolved, Expression::ColumnRef { table: None, column } if column == "n_name"));
+    }
+
+    #[test]
+    fn test_resolve_group_by_alias_case_insensitive() {
+        // Alias matching should be case-insensitive
+        let select_list = vec![select_item(col("n_name"), Some("NATION"))];
+
+        // GROUP BY nation (lowercase) should match NATION (uppercase)
+        let group_expr = col("nation");
+        let resolved = resolve_group_by_alias(&group_expr, &select_list);
+
+        assert!(matches!(resolved, Expression::ColumnRef { table: None, column } if column == "n_name"));
+    }
+
+    #[test]
+    fn test_resolve_group_by_alias_numeric_position() {
+        // GROUP BY 1 should return the first SELECT item
+        let select_list = vec![
+            select_item(col("n_name"), Some("nation")),
+            select_item(col("amount"), None),
+        ];
+
+        let group_expr = Expression::Literal(vibesql_types::SqlValue::Integer(1));
+        let resolved = resolve_group_by_alias(&group_expr, &select_list);
+
+        assert!(matches!(resolved, Expression::ColumnRef { table: None, column } if column == "n_name"));
+
+        // GROUP BY 2 should return the second SELECT item
+        let group_expr2 = Expression::Literal(vibesql_types::SqlValue::Integer(2));
+        let resolved2 = resolve_group_by_alias(&group_expr2, &select_list);
+
+        assert!(matches!(resolved2, Expression::ColumnRef { table: None, column } if column == "amount"));
+    }
+
+    #[test]
+    fn test_resolve_group_by_alias_no_match() {
+        // GROUP BY expression that doesn't match any alias should remain unchanged
+        let select_list = vec![select_item(col("n_name"), Some("nation"))];
+
+        // GROUP BY something_else should not resolve to anything
+        let group_expr = col("something_else");
+        let resolved = resolve_group_by_alias(&group_expr, &select_list);
+
+        assert!(matches!(resolved, Expression::ColumnRef { table: None, column } if column == "something_else"));
+    }
+
+    #[test]
+    fn test_resolve_group_by_alias_qualified_column() {
+        // Qualified column references (e.g., t.col) should NOT resolve aliases
+        let select_list = vec![select_item(col("n_name"), Some("nation"))];
+
+        // GROUP BY t.nation should NOT resolve to n_name (it's table-qualified)
+        let group_expr = Expression::ColumnRef {
+            table: Some("t".to_string()),
+            column: "nation".to_string(),
+        };
+        let resolved = resolve_group_by_alias(&group_expr, &select_list);
+
+        // Should remain unchanged
+        assert!(matches!(resolved, Expression::ColumnRef { table: Some(t), column } if t == "t" && column == "nation"));
+    }
+
+    #[test]
+    fn test_resolve_group_by_alias_expression_alias() {
+        // SELECT SUBSTR(o_orderdate, 1, 4) AS o_year ... GROUP BY o_year
+        let substr_expr = Expression::Function {
+            name: "SUBSTR".to_string(),
+            args: vec![
+                col("o_orderdate"),
+                Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+                Expression::Literal(vibesql_types::SqlValue::Integer(4)),
+            ],
+            character_unit: None,
+        };
+        let select_list = vec![select_item(substr_expr.clone(), Some("o_year"))];
+
+        // GROUP BY o_year should resolve to SUBSTR(o_orderdate, 1, 4)
+        let group_expr = col("o_year");
+        let resolved = resolve_group_by_alias(&group_expr, &select_list);
+
+        // Should be the SUBSTR expression
+        assert!(matches!(resolved, Expression::Function { name, .. } if name == "SUBSTR"));
+    }
+
+    #[test]
+    fn test_resolve_grouping_set_aliases() {
+        // Test resolving aliases in a full grouping set
+        let select_list = vec![
+            select_item(col("n1_n_name"), Some("supp_nation")),
+            select_item(col("n2_n_name"), Some("cust_nation")),
+        ];
+
+        let original_set = ResolvedGroupingSet {
+            group_by_exprs: vec![col("supp_nation"), col("cust_nation")],
+            rolled_up: vec![false, false],
+        };
+
+        let resolved_set = resolve_grouping_set_aliases(&original_set, &select_list);
+
+        // Both should resolve to the actual column names
+        assert_eq!(resolved_set.group_by_exprs.len(), 2);
+        assert!(matches!(&resolved_set.group_by_exprs[0], Expression::ColumnRef { table: None, column } if column == "n1_n_name"));
+        assert!(matches!(&resolved_set.group_by_exprs[1], Expression::ColumnRef { table: None, column } if column == "n2_n_name"));
+        // rolled_up should be preserved
+        assert_eq!(resolved_set.rolled_up, vec![false, false]);
+    }
+
+    #[test]
+    fn test_resolve_base_expressions_aliases() {
+        let select_list = vec![
+            select_item(col("a_col"), Some("a")),
+            select_item(col("b_col"), Some("b")),
+        ];
+
+        let base_exprs = vec![col("a"), col("b")];
+        let resolved = resolve_base_expressions_aliases(&base_exprs, &select_list);
+
+        assert_eq!(resolved.len(), 2);
+        assert!(matches!(&resolved[0], Expression::ColumnRef { table: None, column } if column == "a_col"));
+        assert!(matches!(&resolved[1], Expression::ColumnRef { table: None, column } if column == "b_col"));
     }
 }

--- a/crates/vibesql-executor/src/select/grouping/mod.rs
+++ b/crates/vibesql-executor/src/select/grouping/mod.rs
@@ -14,6 +14,9 @@ mod keys;
 
 // Re-export public API
 pub(super) use aggregates::{AggregateAccumulator, compare_sql_values};
-pub(super) use grouping_sets::{expand_group_by_clause, get_base_expressions, GroupingContext};
+pub(super) use grouping_sets::{
+    expand_group_by_clause, get_base_expressions, resolve_base_expressions_aliases,
+    resolve_grouping_set_aliases, GroupingContext,
+};
 pub(super) use hash::group_rows;
 pub(crate) use keys::{GroupKey, GroupKeySpec};

--- a/crates/vibesql-executor/src/tests/aggregate_group_by_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_group_by_tests.rs
@@ -4,6 +4,195 @@
 
 use super::super::*;
 
+/// Test GROUP BY referencing SELECT list aliases (issue #2910)
+///
+/// Standard SQL allows GROUP BY to reference column aliases defined in SELECT.
+/// Example: SELECT dept AS department, COUNT(*) FROM sales GROUP BY department
+#[test]
+fn test_group_by_select_alias() {
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "sales".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new("id".to_string(), vibesql_types::DataType::Integer, false),
+            vibesql_catalog::ColumnSchema::new("dept".to_string(), vibesql_types::DataType::Integer, false),
+            vibesql_catalog::ColumnSchema::new("amount".to_string(), vibesql_types::DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    db.insert_row(
+        "sales",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(1),
+            vibesql_types::SqlValue::Integer(1),
+            vibesql_types::SqlValue::Integer(100),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "sales",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(2),
+            vibesql_types::SqlValue::Integer(1),
+            vibesql_types::SqlValue::Integer(200),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "sales",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(3),
+            vibesql_types::SqlValue::Integer(2),
+            vibesql_types::SqlValue::Integer(150),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // SELECT dept AS department, COUNT(*) FROM sales GROUP BY department
+    // GROUP BY uses alias "department" which should resolve to column "dept"
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![
+            vibesql_ast::SelectItem::Expression {
+                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "dept".to_string() },
+                alias: Some("department".to_string()),
+            },
+            vibesql_ast::SelectItem::Expression {
+                expr: vibesql_ast::Expression::AggregateFunction {
+                    name: "COUNT".to_string(),
+                    distinct: false,
+                    args: vec![vibesql_ast::Expression::Wildcard],
+                },
+                alias: None,
+            },
+        ],
+        from: Some(vibesql_ast::FromClause::Table { name: "sales".to_string(), alias: None }),
+        where_clause: None,
+        // GROUP BY "department" - uses alias from SELECT list
+        group_by: Some(vibesql_ast::GroupByClause::Simple(vec![vibesql_ast::Expression::ColumnRef {
+            table: None,
+            column: "department".to_string(),
+        }])),
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 2);
+
+    let mut results = result
+        .into_iter()
+        .map(|row| (row.values[0].clone(), row.values[1].clone()))
+        .collect::<Vec<_>>();
+    results.sort_by(|(dept_a, _), (dept_b, _)| match (dept_a, dept_b) {
+        (vibesql_types::SqlValue::Integer(a), vibesql_types::SqlValue::Integer(b)) => a.cmp(b),
+        _ => std::cmp::Ordering::Equal,
+    });
+    // Dept 1 has 2 rows, dept 2 has 1 row
+    assert_eq!(results[0], (vibesql_types::SqlValue::Integer(1), vibesql_types::SqlValue::Integer(2)));
+    assert_eq!(results[1], (vibesql_types::SqlValue::Integer(2), vibesql_types::SqlValue::Integer(1)));
+}
+
+/// Test GROUP BY with numeric column position (GROUP BY 1)
+#[test]
+fn test_group_by_numeric_position() {
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "sales".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new("id".to_string(), vibesql_types::DataType::Integer, false),
+            vibesql_catalog::ColumnSchema::new("dept".to_string(), vibesql_types::DataType::Integer, false),
+            vibesql_catalog::ColumnSchema::new("amount".to_string(), vibesql_types::DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    db.insert_row(
+        "sales",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(1),
+            vibesql_types::SqlValue::Integer(1),
+            vibesql_types::SqlValue::Integer(100),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "sales",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(2),
+            vibesql_types::SqlValue::Integer(1),
+            vibesql_types::SqlValue::Integer(200),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "sales",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(3),
+            vibesql_types::SqlValue::Integer(2),
+            vibesql_types::SqlValue::Integer(150),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // SELECT dept, COUNT(*) FROM sales GROUP BY 1
+    // GROUP BY 1 refers to the first SELECT item (dept)
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![
+            vibesql_ast::SelectItem::Expression {
+                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "dept".to_string() },
+                alias: None,
+            },
+            vibesql_ast::SelectItem::Expression {
+                expr: vibesql_ast::Expression::AggregateFunction {
+                    name: "COUNT".to_string(),
+                    distinct: false,
+                    args: vec![vibesql_ast::Expression::Wildcard],
+                },
+                alias: None,
+            },
+        ],
+        from: Some(vibesql_ast::FromClause::Table { name: "sales".to_string(), alias: None }),
+        where_clause: None,
+        // GROUP BY 1 - first column in SELECT list
+        group_by: Some(vibesql_ast::GroupByClause::Simple(vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+        ])),
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 2);
+
+    let mut results = result
+        .into_iter()
+        .map(|row| (row.values[0].clone(), row.values[1].clone()))
+        .collect::<Vec<_>>();
+    results.sort_by(|(dept_a, _), (dept_b, _)| match (dept_a, dept_b) {
+        (vibesql_types::SqlValue::Integer(a), vibesql_types::SqlValue::Integer(b)) => a.cmp(b),
+        _ => std::cmp::Ordering::Equal,
+    });
+    assert_eq!(results[0], (vibesql_types::SqlValue::Integer(1), vibesql_types::SqlValue::Integer(2)));
+    assert_eq!(results[1], (vibesql_types::SqlValue::Integer(2), vibesql_types::SqlValue::Integer(1)));
+}
+
 #[test]
 fn test_group_by_with_count() {
     let mut db = vibesql_storage::Database::new();


### PR DESCRIPTION
## Summary
- Implements GROUP BY alias resolution allowing queries like:
  `SELECT n_name AS nation, COUNT(*) FROM ... GROUP BY nation`
- Adds support for numeric column positions in GROUP BY (e.g., `GROUP BY 1, 2`)
- Unblocks TPC-H Q7 and Q9 which use aliased GROUP BY

## Changes
- Added `resolve_group_by_alias`, `resolve_grouping_set_aliases`, and `resolve_base_expressions_aliases` functions to `grouping_sets.rs`
- Integrated alias resolution into aggregation execution before grouping
- Added 8 unit tests for alias resolution functions
- Added 2 integration tests for GROUP BY with aliases and numeric positions

## Test plan
- [x] All existing tests pass
- [x] New unit tests for alias resolution
- [x] New integration tests for GROUP BY with aliases
- [ ] TPC-H Q7 and Q9 benchmarks (in progress)

Closes #2910

🤖 Generated with [Claude Code](https://claude.com/claude-code)