### PR TITLE
test(server): Improve test_invalid_column_error diagnostics

### DIFF
--- a/crates/vibesql-server/tests/error_tests.rs
+++ b/crates/vibesql-server/tests/error_tests.rs
@@ -80,9 +80,15 @@ async fn test_invalid_column_error() {
     client.send_startup("testuser", "testdb").await.expect("Failed to send startup");
     let _ = client.read_until_message_type(b'Z').await.expect("Failed to read response");
 
-    // Create table
+    // Create table and verify it succeeded
     client.send_query("CREATE TABLE col_test (id INT, name VARCHAR(50))").await.expect("Failed to CREATE");
-    let _ = client.read_until_message_type(b'Z').await.expect("Failed to read response");
+    let create_data = client.read_until_message_type(b'Z').await.expect("Failed to read response");
+    let create_messages = parse_backend_messages(&create_data);
+    assert!(
+        create_messages.iter().any(|m| m.is_command_complete()),
+        "CREATE TABLE should succeed, got messages: {:?}",
+        create_messages.iter().map(|m| m.msg_type as char).collect::<Vec<_>>()
+    );
 
     // Query non-existent column
     client.send_query("SELECT nonexistent_column FROM col_test").await.expect("Failed to send query");
@@ -92,7 +98,8 @@ async fn test_invalid_column_error() {
 
     assert!(
         messages.iter().any(|m| m.is_error()),
-        "Should receive ErrorResponse for invalid column"
+        "Should receive ErrorResponse for invalid column, got messages: {:?}",
+        messages.iter().map(|m| m.msg_type as char).collect::<Vec<_>>()
     );
 
     client.send_terminate().await.expect("Failed to terminate");


### PR DESCRIPTION
## Summary
- Add better diagnostic output to the `test_invalid_column_error` test that is failing in CI
- Verify CREATE TABLE succeeded before testing column validation
- Include actual message types in assertion failure messages

This will help identify why the test passes locally (macOS) but fails in CI (Linux).

## Investigation Notes
The test passes consistently on macOS (both debug and release builds). The CI failure shows the test expecting an ErrorResponse for `SELECT nonexistent_column FROM col_test` but not receiving one.

The improved assertions will reveal in CI:
1. Whether CREATE TABLE succeeded
2. What message types were actually received instead of ErrorResponse

## Test plan
- [x] All tests pass locally in debug mode
- [x] All tests pass locally in release mode
- [ ] CI will show better diagnostic output if the test still fails

Closes #3147

🤖 Generated with [Claude Code](https://claude.com/claude-code)