### PR TITLE
feat(vector): Distance operators (<->, <#>, <=>) - Phase 3

### DIFF
--- a/crates/vibesql-ast/src/operators.rs
+++ b/crates/vibesql-ast/src/operators.rs
@@ -26,6 +26,11 @@ pub enum BinaryOperator {
     // String
     Concat, /* || */
 
+    // Vector distance operators (pgvector compatible)
+    CosineDistance,        // <-> (1 - cosine_similarity)
+    NegativeInnerProduct,  // <#> (negative dot product for MIPS)
+    L2Distance,            // <=> (Euclidean distance)
+
     // Note: LIKE and IN are not simple binary operators. They are implemented
     // as Expression variants in expression.rs due to their complex structure:
     // - LIKE: Pattern matching with wildcards (%, _)

--- a/crates/vibesql-ast/tests/operators.rs
+++ b/crates/vibesql-ast/tests/operators.rs
@@ -162,3 +162,54 @@ fn test_unary_plus_operator() {
         _ => panic!("Expected unary plus operation"),
     }
 }
+
+// ============================================================================
+// Vector Distance Operator Tests (pgvector compatible)
+// ============================================================================
+
+#[test]
+fn test_cosine_distance_operator() {
+    let expr = Expression::BinaryOp {
+        op: BinaryOperator::CosineDistance,
+        left: Box::new(Expression::Literal(SqlValue::Vector(vec![1.0, 0.0, 0.0]))),
+        right: Box::new(Expression::Literal(SqlValue::Vector(vec![0.0, 1.0, 0.0]))),
+    };
+    match expr {
+        Expression::BinaryOp { op: BinaryOperator::CosineDistance, .. } => {} // Success
+        _ => panic!("Expected cosine distance operation"),
+    }
+}
+
+#[test]
+fn test_negative_inner_product_operator() {
+    let expr = Expression::BinaryOp {
+        op: BinaryOperator::NegativeInnerProduct,
+        left: Box::new(Expression::Literal(SqlValue::Vector(vec![1.0, 2.0, 3.0]))),
+        right: Box::new(Expression::Literal(SqlValue::Vector(vec![4.0, 5.0, 6.0]))),
+    };
+    match expr {
+        Expression::BinaryOp { op: BinaryOperator::NegativeInnerProduct, .. } => {} // Success
+        _ => panic!("Expected negative inner product operation"),
+    }
+}
+
+#[test]
+fn test_l2_distance_operator() {
+    let expr = Expression::BinaryOp {
+        op: BinaryOperator::L2Distance,
+        left: Box::new(Expression::Literal(SqlValue::Vector(vec![0.0, 0.0]))),
+        right: Box::new(Expression::Literal(SqlValue::Vector(vec![3.0, 4.0]))),
+    };
+    match expr {
+        Expression::BinaryOp { op: BinaryOperator::L2Distance, .. } => {} // Success
+        _ => panic!("Expected L2 distance operation"),
+    }
+}
+
+#[test]
+fn test_vector_distance_operators_exist() {
+    let _cosine = BinaryOperator::CosineDistance;
+    let _neg_ip = BinaryOperator::NegativeInnerProduct;
+    let _l2 = BinaryOperator::L2Distance;
+    // If these compile, the operators exist
+}

--- a/crates/vibesql-executor/src/evaluator/operators/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/mod.rs
@@ -2,18 +2,20 @@
 //!
 //! This module provides a pluggable, testable operator system that replaces
 //! the monolithic match statement in the core evaluator. Each operator category
-//! (arithmetic, comparison, logical, string) is implemented in its own module
+//! (arithmetic, comparison, logical, string, vector) is implemented in its own module
 //! with dedicated logic and tests.
 
 mod arithmetic;
 mod comparison;
 mod logical;
 mod string;
+mod vector;
 
 use arithmetic::ArithmeticOps;
 use comparison::ComparisonOps;
 use logical::LogicalOps;
 use string::StringOps;
+use vector::VectorOps;
 use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;
@@ -75,6 +77,11 @@ impl OperatorRegistry {
 
             // String operators
             Concat => StringOps::concat(left, right),
+
+            // Vector distance operators (pgvector compatible)
+            CosineDistance => VectorOps::cosine_distance(left, right),
+            NegativeInnerProduct => VectorOps::negative_inner_product(left, right),
+            L2Distance => VectorOps::l2_distance(left, right),
         }
     }
 }

