### PR TITLE
test(executor): Add regression tests for SUBSTRING with Date type

### DIFF
--- a/crates/vibesql-executor/tests/string_function_tests.rs
+++ b/crates/vibesql-executor/tests/string_function_tests.rs
@@ -181,3 +181,81 @@ fn test_trim_with_char_still_works() {
     let result = evaluator.eval(&expr, &row).unwrap();
     assert_eq!(result, vibesql_types::SqlValue::Varchar("foo".to_string()));
 }
+
+// ============================================================================
+// SUBSTRING with Date/Timestamp Tests (Issue #2955, TPC-H Q7/Q9 support)
+// ============================================================================
+
+#[test]
+fn test_substring_with_date_extract_year() {
+    // TPC-H Q7/Q9 pattern: SUBSTR(l_shipdate, 1, 4) to extract year from date
+    let (evaluator, row) = create_test_evaluator();
+    let date = vibesql_types::Date::new(1996, 7, 15).unwrap();
+    let expr = vibesql_ast::Expression::Function {
+        name: "SUBSTRING".to_string(),
+        args: vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(date)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(4)),
+        ],
+        character_unit: None,
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, vibesql_types::SqlValue::Varchar("1996".to_string()));
+}
+
+#[test]
+fn test_substring_with_date_extract_month() {
+    // Extract month from date: SUBSTR(date, 6, 2)
+    let (evaluator, row) = create_test_evaluator();
+    let date = vibesql_types::Date::new(1996, 7, 15).unwrap();
+    let expr = vibesql_ast::Expression::Function {
+        name: "SUBSTR".to_string(), // Test alias
+        args: vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(date)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(6)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
+        ],
+        character_unit: None,
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, vibesql_types::SqlValue::Varchar("07".to_string()));
+}
+
+#[test]
+fn test_substring_with_date_extract_day() {
+    // Extract day from date: SUBSTR(date, 9, 2)
+    let (evaluator, row) = create_test_evaluator();
+    let date = vibesql_types::Date::new(1996, 7, 15).unwrap();
+    let expr = vibesql_ast::Expression::Function {
+        name: "SUBSTRING".to_string(),
+        args: vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(date)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(9)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
+        ],
+        character_unit: None,
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, vibesql_types::SqlValue::Varchar("15".to_string()));
+}
+
+#[test]
+fn test_substring_with_timestamp() {
+    // Extract date portion from timestamp: SUBSTRING(timestamp, 1, 10)
+    let (evaluator, row) = create_test_evaluator();
+    let date = vibesql_types::Date::new(1996, 7, 15).unwrap();
+    let time = vibesql_types::Time::new(8, 30, 0, 0).unwrap();
+    let timestamp = vibesql_types::Timestamp::new(date, time);
+    let expr = vibesql_ast::Expression::Function {
+        name: "SUBSTRING".to_string(),
+        args: vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Timestamp(timestamp)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(10)),
+        ],
+        character_unit: None,
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, vibesql_types::SqlValue::Varchar("1996-07-15".to_string()));
+}

--- a/crates/vibesql-executor/tests/tpch_subquery_tests.rs
+++ b/crates/vibesql-executor/tests/tpch_subquery_tests.rs
@@ -245,3 +245,59 @@ fn test_q18_in_subquery_with_having() {
         assert!(q18_count > 0, "Q18 should return rows if subquery found matching orders");
     }
 }
+
+#[test]
+fn test_q7_volume_shipping() {
+    // Q7: Volume Shipping
+    // Tests SUBSTR(l_shipdate, 1, 4) to extract year from DATE column
+    // Issue #2955: This query was failing because SUBSTRING didn't support Date type
+    // Pattern: 6-table JOIN with SUBSTR and date filtering
+
+    let db = load_vibesql(0.01);
+
+    let result = execute_tpch_query(&db, TPCH_Q7);
+
+    match result {
+        Ok(count) => {
+            println!("Q7 executed successfully: {} rows", count);
+            // Q7 may return 0 rows on small dataset if no orders match criteria
+            // The important thing is that it doesn't fail with "SUBSTRING requires string argument"
+            println!("Q7 completed without errors (row count: {})", count);
+        }
+        Err(e) => {
+            // Specifically check that the error is NOT about SUBSTRING type mismatch
+            if e.contains("SUBSTRING requires string argument") {
+                panic!("Q7 failed with SUBSTRING type error - Issue #2955 not fixed: {}", e);
+            }
+            panic!("Q7 failed to execute: {}", e);
+        }
+    }
+}
+
+#[test]
+fn test_q9_product_type_profit() {
+    // Q9: Product Type Profit Measure
+    // Tests SUBSTR(o_orderdate, 1, 4) to extract year from DATE column
+    // Issue #2955: This query was failing because SUBSTRING didn't support Date type
+    // Pattern: 6-table JOIN with LIKE and SUBSTR on date
+
+    let db = load_vibesql(0.01);
+
+    let result = execute_tpch_query(&db, TPCH_Q9);
+
+    match result {
+        Ok(count) => {
+            println!("Q9 executed successfully: {} rows", count);
+            // Q9 may return 0 rows on small dataset if no parts match LIKE '%green%'
+            // The important thing is that it doesn't fail with "SUBSTRING requires string argument"
+            println!("Q9 completed without errors (row count: {})", count);
+        }
+        Err(e) => {
+            // Specifically check that the error is NOT about SUBSTRING type mismatch
+            if e.contains("SUBSTRING requires string argument") {
+                panic!("Q9 failed with SUBSTRING type error - Issue #2955 not fixed: {}", e);
+            }
+            panic!("Q9 failed to execute: {}", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add unit tests for SUBSTRING function with Date and Timestamp types
- Add TPC-H Q7 and Q9 integration tests to ensure these queries execute successfully
- The actual fix was already applied in PR #2924; these tests prevent regression

## Test plan
- [x] Run unit tests: `cargo test --test string_function_tests -- test_substring_with_date`
- [x] Run TPC-H tests: `cargo test --test tpch_subquery_tests -- test_q7 test_q9`
- [x] Verify all tests pass

Closes #2955

🤖 Generated with [Claude Code](https://claude.com/claude-code)