### PR TITLE
fix(optimizer): Use correct SQL mode for constant folding in WHERE clauses

### DIFF
--- a/crates/vibesql-executor/src/optimizer/expressions.rs
+++ b/crates/vibesql-executor/src/optimizer/expressions.rs
@@ -108,7 +108,10 @@ pub fn optimize_expression(
             if let (Expression::Literal(left_val), Expression::Literal(right_val)) =
                 (&left_opt, &right_opt)
             {
-                match ExpressionEvaluator::eval_binary_op_static(left_val, op, right_val, vibesql_types::SqlMode::default()) {
+                // Use the evaluator's SQL mode for constant folding to ensure correct behavior
+                // across different database modes (MySQL, SQLite, etc.)
+                let sql_mode = evaluator.database().map(|db| db.sql_mode()).unwrap_or_default();
+                match ExpressionEvaluator::eval_binary_op_static(left_val, op, right_val, sql_mode) {
                     Ok(result) => return Ok(Expression::Literal(result)),
                     Err(_) => {
                         // If evaluation fails, continue with normalization below
@@ -225,13 +228,16 @@ pub fn optimize_expression(
             if let (Expression::Literal(expr_val), Expression::Literal(low_val), Expression::Literal(high_val)) =
                 (&expr_opt, &low_opt, &high_opt)
             {
+                // Use the evaluator's SQL mode for constant folding to ensure correct behavior
+                // across different database modes (MySQL, SQLite, etc.)
+                let sql_mode = evaluator.database().map(|db| db.sql_mode()).unwrap_or_default();
                 match ExpressionEvaluator::eval_between_static(
                     expr_val,
                     low_val,
                     high_val,
                     *negated,
                     *symmetric,
-                    vibesql_types::SqlMode::default(),
+                    sql_mode,
                 ) {
                     Ok(result) => return Ok(Expression::Literal(result)),
                     Err(_) => {


### PR DESCRIPTION
## Summary

- Fixed optimizer constant folding to use the database's actual SQL mode instead of hardcoded MySQL mode
- This fixes integer division expressions in SQLite mode being incorrectly evaluated during query optimization
- The bug caused WHERE clauses with constant integer division (e.g., `WHERE (55 / 79) = 0`) to return no rows in SQLite mode

## Root Cause

The optimizer's constant folding in `expressions.rs` was using `SqlMode::default()` (MySQL mode) instead of the database's actual SQL mode. This caused:

**Before (broken):**
```
SQLite mode: WHERE (55 / 79) = 0
→ Optimizer evaluates: 55 / 79 = 0.695... (MySQL decimal division)
→ Then: 0.695... = 0 evaluates to FALSE
→ WHERE clause eliminated (no matching rows)
```

**After (fixed):**
```
SQLite mode: WHERE (55 / 79) = 0  
→ Optimizer evaluates: 55 / 79 = 0 (SQLite integer division)
→ Then: 0 = 0 evaluates to TRUE
→ WHERE clause preserved correctly
```

## Changes

- `crates/vibesql-executor/src/optimizer/expressions.rs`:
  - Line 111-114: Use evaluator's SQL mode for binary operation constant folding
  - Line 231-240: Use evaluator's SQL mode for BETWEEN expression constant folding

## Test plan

- [x] Code compiles successfully
- [x] Verified fix resolves the `random/aggregates` SQLLogicTest failures related to integer division
- [ ] Full SQLLogicTest suite regression testing

Closes #2996

🤖 Generated with [Claude Code](https://claude.com/claude-code)