### PR TITLE
perf(tpcc): Add prefix_scan_first for early LIMIT termination

### DIFF
--- a/crates/vibesql-executor/benches/tpcc/schema.rs
+++ b/crates/vibesql-executor/benches/tpcc/schema.rs
@@ -359,9 +359,32 @@ fn create_tpcc_indexes_vibesql(db: &mut VibeDB) {
         }
     }
 
+    // Primary key indexes for core tables - TPC-C uses storage layer directly
+    // so we need to manually create these (normally auto-created by executor in #3202)
+    // The pk_new_order index enables prefix_scan_first optimization for Delivery (#3242)
+    db.create_index(
+        "pk_new_order".to_string(),
+        "new_order".to_string(),
+        true,
+        vec![col("no_w_id"), col("no_d_id"), col("no_o_id")],
+    ).ok();
+
+    db.create_index(
+        "pk_orders".to_string(),
+        "orders".to_string(),
+        true,
+        vec![col("o_w_id"), col("o_d_id"), col("o_id")],
+    ).ok();
+
+    db.create_index(
+        "pk_order_line".to_string(),
+        "order_line".to_string(),
+        true,
+        vec![col("ol_w_id"), col("ol_d_id"), col("ol_o_id"), col("ol_number")],
+    ).ok();
+
     // Secondary indexes for queries - these match the indexes created by
     // SQLite, DuckDB, and MySQL for fair benchmark comparison.
-    // Primary key indexes are now auto-created from PRIMARY KEY constraints (#3202).
     db.create_index(
         "idx_customer_name".to_string(),
         "customer".to_string(),

--- a/crates/vibesql-executor/src/select/executor/fast_path.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path.rs
@@ -339,6 +339,11 @@ impl SelectExecutor<'_> {
             return Ok(result);
         }
 
