### PR TITLE
perf(index): Improve index selection for ORDER BY with pinned prefix columns

### DIFF
--- a/crates/vibesql-executor/benches/tpcc/schema.rs
+++ b/crates/vibesql-executor/benches/tpcc/schema.rs
@@ -369,11 +369,14 @@ fn create_tpcc_indexes_vibesql(db: &mut VibeDB) {
         vec![col("c_w_id"), col("c_d_id"), col("c_last"), col("c_first")],
     ).ok();
 
+    // Include o_id in the index to support ORDER BY o_id DESC LIMIT 1 efficiently.
+    // This allows the Order-Status transaction to find a customer's most recent order
+    // via a single index scan rather than fetching all orders and sorting.
     db.create_index(
         "idx_orders_customer".to_string(),
         "orders".to_string(),
         false,
-        vec![col("o_w_id"), col("o_d_id"), col("o_c_id")],
+        vec![col("o_w_id"), col("o_d_id"), col("o_c_id"), col("o_id")],
     ).ok();
 
     // Stock-Level transaction index: enables efficient range scans on order_line
@@ -731,7 +734,7 @@ fn create_tpcc_indexes_sqlite(conn: &SqliteConn) {
     conn.execute_batch(
         "
         CREATE INDEX idx_customer_name ON customer (c_w_id, c_d_id, c_last, c_first);
-        CREATE INDEX idx_orders_customer ON orders (o_w_id, o_d_id, o_c_id);
+        CREATE INDEX idx_orders_customer ON orders (o_w_id, o_d_id, o_c_id, o_id);
         CREATE INDEX idx_order_line_district ON order_line (ol_w_id, ol_d_id, ol_o_id);
         ",
     )
@@ -1014,7 +1017,7 @@ fn create_tpcc_indexes_duckdb(conn: &DuckDBConn) {
     conn.execute_batch(
         "
         CREATE INDEX idx_customer_name ON customer (c_w_id, c_d_id, c_last, c_first);
-        CREATE INDEX idx_orders_customer ON orders (o_w_id, o_d_id, o_c_id);
+        CREATE INDEX idx_orders_customer ON orders (o_w_id, o_d_id, o_c_id, o_id);
         CREATE INDEX idx_order_line_district ON order_line (ol_w_id, ol_d_id, ol_o_id);
         ",
     )
@@ -1354,7 +1357,7 @@ fn create_tpcc_indexes_mysql(conn: &mut PooledConn) {
         "CREATE INDEX idx_customer_name ON customer (c_w_id, c_d_id, c_last, c_first)"
     ).unwrap();
     conn.query_drop(
-        "CREATE INDEX idx_orders_customer ON orders (o_w_id, o_d_id, o_c_id)"
+        "CREATE INDEX idx_orders_customer ON orders (o_w_id, o_d_id, o_c_id, o_id)"
     ).unwrap();
     conn.query_drop(
         "CREATE INDEX idx_order_line_district ON order_line (ol_w_id, ol_d_id, ol_o_id)"

--- a/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
@@ -61,7 +61,11 @@ pub(crate) fn should_use_index_scan(
         return None;
     }
 
-    // Try to find an index that satisfies both WHERE and ORDER BY (if present)
+    // Find the best index (most pinned columns = better filtering)
+    // We evaluate all applicable indexes and pick the one that covers the most WHERE columns
+    let mut best_index: Option<(String, usize, bool, Option<Vec<(String, vibesql_ast::OrderDirection)>>)> = None;
+    // (index_name, pinned_count, can_use_for_order, sorted_columns)
+
     for index_name in &indexes {
         if let Some(index_metadata) = database.get_index(index_name) {
             let first_indexed_column = index_metadata.columns.first()?;
@@ -71,10 +75,17 @@ pub(crate) fn should_use_index_scan(
                 .map(|expr| expression_filters_column(expr, &first_indexed_column.column_name))
                 .unwrap_or(false);
 
+            // Count how many leading index columns are pinned by equality predicates
+            let pinned_columns = count_pinned_index_columns(where_clause, &index_metadata.columns);
+
             // Check if this index can be used for ORDER BY clause
             let can_use_for_order = if let Some(order_items) = order_by {
-                // Check if ORDER BY columns match the index columns
-                let columns_match = can_use_index_for_order_by(order_items, &index_metadata.columns);
+                // Check if ORDER BY columns match the index columns (after skipping pinned columns)
+                let columns_match = can_use_index_for_order_by_with_pinned(
+                    order_items,
+                    &index_metadata.columns,
+                    pinned_columns,
+                );
 
                 // Don't use index for ORDER BY if any column is nullable
                 // BTreeMap orders NULLs first, but SQL default is NULLS LAST for ASC
@@ -88,31 +99,56 @@ pub(crate) fn should_use_index_scan(
                 false
             };
 
-            // Use this index if it satisfies WHERE, ORDER BY, or both
-            if can_use_for_where || can_use_for_order {
-                // Build sorted_columns metadata if ORDER BY can be satisfied
-                let sorted_columns = if can_use_for_order {
-                    // Build sorted_columns from all ORDER BY columns that match the index
-                    let order_items = order_by.unwrap();
-                    Some(
-                        order_items
-                            .iter()
-                            .map(|item| {
-                                let col_name = match &item.expr {
-                                    Expression::ColumnRef { column, .. } => column.clone(),
-                                    _ => unreachable!("can_use_index_for_order_by ensures simple column refs"),
-                                };
-                                (col_name, item.direction.clone())
-                            })
-                            .collect(),
-                    )
-                } else {
-                    None
-                };
+            // Skip if this index can't help with WHERE or ORDER BY
+            if !can_use_for_where && !can_use_for_order {
+                continue;
+            }
 
-                return Some((index_name.clone(), sorted_columns));
+            // Build sorted_columns metadata if ORDER BY can be satisfied
+            let sorted_columns = if can_use_for_order {
+                let order_items = order_by.unwrap();
+                Some(
+                    order_items
+                        .iter()
+                        .map(|item| {
+                            let col_name = match &item.expr {
+                                Expression::ColumnRef { column, .. } => column.clone(),
+                                _ => unreachable!("can_use_index_for_order_by ensures simple column refs"),
+                            };
+                            (col_name, item.direction.clone())
+                        })
+                        .collect(),
+                )
+            } else {
+                None
+            };
+
+            // Compare with best index so far
+            // Prefer: more pinned columns > can satisfy ORDER BY > first found
+            let is_better = match &best_index {
+                None => true,
+                Some((_, best_pinned, best_can_order, _)) => {
+                    // More pinned columns = better (narrows down rows more)
+                    if pinned_columns > *best_pinned {
+                        true
+                    } else if pinned_columns == *best_pinned {
+                        // Same pinned count: prefer one that can satisfy ORDER BY
+                        can_use_for_order && !*best_can_order
+                    } else {
+                        false
+                    }
+                }
+            };
+
+            if is_better {
+                best_index = Some((index_name.clone(), pinned_columns, can_use_for_order, sorted_columns));
             }
         }
+    }
+
+    // Return the best index if we found one
+    if let Some((index_name, _, _, sorted_columns)) = best_index {
+        return Some((index_name, sorted_columns));
     }
 
     None
@@ -208,25 +244,57 @@ fn get_column_stats_ignore_case<'a>(
 
 /// Check if an index can be used to satisfy an ORDER BY clause
 ///
-/// Returns true if the ORDER BY columns match a prefix of the index columns
-/// and the sort directions are compatible (considering ASC/DESC on both sides).
+/// Returns true if the ORDER BY columns match the index columns (after skipping
+/// any prefix columns pinned by equality predicates) and the sort directions
+/// are compatible (either all matching or all reversed).
 ///
 /// Examples:
 /// - ORDER BY col0 ASC can use index (col0 ASC)
-/// - ORDER BY col0 DESC can use index (col0 DESC)
+/// - ORDER BY col0 DESC can use index (col0 DESC) via reversal
 /// - ORDER BY col0, col1 can use index (col0, col1)
-/// - ORDER BY col0 cannot use index (col0 DESC) - wrong direction
+/// - WHERE col0 = 1 ORDER BY col1 can use index (col0, col1) - col0 is pinned
 pub(crate) fn can_use_index_for_order_by(
     order_items: &[vibesql_ast::OrderByItem],
     index_columns: &[vibesql_ast::IndexColumn],
 ) -> bool {
-    // ORDER BY must not have more columns than the index
-    if order_items.len() > index_columns.len() {
+    can_use_index_for_order_by_with_pinned(order_items, index_columns, 0)
+}
+
+/// Check if an index can be used for ORDER BY, accounting for pinned prefix columns
+///
+/// When a query has equality predicates on leading index columns (e.g., WHERE a = 1 AND b = 2),
+/// those columns are "pinned" and the index is effectively sorted by the remaining columns.
+/// This function skips over the pinned columns and checks if the ORDER BY matches.
+///
+/// For example, with index (a, b, c):
+/// - WHERE a = 1 ORDER BY b, c → can use index (skip 1 pinned column)
+/// - WHERE a = 1 AND b = 2 ORDER BY c → can use index (skip 2 pinned columns)
+/// - WHERE a = 1 ORDER BY c → cannot use index (b must come before c)
+pub(crate) fn can_use_index_for_order_by_with_pinned(
+    order_items: &[vibesql_ast::OrderByItem],
+    index_columns: &[vibesql_ast::IndexColumn],
+    pinned_columns: usize,
+) -> bool {
+    // Skip pinned columns
+    let remaining_index_columns = &index_columns[pinned_columns..];
+
+    // ORDER BY must not have more columns than remaining index columns
+    if order_items.len() > remaining_index_columns.len() {
         return false;
     }
 
+    // If no ORDER BY columns, nothing to match
+    if order_items.is_empty() {
+        return false;
+    }
+
+    // Check if ORDER BY matches index direction or is completely reversed
+    // (allowing reverse scan to satisfy DESC ordering)
+    let mut all_match = true;
+    let mut all_reversed = true;
+
     // Check each ORDER BY column against corresponding index column
-    for (order_item, index_col) in order_items.iter().zip(index_columns.iter()) {
+    for (order_item, index_col) in order_items.iter().zip(remaining_index_columns.iter()) {
         // ORDER BY expression must be a simple column reference
         let order_col_name = match &order_item.expr {
             Expression::ColumnRef { table: None, column } => column,
@@ -238,14 +306,87 @@ pub(crate) fn can_use_index_for_order_by(
             return false;
         }
 
-        // Sort directions must be compatible
-        // Note: IndexColumn uses OrderDirection enum, same as OrderByItem
-        if order_item.direction != index_col.direction {
-            return false;
+        // Check sort directions
+        let directions_match = order_item.direction == index_col.direction;
+        let directions_opposite = match (&order_item.direction, &index_col.direction) {
+            (vibesql_ast::OrderDirection::Asc, vibesql_ast::OrderDirection::Desc)
+            | (vibesql_ast::OrderDirection::Desc, vibesql_ast::OrderDirection::Asc) => true,
+            _ => false,
+        };
+
+        if !directions_match {
+            all_match = false;
+        }
+        if !directions_opposite {
+            all_reversed = false;
         }
     }
 
-    true
+    // Accept if all directions match OR all are reversed (reverse scan)
+    all_match || all_reversed
+}
+
+/// Count how many leading index columns are pinned by equality predicates
+///
+/// A column is "pinned" if there's an equality predicate (col = value) in the WHERE clause.
+/// Returns the number of consecutive leading index columns that are pinned.
+pub(crate) fn count_pinned_index_columns(
+    where_clause: Option<&Expression>,
+    index_columns: &[vibesql_ast::IndexColumn],
+) -> usize {
+    let where_clause = match where_clause {
+        Some(expr) => expr,
+        None => return 0,
+    };
+
+    // Collect all columns that have equality predicates
+    let mut pinned_columns = std::collections::HashSet::new();
+    collect_equality_columns(where_clause, &mut pinned_columns);
+
+    // Count consecutive leading index columns that are pinned
+    let mut count = 0;
+    for index_col in index_columns {
+        // Check if this index column is pinned (case-insensitive match)
+        let is_pinned = pinned_columns
+            .iter()
+            .any(|c| c.eq_ignore_ascii_case(&index_col.column_name));
+        if is_pinned {
+            count += 1;
+        } else {
+            break; // Stop at first non-pinned column
+        }
+    }
+    count
+}
+
+/// Collect all column names that have equality predicates (col = literal)
+fn collect_equality_columns(expr: &Expression, columns: &mut std::collections::HashSet<String>) {
+    match expr {
+        Expression::BinaryOp { left, op, right } => {
+            match op {
+                vibesql_ast::BinaryOperator::Equal => {
+                    // Check for column = literal pattern
+                    if let Expression::ColumnRef { column, .. } = &**left {
+                        if is_literal(right) {
+                            columns.insert(column.to_uppercase());
+                        }
+                    }
+                    if let Expression::ColumnRef { column, .. } = &**right {
+                        if is_literal(left) {
+                            columns.insert(column.to_uppercase());
+                        }
+                    }
+                }
+                vibesql_ast::BinaryOperator::And => {
+                    // Recurse into both sides of AND
+                    collect_equality_columns(left, columns);
+                    collect_equality_columns(right, columns);
+                }
+                _ => {}
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Cost-based index selection using statistics
@@ -292,9 +433,10 @@ pub(crate) fn cost_based_index_selection(
         return None; // No indexes available
     }
 
-    // Try each index and find the one with lowest cost
+    // Try each index and find the one with best score (pinned columns + cost)
     #[allow(clippy::type_complexity)]
-    let mut best_index: Option<(String, AccessMethod, Option<Vec<(String, vibesql_ast::OrderDirection)>>)> = None;
+    let mut best_index: Option<(String, AccessMethod, usize, Option<Vec<(String, vibesql_ast::OrderDirection)>>)> = None;
+    // (index_name, access_method, pinned_count, sorted_columns)
     let mut has_applicable_index_without_stats = false;
 
     for index_name in &indexes {
@@ -307,8 +449,16 @@ pub(crate) fn cost_based_index_selection(
                 .map(|expr| expression_filters_column(expr, column_name))
                 .unwrap_or(false);
 
+            // Count how many leading index columns are pinned by equality predicates
+            let pinned_columns = count_pinned_index_columns(where_clause, &index_metadata.columns);
+
             let can_use_for_order = if let Some(order_items) = order_by {
-                let columns_match = can_use_index_for_order_by(order_items, &index_metadata.columns);
+                // Check if ORDER BY columns match the index columns (after skipping pinned columns)
+                let columns_match = can_use_index_for_order_by_with_pinned(
+                    order_items,
+                    &index_metadata.columns,
+                    pinned_columns,
+                );
 
                 // Don't use index for ORDER BY if any column is nullable
                 // BTreeMap orders NULLs first, but SQL default is NULLS LAST for ASC
@@ -370,24 +520,33 @@ pub(crate) fn cost_based_index_selection(
                 None
             };
 
-            // Track the best index (lowest cost)
+            // Track the best index
+            // Priority: more pinned columns (better filtering) > lower cost
             if access_method.is_index_scan() {
-                match &best_index {
-                    None => {
-                        best_index = Some((index_name.clone(), access_method, sorted_columns));
-                    }
-                    Some((_, best_method, _)) => {
-                        if access_method.cost() < best_method.cost() {
-                            best_index = Some((index_name.clone(), access_method, sorted_columns));
+                let is_better = match &best_index {
+                    None => true,
+                    Some((_, best_method, best_pinned, _)) => {
+                        // More pinned columns is always better (filters more rows)
+                        if pinned_columns > *best_pinned {
+                            true
+                        } else if pinned_columns == *best_pinned {
+                            // Same pinned count: prefer lower cost
+                            access_method.cost() < best_method.cost()
+                        } else {
+                            false
                         }
                     }
+                };
+
+                if is_better {
+                    best_index = Some((index_name.clone(), access_method, pinned_columns, sorted_columns));
                 }
             }
         }
     }
 
     // Return the best index if we found one
-    if let Some((index_name, _, sorted_columns)) = best_index {
+    if let Some((index_name, _, _, sorted_columns)) = best_index {
         return Some((index_name, sorted_columns));
     }
 


### PR DESCRIPTION
## Summary

- Add `o_id` to `idx_orders_customer` index to support `ORDER BY o_id DESC LIMIT 1` for the Order-Status transaction
- Add `count_pinned_index_columns()` to detect equality predicates on leading index columns
- Add `can_use_index_for_order_by_with_pinned()` to recognize ORDER BY on remaining index columns after pinned prefix
- Modify index selection to prefer indexes with more pinned columns (better filtering)
- Support reverse scan for DESC ORDER BY when index columns are ASC

This enables efficient index usage for queries like:
```sql
SELECT ... FROM orders
WHERE o_w_id = ? AND o_d_id = ? AND o_c_id = ?
ORDER BY o_id DESC LIMIT 1
```

With index `(o_w_id, o_d_id, o_c_id, o_id)`, the first 3 columns are pinned by equality predicates, allowing the index to satisfy `ORDER BY o_id`.

## Test plan

- [x] All 1632 executor tests pass
- [x] Code compiles without errors
- [ ] Further optimization needed for LIMIT pushdown to achieve full performance improvement

Closes #3240

🤖 Generated with [Claude Code](https://claude.com/claude-code)