### PR TITLE
GraphQL Schema Introspection

### DIFF
--- a/crates/vibesql-server/src/http/graphql.rs
+++ b/crates/vibesql-server/src/http/graphql.rs
@@ -1,7 +1,8 @@
 //! GraphQL API implementation for VibeSQL HTTP interface
 //!
 //! This provides a lightweight GraphQL-like interface over HTTP without a full GraphQL library.
-//! It supports queries and mutations on database tables with structured filtering.
+//! It supports queries and mutations on database tables with structured filtering,
+//! as well as schema introspection (__schema, __type queries).
 //!
 //! # WHERE Clause Operators
 //!
@@ -51,8 +52,12 @@
 //! }
 //! ```
 
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
+use serde_json::{json, Value as JsonValue};
+
+use vibesql_storage::Database;
 
 use super::types::json_to_sql_value;
 
@@ -96,6 +101,10 @@ impl GraphQLError {
         }
     }
 }
+
+// ============================================================================
+// WHERE Clause Types and Parsing
+// ============================================================================
 
 /// Comparison operators for WHERE clause filtering
 #[derive(Debug, Clone, PartialEq)]
@@ -462,6 +471,193 @@ fn escape_identifier(identifier: &str) -> String {
         format!("\"{}\"", identifier.replace('"', "\"\""))
     }
 }
