### PR TITLE
perf(optimizer): Enable hash join for derived tables and CTEs

### DIFF
--- a/crates/vibesql-executor/src/select/join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/mod.rs
@@ -584,6 +584,69 @@ pub(super) fn nested_loop_join(
                 return Ok(result);
             }
         }
+
+        // Phase 3.5: Try arithmetic equijoins from WHERE clause for hash join
+        // For expressions like `col1 = col2 - 53` in WHERE clause with Inner joins
+        // This enables hash join for derived table joins with arithmetic conditions (TPC-DS Q2)
+        for (idx, equijoin) in additional_equijoins.iter().enumerate() {
+            if let Some(arith_info) =
+                join_analyzer::analyze_arithmetic_equi_join(equijoin, &temp_schema, left_col_count)
+            {
+                // Save schemas for NATURAL JOIN processing before moving left/right
+                let (left_schema_for_natural, right_schema_for_natural) = if natural {
+                    (Some(left.schema.clone()), Some(right.schema.clone()))
+                } else {
+                    (None, None)
+                };
+
+                // Found an arithmetic equijoin suitable for hash join!
+                let mut result = hash_join_inner_arithmetic(
+                    left,
+                    right,
+                    arith_info.left_col_idx,
+                    arith_info.right_col_idx,
+                    arith_info.offset,
+                )?;
+
+                // Apply remaining equijoins as post-join filters
+                let remaining_conditions: Vec<_> = additional_equijoins
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != idx)
+                    .map(|(_, e)| e.clone())
+                    .collect();
+
+                if !remaining_conditions.is_empty() {
+                    if let Some(filter_expr) = combine_with_and(remaining_conditions) {
+                        result = apply_post_join_filter(result, &filter_expr, database)?;
+                    }
+                }
+
+                // For NATURAL JOIN, remove duplicate columns from the result
+                if natural {
+                    if let (Some(left_schema), Some(right_schema_orig)) =
+                        (left_schema_for_natural, right_schema_for_natural)
+                    {
+                        let right_schema_for_removal = CombinedSchema {
+                            table_schemas: vec![(
+                                right_table_name_for_natural.clone(),
+                                (0, right_schema_orig.table_schemas.values().next().unwrap().1.clone()),
+                            )]
+                            .into_iter()
+                            .collect(),
+                            total_columns: right_schema_orig.total_columns,
+                        };
+                        result = remove_duplicate_columns_for_natural_join(
+                            result,
+                            &left_schema,
+                            &right_schema_for_removal,
+                        )?;
+                    }
+                }
+
+                return Ok(result);
+            }
+        }
     }
 
     // Try to use hash join for LEFT OUTER JOINs with equi-join conditions

--- a/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
@@ -379,13 +379,20 @@ pub(super) fn extract_where_equijoins_with_schema(
                     } else if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
                         eprintln!("[JOIN_REORDER]   ✗ Skipped: lt==rt or table not found");
                     }