--- a/crates/vibesql-executor/src/evaluator/operators/vector.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/vector.rs
@@ -1,0 +1,237 @@
+//! Vector distance operators for pgvector-compatible similarity search
+//!
+//! Implements distance operators for vector similarity queries:
+//! - `<->` Cosine distance (1 - cosine_similarity)
+//! - `<#>` Negative inner product (for Maximum Inner Product Search)
+//! - `<=>` L2 (Euclidean) distance
+
+use vibesql_types::SqlValue;
+
+use crate::errors::ExecutorError;
+
+/// Vector distance operations
+pub(crate) struct VectorOps;
+
+impl VectorOps {
+    /// Cosine distance: 1 - cosine_similarity
+    /// Maps to pgvector's <-> operator
+    ///
+    /// Cosine similarity = dot(a, b) / (||a|| * ||b||)
+    /// Cosine distance = 1 - cosine_similarity
+    ///
+    /// Returns a value between 0 (identical) and 2 (opposite)
+    #[inline]
+    pub fn cosine_distance(left: &SqlValue, right: &SqlValue) -> Result<SqlValue, ExecutorError> {
+        match (left, right) {
+            (SqlValue::Vector(v1), SqlValue::Vector(v2)) => {
+                if v1.len() != v2.len() {
+                    return Err(ExecutorError::TypeError(format!(
+                        "Vector dimension mismatch: {} vs {}",
+                        v1.len(),
+                        v2.len()
+                    )));
+                }
+
+                if v1.is_empty() {
+                    return Err(ExecutorError::TypeError(
+                        "Cannot compute cosine distance of empty vectors".to_string(),
+                    ));
+                }
+
+                let dot_product: f64 =
+                    v1.iter().zip(v2.iter()).map(|(a, b)| (*a as f64) * (*b as f64)).sum();
+
+                let norm1: f64 = v1.iter().map(|x| (*x as f64) * (*x as f64)).sum::<f64>().sqrt();
+                let norm2: f64 = v2.iter().map(|x| (*x as f64) * (*x as f64)).sum::<f64>().sqrt();
+
+                // Handle zero vectors - distance is 1.0 (orthogonal)
+                if norm1 == 0.0 || norm2 == 0.0 {
+                    return Ok(SqlValue::Double(1.0));
+                }
+
+                let cosine_similarity = dot_product / (norm1 * norm2);
+                // Clamp to handle floating point precision issues
+                let cosine_similarity = cosine_similarity.clamp(-1.0, 1.0);
+                let distance = 1.0 - cosine_similarity;
+
+                Ok(SqlValue::Double(distance))
+            }
+            (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
+            _ => Err(ExecutorError::TypeError(format!(
+                "Cosine distance operator <-> requires VECTOR operands, got {} and {}",
+                left.type_name(),
+                right.type_name()
+            ))),
+        }
+    }
+
+    /// Negative inner product (dot product)
+    /// Maps to pgvector's <#> operator
+    ///
+    /// Used for Maximum Inner Product Search (MIPS)
+    /// Negated so that ORDER BY ... ASC gives highest similarity first
+    #[inline]
+    pub fn negative_inner_product(
+        left: &SqlValue,
+        right: &SqlValue,
+    ) -> Result<SqlValue, ExecutorError> {
+        match (left, right) {
+            (SqlValue::Vector(v1), SqlValue::Vector(v2)) => {
+                if v1.len() != v2.len() {
+                    return Err(ExecutorError::TypeError(format!(
+                        "Vector dimension mismatch: {} vs {}",
+                        v1.len(),
+                        v2.len()
+                    )));
+                }
+
+                let dot_product: f64 =
+                    v1.iter().zip(v2.iter()).map(|(a, b)| (*a as f64) * (*b as f64)).sum();
+
+                // Negate so ORDER BY ASC gives highest similarity first
+                Ok(SqlValue::Double(-dot_product))
+            }
+            (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
+            _ => Err(ExecutorError::TypeError(format!(
+                "Negative inner product operator <#> requires VECTOR operands, got {} and {}",
+                left.type_name(),
+                right.type_name()
+            ))),
+        }
+    }
+
+    /// L2 (Euclidean) distance
+    /// Maps to pgvector's <=> operator
+    ///
+    /// L2 distance = sqrt(sum((v1[i] - v2[i])^2))
+    #[inline]
+    pub fn l2_distance(left: &SqlValue, right: &SqlValue) -> Result<SqlValue, ExecutorError> {
+        match (left, right) {
+            (SqlValue::Vector(v1), SqlValue::Vector(v2)) => {
+                if v1.len() != v2.len() {
+                    return Err(ExecutorError::TypeError(format!(
+                        "Vector dimension mismatch: {} vs {}",
+                        v1.len(),
+                        v2.len()
+                    )));
+                }
+
+                let sum_sq: f64 = v1
+                    .iter()
+                    .zip(v2.iter())
+                    .map(|(a, b)| {
+                        let diff = (*a as f64) - (*b as f64);
+                        diff * diff
+                    })
+                    .sum();
+
+                Ok(SqlValue::Double(sum_sq.sqrt()))
+            }
+            (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
+            _ => Err(ExecutorError::TypeError(format!(
+                "L2 distance operator <=> requires VECTOR operands, got {} and {}",
+                left.type_name(),
+                right.type_name()
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vec_val(v: &[f32]) -> SqlValue {
+        SqlValue::Vector(v.to_vec())
+    }
+
+    #[test]
+    fn test_cosine_distance_identical() {
+        let v = vec_val(&[1.0, 0.0, 0.0]);
+        let result = VectorOps::cosine_distance(&v, &v).unwrap();
+        if let SqlValue::Double(d) = result {
+            assert!((d - 0.0).abs() < 1e-10);
+        } else {
+            panic!("Expected Double");
+        }
+    }
+
+    #[test]
+    fn test_cosine_distance_orthogonal() {
+        let v1 = vec_val(&[1.0, 0.0]);
+        let v2 = vec_val(&[0.0, 1.0]);
+        let result = VectorOps::cosine_distance(&v1, &v2).unwrap();
+        if let SqlValue::Double(d) = result {
+            assert!((d - 1.0).abs() < 1e-10);
+        } else {
+            panic!("Expected Double");
+        }
+    }
+
+    #[test]
+    fn test_cosine_distance_opposite() {
+        let v1 = vec_val(&[1.0, 0.0]);
+        let v2 = vec_val(&[-1.0, 0.0]);
+        let result = VectorOps::cosine_distance(&v1, &v2).unwrap();
+        if let SqlValue::Double(d) = result {
+            assert!((d - 2.0).abs() < 1e-10);
+        } else {
+            panic!("Expected Double");
+        }
+    }
+
+    #[test]
+    fn test_l2_distance() {
+        let v1 = vec_val(&[0.0, 0.0]);
+        let v2 = vec_val(&[3.0, 4.0]);
+        let result = VectorOps::l2_distance(&v1, &v2).unwrap();
+        if let SqlValue::Double(d) = result {
+            assert!((d - 5.0).abs() < 1e-10);
+        } else {
+            panic!("Expected Double");
+        }
+    }
+
+    #[test]
+    fn test_negative_inner_product() {
+        let v1 = vec_val(&[1.0, 2.0, 3.0]);
+        let v2 = vec_val(&[4.0, 5.0, 6.0]);
+        // dot product = 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
+        // negative = -32
+        let result = VectorOps::negative_inner_product(&v1, &v2).unwrap();
+        if let SqlValue::Double(d) = result {
+            assert!((d - (-32.0)).abs() < 1e-10);
+        } else {
+            panic!("Expected Double");
+        }
+    }
+
+    #[test]
+    fn test_dimension_mismatch() {
+        let v1 = vec_val(&[1.0, 2.0]);
+        let v2 = vec_val(&[1.0, 2.0, 3.0]);
+        assert!(VectorOps::cosine_distance(&v1, &v2).is_err());
+        assert!(VectorOps::l2_distance(&v1, &v2).is_err());
+        assert!(VectorOps::negative_inner_product(&v1, &v2).is_err());
+    }
+
+    #[test]
+    fn test_null_handling() {
+        let v = vec_val(&[1.0, 2.0]);
+        assert!(matches!(VectorOps::cosine_distance(&SqlValue::Null, &v).unwrap(), SqlValue::Null));
+        assert!(matches!(VectorOps::l2_distance(&v, &SqlValue::Null).unwrap(), SqlValue::Null));
+        assert!(matches!(
+            VectorOps::negative_inner_product(&SqlValue::Null, &SqlValue::Null).unwrap(),
+            SqlValue::Null
+        ));
+    }
+
+    #[test]
+    fn test_type_error() {
+        let v = vec_val(&[1.0, 2.0]);
+        let i = SqlValue::Integer(42);
+        assert!(VectorOps::cosine_distance(&v, &i).is_err());
+        assert!(VectorOps::l2_distance(&i, &v).is_err());
+        assert!(VectorOps::negative_inner_product(&i, &i).is_err());
+    }
+}

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -108,6 +108,7 @@ mod triggers;
 mod truncate_cascade_tests;
 mod truncate_table_tests;
 mod unique_index_tests;
+mod vector_distance_operators;
 mod view_tests;
 mod sql_mode_tests;
 mod secondary_index_fast_path;

--- a/crates/vibesql-executor/src/tests/vector_distance_operators.rs
+++ b/crates/vibesql-executor/src/tests/vector_distance_operators.rs
@@ -1,0 +1,290 @@
+//! Vector distance operator tests
+//!
+//! Tests for pgvector-compatible distance operators:
+//! - <-> (cosine distance)
+//! - <#> (negative inner product)
+//! - <=> (L2/Euclidean distance)
+
+use super::super::*;
+
+// =============================================================================
+// Cosine Distance (<->) Tests
+// =============================================================================
+
+#[test]
+fn test_cosine_distance_identical_vectors() {
+    let schema = vibesql_catalog::TableSchema::new("test".to_string(), vec![]);
+    let evaluator = ExpressionEvaluator::new(&schema);
+    let row = vibesql_storage::Row::new(vec![]);
+
+    // Identical vectors should have distance 0
+    let expr = vibesql_ast::Expression::BinaryOp {
+        left: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            1.0, 0.0, 0.0,
+        ]))),
+        op: vibesql_ast::BinaryOperator::CosineDistance,
+        right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            1.0, 0.0, 0.0,
+        ]))),
+    };
+
+    let result = evaluator.eval(&expr, &row).unwrap();
+    if let vibesql_types::SqlValue::Double(d) = result {
+        assert!((d - 0.0).abs() < 1e-10, "Expected 0.0, got {}", d);
+    } else {
+        panic!("Expected Double, got {:?}", result);
+    }
+}
+
+#[test]
+fn test_cosine_distance_orthogonal_vectors() {
+    let schema = vibesql_catalog::TableSchema::new("test".to_string(), vec![]);
+    let evaluator = ExpressionEvaluator::new(&schema);
+    let row = vibesql_storage::Row::new(vec![]);
+
+    // Orthogonal vectors should have distance 1
+    let expr = vibesql_ast::Expression::BinaryOp {
+        left: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            1.0, 0.0,
+        ]))),
+        op: vibesql_ast::BinaryOperator::CosineDistance,
+        right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            0.0, 1.0,
+        ]))),
+    };
+
+    let result = evaluator.eval(&expr, &row).unwrap();
+    if let vibesql_types::SqlValue::Double(d) = result {
+        assert!((d - 1.0).abs() < 1e-10, "Expected 1.0, got {}", d);
+    } else {
+        panic!("Expected Double, got {:?}", result);
+    }
+}
+
+#[test]
+fn test_cosine_distance_opposite_vectors() {
+    let schema = vibesql_catalog::TableSchema::new("test".to_string(), vec![]);
+    let evaluator = ExpressionEvaluator::new(&schema);
+    let row = vibesql_storage::Row::new(vec![]);
+
+    // Opposite vectors should have distance 2
+    let expr = vibesql_ast::Expression::BinaryOp {
+        left: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            1.0, 0.0,
+        ]))),
+        op: vibesql_ast::BinaryOperator::CosineDistance,
+        right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            -1.0, 0.0,
+        ]))),
+    };
+
+    let result = evaluator.eval(&expr, &row).unwrap();
+    if let vibesql_types::SqlValue::Double(d) = result {
+        assert!((d - 2.0).abs() < 1e-10, "Expected 2.0, got {}", d);
+    } else {
+        panic!("Expected Double, got {:?}", result);
+    }
+}
+
+// =============================================================================
+// L2 Distance (<=>) Tests
+// =============================================================================
+
+#[test]
+fn test_l2_distance_identical_vectors() {
+    let schema = vibesql_catalog::TableSchema::new("test".to_string(), vec![]);
+    let evaluator = ExpressionEvaluator::new(&schema);
+    let row = vibesql_storage::Row::new(vec![]);
+
+    // Identical vectors should have distance 0
+    let expr = vibesql_ast::Expression::BinaryOp {
+        left: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            1.0, 2.0, 3.0,
+        ]))),
+        op: vibesql_ast::BinaryOperator::L2Distance,
+        right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            1.0, 2.0, 3.0,
+        ]))),
+    };
+
+    let result = evaluator.eval(&expr, &row).unwrap();
+    if let vibesql_types::SqlValue::Double(d) = result {
+        assert!((d - 0.0).abs() < 1e-10, "Expected 0.0, got {}", d);
+    } else {
+        panic!("Expected Double, got {:?}", result);
+    }
+}
+
+#[test]
+fn test_l2_distance_known_values() {
+    let schema = vibesql_catalog::TableSchema::new("test".to_string(), vec![]);
+    let evaluator = ExpressionEvaluator::new(&schema);
+    let row = vibesql_storage::Row::new(vec![]);
+
+    // 3-4-5 triangle: sqrt(3^2 + 4^2) = 5
+    let expr = vibesql_ast::Expression::BinaryOp {
+        left: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            0.0, 0.0,
+        ]))),
+        op: vibesql_ast::BinaryOperator::L2Distance,
+        right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            3.0, 4.0,
+        ]))),
+    };
+
+    let result = evaluator.eval(&expr, &row).unwrap();
+    if let vibesql_types::SqlValue::Double(d) = result {
+        assert!((d - 5.0).abs() < 1e-10, "Expected 5.0, got {}", d);
+    } else {
+        panic!("Expected Double, got {:?}", result);
+    }
+}
+
+// =============================================================================
+// Negative Inner Product (<#>) Tests
+// =============================================================================
+
+#[test]
+fn test_negative_inner_product() {
+    let schema = vibesql_catalog::TableSchema::new("test".to_string(), vec![]);
+    let evaluator = ExpressionEvaluator::new(&schema);
+    let row = vibesql_storage::Row::new(vec![]);
+
+    // dot product = 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
+    // negative = -32
+    let expr = vibesql_ast::Expression::BinaryOp {
+        left: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            1.0, 2.0, 3.0,
+        ]))),
+        op: vibesql_ast::BinaryOperator::NegativeInnerProduct,
+        right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            4.0, 5.0, 6.0,
+        ]))),
+    };
+
+    let result = evaluator.eval(&expr, &row).unwrap();
+    if let vibesql_types::SqlValue::Double(d) = result {
+        assert!((d - (-32.0)).abs() < 1e-10, "Expected -32.0, got {}", d);
+    } else {
+        panic!("Expected Double, got {:?}", result);
+    }
+}
+
+#[test]
+fn test_negative_inner_product_orthogonal() {
+    let schema = vibesql_catalog::TableSchema::new("test".to_string(), vec![]);
+    let evaluator = ExpressionEvaluator::new(&schema);
+    let row = vibesql_storage::Row::new(vec![]);
+
+    // Orthogonal vectors have dot product = 0, negative = 0
+    let expr = vibesql_ast::Expression::BinaryOp {
+        left: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            1.0, 0.0,
+        ]))),
+        op: vibesql_ast::BinaryOperator::NegativeInnerProduct,
+        right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            0.0, 1.0,
+        ]))),
+    };
+
+    let result = evaluator.eval(&expr, &row).unwrap();
+    if let vibesql_types::SqlValue::Double(d) = result {
+        assert!((d - 0.0).abs() < 1e-10, "Expected 0.0, got {}", d);
+    } else {
+        panic!("Expected Double, got {:?}", result);
+    }
+}
+
+// =============================================================================
+// NULL Handling Tests
+// =============================================================================
+
+#[test]
+fn test_distance_operators_null_handling() {
+    let schema = vibesql_catalog::TableSchema::new("test".to_string(), vec![]);
+    let evaluator = ExpressionEvaluator::new(&schema);
+    let row = vibesql_storage::Row::new(vec![]);
+
+    let v = vibesql_types::SqlValue::Vector(vec![1.0, 2.0, 3.0]);
+
+    // NULL <-> vec = NULL
+    let expr = vibesql_ast::Expression::BinaryOp {
+        left: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)),
+        op: vibesql_ast::BinaryOperator::CosineDistance,
+        right: Box::new(vibesql_ast::Expression::Literal(v.clone())),
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert!(matches!(result, vibesql_types::SqlValue::Null));
+
+    // vec <=> NULL = NULL
+    let expr = vibesql_ast::Expression::BinaryOp {
+        left: Box::new(vibesql_ast::Expression::Literal(v.clone())),
+        op: vibesql_ast::BinaryOperator::L2Distance,
+        right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)),
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert!(matches!(result, vibesql_types::SqlValue::Null));
+
+    // NULL <#> NULL = NULL
+    let expr = vibesql_ast::Expression::BinaryOp {
+        left: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)),
+        op: vibesql_ast::BinaryOperator::NegativeInnerProduct,
+        right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)),
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert!(matches!(result, vibesql_types::SqlValue::Null));
+}
+
+// =============================================================================
+// Error Handling Tests
+// =============================================================================
+
+#[test]
+fn test_dimension_mismatch_error() {
+    let schema = vibesql_catalog::TableSchema::new("test".to_string(), vec![]);
+    let evaluator = ExpressionEvaluator::new(&schema);
+    let row = vibesql_storage::Row::new(vec![]);
+
+    // Different dimensions should error
+    let expr = vibesql_ast::Expression::BinaryOp {
+        left: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            1.0, 2.0,
+        ]))),
+        op: vibesql_ast::BinaryOperator::CosineDistance,
+        right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            1.0, 2.0, 3.0,
+        ]))),
+    };
+
+    let err = evaluator.eval(&expr, &row).unwrap_err();
+    match err {
+        ExecutorError::TypeError(msg) => {
+            assert!(msg.contains("dimension mismatch"), "Expected dimension mismatch error, got: {}", msg);
+        }
+        other => panic!("Expected TypeError, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_type_mismatch_error() {
+    let schema = vibesql_catalog::TableSchema::new("test".to_string(), vec![]);
+    let evaluator = ExpressionEvaluator::new(&schema);
+    let row = vibesql_storage::Row::new(vec![]);
+
+    // Non-vector operands should error
+    let expr = vibesql_ast::Expression::BinaryOp {
+        left: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Vector(vec![
+            1.0, 2.0,
+        ]))),
+        op: vibesql_ast::BinaryOperator::L2Distance,
+        right: Box::new(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(42))),
+    };
+
+    let err = evaluator.eval(&expr, &row).unwrap_err();
+    match err {
+        ExecutorError::TypeError(msg) => {
+            assert!(msg.contains("VECTOR"), "Expected VECTOR type error, got: {}", msg);
+        }
+        other => panic!("Expected TypeError, got {:?}", other),
+    }
+}

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -223,6 +223,9 @@ impl<'arena> ArenaParser<'arena> {
                     | MultiCharOperator::GreaterEqual
                     | MultiCharOperator::NotEqual
                     | MultiCharOperator::NotEqualAlt
+                    | MultiCharOperator::CosineDistance
+                    | MultiCharOperator::NegativeInnerProduct
+                    | MultiCharOperator::L2Distance
             ),
             _ => false,
         };
