### PR TITLE
fix(planner): Qualify self-join IN subquery columns with correct table

### DIFF
--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/helpers.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/helpers.rs
@@ -36,22 +36,6 @@ pub(super) fn is_self_join(from: &FromClause, table_name: &str, table_alias: &Op
     existing_names.iter().any(|n| n.eq_ignore_ascii_case(effective_name) || n.eq_ignore_ascii_case(table_name))
 }
 
-/// Get the primary (leftmost) table name from a FROM clause
-/// Returns the effective name (alias if present, otherwise table name)
-pub(super) fn get_primary_table_name(from: &FromClause) -> Option<String> {
-    match from {
-        FromClause::Table { name, alias, .. } => {
-            Some(alias.clone().unwrap_or_else(|| name.clone()))
-        }
-        FromClause::Join { left, .. } => {
-            get_primary_table_name(left)
-        }
-        FromClause::Subquery { alias, .. } => {
-            Some(alias.clone())
-        }
-    }
-}
-
 /// Qualify an unqualified column reference with a table name
 /// Only rewrites unqualified columns, leaves qualified ones unchanged
 pub(super) fn qualify_outer_column_refs(expr: &Expression, outer_table: &str) -> Expression {

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
@@ -26,7 +26,7 @@
 use vibesql_ast::{BinaryOperator, Expression, FromClause, JoinType, SelectItem, SelectStmt};
 
 use super::helpers::{
-    get_primary_table_name, is_self_join, qualify_outer_column_refs, rewrite_column_refs_with_alias,
+    is_self_join, qualify_outer_column_refs, rewrite_column_refs_with_alias,
 };
 
 /// Result of converting an IN subquery to a join
@@ -85,13 +85,16 @@ pub(super) fn try_convert_in_to_join(
             eprintln!("[SUBQUERY_TRANSFORM] Self-join detected: table={}, new_alias={}", table_name, new_alias);
         }
 
-        // Get the outer table name to qualify outer column references
-        let outer_table_name = get_primary_table_name(from)
-            .unwrap_or_else(|| table_name.clone()); // Fallback to table_name if not found
+        // For a self-join, we need to qualify the outer expression columns with the
+        // original table name (not the leftmost table in the FROM clause).
+        // Example: `i_item_id IN (SELECT i_item_id FROM item WHERE ...)`
+        // The outer `i_item_id` refers to the outer `item` table, so we qualify it
+        // as `item.i_item_id`, and the subquery columns get rewritten to `__subquery_item.i_item_id`
+        let outer_table_name = table_alias.as_ref().unwrap_or(&table_name);
 
         // Qualify outer expression columns with the outer table name
         // This prevents ambiguity when both tables have the same column names
-        let qualified_expr = qualify_outer_column_refs(expr, &outer_table_name);
+        let qualified_expr = qualify_outer_column_refs(expr, outer_table_name);
 
         // Use the table alias (if present) for matching column references, not just the table name
         // This is critical for Q21 where the subquery uses an alias like "l2" or "l3"


### PR DESCRIPTION
## Summary

- Fix TPC-DS Q56 failure caused by incorrect column qualification in self-join IN subqueries
- When the outer query and subquery reference the same table, qualify outer expression columns with the self-joined table name instead of the leftmost table in FROM clause
- Remove unused `get_primary_table_name` helper function

## Root Cause

In the IN-to-SEMI-JOIN transformation for self-join cases, the code was incorrectly calling `get_primary_table_name(from)` which returns the leftmost table in the FROM clause. For Q56:
```sql
FROM store_sales, date_dim, customer_address, item
WHERE i_item_id IN (SELECT i_item_id FROM item WHERE ...)
```

This caused `i_item_id` to be qualified as `store_sales.i_item_id` instead of `item.i_item_id`, resulting in `ColumnNotFound` error.

## Fix

Use the self-joined table name directly (`table_alias` or `table_name` from the subquery) rather than the leftmost outer table.

## Test plan

- [x] TPC-DS Q56 now passes
- [x] Full TPC-DS suite: 96/99 queries pass (0 errors, 3 skipped)
- [x] All subquery-related tests pass
- [x] All executor tests pass

Closes #3384

🤖 Generated with [Claude Code](https://claude.com/claude-code)