### PR TITLE
fix(executor): Apply residual predicates in fast path index lookups

### DIFF
--- a/crates/vibesql-executor/src/select/executor/fast_path.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path.rs
@@ -772,19 +772,40 @@ impl SelectExecutor<'_> {
                 .filter_map(|&idx| all_rows.get(idx).cloned())
                 .collect();
 
-            // Build schema for projection
+            // Build schema for projection and filtering
             let effective_name = alias.cloned().unwrap_or_else(|| table_name.to_string());
             let schema = CombinedSchema::from_table(effective_name, table.schema.clone());
+
+            // Check if WHERE clause has predicates not covered by the index lookup.
+            // The index lookup covers:
+            // - Equality predicates on prefix columns (prefix_key)
+            // - The ORDER BY column (next_index_col) is used for ordering, not filtering
+            // Any other predicates need to be applied as a filter.
+            let covered_columns: std::collections::HashSet<String> = index_columns
+                .iter()
+                .take(prefix_key.len())
+                .map(|c| c.to_ascii_lowercase())
+                .collect();
+
+            // Check if WHERE clause is fully satisfied by the index lookup
+            let needs_where_filter = !self.where_fully_satisfied_by_equality_columns(where_clause, &covered_columns);
+
+            // Apply residual WHERE filter if needed
+            let filtered_rows = if needs_where_filter && !rows.is_empty() {
+                self.apply_where_filter_fast(where_clause, rows, &schema)?
+            } else {
+                rows
+            };
 
             // Apply projection
             let is_select_star = stmt.select_list.len() == 1
                 && matches!(&stmt.select_list[0], SelectItem::Wildcard { .. });
 
             if is_select_star {
-                return Ok(Some(rows));
+                return Ok(Some(filtered_rows));
             }
 
-            let projected = self.apply_projection_fast(&stmt.select_list, rows, &schema)?;
+            let projected = self.apply_projection_fast(&stmt.select_list, filtered_rows, &schema)?;
             return Ok(Some(projected));
         }
 
@@ -876,15 +897,37 @@ impl SelectExecutor<'_> {
                     .into_iter().cloned().collect::<Vec<_>>()
             };
 
+            // Check if WHERE clause has predicates not covered by the index lookup.
+            // If so, we need to apply the full WHERE clause as a filter.
+            // Build set of columns covered by index lookup (those with equality predicates)
+            let covered_columns: std::collections::HashSet<String> = index_columns
+                .iter()
+                .take(key_values.len())
+                .map(|c| c.to_ascii_lowercase())
+                .collect();
+
+            // Check if WHERE clause is fully satisfied by the index lookup
+            let needs_where_filter = !self.where_fully_satisfied_by_equality_columns(where_clause, &covered_columns);
+
+            // Apply residual WHERE filter if needed
+            let filtered_rows = if needs_where_filter && !rows.is_empty() {
+                // Build schema for filtering
+                let effective_name = alias.cloned().unwrap_or_else(|| table_name.to_string());
+                let schema = CombinedSchema::from_table(effective_name, table.schema.clone());
+                self.apply_where_filter_fast(where_clause, rows, &schema)?
+            } else {
+                rows
+            };
+
             // Apply ORDER BY if needed (requires schema for column lookup)
             let sorted_rows = if let Some(order_by) = &stmt.order_by {
                 // Only build schema if we need ORDER BY
                 let effective_name = alias.cloned().unwrap_or_else(|| table_name.to_string());
                 let schema = CombinedSchema::from_table(effective_name, table.schema.clone());
                 // Index lookup doesn't guarantee order, so always sort
-                self.apply_order_by_fast(order_by, rows, &schema)?
+                self.apply_order_by_fast(order_by, filtered_rows, &schema)?
             } else {
-                rows
+                filtered_rows
             };
 
             // Apply LIMIT/OFFSET
@@ -986,6 +1029,38 @@ impl SelectExecutor<'_> {
         match expr {
             Expression::Literal(val) => Some(val.clone()),
             _ => None,
+        }
+    }
+
+    /// Check if a WHERE clause is fully satisfied by equality predicates on the given columns.
+    ///
+    /// Returns true ONLY if the WHERE clause contains ONLY equality predicates
+    /// on the specified columns (connected by AND). Any other predicates (non-equality
+    /// comparisons, predicates on other columns, OR, etc.) will cause this to return false.
+    ///
+    /// This is used to determine if additional filtering is needed after an index lookup.
+    fn where_fully_satisfied_by_equality_columns(
+        &self,
+        expr: &Expression,
+        covered_columns: &std::collections::HashSet<String>,
+    ) -> bool {
+        match expr {
+            // Equality predicate: col = literal
+            Expression::BinaryOp { left, op: vibesql_ast::BinaryOperator::Equal, right } => {
+                // Check if this is an equality on a covered column
+                if let Some((col_name, _)) = self.extract_column_literal_pair(left, right) {
+                    covered_columns.contains(&col_name.to_ascii_lowercase())
+                } else {
+                    false // Not a simple column = literal pattern
+                }
+            }
+            // AND: both sides must be fully satisfied
+            Expression::BinaryOp { left, op: vibesql_ast::BinaryOperator::And, right } => {
+                self.where_fully_satisfied_by_equality_columns(left, covered_columns)
+                    && self.where_fully_satisfied_by_equality_columns(right, covered_columns)
+            }
+            // Any other expression type is not satisfied by the index lookup
+            _ => false,
         }
     }
 

--- a/crates/vibesql-executor/src/tests/secondary_index_fast_path.rs
+++ b/crates/vibesql-executor/src/tests/secondary_index_fast_path.rs
@@ -309,3 +309,144 @@ fn test_secondary_index_with_limit() {
         panic!("Expected SELECT statement");
     }
 }
