### PR TITLE
fix(bench): Add ANALYZE calls to SQLite, DuckDB, and MySQL benchmarks

### DIFF
--- a/crates/vibesql-executor/benches/sysbench/schema.rs
+++ b/crates/vibesql-executor/benches/sysbench/schema.rs
@@ -56,6 +56,9 @@ pub fn load_sqlite(table_size: usize) -> SqliteConn {
     // Load data
     load_sbtest_sqlite(&conn, &mut data);
 
+    // Compute statistics for query optimization (ensures fair comparison with VibeSQL)
+    conn.execute("ANALYZE", []).unwrap();
+
     conn
 }
 
@@ -70,6 +73,9 @@ pub fn load_duckdb(table_size: usize) -> DuckDBConn {
 
     // Load data
     load_sbtest_duckdb(&conn, &mut data);
+
+    // Compute statistics for query optimization (ensures fair comparison with VibeSQL)
+    conn.execute_batch("ANALYZE").unwrap();
 
     conn
 }
@@ -89,6 +95,9 @@ pub fn load_mysql(table_size: usize) -> Option<PooledConn> {
 
     // Load data
     load_sbtest_mysql(&mut conn, &mut data);
+
+    // Compute statistics for query optimization (ensures fair comparison with VibeSQL)
+    conn.query_drop("ANALYZE TABLE sbtest1").unwrap();
 
     Some(conn)
 }

--- a/crates/vibesql-executor/benches/tpcc/schema.rs
+++ b/crates/vibesql-executor/benches/tpcc/schema.rs
@@ -88,6 +88,10 @@ pub fn load_sqlite(scale_factor: f64) -> SqliteConn {
     }
 
     create_tpcc_indexes_sqlite(&conn);
+
+    // Compute statistics for query optimization (ensures fair comparison with VibeSQL)
+    conn.execute("ANALYZE", []).unwrap();
+
     conn
 }
 
@@ -113,6 +117,10 @@ pub fn load_duckdb(scale_factor: f64) -> DuckDBConn {
     }
 
     create_tpcc_indexes_duckdb(&conn);
+
+    // Compute statistics for query optimization (ensures fair comparison with VibeSQL)
+    conn.execute_batch("ANALYZE").unwrap();
+
     conn
 }
 
@@ -145,6 +153,10 @@ pub fn load_mysql(scale_factor: f64) -> Option<PooledConn> {
     }
 
     create_tpcc_indexes_mysql(&mut conn);
+
+    // Compute statistics for query optimization (ensures fair comparison with VibeSQL)
+    conn.query_drop("ANALYZE TABLE warehouse, district, customer, history, new_order, orders, order_line, item, stock").unwrap();
+
     Some(conn)
 }
 


### PR DESCRIPTION
## Summary

- Adds `ANALYZE` calls to SQLite, DuckDB, and MySQL database loaders in TPC-C and Sysbench benchmarks
- Previously only VibeSQL called `table.analyze()`, potentially giving it better query plans
- This ensures all databases have optimizer statistics for fair benchmark comparisons

## Changes

**TPC-C** (`benches/tpcc/schema.rs`):
- SQLite: Added `conn.execute("ANALYZE", [])`
- DuckDB: Added `conn.execute_batch("ANALYZE")`
- MySQL: Added `conn.query_drop("ANALYZE TABLE warehouse, district, customer, history, new_order, orders, order_line, item, stock")`

**Sysbench** (`benches/sysbench/schema.rs`):
- SQLite: Added `conn.execute("ANALYZE", [])`
- DuckDB: Added `conn.execute_batch("ANALYZE")`
- MySQL: Added `conn.query_drop("ANALYZE TABLE sbtest1")`

## Test plan

- [x] Verified code compiles with `cargo check --features benchmark-comparison -p vibesql-executor`
- [x] Verified benchmarks build with `cargo build --features benchmark-comparison -p vibesql-executor --benches`

Closes #3211

🤖 Generated with [Claude Code](https://claude.com/claude-code)