### PR TITLE
perf(executor): Optimize TPC-H Q19 with InList predicate pushdown

### DIFF
--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -15,7 +15,8 @@ impl CombinedSchema {
     pub fn from_table(table_name: String, schema: vibesql_catalog::TableSchema) -> Self {
         let total_columns = schema.columns.len();
         let mut table_schemas = HashMap::new();
-        table_schemas.insert(table_name, (0, schema));
+        // Use lowercase table name for consistent lookups in predicate decomposition
+        table_schemas.insert(table_name.to_lowercase(), (0, schema));
         CombinedSchema { table_schemas, total_columns }
     }
 
@@ -41,7 +42,8 @@ impl CombinedSchema {
 
         let schema = vibesql_catalog::TableSchema::new(alias.clone(), columns);
         let mut table_schemas = HashMap::new();
-        table_schemas.insert(alias, (0, schema));
+        // Use lowercase alias for consistent lookups
+        table_schemas.insert(alias.to_lowercase(), (0, schema));
         CombinedSchema { table_schemas, total_columns }
     }
 
@@ -54,7 +56,8 @@ impl CombinedSchema {
         let mut table_schemas = left.table_schemas;
         let left_total = left.total_columns;
         let right_columns = right_schema.columns.len();
-        table_schemas.insert(right_table, (left_total, right_schema));
+        // Use lowercase table name for consistent lookups
+        table_schemas.insert(right_table.to_lowercase(), (left_total, right_schema));
         CombinedSchema { table_schemas, total_columns: left_total + right_columns }
     }
 

--- a/crates/vibesql-executor/src/select/columnar/filter/evaluation.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/evaluation.rs
@@ -58,7 +58,8 @@ where
                 | ColumnPredicate::Equal { column_idx, .. }
                 | ColumnPredicate::NotEqual { column_idx, .. }
                 | ColumnPredicate::Between { column_idx, .. }
-                | ColumnPredicate::Like { column_idx, .. } => *column_idx,
+                | ColumnPredicate::Like { column_idx, .. }
+                | ColumnPredicate::InList { column_idx, .. } => *column_idx,
             };
 
             if let Some(value) = get_value(column_idx) {
@@ -113,6 +114,14 @@ pub fn evaluate_predicate(predicate: &ColumnPredicate, value: &SqlValue) -> bool
             };
 
             let matches = like_match(text, pattern);
+            if *negated { !matches } else { matches }
+        }
+        ColumnPredicate::InList { values: list_values, negated, .. } => {
+            use std::cmp::Ordering;
+            // Check if value matches any in the list
+            let matches = list_values.iter().any(|list_val| {
+                compare_values(value, list_val).equals(Ordering::Equal)
+            });
             if *negated { !matches } else { matches }
         }
     }

--- a/crates/vibesql-executor/src/select/columnar/filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/mod.rs
@@ -100,6 +100,7 @@ where
                 ColumnPredicate::NotEqual { column_idx, .. } => *column_idx,
                 ColumnPredicate::Between { column_idx, .. } => *column_idx,
                 ColumnPredicate::Like { column_idx, .. } => *column_idx,
+                ColumnPredicate::InList { column_idx, .. } => *column_idx,
             };
 
             if let Some(value) = get_value(row_idx, column_idx) {

--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -63,6 +63,13 @@ pub enum ColumnPredicate {
         pattern: String,
         negated: bool,
     },
+
+    /// column IN (value1, value2, ...)
+    InList {
+        column_idx: usize,
+        values: Vec<SqlValue>,
+        negated: bool,
+    },
 }
 
 /// Extract column predicates as a tree from a WHERE clause expression
@@ -298,6 +305,38 @@ fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<
             None
         }
 
+        // IN list: column IN (value1, value2, ...)
+        Expression::InList {
+            expr: inner,
+            values,
+            negated,
+        } => {
+            if let Expression::ColumnRef { table, column } = inner.as_ref() {
+                // Extract all literal values from the IN list
+                let mut literal_values = Vec::with_capacity(values.len());
+                for value_expr in values {
+                    if let Expression::Literal(val) = value_expr {
+                        literal_values.push(val.clone());
+                    } else {
+                        // Non-literal value in IN list - can't optimize
+                        return None;
+                    }
+                }
+
+                if literal_values.is_empty() {
+                    return None;
+                }
+
+                let column_idx = schema.get_column_index(table.as_deref(), column)?;
+                return Some(PredicateTree::Leaf(ColumnPredicate::InList {
+                    column_idx,
+                    values: literal_values,
+                    negated: *negated,
+                }));
+            }
+            None
+        }
+
         _ => None,
     }
 }
