### PR TITLE
feat(server): Complete scheduled functions execution

### DIFF
--- a/crates/vibesql-server/src/scheduler/executor.rs
+++ b/crates/vibesql-server/src/scheduler/executor.rs
@@ -55,23 +55,19 @@ impl ScheduleExecutor {
     ) -> Result<ExecutionHistoryRecord> {
         let started_at = Utc::now();
 
-        // Parse the SQL statement
-        let statement = match Parser::parse_sql(&schedule.sql) {
-            Ok(stmt) => stmt,
-            Err(e) => {
-                let error_msg = e.to_string();
-                return Ok(ExecutionHistoryRecord {
-                    id: None,
-                    schedule_id: Some(schedule.id.clone()),
-                    cron_name: None,
-                    started_at,
-                    completed_at: Some(Utc::now()),
-                    status: ScheduleStatus::Failed,
-                    error: Some(error_msg),
-                    rows_affected: None,
-                });
-            }
-        };
+        // Validate SQL parses before retrying (don't retry parse errors)
+        if let Err(e) = Parser::parse_sql(&schedule.sql) {
+            return Ok(ExecutionHistoryRecord {
+                id: None,
+                schedule_id: Some(schedule.id.clone()),
+                cron_name: None,
+                started_at,
+                completed_at: Some(Utc::now()),
+                status: ScheduleStatus::Failed,
+                error: Some(e.to_string()),
+                rows_affected: None,
+            });
+        }
 
         // Execute with retries
         #[allow(unused_assignments)] // Initial None is never read, but keeps the code clear
@@ -82,7 +78,7 @@ impl ScheduleExecutor {
             attempt += 1;
             let backoff = self.calculate_backoff(attempt - 1);
 
-            match self.execute_statement(&statement, &session).await {
+            match self.execute_statement(&schedule.sql, &session).await {
                 Ok(rows_affected) => {
                     info!(
                         schedule_id = %schedule.id,
@@ -146,15 +142,15 @@ impl ScheduleExecutor {
         StdDuration::from_secs_f64(capped_secs)
     }
 
-    /// Execute a single statement
+    /// Execute a single SQL statement via the session
     async fn execute_statement(
         &self,
-        _statement: &vibesql_ast::Statement,
-        _session: &Arc<Mutex<Session>>,
+        sql: &str,
+        session: &Arc<Mutex<Session>>,
     ) -> Result<usize> {
-        // This will be implemented when we have access to the Executor
-        // For now, return a placeholder
-        Ok(0)
+        let mut session_guard = session.lock().await;
+        let result = session_guard.execute(sql)?;
+        Ok(result.rows_affected() as usize)
     }
 }
 
@@ -185,5 +181,254 @@ mod tests {
         // Should cap at max_backoff (300 seconds)
         let very_high = executor.calculate_backoff(100);
         assert_eq!(very_high, StdDuration::from_secs(300));
+    }
+
+    #[tokio::test]
+    async fn test_execute_schedule_insert() {
+        // Create a session with a table
+        let mut session = Session::new("testdb".to_string(), "testuser".to_string()).unwrap();
+        session.execute("CREATE TABLE schedule_test (id INT, value VARCHAR(100))").unwrap();
+        let session = Arc::new(Mutex::new(session));
+
+        // Create executor
+        let executor = ScheduleExecutor::new(ScheduleExecutorConfig::default());
+
+        // Create a schedule record for INSERT
+        let schedule = ScheduleRecord {
+            id: "test-schedule-1".to_string(),
+            sql: "INSERT INTO schedule_test VALUES (1, 'scheduled')".to_string(),
+            params: None,
+            run_at: Utc::now(),
+            created_at: Utc::now(),
+            status: ScheduleStatus::Pending,
+            attempts: 0,
+            last_error: None,
+            completed_at: None,
+        };
+
+        // Execute the schedule
+        let result = executor.execute_schedule(&schedule, session.clone()).await.unwrap();
+
+        // Verify success
+        assert_eq!(result.status, ScheduleStatus::Completed);
+        assert!(result.error.is_none());
+        assert_eq!(result.rows_affected, Some(1));
+
+        // Verify data was inserted
+        let session_guard = session.lock().await;
+        let select_result = Session::new("testdb".to_string(), "testuser".to_string()).unwrap();
+        drop(session_guard);
+
+        let mut verify_session = session.lock().await;
+        let verify = verify_session.execute("SELECT * FROM schedule_test WHERE id = 1").unwrap();
+        match verify {
+            crate::session::ExecutionResult::Select { rows, .. } => {
+                assert_eq!(rows.len(), 1);
+            }
+            _ => panic!("Expected Select result"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_schedule_update() {
+        // Create a session with a table and initial data
+        let mut session = Session::new("testdb".to_string(), "testuser".to_string()).unwrap();
+        session.execute("CREATE TABLE update_test (id INT, value VARCHAR(100))").unwrap();
+        session.execute("INSERT INTO update_test VALUES (1, 'original')").unwrap();
+        let session = Arc::new(Mutex::new(session));
+
+        // Create executor
+        let executor = ScheduleExecutor::new(ScheduleExecutorConfig::default());
+
+        // Create a schedule record for UPDATE
+        let schedule = ScheduleRecord {
+            id: "test-schedule-2".to_string(),
+            sql: "UPDATE update_test SET value = 'updated' WHERE id = 1".to_string(),
+            params: None,
+            run_at: Utc::now(),
+            created_at: Utc::now(),
+            status: ScheduleStatus::Pending,
+            attempts: 0,
+            last_error: None,
+            completed_at: None,
+        };
+
+        // Execute the schedule
+        let result = executor.execute_schedule(&schedule, session.clone()).await.unwrap();
+
+        // Verify success
+        assert_eq!(result.status, ScheduleStatus::Completed);
+        assert!(result.error.is_none());
+        assert_eq!(result.rows_affected, Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_execute_schedule_delete() {
+        // Create a session with a table and initial data
+        let mut session = Session::new("testdb".to_string(), "testuser".to_string()).unwrap();
+        session.execute("CREATE TABLE delete_test (id INT, value VARCHAR(100))").unwrap();
+        session.execute("INSERT INTO delete_test VALUES (1, 'to_delete')").unwrap();
+        session.execute("INSERT INTO delete_test VALUES (2, 'to_keep')").unwrap();
+        let session = Arc::new(Mutex::new(session));
+
+        // Create executor
+        let executor = ScheduleExecutor::new(ScheduleExecutorConfig::default());
+
+        // Create a schedule record for DELETE
+        let schedule = ScheduleRecord {
+            id: "test-schedule-3".to_string(),
+            sql: "DELETE FROM delete_test WHERE id = 1".to_string(),
+            params: None,
+            run_at: Utc::now(),
+            created_at: Utc::now(),
+            status: ScheduleStatus::Pending,
+            attempts: 0,
+            last_error: None,
+            completed_at: None,
+        };
+
+        // Execute the schedule
+        let result = executor.execute_schedule(&schedule, session.clone()).await.unwrap();
+
+        // Verify success
+        assert_eq!(result.status, ScheduleStatus::Completed);
+        assert!(result.error.is_none());
+        assert_eq!(result.rows_affected, Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_execute_schedule_select() {
+        // Create a session with a table and data
+        let mut session = Session::new("testdb".to_string(), "testuser".to_string()).unwrap();
+        session.execute("CREATE TABLE select_test (id INT, value VARCHAR(100))").unwrap();
+        session.execute("INSERT INTO select_test VALUES (1, 'row1')").unwrap();
+        session.execute("INSERT INTO select_test VALUES (2, 'row2')").unwrap();
+        let session = Arc::new(Mutex::new(session));
+
+        // Create executor
+        let executor = ScheduleExecutor::new(ScheduleExecutorConfig::default());
+
+        // Create a schedule record for SELECT
+        let schedule = ScheduleRecord {
+            id: "test-schedule-4".to_string(),
+            sql: "SELECT * FROM select_test".to_string(),
+            params: None,
+            run_at: Utc::now(),
+            created_at: Utc::now(),
+            status: ScheduleStatus::Pending,
+            attempts: 0,
+            last_error: None,
+            completed_at: None,
+        };
+
+        // Execute the schedule
+        let result = executor.execute_schedule(&schedule, session.clone()).await.unwrap();
+
+        // Verify success - SELECT returns rows as rows_affected
+        assert_eq!(result.status, ScheduleStatus::Completed);
+        assert!(result.error.is_none());
+        assert_eq!(result.rows_affected, Some(2));
+    }
+
+    #[tokio::test]
+    async fn test_execute_schedule_invalid_sql() {
+        // Create a session
+        let session = Session::new("testdb".to_string(), "testuser".to_string()).unwrap();
+        let session = Arc::new(Mutex::new(session));
+
+        // Create executor
+        let executor = ScheduleExecutor::new(ScheduleExecutorConfig::default());
+
+        // Create a schedule record with invalid SQL
+        let schedule = ScheduleRecord {
+            id: "test-schedule-5".to_string(),
+            sql: "INVALID SQL SYNTAX HERE".to_string(),
+            params: None,
+            run_at: Utc::now(),
+            created_at: Utc::now(),
+            status: ScheduleStatus::Pending,
+            attempts: 0,
+            last_error: None,
+            completed_at: None,
+        };
+
+        // Execute the schedule
+        let result = executor.execute_schedule(&schedule, session.clone()).await.unwrap();
+
+        // Verify failure (parse error - no retries)
+        assert_eq!(result.status, ScheduleStatus::Failed);
+        assert!(result.error.is_some());
+        assert!(result.rows_affected.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_execute_schedule_table_not_found() {
+        // Create a session without the table
+        let session = Session::new("testdb".to_string(), "testuser".to_string()).unwrap();
+        let session = Arc::new(Mutex::new(session));
+
+        // Create executor with minimal retries for faster test
+        let executor = ScheduleExecutor::new(ScheduleExecutorConfig {
+            max_retries: 1,
+            initial_backoff: StdDuration::from_millis(10),
+            ..Default::default()
+        });
+
+        // Create a schedule record for a non-existent table
+        let schedule = ScheduleRecord {
+            id: "test-schedule-6".to_string(),
+            sql: "INSERT INTO nonexistent_table VALUES (1, 'test')".to_string(),
+            params: None,
+            run_at: Utc::now(),
+            created_at: Utc::now(),
+            status: ScheduleStatus::Pending,
+            attempts: 0,
+            last_error: None,
+            completed_at: None,
+        };
+
+        // Execute the schedule
+        let result = executor.execute_schedule(&schedule, session.clone()).await.unwrap();
+
+        // Verify failure (execution error after retries)
+        assert_eq!(result.status, ScheduleStatus::Failed);
+        assert!(result.error.is_some());
+        assert!(result.rows_affected.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_execute_schedule_create_table() {
+        // Create a session
+        let session = Session::new("testdb".to_string(), "testuser".to_string()).unwrap();
+        let session = Arc::new(Mutex::new(session));
+
+        // Create executor
+        let executor = ScheduleExecutor::new(ScheduleExecutorConfig::default());
+
+        // Create a schedule record for CREATE TABLE
+        let schedule = ScheduleRecord {
+            id: "test-schedule-7".to_string(),
+            sql: "CREATE TABLE scheduled_table (id INT, name VARCHAR(100))".to_string(),
+            params: None,
+            run_at: Utc::now(),
+            created_at: Utc::now(),
+            status: ScheduleStatus::Pending,
+            attempts: 0,
+            last_error: None,
+            completed_at: None,
+        };
+
+        // Execute the schedule
+        let result = executor.execute_schedule(&schedule, session.clone()).await.unwrap();
+
+        // Verify success - DDL returns 0 rows_affected
+        assert_eq!(result.status, ScheduleStatus::Completed);
+        assert!(result.error.is_none());
+        assert_eq!(result.rows_affected, Some(0));
+
+        // Verify table was created by inserting into it
+        let mut session_guard = session.lock().await;
+        let insert_result = session_guard.execute("INSERT INTO scheduled_table VALUES (1, 'test')");
+        assert!(insert_result.is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- Wire up `ScheduleExecutor.execute_statement()` to actually execute SQL via Session
- Previously this was a stub that always returned 0, making scheduled jobs non-functional
- Phase 2 completion for scheduled functions feature

## Changes

- `execute_statement()` now locks the session mutex and calls `session.execute(sql)`
- Updated `execute_schedule()` to pass SQL string instead of parsed statement
- Keep parse validation outside retry loop (don't retry parse errors)
- Add comprehensive integration tests covering INSERT, UPDATE, DELETE, SELECT
- Add tests for error cases (invalid SQL, missing tables)
- Add test for DDL operations (CREATE TABLE)

## Test plan

- [x] All 8 scheduler executor tests pass
- [x] INSERT scheduled job executes and inserts row
- [x] UPDATE scheduled job executes and updates row
- [x] DELETE scheduled job executes and deletes row
- [x] SELECT scheduled job executes and returns row count
- [x] Invalid SQL fails immediately (no retries)
- [x] Missing table fails after retries
- [x] DDL (CREATE TABLE) executes successfully

Closes #3506

🤖 Generated with [Claude Code](https://claude.com/claude-code)