### PR TITLE
fix(index): Fix index maintenance case-sensitivity and nullable ORDER BY

### DIFF
--- a/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
@@ -4,7 +4,34 @@
 //! Supports both rule-based (simple) and cost-based (statistics-aware) selection.
 
 use vibesql_ast::Expression;
+use vibesql_catalog::TableSchema;
 use vibesql_storage::{Database, statistics::{CostEstimator, AccessMethod}};
+
+/// Check if any ORDER BY column is nullable
+///
+/// BTreeMap orders NULLs first (NULL < everything), but SQL default is:
+/// - NULLS LAST for ASC
+/// - NULLS FIRST for DESC
+///
+/// When a nullable column is used for ORDER BY without explicit NULLS FIRST/LAST,
+/// using an index would produce incorrect NULL ordering. This function helps
+/// detect such cases to avoid using the index for ORDER BY.
+fn any_order_by_column_nullable(
+    order_items: &[vibesql_ast::OrderByItem],
+    table_schema: &TableSchema,
+) -> bool {
+    for item in order_items {
+        if let Expression::ColumnRef { column, .. } = &item.expr {
+            // Look up column in schema (case-insensitive)
+            if let Some(idx) = table_schema.get_column_index(column) {
+                if table_schema.columns[idx].nullable {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
 
 /// Determines if an index scan is beneficial for the given query
 ///
@@ -27,7 +54,7 @@ pub(crate) fn should_use_index_scan(
     // applied as a post-filter in execute_index_scan() to ensure correctness.
 
     // Get all indexes for this table
-    let _table = database.get_table(table_name)?;
+    let table = database.get_table(table_name)?;
     let indexes = database.list_indexes_for_table(table_name);
 
     if indexes.is_empty() {
@@ -47,8 +74,16 @@ pub(crate) fn should_use_index_scan(
             // Check if this index can be used for ORDER BY clause
             let can_use_for_order = if let Some(order_items) = order_by {
                 // Check if ORDER BY columns match the index columns
-                // Support multi-column ORDER BY matching
-                can_use_index_for_order_by(order_items, &index_metadata.columns)
+                let columns_match = can_use_index_for_order_by(order_items, &index_metadata.columns);
+
+                // Don't use index for ORDER BY if any column is nullable
+                // BTreeMap orders NULLs first, but SQL default is NULLS LAST for ASC
+                // This would produce incorrect results for nullable columns
+                if columns_match && any_order_by_column_nullable(order_items, &table.schema) {
+                    false
+                } else {
+                    columns_match
+                }
             } else {
                 false
             };
@@ -257,7 +292,16 @@ pub(crate) fn cost_based_index_selection(
                 .unwrap_or(false);
 
             let can_use_for_order = if let Some(order_items) = order_by {
-                can_use_index_for_order_by(order_items, &index_metadata.columns)
+                let columns_match = can_use_index_for_order_by(order_items, &index_metadata.columns);
+
+                // Don't use index for ORDER BY if any column is nullable
+                // BTreeMap orders NULLs first, but SQL default is NULLS LAST for ASC
+                // This would produce incorrect results for nullable columns
+                if columns_match && any_order_by_column_nullable(order_items, &table.schema) {
+                    false
+                } else {
+                    columns_match
+                }
             } else {
                 false
             };

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance.rs
@@ -207,7 +207,10 @@ impl IndexManager {
         row_index: usize,
     ) {
         for (index_name, metadata) in &self.indexes {
-            if metadata.table_name == table_name {
+            // Case-insensitive comparison for table name matching
+            // SQL parser normalizes identifiers to uppercase, but table/index metadata
+            // may store the original case from DDL statements
+            if metadata.table_name.eq_ignore_ascii_case(table_name) {
                 if let Some(index_data) = self.index_data.get_mut(index_name) {
                     // Build composite key from the indexed columns
                     // Normalize numeric types to ensure consistent comparison
@@ -261,7 +264,10 @@ impl IndexManager {
         row_index: usize,
     ) {
         for (index_name, metadata) in &self.indexes {
-            if metadata.table_name == table_name {
+            // Case-insensitive comparison for table name matching
+            // SQL parser normalizes identifiers to uppercase, but table/index metadata
+            // may store the original case from DDL statements
+            if metadata.table_name.eq_ignore_ascii_case(table_name) {
                 if let Some(index_data) = self.index_data.get_mut(index_name) {
                     // Build keys from old and new rows
                     // Normalize numeric types to ensure consistent comparison
@@ -343,7 +349,10 @@ impl IndexManager {
         row_index: usize,
     ) {
         for (index_name, metadata) in &self.indexes {
-            if metadata.table_name == table_name {
+            // Case-insensitive comparison for table name matching
+            // SQL parser normalizes identifiers to uppercase, but table/index metadata
+            // may store the original case from DDL statements
+            if metadata.table_name.eq_ignore_ascii_case(table_name) {
                 if let Some(index_data) = self.index_data.get_mut(index_name) {
                     // Build key from the row
                     let key_values: Vec<SqlValue> = metadata
@@ -398,10 +407,11 @@ impl IndexManager {
         table_rows: &[Row],
     ) {
         // Collect index names that need rebuilding
+        // Case-insensitive comparison for table name matching
         let indexes_to_rebuild: Vec<String> = self
             .indexes
             .iter()
-            .filter(|(_, metadata)| metadata.table_name == table_name)
+            .filter(|(_, metadata)| metadata.table_name.eq_ignore_ascii_case(table_name))
             .map(|(name, _)| name.clone())
             .collect();
 


### PR DESCRIPTION
## Summary
- Fixed case-sensitive table name comparison in index maintenance that prevented indexes from updating during INSERT/UPDATE/DELETE when parser normalizes identifiers to uppercase
- Fixed incorrect NULL ordering when using index for ORDER BY on nullable columns (BTreeMap orders NULLs first, but SQL default is NULLS LAST for ASC)

## Test plan
- [x] `test_updates_affecting_non_unique_indexes` now passes (was returning 0 rows instead of 1 after UPDATE)
- [x] `test_order_by_with_nulls_asc` now passes (was returning NULLs first instead of last)
- [x] All 21 order_by tests pass
- [x] All 99 index tests pass
- [x] All 256 storage tests pass

Closes #3046

🤖 Generated with [Claude Code](https://claude.com/claude-code)