### PR TITLE
fix(bench): Use standard TPC-C column order for stock index

### DIFF
--- a/crates/vibesql-executor/benches/tpcc/schema.rs
+++ b/crates/vibesql-executor/benches/tpcc/schema.rs
@@ -390,13 +390,12 @@ fn create_tpcc_indexes_vibesql(db: &mut VibeDB) {
         vec![col("i_id")],
     ).ok();
 
-    // Note: Reordering to (s_i_id, s_w_id) puts the more selective column first.
-    // This helps the cost-based index selector choose the index for point queries.
+    // Stock PK per TPC-C spec: (s_w_id, s_i_id)
     db.create_index(
         "idx_stock_pk".to_string(),
         "stock".to_string(),
         true,
-        vec![col("s_i_id"), col("s_w_id")],
+        vec![col("s_w_id"), col("s_i_id")],
     ).ok();
 
     // Secondary indexes for queries (on smaller tables)


### PR DESCRIPTION
## Summary

- Remove index column reordering optimization from TPC-C benchmark stock table
- Use standard TPC-C column order `(s_w_id, s_i_id)` instead of optimized `(s_i_id, s_w_id)`
- Makes benchmark comparisons with SQLite/DuckDB/MySQL fair

## Test plan

- [x] Build passes
- [x] TPC-C benchmark runs successfully (165 TPS, 100% success rate)

Closes #3209

🤖 Generated with [Claude Code](https://claude.com/claude-code)