### PR TITLE
fix(parser): Support parenthesized subqueries in UNION/UNION ALL

### DIFF
--- a/crates/vibesql-parser/src/parser/select/statement.rs
+++ b/crates/vibesql-parser/src/parser/select/statement.rs
@@ -137,7 +137,24 @@ impl Parser {
             // Parse the right-hand side SELECT statement
             // Don't allow ORDER BY/LIMIT on the right side - they should only apply to the final
             // result
-            let right = Box::new(self.parse_select_statement_internal(false)?);
+            //
+            // Standard SQL allows the right-hand SELECT to be wrapped in parentheses:
+            //   SELECT ... UNION ALL (SELECT ...)
+            // This is commonly used in CTEs and TPC-DS queries.
+            let right = if matches!(self.peek(), Token::LParen) {
+                self.advance(); // consume '('
+                let stmt = self.parse_select_statement_internal(false)?;
+                if !matches!(self.peek(), Token::RParen) {
+                    return Err(ParseError {
+                        message: "Expected ')' after parenthesized SELECT in set operation"
+                            .to_string(),
+                    });
+                }
+                self.advance(); // consume ')'
+                Box::new(stmt)
+            } else {
+                Box::new(self.parse_select_statement_internal(false)?)
+            };
 
             Some(vibesql_ast::SetOperation { op, all, right })
         } else {

--- a/crates/vibesql-parser/src/tests/set_operations.rs
+++ b/crates/vibesql-parser/src/tests/set_operations.rs
@@ -226,3 +226,56 @@ fn test_parse_intersect_distinct() {
         Parser::parse_sql("SELECT id FROM users INTERSECT DISTINCT SELECT id FROM customers;");
     assert!(result.is_ok(), "INTERSECT DISTINCT should parse: {:?}", result);
 }
+
+// ========================================================================
+// Parenthesized Subquery Tests (TPC-DS Q2 style)
+// ========================================================================
+
+#[test]
+fn test_parse_union_all_parenthesized() {
+    let result = Parser::parse_sql("SELECT id FROM users UNION ALL (SELECT id FROM customers);");
+    assert!(
+        result.is_ok(),
+        "UNION ALL with parenthesized SELECT should parse: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_parse_union_parenthesized() {
+    let result = Parser::parse_sql("SELECT id FROM users UNION (SELECT id FROM customers);");
+    assert!(result.is_ok(), "UNION with parenthesized SELECT should parse: {:?}", result);
+}
+
+#[test]
+fn test_parse_intersect_parenthesized() {
+    let result = Parser::parse_sql("SELECT id FROM users INTERSECT (SELECT id FROM customers);");
+    assert!(result.is_ok(), "INTERSECT with parenthesized SELECT should parse: {:?}", result);
+}
+
+#[test]
+fn test_parse_except_parenthesized() {
+    let result = Parser::parse_sql("SELECT id FROM users EXCEPT (SELECT id FROM banned);");
+    assert!(result.is_ok(), "EXCEPT with parenthesized SELECT should parse: {:?}", result);
+}
+
+#[test]
+fn test_parse_union_all_parenthesized_complex() {
+    // TPC-DS Q2 style: parenthesized SELECT in UNION ALL within CTE
+    let sql = r#"
+        WITH wscs AS (
+            SELECT ws_sold_date_sk sold_date_sk
+            FROM web_sales
+            UNION ALL
+            (SELECT cs_sold_date_sk sold_date_sk
+             FROM catalog_sales)
+        )
+        SELECT * FROM wscs;
+    "#;
+    let result = Parser::parse_sql(sql);
+    assert!(
+        result.is_ok(),
+        "TPC-DS Q2 style UNION ALL with parenthesized SELECT in CTE should parse: {:?}",
+        result
+    );
+}


### PR DESCRIPTION
## Summary

- Add support for SQL syntax `SELECT ... UNION ALL (SELECT ...)` where the right-hand side of a set operation can be wrapped in parentheses
- This is standard SQL syntax used by TPC-DS Q2 and supported by PostgreSQL, MySQL, SQLite
- Add comprehensive parser tests for parenthesized UNION/INTERSECT/EXCEPT syntax

Closes #2999

## Test plan

- [x] Parser tests for `test_parse_union_all_parenthesized` pass
- [x] Parser tests for `test_parse_union_parenthesized` pass
- [x] Parser tests for `test_parse_intersect_parenthesized` pass
- [x] Parser tests for `test_parse_except_parenthesized` pass
- [x] Parser tests for `test_parse_union_all_parenthesized_complex` (TPC-DS Q2 style CTE) pass
- [x] `test_tpcds_q2_parse` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)