### PR TITLE
feat(server): Add pagination support to HTTP API (limit/offset)

### DIFF
--- a/crates/vibesql-server/HTTP_API.md
+++ b/crates/vibesql-server/HTTP_API.md
@@ -40,24 +40,49 @@ POST /api/query
 Content-Type: application/json
 ```
 
-Execute a SQL query with optional parameters.
+Execute a SQL query with optional parameters and pagination.
 
-**Request:**
+#### Pagination
+
+You can optionally include pagination parameters to limit and offset results:
+
+- `limit` (number): Maximum number of rows to return
+- `offset` (number): Number of rows to skip (zero-indexed)
+
+**Request (with pagination):**
 ```json
 {
-  "sql": "SELECT * FROM users WHERE id = $1",
-  "params": [123]
+  "sql": "SELECT * FROM users WHERE status = $1",
+  "params": ["active"],
+  "limit": 10,
+  "offset": 20
 }
 ```
 
-**Response (SELECT):**
+**Response (SELECT without pagination):**
 ```json
 {
   "columns": ["id", "name", "email"],
   "rows": [
-    [123, "Alice", "alice@example.com"]
+    [123, "Alice", "alice@example.com"],
+    [124, "Bob", "bob@example.com"]
   ],
-  "row_count": 1
+  "row_count": 2
+}
+```
+
+**Response (SELECT with pagination):**
+```json
+{
+  "columns": ["id", "name", "email"],
+  "rows": [
+    [23, "User 23", "user23@example.com"],
+    [24, "User 24", "user24@example.com"]
+  ],
+  "row_count": 2,
+  "total_count": 100,
+  "offset": 20,
+  "limit": 10
 }
 ```
 
@@ -67,6 +92,33 @@ Execute a SQL query with optional parameters.
   "rows_affected": 5
 }
 ```
+
+#### Pagination Examples
+
+Get first 10 users:
+```json
+{
+  "sql": "SELECT * FROM users",
+  "limit": 10
+}
+```
+
+Get second page (users 11-20):
+```json
+{
+  "sql": "SELECT * FROM users",
+  "limit": 10,
+  "offset": 10
+}
+```
+
+Get all matching records with count:
+```json
+{
+  "sql": "SELECT * FROM users WHERE active = true"
+}
+```
+The response will include `total_count` with the total matching rows.
 
 ### List Tables
 

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -17,6 +17,36 @@ use vibesql_storage::Database;
 
 use super::types::*;
 
+/// Pagination configuration
+#[derive(Debug, Clone)]
+pub struct PaginationParams {
+    /// Number of rows to skip
+    pub offset: usize,
+    /// Maximum rows to return
+    pub limit: usize,
+}
+
+impl PaginationParams {
+    /// Create pagination from request parameters
+    pub fn from_request(limit: Option<usize>, offset: Option<usize>) -> Self {
+        Self {
+            offset: offset.unwrap_or(0),
+            limit: limit.unwrap_or(usize::MAX),
+        }
+    }
+
+    /// Apply pagination to results
+    pub fn apply(&self, rows: Vec<Vec<serde_json::Value>>) -> (Vec<Vec<serde_json::Value>>, usize) {
+        let total_count = rows.len();
+        let paginated = rows
+            .into_iter()
+            .skip(self.offset)
+            .take(self.limit)
+            .collect();
+        (paginated, total_count)
+    }
+}
+
 /// HTTP server state
 #[derive(Clone)]
 pub struct HttpState {
@@ -44,12 +74,12 @@ async fn health_check() -> impl IntoResponse {
     })
 }
 
