### PR TITLE
fix(bench): Run TPC-DS database engines sequentially to avoid SIGKILL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VibeSQL Makefile
 # Convenience targets for common development tasks
 
-.PHONY: all build build-all build-wasm build-python test test-unit test-workspace test-sqllogictest benchmark benchmark-tpch benchmark-tpcc benchmark-tpcds benchmark-sysbench clean help analyze-tests analyze-benchmarks analyze flamegraph-tpch flamegraph-tpcc flamegraph-sysbench flamegraph-select profile-query bench-storage bench-executor bench-types
+.PHONY: all build build-all build-wasm build-python test test-unit test-workspace test-sqllogictest benchmark benchmark-tpch benchmark-tpcc benchmark-tpcds benchmark-tpcds-all benchmark-sysbench clean help analyze-tests analyze-benchmarks analyze flamegraph-tpch flamegraph-tpcc flamegraph-sysbench flamegraph-select profile-query bench-storage bench-executor bench-types
 
 # Default target - fully qualify and update the state of the repo
 # Runs build-all (including Python), all tests, benchmarks, and records results to database
@@ -27,7 +27,8 @@ help:
 	@echo "  make benchmark          - Run all benchmarks (TPC-H, TPC-C, TPC-DS, Sysbench)"
 	@echo "  make benchmark-tpch     - Run TPC-H benchmark suite (30s timeout)"
 	@echo "  make benchmark-tpcc     - Run TPC-C benchmark suite (60s duration)"
-	@echo "  make benchmark-tpcds    - Run TPC-DS benchmark suite (99 queries)"
+	@echo "  make benchmark-tpcds    - Run TPC-DS benchmark suite (isolated, memory-safe)"
+	@echo "  make benchmark-tpcds-all - Run TPC-DS with all engines simultaneously (may OOM)"
 	@echo "  make benchmark-sysbench - Run Sysbench OLTP benchmarks"
 	@echo ""
 	@echo "Profiling targets:"
@@ -133,8 +134,19 @@ benchmark-tpcc:
 	./scripts/process_tpcc_results.py --input /tmp/tpcc_results.txt --scale-factor 1 --duration 60
 
 # Run TPC-DS benchmarks with database tracking
+# Uses isolated execution (each database engine in separate process) to avoid memory pressure
 benchmark-tpcds:
-	@echo "Running TPC-DS benchmarks..."
+	@echo "Running TPC-DS benchmarks (isolated mode)..."
+	./scripts/bench-tpcds-isolated.sh /tmp/tpcds_results.txt
+	@echo ""
+	@echo "Processing TPC-DS results into database..."
+	./scripts/process_tpcds_results.py --stdin < /tmp/tpcds_results.txt || \
+		./scripts/process_tpcds_results.py --criterion-dir target/criterion
+
+# Run TPC-DS benchmarks with all engines simultaneously (may cause memory pressure)
+benchmark-tpcds-all:
+	@echo "Running TPC-DS benchmarks (all engines simultaneously)..."
+	@echo "WARNING: This may cause memory pressure. Use 'make benchmark-tpcds' for isolated execution."
 	cargo bench --package vibesql-executor --bench tpcds_benchmark --features benchmark-comparison -- --noplot 2>&1 | tee /tmp/tpcds_results.txt
 	@echo ""
 	@echo "Processing TPC-DS results into database..."

--- a/crates/vibesql-executor/benches/tpcds_benchmark.rs
+++ b/crates/vibesql-executor/benches/tpcds_benchmark.rs
@@ -96,10 +96,49 @@ use tpcds::schema::*;
 // =============================================================================
 // Cache databases to avoid reloading for each benchmark group.
 // TPC-DS data loading is expensive (~10+ minutes), so we load once and reuse.
+//
+// Memory Management:
+// When running with benchmark-comparison feature, you can set TPCDS_ENGINE
+// environment variable to only load specific engines:
+//   - TPCDS_ENGINE=sqlite  - Load VibeSQL + SQLite only
+//   - TPCDS_ENGINE=duckdb  - Load VibeSQL + DuckDB only
+//   - TPCDS_ENGINE=all (or unset) - Load all engines (may cause memory pressure)
+//
+// The isolated benchmark script (scripts/bench-tpcds-isolated.sh) runs each
+// engine in a separate process to avoid memory exhaustion from loading all
+// engines simultaneously.
 
 /// Default scale factor for TPC-DS benchmarks
 /// Using 0.001 for faster loading (~1 minute vs ~10+ minutes at 0.01)
 const SCALE_FACTOR: f64 = 0.001;
