### PR TITLE
perf(storage): Add deferred sync for bulk_load to avoid per-page fsync

### DIFF
--- a/crates/vibesql-storage/src/btree/node/btree_index/bulk_load.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/bulk_load.rs
@@ -2,6 +2,13 @@
 //!
 //! This module provides efficient bottom-up construction of B+ trees from
 //! sorted data, which is approximately 10x faster than incremental inserts.
+//!
+//! # Performance Optimization
+//!
+//! Bulk loading uses deferred sync mode to avoid expensive `fsync` calls on
+//! every page write. Instead, pages are written to the OS buffer cache and
+//! a single `sync` call is made at the end of the bulk load operation.
+//! This can reduce bulk load time from minutes to seconds for large datasets.
 
 use std::sync::Arc;
 use vibesql_types::DataType;
@@ -10,6 +17,7 @@ use crate::page::{PageId, PageManager, PAGE_SIZE};
 use crate::StorageError;
 
 use super::super::super::{calculate_degree, estimate_max_key_size};
+use super::super::super::serialize::{write_leaf_node_no_sync, write_internal_node_no_sync};
 use super::super::structure::{InternalNode, Key, LeafNode};
 use super::BTreeIndex;
 
@@ -145,14 +153,14 @@ impl BTreeIndex {
                 leaf.prev_leaf = prev_id;
 
                 // Update the previous leaf's next_leaf pointer
-                // Read previous leaf, update it, and write it back
+                // Read previous leaf, update it, and write it back (no sync)
                 let mut prev_leaf = super::super::super::serialize::read_leaf_node(&page_manager, prev_id)?;
                 prev_leaf.next_leaf = page_id;
-                super::super::super::serialize::write_leaf_node(&page_manager, &prev_leaf, degree)?;
+                write_leaf_node_no_sync(&page_manager, &prev_leaf, degree)?;
             }
 
-            // Write current leaf to disk
-            super::super::super::serialize::write_leaf_node(&page_manager, &leaf, degree)?;
+            // Write current leaf to disk (no sync - will sync once at end)
+            write_leaf_node_no_sync(&page_manager, &leaf, degree)?;
 
             leaf_page_ids.push(page_id);
             prev_leaf_page_id = Some(page_id);
@@ -194,8 +202,8 @@ impl BTreeIndex {
                     }
                 }
 
-                // Write internal node to disk
-                super::super::super::serialize::write_internal_node(&page_manager, &internal, degree)?;
+                // Write internal node to disk (no sync - will sync once at end)
+                write_internal_node_no_sync(&page_manager, &internal, degree)?;
 
                 next_level.push(page_id);
             }
@@ -215,8 +223,13 @@ impl BTreeIndex {
             metadata_page_id,
         };
 
-        // Save metadata
-        index.save_metadata()?;
+        // Save metadata without syncing (we'll sync once at the end)
+        index.save_metadata_no_sync()?;
+
+        // Sync all page writes to disk in a single fsync call
+        // This is the key optimization: instead of syncing after every page write,
+        // we batch all writes and sync once at the end
+        index.page_manager.sync()?;
 
         Ok(index)
     }

--- a/crates/vibesql-storage/src/btree/node/btree_index/mod.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/mod.rs
@@ -176,8 +176,8 @@ impl BTreeIndex {
         })
     }
 
