### PR TITLE
perf(bench): Add jemalloc allocator option for better memory release

### DIFF
--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -46,6 +46,11 @@ cranelift-jit = { version = "0.126", optional = true }
 cranelift-module = { version = "0.126", optional = true }
 cranelift-native = { version = "0.126", optional = true }
 
+# jemalloc for better memory release characteristics in benchmarks
+# These must be in [dependencies] (not dev-dependencies) to be feature-gated
+tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemalloc-ctl = { version = "0.6", features = ["stats"], optional = true }
+
 [dev-dependencies]
 vibesql-parser = { version = "0.1.0", path = "../vibesql-parser" }
 criterion = { version = "0.7", features = ["html_reports"] }
@@ -79,6 +84,9 @@ native-columnar = []
 jit = ["cranelift", "cranelift-jit", "cranelift-module", "cranelift-native"]
 # Enable experimental SIMD-accelerated group-by aggregation (research/experimental)
 simd = []
+# Use jemalloc allocator for better memory release characteristics
+# Usage: cargo bench --features jemalloc -- tpcds_runner
+jemalloc = ["tikv-jemallocator", "tikv-jemalloc-ctl"]
 
 [[test]]
 name = "foreign_key_tests"

--- a/crates/vibesql-executor/benches/tpcds/memory.rs
+++ b/crates/vibesql-executor/benches/tpcds/memory.rs
@@ -176,7 +176,35 @@ impl MemoryTracker {
 
 /// Hint to the allocator that now is a good time to return memory to the OS
 ///
-/// This doesn't force memory release but can help on some platforms.
+/// When jemalloc feature is enabled, this uses jemalloc's epoch advancement
+/// and arena purging which is much more effective at releasing memory.
+///
+/// Without jemalloc, falls back to platform-specific hints which may have
+/// limited effectiveness.
+#[cfg(feature = "jemalloc")]
+pub fn hint_memory_release() {
+    use tikv_jemalloc_ctl::{epoch, raw};
+
+    // Advance the epoch to update jemalloc's statistics
+    // This is necessary before purging to ensure we have accurate data
+    if let Err(e) = epoch::advance() {
+        eprintln!("[jemalloc] Failed to advance epoch: {}", e);
+    }
+
+    // Purge all arenas to release memory back to the OS
+    // "arenas.purge" is a write-only command that forces immediate page purging
+    let purge_result = unsafe {
+        raw::write(b"arena.0.purge\0", ())
+    };
+    if let Err(e) = purge_result {
+        // Arena 0 might not exist; try the global purge
+        let _ = unsafe { raw::write(b"arenas.purge\0", ()) };
+        let _ = e; // Suppress warning
+    }
+}
+
+/// Fallback hint_memory_release for when jemalloc is not enabled
+#[cfg(not(feature = "jemalloc"))]
 pub fn hint_memory_release() {
     // On macOS, we can use malloc_zone_pressure_relief
     #[cfg(target_os = "macos")]
@@ -199,6 +227,58 @@ pub fn hint_memory_release() {
         unsafe {
             malloc_trim(0);
         }
+    }
+}
+
+/// Returns true if jemalloc is being used as the global allocator
+pub fn is_jemalloc_enabled() -> bool {
+    cfg!(feature = "jemalloc")
+}
+
+/// Get jemalloc memory statistics (only available with jemalloc feature)
+#[cfg(feature = "jemalloc")]
+pub fn get_jemalloc_stats() -> Option<JemallocStats> {
+    use tikv_jemalloc_ctl::{epoch, stats};
+
+    // Advance epoch to get fresh stats
+    epoch::advance().ok()?;
+
+    Some(JemallocStats {
+        allocated: stats::allocated::read().ok()?,
+        active: stats::active::read().ok()?,
+        resident: stats::resident::read().ok()?,
+        retained: stats::retained::read().ok()?,
+    })
+}
+
+#[cfg(not(feature = "jemalloc"))]
+pub fn get_jemalloc_stats() -> Option<JemallocStats> {
+    None
+}
+
+/// jemalloc memory statistics
+#[derive(Debug, Clone, Copy)]
+pub struct JemallocStats {
+    /// Total bytes allocated by the application
+    pub allocated: usize,
+    /// Total bytes in active pages (may include fragmentation)
+    pub active: usize,
+    /// Total bytes mapped by jemalloc (RSS contribution)
+    pub resident: usize,
+    /// Total bytes retained in virtual memory (not returned to OS)
+    pub retained: usize,
+}
+
+impl std::fmt::Display for JemallocStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "allocated: {:.1} MB, active: {:.1} MB, resident: {:.1} MB, retained: {:.1} MB",
+            self.allocated as f64 / (1024.0 * 1024.0),
+            self.active as f64 / (1024.0 * 1024.0),
+            self.resident as f64 / (1024.0 * 1024.0),
+            self.retained as f64 / (1024.0 * 1024.0)
+        )
     }
 }
 