+        // Try PK prefix lookup with early LIMIT termination (TPC-C Delivery optimization)
+        if let Some(result) = self.try_pk_prefix_with_limit_fast(table_name, alias, stmt)? {
+            return Ok(result);
+        }
+
         // Try secondary index lookup path next
         if let Some(result) = self.try_secondary_index_lookup_fast(table_name, alias, stmt)? {
             return Ok(result);
@@ -471,6 +476,136 @@ impl SelectExecutor<'_> {
 
         // Apply projection
         let projected = self.apply_projection_fast(&stmt.select_list, rows, &schema)?;
+        Ok(Some(projected))
+    }
+
+    /// Try PK prefix lookup with early LIMIT termination
+    ///
+    /// This optimization handles queries like TPC-C Delivery:
+    /// `SELECT no_o_id FROM new_order WHERE no_w_id = 1 AND no_d_id = 5 ORDER BY no_o_id LIMIT 1`
+    ///
+    /// For tables with composite PK (no_w_id, no_d_id, no_o_id), this query:
+    /// 1. Filters by prefix of PK (no_w_id, no_d_id)
+    /// 2. Orders by the remaining PK column (no_o_id)
+    /// 3. Uses LIMIT 1
+    ///
+    /// The optimization uses prefix_scan_first to return just the first matching row,
+    /// avoiding the overhead of fetching all matching rows and sorting.
+    ///
+    /// # Performance
+    /// - Before: O(log n + k) to fetch all k matching rows, then sort, then take 1
+    /// - After: O(log n) to fetch just the first matching row (already sorted in index)
+    fn try_pk_prefix_with_limit_fast(
+        &self,
+        table_name: &str,
+        alias: Option<&String>,
+        stmt: &SelectStmt,
+    ) -> Result<Option<Vec<Row>>, ExecutorError> {
+        // Only applies when LIMIT 1 is specified (most common case for this pattern)
+        if stmt.limit != Some(1) {
+            return Ok(None);
+        }
+
+        // Must have an ORDER BY clause
+        let order_by = match &stmt.order_by {
+            Some(ob) if !ob.is_empty() => ob,
+            _ => return Ok(None),
+        };
+
+        // Must have a WHERE clause
+        let where_clause = match &stmt.where_clause {
+            Some(w) => w,
+            None => return Ok(None),
+        };
+
+        // Get the table
+        let table = match self.database.get_table(table_name) {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+
+        // Get primary key columns
+        let pk_column_names = match &table.schema.primary_key {
+            Some(cols) if cols.len() >= 2 => cols, // Need at least 2 columns for prefix pattern
+            _ => return Ok(None),
+        };
+
+        let pk_columns: Vec<&str> = pk_column_names.iter()
+            .map(|s| s.as_str())
+            .collect();
+
+        // Extract equality predicates from WHERE clause
+        let equality_values = self.extract_pk_values(where_clause, &pk_columns);
+
+        // Check if we have a prefix match (equality on first N-1 columns)
+        // For a 3-column PK (a, b, c), we need equality on (a, b) and ORDER BY c
+        let prefix_len = pk_columns.len() - 1;
+        if equality_values.len() != prefix_len {
+            return Ok(None);
+        }
+
+        // Verify we have equality values for the first N-1 columns (in order)
+        let mut prefix_key = Vec::with_capacity(prefix_len);
+        for col in pk_columns.iter().take(prefix_len) {
+            match equality_values.get(*col) {
+                Some(val) => prefix_key.push(val.clone()),
+                None => return Ok(None), // Missing a prefix column
+            }
+        }
+
+        // Verify ORDER BY is on the last PK column
+        let last_pk_col = pk_columns.last().unwrap();
+        let order_col = match &order_by[0].expr {
+            Expression::ColumnRef { column, .. } => column.as_str(),
+            _ => return Ok(None),
+        };
+
+        if !order_col.eq_ignore_ascii_case(last_pk_col) {
+            return Ok(None);
+        }
+
+        // For ASC order, prefix_scan_first gives us the minimum
+        // For DESC order, we would need prefix_scan_last (not implemented yet)
+        if order_by[0].direction != vibesql_ast::OrderDirection::Asc {
+            return Ok(None);
+        }
+
+        // Get PK index from database's index infrastructure (pk_{table_name})
+        let pk_index_name = format!("pk_{}", table_name);
+        let pk_index_data = match self.database.get_index_data(&pk_index_name) {
+            Some(idx) => idx,
+            None => return Ok(None),
+        };
+
+        // Use prefix_scan_first to get just the first matching row
+        let row_idx = match pk_index_data.prefix_scan_first(&prefix_key) {
+            Some(idx) => idx,
+            None => {
+                // No matching rows - return empty result
+                return Ok(Some(vec![]));
+            }
+        };
+
+        // Fetch the single row
+        let all_rows = table.scan();
+        let row = match all_rows.get(row_idx) {
+            Some(r) => r.clone(),
+            None => return Ok(Some(vec![])), // Invalid row index
+        };
+
+        // Build schema for projection
+        let effective_name = alias.cloned().unwrap_or_else(|| table_name.to_string());
+        let schema = CombinedSchema::from_table(effective_name, table.schema.clone());
+
+        // Apply projection
+        let is_select_star = stmt.select_list.len() == 1
+            && matches!(&stmt.select_list[0], SelectItem::Wildcard { .. });
+
+        if is_select_star {
+            return Ok(Some(vec![row]));
+        }
+
+        let projected = self.apply_projection_fast(&stmt.select_list, vec![row], &schema)?;
         Ok(Some(projected))
     }
 

--- a/crates/vibesql-storage/src/btree/node/btree_index/query.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/query.rs
@@ -175,6 +175,95 @@ impl BTreeIndex {
         Ok(result)
     }
 
+    /// Perform a range scan returning only the first matching row
+    ///
+    /// This is an optimized version of range_scan for queries with LIMIT 1.
+    /// It returns immediately after finding the first matching row instead of
+    /// collecting all rows in the range.
+    ///
+    /// # Arguments
+    /// * `start_key` - Optional lower bound key (None = start from beginning)
+    /// * `end_key` - Optional upper bound key (None = scan to end)
+    /// * `inclusive_start` - Whether start_key is inclusive
+    /// * `inclusive_end` - Whether end_key is inclusive
+    ///
+    /// # Returns
+    /// The first row_id in the range, or None if no matching rows
+    ///
+    /// # Performance
+    /// O(log n) - only finds the first leaf and returns immediately
+    ///
+    /// # Example
+    /// ```ignore
+    /// // TPC-C Delivery: find oldest new_order for a district
+    /// // Only returns the first (minimum) order ID
+    /// let first = index.range_scan_first(
+    ///     Some(&vec![w_id, d_id]),  // prefix start
+    ///     Some(&vec![w_id, d_id + 1]),  // prefix end
+    ///     true, false
+    /// )?;
+    /// ```
+    pub fn range_scan_first(
+        &self,
+        start_key: Option<&Key>,
+        end_key: Option<&Key>,
+        inclusive_start: bool,
+        inclusive_end: bool,
+    ) -> Result<Option<RowId>, StorageError> {
+        // Find starting point
+        let mut current_leaf = if let Some(start) = start_key {
+            let (leaf, _) = self.find_leaf_path(start)?;
+            leaf
+        } else {
+            self.find_leftmost_leaf()?
+        };
+
+        let mut started = start_key.is_none();
+
+        // Scan through leaves looking for first match
+        loop {
+            for (key, row_ids) in &current_leaf.entries {
+                // Check if we're past the end key
+                if let Some(end) = end_key {
+                    let cmp = key.cmp(end);
+                    if cmp == std::cmp::Ordering::Greater {
+                        return Ok(None);
+                    }
+                    if cmp == std::cmp::Ordering::Equal && !inclusive_end {
+                        return Ok(None);
+                    }
+                }
+
+                // Check if we're before the start key
+                if !started {
+                    if let Some(start) = start_key {
+                        let cmp = key.cmp(start);
+                        if cmp == std::cmp::Ordering::Less {
+                            continue;
+                        }
+                        if cmp == std::cmp::Ordering::Equal && !inclusive_start {
+                            continue;
+                        }
+                        started = true;
+                    }
+                }
+
+                // Found a key in range - return immediately
+                if let Some(&first_row) = row_ids.first() {
+                    return Ok(Some(first_row));
+                }
+            }
+
+            // Move to next leaf
+            if current_leaf.next_leaf == super::super::super::NULL_PAGE_ID {
+                break;
+            }
+            current_leaf = self.read_leaf_node(current_leaf.next_leaf)?;
+        }
+
+        Ok(None)
+    }
+
     /// Lookup multiple keys in the B+ tree (for IN predicates)
     ///
     /// # Arguments

--- a/crates/vibesql-storage/src/database/indexes/prefix_match.rs
+++ b/crates/vibesql-storage/src/database/indexes/prefix_match.rs
@@ -138,6 +138,83 @@ impl IndexData {
         }
     }
 