@@ -463,6 +502,42 @@ fn extract_predicates_recursive(
                 }
             }
             // Skip non-column LIKE expressions
+            Some(())
+        }
+
+        // IN list: column IN (value1, value2, ...)
+        Expression::InList {
+            expr: inner,
+            values,
+            negated,
+        } => {
+            if let Expression::ColumnRef { table, column } = inner.as_ref() {
+                // Extract all literal values from the IN list
+                let mut literal_values = Vec::with_capacity(values.len());
+                for value_expr in values {
+                    if let Expression::Literal(val) = value_expr {
+                        literal_values.push(val.clone());
+                    } else {
+                        // Non-literal value in IN list - can't optimize
+                        return Some(());
+                    }
+                }
+
+                if literal_values.is_empty() {
+                    return Some(());
+                }
+
+                // Skip if column not in schema (cross-table predicate)
+                if let Some(column_idx) = schema.get_column_index(table.as_deref(), column) {
+                    predicates.push(ColumnPredicate::InList {
+                        column_idx,
+                        values: literal_values,
+                        negated: *negated,
+                    });
+                }
+                return Some(());
+            }
+            // Skip non-column IN expressions
             Some(())
         }
 

--- a/crates/vibesql-executor/src/select/columnar/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/mod.rs
@@ -422,6 +422,13 @@ fn evaluate_predicate(row: &Row, predicate: &ColumnPredicate) -> bool {
                 .unwrap_or(false);
             if *negated { !matches } else { matches }
         }
+        ColumnPredicate::InList { column_idx, values, negated } => {
+            // Check if column value matches any value in the list
+            let matches = row.get(*column_idx)
+                .map(|v| values.iter().any(|list_val| compare_values(v, list_val) == std::cmp::Ordering::Equal))
+                .unwrap_or(false);
+            if *negated { !matches } else { matches }
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/comparison.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/comparison.rs
@@ -159,6 +159,26 @@ pub fn evaluate_predicate_i64_simd(
                 right_type: Some("String pattern".to_string()),
             });
         }
+
+        ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // For i64 columns, check if value is in the list
+            let mut result = vec![false; values.len()];
+            for i64_val in list_values {
+                let target = match i64_val {
+                    SqlValue::Integer(n) => *n,
+                    SqlValue::Bigint(n) => *n,
+                    _ => continue,
+                };
+                let matches = simd_ops::eq_i64(values, target);
+                for (i, &m) in matches.iter().enumerate() {
+                    result[i] = result[i] || m;
+                }
+            }
+            if *negated {
+                result.iter_mut().for_each(|v| *v = !*v);
+            }
+            result
+        }
     };
 
     // Apply NULL mask: NULLs always fail predicates
@@ -271,6 +291,23 @@ pub fn evaluate_predicate_i32_simd(
                 right_type: Some("String pattern".to_string()),
             });
         }
+
+        ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // For date (i32) columns, check if value is in the list
+            let mut result = vec![false; values.len()];
+            for date_val in list_values {
+                if let Some(target) = value_to_date_i32(date_val) {
+                    let matches = simd_ops::eq_i32(values, target);
+                    for (i, &m) in matches.iter().enumerate() {
+                        result[i] = result[i] || m;
+                    }
+                }
+            }
+            if *negated {
+                result.iter_mut().for_each(|v| *v = !*v);
+            }
+            result
+        }
     };
 
     // Apply NULL mask: NULLs always fail predicates
@@ -379,6 +416,23 @@ pub fn evaluate_predicate_f64_simd(
                 left_type: "Float64".to_string(),
                 right_type: Some("String pattern".to_string()),
             });
+        }
+
+        ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // For f64 columns, check if value is in the list
+            let mut result = vec![false; values.len()];
+            for f_val in list_values {
+                if let Some(target) = value_to_f64(f_val) {
+                    let matches = simd_ops::eq_f64(values, target);
+                    for (i, &m) in matches.iter().enumerate() {
+                        result[i] = result[i] || m;
+                    }
+                }
+            }
+            if *negated {
+                result.iter_mut().for_each(|v| *v = !*v);
+            }
+            result
         }
     };
 
