### PR TITLE
perf(tpcds): Fix 5 failing TPC-DS queries to improve coverage

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/numeric/basic.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/numeric/basic.rs
@@ -24,6 +24,8 @@ pub fn abs(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         SqlValue::Float(n) => Ok(SqlValue::Float(n.abs())),
         SqlValue::Double(n) => Ok(SqlValue::Double(n.abs())),
         SqlValue::Real(n) => Ok(SqlValue::Real(n.abs())),
+        SqlValue::Numeric(n) => Ok(SqlValue::Numeric(n.abs())),
+        SqlValue::Unsigned(n) => Ok(SqlValue::Unsigned(*n)), // Unsigned is always positive
         val => Err(ExecutorError::UnsupportedFeature(format!(
             "ABS requires numeric argument, got {:?}",
             val
@@ -59,6 +61,14 @@ pub fn sign(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             };
             Ok(SqlValue::Bigint(sign))
         }
+        SqlValue::Smallint(n) => {
+            let sign: i16 = match n.cmp(&0) {
+                std::cmp::Ordering::Less => -1,
+                std::cmp::Ordering::Greater => 1,
+                std::cmp::Ordering::Equal => 0,
+            };
+            Ok(SqlValue::Smallint(sign))
+        }
         SqlValue::Float(n) => {
             let sign = if *n < 0.0 {
                 -1.0
@@ -88,6 +98,21 @@ pub fn sign(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                 0.0
             };
             Ok(SqlValue::Real(sign))
+        }
+        SqlValue::Numeric(n) => {
+            let sign = if *n < 0.0 {
+                -1.0
+            } else if *n > 0.0 {
+                1.0
+            } else {
+                0.0
+            };
+            Ok(SqlValue::Numeric(sign))
+        }
+        SqlValue::Unsigned(n) => {
+            // Unsigned is always non-negative
+            let sign: u64 = if *n > 0 { 1 } else { 0 };
+            Ok(SqlValue::Unsigned(sign))
         }
         val => Err(ExecutorError::UnsupportedFeature(format!(
             "SIGN requires numeric argument, got {:?}",

--- a/crates/vibesql-parser/src/lexer/identifiers.rs
+++ b/crates/vibesql-parser/src/lexer/identifiers.rs
@@ -26,17 +26,11 @@ impl<'a> Lexer<'a> {
         // Optimization: only allocate/uppercase if needed
         if needs_uppercase {
             let upper_text = text.to_ascii_uppercase();
-            // Use perfect hash map for O(1) keyword lookup
-            match keywords::map_keyword(&upper_text) {
-                Some(keyword) => Ok(Token::Keyword(keyword)),
-                None => Ok(Token::Identifier(upper_text)),
-            }
+            // Use keyword map for O(1) keyword lookup
+            Ok(keywords::map_keyword(upper_text))
         } else {
-            // Text is already uppercase - try keyword lookup on the slice directly
-            match keywords::map_keyword(text) {
-                Some(keyword) => Ok(Token::Keyword(keyword)),
-                None => Ok(Token::Identifier(text.to_string())),
-            }
+            // Text is already uppercase - convert to owned String for keyword lookup
+            Ok(keywords::map_keyword(text.to_string()))
         }
     }
 

--- a/crates/vibesql-parser/src/parser/expressions/identifiers.rs
+++ b/crates/vibesql-parser/src/parser/expressions/identifiers.rs
@@ -100,32 +100,42 @@ impl Parser {
         }
 
         // Check for qualified column reference (table.column)
+        // Keywords are allowed as column names when qualified (e.g., ss.year)
         if matches!(self.peek(), Token::Symbol('.')) {
             self.advance(); // consume '.'
-            match self.peek() {
+            let column = match self.peek() {
                 Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
                     let column = col.clone();
                     self.advance();
-
-                    // Check for pseudo-variable (OLD.column or NEW.column)
-                    let first_upper = first.to_uppercase();
-                    if first_upper == "OLD" || first_upper == "NEW" {
-                        let pseudo_table = if first_upper == "OLD" {
-                            vibesql_ast::PseudoTable::Old
-                        } else {
-                            vibesql_ast::PseudoTable::New
-                        };
-                        Ok(Some(vibesql_ast::Expression::PseudoVariable {
-                            pseudo_table,
-                            column,
-                        }))
-                    } else {
-                        Ok(Some(vibesql_ast::Expression::ColumnRef { table: Some(first), column }))
-                    }
+                    column
                 }
-                _ => Err(ParseError {
-                    message: "Expected column name after '.'".to_string(),
-                }),
+                Token::Keyword(kw) => {
+                    // Allow keywords as column names when qualified (e.g., table.year)
+                    let column = kw.to_string();
+                    self.advance();
+                    column
+                }
+                _ => {
+                    return Err(ParseError {
+                        message: "Expected column name after '.'".to_string(),
+                    });
+                }
+            };
+
+            // Check for pseudo-variable (OLD.column or NEW.column)
+            let first_upper = first.to_uppercase();
+            if first_upper == "OLD" || first_upper == "NEW" {
+                let pseudo_table = if first_upper == "OLD" {
+                    vibesql_ast::PseudoTable::Old
+                } else {
+                    vibesql_ast::PseudoTable::New
+                };
+                Ok(Some(vibesql_ast::Expression::PseudoVariable {
+                    pseudo_table,
+                    column,
+                }))
+            } else {
+                Ok(Some(vibesql_ast::Expression::ColumnRef { table: Some(first), column }))
             }
         } else {
             // Simple column reference

--- a/crates/vibesql-parser/src/parser/helpers.rs
+++ b/crates/vibesql-parser/src/parser/helpers.rs
@@ -94,6 +94,28 @@ impl Parser {
         }
     }
 
+    /// Parse an identifier or keyword as an alias name.
+    /// In SQL, keywords can be used as aliases after AS (e.g., `d_year AS year`).
+    /// This is standard SQL behavior supported by most databases.
+    pub(super) fn parse_alias_name(&mut self) -> Result<String, ParseError> {
+        match self.peek() {
+            Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
+                let identifier = name.clone();
+                self.advance();
+                Ok(identifier)
+            }
+            Token::Keyword(kw) => {
+                // Allow keywords as alias names - convert to uppercase string
+                let name = kw.to_string();
+                self.advance();
+                Ok(name)
+            }
+            _ => Err(ParseError {
+                message: format!("Expected alias name, found {:?}", self.peek()),
+            }),
+        }
+    }
+
     /// Try to consume a keyword, returning true if successful.
     pub(super) fn try_consume_keyword(&mut self, keyword: Keyword) -> bool {
         if self.peek_keyword(keyword) {

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -74,27 +74,26 @@ impl Parser {
 
                     // Support both SQL:1999 (AS required) and MySQL (AS optional) modes
                     // Parse optional AS keyword
-                    let has_as = if self.peek_keyword(Keyword::As) {
+                    if self.peek_keyword(Keyword::As) {
                         self.consume_keyword(Keyword::As)?;
-                        true
-                    } else {
-                        false
-                    };
+                    }
 
-                    // Parse alias (required for derived tables)
+                    // Parse alias (required for derived tables) - keywords allowed as aliases
                     let alias = match self.peek() {
                         Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
                             let alias = id.clone();
                             self.advance();
                             alias
                         }
+                        Token::Keyword(kw) => {
+                            // Allow keywords as alias names for derived tables
+                            let alias = kw.to_string();
+                            self.advance();
+                            alias
+                        }
                         _ => {
                             return Err(ParseError {
-                                message: if has_as {
-                                    "Expected alias after AS keyword".to_string()
-                                } else {
-                                    "Derived table must have an alias".to_string()
-                                }
+                                message: "Derived table must have an alias".to_string()
                             })
                         }
                     };
@@ -127,16 +126,10 @@ impl Parser {
                 let name = self.parse_qualified_identifier()?;
 
                 // Check for optional alias
+                // Parse optional table alias - keywords allowed after AS (e.g., FROM t AS year)
                 let alias = if self.peek_keyword(Keyword::As) {
                     self.consume_keyword(Keyword::As)?;
-                    match self.peek() {
-                        Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                            let alias = id.clone();
-                            self.advance();
-                            Some(alias)
-                        }
-                        _ => None,
-                    }
+                    Some(self.parse_alias_name()?)
                 } else if matches!(
                     self.peek(),
                     Token::Identifier(_) | Token::DelimitedIdentifier(_)

--- a/crates/vibesql-parser/src/parser/select/list.rs
+++ b/crates/vibesql-parser/src/parser/select/list.rs
@@ -100,18 +100,10 @@ impl Parser {
         let expr = self.parse_expression()?;
 
         // Check for optional AS alias (MySQL allows aliases without AS keyword)
+        // Keywords are allowed as aliases after AS (e.g., d_year AS year)
         let alias = if self.peek_keyword(Keyword::As) {
             self.consume_keyword(Keyword::As)?;
-            match self.peek() {
-                Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                    let alias = id.clone();
-                    self.advance();
-                    Some(alias)
-                }
-                _ => {
-                    return Err(ParseError { message: "Expected identifier after AS".to_string() })
-                }
-            }
+            Some(self.parse_alias_name()?)
         } else if matches!(self.peek(), Token::Identifier(_) | Token::DelimitedIdentifier(_)) {
             // MySQL compatibility: allow aliases without AS keyword
             match self.peek() {


### PR DESCRIPTION
## Summary
- Fixed 5 failing TPC-DS queries (Q31, Q66, Q74, Q75, Q57)
- Improved TPC-DS coverage from 83.8% (83/99) to 88.9% (88/99)
- Added support for keywords as identifiers in alias and qualified column contexts
- Fixed ABS/SIGN functions to handle all numeric types

## Changes

### Parser fixes
- Allow SQL keywords as aliases after AS (e.g., `d_year AS year`)
- Allow SQL keywords as column names in qualified references (e.g., `table.year`)
- Added `parse_alias_name()` helper for consistent handling

### Executor fixes
- Added Numeric and Unsigned type support to ABS() function
- Added Smallint, Numeric, Unsigned type support to SIGN() function

## Test plan
- [x] TPC-DS: 88/99 queries passing (88.9%)
- [x] TPC-C: 100% transaction success rate
- [x] Parser tests: 928 passed, 0 failed
- [x] Executor doc tests: 24 passed

Closes #3224

🤖 Generated with [Claude Code](https://claude.com/claude-code)