### PR TITLE
fix(optimizer): Detect equality + IN predicate contradictions in fast path

### DIFF
--- a/crates/vibesql-executor/src/select/executor/fast_path.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path.rs
@@ -863,6 +863,17 @@ impl SelectExecutor<'_> {
                 continue;
             }
 
+            // Check for contradictions (e.g., col = 70 AND col IN (74, 69, 10))
+            // If equality value is not in the IN list, return empty result immediately
+            for (col_name, eq_value) in &index_values {
+                if let Some(in_values) = self.extract_in_values(where_clause, col_name) {
+                    if !in_values.contains(eq_value) {
+                        // Contradiction: equality value not in IN list - no rows can match
+                        return Ok(Some(vec![]));
+                    }
+                }
+            }
+
             // Build key values for the prefix of columns we have equality predicates for
             // This supports partial index usage (e.g., 3-column prefix of 4-column index)
             // Use case-insensitive lookup since schema may have different case than parser output
@@ -1061,6 +1072,40 @@ impl SelectExecutor<'_> {
             }
             // Any other expression type is not satisfied by the index lookup
             _ => false,
+        }
+    }
+
+    /// Extract IN list values for a column from WHERE clause
+    /// Returns None if no IN predicate found for the column
+    fn extract_in_values(&self, expr: &Expression, column_name: &str) -> Option<Vec<SqlValue>> {
+        match expr {
+            Expression::InList { expr: col_expr, values, negated } => {
+                if *negated {
+                    return None; // NOT IN is not a contradiction detector
+                }
+                // Check if the IN expression is for our target column
+                if let Expression::ColumnRef { column, .. } = col_expr.as_ref() {
+                    if column.eq_ignore_ascii_case(column_name) {
+                        // Extract all literal values from the IN list
+                        let mut result = Vec::new();
+                        for v in values {
+                            if let Expression::Literal(val) = v {
+                                result.push(val.clone());
+                            }
+                        }
+                        if !result.is_empty() {
+                            return Some(result);
+                        }
+                    }
+                }
+                None
+            }
+            Expression::BinaryOp { left, op: vibesql_ast::BinaryOperator::And, right } => {
+                // Recursively search both sides of AND
+                self.extract_in_values(left, column_name)
+                    .or_else(|| self.extract_in_values(right, column_name))
+            }
+            _ => None,
         }
     }
 

--- a/crates/vibesql-executor/src/select/scan/index_scan/predicate.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/predicate.rs
@@ -850,7 +850,31 @@ fn extract_column_name(expr: &Expression) -> Option<&str> {
 ///
 /// Returns None if no suitable predicate found for the column.
 pub(crate) fn extract_index_predicate(expr: &Expression, column_name: &str) -> Option<IndexPredicate> {
-    // First try to extract a range predicate
+    // FIRST: Check for contradictions (e.g., col = 70 AND col IN (74, 69, 10))
+    // This must happen before extract_range_predicate() since it returns early
+    // when finding a range (like col = 70), bypassing contradiction checks.
+    if let Expression::BinaryOp { op: BinaryOperator::And, .. } = expr {
+        let mut equality_values: Vec<SqlValue> = Vec::new();
+        let mut in_values: Option<Vec<SqlValue>> = None;
+        let mut range_pred: Option<RangePredicate> = None;
+
+        collect_column_predicates(expr, column_name, &mut equality_values, &mut in_values, &mut range_pred);
+
+        // Check for equality + IN contradiction
+        if !equality_values.is_empty() && in_values.is_some() {
+            let in_vals = in_values.as_ref().unwrap();
+            // If any equality value is NOT in the IN list, we have a contradiction
+            for eq_val in &equality_values {
+                if !in_vals.contains(eq_val) {
+                    // Contradiction: equality value not in IN list - no rows can match
+                    // Return empty IN predicate to signal impossible query
+                    return Some(IndexPredicate::In(vec![]));
+                }
+            }
+        }
+    }
+
+    // Try to extract a range predicate
     if let Some(range) = extract_range_predicate(expr, column_name) {
         return Some(IndexPredicate::Range(range));
     }
@@ -890,35 +914,9 @@ pub(crate) fn extract_index_predicate(expr: &Expression, column_name: &str) -> O
                 }
             }
         }
-        // Handle AND: check for contradictions between equality and IN predicates
-        // e.g., col = 40 AND col IN (84, 23, 58) should return empty result (contradiction)
+        // Handle AND: try to extract predicate from either side
+        // Note: Contradiction checks are handled at the top of this function
         Expression::BinaryOp { left, op: BinaryOperator::And, right } => {
-            // Collect all predicates from both sides
-            let mut equality_values: Vec<SqlValue> = Vec::new();
-            let mut in_values: Option<Vec<SqlValue>> = None;
-            let mut range_pred: Option<RangePredicate> = None;
-
-            collect_column_predicates(left, column_name, &mut equality_values, &mut in_values, &mut range_pred);
-            collect_column_predicates(right, column_name, &mut equality_values, &mut in_values, &mut range_pred);
-
-            // Check for equality + IN contradiction
-            if !equality_values.is_empty() && in_values.is_some() {
-                let in_vals = in_values.as_ref().unwrap();
-                // If any equality value is NOT in the IN list, we have a contradiction
-                for eq_val in &equality_values {
-                    if !in_vals.contains(eq_val) {
-                        // Contradiction: equality value not in IN list - no rows can match
-                        // Return empty IN predicate to signal impossible query
-                        return Some(IndexPredicate::In(vec![]));
-                    }
-                }
-                // All equality values are in the IN list - use the range predicate if available
-                if let Some(range) = range_pred {
-                    return Some(IndexPredicate::Range(range));
-                }
-            }
-
-            // No contradiction found - fall back to normal extraction
             // Try left side first
             if let Some(pred) = extract_index_predicate(left, column_name) {
                 return Some(pred);


### PR DESCRIPTION
## Summary

- Fixed a bug where queries with contradicting predicates like `col = 70 AND col IN (74,69,10)` incorrectly returned rows
- The value 70 is not in the set {74, 69, 10}, so these queries should return no rows

## Root Cause

The bug existed in two code paths:

1. **`extract_index_predicate()`** - Already had contradiction detection logic, but it ran after `extract_range_predicate()` returned early with the equality predicate. The contradiction check was bypassed.

2. **`try_secondary_index_lookup_fast()`** - The fast path extracted equality predicates for index lookup but never checked for contradicting IN predicates in the WHERE clause.

## Changes

- Moved contradiction check to the start of `extract_index_predicate()` before calling `extract_range_predicate()`
- Added `extract_in_values()` helper function to the fast path to detect IN predicates
- Added contradiction check in `try_secondary_index_lookup_fast()` that returns empty result when equality value is not in the IN list

## Test plan

- [x] Verified the failing test case now passes: `SELECT pk FROM tab1 WHERE (((col0 = 70) AND col3 <= 1 AND col0 IN (74,69,10)))`
- [x] Ran full test file `index/in/10/slt_good_2.test` - 100% pass rate (10035/10035 records)
- [x] Ran executor unit tests - all passed
- [x] Ran TPC-C benchmark - no regression (3718 TPS)

Closes #3353

🤖 Generated with [Claude Code](https://claude.com/claude-code)