+
+// ============================================================================
+// Schema Introspection Support
+// ============================================================================
+
+/// Try to handle introspection queries (__schema, __type)
+/// Returns Some(result) if this was an introspection query, None otherwise
+pub fn try_introspection_query(db: &Arc<Database>, query: &str) -> Option<JsonValue> {
+    let query = query.trim();
+
+    // Check for __schema query
+    if query.contains("__schema") {
+        return try_schema_query(db, query);
+    }
+
+    // Check for __type query
+    if query.contains("__type") {
+        return try_type_query(db, query);
+    }
+
+    None
+}
+
+/// Handle __schema introspection query
+fn try_schema_query(db: &Arc<Database>, _query: &str) -> Option<JsonValue> {
+    let table_names = db.list_tables();
+    let mut types = Vec::new();
+
+    // Add built-in scalar types
+    for scalar in &["String", "Int", "Float", "Boolean", "ID"] {
+        types.push(json!({
+            "kind": "SCALAR",
+            "name": scalar,
+            "fields": null,
+            "possibleTypes": null,
+        }));
+    }
+
+    // Add table types
+    for table_name in &table_names {
+        let fields = get_table_fields(db, table_name);
+        types.push(json!({
+            "kind": "OBJECT",
+            "name": table_name,
+            "fields": fields,
+            "possibleTypes": null,
+        }));
+    }
+
+    // Add __Schema and __Type types
+    types.push(json!({
+        "kind": "OBJECT",
+        "name": "__Schema",
+        "fields": vec![
+            json!({"name": "types", "type": "[__Type!]!"}),
+            json!({"name": "queryType", "type": "__Type"}),
+        ],
+        "possibleTypes": null,
+    }));
+
+    types.push(json!({
+        "kind": "OBJECT",
+        "name": "__Type",
+        "fields": vec![
+            json!({"name": "name", "type": "String"}),
+            json!({"name": "kind", "type": "String"}),
+            json!({"name": "fields", "type": "[__Field!]"}),
+        ],
+        "possibleTypes": null,
+    }));
+
+    types.push(json!({
+        "kind": "OBJECT",
+        "name": "__Field",
+        "fields": vec![
+            json!({"name": "name", "type": "String!"}),
+            json!({"name": "type", "type": "__Type!"}),
+        ],
+        "possibleTypes": null,
+    }));
+
+    Some(json!({
+        "__schema": {
+            "types": types,
+            "queryType": {
+                "name": "Query"
+            }
+        }
+    }))
+}
+
+/// Handle __type(name: "...") introspection query
+fn try_type_query(db: &Arc<Database>, query: &str) -> Option<JsonValue> {
+    // Simple pattern matching for __type(name: "TypeName")
+    let type_name = extract_type_name(query)?;
+
+    // Check if it's a built-in scalar type
+    match type_name.as_str() {
+        "String" | "Int" | "Float" | "Boolean" | "ID" => {
+            return Some(json!({
+                "__type": {
+                    "kind": "SCALAR",
+                    "name": type_name,
+                    "fields": null,
+                }
+            }));
+        }
+        _ => {}
+    }
+
+    // Check if it's a table
+    let table_names = db.list_tables();
+    if table_names.contains(&type_name) {
+        let fields = get_table_fields(db, &type_name);
+        return Some(json!({
+            "__type": {
+                "kind": "OBJECT",
+                "name": type_name,
+                "fields": fields,
+            }
+        }));
+    }
+
+    // Type not found
+    Some(json!({
+        "__type": null
+    }))
+}
+
+/// Extract type name from __type(name: "TypeName") query
+fn extract_type_name(query: &str) -> Option<String> {
+    // Look for pattern: __type(name: "TypeName")
+    let start = query.find("__type(name:")?;
+    let substring = &query[start + 11..]; // Skip "__type(name:"
+
+    // Find the quoted string
+    let first_quote = substring.find('"')?;
+    let remaining = &substring[first_quote + 1..];
+    let closing_quote = remaining.find('"')?;
+
+    Some(remaining[..closing_quote].to_string())
+}
+
+/// Get fields for a table (map SQLite columns to GraphQL fields)
+fn get_table_fields(db: &Arc<Database>, table_name: &str) -> Vec<JsonValue> {
+    let mut fields = Vec::new();
+
+    // Get table schema from database
+    let table_names = db.list_tables();
+    if !table_names.iter().any(|t| t == table_name) {
+        return fields;
+    }
+
+    // Try to get table schema from database metadata
+    // Use a basic introspection approach that queries the database
+    // to determine column names
+
+    // Execute a query to get column information
+    if let Ok(mut session) = crate::session::Session::new(
+        "graphql".to_string(),
+        "graphql_introspection".to_string(),
+    ) {
+        let query = format!("SELECT * FROM {} LIMIT 1", table_name);
+        if let Ok(crate::session::ExecutionResult::Select { columns, .. }) = session.execute(&query) {
+            for column in columns {
+                // Default to String type since we don't have column type info from the API
+                // In a real implementation, we would use PRAGMA table_info or similar
+                fields.push(json!({
+                    "name": column.name,
+                    "type": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                    }
+                }));
+            }
+        }
+    }
+
+    // If we couldn't get fields from introspection, return an empty list
+    // This prevents errors when a table exists but has no schema info
+    fields
+}
+
+// ============================================================================
+// Query/Mutation Parsing and SQL Generation
+// ============================================================================
 
 /// Parse a simple GraphQL query and convert to SQL
 pub fn parse_graphql_query(query_str: &str) -> Result<GraphQLQueryInfo, String> {
@@ -1255,5 +1451,38 @@ mod tests {
     #[test]
     fn test_escape_identifier_with_quotes() {
         assert_eq!(escape_identifier("user\"name"), "\"user\"\"name\"");
+    }
+
+    #[test]
+    fn test_extract_type_name() {
+        let query = r#"query { __type(name: "users") { kind name } }"#;
+        assert_eq!(extract_type_name(query), Some("users".to_string()));
+
+        let query = r#"{ __type(name: "Post") { fields { name } } }"#;
+        assert_eq!(extract_type_name(query), Some("Post".to_string()));
+    }
+
+    #[test]
+    fn test_schema_query_detection() {
+        let db = Arc::new(Database::new());
+        let query = "query { __schema { types { name } } }";
+        assert!(try_introspection_query(&db, query).is_some());
+    }
+
+    #[test]
+    fn test_type_query_detection() {
+        let db = Arc::new(Database::new());
+        let query = r#"{ __type(name: "String") { kind } }"#;
+        assert!(try_introspection_query(&db, query).is_some());
+    }
+
+    #[test]
+    fn test_builtin_scalar_type() {
+        let db = Arc::new(Database::new());
+        let query = r#"{ __type(name: "Int") { kind name fields } }"#;
+        let result = try_type_query(&db, query).unwrap();
+        assert_eq!(result["__type"]["kind"], "SCALAR");
+        assert_eq!(result["__type"]["name"], "Int");
+        assert!(result["__type"]["fields"].is_null());
     }
 }

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -85,10 +85,22 @@ pub fn create_http_router(db: Arc<Database>) -> Router {
 
 /// GraphQL endpoint handler
 async fn graphql_handler(
-    State(_state): State<HttpState>,
+    State(state): State<HttpState>,
     Json(req): Json<graphql::GraphQLRequest>,
 ) -> impl IntoResponse {
     debug!("Received GraphQL request: {}", req.query);
+
+    // First, try to handle introspection queries
+    if let Some(introspection_result) = graphql::try_introspection_query(&state.db, &req.query) {
+        return (
+            StatusCode::OK,
+            Json(graphql::GraphQLResponse {
+                data: Some(introspection_result),
+                errors: None,
+            }),
+        )
+            .into_response();
+    }
 
     // Parse the GraphQL query
     let query_info = match graphql::parse_graphql_query(&req.query) {
@@ -451,9 +463,9 @@ pub struct SseEvent {
 }
 
 /// Server-Sent Events subscription endpoint
-/// 
+///
 /// GET /api/subscribe?query=SELECT%20*%20FROM%20users
-/// 
+///
 /// Returns a text/event-stream response with real-time updates
 async fn subscribe_stream(
     State(_state): State<HttpState>,
@@ -493,13 +505,13 @@ async fn subscribe_stream(
                 new: None,
                 error: Some(format!("Failed to create session: {}", e)),
             }).unwrap_or_default();
-            
+
             let stream = futures::stream::once(async move {
                 Ok::<_, Box<dyn std::error::Error + Send + Sync>>(
                     Event::default().data(event_data)
                 )
             });
-            
+
             return Sse::new(stream)
                 .keep_alive(KeepAlive::default())
                 .into_response();
@@ -532,13 +544,13 @@ async fn subscribe_stream(
                 new: None,
                 error: Some("Subscription query must be a SELECT statement".to_string()),
             }).unwrap_or_default();
-            
+
             let stream = futures::stream::once(async move {
                 Ok::<_, Box<dyn std::error::Error + Send + Sync>>(
                     Event::default().data(event_data)
                 )
             });
-            
+
             return Sse::new(stream)
                 .keep_alive(KeepAlive::default())
                 .into_response();
@@ -553,13 +565,13 @@ async fn subscribe_stream(
                 new: None,
                 error: Some(format!("Query execution failed: {}", e)),
             }).unwrap_or_default();
-            
+
             let stream = futures::stream::once(async move {
                 Ok::<_, Box<dyn std::error::Error + Send + Sync>>(
                     Event::default().data(event_data)
                 )
             });
-            
+
             return Sse::new(stream)
                 .keep_alive(KeepAlive::default())
                 .into_response();
@@ -580,11 +592,11 @@ async fn subscribe_stream(
     let stream = {
         let initial = Event::default().data(initial_event_data);
         let mut events = vec![Ok::<_, Box<dyn std::error::Error + Send + Sync>>(initial)];
-        
+
         // For now, add a placeholder keepalive. Real implementation would subscribe
         // to changes and stream updates continuously
         events.push(Ok(Event::default().comment("TODO: add real-time updates")));
-        
+
         futures::stream::iter(events)
     };
 


### PR DESCRIPTION
## Summary

Implement GraphQL schema introspection support for VibeSQL's GraphQL API endpoint.

## Changes

- **New GraphQL module** ():
  - Implements GraphQL query handler with introspection support
  - Supports `__schema` query to discover all available types
  - Supports `__type(name: "TypeName")` query for type details
  - Auto-generates GraphQL types from database tables
  - Maps table columns to GraphQL fields

## Features Implemented

✅ `__schema` introspection query
- Returns all available types (scalars, objects, built-in types)
- Includes schema structure information

✅ `__type(name: "users")` introspection query  
- Returns detailed type information
- Shows field names and types for objects

✅ Built-in scalar types
- String, Int, Float, Boolean, ID
- Properly marked as SCALAR kinds

✅ Table schema introspection
- Discovers table columns dynamically
- Maps columns to GraphQL fields
- Defaults to String type for fields

## Endpoint

- **POST /api/graphql** - GraphQL query endpoint

## Example Usage

```graphql
query {
  __schema {
    types {
      name
      kind
      fields {
        name
        type {
          name
        }
      }
    }
  }
}
```

```graphql
{
  __type(name: "users") {
    kind
    name
    fields {
      name
      type {
        name
      }
    }
  }
}
```

## Tests

- All existing tests pass ✅
- 4 new unit tests for introspection functionality
- Tests verify type extraction, schema detection, and scalar types

Closes #3496