### PR TITLE
perf(executor): Enable hash join for adjusted equi-join patterns

### DIFF
--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -189,6 +189,10 @@ name = "tpcds_runner"
 harness = false
 
 [[bench]]
+name = "tpcds_profiling"
+harness = false
+
+[[bench]]
 name = "simd_filter_benchmark"
 harness = false
 

--- a/crates/vibesql-executor/benches/tpcds_profiling.rs
+++ b/crates/vibesql-executor/benches/tpcds_profiling.rs
@@ -1,0 +1,132 @@
+//! TPC-DS Query Profiling
+//!
+//! Run with:
+//!   cargo bench --package vibesql-executor --bench tpcds_profiling --features benchmark-comparison --no-run && ./target/release/deps/tpcds_profiling-*
+//!
+//! Run single query:
+//!   ./target/release/deps/tpcds_profiling-* Q2
+//!
+//! Run all queries:
+//!   ./target/release/deps/tpcds_profiling-*
+
+mod tpcds;
+
+use std::env;
+use std::time::{Duration, Instant};
+use tpcds::queries::TPCDS_QUERIES;
+use tpcds::schema::load_vibesql;
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+
+fn run_query_detailed(db: &vibesql_storage::Database, name: &str, sql: &str, timeout: Duration) {
+    eprintln!("\n=== {} ===", name);
+    eprintln!("SQL: {}", sql.trim().lines().take(3).collect::<Vec<_>>().join(" ").chars().take(80).collect::<String>());
+
+    // Parse
+    let parse_start = Instant::now();
+    let stmt = match Parser::parse_sql(sql) {
+        Ok(vibesql_ast::Statement::Select(s)) => s,
+        Ok(_) => { eprintln!("ERROR: Not a SELECT"); return; }
+        Err(e) => { eprintln!("ERROR: Parse error: {}", e); return; }
+    };
+    let parse_time = parse_start.elapsed();
+    eprintln!("  Parse:    {:>10.2?}", parse_time);
+
+    // Create executor with timeout
+    let exec_create_start = Instant::now();
+    let executor = SelectExecutor::new(db).with_timeout(timeout.as_secs());
+    let exec_create_time = exec_create_start.elapsed();
+    eprintln!("  Executor: {:>10.2?} (timeout: {:?})", exec_create_time, timeout);
+
+    // Execute query directly (executor has built-in timeout)
+    let execute_start = Instant::now();
+    let result = executor.execute(&stmt);
+    let execute_time = execute_start.elapsed();
+
+    match result {
+        Ok(rows) => {
+            eprintln!("  Execute:  {:>10.2?} ({} rows)", execute_time, rows.len());
+            let total = parse_time + exec_create_time + execute_time;
+            eprintln!("  TOTAL:    {:>10.2?}", total);
+        }
+        Err(e) => {
+            eprintln!("  Execute:  {:>10.2?} ERROR: {}", execute_time, e);
+            if execute_time >= timeout {
+                eprintln!("  TOTAL:    TIMEOUT (>{}s)", timeout.as_secs());
+            }
+        }
+    }
+}
+
+fn main() {
+    eprintln!("=== TPC-DS Query Profiling ===");
+
+    // Get timeout from env (default 30s)
+    let timeout_secs: u64 = env::var("QUERY_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(30);
+    let timeout = Duration::from_secs(timeout_secs);
+    eprintln!("Per-query timeout: {}s (set QUERY_TIMEOUT_SECS to change)", timeout_secs);
+
+    // Get scale factor from env (default 0.01)
+    let scale_factor: f64 = env::var("SCALE_FACTOR")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.01);
+    eprintln!("Scale factor: {} (set SCALE_FACTOR to change)", scale_factor);
+
+    // All TPC-DS queries
+    let all_queries: Vec<(&str, &str)> = TPCDS_QUERIES.to_vec();
+
+    // Check for single-query mode
+    let args: Vec<String> = env::args().collect();
+
+    // Handle help flag
+    if args.len() > 1 && (args[1] == "--help" || args[1] == "-h" || args[1] == "help") {
+        eprintln!("\nUsage:");
+        eprintln!("  {} [QUERY]", args[0]);
+        eprintln!("\nArguments:");
+        eprintln!("  QUERY    Optional query to run (Q1-Q99). If not specified, runs all queries.");
+        eprintln!("\nEnvironment Variables:");
+        eprintln!("  QUERY_TIMEOUT_SECS        Timeout per query in seconds (default: 30)");
+        eprintln!("  SCALE_FACTOR              TPC-DS scale factor (default: 0.01)");
+        eprintln!("\nExamples:");
+        eprintln!("  {}                          # Run all queries", args[0]);
+        eprintln!("  {} Q2                       # Run only Q2", args[0]);
+        eprintln!("  SCALE_FACTOR=0.01 {} Q2     # Run Q2 at scale 0.01", args[0]);
+        std::process::exit(0);
+    }
+
+    let queries_to_run = if args.len() > 1 {
+        // Run only specified query
+        let target_query = &args[1];
+        eprintln!("Single-query mode: {}", target_query);
+        all_queries.into_iter()
+            .filter(|(name, _)| *name == target_query)
+            .collect()
+    } else {
+        // Run all queries
+        eprintln!("Running all {} queries", all_queries.len());
+        all_queries
+    };
+
+    if queries_to_run.is_empty() {
+        eprintln!("Error: Query '{}' not found.", args[1]);
+        eprintln!("Run with --help for usage information.");
+        std::process::exit(1);
+    }
+
+    // Load database
+    eprintln!("\nLoading TPC-DS database (SF {})...", scale_factor);
+    let load_start = Instant::now();
+    let db = load_vibesql(scale_factor);
+    eprintln!("Database loaded in {:?}", load_start.elapsed());
+
+    // Run selected queries
+    for (name, sql) in &queries_to_run {
+        run_query_detailed(&db, name, sql, timeout);
+    }
+
+    eprintln!("\n=== Profiling Complete ===");
+}

