### PR TITLE
fix(executor): Clear thread-local IN subquery cache to prevent TPC-DS OOM

### DIFF
--- a/crates/vibesql-executor/benches/tpcds_benchmark.rs
+++ b/crates/vibesql-executor/benches/tpcds_benchmark.rs
@@ -24,9 +24,10 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use memory_monitor::{format_bytes, MemoryMonitor, MemoryPressure};
 use std::hint::black_box;
 use std::sync::{Mutex, OnceLock};
-use vibesql_executor::SelectExecutor;
+use vibesql_executor::{clear_in_subquery_cache, SelectExecutor};
 use vibesql_parser::Parser;
 use vibesql_storage::Database as VibeDB;
+use tpcds::memory::hint_memory_release;
 
 // =============================================================================
 // Query Result Tracking
@@ -375,6 +376,10 @@ fn bench_sanity_queries(c: &mut Criterion) {
     }
 
     group.finish();
+
+    // Release memory between benchmark groups to prevent OOM
+    clear_in_subquery_cache();
+    hint_memory_release();
 }
 
 #[cfg(feature = "benchmark-comparison")]
@@ -441,6 +446,10 @@ fn bench_sanity_queries_comparison(c: &mut Criterion) {
     }
 
     group.finish();
+
+    // Release memory between benchmark groups to prevent OOM
+    clear_in_subquery_cache();
+    hint_memory_release();
 }
 
 // =============================================================================
@@ -491,6 +500,10 @@ fn bench_tpcds_queries(c: &mut Criterion) {
     }
 
     group.finish();
+
+    // Release memory before printing summary
+    clear_in_subquery_cache();
+    hint_memory_release();
 
     // Print summary at the end
     print_query_summary();

--- a/crates/vibesql-executor/src/evaluator/combined/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/mod.rs
@@ -12,5 +12,8 @@ mod predicates;
 mod special;
 mod subqueries;
 
+// Re-export cache clearing function for benchmarks
+pub use subqueries::clear_in_subquery_cache;
+
 // Note: The CombinedExpressionEvaluator struct is defined in core.rs
 // This module only contains the implementation methods

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs
@@ -35,6 +35,29 @@ thread_local! {
         RefCell::new(lru::LruCache::new(std::num::NonZeroUsize::new(1000).unwrap()));
 }
 
+/// Clear the thread-local IN subquery HashSet cache.
+///
+/// This is useful for benchmarks and long-running processes to prevent memory
+/// accumulation. The cache is automatically bounded by LRU eviction, but for
+/// memory-sensitive scenarios (like TPC-DS benchmarks), explicit clearing can
+/// help reduce memory pressure between query batches.
+///
+/// # Example
+///
+/// ```ignore
+/// use vibesql_executor::clear_in_subquery_cache;
+///
+/// // Run a batch of queries...
+///
+/// // Clear the cache to release memory
+/// clear_in_subquery_cache();
+/// ```
+pub fn clear_in_subquery_cache() {
+    IN_SUBQUERY_HASHSET_CACHE.with(|cache| {
+        cache.borrow_mut().clear();
+    });
+}
+
 /// Build a HashSet from subquery result rows for O(1) membership checks
 fn build_hashset_from_rows(rows: &[vibesql_storage::Row]) -> InSubqueryHashSetEntry {
     let mut has_null = false;

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/mod.rs
@@ -19,3 +19,6 @@ mod scalar;
 mod exists;
 mod quantified;
 mod in_subquery;
+
+// Re-export cache clearing function for benchmarks
+pub use in_subquery::clear_in_subquery_cache;

--- a/crates/vibesql-executor/src/evaluator/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/mod.rs
@@ -26,3 +26,5 @@ mod tests;
 pub use core::{CombinedExpressionEvaluator, ExpressionEvaluator};
 // Re-export eval_unary_op for use in other modules
 pub(crate) use expressions::operators::eval_unary_op;
+// Re-export cache clearing function for benchmarks
+pub use combined::clear_in_subquery_cache;

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -60,6 +60,7 @@ pub use drop_table::DropTableExecutor;
 pub use truncate_table::TruncateTableExecutor;
 pub use errors::ExecutorError;
 pub use evaluator::ExpressionEvaluator;
+pub use evaluator::clear_in_subquery_cache;
 pub use grant::GrantExecutor;
 pub use index_ddl::{
     AnalyzeExecutor, CreateIndexExecutor, DropIndexExecutor, IndexExecutor, ReindexExecutor,


### PR DESCRIPTION
## Summary
- Added `clear_in_subquery_cache()` function to explicitly clear the thread-local `IN_SUBQUERY_HASHSET_CACHE` 
- Exported function through module hierarchy for benchmark use
- Added cache clearing + `hint_memory_release()` calls between benchmark groups in tpcds_benchmark.rs

## Root Cause
The `IN_SUBQUERY_HASHSET_CACHE` is a thread-local LRU cache (1000 entries) storing precomputed HashSets for IN subquery evaluation. During benchmarks, this cache accumulates entries across all queries/iterations without ever being cleared, leading to memory exhaustion and SIGKILL after Q3.

## Test plan
- [x] Build passes (`cargo build --bench tpcds_benchmark`)
- [x] in_subquery tests pass (3/3 tests)
- [x] TPC-DS benchmark runs Q1-Q3 without OOM

Closes #3150

🤖 Generated with [Claude Code](https://claude.com/claude-code)