@@ -542,6 +596,24 @@ pub fn evaluate_predicate_i64_packed(
                 right_type: Some("String pattern".to_string()),
             });
         }
+
+        ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // For i64 columns with packed mask
+            let mut result = PackedMask::new_all_clear(values.len());
+            for i64_val in list_values {
+                let target = match i64_val {
+                    SqlValue::Integer(n) => *n,
+                    SqlValue::Bigint(n) => *n,
+                    _ => continue,
+                };
+                let matches = simd_ops::eq_i64_packed(values, target);
+                result.or_inplace(&matches);
+            }
+            if *negated {
+                result = result.not();
+            }
+            result
+        }
     };
 
     // Apply NULL mask: NULLs always fail predicates
@@ -646,6 +718,21 @@ pub fn evaluate_predicate_i32_packed(
                 right_type: Some("String pattern".to_string()),
             });
         }
+
+        ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // For date (i32) columns with packed mask
+            let mut result = PackedMask::new_all_clear(values.len());
+            for date_val in list_values {
+                if let Some(target) = value_to_date_i32(date_val) {
+                    let matches = simd_ops::eq_i32_packed(values, target);
+                    result.or_inplace(&matches);
+                }
+            }
+            if *negated {
+                result = result.not();
+            }
+            result
+        }
     };
 
     // Apply NULL mask
@@ -749,6 +836,21 @@ pub fn evaluate_predicate_f64_packed(
                 left_type: "Float64".to_string(),
                 right_type: Some("String pattern".to_string()),
             });
+        }
+
+        ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // For f64 columns with packed mask
+            let mut result = PackedMask::new_all_clear(values.len());
+            for f_val in list_values {
+                if let Some(target) = value_to_f64(f_val) {
+                    let matches = simd_ops::eq_f64_packed(values, target);
+                    result.or_inplace(&matches);
+                }
+            }
+            if *negated {
+                result = result.not();
+            }
+            result
         }
     };
 

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/mod.rs
@@ -42,6 +42,8 @@ fn predicate_contains_null(predicate: &ColumnPredicate) -> bool {
         }
         // LIKE patterns don't have NULL values in the pattern itself
         ColumnPredicate::Like { .. } => false,
+        // IN list may contain NULL values
+        ColumnPredicate::InList { values, .. } => values.iter().any(|v| matches!(v, SqlValue::Null)),
     }
 }
 
@@ -163,7 +165,8 @@ fn evaluate_predicate_simd_packed(
         | ColumnPredicate::Equal { column_idx, .. }
         | ColumnPredicate::NotEqual { column_idx, .. }
         | ColumnPredicate::Between { column_idx, .. }
-        | ColumnPredicate::Like { column_idx, .. } => *column_idx,
+        | ColumnPredicate::Like { column_idx, .. }
+        | ColumnPredicate::InList { column_idx, .. } => *column_idx,
     };
 
     let column = batch
@@ -221,7 +224,8 @@ fn evaluate_predicate_simd(
         | ColumnPredicate::Equal { column_idx, .. }
         | ColumnPredicate::NotEqual { column_idx, .. }
         | ColumnPredicate::Between { column_idx, .. }
-        | ColumnPredicate::Like { column_idx, .. } => *column_idx,
+        | ColumnPredicate::Like { column_idx, .. }
+        | ColumnPredicate::InList { column_idx, .. } => *column_idx,
     };
 
     let column = batch

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/string.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/string.rs
@@ -158,6 +158,37 @@ pub fn evaluate_predicate_string_batch(
                 .map(|(&a, &b)| a && b)
                 .collect()
         }
+
+        ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // For string columns, check if value is in the list
+            let mut result = vec![false; values.len()];
+
+            // Apply null mask first
+            if let Some(null_mask) = nulls {
+                for (i, &is_null) in null_mask.iter().enumerate() {
+                    if is_null {
+                        result[i] = false;
+                    }
+                }
+            }
+
+            // Check each list value
+            for list_val in list_values {
+                let target = match list_val {
+                    SqlValue::Character(s) | SqlValue::Varchar(s) => s.as_str(),
+                    _ => continue, // Skip non-string values
+                };
+                let matches = batch_string_eq(values, nulls, target);
+                for (i, &m) in matches.iter().enumerate() {
+                    result[i] = result[i] || m;
+                }
+            }
+
+            if *negated {
+                result.iter_mut().for_each(|v| *v = !*v);
+            }
+            result
+        }
     };
 
     Ok(result)