--- a/crates/vibesql-executor/src/select/join/hash_join/inner.rs
+++ b/crates/vibesql-executor/src/select/join/hash_join/inner.rs
@@ -4,6 +4,7 @@ use super::{combine_rows, FromResult};
 use super::build::{CompositeKey, build_hash_table_composite_parallel, build_hash_table_parallel};
 use super::columnar::{hash_join_indices_columnar, hash_join_indices_columnar_multi};
 use crate::{errors::ExecutorError, schema::CombinedSchema};
+use crate::select::join::join_analyzer::KeyAdjustment;
 
 // Note: Memory limit checking removed from hash join.
 // Hash join uses O(smaller_table) memory for the hash table, not O(result_size).
@@ -120,6 +121,139 @@ pub(in crate::select::join) fn hash_join_inner(
     }
 
     Ok(FromResult::from_rows(combined_schema, result_rows))
+}
+
+/// Adjusted hash join for expressions like `col1 = col2 +/- constant`
+///
+/// This enables hash join for queries like TPC-DS Q2 where the join condition is:
+///   `d_week_seq1 = d_week_seq2 - 53`
+///
+/// Instead of doing a full Cartesian product and filtering, we:
+/// 1. Build: Compute `col2 +/- constant` and insert into hash table
+/// 2. Probe: Lookup `col1` directly
+///
+/// This reduces O(n*m) to O(n+m) for such joins.
+pub(in crate::select::join) fn hash_join_inner_adjusted(
+    left: FromResult,
+    right: FromResult,
+    left_col_idx: usize,
+    right_col_idx: usize,
+    right_adjustment: &KeyAdjustment,
+) -> Result<FromResult, ExecutorError> {
+    // Extract right table name and schema for combining
+    let right_table_name = right
+        .schema
+        .table_schemas
+        .keys()
+        .next()
+        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
+        .clone();
+
+    let right_schema = right
+        .schema
+        .table_schemas
+        .get(&right_table_name)
+        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
+        .1
+        .clone();
+
+    // Combine schemas
+    let combined_schema =
+        CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
+
+    // Use as_slice() for zero-cost access
+    let left_slice = left.as_slice();
+    let right_slice = right.as_slice();
+
+    // For adjusted joins, we always build on the right side (the one with adjustment)
+    // and probe with the left side (simple column reference)
+    let build_rows = right_slice;
+    let probe_rows = left_slice;
+    let build_col_idx = right_col_idx;
+    let probe_col_idx = left_col_idx;
+
+    // Build hash table with adjusted keys
+    use std::collections::HashMap;
+    let mut hash_table: HashMap<vibesql_types::SqlValue, Vec<usize>> =
+        HashMap::with_capacity(build_rows.len());
+
+    for (idx, row) in build_rows.iter().enumerate() {
+        let original_key = &row.values[build_col_idx];
+
+        // Apply adjustment to get the hash key
+        let adjusted_key = apply_key_adjustment(original_key, right_adjustment);
+
+        // Skip NULL values
+        if adjusted_key == vibesql_types::SqlValue::Null {
+            continue;
+        }
+
+        hash_table.entry(adjusted_key).or_default().push(idx);
+    }
+
+    // Probe phase: Lookup with left column values directly
+    let estimated_capacity = probe_rows.len().saturating_mul(2).min(100_000);
+    let mut pairs: Vec<(usize, usize)> = Vec::with_capacity(estimated_capacity);
+
+    for (probe_idx, probe_row) in probe_rows.iter().enumerate() {
+        let key = &probe_row.values[probe_col_idx];
+
+        // Skip NULL values
+        if key == &vibesql_types::SqlValue::Null {
+            continue;
+        }
+
+        if let Some(build_indices) = hash_table.get(key) {
+            for &build_idx in build_indices {
+                pairs.push((build_idx, probe_idx));
+            }
+        }
+    }
+
+    // Materialization phase: Create combined rows
+    // For adjusted join, left is always probe, right is always build
+    let mut result_rows = Vec::with_capacity(pairs.len());
+    for (build_idx, probe_idx) in pairs {
+        // Left (probe) first, then right (build)
+        let combined_row = combine_rows(&probe_rows[probe_idx], &build_rows[build_idx]);
+        result_rows.push(combined_row);
+    }
+
+    Ok(FromResult::from_rows(combined_schema, result_rows))
+}
+
+/// Apply key adjustment for adjusted hash join
+fn apply_key_adjustment(
+    value: &vibesql_types::SqlValue,
+    adjustment: &KeyAdjustment,
+) -> vibesql_types::SqlValue {
+    match adjustment {
+        KeyAdjustment::None => value.clone(),
+        KeyAdjustment::AddInteger(n) => {
+            match value {
+                vibesql_types::SqlValue::Integer(v) => {
+                    vibesql_types::SqlValue::Integer(v.saturating_add(*n))
+                }
+                vibesql_types::SqlValue::Bigint(v) => {
+                    vibesql_types::SqlValue::Bigint(v.saturating_add(*n))
+                }
+                // For non-integer types, return NULL to skip
+                _ => vibesql_types::SqlValue::Null,
+            }
+        }
+        KeyAdjustment::SubtractInteger(n) => {
+            match value {
+                vibesql_types::SqlValue::Integer(v) => {
+                    vibesql_types::SqlValue::Integer(v.saturating_sub(*n))
+                }
+                vibesql_types::SqlValue::Bigint(v) => {
+                    vibesql_types::SqlValue::Bigint(v.saturating_sub(*n))
+                }
+                // For non-integer types, return NULL to skip
+                _ => vibesql_types::SqlValue::Null,
+            }
+        }
+    }
 }
 
 /// Multi-column hash join INNER JOIN implementation

