### PR TITLE
feat(bench): Add MySQL to TPC-C and Sysbench benchmark comparisons

### DIFF
--- a/crates/vibesql-executor/benches/sysbench/schema.rs
+++ b/crates/vibesql-executor/benches/sysbench/schema.rs
@@ -10,6 +10,10 @@ use vibesql_storage::Database as VibeDB;
 use duckdb::Connection as DuckDBConn;
 #[cfg(feature = "benchmark-comparison")]
 use rusqlite::Connection as SqliteConn;
+#[cfg(feature = "benchmark-comparison")]
+use mysql::prelude::*;
+#[cfg(feature = "benchmark-comparison")]
+use mysql::{Pool, PooledConn};
 
 // =============================================================================
 // Database Loaders
@@ -68,6 +72,25 @@ pub fn load_duckdb(table_size: usize) -> DuckDBConn {
     load_sbtest_duckdb(&conn, &mut data);
 
     conn
+}
+
+/// Load MySQL with sysbench schema and data
+/// Requires MYSQL_URL environment variable (e.g., mysql://root:password@localhost:3306/sysbench)
+/// Returns None if MYSQL_URL is not set or connection fails
+#[cfg(feature = "benchmark-comparison")]
+pub fn load_mysql(table_size: usize) -> Option<PooledConn> {
+    let url = std::env::var("MYSQL_URL").ok()?;
+    let pool = Pool::new(url.as_str()).ok()?;
+    let mut conn = pool.get_conn().ok()?;
+    let mut data = SysbenchData::new(table_size);
+
+    // Create schema (drops and recreates table)
+    create_sbtest_schema_mysql(&mut conn);
+
+    // Load data
+    load_sbtest_mysql(&mut conn, &mut data);
+
+    Some(conn)
 }
 
 // =============================================================================
