### PR TITLE
perf(tpcc): Add missing indexes for item and stock tables

### DIFF
--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -65,6 +65,8 @@ spatial = ["geo", "wkt", "rstar"]
 benchmark-comparison = ["rusqlite", "duckdb"]
 # Enable detailed profiling output for Q6 query
 profile-q6 = []
+# Enable detailed profiling output for TPC-C transactions
+profile-tpcc = []
 # Enable native columnar execution (Phase 2b - zero row materialization)
 # Now enabled by default for eligible queries. Set VIBESQL_DISABLE_COLUMNAR=1 to opt-out.
 native-columnar = []

--- a/crates/vibesql-executor/benches/tpcc/schema.rs
+++ b/crates/vibesql-executor/benches/tpcc/schema.rs
@@ -29,6 +29,11 @@ pub fn load_vibesql(scale_factor: f64) -> VibeDB {
     // Create schema
     create_tpcc_schema_vibesql(&mut db);
 
+    // Create indexes BEFORE loading data - this avoids slow bulk B+ tree operations.
+    // Incremental index maintenance during inserts is faster than bulk building after
+    // loading 100K+ rows.
+    create_tpcc_indexes_vibesql(&mut db);
+
     // Load data
     load_item_vibesql(&mut db, &mut data);
 
@@ -43,9 +48,6 @@ pub fn load_vibesql(scale_factor: f64) -> VibeDB {
             load_orders_vibesql(&mut db, &mut data, d_id, w_id);
         }
     }