@@ -238,6 +241,10 @@ impl<'arena> ArenaParser<'arena> {
                     MultiCharOperator::NotEqual | MultiCharOperator::NotEqualAlt => {
                         BinaryOperator::NotEqual
                     }
+                    // Vector distance operators (pgvector compatible)
+                    MultiCharOperator::CosineDistance => BinaryOperator::CosineDistance,
+                    MultiCharOperator::NegativeInnerProduct => BinaryOperator::NegativeInnerProduct,
+                    MultiCharOperator::L2Distance => BinaryOperator::L2Distance,
                     _ => {
                         return Err(ParseError {
                             message: "Unexpected || operator in comparison".to_string(),

--- a/crates/vibesql-parser/src/lexer/operators.rs
+++ b/crates/vibesql-parser/src/lexer/operators.rs
@@ -4,17 +4,62 @@ use crate::token::{MultiCharOperator, Token};
 impl<'a> Lexer<'a> {
     /// Tokenize comparison and logical operators.
     /// Handles multi-character operators like <=, >=, !=, <>, ||
+    /// Also handles pgvector-compatible distance operators: <->, <#>, <=>
     pub(super) fn tokenize_operator(&mut self, ch: char) -> Result<Token, LexerError> {
         match ch {
-            '=' | '<' | '>' | '!' => {
+            '<' => {
+                self.advance();
+                if self.is_eof() {
+                    return Ok(Token::Symbol('<'));
+                }
+
+                let next_ch = self.current_char();
+                match next_ch {
+                    '-' => {
+                        // Could be <-> (cosine distance)
+                        if self.peek_byte(1) == Some(b'>') {
+                            self.advance(); // consume '-'
+                            self.advance(); // consume '>'
+                            Ok(Token::Operator(MultiCharOperator::CosineDistance))
+                        } else {
+                            // Just '<' followed by '-' (separate tokens)
+                            Ok(Token::Symbol('<'))
+                        }
+                    }
+                    '#' => {
+                        // Could be <#> (negative inner product)
+                        if self.peek_byte(1) == Some(b'>') {
+                            self.advance(); // consume '#'
+                            self.advance(); // consume '>'
+                            Ok(Token::Operator(MultiCharOperator::NegativeInnerProduct))
+                        } else {
+                            // Just '<' followed by '#' - return '<' as symbol
+                            Ok(Token::Symbol('<'))
+                        }
+                    }
+                    '=' => {
+                        // Could be <=> (L2 distance) or <= (less than or equal)
+                        if self.peek_byte(1) == Some(b'>') {
+                            self.advance(); // consume '='
+                            self.advance(); // consume '>'
+                            Ok(Token::Operator(MultiCharOperator::L2Distance))
+                        } else {
+                            self.advance(); // consume '='
+                            Ok(Token::Operator(MultiCharOperator::LessEqual))
+                        }
+                    }
+                    '>' => {
+                        self.advance();
+                        Ok(Token::Operator(MultiCharOperator::NotEqualAlt))
+                    }
+                    _ => Ok(Token::Symbol('<')),
+                }
+            }
+            '=' | '>' | '!' => {
                 self.advance();
                 if !self.is_eof() {
                     let next_ch = self.current_char();
                     match (ch, next_ch) {
-                        ('<', '=') => {
-                            self.advance();
-                            Ok(Token::Operator(MultiCharOperator::LessEqual))
-                        }
                         ('>', '=') => {
                             self.advance();
                             Ok(Token::Operator(MultiCharOperator::GreaterEqual))
@@ -22,10 +67,6 @@ impl<'a> Lexer<'a> {
                         ('!', '=') => {
                             self.advance();
                             Ok(Token::Operator(MultiCharOperator::NotEqual))
-                        }
-                        ('<', '>') => {
-                            self.advance();
-                            Ok(Token::Operator(MultiCharOperator::NotEqualAlt))
                         }
                         _ => Ok(Token::Symbol(ch)),
                     }

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -296,6 +296,14 @@ impl Parser {
                         MultiCharOperator::NotEqual | MultiCharOperator::NotEqualAlt => {
                             vibesql_ast::BinaryOperator::NotEqual
                         }
+                        // Vector distance operators (pgvector compatible)
+                        MultiCharOperator::CosineDistance => {
+                            vibesql_ast::BinaryOperator::CosineDistance
+                        }
+                        MultiCharOperator::NegativeInnerProduct => {
+                            vibesql_ast::BinaryOperator::NegativeInnerProduct
+                        }
+                        MultiCharOperator::L2Distance => vibesql_ast::BinaryOperator::L2Distance,
                         MultiCharOperator::Concat => {
                             return Err(ParseError {
                                 message: format!("Unexpected operator: {}", op),

--- a/crates/vibesql-parser/src/token.rs
+++ b/crates/vibesql-parser/src/token.rs
@@ -16,6 +16,12 @@ pub enum MultiCharOperator {
     NotEqualAlt,
     /// || (string concatenation)
     Concat,
+    /// <-> (cosine distance - pgvector compatible)
+    CosineDistance,
+    /// <#> (negative inner product - pgvector compatible)
+    NegativeInnerProduct,
+    /// <=> (L2/Euclidean distance - pgvector compatible)
+    L2Distance,
 }
 
 impl fmt::Display for MultiCharOperator {
@@ -26,6 +32,9 @@ impl fmt::Display for MultiCharOperator {
             MultiCharOperator::NotEqual => write!(f, "!="),
             MultiCharOperator::NotEqualAlt => write!(f, "<>"),
             MultiCharOperator::Concat => write!(f, "||"),
+            MultiCharOperator::CosineDistance => write!(f, "<->"),
+            MultiCharOperator::NegativeInnerProduct => write!(f, "<#>"),
+            MultiCharOperator::L2Distance => write!(f, "<=>"),
         }
     }
 }

--- a/crates/vibesql-storage/src/persistence/binary/expression/operators.rs
+++ b/crates/vibesql-storage/src/persistence/binary/expression/operators.rs
@@ -27,6 +27,10 @@ impl_simple_enum_serialization!(
         BinaryOperator::And => 20,
         BinaryOperator::Or => 21,
         BinaryOperator::Concat => 30,
+        // Vector distance operators (pgvector compatible)
+        BinaryOperator::CosineDistance => 40,
+        BinaryOperator::NegativeInnerProduct => 41,
+        BinaryOperator::L2Distance => 42,
     }
 );
 


### PR DESCRIPTION
## Summary

Implement PostgreSQL/pgvector-compatible distance operators for vector similarity queries. This is Phase 3 of the vector search feature, building on the vector data type from Phase 1.

### Operators Implemented

| Operator | Name | Description |
|----------|------|-------------|
| `<->` | Cosine distance | 1 - cosine_similarity, most common for embeddings |
| `<#>` | Negative inner product | For Maximum Inner Product Search (MIPS) |
| `<=>` | L2 distance | Euclidean distance |

### Example Usage

```sql
-- Cosine distance (most common for embeddings)
SELECT id, content FROM documents
ORDER BY embedding <-> $query_embedding LIMIT 10;

-- L2 distance with filtering
SELECT * FROM items
WHERE features <=> $query < 0.5
ORDER BY features <=> $query;

-- Negative inner product (for MIPS)
SELECT * FROM products
ORDER BY embedding <#> $query LIMIT 5;
```

### Changes

- **Lexer**: Added 3-character operator tokenization for `<->`, `<#>`, `<=>`
- **AST**: Added `CosineDistance`, `NegativeInnerProduct`, `L2Distance` variants to `BinaryOperator`
- **Parser**: Updated both standard and arena parsers to handle new operators
- **Executor**: Implemented distance calculations with proper NULL handling, dimension checking, and type validation
- **Persistence**: Added serialization support for new operators
- **Tests**: Comprehensive unit and integration tests for all operators

### Compatibility

These operators match pgvector syntax for easier migration from PostgreSQL.

## Test plan

- [x] Unit tests for each distance operator
- [x] Tests for NULL handling
- [x] Tests for dimension mismatch errors
- [x] Tests for type mismatch errors
- [x] AST operator tests
- [x] Parser builds and compiles
- [x] All existing tests pass

Closes #3476

🤖 Generated with [Claude Code](https://claude.com/claude-code)