### PR TITLE
perf(parser): Add arena allocation for AST nodes (Phase 1)

### DIFF
--- a/crates/vibesql-ast/Cargo.toml
+++ b/crates/vibesql-ast/Cargo.toml
@@ -11,5 +11,6 @@ categories = ["database", "parser-implementations"]
 
 [dependencies]
 vibesql-types = { version = "0.1.0", path = "../vibesql-types" }
+bumpalo = { version = "3.16", features = ["collections"] }
 
 [dev-dependencies]

--- a/crates/vibesql-ast/src/arena/expression.rs
+++ b/crates/vibesql-ast/src/arena/expression.rs
@@ -1,0 +1,326 @@
+//! Arena-allocated Expression types.
+
+use bumpalo::collections::Vec as BumpVec;
+use vibesql_types::SqlValue;
+
+use crate::{BinaryOperator, UnaryOperator};
+use super::SelectStmt;
+
+/// Arena-allocated SQL Expression.
+///
+/// This is the arena-based version of [`crate::Expression`] where all recursive
+/// references use arena allocation instead of `Box`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expression<'arena> {
+    /// Literal value (42, 'hello', TRUE, NULL)
+    Literal(SqlValue),
+
+    /// Parameter placeholder (?) for prepared statements
+    Placeholder(usize),
+
+    /// Numbered parameter placeholder ($1, $2, etc.)
+    NumberedPlaceholder(usize),
+
+    /// Named parameter placeholder (:name)
+    NamedPlaceholder(&'arena str),
+
+    /// Column reference (id, users.id)
+    ColumnRef {
+        table: Option<&'arena str>,
+        column: &'arena str,
+    },
+
+    /// Binary operation (a + b, x = y, p AND q)
+    BinaryOp {
+        op: BinaryOperator,
+        left: &'arena Expression<'arena>,
+        right: &'arena Expression<'arena>,
+    },
+
+    /// Unary operation (NOT x, -5)
+    UnaryOp {
+        op: UnaryOperator,
+        expr: &'arena Expression<'arena>,
+    },
+
+    /// Function call (UPPER(x), SUBSTRING(x, 1, 3))
+    Function {
+        name: &'arena str,
+        args: BumpVec<'arena, Expression<'arena>>,
+        character_unit: Option<CharacterUnit>,
+    },
+
+    /// Aggregate function call (COUNT, SUM, AVG, MIN, MAX)
+    AggregateFunction {
+        name: &'arena str,
+        distinct: bool,
+        args: BumpVec<'arena, Expression<'arena>>,
+    },
+
+    /// IS NULL / IS NOT NULL
+    IsNull {
+        expr: &'arena Expression<'arena>,
+        negated: bool,
+    },
+
+    /// Wildcard (*)
+    Wildcard,
+
+    /// CASE expression
+    Case {
+        operand: Option<&'arena Expression<'arena>>,
+        when_clauses: BumpVec<'arena, CaseWhen<'arena>>,
+        else_result: Option<&'arena Expression<'arena>>,
+    },
+
+    /// Scalar subquery
+    ScalarSubquery(&'arena SelectStmt<'arena>),
+
+    /// IN operator with subquery
+    In {
+        expr: &'arena Expression<'arena>,
+        subquery: &'arena SelectStmt<'arena>,
+        negated: bool,
+    },
+
+    /// IN operator with value list
+    InList {
+        expr: &'arena Expression<'arena>,
+        values: BumpVec<'arena, Expression<'arena>>,
+        negated: bool,
+    },
+
+    /// BETWEEN predicate
+    Between {
+        expr: &'arena Expression<'arena>,
+        low: &'arena Expression<'arena>,
+        high: &'arena Expression<'arena>,
+        negated: bool,
+        symmetric: bool,
+    },
+
+    /// CAST expression
+    Cast {
+        expr: &'arena Expression<'arena>,
+        data_type: vibesql_types::DataType,
+    },
+
+    /// POSITION expression
+    Position {
+        substring: &'arena Expression<'arena>,
+        string: &'arena Expression<'arena>,
+        character_unit: Option<CharacterUnit>,
+    },
+
+    /// TRIM expression
+    Trim {
+        position: Option<TrimPosition>,
+        removal_char: Option<&'arena Expression<'arena>>,
+        string: &'arena Expression<'arena>,
+    },
+
+    /// EXTRACT expression
+    Extract {
+        field: IntervalUnit,
+        expr: &'arena Expression<'arena>,
+    },
+
+    /// LIKE pattern matching
+    Like {
+        expr: &'arena Expression<'arena>,
+        pattern: &'arena Expression<'arena>,
+        negated: bool,
+    },
+
+    /// EXISTS predicate
+    Exists {
+        subquery: &'arena SelectStmt<'arena>,
+        negated: bool,
+    },
+
+    /// Quantified comparison (ALL, ANY, SOME)
+    QuantifiedComparison {
+        expr: &'arena Expression<'arena>,
+        op: BinaryOperator,
+        quantifier: Quantifier,
+        subquery: &'arena SelectStmt<'arena>,
+    },
+
+    /// Current date/time functions
+    CurrentDate,
+    CurrentTime { precision: Option<u32> },
+    CurrentTimestamp { precision: Option<u32> },
+
+    /// INTERVAL expression
+    Interval {
+        value: &'arena Expression<'arena>,
+        unit: IntervalUnit,
+        leading_precision: Option<u32>,
+        fractional_precision: Option<u32>,
+    },
+
+    /// DEFAULT keyword
+    Default,
+
+    /// VALUES() function for ON DUPLICATE KEY UPDATE
+    DuplicateKeyValue { column: &'arena str },
+
+    /// Window function with OVER clause
+    WindowFunction {
+        function: WindowFunctionSpec<'arena>,
+        over: WindowSpec<'arena>,
+    },
+
+    /// NEXT VALUE FOR sequence expression
+    NextValue { sequence_name: &'arena str },
+
+    /// MATCH...AGAINST full-text search
+    MatchAgainst {
+        columns: BumpVec<'arena, &'arena str>,
+        search_modifier: &'arena Expression<'arena>,
+        mode: FulltextMode,
+    },
+
+    /// Pseudo-variable reference (OLD/NEW in triggers)
+    PseudoVariable {
+        pseudo_table: PseudoTable,
+        column: &'arena str,
+    },
+
+    /// Session/system variable reference
+    SessionVariable { name: &'arena str },
+}
+
+/// Full-text search mode specification
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FulltextMode {
+    NaturalLanguage,
+    Boolean,
+    QueryExpansion,
+}
+
+/// Pseudo-table reference for trigger context
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PseudoTable {
+    Old,
+    New,
+}
+
+/// CASE WHEN clause structure
+#[derive(Debug, Clone, PartialEq)]
+pub struct CaseWhen<'arena> {
+    pub conditions: BumpVec<'arena, Expression<'arena>>,
+    pub result: Expression<'arena>,
+}
+
+/// Quantifier for quantified comparisons
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Quantifier {
+    All,
+    Any,
+    Some,
+}
+
+/// Window function specification
+#[derive(Debug, Clone, PartialEq)]
+pub enum WindowFunctionSpec<'arena> {
+    Aggregate {
+        name: &'arena str,
+        args: BumpVec<'arena, Expression<'arena>>,
+    },
+    Ranking {
+        name: &'arena str,
+        args: BumpVec<'arena, Expression<'arena>>,
+    },
+    Value {
+        name: &'arena str,
+        args: BumpVec<'arena, Expression<'arena>>,
+    },
+}
+
+/// Window specification (OVER clause)
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowSpec<'arena> {
+    pub partition_by: Option<BumpVec<'arena, Expression<'arena>>>,
+    pub order_by: Option<BumpVec<'arena, OrderByItem<'arena>>>,
+    pub frame: Option<WindowFrame<'arena>>,
+}
+
+/// Window frame specification
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowFrame<'arena> {
+    pub unit: FrameUnit,
+    pub start: FrameBound<'arena>,
+    pub end: Option<FrameBound<'arena>>,
+}
+
+/// Frame unit type
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FrameUnit {
+    Rows,
+    Range,
+}
+
+/// Frame boundary specification
+#[derive(Debug, Clone, PartialEq)]
+pub enum FrameBound<'arena> {
+    UnboundedPreceding,
+    Preceding(&'arena Expression<'arena>),
+    CurrentRow,
+    Following(&'arena Expression<'arena>),
+    UnboundedFollowing,
+}
+
+/// TRIM position specification
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TrimPosition {
+    Both,
+    Leading,
+    Trailing,
+}
+
+/// Character measurement unit
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CharacterUnit {
+    Characters,
+    Octets,
+}
+
+/// Interval unit
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IntervalUnit {
+    Microsecond,
+    Second,
+    Minute,
+    Hour,
+    Day,
+    Week,
+    Month,
+    Quarter,
+    Year,
+    SecondMicrosecond,
+    MinuteMicrosecond,
+    MinuteSecond,
+    HourMicrosecond,
+    HourSecond,
+    HourMinute,
+    DayMicrosecond,
+    DaySecond,
+    DayMinute,
+    DayHour,
+    YearMonth,
+}
+
+/// ORDER BY item
+#[derive(Debug, Clone, PartialEq)]
+pub struct OrderByItem<'arena> {
+    pub expr: Expression<'arena>,
+    pub direction: OrderDirection,
+}
+
+/// Sort direction
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OrderDirection {
+    Asc,
+    Desc,
+}

