### PR TITLE
Fix duplicate sanity_date entries in TPC-DS benchmark output

### DIFF
--- a/crates/vibesql-executor/benches/tpcds_benchmark.rs
+++ b/crates/vibesql-executor/benches/tpcds_benchmark.rs
@@ -655,7 +655,6 @@ criterion_group!(
 #[cfg(feature = "benchmark-comparison")]
 criterion_group!(
     benches,
-    bench_sanity_queries,
     bench_sanity_queries_comparison,
     bench_tpcds_queries,
     bench_tpcds_slow_queries,


### PR DESCRIPTION
## Summary

Removes duplicate sanity query entries from TPC-DS benchmark output when the benchmark-comparison feature is enabled.

## Changes

- Removed  from the  criterion_group
-  already benchmarks all sanity queries for both VibeSQL and comparison engines

## Impact

- Benchmark output will no longer show duplicate sanity query entries
- No functional changes to the benchmark itself
- Cleaner CI logs and benchmark results

Closes #3527