### PR TITLE
perf(executor): Add arena-based prepared statement infrastructure (Phase 1)

### DIFF
--- a/crates/vibesql-executor/src/cache/prepared_statement/arena_prepared.rs
+++ b/crates/vibesql-executor/src/cache/prepared_statement/arena_prepared.rs
@@ -1,0 +1,583 @@
+//! Arena-based prepared statement for zero-allocation execution
+//!
+//! This module implements Option A from the arena parser optimization:
+//! storing the arena-allocated AST directly in the prepared statement,
+//! avoiding conversion overhead entirely for simple queries.
+//!
+//! # Key Benefits
+//!
+//! - **Zero conversion overhead**: Arena AST is used directly during execution
+//! - **Near-zero allocation**: Simple prepared queries avoid heap allocation
+//! - **Arena reuse**: Arena can be reset between executions for parameter binding
+//!
+//! # Safety
+//!
+//! This module uses careful unsafe code to manage self-referential data.
+//! The arena is pinned to prevent moves, and the statement pointer is valid
+//! as long as the arena exists.
+
+use std::collections::HashSet;
+use std::pin::Pin;
+
+use bumpalo::Bump;
+use vibesql_ast::arena::{Expression, SelectStmt};
+use vibesql_parser::arena_parser::ArenaParser;
+use vibesql_types::SqlValue;
+
+/// Arena-based prepared statement for zero-allocation execution.
+///
+/// This stores the parsed AST in an arena, keeping it alive for the lifetime
+/// of the prepared statement. This avoids conversion overhead for simple queries.
+///
+/// # Safety Invariants
+///
+/// 1. The arena is pinned and will not move after construction
+/// 2. The statement pointer is valid as long as the arena exists
+/// 3. The arena is only dropped when the ArenaPreparedStatement is dropped
+pub struct ArenaPreparedStatement {
+    /// Original SQL with placeholders
+    sql: String,
+    /// Arena containing the parsed statement (pinned to prevent moves)
+    arena: Pin<Box<Bump>>,
+    /// Pointer to the statement in the arena.
+    ///
+    /// SAFETY: This pointer is valid as long as `arena` is not dropped or reset.
+    /// Since ArenaPreparedStatement owns the arena and only drops it in Drop,
+    /// this pointer is always valid during the lifetime of the struct.
+    statement_ptr: *const SelectStmt<'static>,
+    /// Number of parameters expected (? placeholders)
+    param_count: usize,
+    /// Tables referenced by this statement (for cache invalidation)
+    tables: HashSet<String>,
+}
+
+// SAFETY: The arena and statement are not accessed from multiple threads.
+// The statement pointer is only dereferenced through &self methods.
+unsafe impl Send for ArenaPreparedStatement {}
+unsafe impl Sync for ArenaPreparedStatement {}
+
+impl ArenaPreparedStatement {
+    /// Create a new arena-based prepared statement from SQL.
+    ///
+    /// Parses the SQL using the arena parser and stores the result in an owned arena.
+    pub fn new(sql: String) -> Result<Self, ArenaParseError> {
+        // Create pinned arena (won't move)
+        let arena = Pin::new(Box::new(Bump::new()));
+
+        // Parse into arena
+        // We need to get a reference that lives as long as the arena
+        let stmt: &SelectStmt<'_> = ArenaParser::parse_sql(&sql, &arena)
+            .map_err(|e| ArenaParseError::ParseError(e.to_string()))?;
+
+        // Count placeholders and extract tables
+        let param_count = count_arena_placeholders(stmt);
+        let tables = extract_arena_tables(stmt);
+
+        // Store as raw pointer, erasing the lifetime.
+        // SAFETY: The arena is owned by this struct and won't be dropped
+        // while the statement exists. The pointer remains valid.
+        let statement_ptr = stmt as *const SelectStmt<'_> as *const SelectStmt<'static>;
+
+        Ok(Self {
+            sql,
+            arena,
+            statement_ptr,
+            param_count,
+            tables,
+        })
+    }
+
+    /// Get the original SQL.
+    pub fn sql(&self) -> &str {
+        &self.sql
+    }
+
+    /// Get a reference to the arena-allocated statement.
+    ///
+    /// The returned reference is valid for the lifetime of this struct.
+    pub fn statement(&self) -> &SelectStmt<'_> {
+        // SAFETY: The pointer is valid as documented in the struct invariants.
+        // We're returning a reference tied to self's lifetime, which is correct.
+        unsafe { &*self.statement_ptr }
+    }
+
+    /// Get the number of parameters expected.
+    pub fn param_count(&self) -> usize {
+        self.param_count
+    }
+
+    /// Get the tables referenced by this statement.
+    pub fn tables(&self) -> &HashSet<String> {
+        &self.tables
+    }
+
+    /// Get a reference to the arena for additional allocations.
+    ///
+    /// This can be used for allocating bound values during execution.
+    pub fn arena(&self) -> &Bump {
+        &self.arena
+    }
+
+    /// Validate that the correct number of parameters is provided.
+    pub fn validate_params(&self, params: &[SqlValue]) -> Result<(), ArenaBindError> {
+        if params.len() != self.param_count {
+            return Err(ArenaBindError::ParameterCountMismatch {
+                expected: self.param_count,
+                actual: params.len(),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for ArenaPreparedStatement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ArenaPreparedStatement")
+            .field("sql", &self.sql)
+            .field("param_count", &self.param_count)
+            .field("tables", &self.tables)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Error during arena-based parsing.
+#[derive(Debug, Clone)]
+pub enum ArenaParseError {
+    /// SQL parsing failed
+    ParseError(String),
+    /// Unsupported statement type (only SELECT is supported)
+    UnsupportedStatement(String),
+}
+
+impl std::fmt::Display for ArenaParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArenaParseError::ParseError(msg) => write!(f, "Parse error: {}", msg),
+            ArenaParseError::UnsupportedStatement(msg) => {
+                write!(f, "Unsupported statement: {}", msg)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ArenaParseError {}
+
+/// Error during arena-based parameter binding.
+#[derive(Debug, Clone)]
+pub enum ArenaBindError {
+    /// Wrong number of parameters provided
+    ParameterCountMismatch { expected: usize, actual: usize },
+}
+
+impl std::fmt::Display for ArenaBindError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArenaBindError::ParameterCountMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "Parameter count mismatch: expected {}, got {}",
+                    expected, actual
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ArenaBindError {}
+
+/// Count the number of placeholder parameters in an arena statement.
+fn count_arena_placeholders(stmt: &SelectStmt<'_>) -> usize {
+    let mut count = 0;
+    visit_arena_statement(stmt, &mut |expr| {
+        if matches!(expr, Expression::Placeholder(_)) {
+            count += 1;
+        }
+    });
+    count
+}
+
+/// Extract table names from an arena statement.
+fn extract_arena_tables(stmt: &SelectStmt<'_>) -> HashSet<String> {
+    let mut tables = HashSet::new();
+    visit_arena_from_clause(stmt.from.as_ref(), &mut tables);
+    tables
+}
+
+/// Visit all expressions in an arena statement.
+fn visit_arena_statement<F>(stmt: &SelectStmt<'_>, visitor: &mut F)
+where
+    F: FnMut(&Expression<'_>),
+{
+    // Visit CTEs
+    if let Some(ctes) = &stmt.with_clause {
+        for cte in ctes.iter() {
+            visit_arena_statement(cte.query, visitor);
+        }
+    }
+
+    // Visit select items
+    for item in stmt.select_list.iter() {
+        if let vibesql_ast::arena::SelectItem::Expression { expr, .. } = item {
+            visit_arena_expression(expr, visitor);
+        }
+    }
+
+    // Visit FROM clause
+    if let Some(from) = &stmt.from {
+        visit_arena_from_clause_exprs(from, visitor);
+    }
+
+    // Visit WHERE
+    if let Some(where_clause) = &stmt.where_clause {
+        visit_arena_expression(where_clause, visitor);
+    }
+
+    // Visit GROUP BY
+    if let Some(group_by) = &stmt.group_by {
+        visit_arena_group_by(group_by, visitor);
+    }
+
+    // Visit HAVING
+    if let Some(having) = &stmt.having {
+        visit_arena_expression(having, visitor);
+    }
+
+    // Visit ORDER BY
+    if let Some(order_by) = &stmt.order_by {
+        for item in order_by.iter() {
+            visit_arena_expression(&item.expr, visitor);
+        }
+    }
+
+    // Visit set operation
+    if let Some(set_op) = &stmt.set_operation {
+        visit_arena_statement(set_op.right, visitor);
+    }
+}
+
+/// Visit expressions in a FROM clause.
+fn visit_arena_from_clause_exprs<F>(from: &vibesql_ast::arena::FromClause<'_>, visitor: &mut F)
+where
+    F: FnMut(&Expression<'_>),
+{
+    match from {
+        vibesql_ast::arena::FromClause::Table { .. } => {}
+        vibesql_ast::arena::FromClause::Subquery { query, .. } => {
+            visit_arena_statement(query, visitor);
+        }
+        vibesql_ast::arena::FromClause::Join {
+            left,
+            right,
+            condition,
+            ..
+        } => {
+            visit_arena_from_clause_exprs(left, visitor);
+            visit_arena_from_clause_exprs(right, visitor);
+            if let Some(cond) = condition {
+                visit_arena_expression(cond, visitor);
+            }
+        }
+    }
+}
+
+/// Extract table names from a FROM clause.
+fn visit_arena_from_clause(from: Option<&vibesql_ast::arena::FromClause<'_>>, tables: &mut HashSet<String>) {
+    let Some(from) = from else { return };
+
+    match from {
+        vibesql_ast::arena::FromClause::Table { name, .. } => {
+            tables.insert(name.to_string());
+        }
+        vibesql_ast::arena::FromClause::Subquery { query, .. } => {
+            visit_arena_from_clause(query.from.as_ref(), tables);
+        }
+        vibesql_ast::arena::FromClause::Join { left, right, .. } => {
+            visit_arena_from_clause(Some(left), tables);
+            visit_arena_from_clause(Some(right), tables);
+        }
+    }
+}
+
+/// Visit GROUP BY clause expressions.
+fn visit_arena_group_by<F>(group_by: &vibesql_ast::arena::GroupByClause<'_>, visitor: &mut F)
+where
+    F: FnMut(&Expression<'_>),
+{
+    use vibesql_ast::arena::GroupByClause;
+    match group_by {
+        GroupByClause::Simple(exprs) => {
+            for expr in exprs.iter() {
+                visit_arena_expression(expr, visitor);
+            }
+        }
+        GroupByClause::Rollup(elements) | GroupByClause::Cube(elements) => {
+            for element in elements.iter() {
+                match element {
+                    vibesql_ast::arena::GroupingElement::Single(expr) => {
+                        visit_arena_expression(expr, visitor);
+                    }
+                    vibesql_ast::arena::GroupingElement::Composite(exprs) => {
+                        for expr in exprs.iter() {
+                            visit_arena_expression(expr, visitor);
+                        }
+                    }
+                }
+            }
+        }
+        GroupByClause::GroupingSets(sets) => {
+            for set in sets.iter() {
+                for expr in set.columns.iter() {
+                    visit_arena_expression(expr, visitor);
+                }
+            }
+        }
+        GroupByClause::Mixed(items) => {
+            for item in items.iter() {
+                match item {
+                    vibesql_ast::arena::MixedGroupingItem::Simple(expr) => {
+                        visit_arena_expression(expr, visitor);
+                    }
+                    vibesql_ast::arena::MixedGroupingItem::Rollup(elements)
+                    | vibesql_ast::arena::MixedGroupingItem::Cube(elements) => {
+                        for element in elements.iter() {
+                            match element {
+                                vibesql_ast::arena::GroupingElement::Single(expr) => {
+                                    visit_arena_expression(expr, visitor);
+                                }
+                                vibesql_ast::arena::GroupingElement::Composite(exprs) => {
+                                    for expr in exprs.iter() {
+                                        visit_arena_expression(expr, visitor);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    vibesql_ast::arena::MixedGroupingItem::GroupingSets(sets) => {
+                        for set in sets.iter() {
+                            for expr in set.columns.iter() {
+                                visit_arena_expression(expr, visitor);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Visit all expressions in an arena expression tree.
+fn visit_arena_expression<F>(expr: &Expression<'_>, visitor: &mut F)
+where
+    F: FnMut(&Expression<'_>),
+{
+    visitor(expr);
+
+    match expr {
+        Expression::BinaryOp { left, right, .. } => {
+            visit_arena_expression(left, visitor);
+            visit_arena_expression(right, visitor);
+        }
+        Expression::UnaryOp { expr: inner, .. } => {
+            visit_arena_expression(inner, visitor);
+        }
+        Expression::Function { args, .. } | Expression::AggregateFunction { args, .. } => {
+            for arg in args.iter() {
+                visit_arena_expression(arg, visitor);
+            }
+        }
+        Expression::IsNull { expr: inner, .. } => {
+            visit_arena_expression(inner, visitor);
+        }
+        Expression::Case {
+            operand,
+            when_clauses,
+            else_result,
+        } => {
+            if let Some(op) = operand {
+                visit_arena_expression(op, visitor);
+            }
+            for w in when_clauses.iter() {
+                for c in w.conditions.iter() {
+                    visit_arena_expression(c, visitor);
+                }
+                visit_arena_expression(&w.result, visitor);
+            }
+            if let Some(e) = else_result {
+                visit_arena_expression(e, visitor);
+            }
+        }
+        Expression::ScalarSubquery(select) => visit_arena_statement(select, visitor),
+        Expression::In {
+            expr: inner,
+            subquery,
+            ..
+        } => {
+            visit_arena_expression(inner, visitor);
+            visit_arena_statement(subquery, visitor);
+        }
+        Expression::InList {
+            expr: inner,
+            values,
+            ..
+        } => {
+            visit_arena_expression(inner, visitor);
+            for v in values.iter() {
+                visit_arena_expression(v, visitor);
+            }
+        }
+        Expression::Between {
+            expr: inner,
+            low,
+            high,
+            ..
+        } => {
+            visit_arena_expression(inner, visitor);
+            visit_arena_expression(low, visitor);
+            visit_arena_expression(high, visitor);
+        }
+        Expression::Cast { expr: inner, .. } => {
+            visit_arena_expression(inner, visitor);
+        }
+        Expression::Position {
+            substring, string, ..
+        } => {
+            visit_arena_expression(substring, visitor);
+            visit_arena_expression(string, visitor);
+        }
+        Expression::Trim {
+            removal_char,
+            string,
+            ..
+        } => {
+            if let Some(c) = removal_char {
+                visit_arena_expression(c, visitor);
+            }
+            visit_arena_expression(string, visitor);
+        }
+        Expression::Extract { expr: inner, .. } => {
+            visit_arena_expression(inner, visitor);
+        }
+        Expression::Like {
+            expr: inner,
+            pattern,
+            ..
+        } => {
+            visit_arena_expression(inner, visitor);
+            visit_arena_expression(pattern, visitor);
+        }
+        Expression::Exists { subquery, .. } => {
+            visit_arena_statement(subquery, visitor);
+        }
+        Expression::QuantifiedComparison {
+            expr: inner,
+            subquery,
+            ..
+        } => {
+            visit_arena_expression(inner, visitor);
+            visit_arena_statement(subquery, visitor);
+        }
+        Expression::Interval { value, .. } => {
+            visit_arena_expression(value, visitor);
+        }
+        Expression::WindowFunction { function, over } => {
+            match function {
+                vibesql_ast::arena::WindowFunctionSpec::Aggregate { args, .. }
+                | vibesql_ast::arena::WindowFunctionSpec::Ranking { args, .. }
+                | vibesql_ast::arena::WindowFunctionSpec::Value { args, .. } => {
+                    for arg in args.iter() {
+                        visit_arena_expression(arg, visitor);
+                    }
+                }
+            }
+            if let Some(partition_by) = &over.partition_by {
+                for expr in partition_by.iter() {
+                    visit_arena_expression(expr, visitor);
+                }
+            }
+            if let Some(order_by) = &over.order_by {
+                for item in order_by.iter() {
+                    visit_arena_expression(&item.expr, visitor);
+                }
+            }
+        }
+        Expression::MatchAgainst { search_modifier, .. } => {
+            visit_arena_expression(search_modifier, visitor);
+        }
+        // Leaf nodes - no recursion needed
+        Expression::Literal(_)
+        | Expression::Placeholder(_)
+        | Expression::NumberedPlaceholder(_)
+        | Expression::NamedPlaceholder(_)
+        | Expression::ColumnRef { .. }
+        | Expression::Wildcard
+        | Expression::CurrentDate
+        | Expression::CurrentTime { .. }
+        | Expression::CurrentTimestamp { .. }
+        | Expression::Default
+        | Expression::DuplicateKeyValue { .. }
+        | Expression::NextValue { .. }
+        | Expression::PseudoVariable { .. }
+        | Expression::SessionVariable { .. } => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_arena_prepared_basic() {
+        let sql = "SELECT id, name FROM users WHERE id = 1";
+        let prepared = ArenaPreparedStatement::new(sql.to_string()).unwrap();
+
+        assert_eq!(prepared.sql(), sql);
+        assert_eq!(prepared.param_count(), 0);
+        // Arena parser stores table names in uppercase
+        assert!(prepared.tables().contains("USERS"),
+            "Expected 'USERS' in tables {:?}", prepared.tables());
+    }
+
+    #[test]
+    fn test_arena_prepared_with_placeholder() {
+        let sql = "SELECT * FROM users WHERE id = ?";
+        let prepared = ArenaPreparedStatement::new(sql.to_string()).unwrap();
+
+        assert_eq!(prepared.param_count(), 1);
+        // Arena parser stores table names in uppercase
+        assert!(prepared.tables().contains("USERS"));
+    }
+
+    #[test]
+    fn test_arena_prepared_multiple_placeholders() {
+        let sql = "SELECT * FROM users WHERE id = ? AND name = ? AND age > ?";
+        let prepared = ArenaPreparedStatement::new(sql.to_string()).unwrap();
+
+        assert_eq!(prepared.param_count(), 3);
+    }
+
+    #[test]
+    fn test_arena_prepared_param_validation() {
+        let sql = "SELECT * FROM users WHERE id = ?";
+        let prepared = ArenaPreparedStatement::new(sql.to_string()).unwrap();
+
+        // Correct param count should pass
+        assert!(prepared.validate_params(&[SqlValue::Integer(1)]).is_ok());
+
+        // Wrong param count should fail
+        assert!(prepared.validate_params(&[]).is_err());
+        assert!(prepared
+            .validate_params(&[SqlValue::Integer(1), SqlValue::Integer(2)])
+            .is_err());
+    }
+
+    #[test]
+    fn test_arena_prepared_join_tables() {
+        let sql = "SELECT u.id FROM users u JOIN orders o ON u.id = o.user_id";
+        let prepared = ArenaPreparedStatement::new(sql.to_string()).unwrap();
+
+        let tables = prepared.tables();
+        // Arena parser stores table names in uppercase
+        assert!(tables.contains("USERS"), "Expected 'USERS' in {:?}", tables);
+        assert!(tables.contains("ORDERS"), "Expected 'ORDERS' in {:?}", tables);
+    }
+}

--- a/crates/vibesql-executor/src/cache/prepared_statement/mod.rs
+++ b/crates/vibesql-executor/src/cache/prepared_statement/mod.rs
@@ -33,6 +33,7 @@ use vibesql_types::SqlValue;
 
 use super::{extract_tables_from_statement, QuerySignature};
 
+pub mod arena_prepared;
 mod bind;
 pub mod plan;
 

--- a/crates/vibesql-executor/src/evaluator/arena_eval.rs
+++ b/crates/vibesql-executor/src/evaluator/arena_eval.rs
@@ -1,0 +1,668 @@
+//! Arena-aware expression evaluation for prepared statements.
+//!
+//! This module provides evaluation of arena-allocated expressions with inline
+//! placeholder resolution, eliminating the need to convert arena AST to owned
+//! AST before evaluation.
+//!
+//! # Key Benefits
+//!
+//! - **Zero conversion overhead**: Arena expressions are evaluated directly
+//! - **Inline placeholder resolution**: Placeholders are resolved from params during eval
+//! - **Near-zero allocation**: Only the final result values are heap-allocated
+//!
+//! # Usage
+//!
+//! ```ignore
+//! let evaluator = ArenaExpressionEvaluator::new(schema, &params);
+//! let result = evaluator.eval(expr, row)?;
+//! ```
+
+use vibesql_ast::arena::Expression;
+use vibesql_ast::BinaryOperator;
+use vibesql_catalog::TableSchema;
+use vibesql_storage::{Database, Row};
+use vibesql_types::SqlValue;
+
+use crate::errors::ExecutorError;
+
+/// Evaluates arena-allocated expressions with inline placeholder resolution.
+///
+/// This evaluator is designed for prepared statement execution where:
+/// 1. The statement is stored as arena-allocated AST
+/// 2. Parameters are provided at execution time
+/// 3. Placeholders are resolved inline during evaluation (no AST cloning)
+pub struct ArenaExpressionEvaluator<'a, 'params> {
+    /// Schema of the current table
+    schema: &'a TableSchema,
+    /// Bound parameter values for placeholder resolution
+    params: &'params [SqlValue],
+    /// Database reference for subqueries
+    database: Option<&'a Database>,
+    /// Current depth in expression tree (stack overflow protection)
+    depth: usize,
+}
+
+impl<'a, 'params> ArenaExpressionEvaluator<'a, 'params> {
+    /// Create a new arena expression evaluator.
+    pub fn new(schema: &'a TableSchema, params: &'params [SqlValue]) -> Self {
+        Self {
+            schema,
+            params,
+            database: None,
+            depth: 0,
+        }
+    }
+
+    /// Create an evaluator with database reference for subqueries.
+    pub fn with_database(
+        schema: &'a TableSchema,
+        params: &'params [SqlValue],
+        database: &'a Database,
+    ) -> Self {
+        Self {
+            schema,
+            params,
+            database: Some(database),
+            depth: 0,
+        }
+    }
+
+    /// Evaluate an arena expression in the context of a row.
+    ///
+    /// This method handles all expression types including placeholders,
+    /// which are resolved inline from the params slice.
+    #[inline]
+    pub fn eval<'arena>(
+        &self,
+        expr: &Expression<'arena>,
+        row: &Row,
+    ) -> Result<SqlValue, ExecutorError> {
+        // Check depth limit
+        if self.depth >= crate::limits::MAX_EXPRESSION_DEPTH {
+            return Err(ExecutorError::ExpressionDepthExceeded {
+                depth: self.depth,
+                max_depth: crate::limits::MAX_EXPRESSION_DEPTH,
+            });
+        }
+
+        self.eval_impl(expr, row)
+    }
+
+    /// Internal implementation of eval.
+    fn eval_impl<'arena>(
+        &self,
+        expr: &Expression<'arena>,
+        row: &Row,
+    ) -> Result<SqlValue, ExecutorError> {
+        match expr {
+            // Literals - just return the value
+            Expression::Literal(val) => Ok(val.clone()),
+
+            // PLACEHOLDER RESOLUTION - the key benefit of arena evaluation
+            // Instead of returning an error, resolve from params slice
+            Expression::Placeholder(idx) => {
+                if *idx < self.params.len() {
+                    Ok(self.params[*idx].clone())
+                } else {
+                    Err(ExecutorError::UnsupportedExpression(format!(
+                        "Placeholder index {} out of bounds (params len: {})",
+                        idx,
+                        self.params.len()
+                    )))
+                }
+            }
+
+            // Numbered placeholders ($1, $2, etc.) - 1-indexed
+            Expression::NumberedPlaceholder(idx) => {
+                let array_idx = idx.saturating_sub(1);
+                if array_idx < self.params.len() {
+                    Ok(self.params[array_idx].clone())
+                } else {
+                    Err(ExecutorError::UnsupportedExpression(format!(
+                        "Numbered placeholder ${} out of bounds (params len: {})",
+                        idx,
+                        self.params.len()
+                    )))
+                }
+            }
+
+            // Named placeholders - not supported in positional binding
+            Expression::NamedPlaceholder(name) => Err(ExecutorError::UnsupportedExpression(
+                format!("Named placeholder :{} requires named binding", name),
+            )),
+
+            // Column reference
+            Expression::ColumnRef { table, column } => {
+                self.eval_column_ref(table.as_deref(), column, row)
+            }
+
+            // Binary operations
+            Expression::BinaryOp { left, op, right } => {
+                // Short-circuit evaluation for AND/OR
+                match op {
+                    BinaryOperator::And => {
+                        let left_val = self.with_depth().eval(left, row)?;
+                        match left_val {
+                            SqlValue::Boolean(false) => Ok(SqlValue::Boolean(false)),
+                            _ => {
+                                let right_val = self.with_depth().eval(right, row)?;
+                                // NULL AND FALSE = FALSE
+                                if matches!(left_val, SqlValue::Null)
+                                    && matches!(right_val, SqlValue::Boolean(false))
+                                {
+                                    return Ok(SqlValue::Boolean(false));
+                                }
+                                self.eval_binary_op(&left_val, op, &right_val)
+                            }
+                        }
+                    }
+                    BinaryOperator::Or => {
+                        let left_val = self.with_depth().eval(left, row)?;
+                        match left_val {
+                            SqlValue::Boolean(true) => Ok(SqlValue::Boolean(true)),
+                            _ => {
+                                let right_val = self.with_depth().eval(right, row)?;
+                                // NULL OR TRUE = TRUE
+                                if matches!(left_val, SqlValue::Null)
+                                    && matches!(right_val, SqlValue::Boolean(true))
+                                {
+                                    return Ok(SqlValue::Boolean(true));
+                                }
+                                self.eval_binary_op(&left_val, op, &right_val)
+                            }
+                        }
+                    }
+                    _ => {
+                        let left_val = self.with_depth().eval(left, row)?;
+                        let right_val = self.with_depth().eval(right, row)?;
+                        self.eval_binary_op(&left_val, op, &right_val)
+                    }
+                }
+            }
+
+            // Unary operations
+            Expression::UnaryOp { op, expr: inner } => {
+                let val = self.with_depth().eval(inner, row)?;
+                crate::evaluator::eval_unary_op(op, &val)
+            }
+
+            // IS NULL / IS NOT NULL
+            Expression::IsNull { expr: inner, negated } => {
+                let value = self.with_depth().eval(inner, row)?;
+                let is_null = matches!(value, SqlValue::Null);
+                let result = if *negated { !is_null } else { is_null };
+                Ok(SqlValue::Boolean(result))
+            }
+
+            // IN list
+            Expression::InList {
+                expr: inner,
+                values,
+                negated,
+            } => {
+                let val = self.with_depth().eval(inner, row)?;
+
+                // Check if value matches any in list
+                for list_val_expr in values.iter() {
+                    let list_val = self.with_depth().eval(list_val_expr, row)?;
+                    if super::core::values_are_equal(&val, &list_val) {
+                        return Ok(SqlValue::Boolean(!*negated));
+                    }
+                }
+
+                // Value not found in list
+                Ok(SqlValue::Boolean(*negated))
+            }
+
+            // BETWEEN predicate
+            Expression::Between {
+                expr: inner,
+                low,
+                high,
+                negated,
+                symmetric,
+            } => {
+                let expr_val = self.with_depth().eval(inner, row)?;
+                let low_val = self.with_depth().eval(low, row)?;
+                let high_val = self.with_depth().eval(high, row)?;
+
+                let sql_mode = self
+                    .database
+                    .map(|db| db.sql_mode())
+                    .unwrap_or_default();
+
+                super::core::eval_between_static(
+                    &expr_val, &low_val, &high_val, *negated, *symmetric, sql_mode,
+                )
+            }
+
+            // LIKE pattern matching
+            Expression::Like {
+                expr: inner,
+                pattern,
+                negated,
+            } => {
+                let val = self.with_depth().eval(inner, row)?;
+                let pattern_val = self.with_depth().eval(pattern, row)?;
+
+                let val_str = match &val {
+                    SqlValue::Varchar(s) | SqlValue::Character(s) => s.as_str(),
+                    SqlValue::Null => return Ok(SqlValue::Null),
+                    _ => return Ok(SqlValue::Boolean(*negated)),
+                };
+
+                let pattern_str = match &pattern_val {
+                    SqlValue::Varchar(s) | SqlValue::Character(s) => s.as_str(),
+                    SqlValue::Null => return Ok(SqlValue::Null),
+                    _ => return Ok(SqlValue::Boolean(*negated)),
+                };
+
+                let matches = super::pattern::like_match(val_str, pattern_str);
+                Ok(SqlValue::Boolean(if *negated { !matches } else { matches }))
+            }
+
+            // CAST expression
+            Expression::Cast { expr: inner, data_type } => {
+                let val = self.with_depth().eval(inner, row)?;
+                let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
+                super::casting::cast_value(&val, data_type, &sql_mode)
+            }
+
+            // Current date/time
+            Expression::CurrentDate => {
+                let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
+                super::functions::eval_scalar_function("CURRENT_DATE", &[], &None, &sql_mode)
+            }
+
+            Expression::CurrentTime { .. } => {
+                let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
+                super::functions::eval_scalar_function("CURRENT_TIME", &[], &None, &sql_mode)
+            }
+
+            Expression::CurrentTimestamp { .. } => {
+                let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
+                super::functions::eval_scalar_function("CURRENT_TIMESTAMP", &[], &None, &sql_mode)
+            }
+
+            // Function calls
+            Expression::Function { name, args, character_unit } => {
+                // Evaluate all arguments
+                let mut arg_values = Vec::with_capacity(args.len());
+                for arg in args.iter() {
+                    arg_values.push(self.with_depth().eval(arg, row)?);
+                }
+
+                let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
+
+                // Convert character_unit to the owned type
+                let owned_char_unit = character_unit.map(|cu| match cu {
+                    vibesql_ast::arena::CharacterUnit::Characters => {
+                        vibesql_ast::CharacterUnit::Characters
+                    }
+                    vibesql_ast::arena::CharacterUnit::Octets => vibesql_ast::CharacterUnit::Octets,
+                });
+
+                super::functions::eval_scalar_function(name, &arg_values, &owned_char_unit, &sql_mode)
+            }
+
+            // CASE expression
+            Expression::Case {
+                operand,
+                when_clauses,
+                else_result,
+            } => self.eval_case(operand, when_clauses, else_result, row),
+
+            // Wildcard not supported in expressions
+            Expression::Wildcard => Err(ExecutorError::UnsupportedExpression(
+                "Wildcard (*) not supported in expressions".to_string(),
+            )),
+
+            // DEFAULT keyword
+            Expression::Default => Err(ExecutorError::UnsupportedExpression(
+                "DEFAULT keyword is only valid in INSERT VALUES and UPDATE SET clauses".to_string(),
+            )),
+
+            // Aggregate functions need special handling
+            Expression::AggregateFunction { .. } => Err(ExecutorError::UnsupportedExpression(
+                "Aggregate functions should be evaluated in aggregation context".to_string(),
+            )),
+
+            // Window functions need special handling
+            Expression::WindowFunction { .. } => Err(ExecutorError::UnsupportedExpression(
+                "Window functions should be evaluated separately".to_string(),
+            )),
+
+            // Subqueries - need full executor context
+            Expression::ScalarSubquery(_) => Err(ExecutorError::UnsupportedExpression(
+                "Scalar subqueries not yet supported in arena evaluation".to_string(),
+            )),
+
+            Expression::In { .. } => Err(ExecutorError::UnsupportedExpression(
+                "IN subqueries not yet supported in arena evaluation".to_string(),
+            )),
+
+            Expression::Exists { .. } => Err(ExecutorError::UnsupportedExpression(
+                "EXISTS subqueries not yet supported in arena evaluation".to_string(),
+            )),
+
+            Expression::QuantifiedComparison { .. } => Err(ExecutorError::UnsupportedExpression(
+                "Quantified comparisons not yet supported in arena evaluation".to_string(),
+            )),
+
+            // Other unsupported expressions
+            Expression::Position { .. }
+            | Expression::Trim { .. }
+            | Expression::Extract { .. }
+            | Expression::Interval { .. }
+            | Expression::DuplicateKeyValue { .. }
+            | Expression::NextValue { .. }
+            | Expression::MatchAgainst { .. }
+            | Expression::PseudoVariable { .. }
+            | Expression::SessionVariable { .. } => Err(ExecutorError::UnsupportedExpression(
+                "Expression type not yet supported in arena evaluation".to_string(),
+            )),
+        }
+    }
+
+    /// Evaluate a binary operation.
+    fn eval_binary_op(
+        &self,
+        left: &SqlValue,
+        op: &BinaryOperator,
+        right: &SqlValue,
+    ) -> Result<SqlValue, ExecutorError> {
+        let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
+        super::core::eval_binary_op_static(left, op, right, sql_mode)
+    }
+
+    /// Evaluate column reference.
+    fn eval_column_ref(
+        &self,
+        _table_qualifier: Option<&str>,
+        column: &str,
+        row: &Row,
+    ) -> Result<SqlValue, ExecutorError> {
+        // Special case: "*" wildcard
+        if column == "*" {
+            return Ok(SqlValue::Null);
+        }
+
+        // Look up column in schema
+        if let Some(col_index) = self.schema.get_column_index(column) {
+            row.get(col_index)
+                .cloned()
+                .ok_or(ExecutorError::ColumnIndexOutOfBounds { index: col_index })
+        } else {
+            Err(ExecutorError::ColumnNotFound {
+                column_name: column.to_string(),
+                table_name: self.schema.name.clone(),
+                searched_tables: vec![self.schema.name.clone()],
+                available_columns: self.schema.columns.iter().map(|c| c.name.clone()).collect(),
+            })
+        }
+    }
+
+    /// Evaluate a CASE expression.
+    fn eval_case<'arena>(
+        &self,
+        operand: &Option<&'arena Expression<'arena>>,
+        when_clauses: &bumpalo::collections::Vec<'arena, vibesql_ast::arena::CaseWhen<'arena>>,
+        else_result: &Option<&'arena Expression<'arena>>,
+        row: &Row,
+    ) -> Result<SqlValue, ExecutorError> {
+        // Simple CASE vs searched CASE
+        if let Some(operand_expr) = operand {
+            // Simple CASE: CASE expr WHEN val1 THEN ... WHEN val2 THEN ... END
+            let operand_val = self.with_depth().eval(operand_expr, row)?;
+
+            for when in when_clauses.iter() {
+                for condition in when.conditions.iter() {
+                    let when_val = self.with_depth().eval(condition, row)?;
+                    if super::core::values_are_equal(&operand_val, &when_val) {
+                        return self.with_depth().eval(&when.result, row);
+                    }
+                }
+            }
+        } else {
+            // Searched CASE: CASE WHEN cond1 THEN ... WHEN cond2 THEN ... END
+            for when in when_clauses.iter() {
+                for condition in when.conditions.iter() {
+                    let cond_val = self.with_depth().eval(condition, row)?;
+                    if matches!(cond_val, SqlValue::Boolean(true)) {
+                        return self.with_depth().eval(&when.result, row);
+                    }
+                }
+            }
+        }
+
+        // No match - return ELSE or NULL
+        if let Some(else_expr) = else_result {
+            self.with_depth().eval(else_expr, row)
+        } else {
+            Ok(SqlValue::Null)
+        }
+    }
+
+    /// Create a new evaluator with incremented depth.
+    fn with_depth(&self) -> Self {
+        Self {
+            schema: self.schema,
+            params: self.params,
+            database: self.database,
+            depth: self.depth + 1,
+        }
+    }
+}
+
+/// Evaluate a WHERE clause from an arena statement.
+///
+/// Returns true if the row passes the filter.
+pub fn eval_arena_where_clause<'arena>(
+    where_clause: Option<&Expression<'arena>>,
+    schema: &TableSchema,
+    params: &[SqlValue],
+    row: &Row,
+    database: Option<&Database>,
+) -> Result<bool, ExecutorError> {
+    let Some(expr) = where_clause else {
+        return Ok(true); // No WHERE clause = all rows pass
+    };
+
+    let evaluator = if let Some(db) = database {
+        ArenaExpressionEvaluator::with_database(schema, params, db)
+    } else {
+        ArenaExpressionEvaluator::new(schema, params)
+    };
+
+    match evaluator.eval(expr, row)? {
+        SqlValue::Boolean(b) => Ok(b),
+        SqlValue::Null => Ok(false), // NULL in WHERE means row doesn't match
+        other => Err(ExecutorError::UnsupportedExpression(format!(
+            "WHERE clause must evaluate to BOOLEAN, got {:?}",
+            other
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bumpalo::Bump;
+    use vibesql_ast::arena::Expression;
+    use vibesql_catalog::ColumnSchema;
+    use vibesql_types::DataType;
+
+    fn create_test_schema() -> TableSchema {
+        TableSchema::new(
+            "test".to_string(),
+            vec![
+                ColumnSchema::new("ID".to_string(), DataType::Integer, false),
+                ColumnSchema::new("NAME".to_string(), DataType::Varchar { max_length: Some(100) }, true),
+            ],
+        )
+    }
+
+    fn create_test_row(id: i64, name: Option<&str>) -> Row {
+        Row::new(vec![
+            SqlValue::Integer(id),
+            name.map(|s| SqlValue::Varchar(s.to_string())).unwrap_or(SqlValue::Null),
+        ])
+    }
+
+    #[test]
+    fn test_literal_evaluation() {
+        let schema = create_test_schema();
+        let params = vec![];
+        let evaluator = ArenaExpressionEvaluator::new(&schema, &params);
+
+        let row = create_test_row(1, Some("test"));
+
+        let expr = Expression::Literal(SqlValue::Integer(42));
+        let result = evaluator.eval(&expr, &row).unwrap();
+        assert_eq!(result, SqlValue::Integer(42));
+    }
+
+    #[test]
+    fn test_placeholder_resolution() {
+        let schema = create_test_schema();
+        let params = vec![SqlValue::Integer(42), SqlValue::Varchar("hello".to_string())];
+        let evaluator = ArenaExpressionEvaluator::new(&schema, &params);
+
+        let row = create_test_row(1, Some("test"));
+
+        // Test placeholder 0
+        let expr = Expression::Placeholder(0);
+        let result = evaluator.eval(&expr, &row).unwrap();
+        assert_eq!(result, SqlValue::Integer(42));
+
+        // Test placeholder 1
+        let expr = Expression::Placeholder(1);
+        let result = evaluator.eval(&expr, &row).unwrap();
+        assert_eq!(result, SqlValue::Varchar("hello".to_string()));
+    }
+
+    #[test]
+    fn test_numbered_placeholder_resolution() {
+        let schema = create_test_schema();
+        let params = vec![SqlValue::Integer(42), SqlValue::Varchar("hello".to_string())];
+        let evaluator = ArenaExpressionEvaluator::new(&schema, &params);
+
+        let row = create_test_row(1, Some("test"));
+
+        // Test $1 (maps to params[0])
+        let expr = Expression::NumberedPlaceholder(1);
+        let result = evaluator.eval(&expr, &row).unwrap();
+        assert_eq!(result, SqlValue::Integer(42));
+
+        // Test $2 (maps to params[1])
+        let expr = Expression::NumberedPlaceholder(2);
+        let result = evaluator.eval(&expr, &row).unwrap();
+        assert_eq!(result, SqlValue::Varchar("hello".to_string()));
+    }
+
+    #[test]
+    fn test_column_ref_evaluation() {
+        let schema = create_test_schema();
+        let params = vec![];
+        let evaluator = ArenaExpressionEvaluator::new(&schema, &params);
+
+        let arena = Bump::new();
+        let row = create_test_row(1, Some("test"));
+
+        // Test column reference - using arena-allocated strings
+        let id_str = arena.alloc_str("ID");
+        let expr = Expression::ColumnRef {
+            table: None,
+            column: id_str,
+        };
+        let result = evaluator.eval(&expr, &row).unwrap();
+        assert_eq!(result, SqlValue::Integer(1));
+    }
+
+    #[test]
+    fn test_binary_op_with_placeholder() {
+        let schema = create_test_schema();
+        let params = vec![SqlValue::Integer(1)];
+        let evaluator = ArenaExpressionEvaluator::new(&schema, &params);
+
+        let arena = Bump::new();
+        let row = create_test_row(1, Some("test"));
+
+        // Create: id = ?
+        let id_str = arena.alloc_str("ID");
+        let col_ref = arena.alloc(Expression::ColumnRef {
+            table: None,
+            column: id_str,
+        });
+        let placeholder = arena.alloc(Expression::Placeholder(0));
+
+        let expr = Expression::BinaryOp {
+            op: BinaryOperator::Equal,
+            left: col_ref,
+            right: placeholder,
+        };
+
+        let result = evaluator.eval(&expr, &row).unwrap();
+        assert_eq!(result, SqlValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_is_null() {
+        let schema = create_test_schema();
+        let params = vec![];
+        let evaluator = ArenaExpressionEvaluator::new(&schema, &params);
+
+        let arena = Bump::new();
+        let row = create_test_row(1, None);
+
+        // name IS NULL (name is at index 1 which is NULL)
+        let name_str = arena.alloc_str("NAME");
+        let col_ref = arena.alloc(Expression::ColumnRef {
+            table: None,
+            column: name_str,
+        });
+
+        let expr = Expression::IsNull {
+            expr: col_ref,
+            negated: false,
+        };
+
+        let result = evaluator.eval(&expr, &row).unwrap();
+        assert_eq!(result, SqlValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_in_list_with_placeholders() {
+        let schema = create_test_schema();
+        let params = vec![
+            SqlValue::Integer(1),
+            SqlValue::Integer(2),
+            SqlValue::Integer(3),
+        ];
+        let evaluator = ArenaExpressionEvaluator::new(&schema, &params);
+
+        let arena = Bump::new();
+        let row = create_test_row(2, Some("test"));
+
+        // Create: id IN (?, ?, ?)
+        let id_str = arena.alloc_str("ID");
+        let col_ref = arena.alloc(Expression::ColumnRef {
+            table: None,
+            column: id_str,
+        });
+
+        let mut values = bumpalo::collections::Vec::new_in(&arena);
+        values.push(Expression::Placeholder(0));
+        values.push(Expression::Placeholder(1));
+        values.push(Expression::Placeholder(2));
+
+        let expr = Expression::InList {
+            expr: col_ref,
+            values,
+            negated: false,
+        };
+
+        let result = evaluator.eval(&expr, &row).unwrap();
+        assert_eq!(result, SqlValue::Boolean(true));
+    }
+}

--- a/crates/vibesql-executor/src/evaluator/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/mod.rs
@@ -1,4 +1,5 @@
 // Module declarations
+pub mod arena_eval;
 pub(crate) mod casting;
 pub mod coercion;
 mod combined;


### PR DESCRIPTION
## Summary

- Implements Option A from #3258: arena-throughout pipeline for prepared statements (Phase 1)
- Adds `ArenaPreparedStatement`: self-referential struct that stores a pinned arena with safe references to the parsed AST
- Adds `ArenaExpressionEvaluator`: evaluates arena expressions directly with inline placeholder resolution, avoiding AST conversion/cloning

## Key Benefits

- **Zero conversion overhead**: Arena AST is used directly during execution
- **Inline placeholder resolution**: Placeholders are resolved from params during evaluation (no AST cloning/mutation)
- **Arena reuse potential**: Foundation for arena reuse across executions

## Implementation Details

### ArenaPreparedStatement (`arena_prepared.rs`)
- Uses `Pin<Box<Bump>>` to prevent arena moves
- Stores raw pointer to statement with documented safety invariants
- Includes table extraction and placeholder counting for cache invalidation

### ArenaExpressionEvaluator (`arena_eval.rs`)
- Evaluates `Expression<'arena>` directly without conversion to owned types
- Handles placeholders inline by looking up in params slice
- Supports common expression types: binary ops, column refs, IS NULL, IN list, CASE, etc.

## Test plan

- [x] Unit tests for `ArenaPreparedStatement` (5 tests passing)
- [x] Unit tests for `ArenaExpressionEvaluator` (7 tests passing)
- [x] Full executor test suite (1644 tests passing)

## Future Work (Phase 2+)

- Integration with `PreparedStatementCache`
- Full SELECT execution path using arena types
- Performance benchmarks to measure improvement

Closes #3258

🤖 Generated with [Claude Code](https://claude.com/claude-code)