-                } else if column_to_table.is_empty() {
-                    // CTE fallback: if schema is unavailable, check if both sides reference columns
+                } else {
+                    // Check for arithmetic equijoins like `col1 = col2 +/- constant`
+                    // This enables hash join optimization for derived tables with arithmetic conditions
                     let left_has_column = expr_has_column(left);
                     let right_has_column = expr_has_column(right);
-                    if left_has_column && right_has_column {
+
+                    // If one side resolved to a table but the other didn't (arithmetic expression),
+                    // check if the other side has a column that references a different table
+                    if (left_table.is_some() && right_table.is_none() && right_has_column)
+                        || (left_table.is_none() && right_table.is_some() && left_has_column)
+                        || (column_to_table.is_empty() && left_has_column && right_has_column)
+                    {
                         if std::env::var("JOIN_REORDER_VERBOSE").is_ok() {
-                            eprintln!("[JOIN_REORDER] CTE fallback: adding arithmetic equijoin {:?}", expr);
+                            eprintln!("[JOIN_REORDER] Adding arithmetic equijoin: {:?}", expr);
                         }
                         equijoins.push(expr.clone());
                     }

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -1,9 +1,55 @@
 //! Utility functions for join reordering
 
 use std::collections::HashMap;
-use vibesql_ast::FromClause;
+use vibesql_ast::{Expression, FromClause, SelectItem};
 use crate::schema::CombinedSchema;
 use crate::select::cte::CteResult;
+
+/// Extract column names from a SELECT list for subquery schema inference
+///
+/// This enables join optimizer to resolve column indices for derived tables,
+/// which is required for hash join optimization with arithmetic equijoins.
+fn extract_column_names_from_select_list(select_list: &[SelectItem]) -> Vec<String> {
+    let mut columns = Vec::new();
+    for item in select_list {
+        match item {
+            SelectItem::Wildcard { .. } | SelectItem::QualifiedWildcard { .. } => {
+                // For SELECT *, we can't know column names without executing the query
+                // Return empty to fall back to CTE-fallback path
+                return Vec::new();
+            }
+            SelectItem::Expression { expr, alias } => {
+                let col_name = if let Some(a) = alias {
+                    a.to_lowercase()
+                } else {
+                    // Extract column name from expression
+                    extract_column_name_from_expr(expr).to_lowercase()
+                };
+                columns.push(col_name);
+            }
+        }
+    }
+    columns
+}
+
+/// Extract a column name from an expression (for schema inference)
+fn extract_column_name_from_expr(expr: &Expression) -> String {
+    match expr {
+        Expression::ColumnRef { column, .. } => column.clone(),
+        Expression::AggregateFunction { name, args, .. } => {
+            // For aggregates like SUM(col), use the column name if simple
+            if args.len() == 1 {
+                if let Expression::ColumnRef { column, .. } = &args[0] {
+                    return column.clone();
+                }
+            }
+            name.clone()
+        }
+        Expression::Function { name, .. } => name.clone(),
+        Expression::BinaryOp { left, .. } => extract_column_name_from_expr(left),
+        _ => "?column?".to_string(),
+    }
+}
 
 /// Check if join reordering optimization should be applied
 ///
@@ -194,10 +240,17 @@ pub(super) fn build_column_to_table_map(
         // Get column names for this table
         let column_names: Vec<String> = if let Some(tr) = table_ref {
             if tr.is_subquery {
-                // For subqueries, we don't have schema info readily available
-                // Skip for now - subqueries need explicit qualification anyway
-                continue;
-            } else if let Some(cte_result) = cte_results.get(&tr.name) {
+                // For subqueries (derived tables), infer column names from SELECT list
+                // This enables hash join optimization for queries with derived tables
+                if let Some(subquery) = &tr.subquery {
+                    extract_column_names_from_select_list(&subquery.select_list)
+                } else {
+                    continue;
+                }
+            } else if let Some(cte_result) = cte_results.get(&tr.name)
+                .or_else(|| cte_results.get(&tr.name.to_lowercase()))
+                .or_else(|| cte_results.get(&tr.name.to_uppercase()))
+            {
                 // CTE: get columns from CTE result schema (CteResult is a tuple: (TableSchema, Vec<Row>))
                 cte_result.0.columns.iter().map(|c| c.name.to_lowercase()).collect()
             } else {


### PR DESCRIPTION
## Summary

- Enable hash join for derived table joins with arithmetic equijoins
- Add Phase 3.5 to check arithmetic equijoins for Inner joins
- Infer column schemas from SELECT lists for derived tables
- Fix case-insensitive CTE lookup

## Test plan

- [x] Verified TPC-DS Q2 derived table join improves from 64ms to 0.2ms (320x)
- [ ] Run full TPC-DS benchmark suite
- [ ] Verify no regression in existing tests

Closes #3331

Related:
- #3343 - CTE self-join optimization (follow-up)
- #3345 - Remaining slow queries (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)