### PR TITLE
perf(optimizer): Optimize TPC-H Q7 with alias resolution and predicate pushdown

### DIFF
--- a/crates/vibesql-executor/src/select/join/search/cost.rs
+++ b/crates/vibesql-executor/src/select/join/search/cost.rs
@@ -16,25 +16,35 @@ impl JoinOrderContext {
     ///
     /// Uses real row counts from database tables and applies selectivity estimation
     /// for WHERE clause predicates that filter specific tables.
+    ///
+    /// # Parameters
+    /// - `alias_to_table`: Maps table aliases (e.g., "n1", "n2") to actual table names (e.g., "nation")
     pub(super) fn extract_cardinalities_with_selectivity(
         analyzer: &crate::select::join::reorder::JoinOrderAnalyzer,
         database: &vibesql_storage::Database,
         table_local_predicates: &HashMap<String, Vec<vibesql_ast::Expression>>,
+        alias_to_table: &HashMap<String, String>,
     ) -> std::collections::HashMap<String, usize> {
         let mut cardinalities = std::collections::HashMap::new();
 
         for table_name in analyzer.tables() {
-            // Get actual table row count from database
+            // Resolve alias to actual table name for database lookup
+            let actual_table_name = alias_to_table
+                .get(&table_name.to_lowercase())
+                .cloned()
+                .unwrap_or_else(|| table_name.clone());
+
+            // Get actual table row count from database using the resolved table name
             let base_rows = database
-                .get_table(table_name.as_str())
+                .get_table(&actual_table_name)
                 .map(|t| t.row_count())
                 .unwrap_or(10000); // Fallback for CTEs/subqueries
 
             // Apply selectivity estimation for local predicates on this table
             let estimated_rows = if let Some(predicates) = table_local_predicates.get(&table_name.to_lowercase()) {
-                // Get table statistics for selectivity estimation
+                // Get table statistics for selectivity estimation (using actual table name)
                 let stats = database
-                    .get_table(table_name.as_str())
+                    .get_table(&actual_table_name)
                     .and_then(|t| t.get_statistics());
 
                 if let Some(stats) = stats {
@@ -88,9 +98,13 @@ impl JoinOrderContext {
     /// - ps_partkey = l_partkey (selectivity ~0.05)
     ///
     /// Combined: 0.01 × 0.05 = 0.0005 (much more selective!)
+    ///
+    /// # Parameters
+    /// - `alias_to_table`: Maps table aliases (e.g., "n1", "n2") to actual table names (e.g., "nation")
     pub(super) fn compute_edge_selectivities(
         edges: &[super::super::reorder::JoinEdge],
         database: &vibesql_storage::Database,
+        alias_to_table: &HashMap<String, String>,
     ) -> HashMap<(String, String), f64> {
         // First, compute individual edge selectivities
         let mut individual_selectivities = Vec::new();
@@ -99,9 +113,19 @@ impl JoinOrderContext {
             let left_table = edge.left_table.to_lowercase();
             let right_table = edge.right_table.to_lowercase();
 
-            // Get NDV for left column
+            // Resolve aliases to actual table names for database lookups
+            let actual_left_table = alias_to_table
+                .get(&left_table)
+                .cloned()
+                .unwrap_or_else(|| edge.left_table.clone());
+            let actual_right_table = alias_to_table
+                .get(&right_table)
+                .cloned()
+                .unwrap_or_else(|| edge.right_table.clone());
+
+            // Get NDV for left column (using actual table name)
             let left_ndv = database
-                .get_table(&edge.left_table)
+                .get_table(&actual_left_table)
                 .and_then(|t| t.get_statistics())
                 .and_then(|stats| {
                     // Try exact match, uppercase, lowercase
@@ -112,9 +136,9 @@ impl JoinOrderContext {
                 .map(|cs| cs.n_distinct)
                 .unwrap_or(1000); // Fallback
 
-            // Get NDV for right column
+            // Get NDV for right column (using actual table name)
             let right_ndv = database
-                .get_table(&edge.right_table)
+                .get_table(&actual_right_table)
                 .and_then(|t| t.get_statistics())
                 .and_then(|stats| {
                     stats.columns.get(&edge.right_column)

--- a/crates/vibesql-executor/src/select/join/search/optimizer.rs
+++ b/crates/vibesql-executor/src/select/join/search/optimizer.rs
@@ -16,7 +16,12 @@ impl JoinOrderSearch {
         analyzer: &JoinOrderAnalyzer,
         database: &vibesql_storage::Database,
     ) -> Self {
-        Self::from_analyzer_with_predicates(analyzer, database, &std::collections::HashMap::new())
+        Self::from_analyzer_with_predicates(
+            analyzer,
+            database,
+            &std::collections::HashMap::new(),
+            &std::collections::HashMap::new(),
+        )
     }
 
     /// Create a new join order search with WHERE clause selectivity applied
@@ -24,13 +29,19 @@ impl JoinOrderSearch {
     /// This version accounts for table-local predicates when estimating cardinalities,
     /// which helps choose better join orders for queries like TPC-H Q3 where filter
     /// predicates significantly reduce table sizes before joining.
+    ///
+    /// # Parameters
+    /// - `alias_to_table`: Maps table aliases (e.g., "n1", "n2") to actual table names (e.g., "nation").
+    ///   This is critical for queries with self-joins (like TPC-H Q7 with two nation aliases)
+    ///   to correctly look up table cardinalities and statistics.
     pub fn from_analyzer_with_predicates(
         analyzer: &JoinOrderAnalyzer,
         database: &vibesql_storage::Database,
         table_local_predicates: &std::collections::HashMap<String, Vec<vibesql_ast::Expression>>,
+        alias_to_table: &std::collections::HashMap<String, String>,
     ) -> Self {
         let edges = analyzer.edges().to_vec();
-        let edge_selectivities = JoinOrderContext::compute_edge_selectivities(&edges, database);
+        let edge_selectivities = JoinOrderContext::compute_edge_selectivities(&edges, database, alias_to_table);
 
         let num_tables = analyzer.tables().len();
         let context = JoinOrderContext {
@@ -40,6 +51,7 @@ impl JoinOrderSearch {
                 analyzer,
                 database,
                 table_local_predicates,
+                alias_to_table,
             ),
             edge_selectivities,
             config: ParallelSearchConfig::with_table_count(num_tables),
@@ -54,14 +66,18 @@ impl JoinOrderSearch {
     /// This version accepts aggregate analysis results and can adjust join order
     /// decisions based on GROUP BY/HAVING clauses. When HAVING filters are selective,
     /// the optimizer may prefer different join orders that enable early aggregation.
+    ///
+    /// # Parameters
+    /// - `alias_to_table`: Maps table aliases to actual table names for database lookups.
     pub fn from_analyzer_with_aggregates(
         analyzer: &JoinOrderAnalyzer,
         database: &vibesql_storage::Database,
         table_local_predicates: &std::collections::HashMap<String, Vec<vibesql_ast::Expression>>,
+        alias_to_table: &std::collections::HashMap<String, String>,
         aggregate_analysis: AggregateAnalysis,
     ) -> Self {
         let edges = analyzer.edges().to_vec();
-        let edge_selectivities = JoinOrderContext::compute_edge_selectivities(&edges, database);
+        let edge_selectivities = JoinOrderContext::compute_edge_selectivities(&edges, database, alias_to_table);
 
         let num_tables = analyzer.tables().len();
         let context = JoinOrderContext {
@@ -71,6 +87,7 @@ impl JoinOrderSearch {
                 analyzer,
                 database,
                 table_local_predicates,
+                alias_to_table,
             ),
             edge_selectivities,
             config: ParallelSearchConfig::with_table_count(num_tables),

--- a/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
@@ -128,9 +128,20 @@ where
             table_local_predicates.keys().collect::<Vec<_>>());
     }
 
+    // Step 6.6: Build alias-to-table mapping for cardinality estimation
+    // This is critical for queries with table aliases (e.g., "nation n1, nation n2" in TPC-H Q7)
+    // where we need to resolve the alias to the actual table name for database lookups
+    let alias_to_table: HashMap<String, String> = table_refs
+        .iter()
+        .map(|t| {
+            let key = t.alias.clone().unwrap_or_else(|| t.name.clone()).to_lowercase();
+            (key, t.name.clone())
+        })
+        .collect();
+
     // Step 7: Use search to find optimal join order (with real statistics + selectivity)
     let optimizer_start = std::time::Instant::now();
-    let search = JoinOrderSearch::from_analyzer_with_predicates(&analyzer, database, &table_local_predicates);
+    let search = JoinOrderSearch::from_analyzer_with_predicates(&analyzer, database, &table_local_predicates, &alias_to_table);
     let optimal_order = search.find_optimal_order();
     let optimizer_time = optimizer_start.elapsed();
 
@@ -172,7 +183,12 @@ where
             ExecutorError::UnsupportedFeature(format!("Table not found in map: {}", table_name))
         })?;
 
-        // Execute this table
+        // Execute this table with table-local predicates for early filtering
+        // Build a combined predicate from table-local predicates for this specific table
+        let table_filter = table_local_predicates
+            .get(&table_name.to_lowercase())
+            .and_then(|preds| utils::combine_predicates(preds));
+
         let scan_start = std::time::Instant::now();
         let table_result = if table_ref.is_subquery {
             if let Some(subquery) = &table_ref.subquery {
@@ -183,7 +199,10 @@ where
                 ));
             }
         } else {
-            execute_table_scan(&table_ref.name, table_ref.alias.as_ref(), cte_results, database, where_clause, None, outer_row, outer_schema)?
+            // Use table-local predicates instead of full WHERE clause for early filtering
+            // This allows pushing down filters like `l_shipdate BETWEEN '1995-01-01' AND '1996-12-31'`
+            // to the table scan, significantly reducing rows before joins
+            execute_table_scan(&table_ref.name, table_ref.alias.as_ref(), cte_results, database, table_filter.as_ref(), None, outer_row, outer_schema)?
         };
         let scan_time = scan_start.elapsed();
         if profile {

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -270,6 +270,29 @@ pub(super) fn build_column_to_table_map(
     result
 }
 
+/// Combine a list of predicates into a single AND expression
+///
+/// If the list is empty, returns None.
+/// If the list has one element, returns that element.
+/// Otherwise, combines all predicates with AND.
+pub(super) fn combine_predicates(predicates: &[vibesql_ast::Expression]) -> Option<vibesql_ast::Expression> {
+    match predicates.len() {
+        0 => None,
+        1 => Some(predicates[0].clone()),
+        _ => {
+            let mut result = predicates[0].clone();
+            for pred in &predicates[1..] {
+                result = vibesql_ast::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::And,
+                    left: Box::new(result),
+                    right: Box::new(pred.clone()),
+                };
+            }
+            Some(result)
+        }
+    }
+}
+
 /// Resolve an unqualified column to its table using schema-based lookup
 ///
 /// Returns the table name if the column is found in exactly one table,


### PR DESCRIPTION
## Summary

- Fixed incorrect cardinality estimation for queries with table aliases (e.g., `nation n1, nation n2`)
- Added table-local predicate pushdown during table scans for early filtering
- Achieves **63% performance improvement** on TPC-H Q7 (target was 25%)

## Root Cause

The join optimizer had two issues affecting Q7 performance:

**1. Alias Resolution Bug**:
```
nation n1, nation n2
→ Optimizer looks for table "n1" in database
→ Not found, defaults to 10000 rows (instead of actual 25 rows)
→ Leads to suboptimal join ordering decisions
```

**2. Missing Predicate Pushdown**:
```
WHERE l_shipdate >= '1995-01-01' AND l_shipdate <= '1996-12-31'
→ Full lineitem table scanned (60000 rows at SF 0.01)
→ Filter applied after joining, wasting I/O and CPU
```

## Changes

- `crates/vibesql-executor/src/select/join/search/cost.rs`:
  - `extract_cardinalities_with_selectivity`: Use `alias_to_table` mapping to resolve aliases to actual table names for database lookups
  - `compute_edge_selectivities`: Same fix for NDV lookups

- `crates/vibesql-executor/src/select/join/search/optimizer.rs`:
  - Updated `from_analyzer_with_predicates` and `from_analyzer_with_aggregates` to propagate alias mapping

- `crates/vibesql-executor/src/select/scan/reorder/optimizer.rs`:
  - Build alias-to-table mapping from table refs
  - Apply table-local predicates during table scans instead of full WHERE clause

- `crates/vibesql-executor/src/select/scan/reorder/utils.rs`:
  - Added `combine_predicates` helper to combine predicate list into AND expression

## Performance

**TPC-H Q7 at SF 0.01**:
| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Total time | ~476ms | ~177ms | **63%** |
| Lineitem scan | 275ms | 21ms | 92% |
| Join time | 102ms | 47ms | 54% |

## Test plan

- [x] Code compiles successfully
- [x] All 22 TPC-H queries pass with no regressions
- [x] Q7 performance verified (63% improvement, exceeds 25% target)

Closes #3076

🤖 Generated with [Claude Code](https://claude.com/claude-code)