### PR TITLE
perf(executor): Use zero-copy native columnar execution for eligible queries

### DIFF
--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -224,26 +224,40 @@ impl SelectExecutor<'_> {
         // Pipeline execution returns Option<Vec<Row>> - None means fallback needed
         let mut results = match strategy {
             ExecutionStrategy::NativeColumnar { .. } => {
-                // Try native columnar execution via pipeline
-                match self.execute_via_pipeline(
-                    stmt,
-                    cte_results,
-                    || NativeColumnarPipeline::new(),
-                    "NativeColumnar",
-                )? {
-                    Some(result) => result,
-                    None => {
-                        // Fall back to row-oriented if native columnar fails
-                        log::debug!("Native columnar runtime fallback to row-oriented");
-                        #[cfg(feature = "profile-q6")]
-                        eprintln!("[PROFILE-Q6] Native columnar fallback to row-oriented");
-                        self.execute_row_oriented(stmt, cte_results)?
+                // First try the optimized zero-copy native columnar path
+                // This uses ColumnarBatch::from_storage_columnar() for zero-copy conversion
+                // and executes filter+aggregate in a single pass without row materialization
+                if let Some(result) = self.try_native_columnar_execution(stmt, cte_results)? {
+                    #[cfg(feature = "profile-q6")]
+                    eprintln!("[PROFILE-Q6] Native columnar: zero-copy path succeeded");
+                    result
+                } else {
+                    // Fall back to pipeline-based execution if zero-copy path is not applicable
+                    // (e.g., complex predicates, multiple tables, unsupported aggregates)
+                    log::debug!("Native columnar: zero-copy path not applicable, trying pipeline");
+                    match self.execute_via_pipeline(
+                        stmt,
+                        cte_results,
+                        || NativeColumnarPipeline::new(),
+                        "NativeColumnar",
+                    )? {
+                        Some(result) => result,
+                        None => {
+                            // Fall back to row-oriented if pipeline also fails
+                            log::debug!("Native columnar runtime fallback to row-oriented");
+                            #[cfg(feature = "profile-q6")]
+                            eprintln!("[PROFILE-Q6] Native columnar fallback to row-oriented");
+                            self.execute_row_oriented(stmt, cte_results)?
+                        }
                     }
                 }
             }
 
             ExecutionStrategy::StandardColumnar { .. } => {
-                // Try standard columnar execution via pipeline
+                // StandardColumnar uses the pipeline-based execution path
+                // Note: We don't use try_native_columnar_execution here because row tables
+                // go through the pipeline which correctly handles all data types including dates.
+                // The native columnar zero-copy path has known limitations with certain date comparisons.
                 match self.execute_via_pipeline(
                     stmt,
                     cte_results,


### PR DESCRIPTION
## Summary

- Enable the optimized `try_native_columnar_execution` path for NativeColumnar strategy queries
- Uses `ColumnarBatch::from_storage_columnar()` for zero-copy conversion from storage
- Executes filter+aggregate in a single pass without row materialization  
- Eliminates the O(n*m) `from_rows()` conversion overhead for native columnar tables

## Changes

- Modified `execute_with_ctes` to try the zero-copy native columnar path first when `NativeColumnar` strategy is selected
- Falls back to pipeline-based execution only if zero-copy path is not applicable (e.g., complex predicates, multiple tables)
- StandardColumnar strategy continues using the pipeline path which correctly handles all data types

## Test plan

- [x] All existing columnar storage tests pass (11 tests)
- [x] All TPC-H Q6 tests pass (6 tests) 
- [x] All TPC-H Q1 tests pass (2 tests)
- [x] Full executor test suite passes (1417 tests)

Closes #2937

🤖 Generated with [Claude Code](https://claude.com/claude-code)