### PR TITLE
perf: Make cost-based index selection case-insensitive

### DIFF
--- a/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
@@ -123,11 +123,36 @@ pub(crate) fn expression_filters_column(expr: &Expression, column_name: &str) ->
 }
 
 /// Check if an expression is a reference to a specific column
+///
+/// Uses case-insensitive comparison because:
+/// - SQL parser normalizes unquoted identifiers to uppercase (e.g., `i_id` → `I_ID`)
+/// - Index column names may be lowercase or uppercase depending on how they're created
+/// - Table column statistics are stored with the original column name case
 pub(super) fn is_column_reference(expr: &Expression, column_name: &str) -> bool {
     match expr {
-        Expression::ColumnRef { column, .. } => column == column_name,
+        Expression::ColumnRef { column, .. } => column.eq_ignore_ascii_case(column_name),
         _ => false,
     }
+}
+
+/// Case-insensitive lookup of column statistics
+///
+/// Returns the ColumnStatistics for a column name, ignoring case differences.
+/// This is necessary because schema column names may use different casing than
+/// index column names or query column references.
+fn get_column_stats_ignore_case<'a>(
+    columns: &'a std::collections::HashMap<String, vibesql_storage::statistics::ColumnStatistics>,
+    column_name: &str,
+) -> Option<&'a vibesql_storage::statistics::ColumnStatistics> {
+    // First try exact match for efficiency
+    if let Some(stats) = columns.get(column_name) {
+        return Some(stats);
+    }
+    // Fall back to case-insensitive search
+    columns
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(column_name))
+        .map(|(_, stats)| stats)
 }
 
 /// Check if an index can be used to satisfy an ORDER BY clause
@@ -157,8 +182,8 @@ pub(crate) fn can_use_index_for_order_by(
             _ => return false, // Complex expressions not supported
         };
 