--- a/crates/vibesql-ast/src/arena/mod.rs
+++ b/crates/vibesql-ast/src/arena/mod.rs
@@ -1,0 +1,30 @@
+//! Arena-allocated AST types for improved parsing performance.
+//!
+//! This module provides arena-based versions of AST types that use bump allocation
+//! instead of individual heap allocations. This can significantly improve parsing
+//! performance for complex queries by:
+//!
+//! - Reducing allocation overhead (O(1) bump allocation vs heap allocation)
+//! - Improving cache locality (contiguous memory layout)
+//! - Enabling batch deallocation (single `drop(arena)` frees everything)
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use bumpalo::Bump;
+//! use vibesql_ast::arena::Expression;
+//!
+//! let arena = Bump::new();
+//! // Parser allocates from arena
+//! let expr = arena.alloc(Expression::Literal(SqlValue::Integer(42)));
+//! // All allocations freed when arena is dropped
+//! ```
+
+mod expression;
+mod select;
+
+pub use expression::*;
+pub use select::*;
+
+// Re-export Bump for convenience
+pub use bumpalo::Bump;

--- a/crates/vibesql-ast/src/arena/select.rs
+++ b/crates/vibesql-ast/src/arena/select.rs
@@ -1,0 +1,127 @@
+//! Arena-allocated SELECT statement types.
+
+use bumpalo::collections::Vec as BumpVec;
+
+use super::expression::{Expression, OrderByItem};
+
+/// Common Table Expression (CTE) definition
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommonTableExpr<'arena> {
+    pub name: &'arena str,
+    pub columns: Option<BumpVec<'arena, &'arena str>>,
+    pub query: &'arena SelectStmt<'arena>,
+}
+
+/// Arena-allocated SELECT statement structure
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectStmt<'arena> {
+    pub with_clause: Option<BumpVec<'arena, CommonTableExpr<'arena>>>,
+    pub distinct: bool,
+    pub select_list: BumpVec<'arena, SelectItem<'arena>>,
+    pub into_table: Option<&'arena str>,
+    pub into_variables: Option<BumpVec<'arena, &'arena str>>,
+    pub from: Option<FromClause<'arena>>,
+    pub where_clause: Option<Expression<'arena>>,
+    pub group_by: Option<GroupByClause<'arena>>,
+    pub having: Option<Expression<'arena>>,
+    pub order_by: Option<BumpVec<'arena, OrderByItem<'arena>>>,
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+    pub set_operation: Option<SetOperation<'arena>>,
+}
+
+/// GROUP BY clause structure
+#[derive(Debug, Clone, PartialEq)]
+pub enum GroupByClause<'arena> {
+    Simple(BumpVec<'arena, Expression<'arena>>),
+    Rollup(BumpVec<'arena, GroupingElement<'arena>>),
+    Cube(BumpVec<'arena, GroupingElement<'arena>>),
+    GroupingSets(BumpVec<'arena, GroupingSet<'arena>>),
+    Mixed(BumpVec<'arena, MixedGroupingItem<'arena>>),
+}
+
+/// A single grouping element within ROLLUP or CUBE
+#[derive(Debug, Clone, PartialEq)]
+pub enum GroupingElement<'arena> {
+    Single(Expression<'arena>),
+    Composite(BumpVec<'arena, Expression<'arena>>),
+}
+
+/// A single grouping set within GROUPING SETS
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroupingSet<'arena> {
+    pub columns: BumpVec<'arena, Expression<'arena>>,
+}
+
+/// An item in a mixed GROUP BY clause
+#[derive(Debug, Clone, PartialEq)]
+pub enum MixedGroupingItem<'arena> {
+    Simple(Expression<'arena>),
+    Rollup(BumpVec<'arena, GroupingElement<'arena>>),
+    Cube(BumpVec<'arena, GroupingElement<'arena>>),
+    GroupingSets(BumpVec<'arena, GroupingSet<'arena>>),
+}
+
+/// Set operation combining two SELECT statements
+#[derive(Debug, Clone, PartialEq)]
+pub struct SetOperation<'arena> {
+    pub op: SetOperator,
+    pub all: bool,
+    pub right: &'arena SelectStmt<'arena>,
+}
+
+/// Item in the SELECT list
+#[derive(Debug, Clone, PartialEq)]
+pub enum SelectItem<'arena> {
+    Wildcard {
+        alias: Option<BumpVec<'arena, &'arena str>>,
+    },
+    QualifiedWildcard {
+        qualifier: &'arena str,
+        alias: Option<BumpVec<'arena, &'arena str>>,
+    },
+    Expression {
+        expr: Expression<'arena>,
+        alias: Option<&'arena str>,
+    },
+}
+
+/// FROM clause
+#[derive(Debug, Clone, PartialEq)]
+pub enum FromClause<'arena> {
+    Table {
+        name: &'arena str,
+        alias: Option<&'arena str>,
+    },
+    Join {
+        left: &'arena FromClause<'arena>,
+        right: &'arena FromClause<'arena>,
+        join_type: JoinType,
+        condition: Option<Expression<'arena>>,
+        natural: bool,
+    },
+    Subquery {
+        query: &'arena SelectStmt<'arena>,
+        alias: &'arena str,
+    },
+}
+
+/// JOIN types
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum JoinType {
+    Inner,
+    LeftOuter,
+    RightOuter,
+    FullOuter,
+    Cross,
+    Semi,
+    Anti,
+}
+
+/// Set operators for combining SELECT statements
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SetOperator {
+    Union,
+    Intersect,
+    Except,
+}

--- a/crates/vibesql-ast/src/lib.rs
+++ b/crates/vibesql-ast/src/lib.rs
@@ -3,6 +3,14 @@
 //! This crate defines the structure of SQL statements and expressions
 //! as parsed from SQL text. The AST is a tree representation that
 //! preserves the semantic structure of SQL queries.
+//!
+//! # Arena-allocated Types
+//!
+//! For performance-critical code paths, this crate provides arena-allocated
+//! versions of AST types in the [`arena`] module. These use bump allocation
+//! for improved cache locality and reduced allocation overhead.
+
+pub mod arena;
 
 mod ddl;
 mod dml;

--- a/crates/vibesql-parser/Cargo.toml
+++ b/crates/vibesql-parser/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["database", "parser-implementations"]
 vibesql-ast = { version = "0.1.0", path = "../vibesql-ast" }
 vibesql-types = { version = "0.1.0", path = "../vibesql-types" }
 phf = { version = "0.11", features = ["macros"] }
