### PR TITLE
fix(tests): Clear IN subquery cache when resetting pooled database

### DIFF
--- a/tests/sqllogictest/db_adapter/pool.rs
+++ b/tests/sqllogictest/db_adapter/pool.rs
@@ -6,6 +6,7 @@
 //! that is reset between files.
 
 use std::cell::RefCell;
+use vibesql_executor::clear_in_subquery_cache;
 use vibesql_storage::Database;
 
 // Thread-local Database pool for reuse across test files within the same worker thread.
@@ -18,6 +19,15 @@ thread_local! {
 /// Get a reset Database from the thread-local pool.
 /// First call creates a new Database, subsequent calls reuse and reset the existing one.
 /// Uses take/replace pattern to avoid cloning overhead.
+///
+/// # Cache Invalidation
+///
+/// When reusing a database, we also clear the thread-local IN subquery HashSet cache.
+/// This cache (in vibesql_executor) stores pre-computed HashSets for non-correlated
+/// IN subqueries. The cache key is based only on the subquery's SQL syntax (AST hash),
+/// not the underlying table data. Without clearing, cached results from one test file
+/// would be incorrectly reused for another file with the same subquery syntax but
+/// different data. See issue #3370.
 pub fn get_pooled_database() -> Database {
     DB_POOL.with(|pool| {
         let mut pool_ref = pool.borrow_mut();
@@ -25,6 +35,9 @@ pub fn get_pooled_database() -> Database {
             Some(mut db) => {
                 // Reuse existing database after resetting it (no clone)
                 db.reset();
+                // Clear the IN subquery HashSet cache to prevent stale results
+                // from previous test files with the same subquery syntax but different data
+                clear_in_subquery_cache();
                 db
             }
             None => {


### PR DESCRIPTION
## Summary

Fixes a thread-local IN subquery cache bug that caused intermittent test failures when running multiple SQLLogicTest files in sequence.

## Problem

The thread-local `IN_SUBQUERY_HASHSET_CACHE` was not being cleared between test files when reusing a pooled database. The cache key is based only on the subquery's AST hash (SQL syntax), not the underlying table data. When two test files used:

1. The same table name (`tab0`)
2. The same subquery syntax (`SELECT col3 FROM tab0 WHERE col0 > 63`)
3. But different data in the table

The cached HashSet from the first file was incorrectly returned for the second file.

## Reproduction

```bash
# Passes individually
SQLLOGICTEST_FILES="index/commute/10/slt_good_20.test" cargo test --release --package vibesql --test sqllogictest_suite

# Failed before this fix
SQLLOGICTEST_FILES="index/commute/10/slt_good_2.test,index/commute/10/slt_good_20.test" cargo test --release --package vibesql --test sqllogictest_suite
```

## Solution

Add a call to `clear_in_subquery_cache()` in `get_pooled_database()` alongside the existing `db.reset()` call, ensuring the cache is invalidated when switching between test files.

## Test plan

- [x] Verified the originally failing test combination now passes
- [x] Ran 8 consecutive files that previously failed - all pass
- [x] Unit tests pass (`cargo test --release --workspace --lib`)
- [x] Executor tests pass (`cargo test --release -p vibesql-executor --lib`)

Closes #3370

🤖 Generated with [Claude Code](https://claude.com/claude-code)