--- a/crates/vibesql-executor/src/select/columnar/simd_ops/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_ops/mod.rs
@@ -177,6 +177,65 @@ impl PackedMask {
         }
     }
 
+    /// Performs in-place bitwise OR with another mask.
+    ///
+    /// This is used for combining multiple predicates in IN lists.
+    /// Uses native bitwise OR which maps directly to SIMD instructions.
+    #[inline]
+    pub fn or_inplace(&mut self, other: &PackedMask) {
+        debug_assert_eq!(self.len, other.len, "mask lengths must match");
+
+        // Process in chunks of 4 for potential auto-vectorization
+        let chunks = self.words.len() / 4;
+        for i in 0..chunks {
+            let base = i * 4;
+            self.words[base] |= other.words[base];
+            self.words[base + 1] |= other.words[base + 1];
+            self.words[base + 2] |= other.words[base + 2];
+            self.words[base + 3] |= other.words[base + 3];
+        }
+
+        // Handle remainder
+        for i in (chunks * 4)..self.words.len() {
+            self.words[i] |= other.words[i];
+        }
+    }
+
+    /// Returns a new mask with all bits inverted.
+    ///
+    /// This is used for NOT IN operations.
+    #[inline]
+    pub fn not(&self) -> PackedMask {
+        let mut result = PackedMask {
+            words: vec![0; self.words.len()],
+            len: self.len,
+        };
+
+        // Process in chunks of 4 for potential auto-vectorization
+        let chunks = self.words.len() / 4;
+        for i in 0..chunks {
+            let base = i * 4;
+            result.words[base] = !self.words[base];
+            result.words[base + 1] = !self.words[base + 1];
+            result.words[base + 2] = !self.words[base + 2];
+            result.words[base + 3] = !self.words[base + 3];
+        }
+
+        // Handle remainder
+        for i in (chunks * 4)..self.words.len() {
+            result.words[i] = !self.words[i];
+        }
+
+        // Clear unused bits in the last word
+        let remainder = self.len % 64;
+        let num_words = result.words.len();
+        if remainder != 0 && num_words > 0 {
+            result.words[num_words - 1] &= (1u64 << remainder) - 1;
+        }
+
+        result
+    }
+
     /// Counts the number of set bits (rows that pass the filter).
     ///
     /// Uses the `count_ones()` intrinsic which maps to hardware popcount.

--- a/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
@@ -123,6 +123,14 @@ where
         }
     }
 
