### PR TITLE
perf(bench): Profile lineitem table scan performance

### DIFF
--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -177,3 +177,7 @@ harness = false
 [[bench]]
 name = "simd_filter_benchmark"
 harness = false
+
+[[bench]]
+name = "lineitem_scan_profiling"
+harness = false

--- a/crates/vibesql-executor/benches/lineitem_scan_profiling.rs
+++ b/crates/vibesql-executor/benches/lineitem_scan_profiling.rs
@@ -1,0 +1,234 @@
+//! Lineitem Scan Profiling Benchmark
+//!
+//! This benchmark isolates lineitem table scan performance to understand:
+//! - Pure scan overhead (no predicates, no aggregation)
+//! - Date predicate filtering cost
+//! - Comparison with DuckDB equivalent operations
+//!
+//! Usage:
+//!   cargo bench --bench lineitem_scan_profiling --features benchmark-comparison
+//!
+//! Part of issue #2962: Profile lineitem table scan performance
+
+mod tpch;
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use std::hint::black_box;
+use std::time::Duration;
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+
+use tpch::schema::*;
+
+// =============================================================================
+// Query Constants
+// =============================================================================
+
+/// Pure scan - no predicates, no aggregation
+const LINEITEM_FULL_SCAN: &str = "SELECT * FROM lineitem";
+
+/// Simple COUNT(*) - minimal processing
+const LINEITEM_COUNT: &str = "SELECT COUNT(*) FROM lineitem";
+
+/// Date predicate only (same as Q1)
+const LINEITEM_DATE_FILTER: &str =
+    "SELECT * FROM lineitem WHERE l_shipdate <= '1998-09-01'";
+
+/// Date predicate with COUNT
+const LINEITEM_DATE_COUNT: &str =
+    "SELECT COUNT(*) FROM lineitem WHERE l_shipdate <= '1998-09-01'";
+
+/// Single column projection
+const LINEITEM_SINGLE_COLUMN: &str = "SELECT l_orderkey FROM lineitem";
+
+/// Two columns projection
+const LINEITEM_TWO_COLUMNS: &str = "SELECT l_orderkey, l_quantity FROM lineitem";
+
+/// LIMIT scan (measure startup cost)
+const LINEITEM_LIMIT_100: &str = "SELECT * FROM lineitem LIMIT 100";
+
+/// LIMIT scan with date filter
+const LINEITEM_DATE_LIMIT_100: &str =
+    "SELECT * FROM lineitem WHERE l_shipdate <= '1998-09-01' LIMIT 100";
+
+// =============================================================================
+// VibeSQL Benchmark Functions
+// =============================================================================
+
+fn benchmark_vibesql(c: &mut Criterion, group_name: &str, sql: &str) {
+    let mut group = c.benchmark_group(group_name);
+    group.measurement_time(Duration::from_secs(5));
+
+    let db = load_vibesql(0.01);
+
+    // Get row count for throughput calculation
+    let row_count = db.get_table("lineitem").map(|t| t.row_count()).unwrap_or(0);
+
+    group.throughput(Throughput::Elements(row_count as u64));
+
+    group.bench_function("vibesql", |b| {
+        b.iter(|| {
+            let stmt = Parser::parse_sql(sql).unwrap();
+            if let vibesql_ast::Statement::Select(select) = stmt {
+                let executor = SelectExecutor::new(&db);
+                let result = executor.execute(&select).unwrap();
+                black_box(result.len())
+            } else {
+                0
+            }
+        });
+    });
+
+    group.finish();
+}
+
+// =============================================================================
+// DuckDB Benchmark Functions
+// =============================================================================
+
+#[cfg(feature = "benchmark-comparison")]
+fn benchmark_duckdb(c: &mut Criterion, group_name: &str, sql: &str) {
+    let mut group = c.benchmark_group(group_name);
+    group.measurement_time(Duration::from_secs(5));
+
+    let conn = load_duckdb(0.01);
+
+    // Get row count for throughput calculation
+    let row_count: i64 = conn
+        .prepare("SELECT COUNT(*) FROM lineitem")
+        .unwrap()
+        .query_row([], |row| row.get(0))
+        .unwrap();
+
+    group.throughput(Throughput::Elements(row_count as u64));
+
+    group.bench_function("duckdb", |b| {
+        b.iter(|| {
+            let mut stmt = conn.prepare(sql).unwrap();
+            let mut rows = stmt.query([]).unwrap();
+            let mut count = 0;
+            while rows.next().unwrap().is_some() {
+                count += 1;
+            }
+            black_box(count)
+        });
+    });
+
+    group.finish();
+}
+
+// =============================================================================
+// Benchmark Functions
+// =============================================================================
+
+fn bench_full_scan_vibesql(c: &mut Criterion) {
+    benchmark_vibesql(c, "lineitem_full_scan", LINEITEM_FULL_SCAN);
+}
+
+fn bench_count_vibesql(c: &mut Criterion) {
+    benchmark_vibesql(c, "lineitem_count", LINEITEM_COUNT);
+}
+
+fn bench_date_filter_vibesql(c: &mut Criterion) {
+    benchmark_vibesql(c, "lineitem_date_filter", LINEITEM_DATE_FILTER);
+}
+
+fn bench_date_count_vibesql(c: &mut Criterion) {
+    benchmark_vibesql(c, "lineitem_date_count", LINEITEM_DATE_COUNT);
+}
+
+fn bench_single_column_vibesql(c: &mut Criterion) {
+    benchmark_vibesql(c, "lineitem_single_column", LINEITEM_SINGLE_COLUMN);
+}
+
+fn bench_two_columns_vibesql(c: &mut Criterion) {
+    benchmark_vibesql(c, "lineitem_two_columns", LINEITEM_TWO_COLUMNS);
+}
+
+fn bench_limit_100_vibesql(c: &mut Criterion) {
+    benchmark_vibesql(c, "lineitem_limit_100", LINEITEM_LIMIT_100);
+}
+
+fn bench_date_limit_100_vibesql(c: &mut Criterion) {
+    benchmark_vibesql(c, "lineitem_date_limit_100", LINEITEM_DATE_LIMIT_100);
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn bench_full_scan_duckdb(c: &mut Criterion) {
+    benchmark_duckdb(c, "lineitem_full_scan", LINEITEM_FULL_SCAN);
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn bench_count_duckdb(c: &mut Criterion) {
+    benchmark_duckdb(c, "lineitem_count", LINEITEM_COUNT);
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn bench_date_filter_duckdb(c: &mut Criterion) {
+    benchmark_duckdb(c, "lineitem_date_filter", LINEITEM_DATE_FILTER);
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn bench_date_count_duckdb(c: &mut Criterion) {
+    benchmark_duckdb(c, "lineitem_date_count", LINEITEM_DATE_COUNT);
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn bench_single_column_duckdb(c: &mut Criterion) {
+    benchmark_duckdb(c, "lineitem_single_column", LINEITEM_SINGLE_COLUMN);
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn bench_two_columns_duckdb(c: &mut Criterion) {
+    benchmark_duckdb(c, "lineitem_two_columns", LINEITEM_TWO_COLUMNS);
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn bench_limit_100_duckdb(c: &mut Criterion) {
+    benchmark_duckdb(c, "lineitem_limit_100", LINEITEM_LIMIT_100);
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn bench_date_limit_100_duckdb(c: &mut Criterion) {
+    benchmark_duckdb(c, "lineitem_date_limit_100", LINEITEM_DATE_LIMIT_100);
+}
+
+// =============================================================================
+// Criterion Benchmark Groups
+// =============================================================================
+
+#[cfg(not(feature = "benchmark-comparison"))]
+criterion_group!(
+    benches,
+    bench_full_scan_vibesql,
+    bench_count_vibesql,
+    bench_date_filter_vibesql,
+    bench_date_count_vibesql,
+    bench_single_column_vibesql,
+    bench_two_columns_vibesql,
+    bench_limit_100_vibesql,
+    bench_date_limit_100_vibesql
+);
+
+#[cfg(feature = "benchmark-comparison")]
+criterion_group!(
+    benches,
+    bench_full_scan_vibesql,
+    bench_full_scan_duckdb,
+    bench_count_vibesql,
+    bench_count_duckdb,
+    bench_date_filter_vibesql,
+    bench_date_filter_duckdb,
+    bench_date_count_vibesql,
+    bench_date_count_duckdb,
+    bench_single_column_vibesql,
+    bench_single_column_duckdb,
+    bench_two_columns_vibesql,
+    bench_two_columns_duckdb,
+    bench_limit_100_vibesql,
+    bench_limit_100_duckdb,
+    bench_date_limit_100_vibesql,
+    bench_date_limit_100_duckdb
+);
+
+criterion_main!(benches);

--- a/docs/performance/LINEITEM_SCAN_ANALYSIS.md
+++ b/docs/performance/LINEITEM_SCAN_ANALYSIS.md
@@ -1,0 +1,182 @@
+# Lineitem Table Scan Performance Analysis
+
+Issue #2962 - Performance profiling of lineitem table scans
+
+## Executive Summary
+
+Benchmarks reveal that VibeSQL's lineitem table scan performance lags behind DuckDB by **27-294x** depending on the operation. The primary bottleneck is **eager row materialization** - cloning all rows from storage into `Vec<Row>` before any processing occurs.
+
+## Benchmark Results (SF 0.01, ~60K rows)
+
+| Benchmark | VibeSQL | DuckDB | Gap | Notes |
+|-----------|---------|--------|-----|-------|
+| **Full Scan** (SELECT *) | 295ms | 10.9ms | **27x** | Baseline overhead |
+| **COUNT(*)** | 71ms | 242µs | **294x** | No data needed, but we clone all rows |
+| **Date Filter** (SELECT * WHERE) | 61ms | 7.8ms | **8x** | Best case - columnar filter helps |
+| **Date COUNT** (COUNT(*) WHERE) | 68ms | 290µs | **234x** | Same problem as COUNT(*) |
+| **Single Column** (SELECT l_orderkey) | 39ms | 413µs | **95x** | Should only read 1 column |
+| **Two Columns** | 41ms | 573µs | **72x** | Still reads all columns |
+| **LIMIT 100** | 25ms | 579µs | **43x** | Scans all rows, then limits |
+| **Date + LIMIT 100** | 22ms | 760µs | **29x** | No early termination |
+
+## Root Cause Analysis
+
+### 1. Eager Full-Row Materialization
+
+**Location**: `crates/vibesql-executor/src/select/scan/table.rs:167-218`
+
+Every table scan follows this pattern:
+```rust
+// Get row slice from table (zero-copy reference)
+let row_slice = table.scan();
+
+// ... processing ...
+
+// PROBLEM: Always clones all rows
+let rows = row_slice.to_vec();
+```
+
+Even when:
+- Only SELECT COUNT(*) is needed (no data)
+- Only 1 column is projected (l_orderkey)
+- LIMIT 100 would stop at 100 rows
+
+### 2. Row-Based Storage Model
+
+**Row Structure** (`crates/vibesql-storage/src/row.rs`):
+```rust
+pub struct Row {
+    pub values: Vec<SqlValue>,  // 16 columns for lineitem
+}
+```
+
+**SqlValue enum** (`crates/vibesql-types/src/sql_value/mod.rs`):
+- Contains String variants (Character, Varchar) = 24 bytes
+- Enum discriminant + padding = ~32 bytes per value
+- lineitem has 16 columns = ~512 bytes per row (excluding string content)
+
+**Memory overhead per scan**:
+- 60K rows × 512 bytes = ~30MB copied
+- Plus heap allocations for String values (l_comment: up to 44 chars)
+- Each clone triggers 60K allocations for Vec<SqlValue> headers
+
+### 3. No Column Pruning
+
+When executing `SELECT l_orderkey FROM lineitem`:
+1. All 16 columns are read from storage
+2. All 16 columns are cloned into Vec<Row>
+3. Projection happens AFTER materialization
+
+### 4. No Early Termination for LIMIT
+
+`LIMIT 100` on 60K rows:
+1. Scans all 60K rows from storage
+2. Clones all 60K rows
+3. THEN applies LIMIT (discards 59,900 rows)
+
+See comment at line 213:
+```rust
+// TODO: Future optimization - use zero-copy iterator over row slice
+```
+
+### 5. COUNT(*) Materializes All Data
+
+For COUNT(*), ideal behavior:
+- Just return table.row_count() = O(1)
+- No data access needed
+
+Current behavior:
+- Clone all rows
+- Build full result set
+- Count result.len()
+
+## Performance Gap Breakdown
+
+| Factor | Impact | Evidence |
+|--------|--------|----------|
+| Row cloning | ~20x | Full scan is 27x vs ideal 1-2x |
+| No column pruning | ~3-4x | Single column (95x) vs full scan (27x) |
+| No LIMIT pushdown | ~10x | LIMIT 100 takes 25ms instead of <1ms |
+| COUNT(*) not optimized | ~290x | Could be O(1) |
+
+## Optimization Targets
+
+### High Impact (100x+ improvement potential)
+
+1. **Zero-Copy Iterator for Table Scans**
+   - Return `impl Iterator<Item = &Row>` instead of `Vec<Row>`
+   - Stop cloning 60K rows per scan
+   - Location: `scan/table.rs:167-221`
+
+2. **Optimize COUNT(*) without FROM data**
+   - Return `table.row_count()` directly
+   - Location: Detect in `executor/execute.rs`
+
+3. **LIMIT Pushdown to Scan**
+   - Stop iteration after LIMIT rows collected
+   - Current: `execute_iter` materializes all, then iterates
+   - Location: `executor/execute.rs:129-137`
+
+### Medium Impact (10-50x improvement potential)
+
+4. **Column Pruning at Scan Time**
+   - Project only needed columns during scan
+   - Avoid loading unused columns from storage
+   - Requires: Late projection pattern
+
+5. **Predicate Pushdown to Storage Layer**
+   - Filter rows in storage before Row construction
+   - Currently: Construct all Rows, then filter
+
+### Lower Impact (2-10x improvement)
+
+6. **Small String Optimization in SqlValue**
+   - Use SmallVec or inline small strings
+   - Reduce allocations for l_returnflag (1 char), l_linestatus (1 char)
+
+7. **Arena Allocation for Query Rows**
+   - QueryBufferPool exists but not used for scan
+   - Could pool Row allocations
+
+## DuckDB's Approach (for reference)
+
+DuckDB achieves sub-millisecond scans through:
+1. **Columnar Storage**: Data stored by column, not row
+2. **Vectorized Execution**: Process batches of 1024 values
+3. **Late Materialization**: Only materialize output columns
+4. **Push-Based Execution**: Operators push tuples, LIMIT stops early
+5. **Zone Maps**: Skip blocks that don't match predicates
+
+## Recommended Next Steps
+
+### Phase 1: Quick Wins (1-2 days)
+- [ ] Implement COUNT(*) optimization (bypass scan)
+- [ ] Add LIMIT pushdown to stop early
+
+### Phase 2: Iterator Refactoring (1 week)
+- [ ] Replace `Vec<Row>` returns with `impl Iterator<Item = &Row>`
+- [ ] Stop cloning during scan
+
+### Phase 3: Column Pruning (1-2 weeks)
+- [ ] Add column mask to scan API
+- [ ] Only materialize needed columns
+
+### Phase 4: Columnar Storage (longer term)
+- [ ] Store tables in columnar format
+- [ ] Enable SIMD filtering directly on storage
+
+## Appendix: Benchmark Reproduction
+
+```bash
+# Run lineitem scan profiling benchmark
+cd crates/vibesql-executor
+cargo bench --bench lineitem_scan_profiling --features benchmark-comparison
+
+# Results saved to: target/criterion/
+```
+
+## References
+
+- Issue #2962: Profile lineitem table scan performance
+- Issue #2804: TPC-H Phase 2 Optimization (parent)
+- `crates/vibesql-executor/benches/lineitem_scan_profiling.rs`


### PR DESCRIPTION
## Summary

- Add focused `lineitem_scan_profiling` benchmark to isolate table scan overhead
- Document comprehensive findings in `LINEITEM_SCAN_ANALYSIS.md`
- Identify root causes of 27-294x performance gap vs DuckDB

### Key Findings

| Benchmark | VibeSQL | DuckDB | Gap |
|-----------|---------|--------|-----|
| Full Scan (SELECT *) | 295ms | 10.9ms | **27x** |
| COUNT(*) | 71ms | 242µs | **294x** |
| Date Filter | 61ms | 7.8ms | **8x** |
| Single Column | 39ms | 413µs | **95x** |
| LIMIT 100 | 25ms | 579µs | **43x** |

### Root Causes Identified

1. **Eager Row Materialization**: Every scan clones all 60K rows via `to_vec()` before processing
2. **No Column Pruning**: Single column SELECT reads all 16 columns
3. **No LIMIT Pushdown**: LIMIT 100 scans all rows, then discards 99.8%
4. **COUNT(*) Not Optimized**: Could be O(1) but materializes all data

### Optimization Targets (documented in analysis)

- Zero-copy iterator for table scans
- COUNT(*) bypass (return table.row_count() directly)
- LIMIT pushdown to stop early
- Column pruning at scan time

## Test plan

- [x] Benchmark compiles and runs: `cargo bench --bench lineitem_scan_profiling`
- [x] Analysis document reviewed for accuracy

Closes #2962

🤖 Generated with [Claude Code](https://claude.com/claude-code)