### PR TITLE
feat(server): Implement delta updates for subscriptions

### DIFF
--- a/crates/vibesql-server/src/subscription/manager.rs
+++ b/crates/vibesql-server/src/subscription/manager.rs
@@ -14,7 +14,7 @@ use vibesql_storage::Database;
 use vibesql_storage::change_events::RecvError;
 
 use super::{
-    extract_table_refs, hash_rows, Subscription, SubscriptionError, SubscriptionId,
+    compute_delta, extract_table_refs, hash_rows, Subscription, SubscriptionError, SubscriptionId,
     SubscriptionUpdate,
 };
 
@@ -209,6 +209,10 @@ impl SubscriptionManager {
     }
 
     /// Check a subscription and notify if results changed
+    ///
+    /// This method re-executes the subscription query, computes the delta
+    /// from the previous result, and sends either a Delta or Full update
+    /// to the subscriber.
     async fn check_and_notify(&self, id: SubscriptionId, db: &Database) {
         // Get mutable reference to subscription
         let mut sub_ref = match self.subscriptions.get_mut(&id) {
@@ -269,15 +273,49 @@ impl SubscriptionManager {
                         "Results changed, notifying subscriber"
                     );
 
+                    // Determine whether to send Delta or Full update
+                    let update = if let Some(ref old_rows) = subscription.last_result {
+                        // We have previous results - compute delta
+                        if let Some(delta) = compute_delta(old_rows, &result_rows) {
+                            // Log delta statistics
+                            if let SubscriptionUpdate::Delta {
+                                ref inserts,
+                                ref updates,
+                                ref deletes,
+                            } = delta
+                            {
+                                debug!(
+                                    subscription_id = %id,
+                                    inserts = inserts.len(),
+                                    updates = updates.len(),
+                                    deletes = deletes.len(),
+                                    "Sending delta update"
+                                );
+                            }
+                            delta
+                        } else {
+                            // No delta (shouldn't happen if hash changed, but be safe)
+                            SubscriptionUpdate::Full {
+                                rows: result_rows.clone(),
+                            }
+                        }
+                    } else {
+                        // No previous results - send full (first update after initial)
+                        debug!(
+                            subscription_id = %id,
+                            "No previous result, sending full update"
+                        );
+                        SubscriptionUpdate::Full {
+                            rows: result_rows.clone(),
+                        }
+                    };
+
+                    // Update stored state
                     subscription.last_result_hash = new_hash;
+                    subscription.last_result = Some(result_rows);
 
                     // Send update - ignore errors (channel may be closed)
-                    if subscription
-                        .notify_tx
-                        .send(SubscriptionUpdate::Full { rows: result_rows })
-                        .await
-                        .is_err()
-                    {
+                    if subscription.notify_tx.send(update).await.is_err() {
                         trace!(
                             subscription_id = %id,
                             "Notification channel closed, subscription will be cleaned up"
@@ -349,7 +387,8 @@ impl SubscriptionManager {
     /// Send initial results to a new subscriber
     ///
     /// Executes the query and sends the initial results. This should be called
-    /// right after subscribing to provide immediate data.
+    /// right after subscribing to provide immediate data. The initial results
+    /// are always sent as a Full update.
     pub async fn send_initial_results(
         &self,
         id: SubscriptionId,
@@ -382,10 +421,11 @@ impl SubscriptionManager {
             })
             .collect();
 
-        // Update hash
+        // Update hash and store result for delta computation
         subscription.last_result_hash = hash_rows(&result_rows);
+        subscription.last_result = Some(result_rows.clone());
 
-        // Send initial results
+        // Send initial results (always Full for initial)
         subscription
             .notify_tx
             .send(SubscriptionUpdate::Full { rows: result_rows })
@@ -630,13 +670,24 @@ mod tests {
             )
             .await;
 
-        // Should receive update with new data
+        // Should receive update with new data (as Delta since we have previous results)
         let update = rx.recv().await.unwrap();
         match update {
+            SubscriptionUpdate::Delta {
+                inserts,
+                updates,
+                deletes,
+            } => {
+                // The inserted row should appear as an insert
+                assert_eq!(inserts.len(), 1);
+                assert!(updates.is_empty());
+                assert!(deletes.is_empty());
+            }
             SubscriptionUpdate::Full { rows } => {
+                // Also acceptable if Full is sent
                 assert_eq!(rows.len(), 1);
             }
-            _ => panic!("Expected Full update"),
+            _ => panic!("Expected Delta or Full update"),
         }
     }
 
@@ -690,5 +741,142 @@ mod tests {
         let watched = manager.watched_tables();
         let users_entry = watched.iter().find(|(t, _)| t == "users").unwrap();
         assert_eq!(users_entry.1, 2);
+    }
+
+    #[tokio::test]
+    async fn test_delta_update_on_insert() {
+        let manager = SubscriptionManager::new();
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut db = setup_test_db();
+
+        // Insert initial data
+        let insert = vibesql_parser::Parser::parse_sql("INSERT INTO users VALUES (1, 'Alice', TRUE)")
+            .unwrap();
+        if let vibesql_ast::Statement::Insert(stmt) = insert {
+            vibesql_executor::InsertExecutor::execute(&mut db, &stmt).unwrap();
+        }
+
+        // Subscribe and get initial results
+        let id = manager
+            .subscribe("SELECT * FROM users".to_string(), tx)
+            .unwrap();
+        manager.send_initial_results(id, &db).await.unwrap();
+
+        // Consume initial Full update
+        let initial = rx.recv().await.unwrap();
+        match initial {
+            SubscriptionUpdate::Full { rows } => {
+                assert_eq!(rows.len(), 1);
+            }
+            _ => panic!("Expected Full update for initial results"),
+        }
+
+        // Insert another row
+        let insert2 = vibesql_parser::Parser::parse_sql("INSERT INTO users VALUES (2, 'Bob', TRUE)")
+            .unwrap();
+        if let vibesql_ast::Statement::Insert(stmt) = insert2 {
+            vibesql_executor::InsertExecutor::execute(&mut db, &stmt).unwrap();
+        }
+
+        // Trigger change notification
+        manager
+            .handle_change(
+                vibesql_storage::ChangeEvent::Insert {
+                    table_name: "users".to_string(),
+                    row_index: 1,
+                },
+                &db,
+            )
+            .await;
+
+        // Should receive a Delta update (not Full)
+        let update = rx.recv().await.unwrap();
+        match update {
+            SubscriptionUpdate::Delta {
+                inserts,
+                updates,
+                deletes,
+            } => {
+                assert_eq!(inserts.len(), 1);
+                assert_eq!(inserts[0].values[0], SqlValue::Integer(2));
+                assert!(updates.is_empty());
+                assert!(deletes.is_empty());
+            }
+            SubscriptionUpdate::Full { .. } => {
+                panic!("Expected Delta update, got Full");
+            }
+            _ => panic!("Unexpected update type"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delta_update_on_delete() {
+        let manager = SubscriptionManager::new();
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut db = setup_test_db();
+
+        // Insert initial data
+        let insert1 = vibesql_parser::Parser::parse_sql("INSERT INTO users VALUES (1, 'Alice', TRUE)")
+            .unwrap();
+        if let vibesql_ast::Statement::Insert(stmt) = insert1 {
+            vibesql_executor::InsertExecutor::execute(&mut db, &stmt).unwrap();
+        }
+        let insert2 = vibesql_parser::Parser::parse_sql("INSERT INTO users VALUES (2, 'Bob', TRUE)")
+            .unwrap();
+        if let vibesql_ast::Statement::Insert(stmt) = insert2 {
+            vibesql_executor::InsertExecutor::execute(&mut db, &stmt).unwrap();
+        }
+
+        // Subscribe and get initial results
+        let id = manager
+            .subscribe("SELECT * FROM users".to_string(), tx)
+            .unwrap();
+        manager.send_initial_results(id, &db).await.unwrap();
+
+        // Consume initial Full update
+        let initial = rx.recv().await.unwrap();
+        match initial {
+            SubscriptionUpdate::Full { rows } => {
+                assert_eq!(rows.len(), 2);
+            }
+            _ => panic!("Expected Full update for initial results"),
+        }
+
+        // Delete a row
+        let delete = vibesql_parser::Parser::parse_sql("DELETE FROM users WHERE id = 2")
+            .unwrap();
+        if let vibesql_ast::Statement::Delete(stmt) = delete {
+            vibesql_executor::DeleteExecutor::execute(&stmt, &mut db).unwrap();
+        }
+
+        // Trigger change notification
+        manager
+            .handle_change(
+                vibesql_storage::ChangeEvent::Delete {
+                    table_name: "users".to_string(),
+                    row_index: 1,
+                },
+                &db,
+            )
+            .await;
+
+        // Should receive a Delta update with delete
+        let update = rx.recv().await.unwrap();
+        match update {
+            SubscriptionUpdate::Delta {
+                inserts,
+                updates,
+                deletes,
+            } => {
+                assert!(inserts.is_empty());
+                assert!(updates.is_empty());
+                assert_eq!(deletes.len(), 1);
+                assert_eq!(deletes[0].values[0], SqlValue::Integer(2));
+            }
+            SubscriptionUpdate::Full { .. } => {
+                panic!("Expected Delta update, got Full");
+            }
+            _ => panic!("Unexpected update type"),
+        }
     }
 }

--- a/crates/vibesql-server/src/subscription/mod.rs
+++ b/crates/vibesql-server/src/subscription/mod.rs
@@ -115,6 +115,9 @@ pub struct Subscription {
     pub tables: HashSet<String>,
     /// Hash of the last result set (for change detection)
     pub last_result_hash: u64,
+    /// Last result set (for delta computation)
+    /// This stores the previous result to enable computing deltas on change.
+    pub last_result: Option<Vec<crate::Row>>,
     /// Channel to send updates to the subscriber
     pub notify_tx: mpsc::Sender<SubscriptionUpdate>,
 }
@@ -131,6 +134,7 @@ impl Subscription {
             query,
             tables,
             last_result_hash: 0,
+            last_result: None,
             notify_tx,
         }
     }
@@ -156,17 +160,17 @@ pub enum SubscriptionUpdate {
         rows: Vec<crate::Row>,
     },
 
-    /// Incremental delta (future optimization)
+    /// Incremental delta update
     ///
     /// Contains only the changes since the last update. More efficient
-    /// for large result sets with small changes.
-    #[allow(dead_code)]
+    /// for large result sets with small changes. Sent when the change
+    /// can be expressed as a set of inserts, updates, and deletes.
     Delta {
-        /// Newly inserted rows
+        /// Newly inserted rows (in new result, not in previous)
         inserts: Vec<crate::Row>,
-        /// Updated rows (old value, new value)
+        /// Updated rows (old value, new value) - rows with same identity but different content
         updates: Vec<(crate::Row, crate::Row)>,
-        /// Deleted rows
+        /// Deleted rows (in previous result, not in new)
         deletes: Vec<crate::Row>,
     },
 
@@ -240,6 +244,101 @@ pub fn hash_rows(rows: &[crate::Row]) -> u64 {
     hasher.finish()
 }
 
+/// Compute a hash for a single row (for delta computation)
+fn hash_row(row: &crate::Row) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+
+    let mut hasher = DefaultHasher::new();
+    for value in &row.values {
+        value.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// Compute delta between old and new result sets
+///
+/// This function compares two result sets and produces a delta update
+/// containing the inserts, updates, and deletes needed to transform
+/// the old result into the new result.
+///
+/// # Algorithm
+///
+/// Uses row hashing to efficiently detect changes:
+/// - Rows in new but not in old are inserts
+/// - Rows in old but not in new are deletes
+/// - Updates are not detected in this implementation (would appear as delete + insert)
+///
+/// For proper update detection, primary key information would be needed.
+///
+/// # Returns
+///
+/// Returns `Some(SubscriptionUpdate::Delta)` if there are changes,
+/// or `None` if the result sets are identical.
+pub fn compute_delta(
+    old: &[crate::Row],
+    new: &[crate::Row],
+) -> Option<SubscriptionUpdate> {
+    use std::collections::HashMap;
+
+    // Build hash maps for efficient lookup
+    // Map from row hash -> (count, row reference)
+    // We use count to handle duplicate rows correctly
+    let mut old_map: HashMap<u64, Vec<&crate::Row>> = HashMap::new();
+    for row in old {
+        let hash = hash_row(row);
+        old_map.entry(hash).or_default().push(row);
+    }
+
+    let mut new_map: HashMap<u64, Vec<&crate::Row>> = HashMap::new();
+    for row in new {
+        let hash = hash_row(row);
+        new_map.entry(hash).or_default().push(row);
+    }
+
+    let mut inserts = Vec::new();
+    let mut deletes = Vec::new();
+
+    // Find inserts: rows in new but not in old (or with higher count in new)
+    for (hash, new_rows) in &new_map {
+        let old_rows = old_map.get(hash).map(|v| v.as_slice()).unwrap_or(&[]);
+
+        // For each row in new that exceeds the count in old, it's an insert
+        if new_rows.len() > old_rows.len() {
+            for row in new_rows.iter().skip(old_rows.len()) {
+                inserts.push((*row).clone());
+            }
+        }
+    }
+
+    // Find deletes: rows in old but not in new (or with higher count in old)
+    for (hash, old_rows) in &old_map {
+        let new_rows = new_map.get(hash).map(|v| v.as_slice()).unwrap_or(&[]);
+
+        // For each row in old that exceeds the count in new, it's a delete
+        if old_rows.len() > new_rows.len() {
+            for row in old_rows.iter().skip(new_rows.len()) {
+                deletes.push((*row).clone());
+            }
+        }
+    }
+
+    // If no changes, return None
+    if inserts.is_empty() && deletes.is_empty() {
+        return None;
+    }
+
+    // Updates are not detected in this implementation
+    // A row update would appear as a delete of the old row + insert of the new row
+    // This is semantically correct, just not optimal for clients that could patch in place
+    let updates = Vec::new();
+
+    Some(SubscriptionUpdate::Delta {
+        inserts,
+        updates,
+        deletes,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -307,5 +406,239 @@ mod tests {
 
         // Same content should produce same hash
         assert_eq!(hash1, hash2);
+    }
+
+    // ========================================================================
+    // Tests for compute_delta
+    // ========================================================================
+
+    #[test]
+    fn test_compute_delta_no_changes() {
+        use vibesql_types::SqlValue;
+
+        let rows = vec![
+            crate::Row {
+                values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+            },
+            crate::Row {
+                values: vec![SqlValue::Integer(2), SqlValue::Varchar("Bob".to_string())],
+            },
+        ];
+
+        // Same old and new should return None
+        let delta = compute_delta(&rows, &rows);
+        assert!(delta.is_none());
+    }
+
+    #[test]
+    fn test_compute_delta_single_insert() {
+        use vibesql_types::SqlValue;
+
+        let old = vec![crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+        }];
+
+        let new = vec![
+            crate::Row {
+                values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+            },
+            crate::Row {
+                values: vec![SqlValue::Integer(2), SqlValue::Varchar("Bob".to_string())],
+            },
+        ];
+
+        let delta = compute_delta(&old, &new);
+        assert!(delta.is_some());
+
+        match delta.unwrap() {
+            SubscriptionUpdate::Delta {
+                inserts,
+                updates,
+                deletes,
+            } => {
+                assert_eq!(inserts.len(), 1);
+                assert_eq!(inserts[0].values[0], SqlValue::Integer(2));
+                assert_eq!(
+                    inserts[0].values[1],
+                    SqlValue::Varchar("Bob".to_string())
+                );
+                assert!(updates.is_empty());
+                assert!(deletes.is_empty());
+            }
+            _ => panic!("Expected Delta update"),
+        }
+    }
+
+    #[test]
+    fn test_compute_delta_single_delete() {
+        use vibesql_types::SqlValue;
+
+        let old = vec![
+            crate::Row {
+                values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+            },
+            crate::Row {
+                values: vec![SqlValue::Integer(2), SqlValue::Varchar("Bob".to_string())],
+            },
+        ];
+
+        let new = vec![crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+        }];
+
+        let delta = compute_delta(&old, &new);
+        assert!(delta.is_some());
+
+        match delta.unwrap() {
+            SubscriptionUpdate::Delta {
+                inserts,
+                updates,
+                deletes,
+            } => {
+                assert!(inserts.is_empty());
+                assert!(updates.is_empty());
+                assert_eq!(deletes.len(), 1);
+                assert_eq!(deletes[0].values[0], SqlValue::Integer(2));
+            }
+            _ => panic!("Expected Delta update"),
+        }
+    }
+
+    #[test]
+    fn test_compute_delta_insert_and_delete() {
+        use vibesql_types::SqlValue;
+
+        let old = vec![crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+        }];
+
+        let new = vec![crate::Row {
+            values: vec![SqlValue::Integer(2), SqlValue::Varchar("Bob".to_string())],
+        }];
+
+        let delta = compute_delta(&old, &new);
+        assert!(delta.is_some());
+
+        match delta.unwrap() {
+            SubscriptionUpdate::Delta {
+                inserts,
+                updates,
+                deletes,
+            } => {
+                assert_eq!(inserts.len(), 1);
+                assert_eq!(deletes.len(), 1);
+                assert!(updates.is_empty());
+                // The old row was deleted, new row was inserted
+                assert_eq!(inserts[0].values[0], SqlValue::Integer(2));
+                assert_eq!(deletes[0].values[0], SqlValue::Integer(1));
+            }
+            _ => panic!("Expected Delta update"),
+        }
+    }
+
+    #[test]
+    fn test_compute_delta_empty_to_rows() {
+        use vibesql_types::SqlValue;
+
+        let old: Vec<crate::Row> = vec![];
+        let new = vec![
+            crate::Row {
+                values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+            },
+            crate::Row {
+                values: vec![SqlValue::Integer(2), SqlValue::Varchar("Bob".to_string())],
+            },
+        ];
+
+        let delta = compute_delta(&old, &new);
+        assert!(delta.is_some());
+
+        match delta.unwrap() {
+            SubscriptionUpdate::Delta {
+                inserts,
+                updates,
+                deletes,
+            } => {
+                assert_eq!(inserts.len(), 2);
+                assert!(updates.is_empty());
+                assert!(deletes.is_empty());
+            }
+            _ => panic!("Expected Delta update"),
+        }
+    }
+
+    #[test]
+    fn test_compute_delta_rows_to_empty() {
+        use vibesql_types::SqlValue;
+
+        let old = vec![
+            crate::Row {
+                values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+            },
+            crate::Row {
+                values: vec![SqlValue::Integer(2), SqlValue::Varchar("Bob".to_string())],
+            },
+        ];
+        let new: Vec<crate::Row> = vec![];
+
+        let delta = compute_delta(&old, &new);
+        assert!(delta.is_some());
+
+        match delta.unwrap() {
+            SubscriptionUpdate::Delta {
+                inserts,
+                updates,
+                deletes,
+            } => {
+                assert!(inserts.is_empty());
+                assert!(updates.is_empty());
+                assert_eq!(deletes.len(), 2);
+            }
+            _ => panic!("Expected Delta update"),
+        }
+    }
+
+    #[test]
+    fn test_compute_delta_duplicate_rows() {
+        use vibesql_types::SqlValue;
+
+        // Test handling of duplicate rows
+        let old = vec![
+            crate::Row {
+                values: vec![SqlValue::Integer(1)],
+            },
+            crate::Row {
+                values: vec![SqlValue::Integer(1)],
+            },
+        ];
+
+        let new = vec![
+            crate::Row {
+                values: vec![SqlValue::Integer(1)],
+            },
+            crate::Row {
+                values: vec![SqlValue::Integer(1)],
+            },
+            crate::Row {
+                values: vec![SqlValue::Integer(1)],
+            },
+        ];
+
+        let delta = compute_delta(&old, &new);
+        assert!(delta.is_some());
+
+        match delta.unwrap() {
+            SubscriptionUpdate::Delta {
+                inserts,
+                updates,
+                deletes,
+            } => {
+                // One additional duplicate row was inserted
+                assert_eq!(inserts.len(), 1);
+                assert!(updates.is_empty());
+                assert!(deletes.is_empty());
+            }
+            _ => panic!("Expected Delta update"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Implements incremental delta updates for the subscription system
- Sends only changed rows (inserts/deletes) instead of full result sets on every change
- Significantly reduces bandwidth for real-time applications with large result sets

## Changes

- Added `last_result` field to `Subscription` struct to track previous results for delta computation
- Implemented `compute_delta()` function that efficiently diffs old vs new result sets using row hashing
- Updated `check_and_notify()` to conditionally send `Delta` vs `Full` updates based on whether previous results exist
- Removed `#[allow(dead_code)]` from `SubscriptionUpdate::Delta` variant (it's now actively used)
- Added comprehensive tests for delta computation (7 new tests) and integration tests for delta updates

## How It Works

1. **Initial subscription**: Always sends `Full` update with all matching rows
2. **Subsequent changes**: Computes delta from previous result and sends `Delta` update with:
   - `inserts`: Rows in new result but not in previous
   - `deletes`: Rows in previous result but not in new
   - `updates`: Currently empty (updates appear as delete+insert pairs)

## Test plan

- [x] Unit tests for `compute_delta()` function (7 tests)
  - No changes detection
  - Single insert detection
  - Single delete detection
  - Insert and delete combination
  - Empty to rows transition
  - Rows to empty transition
  - Duplicate row handling
- [x] Integration tests for delta updates in subscription manager
  - `test_delta_update_on_insert`: Verifies Delta sent after insert
  - `test_delta_update_on_delete`: Verifies Delta sent after delete
- [x] All existing subscription tests pass (79 tests)
- [x] All server tests pass

Closes #3504

🤖 Generated with [Claude Code](https://claude.com/claude-code)