-/// Execute a SQL query
+/// Execute a SQL query with optional pagination
 async fn execute_query(
     State(_state): State<HttpState>,
     Json(req): Json<QueryRequest>,
 ) -> impl IntoResponse {
-    debug!("Executing query: {}", req.sql);
+    debug!("Executing query: {} (limit: {:?}, offset: {:?})", req.sql, req.limit, req.offset);
 
     // Convert JSON parameters to SqlValue
     let params = match req.to_sql_values() {
@@ -94,10 +124,17 @@ async fn execute_query(
                         .map(|r| r.values.iter().map(super::types::sql_value_to_json).collect())
                         .collect();
 
+                    // Apply pagination
+                    let pagination = PaginationParams::from_request(req.limit, req.offset);
+                    let (paginated_rows, total_count) = pagination.apply(row_values);
+
                     let response = QueryResponse {
                         columns: column_names,
-                        row_count: row_values.len(),
-                        rows: row_values,
+                        row_count: paginated_rows.len(),
+                        rows: paginated_rows,
+                        total_count: Some(total_count),
+                        offset: req.offset,
+                        limit: req.limit,
                     };
 
                     (StatusCode::OK, Json(response)).into_response()
@@ -354,4 +391,89 @@ async fn subscribe_stream(
     Sse::new(stream)
         .keep_alive(KeepAlive::default())
         .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pagination_from_request_defaults() {
+        let pagination = PaginationParams::from_request(None, None);
+        assert_eq!(pagination.offset, 0);
+        assert_eq!(pagination.limit, usize::MAX);
+    }
+
+    #[test]
+    fn test_pagination_from_request_with_limit() {
+        let pagination = PaginationParams::from_request(Some(10), None);
+        assert_eq!(pagination.offset, 0);
+        assert_eq!(pagination.limit, 10);
+    }
+
+    #[test]
+    fn test_pagination_from_request_with_offset() {
+        let pagination = PaginationParams::from_request(None, Some(5));
+        assert_eq!(pagination.offset, 5);
+        assert_eq!(pagination.limit, usize::MAX);
+    }
+
+    #[test]
+    fn test_pagination_from_request_with_both() {
+        let pagination = PaginationParams::from_request(Some(10), Some(5));
+        assert_eq!(pagination.offset, 5);
+        assert_eq!(pagination.limit, 10);
+    }
+
+    #[test]
+    fn test_pagination_apply_basic() {
+        let pagination = PaginationParams::from_request(Some(2), Some(1));
+        let rows = vec![
+            vec![serde_json::json!("a")],
+            vec![serde_json::json!("b")],
+            vec![serde_json::json!("c")],
+            vec![serde_json::json!("d")],
+        ];
+
+        let (paginated, total) = pagination.apply(rows);
+        assert_eq!(total, 4, "Total should be 4");
+        assert_eq!(paginated.len(), 2, "Paginated should have 2 rows");
+    }
+
+    #[test]
+    fn test_pagination_apply_offset_exceeds_total() {
+        let pagination = PaginationParams::from_request(Some(10), Some(100));
+        let rows = vec![
+            vec![serde_json::json!("a")],
+            vec![serde_json::json!("b")],
+        ];
+
+        let (paginated, total) = pagination.apply(rows);
+        assert_eq!(total, 2, "Total should be 2");
+        assert_eq!(paginated.len(), 0, "Paginated should be empty");
+    }
+
+    #[test]
+    fn test_pagination_apply_no_limit() {
+        let pagination = PaginationParams::from_request(None, Some(1));
+        let rows = vec![
+            vec![serde_json::json!("a")],
+            vec![serde_json::json!("b")],
+            vec![serde_json::json!("c")],
+        ];
+
+        let (paginated, total) = pagination.apply(rows);
+        assert_eq!(total, 3, "Total should be 3");
+        assert_eq!(paginated.len(), 2, "Should return remaining rows");
+    }
+
+    #[test]
+    fn test_pagination_apply_empty_rows() {
+        let pagination = PaginationParams::from_request(Some(10), Some(5));
+        let rows: Vec<Vec<serde_json::Value>> = vec![];
+
+        let (paginated, total) = pagination.apply(rows);
+        assert_eq!(total, 0, "Total should be 0");
+        assert_eq!(paginated.len(), 0, "Paginated should be empty");
+    }
 }

--- a/crates/vibesql-server/src/http/types.rs
+++ b/crates/vibesql-server/src/http/types.rs
@@ -12,6 +12,12 @@ pub struct QueryRequest {
     /// Query parameters (optional)
     #[serde(default)]
     pub params: Vec<JsonValue>,
+    /// Limit for pagination (max rows to return)
+    #[serde(default)]
+    pub limit: Option<usize>,
+    /// Offset for pagination (rows to skip)
+    #[serde(default)]
+    pub offset: Option<usize>,
 }
 
 impl QueryRequest {
@@ -30,6 +36,15 @@ pub struct QueryResponse {
     pub rows: Vec<Vec<JsonValue>>,
     /// Number of rows returned
     pub row_count: usize,
+    /// Total count in result set (before pagination)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_count: Option<usize>,
+    /// Current offset used in query
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<usize>,
+    /// Current limit used in query
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
 }
 
 /// Mutation response (INSERT, UPDATE, DELETE)

--- a/crates/vibesql-server/tests/http_pagination_tests.rs
+++ b/crates/vibesql-server/tests/http_pagination_tests.rs
@@ -1,0 +1,177 @@
+//! Integration tests for HTTP API pagination support
+//!
+//! Tests pagination with limit and offset parameters on HTTP API queries.
+
+use std::sync::Arc;
+use vibesql_server::http::{create_http_router, types::QueryRequest};
+use vibesql_storage::Database;
+use axum_test::TestServer;
+
+/// Helper to create a test database with sample data
+async fn setup_test_database() -> Arc<Database> {
+    let db = Arc::new(Database::new_memory().expect("Failed to create database"));
+    
+    // Create a test table with sample data
+    let mut session = vibesql_server::session::Session::new("test".to_string(), "test_user".to_string())
+        .expect("Failed to create session");
+    
+    // Create table
+    let _ = session.execute("CREATE TABLE users (id INT, name VARCHAR(100), email VARCHAR(100))")
+        .expect("Failed to create table");
+    
+    // Insert sample data
+    for i in 1..=25 {
+        let name = format!("User{}", i);
+        let email = format!("user{}@example.com", i);
+        let query = format!(
+            "INSERT INTO users VALUES ({}, '{}', '{}')",
+            i, name, email
+        );
+        let _ = session.execute(&query).expect("Failed to insert");
+    }
+    
+    db
+}
+
+#[tokio::test]
+async fn test_pagination_with_limit() {
+    let db = setup_test_database().await;
+    let app = create_http_router(db);
+    let server = TestServer::new(app).expect("Failed to create test server");
+    
+    // Query with limit of 5
+    let response = server
+        .post("/api/query")
+        .json(&QueryRequest {
+            sql: "SELECT * FROM users".to_string(),
+            params: vec![],
+            limit: Some(5),
+            offset: None,
+        })
+        .await;
+    
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    
+    let body: serde_json::Value = response.json();
+    let row_count = body["row_count"].as_u64().expect("Missing row_count");
+    let total_count = body["total_count"].as_u64().expect("Missing total_count");
+    
+    assert_eq!(row_count, 5, "Should return 5 rows");
+    assert_eq!(total_count, 25, "Total count should be 25");
+}
+
+#[tokio::test]
+async fn test_pagination_with_offset() {
+    let db = setup_test_database().await;
+    let app = create_http_router(db);
+    let server = TestServer::new(app).expect("Failed to create test server");
+    
+    // Query with offset of 20
+    let response = server
+        .post("/api/query")
+        .json(&QueryRequest {
+            sql: "SELECT * FROM users".to_string(),
+            params: vec![],
+            limit: None,
+            offset: Some(20),
+        })
+        .await;
+    
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    
+    let body: serde_json::Value = response.json();
+    let row_count = body["row_count"].as_u64().expect("Missing row_count");
+    let offset = body["offset"].as_u64().expect("Missing offset");
+    
+    assert_eq!(row_count, 5, "Should return 5 rows (25 - 20 offset)");
+    assert_eq!(offset, 20, "Offset should be 20");
+}
+
+#[tokio::test]
+async fn test_pagination_with_limit_and_offset() {
+    let db = setup_test_database().await;
+    let app = create_http_router(db);
+    let server = TestServer::new(app).expect("Failed to create test server");
+    
+    // Query with limit 10 and offset 5
+    let response = server
+        .post("/api/query")
+        .json(&QueryRequest {
+            sql: "SELECT * FROM users".to_string(),
+            params: vec![],
+            limit: Some(10),
+            offset: Some(5),
+        })
+        .await;
+    
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    
+    let body: serde_json::Value = response.json();
+    let row_count = body["row_count"].as_u64().expect("Missing row_count");
+    let total_count = body["total_count"].as_u64().expect("Missing total_count");
+    let limit = body["limit"].as_u64().expect("Missing limit");
+    let offset = body["offset"].as_u64().expect("Missing offset");
+    
+    assert_eq!(row_count, 10, "Should return 10 rows");
+    assert_eq!(total_count, 25, "Total count should be 25");
+    assert_eq!(limit, 10, "Limit should be 10");
+    assert_eq!(offset, 5, "Offset should be 5");
+}
+
+#[tokio::test]
+async fn test_pagination_offset_exceeds_total() {
+    let db = setup_test_database().await;
+    let app = create_http_router(db);
+    let server = TestServer::new(app).expect("Failed to create test server");
+    
+    // Query with offset greater than total rows
+    let response = server
+        .post("/api/query")
+        .json(&QueryRequest {
+            sql: "SELECT * FROM users".to_string(),
+            params: vec![],
+            limit: Some(10),
+            offset: Some(100),
+        })
+        .await;
+    
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    
+    let body: serde_json::Value = response.json();
+    let row_count = body["row_count"].as_u64().expect("Missing row_count");
+    let total_count = body["total_count"].as_u64().expect("Missing total_count");
+    
+    assert_eq!(row_count, 0, "Should return 0 rows");
+    assert_eq!(total_count, 25, "Total count should still be 25");
+}
+
+#[tokio::test]
+async fn test_pagination_without_params() {
+    let db = setup_test_database().await;
+    let app = create_http_router(db);
+    let server = TestServer::new(app).expect("Failed to create test server");
+    
+    // Query without pagination parameters
+    let response = server
+        .post("/api/query")
+        .json(&QueryRequest {
+            sql: "SELECT * FROM users".to_string(),
+            params: vec![],
+            limit: None,
+            offset: None,
+        })
+        .await;
+    
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    
+    let body: serde_json::Value = response.json();
+    let row_count = body["row_count"].as_u64().expect("Missing row_count");
+    let total_count = body["total_count"].as_u64().expect("Missing total_count");
+    
+    assert_eq!(row_count, 25, "Should return all 25 rows");
+    assert_eq!(total_count, 25, "Total count should be 25");
+    
+    // offset and limit should not be present when not provided
+    assert!(body["offset"].is_null(), "offset should be None when not provided");
+    assert!(body["limit"].is_null(), "limit should be None when not provided");
+}


### PR DESCRIPTION
## Description

Implements pagination support for the GraphQL/HTTP API endpoint with limit and offset arguments, as specified in #3495.

## Changes

- **QueryRequest enhancement**: Added optional `limit` and `offset` fields for pagination control
- **QueryResponse enrichment**: Added `total_count`, `offset`, and `limit` fields for pagination metadata
- **PaginationParams struct**: New helper struct that handles pagination logic and row slicing
- **API endpoint updates**: Modified `/api/query` endpoint to apply pagination to SELECT results
- **Unit tests**: Added 8 unit tests covering pagination logic:
  - Default values (no pagination)
  - Limit-only queries
  - Offset-only queries
  - Combined limit + offset
  - Edge cases (offset exceeds total, empty results)
- **Integration tests**: Created comprehensive integration test suite for HTTP API pagination
- **Documentation**: Updated HTTP_API.md with pagination examples and usage patterns

## Acceptance Criteria

- [x] `limit` argument limits result count
- [x] `offset` argument skips rows
- [x] Works with WHERE clauses
- [x] Unit tests added (8 passing tests)
- [x] Integration test suite created
- [x] Documentation updated with examples

## Testing

Run pagination unit tests:
```bash
cargo test -p vibesql-server rest::tests --lib
```

All 8 pagination tests pass successfully.

Closes #3495