--- a/crates/vibesql-executor/src/select/join/hash_join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/hash_join/mod.rs
@@ -25,6 +25,7 @@ mod tests;
 // Re-export public API
 pub(super) use inner::hash_join_inner;
 pub(super) use inner::hash_join_inner_multi;
+pub(super) use inner::hash_join_inner_adjusted;
 pub(super) use outer::hash_join_left_outer;
 
 // Re-export existence hash table builders for semi-join and anti-join

--- a/crates/vibesql-executor/src/select/join/join_analyzer.rs
+++ b/crates/vibesql-executor/src/select/join/join_analyzer.rs
@@ -37,6 +37,34 @@ pub struct MultiColumnEquiJoinInfo {
     pub right_col_indices: Vec<usize>,
 }
 
+/// Adjustment to apply during hash join for expressions like `col = col +/- constant`
+#[derive(Debug, Clone)]
+pub enum KeyAdjustment {
+    /// No adjustment needed (simple `col = col`)
+    None,
+    /// Add a constant to the key (for `col = other_col - N`, we add N to other_col)
+    AddInteger(i64),
+    /// Subtract a constant from the key (for `col = other_col + N`, we subtract N from other_col)
+    SubtractInteger(i64),
+}
+
+/// Information about an adjusted equi-join condition
+///
+/// Extends EquiJoinInfo to support expressions like:
+/// - `col1 = col2 + 53` (adjust by subtracting 53 from col2)
+/// - `col1 = col2 - 53` (adjust by adding 53 to col2)
+///
+/// This enables hash join for TPC-DS Q2 and similar queries.
+#[derive(Debug, Clone)]
+pub struct AdjustedEquiJoinInfo {
+    /// Column index in the left table
+    pub left_col_idx: usize,
+    /// Column index in the right table
+    pub right_col_idx: usize,
+    /// Adjustment to apply to the right column value during hash table build
+    pub right_adjustment: KeyAdjustment,
+}
+
 /// Analyze a join condition to detect if it's a simple equi-join
 ///
 /// Returns Some(EquiJoinInfo) if the condition is a simple equi-join like:
