### PR TITLE
perf(executor): Optimize IN subquery semi/anti-join predicate pushdown

### DIFF
--- a/crates/vibesql-executor/src/optimizer/where_pushdown/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/where_pushdown/mod.rs
@@ -45,7 +45,7 @@ use crate::schema::CombinedSchema;
 // Re-exports
 pub(crate) use classification::classify_predicate_branch;
 pub(crate) use or_conditions::{combine_predicates_with_and, extract_implied_filters_from_or_predicates};
-pub(crate) use table_refs::flatten_conjuncts;
+pub(crate) use table_refs::{extract_referenced_tables_branch, flatten_conjuncts};
 
 // ============================================================================
 // Unified WHERE Clause Decomposition API

--- a/crates/vibesql-executor/src/select/join/hash_anti_join.rs
+++ b/crates/vibesql-executor/src/select/join/hash_anti_join.rs
@@ -3,9 +3,11 @@
 use ahash::AHashMap;
 
 use super::hash_join::build_existence_hash_table_parallel;
+use super::hash_semi_join::partition_filter_predicates;
 use super::{combine_rows, FromResult};
 use crate::errors::ExecutorError;
 use crate::evaluator::CombinedExpressionEvaluator;
+use crate::schema::CombinedSchema;
 use crate::timeout::{TimeoutContext, CHECK_INTERVAL};
 
 /// Hash anti-join implementation