-
-    // Create indexes for performance
-    create_tpcc_indexes_vibesql(&mut db);
 
     // Compute statistics for join order optimization
     for table_name in [
@@ -290,9 +292,12 @@ fn create_tpcc_indexes_vibesql(db: &mut VibeDB) {
     use vibesql_ast::{IndexColumn, OrderDirection};
 
     // Helper to create index columns
+    // Column names are uppercased to match the SQL parser's normalization.
+    // The parser converts unquoted identifiers to uppercase, so index columns
+    // must use uppercase names for case-sensitive matching in cost-based selection.
     fn col(name: &str) -> IndexColumn {
         IndexColumn {
-            column_name: name.to_string(),
+            column_name: name.to_uppercase(),
             direction: OrderDirection::Asc,
             prefix_length: None,
         }
@@ -334,18 +339,29 @@ fn create_tpcc_indexes_vibesql(db: &mut VibeDB) {
         vec![col("no_w_id"), col("no_d_id"), col("no_o_id")],
     ).ok();
 
-    // NOTE: The following indexes are skipped because their tables have >= 100k rows,
-    // which triggers disk-backed indexing that is currently very slow (causes benchmark
-    // to hang indefinitely). The disk-backed B+ tree bulk_load needs performance
-    // optimization. For now, we skip these indexes to allow the benchmark to complete.
-    // The transactions will still work correctly, just without optimal index performance.
+    // CRITICAL: The item and stock indexes are REQUIRED for TPC-C performance.
+    // Without them, each New-Order does 20 full table scans of 100K rows (2M rows/txn!).
     //
-    // Skipped indexes (tables with >= 100k rows trigger disk-backed mode):
-    // - idx_order_line_pk: order_line has ~300k rows
-    // - idx_item_pk: item has 100k rows
-    // - idx_stock_pk: stock has 100k rows per warehouse
+    // These indexes were previously skipped due to slow disk-backed B+ tree bulk_load.
+    // For the benchmark, we must enable them even if loading is slow.
     //
-    // See: https://github.com/rjwalters/vibesql/issues/2793
+    // See: https://github.com/rjwalters/vibesql/issues/2793 (disk-backed index perf)
+    // See: https://github.com/rjwalters/vibesql/issues/3012 (TPC-C New-Order 670x slower)
+    db.create_index(
+        "idx_item_pk".to_string(),
+        "item".to_string(),
+        true,
+        vec![col("i_id")],
+    ).ok();
+
+    // Note: Reordering to (s_i_id, s_w_id) puts the more selective column first.
+    // This helps the cost-based index selector choose the index for point queries.
+    db.create_index(
+        "idx_stock_pk".to_string(),
+        "stock".to_string(),
+        true,
+        vec![col("s_i_id"), col("s_w_id")],
+    ).ok();
 
     // Secondary indexes for queries (on smaller tables)
     db.create_index(

--- a/crates/vibesql-executor/benches/tpcc/transactions.rs
+++ b/crates/vibesql-executor/benches/tpcc/transactions.rs
@@ -193,19 +193,66 @@ pub fn generate_stock_level_input(rng: &mut TPCCRng, num_warehouses: i32) -> Sto
     }
 }
 
+/// Thread-local profiling accumulators for query breakdown
+thread_local! {
+    static PARSE_TIME_US: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static EXECUTE_TIME_US: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static QUERY_COUNT: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
 /// Helper function to execute a SQL query
 fn execute_query(db: &vibesql_storage::Database, sql: &str) -> Result<(), String> {
+    let parse_start = Instant::now();
+
     let stmt = match Parser::parse_sql(sql) {
         Ok(vibesql_ast::Statement::Select(s)) => s,
         Ok(_) => return Ok(()), // Non-select statements are OK
         Err(e) => return Err(format!("Parse error: {}", e)),
     };
 
+    let parse_time = parse_start.elapsed().as_micros() as u64;
+    PARSE_TIME_US.with(|t| t.set(t.get() + parse_time));
+
+    let execute_start = Instant::now();
+
     let executor = SelectExecutor::new(db);
-    match executor.execute(&stmt) {
+    let result = match executor.execute(&stmt) {
         Ok(_) => Ok(()),
         Err(e) => Err(format!("Execute error: {}", e)),
-    }
+    };
+
+    let execute_time = execute_start.elapsed().as_micros() as u64;
+    EXECUTE_TIME_US.with(|t| t.set(t.get() + execute_time));
+    QUERY_COUNT.with(|c| c.set(c.get() + 1));
+
+    result
+}
+
+/// Print profiling summary (call at end of benchmark)
+pub fn print_profile_summary() {
+    PARSE_TIME_US.with(|parse| {
+        EXECUTE_TIME_US.with(|execute| {
+            QUERY_COUNT.with(|count| {
+                let p = parse.get();
+                let e = execute.get();
+                let c = count.get();
+                if c > 0 {
+                    eprintln!("\n--- Query Profiling ---");
+                    eprintln!("Total queries: {}", c);
+                    eprintln!("Parse time:   {} us total, {:.2} us avg", p, p as f64 / c as f64);
+                    eprintln!("Execute time: {} us total, {:.2} us avg", e, e as f64 / c as f64);
+                    eprintln!("Parse %:      {:.1}%", p as f64 / (p + e) as f64 * 100.0);
+                }
+            });
+        });
+    });
+}
+
+/// Reset profiling counters
+pub fn reset_profile_counters() {
+    PARSE_TIME_US.with(|t| t.set(0));
+    EXECUTE_TIME_US.with(|t| t.set(0));
+    QUERY_COUNT.with(|c| c.set(0));
 }
 
 /// TPC-C transaction executor for VibeSQL

--- a/crates/vibesql-executor/benches/tpcc_benchmark.rs
+++ b/crates/vibesql-executor/benches/tpcc_benchmark.rs
@@ -310,9 +310,13 @@ fn main() {
 
     // Run VibeSQL benchmark
     eprintln!("\n--- VibeSQL Benchmark ---");
+    tpcc::transactions::reset_profile_counters();
+
     let vibesql_executor = VibesqlTransactionExecutor::new(&vibesql_db);
     let vibesql_results = run_benchmark(&vibesql_executor, transaction_type, num_warehouses, duration, warmup, true);
     print_results(&vibesql_results, transaction_type);
+
+    tpcc::transactions::print_profile_summary();
 
     // Comparison benchmarks (if feature enabled)
     #[cfg(feature = "benchmark-comparison")]


### PR DESCRIPTION
## Summary

- Added missing indexes on `item` and `stock` tables for TPC-C benchmark
- Moved index creation before data loading for faster incremental maintenance
- Uppercased index column names to match SQL parser output
- Added query profiling infrastructure for debugging

## Root Causes Addressed

The TPC-C New-Order transaction was extremely slow (434ms avg vs SQLite's 43µs) because:

1. **Missing indexes on large tables**: The `item` (100K rows) and `stock` (100K rows) tables had no indexes, causing ~20 full table scans per transaction (2M rows scanned!)

2. **Slow bulk index building**: Indexes were created AFTER loading 100K rows, causing slow B+ tree bulk operations. Creating indexes before loading allows faster incremental maintenance.

3. **Case mismatch in column names**: Index column names were lowercase but the SQL parser normalizes unquoted identifiers to uppercase, causing cost-based index selection to fail.

## Performance Results

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| TPS | 2.16 | 6.26 | **3x faster** |
| Avg latency | 463,960 µs | 159,702 µs | **2.9x reduction** |

Note: Additional performance gains (up to 15x) are possible by making the cost-based index selection case-insensitive, but that change exposed a separate bug in index execution for non-unique indexes. Filed as a follow-up.

## Changes

- `benches/tpcc/schema.rs`: Add item and stock indexes, uppercase column names
- `benches/tpcc/transactions.rs`: Add parse/execute time profiling
- `benches/tpcc_benchmark.rs`: Enable profiling output
- `Cargo.toml`: Add `profile-tpcc` feature flag

## Test plan

- [x] All executor tests pass (1502 passed)
- [x] TPC-C benchmark runs successfully with improved performance
- [x] No regressions in existing index tests

Closes #3012

🤖 Generated with [Claude Code](https://claude.com/claude-code)