### PR TITLE
perf(parser): Add string interning for SQL identifiers

### DIFF
--- a/crates/vibesql-parser/Cargo.toml
+++ b/crates/vibesql-parser/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["database", "parser-implementations"]
 vibesql-ast = { version = "0.1.0", path = "../vibesql-ast" }
 vibesql-types = { version = "0.1.0", path = "../vibesql-types" }
 phf = { version = "0.11", features = ["macros"] }
+string-interner = "0.17"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/vibesql-parser/src/interner.rs
+++ b/crates/vibesql-parser/src/interner.rs
@@ -1,0 +1,98 @@
+//! String interning for SQL identifiers.
+//!
+//! This module provides string interning to deduplicate identical identifier strings,
+//! reducing memory usage and enabling fast pointer-based equality comparisons.
+
+use string_interner::{backend::StringBackend, DefaultSymbol, StringInterner};
+
+/// Symbol representing an interned string.
+///
+/// This is a lightweight handle (usize) that can be used to retrieve the original string
+/// from the interner. Equality comparisons are O(1) pointer comparisons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StringSymbol(DefaultSymbol);
+
+impl StringSymbol {
+    /// Create a new StringSymbol from a DefaultSymbol.
+    #[inline]
+    pub(crate) fn new(symbol: DefaultSymbol) -> Self {
+        StringSymbol(symbol)
+    }
+
+    /// Get the underlying symbol.
+    #[inline]
+    pub(crate) fn inner(self) -> DefaultSymbol {
+        self.0
+    }
+}
+
+/// Interner for SQL identifiers.
+///
+/// Deduplicates identical strings and provides fast symbol-based equality.
+/// The interner is owned by the lexer and passed to the parser for resolution.
+#[derive(Debug, Default)]
+pub struct IdentifierInterner {
+    interner: StringInterner<StringBackend>,
+}
+
+impl IdentifierInterner {
+    /// Create a new empty interner.
+    #[inline]
+    pub fn new() -> Self {
+        IdentifierInterner { interner: StringInterner::new() }
+    }
+
+    /// Intern a string and return its symbol.
+    ///
+    /// If the string was already interned, returns the existing symbol.
+    /// This is O(1) for cache hits and O(n) for new strings.
+    #[inline]
+    pub fn get_or_intern(&mut self, string: impl AsRef<str>) -> StringSymbol {
+        StringSymbol::new(self.interner.get_or_intern(string))
+    }
+
+    /// Resolve a symbol back to its string.
+    ///
+    /// Returns None if the symbol is not from this interner.
+    #[inline]
+    pub fn resolve(&self, symbol: StringSymbol) -> Option<&str> {
+        self.interner.resolve(symbol.inner())
+    }
+
+    /// Resolve a symbol, panicking if not found.
+    ///
+    /// Use this when you're certain the symbol came from this interner.
+    #[inline]
+    pub fn resolve_unchecked(&self, symbol: StringSymbol) -> &str {
+        self.interner.resolve(symbol.inner()).expect("symbol not found in interner")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_intern_and_resolve() {
+        let mut interner = IdentifierInterner::new();
+        let sym1 = interner.get_or_intern("hello");
+        let sym2 = interner.get_or_intern("world");
+        let sym3 = interner.get_or_intern("hello"); // duplicate
+
+        assert_eq!(sym1, sym3); // same symbol for same string
+        assert_ne!(sym1, sym2); // different symbols for different strings
+
+        assert_eq!(interner.resolve(sym1), Some("hello"));
+        assert_eq!(interner.resolve(sym2), Some("world"));
+    }
+
+    #[test]
+    fn test_symbol_equality_is_fast() {
+        let mut interner = IdentifierInterner::new();
+        let sym1 = interner.get_or_intern("a_very_long_identifier_name");
+        let sym2 = interner.get_or_intern("a_very_long_identifier_name");
+
+        // This is an O(1) comparison, not O(n) string comparison
+        assert_eq!(sym1, sym2);
+    }
+}

--- a/crates/vibesql-parser/src/lexer/identifiers.rs
+++ b/crates/vibesql-parser/src/lexer/identifiers.rs
@@ -29,13 +29,13 @@ impl<'a> Lexer<'a> {
             // Use perfect hash map for O(1) keyword lookup
             match keywords::map_keyword(&upper_text) {
                 Some(keyword) => Ok(Token::Keyword(keyword)),
-                None => Ok(Token::Identifier(upper_text)),
+                None => Ok(Token::Identifier(self.intern(upper_text))),
             }
         } else {
             // Text is already uppercase - try keyword lookup on the slice directly
             match keywords::map_keyword(text) {
                 Some(keyword) => Ok(Token::Keyword(keyword)),
-                None => Ok(Token::Identifier(text.to_string())),
+                None => Ok(Token::Identifier(self.intern(text))),
             }
         }
     }
@@ -65,7 +65,7 @@ impl<'a> Lexer<'a> {
                             position: self.position(),
                         });
                     }
-                    return Ok(Token::DelimitedIdentifier(identifier));
+                    return Ok(Token::DelimitedIdentifier(self.intern(identifier)));
                 }
             } else {
                 identifier.push(ch);
@@ -104,7 +104,7 @@ impl<'a> Lexer<'a> {
                             position: self.position(),
                         });
                     }
-                    return Ok(Token::DelimitedIdentifier(identifier));
+                    return Ok(Token::DelimitedIdentifier(self.intern(identifier)));
                 }
             } else {
                 identifier.push(ch);

--- a/crates/vibesql-parser/src/lexer/mod.rs
+++ b/crates/vibesql-parser/src/lexer/mod.rs
@@ -9,6 +9,7 @@
 
 use std::fmt;
 
+use crate::interner::IdentifierInterner;
 use crate::token::Token;
 
 mod identifiers;
@@ -30,24 +31,54 @@ impl fmt::Display for LexerError {
     }
 }
 
+/// A stream of tokens bundled with the interner for resolving symbols.
+///
+/// This is the result of lexing and provides everything needed for parsing.
+#[derive(Debug)]
+pub struct TokenStream {
+    /// The tokens produced by lexing
+    pub tokens: Vec<Token>,
+    /// The interner for resolving string symbols
+    pub interner: IdentifierInterner,
+}
+
+impl TokenStream {
+    /// Get a slice of all tokens.
+    #[inline]
+    pub fn tokens(&self) -> &[Token] {
+        &self.tokens
+    }
+
+    /// Resolve a symbol to its string value.
+    #[inline]
+    pub fn resolve(&self, sym: crate::interner::StringSymbol) -> &str {
+        self.interner.resolve_unchecked(sym)
+    }
+}
+
 /// SQL Lexer - converts SQL text into tokens.
 ///
 /// Uses direct &str access for zero-copy tokenization.
 /// Tracks byte position for efficient slicing.
+/// Owns an interner for deduplicating identifier strings.
 pub struct Lexer<'a> {
     input: &'a str,
     byte_pos: usize,
+    interner: IdentifierInterner,
 }
 
 impl<'a> Lexer<'a> {
     /// Create a new lexer from SQL input.
     #[inline]
     pub fn new(input: &'a str) -> Self {
-        Lexer { input, byte_pos: 0 }
+        Lexer { input, byte_pos: 0, interner: IdentifierInterner::new() }
     }
 
-    /// Tokenize the entire input.
-    pub fn tokenize(&mut self) -> Result<Vec<Token>, LexerError> {
+    /// Tokenize the entire input and return a TokenStream.
+    ///
+    /// The TokenStream contains both the tokens and the interner needed
+    /// to resolve string symbols back to their values.
+    pub fn tokenize(mut self) -> Result<TokenStream, LexerError> {
         // Pre-allocate based on estimated token count (~1 token per 6 bytes)
         let estimated_tokens = (self.input.len() / 6).max(4);
         let mut tokens = Vec::with_capacity(estimated_tokens);
@@ -64,7 +95,13 @@ impl<'a> Lexer<'a> {
             tokens.push(token);
         }
 
-        Ok(tokens)
+        Ok(TokenStream { tokens, interner: self.interner })
+    }
+
+    /// Intern a string and return its symbol.
+    #[inline]
+    pub(super) fn intern(&mut self, s: impl AsRef<str>) -> crate::interner::StringSymbol {
+        self.interner.get_or_intern(s)
     }
 
     /// Get the next token.
@@ -275,8 +312,8 @@ impl<'a> Lexer<'a> {
             });
         }
 
-        let var_name = self.slice_from(start).to_string();
-        Ok(Token::SessionVariable(var_name))
+        let var_name = self.slice_from(start);
+        Ok(Token::SessionVariable(self.intern(var_name)))
     }
 
     /// Tokenize a user variable (@variable).
@@ -302,8 +339,8 @@ impl<'a> Lexer<'a> {
             });
         }
 
-        let var_name = self.slice_from(start).to_string();
-        Ok(Token::UserVariable(var_name))
+        let var_name = self.slice_from(start);
+        Ok(Token::UserVariable(self.intern(var_name)))
     }
 
     /// Tokenize a numbered placeholder ($1, $2, etc.).
@@ -372,6 +409,6 @@ impl<'a> Lexer<'a> {
             });
         }
 
-        Ok(Token::NamedPlaceholder(name))
+        Ok(Token::NamedPlaceholder(self.intern(name)))
     }
 }

--- a/crates/vibesql-parser/src/lexer/numbers.rs
+++ b/crates/vibesql-parser/src/lexer/numbers.rs
@@ -58,8 +58,8 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        let number = self.slice_from(start).to_string();
-        Ok(Token::Number(number))
+        let number = self.slice_from(start);
+        Ok(Token::Number(self.intern(number)))
     }
 }
 
@@ -82,19 +82,19 @@ mod tests {
         ];
 
         for (input, expected) in test_cases {
-            let mut lexer = Lexer::new(input);
-            let tokens =
+            let lexer = Lexer::new(input);
+            let stream =
                 lexer.tokenize().unwrap_or_else(|_| panic!("Failed to tokenize: {}", input));
 
             // Should have exactly 2 tokens: the number and EOF
-            assert_eq!(tokens.len(), 2, "Input: {}", input);
+            assert_eq!(stream.tokens.len(), 2, "Input: {}", input);
 
-            match &tokens[0] {
-                Token::Number(n) => assert_eq!(n, expected, "Input: {}", input),
+            match stream.tokens[0] {
+                Token::Number(sym) => assert_eq!(stream.resolve(sym), expected, "Input: {}", input),
                 other => panic!("Expected Number token for {}, got {:?}", input, other),
             }
 
-            assert_eq!(tokens[1], Token::Eof);
+            assert_eq!(stream.tokens[1], Token::Eof);
         }
     }
 
