### PR TITLE
perf: Optimize filter mask operations for table scan queries

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/simd_filter.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter.rs
@@ -173,14 +173,12 @@ pub fn simd_create_filter_mask(
     // Start with all rows passing
     let mut mask = vec![true; row_count];
 
-    // Evaluate each predicate and AND the results
+    // Evaluate each predicate and AND the results using vectorized operation
     for predicate in predicates {
         let predicate_mask = evaluate_predicate_simd(batch, predicate)?;
 
-        // AND with existing mask
-        for i in 0..row_count {
-            mask[i] = mask[i] && predicate_mask[i];
-        }
+        // Vectorized AND with existing mask
+        simd_ops::and_masks_inplace(&mut mask, &predicate_mask);
     }
 
     Ok(mask)
@@ -314,7 +312,7 @@ fn evaluate_predicate_i64_simd(
 
         ColumnPredicate::Between { low, high, .. } => {
             // BETWEEN is equivalent to: value >= low AND value <= high
-            // Use i64 SIMD operations to avoid precision loss from i64->f64 conversion
+            // Use single-pass BETWEEN operation for better performance
             let low_i64 = match low {
                 SqlValue::Integer(v) => *v,
                 SqlValue::Bigint(v) => *v,
@@ -338,16 +336,8 @@ fn evaluate_predicate_i64_simd(
                 }
             };
 
-            // Use i64 SIMD operations to avoid precision loss
-            let ge_low = simd_ge_i64(values, low_i64);
-            let le_high = simd_le_i64(values, high_i64);
-
-            // AND the two masks
-            ge_low
-                .iter()
-                .zip(le_high.iter())
-                .map(|(&a, &b)| a && b)
-                .collect()
+            // Single-pass BETWEEN check (more cache-efficient)
+            simd_ops::between_i64(values, low_i64, high_i64)
         }
 
         ColumnPredicate::GreaterThanOrEqual { value, .. } => {
@@ -494,15 +484,8 @@ fn evaluate_predicate_i32_simd(
                     right_type: Some(format!("{:?}", high)),
                 })?;
 
-            let ge_low = simd_ge_i32(values, low_i32);
-            let le_high = simd_le_i32(values, high_i32);
-
-            // AND the two masks
-            ge_low
-                .iter()
-                .zip(le_high.iter())
-                .map(|(&a, &b)| a && b)
-                .collect()
+            // Single-pass BETWEEN check (more cache-efficient)
+            simd_ops::between_i32(values, low_i32, high_i32)
         }
 
         ColumnPredicate::NotEqual { value, .. } => {
@@ -608,15 +591,8 @@ fn evaluate_predicate_f64_simd(
                     right_type: Some(format!("{:?}", high)),
                 })?;
 
-            let ge_low = simd_ge_f64(values, low_f64);
-            let le_high = simd_le_f64(values, high_f64);
-
-            // AND the two masks
-            ge_low
-                .iter()
-                .zip(le_high.iter())
-                .map(|(&a, &b)| a && b)
-                .collect()
+            // Single-pass BETWEEN check (more cache-efficient)
+            simd_ops::between_f64(values, low_f64, high_f64)
         }
 
         ColumnPredicate::NotEqual { value, .. } => {

--- a/crates/vibesql-executor/src/select/columnar/simd_ops.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_ops.rs
@@ -730,6 +730,95 @@ pub fn ne_f64(values: &[f64], target: f64) -> Vec<bool> {
 }
 
 // ============================================================================
+// BETWEEN OPERATIONS (Range checks in single pass)
+// ============================================================================
+
+/// Check if i64 values are in range [low, high] (inclusive).
+/// More efficient than separate ge + le comparisons + AND.
+#[inline]
+pub fn between_i64(values: &[i64], low: i64, high: i64) -> Vec<bool> {
+    values.iter().map(|&v| v >= low && v <= high).collect()
+}
+
+/// Check if i32 values are in range [low, high] (inclusive).
+/// More efficient than separate ge + le comparisons + AND.
+#[inline]
+pub fn between_i32(values: &[i32], low: i32, high: i32) -> Vec<bool> {
+    values.iter().map(|&v| v >= low && v <= high).collect()
+}
+
+/// Check if f64 values are in range [low, high] (inclusive).
+/// More efficient than separate ge + le comparisons + AND.
+#[inline]
+pub fn between_f64(values: &[f64], low: f64, high: f64) -> Vec<bool> {
+    values.iter().map(|&v| v >= low && v <= high).collect()
+}
+
+// ============================================================================
+// MASK OPERATIONS (Boolean operations on filter masks)
+// ============================================================================
+
+/// In-place AND of two boolean masks.
+///
+/// This function ANDs `other` into `mask` in-place, modifying `mask`.
+/// Uses an unrolled loop that LLVM can auto-vectorize effectively.
+///
+/// # Panics
+/// Panics if `mask` and `other` have different lengths.
+#[inline]
+pub fn and_masks_inplace(mask: &mut [bool], other: &[bool]) {
+    assert_eq!(mask.len(), other.len(), "mask lengths must match");
+
+    let len = mask.len();
+
+    // Process in chunks of 8 for better vectorization
+    let chunks = len / 8;
+    let remainder = len % 8;
+
+    for i in 0..chunks {
+        let base = i * 8;
+        // Unrolled loop - LLVM vectorizes this well
+        mask[base] = mask[base] && other[base];
+        mask[base + 1] = mask[base + 1] && other[base + 1];
+        mask[base + 2] = mask[base + 2] && other[base + 2];
+        mask[base + 3] = mask[base + 3] && other[base + 3];
+        mask[base + 4] = mask[base + 4] && other[base + 4];
+        mask[base + 5] = mask[base + 5] && other[base + 5];
+        mask[base + 6] = mask[base + 6] && other[base + 6];
+        mask[base + 7] = mask[base + 7] && other[base + 7];
+    }
+
+    // Handle remainder
+    let base = chunks * 8;
+    for i in 0..remainder {
+        mask[base + i] = mask[base + i] && other[base + i];
+    }
+}
+
+/// Create a combined filter mask from multiple predicates using in-place AND.
+///
+/// Returns a mask where `result[i] = pred1[i] && pred2[i] && ...`
+/// This is more efficient than repeatedly allocating and ANDing masks.
+///
+/// # Arguments
+/// * `masks` - Iterator of boolean mask slices to combine
+/// * `len` - Expected length of each mask
+///
+/// # Returns
+/// Combined mask with all predicates ANDed together
+#[inline]
+pub fn combine_masks<'a>(masks: impl Iterator<Item = &'a [bool]>, len: usize) -> Vec<bool> {
+    let mut result = vec![true; len];
+
+    for mask in masks {
+        assert_eq!(mask.len(), len, "all masks must have same length");
+        and_masks_inplace(&mut result, mask);
+    }
+
+    result
+}
+
+// ============================================================================
 // TESTS
 // ============================================================================
 
