### PR TITLE
chore: Remove unused combine_predicates function

### DIFF
--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -270,32 +270,11 @@ pub(super) fn build_column_to_table_map(
     result
 }
 
-/// Combine a list of predicates into a single AND expression
-///
-/// If the list is empty, returns None.
-/// If the list has one element, returns that element.
-/// Otherwise, combines all predicates with AND.
-pub(super) fn combine_predicates(predicates: &[vibesql_ast::Expression]) -> Option<vibesql_ast::Expression> {
-    match predicates.len() {
-        0 => None,
-        1 => Some(predicates[0].clone()),
-        _ => {
-            let mut result = predicates[0].clone();
-            for pred in &predicates[1..] {
-                result = vibesql_ast::Expression::BinaryOp {
-                    op: vibesql_ast::BinaryOperator::And,
-                    left: Box::new(result),
-                    right: Box::new(pred.clone()),
-                };
-            }
-            Some(result)
-        }
-    }
-}
-
 /// Combine a list of predicates into a single AND expression, qualifying unqualified columns
 ///
-/// This is similar to `combine_predicates` but also adds table qualifiers to any
+/// If the list is empty, returns None.
+/// If the list has one element, returns that element (with column qualification).
+/// Otherwise, combines all predicates with AND, adding table qualifiers to any
 /// unqualified column references. This is necessary for predicates extracted from
 /// OR branches where columns may not have table qualifiers.
 pub(super) fn combine_predicates_with_qualification(


### PR DESCRIPTION
## Summary

- Removes the unused `combine_predicates` function in `crates/vibesql-executor/src/select/scan/reorder/utils.rs`
- This function became dead code after PR #3243 replaced its usage with `combine_predicates_with_qualification`
- Updates the doc comment for `combine_predicates_with_qualification` to be standalone

Closes #3249

## Test plan

- [x] `cargo check` passes without the dead_code warning for `combine_predicates`
- [x] `cargo test --lib -p vibesql-executor -- reorder` - all 7 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)