### PR TITLE
perf(executor): Add CTE fallback for arithmetic hash join in join reorder optimizer

### DIFF
--- a/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
@@ -241,6 +241,14 @@ where
                 if references_new_table && references_joined_table {
                     applicable_conditions.push(condition.clone());
                     applied_conditions.insert(idx);
+                } else if column_to_table.is_empty() && joined_tables.len() == 1 && referenced_tables.is_empty() {
+                    // CTE fallback: When column_to_table is empty (CTE results), include condition
+                    // for 2-table joins since it was already extracted as a WHERE equijoin.
+                    if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+                        eprintln!("[JOIN_REORDER] CTE fallback: including condition {:?} for 2-table join", condition);
+                    }
+                    applicable_conditions.push(condition.clone());
+                    applied_conditions.insert(idx);
                 }
             }
 

--- a/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
@@ -4,6 +4,16 @@ use std::collections::{HashMap, HashSet};
 use vibesql_ast::{BinaryOperator, Expression};
 use super::utils::resolve_column_with_fallback;
 
+/// Check if an expression contains any column reference (for CTE fallback)
+fn expr_has_column(expr: &Expression) -> bool {
+    match expr {
+        Expression::ColumnRef { .. } => true,
+        Expression::BinaryOp { left, right, .. } => expr_has_column(left) || expr_has_column(right),
+        Expression::UnaryOp { expr: inner, .. } => expr_has_column(inner),
+        _ => false,
+    }
+}
+
 /// Extract table-local predicates using schema-based column resolution
 ///
 /// This version accepts a column_to_table map for resolving unqualified column names.
@@ -247,6 +257,16 @@ pub(super) fn extract_where_equijoins_with_schema(
                         }
                     } else if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
                         eprintln!("[JOIN_REORDER]   ✗ Skipped: lt==rt or table not found");
+                    }
+                } else if column_to_table.is_empty() {
+                    // CTE fallback: if schema is unavailable, check if both sides reference columns
+                    let left_has_column = expr_has_column(left);
+                    let right_has_column = expr_has_column(right);
+                    if left_has_column && right_has_column {
+                        if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+                            eprintln!("[JOIN_REORDER] CTE fallback: adding arithmetic equijoin {:?}", expr);
+                        }
+                        equijoins.push(expr.clone());
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Add fallback logic to handle arithmetic equijoins between CTE results where column_to_table mapping is unavailable
- Ensures conditions like `d_week_seq1 = d_week_seq2 - 53` in TPC-DS Q2 are properly passed to the join executor for hash join optimization
- Adds `expr_has_column` helper function to detect column references in expressions

## Test plan

- [x] All 134 join tests pass
- [x] All 7 reorder optimizer tests pass
- [x] Code compiles without errors
- [ ] Run TPC-DS Q2 with verbose logging to verify arithmetic hash join is triggered

Closes #3172

🤖 Generated with [Claude Code](https://claude.com/claude-code)