### PR TITLE
perf(executor): Implement late materialization for query execution

### DIFF
--- a/crates/vibesql-executor/src/select/late_materialization/gather.rs
+++ b/crates/vibesql-executor/src/select/late_materialization/gather.rs
@@ -1,0 +1,541 @@
+//! Gather Operations for Selective Materialization
+//!
+//! This module provides efficient gather operations for materializing
+//! only the columns and rows needed for query output.
+
+use std::sync::Arc;
+use vibesql_storage::Row;
+use vibesql_types::SqlValue;
+
+use super::SelectionVector;
+use crate::errors::ExecutorError;
+use crate::select::columnar::{ColumnArray, ColumnarBatch};
+
+/// Gather specific columns from a columnar batch using a selection vector
+///
+/// This is the key function for late materialization output. It only
+/// materializes the columns needed for the final result.
+///
+/// # Arguments
+///
+/// * `batch` - Source columnar batch
+/// * `selection` - Which rows to include
+/// * `column_indices` - Which columns to include
+///
+/// # Returns
+///
+/// A vector of rows containing only the selected columns for selected rows.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // From 10 columns, only materialize columns 0 and 3
+/// let result = gather_columns(&batch, &selection, &[0, 3])?;
+/// ```
+pub fn gather_columns(
+    batch: &ColumnarBatch,
+    selection: &SelectionVector,
+    column_indices: &[usize],
+) -> Result<Vec<Row>, ExecutorError> {
+    let mut rows = Vec::with_capacity(selection.len());
+
+    for idx in selection.iter() {
+        let row_idx = idx as usize;
+        let mut values = Vec::with_capacity(column_indices.len());
+
+        for &col_idx in column_indices {
+            let value = batch.get_value(row_idx, col_idx)?;
+            values.push(value);
+        }
+
+        rows.push(Row::new(values));
+    }
+
+    Ok(rows)
+}
+
+/// Gather a single column from a columnar batch using a selection vector
+///
+/// Optimized path for extracting a single column, useful for:
+/// - Join key extraction
+/// - Aggregation input
+/// - Single-column projections
+///
+/// # Arguments
+///
+/// * `batch` - Source columnar batch
+/// * `selection` - Which rows to include
+/// * `column_idx` - Which column to extract
+///
+/// # Returns
+///
+/// A vector of SqlValues for the selected column and rows.
+pub fn gather_single_column(
+    batch: &ColumnarBatch,
+    selection: &SelectionVector,
+    column_idx: usize,
+) -> Result<Vec<SqlValue>, ExecutorError> {
+    let column = batch.column(column_idx)
+        .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: column_idx,
+            batch_columns: batch.column_count(),
+        })?;
+
+    gather_from_column_array(column, selection)
+}
+
+/// Gather values from a ColumnArray using a selection vector
+///
+/// This is the lowest-level gather operation, working directly on
+/// typed column arrays for maximum efficiency.
+pub fn gather_from_column_array(
+    column: &ColumnArray,
+    selection: &SelectionVector,
+) -> Result<Vec<SqlValue>, ExecutorError> {
+    let mut values = Vec::with_capacity(selection.len());
+
+    for idx in selection.iter() {
+        let value = column.get_value(idx as usize)?;
+        values.push(value);
+    }
+
+    Ok(values)
+}
+
+/// Gather into a new ColumnArray (staying in columnar format)
+///
+/// This is useful when the result needs to stay columnar for
+/// further vectorized processing.
+pub fn gather_column_array(
+    column: &ColumnArray,
+    selection: &SelectionVector,
+) -> Result<ColumnArray, ExecutorError> {
+    match column {
+        ColumnArray::Int64(values, nulls) => {
+            let gathered: Vec<i64> = selection
+                .iter()
+                .map(|idx| values[idx as usize])
+                .collect();
+            let gathered_nulls = nulls.as_ref().map(|n| {
+                Arc::new(selection.iter().map(|idx| n[idx as usize]).collect::<Vec<_>>())
+            });
+            Ok(ColumnArray::Int64(Arc::new(gathered), gathered_nulls))
+        }
+
+        ColumnArray::Int32(values, nulls) => {
+            let gathered: Vec<i32> = selection
+                .iter()
+                .map(|idx| values[idx as usize])
+                .collect();
+            let gathered_nulls = nulls.as_ref().map(|n| {
+                Arc::new(selection.iter().map(|idx| n[idx as usize]).collect::<Vec<_>>())
+            });
+            Ok(ColumnArray::Int32(Arc::new(gathered), gathered_nulls))
+        }
+
+        ColumnArray::Float64(values, nulls) => {
+            let gathered: Vec<f64> = selection
+                .iter()
+                .map(|idx| values[idx as usize])
+                .collect();
+            let gathered_nulls = nulls.as_ref().map(|n| {
+                Arc::new(selection.iter().map(|idx| n[idx as usize]).collect::<Vec<_>>())
+            });
+            Ok(ColumnArray::Float64(Arc::new(gathered), gathered_nulls))
+        }
+
+        ColumnArray::Float32(values, nulls) => {
+            let gathered: Vec<f32> = selection
+                .iter()
+                .map(|idx| values[idx as usize])
+                .collect();
+            let gathered_nulls = nulls.as_ref().map(|n| {
+                Arc::new(selection.iter().map(|idx| n[idx as usize]).collect::<Vec<_>>())
+            });
+            Ok(ColumnArray::Float32(Arc::new(gathered), gathered_nulls))
+        }
+
+        ColumnArray::String(values, nulls) => {
+            let gathered: Vec<String> = selection
+                .iter()
+                .map(|idx| values[idx as usize].clone())
+                .collect();
+            let gathered_nulls = nulls.as_ref().map(|n| {
+                Arc::new(selection.iter().map(|idx| n[idx as usize]).collect::<Vec<_>>())
+            });
+            Ok(ColumnArray::String(Arc::new(gathered), gathered_nulls))
+        }
+
+        ColumnArray::FixedString(values, nulls) => {
+            let gathered: Vec<String> = selection
+                .iter()
+                .map(|idx| values[idx as usize].clone())
+                .collect();
+            let gathered_nulls = nulls.as_ref().map(|n| {
+                Arc::new(selection.iter().map(|idx| n[idx as usize]).collect::<Vec<_>>())
+            });
+            Ok(ColumnArray::FixedString(Arc::new(gathered), gathered_nulls))
+        }
+
+        ColumnArray::Date(values, nulls) => {
+            let gathered: Vec<i32> = selection
+                .iter()
+                .map(|idx| values[idx as usize])
+                .collect();
+            let gathered_nulls = nulls.as_ref().map(|n| {
+                Arc::new(selection.iter().map(|idx| n[idx as usize]).collect::<Vec<_>>())
+            });
+            Ok(ColumnArray::Date(Arc::new(gathered), gathered_nulls))
+        }
+
+        ColumnArray::Timestamp(values, nulls) => {
+            let gathered: Vec<i64> = selection
+                .iter()
+                .map(|idx| values[idx as usize])
+                .collect();
+            let gathered_nulls = nulls.as_ref().map(|n| {
+                Arc::new(selection.iter().map(|idx| n[idx as usize]).collect::<Vec<_>>())
+            });
+            Ok(ColumnArray::Timestamp(Arc::new(gathered), gathered_nulls))
+        }
+
+        ColumnArray::Boolean(values, nulls) => {
+            let gathered: Vec<u8> = selection
+                .iter()
+                .map(|idx| values[idx as usize])
+                .collect();
+            let gathered_nulls = nulls.as_ref().map(|n| {
+                Arc::new(selection.iter().map(|idx| n[idx as usize]).collect::<Vec<_>>())
+            });
+            Ok(ColumnArray::Boolean(Arc::new(gathered), gathered_nulls))
+        }
+
+        ColumnArray::Mixed(values) => {
+            let gathered: Vec<SqlValue> = selection
+                .iter()
+                .map(|idx| values[idx as usize].clone())
+                .collect();
+            Ok(ColumnArray::Mixed(Arc::new(gathered)))
+        }
+    }
+}
+
+/// Gather a columnar batch with selection applied to all columns
+///
+/// Creates a new ColumnarBatch containing only the selected rows.
+pub fn gather_batch(
+    batch: &ColumnarBatch,
+    selection: &SelectionVector,
+) -> Result<ColumnarBatch, ExecutorError> {
+    let mut columns = Vec::with_capacity(batch.column_count());
+
+    for col_idx in 0..batch.column_count() {
+        let column = batch.column(col_idx)
+            .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+                column_index: col_idx,
+                batch_columns: batch.column_count(),
+            })?;
+
+        let gathered = gather_column_array(column, selection)?;
+        columns.push(gathered);
+    }
+
+    ColumnarBatch::from_columns(columns, batch.column_names().map(|n| n.to_vec()))
+}
+
+/// Gather specific columns from a batch, staying columnar
+pub fn gather_batch_columns(
+    batch: &ColumnarBatch,
+    selection: &SelectionVector,
+    column_indices: &[usize],
+) -> Result<ColumnarBatch, ExecutorError> {
+    let mut columns = Vec::with_capacity(column_indices.len());
+    let mut names = batch.column_names().map(|_| Vec::with_capacity(column_indices.len()));
+
+    for &col_idx in column_indices {
+        let column = batch.column(col_idx)
+            .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+                column_index: col_idx,
+                batch_columns: batch.column_count(),
+            })?;
+
+        let gathered = gather_column_array(column, selection)?;
+        columns.push(gathered);
+
+        if let Some(ref mut name_vec) = names {
+            if let Some(all_names) = batch.column_names() {
+                if col_idx < all_names.len() {
+                    name_vec.push(all_names[col_idx].clone());
+                }
+            }
+        }
+    }
+
+    ColumnarBatch::from_columns(columns, names)
+}
+
+/// Gather from row-based data
+///
+/// Fallback for when data is not columnar.
+pub fn gather_rows(
+    rows: &[Row],
+    selection: &SelectionVector,
+) -> Vec<Row> {
+    selection
+        .iter()
+        .map(|idx| rows[idx as usize].clone())
+        .collect()
+}
+
+/// Gather specific columns from row-based data
+pub fn gather_row_columns(
+    rows: &[Row],
+    selection: &SelectionVector,
+    column_indices: &[usize],
+) -> Vec<Row> {
+    selection
+        .iter()
+        .map(|idx| {
+            let source_row = &rows[idx as usize];
+            let values: Vec<SqlValue> = column_indices
+                .iter()
+                .map(|&col_idx| source_row.get(col_idx).cloned().unwrap_or(SqlValue::Null))
+                .collect();
+            Row::new(values)
+        })
+        .collect()
+}
+
+/// Specialized gather for join output
+///
+/// Combines columns from left and right batches based on join indices.
+/// Uses u32::MAX as a marker for NULL (outer join unmatched rows).
+pub fn gather_join_output(
+    left_batch: &ColumnarBatch,
+    right_batch: &ColumnarBatch,
+    left_indices: &[u32],
+    right_indices: &[u32],
+    left_columns: Option<&[usize]>,
+    right_columns: Option<&[usize]>,
+) -> Result<Vec<Row>, ExecutorError> {
+    let left_cols = left_columns
+        .map(|c| c.to_vec())
+        .unwrap_or_else(|| (0..left_batch.column_count()).collect());
+    let right_cols = right_columns
+        .map(|c| c.to_vec())
+        .unwrap_or_else(|| (0..right_batch.column_count()).collect());
+
+    let total_cols = left_cols.len() + right_cols.len();
+    let mut rows = Vec::with_capacity(left_indices.len());
+
+    for (&left_idx, &right_idx) in left_indices.iter().zip(right_indices) {
+        let mut values = Vec::with_capacity(total_cols);
+
+        // Gather left columns
+        if left_idx == u32::MAX {
+            // NULL row for RIGHT OUTER join
+            for _ in 0..left_cols.len() {
+                values.push(SqlValue::Null);
+            }
+        } else {
+            for &col_idx in &left_cols {
+                values.push(left_batch.get_value(left_idx as usize, col_idx)?);
+            }
+        }
+
+        // Gather right columns
+        if right_idx == u32::MAX {
+            // NULL row for LEFT OUTER join
+            for _ in 0..right_cols.len() {
+                values.push(SqlValue::Null);
+            }
+        } else {
+            for &col_idx in &right_cols {
+                values.push(right_batch.get_value(right_idx as usize, col_idx)?);
+            }
+        }
+
+        rows.push(Row::new(values));
+    }
+
+    Ok(rows)
+}
+
+/// Estimate memory savings from late materialization
+///
+/// Returns (early_materialization_bytes, late_materialization_bytes, savings_ratio)
+pub fn estimate_savings(
+    total_rows: usize,
+    selected_rows: usize,
+    total_columns: usize,
+    projected_columns: usize,
+    avg_value_bytes: usize,
+) -> (usize, usize, f64) {
+    // Early materialization: all rows × all columns
+    let early = total_rows * total_columns * avg_value_bytes;
+
+    // Late materialization: indices + selected rows × projected columns
+    let index_overhead = selected_rows * std::mem::size_of::<u32>();
+    let late = index_overhead + (selected_rows * projected_columns * avg_value_bytes);
+
+    let savings = if early > 0 {
+        1.0 - (late as f64 / early as f64)
+    } else {
+        0.0
+    };
+
+    (early, late, savings)
+}
+
+#[cfg(test)]
+mod gather_tests {
+    use super::*;
+
+    fn sample_batch() -> ColumnarBatch {
+        let columns = vec![
+            ColumnArray::Int64(Arc::new(vec![1, 2, 3, 4, 5]), None),
+            ColumnArray::String(Arc::new(vec![
+                "Alice".into(),
+                "Bob".into(),
+                "Carol".into(),
+                "Dave".into(),
+                "Eve".into(),
+            ]), None),
+            ColumnArray::Float64(Arc::new(vec![10.0, 20.0, 30.0, 40.0, 50.0]), None),
+        ];
+        ColumnarBatch::from_columns(columns, Some(vec!["id".into(), "name".into(), "score".into()])).unwrap()
+    }
+
+    #[test]
+    fn test_gather_columns() {
+        let batch = sample_batch();
+        let selection = SelectionVector::from_indices(vec![0, 2, 4]);
+
+        // Gather only columns 0 and 2 (id, score)
+        let rows = gather_columns(&batch, &selection, &[0, 2]).unwrap();
+
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].len(), 2);
+        assert_eq!(rows[0].get(0), Some(&SqlValue::Integer(1)));
+        assert_eq!(rows[0].get(1), Some(&SqlValue::Double(10.0)));
+        assert_eq!(rows[2].get(0), Some(&SqlValue::Integer(5)));
+    }
+
+    #[test]
+    fn test_gather_single_column() {
+        let batch = sample_batch();
+        let selection = SelectionVector::from_indices(vec![1, 3]);
+
+        let names = gather_single_column(&batch, &selection, 1).unwrap();
+
+        assert_eq!(names.len(), 2);
+        assert_eq!(names[0], SqlValue::Varchar("Bob".into()));
+        assert_eq!(names[1], SqlValue::Varchar("Dave".into()));
+    }
+
+    #[test]
+    fn test_gather_column_array() {
+        let batch = sample_batch();
+        let selection = SelectionVector::from_indices(vec![0, 2, 4]);
+
+        let int_col = batch.column(0).unwrap();
+        let gathered = gather_column_array(int_col, &selection).unwrap();
+
+        if let ColumnArray::Int64(values, _) = gathered {
+            assert_eq!(&*values, &[1, 3, 5]);
+        } else {
+            panic!("Expected Int64 column");
+        }
+    }
+
+    #[test]
+    fn test_gather_batch() {
+        let batch = sample_batch();
+        let selection = SelectionVector::from_indices(vec![1, 3]);
+
+        let gathered = gather_batch(&batch, &selection).unwrap();
+
+        assert_eq!(gathered.row_count(), 2);
+        assert_eq!(gathered.column_count(), 3);
+        assert_eq!(gathered.get_value(0, 0).unwrap(), SqlValue::Integer(2));
+        assert_eq!(gathered.get_value(1, 0).unwrap(), SqlValue::Integer(4));
+    }
+
+    #[test]
+    fn test_gather_batch_columns() {
+        let batch = sample_batch();
+        let selection = SelectionVector::from_indices(vec![0, 4]);
+
+        let gathered = gather_batch_columns(&batch, &selection, &[1]).unwrap();
+
+        assert_eq!(gathered.row_count(), 2);
+        assert_eq!(gathered.column_count(), 1);
+        assert_eq!(gathered.get_value(0, 0).unwrap(), SqlValue::Varchar("Alice".into()));
+        assert_eq!(gathered.get_value(1, 0).unwrap(), SqlValue::Varchar("Eve".into()));
+    }
+
+    #[test]
+    fn test_gather_rows() {
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1)]),
+            Row::new(vec![SqlValue::Integer(2)]),
+            Row::new(vec![SqlValue::Integer(3)]),
+        ];
+        let selection = SelectionVector::from_indices(vec![0, 2]);
+
+        let gathered = gather_rows(&rows, &selection);
+
+        assert_eq!(gathered.len(), 2);
+        assert_eq!(gathered[0].get(0), Some(&SqlValue::Integer(1)));
+        assert_eq!(gathered[1].get(0), Some(&SqlValue::Integer(3)));
+    }
+
+    #[test]
+    fn test_gather_join_output() {
+        let left = ColumnarBatch::from_columns(
+            vec![
+                ColumnArray::Int64(Arc::new(vec![1, 2]), None),
+                ColumnArray::String(Arc::new(vec!["A".into(), "B".into()]), None),
+            ],
+            None,
+        ).unwrap();
+
+        let right = ColumnarBatch::from_columns(
+            vec![
+                ColumnArray::Int64(Arc::new(vec![1, 1]), None),
+                ColumnArray::String(Arc::new(vec!["X".into(), "Y".into()]), None),
+            ],
+            None,
+        ).unwrap();
+
+        let left_indices = vec![0, 0, 1];
+        let right_indices = vec![0, 1, u32::MAX]; // Last is left outer NULL
+
+        let rows = gather_join_output(&left, &right, &left_indices, &right_indices, None, None).unwrap();
+
+        assert_eq!(rows.len(), 3);
+
+        // First join: (1, A, 1, X)
+        assert_eq!(rows[0].get(0), Some(&SqlValue::Integer(1)));
+        assert_eq!(rows[0].get(2), Some(&SqlValue::Integer(1)));
+
+        // Left outer null: (2, B, NULL, NULL)
+        assert_eq!(rows[2].get(0), Some(&SqlValue::Integer(2)));
+        assert_eq!(rows[2].get(2), Some(&SqlValue::Null));
+    }
+
+    #[test]
+    fn test_estimate_savings() {
+        // 1M rows, 10 columns, 1% selectivity, 4 projected columns
+        let (early, late, savings) = estimate_savings(1_000_000, 10_000, 10, 4, 32);
+
+        // Early: 1M × 10 × 32 = 320MB
+        assert_eq!(early, 320_000_000);
+
+        // Late: 10K × 4 bytes (indices) + 10K × 4 × 32 = 40KB + 1.28MB ≈ 1.32MB
+        assert!(late < 2_000_000);
+
+        // Savings should be ~99%
+        assert!(savings > 0.95);
+    }
+}

