### PR TITLE
perf(tpcds): Fix Q69 by removing unnecessary date_dim cross join

### DIFF
--- a/crates/vibesql-executor/benches/tpcds/queries.rs
+++ b/crates/vibesql-executor/benches/tpcds/queries.rs
@@ -2447,7 +2447,8 @@ LIMIT 100
 "#;
 
 // TPC-DS Q69: Customer analysis with address
-// Tests: NOT EXISTS, multiple subqueries
+// Tests: NOT EXISTS, multiple subqueries (EXISTS and NOT EXISTS patterns)
+// Fixed: Removed unnecessary date_dim cross join from outer query
 pub const TPCDS_Q69: &str = r#"
 SELECT
     c_customer_id,
@@ -2457,10 +2458,9 @@ SELECT
     c_birth_country,
     c_login,
     c_email_address
-FROM customer c, customer_address ca, date_dim
+FROM customer c, customer_address ca
 WHERE c.c_current_addr_sk = ca.ca_address_sk
     AND ca_state IN ('KY', 'GA', 'NM')
-    AND d_year = 2000
     AND EXISTS (
         SELECT 1
         FROM store_sales, date_dim d2


### PR DESCRIPTION
## Summary

- Fixed TPC-DS Q69 query which had an unnecessary `date_dim` in the outer FROM clause
- This `date_dim` had no join condition with `customer` or `customer_address`, creating an expensive cross join
- The date filtering is already performed inside the EXISTS and NOT EXISTS subqueries

## Performance Improvement (at SF=0.001)

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Time | 2062 ms | 20 ms | **100x faster** |
| Memory | 2761 MB | 136 MB | **20x less** |

## Test plan

- [x] Q69 completes within 60 seconds at SF=0.001 (completes in 20ms)
- [x] All TPC-DS queries pass (97/99, same as before - 2 pre-existing errors)
- [x] All executor unit tests pass

Closes #3556

🤖 Generated with [Claude Code](https://claude.com/claude-code)