### PR TITLE
fix(executor): Support Date/Timestamp types in SUBSTRING function

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/string/substring.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/string/substring.rs
@@ -3,6 +3,7 @@
 //! SQL:1999 Section 6.29: String value functions
 
 use crate::errors::ExecutorError;
+use std::borrow::Cow;
 
 /// SUBSTRING(string, start [, length]) - Extract substring
 /// SQL:1999 Section 6.29: String value functions
@@ -29,13 +30,16 @@ pub(in crate::evaluator::functions) fn substring(
         return Ok(vibesql_types::SqlValue::Null);
     }
 
-    // Extract string
-    let s = match string_val {
-        vibesql_types::SqlValue::Varchar(s) => s.as_str(),
-        vibesql_types::SqlValue::Character(s) => s.as_str(),
+    // Extract string - supports implicit coercion from Date/Timestamp to string
+    // This enables TPC-H Q9 pattern: SUBSTR(o_orderdate, 1, 4) to extract year
+    let s: Cow<str> = match string_val {
+        vibesql_types::SqlValue::Varchar(s) => Cow::Borrowed(s.as_str()),
+        vibesql_types::SqlValue::Character(s) => Cow::Borrowed(s.as_str()),
+        vibesql_types::SqlValue::Date(d) => Cow::Owned(d.to_string()),
+        vibesql_types::SqlValue::Timestamp(ts) => Cow::Owned(ts.to_string()),
         _ => {
             return Err(ExecutorError::UnsupportedFeature(format!(
-                "SUBSTRING requires string argument, got {:?}",
+                "SUBSTRING requires string or date/timestamp argument, got {:?}",
                 string_val
             )))
         }

--- a/tests/sqllogictest-files/functions/string.slt
+++ b/tests/sqllogictest-files/functions/string.slt
@@ -18,6 +18,31 @@ SELECT SUBSTRING('hello' FROM 2 FOR 3)
 ----
 ell
 
+# SUBSTRING with Date (implicit coercion)
+# Extracts year from date in YYYY-MM-DD format
+query T
+SELECT SUBSTRING(DATE '1996-07-15' FROM 1 FOR 4)
+----
+1996
+
+# SUBSTR alias with Date - extract month
+query T
+SELECT SUBSTR(DATE '1996-07-15', 6, 2)
+----
+07
+
+# SUBSTR with Date - extract day
+query T
+SELECT SUBSTR(DATE '1996-07-15', 9, 2)
+----
+15
+
+# SUBSTRING with Timestamp (implicit coercion)
+query T
+SELECT SUBSTRING(TIMESTAMP '1996-07-15 08:30:00' FROM 1 FOR 10)
+----
+1996-07-15
+
 # CHAR_LENGTH
 query I
 SELECT CHAR_LENGTH('test')


### PR DESCRIPTION
## Summary

- Add implicit type coercion for Date and Timestamp types in the SUBSTRING function
- This enables TPC-H Q9 pattern: `SUBSTR(o_orderdate, 1, 4)` to extract the year from a date column
- Use `Cow<str>` to handle both borrowed strings and owned Date/Timestamp string representations efficiently

## Changes

- Modified `substring.rs` to accept `Date` and `Timestamp` types by converting them to their string representation (YYYY-MM-DD for Date, YYYY-MM-DD HH:MM:SS for Timestamp)
- Updated error message to reflect the expanded type support
- Added sqllogictest tests verifying Date and Timestamp SUBSTRING operations

## Test plan

- [x] All existing function tests pass
- [x] New sqllogictest tests for Date/Timestamp SUBSTRING operations pass
- [x] TPC-H related tests continue to pass

Closes #2919

🤖 Generated with [Claude Code](https://claude.com/claude-code)