### PR TITLE
fix(storage): Fix B-tree bulk_load leaf capacity calculation

### DIFF
--- a/crates/vibesql-storage/src/btree/node/btree_index/bulk_load.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/bulk_load.rs
@@ -94,11 +94,11 @@ impl BTreeIndex {
         }
         let grouped_entries = chunked_entries;
 
-        // Calculate leaf capacity based on actual entry sizes with chunked row_ids
-        // Each entry now has up to max_row_ids_per_entry row_ids
-        let entry_size_with_chunk = key_size + 5 + 8 * max_row_ids_per_entry;
+        // Calculate leaf capacity based on typical entry sizes (most entries have 1 row_id)
+        // Entry size for single row_id: key + 1 byte varint + 8 bytes row_id
+        let typical_entry_size = key_size + 1 + 8;
         let available_for_entries = PAGE_SIZE.saturating_sub(19); // header + prev/next leaf
-        let leaf_capacity = (available_for_entries / entry_size_with_chunk).max(1);
+        let leaf_capacity = (available_for_entries / typical_entry_size).max(1);
         // Apply 75% fill factor
         let leaf_capacity = ((leaf_capacity * 3) / 4).max(1);
 
@@ -113,11 +113,28 @@ impl BTreeIndex {
             let page_id = page_manager.allocate_page()?;
             let mut leaf = LeafNode::new(page_id);
 
-            // Fill leaf node to target capacity
-            for _ in 0..leaf_capacity {
-                if let Some((key, row_ids)) = entries_iter.next() {
-                    leaf.entries.push((key, row_ids));
-                } else {
+            // Fill leaf node based on actual serialized size
+            let mut current_size = 0;
+            let max_size = available_for_entries;
+
+            while let Some((_key, row_ids)) = entries_iter.peek() {
+                // Calculate actual size of this entry
+                // varint encoding: 1 byte for counts < 128, 2 bytes for < 16384, etc.
+                let varint_size = if row_ids.len() < 128 { 1 } else if row_ids.len() < 16384 { 2 } else { 3 };
+                let entry_size = key_size + varint_size + row_ids.len() * 8;
+
+                // Check if we have room for this entry
+                if current_size > 0 && current_size + entry_size > max_size {
+                    break; // This entry would overflow the page
+                }
+
+                // Add the entry
+                current_size += entry_size;
+                let (key, row_ids) = entries_iter.next().unwrap();
+                leaf.entries.push((key, row_ids));
+
+                // Also respect the target fill factor (approx leaf_capacity entries)
+                if leaf.entries.len() >= leaf_capacity {
                     break;
                 }
             }


### PR DESCRIPTION
## Summary

- Fixed B-tree `bulk_load` function that was incorrectly calculating leaf capacity based on worst-case chunked entry sizes, causing small datasets to create multi-level trees when they should fit in a single leaf
- Changed leaf capacity calculation to use typical entry sizes (1 row_id per entry) and fill leaves based on actual serialized entry sizes

## Test plan

- [x] All 7 previously failing B-tree tests now pass:
  - `test_bulk_load_small`
  - `test_bulk_load_multi_column`
  - `test_delete_single_level_tree`
  - `test_delete_nonexistent_key`
  - `test_delete_sequence`
  - `test_delete_multi_column_keys`
  - `test_delete_specific_with_rebalancing`
- [x] Full vibesql-storage test suite passes (314 tests)
- [x] No clippy warnings

Closes #3383

🤖 Generated with [Claude Code](https://claude.com/claude-code)