### PR TITLE
feat(simd): Add packed bitmask type for filter masks

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/mod.rs
@@ -59,8 +59,9 @@ pub use aggregate::{columnar_group_by, columnar_group_by_batch, compute_multiple
 
 pub use aggregate::compute_aggregates_from_batch;
 pub use simd_aggregate::{can_use_simd_for_column, simd_aggregate_f64, simd_aggregate_i64};
-pub use simd_filter::{simd_create_filter_mask, simd_filter_batch};
+pub use simd_filter::{simd_create_filter_mask, simd_create_filter_mask_packed, simd_filter_batch};
 pub use simd_join::columnar_hash_join_inner;
+pub use simd_ops::PackedMask;
 
 use crate::errors::ExecutorError;
 use crate::schema::CombinedSchema;

--- a/crates/vibesql-executor/src/select/columnar/simd_filter.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 use super::batch::{ColumnArray, ColumnarBatch};
 use super::filter::{parse_date_string, ColumnPredicate};
-use super::simd_ops;
+use super::simd_ops::{self, PackedMask};
 use super::string_ops::{
     batch_string_eq, batch_string_ge, batch_string_gt, batch_string_le, batch_string_like,
     batch_string_lt, batch_string_ne, LikePattern,
@@ -182,6 +182,471 @@ pub fn simd_create_filter_mask(
     }
 
     Ok(mask)
+}
+
+/// Create a filter mask using packed bitmasks for improved efficiency.
+///
+/// This function provides 8x memory reduction compared to `simd_create_filter_mask`
+/// by using packed bitmasks (1 bit per row) instead of Vec<bool> (1 byte per row).
+///
+/// # Performance Benefits
+///
+/// - **8x memory reduction**: For 6M rows, uses 750KB instead of 6MB
+/// - **Native SIMD bitwise AND**: Combining predicates uses hardware SIMD instructions
+/// - **Better cache utilization**: Smaller footprint means better cache hit rates
+/// - **Faster popcount**: `count_ones()` maps to hardware popcount instruction
+///
+/// # Usage
+///
+/// This function is designed for use with fused filter+aggregate optimization:
+///
+/// ```ignore
+/// let filter_mask = simd_create_filter_mask_packed(batch, predicates)?;
+/// let sum = simd_ops::sum_f64_packed_filtered(values, &filter_mask);
+/// let count = filter_mask.count_ones();
+/// ```
+pub fn simd_create_filter_mask_packed(
+    batch: &ColumnarBatch,
+    predicates: &[ColumnPredicate],
+) -> Result<PackedMask, ExecutorError> {
+    let row_count = batch.row_count();
+
+    // Start with all rows passing
+    let mut mask = PackedMask::new_all_set(row_count);
+
+    // Evaluate each predicate and AND the results
+    for predicate in predicates {
+        let predicate_mask = evaluate_predicate_simd_packed(batch, predicate)?;
+
+        // Bitwise AND - this is a native SIMD operation
+        mask.and_inplace(&predicate_mask);
+    }
+
+    Ok(mask)
+}
+
+/// Evaluate a single predicate returning a packed mask
+fn evaluate_predicate_simd_packed(
+    batch: &ColumnarBatch,
+    predicate: &ColumnPredicate,
+) -> Result<PackedMask, ExecutorError> {
+    // NULL handling: any comparison with NULL returns false (UNKNOWN in SQL)
+    if predicate_contains_null(predicate) {
+        return Ok(PackedMask::new_all_clear(batch.row_count()));
+    }
+
+    let column_idx = match predicate {
+        ColumnPredicate::LessThan { column_idx, .. }
+        | ColumnPredicate::GreaterThan { column_idx, .. }
+        | ColumnPredicate::GreaterThanOrEqual { column_idx, .. }
+        | ColumnPredicate::LessThanOrEqual { column_idx, .. }
+        | ColumnPredicate::Equal { column_idx, .. }
+        | ColumnPredicate::NotEqual { column_idx, .. }
+        | ColumnPredicate::Between { column_idx, .. }
+        | ColumnPredicate::Like { column_idx, .. } => *column_idx,
+    };
+
+    let column = batch
+        .column(column_idx)
+        .ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: column_idx,
+            batch_columns: batch.column_count(),
+        })?;
+
+    match column {
+        // Packed path for i64 columns
+        ColumnArray::Int64(values, nulls) => {
+            evaluate_predicate_i64_packed(predicate, values, nulls.as_ref().map(|n| n.as_slice()))
+        }
+
+        // Packed path for f64 columns
+        ColumnArray::Float64(values, nulls) => {
+            evaluate_predicate_f64_packed(predicate, values, nulls.as_ref().map(|n| n.as_slice()))
+        }
+
+        // Packed path for Date columns (i32)
+        ColumnArray::Date(values, nulls) => {
+            evaluate_predicate_i32_packed(predicate, values, nulls.as_ref().map(|n| n.as_slice()))
+        }
+
+        // Packed path for Timestamp columns (i64)
+        ColumnArray::Timestamp(values, nulls) => {
+            evaluate_predicate_i64_packed(predicate, values, nulls.as_ref().map(|n| n.as_slice()))
+        }
+
+        // For other types, fall back to Vec<bool> and convert
+        _ => {
+            let bool_mask = evaluate_predicate_simd(batch, predicate)?;
+            Ok(PackedMask::from_bool_slice(&bool_mask))
+        }
+    }
+}
+
+/// Evaluate predicate on i64 column returning packed mask
+fn evaluate_predicate_i64_packed(
+    predicate: &ColumnPredicate,
+    values: &[i64],
+    nulls: Option<&[bool]>,
+) -> Result<PackedMask, ExecutorError> {
+    let mut result = match predicate {
+        ColumnPredicate::LessThan { value, .. } => {
+            if let SqlValue::Integer(threshold) = value {
+                simd_ops::lt_i64_packed(values, *threshold)
+            } else if let SqlValue::Bigint(threshold) = value {
+                simd_ops::lt_i64_packed(values, *threshold)
+            } else if let Some(threshold) = value_to_timestamp_i64(value) {
+                simd_ops::lt_i64_packed(values, threshold)
+            } else {
+                // Type mismatch: fall back to Vec<bool> path
+                let threshold = value_to_f64(value)
+                    .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                        operation: "comparison".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: Some(format!("{:?}", value)),
+                    })?;
+                let f64_values: Vec<f64> = values.iter().map(|&v| v as f64).collect();
+                simd_ops::lt_f64_packed(&f64_values, threshold)
+            }
+        }
+
+        ColumnPredicate::GreaterThan { value, .. } => {
+            if let SqlValue::Integer(threshold) = value {
+                simd_ops::gt_i64_packed(values, *threshold)
+            } else if let SqlValue::Bigint(threshold) = value {
+                simd_ops::gt_i64_packed(values, *threshold)
+            } else {
+                let threshold = value_to_f64(value)
+                    .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                        operation: "comparison".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: Some(format!("{:?}", value)),
+                    })?;
+                let f64_values: Vec<f64> = values.iter().map(|&v| v as f64).collect();
+                simd_ops::gt_f64_packed(&f64_values, threshold)
+            }
+        }
+
+        ColumnPredicate::Equal { value, .. } => {
+            if let SqlValue::Integer(target) = value {
+                simd_ops::eq_i64_packed(values, *target)
+            } else if let SqlValue::Bigint(target) = value {
+                simd_ops::eq_i64_packed(values, *target)
+            } else {
+                let target = value_to_f64(value)
+                    .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                        operation: "comparison".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: Some(format!("{:?}", value)),
+                    })?;
+                let f64_values: Vec<f64> = values.iter().map(|&v| v as f64).collect();
+                simd_ops::eq_f64_packed(&f64_values, target)
+            }
+        }
+
+        ColumnPredicate::Between { low, high, .. } => {
+            let low_i64 = match low {
+                SqlValue::Integer(v) => *v,
+                SqlValue::Bigint(v) => *v,
+                _ => {
+                    return Err(ExecutorError::ColumnarTypeMismatch {
+                        operation: "BETWEEN".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: None,
+                    })
+                }
+            };
+            let high_i64 = match high {
+                SqlValue::Integer(v) => *v,
+                SqlValue::Bigint(v) => *v,
+                _ => {
+                    return Err(ExecutorError::ColumnarTypeMismatch {
+                        operation: "BETWEEN".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: None,
+                    })
+                }
+            };
+            simd_ops::between_i64_packed(values, low_i64, high_i64)
+        }
+
+        ColumnPredicate::GreaterThanOrEqual { value, .. } => {
+            if let SqlValue::Integer(threshold) = value {
+                simd_ops::ge_i64_packed(values, *threshold)
+            } else if let SqlValue::Bigint(threshold) = value {
+                simd_ops::ge_i64_packed(values, *threshold)
+            } else {
+                let threshold = value_to_f64(value)
+                    .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                        operation: "comparison".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: Some(format!("{:?}", value)),
+                    })?;
+                let f64_values: Vec<f64> = values.iter().map(|&v| v as f64).collect();
+                simd_ops::ge_f64_packed(&f64_values, threshold)
+            }
+        }
+
+        ColumnPredicate::LessThanOrEqual { value, .. } => {
+            if let SqlValue::Integer(threshold) = value {
+                simd_ops::le_i64_packed(values, *threshold)
+            } else if let SqlValue::Bigint(threshold) = value {
+                simd_ops::le_i64_packed(values, *threshold)
+            } else {
+                let threshold = value_to_f64(value)
+                    .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                        operation: "comparison".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: Some(format!("{:?}", value)),
+                    })?;
+                let f64_values: Vec<f64> = values.iter().map(|&v| v as f64).collect();
+                simd_ops::le_f64_packed(&f64_values, threshold)
+            }
+        }
+
+        ColumnPredicate::NotEqual { value, .. } => {
+            if let SqlValue::Integer(target) = value {
+                simd_ops::ne_i64_packed(values, *target)
+            } else if let SqlValue::Bigint(target) = value {
+                simd_ops::ne_i64_packed(values, *target)
+            } else {
+                let target = value_to_f64(value)
+                    .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                        operation: "comparison".to_string(),
+                        left_type: "Int64".to_string(),
+                        right_type: Some(format!("{:?}", value)),
+                    })?;
+                let f64_values: Vec<f64> = values.iter().map(|&v| v as f64).collect();
+                simd_ops::ne_f64_packed(&f64_values, target)
+            }
+        }
+
+        ColumnPredicate::Like { .. } => {
+            return Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "LIKE".to_string(),
+                left_type: "Int64".to_string(),
+                right_type: Some("String pattern".to_string()),
+            });
+        }
+    };
+
+    // Apply NULL mask: NULLs always fail predicates
+    if let Some(null_mask) = nulls {
+        for (i, &is_null) in null_mask.iter().enumerate() {
+            if is_null {
+                result.set(i, false);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Evaluate predicate on i32 column returning packed mask (for dates)
+fn evaluate_predicate_i32_packed(
+    predicate: &ColumnPredicate,
+    values: &[i32],
+    nulls: Option<&[bool]>,
+) -> Result<PackedMask, ExecutorError> {
+    let mut result = match predicate {
+        ColumnPredicate::LessThan { value, .. } => {
+            let threshold = value_to_date_i32(value)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "date comparison".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: None,
+                })?;
+            simd_ops::lt_i32_packed(values, threshold)
+        }
+
+        ColumnPredicate::GreaterThan { value, .. } => {
+            let threshold = value_to_date_i32(value)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "date comparison".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: None,
+                })?;
+            simd_ops::gt_i32_packed(values, threshold)
+        }
+
+        ColumnPredicate::GreaterThanOrEqual { value, .. } => {
+            let threshold = value_to_date_i32(value)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "date comparison".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: None,
+                })?;
+            simd_ops::ge_i32_packed(values, threshold)
+        }
+
+        ColumnPredicate::LessThanOrEqual { value, .. } => {
+            let threshold = value_to_date_i32(value)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "date comparison".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: None,
+                })?;
+            simd_ops::le_i32_packed(values, threshold)
+        }
+
+        ColumnPredicate::Equal { value, .. } => {
+            let target = value_to_date_i32(value)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "date comparison".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: None,
+                })?;
+            simd_ops::eq_i32_packed(values, target)
+        }
+
+        ColumnPredicate::Between { low, high, .. } => {
+            let low_i32 = value_to_date_i32(low)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "BETWEEN".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: Some(format!("{:?}", low)),
+                })?;
+            let high_i32 = value_to_date_i32(high)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "BETWEEN".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: Some(format!("{:?}", high)),
+                })?;
+            simd_ops::between_i32_packed(values, low_i32, high_i32)
+        }
+
+        ColumnPredicate::NotEqual { value, .. } => {
+            let target = value_to_date_i32(value)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "date comparison".to_string(),
+                    left_type: "Date".to_string(),
+                    right_type: None,
+                })?;
+            simd_ops::ne_i32_packed(values, target)
+        }
+
+        ColumnPredicate::Like { .. } => {
+            return Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "LIKE".to_string(),
+                left_type: "Date".to_string(),
+                right_type: Some("String pattern".to_string()),
+            });
+        }
+    };
+
+    // Apply NULL mask
+    if let Some(null_mask) = nulls {
+        for (i, &is_null) in null_mask.iter().enumerate() {
+            if is_null {
+                result.set(i, false);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Evaluate predicate on f64 column returning packed mask
+fn evaluate_predicate_f64_packed(
+    predicate: &ColumnPredicate,
+    values: &[f64],
+    nulls: Option<&[bool]>,
+) -> Result<PackedMask, ExecutorError> {
+    let mut result = match predicate {
+        ColumnPredicate::LessThan { value, .. } => {
+            let threshold = value_to_f64(value)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "comparison".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", value)),
+                })?;
+            simd_ops::lt_f64_packed(values, threshold)
+        }
+
+        ColumnPredicate::GreaterThan { value, .. } => {
+            let threshold = value_to_f64(value)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "comparison".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", value)),
+                })?;
+            simd_ops::gt_f64_packed(values, threshold)
+        }
+
+        ColumnPredicate::GreaterThanOrEqual { value, .. } => {
+            let threshold = value_to_f64(value)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "comparison".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", value)),
+                })?;
+            simd_ops::ge_f64_packed(values, threshold)
+        }
+
+        ColumnPredicate::LessThanOrEqual { value, .. } => {
+            let threshold = value_to_f64(value)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "comparison".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", value)),
+                })?;
+            simd_ops::le_f64_packed(values, threshold)
+        }
+
+        ColumnPredicate::Equal { value, .. } => {
+            let target = value_to_f64(value)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "comparison".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", value)),
+                })?;
+            simd_ops::eq_f64_packed(values, target)
+        }
+
+        ColumnPredicate::Between { low, high, .. } => {
+            let low_f64 = value_to_f64(low)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "BETWEEN".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", low)),
+                })?;
+            let high_f64 = value_to_f64(high)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "BETWEEN".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", high)),
+                })?;
+            simd_ops::between_f64_packed(values, low_f64, high_f64)
+        }
+
+        ColumnPredicate::NotEqual { value, .. } => {
+            let target = value_to_f64(value)
+                .ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
+                    operation: "comparison".to_string(),
+                    left_type: "Float64".to_string(),
+                    right_type: Some(format!("{:?}", value)),
+                })?;
+            simd_ops::ne_f64_packed(values, target)
+        }
+
+        ColumnPredicate::Like { .. } => {
+            return Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "LIKE".to_string(),
+                left_type: "Float64".to_string(),
+                right_type: Some("String pattern".to_string()),
+            });
+        }
+    };
+
+    // Apply NULL mask
+    if let Some(null_mask) = nulls {
+        for (i, &is_null) in null_mask.iter().enumerate() {
+            if is_null {
+                result.set(i, false);
+            }
+        }
+    }
+
+    Ok(result)
 }
 
 /// Evaluate a single predicate using SIMD operations when possible

