### PR TITLE
perf(executor): Add memory tracking to CTEs and set operations

### DIFF
--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -27,6 +27,27 @@ where
         &HashMap<String, CteResult>,
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError>,
 {
+    // Use the memory-tracking version with a no-op memory check
+    execute_ctes_with_memory_check(ctes, executor, |_| Ok(()))
+}
+
+/// Execute all CTEs with memory tracking
+///
+/// CTEs are executed in order, allowing later CTEs to reference earlier ones.
+/// After each CTE is materialized, the memory_check callback is called with
+/// the estimated size of the CTE result to enforce memory limits.
+pub(super) fn execute_ctes_with_memory_check<F, M>(
+    ctes: &[vibesql_ast::CommonTableExpr],
+    executor: F,
+    memory_check: M,
+) -> Result<HashMap<String, CteResult>, ExecutorError>
+where
+    F: Fn(
+        &vibesql_ast::SelectStmt,
+        &HashMap<String, CteResult>,
+    ) -> Result<Vec<vibesql_storage::Row>, ExecutorError>,
+    M: Fn(usize) -> Result<(), ExecutorError>,
+{
     let mut cte_results = HashMap::new();
 
     // Execute each CTE in order
@@ -35,6 +56,10 @@ where
         // Execute the CTE query with accumulated CTE results so far
         // This allows later CTEs to reference earlier ones
         let rows = executor(&cte.query, &cte_results)?;
+
+        // Track memory for this CTE result before storing
+        let estimated_size = super::helpers::estimate_result_size(&rows);
+        memory_check(estimated_size)?;
 
         //  Determine the schema for this CTE
         let schema = derive_cte_schema(cte, &rows)?;

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -32,8 +32,8 @@ use crate::{
         PipelineInput,
     },
     select::{
-        cte::{execute_ctes, CteResult},
-        helpers::apply_limit_offset,
+        cte::{execute_ctes, execute_ctes_with_memory_check, CteResult},
+        helpers::{apply_limit_offset, estimate_result_size},
         join::FromResult,
         set_operations::apply_set_operation,
         SelectResult,
@@ -95,8 +95,12 @@ impl SelectExecutor<'_> {
 
         // Execute CTEs if present and merge with outer query's CTE context
         let mut cte_results = if let Some(with_clause) = &optimized_stmt.with_clause {
-            // This query has its own CTEs - execute them
-            execute_ctes(with_clause, |query, cte_ctx| self.execute_with_ctes(query, cte_ctx))?
+            // This query has its own CTEs - execute them with memory tracking
+            execute_ctes_with_memory_check(
+                with_clause,
+                |query, cte_ctx| self.execute_with_ctes(query, cte_ctx),
+                |size| self.track_memory_allocation(size),
+            )?
         } else {
             HashMap::new()
         };
@@ -682,8 +686,16 @@ impl SelectExecutor<'_> {
             self.execute_select_without_from(right_stmt)?
         };
 
+        // Track memory for right result before set operation
+        let right_size = estimate_result_size(&right_results);
+        self.track_memory_allocation(right_size)?;
+
         // Apply the current operation
         left_results = apply_set_operation(left_results, right_results, set_op)?;
+
+        // Track memory for combined result after set operation
+        let combined_size = estimate_result_size(&left_results);
+        self.track_memory_allocation(combined_size)?;
 
         // If the right side has more set operations, continue processing them
         // This creates the left-to-right evaluation: ((A op B) op C) op D

--- a/crates/vibesql-executor/src/select/helpers.rs
+++ b/crates/vibesql-executor/src/select/helpers.rs
@@ -2,6 +2,35 @@
 
 use indexmap::IndexSet;
 
+/// Estimate the memory size of a result set in bytes
+///
+/// Used for memory limit tracking during query execution.
+/// Samples a subset of rows to avoid O(n) overhead on large result sets.
+pub(super) fn estimate_result_size(rows: &[vibesql_storage::Row]) -> usize {
+    if rows.is_empty() {
+        return 0;
+    }
+
+    // For small result sets, measure exactly
+    if rows.len() <= 100 {
+        return rows.iter().map(|r| r.estimated_size_bytes()).sum();
+    }
+
+    // For large result sets, sample and extrapolate
+    // Sample first 10, middle 10, and last 10 rows
+    let sample_size = 30;
+    let step = rows.len() / sample_size;
+    let sample_total: usize = rows
+        .iter()
+        .step_by(step.max(1))
+        .take(sample_size)
+        .map(|r| r.estimated_size_bytes())
+        .sum();
+
+    let avg_row_size = sample_total / sample_size.min(rows.len());
+    avg_row_size * rows.len()
+}
+
 /// Apply DISTINCT to remove duplicate rows
 ///
 /// Uses an IndexSet to track unique rows while preserving insertion order.

--- a/crates/vibesql-storage/src/row.rs
+++ b/crates/vibesql-storage/src/row.rs
@@ -27,6 +27,22 @@ impl Row {
         self.values.is_empty()
     }
 
+    /// Estimate the memory size of this row in bytes
+    ///
+    /// Used for memory limit tracking during query execution.
+    /// Provides a reasonable approximation without deep inspection.
+    pub fn estimated_size_bytes(&self) -> usize {
+        use std::mem::size_of;
+
+        // Base overhead: Vec header + Row struct
+        let base_overhead = size_of::<Vec<SqlValue>>() + size_of::<Row>();
+
+        // Estimate size of each value
+        let values_size: usize = self.values.iter().map(|v| v.estimated_size_bytes()).sum();
+
+        base_overhead + values_size
+    }
+
     /// Set value at column index
     pub fn set(&mut self, index: usize, value: SqlValue) -> Result<(), crate::StorageError> {
         if index >= self.values.len() {

--- a/crates/vibesql-types/src/sql_value/mod.rs
+++ b/crates/vibesql-types/src/sql_value/mod.rs
@@ -94,4 +94,41 @@ impl SqlValue {
             SqlValue::Null => DataType::Null,
         }
     }
+
+    /// Estimate the memory size of this value in bytes
+    ///
+    /// Used for memory limit tracking during query execution.
+    /// Provides a reasonable approximation including heap allocations.
+    pub fn estimated_size_bytes(&self) -> usize {
+        use std::mem::size_of;
+
+        // Base size of the enum (24 bytes for largest variant discriminant + data)
+        let base_size = size_of::<SqlValue>();
+
+        // Add heap allocation size for variable-length types
+        match self {
+            SqlValue::Character(s) | SqlValue::Varchar(s) => {
+                // String: base + heap capacity
+                base_size + s.capacity()
+            }
+            SqlValue::Interval(i) => {
+                // Interval stores a String internally
+                base_size + i.to_string().len()
+            }
+            // Fixed-size types: just the enum size
+            SqlValue::Integer(_)
+            | SqlValue::Smallint(_)
+            | SqlValue::Bigint(_)
+            | SqlValue::Unsigned(_)
+            | SqlValue::Numeric(_)
+            | SqlValue::Float(_)
+            | SqlValue::Real(_)
+            | SqlValue::Double(_)
+            | SqlValue::Boolean(_)
+            | SqlValue::Date(_)
+            | SqlValue::Time(_)
+            | SqlValue::Timestamp(_)
+            | SqlValue::Null => base_size,
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add memory tracking during CTE materialization and UNION ALL operations
- Enables early failure when memory limits are exceeded instead of consuming 28.9GB (Q5)
- Add `estimated_size_bytes()` to `SqlValue` and `Row` for memory estimation
- Add sampling-based `estimate_result_size()` helper for large result sets

## Test plan
- [x] Code compiles without errors
- [x] CTE-related tests pass (3 tests)
- [x] SQL logic tests pass (47 tests)
- [ ] Run TPC-DS Q5 to verify MemoryLimitExceeded error

Closes #3329

🤖 Generated with [Claude Code](https://claude.com/claude-code)