### PR TITLE
feat(benchmarks): Add WASM binary size to footprint benchmarks

### DIFF
--- a/scripts/benchmark_footprint.py
+++ b/scripts/benchmark_footprint.py
@@ -18,6 +18,7 @@ Usage:
     ./scripts/benchmark_footprint.py --output web-demo/public/benchmarks/footprint_results.json
 """
 
+import gzip
 import json
 import os
 import platform
@@ -30,7 +31,7 @@ import time
 from dataclasses import dataclass, asdict
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 
 # Number of runs for averaging startup/memory measurements
 NUM_RUNS = 10
@@ -49,6 +50,10 @@ class FootprintResult:
     version: str
     available: bool
     error: Optional[str] = None
+    # WASM-specific fields (only for VibeSQL)
+    wasm_size_bytes: Optional[int] = None
+    wasm_size_gzip_bytes: Optional[int] = None
+    wasm_size_brotli_bytes: Optional[int] = None
 
 
 @dataclass
@@ -76,6 +81,61 @@ def get_binary_size(path: str) -> int:
     if not os.path.exists(path):
         return 0
     return os.path.getsize(path)
+
+
+def get_compressed_size(path: str, compression: str = 'gzip') -> Optional[int]:
+    """Get the compressed size of a file.
+
+    Args:
+        path: Path to the file to compress
+        compression: 'gzip' or 'brotli'
+
+    Returns:
+        Compressed size in bytes, or None if compression fails
+    """
+    if not os.path.exists(path):
+        return None
+
+    try:
+        with open(path, 'rb') as f:
+            data = f.read()
+
+        if compression == 'gzip':
+            compressed = gzip.compress(data, compresslevel=9)
+            return len(compressed)
+        elif compression == 'brotli':
+            # Try to import brotli, but don't fail if not available
+            try:
+                import brotli
+                compressed = brotli.compress(data, quality=11)
+                return len(compressed)
+            except ImportError:
+                return None
+    except Exception:
+        return None
+
+    return None
+
+
+def measure_wasm_sizes(repo_root: Path) -> Tuple[Optional[int], Optional[int], Optional[int]]:
+    """Measure WASM binary sizes (raw, gzip, brotli).
+
+    Returns:
+        Tuple of (raw_size, gzip_size, brotli_size) in bytes.
+        Returns (None, None, None) if WASM file not found.
+    """
+    wasm_path = repo_root / "web-demo" / "public" / "pkg" / "vibesql_wasm_bg.wasm"
+
+    if not wasm_path.exists():
+        print(f"    WASM file not found: {wasm_path}")
+        print("    Run 'make build-wasm' to generate WASM bindings")
+        return None, None, None
+
+    raw_size = get_binary_size(str(wasm_path))
+    gzip_size = get_compressed_size(str(wasm_path), 'gzip')
+    brotli_size = get_compressed_size(str(wasm_path), 'brotli')
+
+    return raw_size, gzip_size, brotli_size
 
 
 def get_binary_version(db_name: str, binary_path: str) -> str:
@@ -312,7 +372,12 @@ def measure_startup_and_memory_linux(
     return avg_startup, stddev_startup, avg_memory, stddev_memory
 
 
-def measure_database(db_name: str, binary_path: str, num_runs: int = NUM_RUNS) -> FootprintResult:
+def measure_database(
+    db_name: str,
+    binary_path: str,
+    repo_root: Path,
+    num_runs: int = NUM_RUNS
+) -> FootprintResult:
     """Measure footprint for a single database."""
     print(f"  Measuring {db_name}...")
 
@@ -351,6 +416,20 @@ def measure_database(db_name: str, binary_path: str, num_runs: int = NUM_RUNS) -
     print(f"    Startup time: {avg_startup:.2f} ± {stddev_startup:.2f} ms")
     print(f"    Peak memory: {avg_memory:.0f} ± {stddev_memory:.0f} KB ({avg_memory/1024:.1f} MB)")
 
+    # Measure WASM sizes (only for VibeSQL)
+    wasm_size = None
+    wasm_gzip_size = None
+    wasm_brotli_size = None
+
+    if db_name == "vibesql":
+        wasm_size, wasm_gzip_size, wasm_brotli_size = measure_wasm_sizes(repo_root)
+        if wasm_size:
+            print(f"    WASM size: {wasm_size / (1024*1024):.2f} MB")
+            if wasm_gzip_size:
+                print(f"    WASM gzip: {wasm_gzip_size / (1024*1024):.2f} MB ({wasm_gzip_size/wasm_size*100:.1f}%)")
+            if wasm_brotli_size:
+                print(f"    WASM brotli: {wasm_brotli_size / (1024*1024):.2f} MB ({wasm_brotli_size/wasm_size*100:.1f}%)")
+
     return FootprintResult(
         database=db_name,
         binary_path=binary_path,
@@ -360,7 +439,10 @@ def measure_database(db_name: str, binary_path: str, num_runs: int = NUM_RUNS) -
         peak_memory_kb=avg_memory,
         peak_memory_stddev_kb=stddev_memory,
         version=version,
-        available=True
+        available=True,
+        wasm_size_bytes=wasm_size,
+        wasm_size_gzip_bytes=wasm_gzip_size,
+        wasm_size_brotli_bytes=wasm_brotli_size
     )
 
 
@@ -408,6 +490,9 @@ def run_benchmarks(output_path: Optional[str] = None, num_runs: int = NUM_RUNS) 
     print(f"Runs per database: {num_runs}")
     print()
 
+    # Get repo root for WASM path lookup
+    repo_root = Path(__file__).parent.parent
+
     # Find binaries
     print("📂 Locating database binaries...")
     binaries = find_binaries()
@@ -420,7 +505,7 @@ def run_benchmarks(output_path: Optional[str] = None, num_runs: int = NUM_RUNS) 
 
     results = []
     for db_name, binary_path in binaries.items():
-        result = measure_database(db_name, binary_path, num_runs)
+        result = measure_database(db_name, binary_path, repo_root, num_runs)
         results.append(asdict(result))
 
     # Create final results object

--- a/web-demo/src/benchmarks.ts
+++ b/web-demo/src/benchmarks.ts
@@ -181,6 +181,7 @@ const SUITE_CONFIGS: Record<BenchmarkSuite, SuiteConfig> = {
     opsLabel: 'databases compared',
     descriptions: {
       'binary_size': 'Binary Size - Size of the compiled database binary on disk',
+      'wasm_size': 'WASM Size - Size of the WebAssembly module for browser deployment',
       'startup_time': 'Startup Time - Time to cold-start and execute first query',
       'peak_memory': 'Peak Memory - Maximum resident set size during initialization',
     },
@@ -188,11 +189,12 @@ const SUITE_CONFIGS: Record<BenchmarkSuite, SuiteConfig> = {
       <h3 class="text-lg font-semibold text-foreground mb-2">Binary Footprint Benchmarks</h3>
       <p class="text-muted mb-4">
         <strong>Footprint benchmarks</strong> measure the resource efficiency of database binaries,
-        comparing binary size, cold startup time, and peak memory usage during initialization.
+        comparing binary size, WASM bundle size, cold startup time, and peak memory usage during initialization.
       </p>
 
       <ul class="space-y-2 text-muted">
-        <li><strong>Binary Size:</strong> Size of the compiled binary in bytes (stripped release build)</li>
+        <li><strong>Binary Size:</strong> Size of the compiled native binary in bytes (stripped release build)</li>
+        <li><strong>WASM Size:</strong> Size of the WebAssembly module (raw and gzip-compressed)</li>
         <li><strong>Startup Time:</strong> Time from process start to first query result (CREATE TABLE, INSERT, SELECT)</li>
         <li><strong>Peak Memory:</strong> Maximum resident set size (RSS) during cold startup</li>
         <li><strong>Measurement:</strong> macOS /usr/bin/time -l for memory, perf_counter for timing</li>
@@ -200,8 +202,9 @@ const SUITE_CONFIGS: Record<BenchmarkSuite, SuiteConfig> = {
       </ul>
 
       <p class="mt-4 text-muted">
-        Footprint benchmarks are critical for <strong>embedded and edge deployments</strong> where
-        binary size, startup latency, and memory consumption directly impact user experience and costs.
+        Footprint benchmarks are critical for <strong>embedded, edge, and web deployments</strong> where
+        binary size, WASM bundle size, startup latency, and memory consumption directly impact user experience and costs.
+        WASM gzip sizes are particularly relevant for web delivery, as browsers automatically decompress gzip content.
       </p>
 
       <p class="mt-2 text-muted text-sm">
@@ -248,6 +251,10 @@ interface FootprintBenchmark {
   version: string;
   available: boolean;
   error: string | null;
+  // WASM-specific fields (only for VibeSQL)
+  wasm_size_bytes?: number | null;
+  wasm_size_gzip_bytes?: number | null;
+  wasm_size_brotli_bytes?: number | null;
 }
 
 interface FootprintResults {
@@ -704,6 +711,8 @@ function renderFootprintTable(data: FootprintResults): void {
     thead.innerHTML = `
       <th class="px-4 py-3">Database</th>
       <th class="px-4 py-3 text-right">Binary Size</th>
+      <th class="px-4 py-3 text-right">WASM Size</th>
+      <th class="px-4 py-3 text-right">WASM (gzip)</th>
       <th class="px-4 py-3 text-right">Startup Time</th>
       <th class="px-4 py-3 text-right">Peak Memory</th>
       <th class="px-4 py-3 text-right">Version</th>
@@ -747,6 +756,33 @@ function renderFootprintTable(data: FootprintResults): void {
       ? `<span class="text-green-600 dark:text-green-400 font-semibold">${formatBytes(benchmark.binary_size_bytes)}</span>`
       : `<span class="text-muted">${formatBytes(benchmark.binary_size_bytes)}</span>`;
     row.appendChild(sizeCell);
+
+    // WASM size (only for VibeSQL)
+    const wasmCell = document.createElement('td');
+    wasmCell.className = 'px-4 py-3 text-right';
+    if (benchmark.wasm_size_bytes) {
+      wasmCell.innerHTML = `<span class="text-muted">${formatBytes(benchmark.wasm_size_bytes)}</span>`;
+    } else {
+      wasmCell.innerHTML = '<span class="text-muted/50">-</span>';
+    }
+    row.appendChild(wasmCell);
+
+    // WASM gzip size (only for VibeSQL)
+    const wasmGzipCell = document.createElement('td');
+    wasmGzipCell.className = 'px-4 py-3 text-right';
+    if (benchmark.wasm_size_gzip_bytes) {
+      // Show percentage of original WASM size
+      const ratio = benchmark.wasm_size_bytes
+        ? ((benchmark.wasm_size_gzip_bytes / benchmark.wasm_size_bytes) * 100).toFixed(0)
+        : '';
+      wasmGzipCell.innerHTML = `<span class="text-muted">${formatBytes(benchmark.wasm_size_gzip_bytes)}</span>`;
+      if (ratio) {
+        wasmGzipCell.title = `${ratio}% of uncompressed WASM`;
+      }
+    } else {
+      wasmGzipCell.innerHTML = '<span class="text-muted/50">-</span>';
+    }
+    row.appendChild(wasmGzipCell);
 
     // Startup time
     const startupCell = document.createElement('td');
@@ -844,12 +880,14 @@ function renderFootprintChart(data: FootprintResults): void {
     'mysql': 'MySQL',
   };
 
-  const labels = ['Binary Size (MB)', 'Startup Time (ms)', 'Peak Memory (MB)'];
+  const labels = ['Binary Size (MB)', 'WASM Size (MB)', 'WASM gzip (MB)', 'Startup Time (ms)', 'Peak Memory (MB)'];
 
   const datasets = availableBenchmarks.map(bench => ({
     label: dbDisplayNames[bench.database] || bench.database,
     data: [
       bench.binary_size_bytes / (1024 * 1024), // Convert to MB
+      bench.wasm_size_bytes ? bench.wasm_size_bytes / (1024 * 1024) : 0, // WASM size
+      bench.wasm_size_gzip_bytes ? bench.wasm_size_gzip_bytes / (1024 * 1024) : 0, // WASM gzip
       bench.startup_time_ms,
       bench.peak_memory_kb / 1024, // Convert to MB
     ],


### PR DESCRIPTION
## Summary
- Add WASM binary size tracking to footprint benchmarks for web deployment users
- Measure raw WASM size, gzip-compressed size, and optionally brotli-compressed size
- Display WASM size columns in the Footprint tab table and chart
- Update methodology text to document WASM metrics

## Changes
- `scripts/benchmark_footprint.py`: Add `measure_wasm_sizes()` function and `wasm_size_bytes`, `wasm_size_gzip_bytes`, `wasm_size_brotli_bytes` fields
- `web-demo/src/benchmarks.ts`: Update `FootprintBenchmark` interface and table/chart rendering

## Test plan
- [x] Python script runs successfully (handles missing WASM file gracefully)
- [x] New JSON fields appear in footprint benchmark output
- [ ] Web UI displays WASM columns in Footprint tab
- [ ] Chart shows WASM size bars for VibeSQL

Closes #3081

🤖 Generated with [Claude Code](https://claude.com/claude-code)