@@ -979,5 +1068,40 @@ mod tests {
         let filter = vec![true, false, true, false, true, false, true];  // 1, 3, 5, 7 = 16
         assert!((sum_f64_filtered(&values, &filter) - 16.0).abs() < 0.001);
         assert_eq!(count_filtered(&filter), 4);
+    }
+
+    #[test]
+    fn test_and_masks_inplace() {
+        let mut mask = vec![true, true, false, true, true, false, true, true];
+        let other = vec![true, false, true, true, false, true, true, false];
+        and_masks_inplace(&mut mask, &other);
+        assert_eq!(mask, vec![true, false, false, true, false, false, true, false]);
+    }
+
+    #[test]
+    fn test_and_masks_inplace_remainder() {
+        // Test with non-multiple-of-8 length
+        let mut mask = vec![true, true, false, true, true];
+        let other = vec![true, false, true, true, false];
+        and_masks_inplace(&mut mask, &other);
+        assert_eq!(mask, vec![true, false, false, true, false]);
+    }
+
+    #[test]
+    fn test_between_i64() {
+        let values = vec![1, 5, 10, 15, 20, 25];
+        assert_eq!(between_i64(&values, 5, 20), vec![false, true, true, true, true, false]);
+    }
+
+    #[test]
+    fn test_between_i32() {
+        let values: Vec<i32> = vec![1, 5, 10, 15, 20, 25];
+        assert_eq!(between_i32(&values, 5, 20), vec![false, true, true, true, true, false]);
+    }
+
+    #[test]
+    fn test_between_f64() {
+        let values = vec![0.01, 0.05, 0.06, 0.07, 0.08];
+        assert_eq!(between_f64(&values, 0.05, 0.07), vec![false, true, true, true, false]);
     }
 }


### PR DESCRIPTION
## Summary

- Add vectorized `and_masks_inplace` function for combining predicate masks with unrolled SIMD-friendly loop
- Add single-pass BETWEEN operations (`between_i64`, `between_i32`, `between_f64`) that evaluate range checks in one pass instead of two
- Update `simd_create_filter_mask` to use vectorized AND instead of scalar loop
- Update BETWEEN handling in simd_filter.rs to use optimized single-pass functions

These changes reduce memory allocation and improve cache efficiency when filtering with multiple predicates, which is common in table scan queries like TPC-H Q6.

## Test plan

- [x] All 52 simd tests pass
- [ ] Run TPC-H Q6 benchmark to verify performance improvement

Closes #3011

🤖 Generated with [Claude Code](https://claude.com/claude-code)