@@ -104,14 +104,14 @@ mod tests {
         let test_cases = vec![(".5", ".5"), (".123", ".123"), (".2E+2", ".2E+2")];
 
         for (input, expected) in test_cases {
-            let mut lexer = Lexer::new(input);
-            let tokens =
+            let lexer = Lexer::new(input);
+            let stream =
                 lexer.tokenize().unwrap_or_else(|_| panic!("Failed to tokenize: {}", input));
 
-            assert_eq!(tokens.len(), 2, "Input: {}", input);
+            assert_eq!(stream.tokens.len(), 2, "Input: {}", input);
 
-            match &tokens[0] {
-                Token::Number(n) => assert_eq!(n, expected, "Input: {}", input),
+            match stream.tokens[0] {
+                Token::Number(sym) => assert_eq!(stream.resolve(sym), expected, "Input: {}", input),
                 other => panic!("Expected Number token for {}, got {:?}", input, other),
             }
         }
@@ -127,7 +127,7 @@ mod tests {
         ];
 
         for input in invalid_cases {
-            let mut lexer = Lexer::new(input);
+            let lexer = Lexer::new(input);
             let result = lexer.tokenize();
             assert!(result.is_err(), "Expected error for input: {}", input);
         }

--- a/crates/vibesql-parser/src/lexer/operators.rs
+++ b/crates/vibesql-parser/src/lexer/operators.rs
@@ -13,19 +13,19 @@ impl<'a> Lexer<'a> {
                     match (ch, next_ch) {
                         ('<', '=') => {
                             self.advance();
-                            Ok(Token::Operator("<=".to_string()))
+                            Ok(Token::Operator(self.intern("<=")))
                         }
                         ('>', '=') => {
                             self.advance();
-                            Ok(Token::Operator(">=".to_string()))
+                            Ok(Token::Operator(self.intern(">=")))
                         }
                         ('!', '=') => {
                             self.advance();
-                            Ok(Token::Operator("!=".to_string()))
+                            Ok(Token::Operator(self.intern("!=")))
                         }
                         ('<', '>') => {
                             self.advance();
-                            Ok(Token::Operator("<>".to_string()))
+                            Ok(Token::Operator(self.intern("<>")))
                         }
                         _ => Ok(Token::Symbol(ch)),
                     }
@@ -37,7 +37,7 @@ impl<'a> Lexer<'a> {
                 self.advance();
                 if !self.is_eof() && self.current_char() == '|' {
                     self.advance();
-                    Ok(Token::Operator("||".to_string()))
+                    Ok(Token::Operator(self.intern("||")))
                 } else {
                     Err(LexerError {
                         message: "Unexpected character: '|' (did you mean '||'?)".to_string(),

--- a/crates/vibesql-parser/src/lexer/strings.rs
+++ b/crates/vibesql-parser/src/lexer/strings.rs
@@ -20,7 +20,7 @@ impl<'a> Lexer<'a> {
                     self.advance();
                 } else {
                     // End of string
-                    return Ok(Token::String(string_content));
+                    return Ok(Token::String(self.intern(string_content)));
                 }
             } else {
                 string_content.push(ch);

--- a/crates/vibesql-parser/src/lib.rs
+++ b/crates/vibesql-parser/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides tokenization and parsing of SQL statements into the shared AST.
 
+mod interner;
 mod keywords;
 mod lexer;
 mod parser;
@@ -9,7 +10,8 @@ mod parser;
 mod tests;
 mod token;
 
+pub use interner::{IdentifierInterner, StringSymbol};
 pub use keywords::Keyword;
-pub use lexer::{Lexer, LexerError};
+pub use lexer::{Lexer, LexerError, TokenStream};
 pub use parser::{ParseError, Parser};
 pub use token::Token;

--- a/crates/vibesql-parser/src/parser/advanced_objects/collation.rs
+++ b/crates/vibesql-parser/src/parser/advanced_objects/collation.rs
@@ -35,13 +35,13 @@ pub fn parse_create_collation(
     let source_collation = if parser.try_consume_keyword(Keyword::From) {
         match parser.peek() {
             Token::Identifier(s) | Token::DelimitedIdentifier(s) => {
-                let source = s.clone();
+                let source = parser.resolve(*s);
                 parser.advance();
                 Some(source)
             }
             Token::String(s) => {
                 // SQL:1999 allows string literal for locale (e.g., 'de_DE')
-                let source = s.clone();
+                let source = parser.resolve(*s);
                 parser.advance();
                 Some(source)
             }

--- a/crates/vibesql-parser/src/parser/advanced_objects/routines.rs
+++ b/crates/vibesql-parser/src/parser/advanced_objects/routines.rs
@@ -471,7 +471,8 @@ impl Parser {
                     });
                 }
             } else if self.try_consume_keyword(Keyword::Comment) {
-                if let Token::String(s) = self.peek().clone() {
+                if let Token::String(sym) = self.peek() {
+                    let s = self.resolve(*sym);
                     self.advance();
                     comment = Some(s);
                 } else {
@@ -520,7 +521,8 @@ impl Parser {
                     });
                 }
             } else if self.try_consume_keyword(Keyword::Comment) {
-                if let Token::String(s) = self.peek().clone() {
+                if let Token::String(sym) = self.peek() {
+                    let s = self.resolve(*sym);
                     self.advance();
                     comment = Some(s);
                 } else {

--- a/crates/vibesql-parser/src/parser/advanced_objects/sequence.rs
+++ b/crates/vibesql-parser/src/parser/advanced_objects/sequence.rs
@@ -118,7 +118,7 @@ pub fn parse_alter_sequence(parser: &mut crate::Parser) -> Result<AlterSequenceS
         if parser.try_consume_keyword(Keyword::Restart) {
             if parser.try_consume_keyword(Keyword::With) {
                 let num_str = match parser.peek() {
-                    Token::Number(n) => n.clone(),
+                    Token::Number(sym) => parser.resolve(*sym),
                     _ => {
                         return Err(ParseError {
                             message: "Expected number after RESTART WITH".to_string(),
@@ -136,7 +136,7 @@ pub fn parse_alter_sequence(parser: &mut crate::Parser) -> Result<AlterSequenceS
         } else if parser.try_consume_keyword(Keyword::Increment) {
             parser.expect_keyword(Keyword::By)?;
             let num_str = match parser.peek() {
-                Token::Number(n) => n.clone(),
+                Token::Number(sym) => parser.resolve(*sym),
                 _ => {
                     return Err(ParseError {
                         message: "Expected number after INCREMENT BY".to_string(),
@@ -149,7 +149,7 @@ pub fn parse_alter_sequence(parser: &mut crate::Parser) -> Result<AlterSequenceS
             })?);
         } else if parser.try_consume_keyword(Keyword::Minvalue) {
             let num_str = match parser.peek() {
-                Token::Number(n) => n.clone(),
+                Token::Number(sym) => parser.resolve(*sym),
                 _ => {
                     return Err(ParseError {
                         message: "Expected number after MINVALUE".to_string(),
@@ -163,7 +163,7 @@ pub fn parse_alter_sequence(parser: &mut crate::Parser) -> Result<AlterSequenceS
                 })?));
         } else if parser.try_consume_keyword(Keyword::Maxvalue) {
             let num_str = match parser.peek() {
-                Token::Number(n) => n.clone(),
+                Token::Number(sym) => parser.resolve(*sym),
                 _ => {
                     return Err(ParseError {
                         message: "Expected number after MAXVALUE".to_string(),

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -14,8 +14,8 @@ impl Parser {
 
             // Parse the integer length
             let length = match self.peek() {
-                Token::Number(n) => {
-                    let value = n.parse::<i64>().map_err(|_| ParseError {
+                Token::Number(sym) => {
+                    let value = self.resolve_str(*sym).parse::<i64>().map_err(|_| ParseError {
                         message: "Invalid integer for column prefix length".to_string(),
                     })?;
                     self.advance();
@@ -135,8 +135,8 @@ impl Parser {
             let name = if self.peek_keyword(Keyword::Constraint) {
                 self.advance(); // consume CONSTRAINT
                 match self.peek() {
-                    Token::Identifier(n) => {
-                        let constraint_name = n.clone();
+                    Token::Identifier(sym) => {
+                        let constraint_name = self.resolve(*sym);
                         self.advance();
                         Some(constraint_name)
                     }
@@ -197,8 +197,8 @@ impl Parser {
                 Token::Keyword(Keyword::References) => {
                     self.advance(); // consume REFERENCES
                     let table = match self.peek() {
-                        Token::Identifier(t) => {
-                            let table_name = t.clone();
+                        Token::Identifier(sym) => {
+                            let table_name = self.resolve(*sym);
                             self.advance();
                             table_name
                         }
@@ -211,8 +211,8 @@ impl Parser {
 
                     self.expect_token(Token::LParen)?;
                     let column = match self.peek() {
-                        Token::Identifier(c) => {
-                            let col_name = c.clone();
+                        Token::Identifier(sym) => {
+                            let col_name = self.resolve(*sym);
                             self.advance();
                             col_name
                         }
@@ -274,7 +274,7 @@ impl Parser {
             self.advance(); // consume CONSTRAINT
             match self.peek() {
                 Token::Identifier(n) => {
-                    let constraint_name = n.clone();
+                    let constraint_name = self.resolve(*n);
                     self.advance();
                     Some(constraint_name)
                 }
@@ -317,7 +317,7 @@ impl Parser {
                 loop {
                     match self.peek() {
                         Token::Identifier(col) => {
-                            columns.push(col.clone());
+                            columns.push(self.resolve(*col));
                             self.advance();
                         }
                         _ => {
@@ -339,7 +339,7 @@ impl Parser {
 
                 let references_table = match self.peek() {
                     Token::Identifier(t) => {
-                        let table_name = t.clone();
+                        let table_name = self.resolve(*t);
                         self.advance();
                         table_name
                     }
@@ -356,7 +356,7 @@ impl Parser {
                 loop {
                     match self.peek() {
                         Token::Identifier(col) => {
-                            references_columns.push(col.clone());
+                            references_columns.push(self.resolve(*col));
                             self.advance();
                         }
                         _ => {
@@ -421,10 +421,10 @@ impl Parser {
                 // Optional index name
                 let index_name = if matches!(self.peek(), Token::Identifier(_)) {
                     // Look ahead to see if next token is LParen
-                    if self.position + 1 < self.tokens.len() 
+                    if self.position + 1 < self.tokens.len()
                         && matches!(self.tokens[self.position + 1], Token::LParen) {
                         let name = match self.peek() {
-                            Token::Identifier(n) => Some(n.clone()),
+                            Token::Identifier(sym) => Some(self.resolve(*sym)),
                             _ => None,
                         };
                         if name.is_some() {

--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -38,8 +38,8 @@ impl Parser {
 
             // Parse column name
             let name = match self.peek() {
-                Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
-                    let c = col.clone();
+                Token::Identifier(sym) | Token::DelimitedIdentifier(sym) => {
+                    let c = self.resolve(*sym);
                     self.advance();
                     c
                 }
@@ -67,8 +67,8 @@ impl Parser {
             let comment = if self.peek_keyword(Keyword::Comment) {
                 self.advance(); // consume COMMENT
                 match self.peek() {
-                    Token::String(s) => {
-                        let c = s.clone();
+                    Token::String(sym) => {
+                        let c = self.resolve(*sym);
                         self.advance();
                         Some(c)
                     }

--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -6,7 +6,7 @@ impl Parser {
     /// Parse data type
     pub(in crate::parser) fn parse_data_type(&mut self) -> Result<vibesql_types::DataType, ParseError> {
         let type_upper = match self.peek() {
-            Token::Identifier(type_name) => type_name.to_uppercase(),
+            Token::Identifier(sym) => self.resolve_str(*sym).to_uppercase(),
             Token::Keyword(Keyword::Date) => "DATE".to_string(),
             Token::Keyword(Keyword::Time) => "TIME".to_string(),
             Token::Keyword(Keyword::Timestamp) => "TIMESTAMP".to_string(),
@@ -38,8 +38,8 @@ impl Parser {
                 let length = if matches!(self.peek(), Token::LParen) {
                     self.advance(); // consume (
                     let len = match self.peek() {
-                        Token::Number(n) => {
-                            let parsed = n.parse::<usize>().map_err(|_| ParseError {
+                        Token::Number(sym) => {
+                            let parsed = self.resolve_str(*sym).parse::<usize>().map_err(|_| ParseError {
                                 message: "Invalid BIT length".to_string(),
                             })?;
                             self.advance();
@@ -64,8 +64,8 @@ impl Parser {
                 if matches!(self.peek(), Token::LParen) {
                     self.advance(); // consume (
                     let precision = match self.peek() {
-                        Token::Number(n) => {
-                            let p = n.parse::<u8>().map_err(|_| ParseError {
+                        Token::Number(sym) => {
+                            let p = self.resolve_str(*sym).parse::<u8>().map_err(|_| ParseError {
                                 message: "Invalid FLOAT precision".to_string(),
                             })?;
                             self.advance();
@@ -87,8 +87,8 @@ impl Parser {
             "REAL" => Ok(vibesql_types::DataType::Real),
             "DOUBLE" => {
                 // Check for DOUBLE PRECISION
-                if let Token::Identifier(next) = self.peek() {
-                    if next.to_uppercase() == "PRECISION" {
+                if let Token::Identifier(sym) = self.peek() {
+                    if self.resolve_str(*sym).to_uppercase() == "PRECISION" {
                         self.advance();
                         return Ok(vibesql_types::DataType::DoublePrecision);
                     }
@@ -104,8 +104,8 @@ impl Parser {
                     self.advance(); // consume (
 
                     let precision = match self.peek() {
-                        Token::Number(n) => {
-                            let p = n.parse::<u8>().map_err(|_| ParseError {
+                        Token::Number(sym) => {
+                            let p = self.resolve_str(*sym).parse::<u8>().map_err(|_| ParseError {
                                 message: "Invalid NUMERIC precision".to_string(),
                             })?;
                             self.advance();
@@ -121,8 +121,8 @@ impl Parser {
                     let scale = if matches!(self.peek(), Token::Comma) {
                         self.advance(); // consume comma
                         match self.peek() {
-                            Token::Number(n) => {
-                                let s = n.parse::<u8>().map_err(|_| ParseError {
+                            Token::Number(sym) => {
+                                let s = self.resolve_str(*sym).parse::<u8>().map_err(|_| ParseError {
                                     message: "Invalid NUMERIC scale".to_string(),
                                 })?;
                                 self.advance();
@@ -188,7 +188,7 @@ impl Parser {
                         self.advance(); // consume TO keyword
                         Some(self.parse_interval_field()?)
                     }
-                    Token::Identifier(word) if word.to_uppercase() == "TO" => {
+                    Token::Identifier(word) if self.resolve_str(*word).to_uppercase() == "TO" => {
                         self.advance(); // consume TO identifier (backward compat)
                         Some(self.parse_interval_field()?)
                     }
@@ -204,7 +204,7 @@ impl Parser {
                     self.advance(); // consume LParen
                     let len = match self.peek() {
                         Token::Number(n) => {
-                            let len = n.parse::<usize>().map_err(|_| ParseError {
+                            let len = self.resolve_str(*n).parse::<usize>().map_err(|_| ParseError {
                                 message: "Invalid VARCHAR length".to_string(),
                             })?;
                             self.advance();
@@ -239,7 +239,7 @@ impl Parser {
                 let is_varing = if !is_varying {
                     // Check for VARING as identifier (deprecated SQL:1999 variant)
                     if let Token::Identifier(next) = self.peek() {
-                        if next.to_uppercase() == "VARING" {
+                        if self.resolve_str(*next).to_uppercase() == "VARING" {
                             self.advance(); // consume VARING
                             true
                         } else {
@@ -258,7 +258,7 @@ impl Parser {
                         self.advance();
                         let len = match self.peek() {
                             Token::Number(n) => {
-                                let parsed = n.parse::<usize>().map_err(|_| ParseError {
+                                let parsed = self.resolve_str(*n).parse::<usize>().map_err(|_| ParseError {
                                     message: "Invalid VARCHAR length".to_string(),
                                 })?;
                                 self.advance();
@@ -292,7 +292,7 @@ impl Parser {
                     self.advance(); // consume (
                     let len = match self.peek() {
                         Token::Number(n) => {
-                            let parsed = n.parse::<usize>().map_err(|_| ParseError {
+                            let parsed = self.resolve_str(*n).parse::<usize>().map_err(|_| ParseError {
                                 message: "Invalid CHAR length".to_string(),
                             })?;
                             self.advance();
@@ -335,7 +335,7 @@ impl Parser {
                         self.advance();
                         let len = match self.peek() {
                             Token::Number(n) => {
-                                let parsed = n.parse::<usize>().map_err(|_| ParseError {
+                                let parsed = self.resolve_str(*n).parse::<usize>().map_err(|_| ParseError {
                                     message: "Invalid NCHAR VARYING length".to_string(),
                                 })?;
                                 self.advance();
@@ -369,7 +369,7 @@ impl Parser {
                     self.advance(); // consume (
                     let len = match self.peek() {
                         Token::Number(n) => {
-                            let parsed = n.parse::<usize>().map_err(|_| ParseError {
+                            let parsed = self.resolve_str(*n).parse::<usize>().map_err(|_| ParseError {
                                 message: "Invalid NCHAR length".to_string(),
                             })?;
                             self.advance();
@@ -405,7 +405,7 @@ impl Parser {
                     self.advance();
                     let len = match self.peek() {
                         Token::Number(n) => {
-                            let parsed = n.parse::<usize>().map_err(|_| ParseError {
+                            let parsed = self.resolve_str(*n).parse::<usize>().map_err(|_| ParseError {
                                 message: "Invalid NVARCHAR length".to_string(),
                             })?;
                             self.advance();
@@ -448,7 +448,7 @@ impl Parser {
                     match self.peek() {
                         Token::Number(n) => {
                             // Validate it's a valid number (we don't store it currently)
-                            let _ = n.parse::<usize>().map_err(|_| ParseError {
+                            let _ = self.resolve_str(*n).parse::<usize>().map_err(|_| ParseError {
                                 message: format!("Invalid {} size", type_upper),
                             })?;
                             self.advance();
@@ -509,7 +509,7 @@ impl Parser {
 
                 // Look ahead to determine which national type follows
                 let next = match self.peek() {
-                    Token::Identifier(word) => word.to_uppercase(),
+                    Token::Identifier(word) => self.resolve_str(*word).to_uppercase(),
                     Token::Keyword(Keyword::Character) => "CHARACTER".to_string(),
                     _ => {
                         return Err(ParseError {
@@ -527,7 +527,7 @@ impl Parser {
                             self.advance();
                             let len = match self.peek() {
                                 Token::Number(n) => {
-                                    let parsed = n.parse::<usize>().map_err(|_| ParseError {
+                                    let parsed = self.resolve_str(*n).parse::<usize>().map_err(|_| ParseError {
                                         message: "Invalid NATIONAL VARCHAR length".to_string(),
                                     })?;
                                     self.advance();
@@ -562,7 +562,7 @@ impl Parser {
                             self.advance(); // consume (
                             let len = match self.peek() {
                                 Token::Number(n) => {
-                                    let parsed = n.parse::<usize>().map_err(|_| ParseError {
+                                    let parsed = self.resolve_str(*n).parse::<usize>().map_err(|_| ParseError {
                                         message: "Invalid NATIONAL CHARACTER length".to_string(),
                                     })?;
                                     self.advance();
@@ -648,7 +648,7 @@ impl Parser {
         &mut self,
     ) -> Result<vibesql_types::IntervalField, ParseError> {
         let field_upper = match self.peek() {
-            Token::Identifier(field) => field.to_uppercase(),
+            Token::Identifier(field) => self.resolve_str(*field).to_uppercase(),
             Token::Keyword(Keyword::Year) => "YEAR".to_string(),
             Token::Keyword(Keyword::Month) => "MONTH".to_string(),
             Token::Keyword(Keyword::Day) => "DAY".to_string(),

--- a/crates/vibesql-parser/src/parser/delete.rs
+++ b/crates/vibesql-parser/src/parser/delete.rs
@@ -17,8 +17,8 @@ impl Parser {
 
         // Parse table name
         let table_name = match self.peek() {
-            Token::Identifier(name) => {
-                let table = name.clone();
+            Token::Identifier(sym) => {
+                let table = self.resolve(*sym);
                 self.advance();
                 table
             }

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -16,8 +16,8 @@ impl Parser {
     pub(super) fn parse_function_call(&mut self) -> Result<Option<vibesql_ast::Expression>, ParseError> {
         // Try to match either an identifier or specific keywords that can be function names
         let function_name = match self.peek() {
-            Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                let name = id.clone();
+            Token::Identifier(sym) | Token::DelimitedIdentifier(sym) => {
+                let name = self.resolve(*sym);
                 self.advance();
                 // Check if followed by '('
                 if !matches!(self.peek(), Token::LParen) {
@@ -72,8 +72,8 @@ impl Parser {
         if first.to_uppercase() == "VALUES" {
             // Expect a single column name as argument
             let column = match self.peek() {
-                Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
-                    let column_name = col.clone();
+                Token::Identifier(sym) | Token::DelimitedIdentifier(sym) => {
+                    let column_name = self.resolve(*sym);
                     self.advance();
                     column_name
                 }

--- a/crates/vibesql-parser/src/parser/expressions/functions/window.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/window.rs
@@ -179,7 +179,7 @@ impl Parser {
                         self.advance();
                         Ok(vibesql_ast::FrameBound::CurrentRow)
                     }
-                    Token::Identifier(ref id) if id.to_uppercase() == "ROW" => {
+                    Token::Identifier(ref id) if self.resolve_str(*id).to_uppercase() == "ROW" => {
                         self.advance();
                         Ok(vibesql_ast::FrameBound::CurrentRow)
                     }

--- a/crates/vibesql-parser/src/parser/expressions/identifiers.rs
+++ b/crates/vibesql-parser/src/parser/expressions/identifiers.rs
@@ -7,8 +7,8 @@ impl Parser {
     ) -> Result<Option<vibesql_ast::Expression>, ParseError> {
         // Extract identifier string from token (handles regular identifiers and keywords-as-identifiers)
         let first = match self.peek() {
-            Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                let name = id.clone();
+            Token::Identifier(sym) | Token::DelimitedIdentifier(sym) => {
+                let name = self.resolve(*sym);
                 self.advance();
                 name
             }
@@ -24,8 +24,8 @@ impl Parser {
         // Check for hex/binary literal (x'...' or b'...')
         let first_upper = first.to_uppercase();
         if (first_upper == "X" || first_upper == "B") && matches!(self.peek(), Token::String(_)) {
-            if let Token::String(s) = self.peek() {
-                let string_val = s.clone();
+            if let Token::String(sym) = self.peek() {
+                let string_val = self.resolve(*sym);
                 self.advance();
 
                 if first_upper == "X" {
@@ -103,8 +103,8 @@ impl Parser {
         if matches!(self.peek(), Token::Symbol('.')) {
             self.advance(); // consume '.'
             match self.peek() {
-                Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
-                    let column = col.clone();
+                Token::Identifier(sym) | Token::DelimitedIdentifier(sym) => {
+                    let column = self.resolve(*sym);
                     self.advance();
 
                     // Check for pseudo-variable (OLD.column or NEW.column)

--- a/crates/vibesql-parser/src/parser/expressions/literals.rs
+++ b/crates/vibesql-parser/src/parser/expressions/literals.rs
@@ -4,8 +4,8 @@ impl Parser {
     /// Parse literal expressions (numbers, strings, booleans, NULL)
     pub(super) fn parse_literal(&mut self) -> Result<Option<vibesql_ast::Expression>, ParseError> {
         match self.peek() {
-            Token::Number(n) => {
-                let num_str = n.clone();
+            Token::Number(sym) => {
+                let num_str = self.resolve_str(*sym).to_string();
                 self.advance();
 
                 // Try to parse as integer first
@@ -21,8 +21,8 @@ impl Parser {
                     }
                 }
             }
-            Token::String(s) => {
-                let string_val = s.clone();
+            Token::String(sym) => {
+                let string_val = self.resolve(*sym);
                 self.advance();
                 Ok(Some(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(string_val))))
             }
@@ -42,8 +42,8 @@ impl Parser {
             Token::Keyword(Keyword::Date) => {
                 self.advance();
                 match self.peek() {
-                    Token::String(s) => {
-                        let date_str = s.clone();
+                    Token::String(sym) => {
+                        let date_str = self.resolve(*sym);
                         self.advance();
 
                         // Parse the date string into a Date type
@@ -62,8 +62,8 @@ impl Parser {
             Token::Keyword(Keyword::Time) => {
                 self.advance();
                 match self.peek() {
-                    Token::String(s) => {
-                        let time_str = s.clone();
+                    Token::String(sym) => {
+                        let time_str = self.resolve(*sym);
                         self.advance();
 
                         // Parse the time string into a Time type
@@ -82,8 +82,8 @@ impl Parser {
             Token::Keyword(Keyword::Timestamp) => {
                 self.advance();
                 match self.peek() {
-                    Token::String(s) => {
-                        let timestamp_str = s.clone();
+                    Token::String(sym) => {
+                        let timestamp_str = self.resolve(*sym);
                         self.advance();
 
                         // Parse the timestamp string into a Timestamp type
@@ -103,13 +103,13 @@ impl Parser {
                 self.advance();
                 // Parse INTERVAL 'value' field [TO field]
                 match self.peek() {
-                    Token::String(interval_str) => {
-                        let value_str = interval_str.clone();
+                    Token::String(sym) => {
+                        let value_str = self.resolve(*sym);
                         self.advance();
 
                         // Parse interval field (YEAR, MONTH, DAY, etc.)
                         let start_field = match self.peek() {
-                            Token::Identifier(field) => field.to_uppercase(),
+                            Token::Identifier(sym) => self.resolve_str(*sym).to_uppercase(),
                             Token::Keyword(Keyword::Year) => "YEAR".to_string(),
                             Token::Keyword(Keyword::Month) => "MONTH".to_string(),
                             Token::Keyword(Keyword::Day) => "DAY".to_string(),
@@ -130,7 +130,7 @@ impl Parser {
                             Token::Keyword(Keyword::To) => {
                                 self.advance(); // consume TO keyword
                                 let end_field = match self.peek() {
-                                    Token::Identifier(field) => field.to_uppercase(),
+                                    Token::Identifier(sym) => self.resolve_str(*sym).to_uppercase(),
                                     Token::Keyword(Keyword::Year) => "YEAR".to_string(),
                                     Token::Keyword(Keyword::Month) => "MONTH".to_string(),
                                     Token::Keyword(Keyword::Day) => "DAY".to_string(),
@@ -146,10 +146,10 @@ impl Parser {
                                 self.advance();
                                 format!("{} {} TO {}", value_str, start_field, end_field)
                             }
-                            Token::Identifier(word) if word.to_uppercase() == "TO" => {
+                            Token::Identifier(sym) if self.resolve_str(*sym).to_uppercase() == "TO" => {
                                 self.advance(); // consume TO identifier (backward compat)
                                 let end_field = match self.peek() {
-                                    Token::Identifier(field) => field.to_uppercase(),
+                                    Token::Identifier(sym) => self.resolve_str(*sym).to_uppercase(),
                                     Token::Keyword(Keyword::Year) => "YEAR".to_string(),
                                     Token::Keyword(Keyword::Month) => "MONTH".to_string(),
                                     Token::Keyword(Keyword::Day) => "DAY".to_string(),

--- a/crates/vibesql-parser/src/parser/expressions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/mod.rs
@@ -32,8 +32,8 @@ impl Parser {
         }
 
         // Try to parse as a named placeholder (:name)
-        if let Token::NamedPlaceholder(name) = self.peek() {
-            let param_name = name.clone();
+        if let Token::NamedPlaceholder(sym) = self.peek() {
+            let param_name = self.resolve(*sym);
             self.advance();
             return Ok(vibesql_ast::Expression::NamedPlaceholder(param_name));
         }
@@ -44,8 +44,8 @@ impl Parser {
         }
 
         // Try to parse as a session variable (@@sql_mode, @@session.variable, etc.)
-        if let Token::SessionVariable(name) = self.peek() {
-            let var_name = name.clone();
+        if let Token::SessionVariable(sym) = self.peek() {
+            let var_name = self.resolve(*sym);
             self.advance();
             return Ok(vibesql_ast::Expression::SessionVariable { name: var_name });
         }

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -78,7 +78,7 @@ impl Parser {
             let op = match self.peek() {
                 Token::Symbol('+') => vibesql_ast::BinaryOperator::Plus,
                 Token::Symbol('-') => vibesql_ast::BinaryOperator::Minus,
-                Token::Operator(ref s) if s == "||" => vibesql_ast::BinaryOperator::Concat,
+                Token::Operator(sym) if self.resolve_str(*sym) == "||" => vibesql_ast::BinaryOperator::Concat,
                 _ => break,
             };
             self.advance();
@@ -275,7 +275,7 @@ impl Parser {
         // Note: Exclude || (concat) operator which should be handled in additive expression
         let is_comparison = match self.peek() {
             Token::Symbol('=') | Token::Symbol('<') | Token::Symbol('>') => true,
-            Token::Operator(ref s) => matches!(s.as_str(), "<=" | ">=" | "!=" | "<>"),
+            Token::Operator(sym) => matches!(self.resolve_str(*sym), "<=" | ">=" | "!=" | "<>"),
             _ => false,
         };
 
@@ -284,12 +284,12 @@ impl Parser {
                 Token::Symbol('=') => vibesql_ast::BinaryOperator::Equal,
                 Token::Symbol('<') => vibesql_ast::BinaryOperator::LessThan,
                 Token::Symbol('>') => vibesql_ast::BinaryOperator::GreaterThan,
-                Token::Operator(ref s) => match s.as_str() {
+                Token::Operator(sym) => match self.resolve_str(*sym) {
                     "<=" => vibesql_ast::BinaryOperator::LessThanOrEqual,
                     ">=" => vibesql_ast::BinaryOperator::GreaterThanOrEqual,
                     "!=" => vibesql_ast::BinaryOperator::NotEqual,
                     "<>" => vibesql_ast::BinaryOperator::NotEqual, // SQL standard
-                    _ => return Err(ParseError { message: format!("Unexpected operator: {}", s) }),
+                    op_str => return Err(ParseError { message: format!("Unexpected operator: {}", op_str) }),
                 },
                 _ => unreachable!(),
             };

--- a/crates/vibesql-parser/src/parser/expressions/special_forms.rs
+++ b/crates/vibesql-parser/src/parser/expressions/special_forms.rs
@@ -5,7 +5,7 @@ impl Parser {
     pub(super) fn parse_special_form(&mut self) -> Result<Option<vibesql_ast::Expression>, ParseError> {
         match self.peek() {
             // CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP (as identifiers)
-            Token::Identifier(ref id) if id.to_uppercase() == "CURRENT_DATE" => {
+            Token::Identifier(sym) if self.resolve_str(*sym).to_uppercase() == "CURRENT_DATE" => {
                 self.advance();
                 Ok(Some(vibesql_ast::Expression::Function {
                     name: "CURRENT_DATE".to_string(),
@@ -13,7 +13,7 @@ impl Parser {
                     character_unit: None,
                 }))
             }
-            Token::Identifier(ref id) if id.to_uppercase() == "CURRENT_TIME" => {
+            Token::Identifier(sym) if self.resolve_str(*sym).to_uppercase() == "CURRENT_TIME" => {
                 self.advance();
                 Ok(Some(vibesql_ast::Expression::Function {
                     name: "CURRENT_TIME".to_string(),
@@ -21,7 +21,7 @@ impl Parser {
                     character_unit: None,
                 }))
             }
-            Token::Identifier(ref id) if id.to_uppercase() == "CURRENT_TIMESTAMP" => {
+            Token::Identifier(sym) if self.resolve_str(*sym).to_uppercase() == "CURRENT_TIMESTAMP" => {
                 self.advance();
                 Ok(Some(vibesql_ast::Expression::Function {
                     name: "CURRENT_TIMESTAMP".to_string(),
@@ -37,8 +37,9 @@ impl Parser {
                 self.advance(); // consume CURRENT
 
                 // Check for underscore followed by DATE/TIME/TIMESTAMP
-                if let Token::Identifier(ref id) = self.peek() {
-                    let function_name = match id.to_uppercase().as_str() {
+                if let Token::Identifier(sym) = self.peek() {
+                    let id_str = self.resolve_str(*sym);
+                    let function_name = match id_str.to_uppercase().as_str() {
                         "_DATE" => {
                             self.advance(); // consume _DATE
                             "CURRENT_DATE"
@@ -55,7 +56,7 @@ impl Parser {
                             return Err(ParseError {
                                 message: format!(
                                     "Expected DATE, TIME, or TIMESTAMP after CURRENT, found {}",
-                                    id
+                                    id_str
                                 ),
                             })
                         }
@@ -235,7 +236,7 @@ impl Parser {
                 self.advance(); // consume CURRENT_TIME
                 let precision = if self.try_consume(&Token::LParen) {
                     let prec_str = match self.peek() {
-                        Token::Number(n) => n.clone(),
+                        Token::Number(sym) => self.resolve(*sym),
                         _ => {
                             return Err(ParseError {
                                 message: "Expected integer precision for CURRENT_TIME".to_string(),
@@ -265,7 +266,7 @@ impl Parser {
                 self.advance(); // consume CURRENT_TIMESTAMP
                 let precision = if self.try_consume(&Token::LParen) {
                     let prec_str = match self.peek() {
-                        Token::Number(n) => n.clone(),
+                        Token::Number(sym) => self.resolve(*sym),
                         _ => {
                             return Err(ParseError {
                                 message: "Expected integer precision for CURRENT_TIMESTAMP"
@@ -306,7 +307,7 @@ impl Parser {
 
             // Parse "VALUE" as identifier (not a reserved keyword)
             match self.peek() {
-                Token::Identifier(s) if s.eq_ignore_ascii_case("VALUE") => {
+                Token::Identifier(s) if self.resolve_str(*s).eq_ignore_ascii_case("VALUE") => {
                     self.advance();
                 }
                 _ => return Err(ParseError { message: "Expected VALUE after NEXT".to_string() }),
@@ -348,10 +349,14 @@ impl Parser {
                     self.advance(); // consume BOOLEAN
                     // MODE is a required keyword after BOOLEAN in MySQL syntax
                     // It might be a keyword or identifier depending on lexer
-                    if matches!(self.peek(), Token::Identifier(s) | Token::DelimitedIdentifier(s) if s.eq_ignore_ascii_case("MODE")) {
-                        self.advance(); // consume MODE
-                    } else if self.peek_keyword(Keyword::Mode) {
-                        self.advance(); // consume MODE keyword if it exists
+                    match self.peek() {
+                        Token::Identifier(s) | Token::DelimitedIdentifier(s) if self.resolve_str(*s).eq_ignore_ascii_case("MODE") => {
+                            self.advance(); // consume MODE
+                        }
+                        _ if self.peek_keyword(Keyword::Mode) => {
+                            self.advance(); // consume MODE keyword if it exists
+                        }
+                        _ => {} // MODE is optional in some implementations
                     }
                     vibesql_ast::FulltextMode::Boolean
                 } else {

--- a/crates/vibesql-parser/src/parser/helpers.rs
+++ b/crates/vibesql-parser/src/parser/helpers.rs
@@ -75,8 +75,8 @@ impl Parser {
     /// Parse an identifier token (regular or delimited).
     pub(super) fn parse_identifier(&mut self) -> Result<String, ParseError> {
         match self.peek() {
-            Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
-                let identifier = name.clone();
+            Token::Identifier(sym) | Token::DelimitedIdentifier(sym) => {
+                let identifier = self.resolve(*sym);
                 self.advance();
                 Ok(identifier)
             }
@@ -125,8 +125,8 @@ impl Parser {
 
         // Parse the number
         match self.peek() {
-            Token::Number(n) => {
-                num_str.push_str(n);
+            Token::Number(sym) => {
+                num_str.push_str(self.resolve_str(*sym));
                 self.advance();
                 Ok(num_str)
             }
@@ -138,8 +138,8 @@ impl Parser {
     pub(super) fn parse_qualified_identifier(&mut self) -> Result<String, ParseError> {
         // Parse first identifier
         let first_part = match self.peek() {
-            Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
-                let identifier = name.clone();
+            Token::Identifier(sym) | Token::DelimitedIdentifier(sym) => {
+                let identifier = self.resolve(*sym);
                 self.advance();
                 identifier
             }
@@ -155,8 +155,8 @@ impl Parser {
         if self.peek() == &Token::Symbol('.') {
             self.advance(); // consume the dot
             let second_part = match self.peek() {
-                Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
-                    let identifier = name.clone();
+                Token::Identifier(sym) | Token::DelimitedIdentifier(sym) => {
+                    let identifier = self.resolve(*sym);
                     self.advance();
                     identifier
                 }
@@ -178,8 +178,8 @@ impl Parser {
     /// Parse an integer literal and return its value
     pub(super) fn parse_integer_literal(&mut self) -> Result<i64, ParseError> {
         match self.peek() {
-            Token::Number(n) => {
-                let num_str = n.clone();
+            Token::Number(sym) => {
+                let num_str = self.resolve_str(*sym).to_string();
                 self.advance();
                 num_str.parse::<i64>().map_err(|_| ParseError {
                     message: format!("Expected integer, found '{}'", num_str),

--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -92,7 +92,7 @@ impl Parser {
                 // Parse the integer length
                 let length = match self.peek() {
                     Token::Number(n) => {
-                        let value = n.parse::<i64>().map_err(|_| ParseError {
+                        let value = self.resolve_str(*n).parse::<i64>().map_err(|_| ParseError {
                             message: "Invalid integer for column prefix length".to_string(),
                         })?;
                         self.advance();

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -27,8 +27,8 @@ impl Parser {
 
         // Parse table name
         let table_name = match self.peek() {
-            Token::Identifier(name) => {
-                let table = name.clone();
+            Token::Identifier(sym) => {
+                let table = self.resolve(*sym);
                 self.advance();
                 table
             }
@@ -43,8 +43,8 @@ impl Parser {
         let columns = if matches!(self.peek(), Token::LParen) {
             self.advance(); // consume (
             let cols = self.parse_comma_separated_list(|p| match p.peek() {
-                Token::Identifier(col) => {
-                    let name = col.clone();
+                Token::Identifier(sym) => {
+                    let name = p.resolve(*sym);
                     p.advance();
                     Ok(name)
                 }
@@ -97,8 +97,8 @@ impl Parser {
             let mut assignments = Vec::new();
             loop {
                 let column = match self.peek() {
-                    Token::Identifier(col) => {
-                        let column_name = col.clone();
+                    Token::Identifier(sym) => {
+                        let column_name = self.resolve(*sym);
                         self.advance();
                         column_name
                     }
@@ -146,8 +146,8 @@ impl Parser {
 
         // Parse table name
         let table_name = match self.peek() {
-            Token::Identifier(name) => {
-                let table = name.clone();
+            Token::Identifier(sym) => {
+                let table = self.resolve(*sym);
                 self.advance();
                 table
             }
@@ -164,8 +164,8 @@ impl Parser {
             let mut cols = Vec::new();
             loop {
                 match self.peek() {
-                    Token::Identifier(col) => {
-                        cols.push(col.clone());
+                    Token::Identifier(sym) => {
+                        cols.push(self.resolve(*sym));
                         self.advance();
                     }
                     _ => return Err(ParseError { message: "Expected column name".to_string() }),
@@ -222,8 +222,8 @@ impl Parser {
             let mut assignments = Vec::new();
             loop {
                 let column = match self.peek() {
-                    Token::Identifier(col) => {
-                        let column_name = col.clone();
+                    Token::Identifier(sym) => {
+                        let column_name = self.resolve(*sym);
                         self.advance();
                         column_name
                     }

--- a/crates/vibesql-parser/src/parser/introspection.rs
+++ b/crates/vibesql-parser/src/parser/introspection.rs
@@ -9,7 +9,7 @@ impl Parser {
     fn parse_string(&mut self) -> Result<String, ParseError> {
         match self.peek() {
             Token::String(s) => {
-                let string_val = s.clone();
+                let string_val = self.resolve(*s);
                 self.advance();
                 Ok(string_val)
             }

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -1,6 +1,11 @@
 use std::fmt;
 
-use crate::{keywords::Keyword, lexer::Lexer, token::Token};
+use crate::{
+    interner::{IdentifierInterner, StringSymbol},
+    keywords::Keyword,
+    lexer::{Lexer, TokenStream},
+    token::Token,
+};
 
 mod advanced_objects;
 mod alter;
@@ -41,6 +46,7 @@ impl fmt::Display for ParseError {
 /// SQL Parser - converts tokens into AST
 pub struct Parser {
     tokens: Vec<Token>,
+    interner: IdentifierInterner,
     position: usize,
     /// Counter for placeholder parameters (?)
     /// Incremented each time a placeholder is parsed, providing 0-indexed parameter positions
@@ -48,9 +54,26 @@ pub struct Parser {
 }
 
 impl Parser {
-    /// Create a new parser from tokens
-    pub fn new(tokens: Vec<Token>) -> Self {
-        Parser { tokens, position: 0, placeholder_count: 0 }
+    /// Create a new parser from a token stream
+    pub fn new(token_stream: TokenStream) -> Self {
+        Parser {
+            tokens: token_stream.tokens,
+            interner: token_stream.interner,
+            position: 0,
+            placeholder_count: 0,
+        }
+    }
+
+    /// Resolve a string symbol to its string value.
+    #[inline]
+    pub(crate) fn resolve(&self, symbol: StringSymbol) -> String {
+        self.interner.resolve_unchecked(symbol).to_string()
+    }
+
+    /// Resolve a string symbol to a borrowed string slice.
+    #[inline]
+    pub(crate) fn resolve_str(&self, symbol: StringSymbol) -> &str {
+        self.interner.resolve_unchecked(symbol)
     }
 
     /// Parse a comma-separated list of items using a provided parser function
@@ -94,11 +117,11 @@ impl Parser {
 
     /// Parse SQL input string into a Statement
     pub fn parse_sql(input: &str) -> Result<vibesql_ast::Statement, ParseError> {
-        let mut lexer = Lexer::new(input);
-        let tokens =
+        let lexer = Lexer::new(input);
+        let token_stream =
             lexer.tokenize().map_err(|e| ParseError { message: format!("Lexer error: {}", e) })?;
 
-        let mut parser = Parser::new(tokens);
+        let mut parser = Parser::new(token_stream);
         parser.parse_statement()
     }
 

--- a/crates/vibesql-parser/src/parser/schema.rs
+++ b/crates/vibesql-parser/src/parser/schema.rs
@@ -98,7 +98,7 @@ pub fn parse_set_names(parser: &mut crate::Parser) -> Result<vibesql_ast::SetNam
     // Parse charset name (can be identifier or string literal)
     let charset_name = match parser.peek() {
         crate::token::Token::String(s) => {
-            let val = s.clone();
+            let val = parser.resolve(*s);
             parser.advance();
             val
         }
@@ -110,7 +110,7 @@ pub fn parse_set_names(parser: &mut crate::Parser) -> Result<vibesql_ast::SetNam
         parser.advance();
         Some(match parser.peek() {
             crate::token::Token::String(s) => {
-                let val = s.clone();
+                let val = parser.resolve(*s);
                 parser.advance();
                 val
             }
@@ -138,7 +138,7 @@ pub fn parse_set_time_zone(parser: &mut crate::Parser) -> Result<vibesql_ast::Se
         // Parse the interval string
         let interval_str = match parser.peek() {
             crate::token::Token::String(s) => {
-                let val = s.clone();
+                let val = parser.resolve(*s);
                 parser.advance();
                 val
             }

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -84,7 +84,7 @@ impl Parser {
                     // Parse alias (required for derived tables)
                     let alias = match self.peek() {
                         Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                            let alias = id.clone();
+                            let alias = self.resolve(*id);
                             self.advance();
                             alias
                         }
@@ -131,7 +131,7 @@ impl Parser {
                     self.consume_keyword(Keyword::As)?;
                     match self.peek() {
                         Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                            let alias = id.clone();
+                            let alias = self.resolve(*id);
                             self.advance();
                             Some(alias)
                         }
@@ -145,7 +145,7 @@ impl Parser {
                     // Implicit alias (no AS keyword) - but not a JOIN keyword
                     match self.peek() {
                         Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                            let alias = id.clone();
+                            let alias = self.resolve(*id);
                             self.advance();
                             Some(alias)
                         }

--- a/crates/vibesql-parser/src/parser/select/list.rs
+++ b/crates/vibesql-parser/src/parser/select/list.rs
@@ -34,7 +34,7 @@ impl Parser {
         loop {
             match self.peek() {
                 Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                    columns.push(id.clone());
+                    columns.push(self.resolve(*id));
                     self.advance();
                 }
                 _ => {
@@ -67,7 +67,7 @@ impl Parser {
         let qualifier = if let Token::Identifier(ref qualifier)
         | Token::DelimitedIdentifier(ref qualifier) = self.peek()
         {
-            Some(qualifier.clone())
+            Some(self.resolve(*qualifier))
         } else {
             None
         };
@@ -104,7 +104,7 @@ impl Parser {
             self.consume_keyword(Keyword::As)?;
             match self.peek() {
                 Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                    let alias = id.clone();
+                    let alias = self.resolve(*id);
                     self.advance();
                     Some(alias)
                 }
@@ -116,7 +116,7 @@ impl Parser {
             // MySQL compatibility: allow aliases without AS keyword
             match self.peek() {
                 Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                    let alias = id.clone();
+                    let alias = self.resolve(*id);
                     self.advance();
                     Some(alias)
                 }

--- a/crates/vibesql-parser/src/parser/select/statement.rs
+++ b/crates/vibesql-parser/src/parser/select/statement.rs
@@ -54,7 +54,7 @@ impl Parser {
                 let variables = self.parse_comma_separated_list(|p| {
                     match p.peek() {
                         Token::UserVariable(var_name) => {
-                            let name = var_name.clone();
+                            let name = p.resolve(*var_name);
                             p.advance();
                             Ok(name)
                         }
@@ -197,8 +197,9 @@ impl Parser {
             self.consume_keyword(Keyword::Limit)?;
             match self.peek() {
                 Token::Number(n) => {
-                    let limit_value = n.parse::<usize>().map_err(|_| ParseError {
-                        message: format!("Invalid LIMIT value: {}", n),
+                    let n_str = self.resolve_str(*n);
+                    let limit_value = n_str.parse::<usize>().map_err(|_| ParseError {
+                        message: format!("Invalid LIMIT value: {}", n_str),
                     })?;
 
                     self.advance();
@@ -215,8 +216,9 @@ impl Parser {
             self.consume_keyword(Keyword::Offset)?;
             match self.peek() {
                 Token::Number(n) => {
-                    let offset_value = n.parse::<usize>().map_err(|_| ParseError {
-                        message: format!("Invalid OFFSET value: {}", n),
+                    let n_str = self.resolve_str(*n);
+                    let offset_value = n_str.parse::<usize>().map_err(|_| ParseError {
+                        message: format!("Invalid OFFSET value: {}", n_str),
                     })?;
                     self.advance();
                     Some(offset_value)
@@ -265,7 +267,7 @@ impl Parser {
         // Parse CTE name
         let name = match self.peek() {
             Token::Identifier(id) => {
-                let name = id.clone();
+                let name = self.resolve(*id);
                 self.advance();
                 name
             }
@@ -284,7 +286,7 @@ impl Parser {
             // Parse comma-separated list of column identifiers
             let cols = self.parse_comma_separated_list(|p| match p.peek() {
                 Token::Identifier(col) => {
-                    let name = col.clone();
+                    let name = p.resolve(*col);
                     p.advance();
                     Ok(name)
                 }

--- a/crates/vibesql-parser/src/parser/table_options.rs
+++ b/crates/vibesql-parser/src/parser/table_options.rs
@@ -70,7 +70,7 @@ impl Parser {
         // Parse string value
         match self.peek() {
             Token::String(s) => {
-                let val = s.clone();
+                let val = self.resolve(*s);
                 self.advance();
                 Ok(vibesql_ast::TableOption::Connection(Some(val)))
             }
@@ -105,7 +105,7 @@ impl Parser {
             loop {
                 match self.peek() {
                     Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                        tables.push(id.clone());
+                        tables.push(self.resolve(*id));
                         self.advance();
                     }
                     _ => {
@@ -176,7 +176,7 @@ impl Parser {
         // Parse string value
         match self.peek() {
             Token::String(s) => {
-                let val = s.clone();
+                let val = self.resolve(*s);
                 self.advance();
                 Ok(vibesql_ast::TableOption::Password(Some(val)))
             }
@@ -215,7 +215,7 @@ impl Parser {
         let value = if self.try_consume_keyword(Keyword::Null) {
             Some("NULL".to_string())
         } else if let Token::Identifier(id) = self.peek() {
-            let val = id.clone();
+            let val = self.resolve(*id);
             self.advance();
             Some(val)
         } else {
@@ -230,7 +230,7 @@ impl Parser {
         // Parse collation name
         match self.peek() {
             Token::Identifier(id) => {
-                let val = id.clone();
+                let val = self.resolve(*id);
                 self.advance();
                 Ok(vibesql_ast::TableOption::Collate(Some(val)))
             }
@@ -244,7 +244,7 @@ impl Parser {
         // Parse string value
         match self.peek() {
             Token::String(s) => {
-                let val = s.clone();
+                let val = self.resolve(*s);
                 self.advance();
                 Ok(vibesql_ast::TableOption::Comment(Some(val)))
             }
@@ -272,10 +272,11 @@ impl Parser {
     /// Parse a numeric value that can be integer or float (converts float to int by truncation)
     pub(super) fn parse_numeric_value(&mut self) -> Result<Option<i64>, ParseError> {
         if let Token::Number(n) = self.peek() {
+            let n_str = self.resolve_str(*n);
             // Try parsing as i64 first, then as f64 and truncate
-            let val = if let Ok(int_val) = n.parse::<i64>() {
+            let val = if let Ok(int_val) = n_str.parse::<i64>() {
                 int_val
-            } else if let Ok(float_val) = n.parse::<f64>() {
+            } else if let Ok(float_val) = n_str.parse::<f64>() {
                 float_val as i64
             } else {
                 return Err(ParseError { message: "Invalid numeric value".to_string() });

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -7,8 +7,8 @@ impl Parser {
 
         // Parse table name
         let table_name = match self.peek() {
-            Token::Identifier(name) => {
-                let table = name.clone();
+            Token::Identifier(sym) => {
+                let table = self.resolve(*sym);
                 self.advance();
                 table
             }
@@ -25,8 +25,8 @@ impl Parser {
         loop {
             // Parse column name
             let column = match self.peek() {
-                Token::Identifier(col) => {
-                    let c = col.clone();
+                Token::Identifier(sym) => {
+                    let c = self.resolve(*sym);
                     self.advance();
                     c
                 }

--- a/crates/vibesql-parser/src/parser/view.rs
+++ b/crates/vibesql-parser/src/parser/view.rs
@@ -49,7 +49,7 @@ impl Parser {
             loop {
                 match self.peek() {
                     Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
-                        cols.push(name.clone());
+                        cols.push(self.resolve(*name));
                         self.advance();
                     }
                     _ => {

--- a/crates/vibesql-parser/src/tests/display.rs
+++ b/crates/vibesql-parser/src/tests/display.rs
@@ -190,20 +190,29 @@ fn test_token_display_keyword() {
 
 #[test]
 fn test_token_display_identifier() {
-    let token = Token::Identifier("users".to_string());
-    assert_eq!(format!("{}", token), "Identifier(users)");
+    use crate::interner::IdentifierInterner;
+    let mut interner = IdentifierInterner::new();
+    let sym = interner.get_or_intern("users");
+    let token = Token::Identifier(sym);
+    assert_eq!(format!("{}", token.display_with_interner(&interner)), "Identifier(users)");
 }
 
 #[test]
 fn test_token_display_number() {
-    let token = Token::Number("42".to_string());
-    assert_eq!(format!("{}", token), "Number(42)");
+    use crate::interner::IdentifierInterner;
+    let mut interner = IdentifierInterner::new();
+    let sym = interner.get_or_intern("42");
+    let token = Token::Number(sym);
+    assert_eq!(format!("{}", token.display_with_interner(&interner)), "Number(42)");
 }
 
 #[test]
 fn test_token_display_string() {
-    let token = Token::String("hello".to_string());
-    assert_eq!(format!("{}", token), "String('hello')");
+    use crate::interner::IdentifierInterner;
+    let mut interner = IdentifierInterner::new();
+    let sym = interner.get_or_intern("hello");
+    let token = Token::String(sym);
+    assert_eq!(format!("{}", token.display_with_interner(&interner)), "String('hello')");
 }
 
 #[test]
@@ -214,8 +223,11 @@ fn test_token_display_symbol() {
 
 #[test]
 fn test_token_display_operator() {
-    let token = Token::Operator("<=".to_string());
-    assert_eq!(format!("{}", token), "Operator(<=)");
+    use crate::interner::IdentifierInterner;
+    let mut interner = IdentifierInterner::new();
+    let sym = interner.get_or_intern("<=");
+    let token = Token::Operator(sym);
+    assert_eq!(format!("{}", token.display_with_interner(&interner)), "Operator(<=)");
 }
 
 #[test]

--- a/crates/vibesql-parser/src/tests/lexer/comments.rs
+++ b/crates/vibesql-parser/src/tests/lexer/comments.rs
@@ -3,25 +3,31 @@ use crate::{keywords::Keyword, lexer::Lexer, token::Token};
 #[test]
 fn test_line_comment_simple() {
     let input = "-- This is a comment\nSELECT 1";
-    let mut lexer = Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new(input);
+    let stream = lexer.tokenize().unwrap();
 
-    assert_eq!(
-        tokens,
-        vec![Token::Keyword(Keyword::Select), Token::Number("1".to_string()), Token::Eof,]
-    );
+    assert_eq!(stream.tokens.len(), 3);
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "1"),
+        _ => panic!("Expected Number token"),
+    }
+    assert_eq!(stream.tokens[2], Token::Eof);
 }
 
 #[test]
 fn test_line_comment_at_end() {
     let input = "SELECT 1 -- comment at end";
-    let mut lexer = Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new(input);
+    let stream = lexer.tokenize().unwrap();
 
-    assert_eq!(
-        tokens,
-        vec![Token::Keyword(Keyword::Select), Token::Number("1".to_string()), Token::Eof,]
-    );
+    assert_eq!(stream.tokens.len(), 3);
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "1"),
+        _ => panic!("Expected Number token"),
+    }
+    assert_eq!(stream.tokens[2], Token::Eof);
 }
 
 #[test]
@@ -30,67 +36,70 @@ fn test_multiple_line_comments() {
 -- Second comment
 SELECT 1 -- inline comment
 -- Final comment"#;
-    let mut lexer = Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new(input);
+    let stream = lexer.tokenize().unwrap();
 
-    assert_eq!(
-        tokens,
-        vec![Token::Keyword(Keyword::Select), Token::Number("1".to_string()), Token::Eof,]
-    );
+    assert_eq!(stream.tokens.len(), 3);
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "1"),
+        _ => panic!("Expected Number token"),
+    }
+    assert_eq!(stream.tokens[2], Token::Eof);
 }
 
 #[test]
 fn test_comment_with_sql_keywords() {
     let input = "-- SELECT FROM WHERE\nSELECT * FROM users";
-    let mut lexer = Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new(input);
+    let stream = lexer.tokenize().unwrap();
 
-    assert_eq!(
-        tokens,
-        vec![
-            Token::Keyword(Keyword::Select),
-            Token::Symbol('*'),
-            Token::Keyword(Keyword::From),
-            Token::Identifier("USERS".to_string()),
-            Token::Eof,
-        ]
-    );
+    assert_eq!(stream.tokens.len(), 5);
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    assert_eq!(stream.tokens[1], Token::Symbol('*'));
+    assert_eq!(stream.tokens[2], Token::Keyword(Keyword::From));
+    match stream.tokens[3] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "USERS"),
+        _ => panic!("Expected Identifier token"),
+    }
+    assert_eq!(stream.tokens[4], Token::Eof);
 }
 
 #[test]
 fn test_dash_vs_comment() {
     // Single dash should be tokenized as minus operator
     let input = "SELECT 5 - 3";
-    let mut lexer = Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new(input);
+    let stream = lexer.tokenize().unwrap();
 
-    assert_eq!(
-        tokens,
-        vec![
-            Token::Keyword(Keyword::Select),
-            Token::Number("5".to_string()),
-            Token::Symbol('-'),
-            Token::Number("3".to_string()),
-            Token::Eof,
-        ]
-    );
+    assert_eq!(stream.tokens.len(), 5);
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "5"),
+        _ => panic!("Expected Number token"),
+    }
+    assert_eq!(stream.tokens[2], Token::Symbol('-'));
+    match stream.tokens[3] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "3"),
+        _ => panic!("Expected Number token"),
+    }
+    assert_eq!(stream.tokens[4], Token::Eof);
 }
 
 #[test]
 fn test_default_demo_sql() {
     let input = "-- Welcome to NIST MemSQL\n-- Use Ctrl/Cmd + Enter to execute the current query\nSELECT * FROM employees;";
-    let mut lexer = Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new(input);
+    let stream = lexer.tokenize().unwrap();
 
-    assert_eq!(
-        tokens,
-        vec![
-            Token::Keyword(Keyword::Select),
-            Token::Symbol('*'),
-            Token::Keyword(Keyword::From),
-            Token::Identifier("EMPLOYEES".to_string()),
-            Token::Semicolon,
-            Token::Eof,
-        ]
-    );
+    assert_eq!(stream.tokens.len(), 6);
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    assert_eq!(stream.tokens[1], Token::Symbol('*'));
+    assert_eq!(stream.tokens[2], Token::Keyword(Keyword::From));
+    match stream.tokens[3] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "EMPLOYEES"),
+        _ => panic!("Expected Identifier token"),
+    }
+    assert_eq!(stream.tokens[4], Token::Semicolon);
+    assert_eq!(stream.tokens[5], Token::Eof);
 }

--- a/crates/vibesql-parser/src/tests/lexer/errors.rs
+++ b/crates/vibesql-parser/src/tests/lexer/errors.rs
@@ -4,7 +4,7 @@ use super::super::*;
 
 #[test]
 fn test_tokenize_invalid_character() {
-    let mut lexer = Lexer::new("SELECT @");
+    let lexer = Lexer::new("SELECT @");
     let result = lexer.tokenize();
     assert!(result.is_err());
     let err = result.unwrap_err();

--- a/crates/vibesql-parser/src/tests/lexer/identifiers.rs
+++ b/crates/vibesql-parser/src/tests/lexer/identifiers.rs
@@ -4,31 +4,43 @@ use super::super::*;
 
 #[test]
 fn test_tokenize_simple_identifier() {
-    let mut lexer = Lexer::new("users");
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new("users");
+    let stream = lexer.tokenize().unwrap();
     // Regular identifiers are normalized to uppercase
-    assert_eq!(tokens[0], Token::Identifier("USERS".to_string()));
+    match stream.tokens[0] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "USERS"),
+        _ => panic!("Expected Identifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_identifier_with_underscore() {
-    let mut lexer = Lexer::new("user_id");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Identifier("USER_ID".to_string()));
+    let lexer = Lexer::new("user_id");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "USER_ID"),
+        _ => panic!("Expected Identifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_identifier_with_numbers() {
-    let mut lexer = Lexer::new("table123");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Identifier("TABLE123".to_string()));
+    let lexer = Lexer::new("table123");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "TABLE123"),
+        _ => panic!("Expected Identifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_identifier_starting_with_underscore() {
-    let mut lexer = Lexer::new("_internal");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Identifier("_INTERNAL".to_string()));
+    let lexer = Lexer::new("_internal");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "_INTERNAL"),
+        _ => panic!("Expected Identifier token"),
+    }
 }
 
 // ============================================================================
@@ -37,52 +49,70 @@ fn test_tokenize_identifier_starting_with_underscore() {
 
 #[test]
 fn test_tokenize_delimited_identifier_simple() {
-    let mut lexer = Lexer::new(r#""columnName""#);
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new(r#""columnName""#);
+    let stream = lexer.tokenize().unwrap();
     // Delimited identifiers preserve case
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("columnName".to_string()));
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "columnName"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_delimited_identifier_uppercase() {
-    let mut lexer = Lexer::new(r#""A""#);
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("A".to_string()));
+    let lexer = Lexer::new(r#""A""#);
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "A"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_delimited_identifier_lowercase() {
-    let mut lexer = Lexer::new(r#""a""#);
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("a".to_string()));
+    let lexer = Lexer::new(r#""a""#);
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "a"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_delimited_identifier_with_spaces() {
-    let mut lexer = Lexer::new(r#""First Name""#);
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("First Name".to_string()));
+    let lexer = Lexer::new(r#""First Name""#);
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "First Name"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_delimited_identifier_reserved_word() {
-    let mut lexer = Lexer::new(r#""SELECT""#);
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new(r#""SELECT""#);
+    let stream = lexer.tokenize().unwrap();
     // Reserved words can be used as delimited identifiers
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("SELECT".to_string()));
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "SELECT"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_delimited_identifier_with_escaped_quotes() {
-    let mut lexer = Lexer::new(r#""O""Reilly""#);
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new(r#""O""Reilly""#);
+    let stream = lexer.tokenize().unwrap();
     // Doubled quotes become single quote in the identifier
-    assert_eq!(tokens[0], Token::DelimitedIdentifier(r#"O"Reilly"#.to_string()));
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), r#"O"Reilly"#),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_empty_delimited_identifier_error() {
-    let mut lexer = Lexer::new(r#""""#);
+    let lexer = Lexer::new(r#""""#);
     let result = lexer.tokenize();
     assert!(result.is_err());
     assert!(result.unwrap_err().message.contains("Empty delimited identifier"));
@@ -90,7 +120,7 @@ fn test_tokenize_empty_delimited_identifier_error() {
 
 #[test]
 fn test_tokenize_unterminated_delimited_identifier_error() {
-    let mut lexer = Lexer::new(r#""unterminated"#);
+    let lexer = Lexer::new(r#""unterminated"#);
     let result = lexer.tokenize();
     assert!(result.is_err());
     assert!(result.unwrap_err().message.contains("Unterminated delimited identifier"));
@@ -98,14 +128,20 @@ fn test_tokenize_unterminated_delimited_identifier_error() {
 
 #[test]
 fn test_tokenize_mixed_identifiers() {
-    let mut lexer = Lexer::new(r#"SELECT "columnName", regularColumn FROM table"#);
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::DelimitedIdentifier("columnName".to_string()));
-    assert_eq!(tokens[2], Token::Comma);
-    assert_eq!(tokens[3], Token::Identifier("REGULARCOLUMN".to_string()));
-    assert_eq!(tokens[4], Token::Keyword(Keyword::From));
-    assert_eq!(tokens[5], Token::Keyword(Keyword::Table)); // "table" is a reserved keyword
+    let lexer = Lexer::new(r#"SELECT "columnName", regularColumn FROM table"#);
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "columnName"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
+    assert_eq!(stream.tokens[2], Token::Comma);
+    match stream.tokens[3] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "REGULARCOLUMN"),
+        _ => panic!("Expected Identifier token"),
+    }
+    assert_eq!(stream.tokens[4], Token::Keyword(Keyword::From));
+    assert_eq!(stream.tokens[5], Token::Keyword(Keyword::Table)); // "table" is a reserved keyword
 }
 
 // ============================================================================
@@ -114,59 +150,80 @@ fn test_tokenize_mixed_identifiers() {
 
 #[test]
 fn test_tokenize_backtick_identifier_simple() {
-    let mut lexer = Lexer::new("`columnName`");
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new("`columnName`");
+    let stream = lexer.tokenize().unwrap();
     // Backtick identifiers preserve case
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("columnName".to_string()));
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "columnName"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_backtick_identifier_uppercase() {
-    let mut lexer = Lexer::new("`A`");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("A".to_string()));
+    let lexer = Lexer::new("`A`");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "A"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_backtick_identifier_lowercase() {
-    let mut lexer = Lexer::new("`a`");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("a".to_string()));
+    let lexer = Lexer::new("`a`");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "a"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_backtick_identifier_with_spaces() {
-    let mut lexer = Lexer::new("`First Name`");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("First Name".to_string()));
+    let lexer = Lexer::new("`First Name`");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "First Name"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_backtick_identifier_with_special_chars() {
-    let mut lexer = Lexer::new("`my-table`");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("my-table".to_string()));
+    let lexer = Lexer::new("`my-table`");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "my-table"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_backtick_identifier_reserved_word() {
-    let mut lexer = Lexer::new("`SELECT`");
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new("`SELECT`");
+    let stream = lexer.tokenize().unwrap();
     // Reserved words can be used as backtick identifiers
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("SELECT".to_string()));
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "SELECT"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_backtick_identifier_with_escaped_backticks() {
-    let mut lexer = Lexer::new("`O``Reilly`");
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new("`O``Reilly`");
+    let stream = lexer.tokenize().unwrap();
     // Doubled backticks become single backtick in the identifier
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("O`Reilly".to_string()));
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "O`Reilly"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_empty_backtick_identifier_error() {
-    let mut lexer = Lexer::new("``");
+    let lexer = Lexer::new("``");
     let result = lexer.tokenize();
     assert!(result.is_err());
     assert!(result.unwrap_err().message.contains("Empty delimited identifier"));
@@ -174,7 +231,7 @@ fn test_tokenize_empty_backtick_identifier_error() {
 
 #[test]
 fn test_tokenize_unterminated_backtick_identifier_error() {
-    let mut lexer = Lexer::new("`unterminated");
+    let lexer = Lexer::new("`unterminated");
     let result = lexer.tokenize();
     assert!(result.is_err());
     assert!(result.unwrap_err().message.contains("Unterminated delimited identifier"));
@@ -182,26 +239,41 @@ fn test_tokenize_unterminated_backtick_identifier_error() {
 
 #[test]
 fn test_tokenize_mixed_backtick_and_regular_identifiers() {
-    let mut lexer = Lexer::new("SELECT `columnName`, regularColumn FROM `table_name`");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::DelimitedIdentifier("columnName".to_string()));
-    assert_eq!(tokens[2], Token::Comma);
-    assert_eq!(tokens[3], Token::Identifier("REGULARCOLUMN".to_string()));
-    assert_eq!(tokens[4], Token::Keyword(Keyword::From));
-    assert_eq!(tokens[5], Token::DelimitedIdentifier("table_name".to_string()));
+    let lexer = Lexer::new("SELECT `columnName`, regularColumn FROM `table_name`");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "columnName"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
+    assert_eq!(stream.tokens[2], Token::Comma);
+    match stream.tokens[3] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "REGULARCOLUMN"),
+        _ => panic!("Expected Identifier token"),
+    }
+    assert_eq!(stream.tokens[4], Token::Keyword(Keyword::From));
+    match stream.tokens[5] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "table_name"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_backtick_vs_doublequote_identifiers() {
-    let mut lexer = Lexer::new("SELECT `backtick`, \"doublequote\" FROM table");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::DelimitedIdentifier("backtick".to_string()));
-    assert_eq!(tokens[2], Token::Comma);
-    assert_eq!(tokens[3], Token::DelimitedIdentifier("doublequote".to_string()));
-    assert_eq!(tokens[4], Token::Keyword(Keyword::From));
-    assert_eq!(tokens[5], Token::Keyword(Keyword::Table));
+    let lexer = Lexer::new("SELECT `backtick`, \"doublequote\" FROM table");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "backtick"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
+    assert_eq!(stream.tokens[2], Token::Comma);
+    match stream.tokens[3] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "doublequote"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
+    assert_eq!(stream.tokens[4], Token::Keyword(Keyword::From));
+    assert_eq!(stream.tokens[5], Token::Keyword(Keyword::Table));
 }
 
 // ============================================================================

--- a/crates/vibesql-parser/src/tests/lexer/keywords.rs
+++ b/crates/vibesql-parser/src/tests/lexer/keywords.rs
@@ -5,50 +5,50 @@ use super::super::*;
 
 #[test]
 fn test_tokenize_select_keyword() {
-    let mut lexer = Lexer::new("SELECT");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens.len(), 2); // SELECT + EOF
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::Eof);
+    let lexer = Lexer::new("SELECT");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens.len(), 2); // SELECT + EOF
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    assert_eq!(stream.tokens[1], Token::Eof);
 }
 
 #[test]
 fn test_tokenize_select_lowercase() {
-    let mut lexer = Lexer::new("select");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
+    let lexer = Lexer::new("select");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
 }
 
 #[test]
 fn test_tokenize_select_mixed_case() {
-    let mut lexer = Lexer::new("SeLeCt");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
+    let lexer = Lexer::new("SeLeCt");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
 }
 
 #[test]
 fn test_tokenize_from_keyword() {
-    let mut lexer = Lexer::new("FROM");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Keyword(Keyword::From));
+    let lexer = Lexer::new("FROM");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::From));
 }
 
 #[test]
 fn test_tokenize_where_keyword() {
-    let mut lexer = Lexer::new("WHERE");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Where));
+    let lexer = Lexer::new("WHERE");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Where));
 }
 
 #[test]
 fn test_tokenize_multiple_keywords() {
-    let mut lexer = Lexer::new("SELECT FROM WHERE");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens.len(), 4); // 3 keywords + EOF
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::Keyword(Keyword::From));
-    assert_eq!(tokens[2], Token::Keyword(Keyword::Where));
-    assert_eq!(tokens[3], Token::Eof);
+    let lexer = Lexer::new("SELECT FROM WHERE");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens.len(), 4); // 3 keywords + EOF
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    assert_eq!(stream.tokens[1], Token::Keyword(Keyword::From));
+    assert_eq!(stream.tokens[2], Token::Keyword(Keyword::Where));
+    assert_eq!(stream.tokens[3], Token::Eof);
 }
 
 // ============================================================================

--- a/crates/vibesql-parser/src/tests/lexer/numbers.rs
+++ b/crates/vibesql-parser/src/tests/lexer/numbers.rs
@@ -4,30 +4,42 @@ use super::super::*;
 
 #[test]
 fn test_tokenize_integer() {
-    let mut lexer = Lexer::new("42");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Number("42".to_string()));
+    let lexer = Lexer::new("42");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "42"),
+        _ => panic!("Expected Number token"),
+    }
 }
 
 #[test]
 fn test_tokenize_decimal() {
-    let mut lexer = Lexer::new("3.14");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Number("3.14".to_string()));
+    let lexer = Lexer::new("3.14");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "3.14"),
+        _ => panic!("Expected Number token"),
+    }
 }
 
 #[test]
 fn test_tokenize_zero() {
-    let mut lexer = Lexer::new("0");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Number("0".to_string()));
+    let lexer = Lexer::new("0");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "0"),
+        _ => panic!("Expected Number token"),
+    }
 }
 
 #[test]
 fn test_tokenize_large_number() {
-    let mut lexer = Lexer::new("999999");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Number("999999".to_string()));
+    let lexer = Lexer::new("999999");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "999999"),
+        _ => panic!("Expected Number token"),
+    }
 }
 
 // ============================================================================

--- a/crates/vibesql-parser/src/tests/lexer/statements.rs
+++ b/crates/vibesql-parser/src/tests/lexer/statements.rs
@@ -4,76 +4,115 @@ use super::super::*;
 
 #[test]
 fn test_tokenize_select_42() {
-    let mut lexer = Lexer::new("SELECT 42;");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens.len(), 4); // SELECT, 42, ;, EOF
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::Number("42".to_string()));
-    assert_eq!(tokens[2], Token::Semicolon);
-    assert_eq!(tokens[3], Token::Eof);
+    let lexer = Lexer::new("SELECT 42;");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens.len(), 4); // SELECT, 42, ;, EOF
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "42"),
+        _ => panic!("Expected Number token"),
+    }
+    assert_eq!(stream.tokens[2], Token::Semicolon);
+    assert_eq!(stream.tokens[3], Token::Eof);
 }
 
 #[test]
 fn test_tokenize_select_string() {
-    let mut lexer = Lexer::new("SELECT 'hello';");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens.len(), 4);
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::String("hello".to_string()));
-    assert_eq!(tokens[2], Token::Semicolon);
+    let lexer = Lexer::new("SELECT 'hello';");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens.len(), 4);
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::String(sym) => assert_eq!(stream.resolve(sym), "hello"),
+        _ => panic!("Expected String token"),
+    }
+    assert_eq!(stream.tokens[2], Token::Semicolon);
 }
 
 #[test]
 fn test_tokenize_select_with_arithmetic() {
-    let mut lexer = Lexer::new("SELECT 1 + 2;");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens.len(), 6); // SELECT, 1, +, 2, ;, EOF
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::Number("1".to_string()));
-    assert_eq!(tokens[2], Token::Symbol('+'));
-    assert_eq!(tokens[3], Token::Number("2".to_string()));
-    assert_eq!(tokens[4], Token::Semicolon);
+    let lexer = Lexer::new("SELECT 1 + 2;");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens.len(), 6); // SELECT, 1, +, 2, ;, EOF
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "1"),
+        _ => panic!("Expected Number token"),
+    }
+    assert_eq!(stream.tokens[2], Token::Symbol('+'));
+    match stream.tokens[3] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "2"),
+        _ => panic!("Expected Number token"),
+    }
+    assert_eq!(stream.tokens[4], Token::Semicolon);
 }
 
 #[test]
 fn test_tokenize_select_from_table() {
-    let mut lexer = Lexer::new("SELECT * FROM users;");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens.len(), 6); // SELECT, *, FROM, users, ;, EOF
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::Symbol('*'));
-    assert_eq!(tokens[2], Token::Keyword(Keyword::From));
-    assert_eq!(tokens[3], Token::Identifier("USERS".to_string()));
-    assert_eq!(tokens[4], Token::Semicolon);
+    let lexer = Lexer::new("SELECT * FROM users;");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens.len(), 6); // SELECT, *, FROM, users, ;, EOF
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    assert_eq!(stream.tokens[1], Token::Symbol('*'));
+    assert_eq!(stream.tokens[2], Token::Keyword(Keyword::From));
+    match stream.tokens[3] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "USERS"),
+        _ => panic!("Expected Identifier token"),
+    }
+    assert_eq!(stream.tokens[4], Token::Semicolon);
 }
 
 #[test]
 fn test_tokenize_select_columns() {
-    let mut lexer = Lexer::new("SELECT id, name, age FROM users;");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::Identifier("ID".to_string()));
-    assert_eq!(tokens[2], Token::Comma);
-    assert_eq!(tokens[3], Token::Identifier("NAME".to_string()));
-    assert_eq!(tokens[4], Token::Comma);
-    assert_eq!(tokens[5], Token::Identifier("AGE".to_string()));
-    assert_eq!(tokens[6], Token::Keyword(Keyword::From));
-    assert_eq!(tokens[7], Token::Identifier("USERS".to_string()));
+    let lexer = Lexer::new("SELECT id, name, age FROM users;");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "ID"),
+        _ => panic!("Expected Identifier token"),
+    }
+    assert_eq!(stream.tokens[2], Token::Comma);
+    match stream.tokens[3] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "NAME"),
+        _ => panic!("Expected Identifier token"),
+    }
+    assert_eq!(stream.tokens[4], Token::Comma);
+    match stream.tokens[5] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "AGE"),
+        _ => panic!("Expected Identifier token"),
+    }
+    assert_eq!(stream.tokens[6], Token::Keyword(Keyword::From));
+    match stream.tokens[7] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "USERS"),
+        _ => panic!("Expected Identifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_select_with_where() {
-    let mut lexer = Lexer::new("SELECT name FROM users WHERE id = 1;");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::Identifier("NAME".to_string()));
-    assert_eq!(tokens[2], Token::Keyword(Keyword::From));
-    assert_eq!(tokens[3], Token::Identifier("USERS".to_string()));
-    assert_eq!(tokens[4], Token::Keyword(Keyword::Where));
-    assert_eq!(tokens[5], Token::Identifier("ID".to_string()));
-    assert_eq!(tokens[6], Token::Symbol('='));
-    assert_eq!(tokens[7], Token::Number("1".to_string()));
-    assert_eq!(tokens[8], Token::Semicolon);
+    let lexer = Lexer::new("SELECT name FROM users WHERE id = 1;");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "NAME"),
+        _ => panic!("Expected Identifier token"),
+    }
+    assert_eq!(stream.tokens[2], Token::Keyword(Keyword::From));
+    match stream.tokens[3] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "USERS"),
+        _ => panic!("Expected Identifier token"),
+    }
+    assert_eq!(stream.tokens[4], Token::Keyword(Keyword::Where));
+    match stream.tokens[5] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "ID"),
+        _ => panic!("Expected Identifier token"),
+    }
+    assert_eq!(stream.tokens[6], Token::Symbol('='));
+    match stream.tokens[7] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "1"),
+        _ => panic!("Expected Number token"),
+    }
+    assert_eq!(stream.tokens[8], Token::Semicolon);
 }
 
 // ============================================================================

--- a/crates/vibesql-parser/src/tests/lexer/strings.rs
+++ b/crates/vibesql-parser/src/tests/lexer/strings.rs
@@ -4,36 +4,48 @@ use super::super::*;
 
 #[test]
 fn test_tokenize_single_quoted_string() {
-    let mut lexer = Lexer::new("'hello'");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::String("hello".to_string()));
+    let lexer = Lexer::new("'hello'");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::String(sym) => assert_eq!(stream.resolve(sym), "hello"),
+        _ => panic!("Expected String token"),
+    }
 }
 
 #[test]
 fn test_tokenize_double_quoted_string() {
     // Double quotes now create delimited identifiers, not strings (SQL:1999 compliance)
-    let mut lexer = Lexer::new("\"world\"");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::DelimitedIdentifier("world".to_string()));
+    let lexer = Lexer::new("\"world\"");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::DelimitedIdentifier(sym) => assert_eq!(stream.resolve(sym), "world"),
+        _ => panic!("Expected DelimitedIdentifier token"),
+    }
 }
 
 #[test]
 fn test_tokenize_empty_string() {
-    let mut lexer = Lexer::new("''");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::String("".to_string()));
+    let lexer = Lexer::new("''");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::String(sym) => assert_eq!(stream.resolve(sym), ""),
+        _ => panic!("Expected String token"),
+    }
 }
 
 #[test]
 fn test_tokenize_string_with_spaces() {
-    let mut lexer = Lexer::new("'hello world'");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::String("hello world".to_string()));
+    let lexer = Lexer::new("'hello world'");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::String(sym) => assert_eq!(stream.resolve(sym), "hello world"),
+        _ => panic!("Expected String token"),
+    }
 }
 
 #[test]
 fn test_tokenize_unterminated_string() {
-    let mut lexer = Lexer::new("'hello");
+    let lexer = Lexer::new("'hello");
     let result = lexer.tokenize();
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -42,30 +54,42 @@ fn test_tokenize_unterminated_string() {
 
 #[test]
 fn test_tokenize_string_with_escaped_quote() {
-    let mut lexer = Lexer::new("'O''Reilly'");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::String("O'Reilly".to_string()));
+    let lexer = Lexer::new("'O''Reilly'");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::String(sym) => assert_eq!(stream.resolve(sym), "O'Reilly"),
+        _ => panic!("Expected String token"),
+    }
 }
 
 #[test]
 fn test_tokenize_string_with_multiple_escaped_quotes() {
-    let mut lexer = Lexer::new("'Chef Anton''s Cajun Seasoning'");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::String("Chef Anton's Cajun Seasoning".to_string()));
+    let lexer = Lexer::new("'Chef Anton''s Cajun Seasoning'");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::String(sym) => assert_eq!(stream.resolve(sym), "Chef Anton's Cajun Seasoning"),
+        _ => panic!("Expected String token"),
+    }
 }
 
 #[test]
 fn test_tokenize_string_with_double_escaped_quote() {
-    let mut lexer = Lexer::new("'It''s ''great'''");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::String("It's 'great'".to_string()));
+    let lexer = Lexer::new("'It''s ''great'''");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::String(sym) => assert_eq!(stream.resolve(sym), "It's 'great'"),
+        _ => panic!("Expected String token"),
+    }
 }
 
 #[test]
 fn test_tokenize_empty_string_not_confused_with_escaped_quote() {
-    let mut lexer = Lexer::new("''");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::String("".to_string()));
+    let lexer = Lexer::new("''");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::String(sym) => assert_eq!(stream.resolve(sym), ""),
+        _ => panic!("Expected String token"),
+    }
 }
 
 // ============================================================================

--- a/crates/vibesql-parser/src/tests/lexer/symbols.rs
+++ b/crates/vibesql-parser/src/tests/lexer/symbols.rs
@@ -4,113 +4,151 @@ use super::super::*;
 
 #[test]
 fn test_tokenize_semicolon() {
-    let mut lexer = Lexer::new(";");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Semicolon);
+    let lexer = Lexer::new(";");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Semicolon);
 }
 
 #[test]
 fn test_tokenize_comma() {
-    let mut lexer = Lexer::new(",");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Comma);
+    let lexer = Lexer::new(",");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Comma);
 }
 
 #[test]
 fn test_tokenize_parentheses() {
-    let mut lexer = Lexer::new("()");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::LParen);
-    assert_eq!(tokens[1], Token::RParen);
+    let lexer = Lexer::new("()");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::LParen);
+    assert_eq!(stream.tokens[1], Token::RParen);
 }
 
 #[test]
 fn test_tokenize_arithmetic_symbols() {
-    let mut lexer = Lexer::new("+ - * /");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Symbol('+'));
-    assert_eq!(tokens[1], Token::Symbol('-'));
-    assert_eq!(tokens[2], Token::Symbol('*'));
-    assert_eq!(tokens[3], Token::Symbol('/'));
+    let lexer = Lexer::new("+ - * /");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Symbol('+'));
+    assert_eq!(stream.tokens[1], Token::Symbol('-'));
+    assert_eq!(stream.tokens[2], Token::Symbol('*'));
+    assert_eq!(stream.tokens[3], Token::Symbol('/'));
 }
 
 #[test]
 fn test_tokenize_comparison_symbols() {
-    let mut lexer = Lexer::new("= < >");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Symbol('='));
-    assert_eq!(tokens[1], Token::Symbol('<'));
-    assert_eq!(tokens[2], Token::Symbol('>'));
+    let lexer = Lexer::new("= < >");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Symbol('='));
+    assert_eq!(stream.tokens[1], Token::Symbol('<'));
+    assert_eq!(stream.tokens[2], Token::Symbol('>'));
 }
 
 #[test]
 fn test_tokenize_multi_char_operators() {
-    let mut lexer = Lexer::new("<= >= != <>");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Operator("<=".to_string()));
-    assert_eq!(tokens[1], Token::Operator(">=".to_string()));
-    assert_eq!(tokens[2], Token::Operator("!=".to_string()));
-    assert_eq!(tokens[3], Token::Operator("<>".to_string()));
+    let lexer = Lexer::new("<= >= != <>");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::Operator(sym) => assert_eq!(stream.resolve(sym), "<="),
+        _ => panic!("Expected Operator token"),
+    }
+    match stream.tokens[1] {
+        Token::Operator(sym) => assert_eq!(stream.resolve(sym), ">="),
+        _ => panic!("Expected Operator token"),
+    }
+    match stream.tokens[2] {
+        Token::Operator(sym) => assert_eq!(stream.resolve(sym), "!="),
+        _ => panic!("Expected Operator token"),
+    }
+    match stream.tokens[3] {
+        Token::Operator(sym) => assert_eq!(stream.resolve(sym), "<>"),
+        _ => panic!("Expected Operator token"),
+    }
 }
 
 #[test]
 fn test_tokenize_operators_without_spaces() {
     // Test that >= is tokenized as one operator, not two
-    let mut lexer = Lexer::new("age>=18");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Identifier("AGE".to_string()));
-    assert_eq!(tokens[1], Token::Operator(">=".to_string()));
-    assert_eq!(tokens[2], Token::Number("18".to_string()));
+    let lexer = Lexer::new("age>=18");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::Identifier(sym) => assert_eq!(stream.resolve(sym), "AGE"),
+        _ => panic!("Expected Identifier token"),
+    }
+    match stream.tokens[1] {
+        Token::Operator(sym) => assert_eq!(stream.resolve(sym), ">="),
+        _ => panic!("Expected Operator token"),
+    }
+    match stream.tokens[2] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "18"),
+        _ => panic!("Expected Number token"),
+    }
 }
 
 #[test]
 fn test_tokenize_single_vs_multi_char() {
     // Test that > and = are separate when not adjacent
-    let mut lexer = Lexer::new("> =");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::Symbol('>'));
-    assert_eq!(tokens[1], Token::Symbol('='));
+    let lexer = Lexer::new("> =");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens[0], Token::Symbol('>'));
+    assert_eq!(stream.tokens[1], Token::Symbol('='));
 
     // But >= is one token when adjacent
-    let mut lexer2 = Lexer::new(">=");
-    let tokens2 = lexer2.tokenize().unwrap();
-    assert_eq!(tokens2[0], Token::Operator(">=".to_string()));
+    let lexer2 = Lexer::new(">=");
+    let stream2 = lexer2.tokenize().unwrap();
+    match stream2.tokens[0] {
+        Token::Operator(sym) => assert_eq!(stream2.resolve(sym), ">="),
+        _ => panic!("Expected Operator token"),
+    }
 }
 
 #[test]
 fn test_tokenize_session_variable() {
-    let mut lexer = Lexer::new("@@sql_mode");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::SessionVariable("sql_mode".to_string()));
+    let lexer = Lexer::new("@@sql_mode");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::SessionVariable(sym) => assert_eq!(stream.resolve(sym), "sql_mode"),
+        _ => panic!("Expected SessionVariable token"),
+    }
 }
 
 #[test]
 fn test_tokenize_session_variable_with_scope() {
-    let mut lexer = Lexer::new("@@global.variable");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::SessionVariable("global.variable".to_string()));
+    let lexer = Lexer::new("@@global.variable");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::SessionVariable(sym) => assert_eq!(stream.resolve(sym), "global.variable"),
+        _ => panic!("Expected SessionVariable token"),
+    }
 }
 
 #[test]
 fn test_tokenize_session_variable_explicit_scope() {
-    let mut lexer = Lexer::new("@@session.sql_mode");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::SessionVariable("session.sql_mode".to_string()));
+    let lexer = Lexer::new("@@session.sql_mode");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::SessionVariable(sym) => assert_eq!(stream.resolve(sym), "session.sql_mode"),
+        _ => panic!("Expected SessionVariable token"),
+    }
 }
 
 #[test]
 fn test_tokenize_user_variable() {
-    let mut lexer = Lexer::new("@user_var");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens[0], Token::UserVariable("user_var".to_string()));
+    let lexer = Lexer::new("@user_var");
+    let stream = lexer.tokenize().unwrap();
+    match stream.tokens[0] {
+        Token::UserVariable(sym) => assert_eq!(stream.resolve(sym), "user_var"),
+        _ => panic!("Expected UserVariable token"),
+    }
 }
 
 #[test]
 fn test_tokenize_session_variable_in_expression() {
-    let mut lexer = Lexer::new("SET SESSION sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))");
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new("SET SESSION sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))");
+    let stream = lexer.tokenize().unwrap();
     // Find the SessionVariable token
-    let found = tokens.iter().any(|t| matches!(t, Token::SessionVariable(s) if s == "sql_mode"));
+    let found = stream.tokens.iter().any(|t| {
+        matches!(t, Token::SessionVariable(sym) if stream.resolve(*sym) == "sql_mode")
+    });
     assert!(found, "Session variable @@sql_mode not found in tokens");
 }
 

--- a/crates/vibesql-parser/src/tests/lexer/whitespace.rs
+++ b/crates/vibesql-parser/src/tests/lexer/whitespace.rs
@@ -4,29 +4,38 @@ use super::super::*;
 
 #[test]
 fn test_tokenize_with_multiple_spaces() {
-    let mut lexer = Lexer::new("SELECT    42");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens.len(), 3); // SELECT, 42, EOF
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::Number("42".to_string()));
+    let lexer = Lexer::new("SELECT    42");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens.len(), 3); // SELECT, 42, EOF
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "42"),
+        _ => panic!("Expected Number token"),
+    }
 }
 
 #[test]
 fn test_tokenize_with_tabs() {
-    let mut lexer = Lexer::new("SELECT\t42");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens.len(), 3);
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::Number("42".to_string()));
+    let lexer = Lexer::new("SELECT\t42");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens.len(), 3);
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "42"),
+        _ => panic!("Expected Number token"),
+    }
 }
 
 #[test]
 fn test_tokenize_with_newlines() {
-    let mut lexer = Lexer::new("SELECT\n42");
-    let tokens = lexer.tokenize().unwrap();
-    assert_eq!(tokens.len(), 3);
-    assert_eq!(tokens[0], Token::Keyword(Keyword::Select));
-    assert_eq!(tokens[1], Token::Number("42".to_string()));
+    let lexer = Lexer::new("SELECT\n42");
+    let stream = lexer.tokenize().unwrap();
+    assert_eq!(stream.tokens.len(), 3);
+    assert_eq!(stream.tokens[0], Token::Keyword(Keyword::Select));
+    match stream.tokens[1] {
+        Token::Number(sym) => assert_eq!(stream.resolve(sym), "42"),
+        _ => panic!("Expected Number token"),
+    }
 }
 
 // ============================================================================

--- a/crates/vibesql-parser/src/tests/select/concat.rs
+++ b/crates/vibesql-parser/src/tests/select/concat.rs
@@ -74,19 +74,28 @@ fn test_parse_concat_precedence() {
 
 #[test]
 fn test_lex_concat_operator() {
-    let mut lexer = Lexer::new("'a' || 'b'");
-    let tokens = lexer.tokenize().unwrap();
+    let lexer = Lexer::new("'a' || 'b'");
+    let stream = lexer.tokenize().unwrap();
 
-    assert_eq!(tokens.len(), 4); // 'a', ||, 'b', EOF
-    assert_eq!(tokens[0], Token::String("a".to_string()));
-    assert_eq!(tokens[1], Token::Operator("||".to_string()));
-    assert_eq!(tokens[2], Token::String("b".to_string()));
-    assert_eq!(tokens[3], Token::Eof);
+    assert_eq!(stream.tokens.len(), 4); // 'a', ||, 'b', EOF
+    match stream.tokens[0] {
+        Token::String(sym) => assert_eq!(stream.resolve(sym), "a"),
+        _ => panic!("Expected String token"),
+    }
+    match stream.tokens[1] {
+        Token::Operator(sym) => assert_eq!(stream.resolve(sym), "||"),
+        _ => panic!("Expected Operator token"),
+    }
+    match stream.tokens[2] {
+        Token::String(sym) => assert_eq!(stream.resolve(sym), "b"),
+        _ => panic!("Expected String token"),
+    }
+    assert_eq!(stream.tokens[3], Token::Eof);
 }
 
 #[test]
 fn test_lex_single_pipe_error() {
-    let mut lexer = Lexer::new("'a' | 'b'");
+    let lexer = Lexer::new("'a' | 'b'");
     let result = lexer.tokenize();
 
     assert!(result.is_err());

--- a/crates/vibesql-parser/src/tests/truncate.rs
+++ b/crates/vibesql-parser/src/tests/truncate.rs
@@ -5,9 +5,9 @@ use vibesql_ast::Statement;
 #[test]
 fn test_truncate_table_basic() {
     let input = "TRUNCATE TABLE users;";
-    let mut lexer = crate::lexer::Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
-    let mut parser = crate::Parser::new(tokens);
+    let lexer = crate::lexer::Lexer::new(input);
+    let token_stream = lexer.tokenize().unwrap();
+    let mut parser = crate::Parser::new(token_stream);
     let stmt = parser.parse_statement().unwrap();
 
     match stmt {
@@ -22,9 +22,9 @@ fn test_truncate_table_basic() {
 #[test]
 fn test_truncate_without_table_keyword() {
     let input = "TRUNCATE users;";
-    let mut lexer = crate::lexer::Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
-    let mut parser = crate::Parser::new(tokens);
+    let lexer = crate::lexer::Lexer::new(input);
+    let token_stream = lexer.tokenize().unwrap();
+    let mut parser = crate::Parser::new(token_stream);
     let stmt = parser.parse_statement().unwrap();
 
     match stmt {
@@ -39,9 +39,9 @@ fn test_truncate_without_table_keyword() {
 #[test]
 fn test_truncate_table_if_exists() {
     let input = "TRUNCATE TABLE IF EXISTS users;";
-    let mut lexer = crate::lexer::Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
-    let mut parser = crate::Parser::new(tokens);
+    let lexer = crate::lexer::Lexer::new(input);
+    let token_stream = lexer.tokenize().unwrap();
+    let mut parser = crate::Parser::new(token_stream);
     let stmt = parser.parse_statement().unwrap();
 
     match stmt {
@@ -56,9 +56,9 @@ fn test_truncate_table_if_exists() {
 #[test]
 fn test_truncate_if_exists_without_table() {
     let input = "TRUNCATE IF EXISTS users;";
-    let mut lexer = crate::lexer::Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
-    let mut parser = crate::Parser::new(tokens);
+    let lexer = crate::lexer::Lexer::new(input);
+    let token_stream = lexer.tokenize().unwrap();
+    let mut parser = crate::Parser::new(token_stream);
     let stmt = parser.parse_statement().unwrap();
 
     match stmt {
@@ -73,9 +73,9 @@ fn test_truncate_if_exists_without_table() {
 #[test]
 fn test_truncate_qualified_table() {
     let input = "TRUNCATE TABLE myschema.users;";
-    let mut lexer = crate::lexer::Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
-    let mut parser = crate::Parser::new(tokens);
+    let lexer = crate::lexer::Lexer::new(input);
+    let token_stream = lexer.tokenize().unwrap();
+    let mut parser = crate::Parser::new(token_stream);
     let stmt = parser.parse_statement().unwrap();
 
     match stmt {
@@ -90,9 +90,9 @@ fn test_truncate_qualified_table() {
 #[test]
 fn test_truncate_multiple_tables() {
     let input = "TRUNCATE TABLE orders, order_items, order_history;";
-    let mut lexer = crate::lexer::Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
-    let mut parser = crate::Parser::new(tokens);
+    let lexer = crate::lexer::Lexer::new(input);
+    let token_stream = lexer.tokenize().unwrap();
+    let mut parser = crate::Parser::new(token_stream);
     let stmt = parser.parse_statement().unwrap();
 
     match stmt {
@@ -110,9 +110,9 @@ fn test_truncate_multiple_tables() {
 #[test]
 fn test_truncate_multiple_tables_without_table_keyword() {
     let input = "TRUNCATE orders, order_items;";
-    let mut lexer = crate::lexer::Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
-    let mut parser = crate::Parser::new(tokens);
+    let lexer = crate::lexer::Lexer::new(input);
+    let token_stream = lexer.tokenize().unwrap();
+    let mut parser = crate::Parser::new(token_stream);
     let stmt = parser.parse_statement().unwrap();
 
     match stmt {
@@ -127,9 +127,9 @@ fn test_truncate_multiple_tables_without_table_keyword() {
 #[test]
 fn test_truncate_multiple_tables_if_exists() {
     let input = "TRUNCATE TABLE IF EXISTS temp_data, staging_data, cache_data;";
-    let mut lexer = crate::lexer::Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
-    let mut parser = crate::Parser::new(tokens);
+    let lexer = crate::lexer::Lexer::new(input);
+    let token_stream = lexer.tokenize().unwrap();
+    let mut parser = crate::Parser::new(token_stream);
     let stmt = parser.parse_statement().unwrap();
 
     match stmt {
@@ -147,9 +147,9 @@ fn test_truncate_multiple_tables_if_exists() {
 #[test]
 fn test_truncate_multiple_qualified_tables() {
     let input = "TRUNCATE TABLE schema1.table1, schema2.table2;";
-    let mut lexer = crate::lexer::Lexer::new(input);
-    let tokens = lexer.tokenize().unwrap();
-    let mut parser = crate::Parser::new(tokens);
+    let lexer = crate::lexer::Lexer::new(input);
+    let token_stream = lexer.tokenize().unwrap();
+    let mut parser = crate::Parser::new(token_stream);
     let stmt = parser.parse_statement().unwrap();
 
     match stmt {

--- a/crates/vibesql-parser/src/token.rs
+++ b/crates/vibesql-parser/src/token.rs
@@ -1,37 +1,43 @@
 use std::fmt;
 
+use crate::interner::StringSymbol;
 use crate::keywords::Keyword;
 
 /// SQL Token produced by the lexer.
-#[derive(Debug, Clone, PartialEq)]
+///
+/// Identifier-based tokens (Identifier, DelimitedIdentifier, NamedPlaceholder,
+/// SessionVariable, UserVariable) use interned StringSymbol for:
+/// - Memory efficiency: identical identifiers share storage
+/// - Fast equality: O(1) symbol comparison instead of O(n) string comparison
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Token {
     /// SQL keyword (SELECT, FROM, etc.)
     Keyword(Keyword),
-    /// Identifier (table name, column name, etc.)
-    Identifier(String),
-    /// Delimited identifier ("columnName" - case-sensitive, can use reserved words)
-    DelimitedIdentifier(String),
-    /// Numeric literal (42, 3.14, etc.)
-    Number(String),
-    /// String literal ('hello')
-    String(String),
+    /// Identifier (table name, column name, etc.) - interned for deduplication
+    Identifier(StringSymbol),
+    /// Delimited identifier ("columnName" - case-sensitive, can use reserved words) - interned
+    DelimitedIdentifier(StringSymbol),
+    /// Numeric literal (42, 3.14, etc.) - stored as symbol for consistency
+    Number(StringSymbol),
+    /// String literal ('hello') - stored as symbol for consistency
+    String(StringSymbol),
     /// Single character symbols (+, -, *, /, =, <, >, etc.)
     Symbol(char),
-    /// Multi-character operators (<=, >=, !=, <>, ||)
-    Operator(String),
-    /// Session variable (@@variable, @@session.variable, @@global.variable)
-    SessionVariable(String),
-    /// User variable (@variable)
-    UserVariable(String),
+    /// Multi-character operators (<=, >=, !=, <>, ||) - interned
+    Operator(StringSymbol),
+    /// Session variable (@@variable, @@session.variable, @@global.variable) - interned
+    SessionVariable(StringSymbol),
+    /// User variable (@variable) - interned
+    UserVariable(StringSymbol),
     /// Parameter placeholder (?) for prepared statements
     /// The index is assigned during parsing (0-indexed, in order of appearance)
     Placeholder,
     /// Numbered parameter placeholder ($1, $2, etc.) for prepared statements
     /// PostgreSQL-style: 1-indexed as written in SQL ($1 = first parameter)
     NumberedPlaceholder(usize),
-    /// Named parameter placeholder (:name) for prepared statements
+    /// Named parameter placeholder (:name) for prepared statements - interned
     /// Used by many ORMs and applications for readability
-    NamedPlaceholder(String),
+    NamedPlaceholder(StringSymbol),
     /// Semicolon (statement terminator)
     Semicolon,
     /// Comma (separator)
@@ -46,19 +52,77 @@ pub enum Token {
 
 impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Note: Display shows token type and symbol index (not resolved string)
+        // For full string display, use Token::display_with_interner()
         match self {
             Token::Keyword(kw) => write!(f, "Keyword({})", kw),
-            Token::Identifier(id) => write!(f, "Identifier({})", id),
-            Token::DelimitedIdentifier(id) => write!(f, "DelimitedIdentifier(\"{}\")", id),
-            Token::Number(n) => write!(f, "Number({})", n),
-            Token::String(s) => write!(f, "String('{}')", s),
+            Token::Identifier(sym) => write!(f, "Identifier({:?})", sym),
+            Token::DelimitedIdentifier(sym) => write!(f, "DelimitedIdentifier({:?})", sym),
+            Token::Number(sym) => write!(f, "Number({:?})", sym),
+            Token::String(sym) => write!(f, "String({:?})", sym),
             Token::Symbol(c) => write!(f, "Symbol({})", c),
-            Token::Operator(op) => write!(f, "Operator({})", op),
-            Token::SessionVariable(v) => write!(f, "SessionVariable({})", v),
-            Token::UserVariable(v) => write!(f, "UserVariable({})", v),
+            Token::Operator(sym) => write!(f, "Operator({:?})", sym),
+            Token::SessionVariable(sym) => write!(f, "SessionVariable({:?})", sym),
+            Token::UserVariable(sym) => write!(f, "UserVariable({:?})", sym),
             Token::Placeholder => write!(f, "Placeholder"),
             Token::NumberedPlaceholder(n) => write!(f, "NumberedPlaceholder(${})", n),
-            Token::NamedPlaceholder(name) => write!(f, "NamedPlaceholder(:{})", name),
+            Token::NamedPlaceholder(sym) => write!(f, "NamedPlaceholder({:?})", sym),
+            Token::Semicolon => write!(f, "Semicolon"),
+            Token::Comma => write!(f, "Comma"),
+            Token::LParen => write!(f, "LParen"),
+            Token::RParen => write!(f, "RParen"),
+            Token::Eof => write!(f, "Eof"),
+        }
+    }
+}
+
+impl Token {
+    /// Display the token with resolved strings from the interner.
+    pub fn display_with_interner<'a>(
+        &'a self,
+        interner: &'a crate::interner::IdentifierInterner,
+    ) -> TokenDisplay<'a> {
+        TokenDisplay { token: self, interner }
+    }
+}
+
+/// Helper for displaying tokens with resolved strings.
+pub struct TokenDisplay<'a> {
+    token: &'a Token,
+    interner: &'a crate::interner::IdentifierInterner,
+}
+
+impl<'a> fmt::Display for TokenDisplay<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.token {
+            Token::Keyword(kw) => write!(f, "Keyword({})", kw),
+            Token::Identifier(sym) => {
+                write!(f, "Identifier({})", self.interner.resolve_unchecked(*sym))
+            }
+            Token::DelimitedIdentifier(sym) => {
+                write!(f, "DelimitedIdentifier(\"{}\")", self.interner.resolve_unchecked(*sym))
+            }
+            Token::Number(sym) => {
+                write!(f, "Number({})", self.interner.resolve_unchecked(*sym))
+            }
+            Token::String(sym) => {
+                write!(f, "String('{}')", self.interner.resolve_unchecked(*sym))
+            }
+            Token::Symbol(c) => write!(f, "Symbol({})", c),
+            Token::Operator(sym) => {
+                write!(f, "Operator({})", self.interner.resolve_unchecked(*sym))
+            }
+            Token::SessionVariable(sym) => {
+                write!(f, "SessionVariable({})", self.interner.resolve_unchecked(*sym))
+            }
+            Token::UserVariable(sym) => {
+                write!(f, "UserVariable({})", self.interner.resolve_unchecked(*sym))
+            }
+            Token::Placeholder => write!(f, "Placeholder"),
+            Token::NumberedPlaceholder(n) => write!(f, "NumberedPlaceholder(${})", n),
+            Token::NamedPlaceholder(sym) => {
+                write!(f, "NamedPlaceholder(:{})", self.interner.resolve_unchecked(*sym))
+            }
             Token::Semicolon => write!(f, "Semicolon"),
             Token::Comma => write!(f, "Comma"),
             Token::LParen => write!(f, "LParen"),


### PR DESCRIPTION
## Summary

- Add `string-interner` crate for efficient string deduplication during SQL lexing
- Tokens now use `StringSymbol` instead of `String` for identifier-based variants
- Lexer returns `TokenStream` which bundles tokens with the interner
- Parser resolves symbols to strings when building AST
- Token is now `Copy` since `StringSymbol` is `Copy`

### Benefits

- **Memory reduction**: Identical identifiers (e.g., column names appearing multiple times) share storage
- **O(1) equality checks**: Symbol comparison is pointer-based, not O(n) string comparison
- **Efficient Token**: Token is now `Copy`, enabling more efficient pattern matching

### Key Changes

1. New `interner.rs` module with `IdentifierInterner` and `StringSymbol` types
2. `Token` enum updated to use `StringSymbol` for: `Identifier`, `DelimitedIdentifier`, `Number`, `String`, `Operator`, `SessionVariable`, `UserVariable`, `NamedPlaceholder`
3. `Lexer.tokenize()` now returns `TokenStream` (tokens + interner)
4. `Parser` stores the interner and uses `resolve(symbol)` to convert symbols back to strings
5. All parser code updated to resolve symbols when needed
6. All tests updated for new `TokenStream` API

## Test plan

- [x] All 930 parser tests pass
- [x] Full workspace compiles successfully
- [x] All workspace tests pass

Closes #3232

🤖 Generated with [Claude Code](https://claude.com/claude-code)