+
+/// Check which comparison engine to use (for memory-conscious sequential execution)
+#[cfg(feature = "benchmark-comparison")]
+fn get_comparison_engine() -> Option<String> {
+    std::env::var("TPCDS_ENGINE").ok()
+}
+
+/// Check if SQLite comparison should be enabled
+#[cfg(feature = "benchmark-comparison")]
+fn sqlite_enabled() -> bool {
+    match get_comparison_engine() {
+        None => true,                                    // Default: all engines
+        Some(ref e) if e == "all" => true,               // Explicit all
+        Some(ref e) if e == "sqlite" => true,            // SQLite only
+        _ => false,
+    }
+}
+
+/// Check if DuckDB comparison should be enabled
+#[cfg(feature = "benchmark-comparison")]
+fn duckdb_enabled() -> bool {
+    match get_comparison_engine() {
+        None => true,                                    // Default: all engines
+        Some(ref e) if e == "all" => true,               // Explicit all
+        Some(ref e) if e == "duckdb" => true,            // DuckDB only
+        _ => false,
+    }
+}
 
 /// Cached VibeSQL database (loaded once, reused across all benchmarks)
 static VIBESQL_DB: OnceLock<VibeDB> = OnceLock::new();
@@ -119,28 +158,34 @@ fn get_vibesql_db() -> &'static VibeDB {
 static SQLITE_CONN: OnceLock<Mutex<SqliteConn>> = OnceLock::new();
 
 #[cfg(feature = "benchmark-comparison")]
-fn get_sqlite_conn() -> &'static Mutex<SqliteConn> {
-    SQLITE_CONN.get_or_init(|| {
+fn get_sqlite_conn() -> Option<&'static Mutex<SqliteConn>> {
+    if !sqlite_enabled() {
+        return None;
+    }
+    Some(SQLITE_CONN.get_or_init(|| {
         eprintln!("Loading TPC-DS SQLite database (scale factor {})...", SCALE_FACTOR);
         let start = std::time::Instant::now();
         let conn = load_sqlite(SCALE_FACTOR);
         eprintln!("SQLite database loaded in {:?}", start.elapsed());
         Mutex::new(conn)
-    })
+    }))
 }
 
 #[cfg(feature = "benchmark-comparison")]
 static DUCKDB_CONN: OnceLock<Mutex<DuckDBConn>> = OnceLock::new();
 
 #[cfg(feature = "benchmark-comparison")]
-fn get_duckdb_conn() -> &'static Mutex<DuckDBConn> {
-    DUCKDB_CONN.get_or_init(|| {
+fn get_duckdb_conn() -> Option<&'static Mutex<DuckDBConn>> {
+    if !duckdb_enabled() {
+        return None;
+    }
+    Some(DUCKDB_CONN.get_or_init(|| {
         eprintln!("Loading TPC-DS DuckDB database (scale factor {})...", SCALE_FACTOR);
         let start = std::time::Instant::now();
         let conn = load_duckdb(SCALE_FACTOR);
         eprintln!("DuckDB database loaded in {:?}", start.elapsed());
         Mutex::new(conn)
-    })
+    }))
 }
 
 // =============================================================================
@@ -260,10 +305,15 @@ fn bench_sanity_queries_comparison(c: &mut Criterion) {
     let mut group = c.benchmark_group("tpcds_sanity_comparison");
     group.measurement_time(Duration::from_secs(5));
 
-    // Use cached databases
+    // Use cached databases (only load if enabled via TPCDS_ENGINE env var)
     let vibesql_db = get_vibesql_db();
-    let sqlite_conn = get_sqlite_conn();
-    let duckdb_conn = get_duckdb_conn();
+    let sqlite_conn = get_sqlite_conn();  // Returns None if SQLite disabled
+    let duckdb_conn = get_duckdb_conn();  // Returns None if DuckDB disabled
+
+    // Log which engines are enabled
+    if let Some(engine) = get_comparison_engine() {
+        eprintln!("Running comparison with TPCDS_ENGINE={}", engine);
+    }
 
     for (name, sql) in TPCDS_SANITY_QUERIES {
         // Only benchmark if VibeSQL can parse and execute the query
@@ -279,21 +329,27 @@ fn bench_sanity_queries_comparison(c: &mut Criterion) {
             });
         });
 