--- a/crates/vibesql-executor/benches/tpcds_runner.rs
+++ b/crates/vibesql-executor/benches/tpcds_runner.rs
@@ -9,6 +9,7 @@
 //! - Batched query execution with cleanup between batches
 //! - Memory usage tracking and reporting
 //! - Configurable memory warning thresholds
+//! - Optional jemalloc allocator for better memory release
 //!
 //! Usage:
 //!   cargo run --release --bench tpcds_runner
@@ -16,12 +17,20 @@
 //!   SKIP_SLOW=1 cargo run --release --bench tpcds_runner  # Skip known slow queries
 //!   BATCH_SIZE=5 cargo run --release --bench tpcds_runner  # Run 5 queries per batch
 //!   MEMORY_WARN_MB=4000 cargo run --release --bench tpcds_runner  # Warn at 4GB RSS
+//!
+//! For better memory release, use jemalloc:
+//!   cargo run --release --bench tpcds_runner --features jemalloc
+
+// Set up jemalloc as the global allocator when feature is enabled
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 mod tpcds;
 
 use std::collections::HashSet;
 use std::time::{Duration, Instant};
-use tpcds::memory::{get_memory_usage, hint_memory_release, MemoryTracker};
+use tpcds::memory::{get_jemalloc_stats, get_memory_usage, hint_memory_release, is_jemalloc_enabled, MemoryTracker};
 use tpcds::queries::TPCDS_QUERIES;
 use tpcds::schema::load_vibesql;
 use vibesql_executor::SelectExecutor;
@@ -74,6 +83,7 @@ fn main() {
     println!("  Scale factor:    {}", scale_factor);
     println!("  Batch size:      {} queries", batch_size);
     println!("  Memory warning:  {:.0} MB", memory_warn_mb);
+    println!("  Allocator:       {}", if is_jemalloc_enabled() { "jemalloc" } else { "system" });
     if skip_slow {
         println!("  Skipping:        {} known slow queries", SLOW_QUERIES.len());
     }
@@ -213,11 +223,20 @@ fn main() {
 
             // Report batch completion
             if let Some(stats) = memory_tracker.record() {
-                eprintln!(
-                    "  [Batch {} complete, RSS: {:.1} MB]",
-                    (idx / batch_size) + 1,
-                    stats.rss_mb()
-                );
+                if let Some(je_stats) = get_jemalloc_stats() {
+                    eprintln!(
+                        "  [Batch {} complete, RSS: {:.1} MB, jemalloc resident: {:.1} MB]",
+                        (idx / batch_size) + 1,
+                        stats.rss_mb(),
+                        je_stats.resident as f64 / (1024.0 * 1024.0)
+                    );
+                } else {
+                    eprintln!(
+                        "  [Batch {} complete, RSS: {:.1} MB]",
+                        (idx / batch_size) + 1,
+                        stats.rss_mb()
+                    );
+                }
             }
         }
     }
@@ -242,6 +261,12 @@ fn main() {
 
     // Print memory summary
     memory_tracker.print_summary();
+
+    // Print jemalloc-specific stats if available
+    if let Some(je_stats) = get_jemalloc_stats() {
+        eprintln!("\n--- jemalloc Stats ---");
+        eprintln!("{}", je_stats);
+    }
 
     // Output CSV for documentation
     println!("\n=== CSV Output ===");


### PR DESCRIPTION
## Summary

- Add optional `jemalloc` feature flag to vibesql-executor
- Update `hint_memory_release()` to use jemalloc's arena purging when enabled
- Add jemalloc-specific memory stats (allocated, active, resident, retained)
- Show allocator type in benchmark configuration output
- Display jemalloc resident memory in batch completion messages

This addresses the memory release issue described in #3043 by providing a better allocator with stronger memory release characteristics for TPC-DS benchmarks.

## Changes

### Cargo.toml
- Added `tikv-jemallocator` and `tikv-jemalloc-ctl` as optional dependencies
- Added `jemalloc` feature flag

### memory.rs
- Added jemalloc-specific `hint_memory_release()` using epoch advancement and arena purging
- Added `is_jemalloc_enabled()` helper function
- Added `get_jemalloc_stats()` and `JemallocStats` struct for detailed memory reporting

### tpcds_runner.rs
- Added jemalloc global allocator setup when feature is enabled
- Show allocator type in configuration output
- Display jemalloc resident memory in batch completion messages
- Print jemalloc-specific stats in memory summary

## Usage

```bash
# Run with jemalloc allocator
cargo bench -p vibesql-executor --bench tpcds_runner --features jemalloc

# Run with system allocator (default)
cargo bench -p vibesql-executor --bench tpcds_runner
```

## Test plan

- [x] Compiles without jemalloc feature
- [x] Compiles with jemalloc feature
- [x] TPC-DS runner shows "Allocator: jemalloc" when feature enabled
- [x] Batch completion messages show jemalloc resident memory
- [x] Memory stats display correctly

Closes #3043

🤖 Generated with [Claude Code](https://claude.com/claude-code)