--- a/crates/vibesql-executor/src/select/late_materialization/lazy_batch.rs
+++ b/crates/vibesql-executor/src/select/late_materialization/lazy_batch.rs
@@ -1,0 +1,626 @@
+//! Lazy Materialized Batch
+//!
+//! A batch that holds source data and selection, materializing rows on demand.
+
+use std::sync::Arc;
+use vibesql_storage::Row;
+use vibesql_types::SqlValue;
+
+use super::SelectionVector;
+use crate::errors::ExecutorError;
+use crate::select::columnar::{ColumnArray, ColumnarBatch};
+
+/// Source data format for lazy materialization
+#[derive(Debug, Clone)]
+pub enum SourceData {
+    /// Row-based source data (Vec<Row>)
+    Rows(Arc<Vec<Row>>),
+    /// Columnar source data (ColumnarBatch)
+    Columnar(Arc<ColumnarBatch>),
+}
+
+impl SourceData {
+    /// Get the number of rows in the source data
+    pub fn row_count(&self) -> usize {
+        match self {
+            SourceData::Rows(rows) => rows.len(),
+            SourceData::Columnar(batch) => batch.row_count(),
+        }
+    }
+
+    /// Get the number of columns
+    pub fn column_count(&self) -> usize {
+        match self {
+            SourceData::Rows(rows) => rows.first().map(|r| r.len()).unwrap_or(0),
+            SourceData::Columnar(batch) => batch.column_count(),
+        }
+    }
+
+    /// Get a value at a specific position
+    pub fn get_value(&self, row_idx: usize, col_idx: usize) -> Result<SqlValue, ExecutorError> {
+        match self {
+            SourceData::Rows(rows) => {
+                rows.get(row_idx)
+                    .and_then(|row| row.get(col_idx))
+                    .cloned()
+                    .ok_or_else(|| ExecutorError::ColumnIndexOutOfBounds { index: col_idx })
+            }
+            SourceData::Columnar(batch) => batch.get_value(row_idx, col_idx),
+        }
+    }
+
+    /// Get a row at a specific index (materializes if columnar)
+    pub fn get_row(&self, row_idx: usize) -> Result<Row, ExecutorError> {
+        match self {
+            SourceData::Rows(rows) => {
+                rows.get(row_idx)
+                    .cloned()
+                    .ok_or_else(|| ExecutorError::ColumnIndexOutOfBounds { index: row_idx })
+            }
+            SourceData::Columnar(batch) => {
+                let mut values = Vec::with_capacity(batch.column_count());
+                for col_idx in 0..batch.column_count() {
+                    values.push(batch.get_value(row_idx, col_idx)?);
+                }
+                Ok(Row::new(values))
+            }
+        }
+    }
+}
+
+/// A lazy materialized batch that defers row materialization
+///
+/// This is the key abstraction for late materialization. It holds:
+/// - Source data (either row-based or columnar)
+/// - A selection vector indicating which rows are active
+///
+/// Rows are only materialized when explicitly requested, typically
+/// at the output boundary of query execution.
+///
+/// # Performance Benefits
+///
+/// 1. **Memory**: Only stores indices (4 bytes each) instead of full rows
+/// 2. **Cache**: Selection vectors are cache-friendly during iteration
+/// 3. **Composition**: Multiple operations can share source data via Arc
+/// 4. **Lazy Evaluation**: Skips materialization for filtered rows
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // Create a lazy batch from source data
+/// let source = SourceData::Rows(Arc::new(rows));
+/// let lazy_batch = LazyMaterializedBatch::new(source);
+///
+/// // Apply filter (just updates selection, no materialization)
+/// let filtered = lazy_batch.filter(&filter_bitmap);
+///
+/// // Only materialize at output
+/// let result_rows = filtered.materialize_selected(&[0, 2, 3])?; // Only these columns
+/// ```
+#[derive(Debug, Clone)]
+pub struct LazyMaterializedBatch {
+    /// The underlying source data
+    source: SourceData,
+    /// Selection vector (which rows are active)
+    selection: SelectionVector,
+    /// Column names (optional metadata)
+    column_names: Option<Vec<String>>,
+}
+
+impl LazyMaterializedBatch {
+    /// Create a new lazy batch from source data (selects all rows)
+    pub fn new(source: SourceData) -> Self {
+        let row_count = source.row_count();
+        Self {
+            source,
+            selection: SelectionVector::all(row_count),
+            column_names: None,
+        }
+    }
+
+    /// Create a new lazy batch with a specific selection
+    pub fn with_selection(source: SourceData, selection: SelectionVector) -> Self {
+        Self {
+            source,
+            selection,
+            column_names: None,
+        }
+    }
+
+    /// Create from row-based data
+    pub fn from_rows(rows: Vec<Row>) -> Self {
+        Self::new(SourceData::Rows(Arc::new(rows)))
+    }
+
+    /// Create from columnar data
+    pub fn from_columnar(batch: ColumnarBatch) -> Self {
+        Self::new(SourceData::Columnar(Arc::new(batch)))
+    }
+
+    /// Set column names
+    pub fn with_column_names(mut self, names: Vec<String>) -> Self {
+        self.column_names = Some(names);
+        self
+    }
+
+    /// Get the source data
+    pub fn source(&self) -> &SourceData {
+        &self.source
+    }
+
+    /// Get the selection vector
+    pub fn selection(&self) -> &SelectionVector {
+        &self.selection
+    }
+
+    /// Get column names if available
+    pub fn column_names(&self) -> Option<&[String]> {
+        self.column_names.as_deref()
+    }
+
+    /// Number of selected (active) rows
+    pub fn len(&self) -> usize {
+        self.selection.len()
+    }
+
+    /// Check if no rows are selected
+    pub fn is_empty(&self) -> bool {
+        self.selection.is_empty()
+    }
+
+    /// Number of columns in the source
+    pub fn column_count(&self) -> usize {
+        self.source.column_count()
+    }
+
+    /// Total rows in source (before selection)
+    pub fn source_row_count(&self) -> usize {
+        self.source.row_count()
+    }
+
+    /// Apply a filter bitmap, returning a new lazy batch with refined selection
+    ///
+    /// This is a lazy operation - it updates the selection vector without
+    /// materializing any row data.
+    pub fn filter(&self, bitmap: &[bool]) -> Self {
+        let new_selection = self.selection.filter(bitmap, |&idx| bitmap[idx as usize]);
+        Self {
+            source: self.source.clone(),
+            selection: new_selection,
+            column_names: self.column_names.clone(),
+        }
+    }
+
+    /// Apply a filter to the current selection
+    ///
+    /// The predicate receives the source row index and should return true
+    /// to keep the row.
+    pub fn filter_with<F>(&self, predicate: F) -> Self
+    where
+        F: Fn(usize) -> bool,
+    {
+        let new_indices: Vec<u32> = self
+            .selection
+            .iter()
+            .filter(|&idx| predicate(idx as usize))
+            .collect();
+
+        Self {
+            source: self.source.clone(),
+            selection: SelectionVector::from_indices(new_indices),
+            column_names: self.column_names.clone(),
+        }
+    }
+
+    /// Intersect selection with another selection vector
+    pub fn intersect_selection(&self, other: &SelectionVector) -> Self {
+        Self {
+            source: self.source.clone(),
+            selection: self.selection.intersect(other),
+            column_names: self.column_names.clone(),
+        }
+    }
+
+    /// Union selection with another selection vector
+    pub fn union_selection(&self, other: &SelectionVector) -> Self {
+        Self {
+            source: self.source.clone(),
+            selection: self.selection.union(other),
+            column_names: self.column_names.clone(),
+        }
+    }
+
+    /// Materialize all selected rows
+    ///
+    /// This is typically called at the output boundary when results
+    /// need to be returned to the caller.
+    pub fn materialize(&self) -> Result<Vec<Row>, ExecutorError> {
+        let mut rows = Vec::with_capacity(self.selection.len());
+
+        for idx in self.selection.iter() {
+            let row = self.source.get_row(idx as usize)?;
+            rows.push(row);
+        }
+
+        Ok(rows)
+    }
+
+    /// Materialize only specific columns for selected rows
+    ///
+    /// This is the most efficient output path - only materializes
+    /// columns that appear in the final SELECT projection.
+    pub fn materialize_columns(&self, column_indices: &[usize]) -> Result<Vec<Row>, ExecutorError> {
+        let mut rows = Vec::with_capacity(self.selection.len());
+
+        for idx in self.selection.iter() {
+            let mut values = Vec::with_capacity(column_indices.len());
+            for &col_idx in column_indices {
+                let value = self.source.get_value(idx as usize, col_idx)?;
+                values.push(value);
+            }
+            rows.push(Row::new(values));
+        }
+
+        Ok(rows)
+    }
+
+    /// Materialize a single column for selected rows
+    ///
+    /// Useful for extracting join keys or aggregation inputs.
+    pub fn materialize_column(&self, column_idx: usize) -> Result<Vec<SqlValue>, ExecutorError> {
+        let mut values = Vec::with_capacity(self.selection.len());
+
+        for idx in self.selection.iter() {
+            let value = self.source.get_value(idx as usize, column_idx)?;
+            values.push(value);
+        }
+
+        Ok(values)
+    }
+
+    /// Get a single value from selected row
+    pub fn get_selected_value(
+        &self,
+        selection_idx: usize,
+        column_idx: usize,
+    ) -> Result<SqlValue, ExecutorError> {
+        let row_idx = self.selection.get(selection_idx)
+            .ok_or_else(|| ExecutorError::ColumnIndexOutOfBounds { index: selection_idx })?;
+
+        self.source.get_value(row_idx as usize, column_idx)
+    }
+
+    /// Iterate over selected row indices
+    pub fn iter_indices(&self) -> impl Iterator<Item = u32> + '_ {
+        self.selection.iter()
+    }
+
+    /// Create a child batch with remapped selection
+    ///
+    /// Used when chaining operations: if we filter a filtered result,
+    /// we need to maintain the chain of selections.
+    pub fn remap_selection(&self, child_selection: &SelectionVector) -> Self {
+        let remapped = child_selection.remap(&self.selection);
+        Self {
+            source: self.source.clone(),
+            selection: remapped,
+            column_names: self.column_names.clone(),
+        }
+    }
+
+    /// Get the raw column array if source is columnar
+    ///
+    /// Returns None if source is row-based.
+    pub fn column_array(&self, column_idx: usize) -> Option<&ColumnArray> {
+        match &self.source {
+            SourceData::Columnar(batch) => batch.column(column_idx),
+            SourceData::Rows(_) => None,
+        }
+    }
+
+    /// Check if the source is columnar
+    pub fn is_columnar(&self) -> bool {
+        matches!(&self.source, SourceData::Columnar(_))
+    }
+
+    /// Convert to columnar format if not already
+    ///
+    /// This is useful when downstream operations benefit from columnar access.
+    pub fn to_columnar(&self) -> Result<LazyMaterializedBatch, ExecutorError> {
+        match &self.source {
+            SourceData::Columnar(_) => Ok(self.clone()),
+            SourceData::Rows(rows) => {
+                let batch = ColumnarBatch::from_rows(rows)?;
+                Ok(LazyMaterializedBatch {
+                    source: SourceData::Columnar(Arc::new(batch)),
+                    selection: self.selection.clone(),
+                    column_names: self.column_names.clone(),
+                })
+            }
+        }
+    }
+
+    /// Selectivity ratio
+    pub fn selectivity(&self) -> f64 {
+        self.selection.selectivity(self.source_row_count())
+    }
+}
+
+/// Builder for creating lazy batches with joined sources
+///
+/// Used for join operations that combine multiple source tables.
+pub struct JoinedLazyBatchBuilder {
+    /// Left source
+    left_source: SourceData,
+    /// Right source
+    right_source: SourceData,
+    /// Left selection indices
+    left_indices: Vec<u32>,
+    /// Right selection indices (u32::MAX for outer join NULL rows)
+    right_indices: Vec<u32>,
+}
+
+impl JoinedLazyBatchBuilder {
+    /// Create a new builder for joining two sources
+    pub fn new(left_source: SourceData, right_source: SourceData) -> Self {
+        Self {
+            left_source,
+            right_source,
+            left_indices: Vec::new(),
+            right_indices: Vec::new(),
+        }
+    }
+
+    /// Add a matched pair of indices
+    pub fn add_match(&mut self, left_idx: u32, right_idx: u32) {
+        self.left_indices.push(left_idx);
+        self.right_indices.push(right_idx);
+    }
+
+    /// Add a left-only row (for LEFT OUTER join)
+    pub fn add_left_only(&mut self, left_idx: u32) {
+        self.left_indices.push(left_idx);
+        self.right_indices.push(u32::MAX); // NULL marker
+    }
+
+    /// Add a right-only row (for RIGHT OUTER join)
+    pub fn add_right_only(&mut self, right_idx: u32) {
+        self.left_indices.push(u32::MAX); // NULL marker
+        self.right_indices.push(right_idx);
+    }
+
+    /// Get left indices
+    pub fn left_indices(&self) -> &[u32] {
+        &self.left_indices
+    }
+
+    /// Get right indices
+    pub fn right_indices(&self) -> &[u32] {
+        &self.right_indices
+    }
+
+    /// Build the result count
+    pub fn result_count(&self) -> usize {
+        self.left_indices.len()
+    }
+
+    /// Materialize the joined result
+    ///
+    /// Combines columns from both sources for each matching pair.
+    pub fn materialize(&self) -> Result<Vec<Row>, ExecutorError> {
+        let left_cols = self.left_source.column_count();
+        let right_cols = self.right_source.column_count();
+        let total_cols = left_cols + right_cols;
+
+        let mut rows = Vec::with_capacity(self.left_indices.len());
+
+        for (&left_idx, &right_idx) in self.left_indices.iter().zip(&self.right_indices) {
+            let mut values = Vec::with_capacity(total_cols);
+
+            // Left columns
+            if left_idx == u32::MAX {
+                // NULL row for RIGHT OUTER join
+                for _ in 0..left_cols {
+                    values.push(SqlValue::Null);
+                }
+            } else {
+                for col_idx in 0..left_cols {
+                    values.push(self.left_source.get_value(left_idx as usize, col_idx)?);
+                }
+            }
+
+            // Right columns
+            if right_idx == u32::MAX {
+                // NULL row for LEFT OUTER join
+                for _ in 0..right_cols {
+                    values.push(SqlValue::Null);
+                }
+            } else {
+                for col_idx in 0..right_cols {
+                    values.push(self.right_source.get_value(right_idx as usize, col_idx)?);
+                }
+            }
+
+            rows.push(Row::new(values));
+        }
+
+        Ok(rows)
+    }
+
+    /// Materialize only specific columns
+    ///
+    /// `left_columns` and `right_columns` specify which columns to include from each source.
+    pub fn materialize_columns(
+        &self,
+        left_columns: &[usize],
+        right_columns: &[usize],
+    ) -> Result<Vec<Row>, ExecutorError> {
+        let total_cols = left_columns.len() + right_columns.len();
+        let mut rows = Vec::with_capacity(self.left_indices.len());
+
+        for (&left_idx, &right_idx) in self.left_indices.iter().zip(&self.right_indices) {
+            let mut values = Vec::with_capacity(total_cols);
+
+            // Selected left columns
+            if left_idx == u32::MAX {
+                for _ in 0..left_columns.len() {
+                    values.push(SqlValue::Null);
+                }
+            } else {
+                for &col_idx in left_columns {
+                    values.push(self.left_source.get_value(left_idx as usize, col_idx)?);
+                }
+            }
+
+            // Selected right columns
+            if right_idx == u32::MAX {
+                for _ in 0..right_columns.len() {
+                    values.push(SqlValue::Null);
+                }
+            } else {
+                for &col_idx in right_columns {
+                    values.push(self.right_source.get_value(right_idx as usize, col_idx)?);
+                }
+            }
+
+            rows.push(Row::new(values));
+        }
+
+        Ok(rows)
+    }
+}
+
+#[cfg(test)]
+mod lazy_batch_tests {
+    use super::*;
+
+    fn sample_rows() -> Vec<Row> {
+        vec![
+            Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".into())]),
+            Row::new(vec![SqlValue::Integer(2), SqlValue::Varchar("Bob".into())]),
+            Row::new(vec![SqlValue::Integer(3), SqlValue::Varchar("Carol".into())]),
+            Row::new(vec![SqlValue::Integer(4), SqlValue::Varchar("Dave".into())]),
+            Row::new(vec![SqlValue::Integer(5), SqlValue::Varchar("Eve".into())]),
+        ]
+    }
+
+    #[test]
+    fn test_lazy_batch_creation() {
+        let rows = sample_rows();
+        let batch = LazyMaterializedBatch::from_rows(rows);
+
+        assert_eq!(batch.len(), 5);
+        assert_eq!(batch.column_count(), 2);
+        assert_eq!(batch.source_row_count(), 5);
+    }
+
+    #[test]
+    fn test_lazy_batch_filter() {
+        let rows = sample_rows();
+        let batch = LazyMaterializedBatch::from_rows(rows);
+
+        // Filter to rows where id > 2
+        let filtered = batch.filter_with(|idx| {
+            if let SourceData::Rows(rows) = batch.source() {
+                if let Some(SqlValue::Integer(id)) = rows[idx].get(0) {
+                    return *id > 2;
+                }
+            }
+            false
+        });
+
+        assert_eq!(filtered.len(), 3); // Carol, Dave, Eve
+    }
+
+    #[test]
+    fn test_lazy_batch_materialize() {
+        let rows = sample_rows();
+        let batch = LazyMaterializedBatch::from_rows(rows);
+
+        let materialized = batch.materialize().unwrap();
+        assert_eq!(materialized.len(), 5);
+        assert_eq!(materialized[0].get(0), Some(&SqlValue::Integer(1)));
+    }
+
+    #[test]
+    fn test_lazy_batch_materialize_columns() {
+        let rows = sample_rows();
+        let batch = LazyMaterializedBatch::from_rows(rows);
+
+        // Only materialize the name column
+        let names = batch.materialize_columns(&[1]).unwrap();
+        assert_eq!(names.len(), 5);
+        assert_eq!(names[0].len(), 1); // Only 1 column
+        assert_eq!(names[0].get(0), Some(&SqlValue::Varchar("Alice".into())));
+    }
+
+    #[test]
+    fn test_lazy_batch_with_selection() {
+        let rows = sample_rows();
+        let selection = SelectionVector::from_indices(vec![0, 2, 4]); // Alice, Carol, Eve
+        let batch = LazyMaterializedBatch::with_selection(
+            SourceData::Rows(Arc::new(rows)),
+            selection,
+        );
+
+        assert_eq!(batch.len(), 3);
+
+        let materialized = batch.materialize().unwrap();
+        assert_eq!(materialized[0].get(1), Some(&SqlValue::Varchar("Alice".into())));
+        assert_eq!(materialized[1].get(1), Some(&SqlValue::Varchar("Carol".into())));
+        assert_eq!(materialized[2].get(1), Some(&SqlValue::Varchar("Eve".into())));
+    }
+
+    #[test]
+    fn test_joined_batch_builder() {
+        let left_rows = vec![
+            Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar("A".into())]),
+            Row::new(vec![SqlValue::Integer(2), SqlValue::Varchar("B".into())]),
+        ];
+        let right_rows = vec![
+            Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar("X".into())]),
+            Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar("Y".into())]),
+        ];
+
+        let mut builder = JoinedLazyBatchBuilder::new(
+            SourceData::Rows(Arc::new(left_rows)),
+            SourceData::Rows(Arc::new(right_rows)),
+        );
+
+        // Left row 0 matches right rows 0 and 1
+        builder.add_match(0, 0);
+        builder.add_match(0, 1);
+        // Left row 1 has no match (left outer join)
+        builder.add_left_only(1);
+
+        assert_eq!(builder.result_count(), 3);
+
+        let rows = builder.materialize().unwrap();
+        assert_eq!(rows.len(), 3);
+
+        // First match: (1, A, 1, X)
+        assert_eq!(rows[0].get(0), Some(&SqlValue::Integer(1)));
+        assert_eq!(rows[0].get(2), Some(&SqlValue::Integer(1)));
+        assert_eq!(rows[0].get(3), Some(&SqlValue::Varchar("X".into())));
+
+        // Second match: (1, A, 1, Y)
+        assert_eq!(rows[1].get(3), Some(&SqlValue::Varchar("Y".into())));
+
+        // Left-only: (2, B, NULL, NULL)
+        assert_eq!(rows[2].get(0), Some(&SqlValue::Integer(2)));
+        assert_eq!(rows[2].get(2), Some(&SqlValue::Null));
+        assert_eq!(rows[2].get(3), Some(&SqlValue::Null));
+    }
+
+    #[test]
+    fn test_selectivity() {
+        let rows = sample_rows();
+        let selection = SelectionVector::from_indices(vec![0, 2]); // 2 out of 5
+        let batch = LazyMaterializedBatch::with_selection(
+            SourceData::Rows(Arc::new(rows)),
+            selection,
+        );
+
+        assert!((batch.selectivity() - 0.4).abs() < 0.001);
+    }
+}