@@ -83,6 +111,184 @@ fn analyze_single_equi_join(
                 }
             }
             None
+        }
+        _ => None,
+    }
+}
+
+/// Analyze an equality expression for adjusted equi-join (col = col +/- constant)
+///
+/// Handles patterns like:
+/// - `col1 = col2 + 53` → adjust by subtracting 53 from col2
+/// - `col1 = col2 - 53` → adjust by adding 53 to col2
+///
+/// This enables hash join for TPC-DS Q2 and similar queries with temporal offsets.
+pub fn analyze_adjusted_equi_join(
+    condition: &Expression,
+    schema: &CombinedSchema,
+    left_column_count: usize,
+) -> Option<AdjustedEquiJoinInfo> {
+    let debug = std::env::var("ADJ_JOIN_DEBUG").is_ok();
+    if debug {
+        eprintln!("[ADJ_JOIN_DEBUG] Analyzing condition: {:?}", condition);
+        eprintln!("[ADJ_JOIN_DEBUG] Schema tables: {:?}", schema.table_schemas.keys().collect::<Vec<_>>());
+        eprintln!("[ADJ_JOIN_DEBUG] Left column count: {}", left_column_count);
+    }
+
+    // First try simple equi-join (no adjustment)
+    if let Some(simple) = analyze_single_equi_join(condition, schema, left_column_count) {
+        if debug {
+            eprintln!("[ADJ_JOIN_DEBUG] Found simple equi-join: left={}, right={}", simple.left_col_idx, simple.right_col_idx);
+        }
+        return Some(AdjustedEquiJoinInfo {
+            left_col_idx: simple.left_col_idx,
+            right_col_idx: simple.right_col_idx,
+            right_adjustment: KeyAdjustment::None,
+        });
+    }
+
+    // Try to match patterns like `col = col +/- constant`
+    match condition {
+        Expression::BinaryOp { op: BinaryOperator::Equal, left, right } => {
+            if debug {
+                eprintln!("[ADJ_JOIN_DEBUG] Trying adjusted equi-join: left={:?}, right={:?}", left, right);
+            }
+            // Try both orderings: col = expr and expr = col
+            if let Some(result) = try_adjusted_equi_join(left, right, schema, left_column_count) {
+                if debug {
+                    eprintln!("[ADJ_JOIN_DEBUG] SUCCESS with left-right ordering: {:?}", result);
+                }
+                return Some(result);
+            }
+            if let Some(result) = try_adjusted_equi_join(right, left, schema, left_column_count) {
+                if debug {
+                    eprintln!("[ADJ_JOIN_DEBUG] SUCCESS with right-left ordering: {:?}", result);
+                }
+                return Some(result);
+            }
+            if debug {
+                eprintln!("[ADJ_JOIN_DEBUG] No adjusted equi-join found");
+            }
+            None
+        }
+        _ => {
+            if debug {
+                eprintln!("[ADJ_JOIN_DEBUG] Not a BinaryOp::Equal expression");
+            }
+            None
+        }
+    }
+}
+
+/// Helper to try matching `simple_col = col +/- constant`
+fn try_adjusted_equi_join(
+    simple_side: &Expression,
+    adjusted_side: &Expression,
+    schema: &CombinedSchema,
+    left_column_count: usize,
+) -> Option<AdjustedEquiJoinInfo> {
+    let debug = std::env::var("ADJ_JOIN_DEBUG").is_ok();
+
+    // Check if simple_side is a plain column reference
+    let simple_col_idx = extract_column_index(simple_side, schema);
+    if debug {
+        eprintln!("[ADJ_JOIN_DEBUG] try_adjusted: simple_side={:?}, simple_col_idx={:?}", simple_side, simple_col_idx);
+        eprintln!("[ADJ_JOIN_DEBUG]   Schema columns: {:?}",
+            schema.table_schemas.iter()
+                .flat_map(|(t, (_, s))| s.columns.iter().map(move |c| format!("{}.{}", t, c.name)))
+                .collect::<Vec<_>>());
+    }
+    let simple_col_idx = simple_col_idx?;
+
+    // Check if adjusted_side is `col +/- constant`
+    let (adj_col_idx, adjustment) = extract_column_with_constant_adjustment(adjusted_side, schema)?;
+
+    // Check if one is from left table and one is from right table
+    if simple_col_idx < left_column_count && adj_col_idx >= left_column_count {
+        // Simple column from left, adjusted column from right
+        Some(AdjustedEquiJoinInfo {
+            left_col_idx: simple_col_idx,
+            right_col_idx: adj_col_idx - left_column_count,
+            right_adjustment: adjustment,
+        })
+    } else if adj_col_idx < left_column_count && simple_col_idx >= left_column_count {
+        // Adjusted column from left, simple column from right
+        // We need to swap and invert the adjustment
+        // If left = right + N, then we build on (right + N) and probe with left
+        // But our structure assumes adjustment on right, so we need to handle differently
+        // For simplicity, we only support adjustment on the right side for now
+        None
+    } else {
+        None
+    }
+}
+
+/// Extract a column reference with an integer constant adjustment
+///
+/// Matches patterns like:
+/// - `col + 53` → returns (col_idx, SubtractInteger(53))
+/// - `col - 53` → returns (col_idx, AddInteger(53))
+///
+/// The adjustment is inverted because to make `left_col = right_col - 53` work with hash join,
+/// we need to compute `right_col - 53` during build (which equals adding 53 in the opposite direction).
+fn extract_column_with_constant_adjustment(
+    expr: &Expression,
+    schema: &CombinedSchema,
+) -> Option<(usize, KeyAdjustment)> {
+    match expr {
+        Expression::BinaryOp { op, left, right } => {
+            // Try col +/- constant
+            if let (Some(col_idx), Some(constant)) = (
+                extract_column_index(left, schema),
+                extract_integer_literal(right),
+            ) {
+                match op {
+                    BinaryOperator::Plus => {
+                        // col + N: to match, we subtract N from col
+                        Some((col_idx, KeyAdjustment::SubtractInteger(constant)))
+                    }
+                    BinaryOperator::Minus => {
+                        // col - N: to match, we add N to col
+                        Some((col_idx, KeyAdjustment::AddInteger(constant)))
+                    }
+                    _ => None,
+                }
+            } else if let (Some(constant), Some(col_idx)) = (
+                extract_integer_literal(left),
+                extract_column_index(right, schema),
+            ) {
+                // constant +/- col (less common but supported)
+                match op {
+                    BinaryOperator::Plus => {
+                        // N + col: same as col + N
+                        Some((col_idx, KeyAdjustment::SubtractInteger(constant)))
+                    }
+                    BinaryOperator::Minus => {
+                        // N - col: this would require negation, skip for now
+                        None
+                    }
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Extract an integer literal from an expression
+fn extract_integer_literal(expr: &Expression) -> Option<i64> {
+    use vibesql_types::SqlValue;
+    match expr {
+        Expression::Literal(SqlValue::Integer(n)) => Some(*n),
+        Expression::Literal(SqlValue::Bigint(n)) => Some(*n),
+        Expression::UnaryOp { op: vibesql_ast::UnaryOperator::Minus, expr } => {
+            match expr.as_ref() {
+                Expression::Literal(SqlValue::Integer(n)) => Some(-n),
+                Expression::Literal(SqlValue::Bigint(n)) => Some(-n),
+                _ => None,
+            }
         }
         _ => None,
     }

--- a/crates/vibesql-executor/src/select/join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/mod.rs
@@ -21,7 +21,7 @@ mod tests;
 
 // Re-export join reorder analyzer for public tests
 // Re-export hash_join functions for internal use
-use hash_join::{hash_join_inner, hash_join_inner_multi, hash_join_left_outer};
+use hash_join::{hash_join_inner, hash_join_inner_multi, hash_join_inner_adjusted, hash_join_left_outer};
 use hash_semi_join::{hash_semi_join, hash_semi_join_with_filter};
 use hash_anti_join::{hash_anti_join, hash_anti_join_with_filter};
 // Re-export hash join iterator for public use
@@ -290,8 +290,15 @@ pub(super) fn nested_loop_join(
     additional_equijoins: &[vibesql_ast::Expression],
     timeout_ctx: &TimeoutContext,
 ) -> Result<FromResult, ExecutorError> {
-    // Try to use hash join for INNER JOINs with simple equi-join conditions
-    if let vibesql_ast::JoinType::Inner = join_type {
+    // Try to use hash join for INNER JOINs with simple equi-join conditions,
+    // or CROSS JOINs (comma joins) with equi-join predicates in WHERE clause.
+    // This optimization is critical for queries like TPC-DS Q2 which use:
+    //   FROM wscs, date_dim WHERE d_date_sk = sold_date_sk
+    // Without this, such queries use O(n*m) nested loop instead of O(n+m) hash join.
+    let use_hash_join = matches!(join_type, vibesql_ast::JoinType::Inner)
+        || (matches!(join_type, vibesql_ast::JoinType::Cross) && !additional_equijoins.is_empty());
+
+    if use_hash_join {
         // Get column count and right table info once for analysis
         // IMPORTANT: Sum up columns from ALL tables in the left schema,
         // not just the first table, to handle accumulated multi-table joins
@@ -535,6 +542,71 @@ pub(super) fn nested_loop_join(
                 }
 
                 return Ok(result);
+            }
+        }
+
+        // Phase 3.2: Try adjusted equi-joins (col = col +/- constant patterns)
+        // This enables hash join for TPC-DS Q2 style queries with temporal offsets
+        for (idx, equijoin) in additional_equijoins.iter().enumerate() {
+            if let Some(adj_info) =
+                join_analyzer::analyze_adjusted_equi_join(equijoin, &temp_schema, left_col_count)
+            {
+                // Only use adjusted hash join if there's actually an adjustment
+                if !matches!(adj_info.right_adjustment, join_analyzer::KeyAdjustment::None) {
+                    // Save schemas for NATURAL JOIN processing before moving left/right
+                    let (left_schema_for_natural, right_schema_for_natural) = if natural {
+                        (Some(left.schema.clone()), Some(right.schema.clone()))
+                    } else {
+                        (None, None)
+                    };
+
+                    // Found an adjusted equijoin suitable for hash join!
+                    let mut result = hash_join_inner_adjusted(
+                        left,
+                        right,
+                        adj_info.left_col_idx,
+                        adj_info.right_col_idx,
+                        &adj_info.right_adjustment,
+                    )?;
+
+                    // Apply remaining equijoins and conditions as post-join filters
+                    let remaining_conditions: Vec<_> = additional_equijoins
+                        .iter()
+                        .enumerate()
+                        .filter(|(i, _)| *i != idx)
+                        .map(|(_, e)| e.clone())
+                        .collect();
+
+                    if !remaining_conditions.is_empty() {
+                        if let Some(filter_expr) = combine_with_and(remaining_conditions) {
+                            result = apply_post_join_filter(result, &filter_expr, database)?;
+                        }
+                    }
+
+                    // For NATURAL JOIN, remove duplicate columns from the result
+                    if natural {
+                        if let (Some(left_schema), Some(right_schema_orig)) =
+                            (left_schema_for_natural, right_schema_for_natural)
+                        {
+                            let right_schema_for_removal = CombinedSchema {
+                                table_schemas: vec![(
+                                    right_table_name_for_natural.clone(),
+                                    (0, right_schema_orig.table_schemas.values().next().unwrap().1.clone()),
+                                )]
+                                .into_iter()
+                                .collect(),
+                                total_columns: right_schema_orig.total_columns,
+                            };
+                            result = remove_duplicate_columns_for_natural_join(
+                                result,
+                                &left_schema,
+                                &right_schema_for_removal,
+                            )?;
+                        }
+                    }
+
+                    return Ok(result);
+                }
             }
         }
     }

--- a/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
@@ -241,6 +241,16 @@ where
                 if references_new_table && references_joined_table {
                     applicable_conditions.push(condition.clone());
                     applied_conditions.insert(idx);
+                } else if column_to_table.is_empty() && joined_tables.len() == 1 && referenced_tables.is_empty() {
+                    // CTE fallback: When column_to_table is empty (CTE results), we can't resolve
+                    // table references, but if the condition was already extracted as a WHERE equijoin
+                    // for exactly these two tables, it must be applicable.
+                    // This enables hash join for patterns like `d_week_seq1 = d_week_seq2 - 53` in TPC-DS Q2.
+                    if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+                        eprintln!("[JOIN_REORDER] CTE fallback: including condition for 2-table join: {:?}", condition);
+                    }
+                    applicable_conditions.push(condition.clone());
+                    applied_conditions.insert(idx);
                 }
             }
 

--- a/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
@@ -112,9 +112,66 @@ pub(super) fn extract_in_predicates_from_or(
     result
 }
 
+/// Check if an expression contains a column reference (possibly nested in arithmetic)
+///
+/// Used for fallback CTE join handling when schema lookup isn't available.
+fn expr_has_column(expr: &Expression) -> bool {
+    match expr {
+        Expression::ColumnRef { .. } => true,
+        Expression::BinaryOp { left, right, .. } => {
+            expr_has_column(left) || expr_has_column(right)
+        }
+        Expression::UnaryOp { expr: inner, .. } => expr_has_column(inner),
+        _ => false,
+    }
+}
+
+/// Extract the table name from an expression
+///
+/// Handles:
+/// - Simple column references: `table.col` or `col`
+/// - Adjusted expressions: `col +/- constant` (for adjusted equi-joins like `d_week_seq1 = d_week_seq2 - 53`)
+fn extract_table_from_expr(
+    expr: &Expression,
+    column_to_table: &HashMap<String, String>,
+) -> Option<String> {
+    match expr {
+        // Simple column reference with explicit table
+        Expression::ColumnRef { table: Some(t), .. } => Some(t.to_lowercase()),
+        // Unqualified column - use schema-based lookup
+        Expression::ColumnRef { table: None, column } => {
+            resolve_column_with_fallback(column, column_to_table)
+        }
+        // Adjusted expression: col +/- constant
+        // This enables hash joins for conditions like `d_week_seq1 = d_week_seq2 - 53`
+        Expression::BinaryOp { op, left, right } => {
+            match op {
+                BinaryOperator::Plus | BinaryOperator::Minus => {
+                    // Check if one side is a column and the other is a literal
+                    let left_is_literal = matches!(left.as_ref(), Expression::Literal(_));
+                    let right_is_literal = matches!(right.as_ref(), Expression::Literal(_));
+
+                    if right_is_literal && !left_is_literal {
+                        // Pattern: col +/- constant
+                        extract_table_from_expr(left, column_to_table)
+                    } else if left_is_literal && !right_is_literal {
+                        // Pattern: constant +/- col (less common but valid)
+                        extract_table_from_expr(right, column_to_table)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
 /// Extract equijoin conditions from a WHERE clause expression using schema-based column resolution
 ///
 /// This is the preferred method that uses actual database schema to resolve unqualified columns.
+/// It handles both simple equijoins (col1 = col2) and adjusted equijoins (col1 = col2 +/- constant).
 pub(super) fn extract_where_equijoins_with_schema(
     expr: &Expression,
     tables: &HashSet<String>,
@@ -212,25 +269,14 @@ pub(super) fn extract_where_equijoins_with_schema(
                     equijoins.extend(common_eqs);
                 }
             }
-            // Binary EQUAL: check if it's an equijoin
+            // Binary EQUAL: check if it's an equijoin (simple or adjusted)
             Expression::BinaryOp { op: BinaryOperator::Equal, left, right } => {
-                // Check if both sides are column references
+                // Check if both sides are column references (simple equijoin)
+                // or if one side is a column and the other is col +/- constant (adjusted equijoin)
                 // Use schema-based lookup
 
-                let left_table = match left.as_ref() {
-                    Expression::ColumnRef { table: Some(t), .. } => Some(t.to_lowercase()),
-                    Expression::ColumnRef { table: None, column } => {
-                        resolve_column_with_fallback(column, column_to_table)
-                    }
-                    _ => None,
-                };
-                let right_table = match right.as_ref() {
-                    Expression::ColumnRef { table: Some(t), .. } => Some(t.to_lowercase()),
-                    Expression::ColumnRef { table: None, column } => {
-                        resolve_column_with_fallback(column, column_to_table)
-                    }
-                    _ => None,
-                };
+                let left_table = extract_table_from_expr(left, column_to_table);
+                let right_table = extract_table_from_expr(right, column_to_table);
 
                 // If both sides reference columns from different tables, it's an equijoin
                 if let (Some(lt), Some(rt)) = (left_table.clone(), right_table.clone()) {
@@ -247,6 +293,19 @@ pub(super) fn extract_where_equijoins_with_schema(
                         }
                     } else if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
                         eprintln!("[JOIN_REORDER]   ✗ Skipped: lt==rt or table not found");
+                    }
+                } else if column_to_table.is_empty() {
+                    // Fallback for CTE joins: if schema is unavailable, check if both sides
+                    // reference columns (possibly with arithmetic). Include the condition and
+                    // let the join executor figure out how to use it.
+                    let left_has_column = expr_has_column(left);
+                    let right_has_column = expr_has_column(right);
+
+                    if left_has_column && right_has_column {
+                        if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+                            eprintln!("[JOIN_REORDER] CTE fallback: including unresolved equijoin: {:?}", expr);
+                        }
+                        equijoins.push(expr.clone());
                     }
                 }
             }

--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -58,9 +58,10 @@ pub(crate) fn execute_table_scan(
             let predicate_plan = PredicatePlan::from_where_clause(where_clause, &schema)
                 .map_err(ExecutorError::InvalidWhereClause)?;
 
-            // Must clone rows for filtering (copy-on-write semantics)
-            let rows = apply_table_local_predicates(
-                cte_rows.as_ref().clone(),
+            // Use zero-copy filtering: only clone rows that pass the filter
+            // This avoids O(n) deep cloning when most rows are filtered out
+            let rows = apply_table_local_predicates_ref(
+                cte_rows.as_ref(),
                 schema.clone(),
                 &predicate_plan,
                 table_name,


### PR DESCRIPTION
## Summary

- Enable hash join optimization for `col = col +/- constant` patterns (e.g., `d_week_seq1 = d_week_seq2 - 53` in TPC-DS Q2)
- Add CTE fallback for unresolved column references in comma-join optimizer
- Include TPC-DS profiling benchmark for testing adjusted joins

## Problem

TPC-DS Q2 contains a join condition `d_week_seq1 = d_week_seq2 - 53` between two CTE results. Previously, this fell back to a Cartesian product with filter because:
1. The arithmetic expression wasn't recognized as a hash-joinable equi-join
2. CTE column references couldn't be resolved to table names

## Solution

1. **predicates.rs**: Extended `extract_table_from_expr` to handle `col +/- constant` expressions
2. **predicates.rs**: Added CTE fallback when `column_to_table` is empty
3. **optimizer.rs**: Added CTE fallback to include unresolved conditions for 2-table joins
4. **join_analyzer.rs**: Added `analyze_adjusted_equi_join` to detect and extract adjustment info
5. **hash_join/inner.rs**: Added `hash_join_inner_adjusted` for adjusted key hashing

## Test plan

- [x] All 134 join unit tests pass
- [x] Verified adjusted equi-join detection with verbose debug output at SF=0.001
- [ ] Run TPC-DS Q2 benchmark at larger scale factors

Closes #3126

🤖 Generated with [Claude Code](https://claude.com/claude-code)