+
+/// Regression test for issue #3354: Secondary index fast path must apply residual predicates
+///
+/// When using a secondary index for lookup, any predicates NOT covered by the index
+/// (i.e., non-equality predicates or predicates on columns not in the index) must still
+/// be applied as a filter.
+///
+/// Bug: Query `WHERE col3 = 81814 AND col0 < 1013` with index on col3 would:
+/// 1. Use index to find rows where col3 = 81814
+/// 2. Return rows WITHOUT checking `col0 < 1013`
+///
+/// This test verifies that residual predicates are correctly applied.
+#[test]
+fn test_secondary_index_residual_predicate_filter() {
+    let mut db = Database::new();
+    db.catalog.set_case_sensitive_identifiers(false);
+
+    // Create simple table with pk, col0, col3
+    let schema = TableSchema::new(
+        "tab1".to_string(),
+        vec![
+            ColumnSchema::new("pk".to_string(), DataType::Integer, false),
+            ColumnSchema::new("col0".to_string(), DataType::Integer, false),
+            ColumnSchema::new("col3".to_string(), DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    // Create secondary index on col3 only
+    db.create_index(
+        "idx_tab1_3".to_string(),
+        "tab1".to_string(),
+        false,
+        vec![IndexColumn {
+            column_name: "col3".to_string(),
+            prefix_length: None,
+            direction: OrderDirection::Asc,
+        }],
+    )
+    .unwrap();
+
+    // Insert row: pk=881, col0=20123, col3=81814
+    // Note: col0=20123 does NOT satisfy col0 < 1013
+    db.insert_row(
+        "tab1",
+        Row::new(vec![
+            SqlValue::Integer(881),
+            SqlValue::Integer(20123),
+            SqlValue::Integer(81814),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // Query: col3 = 81814 (uses index) AND col0 < 1013 (residual filter)
+    // The row has col0=20123 which does NOT satisfy col0 < 1013, so should return 0 rows
+    let query = "SELECT pk, col0, col3 FROM tab1 WHERE col3 = 81814 AND col0 < 1013";
+    let stmt = Parser::parse_sql(query).unwrap();
+
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute(&select_stmt).unwrap();
+
+        // Should return 0 rows because col0=20123 does NOT satisfy col0 < 1013
+        assert_eq!(result.len(), 0, "Residual predicate col0 < 1013 should filter out the row");
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+/// Test that rows matching both index predicate AND residual predicate are returned
+#[test]
+fn test_secondary_index_residual_predicate_match() {
+    let mut db = Database::new();
+    db.catalog.set_case_sensitive_identifiers(false);
+
+    // Create simple table with pk, col0, col3
+    let schema = TableSchema::new(
+        "tab1".to_string(),
+        vec![
+            ColumnSchema::new("pk".to_string(), DataType::Integer, false),
+            ColumnSchema::new("col0".to_string(), DataType::Integer, false),
+            ColumnSchema::new("col3".to_string(), DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    // Create secondary index on col3 only
+    db.create_index(
+        "idx_tab1_3".to_string(),
+        "tab1".to_string(),
+        false,
+        vec![IndexColumn {
+            column_name: "col3".to_string(),
+            prefix_length: None,
+            direction: OrderDirection::Asc,
+        }],
+    )
+    .unwrap();
+
+    // Insert two rows with same col3 value but different col0 values
+    // Row 881: col0=20123 (does NOT satisfy col0 < 1013)
+    // Row 882: col0=500 (DOES satisfy col0 < 1013)
+    db.insert_row(
+        "tab1",
+        Row::new(vec![
+            SqlValue::Integer(881),
+            SqlValue::Integer(20123),
+            SqlValue::Integer(81814),
+        ]),
+    )
+    .unwrap();
+
+    db.insert_row(
+        "tab1",
+        Row::new(vec![
+            SqlValue::Integer(882),
+            SqlValue::Integer(500),
+            SqlValue::Integer(81814),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // Query: col3 = 81814 (uses index, finds both rows) AND col0 < 1013 (residual filter)
+    // Only row 882 should be returned (col0=500 < 1013)
+    let query = "SELECT pk, col0, col3 FROM tab1 WHERE col3 = 81814 AND col0 < 1013";
+    let stmt = Parser::parse_sql(query).unwrap();
+
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute(&select_stmt).unwrap();
+
+        // Should return only 1 row (pk=882)
+        assert_eq!(result.len(), 1, "Should return only the row matching residual predicate");
+        assert_eq!(result[0].values[0], SqlValue::Integer(882), "Should return pk=882");
+        assert_eq!(result[0].values[1], SqlValue::Integer(500), "Should return col0=500");
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}


### PR DESCRIPTION
## Summary
- Fix bug where fast path secondary index lookups were not applying residual WHERE predicates
- Add `where_fully_satisfied_by_equality_columns()` helper to detect when WHERE clause has uncovered predicates
- Apply residual filter after index lookup in both `try_secondary_index_lookup_fast()` and `try_secondary_index_prefix_with_limit_fast()`

## Root Cause
The fast path functions extract equality predicates from the WHERE clause for index lookup, but then return results without checking any remaining predicates. For example:
- Query: `WHERE col3 = 81814 AND col0 < 1013`
- Index on: `col3`
- Bug: Would find rows where `col3 = 81814` but NOT filter by `col0 < 1013`

## Test plan
- [x] Added regression tests for the bug fix in `secondary_index_fast_path.rs`
- [x] Verified failing sqllogictest `index/delete/10000/slt_good_0.test` now passes
- [x] All existing secondary index fast path tests still pass

Closes #3354

🤖 Generated with [Claude Code](https://claude.com/claude-code)