--- a/crates/vibesql-executor/src/select/late_materialization/mod.rs
+++ b/crates/vibesql-executor/src/select/late_materialization/mod.rs
@@ -1,0 +1,72 @@
+//! Late Materialization for Query Execution
+//!
+//! This module implements late (or deferred) materialization, a query execution
+//! optimization that delays converting row data to `SqlValue` until absolutely necessary.
+//!
+//! Note: This module is experimental/research code. Some types and functions
+//! are not yet integrated into the main execution path.
+//!
+//! ## Problem
+//!
+//! Traditional row-at-a-time execution materializes all columns immediately:
+//!
+//! ```text
+//! Scan → [Full Rows with all columns] → Filter → [Full Rows] → Join → [Full Rows] → Project
+//! ```
+//!
+//! This is wasteful because:
+//! - Many rows are filtered out (e.g., 99% in TPC-H Q6)
+//! - Many columns aren't needed in the final result
+//! - Join operations only need key columns for matching
+//!
+//! ## Solution
+//!
+//! Late materialization tracks row indices instead of materializing data:
+//!
+//! ```text
+//! Scan → [SelectionVector: row indices] → Filter → [indices] → Join → [indices]
+//!                                                                          ↓
+//! Project → [Materialize only selected columns for final rows] → Output
+//! ```
+//!
+//! ## Key Components
+//!
+//! - [`SelectionVector`]: Tracks qualifying row indices efficiently
+//! - [`RowReference`]: Lightweight reference to a row in a source table
+//! - [`LazyMaterializedBatch`]: Holds source data + selection, materializes on demand
+//! - [`gather_columns`]: Selectively materializes only needed columns
+//!
+//! ## Performance Impact
+//!
+//! For TPC-H Q3 (multi-way JOIN with filters):
+//! - Before: Materialize 480K rows × 15 columns = ~7.2M SqlValue allocations
+//! - After: Materialize 3K result rows × 4 columns = ~12K SqlValue allocations
+//! - **600x reduction** in materialization overhead
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! // Create selection vector from filter
+//! let selection = SelectionVector::from_bitmap(&filter_result);
+//!
+//! // Perform join using only indices
+//! let (left_sel, right_sel) = join_indices(&left_batch, &right_batch, &selection);
+//!
+//! // Materialize only at output boundary
+//! let result_rows = gather_columns(&source_batch, &final_selection, &projected_columns);
+//! ```
+
+#![allow(dead_code)]
+
+mod selection;
+mod row_ref;
+mod lazy_batch;
+mod gather;
+
+pub use selection::SelectionVector;
+pub use row_ref::RowReference;
+pub use lazy_batch::LazyMaterializedBatch;
+pub use gather::{gather_columns, gather_single_column};
+
+#[cfg(test)]
+mod tests;

