### PR TITLE
fix(arena_parser): Add DATE/TIME/INTERVAL literal support

### DIFF
--- a/crates/vibesql-parser/benches/parser_benchmark.rs
+++ b/crates/vibesql-parser/benches/parser_benchmark.rs
@@ -227,13 +227,14 @@ fn bench_arena_parser(c: &mut Criterion) {
 fn bench_parser_comparison(c: &mut Criterion) {
     let mut group = c.benchmark_group("parser_comparison");
 
-    // Phase 2: Arena parser now supports DML statements
+    // Phase 2: Arena parser now supports DML statements + DATE/INTERVAL literals (TPC-H Q1)
     let queries = [
         ("simple_select", SIMPLE_SELECT),
         ("point_lookup", POINT_LOOKUP),
         ("multi_column", MULTI_COLUMN),
         ("insert_single", INSERT_SINGLE),
         ("complex_join", COMPLEX_JOIN),
+        ("tpch_q1", TPCH_Q1),
     ];
 
     for (name, sql) in queries {

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -529,9 +529,133 @@ impl<'arena> ArenaParser<'arena> {
                 self.advance();
                 Some(Expression::Default)
             }
+            // Typed literals: DATE 'string', TIME 'string', TIMESTAMP 'string'
+            Token::Keyword(Keyword::Date) => {
+                self.advance();
+                match self.peek() {
+                    Token::String(s) => {
+                        let date_str = s.clone();
+                        self.advance();
+                        match date_str.parse::<vibesql_types::Date>() {
+                            Ok(date) => Some(Expression::Literal(SqlValue::Date(date))),
+                            Err(e) => {
+                                return Err(ParseError {
+                                    message: format!("Invalid DATE literal: {}", e),
+                                })
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(ParseError {
+                            message: "Expected string literal after DATE keyword".to_string(),
+                        })
+                    }
+                }
+            }
+            Token::Keyword(Keyword::Time) => {
+                self.advance();
+                match self.peek() {
+                    Token::String(s) => {
+                        let time_str = s.clone();
+                        self.advance();
+                        match time_str.parse::<vibesql_types::Time>() {
+                            Ok(time) => Some(Expression::Literal(SqlValue::Time(time))),
+                            Err(e) => {
+                                return Err(ParseError {
+                                    message: format!("Invalid TIME literal: {}", e),
+                                })
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(ParseError {
+                            message: "Expected string literal after TIME keyword".to_string(),
+                        })
+                    }
+                }
+            }
+            Token::Keyword(Keyword::Timestamp) => {
+                self.advance();
+                match self.peek() {
+                    Token::String(s) => {
+                        let timestamp_str = s.clone();
+                        self.advance();
+                        match timestamp_str.parse::<vibesql_types::Timestamp>() {
+                            Ok(timestamp) => Some(Expression::Literal(SqlValue::Timestamp(timestamp))),
+                            Err(e) => {
+                                return Err(ParseError {
+                                    message: format!("Invalid TIMESTAMP literal: {}", e),
+                                })
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(ParseError {
+                            message: "Expected string literal after TIMESTAMP keyword".to_string(),
+                        })
+                    }
+                }
+            }
+            Token::Keyword(Keyword::Interval) => {
+                return self.parse_interval_literal();
+            }
             _ => None,
         };
         Ok(expr)
+    }
+
+    /// Parse INTERVAL literal: INTERVAL 'value' field [TO field]
+    fn parse_interval_literal(&mut self) -> Result<Option<Expression<'arena>>, ParseError> {
+        self.advance(); // consume INTERVAL keyword
+        match self.peek() {
+            Token::String(interval_str) => {
+                let value_str = interval_str.clone();
+                self.advance();
+
+                // Parse interval field (YEAR, MONTH, DAY, etc.)
+                let start_field = self.parse_interval_field()?;
+
+                // Check for TO (multi-field interval)
+                let interval_spec = if self.try_consume_keyword(Keyword::To) {
+                    let end_field = self.parse_interval_field()?;
+                    format!("{} {} TO {}", value_str, start_field, end_field)
+                } else {
+                    format!("{} {}", value_str, start_field)
+                };
+
+                // Parse the interval string into an Interval type
+                match interval_spec.parse::<vibesql_types::Interval>() {
+                    Ok(interval) => Ok(Some(Expression::Literal(SqlValue::Interval(interval)))),
+                    Err(e) => Err(ParseError {
+                        message: format!("Invalid INTERVAL literal: {}", e),
+                    }),
+                }
+            }
+            _ => Err(ParseError {
+                message: "Expected string literal after INTERVAL keyword".to_string(),
+            }),
+        }
+    }
+
+    /// Parse an interval field name (YEAR, MONTH, DAY, HOUR, MINUTE, SECOND).
+    fn parse_interval_field(&mut self) -> Result<String, ParseError> {
+        let field = match self.peek() {
+            Token::Identifier(field) => field.to_uppercase(),
+            Token::Keyword(Keyword::Year) => "YEAR".to_string(),
+            Token::Keyword(Keyword::Month) => "MONTH".to_string(),
+            Token::Keyword(Keyword::Day) => "DAY".to_string(),
+            Token::Keyword(Keyword::Hour) => "HOUR".to_string(),
+            Token::Keyword(Keyword::Minute) => "MINUTE".to_string(),
+            Token::Keyword(Keyword::Second) => "SECOND".to_string(),
+            _ => {
+                return Err(ParseError {
+                    message: "Expected interval field (YEAR, MONTH, DAY, HOUR, MINUTE, SECOND)"
+                        .to_string(),
+                })
+            }
+        };
+        self.advance();
+        Ok(field)
     }
 
     /// Parse EXISTS / NOT EXISTS.

--- a/crates/vibesql-parser/src/arena_parser/mod.rs
+++ b/crates/vibesql-parser/src/arena_parser/mod.rs
@@ -441,3 +441,104 @@ pub fn parse_expression_to_owned(input: &str) -> Result<vibesql_ast::Expression,
     let arena_expr = ArenaParser::parse_expression_sql(input, &arena)?;
     Ok(vibesql_ast::Expression::from(arena_expr))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibesql_ast::arena::Expression;
+    use vibesql_types::SqlValue;
+
+    #[test]
+    fn test_date_literal() {
+        let arena = Bump::new();
+        let expr = ArenaParser::parse_expression_sql("DATE '1998-12-01'", &arena).unwrap();
+        match expr {
+            Expression::Literal(SqlValue::Date(d)) => {
+                assert_eq!(d.year, 1998);
+                assert_eq!(d.month, 12);
+                assert_eq!(d.day, 1);
+            }
+            _ => panic!("Expected Date literal, got {:?}", expr),
+        }
+    }
+
+    #[test]
+    fn test_time_literal() {
+        let arena = Bump::new();
+        let expr = ArenaParser::parse_expression_sql("TIME '12:30:45'", &arena).unwrap();
+        match expr {
+            Expression::Literal(SqlValue::Time(t)) => {
+                assert_eq!(t.hour, 12);
+                assert_eq!(t.minute, 30);
+                assert_eq!(t.second, 45);
+            }
+            _ => panic!("Expected Time literal, got {:?}", expr),
+        }
+    }
+
+    #[test]
+    fn test_timestamp_literal() {
+        let arena = Bump::new();
+        let expr = ArenaParser::parse_expression_sql("TIMESTAMP '2024-01-15 10:30:00'", &arena).unwrap();
+        match expr {
+            Expression::Literal(SqlValue::Timestamp(ts)) => {
+                assert_eq!(ts.date.year, 2024);
+                assert_eq!(ts.date.month, 1);
+                assert_eq!(ts.date.day, 15);
+            }
+            _ => panic!("Expected Timestamp literal, got {:?}", expr),
+        }
+    }
+
+    #[test]
+    fn test_interval_literal() {
+        let arena = Bump::new();
+        let expr = ArenaParser::parse_expression_sql("INTERVAL '90' DAY", &arena).unwrap();
+        // Just verify it parses to an Interval type
+        assert!(matches!(expr, Expression::Literal(SqlValue::Interval(_))));
+    }
+
+    #[test]
+    fn test_date_minus_interval_expression() {
+        let arena = Bump::new();
+        let expr = ArenaParser::parse_expression_sql("DATE '1998-12-01' - INTERVAL '90' DAY", &arena).unwrap();
+        match expr {
+            Expression::BinaryOp { op, left, right } => {
+                assert_eq!(*op, vibesql_ast::BinaryOperator::Minus);
+                assert!(matches!(left, Expression::Literal(SqlValue::Date(_))));
+                assert!(matches!(right, Expression::Literal(SqlValue::Interval(_))));
+            }
+            _ => panic!("Expected BinaryOp, got {:?}", expr),
+        }
+    }
+
+    #[test]
+    fn test_tpch_q1_parses() {
+        let arena = Bump::new();
+        let sql = r#"SELECT
+            l_returnflag,
+            l_linestatus,
+            SUM(l_quantity) AS sum_qty,
+            SUM(l_extendedprice) AS sum_base_price,
+            SUM(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+            SUM(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+            AVG(l_quantity) AS avg_qty,
+            AVG(l_extendedprice) AS avg_price,
+            AVG(l_discount) AS avg_disc,
+            COUNT(*) AS count_order
+        FROM
+            lineitem
+        WHERE
+            l_shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY
+        GROUP BY
+            l_returnflag,
+            l_linestatus
+        ORDER BY
+            l_returnflag,
+            l_linestatus"#;
+
+        // This should parse successfully now with typed literal support
+        let result = ArenaParser::parse_sql(sql, &arena);
+        assert!(result.is_ok(), "TPC-H Q1 should parse successfully: {:?}", result.err());
+    }
+}


### PR DESCRIPTION
## Summary

- Add support for typed literals (DATE, TIME, TIMESTAMP, INTERVAL) to the arena parser
- This enables benchmarking TPC-H Q1 and other complex queries that use these constructs

## Changes

- Add `DATE 'string'`, `TIME 'string'`, `TIMESTAMP 'string'` parsing
- Add `INTERVAL 'string' FIELD` parsing with optional `TO FIELD` syntax
- Add comprehensive tests for typed literal parsing
- Update benchmark to include TPC-H Q1 in arena parser comparison

## Test plan

- [x] All 6 new typed literal tests pass
- [x] All 934 parser tests pass (no regressions)
- [x] Benchmark compiles and includes TPC-H Q1

Closes #3248

🤖 Generated with [Claude Code](https://claude.com/claude-code)