### PR TITLE
feat(subscription): Add retry with exponential backoff for transient errors

### DIFF
--- a/crates/vibesql-server/src/subscription/error.rs
+++ b/crates/vibesql-server/src/subscription/error.rs
@@ -1,0 +1,190 @@
+//! Error classification for subscription retry logic
+//!
+//! Categorizes errors as transient (retry) or permanent (don't retry)
+//! to enable smart retry behavior with circuit breaker pattern.
+
+use std::fmt::Display;
+
+/// Classification of subscription query errors
+///
+/// Used to determine retry strategy:
+/// - Transient: Retry with exponential backoff (lock timeouts, connection issues)
+/// - Permanent: Don't retry, send error to client (table dropped, syntax error)
+/// - Unknown: Retry with caution (unrecognized errors)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscriptionErrorKind {
+    /// Transient error - safe to retry
+    /// Examples: database lock timeout, connection reset, temporary unavailability
+    Transient,
+
+    /// Permanent error - don't retry
+    /// Examples: table dropped, syntax error, permission denied, invalid column
+    Permanent,
+
+    /// Unknown error - retry with caution
+    /// Examples: errors we haven't classified yet
+    Unknown,
+}
+
+impl Display for SubscriptionErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transient => write!(f, "transient"),
+            Self::Permanent => write!(f, "permanent"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+/// Classify an error from query execution
+///
+/// Examines error messages and types to determine if the error is likely
+/// transient (safe to retry) or permanent (should not be retried).
+pub fn classify_error(error: &dyn std::error::Error) -> SubscriptionErrorKind {
+    let error_str = error.to_string().to_lowercase();
+
+    // Transient errors
+    if error_str.contains("lock") || error_str.contains("timeout") {
+        return SubscriptionErrorKind::Transient;
+    }
+    if error_str.contains("connection") || error_str.contains("reset") {
+        return SubscriptionErrorKind::Transient;
+    }
+    if error_str.contains("unavailable") || error_str.contains("busy") {
+        return SubscriptionErrorKind::Transient;
+    }
+    if error_str.contains("temporarily") || error_str.contains("temporary") {
+        return SubscriptionErrorKind::Transient;
+    }
+
+    // Permanent errors
+    if error_str.contains("table") && error_str.contains("not found")
+        || error_str.contains("table") && error_str.contains("doesn't exist")
+        || error_str.contains("table") && error_str.contains("does not exist")
+    {
+        return SubscriptionErrorKind::Permanent;
+    }
+    if error_str.contains("column") && error_str.contains("not found")
+        || error_str.contains("column") && error_str.contains("doesn't exist")
+        || error_str.contains("column") && error_str.contains("does not exist")
+    {
+        return SubscriptionErrorKind::Permanent;
+    }
+    if error_str.contains("syntax") || error_str.contains("parse") {
+        return SubscriptionErrorKind::Permanent;
+    }
+    if error_str.contains("permission") || error_str.contains("denied") {
+        return SubscriptionErrorKind::Permanent;
+    }
+    if error_str.contains("invalid") {
+        return SubscriptionErrorKind::Permanent;
+    }
+
+    // Unknown - default to retrying with caution
+    SubscriptionErrorKind::Unknown
+}
+
+/// Classify an error from a string representation
+pub fn classify_error_str(error_msg: &str) -> SubscriptionErrorKind {
+    let error_str = error_msg.to_lowercase();
+
+    // Transient errors
+    if error_str.contains("lock") || error_str.contains("timeout") {
+        return SubscriptionErrorKind::Transient;
+    }
+    if error_str.contains("connection") || error_str.contains("reset") {
+        return SubscriptionErrorKind::Transient;
+    }
+    if error_str.contains("unavailable") || error_str.contains("busy") {
+        return SubscriptionErrorKind::Transient;
+    }
+    if error_str.contains("temporarily") || error_str.contains("temporary") {
+        return SubscriptionErrorKind::Transient;
+    }
+
+    // Permanent errors
+    if (error_str.contains("table") && error_str.contains("not found"))
+        || (error_str.contains("table") && error_str.contains("doesn't exist"))
+        || (error_str.contains("table") && error_str.contains("does not exist"))
+    {
+        return SubscriptionErrorKind::Permanent;
+    }
+    if (error_str.contains("column") && error_str.contains("not found"))
+        || (error_str.contains("column") && error_str.contains("doesn't exist"))
+        || (error_str.contains("column") && error_str.contains("does not exist"))
+    {
+        return SubscriptionErrorKind::Permanent;
+    }
+    if error_str.contains("syntax") || error_str.contains("parse") {
+        return SubscriptionErrorKind::Permanent;
+    }
+    if error_str.contains("permission") || error_str.contains("denied") {
+        return SubscriptionErrorKind::Permanent;
+    }
+    if error_str.contains("invalid") {
+        return SubscriptionErrorKind::Permanent;
+    }
+
+    // Unknown - default to retrying with caution
+    SubscriptionErrorKind::Unknown
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_classify_transient_timeout() {
+        let kind = classify_error_str("Query timeout");
+        assert_eq!(kind, SubscriptionErrorKind::Transient);
+    }
+
+    #[test]
+    fn test_classify_transient_lock() {
+        let kind = classify_error_str("Database lock timeout");
+        assert_eq!(kind, SubscriptionErrorKind::Transient);
+    }
+
+    #[test]
+    fn test_classify_transient_connection() {
+        let kind = classify_error_str("Connection reset by peer");
+        assert_eq!(kind, SubscriptionErrorKind::Transient);
+    }
+
+    #[test]
+    fn test_classify_permanent_table_not_found() {
+        let kind = classify_error_str("Table 'users' not found");
+        assert_eq!(kind, SubscriptionErrorKind::Permanent);
+    }
+
+    #[test]
+    fn test_classify_permanent_column_not_found() {
+        let kind = classify_error_str("Column 'name' doesn't exist");
+        assert_eq!(kind, SubscriptionErrorKind::Permanent);
+    }
+
+    #[test]
+    fn test_classify_permanent_syntax() {
+        let kind = classify_error_str("Syntax error in SELECT");
+        assert_eq!(kind, SubscriptionErrorKind::Permanent);
+    }
+
+    #[test]
+    fn test_classify_permanent_permission() {
+        let kind = classify_error_str("Permission denied");
+        assert_eq!(kind, SubscriptionErrorKind::Permanent);
+    }
+
+    #[test]
+    fn test_classify_unknown() {
+        let kind = classify_error_str("Some other error");
+        assert_eq!(kind, SubscriptionErrorKind::Unknown);
+    }
+
+    #[test]
+    fn test_error_kind_display() {
+        assert_eq!(format!("{}", SubscriptionErrorKind::Transient), "transient");
+        assert_eq!(format!("{}", SubscriptionErrorKind::Permanent), "permanent");
+        assert_eq!(format!("{}", SubscriptionErrorKind::Unknown), "unknown");
+    }
+}

--- a/crates/vibesql-server/src/subscription/manager.rs
+++ b/crates/vibesql-server/src/subscription/manager.rs
@@ -15,7 +15,8 @@ use vibesql_storage::Database;
 use vibesql_storage::change_events::RecvError;
 
 use super::{
-    compute_delta, extract_table_refs, hash_rows, Subscription, SubscriptionConfig, SubscriptionError, SubscriptionId,
+    classify_error_str, compute_delta, extract_table_refs, hash_rows, Subscription,
+    SubscriptionConfig, SubscriptionError, SubscriptionErrorKind, SubscriptionId,
     SubscriptionUpdate,
 };
 
@@ -288,118 +289,197 @@ impl SubscriptionManager {
 
         let subscription = sub_ref.value_mut();
 
+        // Try to execute with retry logic
+        self.execute_with_retry(subscription, db, id).await;
+    }
+
+    /// Execute query with retry logic for transient errors
+    async fn execute_with_retry(
+        &self,
+        subscription: &mut Subscription,
+        db: &Database,
+        id: SubscriptionId,
+    ) {
+        loop {
+            // Parse and execute the query
+            let result = self.execute_subscription_query(subscription, db, id).await;
+
+            match result {
+                Ok(rows) => {
+                    // Successful execution - reset retry count
+                    subscription.retry_count = 0;
+
+                    // Convert to Row format
+                    let result_rows: Vec<crate::Row> = rows
+                        .iter()
+                        .map(|r| crate::Row {
+                            values: r.values.clone(),
+                        })
+                        .collect();
+
+                    // Hash results for comparison
+                    let new_hash = hash_rows(&result_rows);
+
+                    if new_hash != subscription.last_result_hash {
+                        debug!(
+                            subscription_id = %id,
+                            old_hash = subscription.last_result_hash,
+                            new_hash = new_hash,
+                            row_count = result_rows.len(),
+                            "Results changed, notifying subscriber"
+                        );
+
+                        // Determine whether to send Delta or Full update
+                        let update = if let Some(ref old_rows) = subscription.last_result {
+                            // We have previous results - compute delta
+                            if let Some(delta) = compute_delta(old_rows, &result_rows) {
+                                // Log delta statistics
+                                if let SubscriptionUpdate::Delta {
+                                    ref inserts,
+                                    ref updates,
+                                    ref deletes,
+                                } = delta
+                                {
+                                    debug!(
+                                        subscription_id = %id,
+                                        inserts = inserts.len(),
+                                        updates = updates.len(),
+                                        deletes = deletes.len(),
+                                        "Sending delta update"
+                                    );
+                                }
+                                delta
+                            } else {
+                                // No delta (shouldn't happen if hash changed, but be safe)
+                                SubscriptionUpdate::Full {
+                                    rows: result_rows.clone(),
+                                }
+                            }
+                        } else {
+                            // No previous results - send full (first update after initial)
+                            debug!(
+                                subscription_id = %id,
+                                "No previous result, sending full update"
+                            );
+                            SubscriptionUpdate::Full {
+                                rows: result_rows.clone(),
+                            }
+                        };
+
+                        // Update stored state
+                        subscription.last_result_hash = new_hash;
+                        subscription.last_result = Some(result_rows);
+
+                        // Send update - ignore errors (channel may be closed)
+                        if subscription.notify_tx.send(update).await.is_err() {
+                            trace!(
+                                subscription_id = %id,
+                                "Notification channel closed, subscription will be cleaned up"
+                            );
+                        }
+                    } else {
+                        trace!(
+                            subscription_id = %id,
+                            "Results unchanged, no notification needed"
+                        );
+                    }
+                    return;
+                }
+                Err(error_msg) => {
+                    // Classify the error to determine retry strategy
+                    let error_kind = classify_error_str(&error_msg);
+
+                    match error_kind {
+                        SubscriptionErrorKind::Permanent => {
+                            // Permanent error - don't retry, notify subscriber and stop
+                            debug!(
+                                subscription_id = %id,
+                                error = %error_msg,
+                                "Permanent error, not retrying"
+                            );
+                            let _ = subscription
+                                .notify_tx
+                                .send(SubscriptionUpdate::Error {
+                                    message: format!(
+                                        "Query execution failed: {} (error will not be retried)",
+                                        error_msg
+                                    ),
+                                })
+                                .await;
+                            return;
+                        }
+                        SubscriptionErrorKind::Transient | SubscriptionErrorKind::Unknown => {
+                            // Transient error - may retry
+                            subscription.retry_count += 1;
+
+                            if subscription.retry_count > subscription.retry_policy.max_retries {
+                                // Exceeded max retries - circuit breaker
+                                warn!(
+                                    subscription_id = %id,
+                                    retry_count = subscription.retry_count,
+                                    max_retries = subscription.retry_policy.max_retries,
+                                    error = %error_msg,
+                                    "Subscription failed after max retries"
+                                );
+                                let _ = subscription
+                                    .notify_tx
+                                    .send(SubscriptionUpdate::Error {
+                                        message: format!(
+                                            "Subscription failed after {} retries: {}",
+                                            subscription.retry_policy.max_retries, error_msg
+                                        ),
+                                    })
+                                    .await;
+                                return;
+                            }
+
+                            // Calculate backoff and retry
+                            let backoff = subscription
+                                .retry_policy
+                                .calculate_backoff(subscription.retry_count - 1);
+
+                            warn!(
+                                subscription_id = %id,
+                                retry_attempt = subscription.retry_count,
+                                backoff_ms = backoff.as_millis(),
+                                error_kind = %error_kind,
+                                error = %error_msg,
+                                "Retrying subscription query after transient error"
+                            );
+
+                            tokio::time::sleep(backoff).await;
+                            // Loop continues to retry
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Execute the subscription query and return rows or error message
+    async fn execute_subscription_query(
+        &self,
+        subscription: &Subscription,
+        db: &Database,
+        id: SubscriptionId,
+    ) -> Result<Vec<vibesql_storage::Row>, String> {
         // Re-execute the query
         let executor = vibesql_executor::SelectExecutor::new(db);
 
         // Parse and execute the query
-        let result = match vibesql_parser::Parser::parse_sql(&subscription.query) {
-            Ok(vibesql_ast::Statement::Select(select)) => executor.execute(&select),
+        match vibesql_parser::Parser::parse_sql(&subscription.query) {
+            Ok(vibesql_ast::Statement::Select(select)) => {
+                executor.execute(&select).map_err(|e| e.to_string())
+            }
             Ok(_) => {
                 // Not a SELECT - shouldn't happen for subscriptions
                 warn!(
                     subscription_id = %id,
                     "Subscription query is not a SELECT"
                 );
-                return;
+                Err("Subscription query is not a SELECT".to_string())
             }
-            Err(e) => {
-                // Query parse error - notify subscriber
-                let _ = subscription
-                    .notify_tx
-                    .send(SubscriptionUpdate::Error {
-                        message: format!("Failed to parse query: {}", e),
-                    })
-                    .await;
-                return;
-            }
-        };
-
-        match result {
-            Ok(rows) => {
-                // Convert to Row format
-                let result_rows: Vec<crate::Row> = rows
-                    .iter()
-                    .map(|r| crate::Row {
-                        values: r.values.clone(),
-                    })
-                    .collect();
-
-                // Hash results for comparison
-                let new_hash = hash_rows(&result_rows);
-
-                if new_hash != subscription.last_result_hash {
-                    debug!(
-                        subscription_id = %id,
-                        old_hash = subscription.last_result_hash,
-                        new_hash = new_hash,
-                        row_count = result_rows.len(),
-                        "Results changed, notifying subscriber"
-                    );
-
-                    // Determine whether to send Delta or Full update
-                    let update = if let Some(ref old_rows) = subscription.last_result {
-                        // We have previous results - compute delta
-                        if let Some(delta) = compute_delta(old_rows, &result_rows) {
-                            // Log delta statistics
-                            if let SubscriptionUpdate::Delta {
-                                ref inserts,
-                                ref updates,
-                                ref deletes,
-                            } = delta
-                            {
-                                debug!(
-                                    subscription_id = %id,
-                                    inserts = inserts.len(),
-                                    updates = updates.len(),
-                                    deletes = deletes.len(),
-                                    "Sending delta update"
-                                );
-                            }
-                            delta
-                        } else {
-                            // No delta (shouldn't happen if hash changed, but be safe)
-                            SubscriptionUpdate::Full {
-                                rows: result_rows.clone(),
-                            }
-                        }
-                    } else {
-                        // No previous results - send full (first update after initial)
-                        debug!(
-                            subscription_id = %id,
-                            "No previous result, sending full update"
-                        );
-                        SubscriptionUpdate::Full {
-                            rows: result_rows.clone(),
-                        }
-                    };
-
-                    // Update stored state
-                    subscription.last_result_hash = new_hash;
-                    subscription.last_result = Some(result_rows);
-
-                    // Send update - ignore errors (channel may be closed)
-                    if subscription.notify_tx.send(update).await.is_err() {
-                        trace!(
-                            subscription_id = %id,
-                            "Notification channel closed, subscription will be cleaned up"
-                        );
-                    }
-                } else {
-                    trace!(
-                        subscription_id = %id,
-                        "Results unchanged, no notification needed"
-                    );
-                }
-            }
-            Err(e) => {
-                // Query execution error - notify subscriber
-                let _ = subscription
-                    .notify_tx
-                    .send(SubscriptionUpdate::Error {
-                        message: format!("Query execution failed: {}", e),
-                    })
-                    .await;
-            }
+            Err(e) => Err(format!("Failed to parse query: {}", e)),
         }
     }
 
@@ -1031,5 +1111,72 @@ mod tests {
 
         // Metrics should reflect the result set exceeded event
         assert_eq!(manager.result_set_exceeded_count(), 1);
+    }
+
+    #[test]
+    fn test_retry_policy_backoff_calculation() {
+        use crate::subscription::SubscriptionRetryPolicy;
+
+        let policy = SubscriptionRetryPolicy {
+            max_retries: 3,
+            base_delay_ms: 1000,
+            max_delay_ms: 30000,
+            backoff_multiplier: 2.0,
+        };
+
+        // First retry: 1000ms
+        let backoff0 = policy.calculate_backoff(0);
+        assert_eq!(backoff0.as_millis(), 1000);
+
+        // Second retry: 2000ms
+        let backoff1 = policy.calculate_backoff(1);
+        assert_eq!(backoff1.as_millis(), 2000);
+
+        // Third retry: 4000ms
+        let backoff2 = policy.calculate_backoff(2);
+        assert_eq!(backoff2.as_millis(), 4000);
+
+        // Fourth retry: 8000ms
+        let backoff3 = policy.calculate_backoff(3);
+        assert_eq!(backoff3.as_millis(), 8000);
+
+        // High attempt should be capped at max_delay_ms
+        let backoff10 = policy.calculate_backoff(10);
+        assert_eq!(backoff10.as_millis(), 30000);
+    }
+
+    #[test]
+    fn test_subscription_retry_count_initialization() {
+        let (tx, _rx) = mpsc::channel(16);
+        let tables: std::collections::HashSet<_> = vec!["users".to_string()].into_iter().collect();
+
+        let sub = Subscription::new("SELECT * FROM users".to_string(), tables, tx);
+        assert_eq!(sub.retry_count, 0);
+    }
+
+    #[test]
+    fn test_subscription_with_custom_policy() {
+        use crate::subscription::SubscriptionRetryPolicy;
+
+        let (tx, _rx) = mpsc::channel(16);
+        let tables: std::collections::HashSet<_> = vec!["users".to_string()].into_iter().collect();
+
+        let policy = SubscriptionRetryPolicy {
+            max_retries: 5,
+            base_delay_ms: 500,
+            max_delay_ms: 60000,
+            backoff_multiplier: 3.0,
+        };
+
+        let sub = Subscription::with_policy(
+            "SELECT * FROM users".to_string(),
+            tables,
+            tx,
+            policy.clone(),
+        );
+
+        assert_eq!(sub.retry_count, 0);
+        assert_eq!(sub.retry_policy.max_retries, 5);
+        assert_eq!(sub.retry_policy.base_delay_ms, 500);
     }
 }

--- a/crates/vibesql-server/src/subscription/mod.rs
+++ b/crates/vibesql-server/src/subscription/mod.rs
@@ -47,9 +47,11 @@ mod router;
 pub mod session;
 mod table_dependencies;
 mod table_extract;
+pub mod error;
 
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
@@ -59,6 +61,7 @@ pub use router::{ChangeRouter, SubscriptionUpdate as RouterUpdate};
 pub use session::{SessionSubscription, SessionSubscriptionId, SessionSubscriptionManager};
 pub use table_dependencies::extract_table_dependencies;
 pub use table_extract::extract_table_refs;
+pub use error::{SubscriptionErrorKind, classify_error, classify_error_str};
 
 // ============================================================================
 // Subscription Configuration
@@ -165,6 +168,72 @@ impl std::fmt::Display for SubscriptionId {
 }
 
 // ============================================================================
+// Retry Policy
+// ============================================================================
+
+/// Configuration for subscription query retry behavior
+///
+/// When a subscription query fails during re-execution, it may be automatically
+/// retried with exponential backoff if the error is classified as transient.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubscriptionRetryPolicy {
+    /// Maximum number of retry attempts after initial failure
+    ///
+    /// Default: 3
+    /// Once retries are exhausted, the subscription enters a failed state
+    /// and the error is sent to the client.
+    pub max_retries: u32,
+
+    /// Base delay for the first retry in milliseconds
+    ///
+    /// Default: 1000 (1 second)
+    /// Used as the starting point for exponential backoff calculation.
+    pub base_delay_ms: u64,
+
+    /// Maximum delay between retries in milliseconds
+    ///
+    /// Default: 30000 (30 seconds)
+    /// Exponential backoff is capped at this duration to prevent excessive delays.
+    pub max_delay_ms: u64,
+
+    /// Multiplier for exponential backoff
+    ///
+    /// Default: 2.0
+    /// Delay for retry N = base_delay * (multiplier ^ N), capped at max_delay
+    pub backoff_multiplier: f64,
+}
+
+impl Default for SubscriptionRetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            base_delay_ms: 1000,
+            max_delay_ms: 30000,
+            backoff_multiplier: 2.0,
+        }
+    }
+}
+
+impl SubscriptionRetryPolicy {
+    /// Calculate the backoff delay for a given retry attempt
+    ///
+    /// # Arguments
+    ///
+    /// * `attempt` - The retry attempt number (0-indexed, so first retry is 0)
+    ///
+    /// # Returns
+    ///
+    /// Duration to wait before the next retry
+    fn calculate_backoff(&self, attempt: u32) -> Duration {
+        let backoff_ms = self.base_delay_ms as f64
+            * self.backoff_multiplier.powi(attempt as i32);
+
+        let capped_ms = backoff_ms.min(self.max_delay_ms as f64);
+        Duration::from_millis(capped_ms as u64)
+    }
+}
+
+// ============================================================================
 // Subscription
 // ============================================================================
 
@@ -186,6 +255,10 @@ pub struct Subscription {
     pub last_result: Option<Vec<crate::Row>>,
     /// Channel to send updates to the subscriber
     pub notify_tx: mpsc::Sender<SubscriptionUpdate>,
+    /// Retry policy for handling transient errors
+    pub retry_policy: SubscriptionRetryPolicy,
+    /// Current retry attempt count (resets on successful execution)
+    pub retry_count: u32,
 }
 
 impl Subscription {
@@ -195,6 +268,16 @@ impl Subscription {
         tables: HashSet<String>,
         notify_tx: mpsc::Sender<SubscriptionUpdate>,
     ) -> Self {
+        Self::with_policy(query, tables, notify_tx, SubscriptionRetryPolicy::default())
+    }
+
+    /// Create a new subscription with a custom retry policy
+    pub fn with_policy(
+        query: String,
+        tables: HashSet<String>,
+        notify_tx: mpsc::Sender<SubscriptionUpdate>,
+        retry_policy: SubscriptionRetryPolicy,
+    ) -> Self {
         Self {
             id: SubscriptionId::new(),
             query,
@@ -202,6 +285,8 @@ impl Subscription {
             last_result_hash: 0,
             last_result: None,
             notify_tx,
+            retry_policy,
+            retry_count: 0,
         }
     }
 }


### PR DESCRIPTION
Implements subscription error retry logic with circuit breaker pattern to handle transient failures gracefully.

## Changes

- Add SubscriptionRetryPolicy struct with configurable backoff parameters
- Add error classification module to distinguish transient vs permanent errors
- Implement exponential backoff retry loop in SubscriptionManager
- Add comprehensive tests for retry behavior and error classification

## Acceptance Criteria

✓ Add retry policy configuration
✓ Implement exponential backoff for failed queries
✓ Classify errors as transient vs permanent
✓ Add circuit breaker (max retries)
✓ Reset retry count on successful execution
✓ Send appropriate error messages to client
✓ Add test for retry behavior

Closes #3511