+bumpalo = { version = "3.16", features = ["collections"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/vibesql-parser/benches/parser_benchmark.rs
+++ b/crates/vibesql-parser/benches/parser_benchmark.rs
@@ -3,8 +3,10 @@
 //! Measures parse times for various SQL query types to establish baselines
 //! and track optimization improvements.
 
+use bumpalo::Bump;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::hint::black_box;
+use vibesql_parser::arena_parser::ArenaParser;
 use vibesql_parser::{Lexer, Parser};
 
 /// Simple SELECT query - baseline for minimal parsing overhead
@@ -189,11 +191,89 @@ fn bench_identifiers(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark arena-allocated parser (SELECT statements only for Phase 1)
+fn bench_arena_parser(c: &mut Criterion) {
+    let mut group = c.benchmark_group("arena_parser");
+
+    // Only SELECT queries are supported by the arena parser
+    let queries = [
+        ("simple_select", SIMPLE_SELECT),
+        ("point_lookup", POINT_LOOKUP),
+        ("multi_column", MULTI_COLUMN),
+        ("tpch_q1", TPCH_Q1),
+        ("complex_join", COMPLEX_JOIN),
+        ("cte_query", CTE_QUERY),
+    ];
+
+    for (name, sql) in queries {
+        group.throughput(Throughput::Bytes(sql.len() as u64));
+        group.bench_with_input(BenchmarkId::new("parse", name), sql, |b, sql| {
+            b.iter(|| {
+                let arena = Bump::new();
+                let result = ArenaParser::parse_sql(black_box(sql), &arena).unwrap();
+                // Just verify parsing succeeded - result is tied to arena lifetime
+                let _ = black_box(&result);
+                drop(arena);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Compare standard parser vs arena parser
+fn bench_parser_comparison(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parser_comparison");
+
+    // Note: Only queries that work with Phase 1 arena parser (no DATE literals, etc.)
+    let queries = [
+        ("simple_select", SIMPLE_SELECT),
+        ("point_lookup", POINT_LOOKUP),
+        ("multi_column", MULTI_COLUMN),
+        ("complex_join", COMPLEX_JOIN),
+    ];
+
+    for (name, sql) in queries {
+        group.throughput(Throughput::Bytes(sql.len() as u64));
+
+        // Standard parser
+        group.bench_with_input(BenchmarkId::new("standard", name), sql, |b, sql| {
+            b.iter(|| {
+                black_box(Parser::parse_sql(black_box(sql)).unwrap())
+            });
+        });
+
+        // Arena parser (fresh arena each time)
+        group.bench_with_input(BenchmarkId::new("arena", name), sql, |b, sql| {
+            b.iter(|| {
+                let arena = Bump::new();
+                let result = ArenaParser::parse_sql(black_box(sql), &arena).unwrap();
+                let _ = black_box(&result);
+                drop(arena);
+            });
+        });
+
+        // Arena parser with reused arena (amortized allocation cost)
+        group.bench_with_input(BenchmarkId::new("arena_reuse", name), sql, |b, sql| {
+            let mut arena = Bump::with_capacity(4096);
+            b.iter(|| {
+                arena.reset();
+                let result = ArenaParser::parse_sql(black_box(sql), &arena).unwrap();
+                let _ = black_box(&result);
+            });
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_lexer,
     bench_parser,
     bench_keywords,
     bench_identifiers,
+    bench_arena_parser,
+    bench_parser_comparison,
 );
 criterion_main!(benches);

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -1,0 +1,864 @@
+//! Arena-allocated expression parsing.
+
+use bumpalo::collections::Vec as BumpVec;
+use vibesql_ast::arena::{
+    CaseWhen, Expression, OrderByItem, OrderDirection, Quantifier, WindowFunctionSpec, WindowSpec,
+};
+use vibesql_ast::{BinaryOperator, UnaryOperator};
+use vibesql_types::SqlValue;
+
+use super::ArenaParser;
+use crate::keywords::Keyword;
+use crate::token::Token;
+use crate::ParseError;
+
+impl<'arena> ArenaParser<'arena> {
+    /// Parse an expression (entry point).
+    pub(crate) fn parse_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        self.parse_or_expression()
+    }
+
+    /// Parse OR expression (lowest precedence).
+    fn parse_or_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        let mut left = self.parse_and_expression()?;
+
+        while self.peek_keyword(Keyword::Or) {
+            self.consume_keyword(Keyword::Or)?;
+            let right = self.parse_and_expression()?;
+            let left_ref = self.arena.alloc(left);
+            let right_ref = self.arena.alloc(right);
+            left = Expression::BinaryOp {
+                op: BinaryOperator::Or,
+                left: left_ref,
+                right: right_ref,
+            };
+        }
+
+        Ok(left)
+    }
+
+    /// Parse AND expression.
+    fn parse_and_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        let mut left = self.parse_not_expression()?;
+
+        while self.peek_keyword(Keyword::And) {
+            self.consume_keyword(Keyword::And)?;
+            let right = self.parse_not_expression()?;
+            let left_ref = self.arena.alloc(left);
+            let right_ref = self.arena.alloc(right);
+            left = Expression::BinaryOp {
+                op: BinaryOperator::And,
+                left: left_ref,
+                right: right_ref,
+            };
+        }
+
+        Ok(left)
+    }
+
+    /// Parse NOT expression.
+    fn parse_not_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        if self.peek_keyword(Keyword::Not) {
+            let saved_pos = self.position;
+            self.advance();
+
+            if self.peek_keyword(Keyword::In)
+                || self.peek_keyword(Keyword::Between)
+                || self.peek_keyword(Keyword::Like)
+                || self.peek_keyword(Keyword::Exists)
+            {
+                self.position = saved_pos;
+                return self.parse_comparison_expression();
+            }
+
+            let expr = self.parse_not_expression()?;
+            let expr_ref = self.arena.alloc(expr);
+
+            Ok(Expression::UnaryOp {
+                op: UnaryOperator::Not,
+                expr: expr_ref,
+            })
+        } else {
+            self.parse_comparison_expression()
+        }
+    }
+
+    /// Parse comparison expression.
+    fn parse_comparison_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        let mut left = self.parse_additive_expression()?;
+
+        // Check for IN, BETWEEN, LIKE operators
+        if self.peek_keyword(Keyword::Not) {
+            let saved_pos = self.position;
+            self.advance();
+
+            if self.peek_keyword(Keyword::In) {
+                self.consume_keyword(Keyword::In)?;
+                self.expect_token(Token::LParen)?;
+
+                if self.peek_keyword(Keyword::Select) {
+                    let subquery = self.parse_select_statement()?;
+                    self.expect_token(Token::RParen)?;
+                    let left_ref = self.arena.alloc(left);
+                    return Ok(Expression::In {
+                        expr: left_ref,
+                        subquery,
+                        negated: true,
+                    });
+                } else {
+                    let values = self.parse_expression_list()?;
+                    self.expect_token(Token::RParen)?;
+                    let left_ref = self.arena.alloc(left);
+                    return Ok(Expression::InList {
+                        expr: left_ref,
+                        values,
+                        negated: true,
+                    });
+                }
+            } else if self.peek_keyword(Keyword::Between) {
+                self.consume_keyword(Keyword::Between)?;
+                let symmetric = self.try_consume_keyword(Keyword::Symmetric);
+                if !symmetric {
+                    self.try_consume_keyword(Keyword::Asymmetric);
+                }
+
+                let low = self.parse_additive_expression()?;
+                self.consume_keyword(Keyword::And)?;
+                let high = self.parse_additive_expression()?;
+
+                let left_ref = self.arena.alloc(left);
+                let low_ref = self.arena.alloc(low);
+                let high_ref = self.arena.alloc(high);
+
+                return Ok(Expression::Between {
+                    expr: left_ref,
+                    low: low_ref,
+                    high: high_ref,
+                    negated: true,
+                    symmetric,
+                });
+            } else if self.peek_keyword(Keyword::Like) {
+                self.consume_keyword(Keyword::Like)?;
+                let pattern = self.parse_additive_expression()?;
+                let left_ref = self.arena.alloc(left);
+                let pattern_ref = self.arena.alloc(pattern);
+                return Ok(Expression::Like {
+                    expr: left_ref,
+                    pattern: pattern_ref,
+                    negated: true,
+                });
+            } else {
+                self.position = saved_pos;
+            }
+        } else if self.peek_keyword(Keyword::In) {
+            self.consume_keyword(Keyword::In)?;
+            self.expect_token(Token::LParen)?;
+
+            if self.peek_keyword(Keyword::Select) {
+                let subquery = self.parse_select_statement()?;
+                self.expect_token(Token::RParen)?;
+                let left_ref = self.arena.alloc(left);
+                return Ok(Expression::In {
+                    expr: left_ref,
+                    subquery,
+                    negated: false,
+                });
+            } else {
+                let values = self.parse_expression_list()?;
+                self.expect_token(Token::RParen)?;
+                let left_ref = self.arena.alloc(left);
+                return Ok(Expression::InList {
+                    expr: left_ref,
+                    values,
+                    negated: false,
+                });
+            }
+        } else if self.peek_keyword(Keyword::Between) {
+            self.consume_keyword(Keyword::Between)?;
+            let symmetric = self.try_consume_keyword(Keyword::Symmetric);
+            if !symmetric {
+                self.try_consume_keyword(Keyword::Asymmetric);
+            }
+
+            let low = self.parse_additive_expression()?;
+            self.consume_keyword(Keyword::And)?;
+            let high = self.parse_additive_expression()?;
+
+            let left_ref = self.arena.alloc(left);
+            let low_ref = self.arena.alloc(low);
+            let high_ref = self.arena.alloc(high);
+
+            return Ok(Expression::Between {
+                expr: left_ref,
+                low: low_ref,
+                high: high_ref,
+                negated: false,
+                symmetric,
+            });
+        } else if self.peek_keyword(Keyword::Like) {
+            self.consume_keyword(Keyword::Like)?;
+            let pattern = self.parse_additive_expression()?;
+            let left_ref = self.arena.alloc(left);
+            let pattern_ref = self.arena.alloc(pattern);
+            return Ok(Expression::Like {
+                expr: left_ref,
+                pattern: pattern_ref,
+                negated: false,
+            });
+        }
+
+        // Check for comparison operators
+        let is_comparison = match self.peek() {
+            Token::Symbol('=') | Token::Symbol('<') | Token::Symbol('>') => true,
+            Token::Operator(ref s) => matches!(s.as_str(), "<=" | ">=" | "!=" | "<>"),
+            _ => false,
+        };
+
+        if is_comparison {
+            let op = match self.peek() {
+                Token::Symbol('=') => BinaryOperator::Equal,
+                Token::Symbol('<') => BinaryOperator::LessThan,
+                Token::Symbol('>') => BinaryOperator::GreaterThan,
+                Token::Operator(ref s) => match s.as_str() {
+                    "<=" => BinaryOperator::LessThanOrEqual,
+                    ">=" => BinaryOperator::GreaterThanOrEqual,
+                    "!=" | "<>" => BinaryOperator::NotEqual,
+                    _ => {
+                        return Err(ParseError {
+                            message: format!("Unexpected operator: {}", s),
+                        })
+                    }
+                },
+                _ => unreachable!(),
+            };
+            self.advance();
+
+            // Check for quantified comparison (ALL, ANY, SOME)
+            if self.peek_keyword(Keyword::All)
+                || self.peek_keyword(Keyword::Any)
+                || self.peek_keyword(Keyword::Some)
+            {
+                let quantifier = if self.try_consume_keyword(Keyword::All) {
+                    Quantifier::All
+                } else if self.try_consume_keyword(Keyword::Any) {
+                    Quantifier::Any
+                } else {
+                    self.consume_keyword(Keyword::Some)?;
+                    Quantifier::Some
+                };
+
+                self.expect_token(Token::LParen)?;
+                let subquery = self.parse_select_statement()?;
+                self.expect_token(Token::RParen)?;
+
+                let left_ref = self.arena.alloc(left);
+                return Ok(Expression::QuantifiedComparison {
+                    expr: left_ref,
+                    op,
+                    quantifier,
+                    subquery,
+                });
+            }
+
+            let right = self.parse_additive_expression()?;
+            let left_ref = self.arena.alloc(left);
+            let right_ref = self.arena.alloc(right);
+            left = Expression::BinaryOp {
+                op,
+                left: left_ref,
+                right: right_ref,
+            };
+        }
+
+        // Check for IS NULL / IS NOT NULL
+        if self.peek_keyword(Keyword::Is) {
+            self.consume_keyword(Keyword::Is)?;
+            let negated = self.try_consume_keyword(Keyword::Not);
+            self.expect_keyword(Keyword::Null)?;
+
+            let left_ref = self.arena.alloc(left);
+            left = Expression::IsNull {
+                expr: left_ref,
+                negated,
+            };
+        }
+
+        Ok(left)
+    }
+
+    /// Parse additive expression.
+    fn parse_additive_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        let mut left = self.parse_multiplicative_expression()?;
+
+        loop {
+            let op = match self.peek() {
+                Token::Symbol('+') => BinaryOperator::Plus,
+                Token::Symbol('-') => BinaryOperator::Minus,
+                Token::Operator(ref s) if s == "||" => BinaryOperator::Concat,
+                _ => break,
+            };
+            self.advance();
+
+            let right = self.parse_multiplicative_expression()?;
+            let left_ref = self.arena.alloc(left);
+            let right_ref = self.arena.alloc(right);
+            left = Expression::BinaryOp {
+                op,
+                left: left_ref,
+                right: right_ref,
+            };
+        }
+
+        Ok(left)
+    }
+
+    /// Parse multiplicative expression.
+    fn parse_multiplicative_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        let mut left = self.parse_unary_expression()?;
+
+        loop {
+            let op = match self.peek() {
+                Token::Symbol('*') => BinaryOperator::Multiply,
+                Token::Symbol('/') => BinaryOperator::Divide,
+                Token::Symbol('%') => BinaryOperator::Modulo,
+                Token::Keyword(Keyword::Div) => BinaryOperator::IntegerDivide,
+                _ => break,
+            };
+            self.advance();
+
+            let right = self.parse_unary_expression()?;
+            let left_ref = self.arena.alloc(left);
+            let right_ref = self.arena.alloc(right);
+            left = Expression::BinaryOp {
+                op,
+                left: left_ref,
+                right: right_ref,
+            };
+        }
+
+        Ok(left)
+    }
+
+    /// Parse unary expression.
+    fn parse_unary_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        match self.peek() {
+            Token::Symbol('+') => {
+                self.advance();
+                let expr = self.parse_unary_expression()?;
+                let expr_ref = self.arena.alloc(expr);
+                Ok(Expression::UnaryOp {
+                    op: UnaryOperator::Plus,
+                    expr: expr_ref,
+                })
+            }
+            Token::Symbol('-') => {
+                self.advance();
+                let expr = self.parse_unary_expression()?;
+                let expr_ref = self.arena.alloc(expr);
+                Ok(Expression::UnaryOp {
+                    op: UnaryOperator::Minus,
+                    expr: expr_ref,
+                })
+            }
+            _ => self.parse_primary_expression(),
+        }
+    }
+
+    /// Parse primary expression.
+    fn parse_primary_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        // Placeholder (?)
+        if matches!(self.peek(), Token::Placeholder) {
+            self.advance();
+            let index = self.next_placeholder();
+            return Ok(Expression::Placeholder(index));
+        }
+
+        // Numbered placeholder ($1, $2, etc.)
+        if let Token::NumberedPlaceholder(n) = self.peek() {
+            let index = *n;
+            self.advance();
+            return Ok(Expression::NumberedPlaceholder(index));
+        }
+
+        // Named placeholder (:name)
+        if let Token::NamedPlaceholder(name) = self.peek() {
+            let name = self.alloc_str(name);
+            self.advance();
+            return Ok(Expression::NamedPlaceholder(name));
+        }
+
+        // Session variable (@@...)
+        if let Token::SessionVariable(name) = self.peek() {
+            let name = self.alloc_str(name);
+            self.advance();
+            return Ok(Expression::SessionVariable { name });
+        }
+
+        // Literals
+        if let Some(expr) = self.parse_literal()? {
+            return Ok(expr);
+        }
+
+        // EXISTS / NOT EXISTS
+        if self.peek_keyword(Keyword::Exists) || self.peek_keyword(Keyword::Not) {
+            if let Some(expr) = self.parse_exists()? {
+                return Ok(expr);
+            }
+        }
+
+        // CASE expression
+        if self.peek_keyword(Keyword::Case) {
+            return self.parse_case_expression();
+        }
+
+        // CAST expression
+        if self.peek_keyword(Keyword::Cast) {
+            return self.parse_cast_expression();
+        }
+
+        // Current date/time
+        if let Some(expr) = self.parse_current_datetime()? {
+            return Ok(expr);
+        }
+
+        // Function call or identifier
+        if let Token::Identifier(name) = self.peek() {
+            let name = name.clone();
+
+            // Check if it's a function call
+            if matches!(self.tokens.get(self.position + 1), Some(Token::LParen)) {
+                return self.parse_function_call(&name);
+            }
+
+            // Otherwise it's a column reference
+            self.advance();
+            let name = self.alloc_str(&name);
+
+            // Check for qualified name (table.column)
+            if self.try_consume(&Token::Symbol('.')) {
+                if let Token::Identifier(col) = self.peek() {
+                    let col = self.alloc_str(col);
+                    self.advance();
+                    return Ok(Expression::ColumnRef {
+                        table: Some(name),
+                        column: col,
+                    });
+                } else if matches!(self.peek(), Token::Symbol('*')) {
+                    self.advance();
+                    return Ok(Expression::Wildcard);
+                }
+            }
+
+            return Ok(Expression::ColumnRef {
+                table: None,
+                column: name,
+            });
+        }
+
+        // Wildcard (*)
+        if matches!(self.peek(), Token::Symbol('*')) {
+            self.advance();
+            return Ok(Expression::Wildcard);
+        }
+
+        // Parenthesized expression or subquery
+        if matches!(self.peek(), Token::LParen) {
+            self.advance();
+
+            // Check for subquery
+            if self.peek_keyword(Keyword::Select) {
+                let subquery = self.parse_select_statement()?;
+                self.expect_token(Token::RParen)?;
+                return Ok(Expression::ScalarSubquery(subquery));
+            }
+
+            // Regular parenthesized expression
+            let expr = self.parse_expression()?;
+            self.expect_token(Token::RParen)?;
+            return Ok(expr);
+        }
+
+        Err(ParseError {
+            message: format!("Expected expression, found {:?}", self.peek()),
+        })
+    }
+
+    /// Parse literal values.
+    fn parse_literal(&mut self) -> Result<Option<Expression<'arena>>, ParseError> {
+        let expr = match self.peek() {
+            Token::Number(n) => {
+                let n = n.clone();
+                self.advance();
+                // Try to parse as integer first, then as float
+                if let Ok(i) = n.parse::<i64>() {
+                    Some(Expression::Literal(SqlValue::Integer(i)))
+                } else if let Ok(f) = n.parse::<f64>() {
+                    Some(Expression::Literal(SqlValue::Double(f)))
+                } else {
+                    return Err(ParseError {
+                        message: format!("Invalid number: {}", n),
+                    });
+                }
+            }
+            Token::String(s) => {
+                let s = s.clone();
+                self.advance();
+                Some(Expression::Literal(SqlValue::Varchar(s)))
+            }
+            Token::Keyword(Keyword::True) => {
+                self.advance();
+                Some(Expression::Literal(SqlValue::Boolean(true)))
+            }
+            Token::Keyword(Keyword::False) => {
+                self.advance();
+                Some(Expression::Literal(SqlValue::Boolean(false)))
+            }
+            Token::Keyword(Keyword::Null) => {
+                self.advance();
+                Some(Expression::Literal(SqlValue::Null))
+            }
+            Token::Keyword(Keyword::Default) => {
+                self.advance();
+                Some(Expression::Default)
+            }
+            _ => None,
+        };
+        Ok(expr)
+    }
+
+    /// Parse EXISTS / NOT EXISTS.
+    fn parse_exists(&mut self) -> Result<Option<Expression<'arena>>, ParseError> {
+        let negated = if self.peek_keyword(Keyword::Not) {
+            self.advance();
+            if !self.peek_keyword(Keyword::Exists) {
+                self.position -= 1;
+                return Ok(None);
+            }
+            true
+        } else {
+            false
+        };
+
+        if self.peek_keyword(Keyword::Exists) {
+            self.advance();
+            self.expect_token(Token::LParen)?;
+            let subquery = self.parse_select_statement()?;
+            self.expect_token(Token::RParen)?;
+            return Ok(Some(Expression::Exists { subquery, negated }));
+        }
+
+        Ok(None)
+    }
+
+    /// Parse CASE expression.
+    fn parse_case_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        self.consume_keyword(Keyword::Case)?;
+
+        // Check for simple CASE (CASE expr WHEN ...)
+        let operand: Option<&'arena Expression<'arena>> = if !self.peek_keyword(Keyword::When) {
+            let expr = self.parse_expression()?;
+            Some(self.arena.alloc(expr))
+        } else {
+            None
+        };
+
+        // Parse WHEN clauses
+        let mut when_clauses = BumpVec::new_in(self.arena);
+        while self.peek_keyword(Keyword::When) {
+            self.consume_keyword(Keyword::When)?;
+
+            let mut conditions = BumpVec::new_in(self.arena);
+            conditions.push(self.parse_expression()?);
+
+            // Handle multiple conditions (WHEN a, b, c THEN ...)
+            while self.try_consume(&Token::Comma) {
+                conditions.push(self.parse_expression()?);
+            }
+
+            self.consume_keyword(Keyword::Then)?;
+            let result = self.parse_expression()?;
+
+            when_clauses.push(CaseWhen { conditions, result });
+        }
+
+        // Parse optional ELSE
+        let else_result: Option<&'arena Expression<'arena>> = if self.try_consume_keyword(Keyword::Else) {
+            let expr = self.parse_expression()?;
+            Some(self.arena.alloc(expr))
+        } else {
+            None
+        };
+
+        self.consume_keyword(Keyword::End)?;
+
+        Ok(Expression::Case {
+            operand,
+            when_clauses,
+            else_result,
+        })
+    }
+
+    /// Parse CAST expression.
+    fn parse_cast_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        self.consume_keyword(Keyword::Cast)?;
+        self.expect_token(Token::LParen)?;
+
+        let expr = self.parse_expression()?;
+        let expr_ref = self.arena.alloc(expr);
+
+        self.consume_keyword(Keyword::As)?;
+        let data_type = self.parse_data_type()?;
+
+        self.expect_token(Token::RParen)?;
+
+        Ok(Expression::Cast {
+            expr: expr_ref,
+            data_type,
+        })
+    }
+
+    /// Parse current date/time functions.
+    fn parse_current_datetime(&mut self) -> Result<Option<Expression<'arena>>, ParseError> {
+        if self.peek_keyword(Keyword::CurrentDate) {
+            self.advance();
+            return Ok(Some(Expression::CurrentDate));
+        }
+
+        if self.peek_keyword(Keyword::CurrentTime) {
+            self.advance();
+            let precision = self.parse_optional_precision()?;
+            return Ok(Some(Expression::CurrentTime { precision }));
+        }
+
+        if self.peek_keyword(Keyword::CurrentTimestamp) {
+            self.advance();
+            let precision = self.parse_optional_precision()?;
+            return Ok(Some(Expression::CurrentTimestamp { precision }));
+        }
+
+        Ok(None)
+    }
+
+    /// Parse optional precision (e.g., CURRENT_TIME(3)).
+    fn parse_optional_precision(&mut self) -> Result<Option<u32>, ParseError> {
+        if self.try_consume(&Token::LParen) {
+            if let Token::Number(n) = self.peek() {
+                let n = n.parse::<u32>().map_err(|_| ParseError {
+                    message: "Invalid precision".to_string(),
+                })?;
+                self.advance();
+                self.expect_token(Token::RParen)?;
+                return Ok(Some(n));
+            }
+            self.expect_token(Token::RParen)?;
+        }
+        Ok(None)
+    }
+
+    /// Parse function call.
+    fn parse_function_call(&mut self, name: &str) -> Result<Expression<'arena>, ParseError> {
+        let name = self.alloc_str(name);
+        self.advance(); // consume function name
+        self.expect_token(Token::LParen)?;
+
+        // Check for aggregate functions with DISTINCT
+        let is_aggregate = matches!(
+            name.to_uppercase().as_str(),
+            "COUNT" | "SUM" | "AVG" | "MIN" | "MAX"
+        );
+
+        if is_aggregate {
+            let distinct = self.try_consume_keyword(Keyword::Distinct);
+            self.try_consume_keyword(Keyword::All); // ALL is default
+
+            let args = if matches!(self.peek(), Token::RParen) {
+                BumpVec::new_in(self.arena)
+            } else {
+                self.parse_expression_list()?
+            };
+
+            self.expect_token(Token::RParen)?;
+
+            // Check for OVER clause (window function)
+            if self.peek_keyword(Keyword::Over) {
+                return self.parse_window_function(name, args);
+            }
+
+            return Ok(Expression::AggregateFunction {
+                name,
+                distinct,
+                args,
+            });
+        }
+
+        // Regular function
+        let args = if matches!(self.peek(), Token::RParen) {
+            BumpVec::new_in(self.arena)
+        } else {
+            self.parse_expression_list()?
+        };
+
+        self.expect_token(Token::RParen)?;
+
+        // Check for OVER clause
+        if self.peek_keyword(Keyword::Over) {
+            return self.parse_window_function(name, args);
+        }
+
+        Ok(Expression::Function {
+            name,
+            args,
+            character_unit: None,
+        })
+    }
+
+    /// Parse window function (OVER clause).
+    fn parse_window_function(
+        &mut self,
+        name: &'arena str,
+        args: BumpVec<'arena, Expression<'arena>>,
+    ) -> Result<Expression<'arena>, ParseError> {
+        self.consume_keyword(Keyword::Over)?;
+        self.expect_token(Token::LParen)?;
+
+        // Parse PARTITION BY
+        let partition_by = if self.try_consume_keyword(Keyword::Partition) {
+            self.consume_keyword(Keyword::By)?;
+            Some(self.parse_expression_list()?)
+        } else {
+            None
+        };
+
+        // Parse ORDER BY
+        let order_by = if self.try_consume_keyword(Keyword::Order) {
+            self.consume_keyword(Keyword::By)?;
+            Some(self.parse_order_by_list()?)
+        } else {
+            None
+        };
+
+        // Parse frame clause (simplified)
+        let frame = None; // TODO: implement frame parsing
+
+        self.expect_token(Token::RParen)?;
+
+        let function = WindowFunctionSpec::Aggregate { name, args };
+        let over = WindowSpec {
+            partition_by,
+            order_by,
+            frame,
+        };
+
+        Ok(Expression::WindowFunction { function, over })
+    }
+
+    /// Parse comma-separated expression list.
+    pub(crate) fn parse_expression_list(
+        &mut self,
+    ) -> Result<BumpVec<'arena, Expression<'arena>>, ParseError> {
+        let mut exprs = BumpVec::new_in(self.arena);
+
+        if matches!(self.peek(), Token::RParen) {
+            return Ok(exprs);
+        }
+
+        exprs.push(self.parse_expression()?);
+
+        while self.try_consume(&Token::Comma) {
+            exprs.push(self.parse_expression()?);
+        }
+
+        Ok(exprs)
+    }
+
+    /// Parse ORDER BY list.
+    fn parse_order_by_list(&mut self) -> Result<BumpVec<'arena, OrderByItem<'arena>>, ParseError> {
+        let mut items = BumpVec::new_in(self.arena);
+
+        loop {
+            let expr = self.parse_expression()?;
+            let direction = if self.try_consume_keyword(Keyword::Desc) {
+                OrderDirection::Desc
+            } else {
+                self.try_consume_keyword(Keyword::Asc);
+                OrderDirection::Asc
+            };
+
+            items.push(OrderByItem { expr, direction });
+
+            if !self.try_consume(&Token::Comma) {
+                break;
+            }
+        }
+
+        Ok(items)
+    }
+
+    /// Parse data type (simplified).
+    fn parse_data_type(&mut self) -> Result<vibesql_types::DataType, ParseError> {
+        // Get type name as uppercase string
+        let type_upper = match self.peek() {
+            Token::Identifier(type_name) => type_name.to_uppercase(),
+            Token::Keyword(Keyword::Date) => "DATE".to_string(),
+            Token::Keyword(Keyword::Time) => "TIME".to_string(),
+            Token::Keyword(Keyword::Timestamp) => "TIMESTAMP".to_string(),
+            Token::Keyword(Keyword::Interval) => "INTERVAL".to_string(),
+            Token::Keyword(Keyword::Character) => "CHARACTER".to_string(),
+            Token::Keyword(Keyword::Boolean) => "BOOLEAN".to_string(),
+            _ => {
+                return Err(ParseError {
+                    message: format!("Expected data type, found {:?}", self.peek()),
+                })
+            }
+        };
+        self.advance();
+
+        match type_upper.as_str() {
+            "INTEGER" | "INT" => Ok(vibesql_types::DataType::Integer),
+            "SMALLINT" => Ok(vibesql_types::DataType::Smallint),
+            "BIGINT" => Ok(vibesql_types::DataType::Bigint),
+            "BOOLEAN" | "BOOL" => Ok(vibesql_types::DataType::Boolean),
+            "FLOAT" => {
+                // Parse optional precision
+                if self.try_consume(&Token::LParen) {
+                    if let Token::Number(_) = self.peek() {
+                        self.advance();
+                    }
+                    self.expect_token(Token::RParen)?;
+                }
+                Ok(vibesql_types::DataType::Float { precision: 53 })
+            }
+            "REAL" => Ok(vibesql_types::DataType::Real),
+            "DOUBLE" => {
+                // Check for DOUBLE PRECISION
+                if let Token::Identifier(next) = self.peek() {
+                    if next.to_uppercase() == "PRECISION" {
+                        self.advance();
+                    }
+                }
+                Ok(vibesql_types::DataType::DoublePrecision)
+            }
+            "VARCHAR" | "CHARACTER" => {
+                // Parse optional length
+                if self.try_consume(&Token::LParen) {
+                    if let Token::Number(n) = self.peek() {
+                        let len = n.parse::<usize>().ok();
+                        self.advance();
+                        self.expect_token(Token::RParen)?;
+                        return Ok(vibesql_types::DataType::Varchar { max_length: len });
+                    }
+                    self.expect_token(Token::RParen)?;
+                }
+                Ok(vibesql_types::DataType::Varchar { max_length: None })
+            }
+            "TEXT" => Ok(vibesql_types::DataType::Varchar { max_length: None }),
+            "DATE" => Ok(vibesql_types::DataType::Date),
+            "TIME" => Ok(vibesql_types::DataType::Time { with_timezone: false }),
+            "TIMESTAMP" => Ok(vibesql_types::DataType::Timestamp { with_timezone: false }),
+            _ => {
+                // Unknown type - default to varchar
+                Ok(vibesql_types::DataType::Varchar { max_length: None })
+            }
+        }
+    }
+}

