### PR TITLE
perf(executor): Use prefix_scan_reverse_limit for DESC LIMIT queries

### DIFF
--- a/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
@@ -227,7 +227,17 @@ pub(crate) fn execute_index_scan(
             // Use reverse iteration - rows come in descending key order
             // This is more efficient than fetching all and reversing
             used_reverse_iteration = true;
-            index_data.prefix_scan_reverse(&prefix.prefix_key)
+
+            // Optimization: Use prefix_scan_reverse_limit for true early termination (#3285)
+            // When we have DESC order + LIMIT + no WHERE filtering needed,
+            // stop scanning at the index level instead of fetching all rows
+            if let (Some(limit_val), false) = (limit, need_where_filter) {
+                // O(log n + limit) instead of O(log n + k) where k = all matching rows
+                // Critical for TPC-C Order Status: customer may have 30+ orders, we only need 1
+                index_data.prefix_scan_reverse_limit(&prefix.prefix_key, limit_val)
+            } else {
+                index_data.prefix_scan_reverse(&prefix.prefix_key)
+            }
         } else {
             index_data.prefix_scan(&prefix.prefix_key)
         }


### PR DESCRIPTION
## Summary
- Uses `prefix_scan_reverse_limit()` for true early termination at the index level when executing queries with ORDER BY DESC LIMIT N on prefix scans
- Provides O(log n + limit) instead of O(log n + k) performance where k = all matching rows
- Critical for TPC-C Order Status where a customer may have 30+ orders but we only need the most recent one

## Test plan
- [x] Verified ORDER BY DESC LIMIT 1 query returns correct result
- [x] All storage layer prefix_scan_reverse tests pass
- [x] All executor tests pass
- [x] Code compiles without errors

Closes #3285

🤖 Generated with [Claude Code](https://claude.com/claude-code)