### PR TITLE
feat(bench): Add memory monitoring and graceful degradation for benchmarks

### DIFF
--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -54,6 +54,7 @@ rand_chacha = "0.9"
 rust_decimal = "1.33"
 paste = "1.0"
 env_logger = "0.11"
+sysinfo = "0.33"
 
 [features]
 default = ["parallel", "spatial"]

--- a/crates/vibesql-executor/benches/memory_monitor.rs
+++ b/crates/vibesql-executor/benches/memory_monitor.rs
@@ -1,0 +1,290 @@
+//! Memory monitoring utility for benchmark graceful degradation
+//!
+//! Provides runtime memory monitoring to detect memory pressure before
+//! the OS sends SIGKILL, allowing graceful handling of memory-intensive
+//! operations in benchmarks.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use memory_monitor::MemoryMonitor;
+//!
+//! let monitor = MemoryMonitor::new();
+//!
+//! // Check before executing a memory-intensive query
+//! if monitor.check_pressure() {
+//!     eprintln!("[SKIP] Query skipped due to memory pressure");
+//!     return;
+//! }
+//!
+//! // Get current memory stats for logging
+//! let stats = monitor.current_stats();
+//! eprintln!("Memory: {} / {} ({:.1}% used)",
+//!     format_bytes(stats.used_bytes),
+//!     format_bytes(stats.total_bytes),
+//!     stats.usage_percent
+//! );
+//! ```
+
+// Allow dead_code for API completeness - these are public utilities that may be used
+// by other benchmarks or future enhancements
+#![allow(dead_code)]
+
+use sysinfo::System;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Default memory pressure threshold (80% of available RAM)
+const DEFAULT_THRESHOLD_PERCENT: f64 = 80.0;
+
+/// Environment variable to override the default threshold
+const THRESHOLD_ENV_VAR: &str = "VIBESQL_MEMORY_THRESHOLD";
+
+/// Memory statistics snapshot
+#[derive(Debug, Clone)]
+pub struct MemoryStats {
+    /// Total system memory in bytes
+    pub total_bytes: u64,
+    /// Currently used memory in bytes
+    pub used_bytes: u64,
+    /// Available memory in bytes
+    pub available_bytes: u64,
+    /// Memory usage as a percentage (0-100)
+    pub usage_percent: f64,
+}
+
+/// Memory pressure result
+#[derive(Debug, Clone)]
+pub enum MemoryPressure {
+    /// Memory usage is within acceptable limits
+    Ok(MemoryStats),
+    /// Memory usage exceeds threshold
+    High {
+        stats: MemoryStats,
+        threshold_percent: f64,
+    },
+}
+
+impl MemoryPressure {
+    /// Returns true if memory pressure is high
+    pub fn is_high(&self) -> bool {
+        matches!(self, MemoryPressure::High { .. })
+    }
+
+    /// Get the underlying memory stats
+    pub fn stats(&self) -> &MemoryStats {
+        match self {
+            MemoryPressure::Ok(stats) => stats,
+            MemoryPressure::High { stats, .. } => stats,
+        }
+    }
+}
+
+/// Memory monitor for detecting memory pressure during benchmark execution
+pub struct MemoryMonitor {
+    /// Threshold as a percentage (0-100)
+    threshold_percent: f64,
+    /// High-water mark for memory usage during benchmark run
+    high_water_mark_bytes: AtomicU64,
+    /// System info handle
+    system: System,
+}
+
+impl MemoryMonitor {
+    /// Create a new memory monitor with default threshold (80%)
+    ///
+    /// The threshold can be overridden via the VIBESQL_MEMORY_THRESHOLD environment
+    /// variable (value should be a percentage like "75" for 75%).
+    pub fn new() -> Self {
+        let threshold_percent = std::env::var(THRESHOLD_ENV_VAR)
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(DEFAULT_THRESHOLD_PERCENT)
+            .clamp(10.0, 99.0);
+
+        Self {
+            threshold_percent,
+            high_water_mark_bytes: AtomicU64::new(0),
+            system: System::new_all(),
+        }
+    }
+
+    /// Create a memory monitor with a specific threshold percentage
+    pub fn with_threshold(threshold_percent: f64) -> Self {
+        Self {
+            threshold_percent: threshold_percent.clamp(10.0, 99.0),
+            high_water_mark_bytes: AtomicU64::new(0),
+            system: System::new_all(),
+        }
+    }
+
+    /// Refresh memory information and get current stats
+    pub fn current_stats(&mut self) -> MemoryStats {
+        self.system.refresh_memory();
+
+        let total = self.system.total_memory();
+        let available = self.system.available_memory();
+        let used = total.saturating_sub(available);
+        let usage_percent = if total > 0 {
+            (used as f64 / total as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        // Update high-water mark
+        self.high_water_mark_bytes.fetch_max(used, Ordering::Relaxed);
+
+        MemoryStats {
+            total_bytes: total,
+            used_bytes: used,
+            available_bytes: available,
+            usage_percent,
+        }
+    }
+
+    /// Check if memory pressure exceeds the threshold
+    ///
+    /// Returns `MemoryPressure::High` if current usage exceeds the threshold,
+    /// otherwise returns `MemoryPressure::Ok` with current stats.
+    pub fn check_pressure(&mut self) -> MemoryPressure {
+        let stats = self.current_stats();
+
+        if stats.usage_percent >= self.threshold_percent {
+            MemoryPressure::High {
+                stats,
+                threshold_percent: self.threshold_percent,
+            }
+        } else {
+            MemoryPressure::Ok(stats)
+        }
+    }
+
+    /// Quick check if memory pressure is high (convenience method)
+    pub fn is_pressure_high(&mut self) -> bool {
+        self.check_pressure().is_high()
+    }
+
+    /// Get the configured threshold percentage
+    pub fn threshold_percent(&self) -> f64 {
+        self.threshold_percent
+    }
+
+    /// Get the high-water mark (peak memory usage) in bytes
+    pub fn high_water_mark_bytes(&self) -> u64 {
+        self.high_water_mark_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Reset the high-water mark (call between benchmark groups)
+    pub fn reset_high_water_mark(&self) {
+        self.high_water_mark_bytes.store(0, Ordering::Relaxed);
+    }
+}
+
+impl Default for MemoryMonitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Format bytes as a human-readable string
+pub fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+/// Result of a memory-guarded operation
+#[derive(Debug)]
+pub enum GuardedResult<T> {
+    /// Operation completed successfully
+    Success(T),
+    /// Operation skipped due to memory pressure
+    Skipped {
+        reason: String,
+        stats: MemoryStats,
+    },
+}
+
+impl<T> GuardedResult<T> {
+    /// Returns true if the operation was skipped
+    pub fn was_skipped(&self) -> bool {
+        matches!(self, GuardedResult::Skipped { .. })
+    }
+
+    /// Convert to Option, returning None if skipped
+    pub fn ok(self) -> Option<T> {
+        match self {
+            GuardedResult::Success(val) => Some(val),
+            GuardedResult::Skipped { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use super::{format_bytes, MemoryMonitor};
+
+    #[test]
+    fn test_memory_monitor_creation() {
+        let monitor = MemoryMonitor::new();
+        assert!(monitor.threshold_percent() >= 10.0);
+        assert!(monitor.threshold_percent() <= 99.0);
+    }
+
+    #[test]
+    fn test_custom_threshold() {
+        let monitor = MemoryMonitor::with_threshold(50.0);
+        assert_eq!(monitor.threshold_percent(), 50.0);
+    }
+
+    #[test]
+    fn test_threshold_clamping() {
+        let low = MemoryMonitor::with_threshold(5.0);
+        assert_eq!(low.threshold_percent(), 10.0);
+
+        let high = MemoryMonitor::with_threshold(150.0);
+        assert_eq!(high.threshold_percent(), 99.0);
+    }
+
+    #[test]
+    fn test_current_stats() {
+        let mut monitor = MemoryMonitor::new();
+        let stats = monitor.current_stats();
+
+        assert!(stats.total_bytes > 0);
+        assert!(stats.usage_percent >= 0.0);
+        assert!(stats.usage_percent <= 100.0);
+    }
+
+    #[test]
+    fn test_high_water_mark() {
+        let mut monitor = MemoryMonitor::new();
+
+        // Get initial stats to set high-water mark
+        let _ = monitor.current_stats();
+        let hwm1 = monitor.high_water_mark_bytes();
+        assert!(hwm1 > 0);
+
+        // Reset and verify
+        monitor.reset_high_water_mark();
+        assert_eq!(monitor.high_water_mark_bytes(), 0);
+    }
+
+    #[test]
+    fn test_format_bytes() {
+        assert_eq!(format_bytes(500), "500 B");
+        assert_eq!(format_bytes(1536), "1.50 KB");
+        assert_eq!(format_bytes(1_572_864), "1.50 MB");
+        assert_eq!(format_bytes(1_610_612_736), "1.50 GB");
+    }
+}

--- a/crates/vibesql-executor/benches/tpcds_benchmark.rs
+++ b/crates/vibesql-executor/benches/tpcds_benchmark.rs
@@ -8,13 +8,20 @@
 //! Parse errors are handled gracefully - queries that fail to parse are skipped
 //! with a warning, allowing the benchmark suite to continue.
 //!
+//! Memory monitoring:
+//!   The benchmark monitors system memory and skips queries when memory pressure
+//!   exceeds the threshold (default 80%). Override with VIBESQL_MEMORY_THRESHOLD env var.
+//!
 //! Usage:
 //!   cargo bench --bench tpcds_benchmark
 //!   cargo bench --bench tpcds_benchmark --features benchmark-comparison
+//!   VIBESQL_MEMORY_THRESHOLD=70 cargo bench --bench tpcds_benchmark  # Lower threshold
 
+mod memory_monitor;
 mod tpcds;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use memory_monitor::{format_bytes, MemoryMonitor, MemoryPressure};
 use std::hint::black_box;
 use std::sync::{Mutex, OnceLock};
 use vibesql_executor::SelectExecutor;
@@ -36,8 +43,44 @@ enum QueryResult {
 /// Global tracker for query results
 static QUERY_RESULTS: OnceLock<Mutex<Vec<QueryResult>>> = OnceLock::new();
 
+/// Global memory monitor for tracking memory pressure
+static MEMORY_MONITOR: OnceLock<Mutex<MemoryMonitor>> = OnceLock::new();
+
 fn get_query_results() -> &'static Mutex<Vec<QueryResult>> {
     QUERY_RESULTS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn get_memory_monitor() -> &'static Mutex<MemoryMonitor> {
+    MEMORY_MONITOR.get_or_init(|| {
+        let monitor = MemoryMonitor::new();
+        eprintln!(
+            "Memory monitor initialized (threshold: {:.0}%)",
+            monitor.threshold_percent()
+        );
+        Mutex::new(monitor)
+    })
+}
+
+/// Check memory pressure and return a skip reason if pressure is high
+fn check_memory_before_query(query_name: &str) -> Option<String> {
+    if let Ok(mut monitor) = get_memory_monitor().lock() {
+        match monitor.check_pressure() {
+            MemoryPressure::High { stats, threshold_percent } => {
+                let reason = format!(
+                    "Memory pressure ({:.1}% > {:.0}% threshold, {} used of {})",
+                    stats.usage_percent,
+                    threshold_percent,
+                    format_bytes(stats.used_bytes),
+                    format_bytes(stats.total_bytes)
+                );
+                eprintln!("[MEMORY] Skipping {} - {}", query_name, reason);
+                Some(reason)
+            }
+            MemoryPressure::Ok(_) => None,
+        }
+    } else {
+        None
+    }
 }
 
 fn record_query_result(result: QueryResult) {
@@ -61,13 +104,36 @@ fn print_query_summary() {
             .iter()
             .filter(|r| matches!(r, QueryResult::Skipped { .. }))
             .collect();
+        let memory_skipped: Vec<_> = skipped
+            .iter()
+            .filter(|r| {
+                if let QueryResult::Skipped { reason, .. } = r {
+                    reason.contains("Memory pressure")
+                } else {
+                    false
+                }
+            })
+            .collect();
 
         eprintln!("\n{}", "=".repeat(60));
         eprintln!("TPC-DS BENCHMARK SUMMARY");
         eprintln!("{}", "=".repeat(60));
         eprintln!("Passed:  {} queries", passed.len());
-        eprintln!("Skipped: {} queries", skipped.len());
+        eprintln!("Skipped: {} queries ({} due to memory pressure)", skipped.len(), memory_skipped.len());
         eprintln!("{}", "-".repeat(60));
+
+        // Print memory statistics
+        if let Ok(mut monitor) = get_memory_monitor().lock() {
+            let stats = monitor.current_stats();
+            eprintln!("\nMemory Statistics:");
+            eprintln!("  Current usage: {} / {} ({:.1}%)",
+                format_bytes(stats.used_bytes),
+                format_bytes(stats.total_bytes),
+                stats.usage_percent
+            );
+            eprintln!("  High-water mark: {}", format_bytes(monitor.high_water_mark_bytes()));
+            eprintln!("  Threshold: {:.0}%", monitor.threshold_percent());
+        }
 
         if !skipped.is_empty() {
             eprintln!("\nSkipped queries:");
@@ -228,11 +294,22 @@ fn bench_sanity_queries(c: &mut Criterion) {
     let db = get_vibesql_db();
 
     for (name, sql) in TPCDS_SANITY_QUERIES {
+        let query_name = format!("sanity_{}", name);
+
+        // Check memory pressure before executing query
+        if let Some(reason) = check_memory_before_query(&query_name) {
+            record_query_result(QueryResult::Skipped {
+                name: query_name,
+                reason,
+            });
+            continue;
+        }
+
         // Validate query before benchmarking
         match try_vibesql_query(db, sql) {
             Ok(row_count) => {
                 record_query_result(QueryResult::Passed {
-                    name: format!("sanity_{}", name),
+                    name: query_name,
                     row_count,
                 });
                 group.bench_function(BenchmarkId::new("vibesql", *name), |b| {
@@ -266,6 +343,17 @@ fn bench_sanity_queries_comparison(c: &mut Criterion) {
     let duckdb_conn = get_duckdb_conn();
 
     for (name, sql) in TPCDS_SANITY_QUERIES {
+        let query_name = format!("comparison_{}", name);
+
+        // Check memory pressure before executing query
+        if let Some(reason) = check_memory_before_query(&query_name) {
+            record_query_result(QueryResult::Skipped {
+                name: query_name,
+                reason,
+            });
+            continue;
+        }
+
         // Only benchmark if VibeSQL can parse and execute the query
         if let Err(e) = try_vibesql_query(vibesql_db, sql) {
             eprintln!("[SKIP] comparison_{}: {}", name, e);
@@ -311,11 +399,22 @@ fn bench_tpcds_queries(c: &mut Criterion) {
     let db = get_vibesql_db();
 
     for (name, sql) in TPCDS_QUERIES {
+        let query_name = name.to_string();
+
+        // Check memory pressure before executing query
+        if let Some(reason) = check_memory_before_query(&query_name) {
+            record_query_result(QueryResult::Skipped {
+                name: query_name,
+                reason,
+            });
+            continue;
+        }
+
         // Validate query before benchmarking
         match try_vibesql_query(db, sql) {
             Ok(row_count) => {
                 record_query_result(QueryResult::Passed {
-                    name: name.to_string(),
+                    name: query_name,
                     row_count,
                 });
                 group.bench_function(BenchmarkId::new("vibesql", *name), |b| {


### PR DESCRIPTION
## Summary

- Add runtime memory monitoring to detect memory pressure before the OS sends SIGKILL
- Enable graceful handling of memory-intensive benchmark operations
- Allow benchmarks to skip queries when memory usage exceeds threshold (default 80%)

## Changes

- Add `sysinfo` dev-dependency for cross-platform memory monitoring (macOS/Linux)
- Create `memory_monitor.rs` module with `MemoryMonitor` utility
- Integrate memory checks into TPC-DS benchmark before each query execution
- Add memory statistics (current usage, high-water mark) to benchmark summary
- Support `VIBESQL_MEMORY_THRESHOLD` env var to customize threshold (e.g., `70` for 70%)

## Benefits

This enables benchmarks to:
- Log what query/operation would cause memory issues
- Skip problematic queries and continue with remaining benchmarks
- Report memory high-water mark and usage statistics
- Gracefully degrade instead of being killed by OS with SIGKILL

## Usage

```bash
# Run with default 80% threshold
cargo bench --bench tpcds_benchmark

# Run with custom 70% threshold
VIBESQL_MEMORY_THRESHOLD=70 cargo bench --bench tpcds_benchmark
```

## Test plan

- [x] Code compiles without warnings
- [x] Memory monitor initializes correctly (verified via test output)
- [x] Benchmark runs and shows memory monitor initialization message

Closes #3037

🤖 Generated with [Claude Code](https://claude.com/claude-code)