### PR TITLE
fix(benchmark): Prefer Criterion JSON over stdout for sysbench results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,8 @@ benchmark-sysbench:
 	cargo bench --package vibesql-executor --bench sysbench_oltp --features benchmark-comparison -- --noplot 2>&1 | tee /tmp/sysbench_results.txt
 	@echo ""
 	@echo "Processing Sysbench results into database..."
-	./scripts/process_sysbench_results.py --stdin < /tmp/sysbench_results.txt || \
-		./scripts/process_sysbench_results.py --criterion-dir target/criterion
+	./scripts/process_sysbench_results.py --criterion-dir target/criterion || \
+		./scripts/process_sysbench_results.py --stdin < /tmp/sysbench_results.txt
 
 #
 # Analysis Targets


### PR DESCRIPTION
## Summary

- Flip the order of sysbench result processing to prefer Criterion JSON files over stdout parsing
- JSON files contain more accurate statistical data (actual std_dev, median, iteration counts) vs. estimates from confidence intervals

Closes #2976

## Test plan

- [ ] Verify `make benchmark-sysbench` still processes results correctly
- [ ] Confirm JSON files are preferred when available
- [ ] Verify fallback to stdin parsing works when JSON files are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)