### PR TITLE
chore(executor): Remove unused combine_masks function from simd_ops.rs

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/simd_ops.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_ops.rs
@@ -795,29 +795,6 @@ pub fn and_masks_inplace(mask: &mut [bool], other: &[bool]) {
     }
 }
 
-/// Create a combined filter mask from multiple predicates using in-place AND.
-///
-/// Returns a mask where `result[i] = pred1[i] && pred2[i] && ...`
-/// This is more efficient than repeatedly allocating and ANDing masks.
-///
-/// # Arguments
-/// * `masks` - Iterator of boolean mask slices to combine
-/// * `len` - Expected length of each mask
-///
-/// # Returns
-/// Combined mask with all predicates ANDed together
-#[inline]
-pub fn combine_masks<'a>(masks: impl Iterator<Item = &'a [bool]>, len: usize) -> Vec<bool> {
-    let mut result = vec![true; len];
-
-    for mask in masks {
-        assert_eq!(mask.len(), len, "all masks must have same length");
-        and_masks_inplace(&mut result, mask);
-    }
-
-    result
-}
-
 // ============================================================================
 // TESTS
 // ============================================================================


### PR DESCRIPTION
## Summary
- Removes the unused `combine_masks` function from `simd_ops.rs`
- The function was added in #3030 but never used

## Analysis

The current implementation uses `and_masks_inplace` directly in a loop, which is the correct approach:

| Factor | Current Approach | Parallel Predicates (what combine_masks was for) |
|--------|-----------------|---------------------|
| Data parallelism | SIMD (4-8 elements/instruction) | Same |
| Thread overhead | None at predicate level | Significant for <100K rows |
| Memory bandwidth | Single-pass through data | Multiple concurrent accesses |
| Cache efficiency | Sequential access | Potential cache thrashing |

Parallel predicate evaluation is not a compelling optimization because:
1. SIMD already handles data-level parallelism effectively
2. Batch/scan-level parallelism is the right granularity for thread parallelism
3. Sequential predicate evaluation has better cache locality

## Test plan
- [x] `cargo check -p vibesql-executor` passes
- [x] All 22 simd_ops tests pass

Closes #3034

🤖 Generated with [Claude Code](https://claude.com/claude-code)