-        group.bench_function(BenchmarkId::new("sqlite", *name), |b| {
-            b.iter(|| {
-                let conn = sqlite_conn.lock().unwrap();
-                let count = benchmark_sqlite_query(&conn, sql);
-                black_box(count);
+        // SQLite benchmark (only if enabled)
+        if let Some(sqlite) = sqlite_conn {
+            group.bench_function(BenchmarkId::new("sqlite", *name), |b| {
+                b.iter(|| {
+                    let conn = sqlite.lock().unwrap();
+                    let count = benchmark_sqlite_query(&conn, sql);
+                    black_box(count);
+                });
             });
-        });
+        }
 
-        group.bench_function(BenchmarkId::new("duckdb", *name), |b| {
-            b.iter(|| {
-                let conn = duckdb_conn.lock().unwrap();
-                let count = benchmark_duckdb_query(&conn, sql);
-                black_box(count);
+        // DuckDB benchmark (only if enabled)
+        if let Some(duckdb) = duckdb_conn {
+            group.bench_function(BenchmarkId::new("duckdb", *name), |b| {
+                b.iter(|| {
+                    let conn = duckdb.lock().unwrap();
+                    let count = benchmark_duckdb_query(&conn, sql);
+                    black_box(count);
+                });
             });
-        });
+        }
     }
 
     group.finish();

--- a/scripts/bench-tpcds-isolated.sh
+++ b/scripts/bench-tpcds-isolated.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# TPC-DS Isolated Benchmark Runner
+#
+# Runs TPC-DS benchmarks with each database engine in a separate process
+# to prevent memory pressure from running all engines simultaneously.
+#
+# Usage:
+#   ./scripts/bench-tpcds-isolated.sh [output_file]
+#
+# Examples:
+#   ./scripts/bench-tpcds-isolated.sh /tmp/tpcds_results.txt
+#   ./scripts/bench-tpcds-isolated.sh  # Uses default output
+
+set -e
+
+# Configuration
+OUTPUT_FILE=${1:-/tmp/tpcds_results.txt}
+BENCH_NAME="tpcds_benchmark"
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== TPC-DS Isolated Benchmark Runner ===${NC}"
+echo "Output: ${OUTPUT_FILE}"
+echo ""
+echo "This script runs each database engine in a separate process"
+echo "to avoid memory pressure from concurrent engine loading."
+echo ""
+
+# Initialize output file
+cat > "$OUTPUT_FILE" << EOF
+=== TPC-DS Isolated Benchmark Results ===
+Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
+EOF
+
+# Track results
+ENGINES_PASSED=0
+ENGINES_FAILED=0
+
+# Phase 1: Run VibeSQL-only benchmark (sanity + queries)
+echo -e "${YELLOW}Phase 1: Running VibeSQL-only benchmark...${NC}"
+echo ""
+echo "--- Phase 1: VibeSQL-only ---" >> "$OUTPUT_FILE"
+
+if cargo bench --package vibesql-executor --bench ${BENCH_NAME} -- --noplot 2>&1 | tee -a "$OUTPUT_FILE"; then
+    echo -e "${GREEN}✓ VibeSQL benchmark completed${NC}"
+    ((ENGINES_PASSED++))
+else
+    echo -e "${RED}✗ VibeSQL benchmark failed${NC}"
+    ((ENGINES_FAILED++))
+fi
+echo "" >> "$OUTPUT_FILE"
+echo ""
+
+# Phase 2: Run SQLite comparison benchmark (in separate process)
+echo -e "${YELLOW}Phase 2: Running SQLite comparison benchmark...${NC}"
+echo ""
+echo "--- Phase 2: SQLite comparison ---" >> "$OUTPUT_FILE"
+
+if TPCDS_ENGINE=sqlite cargo bench --package vibesql-executor --bench ${BENCH_NAME} --features benchmark-comparison -- --noplot 2>&1 | tee -a "$OUTPUT_FILE"; then
+    echo -e "${GREEN}✓ SQLite comparison completed${NC}"
+    ((ENGINES_PASSED++))
+else
+    echo -e "${YELLOW}⚠ SQLite comparison failed (continuing)${NC}"
+    ((ENGINES_FAILED++))
+fi
+echo "" >> "$OUTPUT_FILE"
+echo ""
+
+# Phase 3: Run DuckDB comparison benchmark (in separate process)
+echo -e "${YELLOW}Phase 3: Running DuckDB comparison benchmark...${NC}"
+echo ""
+echo "--- Phase 3: DuckDB comparison ---" >> "$OUTPUT_FILE"
+
+if TPCDS_ENGINE=duckdb cargo bench --package vibesql-executor --bench ${BENCH_NAME} --features benchmark-comparison -- --noplot 2>&1 | tee -a "$OUTPUT_FILE"; then
+    echo -e "${GREEN}✓ DuckDB comparison completed${NC}"
+    ((ENGINES_PASSED++))
+else
+    echo -e "${YELLOW}⚠ DuckDB comparison failed (continuing)${NC}"
+    ((ENGINES_FAILED++))
+fi
+echo "" >> "$OUTPUT_FILE"
+echo ""
+
+# Summary
+echo -e "${BLUE}=== Summary ===${NC}"
+echo -e "Engines passed: ${GREEN}$ENGINES_PASSED${NC}"
+echo -e "Engines failed: ${RED}$ENGINES_FAILED${NC}"
+echo ""
+echo "Full results: $OUTPUT_FILE"
+
+# Add summary to output file
+cat >> "$OUTPUT_FILE" << EOF
+
+=== Summary ===
+Engines passed: $ENGINES_PASSED
+Engines failed: $ENGINES_FAILED
+EOF
+
+# Exit with success if at least VibeSQL completed
+[ $ENGINES_PASSED -ge 1 ]


### PR DESCRIPTION
## Summary

- Add isolated benchmark script that runs each database engine in separate process
- Add TPCDS_ENGINE environment variable to control which engines are loaded
- Update Makefile to use isolated execution by default

The TPC-DS benchmark was being terminated by SIGKILL due to memory pressure from loading all three database engines simultaneously.

## Test plan

- [x] Verified `TPCDS_ENGINE=sqlite` correctly loads only VibeSQL and SQLite
- [x] Verified sanity benchmarks run successfully with isolated execution
- [x] Verified benchmark code compiles with `benchmark-comparison` feature

Closes #3023

🤖 Generated with [Claude Code](https://claude.com/claude-code)