-        // Column names must match
-        if order_col_name != &index_col.column_name {
+        // Column names must match (case-insensitive due to SQL identifier normalization)
+        if !order_col_name.eq_ignore_ascii_case(&index_col.column_name) {
             return false;
         }
 
@@ -242,8 +267,8 @@ pub(crate) fn cost_based_index_selection(
                 continue;
             }
 
-            // Get column statistics for the indexed column
-            let col_stats = table_stats.columns.get(column_name);
+            // Get column statistics for the indexed column (case-insensitive lookup)
+            let col_stats = get_column_stats_ignore_case(&table_stats.columns, column_name);
             if col_stats.is_none() {
                 // Track that we found an applicable index without column stats
                 // We'll fall back to rule-based selection if cost-based fails
@@ -329,14 +354,14 @@ pub(crate) fn estimate_selectivity(
         Expression::BinaryOp { left, op, right } => {
             match op {
                 vibesql_ast::BinaryOperator::Equal => {
-                    // Check if this is a predicate on our column
+                    // Check if this is a predicate on our column (case-insensitive)
                     if let (Expression::ColumnRef { column, .. }, Expression::Literal(value)) = (&**left, &**right) {
-                        if column == column_name {
+                        if column.eq_ignore_ascii_case(column_name) {
                             return col_stats.estimate_eq_selectivity(value);
                         }
                     }
                     if let (Expression::Literal(value), Expression::ColumnRef { column, .. }) = (&**left, &**right) {
-                        if column == column_name {
+                        if column.eq_ignore_ascii_case(column_name) {
                             return col_stats.estimate_eq_selectivity(value);
                         }
                     }
@@ -346,9 +371,9 @@ pub(crate) fn estimate_selectivity(
                 | vibesql_ast::BinaryOperator::GreaterThanOrEqual
                 | vibesql_ast::BinaryOperator::LessThan
                 | vibesql_ast::BinaryOperator::LessThanOrEqual => {
-                    // Range predicates
+                    // Range predicates (case-insensitive column comparison)
                     if let (Expression::ColumnRef { column, .. }, Expression::Literal(value)) = (&**left, &**right) {
-                        if column == column_name {
+                        if column.eq_ignore_ascii_case(column_name) {
                             let op_str = match op {
                                 vibesql_ast::BinaryOperator::GreaterThan => ">",
                                 vibesql_ast::BinaryOperator::GreaterThanOrEqual => ">=",
@@ -379,7 +404,7 @@ pub(crate) fn estimate_selectivity(
         }
         Expression::Between { expr, low, high, negated: _, symmetric: _ } => {
             if let Expression::ColumnRef { column, .. } = &**expr {
-                if column == column_name {
+                if column.eq_ignore_ascii_case(column_name) {
                     // Estimate BETWEEN as: P(col >= low AND col <= high)
                     if let (Expression::Literal(low_val), Expression::Literal(high_val)) = (&**low, &**high) {
                         let low_sel = col_stats.estimate_range_selectivity(low_val, ">=");
@@ -451,5 +476,39 @@ mod tests {
 
         assert!(is_column_reference(&expr, "age"));
         assert!(!is_column_reference(&expr, "name"));
+    }
+
+    #[test]
+    fn test_is_column_reference_case_insensitive() {
+        // SQL parser normalizes unquoted identifiers to uppercase
+        // but index columns might be lowercase
+        let expr = Expression::ColumnRef {
+            table: None,
+            column: "I_ID".to_string(), // Uppercase from parser
+        };
+
+        // Should match regardless of case
+        assert!(is_column_reference(&expr, "i_id"));  // lowercase
+        assert!(is_column_reference(&expr, "I_ID"));  // exact match
+        assert!(is_column_reference(&expr, "I_id"));  // mixed case
+        assert!(!is_column_reference(&expr, "other_column"));
+    }
+
+    #[test]
+    fn test_expression_filters_column_case_insensitive() {
+        // WHERE I_ID = 42 (uppercase from parser)
+        let expr = Expression::BinaryOp {
+            op: BinaryOperator::Equal,
+            left: Box::new(Expression::ColumnRef {
+                table: None,
+                column: "I_ID".to_string(),
+            }),
+            right: Box::new(Expression::Literal(SqlValue::Integer(42))),
+        };
+
+        // Should match lowercase index column name
+        assert!(expression_filters_column(&expr, "i_id"));
+        assert!(expression_filters_column(&expr, "I_ID"));
+        assert!(!expression_filters_column(&expr, "other"));
     }
 }


### PR DESCRIPTION
## Summary

- Make `is_column_reference()` use case-insensitive comparison
- Make `can_use_index_for_order_by()` use case-insensitive column matching
- Make `estimate_selectivity()` use case-insensitive predicate matching
- Add `get_column_stats_ignore_case()` helper for case-insensitive stats lookup
- Add unit tests verifying case-insensitive behavior

## Background

The SQL parser normalizes unquoted identifiers to uppercase (e.g., `i_id` → `I_ID`), but:
- Table column statistics are stored with the original column name case
- Index column names may be lowercase or uppercase depending on creation

This caused the cost-based index selector to fail column name matching when cases differ, falling back to less optimal rule-based selection.

## Expected Impact

- TPC-C New-Order: 6.26 TPS → ~35 TPS (additional 5x improvement)
- Better index utilization for queries with mixed-case column references

## ⚠️ Blocking Issue

This PR exposes pre-existing bugs in index scan execution (#3025):
- `test_updates_affecting_non_unique_indexes` fails (0 rows returned instead of 1)
- `test_order_by_with_nulls_asc` fails (wrong ordering)

The selection logic implemented here is correct. These failures occur because:
1. Case-insensitive matching causes more indexes to be selected
2. The index scan execution has bugs when handling non-unique indexes after UPDATE
3. These bugs existed before but weren't triggered because indexes weren't being selected

**This PR should wait for #3025 to be fixed before merging.**

## Test plan

- [x] All selection unit tests pass (including new case-insensitive tests)
- [x] 1516 executor tests pass
- [ ] Blocked: 2 tests fail due to #3025 (pre-existing index execution bugs)

Closes #3022

🤖 Generated with [Claude Code](https://claude.com/claude-code)