--- a/crates/vibesql-executor/src/select/late_materialization/row_ref.rs
+++ b/crates/vibesql-executor/src/select/late_materialization/row_ref.rs
@@ -1,0 +1,371 @@
+//! Row Reference Implementation
+//!
+//! A row reference is a lightweight pointer to a row in source data,
+//! avoiding data copying during intermediate query operations.
+
+use std::sync::Arc;
+use vibesql_storage::Row;
+use vibesql_types::SqlValue;
+
+/// A lightweight reference to a row in source data
+///
+/// Instead of cloning entire rows during query processing, `RowReference`
+/// stores just enough information to locate the row when materialization
+/// is needed.
+///
+/// # Memory Comparison
+///
+/// For a row with 10 columns averaging 32 bytes each:
+/// - Full Row: 320+ bytes (plus heap allocations for strings)
+/// - RowReference: 16 bytes (table_id + row_index)
+///
+/// This is **20x** more memory efficient for intermediate results.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // Create references instead of copying rows
+/// let refs: Vec<RowReference> = qualifying_indices
+///     .iter()
+///     .map(|&idx| RowReference::new(0, idx as u32))
+///     .collect();
+///
+/// // Only materialize at output boundary
+/// let output_rows: Vec<Row> = refs
+///     .iter()
+///     .map(|r| source_tables[r.table_id()].row(r.row_index()))
+///     .collect();
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RowReference {
+    /// Identifier for the source table (index into a table registry)
+    table_id: u16,
+    /// Row index within the source table
+    row_index: u32,
+}
+
+impl RowReference {
+    /// Create a new row reference
+    #[inline]
+    pub const fn new(table_id: u16, row_index: u32) -> Self {
+        Self { table_id, row_index }
+    }
+
+    /// Get the table identifier
+    #[inline]
+    pub const fn table_id(&self) -> u16 {
+        self.table_id
+    }
+
+    /// Get the row index within the table
+    #[inline]
+    pub const fn row_index(&self) -> u32 {
+        self.row_index
+    }
+
+    /// Create a vector of row references for a range of rows
+    #[inline]
+    pub fn range(table_id: u16, start: u32, end: u32) -> Vec<Self> {
+        (start..end).map(|idx| Self::new(table_id, idx)).collect()
+    }
+
+    /// Create row references from a selection vector
+    #[inline]
+    pub fn from_selection(table_id: u16, indices: &[u32]) -> Vec<Self> {
+        indices.iter().map(|&idx| Self::new(table_id, idx)).collect()
+    }
+}
+
+/// A pair of row references for join results
+///
+/// When joining tables, we track which rows from each side matched
+/// without materializing the combined row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JoinedRowRef {
+    /// Reference to the left (probe) side row
+    pub left: RowReference,
+    /// Reference to the right (build) side row
+    /// None for LEFT OUTER join when there's no match
+    pub right: Option<RowReference>,
+}
+
+impl JoinedRowRef {
+    /// Create a new joined row reference (inner join match)
+    #[inline]
+    pub const fn matched(left: RowReference, right: RowReference) -> Self {
+        Self {
+            left,
+            right: Some(right),
+        }
+    }
+
+    /// Create a new joined row reference (left outer, no match)
+    #[inline]
+    pub const fn left_only(left: RowReference) -> Self {
+        Self { left, right: None }
+    }
+
+    /// Check if this is a matched pair
+    #[inline]
+    pub const fn is_matched(&self) -> bool {
+        self.right.is_some()
+    }
+}
+
+/// A resolver that can materialize row references into actual rows
+///
+/// This trait abstracts over different source data formats (row-based, columnar)
+/// allowing late materialization to work with various storage layouts.
+pub trait RowResolver {
+    /// Get a row by its reference
+    fn resolve(&self, reference: &RowReference) -> Option<&Row>;
+
+    /// Get a specific column value from a row reference
+    fn resolve_column(&self, reference: &RowReference, column_idx: usize) -> Option<&SqlValue>;
+
+    /// Batch resolve multiple row references
+    ///
+    /// Default implementation calls resolve() for each, but implementations
+    /// can override for better performance with columnar storage.
+    fn resolve_batch(&self, references: &[RowReference]) -> Vec<Option<&Row>> {
+        references.iter().map(|r| self.resolve(r)).collect()
+    }
+}
+
+/// Simple row resolver backed by a vector of rows
+///
+/// This is the most common case for row-based table scans.
+pub struct VecRowResolver<'a> {
+    table_id: u16,
+    rows: &'a [Row],
+}
+
+impl<'a> VecRowResolver<'a> {
+    /// Create a new resolver for a specific table
+    pub fn new(table_id: u16, rows: &'a [Row]) -> Self {
+        Self { table_id, rows }
+    }
+}
+
+impl<'a> RowResolver for VecRowResolver<'a> {
+    fn resolve(&self, reference: &RowReference) -> Option<&Row> {
+        if reference.table_id == self.table_id {
+            self.rows.get(reference.row_index as usize)
+        } else {
+            None
+        }
+    }
+
+    fn resolve_column(&self, reference: &RowReference, column_idx: usize) -> Option<&SqlValue> {
+        self.resolve(reference)
+            .and_then(|row| row.get(column_idx))
+    }
+}
+
+/// Multi-table row resolver for joins
+///
+/// Resolves row references across multiple source tables.
+pub struct MultiTableResolver<'a> {
+    tables: Vec<(u16, &'a [Row])>,
+}
+
+impl<'a> MultiTableResolver<'a> {
+    /// Create a new multi-table resolver
+    pub fn new() -> Self {
+        Self { tables: Vec::new() }
+    }
+
+    /// Register a table with the resolver
+    pub fn add_table(&mut self, table_id: u16, rows: &'a [Row]) {
+        self.tables.push((table_id, rows));
+    }
+
+    /// Create from a list of tables
+    pub fn from_tables(tables: Vec<(u16, &'a [Row])>) -> Self {
+        Self { tables }
+    }
+}
+
+impl<'a> Default for MultiTableResolver<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a> RowResolver for MultiTableResolver<'a> {
+    fn resolve(&self, reference: &RowReference) -> Option<&Row> {
+        for (table_id, rows) in &self.tables {
+            if *table_id == reference.table_id {
+                return rows.get(reference.row_index as usize);
+            }
+        }
+        None
+    }
+
+    fn resolve_column(&self, reference: &RowReference, column_idx: usize) -> Option<&SqlValue> {
+        self.resolve(reference)
+            .and_then(|row| row.get(column_idx))
+    }
+}
+
+/// Owned row data for late materialization
+///
+/// When rows need to be owned (e.g., for cross-thread operations),
+/// this wrapper allows efficient reference-based access while
+/// maintaining ownership of the underlying data.
+pub struct OwnedRowSource {
+    table_id: u16,
+    rows: Arc<Vec<Row>>,
+}
+
+impl OwnedRowSource {
+    /// Create a new owned row source
+    pub fn new(table_id: u16, rows: Vec<Row>) -> Self {
+        Self {
+            table_id,
+            rows: Arc::new(rows),
+        }
+    }
+
+    /// Get the table ID
+    #[inline]
+    pub fn table_id(&self) -> u16 {
+        self.table_id
+    }
+
+    /// Get the number of rows
+    #[inline]
+    pub fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Get a reference to the rows
+    #[inline]
+    pub fn rows(&self) -> &[Row] {
+        &self.rows
+    }
+
+    /// Create a row reference for an index
+    #[inline]
+    pub fn reference(&self, row_index: u32) -> RowReference {
+        RowReference::new(self.table_id, row_index)
+    }
+
+    /// Resolve a row reference
+    #[inline]
+    pub fn resolve(&self, reference: &RowReference) -> Option<&Row> {
+        if reference.table_id == self.table_id {
+            self.rows.get(reference.row_index as usize)
+        } else {
+            None
+        }
+    }
+
+    /// Clone the Arc (cheap, just bumps reference count)
+    pub fn share(&self) -> Self {
+        Self {
+            table_id: self.table_id,
+            rows: Arc::clone(&self.rows),
+        }
+    }
+}
+
+impl Clone for OwnedRowSource {
+    fn clone(&self) -> Self {
+        self.share()
+    }
+}
+
+#[cfg(test)]
+mod row_ref_tests {
+    use super::*;
+
+    #[test]
+    fn test_row_reference_creation() {
+        let r = RowReference::new(1, 42);
+        assert_eq!(r.table_id(), 1);
+        assert_eq!(r.row_index(), 42);
+    }
+
+    #[test]
+    fn test_row_reference_range() {
+        let refs = RowReference::range(0, 10, 15);
+        assert_eq!(refs.len(), 5);
+        assert_eq!(refs[0].row_index(), 10);
+        assert_eq!(refs[4].row_index(), 14);
+    }
+
+    #[test]
+    fn test_vec_resolver() {
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1)]),
+            Row::new(vec![SqlValue::Integer(2)]),
+            Row::new(vec![SqlValue::Integer(3)]),
+        ];
+
+        let resolver = VecRowResolver::new(0, &rows);
+
+        let ref1 = RowReference::new(0, 1);
+        let resolved = resolver.resolve(&ref1).unwrap();
+        assert_eq!(resolved.get(0), Some(&SqlValue::Integer(2)));
+
+        // Wrong table_id returns None
+        let ref_wrong = RowReference::new(1, 1);
+        assert!(resolver.resolve(&ref_wrong).is_none());
+    }
+
+    #[test]
+    fn test_multi_table_resolver() {
+        let table0 = vec![Row::new(vec![SqlValue::Varchar("A".into())])];
+        let table1 = vec![Row::new(vec![SqlValue::Varchar("B".into())])];
+
+        let resolver = MultiTableResolver::from_tables(vec![
+            (0, &table0[..]),
+            (1, &table1[..]),
+        ]);
+
+        let ref0 = RowReference::new(0, 0);
+        let ref1 = RowReference::new(1, 0);
+
+        assert_eq!(
+            resolver.resolve_column(&ref0, 0),
+            Some(&SqlValue::Varchar("A".into()))
+        );
+        assert_eq!(
+            resolver.resolve_column(&ref1, 0),
+            Some(&SqlValue::Varchar("B".into()))
+        );
+    }
+
+    #[test]
+    fn test_joined_row_ref() {
+        let left = RowReference::new(0, 10);
+        let right = RowReference::new(1, 20);
+
+        let matched = JoinedRowRef::matched(left, right);
+        assert!(matched.is_matched());
+        assert_eq!(matched.left.row_index(), 10);
+        assert_eq!(matched.right.unwrap().row_index(), 20);
+
+        let left_only = JoinedRowRef::left_only(left);
+        assert!(!left_only.is_matched());
+    }
+
+    #[test]
+    fn test_owned_row_source() {
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(100)]),
+            Row::new(vec![SqlValue::Integer(200)]),
+        ];
+
+        let source = OwnedRowSource::new(0, rows);
+        assert_eq!(source.row_count(), 2);
+
+        let r = source.reference(1);
+        assert_eq!(source.resolve(&r).unwrap().get(0), Some(&SqlValue::Integer(200)));
+
+        // Test sharing (Arc clone)
+        let shared = source.share();
+        assert_eq!(shared.row_count(), 2);
+    }
+}