@@ -220,5 +243,40 @@ fn load_sbtest_duckdb(conn: &DuckDBConn, data: &mut SysbenchData) {
 
     while let Some((id, k, c, pad)) = data.next_row() {
         stmt.execute(duckdb::params![id, k, c, pad]).unwrap();
+    }
+}
+
+// =============================================================================
+// Schema Creation - MySQL
+// =============================================================================
+
+#[cfg(feature = "benchmark-comparison")]
+fn create_sbtest_schema_mysql(conn: &mut PooledConn) {
+    // Drop table if exists
+    conn.query_drop("DROP TABLE IF EXISTS sbtest1").unwrap();
+
+    conn.query_drop(
+        r#"
+        CREATE TABLE sbtest1 (
+            id INTEGER PRIMARY KEY,
+            k INTEGER NOT NULL DEFAULT 0,
+            c VARCHAR(120) NOT NULL DEFAULT '',
+            pad VARCHAR(60) NOT NULL DEFAULT ''
+        ) ENGINE=InnoDB
+    "#,
+    )
+    .unwrap();
+
+    // Create index on k column
+    conn.query_drop("CREATE INDEX k_1 ON sbtest1(k)").unwrap();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn load_sbtest_mysql(conn: &mut PooledConn, data: &mut SysbenchData) {
+    while let Some((id, k, c, pad)) = data.next_row() {
+        conn.exec_drop(
+            "INSERT INTO sbtest1 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+            (id, k, &c, &pad),
+        ).unwrap();
     }
 }

--- a/crates/vibesql-executor/benches/sysbench_oltp.rs
+++ b/crates/vibesql-executor/benches/sysbench_oltp.rs
@@ -76,7 +76,14 @@ use duckdb::Connection as DuckDBConn;
 #[cfg(feature = "benchmark-comparison")]
 use rusqlite::Connection as SqliteConn;
 #[cfg(feature = "benchmark-comparison")]
-use sysbench::schema::{load_duckdb, load_sqlite};
+#[allow(unused_imports)]
+use mysql::prelude::*;
+#[cfg(feature = "benchmark-comparison")]
+#[allow(dead_code)]
+use mysql::PooledConn as MysqlConn;
+#[cfg(feature = "benchmark-comparison")]
+#[allow(unused_imports)]
+use sysbench::schema::{load_duckdb, load_mysql, load_sqlite};
 
 /// Default table size for sysbench tests
 const TABLE_SIZE: usize = 10_000;
@@ -441,6 +448,97 @@ fn duckdb_distinct_range(conn: &DuckDBConn, start: i64, end: i64) -> usize {
         count += 1;
     }
     count
+}
+
+// =============================================================================
+// Helper Functions - MySQL
+// NOTE: These functions are not yet used in benchmark groups because MySQL
+// requires &mut self for queries, making it incompatible with criterion's
+// iter_batched API. They are provided for future use when MySQL benchmarks
+// are added separately (similar to TPC-C/TPC-H).
+// =============================================================================
+
+#[cfg(feature = "benchmark-comparison")]
+#[allow(dead_code)]
+fn mysql_point_select(conn: &mut MysqlConn, id: i64) -> usize {
+    let result: Option<(String,)> = conn
+        .exec_first("SELECT c FROM sbtest1 WHERE id = ?", (id,))
+        .ok()
+        .flatten();
+    if result.is_some() { 1 } else { 0 }
+}
+
+#[cfg(feature = "benchmark-comparison")]
+#[allow(dead_code)]
+fn mysql_insert(conn: &mut MysqlConn, id: i64, k: i64, c: &str, pad: &str) {
+    conn.exec_drop(
+        "INSERT INTO sbtest1 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+        (id, k, c, pad),
+    ).unwrap();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+#[allow(dead_code)]
+fn mysql_update_non_index(conn: &mut MysqlConn, id: i64, c: &str) {
+    conn.exec_drop(
+        "UPDATE sbtest1 SET c = ? WHERE id = ?",
+        (c, id),
+    ).unwrap();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+#[allow(dead_code)]
+fn mysql_update_index(conn: &mut MysqlConn, id: i64) {
+    conn.exec_drop(
+        "UPDATE sbtest1 SET k = k + 1 WHERE id = ?",
+        (id,),
+    ).unwrap();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+#[allow(dead_code)]
+fn mysql_delete(conn: &mut MysqlConn, id: i64) {
+    conn.exec_drop(
+        "DELETE FROM sbtest1 WHERE id = ?",
+        (id,),
+    ).unwrap();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+#[allow(dead_code)]
+fn mysql_simple_range(conn: &mut MysqlConn, start: i64, end: i64) -> usize {
+    let result: Vec<(String,)> = conn
+        .exec("SELECT c FROM sbtest1 WHERE id BETWEEN ? AND ?", (start, end))
+        .unwrap_or_default();
+    result.len()
+}
+
+#[cfg(feature = "benchmark-comparison")]
+#[allow(dead_code)]
+fn mysql_sum_range(conn: &mut MysqlConn, start: i64, end: i64) -> usize {
+    let _result: Option<(Option<i64>,)> = conn
+        .exec_first("SELECT SUM(k) FROM sbtest1 WHERE id BETWEEN ? AND ?", (start, end))
+        .ok()
+        .flatten();
+    1
+}
+
+#[cfg(feature = "benchmark-comparison")]
+#[allow(dead_code)]
+fn mysql_order_range(conn: &mut MysqlConn, start: i64, end: i64) -> usize {
+    let result: Vec<(String,)> = conn
+        .exec("SELECT c FROM sbtest1 WHERE id BETWEEN ? AND ? ORDER BY c", (start, end))
+        .unwrap_or_default();
+    result.len()
+}
+
+#[cfg(feature = "benchmark-comparison")]
+#[allow(dead_code)]
+fn mysql_distinct_range(conn: &mut MysqlConn, start: i64, end: i64) -> usize {
+    let result: Vec<(String,)> = conn
+        .exec("SELECT DISTINCT c FROM sbtest1 WHERE id BETWEEN ? AND ? ORDER BY c", (start, end))
+        .unwrap_or_default();
+    result.len()
 }
 
 // =============================================================================

--- a/crates/vibesql-executor/benches/tpcc/schema.rs
+++ b/crates/vibesql-executor/benches/tpcc/schema.rs
@@ -10,6 +10,10 @@ use vibesql_storage::Database as VibeDB;
 use duckdb::Connection as DuckDBConn;
 #[cfg(feature = "benchmark-comparison")]
 use rusqlite::Connection as SqliteConn;
+#[cfg(feature = "benchmark-comparison")]
+use mysql::prelude::*;
+#[cfg(feature = "benchmark-comparison")]
+use mysql::{Pool, PooledConn};
 
 // =============================================================================
 // Database Loaders
@@ -108,6 +112,38 @@ pub fn load_duckdb(scale_factor: f64) -> DuckDBConn {
 
     create_tpcc_indexes_duckdb(&conn);
     conn
+}
+
+/// Load MySQL TPC-C database
+/// Requires MYSQL_URL environment variable (e.g., mysql://root:password@localhost:3306/tpcc)
+/// Returns None if MYSQL_URL is not set or connection fails
+#[cfg(feature = "benchmark-comparison")]
+pub fn load_mysql(scale_factor: f64) -> Option<PooledConn> {
+    let url = std::env::var("MYSQL_URL").ok()?;
+    let pool = Pool::new(url.as_str()).ok()?;
+    let mut conn = pool.get_conn().ok()?;
+    let mut data = TPCCData::new(scale_factor);
+
+    // Create schema (drops and recreates tables)
+    create_tpcc_schema_mysql(&mut conn);
+
+    // Load data
+    load_item_mysql(&mut conn, &mut data);
+
+    let districts_per_warehouse = data.districts_per_warehouse();
+    for w_id in 1..=data.num_warehouses() {
+        load_warehouse_mysql(&mut conn, &mut data, w_id);
+        load_stock_mysql(&mut conn, &mut data, w_id);
+
+        for d_id in 1..=districts_per_warehouse {
+            load_district_mysql(&mut conn, &mut data, d_id, w_id);
+            load_customer_mysql(&mut conn, &mut data, d_id, w_id);
+            load_orders_mysql(&mut conn, &mut data, d_id, w_id);
+        }
+    }
+
+    create_tpcc_indexes_mysql(&mut conn);
+    Some(conn)
 }
 
 // =============================================================================
@@ -1125,6 +1161,394 @@ fn load_orders_duckdb(conn: &DuckDBConn, data: &mut TPCCData, d_id: i32, w_id: i
         if o_id > delivered_threshold {
             let no = data.gen_new_order(o_id, d_id, w_id);
             no_stmt.execute(duckdb::params![no.no_o_id, no.no_d_id, no.no_w_id]).unwrap();
+        }
+    }
+}
+
+// =============================================================================
+// MySQL Schema and Loading (for comparison)
+// =============================================================================
+
+#[cfg(feature = "benchmark-comparison")]
+fn create_tpcc_schema_mysql(conn: &mut PooledConn) {
+    // Drop tables if they exist (in reverse dependency order)
+    let drop_tables = [
+        "DROP TABLE IF EXISTS order_line",
+        "DROP TABLE IF EXISTS new_order",
+        "DROP TABLE IF EXISTS orders",
+        "DROP TABLE IF EXISTS history",
+        "DROP TABLE IF EXISTS customer",
+        "DROP TABLE IF EXISTS stock",
+        "DROP TABLE IF EXISTS district",
+        "DROP TABLE IF EXISTS warehouse",
+        "DROP TABLE IF EXISTS item",
+    ];
+    for stmt in drop_tables {
+        conn.query_drop(stmt).unwrap();
+    }
+
+    conn.query_drop(
+        r#"
+        CREATE TABLE warehouse (
+            w_id INTEGER PRIMARY KEY,
+            w_name VARCHAR(10) NOT NULL,
+            w_street_1 VARCHAR(20) NOT NULL,
+            w_street_2 VARCHAR(20) NOT NULL,
+            w_city VARCHAR(20) NOT NULL,
+            w_state VARCHAR(2) NOT NULL,
+            w_zip VARCHAR(9) NOT NULL,
+            w_tax DECIMAL(4,4) NOT NULL,
+            w_ytd DECIMAL(12,2) NOT NULL
+        ) ENGINE=InnoDB
+    "#,
+    )
+    .unwrap();
+
+    conn.query_drop(
+        r#"
+        CREATE TABLE district (
+            d_id INTEGER NOT NULL,
+            d_w_id INTEGER NOT NULL,
+            d_name VARCHAR(10) NOT NULL,
+            d_street_1 VARCHAR(20) NOT NULL,
+            d_street_2 VARCHAR(20) NOT NULL,
+            d_city VARCHAR(20) NOT NULL,
+            d_state VARCHAR(2) NOT NULL,
+            d_zip VARCHAR(9) NOT NULL,
+            d_tax DECIMAL(4,4) NOT NULL,
+            d_ytd DECIMAL(12,2) NOT NULL,
+            d_next_o_id INTEGER NOT NULL,
+            PRIMARY KEY (d_w_id, d_id)
+        ) ENGINE=InnoDB
+    "#,
+    )
+    .unwrap();
+
+    conn.query_drop(
+        r#"
+        CREATE TABLE customer (
+            c_id INTEGER NOT NULL,
+            c_d_id INTEGER NOT NULL,
+            c_w_id INTEGER NOT NULL,
+            c_first VARCHAR(16) NOT NULL,
+            c_middle VARCHAR(2) NOT NULL,
+            c_last VARCHAR(16) NOT NULL,
+            c_street_1 VARCHAR(20) NOT NULL,
+            c_street_2 VARCHAR(20) NOT NULL,
+            c_city VARCHAR(20) NOT NULL,
+            c_state VARCHAR(2) NOT NULL,
+            c_zip VARCHAR(9) NOT NULL,
+            c_phone VARCHAR(16) NOT NULL,
+            c_since VARCHAR(25) NOT NULL,
+            c_credit VARCHAR(2) NOT NULL,
+            c_credit_lim DECIMAL(12,2) NOT NULL,
+            c_discount DECIMAL(4,4) NOT NULL,
+            c_balance DECIMAL(12,2) NOT NULL,
+            c_ytd_payment DECIMAL(12,2) NOT NULL,
+            c_payment_cnt INTEGER NOT NULL,
+            c_delivery_cnt INTEGER NOT NULL,
+            c_data VARCHAR(500) NOT NULL,
+            PRIMARY KEY (c_w_id, c_d_id, c_id)
+        ) ENGINE=InnoDB
+    "#,
+    )
+    .unwrap();
+
+    conn.query_drop(
+        r#"
+        CREATE TABLE history (
+            h_c_id INTEGER NOT NULL,
+            h_c_d_id INTEGER NOT NULL,
+            h_c_w_id INTEGER NOT NULL,
+            h_d_id INTEGER NOT NULL,
+            h_w_id INTEGER NOT NULL,
+            h_date VARCHAR(25) NOT NULL,
+            h_amount DECIMAL(6,2) NOT NULL,
+            h_data VARCHAR(24) NOT NULL
+        ) ENGINE=InnoDB
+    "#,
+    )
+    .unwrap();
+
+    conn.query_drop(
+        r#"
+        CREATE TABLE new_order (
+            no_o_id INTEGER NOT NULL,
+            no_d_id INTEGER NOT NULL,
+            no_w_id INTEGER NOT NULL,
+            PRIMARY KEY (no_w_id, no_d_id, no_o_id)
+        ) ENGINE=InnoDB
+    "#,
+    )
+    .unwrap();
+
+    conn.query_drop(
+        r#"
+        CREATE TABLE orders (
+            o_id INTEGER NOT NULL,
+            o_d_id INTEGER NOT NULL,
+            o_w_id INTEGER NOT NULL,
+            o_c_id INTEGER NOT NULL,
+            o_entry_d VARCHAR(25) NOT NULL,
+            o_carrier_id INTEGER,
+            o_ol_cnt INTEGER NOT NULL,
+            o_all_local INTEGER NOT NULL,
+            PRIMARY KEY (o_w_id, o_d_id, o_id)
+        ) ENGINE=InnoDB
+    "#,
+    )
+    .unwrap();
+
+    conn.query_drop(
+        r#"
+        CREATE TABLE order_line (
+            ol_o_id INTEGER NOT NULL,
+            ol_d_id INTEGER NOT NULL,
+            ol_w_id INTEGER NOT NULL,
+            ol_number INTEGER NOT NULL,
+            ol_i_id INTEGER NOT NULL,
+            ol_supply_w_id INTEGER NOT NULL,
+            ol_delivery_d VARCHAR(25),
+            ol_quantity INTEGER NOT NULL,
+            ol_amount DECIMAL(6,2) NOT NULL,
+            ol_dist_info VARCHAR(24) NOT NULL,
+            PRIMARY KEY (ol_w_id, ol_d_id, ol_o_id, ol_number)
+        ) ENGINE=InnoDB
+    "#,
+    )
+    .unwrap();
+
+    conn.query_drop(
+        r#"
+        CREATE TABLE item (
+            i_id INTEGER PRIMARY KEY,
+            i_im_id INTEGER NOT NULL,
+            i_name VARCHAR(24) NOT NULL,
+            i_price DECIMAL(5,2) NOT NULL,
+            i_data VARCHAR(50) NOT NULL
+        ) ENGINE=InnoDB
+    "#,
+    )
+    .unwrap();
+
+    conn.query_drop(
+        r#"
+        CREATE TABLE stock (
+            s_i_id INTEGER NOT NULL,
+            s_w_id INTEGER NOT NULL,
+            s_quantity INTEGER NOT NULL,
+            s_dist_01 VARCHAR(24) NOT NULL,
+            s_dist_02 VARCHAR(24) NOT NULL,
+            s_dist_03 VARCHAR(24) NOT NULL,
+            s_dist_04 VARCHAR(24) NOT NULL,
+            s_dist_05 VARCHAR(24) NOT NULL,
+            s_dist_06 VARCHAR(24) NOT NULL,
+            s_dist_07 VARCHAR(24) NOT NULL,
+            s_dist_08 VARCHAR(24) NOT NULL,
+            s_dist_09 VARCHAR(24) NOT NULL,
+            s_dist_10 VARCHAR(24) NOT NULL,
+            s_ytd INTEGER NOT NULL,
+            s_order_cnt INTEGER NOT NULL,
+            s_remote_cnt INTEGER NOT NULL,
+            s_data VARCHAR(50) NOT NULL,
+            PRIMARY KEY (s_w_id, s_i_id)
+        ) ENGINE=InnoDB
+    "#,
+    )
+    .unwrap();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn create_tpcc_indexes_mysql(conn: &mut PooledConn) {
+    conn.query_drop(
+        "CREATE INDEX idx_customer_name ON customer (c_w_id, c_d_id, c_last, c_first)"
+    ).unwrap();
+    conn.query_drop(
+        "CREATE INDEX idx_orders_customer ON orders (o_w_id, o_d_id, o_c_id)"
+    ).unwrap();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn load_item_mysql(conn: &mut PooledConn, data: &mut TPCCData) {
+    let num_items = data.num_items();
+    for i_id in 1..=num_items {
+        let item = data.gen_item(i_id);
+        conn.exec_drop(
+            "INSERT INTO item VALUES (?, ?, ?, ?, ?)",
+            (item.i_id, item.i_im_id, &item.i_name, item.i_price, &item.i_data),
+        ).unwrap();
+    }
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn load_warehouse_mysql(conn: &mut PooledConn, data: &mut TPCCData, w_id: i32) {
+    let warehouse = data.gen_warehouse(w_id);
+    conn.exec_drop(
+        "INSERT INTO warehouse VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            warehouse.w_id, &warehouse.w_name, &warehouse.w_street_1, &warehouse.w_street_2,
+            &warehouse.w_city, &warehouse.w_state, &warehouse.w_zip, warehouse.w_tax, warehouse.w_ytd
+        ),
+    ).unwrap();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn load_stock_mysql(conn: &mut PooledConn, data: &mut TPCCData, w_id: i32) {
+    use mysql::Value;
+
+    let num_items = data.num_items();
+    for i_id in 1..=num_items {
+        let stock = data.gen_stock(i_id, w_id);
+        // MySQL Params doesn't support 17-element tuples, so use Vec<Value>
+        let params: Vec<Value> = vec![
+            Value::from(stock.s_i_id),
+            Value::from(stock.s_w_id),
+            Value::from(stock.s_quantity),
+            Value::from(stock.s_dist_01),
+            Value::from(stock.s_dist_02),
+            Value::from(stock.s_dist_03),
+            Value::from(stock.s_dist_04),
+            Value::from(stock.s_dist_05),
+            Value::from(stock.s_dist_06),
+            Value::from(stock.s_dist_07),
+            Value::from(stock.s_dist_08),
+            Value::from(stock.s_dist_09),
+            Value::from(stock.s_dist_10),
+            Value::from(stock.s_ytd),
+            Value::from(stock.s_order_cnt),
+            Value::from(stock.s_remote_cnt),
+            Value::from(stock.s_data),
+        ];
+        conn.exec_drop(
+            "INSERT INTO stock VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            params,
+        ).unwrap();
+    }
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn load_district_mysql(conn: &mut PooledConn, data: &mut TPCCData, d_id: i32, w_id: i32) {
+    use mysql::Value;
+
+    let district = data.gen_district(d_id, w_id);
+    let params: Vec<Value> = vec![
+        Value::from(district.d_id),
+        Value::from(district.d_w_id),
+        Value::from(district.d_name),
+        Value::from(district.d_street_1),
+        Value::from(district.d_street_2),
+        Value::from(district.d_city),
+        Value::from(district.d_state),
+        Value::from(district.d_zip),
+        Value::from(district.d_tax),
+        Value::from(district.d_ytd),
+        Value::from(district.d_next_o_id),
+    ];
+    conn.exec_drop(
+        "INSERT INTO district VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        params,
+    ).unwrap();
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn load_customer_mysql(conn: &mut PooledConn, data: &mut TPCCData, d_id: i32, w_id: i32) {
+    use mysql::Value;
+
+    let customers_per_district = data.customers_per_district();
+    for c_id in 1..=customers_per_district {
+        let customer = data.gen_customer(c_id, d_id, w_id);
+        let params: Vec<Value> = vec![
+            Value::from(customer.c_id),
+            Value::from(customer.c_d_id),
+            Value::from(customer.c_w_id),
+            Value::from(customer.c_first),
+            Value::from(customer.c_middle),
+            Value::from(customer.c_last),
+            Value::from(customer.c_street_1),
+            Value::from(customer.c_street_2),
+            Value::from(customer.c_city),
+            Value::from(customer.c_state),
+            Value::from(customer.c_zip),
+            Value::from(customer.c_phone),
+            Value::from(customer.c_since),
+            Value::from(customer.c_credit),
+            Value::from(customer.c_credit_lim),
+            Value::from(customer.c_discount),
+            Value::from(customer.c_balance),
+            Value::from(customer.c_ytd_payment),
+            Value::from(customer.c_payment_cnt),
+            Value::from(customer.c_delivery_cnt),
+            Value::from(customer.c_data),
+        ];
+        conn.exec_drop(
+            "INSERT INTO customer VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            params,
+        ).unwrap();
+
+        let history = data.gen_history(c_id, d_id, w_id);
+        conn.exec_drop(
+            "INSERT INTO history VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                history.h_c_id, history.h_c_d_id, history.h_c_w_id,
+                history.h_d_id, history.h_w_id, &history.h_date, history.h_amount, &history.h_data
+            ),
+        ).unwrap();
+    }
+}
+
+#[cfg(feature = "benchmark-comparison")]
+fn load_orders_mysql(conn: &mut PooledConn, data: &mut TPCCData, d_id: i32, w_id: i32) {
+    use mysql::Value;
+
+    let customers_per_district = data.customers_per_district();
+    let orders_per_district = data.orders_per_district();
+    let delivered_threshold = (orders_per_district as f64 * 0.7) as i32;
+
+    let mut c_ids: Vec<i32> = (1..=customers_per_district).collect();
+    for i in (1..c_ids.len()).rev() {
+        let j = data.rng.random_int(0, i as i64) as usize;
+        c_ids.swap(i, j);
+    }
+
+    for o_id in 1..=orders_per_district {
+        let c_id = c_ids[(o_id - 1) as usize];
+        let order = data.gen_order(o_id, d_id, w_id, c_id);
+
+        conn.exec_drop(
+            "INSERT INTO orders VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                order.o_id, order.o_d_id, order.o_w_id, order.o_c_id,
+                &order.o_entry_d, order.o_carrier_id, order.o_ol_cnt, order.o_all_local
+            ),
+        ).unwrap();
+
+        let delivered = o_id <= delivered_threshold;
+        for ol_number in 1..=order.o_ol_cnt {
+            let ol = data.gen_order_line(o_id, d_id, w_id, ol_number, delivered);
+            let params: Vec<Value> = vec![
+                Value::from(ol.ol_o_id),
+                Value::from(ol.ol_d_id),
+                Value::from(ol.ol_w_id),
+                Value::from(ol.ol_number),
+                Value::from(ol.ol_i_id),
+                Value::from(ol.ol_supply_w_id),
+                ol.ol_delivery_d.map(Value::from).unwrap_or(Value::NULL),
+                Value::from(ol.ol_quantity),
+                Value::from(ol.ol_amount),
+                Value::from(ol.ol_dist_info),
+            ];
+            conn.exec_drop(
+                "INSERT INTO order_line VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params,
+            ).unwrap();
+        }
+
+        if o_id > delivered_threshold {
+            let no = data.gen_new_order(o_id, d_id, w_id);
+            conn.exec_drop(
+                "INSERT INTO new_order VALUES (?, ?, ?)",
+                (no.no_o_id, no.no_d_id, no.no_w_id),
+            ).unwrap();
         }
     }
 }

--- a/crates/vibesql-executor/benches/tpcc/transactions.rs
+++ b/crates/vibesql-executor/benches/tpcc/transactions.rs
@@ -944,6 +944,220 @@ impl<'a> TPCCExecutor for DuckdbTransactionExecutor<'a> {
     }
 }
 
+/// TPC-C transaction executor for MySQL
+#[cfg(feature = "benchmark-comparison")]
+pub struct MysqlTransactionExecutor<'a> {
+    pub conn: &'a mut mysql::PooledConn,
+}
+
+#[cfg(feature = "benchmark-comparison")]
+impl<'a> MysqlTransactionExecutor<'a> {
+    pub fn new(conn: &'a mut mysql::PooledConn) -> Self {
+        Self { conn }
+    }
+
+    pub fn new_order(&mut self, input: &NewOrderInput) -> TransactionResult {
+        use mysql::prelude::*;
+        let start = Instant::now();
+
+        // Get warehouse tax rate
+        let _: Option<(f64,)> = self.conn.exec_first(
+            "SELECT w_tax FROM warehouse WHERE w_id = ?",
+            (input.w_id,),
+        ).ok().flatten();
+
+        // Get district info
+        let _: Option<(f64, i32)> = self.conn.exec_first(
+            "SELECT d_tax, d_next_o_id FROM district WHERE d_w_id = ? AND d_id = ?",
+            (input.w_id, input.d_id),
+        ).ok().flatten();
+
+        // Get customer info
+        let _: Option<(f64, String, String)> = self.conn.exec_first(
+            "SELECT c_discount, c_last, c_credit FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+            (input.w_id, input.d_id, input.c_id),
+        ).ok().flatten();
+
+        // Process each order line - query item and stock info
+        for item in &input.items {
+            // Get item info
+            let _: Option<(f64, String, String)> = self.conn.exec_first(
+                "SELECT i_price, i_name, i_data FROM item WHERE i_id = ?",
+                (item.ol_i_id,),
+            ).ok().flatten();
+
+            // Get stock info
+            let _: Option<(i32, i32, i32)> = self.conn.exec_first(
+                "SELECT s_quantity, s_ytd, s_order_cnt FROM stock WHERE s_i_id = ? AND s_w_id = ?",
+                (item.ol_i_id, item.ol_supply_w_id),
+            ).ok().flatten();
+        }
+
+        TransactionResult {
+            success: true,
+            duration_us: start.elapsed().as_micros() as u64,
+            error: None,
+        }
+    }
+
+    pub fn payment(&mut self, input: &PaymentInput) -> TransactionResult {
+        use mysql::prelude::*;
+        let start = Instant::now();
+
+        // Get warehouse info
+        let _: Option<(String, String, String, String, String, String)> = self.conn.exec_first(
+            "SELECT w_street_1, w_street_2, w_city, w_state, w_zip, w_name FROM warehouse WHERE w_id = ?",
+            (input.w_id,),
+        ).ok().flatten();
+
+        // Get district info
+        let _: Option<(String, String, String, String, String, String)> = self.conn.exec_first(
+            "SELECT d_street_1, d_street_2, d_city, d_state, d_zip, d_name FROM district WHERE d_w_id = ? AND d_id = ?",
+            (input.w_id, input.d_id),
+        ).ok().flatten();
+
+        // Get customer (by ID or last name)
+        if let Some(c_id) = input.c_id {
+            let _: Option<(i32, String, String, String, f64)> = self.conn.exec_first(
+                "SELECT c_id, c_first, c_middle, c_last, c_balance FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+                (input.c_w_id, input.c_d_id, c_id),
+            ).ok().flatten();
+        } else {
+            let _: Option<(i32, String, String, String, f64)> = self.conn.exec_first(
+                "SELECT c_id, c_first, c_middle, c_last, c_balance FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_last = ? ORDER BY c_first",
+                (input.c_w_id, input.c_d_id, input.c_last.as_ref().unwrap()),
+            ).ok().flatten();
+        }
+
+        TransactionResult {
+            success: true,
+            duration_us: start.elapsed().as_micros() as u64,
+            error: None,
+        }
+    }
+
+    pub fn order_status(&mut self, input: &OrderStatusInput) -> TransactionResult {
+        use mysql::prelude::*;
+        let start = Instant::now();
+
+        // Get customer (by ID or last name)
+        let c_id = if let Some(c_id) = input.c_id {
+            let _: Option<(i32, String, String, String, f64)> = self.conn.exec_first(
+                "SELECT c_id, c_first, c_middle, c_last, c_balance FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+                (input.w_id, input.d_id, c_id),
+            ).ok().flatten();
+            c_id
+        } else {
+            let _: Option<(i32, String, String, String, f64)> = self.conn.exec_first(
+                "SELECT c_id, c_first, c_middle, c_last, c_balance FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_last = ? ORDER BY c_first",
+                (input.w_id, input.d_id, input.c_last.as_ref().unwrap()),
+            ).ok().flatten();
+            1 // Default c_id for order lookup
+        };
+
+        // Get last order for customer
+        let _: Option<(i32, String, Option<i32>)> = self.conn.exec_first(
+            "SELECT o_id, o_entry_d, o_carrier_id FROM orders WHERE o_w_id = ? AND o_d_id = ? AND o_c_id = ? ORDER BY o_id DESC LIMIT 1",
+            (input.w_id, input.d_id, c_id),
+        ).ok().flatten();
+
+        TransactionResult {
+            success: true,
+            duration_us: start.elapsed().as_micros() as u64,
+            error: None,
+        }
+    }
+
+    pub fn delivery(&mut self, input: &DeliveryInput) -> TransactionResult {
+        use mysql::prelude::*;
+        let start = Instant::now();
+
+        // Process each district - query for new orders
+        for d_id in 1..=10 {
+            let _: Option<(i32,)> = self.conn.exec_first(
+                "SELECT no_o_id FROM new_order WHERE no_w_id = ? AND no_d_id = ? ORDER BY no_o_id LIMIT 1",
+                (input.w_id, d_id),
+            ).ok().flatten();
+        }
+
+        TransactionResult {
+            success: true,
+            duration_us: start.elapsed().as_micros() as u64,
+            error: None,
+        }
+    }
+
+    pub fn stock_level(&mut self, input: &StockLevelInput) -> TransactionResult {
+        use mysql::prelude::*;
+        let start = Instant::now();
+
+        // Get district next order ID
+        let _: Option<(i32,)> = self.conn.exec_first(
+            "SELECT d_next_o_id FROM district WHERE d_w_id = ? AND d_id = ?",
+            (input.w_id, input.d_id),
+        ).ok().flatten();
+
+        // Count low stock items (same query as other engines)
+        let _: Option<(i64,)> = self.conn.exec_first(
+            "SELECT COUNT(DISTINCT s_i_id) FROM order_line, stock \
+             WHERE ol_w_id = ? AND ol_d_id = ? \
+             AND s_w_id = ? AND s_i_id = ol_i_id AND s_quantity < ?",
+            (input.w_id, input.d_id, input.w_id, input.threshold),
+        ).ok().flatten();
+
+        TransactionResult {
+            success: true,
+            duration_us: start.elapsed().as_micros() as u64,
+            error: None,
+        }
+    }
+}
+
+#[cfg(feature = "benchmark-comparison")]
+impl<'a> TPCCExecutor for MysqlTransactionExecutor<'a> {
+    fn new_order(&self, _input: &NewOrderInput) -> TransactionResult {
+        // This trait requires &self but MySQL needs &mut self for queries
+        // We implement the trait for benchmarking compatibility but use the &mut self methods directly
+        TransactionResult {
+            success: false,
+            duration_us: 0,
+            error: Some("Use MysqlTransactionExecutor methods directly".to_string()),
+        }
+    }
+
+    fn payment(&self, _input: &PaymentInput) -> TransactionResult {
+        TransactionResult {
+            success: false,
+            duration_us: 0,
+            error: Some("Use MysqlTransactionExecutor methods directly".to_string()),
+        }
+    }
+
+    fn order_status(&self, _input: &OrderStatusInput) -> TransactionResult {
+        TransactionResult {
+            success: false,
+            duration_us: 0,
+            error: Some("Use MysqlTransactionExecutor methods directly".to_string()),
+        }
+    }
+
+    fn delivery(&self, _input: &DeliveryInput) -> TransactionResult {
+        TransactionResult {
+            success: false,
+            duration_us: 0,
+            error: Some("Use MysqlTransactionExecutor methods directly".to_string()),
+        }
+    }
+
+    fn stock_level(&self, _input: &StockLevelInput) -> TransactionResult {
+        TransactionResult {
+            success: false,
+            duration_us: 0,
+            error: Some("Use MysqlTransactionExecutor methods directly".to_string()),
+        }
+    }
+}
+
 /// TPC-C workload generator following standard transaction mix
 pub struct TPCCWorkload {
     pub rng: TPCCRng,

--- a/crates/vibesql-executor/benches/tpcc_benchmark.rs
+++ b/crates/vibesql-executor/benches/tpcc_benchmark.rs
@@ -228,6 +228,139 @@ fn run_benchmark<E: TPCCExecutor>(
     results
 }
 
+/// Run MySQL benchmark separately since it requires &mut self for queries
+#[cfg(feature = "benchmark-comparison")]
+fn run_mysql_benchmark(
+    conn: &mut mysql::PooledConn,
+    transaction_type: TransactionType,
+    num_warehouses: i32,
+    duration: Duration,
+    warmup: Duration,
+    print_phases: bool,
+) -> TPCCBenchmarkResults {
+    let mut workload = TPCCWorkload::new(42, num_warehouses);
+    let executor = MysqlTransactionExecutor::new(conn);
+
+    let mut results = TPCCBenchmarkResults::new();
+    let mut new_order_times: Vec<u64> = Vec::new();
+    let mut payment_times: Vec<u64> = Vec::new();
+    let mut order_status_times: Vec<u64> = Vec::new();
+    let mut delivery_times: Vec<u64> = Vec::new();
+    let mut stock_level_times: Vec<u64> = Vec::new();
+
+    // Warmup phase
+    if print_phases {
+        eprintln!("Warmup phase ({:?})...", warmup);
+    }
+    let warmup_start = Instant::now();
+    while warmup_start.elapsed() < warmup {
+        let txn_type = match transaction_type {
+            TransactionType::Mixed => workload.next_transaction_type(),
+            TransactionType::NewOrder => 0,
+            TransactionType::Payment => 1,
+            TransactionType::OrderStatus => 2,
+            TransactionType::Delivery => 3,
+            TransactionType::StockLevel => 4,
+        };
+
+        match txn_type {
+            0 => { let _ = executor.new_order(&workload.generate_new_order()); }
+            1 => { let _ = executor.payment(&workload.generate_payment()); }
+            2 => { let _ = executor.order_status(&workload.generate_order_status()); }
+            3 => { let _ = executor.delivery(&workload.generate_delivery()); }
+            4 => { let _ = executor.stock_level(&workload.generate_stock_level()); }
+            _ => unreachable!(),
+        }
+    }
+
+    // Measurement phase
+    if print_phases {
+        eprintln!("Measurement phase ({:?})...", duration);
+    }
+    let benchmark_start = Instant::now();
+    while benchmark_start.elapsed() < duration {
+        let txn_type = match transaction_type {
+            TransactionType::Mixed => workload.next_transaction_type(),
+            TransactionType::NewOrder => 0,
+            TransactionType::Payment => 1,
+            TransactionType::OrderStatus => 2,
+            TransactionType::Delivery => 3,
+            TransactionType::StockLevel => 4,
+        };
+
+        let result = match txn_type {
+            0 => {
+                let r = executor.new_order(&workload.generate_new_order());
+                new_order_times.push(r.duration_us);
+                r
+            }
+            1 => {
+                let r = executor.payment(&workload.generate_payment());
+                payment_times.push(r.duration_us);
+                r
+            }
+            2 => {
+                let r = executor.order_status(&workload.generate_order_status());
+                order_status_times.push(r.duration_us);
+                r
+            }
+            3 => {
+                let r = executor.delivery(&workload.generate_delivery());
+                delivery_times.push(r.duration_us);
+                r
+            }
+            4 => {
+                let r = executor.stock_level(&workload.generate_stock_level());
+                stock_level_times.push(r.duration_us);
+                r
+            }
+            _ => unreachable!(),
+        };
+
+        results.total_transactions += 1;
+        if result.success {
+            results.successful_transactions += 1;
+        } else {
+            results.failed_transactions += 1;
+        }
+    }
+
+    results.total_duration_ms = benchmark_start.elapsed().as_millis() as u64;
+    if results.total_duration_ms > 0 {
+        results.transactions_per_second =
+            results.total_transactions as f64 / (results.total_duration_ms as f64 / 1000.0);
+    }
+
+    // Calculate averages
+    if !new_order_times.is_empty() {
+        results.new_order_count = new_order_times.len() as u64;
+        results.new_order_avg_us =
+            new_order_times.iter().sum::<u64>() as f64 / new_order_times.len() as f64;
+    }
+    if !payment_times.is_empty() {
+        results.payment_count = payment_times.len() as u64;
+        results.payment_avg_us =
+            payment_times.iter().sum::<u64>() as f64 / payment_times.len() as f64;
+    }
+    if !order_status_times.is_empty() {
+        results.order_status_count = order_status_times.len() as u64;
+        results.order_status_avg_us =
+            order_status_times.iter().sum::<u64>() as f64 / order_status_times.len() as f64;
+    }
+    if !delivery_times.is_empty() {
+        results.delivery_count = delivery_times.len() as u64;
+        results.delivery_avg_us =
+            delivery_times.iter().sum::<u64>() as f64 / delivery_times.len() as f64;
+    }
+    if !stock_level_times.is_empty() {
+        results.stock_level_count = stock_level_times.len() as u64;
+        results.stock_level_avg_us =
+            stock_level_times.iter().sum::<u64>() as f64 / stock_level_times.len() as f64;
+    }
+
+    results
+}
+
 fn main() {
     eprintln!("=== TPC-C Benchmark Profiling ===");
 
@@ -317,7 +450,7 @@ fn main() {
     // Comparison benchmarks (if feature enabled)
     #[cfg(feature = "benchmark-comparison")]
     {
-        use tpcc::schema::{load_duckdb, load_sqlite};
+        use tpcc::schema::{load_duckdb, load_mysql, load_sqlite};
 
         // SQLite benchmark
         eprintln!("\n\n--- SQLite Benchmark ---");
@@ -341,6 +474,28 @@ fn main() {
         let duckdb_results = run_benchmark(&duckdb_executor, transaction_type, num_warehouses, duration, warmup, true);
         print_results(&duckdb_results, transaction_type);
 
+        // MySQL benchmark (if MYSQL_URL is set)
+        let mysql_results = if let Some(mut mysql_conn) = load_mysql(scale_factor) {
+            eprintln!("\n\n--- MySQL Benchmark ---");
+            eprintln!("MySQL connected and loaded");
+
+            // MySQL requires &mut self, so we run it manually instead of using run_benchmark
+            let mysql_results = run_mysql_benchmark(
+                &mut mysql_conn,
+                transaction_type,
+                num_warehouses,
+                duration,
+                warmup,
+                true,
+            );
+            print_results(&mysql_results, transaction_type);
+            Some(mysql_results)
+        } else {
+            eprintln!("\n\n--- MySQL Benchmark ---");
+            eprintln!("Skipping MySQL (set MYSQL_URL env var to enable)");
+            None
+        };
+
         // Summary comparison
         eprintln!("\n\n=== Comparison Summary ===");
         eprintln!("Transaction type: {}", transaction_type.name());
@@ -363,6 +518,9 @@ fn main() {
         eprintln!("{:<12} {:>12.2} {:>12.2}", "VibeSQL", vibesql_results.transactions_per_second, compute_avg(&vibesql_results));
         eprintln!("{:<12} {:>12.2} {:>12.2}", "SQLite", sqlite_results.transactions_per_second, compute_avg(&sqlite_results));
         eprintln!("{:<12} {:>12.2} {:>12.2}", "DuckDB", duckdb_results.transactions_per_second, compute_avg(&duckdb_results));
+        if let Some(ref mysql_res) = mysql_results {
+            eprintln!("{:<12} {:>12.2} {:>12.2}", "MySQL", mysql_res.transactions_per_second, compute_avg(mysql_res));
+        }
     }
 
     #[cfg(not(feature = "benchmark-comparison"))]


### PR DESCRIPTION
## Summary
- Add MySQL schema and data loading to TPC-C benchmark
- Implement MysqlTransactionExecutor with all 5 TPC-C transaction types
- Add MySQL helper functions to Sysbench benchmark for future use
- Integration via optional MYSQL_URL environment variable

## Test plan
- [x] Benchmarks compile without errors: `cargo check --package vibesql-executor --benches --features benchmark-comparison`
- [ ] TPC-C MySQL benchmark runs correctly with MYSQL_URL set
- [ ] Sysbench MySQL helpers work when integrated into criterion groups

Closes #3026

🤖 Generated with [Claude Code](https://claude.com/claude-code)