### PR TITLE
fix(executor): use case-insensitive matching for PK lookup columns

### DIFF
--- a/crates/vibesql-executor/src/select/executor/fast_path.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path.rs
@@ -433,9 +433,9 @@ impl SelectExecutor<'_> {
             return Ok(None); // Can't use PK lookup
         }
 
-        // Build PK values in column order
+        // Build PK values in column order (use lowercase for lookup to match insert)
         let pk_key: Vec<vibesql_types::SqlValue> = pk_columns.iter()
-            .filter_map(|col| pk_values.get(*col).cloned())
+            .filter_map(|col| pk_values.get(&col.to_ascii_lowercase()).cloned())
             .collect();
 
         if pk_key.len() != pk_columns.len() {
@@ -524,9 +524,9 @@ impl SelectExecutor<'_> {
                 continue; // Try next index
             }
 
-            // Build key values in column order
+            // Build key values in column order (use lowercase for lookup to match insert)
             let key_values: Vec<SqlValue> = index_columns.iter()
-                .filter_map(|col| index_values.get(*col).cloned())
+                .filter_map(|col| index_values.get(&col.to_ascii_lowercase()).cloned())
                 .collect();
 
             if key_values.len() != index_columns.len() {
@@ -606,8 +606,10 @@ impl SelectExecutor<'_> {
                 vibesql_ast::BinaryOperator::Equal => {
                     // Check for column = literal pattern
                     if let Some((col_name, value)) = self.extract_column_literal_pair(left, right) {
-                        if pk_columns.contains(&col_name.as_str()) {
-                            values.insert(col_name, value);
+                        // Case-insensitive comparison for SQL identifiers
+                        if pk_columns.iter().any(|pk| pk.eq_ignore_ascii_case(&col_name)) {
+                            // Store with lowercase key for consistent lookup
+                            values.insert(col_name.to_ascii_lowercase(), value);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- Fixed case-sensitivity bug in fast path PK lookup that was causing 335x slower performance vs SQLite
- The schema stores PK column names in lowercase (e.g., `s_w_id`) but the SQL parser normalizes WHERE clause columns to uppercase (e.g., `S_W_ID`), causing PK lookup to always fail and fall back to slow table scan
- Used case-insensitive comparison (`eq_ignore_ascii_case`) and normalized HashMap keys for consistent lookup

## Performance Impact (TPC-C Scale Factor 1)

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Throughput | 6 TPS | 193 TPS | **32x faster** |
| Execute time/query | 17ms | 435μs | **39x faster** |
| PK lookups used | 0 | 25,928 | **Now working** |
| vs SQLite gap | 335x slower | 15x slower | **22x better** |

This significantly improves OLTP workload performance. The gap vs SQLite went from 335x to 15x.

## Test plan

- [x] Build succeeds
- [x] All existing tests pass
- [x] TPC-C benchmark shows significant improvement
- [ ] Run additional SELECT tests with mixed-case column names

Closes #3223

🤖 Generated with [Claude Code](https://claude.com/claude-code)