@@ -90,22 +92,29 @@ pub(super) fn hash_anti_join(
 /// )
 /// ```
 ///
+/// ## Optimization: Right-Side Predicate Pushdown
+///
+/// When the filter contains predicates that reference only the right table (e.g., `s_quantity < 10`),
+/// these predicates are applied during the hash table build phase, reducing the hash table size.
+/// This is critical for NOT IN subquery performance.
+///
 /// Algorithm:
-/// 1. Build phase: Hash the RIGHT table on the equi-join column (O(n))
-/// 2. Probe phase: For each LEFT row:
+/// 1. **Predicate partitioning**: Split filter into right-only and cross-table predicates
+/// 2. **Build phase**: Hash the RIGHT table, applying right-only predicates as a pre-filter
+/// 3. **Probe phase**: For each LEFT row:
 ///    a. Check if hash table contains matching key
-///    b. If yes, verify additional filter conditions against ALL matching right rows
-///    c. If NO right row passes the filter, emit the left row (only once)
+///    b. If yes, verify cross-table predicates against ALL matching right rows
+///    c. If NO right row passes, emit the left row
 ///    d. If no matching key, emit the left row
 ///
-/// Performance: Still O(n + m) average case, much faster than nested loop O(n*m)
+/// Performance: O(n + m) average case with reduced hash table size
 pub(super) fn hash_anti_join_with_filter(
     left: FromResult,
     right: FromResult,
     left_col_idx: usize,
     right_col_idx: usize,
     additional_filter: Option<&vibesql_ast::Expression>,
-    combined_schema: &crate::schema::CombinedSchema,
+    combined_schema: &CombinedSchema,
     database: &vibesql_storage::Database,
 ) -> Result<FromResult, ExecutorError> {
     // If no additional filter, use the simpler version
@@ -122,28 +131,78 @@ pub(super) fn hash_anti_join_with_filter(
     let left_slice = left.as_slice();
     let right_slice = right.as_slice();
 
-    // Build phase: Create hash table from right side
-    // Unlike simple hash_anti_join, we need to store row indices to check the filter
+    // Partition the filter into right-only and cross-table predicates
+    let (right_only_filter, probe_filter) = partition_filter_predicates(
+        filter,
+        combined_schema,
+        &left.schema,
+        &right.schema,
+    );
+
+    // Create evaluators for build and probe phases
+    let right_only_evaluator = right_only_filter.as_ref().map(|_| {
+        CombinedExpressionEvaluator::with_database(&right.schema, database)
+    });
+
+    let probe_evaluator = probe_filter.as_ref().map(|_| {
+        CombinedExpressionEvaluator::with_database(combined_schema, database)
+    });
+
+    // Build phase: Create hash table from right side with right-only predicate filtering
     let mut hash_table: AHashMap<vibesql_types::SqlValue, Vec<usize>> = AHashMap::new();
+    let mut filtered_count = 0usize;
 
     for (idx, row) in right_slice.iter().enumerate() {
         // Check timeout periodically during build phase
         if idx % CHECK_INTERVAL == 0 {
             timeout_ctx.check()?;
         }
+
         let key = row.values[right_col_idx].clone();
         // Skip NULL values - they never match in equi-joins
-        if key != vibesql_types::SqlValue::Null {
+        if key == vibesql_types::SqlValue::Null {
+            continue;
+        }
+
+        // Apply right-only predicates as a pre-filter during build
+        if let (Some(right_filter), Some(evaluator)) = (&right_only_filter, &right_only_evaluator) {
+            evaluator.clear_cse_cache();
+            match evaluator.eval(right_filter, row) {
+                Ok(vibesql_types::SqlValue::Boolean(true)) => {
+                    // Row passes filter, add to hash table
+                    hash_table.entry(key).or_default().push(idx);
+                }
+                Ok(vibesql_types::SqlValue::Boolean(false))
+                | Ok(vibesql_types::SqlValue::Null) => {
+                    // Row doesn't pass filter, skip it
+                    filtered_count += 1;
+                    continue;
+                }
+                Err(_) | Ok(_) => {
+                    // Filter evaluation error or non-boolean, skip this row
+                    filtered_count += 1;
+                    continue;
+                }
+            }
+        } else {
+            // No right-only filter, add all rows
             hash_table.entry(key).or_default().push(idx);
         }
+    }
+
+    // Log build-time filtering if significant
+    if std::env::var("SEMI_JOIN_DEBUG").is_ok() && filtered_count > 0 {
+        eprintln!(
+            "[ANTI_JOIN] Build-time filtering: {} rows filtered out of {} ({:.1}%)",
+            filtered_count,
+            right_slice.len(),
+            (filtered_count as f64 / right_slice.len() as f64) * 100.0
+        );
     }
 
     // Probe phase: Check each left row for absence of a match that passes the filter
     let estimated_capacity = left_slice.len().min(100_000);
     let mut result_rows = Vec::with_capacity(estimated_capacity);
-
-    // Create evaluator for filter evaluation
-    let evaluator = CombinedExpressionEvaluator::with_database(combined_schema, database);
     let mut probe_iterations = 0;
 
     for left_row in left_slice.iter() {
@@ -164,8 +223,20 @@ pub(super) fn hash_anti_join_with_filter(
 
         // Check if key exists in hash table
         if let Some(right_indices) = hash_table.get(key) {
-            // Check if ANY matching right row passes the additional filter
+            // If no probe filter, any match means we skip this left row
+            if probe_filter.is_none() {
+                if right_indices.is_empty() {
+                    result_rows.push(left_row.clone());
+                }
+                // Otherwise, there's a match, so don't emit this left row
+                continue;
+            }
+
+            // Check if ANY matching right row passes the probe filter
             let mut found_match = false;
+            let evaluator = probe_evaluator.as_ref().unwrap();
+            let pf = probe_filter.as_ref().unwrap();
+
             for &right_idx in right_indices {
                 let right_row = &right_slice[right_idx];
 
@@ -175,8 +246,8 @@ pub(super) fn hash_anti_join_with_filter(
                 // Clear CSE cache before evaluation
                 evaluator.clear_cse_cache();
 
-                // Evaluate the additional filter
-                match evaluator.eval(filter, &combined_row) {
+                // Evaluate the probe filter
+                match evaluator.eval(pf, &combined_row) {
                     Ok(vibesql_types::SqlValue::Boolean(true)) => {
                         found_match = true;
                         break; // Anti-join: if we find one match, skip this left row

--- a/crates/vibesql-executor/src/select/join/hash_semi_join.rs
+++ b/crates/vibesql-executor/src/select/join/hash_semi_join.rs
@@ -1,9 +1,14 @@
 #![allow(clippy::doc_lazy_continuation)]
 
+use std::collections::HashSet;
+
 use super::hash_join::build_existence_hash_table_parallel;
 use super::{combine_rows, FromResult};
 use crate::errors::ExecutorError;
 use crate::evaluator::CombinedExpressionEvaluator;
+use crate::optimizer::where_pushdown::{extract_referenced_tables_branch, flatten_conjuncts};
+use crate::optimizer::combine_with_and;
+use crate::schema::CombinedSchema;
 use crate::timeout::{TimeoutContext, CHECK_INTERVAL};
 
 /// Hash semi-join implementation
@@ -87,21 +92,34 @@ pub(super) fn hash_semi_join(
 /// )
 /// ```
 ///
-/// Algorithm:
-/// 1. Build phase: Hash the RIGHT table on the equi-join column (O(n))
-/// 2. Probe phase: For each LEFT row:
-///    a. Check if hash table contains matching key
-///    b. If yes, verify additional filter conditions against ALL matching right rows
-///    c. If any right row passes the filter, emit the left row (only once)
+/// ## Optimization: Right-Side Predicate Pushdown
 ///
-/// Performance: Still O(n + m) average case, much faster than nested loop O(n*m)
+/// When the filter contains predicates that reference only the right table (e.g., `s_quantity < 10`),
+/// these predicates are applied during the hash table build phase, reducing the hash table size
+/// and avoiding unnecessary probing. This is critical for IN subquery performance.
+///
+/// Example (TPC-C Stock-Level):
+/// ```sql
+/// ol_i_id IN (SELECT s_i_id FROM stock WHERE s_w_id = 1 AND s_quantity < 10)
+/// ```
+/// The predicates `s_w_id = 1 AND s_quantity < 10` are applied during build, not probe.
+///
+/// Algorithm:
+/// 1. **Predicate partitioning**: Split filter into right-only and cross-table predicates
+/// 2. **Build phase**: Hash the RIGHT table, applying right-only predicates as a pre-filter
+/// 3. **Probe phase**: For each LEFT row:
+///    a. Check if hash table contains matching key
+///    b. If yes, verify cross-table predicates against matching right rows
+///    c. If any right row passes, emit the left row (only once)
+///
+/// Performance: O(n + m) average case with reduced hash table size
 pub(super) fn hash_semi_join_with_filter(
     left: FromResult,
     right: FromResult,
     left_col_idx: usize,
     right_col_idx: usize,
     additional_filter: Option<&vibesql_ast::Expression>,
-    combined_schema: &crate::schema::CombinedSchema,
+    combined_schema: &CombinedSchema,
     database: &vibesql_storage::Database,
 ) -> Result<FromResult, ExecutorError> {
     // If no additional filter, use the simpler version
@@ -118,29 +136,82 @@ pub(super) fn hash_semi_join_with_filter(
     let left_slice = left.as_slice();
     let right_slice = right.as_slice();
 
-    // Build phase: Create hash table from right side
-    // Unlike simple hash_semi_join, we need to store row indices to check the filter
+    // Partition the filter into right-only and cross-table predicates
+    // Right-only predicates are applied during build, cross-table during probe
+    let (right_only_filter, probe_filter) = partition_filter_predicates(
+        filter,
+        combined_schema,
+        &left.schema,
+        &right.schema,
+    );
+
+    // Create evaluators for build and probe phases
+    // Right-only evaluator uses only right schema
+    let right_only_evaluator = right_only_filter.as_ref().map(|_| {
+        CombinedExpressionEvaluator::with_database(&right.schema, database)
+    });
+
+    // Combined evaluator for probe phase (if we have cross-table predicates)
+    let probe_evaluator = probe_filter.as_ref().map(|_| {
+        CombinedExpressionEvaluator::with_database(combined_schema, database)
+    });
+
+    // Build phase: Create hash table from right side with right-only predicate filtering
     use ahash::AHashMap;
     let mut hash_table: AHashMap<vibesql_types::SqlValue, Vec<usize>> = AHashMap::new();
+    let mut filtered_count = 0usize;
 
     for (idx, row) in right_slice.iter().enumerate() {
         // Check timeout periodically during build phase
         if idx % CHECK_INTERVAL == 0 {
             timeout_ctx.check()?;
         }
+
         let key = row.values[right_col_idx].clone();
         // Skip NULL values - they never match in equi-joins
-        if key != vibesql_types::SqlValue::Null {
+        if key == vibesql_types::SqlValue::Null {
+            continue;
+        }
+
+        // Apply right-only predicates as a pre-filter during build
+        if let (Some(right_filter), Some(evaluator)) = (&right_only_filter, &right_only_evaluator) {
+            evaluator.clear_cse_cache();
+            match evaluator.eval(right_filter, row) {
+                Ok(vibesql_types::SqlValue::Boolean(true)) => {
+                    // Row passes filter, add to hash table
+                    hash_table.entry(key).or_default().push(idx);
+                }
+                Ok(vibesql_types::SqlValue::Boolean(false))
+                | Ok(vibesql_types::SqlValue::Null) => {
+                    // Row doesn't pass filter, skip it
+                    filtered_count += 1;
+                    continue;
+                }
+                Err(_) | Ok(_) => {
+                    // Filter evaluation error or non-boolean, skip this row
+                    filtered_count += 1;
+                    continue;
+                }
+            }
+        } else {
+            // No right-only filter, add all rows
             hash_table.entry(key).or_default().push(idx);
         }
     }
 
-    // Probe phase: Check each left row for a match that passes the filter
+    // Log build-time filtering if significant
+    if std::env::var("SEMI_JOIN_DEBUG").is_ok() && filtered_count > 0 {
+        eprintln!(
+            "[SEMI_JOIN] Build-time filtering: {} rows filtered out of {} ({:.1}%)",
+            filtered_count,
+            right_slice.len(),
+            (filtered_count as f64 / right_slice.len() as f64) * 100.0
+        );
+    }
+
+    // Probe phase: Check each left row for a match that passes the probe filter
     let estimated_capacity = left_slice.len().min(100_000);
     let mut result_rows = Vec::with_capacity(estimated_capacity);
-
-    // Create evaluator for filter evaluation
-    let evaluator = CombinedExpressionEvaluator::with_database(combined_schema, database);
     let mut probe_iterations = 0;
 
     for left_row in left_slice.iter() {
@@ -159,8 +230,19 @@ pub(super) fn hash_semi_join_with_filter(
 
         // Check if key exists in hash table
         if let Some(right_indices) = hash_table.get(key) {
-            // Check if any matching right row passes the additional filter
+            // If no probe filter, any match is sufficient (right-only filter already applied)
+            if probe_filter.is_none() {
+                if !right_indices.is_empty() {
+                    result_rows.push(left_row.clone());
+                }
+                continue;
+            }
+
+            // Check if any matching right row passes the probe filter
             let mut found_match = false;
+            let evaluator = probe_evaluator.as_ref().unwrap();
+            let pf = probe_filter.as_ref().unwrap();
+
             for &right_idx in right_indices {
                 let right_row = &right_slice[right_idx];
 
@@ -170,8 +252,8 @@ pub(super) fn hash_semi_join_with_filter(
                 // Clear CSE cache before evaluation
                 evaluator.clear_cse_cache();
 
-                // Evaluate the additional filter
-                match evaluator.eval(filter, &combined_row) {
+                // Evaluate the probe filter
+                match evaluator.eval(pf, &combined_row) {
                     Ok(vibesql_types::SqlValue::Boolean(true)) => {
                         found_match = true;
                         break; // Semi-join: we only need one match
@@ -191,6 +273,66 @@ pub(super) fn hash_semi_join_with_filter(
 
     // Return result with left schema only
     Ok(FromResult::from_rows(left.schema.clone(), result_rows))
+}
+
+/// Partition filter predicates into right-only and cross-table predicates
+///
+/// Right-only predicates reference only columns from the right table and can be
+/// applied during the hash table build phase for early filtering.
+///
+/// Cross-table predicates reference columns from both tables and must be
+/// evaluated during the probe phase.
+pub(super) fn partition_filter_predicates(
+    filter: &vibesql_ast::Expression,
+    combined_schema: &CombinedSchema,
+    left_schema: &CombinedSchema,
+    right_schema: &CombinedSchema,
+) -> (Option<vibesql_ast::Expression>, Option<vibesql_ast::Expression>) {
+    // Get the set of right-only table names
+    let right_table_names: HashSet<String> = right_schema
+        .table_schemas
+        .keys()
+        .cloned()
+        .collect();
+
+    // Get the set of left table names
+    let left_table_names: HashSet<String> = left_schema
+        .table_schemas
+        .keys()
+        .cloned()
+        .collect();
+
+    // Flatten the filter into individual conjuncts
+    let conjuncts = flatten_conjuncts(filter);
+
+    let mut right_only_predicates = Vec::new();
+    let mut cross_table_predicates = Vec::new();
+
+    for conjunct in conjuncts {
+        // Extract tables referenced by this predicate
+        if let Some(referenced_tables) = extract_referenced_tables_branch(&conjunct, combined_schema) {
+            // Check if predicate references only right tables
+            let refs_left = referenced_tables.iter().any(|t| left_table_names.contains(t));
+            let refs_right = referenced_tables.iter().any(|t| right_table_names.contains(t));
+
+            if refs_right && !refs_left {
+                // Right-only predicate: can be applied during build phase
+                right_only_predicates.push(conjunct);
+            } else {
+                // Cross-table or left-only predicate: apply during probe
+                cross_table_predicates.push(conjunct);
+            }
+        } else {
+            // Couldn't determine table references, treat as cross-table
+            cross_table_predicates.push(conjunct);
+        }
+    }
+
+    // Combine predicates back into expressions
+    let right_only = combine_with_and(right_only_predicates);
+    let cross_table = combine_with_and(cross_table_predicates);
+
+    (right_only, cross_table)
 }
 
 #[cfg(test)]

--- a/crates/vibesql-executor/src/select/scan/join_scan.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan.rs
@@ -4,11 +4,23 @@
 //! - Recursively executing left and right sides
 //! - Extracting equijoin predicates from WHERE clause
 //! - Delegating to nested loop join implementation
+//!
+//! ## SEMI/ANTI Join Optimization
+//!
+//! For SEMI and ANTI joins (from IN/EXISTS subquery transformations), this module
+//! extracts right-table-only predicates from the join condition and passes them
+//! to the right-side scan for index selection. This enables index usage for
+//! predicates like `s_quantity < ?` in TPC-C Stock-Level queries.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::{
-    errors::ExecutorError, optimizer::PredicatePlan, select::cte::CteResult,
+    errors::ExecutorError,
+    optimizer::{
+        combine_with_and, PredicatePlan,
+        where_pushdown::{extract_referenced_tables_branch, flatten_conjuncts},
+    },
+    select::cte::CteResult,
     timeout::TimeoutContext,
 };
 
@@ -37,16 +49,28 @@ where
     // For SEMI and ANTI joins (from IN/EXISTS subquery transformations), we must NOT pass
     // the outer WHERE clause to the right side. The right side represents the subquery
     // table, and the outer query's WHERE conditions should not be pushed down to it.
-    // The subquery's own WHERE conditions are already included in the JOIN condition
-    // (see subquery_to_join.rs), so they will be applied during the join.
     //
     // Bug fix for #2599: Passing outer WHERE clause to the right side caused incorrect
     // index scans that filtered out rows that should have been in the subquery result.
+    //
+    // HOWEVER, we DO want to extract right-table-only predicates from the JOIN condition
+    // (which contains the subquery's original WHERE clause) and pass them to the right-side
+    // scan for index selection. This enables efficient index usage for predicates like
+    // `s_quantity < ?` in TPC-C Stock-Level queries.
+    //
+    // Performance fix for #3130: Extract right-only predicates from JOIN condition.
     let right_where_clause = match join_type {
-        vibesql_ast::JoinType::Semi | vibesql_ast::JoinType::Anti => None,
-        _ => where_clause,
+        vibesql_ast::JoinType::Semi | vibesql_ast::JoinType::Anti => {
+            // Extract right-table-only predicates from the join condition
+            if let Some(cond) = condition {
+                extract_right_only_predicates(right, cond, database)
+            } else {
+                None
+            }
+        }
+        _ => where_clause.cloned(),
     };
-    let right_result = super::execute_from_clause(right, cte_results, database, right_where_clause, None, outer_row, outer_schema, execute_subquery)?;
+    let right_result = super::execute_from_clause(right, cte_results, database, right_where_clause.as_ref(), None, outer_row, outer_schema, execute_subquery)?;
 
     // For NATURAL JOIN, generate the implicit join condition based on common column names
     let natural_join_condition = if natural {
@@ -190,4 +214,112 @@ fn generate_natural_join_condition(
     }
 
     Ok(condition)
+}
+
+/// Extract right-table-only predicates from a join condition for SEMI/ANTI join pushdown
+///
+/// For IN subquery to SEMI JOIN conversions, the subquery's WHERE clause predicates are
+/// combined into the JOIN condition. This function extracts predicates that only reference
+/// the right-side table(s) so they can be pushed down to the right-side scan for index selection.
+///
+/// Example: For `WHERE ol_i_id IN (SELECT s_i_id FROM stock WHERE s_w_id = ? AND s_quantity < ?)`
+/// The JOIN condition is: `ol_i_id = s_i_id AND s_w_id = ? AND s_quantity < ?`
+/// This function extracts: `s_w_id = ? AND s_quantity < ?` (right-only predicates)
+///
+/// Returns None if no right-only predicates can be extracted.
+fn extract_right_only_predicates(
+    right_from: &vibesql_ast::FromClause,
+    condition: &vibesql_ast::Expression,
+    database: &vibesql_storage::Database,
+) -> Option<vibesql_ast::Expression> {
+    // Get the table name(s) from the right-side FROM clause
+    let right_tables = extract_table_names_from_from_clause(right_from);
+    if right_tables.is_empty() {
+        return None;
+    }
+
+    // We need to build a minimal schema to analyze predicates
+    // For each table, get its schema from the database
+    let mut right_table_set: HashSet<String> = HashSet::new();
+    let mut schema_builder = crate::schema::SchemaBuilder::new();
+
+    for table_name in &right_tables {
+        // Normalize table name for lookup
+        let normalized = table_name.to_lowercase();
+        if let Some(table) = database.get_table(&normalized) {
+            schema_builder.add_table(table_name.clone(), table.schema.clone());
+            right_table_set.insert(table_name.clone());
+            // Also add normalized version
+            right_table_set.insert(normalized);
+        }
+    }
+
+    if right_table_set.is_empty() {
+        return None;
+    }
+
+    let right_schema = schema_builder.build();
+
+    // Flatten the condition into conjuncts (AND-separated predicates)
+    let conjuncts = flatten_conjuncts(condition);
+
+    // Filter to keep only predicates that reference only right-side tables
+    let right_only_predicates: Vec<vibesql_ast::Expression> = conjuncts
+        .into_iter()
+        .filter(|pred| {
+            // extract_referenced_tables_branch returns Option<HashSet<String>>
+            // None means the expression couldn't be analyzed (skip it)
+            // Some(empty set) means no tables referenced (skip it)
+            // Some(non-empty set) - check if all tables are in right_table_set
+            match extract_referenced_tables_branch(pred, &right_schema) {
+                Some(ref tables) if !tables.is_empty() => {
+                    tables.iter().all(|t| {
+                        let t_lower = t.to_lowercase();
+                        right_table_set.contains(t) || right_table_set.contains(&t_lower)
+                    })
+                }
+                _ => false,
+            }
+        })
+        .collect();
+
+    if right_only_predicates.is_empty() {
+        return None;
+    }
+
+    // Debug output
+    if std::env::var("JOIN_SCAN_DEBUG").is_ok() {
+        eprintln!(
+            "[JOIN_SCAN] Extracted {} right-only predicates for tables {:?}",
+            right_only_predicates.len(),
+            right_tables
+        );
+    }
+
+    // Combine predicates with AND
+    combine_with_and(right_only_predicates)
+}
+
+/// Extract table names from a FROM clause
+fn extract_table_names_from_from_clause(from: &vibesql_ast::FromClause) -> Vec<String> {
+    let mut tables = Vec::new();
+    collect_table_names(from, &mut tables);
+    tables
+}
+
+fn collect_table_names(from: &vibesql_ast::FromClause, tables: &mut Vec<String>) {
+    match from {
+        vibesql_ast::FromClause::Table { name, alias } => {
+            // Use alias if present, otherwise use table name
+            tables.push(alias.clone().unwrap_or_else(|| name.clone()));
+        }
+        vibesql_ast::FromClause::Join { left, right, .. } => {
+            collect_table_names(left, tables);
+            collect_table_names(right, tables);
+        }
+        vibesql_ast::FromClause::Subquery { alias, .. } => {
+            // Subquery alias is required (String, not Option<String>)
+            tables.push(alias.clone());
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Extract right-table-only predicates from SEMI/ANTI JOIN conditions and push to right-side scan for index selection
- Add build-time filtering in hash semi/anti-join as fallback when scan doesn't filter rows
- Foundation for index-based optimization of IN subqueries (TPC-C Stock-Level)

## Problem

For IN subquery to SEMI JOIN transformations, the subquery's WHERE clause predicates (e.g., `s_w_id = ? AND s_quantity < ?`) were combined into the JOIN condition but not pushed to the right-side scan. This prevented index usage on predicates like `s_quantity < ?`.

```sql
-- TPC-C Stock-Level query
SELECT COUNT(DISTINCT ol_i_id) FROM order_line 
WHERE ol_w_id = ? AND ol_d_id = ? AND ol_o_id >= ? AND ol_o_id < ? 
AND ol_i_id IN (SELECT s_i_id FROM stock WHERE s_w_id = ? AND s_quantity < ?)
```

## Solution

Two-level optimization:

1. **Scan-level pushdown** (`join_scan.rs`): For SEMI/ANTI joins, extract right-only predicates from JOIN condition and pass them to the right-side scan. This enables index selection.

2. **Build-time filtering** (`hash_semi_join.rs`, `hash_anti_join.rs`): Partition filter predicates into right-only and cross-table. Apply right-only predicates during hash table build phase to reduce memory usage.

## Changes

- `join_scan.rs`: Add `extract_right_only_predicates()` to extract and push predicates for SEMI/ANTI joins
- `hash_semi_join.rs`: Add `partition_filter_predicates()` for build-time filtering
- `hash_anti_join.rs`: Same optimization for NOT IN subqueries  
- `where_pushdown/mod.rs`: Export `extract_referenced_tables_branch`

## Test plan

- [x] All subquery tests pass
- [x] TPC-C Stock-Level benchmark runs correctly
- [x] Predicates correctly extracted and pushed (verified with debug output)
- [ ] Full CI test suite

Closes #3130

🤖 Generated with [Claude Code](https://claude.com/claude-code)