### PR TITLE
refactor(executor): Add ColumnarColumnNotFoundByName error variant

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -186,6 +186,8 @@ pub enum ExecutorError {
         column_index: usize,
         batch_columns: usize,
     },
+    /// Column not found in batch by name
+    ColumnarColumnNotFoundByName { column_name: String },
     /// Column length mismatch in batch operations
     ColumnarLengthMismatch {
         context: String,
@@ -580,6 +582,9 @@ impl std::fmt::Display for ExecutorError {
                     "Column index {} out of bounds (batch has {} columns)",
                     column_index, batch_columns
                 )
+            }
+            ExecutorError::ColumnarColumnNotFoundByName { column_name } => {
+                write!(f, "Column not found: {}", column_name)
             }
             ExecutorError::ColumnarLengthMismatch { context, expected, actual } => {
                 write!(

--- a/crates/vibesql-executor/src/select/columnar/batch.rs
+++ b/crates/vibesql-executor/src/select/columnar/batch.rs
@@ -432,11 +432,10 @@ impl ColumnarBatch {
         let row_count = storage_columnar.row_count();
         let mut columns = Vec::with_capacity(column_names.len());
 
-        for (col_idx, col_name) in column_names.iter().enumerate() {
+        for col_name in column_names.iter() {
             let storage_col = storage_columnar.get_column(col_name).ok_or_else(|| {
-                ExecutorError::ColumnarColumnNotFound {
-                    column_index: col_idx,
-                    batch_columns: column_names.len(),
+                ExecutorError::ColumnarColumnNotFoundByName {
+                    column_name: col_name.clone(),
                 }
             })?;
 


### PR DESCRIPTION
## Summary
- Add dedicated `ColumnarColumnNotFoundByName` error variant for name-based column lookups
- Update `from_storage_columnar` in batch.rs to use the new variant instead of the semantically incorrect `ColumnarColumnNotFound` with placeholder index
- Provides clearer error messages showing the actual column name that wasn't found

Closes #2917

## Test plan
- [x] All existing tests pass (1553 tests)
- [x] Changes are minimal and localized to error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)