--- a/crates/vibesql-executor/src/select/late_materialization/selection.rs
+++ b/crates/vibesql-executor/src/select/late_materialization/selection.rs
@@ -1,0 +1,427 @@
+//! Selection Vector Implementation
+//!
+//! A selection vector tracks which rows qualify from a source dataset,
+//! enabling late materialization by deferring actual data access.
+
+use std::ops::Range;
+
+/// A selection vector tracks qualifying row indices
+///
+/// This is the core data structure for late materialization. Instead of
+/// copying row data, we track which row indices qualify and only materialize
+/// when needed.
+///
+/// # Memory Layout
+///
+/// Uses `u32` indices (4 bytes each) instead of full rows (potentially
+/// hundreds of bytes each). For a 1M row table filtered to 10K rows:
+/// - Old: 1M × sizeof(Row) = potentially gigabytes
+/// - New: 10K × 4 bytes = 40KB
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // Create from filter bitmap
+/// let selection = SelectionVector::from_bitmap(&[true, false, true, true, false]);
+/// assert_eq!(selection.len(), 3);
+/// assert_eq!(selection.indices(), &[0, 2, 3]);
+///
+/// // Iterate over qualifying indices
+/// for idx in selection.iter() {
+///     let row = &source_rows[idx as usize];
+///     // Process row...
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct SelectionVector {
+    /// Indices of qualifying rows (sorted, unique)
+    indices: Vec<u32>,
+}
+
+impl SelectionVector {
+    /// Create an empty selection vector
+    #[inline]
+    pub fn empty() -> Self {
+        Self { indices: Vec::new() }
+    }
+
+    /// Create a selection vector that selects all rows in range [0, count)
+    #[inline]
+    pub fn all(count: usize) -> Self {
+        Self {
+            indices: (0..count as u32).collect(),
+        }
+    }
+
+    /// Create a selection vector from a range
+    #[inline]
+    pub fn from_range(range: Range<usize>) -> Self {
+        Self {
+            indices: (range.start as u32..range.end as u32).collect(),
+        }
+    }
+
+    /// Create from pre-computed indices (assumes sorted, unique)
+    #[inline]
+    pub fn from_indices(indices: Vec<u32>) -> Self {
+        Self { indices }
+    }
+
+    /// Create from a boolean filter bitmap
+    ///
+    /// This is the most common creation path after evaluating predicates.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let bitmap = vec![true, false, true, true, false];
+    /// let selection = SelectionVector::from_bitmap(&bitmap);
+    /// assert_eq!(selection.indices(), &[0, 2, 3]);
+    /// ```
+    pub fn from_bitmap(bitmap: &[bool]) -> Self {
+        let mut indices = Vec::with_capacity(bitmap.len() / 4); // Estimate 25% selectivity
+
+        for (i, &selected) in bitmap.iter().enumerate() {
+            if selected {
+                indices.push(i as u32);
+            }
+        }
+
+        Self { indices }
+    }
+
+    /// Create from a bitmap with pre-allocated capacity hint
+    ///
+    /// Use when you have an estimate of how many rows will match.
+    pub fn from_bitmap_with_capacity(bitmap: &[bool], capacity_hint: usize) -> Self {
+        let mut indices = Vec::with_capacity(capacity_hint);
+
+        for (i, &selected) in bitmap.iter().enumerate() {
+            if selected {
+                indices.push(i as u32);
+            }
+        }
+
+        Self { indices }
+    }
+
+    /// Number of selected rows
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.indices.len()
+    }
+
+    /// Check if no rows are selected
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.indices.is_empty()
+    }
+
+    /// Get the underlying indices slice
+    #[inline]
+    pub fn indices(&self) -> &[u32] {
+        &self.indices
+    }
+
+    /// Consume and return the indices vector
+    #[inline]
+    pub fn into_indices(self) -> Vec<u32> {
+        self.indices
+    }
+
+    /// Get index at position
+    #[inline]
+    pub fn get(&self, pos: usize) -> Option<u32> {
+        self.indices.get(pos).copied()
+    }
+
+    /// Iterate over selected indices
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = u32> + '_ {
+        self.indices.iter().copied()
+    }
+
+    /// Intersect with another selection vector (AND operation)
+    ///
+    /// Returns indices that appear in both selections. Useful for
+    /// combining multiple filter conditions.
+    pub fn intersect(&self, other: &SelectionVector) -> SelectionVector {
+        // Both are sorted, so we can do a merge-style intersection
+        let mut result = Vec::with_capacity(self.len().min(other.len()));
+        let mut i = 0;
+        let mut j = 0;
+
+        while i < self.indices.len() && j < other.indices.len() {
+            match self.indices[i].cmp(&other.indices[j]) {
+                std::cmp::Ordering::Less => i += 1,
+                std::cmp::Ordering::Greater => j += 1,
+                std::cmp::Ordering::Equal => {
+                    result.push(self.indices[i]);
+                    i += 1;
+                    j += 1;
+                }
+            }
+        }
+
+        SelectionVector { indices: result }
+    }
+
+    /// Union with another selection vector (OR operation)
+    ///
+    /// Returns indices that appear in either selection.
+    pub fn union(&self, other: &SelectionVector) -> SelectionVector {
+        // Both are sorted, so we can do a merge-style union
+        let mut result = Vec::with_capacity(self.len() + other.len());
+        let mut i = 0;
+        let mut j = 0;
+
+        while i < self.indices.len() && j < other.indices.len() {
+            match self.indices[i].cmp(&other.indices[j]) {
+                std::cmp::Ordering::Less => {
+                    result.push(self.indices[i]);
+                    i += 1;
+                }
+                std::cmp::Ordering::Greater => {
+                    result.push(other.indices[j]);
+                    j += 1;
+                }
+                std::cmp::Ordering::Equal => {
+                    result.push(self.indices[i]);
+                    i += 1;
+                    j += 1;
+                }
+            }
+        }
+
+        // Append remaining
+        result.extend_from_slice(&self.indices[i..]);
+        result.extend_from_slice(&other.indices[j..]);
+
+        SelectionVector { indices: result }
+    }
+
+    /// Remap indices through another selection
+    ///
+    /// If `self` contains indices [0, 2, 3] and `base` contains [10, 20, 30, 40, 50],
+    /// returns [10, 30, 40] (indices 0, 2, 3 from base).
+    ///
+    /// This is used when chaining operations: if we filter a filtered result,
+    /// we need to map back to original row indices.
+    pub fn remap(&self, base: &SelectionVector) -> SelectionVector {
+        let remapped: Vec<u32> = self
+            .indices
+            .iter()
+            .filter_map(|&idx| base.get(idx as usize))
+            .collect();
+
+        SelectionVector { indices: remapped }
+    }
+
+    /// Create a dense bitmap representation
+    ///
+    /// Returns a boolean vector where `result[i] = true` iff `i` is in the selection.
+    /// `total_count` is the total number of rows in the source.
+    pub fn to_bitmap(&self, total_count: usize) -> Vec<bool> {
+        let mut bitmap = vec![false; total_count];
+        for &idx in &self.indices {
+            if (idx as usize) < total_count {
+                bitmap[idx as usize] = true;
+            }
+        }
+        bitmap
+    }
+
+    /// Filter this selection based on a predicate applied to a slice of data
+    ///
+    /// This is useful for applying additional filters without materializing rows.
+    pub fn filter<T, F>(&self, data: &[T], predicate: F) -> SelectionVector
+    where
+        F: Fn(&T) -> bool,
+    {
+        let filtered: Vec<u32> = self
+            .indices
+            .iter()
+            .filter(|&&idx| predicate(&data[idx as usize]))
+            .copied()
+            .collect();
+
+        SelectionVector { indices: filtered }
+    }
+
+    /// Apply a function to each selected index, collecting results
+    pub fn map<T, F>(&self, mut f: F) -> Vec<T>
+    where
+        F: FnMut(u32) -> T,
+    {
+        self.indices.iter().map(|&idx| f(idx)).collect()
+    }
+
+    /// Selectivity ratio (selected / total)
+    ///
+    /// Returns a value between 0.0 and 1.0 indicating what fraction
+    /// of the total rows are selected.
+    #[inline]
+    pub fn selectivity(&self, total_count: usize) -> f64 {
+        if total_count == 0 {
+            0.0
+        } else {
+            self.len() as f64 / total_count as f64
+        }
+    }
+
+    /// Compact representation check
+    ///
+    /// Returns true if this selection represents a contiguous range,
+    /// which allows for more efficient processing.
+    pub fn is_contiguous(&self) -> bool {
+        if self.indices.len() <= 1 {
+            return true;
+        }
+
+        let first = self.indices[0];
+        let last = self.indices[self.indices.len() - 1];
+        (last - first + 1) as usize == self.indices.len()
+    }
+
+    /// Get the range if this selection is contiguous
+    pub fn as_range(&self) -> Option<Range<usize>> {
+        if self.is_contiguous() && !self.indices.is_empty() {
+            Some(self.indices[0] as usize..self.indices[self.indices.len() - 1] as usize + 1)
+        } else {
+            None
+        }
+    }
+}
+
+impl Default for SelectionVector {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl From<Vec<u32>> for SelectionVector {
+    fn from(indices: Vec<u32>) -> Self {
+        Self::from_indices(indices)
+    }
+}
+
+impl From<Vec<usize>> for SelectionVector {
+    fn from(indices: Vec<usize>) -> Self {
+        Self::from_indices(indices.into_iter().map(|i| i as u32).collect())
+    }
+}
+
+impl IntoIterator for SelectionVector {
+    type Item = u32;
+    type IntoIter = std::vec::IntoIter<u32>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.indices.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a SelectionVector {
+    type Item = &'a u32;
+    type IntoIter = std::slice::Iter<'a, u32>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.indices.iter()
+    }
+}
+
+#[cfg(test)]
+mod selection_tests {
+    use super::*;
+
+    #[test]
+    fn test_from_bitmap() {
+        let bitmap = vec![true, false, true, true, false, true];
+        let selection = SelectionVector::from_bitmap(&bitmap);
+
+        assert_eq!(selection.len(), 4);
+        assert_eq!(selection.indices(), &[0, 2, 3, 5]);
+    }
+
+    #[test]
+    fn test_empty() {
+        let selection = SelectionVector::empty();
+        assert!(selection.is_empty());
+        assert_eq!(selection.len(), 0);
+    }
+
+    #[test]
+    fn test_all() {
+        let selection = SelectionVector::all(5);
+        assert_eq!(selection.len(), 5);
+        assert_eq!(selection.indices(), &[0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_intersect() {
+        let a = SelectionVector::from_indices(vec![1, 2, 4, 6, 8]);
+        let b = SelectionVector::from_indices(vec![2, 3, 4, 5, 6]);
+
+        let result = a.intersect(&b);
+        assert_eq!(result.indices(), &[2, 4, 6]);
+    }
+
+    #[test]
+    fn test_union() {
+        let a = SelectionVector::from_indices(vec![1, 3, 5]);
+        let b = SelectionVector::from_indices(vec![2, 3, 4]);
+
+        let result = a.union(&b);
+        assert_eq!(result.indices(), &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_remap() {
+        let base = SelectionVector::from_indices(vec![10, 20, 30, 40, 50]);
+        let child = SelectionVector::from_indices(vec![0, 2, 4]); // Select indices 0, 2, 4 from base
+
+        let remapped = child.remap(&base);
+        assert_eq!(remapped.indices(), &[10, 30, 50]);
+    }
+
+    #[test]
+    fn test_to_bitmap() {
+        let selection = SelectionVector::from_indices(vec![1, 3, 4]);
+        let bitmap = selection.to_bitmap(6);
+
+        assert_eq!(bitmap, vec![false, true, false, true, true, false]);
+    }
+
+    #[test]
+    fn test_is_contiguous() {
+        let contiguous = SelectionVector::from_indices(vec![2, 3, 4, 5]);
+        let non_contiguous = SelectionVector::from_indices(vec![2, 4, 6]);
+
+        assert!(contiguous.is_contiguous());
+        assert!(!non_contiguous.is_contiguous());
+    }
+
+    #[test]
+    fn test_as_range() {
+        let contiguous = SelectionVector::from_indices(vec![2, 3, 4, 5]);
+        assert_eq!(contiguous.as_range(), Some(2..6));
+
+        let non_contiguous = SelectionVector::from_indices(vec![2, 4, 6]);
+        assert_eq!(non_contiguous.as_range(), None);
+    }
+
+    #[test]
+    fn test_selectivity() {
+        let selection = SelectionVector::from_indices(vec![0, 5, 10]);
+        assert!((selection.selectivity(100) - 0.03).abs() < 0.001);
+        assert!((selection.selectivity(30) - 0.1).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_filter() {
+        let data = vec![10, 20, 30, 40, 50];
+        let selection = SelectionVector::from_indices(vec![0, 2, 4]);
+
+        let filtered = selection.filter(&data, |&x| x > 20);
+        assert_eq!(filtered.indices(), &[2, 4]); // indices where data > 20
+    }
+}

--- a/crates/vibesql-executor/src/select/late_materialization/tests.rs
+++ b/crates/vibesql-executor/src/select/late_materialization/tests.rs
@@ -1,0 +1,326 @@
+//! Integration tests for late materialization
+//!
+//! These tests verify the end-to-end behavior of late materialization
+//! for common query patterns.
+
+use std::sync::Arc;
+use vibesql_storage::Row;
+use vibesql_types::SqlValue;
+
+use super::{gather, lazy_batch, row_ref};
+use super::{SelectionVector, RowReference, LazyMaterializedBatch, gather_columns};
+use gather::gather_join_output;
+use crate::select::columnar::{ColumnArray, ColumnarBatch};
+
+/// Create a sample dataset simulating TPC-H lineitem style data
+fn create_tpch_lineitem_sample(row_count: usize) -> ColumnarBatch {
+    // Simulated columns: orderkey, partkey, suppkey, quantity, extendedprice, discount, tax
+    let orderkeys: Vec<i64> = (0..row_count as i64).collect();
+    let partkeys: Vec<i64> = (0..row_count as i64).map(|i| i % 100).collect();
+    let suppkeys: Vec<i64> = (0..row_count as i64).map(|i| i % 50).collect();
+    let quantities: Vec<f64> = (0..row_count).map(|i| (i % 50) as f64 + 1.0).collect();
+    let prices: Vec<f64> = (0..row_count).map(|i| (i % 1000) as f64 * 10.0).collect();
+    let discounts: Vec<f64> = (0..row_count).map(|i| (i % 11) as f64 / 100.0).collect();
+    let taxes: Vec<f64> = (0..row_count).map(|i| (i % 9) as f64 / 100.0).collect();
+
+    let columns = vec![
+        ColumnArray::Int64(Arc::new(orderkeys), None),
+        ColumnArray::Int64(Arc::new(partkeys), None),
+        ColumnArray::Int64(Arc::new(suppkeys), None),
+        ColumnArray::Float64(Arc::new(quantities), None),
+        ColumnArray::Float64(Arc::new(prices), None),
+        ColumnArray::Float64(Arc::new(discounts), None),
+        ColumnArray::Float64(Arc::new(taxes), None),
+    ];
+
+    ColumnarBatch::from_columns(
+        columns,
+        Some(vec![
+            "l_orderkey".into(),
+            "l_partkey".into(),
+            "l_suppkey".into(),
+            "l_quantity".into(),
+            "l_extendedprice".into(),
+            "l_discount".into(),
+            "l_tax".into(),
+        ]),
+    ).unwrap()
+}
+
+#[test]
+fn test_filter_with_late_materialization() {
+    // Create 10K rows
+    let batch = create_tpch_lineitem_sample(10_000);
+
+    // Simulate filter: quantity > 25 AND discount BETWEEN 0.05 AND 0.07
+    // Should select roughly 5% of rows
+    let filter_bitmap: Vec<bool> = (0..10_000)
+        .map(|i| {
+            let qty = (i % 50) as f64 + 1.0;
+            let discount = (i % 11) as f64 / 100.0;
+            qty > 25.0 && discount >= 0.05 && discount <= 0.07
+        })
+        .collect();
+
+    let selection = SelectionVector::from_bitmap(&filter_bitmap);
+
+    // qty > 25 selects 24/50 = 48% of rows
+    // discount in [0.05, 0.07] selects 3/11 = 27% of rows
+    // Combined: ~13% = ~1300 rows
+    assert!(selection.len() < 2000); // Rough upper bound
+
+    // Create lazy batch with selection
+    let lazy_batch = LazyMaterializedBatch::with_selection(
+        lazy_batch::SourceData::Columnar(Arc::new(batch)),
+        selection.clone(),
+    );
+
+    // Only materialize columns needed for output: l_extendedprice (4) and l_discount (5)
+    let result = gather_columns(
+        match lazy_batch.source() {
+            lazy_batch::SourceData::Columnar(b) => b,
+            _ => panic!("Expected columnar"),
+        },
+        lazy_batch.selection(),
+        &[4, 5], // extendedprice, discount
+    ).unwrap();
+
+    // Verify we got the right columns
+    assert_eq!(result.len(), selection.len());
+    assert!(result.len() < 2000);
+
+    // Each result row should have exactly 2 columns
+    for row in &result {
+        assert_eq!(row.len(), 2);
+    }
+}
+
+#[test]
+fn test_join_with_late_materialization() {
+    // Left: orders table (1000 rows)
+    let orders_columns = vec![
+        ColumnArray::Int64(Arc::new((0..1000).collect()), None),
+        ColumnArray::Int64(Arc::new((0..1000).map(|i| i % 100).collect()), None), // custkey
+        ColumnArray::String(Arc::new((0..1000).map(|i| format!("order_{}", i)).collect()), None),
+    ];
+    let orders = ColumnarBatch::from_columns(
+        orders_columns,
+        Some(vec!["o_orderkey".into(), "o_custkey".into(), "o_comment".into()]),
+    ).unwrap();
+
+    // Right: customers table (100 rows)
+    let customers_columns = vec![
+        ColumnArray::Int64(Arc::new((0..100).collect()), None),
+        ColumnArray::String(Arc::new((0..100).map(|i| format!("customer_{}", i)).collect()), None),
+    ];
+    let customers = ColumnarBatch::from_columns(
+        customers_columns,
+        Some(vec!["c_custkey".into(), "c_name".into()]),
+    ).unwrap();
+
+    // Build selection for orders (simulate filter: orderkey < 50)
+    let order_filter: Vec<bool> = (0..1000).map(|i| i < 50).collect();
+    let order_selection = SelectionVector::from_bitmap(&order_filter);
+
+    // Simulate hash join: for each selected order, find matching customer
+    let mut left_indices: Vec<u32> = Vec::new();
+    let mut right_indices: Vec<u32> = Vec::new();
+
+    for order_idx in order_selection.iter() {
+        let custkey = order_idx % 100; // Same as custkey calculation
+        left_indices.push(order_idx);
+        right_indices.push(custkey);
+    }
+
+    // Late materialization: only gather the columns we need
+    // From orders: o_orderkey (0), o_comment (2)
+    // From customers: c_name (1)
+    let result = gather_join_output(
+        &orders,
+        &customers,
+        &left_indices,
+        &right_indices,
+        Some(&[0, 2]), // o_orderkey, o_comment
+        Some(&[1]),    // c_name
+    ).unwrap();
+
+    assert_eq!(result.len(), 50); // 50 orders matched
+
+    // Each row should have 3 columns
+    for row in &result {
+        assert_eq!(row.len(), 3);
+        // Verify structure
+        assert!(matches!(row.get(0), Some(SqlValue::Integer(_))));
+        assert!(matches!(row.get(1), Some(SqlValue::Varchar(_))));
+        assert!(matches!(row.get(2), Some(SqlValue::Varchar(_))));
+    }
+}
+
+#[test]
+fn test_multi_filter_chain() {
+    let batch = create_tpch_lineitem_sample(5000);
+
+    // First filter: quantity > 10
+    let filter1: Vec<bool> = (0..5000)
+        .map(|i| (i % 50) as f64 + 1.0 > 10.0)
+        .collect();
+    let sel1 = SelectionVector::from_bitmap(&filter1);
+
+    // Second filter on sel1 result: discount > 0.05
+    // Need to apply relative to sel1
+    let mut sel2_indices = Vec::new();
+    for idx in sel1.iter() {
+        let discount = (idx % 11) as f64 / 100.0;
+        if discount > 0.05 {
+            sel2_indices.push(idx);
+        }
+    }
+    let sel2 = SelectionVector::from_indices(sel2_indices);
+
+    // Verify chained filtering works
+    assert!(sel2.len() < sel1.len());
+
+    // Create lazy batch and materialize
+    let lazy = LazyMaterializedBatch::with_selection(
+        lazy_batch::SourceData::Columnar(Arc::new(batch)),
+        sel2,
+    );
+
+    let result = lazy.materialize_column(4).unwrap(); // l_extendedprice
+    assert_eq!(result.len(), lazy.len());
+}
+
+#[test]
+fn test_selection_vector_operations() {
+    let a = SelectionVector::from_indices(vec![1, 3, 5, 7, 9]);
+    let b = SelectionVector::from_indices(vec![2, 3, 4, 5, 6]);
+
+    // Intersection: 3, 5
+    let intersection = a.intersect(&b);
+    assert_eq!(intersection.indices(), &[3, 5]);
+
+    // Union: 1, 2, 3, 4, 5, 6, 7, 9
+    let union = a.union(&b);
+    assert_eq!(union.indices(), &[1, 2, 3, 4, 5, 6, 7, 9]);
+}
+
+#[test]
+fn test_memory_estimation() {
+    // Simulate TPC-H Q6 scenario:
+    // - 6M lineitem rows
+    // - ~1% pass the filter (60K rows)
+    // - Only need 2 columns for the aggregate
+
+    let (early, late, savings) = gather::estimate_savings(
+        6_000_000, // total rows
+        60_000,    // selected rows
+        16,        // total columns in lineitem
+        2,         // columns needed for aggregate
+        32,        // avg bytes per value
+    );
+
+    // Early: 6M × 16 × 32 = 3.07 GB
+    assert_eq!(early, 3_072_000_000);
+
+    // Late: 60K × 4 + 60K × 2 × 32 = 240KB + 3.84MB ≈ 4MB
+    assert!(late < 5_000_000);
+
+    // Savings should be ~99.8%
+    assert!(savings > 0.99);
+
+    println!("TPC-H Q6 Memory Comparison:");
+    println!("  Early materialization: {} MB", early / 1_000_000);
+    println!("  Late materialization:  {} MB", late / 1_000_000);
+    println!("  Savings: {:.1}%", savings * 100.0);
+}
+
+#[test]
+fn test_row_reference_based_join() {
+    // Simulate a join using row references instead of copying data
+    let left_rows = vec![
+        Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".into())]),
+        Row::new(vec![SqlValue::Integer(2), SqlValue::Varchar("Bob".into())]),
+        Row::new(vec![SqlValue::Integer(3), SqlValue::Varchar("Carol".into())]),
+    ];
+
+    let right_rows = vec![
+        Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar("Order-A".into())]),
+        Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar("Order-B".into())]),
+        Row::new(vec![SqlValue::Integer(2), SqlValue::Varchar("Order-C".into())]),
+    ];
+
+    // Instead of copying rows, track references
+    let left_source = row_ref::OwnedRowSource::new(0, left_rows);
+    let right_source = row_ref::OwnedRowSource::new(1, right_rows);
+
+    // Join result: track which rows matched
+    let join_pairs: Vec<(RowReference, RowReference)> = vec![
+        (left_source.reference(0), right_source.reference(0)),  // Alice - Order-A
+        (left_source.reference(0), right_source.reference(1)),  // Alice - Order-B
+        (left_source.reference(1), right_source.reference(2)),  // Bob - Order-C
+        // Carol has no orders
+    ];
+
+    // Only materialize at output
+    let mut output_rows = Vec::new();
+    for (left_ref, right_ref) in &join_pairs {
+        let left_row = left_source.resolve(left_ref).unwrap();
+        let right_row = right_source.resolve(right_ref).unwrap();
+
+        // Combine specific columns
+        let values = vec![
+            left_row.get(1).unwrap().clone(),  // name
+            right_row.get(1).unwrap().clone(), // order description
+        ];
+        output_rows.push(Row::new(values));
+    }
+
+    assert_eq!(output_rows.len(), 3);
+    assert_eq!(output_rows[0].get(0), Some(&SqlValue::Varchar("Alice".into())));
+    assert_eq!(output_rows[0].get(1), Some(&SqlValue::Varchar("Order-A".into())));
+    assert_eq!(output_rows[2].get(0), Some(&SqlValue::Varchar("Bob".into())));
+}
+
+#[test]
+fn test_contiguous_selection_optimization() {
+    // When selection is contiguous, we can use range-based access
+    let selection = SelectionVector::from_indices(vec![100, 101, 102, 103, 104]);
+
+    assert!(selection.is_contiguous());
+    assert_eq!(selection.as_range(), Some(100..105));
+
+    // Non-contiguous selection
+    let sparse = SelectionVector::from_indices(vec![100, 102, 105]);
+    assert!(!sparse.is_contiguous());
+    assert_eq!(sparse.as_range(), None);
+}
+
+#[test]
+fn test_selectivity_tracking() {
+    let selection = SelectionVector::from_indices(vec![0, 5, 10, 15]);
+
+    // 4 out of 100 = 4%
+    let selectivity = selection.selectivity(100);
+    assert!((selectivity - 0.04).abs() < 0.001);
+
+    // 4 out of 20 = 20%
+    let selectivity = selection.selectivity(20);
+    assert!((selectivity - 0.2).abs() < 0.001);
+}
+
+#[test]
+fn test_lazy_batch_columnar_access() {
+    let batch = create_tpch_lineitem_sample(1000);
+    let selection = SelectionVector::from_indices(vec![0, 100, 200, 300]);
+
+    let lazy = LazyMaterializedBatch::with_selection(
+        lazy_batch::SourceData::Columnar(Arc::new(batch)),
+        selection,
+    );
+
+    assert!(lazy.is_columnar());
+
+    // Access column array directly for SIMD operations
+    let qty_col = lazy.column_array(3).unwrap(); // l_quantity
+    assert!(matches!(qty_col, ColumnArray::Float64(_, _)));
+}

--- a/crates/vibesql-executor/src/select/mod.rs
+++ b/crates/vibesql-executor/src/select/mod.rs
@@ -8,6 +8,8 @@ mod helpers;
 mod iterator;
 pub mod join;
 #[allow(dead_code)] // Experimental feature with tests, not yet enabled in production
+pub mod late_materialization;
+#[allow(dead_code)] // Experimental feature with tests, not yet enabled in production
 mod monomorphic;
 mod order;
 #[cfg(feature = "parallel")]
@@ -21,6 +23,10 @@ pub(crate) mod window;
 
 pub use cte::CteResult;
 pub use iterator::{RowIterator, TableScanIterator};
+pub use late_materialization::{
+    SelectionVector, RowReference, LazyMaterializedBatch,
+    gather_columns, gather_single_column,
+};
 pub use window::WindowFunctionKey;
 
 /// Result of a SELECT query including column metadata


### PR DESCRIPTION
## Summary

- Adds late materialization infrastructure to reduce memory pressure during query execution
- Defers SqlValue materialization until the output boundary of query execution
- Provides foundation for significant performance improvements on multi-way JOINs

## Key Components

- **SelectionVector**: Tracks qualifying row indices efficiently using `u32` (4 bytes) instead of full rows (potentially hundreds of bytes)
- **RowReference**: Lightweight 6-byte reference to source table + row index
- **LazyMaterializedBatch**: Holds source data + selection, materializes on demand
- **gather_columns**: Selectively materializes only needed columns for final output

## Architecture Change

```
Current:
  Scan → [Full Rows] → Filter → [Full Rows] → Join → [Full Rows] → Project → Output

Proposed:
  Scan → [Column Refs + Indices] → Filter → [Indices] → Join → [Indices]
                                                                      ↓
  Project → [Materialize Selected Columns] → Output
```

## Expected Performance Impact

For multi-way JOINs like TPC-H Q3:
- **Before**: Materialize 480K rows × 15 columns = ~7.2M SqlValue allocations
- **After**: Materialize 3K result rows × 4 columns = ~12K SqlValue allocations
- **~600x reduction** in materialization overhead

## Test Plan

- [x] All 41 unit tests pass for the new late materialization module
- [x] Existing executor tests continue to pass
- [ ] Integration with main execution path (follow-up work)
- [ ] Benchmark on TPC-H Q3, Q6 to validate performance gains

Closes #2973

🤖 Generated with [Claude Code](https://claude.com/claude-code)