+    /// Lookup the first row matching a multi-column prefix in a composite index
+    ///
+    /// This is an optimized version of `prefix_scan` that returns only the first matching row.
+    /// For queries with `ORDER BY <remaining_pk_column> LIMIT 1`, this avoids fetching all
+    /// matching rows when we only need the minimum/first one.
+    ///
+    /// # Arguments
+    /// * `prefix` - Prefix values for the first N index columns (N < total columns)
+    ///
+    /// # Returns
+    /// The row index of the first matching row, or None if no match
+    ///
+    /// # Performance
+    /// O(log n) - only accesses the first matching entry in the BTreeMap range
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// // TPC-C Delivery: find oldest new_order for warehouse 1, district 5
+    /// // Index: (no_w_id, no_d_id, no_o_id)
+    /// // Returns the row with minimum no_o_id for the given warehouse/district
+    /// let first_row = index_data.prefix_scan_first(&[SqlValue::Integer(1), SqlValue::Integer(5)]);
+    /// ```
+    pub fn prefix_scan_first(&self, prefix: &[SqlValue]) -> Option<usize> {
+        if prefix.is_empty() {
+            // Empty prefix - return first row in index
+            return self.values().flatten().next();
+        }
+
+        // Normalize prefix values for consistent comparison
+        let normalized_prefix: Vec<SqlValue> = prefix.iter().map(normalize_for_comparison).collect();
+
+        match self {
+            IndexData::InMemory { data } => {
+                // Calculate upper bound by incrementing the last element of the prefix
+                let end_key = compute_prefix_upper_bound(&normalized_prefix);
+
+                let start_bound: Bound<&[SqlValue]> = Bound::Included(normalized_prefix.as_slice());
+                let end_bound: Bound<&[SqlValue]> = match end_key.as_ref() {
+                    Some(key) => Bound::Excluded(key.as_slice()),
+                    None => Bound::Unbounded,
+                };
+
+                // Get just the first matching entry
+                for (key_values, row_indices) in data.range::<[SqlValue], _>((start_bound, end_bound)) {
+                    // Verify prefix match (needed for Unbounded end bound case)
+                    if key_values.len() >= normalized_prefix.len()
+                        && key_values[..normalized_prefix.len()] == normalized_prefix[..]
+                    {
+                        // Return the first row index from this key
+                        return row_indices.first().copied();
+                    }
+                }
+
+                None
+            }
+            IndexData::DiskBacked { btree, .. } => {
+                // Calculate upper bound for disk-backed index
+                let end_key = compute_prefix_upper_bound(&normalized_prefix);
+
+                match acquire_btree_lock(btree) {
+                    Ok(guard) => guard
+                        .range_scan_first(
+                            Some(&normalized_prefix),
+                            end_key.as_ref(),
+                            true,  // Inclusive start
+                            false, // Exclusive end
+                        )
+                        .unwrap_or(None),
+                    Err(e) => {
+                        log::warn!("BTreeIndex lock acquisition failed in prefix_scan_first: {}", e);
+                        None
+                    }
+                }
+            }
+        }
+    }
+
     /// Batch prefix scan - look up multiple prefixes in a single call
     ///
     /// This method is optimized for batch prefix lookups where you need to retrieve