+    // Extract common single-table predicates from OR branches (e.g., TPC-H Q19)
+    // This handles cases like `l_shipmode IN ('AIR', 'AIR REG')` that appear in all OR branches
+    if let Some(where_expr) = where_clause {
+        for (table, preds) in predicates::extract_common_or_predicates_with_schema(where_expr, &table_set, &column_to_table) {
+            table_local_predicates.entry(table).or_default().extend(preds);
+        }
+    }
+
     if std::env::var("JOIN_REORDER_VERBOSE").is_ok() && !table_local_predicates.is_empty() {
         eprintln!("[JOIN_REORDER] Table-local predicates: {:?}",
             table_local_predicates.keys().collect::<Vec<_>>());
@@ -185,9 +193,11 @@ where
 
         // Execute this table with table-local predicates for early filtering
         // Build a combined predicate from table-local predicates for this specific table
+        // Use the actual table name (table_ref.name) for column qualification so that
+        // PredicatePlan can correctly identify the predicates as table-local
         let table_filter = table_local_predicates
             .get(&table_name.to_lowercase())
-            .and_then(|preds| utils::combine_predicates(preds));
+            .and_then(|preds| utils::combine_predicates_with_qualification(preds, &table_ref.name));
 
         let scan_start = std::time::Instant::now();
         let table_result = if table_ref.is_subquery {

--- a/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
@@ -122,6 +122,127 @@ pub(super) fn extract_in_predicates_from_or(
     result
 }
 
+/// Extract common single-table predicates from OR expressions.
+///
+/// For queries like TPC-H Q19 where all OR branches share predicates like:
+/// `l_shipmode IN ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON'`
+///
+/// This function extracts those common predicates and returns them grouped by table,
+/// allowing them to be pushed down to table scans.
+pub(super) fn extract_common_or_predicates_with_schema(
+    where_expr: &Expression,
+    table_set: &HashSet<String>,
+    column_to_table: &HashMap<String, String>,
+) -> HashMap<String, Vec<Expression>> {
+    let mut result: HashMap<String, Vec<Expression>> = HashMap::new();
+
+    /// Helper to collect all branches of an OR expression
+    fn collect_or_branches(expr: &Expression) -> Vec<Expression> {
+        match expr {
+            Expression::BinaryOp { op: BinaryOperator::Or, left, right } => {
+                let mut branches = collect_or_branches(left);
+                branches.extend(collect_or_branches(right));
+                branches
+            }
+            _ => vec![expr.clone()],
+        }
+    }
+
+    /// Normalize predicate for comparison (handles IN lists with different orderings)
+    fn normalize_predicate(pred: &Expression) -> String {
+        match pred {
+            Expression::InList { expr, values, negated } => {
+                // Sort values for comparison since order doesn't matter for IN lists
+                let mut sorted_vals: Vec<String> = values.iter().map(|v| format!("{:?}", v)).collect();
+                sorted_vals.sort();
+                format!("InList({:?},{:?},{:?})", expr, sorted_vals, negated)
+            }
+            Expression::Between { expr, low, high, negated, symmetric } => {
+                format!("Between({:?},{:?},{:?},{:?},{:?})", expr, low, high, negated, symmetric)
+            }
+            _ => format!("{:?}", pred),
+        }
+    }
+
+    /// Check if a predicate references only a single table
+    fn get_single_table(
+        pred: &Expression,
+        table_set: &HashSet<String>,
+        column_to_table: &HashMap<String, String>,
+    ) -> Option<String> {
+        let mut referenced_tables = HashSet::new();
+        super::graph::extract_referenced_tables_with_schema(pred, &mut referenced_tables, table_set, column_to_table);
+
+        if referenced_tables.len() == 1 {
+            referenced_tables.into_iter().next()
+        } else {
+            None
+        }
+    }
+
+    // Process top-level AND predicates looking for OR expressions
+    for pred in flatten_and_chain(where_expr) {
+        // Only process OR expressions
+        if !matches!(&pred, Expression::BinaryOp { op: BinaryOperator::Or, .. }) {
+            continue;
+        }
+
+        // Collect all OR branches
+        let branches = collect_or_branches(&pred);
+        if branches.len() < 2 {
+            continue;
+        }
+
+        // For each branch, extract single-table predicates
+        let mut branch_predicates: Vec<HashMap<String, Vec<(Expression, String)>>> = Vec::new();
+
+        for branch in &branches {
+            let mut branch_preds: HashMap<String, Vec<(Expression, String)>> = HashMap::new();
+
+            for sub_pred in flatten_and_chain(branch) {
+                if let Some(table) = get_single_table(&sub_pred, table_set, column_to_table) {
+                    let normalized = normalize_predicate(&sub_pred);
+                    branch_preds.entry(table).or_default().push((sub_pred, normalized));
+                }
+            }
+
+            branch_predicates.push(branch_preds);
+        }
+
+        // Find predicates that appear in ALL branches for each table
+        if branch_predicates.is_empty() {
+            continue;
+        }
+
+        // Get all tables from first branch
+        let first_branch = &branch_predicates[0];
+
+        for (table, first_preds) in first_branch {
+            // For each predicate in first branch, check if it appears in all other branches
+            for (pred, normalized) in first_preds {
+                let appears_in_all = branch_predicates[1..].iter().all(|branch| {
+                    branch.get(table).map_or(false, |preds| {
+                        preds.iter().any(|(_, n)| n == normalized)
+                    })
+                });
+
+                if appears_in_all {
+                    // Avoid duplicates
+                    let existing = result.entry(table.clone()).or_default();
+                    if !existing.iter().any(|e| normalize_predicate(e) == *normalized) {
+                        if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
+                            eprintln!("[JOIN_REORDER] Extracted common OR predicate for table {}: {:?}", table, pred);
+                        }
+                        existing.push(pred.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    result
+}
+
 /// Extract equijoin conditions from a WHERE clause expression using schema-based column resolution
 ///
 /// This is the preferred method that uses actual database schema to resolve unqualified columns.

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -293,6 +293,88 @@ pub(super) fn combine_predicates(predicates: &[vibesql_ast::Expression]) -> Opti
     }
 }
 
+/// Combine a list of predicates into a single AND expression, qualifying unqualified columns
+///
+/// This is similar to `combine_predicates` but also adds table qualifiers to any
+/// unqualified column references. This is necessary for predicates extracted from
+/// OR branches where columns may not have table qualifiers.
+pub(super) fn combine_predicates_with_qualification(
+    predicates: &[vibesql_ast::Expression],
+    table_name: &str,
+) -> Option<vibesql_ast::Expression> {
+    match predicates.len() {
+        0 => None,
+        1 => Some(qualify_columns(&predicates[0], table_name)),
+        _ => {
+            let mut result = qualify_columns(&predicates[0], table_name);
+            for pred in &predicates[1..] {
+                result = vibesql_ast::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::And,
+                    left: Box::new(result),
+                    right: Box::new(qualify_columns(pred, table_name)),
+                };
+            }
+            Some(result)
+        }
+    }
+}
+
+/// Add table qualifiers to unqualified column references in an expression
+fn qualify_columns(expr: &vibesql_ast::Expression, table_name: &str) -> vibesql_ast::Expression {
+    use vibesql_ast::Expression;
+
+    // Use lowercase table name for consistency with schema lookups
+    let table_name_lower = table_name.to_lowercase();
+
+    match expr {
+        Expression::ColumnRef { table: None, column } => {
+            // Add table qualifier to unqualified column
+            Expression::ColumnRef {
+                table: Some(table_name_lower.clone()),
+                column: column.clone(),
+            }
+        }
+        Expression::ColumnRef { table: Some(t), column } => {
+            // Already qualified, keep as is
+            Expression::ColumnRef {
+                table: Some(t.clone()),
+                column: column.clone(),
+            }
+        }
+        Expression::BinaryOp { op, left, right } => {
+            Expression::BinaryOp {
+                op: op.clone(),
+                left: Box::new(qualify_columns(left, table_name)),
+                right: Box::new(qualify_columns(right, table_name)),
+            }
+        }
+        Expression::UnaryOp { op, expr: inner } => {
+            Expression::UnaryOp {
+                op: op.clone(),
+                expr: Box::new(qualify_columns(inner, table_name)),
+            }
+        }
+        Expression::InList { expr: inner, values, negated } => {
+            Expression::InList {
+                expr: Box::new(qualify_columns(inner, table_name)),
+                values: values.iter().map(|v| qualify_columns(v, table_name)).collect(),
+                negated: *negated,
+            }
+        }
+        Expression::Between { expr: inner, low, high, negated, symmetric } => {
+            Expression::Between {
+                expr: Box::new(qualify_columns(inner, table_name)),
+                low: Box::new(qualify_columns(low, table_name)),
+                high: Box::new(qualify_columns(high, table_name)),
+                negated: *negated,
+                symmetric: *symmetric,
+            }
+        }
+        // For other expressions (literals, etc.), return as-is
+        _ => expr.clone(),
+    }
+}
+
 /// Resolve an unqualified column to its table using schema-based lookup
 ///
 /// Returns the table name if the column is found in exactly one table,


### PR DESCRIPTION
## Summary

This PR significantly improves TPC-H Q19 performance by extracting common predicates from OR branches and pushing them down to table scans.

### Key changes:

- **Add InList support to columnar filter system**: New `InList` variant in ColumnPredicate enum with SIMD-accelerated evaluation for all types
- **Extract common OR predicates**: New `extract_common_or_predicates_with_schema` function finds predicates that appear in ALL OR branches (e.g., `l_shipmode IN ('AIR', 'AIR REG')`)  
- **Fix predicate qualification**: Properly qualifies unqualified column references and fixes case sensitivity in schema lookups
- **Add PackedMask operations**: New `or_inplace` and `not` methods for efficient IN list evaluation

### Performance results (TPC-H SF=0.01):

| Query | Before | After | Improvement |
|-------|--------|-------|-------------|
| Q19 | ~400ms | ~130ms | **3x faster** |
| Q7 | ~385ms | ~380ms | unchanged |

Q19's complex OR condition with common predicates (`l_shipmode IN ('AIR', 'AIR REG')` and `l_shipinstruct = 'DELIVER IN PERSON'` appearing in all 3 OR branches) is now pushed down to the LINEITEM scan, reducing rows from 60,000 to ~17,000 before the join.

## Test plan

- [x] All 22 TPC-H queries pass
- [x] Q19 performance improved from ~400ms to ~130ms (exceeds <200ms target)
- [x] Executor tests pass
- [x] Build succeeds

Closes #3222

🤖 Generated with [Claude Code](https://claude.com/claude-code)