### PR TITLE
fix(storage): Use delete_specific for non-unique index maintenance

### DIFF
--- a/crates/vibesql-storage/src/database/indexes/index_maintenance.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance.rs
@@ -312,9 +312,11 @@ impl IndexManager {
                             }
                             IndexData::DiskBacked { btree, .. } => {
                                 // Safely acquire lock and update B+tree: delete old key, insert new key
+                                // Use delete_specific to only remove the specific row_index, not all rows
+                                // with this key (important for non-unique indexes with duplicate keys)
                                 match acquire_btree_lock(btree) {
                                     Ok(mut guard) => {
-                                        let _ = guard.delete(&old_key_values);
+                                        let _ = guard.delete_specific(&old_key_values, row_index);
                                         if let Err(e) = guard.insert(new_key_values, row_index) {
                                             log::warn!("Failed to update disk-backed index '{}': {:?}", index_name, e);
                                         }
@@ -371,9 +373,11 @@ impl IndexManager {
                         }
                         IndexData::DiskBacked { btree, .. } => {
                             // Safely acquire lock and delete from B+tree
+                            // Use delete_specific to only remove the specific row_index, not all rows
+                            // with this key (important for non-unique indexes with duplicate keys)
                             match acquire_btree_lock(btree) {
                                 Ok(mut guard) => {
-                                    let _ = guard.delete(&key_values);
+                                    let _ = guard.delete_specific(&key_values, row_index);
                                 }
                                 Err(e) => {
                                     log::warn!("BTreeIndex lock acquisition failed in update_indexes_for_delete: {}", e);


### PR DESCRIPTION
## Summary

- Fixed disk-backed BTree index maintenance to use `delete_specific()` instead of `delete()`
- This ensures only the specific row is removed from non-unique indexes, not all rows with the same key
- The bug caused UPDATE/DELETE operations to incorrectly remove other rows from the index when multiple rows shared the same key value

## Root Cause

The disk-backed index maintenance in `index_maintenance.rs` was using `guard.delete(&key)` which removes ALL row_ids for a key. For non-unique indexes with duplicate keys, this meant:

**Before (broken):**
```
Non-unique index with key "Engineering": [row 1, row 2, row 4]
UPDATE row 2 to "Marketing"
→ delete("Engineering") removes ALL entries: [row 1, row 2, row 4]
→ insert("Marketing", row 2) adds: [row 2]
Result: rows 1 and 4 are lost from the index!
```

**After (fixed):**
```
Non-unique index with key "Engineering": [row 1, row 2, row 4]
UPDATE row 2 to "Marketing"  
→ delete_specific("Engineering", row 2) removes only row 2: [row 1, row 4]
→ insert("Marketing", row 2) adds: [row 2]
Result: index is correct!
```

## Changes

- `crates/vibesql-storage/src/database/indexes/index_maintenance.rs`:
  - Line 319: Use `delete_specific()` in `update_indexes_for_update`
  - Line 380: Use `delete_specific()` in `update_indexes_for_delete`

This aligns the disk-backed index behavior with the in-memory index behavior, which correctly uses `retain()` to only remove the specific row_index.

## Test plan

- [x] Code compiles successfully
- [x] All non-unique disk index tests pass (6/6)
- [x] All update tests pass (7/7)
- [x] All delete tests pass (11/11)
- [x] All truncate tests pass (14/14)
- [x] All storage tests pass (15/15)

## Impact

This fix unblocks #3022 (case-insensitive index selection) which provides an additional 5x TPC-C performance improvement.

Closes #3025

🤖 Generated with [Claude Code](https://claude.com/claude-code)