--- a/crates/vibesql-parser/src/arena_parser/mod.rs
+++ b/crates/vibesql-parser/src/arena_parser/mod.rs
@@ -1,0 +1,188 @@
+//! Arena-allocated SQL parser.
+//!
+//! This module provides a parser that allocates AST nodes from a bump arena
+//! for improved performance. All allocations are contiguous in memory and
+//! freed in a single operation when the arena is dropped.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use bumpalo::Bump;
+//! use vibesql_parser::arena_parser::ArenaParser;
+//!
+//! let arena = Bump::new();
+//! let result = ArenaParser::parse_sql("SELECT * FROM users", &arena);
+//! ```
+
+mod expression;
+mod select;
+
+use bumpalo::Bump;
+use vibesql_ast::arena::{Expression, SelectStmt};
+
+use crate::{Lexer, ParseError, Token};
+use crate::keywords::Keyword;
+
+/// Arena-based SQL parser.
+///
+/// Unlike the standard [`Parser`](crate::Parser), this parser allocates all
+/// AST nodes from a bump arena, resulting in:
+/// - O(1) allocation time (vs heap allocation overhead)
+/// - Better cache locality (contiguous memory)
+/// - Single deallocation when arena is dropped
+pub struct ArenaParser<'arena> {
+    tokens: Vec<Token>,
+    position: usize,
+    placeholder_count: usize,
+    arena: &'arena Bump,
+}
+
+impl<'arena> ArenaParser<'arena> {
+    /// Create a new arena parser from tokens.
+    pub fn new(tokens: Vec<Token>, arena: &'arena Bump) -> Self {
+        ArenaParser {
+            tokens,
+            position: 0,
+            placeholder_count: 0,
+            arena,
+        }
+    }
+
+    /// Parse SQL input string into an arena-allocated SelectStmt.
+    ///
+    /// Currently only supports SELECT statements for Phase 1 prototype.
+    pub fn parse_sql(
+        input: &str,
+        arena: &'arena Bump,
+    ) -> Result<&'arena SelectStmt<'arena>, ParseError> {
+        let mut lexer = Lexer::new(input);
+        let tokens = lexer
+            .tokenize()
+            .map_err(|e| ParseError { message: format!("Lexer error: {}", e) })?;
+
+        let mut parser = ArenaParser::new(tokens, arena);
+        parser.parse_select_statement()
+    }
+
+    /// Parse an expression and return an arena-allocated reference.
+    pub fn parse_expression_sql(
+        input: &str,
+        arena: &'arena Bump,
+    ) -> Result<&'arena Expression<'arena>, ParseError> {
+        let mut lexer = Lexer::new(input);
+        let tokens = lexer
+            .tokenize()
+            .map_err(|e| ParseError { message: format!("Lexer error: {}", e) })?;
+
+        let mut parser = ArenaParser::new(tokens, arena);
+        let expr = parser.parse_expression()?;
+        Ok(arena.alloc(expr))
+    }
+
+    /// Allocate a string in the arena.
+    #[inline]
+    pub(crate) fn alloc_str(&self, s: &str) -> &'arena str {
+        self.arena.alloc_str(s)
+    }
+
+    /// Get a reference to the arena.
+    #[inline]
+    pub(crate) fn arena(&self) -> &'arena Bump {
+        self.arena
+    }
+
+    // ========================================================================
+    // Token manipulation helpers (same as standard parser)
+    // ========================================================================
+
+    /// Peek at the current token without consuming it.
+    pub(crate) fn peek(&self) -> &Token {
+        self.tokens.get(self.position).unwrap_or(&Token::Eof)
+    }
+
+    /// Peek at the next token (position + 1) without consuming.
+    #[allow(dead_code)]
+    pub(crate) fn peek_next(&self) -> &Token {
+        self.tokens.get(self.position + 1).unwrap_or(&Token::Eof)
+    }
+
+    /// Peek at token at specific offset from current position.
+    #[allow(dead_code)]
+    pub(crate) fn peek_at_offset(&self, offset: usize) -> &Token {
+        self.tokens.get(self.position + offset).unwrap_or(&Token::Eof)
+    }
+
+    /// Advance to the next token.
+    pub(crate) fn advance(&mut self) {
+        if self.position < self.tokens.len() {
+            self.position += 1;
+        }
+    }
+
+    /// Check if current token is a specific keyword.
+    pub(crate) fn peek_keyword(&self, keyword: Keyword) -> bool {
+        matches!(self.peek(), Token::Keyword(kw) if *kw == keyword)
+    }
+
+    /// Check if next token (position + 1) is a specific keyword.
+    #[allow(dead_code)]
+    pub(crate) fn peek_next_keyword(&self, keyword: Keyword) -> bool {
+        matches!(self.peek_next(), Token::Keyword(kw) if *kw == keyword)
+    }
+
+    /// Consume a keyword, returning an error if it's not the expected keyword.
+    pub(crate) fn consume_keyword(&mut self, keyword: Keyword) -> Result<(), ParseError> {
+        if self.peek_keyword(keyword) {
+            self.advance();
+            Ok(())
+        } else {
+            Err(ParseError {
+                message: format!("Expected keyword {:?}, found {:?}", keyword, self.peek()),
+            })
+        }
+    }
+
+    /// Try to consume a keyword, returning true if successful.
+    pub(crate) fn try_consume_keyword(&mut self, keyword: Keyword) -> bool {
+        if self.peek_keyword(keyword) {
+            self.advance();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Expect a specific keyword.
+    pub(crate) fn expect_keyword(&mut self, keyword: Keyword) -> Result<(), ParseError> {
+        self.consume_keyword(keyword)
+    }
+
+    /// Expect a specific token.
+    pub(crate) fn expect_token(&mut self, expected: Token) -> Result<(), ParseError> {
+        if self.peek() == &expected {
+            self.advance();
+            Ok(())
+        } else {
+            Err(ParseError {
+                message: format!("Expected {:?}, found {:?}", expected, self.peek()),
+            })
+        }
+    }
+
+    /// Try to consume a specific token, returning true if successful.
+    pub(crate) fn try_consume(&mut self, token: &Token) -> bool {
+        if self.peek() == token {
+            self.advance();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get the next placeholder index.
+    pub(crate) fn next_placeholder(&mut self) -> usize {
+        let index = self.placeholder_count;
+        self.placeholder_count += 1;
+        index
+    }
+}

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -1,0 +1,566 @@
+//! Arena-allocated SELECT statement parsing.
+
+use bumpalo::collections::Vec as BumpVec;
+use vibesql_ast::arena::{
+    CommonTableExpr, Expression, FromClause, GroupByClause, GroupingElement, GroupingSet,
+    JoinType, OrderByItem, OrderDirection, SelectItem, SelectStmt, SetOperation, SetOperator,
+};
+
+use super::ArenaParser;
+use crate::keywords::Keyword;
+use crate::token::Token;
+use crate::ParseError;
+
+impl<'arena> ArenaParser<'arena> {
+    /// Parse a SELECT statement.
+    pub(crate) fn parse_select_statement(
+        &mut self,
+    ) -> Result<&'arena SelectStmt<'arena>, ParseError> {
+        // Parse optional WITH clause
+        let with_clause = if self.try_consume_keyword(Keyword::With) {
+            Some(self.parse_with_clause()?)
+        } else {
+            None
+        };
+
+        self.consume_keyword(Keyword::Select)?;
+
+        // Parse DISTINCT
+        let distinct = self.try_consume_keyword(Keyword::Distinct);
+        self.try_consume_keyword(Keyword::All);
+
+        // Parse select list
+        let select_list = self.parse_select_list()?;
+
+        // Parse optional INTO
+        let (into_table, into_variables) = self.parse_into_clause()?;
+
+        // Parse FROM
+        let from = if self.try_consume_keyword(Keyword::From) {
+            Some(self.parse_from_clause()?)
+        } else {
+            None
+        };
+
+        // Parse WHERE
+        let where_clause = if self.try_consume_keyword(Keyword::Where) {
+            Some(self.parse_expression()?)
+        } else {
+            None
+        };
+
+        // Parse GROUP BY
+        let group_by = if self.try_consume_keyword(Keyword::Group) {
+            self.consume_keyword(Keyword::By)?;
+            Some(self.parse_group_by_clause()?)
+        } else {
+            None
+        };
+
+        // Parse HAVING
+        let having = if self.try_consume_keyword(Keyword::Having) {
+            Some(self.parse_expression()?)
+        } else {
+            None
+        };
+
+        // Parse ORDER BY
+        let order_by = if self.try_consume_keyword(Keyword::Order) {
+            self.consume_keyword(Keyword::By)?;
+            Some(self.parse_order_by_clause()?)
+        } else {
+            None
+        };
+
+        // Parse LIMIT
+        let limit = if self.try_consume_keyword(Keyword::Limit) {
+            if let Token::Number(n) = self.peek() {
+                let n = n.parse::<usize>().map_err(|_| ParseError {
+                    message: "Invalid LIMIT value".to_string(),
+                })?;
+                self.advance();
+                Some(n)
+            } else {
+                return Err(ParseError {
+                    message: "Expected integer after LIMIT".to_string(),
+                });
+            }
+        } else {
+            None
+        };
+
+        // Parse OFFSET
+        let offset = if self.try_consume_keyword(Keyword::Offset) {
+            if let Token::Number(n) = self.peek() {
+                let n = n.parse::<usize>().map_err(|_| ParseError {
+                    message: "Invalid OFFSET value".to_string(),
+                })?;
+                self.advance();
+                Some(n)
+            } else {
+                return Err(ParseError {
+                    message: "Expected integer after OFFSET".to_string(),
+                });
+            }
+        } else {
+            None
+        };
+
+        // Parse set operations (UNION, INTERSECT, EXCEPT)
+        let set_operation = self.parse_set_operation()?;
+
+        let stmt = SelectStmt {
+            with_clause,
+            distinct,
+            select_list,
+            into_table,
+            into_variables,
+            from,
+            where_clause,
+            group_by,
+            having,
+            order_by,
+            limit,
+            offset,
+            set_operation,
+        };
+
+        Ok(self.arena.alloc(stmt))
+    }
+
+    /// Parse WITH clause (CTEs).
+    fn parse_with_clause(
+        &mut self,
+    ) -> Result<BumpVec<'arena, CommonTableExpr<'arena>>, ParseError> {
+        let mut ctes = BumpVec::new_in(self.arena);
+
+        loop {
+            let cte = self.parse_cte()?;
+            ctes.push(cte);
+
+            if !self.try_consume(&Token::Comma) {
+                break;
+            }
+        }
+
+        Ok(ctes)
+    }
+
+    /// Parse a single CTE.
+    fn parse_cte(&mut self) -> Result<CommonTableExpr<'arena>, ParseError> {
+        // Parse CTE name
+        let name = if let Token::Identifier(name) = self.peek() {
+            let name = self.alloc_str(name);
+            self.advance();
+            name
+        } else {
+            return Err(ParseError {
+                message: "Expected CTE name".to_string(),
+            });
+        };
+
+        // Parse optional column list
+        let columns = if self.try_consume(&Token::LParen) {
+            let mut cols = BumpVec::new_in(self.arena);
+            loop {
+                if let Token::Identifier(col) = self.peek() {
+                    cols.push(self.alloc_str(col));
+                    self.advance();
+                } else {
+                    break;
+                }
+                if !self.try_consume(&Token::Comma) {
+                    break;
+                }
+            }
+            self.expect_token(Token::RParen)?;
+            Some(cols)
+        } else {
+            None
+        };
+
+        self.consume_keyword(Keyword::As)?;
+        self.expect_token(Token::LParen)?;
+        let query = self.parse_select_statement()?;
+        self.expect_token(Token::RParen)?;
+
+        Ok(CommonTableExpr {
+            name,
+            columns,
+            query,
+        })
+    }
+
+    /// Parse select list.
+    fn parse_select_list(&mut self) -> Result<BumpVec<'arena, SelectItem<'arena>>, ParseError> {
+        let mut items = BumpVec::new_in(self.arena);
+
+        loop {
+            let item = self.parse_select_item()?;
+            items.push(item);
+
+            if !self.try_consume(&Token::Comma) {
+                break;
+            }
+        }
+
+        Ok(items)
+    }
+
+    /// Parse a single select item.
+    fn parse_select_item(&mut self) -> Result<SelectItem<'arena>, ParseError> {
+        // Check for * wildcard
+        if matches!(self.peek(), Token::Symbol('*')) {
+            self.advance();
+            return Ok(SelectItem::Wildcard { alias: None });
+        }
+
+        // Parse expression
+        let expr = self.parse_expression()?;
+
+        // Check for qualified wildcard (table.*)
+        if let Expression::ColumnRef { table: Some(t), column } = &expr {
+            if column == &"*" {
+                return Ok(SelectItem::QualifiedWildcard {
+                    qualifier: t,
+                    alias: None,
+                });
+            }
+        }
+
+        // Check for alias
+        let alias = if self.try_consume_keyword(Keyword::As) {
+            if let Token::Identifier(name) = self.peek() {
+                let name = self.alloc_str(name);
+                self.advance();
+                Some(name)
+            } else {
+                return Err(ParseError {
+                    message: "Expected alias after AS".to_string(),
+                });
+            }
+        } else if let Token::Identifier(name) = self.peek() {
+            // Implicit alias (no AS keyword)
+            let name = self.alloc_str(name);
+            self.advance();
+            Some(name)
+        } else {
+            None
+        };
+
+        Ok(SelectItem::Expression { expr, alias })
+    }
+
+    /// Parse INTO clause.
+    fn parse_into_clause(
+        &mut self,
+    ) -> Result<(Option<&'arena str>, Option<BumpVec<'arena, &'arena str>>), ParseError> {
+        if !self.try_consume_keyword(Keyword::Into) {
+            return Ok((None, None));
+        }
+
+        // Check if it's SELECT INTO table_name or SELECT INTO @var1, @var2
+        if let Token::Identifier(name) = self.peek() {
+            let name = self.alloc_str(name);
+            self.advance();
+            return Ok((Some(name), None));
+        }
+
+        // Parse variable list
+        let mut vars = BumpVec::new_in(self.arena);
+        loop {
+            if let Token::Identifier(var) = self.peek() {
+                vars.push(self.alloc_str(var));
+                self.advance();
+            } else {
+                break;
+            }
+            if !self.try_consume(&Token::Comma) {
+                break;
+            }
+        }
+
+        if vars.is_empty() {
+            return Err(ParseError {
+                message: "Expected table name or variables after INTO".to_string(),
+            });
+        }
+
+        Ok((None, Some(vars)))
+    }
+
+    /// Parse FROM clause.
+    fn parse_from_clause(&mut self) -> Result<FromClause<'arena>, ParseError> {
+        let mut from = self.parse_table_reference()?;
+
+        // Parse JOINs
+        loop {
+            let join_type = if self.try_consume_keyword(Keyword::Inner) {
+                self.consume_keyword(Keyword::Join)?;
+                Some(JoinType::Inner)
+            } else if self.try_consume_keyword(Keyword::Left) {
+                self.try_consume_keyword(Keyword::Outer);
+                self.consume_keyword(Keyword::Join)?;
+                Some(JoinType::LeftOuter)
+            } else if self.try_consume_keyword(Keyword::Right) {
+                self.try_consume_keyword(Keyword::Outer);
+                self.consume_keyword(Keyword::Join)?;
+                Some(JoinType::RightOuter)
+            } else if self.try_consume_keyword(Keyword::Full) {
+                self.try_consume_keyword(Keyword::Outer);
+                self.consume_keyword(Keyword::Join)?;
+                Some(JoinType::FullOuter)
+            } else if self.try_consume_keyword(Keyword::Cross) {
+                self.consume_keyword(Keyword::Join)?;
+                Some(JoinType::Cross)
+            } else if self.try_consume_keyword(Keyword::Join) {
+                Some(JoinType::Inner)
+            } else if self.try_consume(&Token::Comma) {
+                Some(JoinType::Cross)
+            } else {
+                None
+            };
+
+            if let Some(jt) = join_type {
+                let natural = self.try_consume_keyword(Keyword::Natural);
+                let right = self.parse_table_reference()?;
+
+                let condition = if jt != JoinType::Cross && !natural {
+                    if self.try_consume_keyword(Keyword::On) {
+                        Some(self.parse_expression()?)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                let left_ref = self.arena.alloc(from);
+                let right_ref = self.arena.alloc(right);
+
+                from = FromClause::Join {
+                    left: left_ref,
+                    right: right_ref,
+                    join_type: jt,
+                    condition,
+                    natural,
+                };
+            } else {
+                break;
+            }
+        }
+
+        Ok(from)
+    }
+
+    /// Parse a table reference.
+    fn parse_table_reference(&mut self) -> Result<FromClause<'arena>, ParseError> {
+        // Check for subquery
+        if self.try_consume(&Token::LParen) {
+            let query = self.parse_select_statement()?;
+            self.expect_token(Token::RParen)?;
+
+            // Subquery requires alias
+            self.try_consume_keyword(Keyword::As);
+            let alias = if let Token::Identifier(name) = self.peek() {
+                let name = self.alloc_str(name);
+                self.advance();
+                name
+            } else {
+                return Err(ParseError {
+                    message: "Subquery requires alias".to_string(),
+                });
+            };
+
+            return Ok(FromClause::Subquery { query, alias });
+        }
+
+        // Regular table reference
+        let name = if let Token::Identifier(name) = self.peek() {
+            let name = self.alloc_str(name);
+            self.advance();
+            name
+        } else {
+            return Err(ParseError {
+                message: format!("Expected table name, found {:?}", self.peek()),
+            });
+        };
+
+        // Check for alias
+        self.try_consume_keyword(Keyword::As);
+        let alias = if let Token::Identifier(alias) = self.peek() {
+            // Make sure it's not a keyword that would start a new clause
+            if !matches!(
+                self.peek(),
+                Token::Keyword(Keyword::Where)
+                    | Token::Keyword(Keyword::Join)
+                    | Token::Keyword(Keyword::Inner)
+                    | Token::Keyword(Keyword::Left)
+                    | Token::Keyword(Keyword::Right)
+                    | Token::Keyword(Keyword::Full)
+                    | Token::Keyword(Keyword::Cross)
+                    | Token::Keyword(Keyword::On)
+                    | Token::Keyword(Keyword::Group)
+                    | Token::Keyword(Keyword::Order)
+                    | Token::Keyword(Keyword::Having)
+                    | Token::Keyword(Keyword::Limit)
+                    | Token::Keyword(Keyword::Union)
+                    | Token::Keyword(Keyword::Intersect)
+                    | Token::Keyword(Keyword::Except)
+            ) {
+                let alias = self.alloc_str(alias);
+                self.advance();
+                Some(alias)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        Ok(FromClause::Table { name, alias })
+    }
+
+    /// Parse GROUP BY clause.
+    fn parse_group_by_clause(&mut self) -> Result<GroupByClause<'arena>, ParseError> {
+        // Check for ROLLUP, CUBE, GROUPING SETS
+        if self.peek_keyword(Keyword::Rollup) {
+            self.advance();
+            self.expect_token(Token::LParen)?;
+            let elements = self.parse_grouping_elements()?;
+            self.expect_token(Token::RParen)?;
+            return Ok(GroupByClause::Rollup(elements));
+        }
+
+        if self.peek_keyword(Keyword::Cube) {
+            self.advance();
+            self.expect_token(Token::LParen)?;
+            let elements = self.parse_grouping_elements()?;
+            self.expect_token(Token::RParen)?;
+            return Ok(GroupByClause::Cube(elements));
+        }
+
+        if self.peek_keyword(Keyword::Grouping) {
+            self.advance();
+            self.consume_keyword(Keyword::Sets)?;
+            self.expect_token(Token::LParen)?;
+            let sets = self.parse_grouping_sets()?;
+            self.expect_token(Token::RParen)?;
+            return Ok(GroupByClause::GroupingSets(sets));
+        }
+
+        // Simple GROUP BY
+        let mut exprs = BumpVec::new_in(self.arena);
+        loop {
+            exprs.push(self.parse_expression()?);
+            if !self.try_consume(&Token::Comma) {
+                break;
+            }
+        }
+
+        Ok(GroupByClause::Simple(exprs))
+    }
+
+    /// Parse grouping elements.
+    fn parse_grouping_elements(
+        &mut self,
+    ) -> Result<BumpVec<'arena, GroupingElement<'arena>>, ParseError> {
+        let mut elements = BumpVec::new_in(self.arena);
+
+        loop {
+            if self.try_consume(&Token::LParen) {
+                // Composite element
+                let mut exprs = BumpVec::new_in(self.arena);
+                loop {
+                    exprs.push(self.parse_expression()?);
+                    if !self.try_consume(&Token::Comma) {
+                        break;
+                    }
+                }
+                self.expect_token(Token::RParen)?;
+                elements.push(GroupingElement::Composite(exprs));
+            } else {
+                // Single element
+                let expr = self.parse_expression()?;
+                elements.push(GroupingElement::Single(expr));
+            }
+
+            if !self.try_consume(&Token::Comma) {
+                break;
+            }
+        }
+
+        Ok(elements)
+    }
+
+    /// Parse grouping sets.
+    fn parse_grouping_sets(&mut self) -> Result<BumpVec<'arena, GroupingSet<'arena>>, ParseError> {
+        let mut sets = BumpVec::new_in(self.arena);
+
+        loop {
+            self.expect_token(Token::LParen)?;
+            let mut columns = BumpVec::new_in(self.arena);
+
+            if !matches!(self.peek(), Token::RParen) {
+                loop {
+                    columns.push(self.parse_expression()?);
+                    if !self.try_consume(&Token::Comma) {
+                        break;
+                    }
+                }
+            }
+
+            self.expect_token(Token::RParen)?;
+            sets.push(GroupingSet { columns });
+
+            if !self.try_consume(&Token::Comma) {
+                break;
+            }
+        }
+
+        Ok(sets)
+    }
+
+    /// Parse ORDER BY clause.
+    fn parse_order_by_clause(&mut self) -> Result<BumpVec<'arena, OrderByItem<'arena>>, ParseError> {
+        let mut items = BumpVec::new_in(self.arena);
+
+        loop {
+            let expr = self.parse_expression()?;
+            let direction = if self.try_consume_keyword(Keyword::Desc) {
+                OrderDirection::Desc
+            } else {
+                self.try_consume_keyword(Keyword::Asc);
+                OrderDirection::Asc
+            };
+
+            items.push(OrderByItem { expr, direction });
+
+            if !self.try_consume(&Token::Comma) {
+                break;
+            }
+        }
+
+        Ok(items)
+    }
+
+    /// Parse set operation (UNION, INTERSECT, EXCEPT).
+    fn parse_set_operation(&mut self) -> Result<Option<SetOperation<'arena>>, ParseError> {
+        let op = if self.try_consume_keyword(Keyword::Union) {
+            SetOperator::Union
+        } else if self.try_consume_keyword(Keyword::Intersect) {
+            SetOperator::Intersect
+        } else if self.try_consume_keyword(Keyword::Except) {
+            SetOperator::Except
+        } else {
+            return Ok(None);
+        };
+
+        let all = self.try_consume_keyword(Keyword::All);
+        self.try_consume_keyword(Keyword::Distinct);
+
+        let right = self.parse_select_statement()?;
+
+        Ok(Some(SetOperation { op, all, right }))
+    }
+}

--- a/crates/vibesql-parser/src/lib.rs
+++ b/crates/vibesql-parser/src/lib.rs
@@ -1,6 +1,13 @@
 //! SQL:1999 Parser crate.
 //!
 //! Provides tokenization and parsing of SQL statements into the shared AST.
+//!
+//! # Arena-allocated Parser
+//!
+//! For performance-critical code paths, the [`arena_parser`] module provides
+//! an arena-based parser that allocates AST nodes from a bump allocator.
+
+pub mod arena_parser;
 
 mod keywords;
 mod lexer;


### PR DESCRIPTION
## Summary

Add bumpalo arena allocator for SQL AST nodes to reduce allocation overhead and improve cache locality during parsing. This is Phase 1 of the arena allocation implementation, supporting SELECT statements.

### Changes:
- Add `arena` module to `vibesql-ast` with lifetime-parameterized AST types (`Expression<'arena>`, `SelectStmt<'arena>`, etc.)
- Add `arena_parser` module to `vibesql-parser` with `ArenaParser` struct
- Replace `Box<T>` allocations with `&'arena T` arena references  
- Replace `Vec<T>` with `bumpalo::collections::Vec<'arena, T>`
- Add comprehensive benchmarks comparing standard vs arena parsers

### Performance Results

| Query | Standard | Arena | Arena Reuse | Improvement |
|-------|----------|-------|-------------|-------------|
| simple_select | 442 ns | 316 ns | 256 ns | **29% / 42%** |
| point_lookup | 600 ns | 405 ns | 347 ns | **33% / 42%** |
| multi_column | 1.89 µs | 1.21 µs | 1.07 µs | **36% / 43%** |
| complex_join | 4.46 µs | 2.78 µs | 2.63 µs | **38% / 41%** |

The arena parser achieves **29-38% faster** parsing with fresh arenas and **41-43% faster** with arena reuse, exceeding the expected 20-40% improvement target.

## Test plan

- [x] All 928 parser tests pass
- [x] Benchmark shows expected performance improvements
- [x] Run `cargo test -p vibesql-parser`
- [x] Run `cargo bench -p vibesql-parser -- parser_comparison`

Closes #3233

🤖 Generated with [Claude Code](https://claude.com/claude-code)