--- a/crates/vibesql-executor/src/select/columnar/simd_ops.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_ops.rs
@@ -50,6 +50,200 @@
 #![allow(clippy::needless_range_loop)]
 
 // ============================================================================
+// PACKED BITMASK TYPE
+// ============================================================================
+// Using packed bitmasks (1 bit per row) instead of Vec<bool> (1 byte per row)
+// provides 8x memory reduction and enables native SIMD bitwise operations.
+
+/// A packed bitmask where each bit represents whether a row passes a filter.
+///
+/// # Memory Efficiency
+///
+/// For 6M rows (lineitem at TPC-H SF 1):
+/// - `Vec<bool>`: 6 MB per predicate
+/// - `PackedMask`: 750 KB per predicate (8x reduction)
+///
+/// # Performance Benefits
+///
+/// - Bitwise AND is a native SIMD instruction (`vpand` on x86, `and` on ARM)
+/// - Better cache utilization due to reduced memory footprint
+/// - Faster popcount using `count_ones()` intrinsic
+///
+/// # Implementation
+///
+/// Bits are stored in little-endian order within each u64 word:
+/// - Bit 0 of word 0 = row 0
+/// - Bit 63 of word 0 = row 63
+/// - Bit 0 of word 1 = row 64
+/// - etc.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackedMask {
+    /// The packed bits. Each u64 holds 64 row flags.
+    words: Vec<u64>,
+    /// The actual number of rows (since the last word may be partial).
+    len: usize,
+}
+
+impl PackedMask {
+    /// Creates a new mask with all bits set (all rows pass).
+    #[inline]
+    pub fn new_all_set(len: usize) -> Self {
+        if len == 0 {
+            return Self { words: vec![], len: 0 };
+        }
+        let num_words = (len + 63) / 64;
+        let mut words = vec![u64::MAX; num_words];
+
+        // Clear unused bits in the last word
+        let remainder = len % 64;
+        if remainder != 0 {
+            words[num_words - 1] = (1u64 << remainder) - 1;
+        }
+
+        Self { words, len }
+    }
+
+    /// Creates a new mask with all bits clear (no rows pass).
+    #[inline]
+    pub fn new_all_clear(len: usize) -> Self {
+        if len == 0 {
+            return Self { words: vec![], len: 0 };
+        }
+        let num_words = (len + 63) / 64;
+        Self { words: vec![0; num_words], len }
+    }
+
+    /// Returns the number of rows this mask represents.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if this mask is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Gets the value of the bit at the given index.
+    #[inline]
+    pub fn get(&self, index: usize) -> bool {
+        debug_assert!(index < self.len, "index out of bounds");
+        let word_idx = index / 64;
+        let bit_idx = index % 64;
+        (self.words[word_idx] >> bit_idx) & 1 == 1
+    }
+
+    /// Sets the bit at the given index.
+    #[inline]
+    pub fn set(&mut self, index: usize, value: bool) {
+        debug_assert!(index < self.len, "index out of bounds");
+        let word_idx = index / 64;
+        let bit_idx = index % 64;
+        if value {
+            self.words[word_idx] |= 1u64 << bit_idx;
+        } else {
+            self.words[word_idx] &= !(1u64 << bit_idx);
+        }
+    }
+
+    /// Performs in-place bitwise AND with another mask.
+    ///
+    /// This is the key operation for combining multiple predicates.
+    /// Uses native bitwise AND which maps directly to SIMD instructions.
+    #[inline]
+    pub fn and_inplace(&mut self, other: &PackedMask) {
+        debug_assert_eq!(self.len, other.len, "mask lengths must match");
+
+        // Process in chunks of 4 for potential auto-vectorization
+        let chunks = self.words.len() / 4;
+        for i in 0..chunks {
+            let base = i * 4;
+            self.words[base] &= other.words[base];
+            self.words[base + 1] &= other.words[base + 1];
+            self.words[base + 2] &= other.words[base + 2];
+            self.words[base + 3] &= other.words[base + 3];
+        }
+
+        // Handle remainder
+        for i in (chunks * 4)..self.words.len() {
+            self.words[i] &= other.words[i];
+        }
+    }
+
+    /// Counts the number of set bits (rows that pass the filter).
+    ///
+    /// Uses the `count_ones()` intrinsic which maps to hardware popcount.
+    #[inline]
+    pub fn count_ones(&self) -> usize {
+        // Use 4-accumulator pattern for better throughput
+        let chunks = self.words.len() / 4;
+        let (mut c0, mut c1, mut c2, mut c3) = (0u32, 0u32, 0u32, 0u32);
+
+        for i in 0..chunks {
+            let base = i * 4;
+            c0 += self.words[base].count_ones();
+            c1 += self.words[base + 1].count_ones();
+            c2 += self.words[base + 2].count_ones();
+            c3 += self.words[base + 3].count_ones();
+        }
+
+        let mut total = (c0 + c1 + c2 + c3) as usize;
+        for i in (chunks * 4)..self.words.len() {
+            total += self.words[i].count_ones() as usize;
+        }
+        total
+    }
+
+    /// Creates a packed mask from a boolean slice.
+    ///
+    /// Used for compatibility with existing code during migration.
+    #[inline]
+    pub fn from_bool_slice(slice: &[bool]) -> Self {
+        let len = slice.len();
+        if len == 0 {
+            return Self { words: vec![], len: 0 };
+        }
+
+        let num_words = (len + 63) / 64;
+        let mut words = vec![0u64; num_words];
+
+        // Process 64 bits at a time
+        for (word_idx, word) in words.iter_mut().enumerate() {
+            let start = word_idx * 64;
+            let end = (start + 64).min(len);
+            let mut bits = 0u64;
+            for (bit_idx, &value) in slice[start..end].iter().enumerate() {
+                if value {
+                    bits |= 1u64 << bit_idx;
+                }
+            }
+            *word = bits;
+        }
+
+        Self { words, len }
+    }
+
+    /// Converts this packed mask back to a boolean vector.
+    ///
+    /// Used for compatibility with existing code during migration.
+    #[inline]
+    pub fn to_bool_vec(&self) -> Vec<bool> {
+        let mut result = Vec::with_capacity(self.len);
+        for i in 0..self.len {
+            result.push(self.get(i));
+        }
+        result
+    }
+
+    /// Returns a reference to the underlying word slice.
+    #[inline]
+    pub fn words(&self) -> &[u64] {
+        &self.words
+    }
+}
+
+// ============================================================================
 // AGGREGATION OPERATIONS
 // ============================================================================
 
