### PR TITLE
fix(optimizer): Handle disconnected join graphs in BFS/DFS search

### DIFF
--- a/crates/vibesql-executor/src/select/join/search/bfs.rs
+++ b/crates/vibesql-executor/src/select/join/search/bfs.rs
@@ -131,7 +131,8 @@ impl JoinOrderContext {
     /// to the current join sequence. Prunes states that exceed the best known cost.
     fn expand_state_parallel(&self, state: &SearchState, best_cost: u64) -> Vec<SearchState> {
         // For the first table, any table is valid
-        // For subsequent tables, ONLY consider tables with join edges (enforce connectivity)
+        // For subsequent tables, prefer tables with join edges but allow disconnected tables
+        // when the join graph is not fully connected (e.g., Cartesian products)
         let candidates: Vec<&String> = if state.joined_tables.is_empty() {
             // First table: any unjoined table
             self.all_tables
@@ -139,13 +140,31 @@ impl JoinOrderContext {
                 .filter(|t| !state.joined_tables.contains(*t))
                 .collect()
         } else {
-            // Subsequent tables: MUST have join edge to already-joined tables
-            // This enforces connected subgraph enumeration (no CROSS JOINs)
-            self.all_tables
+            // Try to find tables with join edges first (connected subgraph)
+            let connected: Vec<&String> = self.all_tables
                 .iter()
                 .filter(|t| !state.joined_tables.contains(*t))
                 .filter(|t| self.has_join_edge(&state.joined_tables, t))
-                .collect()
+                .collect();
+
+            if !connected.is_empty() {
+                // Prefer connected tables to avoid Cartesian products
+                connected
+            } else {
+                // No connected tables remain - this is a disconnected join graph
+                // Allow ANY remaining table (Cartesian product is unavoidable)
+                // For Cartesian products, order by cardinality (smallest first) to minimize
+                // intermediate result sizes
+                let mut unjoined: Vec<&String> = self.all_tables
+                    .iter()
+                    .filter(|t| !state.joined_tables.contains(*t))
+                    .collect();
+
+                // Sort by cardinality (smallest first) to minimize intermediate sizes
+                unjoined.sort_by_key(|t| self.table_cardinalities.get(*t).copied().unwrap_or(10000));
+
+                unjoined
+            }
         };
 
         candidates

--- a/crates/vibesql-executor/src/select/join/search/dfs.rs
+++ b/crates/vibesql-executor/src/select/join/search/dfs.rs
@@ -87,7 +87,8 @@ impl JoinOrderContext {
 
         // Try adding each unjoined table that can be joined to already-joined tables
         // For the first table, any table is valid
-        // For subsequent tables, ONLY consider tables with join edges (enforce connectivity)
+        // For subsequent tables, prefer tables with join edges but allow disconnected tables
+        // when the join graph is not fully connected (e.g., Cartesian products)
         let candidates: Vec<&String> = if state.joined_tables.is_empty() {
             // First table: any unjoined table
             self.all_tables
@@ -95,13 +96,31 @@ impl JoinOrderContext {
                 .filter(|t| !state.joined_tables.contains(*t))
                 .collect()
         } else {
-            // Subsequent tables: MUST have join edge to already-joined tables
-            // This enforces connected subgraph enumeration (no CROSS JOINs)
-            self.all_tables
+            // Try to find tables with join edges first (connected subgraph)
+            let connected: Vec<&String> = self.all_tables
                 .iter()
                 .filter(|t| !state.joined_tables.contains(*t))
                 .filter(|t| self.has_join_edge(&state.joined_tables, t))
-                .collect()
+                .collect();
+
+            if !connected.is_empty() {
+                // Prefer connected tables to avoid Cartesian products
+                connected
+            } else {
+                // No connected tables remain - this is a disconnected join graph
+                // Allow ANY remaining table (Cartesian product is unavoidable)
+                // For Cartesian products, order by cardinality (smallest first) to minimize
+                // intermediate result sizes
+                let mut unjoined: Vec<&String> = self.all_tables
+                    .iter()
+                    .filter(|t| !state.joined_tables.contains(*t))
+                    .collect();
+
+                // Sort by cardinality (smallest first) to minimize intermediate sizes
+                unjoined.sort_by_key(|t| self.table_cardinalities.get(*t).copied().unwrap_or(10000));
+
+                unjoined
+            }
         };
 
         for next_table in candidates {

--- a/crates/vibesql-executor/src/select/join/search/greedy.rs
+++ b/crates/vibesql-executor/src/select/join/search/greedy.rs
@@ -76,9 +76,10 @@ impl JoinOrderContext {
                 // Update current cardinality to the result of this join
                 current_cardinality = best_cost.cardinality;
             } else {
-                // No connected tables remain - this indicates a disconnected join graph
-                // In well-formed SQL queries, this shouldn't happen
-                // Fall back to adding smallest remaining table to handle edge cases
+                // No connected tables remain - this is a disconnected join graph
+                // This is common in SQLLogicTest where queries have multiple table-local
+                // predicates but no join conditions (Cartesian products)
+                // Pick smallest remaining table to minimize intermediate result size
                 if let Some(table) = remaining_tables
                     .iter()
                     .min_by_key(|t| self.table_cardinalities.get(*t).copied().unwrap_or(10000))


### PR DESCRIPTION
## Summary

- Fix join order search (BFS/DFS) to handle disconnected join graphs
- Allows Cartesian products by falling back to ANY remaining table when no connected tables exist
- Orders disconnected tables by cardinality (smallest first) to minimize intermediate result sizes

## Test plan

- [x] Run select4.test - now passes 100% (was failing with MemoryLimitExceeded)
- [x] Run select1.test - passes 100%
- [x] Run join_order unit tests - passes

Closes #3361

🤖 Generated with [Claude Code](https://claude.com/claude-code)