@@ -670,5 +747,64 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert!(results.contains(&0));
         assert!(results.contains(&1));
+    }
+
+    // ========================================================================
+    // prefix_scan_first() Tests - InMemory
+    // ========================================================================
+
+    #[test]
+    fn test_prefix_scan_first_basic() {
+        // Index on (w_id, d_id, o_id) - TPC-C style
+        let index = create_test_index_data(vec![
+            (vec![SqlValue::Integer(1), SqlValue::Integer(1), SqlValue::Integer(100)], vec![0]),
+            (vec![SqlValue::Integer(1), SqlValue::Integer(1), SqlValue::Integer(200)], vec![1]),
+            (vec![SqlValue::Integer(1), SqlValue::Integer(1), SqlValue::Integer(300)], vec![2]),
+            (vec![SqlValue::Integer(1), SqlValue::Integer(2), SqlValue::Integer(100)], vec![3]),
+        ]);
+
+        // Prefix [1, 1] should return first matching row (row 0)
+        let result = index.prefix_scan_first(&[SqlValue::Integer(1), SqlValue::Integer(1)]);
+        assert_eq!(result, Some(0));
+    }
+
+    #[test]
+    fn test_prefix_scan_first_no_match() {
+        let index = create_test_index_data(vec![
+            (vec![SqlValue::Integer(1), SqlValue::Integer(1), SqlValue::Integer(100)], vec![0]),
+        ]);
+
+        // Prefix [2, 1] should return None (no match)
+        let result = index.prefix_scan_first(&[SqlValue::Integer(2), SqlValue::Integer(1)]);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_prefix_scan_first_empty_prefix() {
+        let index = create_test_index_data(vec![
+            (vec![SqlValue::Integer(1)], vec![0]),
+            (vec![SqlValue::Integer(2)], vec![1]),
+        ]);
+
+        // Empty prefix should return first row in index
+        let result = index.prefix_scan_first(&[]);
+        assert_eq!(result, Some(0));
+    }
+
+    #[test]
+    fn test_prefix_scan_first_returns_minimum_third_column() {
+        // Index on (w_id, d_id, o_id)
+        // This tests the TPC-C Delivery query pattern:
+        // SELECT no_o_id FROM new_order WHERE no_w_id = 1 AND no_d_id = 5 ORDER BY no_o_id LIMIT 1
+        let index = create_test_index_data(vec![
+            (vec![SqlValue::Integer(1), SqlValue::Integer(5), SqlValue::Integer(300)], vec![3]),
+            (vec![SqlValue::Integer(1), SqlValue::Integer(5), SqlValue::Integer(100)], vec![1]),
+            (vec![SqlValue::Integer(1), SqlValue::Integer(5), SqlValue::Integer(200)], vec![2]),
+        ]);
+
+        // Prefix [1, 5] should return row with minimum o_id (100) = row 1
+        // BTreeMap stores in sorted order, so [1, 5, 100] comes first
+        let result = index.prefix_scan_first(&[SqlValue::Integer(1), SqlValue::Integer(5)]);
+        assert_eq!(result, Some(1)); // Row index for o_id=100
     }
 }


### PR DESCRIPTION
## Summary
- Add `prefix_scan_first` method that returns only the first matching row from a multi-column index prefix scan
- Add fast path optimization `try_pk_prefix_with_limit_fast` for queries with PK prefix + ORDER BY + LIMIT 1
- Create explicit PK indexes for TPC-C tables (new_order, orders, order_line) to enable the optimization

## Test plan
- [x] Added unit tests for `prefix_scan_first` (4 tests pass)
- [x] All existing fast_path tests pass (20 tests)
- [ ] Run TPC-C benchmark to verify Delivery transaction improvement

Closes #3242

🤖 Generated with [Claude Code](https://claude.com/claude-code)