@@ -755,6 +949,922 @@ pub fn between_f64(values: &[f64], low: f64, high: f64) -> Vec<bool> {
 }
 
 // ============================================================================
+// PACKED COMPARISON OPERATIONS (Return PackedMask instead of Vec<bool>)
+// ============================================================================
+// These functions return packed bitmasks for 8x memory reduction and
+// native SIMD bitwise operations.
+
+/// Less-than comparison returning packed mask.
+#[inline]
+pub fn lt_i64_packed(values: &[i64], threshold: i64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v < threshold {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Greater-than comparison returning packed mask.
+#[inline]
+pub fn gt_i64_packed(values: &[i64], threshold: i64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v > threshold {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Less-than-or-equal comparison returning packed mask.
+#[inline]
+pub fn le_i64_packed(values: &[i64], threshold: i64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v <= threshold {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Greater-than-or-equal comparison returning packed mask.
+#[inline]
+pub fn ge_i64_packed(values: &[i64], threshold: i64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v >= threshold {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Equality comparison returning packed mask.
+#[inline]
+pub fn eq_i64_packed(values: &[i64], target: i64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v == target {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Inequality comparison returning packed mask.
+#[inline]
+pub fn ne_i64_packed(values: &[i64], target: i64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v != target {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Less-than comparison for i32 returning packed mask.
+#[inline]
+pub fn lt_i32_packed(values: &[i32], threshold: i32) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v < threshold {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Greater-than comparison for i32 returning packed mask.
+#[inline]
+pub fn gt_i32_packed(values: &[i32], threshold: i32) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v > threshold {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Less-than-or-equal comparison for i32 returning packed mask.
+#[inline]
+pub fn le_i32_packed(values: &[i32], threshold: i32) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v <= threshold {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Greater-than-or-equal comparison for i32 returning packed mask.
+#[inline]
+pub fn ge_i32_packed(values: &[i32], threshold: i32) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v >= threshold {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Equality comparison for i32 returning packed mask.
+#[inline]
+pub fn eq_i32_packed(values: &[i32], target: i32) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v == target {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Inequality comparison for i32 returning packed mask.
+#[inline]
+pub fn ne_i32_packed(values: &[i32], target: i32) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v != target {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Less-than comparison for f64 returning packed mask.
+#[inline]
+pub fn lt_f64_packed(values: &[f64], threshold: f64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v < threshold {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Greater-than comparison for f64 returning packed mask.
+#[inline]
+pub fn gt_f64_packed(values: &[f64], threshold: f64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v > threshold {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Less-than-or-equal comparison for f64 returning packed mask.
+#[inline]
+pub fn le_f64_packed(values: &[f64], threshold: f64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v <= threshold {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Greater-than-or-equal comparison for f64 returning packed mask.
+#[inline]
+pub fn ge_f64_packed(values: &[f64], threshold: f64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v >= threshold {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Equality comparison for f64 returning packed mask.
+#[inline]
+pub fn eq_f64_packed(values: &[f64], target: f64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v == target {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Inequality comparison for f64 returning packed mask.
+#[inline]
+pub fn ne_f64_packed(values: &[f64], target: f64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v != target {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+// ============================================================================
+// PACKED BETWEEN OPERATIONS
+// ============================================================================
+
+/// Check if i64 values are in range [low, high] (inclusive), returning packed mask.
+#[inline]
+pub fn between_i64_packed(values: &[i64], low: i64, high: i64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v >= low && v <= high {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Check if i32 values are in range [low, high] (inclusive), returning packed mask.
+#[inline]
+pub fn between_i32_packed(values: &[i32], low: i32, high: i32) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v >= low && v <= high {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+/// Check if f64 values are in range [low, high] (inclusive), returning packed mask.
+#[inline]
+pub fn between_f64_packed(values: &[f64], low: f64, high: f64) -> PackedMask {
+    let len = values.len();
+    if len == 0 {
+        return PackedMask::new_all_clear(0);
+    }
+
+    let num_words = (len + 63) / 64;
+    let mut words = vec![0u64; num_words];
+
+    for (word_idx, word) in words.iter_mut().enumerate() {
+        let start = word_idx * 64;
+        let end = (start + 64).min(len);
+        let mut bits = 0u64;
+        for (bit_idx, &v) in values[start..end].iter().enumerate() {
+            if v >= low && v <= high {
+                bits |= 1u64 << bit_idx;
+            }
+        }
+        *word = bits;
+    }
+
+    PackedMask { words, len }
+}
+
+// ============================================================================
+// PACKED FILTERED AGGREGATION OPERATIONS
+// ============================================================================
+// These operations aggregate data directly using a packed filter mask,
+// providing both memory efficiency and SIMD-friendly access patterns.
+
+/// Sum of f64 values where the corresponding bit in filter_mask is set.
+#[inline]
+pub fn sum_f64_packed_filtered(values: &[f64], filter_mask: &PackedMask) -> f64 {
+    debug_assert_eq!(values.len(), filter_mask.len(), "Arrays must have same length");
+
+    let len = values.len();
+    if len == 0 {
+        return 0.0;
+    }
+
+    // Process word by word for better cache utilization
+    let (mut s0, mut s1, mut s2, mut s3) = (0.0f64, 0.0f64, 0.0f64, 0.0f64);
+    let words = filter_mask.words();
+
+    for (word_idx, &word) in words.iter().enumerate() {
+        if word == 0 {
+            continue; // Skip entirely zero words
+        }
+
+        let base = word_idx * 64;
+        let end = (base + 64).min(len);
+
+        // Process set bits in this word
+        let mut bits = word;
+        while bits != 0 {
+            let bit_pos = bits.trailing_zeros() as usize;
+            let idx = base + bit_pos;
+            if idx < end {
+                // Distribute across 4 accumulators based on bit position
+                match bit_pos % 4 {
+                    0 => s0 += values[idx],
+                    1 => s1 += values[idx],
+                    2 => s2 += values[idx],
+                    _ => s3 += values[idx],
+                }
+            }
+            bits &= bits - 1; // Clear lowest set bit
+        }
+    }
+
+    s0 + s1 + s2 + s3
+}
+
+/// Sum of i64 values where the corresponding bit in filter_mask is set.
+#[inline]
+pub fn sum_i64_packed_filtered(values: &[i64], filter_mask: &PackedMask) -> i64 {
+    debug_assert_eq!(values.len(), filter_mask.len(), "Arrays must have same length");
+
+    let len = values.len();
+    if len == 0 {
+        return 0;
+    }
+
+    let (mut s0, mut s1, mut s2, mut s3) = (0i64, 0i64, 0i64, 0i64);
+    let words = filter_mask.words();
+
+    for (word_idx, &word) in words.iter().enumerate() {
+        if word == 0 {
+            continue;
+        }
+
+        let base = word_idx * 64;
+        let end = (base + 64).min(len);
+
+        let mut bits = word;
+        while bits != 0 {
+            let bit_pos = bits.trailing_zeros() as usize;
+            let idx = base + bit_pos;
+            if idx < end {
+                match bit_pos % 4 {
+                    0 => s0 = s0.wrapping_add(values[idx]),
+                    1 => s1 = s1.wrapping_add(values[idx]),
+                    2 => s2 = s2.wrapping_add(values[idx]),
+                    _ => s3 = s3.wrapping_add(values[idx]),
+                }
+            }
+            bits &= bits - 1;
+        }
+    }
+
+    s0.wrapping_add(s1).wrapping_add(s2).wrapping_add(s3)
+}
+
+/// Count of set bits in filter mask (number of rows passing filter).
+///
+/// This is a convenience wrapper around PackedMask::count_ones().
+#[inline]
+pub fn count_packed_filtered(filter_mask: &PackedMask) -> i64 {
+    filter_mask.count_ones() as i64
+}
+
+/// Sum of element-wise product of two f64 arrays with packed filter mask.
+///
+/// This is the key operation for TPC-H Q6: SUM(l_extendedprice * l_discount)
+/// with WHERE clause filtering.
+#[inline]
+pub fn sum_product_f64_packed_filtered(a: &[f64], b: &[f64], filter_mask: &PackedMask) -> (f64, i64) {
+    debug_assert_eq!(a.len(), b.len(), "Arrays must have same length");
+    debug_assert_eq!(a.len(), filter_mask.len(), "Arrays and filter must have same length");
+
+    let len = a.len();
+    if len == 0 {
+        return (0.0, 0);
+    }
+
+    let (mut s0, mut s1, mut s2, mut s3) = (0.0f64, 0.0f64, 0.0f64, 0.0f64);
+    let mut count = 0i64;
+    let words = filter_mask.words();
+
+    for (word_idx, &word) in words.iter().enumerate() {
+        if word == 0 {
+            continue;
+        }
+
+        let base = word_idx * 64;
+        let end = (base + 64).min(len);
+
+        let mut bits = word;
+        while bits != 0 {
+            let bit_pos = bits.trailing_zeros() as usize;
+            let idx = base + bit_pos;
+            if idx < end {
+                let product = a[idx] * b[idx];
+                match bit_pos % 4 {
+                    0 => s0 += product,
+                    1 => s1 += product,
+                    2 => s2 += product,
+                    _ => s3 += product,
+                }
+                count += 1;
+            }
+            bits &= bits - 1;
+        }
+    }
+
+    (s0 + s1 + s2 + s3, count)
+}
+
+/// Min of f64 values where the corresponding bit in filter_mask is set.
+#[inline]
+pub fn min_f64_packed_filtered(values: &[f64], filter_mask: &PackedMask) -> Option<f64> {
+    debug_assert_eq!(values.len(), filter_mask.len(), "Arrays must have same length");
+
+    let len = values.len();
+    if len == 0 {
+        return None;
+    }
+
+    let mut result = f64::INFINITY;
+    let words = filter_mask.words();
+
+    for (word_idx, &word) in words.iter().enumerate() {
+        if word == 0 {
+            continue;
+        }
+
+        let base = word_idx * 64;
+        let end = (base + 64).min(len);
+
+        let mut bits = word;
+        while bits != 0 {
+            let bit_pos = bits.trailing_zeros() as usize;
+            let idx = base + bit_pos;
+            if idx < end {
+                result = result.min(values[idx]);
+            }
+            bits &= bits - 1;
+        }
+    }
+
+    if result == f64::INFINITY {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+/// Max of f64 values where the corresponding bit in filter_mask is set.
+#[inline]
+pub fn max_f64_packed_filtered(values: &[f64], filter_mask: &PackedMask) -> Option<f64> {
+    debug_assert_eq!(values.len(), filter_mask.len(), "Arrays must have same length");
+
+    let len = values.len();
+    if len == 0 {
+        return None;
+    }
+
+    let mut result = f64::NEG_INFINITY;
+    let words = filter_mask.words();
+
+    for (word_idx, &word) in words.iter().enumerate() {
+        if word == 0 {
+            continue;
+        }
+
+        let base = word_idx * 64;
+        let end = (base + 64).min(len);
+
+        let mut bits = word;
+        while bits != 0 {
+            let bit_pos = bits.trailing_zeros() as usize;
+            let idx = base + bit_pos;
+            if idx < end {
+                result = result.max(values[idx]);
+            }
+            bits &= bits - 1;
+        }
+    }
+
+    if result == f64::NEG_INFINITY {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+/// Min of i64 values where the corresponding bit in filter_mask is set.
+#[inline]
+pub fn min_i64_packed_filtered(values: &[i64], filter_mask: &PackedMask) -> Option<i64> {
+    debug_assert_eq!(values.len(), filter_mask.len(), "Arrays must have same length");
+
+    let len = values.len();
+    if len == 0 {
+        return None;
+    }
+
+    let mut result = i64::MAX;
+    let words = filter_mask.words();
+
+    for (word_idx, &word) in words.iter().enumerate() {
+        if word == 0 {
+            continue;
+        }
+
+        let base = word_idx * 64;
+        let end = (base + 64).min(len);
+
+        let mut bits = word;
+        while bits != 0 {
+            let bit_pos = bits.trailing_zeros() as usize;
+            let idx = base + bit_pos;
+            if idx < end {
+                result = result.min(values[idx]);
+            }
+            bits &= bits - 1;
+        }
+    }
+
+    if result == i64::MAX {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+/// Max of i64 values where the corresponding bit in filter_mask is set.
+#[inline]
+pub fn max_i64_packed_filtered(values: &[i64], filter_mask: &PackedMask) -> Option<i64> {
+    debug_assert_eq!(values.len(), filter_mask.len(), "Arrays must have same length");
+
+    let len = values.len();
+    if len == 0 {
+        return None;
+    }
+
+    let mut result = i64::MIN;
+    let words = filter_mask.words();
+
+    for (word_idx, &word) in words.iter().enumerate() {
+        if word == 0 {
+            continue;
+        }
+
+        let base = word_idx * 64;
+        let end = (base + 64).min(len);
+
+        let mut bits = word;
+        while bits != 0 {
+            let bit_pos = bits.trailing_zeros() as usize;
+            let idx = base + bit_pos;
+            if idx < end {
+                result = result.max(values[idx]);
+            }
+            bits &= bits - 1;
+        }
+    }
+
+    if result == i64::MIN {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+/// Sum of element-wise product with packed filter mask AND null masks.
+///
+/// Full version that handles both filter predicates and NULL values.
+#[inline]
+pub fn sum_product_f64_packed_filtered_masked(
+    a: &[f64],
+    b: &[f64],
+    filter_mask: &PackedMask,
+    null_a: Option<&[bool]>,
+    null_b: Option<&[bool]>,
+) -> (f64, i64) {
+    let len = a.len().min(b.len()).min(filter_mask.len());
+    if len == 0 {
+        return (0.0, 0);
+    }
+
+    // Fast path: no nulls
+    let no_nulls_a = null_a.is_none_or(|n| n.len() < len || !n[..len].iter().any(|&x| x));
+    let no_nulls_b = null_b.is_none_or(|n| n.len() < len || !n[..len].iter().any(|&x| x));
+
+    if no_nulls_a && no_nulls_b {
+        return sum_product_f64_packed_filtered(a, b, filter_mask);
+    }
+
+    // Slow path with null handling
+    let null_mask_a = null_a.unwrap_or(&[]);
+    let null_mask_b = null_b.unwrap_or(&[]);
+
+    let mut sum = 0.0f64;
+    let mut count = 0i64;
+    let words = filter_mask.words();
+
+    for (word_idx, &word) in words.iter().enumerate() {
+        if word == 0 {
+            continue;
+        }
+
+        let base = word_idx * 64;
+        let end = (base + 64).min(len);
+
+        let mut bits = word;
+        while bits != 0 {
+            let bit_pos = bits.trailing_zeros() as usize;
+            let idx = base + bit_pos;
+            if idx < end {
+                let is_null_a = null_mask_a.get(idx).copied().unwrap_or(false);
+                let is_null_b = null_mask_b.get(idx).copied().unwrap_or(false);
+
+                if !is_null_a && !is_null_b {
+                    sum += a[idx] * b[idx];
+                    count += 1;
+                }
+            }
+            bits &= bits - 1;
+        }
+    }
+
+    (sum, count)
+}
+
+// ============================================================================
 // MASK OPERATIONS (Boolean operations on filter masks)
 // ============================================================================
 
@@ -1103,5 +2213,299 @@ mod tests {
     fn test_between_f64() {
         let values = vec![0.01, 0.05, 0.06, 0.07, 0.08];
         assert_eq!(between_f64(&values, 0.05, 0.07), vec![false, true, true, true, false]);
+    }
+
+    // ========================================================================
+    // PACKED MASK TESTS
+    // ========================================================================
+
+    #[test]
+    fn test_packed_mask_new_all_set() {
+        let mask = PackedMask::new_all_set(100);
+        assert_eq!(mask.len(), 100);
+        for i in 0..100 {
+            assert!(mask.get(i), "bit {} should be set", i);
+        }
+
+        // Empty mask
+        let empty = PackedMask::new_all_set(0);
+        assert_eq!(empty.len(), 0);
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn test_packed_mask_new_all_clear() {
+        let mask = PackedMask::new_all_clear(100);
+        assert_eq!(mask.len(), 100);
+        for i in 0..100 {
+            assert!(!mask.get(i), "bit {} should be clear", i);
+        }
+    }
+
+    #[test]
+    fn test_packed_mask_set_get() {
+        let mut mask = PackedMask::new_all_clear(128);
+
+        // Set some bits
+        mask.set(0, true);
+        mask.set(63, true);
+        mask.set(64, true);
+        mask.set(127, true);
+
+        assert!(mask.get(0));
+        assert!(mask.get(63));
+        assert!(mask.get(64));
+        assert!(mask.get(127));
+        assert!(!mask.get(1));
+        assert!(!mask.get(62));
+        assert!(!mask.get(65));
+    }
+
+    #[test]
+    fn test_packed_mask_and_inplace() {
+        let mut mask_a = PackedMask::new_all_set(128);
+        let mut mask_b = PackedMask::new_all_clear(128);
+
+        // Set every other bit in mask_b
+        for i in (0..128).step_by(2) {
+            mask_b.set(i, true);
+        }
+
+        mask_a.and_inplace(&mask_b);
+
+        for i in 0..128 {
+            if i % 2 == 0 {
+                assert!(mask_a.get(i), "bit {} should be set (even)", i);
+            } else {
+                assert!(!mask_a.get(i), "bit {} should be clear (odd)", i);
+            }
+        }
+    }
+
+    #[test]
+    fn test_packed_mask_count_ones() {
+        let mask = PackedMask::new_all_set(100);
+        assert_eq!(mask.count_ones(), 100);
+
+        let mask = PackedMask::new_all_clear(100);
+        assert_eq!(mask.count_ones(), 0);
+
+        let mut mask = PackedMask::new_all_clear(128);
+        for i in (0..128).step_by(2) {
+            mask.set(i, true);
+        }
+        assert_eq!(mask.count_ones(), 64);
+    }
+
+    #[test]
+    fn test_packed_mask_from_bool_slice() {
+        let bools = vec![true, false, true, true, false, true];
+        let mask = PackedMask::from_bool_slice(&bools);
+
+        assert_eq!(mask.len(), 6);
+        assert!(mask.get(0));
+        assert!(!mask.get(1));
+        assert!(mask.get(2));
+        assert!(mask.get(3));
+        assert!(!mask.get(4));
+        assert!(mask.get(5));
+        assert_eq!(mask.count_ones(), 4);
+    }
+
+    #[test]
+    fn test_packed_mask_to_bool_vec() {
+        let mut mask = PackedMask::new_all_clear(6);
+        mask.set(0, true);
+        mask.set(2, true);
+        mask.set(3, true);
+        mask.set(5, true);
+
+        let bools = mask.to_bool_vec();
+        assert_eq!(bools, vec![true, false, true, true, false, true]);
+    }
+
+    #[test]
+    fn test_packed_mask_round_trip() {
+        let original = vec![true, false, true, true, false, true, false, false, true];
+        let mask = PackedMask::from_bool_slice(&original);
+        let result = mask.to_bool_vec();
+        assert_eq!(original, result);
+    }
+
+    #[test]
+    fn test_packed_comparison_i64() {
+        let values = vec![1i64, 2, 3, 4, 5];
+
+        let mask = lt_i64_packed(&values, 3);
+        assert_eq!(mask.to_bool_vec(), vec![true, true, false, false, false]);
+
+        let mask = gt_i64_packed(&values, 3);
+        assert_eq!(mask.to_bool_vec(), vec![false, false, false, true, true]);
+
+        let mask = le_i64_packed(&values, 3);
+        assert_eq!(mask.to_bool_vec(), vec![true, true, true, false, false]);
+
+        let mask = ge_i64_packed(&values, 3);
+        assert_eq!(mask.to_bool_vec(), vec![false, false, true, true, true]);
+
+        let mask = eq_i64_packed(&values, 3);
+        assert_eq!(mask.to_bool_vec(), vec![false, false, true, false, false]);
+
+        let mask = ne_i64_packed(&values, 3);
+        assert_eq!(mask.to_bool_vec(), vec![true, true, false, true, true]);
+    }
+
+    #[test]
+    fn test_packed_comparison_f64() {
+        let values = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+
+        let mask = lt_f64_packed(&values, 3.0);
+        assert_eq!(mask.to_bool_vec(), vec![true, true, false, false, false]);
+
+        let mask = ge_f64_packed(&values, 3.0);
+        assert_eq!(mask.to_bool_vec(), vec![false, false, true, true, true]);
+    }
+
+    #[test]
+    fn test_packed_between_i64() {
+        let values = vec![1i64, 5, 10, 15, 20, 25];
+        let mask = between_i64_packed(&values, 5, 20);
+        assert_eq!(mask.to_bool_vec(), vec![false, true, true, true, true, false]);
+    }
+
+    #[test]
+    fn test_packed_between_f64() {
+        let values = vec![0.01, 0.05, 0.06, 0.07, 0.08];
+        let mask = between_f64_packed(&values, 0.05, 0.07);
+        assert_eq!(mask.to_bool_vec(), vec![false, true, true, true, false]);
+    }
+
+    #[test]
+    fn test_sum_f64_packed_filtered() {
+        let values = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let mut mask = PackedMask::new_all_clear(8);
+        for i in (0..8).step_by(2) {
+            mask.set(i, true);
+        }
+        // Sum of 1, 3, 5, 7 = 16
+        assert!((sum_f64_packed_filtered(&values, &mask) - 16.0).abs() < 0.001);
+
+        // All true
+        let mask_all = PackedMask::new_all_set(8);
+        assert!((sum_f64_packed_filtered(&values, &mask_all) - 36.0).abs() < 0.001);
+
+        // All false
+        let mask_none = PackedMask::new_all_clear(8);
+        assert_eq!(sum_f64_packed_filtered(&values, &mask_none), 0.0);
+    }
+
+    #[test]
+    fn test_sum_i64_packed_filtered() {
+        let values = vec![1i64, 2, 3, 4, 5, 6, 7, 8];
+        let mut mask = PackedMask::new_all_clear(8);
+        for i in (0..8).step_by(2) {
+            mask.set(i, true);
+        }
+        assert_eq!(sum_i64_packed_filtered(&values, &mask), 16);
+    }
+
+    #[test]
+    fn test_count_packed_filtered() {
+        let mut mask = PackedMask::new_all_clear(8);
+        for i in (0..8).step_by(2) {
+            mask.set(i, true);
+        }
+        assert_eq!(count_packed_filtered(&mask), 4);
+    }
+
+    #[test]
+    fn test_sum_product_f64_packed_filtered() {
+        let prices = vec![100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0];
+        let discounts = vec![0.05, 0.06, 0.07, 0.05, 0.06, 0.07, 0.05, 0.06];
+
+        let mut filter = PackedMask::new_all_clear(8);
+        for i in (0..8).step_by(2) {
+            filter.set(i, true);
+        }
+
+        // Only indices 0, 2, 4, 6: 100*0.05 + 300*0.07 + 500*0.06 + 700*0.05
+        //                        = 5 + 21 + 30 + 35 = 91
+        let (sum, count) = sum_product_f64_packed_filtered(&prices, &discounts, &filter);
+        assert!((sum - 91.0).abs() < 0.001);
+        assert_eq!(count, 4);
+
+        // All pass filter
+        let filter_all = PackedMask::new_all_set(8);
+        let (sum, count) = sum_product_f64_packed_filtered(&prices, &discounts, &filter_all);
+        assert!((sum - 213.0).abs() < 0.001);
+        assert_eq!(count, 8);
+    }
+
+    #[test]
+    fn test_min_max_f64_packed_filtered() {
+        let values = vec![5.0, 2.0, 8.0, 1.0, 9.0, 3.0, 7.0, 4.0];
+        let mut filter = PackedMask::new_all_clear(8);
+        for i in (0..8).step_by(2) {
+            filter.set(i, true);
+        }
+
+        // Only indices 0, 2, 4, 6: values 5, 8, 9, 7
+        assert_eq!(min_f64_packed_filtered(&values, &filter), Some(5.0));
+        assert_eq!(max_f64_packed_filtered(&values, &filter), Some(9.0));
+
+        // No rows pass filter
+        let filter_none = PackedMask::new_all_clear(8);
+        assert_eq!(min_f64_packed_filtered(&values, &filter_none), None);
+        assert_eq!(max_f64_packed_filtered(&values, &filter_none), None);
+    }
+
+    #[test]
+    fn test_min_max_i64_packed_filtered() {
+        let values = vec![5i64, 2, 8, 1, 9, 3, 7, 4];
+        let mut filter = PackedMask::new_all_clear(8);
+        for i in (0..8).step_by(2) {
+            filter.set(i, true);
+        }
+
+        assert_eq!(min_i64_packed_filtered(&values, &filter), Some(5));
+        assert_eq!(max_i64_packed_filtered(&values, &filter), Some(9));
+
+        let filter_none = PackedMask::new_all_clear(8);
+        assert_eq!(min_i64_packed_filtered(&values, &filter_none), None);
+        assert_eq!(max_i64_packed_filtered(&values, &filter_none), None);
+    }
+
+    #[test]
+    fn test_packed_mask_large_dataset() {
+        // Test with a large dataset to ensure correctness at scale
+        let n = 10_000;
+        let values: Vec<f64> = (0..n).map(|i| i as f64).collect();
+
+        // Filter: values < 5000 (half the dataset)
+        let mask = lt_f64_packed(&values, 5000.0);
+
+        assert_eq!(mask.count_ones(), 5000);
+
+        // Sum of 0..4999 = 4999 * 5000 / 2 = 12497500
+        let sum = sum_f64_packed_filtered(&values, &mask);
+        assert!((sum - 12497500.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_packed_mask_partial_word() {
+        // Test with sizes that don't fill a complete u64 word
+        for size in [1, 7, 15, 63, 65, 100, 127, 129] {
+            let mask = PackedMask::new_all_set(size);
+            assert_eq!(mask.count_ones(), size, "failed for size {}", size);
+
+            let mask = PackedMask::new_all_clear(size);
+            assert_eq!(mask.count_ones(), 0, "failed for size {}", size);
+
+            // Test conversion round-trip
+            let bools = vec![true; size];
+            let mask = PackedMask::from_bool_slice(&bools);
+            assert_eq!(mask.count_ones(), size, "round-trip failed for size {}", size);
+            assert_eq!(mask.to_bool_vec(), bools, "round-trip failed for size {}", size);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add `PackedMask` type wrapping `Vec<u64>` for 8x memory reduction in filter masks
- Add packed comparison operations (`lt_i64_packed`, `gt_f64_packed`, `between_*_packed`, etc.)
- Add packed filtered aggregation operations (`sum_f64_packed_filtered`, `sum_product_f64_packed_filtered`, etc.)
- Add `simd_create_filter_mask_packed()` function for creating packed filter masks
- Export `PackedMask` and `simd_create_filter_mask_packed` from columnar module

## Performance Benefits

For 6M rows (lineitem at TPC-H SF 1):
- `Vec<bool>`: 6 MB per predicate
- `PackedMask`: 750 KB per predicate (8x reduction)

Bitwise AND for combining predicates maps directly to SIMD instructions (`vpand` on x86, `and` on ARM).

## Test plan

- [x] Add 20 unit tests for `PackedMask` type
- [x] Run all 1541 executor tests - all pass
- [ ] Run TPC-H Q6 benchmark to verify performance improvement

Closes #3033

🤖 Generated with [Claude Code](https://claude.com/claude-code)