### PR TITLE
fix(grouping): Support GROUPING() in nested expressions for TPC-DS Q36,Q70,Q86

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -242,6 +242,9 @@ impl SelectExecutor<'_> {
     ///
     /// This is used for ROLLUP/CUBE/GROUPING SETS to support the GROUPING() function
     /// and to return NULL for columns that are rolled up in the current grouping set.
+    ///
+    /// This function handles all expression types recursively to ensure GROUPING() calls
+    /// nested within binary operations, CASE expressions, etc. are properly evaluated.
     #[allow(clippy::only_used_in_recursion)]
     pub(in crate::select::executor) fn evaluate_with_aggregates_and_grouping(
         &self,
@@ -251,43 +254,203 @@ impl SelectExecutor<'_> {
         evaluator: &CombinedExpressionEvaluator,
         grouping_context: &GroupingContext,
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
-        // Check for GROUPING() or GROUPING_ID() function call
-        if let vibesql_ast::Expression::Function { name, args, .. } = expr {
-            if name.eq_ignore_ascii_case("GROUPING") {
-                // GROUPING() function - returns 1 if the column is rolled up, 0 otherwise
-                if args.len() != 1 {
-                    return Err(ExecutorError::UnsupportedExpression(format!(
-                        "GROUPING() requires exactly 1 argument, got {}",
-                        args.len()
-                    )));
+        match expr {
+            // Check for GROUPING() or GROUPING_ID() function call
+            vibesql_ast::Expression::Function { name, args, .. } => {
+                if name.eq_ignore_ascii_case("GROUPING") {
+                    // GROUPING() function - returns 1 if the column is rolled up, 0 otherwise
+                    if args.len() != 1 {
+                        return Err(ExecutorError::UnsupportedExpression(format!(
+                            "GROUPING() requires exactly 1 argument, got {}",
+                            args.len()
+                        )));
+                    }
+                    let result = grouping_context.is_rolled_up(&args[0]);
+                    return Ok(vibesql_types::SqlValue::Integer(result as i64));
                 }
-                let result = grouping_context.is_rolled_up(&args[0]);
-                return Ok(vibesql_types::SqlValue::Integer(result as i64));
-            }
 
-            if name.eq_ignore_ascii_case("GROUPING_ID") {
-                // GROUPING_ID() function - returns a bitmap for multiple columns
-                // Formula: GROUPING(c1) * 2^(n-1) + GROUPING(c2) * 2^(n-2) + ... + GROUPING(cn)
-                if args.is_empty() {
-                    return Err(ExecutorError::UnsupportedExpression(
-                        "GROUPING_ID() requires at least 1 argument".to_string(),
-                    ));
+                if name.eq_ignore_ascii_case("GROUPING_ID") {
+                    // GROUPING_ID() function - returns a bitmap for multiple columns
+                    // Formula: GROUPING(c1) * 2^(n-1) + GROUPING(c2) * 2^(n-2) + ... + GROUPING(cn)
+                    if args.is_empty() {
+                        return Err(ExecutorError::UnsupportedExpression(
+                            "GROUPING_ID() requires at least 1 argument".to_string(),
+                        ));
+                    }
+                    let result = grouping_context.grouping_id(args);
+                    return Ok(vibesql_types::SqlValue::Integer(result));
                 }
-                let result = grouping_context.grouping_id(args);
-                return Ok(vibesql_types::SqlValue::Integer(result));
-            }
-        }
 
-        // For column references, check if the column is rolled up
-        // If rolled up, return NULL instead of the actual value
-        if let vibesql_ast::Expression::ColumnRef { .. } = expr {
-            if grouping_context.is_rolled_up(expr) == 1 {
-                return Ok(vibesql_types::SqlValue::Null);
+                // For other functions (including aggregates like COUNT, SUM, etc.),
+                // delegate to the function evaluator which handles Wildcard and other
+                // special arguments appropriately
+                function::evaluate(self, expr, group_rows, group_key, evaluator)
             }
-        }
 
-        // For other expressions, delegate to the existing evaluation
-        self.evaluate_with_aggregates(expr, group_rows, group_key, evaluator)
+            // Binary operation - recursively evaluate both sides with grouping context
+            vibesql_ast::Expression::BinaryOp { left, op, right } => {
+                let left_val = self.evaluate_with_aggregates_and_grouping(
+                    left,
+                    group_rows,
+                    group_key,
+                    evaluator,
+                    grouping_context,
+                )?;
+                let right_val = self.evaluate_with_aggregates_and_grouping(
+                    right,
+                    group_rows,
+                    group_key,
+                    evaluator,
+                    grouping_context,
+                )?;
+                crate::evaluator::ExpressionEvaluator::eval_binary_op_static(
+                    &left_val,
+                    op,
+                    &right_val,
+                    vibesql_types::SqlMode::default(),
+                )
+            }
+
+            // Unary operations - recursively evaluate inner expression with grouping context
+            vibesql_ast::Expression::UnaryOp { op, expr: inner_expr } => {
+                let inner_val = self.evaluate_with_aggregates_and_grouping(
+                    inner_expr,
+                    group_rows,
+                    group_key,
+                    evaluator,
+                    grouping_context,
+                )?;
+                crate::evaluator::eval_unary_op(op, &inner_val)
+            }
+
+            // CASE expression - evaluate with grouping context
+            // Need to handle both simple CASE (CASE x WHEN v THEN ...) and searched CASE (CASE WHEN cond THEN ...)
+            vibesql_ast::Expression::Case { operand, when_clauses, else_result } => {
+                match operand {
+                    // Simple CASE: CASE operand WHEN value THEN result ...
+                    Some(operand_expr) => {
+                        let operand_value = self.evaluate_with_aggregates_and_grouping(
+                            operand_expr,
+                            group_rows,
+                            group_key,
+                            evaluator,
+                            grouping_context,
+                        )?;
+
+                        for when_clause in when_clauses {
+                            // Check if ANY condition matches (OR logic)
+                            for condition_expr in &when_clause.conditions {
+                                let when_value = self.evaluate_with_aggregates_and_grouping(
+                                    condition_expr,
+                                    group_rows,
+                                    group_key,
+                                    evaluator,
+                                    grouping_context,
+                                )?;
+
+                                if crate::evaluator::ExpressionEvaluator::values_are_equal(&operand_value, &when_value) {
+                                    return self.evaluate_with_aggregates_and_grouping(
+                                        &when_clause.result,
+                                        group_rows,
+                                        group_key,
+                                        evaluator,
+                                        grouping_context,
+                                    );
+                                }
+                            }
+                        }
+
+                        if let Some(else_expr) = else_result {
+                            self.evaluate_with_aggregates_and_grouping(else_expr, group_rows, group_key, evaluator, grouping_context)
+                        } else {
+                            Ok(vibesql_types::SqlValue::Null)
+                        }
+                    }
+
+                    // Searched CASE: CASE WHEN condition THEN result ...
+                    None => {
+                        for when_clause in when_clauses {
+                            for condition_expr in &when_clause.conditions {
+                                let condition_value = self.evaluate_with_aggregates_and_grouping(
+                                    condition_expr,
+                                    group_rows,
+                                    group_key,
+                                    evaluator,
+                                    grouping_context,
+                                )?;
+
+                                let is_true = match condition_value {
+                                    vibesql_types::SqlValue::Boolean(true) => true,
+                                    vibesql_types::SqlValue::Boolean(false) | vibesql_types::SqlValue::Null => false,
+                                    vibesql_types::SqlValue::Integer(0) => false,
+                                    vibesql_types::SqlValue::Integer(_) => true,
+                                    _ => false,
+                                };
+
+                                if is_true {
+                                    return self.evaluate_with_aggregates_and_grouping(
+                                        &when_clause.result,
+                                        group_rows,
+                                        group_key,
+                                        evaluator,
+                                        grouping_context,
+                                    );
+                                }
+                            }
+                        }
+
+                        if let Some(else_expr) = else_result {
+                            self.evaluate_with_aggregates_and_grouping(else_expr, group_rows, group_key, evaluator, grouping_context)
+                        } else {
+                            Ok(vibesql_types::SqlValue::Null)
+                        }
+                    }
+                }
+            }
+
+            // Column references - check if the column is rolled up
+            vibesql_ast::Expression::ColumnRef { .. } => {
+                if grouping_context.is_rolled_up(expr) == 1 {
+                    return Ok(vibesql_types::SqlValue::Null);
+                }
+                // Not rolled up, evaluate normally
+                simple::evaluate_no_aggregates(expr, group_rows, evaluator)
+            }
+
+            // Aggregate functions - delegate to aggregate handler
+            vibesql_ast::Expression::AggregateFunction { .. } => {
+                aggregate_function::evaluate(self, expr, group_rows, evaluator)
+            }
+
+            // Cast - evaluate inner expression with grouping context
+            vibesql_ast::Expression::Cast { expr: inner, data_type } => {
+                let inner_val = self.evaluate_with_aggregates_and_grouping(
+                    inner,
+                    group_rows,
+                    group_key,
+                    evaluator,
+                    grouping_context,
+                )?;
+                crate::evaluator::casting::cast_value(&inner_val, data_type, &vibesql_types::SqlMode::default())
+            }
+
+            // IsNull - evaluate inner expression with grouping context
+            vibesql_ast::Expression::IsNull { expr: inner, negated } => {
+                let inner_val = self.evaluate_with_aggregates_and_grouping(
+                    inner,
+                    group_rows,
+                    group_key,
+                    evaluator,
+                    grouping_context,
+                )?;
+                let is_null = matches!(inner_val, vibesql_types::SqlValue::Null);
+                Ok(vibesql_types::SqlValue::Boolean(if *negated { !is_null } else { is_null }))
+            }
+
+            // For all other expressions, delegate to existing evaluation
+            // These don't typically contain GROUPING() calls
+            _ => self.evaluate_with_aggregates(expr, group_rows, group_key, evaluator),
+        }
     }
 
     /// Check if a SQL value is truthy (for HAVING clause evaluation)

--- a/crates/vibesql-executor/src/select/order.rs
+++ b/crates/vibesql-executor/src/select/order.rs
@@ -106,7 +106,8 @@ pub(super) fn apply_order_by(
 /// 1. Numeric position (ORDER BY 1) - returns ColumnRef to the alias/column at that position
 /// 2. Alias name (ORDER BY alias) - returns ColumnRef to that alias
 /// 3. Original column name (ORDER BY col where col is aliased to alias) - returns ColumnRef to alias
-/// 4. Otherwise - returns the original expression (for expressions not matching aliases)
+/// 4. Complex expressions containing GROUPING() - recursively resolves sub-expressions
+/// 5. Otherwise - returns the original expression (for expressions not matching aliases)
 pub(crate) fn resolve_order_by_for_aggregates(
     order_expr: &vibesql_ast::Expression,
     select_list: &[vibesql_ast::SelectItem],
@@ -179,8 +180,132 @@ pub(crate) fn resolve_order_by_for_aggregates(
         }
     }
 
+    // IMPORTANT: Check if the ENTIRE expression matches any SELECT list expression FIRST
+    // This handles cases like GROUPING(a) + GROUPING(b) matching an alias like "lochierarchy"
+    // before we try to recursively decompose the expression
+    if let Some(alias) = find_matching_select_expression(order_expr, select_list) {
+        return vibesql_ast::Expression::ColumnRef {
+            table: None,
+            column: alias,
+        };
+    }
+
+    // Handle CASE expressions by recursively resolving sub-expressions
+    if let vibesql_ast::Expression::Case { operand, when_clauses, else_result } = order_expr {
+        let resolved_operand = operand.as_ref().map(|op| {
+            Box::new(resolve_order_by_for_aggregates(op, select_list))
+        });
+
+        let resolved_when_clauses: Vec<vibesql_ast::CaseWhen> = when_clauses
+            .iter()
+            .map(|clause| {
+                vibesql_ast::CaseWhen {
+                    conditions: clause
+                        .conditions
+                        .iter()
+                        .map(|cond| resolve_order_by_for_aggregates(cond, select_list))
+                        .collect(),
+                    result: resolve_order_by_for_aggregates(&clause.result, select_list),
+                }
+            })
+            .collect();
+
+        let resolved_else = else_result.as_ref().map(|e| {
+            Box::new(resolve_order_by_for_aggregates(e, select_list))
+        });
+
+        return vibesql_ast::Expression::Case {
+            operand: resolved_operand,
+            when_clauses: resolved_when_clauses,
+            else_result: resolved_else,
+        };
+    }
+
+    // Handle BinaryOp expressions by recursively resolving sub-expressions
+    // Try to match the entire binary expression first (already done above with find_matching_select_expression)
+    // If no match, try matching each side separately
+    if let vibesql_ast::Expression::BinaryOp { left, op, right } = order_expr {
+        let resolved_left = resolve_order_by_for_aggregates(left, select_list);
+        let resolved_right = resolve_order_by_for_aggregates(right, select_list);
+
+        return vibesql_ast::Expression::BinaryOp {
+            left: Box::new(resolved_left),
+            op: op.clone(),
+            right: Box::new(resolved_right),
+        };
+    }
+
+    // Handle Function calls (including GROUPING) by checking if they match a SELECT expression
+    // This is already handled by find_matching_select_expression above, but keep as fallback
+    if let vibesql_ast::Expression::Function { name, .. } = order_expr {
+        if name.eq_ignore_ascii_case("GROUPING") || name.eq_ignore_ascii_case("GROUPING_ID") {
+            // Try to find a matching GROUPING expression in the SELECT list
+            if let Some(alias) = find_matching_select_expression(order_expr, select_list) {
+                return vibesql_ast::Expression::ColumnRef {
+                    table: None,
+                    column: alias,
+                };
+            }
+        }
+    }
+
     // Not an alias or column position, return the original expression
     order_expr.clone()
+}
+
+/// Find a matching expression in the SELECT list and return its alias or generated column name
+fn find_matching_select_expression(
+    expr: &vibesql_ast::Expression,
+    select_list: &[vibesql_ast::SelectItem],
+) -> Option<String> {
+    for (idx, item) in select_list.iter().enumerate() {
+        if let vibesql_ast::SelectItem::Expression { expr: select_expr, alias } = item {
+            if expressions_equal(expr, select_expr) {
+                // Found matching expression
+                return Some(if let Some(alias_name) = alias {
+                    alias_name.clone()
+                } else if let vibesql_ast::Expression::ColumnRef { column, .. } = select_expr {
+                    column.clone()
+                } else {
+                    format!("col{}", idx + 1)
+                });
+            }
+        }
+    }
+    None
+}
+
+/// Check if two expressions are structurally equal (for matching ORDER BY expressions to SELECT list)
+fn expressions_equal(a: &vibesql_ast::Expression, b: &vibesql_ast::Expression) -> bool {
+    match (a, b) {
+        (
+            vibesql_ast::Expression::ColumnRef { table: t1, column: c1 },
+            vibesql_ast::Expression::ColumnRef { table: t2, column: c2 },
+        ) => t1 == t2 && c1.eq_ignore_ascii_case(c2),
+
+        (
+            vibesql_ast::Expression::Literal(v1),
+            vibesql_ast::Expression::Literal(v2),
+        ) => v1 == v2,
+
+        (
+            vibesql_ast::Expression::BinaryOp { left: l1, op: o1, right: r1 },
+            vibesql_ast::Expression::BinaryOp { left: l2, op: o2, right: r2 },
+        ) => o1 == o2 && expressions_equal(l1, l2) && expressions_equal(r1, r2),
+
+        (
+            vibesql_ast::Expression::Function { name: n1, args: a1, .. },
+            vibesql_ast::Expression::Function { name: n2, args: a2, .. },
+        ) => {
+            n1.eq_ignore_ascii_case(n2)
+                && a1.len() == a2.len()
+                && a1.iter().zip(a2.iter()).all(|(x, y)| expressions_equal(x, y))
+        }
+
+        // For other expression types, use debug representation comparison as fallback
+        // This is not perfect but handles most common cases
+        _ => format!("{:?}", a) == format!("{:?}", b),
+    }
 }
 
 /// Resolve ORDER BY expression that might be a SELECT list alias or column position

--- a/crates/vibesql-executor/tests/grouping_sets_tests.rs
+++ b/crates/vibesql-executor/tests/grouping_sets_tests.rs
@@ -511,3 +511,32 @@ fn test_grouping_id_subset_of_groupby_columns() {
     assert!(grand_total.is_some());
     assert_eq!(get_i64(&grand_total.unwrap().values[3]), 3);
 }
+
+#[test]
+fn test_grouping_in_order_by_tpcds_q70_pattern() {
+    // This test replicates the TPC-DS Q70 pattern that was failing:
+    // ORDER BY with a CASE expression containing GROUPING() in the condition
+    let db = setup_db();
+
+    // Q70-style query: GROUPING() sum in SELECT list, CASE with GROUPING() in ORDER BY
+    let rows = execute_query(
+        &db,
+        "SELECT
+            SUM(amount) AS total,
+            year,
+            quarter,
+            GROUPING(year) + GROUPING(quarter) AS lochierarchy
+         FROM sales
+         GROUP BY ROLLUP(year, quarter)
+         ORDER BY
+            lochierarchy DESC,
+            CASE WHEN GROUPING(year) + GROUPING(quarter) = 0 THEN year END
+         LIMIT 10",
+    );
+
+    // Should have at least 1 row
+    assert!(!rows.is_empty(), "Expected at least one row");
+
+    // Verify grand total row is first (lochierarchy = 2)
+    assert_eq!(get_i64(&rows[0].values[3]), 2, "First row should be grand total (lochierarchy=2)");
+}


### PR DESCRIPTION
## Summary
- Fixes GROUPING() function when used inside nested expressions like binary operations and CASE conditions
- Enables TPC-DS queries Q36, Q70, and Q86 which use `GROUPING(a) + GROUPING(b)` patterns
- Adds recursive ORDER BY resolution for aggregate queries containing GROUPING() calls

## Test plan
- [x] TPC-DS Q36 passes (28ms)
- [x] TPC-DS Q70 passes (13ms)
- [x] TPC-DS Q86 passes (7ms)
- [x] All 1676 existing unit tests pass
- [x] Added new test `test_grouping_in_order_by_tpcds_q70_pattern`

Closes #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)