### PR TITLE
feat(executor): Auto-create B-tree indexes for PRIMARY KEY and UNIQUE constraints

### DIFF
--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -1,6 +1,6 @@
 //! CREATE TABLE statement execution
 
-use vibesql_ast::CreateTableStmt;
+use vibesql_ast::{CreateTableStmt, IndexColumn, OrderDirection};
 use vibesql_catalog::{ColumnSchema, TableSchema};
 use vibesql_storage::Database;
 
@@ -269,8 +269,14 @@ impl CreateTableExecutor {
 
         // Create table using Database API (handles both catalog and storage)
         let result = database
-            .create_table(table_schema)
+            .create_table(table_schema.clone())
             .map_err(|e| ExecutorError::StorageError(e.to_string()));
+
+        // Check if table creation succeeded before creating indexes
+        result?;
+
+        // Auto-create indexes for PRIMARY KEY and UNIQUE constraints
+        Self::create_implicit_indexes(database, &table_name, &table_schema)?;
 
         // Restore original schema if we switched
         if needs_schema_switch {
@@ -280,10 +286,99 @@ impl CreateTableExecutor {
                 .map_err(|e| ExecutorError::StorageError(format!("Schema error: {:?}", e)))?;
         }
 
-        // Check if table creation succeeded
-        result?;
-
         // Return success message
         Ok(format!("Table '{}' created successfully in schema '{}'", table_name, schema_name))
+    }
+
+    /// Create implicit indexes for PRIMARY KEY and UNIQUE constraints
+    ///
+    /// Production databases automatically create B-tree indexes for these constraints
+    /// to enable efficient query optimization. This function replicates that behavior.
+    fn create_implicit_indexes(
+        database: &mut Database,
+        table_name: &str,
+        table_schema: &TableSchema,
+    ) -> Result<(), ExecutorError> {
+        // Auto-create PRIMARY KEY index
+        if let Some(pk_cols) = &table_schema.primary_key {
+            let index_name = format!("pk_{}", table_name);
+
+            // Create IndexColumn specs for the PRIMARY KEY columns
+            let index_columns: Vec<IndexColumn> = pk_cols
+                .iter()
+                .map(|col_name| IndexColumn {
+                    column_name: col_name.clone(),
+                    direction: OrderDirection::Asc,
+                    prefix_length: None,
+                })
+                .collect();
+
+            // Add to catalog first
+            let index_metadata = vibesql_catalog::IndexMetadata::new(
+                index_name.clone(),
+                table_name.to_string(),
+                vibesql_catalog::IndexType::BTree,
+                index_columns
+                    .iter()
+                    .map(|col| vibesql_catalog::IndexedColumn {
+                        column_name: col.column_name.clone(),
+                        order: vibesql_catalog::SortOrder::Ascending,
+                        prefix_length: None,
+                    })
+                    .collect(),
+                true, // unique
+            );
+            database
+                .catalog
+                .add_index(index_metadata)
+                .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+
+            // Create the actual B-tree index
+            database
+                .create_index(index_name, table_name.to_string(), true, index_columns)
+                .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+        }
+
+        // Auto-create UNIQUE constraint indexes
+        for unique_cols in &table_schema.unique_constraints {
+            let index_name = format!("uq_{}_{}", table_name, unique_cols.join("_"));
+
+            // Create IndexColumn specs for the UNIQUE columns
+            let index_columns: Vec<IndexColumn> = unique_cols
+                .iter()
+                .map(|col_name| IndexColumn {
+                    column_name: col_name.clone(),
+                    direction: OrderDirection::Asc,
+                    prefix_length: None,
+                })
+                .collect();
+
+            // Add to catalog first
+            let index_metadata = vibesql_catalog::IndexMetadata::new(
+                index_name.clone(),
+                table_name.to_string(),
+                vibesql_catalog::IndexType::BTree,
+                index_columns
+                    .iter()
+                    .map(|col| vibesql_catalog::IndexedColumn {
+                        column_name: col.column_name.clone(),
+                        order: vibesql_catalog::SortOrder::Ascending,
+                        prefix_length: None,
+                    })
+                    .collect(),
+                true, // unique
+            );
+            database
+                .catalog
+                .add_index(index_metadata)
+                .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+
+            // Create the actual B-tree index
+            database
+                .create_index(index_name, table_name.to_string(), true, index_columns)
+                .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/vibesql-executor/src/tests/create_table_constraints.rs
+++ b/crates/vibesql-executor/src/tests/create_table_constraints.rs
@@ -255,3 +255,336 @@ fn test_create_table_with_check_constraint() {
     assert_eq!(schema.check_constraints.len(), 1);
     assert_eq!(schema.check_constraints[0].1, check_expr);
 }
+
+// ============================================================================
+// Auto-Index Creation Tests
+// Issue #3202: Auto-create indexes for PRIMARY KEY and UNIQUE constraints
+// ============================================================================
+
+#[test]
+fn test_auto_index_for_single_column_primary_key() {
+    let mut db = Database::new();
+    let stmt = CreateTableStmt {
+        table_name: "t1".to_string(),
+        columns: vec![ColumnDef {
+            name: "id".to_string(),
+            data_type: DataType::Integer,
+            nullable: false,
+            constraints: vec![ColumnConstraint {
+                name: None,
+                kind: ColumnConstraintKind::PrimaryKey,
+            }],
+            default_value: None,
+            comment: None,
+        }],
+        table_constraints: vec![],
+        table_options: vec![],
+    };
+
+    let result = CreateTableExecutor::execute(&stmt, &mut db);
+    assert!(result.is_ok());
+
+    // Verify pk_t1 index was auto-created
+    assert!(db.index_exists("pk_t1"), "Expected pk_t1 index to be auto-created");
+
+    // Verify index metadata in catalog
+    let index_meta = db.catalog.get_index("t1", "pk_t1");
+    assert!(index_meta.is_some(), "Expected pk_t1 in catalog");
+    let index_meta = index_meta.unwrap();
+    assert_eq!(index_meta.table_name, "t1");
+    assert!(index_meta.is_unique);
+    assert_eq!(index_meta.columns.len(), 1);
+    assert_eq!(index_meta.columns[0].column_name, "id");
+}
+
+#[test]
+fn test_auto_index_for_composite_primary_key() {
+    let mut db = Database::new();
+    let stmt = CreateTableStmt {
+        table_name: "t2".to_string(),
+        columns: vec![
+            ColumnDef {
+                name: "a".to_string(),
+                data_type: DataType::Integer,
+                nullable: true,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+            ColumnDef {
+                name: "b".to_string(),
+                data_type: DataType::Integer,
+                nullable: true,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+        ],
+        table_constraints: vec![TableConstraint {
+            name: None,
+            kind: TableConstraintKind::PrimaryKey {
+                columns: vec![
+                    vibesql_ast::IndexColumn {
+                        column_name: "a".to_string(),
+                        direction: vibesql_ast::OrderDirection::Asc,
+                        prefix_length: None,
+                    },
+                    vibesql_ast::IndexColumn {
+                        column_name: "b".to_string(),
+                        direction: vibesql_ast::OrderDirection::Asc,
+                        prefix_length: None,
+                    },
+                ],
+            },
+        }],
+        table_options: vec![],
+    };
+
+    let result = CreateTableExecutor::execute(&stmt, &mut db);
+    assert!(result.is_ok());
+
+    // Verify pk_t2 index was auto-created
+    assert!(db.index_exists("pk_t2"), "Expected pk_t2 index to be auto-created");
+
+    // Verify index has both columns
+    let index_meta = db.catalog.get_index("t2", "pk_t2").unwrap();
+    assert_eq!(index_meta.columns.len(), 2);
+    assert_eq!(index_meta.columns[0].column_name, "a");
+    assert_eq!(index_meta.columns[1].column_name, "b");
+}
+
+#[test]
+fn test_auto_index_for_single_unique_constraint() {
+    let mut db = Database::new();
+    let stmt = CreateTableStmt {
+        table_name: "t3".to_string(),
+        columns: vec![
+            ColumnDef {
+                name: "id".to_string(),
+                data_type: DataType::Integer,
+                nullable: false,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+            ColumnDef {
+                name: "email".to_string(),
+                data_type: DataType::Varchar { max_length: Some(255) },
+                nullable: false,
+                constraints: vec![ColumnConstraint {
+                    name: None,
+                    kind: ColumnConstraintKind::Unique,
+                }],
+                default_value: None,
+                comment: None,
+            },
+        ],
+        table_constraints: vec![],
+        table_options: vec![],
+    };
+
+    let result = CreateTableExecutor::execute(&stmt, &mut db);
+    assert!(result.is_ok());
+
+    // Verify uq_t3_email index was auto-created
+    assert!(db.index_exists("uq_t3_email"), "Expected uq_t3_email index to be auto-created");
+
+    // Verify index metadata
+    let index_meta = db.catalog.get_index("t3", "uq_t3_email").unwrap();
+    assert_eq!(index_meta.table_name, "t3");
+    assert!(index_meta.is_unique);
+    assert_eq!(index_meta.columns.len(), 1);
+    assert_eq!(index_meta.columns[0].column_name, "email");
+}
+
+#[test]
+fn test_auto_index_for_multiple_unique_constraints() {
+    let mut db = Database::new();
+    let stmt = CreateTableStmt {
+        table_name: "t4".to_string(),
+        columns: vec![
+            ColumnDef {
+                name: "id".to_string(),
+                data_type: DataType::Integer,
+                nullable: false,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+            ColumnDef {
+                name: "email".to_string(),
+                data_type: DataType::Varchar { max_length: Some(255) },
+                nullable: false,
+                constraints: vec![ColumnConstraint {
+                    name: None,
+                    kind: ColumnConstraintKind::Unique,
+                }],
+                default_value: None,
+                comment: None,
+            },
+            ColumnDef {
+                name: "phone".to_string(),
+                data_type: DataType::Varchar { max_length: Some(20) },
+                nullable: false,
+                constraints: vec![ColumnConstraint {
+                    name: None,
+                    kind: ColumnConstraintKind::Unique,
+                }],
+                default_value: None,
+                comment: None,
+            },
+        ],
+        table_constraints: vec![],
+        table_options: vec![],
+    };
+
+    let result = CreateTableExecutor::execute(&stmt, &mut db);
+    assert!(result.is_ok());
+
+    // Verify both unique indexes were auto-created
+    assert!(db.index_exists("uq_t4_email"), "Expected uq_t4_email index to be auto-created");
+    assert!(db.index_exists("uq_t4_phone"), "Expected uq_t4_phone index to be auto-created");
+}
+
+#[test]
+fn test_auto_index_for_composite_unique_constraint() {
+    let mut db = Database::new();
+    let stmt = CreateTableStmt {
+        table_name: "t5".to_string(),
+        columns: vec![
+            ColumnDef {
+                name: "a".to_string(),
+                data_type: DataType::Integer,
+                nullable: false,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+            ColumnDef {
+                name: "b".to_string(),
+                data_type: DataType::Integer,
+                nullable: false,
+                constraints: vec![],
+                default_value: None,
+                comment: None,
+            },
+        ],
+        table_constraints: vec![TableConstraint {
+            name: None,
+            kind: TableConstraintKind::Unique {
+                columns: vec![
+                    vibesql_ast::IndexColumn {
+                        column_name: "a".to_string(),
+                        direction: vibesql_ast::OrderDirection::Asc,
+                        prefix_length: None,
+                    },
+                    vibesql_ast::IndexColumn {
+                        column_name: "b".to_string(),
+                        direction: vibesql_ast::OrderDirection::Asc,
+                        prefix_length: None,
+                    },
+                ],
+            },
+        }],
+        table_options: vec![],
+    };
+
+    let result = CreateTableExecutor::execute(&stmt, &mut db);
+    assert!(result.is_ok());
+
+    // Verify uq_t5_a_b index was auto-created
+    assert!(db.index_exists("uq_t5_a_b"), "Expected uq_t5_a_b index to be auto-created");
+
+    // Verify index has both columns
+    let index_meta = db.catalog.get_index("t5", "uq_t5_a_b").unwrap();
+    assert_eq!(index_meta.columns.len(), 2);
+    assert_eq!(index_meta.columns[0].column_name, "a");
+    assert_eq!(index_meta.columns[1].column_name, "b");
+}
+
+#[test]
+fn test_auto_index_for_primary_key_plus_unique() {
+    let mut db = Database::new();
+    let stmt = CreateTableStmt {
+        table_name: "t6".to_string(),
+        columns: vec![
+            ColumnDef {
+                name: "id".to_string(),
+                data_type: DataType::Integer,
+                nullable: false,
+                constraints: vec![ColumnConstraint {
+                    name: None,
+                    kind: ColumnConstraintKind::PrimaryKey,
+                }],
+                default_value: None,
+                comment: None,
+            },
+            ColumnDef {
+                name: "email".to_string(),
+                data_type: DataType::Varchar { max_length: Some(255) },
+                nullable: false,
+                constraints: vec![ColumnConstraint {
+                    name: None,
+                    kind: ColumnConstraintKind::Unique,
+                }],
+                default_value: None,
+                comment: None,
+            },
+        ],
+        table_constraints: vec![],
+        table_options: vec![],
+    };
+
+    let result = CreateTableExecutor::execute(&stmt, &mut db);
+    assert!(result.is_ok());
+
+    // Verify both indexes were auto-created
+    assert!(db.index_exists("pk_t6"), "Expected pk_t6 index to be auto-created");
+    assert!(db.index_exists("uq_t6_email"), "Expected uq_t6_email index to be auto-created");
+}
+
+#[test]
+fn test_auto_index_visible_in_catalog() {
+    let mut db = Database::new();
+    let stmt = CreateTableStmt {
+        table_name: "users".to_string(),
+        columns: vec![
+            ColumnDef {
+                name: "id".to_string(),
+                data_type: DataType::Integer,
+                nullable: false,
+                constraints: vec![ColumnConstraint {
+                    name: None,
+                    kind: ColumnConstraintKind::PrimaryKey,
+                }],
+                default_value: None,
+                comment: None,
+            },
+            ColumnDef {
+                name: "email".to_string(),
+                data_type: DataType::Varchar { max_length: Some(255) },
+                nullable: false,
+                constraints: vec![ColumnConstraint {
+                    name: None,
+                    kind: ColumnConstraintKind::Unique,
+                }],
+                default_value: None,
+                comment: None,
+            },
+        ],
+        table_constraints: vec![],
+        table_options: vec![],
+    };
+
+    let result = CreateTableExecutor::execute(&stmt, &mut db);
+    assert!(result.is_ok());
+
+    // Both indexes should be visible in the catalog
+    let indexes = db.catalog.get_table_indexes("users");
+    assert_eq!(indexes.len(), 2, "Expected 2 indexes for users table");
+
+    // Index names should include both pk and uq indexes
+    let index_names: Vec<&str> = indexes.iter().map(|i| i.name.as_str()).collect();
+    assert!(index_names.contains(&"pk_users"), "pk_users should be in catalog");
+    assert!(index_names.contains(&"uq_users_email"), "uq_users_email should be in catalog");
+}

--- a/crates/vibesql-executor/src/truncate/core.rs
+++ b/crates/vibesql-executor/src/truncate/core.rs
@@ -57,6 +57,10 @@ pub fn execute_truncate(database: &mut Database, table_name: &str) -> Result<usi
     // Clear all data at once (O(1) operation)
     table.clear();
 
+    // Rebuild user-defined B-tree indexes (clears them since table is now empty)
+    // This ensures auto-created indexes for PK/UNIQUE constraints are also cleared
+    database.rebuild_indexes(table_name);
+
     // Reset AUTO_INCREMENT sequences
     reset_auto_increment_sequences(database, table_name)?;
 

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -481,8 +481,25 @@ impl Operations {
         tables: &HashMap<String, Table>,
         table_name: &str,
     ) {
-        let table_rows: Vec<Row> = if let Some(table) = tables.get(table_name) {
+        // Normalize table name for lookup (matches catalog normalization)
+        let normalized_name = if catalog.is_case_sensitive_identifiers() {
+            table_name.to_string()
+        } else {
+            table_name.to_uppercase()
+        };
+
+        // First try direct lookup, then try with schema prefix if needed
+        let table_rows: Vec<Row> = if let Some(table) = tables.get(&normalized_name) {
             table.scan().to_vec()
+        } else if !table_name.contains('.') {
+            // Try with schema prefix
+            let current_schema = catalog.get_current_schema();
+            let qualified_name = format!("{}.{}", current_schema, normalized_name);
+            if let Some(table) = tables.get(&qualified_name) {
+                table.scan().to_vec()
+            } else {
+                return;
+            }
         } else {
             return;
         };


### PR DESCRIPTION
## Summary

- Add `create_implicit_indexes()` function that auto-creates B-tree indexes when tables are created with PRIMARY KEY or UNIQUE constraints
- Naming convention: `pk_{table}` for PRIMARY KEY, `uq_{table}_{col1}_{col2}` for UNIQUE
- Fix truncate to rebuild user-defined indexes after clearing table data
- Fix `Operations::rebuild_indexes` to handle qualified/normalized table names

This matches the behavior of production databases like PostgreSQL and MySQL, enabling the query optimizer to automatically benefit from constraint-based indexes without requiring explicit CREATE INDEX statements.

Closes #3202

## Test plan

- [x] Add 7 new tests for auto-index creation scenarios:
  - Single column PRIMARY KEY
  - Composite PRIMARY KEY
  - Single UNIQUE constraint
  - Multiple UNIQUE constraints
  - Composite UNIQUE constraint
  - PRIMARY KEY + UNIQUE combined
  - Auto-indexes visible in catalog
- [x] All 1620 executor tests pass
- [x] Truncate tests with AUTO_INCREMENT pass (regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)