-    /// Save metadata to page 0
-    pub(super) fn save_metadata(&self) -> Result<(), StorageError> {
+    /// Serialize metadata to a page (without writing to disk)
+    fn serialize_metadata(&self) -> Result<crate::page::Page, StorageError> {
         let mut metadata_page = self.page_manager.read_page(0)?;
         let mut offset = 0;
 
@@ -208,8 +208,22 @@ impl BTreeIndex {
         }
 
         metadata_page.mark_dirty();
-        self.page_manager.write_page(&mut metadata_page)?;
+        Ok(metadata_page)
+    }
 
+    /// Save metadata to page 0 with immediate sync
+    pub(super) fn save_metadata(&self) -> Result<(), StorageError> {
+        let mut page = self.serialize_metadata()?;
+        self.page_manager.write_page(&mut page)?;
+        Ok(())
+    }
+
+    /// Save metadata to page 0 without syncing
+    ///
+    /// Use this for bulk operations. Call `page_manager.sync()` after all writes.
+    pub(super) fn save_metadata_no_sync(&self) -> Result<(), StorageError> {
+        let mut page = self.serialize_metadata()?;
+        self.page_manager.write_page_no_sync(&mut page)?;
         Ok(())
     }
 

--- a/crates/vibesql-storage/src/btree/serialize.rs
+++ b/crates/vibesql-storage/src/btree/serialize.rs
@@ -66,12 +66,8 @@ fn read_varint(cursor: &mut Cursor<&[u8]>) -> Result<usize, StorageError> {
     Ok(value)
 }
 
-/// Write an internal node to disk
-pub fn write_internal_node(
-    page_manager: &Arc<PageManager>,
-    node: &InternalNode,
-    _degree: usize,
-) -> Result<(), StorageError> {
+/// Serialize an internal node to a page (without writing to disk)
+fn serialize_internal_node(node: &InternalNode) -> Result<Page, StorageError> {
     let mut page = Page::new(node.page_id);
     let mut cursor = Cursor::new(&mut page.data[..]);
 
@@ -117,8 +113,30 @@ pub fn write_internal_node(
     }
 
     page.mark_dirty();
-    page_manager.write_page(&mut page)?;
+    Ok(page)
+}
 
+/// Write an internal node to disk with immediate sync
+pub fn write_internal_node(
+    page_manager: &Arc<PageManager>,
+    node: &InternalNode,
+    _degree: usize,
+) -> Result<(), StorageError> {
+    let mut page = serialize_internal_node(node)?;
+    page_manager.write_page(&mut page)?;
+    Ok(())
+}
+
+/// Write an internal node to disk without syncing
+///
+/// Use this for bulk operations. Call `page_manager.sync()` after all writes.
+pub fn write_internal_node_no_sync(
+    page_manager: &Arc<PageManager>,
+    node: &InternalNode,
+    _degree: usize,
+) -> Result<(), StorageError> {
+    let mut page = serialize_internal_node(node)?;
+    page_manager.write_page_no_sync(&mut page)?;
     Ok(())
 }
 
@@ -179,12 +197,8 @@ pub fn read_internal_node(
     Ok(node)
 }
 
-/// Write a leaf node to disk
-pub fn write_leaf_node(
-    page_manager: &Arc<PageManager>,
-    node: &LeafNode,
-    _degree: usize,
-) -> Result<(), StorageError> {
+/// Serialize a leaf node to a page (without writing to disk)
+fn serialize_leaf_node(node: &LeafNode) -> Result<Page, StorageError> {
     let mut page = Page::new(node.page_id);
     let mut cursor = Cursor::new(&mut page.data[..]);
 
@@ -243,8 +257,30 @@ pub fn write_leaf_node(
     }
 
     page.mark_dirty();
-    page_manager.write_page(&mut page)?;
+    Ok(page)
+}
 
+/// Write a leaf node to disk with immediate sync
+pub fn write_leaf_node(
+    page_manager: &Arc<PageManager>,
+    node: &LeafNode,
+    _degree: usize,
+) -> Result<(), StorageError> {
+    let mut page = serialize_leaf_node(node)?;
+    page_manager.write_page(&mut page)?;
+    Ok(())
+}
+
+/// Write a leaf node to disk without syncing
+///
+/// Use this for bulk operations. Call `page_manager.sync()` after all writes.
+pub fn write_leaf_node_no_sync(
+    page_manager: &Arc<PageManager>,
+    node: &LeafNode,
+    _degree: usize,
+) -> Result<(), StorageError> {
+    let mut page = serialize_leaf_node(node)?;
+    page_manager.write_page_no_sync(&mut page)?;
     Ok(())
 }
 

--- a/crates/vibesql-storage/src/page/mod.rs
+++ b/crates/vibesql-storage/src/page/mod.rs
@@ -174,7 +174,11 @@ impl PageManager {
         }
     }
 
-    /// Write a page to disk
+    /// Write a page to disk with immediate sync
+    ///
+    /// This ensures durability by syncing data to disk after each write.
+    /// For bulk operations, consider using `write_page_no_sync` followed
+    /// by a single `sync` call for better performance.
     pub fn write_page(&self, page: &mut Page) -> Result<(), StorageError> {
         let mut file = lock!(self.file);
 
@@ -183,6 +187,35 @@ impl PageManager {
         file.sync_data()?;
 
         page.mark_clean();
+        Ok(())
+    }
+
+    /// Write a page to disk without syncing
+    ///
+    /// This is faster than `write_page` but does not guarantee durability
+    /// until `sync` is called. Use this for bulk operations where you want
+    /// to batch many writes before a single sync.
+    ///
+    /// # Safety
+    /// Data may be lost on crash until `sync` is called.
+    pub fn write_page_no_sync(&self, page: &mut Page) -> Result<(), StorageError> {
+        let mut file = lock!(self.file);
+
+        let offset = page.id * (PAGE_SIZE as u64);
+        file.write_at(offset, &page.data)?;
+
+        page.mark_clean();
+        Ok(())
+    }
+
+    /// Sync all pending writes to disk
+    ///
+    /// This ensures all data written via `write_page_no_sync` is persisted.
+    /// Call this after a batch of `write_page_no_sync` operations to ensure
+    /// durability.
+    pub fn sync(&self) -> Result<(), StorageError> {
+        let mut file = lock!(self.file);
+        file.sync_data()?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Add `write_page_no_sync` and `sync` methods to PageManager to support batched writes without per-page fsync overhead. Update bulk_load and related serialization functions to use deferred sync mode.

### Problem

The tests `test_budget_enforcement_with_spill_policy` and `test_lru_eviction_order` were taking over 60 seconds each despite operating on small datasets (50-100 rows). The root cause was that `PageManager::write_page()` called `sync_data()` (fsync) after every single page write.

During `bulk_load()`, this happened dozens of times:
- Each leaf node write → fsync
- Each doubly-linked list pointer update → fsync  
- Each internal node write → fsync
- Metadata save → fsync

Each fsync can take 10-50ms on typical hardware, causing small indexes to take minutes to spill.

### Solution

Add deferred sync mode for bulk operations:

- **PageManager**: Add `write_page_no_sync()` for writes without immediate sync, and `sync()` to flush all pending writes
- **BTree serialize**: Add `write_leaf_node_no_sync()` and `write_internal_node_no_sync()`  
- **BTreeIndex**: Add `save_metadata_no_sync()`
- **bulk_load**: Use all no_sync variants, then call single `sync()` at the end

This batches all fsync overhead into one call per bulk_load operation.

## Test plan

- [x] `cargo check --package vibesql-storage` passes
- [x] All btree tests pass (54 tests including `test_bulk_load_produces_searchable_index`)
- [x] All page module tests pass (6 tests)
- [x] All storage tests pass (15 unit + 36 ignored doc tests)

Closes #3395

🤖 Generated with [Claude Code](https://claude.com/claude-code)