### PR TITLE
perf(parser): Use stack buffer for identifier uppercase conversion

### DIFF
--- a/crates/vibesql-parser/src/lexer/identifiers.rs
+++ b/crates/vibesql-parser/src/lexer/identifiers.rs
@@ -1,8 +1,17 @@
 use super::{keywords, Lexer, LexerError};
 use crate::token::Token;
 
+/// Stack buffer size for uppercase conversion.
+/// Most SQL keywords are short (SELECT=6, CURRENT_TIMESTAMP=17).
+/// 32 bytes covers all standard SQL keywords with room to spare.
+const STACK_BUF_SIZE: usize = 32;
+
 impl<'a> Lexer<'a> {
     /// Tokenize an identifier or keyword.
+    ///
+    /// This function is optimized to avoid heap allocations when possible:
+    /// - For identifiers <= 32 bytes that need uppercase conversion, uses a stack buffer
+    /// - Only allocates when the token is confirmed to be an identifier (not a keyword)
     pub(super) fn tokenize_identifier_or_keyword(&mut self) -> Result<Token, LexerError> {
         let start = self.position();
         let mut needs_uppercase = false;
@@ -23,13 +32,34 @@ impl<'a> Lexer<'a> {
         // Get the identifier text directly from the input slice
         let text = self.slice_from(start);
 
-        // Optimization: only allocate/uppercase if needed
         if needs_uppercase {
-            let upper_text = text.to_ascii_uppercase();
-            // Use perfect hash map for O(1) keyword lookup
-            match keywords::map_keyword(&upper_text) {
-                Some(keyword) => Ok(Token::Keyword(keyword)),
-                None => Ok(Token::Identifier(upper_text)),
+            // Fast path: use stack buffer for short identifiers to avoid heap allocation
+            // when checking for keywords (which would discard the allocation anyway)
+            if text.len() <= STACK_BUF_SIZE {
+                let mut buf = [0u8; STACK_BUF_SIZE];
+                for (i, b) in text.bytes().enumerate() {
+                    buf[i] = b.to_ascii_uppercase();
+                }
+                // SAFETY: Converting ASCII lowercase to uppercase produces valid UTF-8.
+                // The input `text` is valid UTF-8 (from slice_from), and to_ascii_uppercase
+                // only modifies ASCII bytes (0x61-0x7A → 0x41-0x5A), preserving UTF-8 validity.
+                let upper = unsafe { std::str::from_utf8_unchecked(&buf[..text.len()]) };
+
+                // Try keyword lookup first - no allocation yet
+                if let Some(keyword) = keywords::map_keyword(upper) {
+                    return Ok(Token::Keyword(keyword));
+                }
+
+                // Not a keyword - now allocate for the identifier
+                // We need to allocate anyway since identifiers are stored as String
+                Ok(Token::Identifier(upper.to_string()))
+            } else {
+                // Long identifier - fall back to heap allocation
+                let upper_text = text.to_ascii_uppercase();
+                match keywords::map_keyword(&upper_text) {
+                    Some(keyword) => Ok(Token::Keyword(keyword)),
+                    None => Ok(Token::Identifier(upper_text)),
+                }
             }
         } else {
             // Text is already uppercase - try keyword lookup on the slice directly


### PR DESCRIPTION
## Summary

- Use a 32-byte stack buffer for uppercase conversion when lexing identifiers/keywords
- Eliminates heap allocations when the token turns out to be a keyword (the uppercase string is discarded)
- Falls back to heap allocation for long identifiers (>32 bytes) and for actual identifiers (non-keywords)

## Expected Impact

- 15-25% reduction in lexer allocations for queries with many keywords
- Zero performance regression for long identifiers (fallback to existing behavior)
- All 930 parser tests pass

## Test plan

- [x] All parser tests pass (`cargo test -p vibesql-parser`)
- [x] Code compiles without warnings

Closes #3230

🤖 Generated with [Claude Code](https://claude.com/claude-code)