### PR TITLE
test(optimizer): Add unit tests for table_elimination pass

### DIFF
--- a/crates/vibesql-executor/src/optimizer/table_elimination.rs
+++ b/crates/vibesql-executor/src/optimizer/table_elimination.rs
@@ -969,3 +969,463 @@ fn find_common_prefix(columns: &[String]) -> Option<String> {
 
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod derive_prefix_from_table_name_tests {
+        use super::*;
+
+        #[test]
+        fn short_aliases_two_chars() {
+            // TPC-DS style 2-char aliases
+            assert_eq!(derive_prefix_from_table_name("ss"), Some("ss_".to_string()));
+            assert_eq!(derive_prefix_from_table_name("ws"), Some("ws_".to_string()));
+            assert_eq!(derive_prefix_from_table_name("cs"), Some("cs_".to_string()));
+        }
+
+        #[test]
+        fn short_aliases_three_chars() {
+            // 3-char aliases
+            assert_eq!(derive_prefix_from_table_name("inv"), Some("inv_".to_string()));
+        }
+
+        #[test]
+        fn dimension_tables() {
+            // Tables ending with _dim use first letter
+            assert_eq!(derive_prefix_from_table_name("date_dim"), Some("d_".to_string()));
+            assert_eq!(derive_prefix_from_table_name("time_dim"), Some("t_".to_string()));
+            assert_eq!(derive_prefix_from_table_name("item_dim"), Some("i_".to_string()));
+        }
+
+        #[test]
+        fn multi_word_tables() {
+            // Multi-word tables use acronym (first letter of each word)
+            assert_eq!(derive_prefix_from_table_name("customer_address"), Some("ca_".to_string()));
+            assert_eq!(derive_prefix_from_table_name("store_sales"), Some("ss_".to_string()));
+            assert_eq!(derive_prefix_from_table_name("web_returns"), Some("wr_".to_string()));
+            assert_eq!(derive_prefix_from_table_name("catalog_page"), Some("cp_".to_string()));
+        }
+
+        #[test]
+        fn single_word_tables() {
+            // Single word tables use first letter
+            assert_eq!(derive_prefix_from_table_name("customer"), Some("c_".to_string()));
+            assert_eq!(derive_prefix_from_table_name("item"), Some("i_".to_string()));
+            assert_eq!(derive_prefix_from_table_name("store"), Some("s_".to_string()));
+            assert_eq!(derive_prefix_from_table_name("warehouse"), Some("w_".to_string()));
+        }
+
+        #[test]
+        fn case_insensitive() {
+            // Should handle mixed case
+            assert_eq!(derive_prefix_from_table_name("DATE_DIM"), Some("d_".to_string()));
+            assert_eq!(derive_prefix_from_table_name("Customer"), Some("c_".to_string()));
+            assert_eq!(derive_prefix_from_table_name("Store_Sales"), Some("ss_".to_string()));
+        }
+
+        #[test]
+        fn empty_string() {
+            // Empty string falls through to short alias logic (len <= 3)
+            // and returns "_" (empty + underscore)
+            assert_eq!(derive_prefix_from_table_name(""), Some("_".to_string()));
+        }
+    }
+
+    mod find_common_prefix_tests {
+        use super::*;
+
+        #[test]
+        fn common_underscore_prefix() {
+            let cols = vec!["d_year".to_string(), "d_date_sk".to_string(), "d_month".to_string()];
+            assert_eq!(find_common_prefix(&cols), Some("d_".to_string()));
+        }
+
+        #[test]
+        fn two_char_prefix() {
+            let cols = vec!["ca_state".to_string(), "ca_city".to_string(), "ca_zip".to_string()];
+            assert_eq!(find_common_prefix(&cols), Some("ca_".to_string()));
+        }
+
+        #[test]
+        fn no_common_prefix() {
+            let cols = vec!["foo".to_string(), "bar".to_string(), "baz".to_string()];
+            assert_eq!(find_common_prefix(&cols), None);
+        }
+
+        #[test]
+        fn empty_columns() {
+            let cols: Vec<String> = vec![];
+            assert_eq!(find_common_prefix(&cols), None);
+        }
+
+        #[test]
+        fn single_column() {
+            let cols = vec!["d_year".to_string()];
+            assert_eq!(find_common_prefix(&cols), Some("d_".to_string()));
+        }
+
+        #[test]
+        fn partial_match_not_all_columns() {
+            // First two columns share prefix, but third doesn't
+            let cols = vec!["d_year".to_string(), "d_month".to_string(), "t_hour".to_string()];
+            assert_eq!(find_common_prefix(&cols), None);
+        }
+
+        #[test]
+        fn fallback_to_two_char_prefix() {
+            // No underscore, but shares first 2 chars
+            let cols = vec!["item1".to_string(), "item2".to_string()];
+            assert_eq!(find_common_prefix(&cols), Some("it".to_string()));
+        }
+    }
+
+    mod eliminate_unused_tables_tests {
+        use super::*;
+        use vibesql_ast::{BinaryOperator, Expression, FromClause, SelectItem, SelectStmt};
+        use vibesql_types::SqlValue;
+
+        fn make_column_ref(table: Option<&str>, column: &str) -> Expression {
+            Expression::ColumnRef {
+                table: table.map(|t| t.to_string()),
+                column: column.to_string(),
+            }
+        }
+
+        fn make_table(name: &str, alias: Option<&str>) -> FromClause {
+            FromClause::Table {
+                name: name.to_string(),
+                alias: alias.map(|a| a.to_string()),
+                column_aliases: None,
+            }
+        }
+
+        fn make_cross_join(left: FromClause, right: FromClause) -> FromClause {
+            FromClause::Join {
+                left: Box::new(left),
+                right: Box::new(right),
+                join_type: JoinType::Cross,
+                condition: None,
+                natural: false,
+            }
+        }
+
+        #[test]
+        fn single_table_unchanged() {
+            // Single table should not be eliminated
+            let stmt = SelectStmt {
+                with_clause: None,
+                distinct: false,
+                select_list: vec![SelectItem::Expression {
+                    expr: make_column_ref(Some("t1"), "col1"),
+                    alias: None,
+                }],
+                into_table: None,
+                into_variables: None,
+                from: Some(make_table("table1", Some("t1"))),
+                where_clause: None,
+                group_by: None,
+                having: None,
+                order_by: None,
+                limit: None,
+                offset: None,
+                set_operation: None,
+            };
+
+            let result = eliminate_unused_tables(&stmt);
+            assert!(matches!(result.from, Some(FromClause::Table { .. })));
+        }
+
+        #[test]
+        fn table_in_select_not_eliminated() {
+            // Table referenced in SELECT should not be eliminated
+            let stmt = SelectStmt {
+                with_clause: None,
+                distinct: false,
+                select_list: vec![
+                    SelectItem::Expression {
+                        expr: make_column_ref(Some("t1"), "col1"),
+                        alias: None,
+                    },
+                    SelectItem::Expression {
+                        expr: make_column_ref(Some("t2"), "col2"),
+                        alias: None,
+                    },
+                ],
+                into_table: None,
+                into_variables: None,
+                from: Some(make_cross_join(
+                    make_table("table1", Some("t1")),
+                    make_table("table2", Some("t2")),
+                )),
+                where_clause: None,
+                group_by: None,
+                having: None,
+                order_by: None,
+                limit: None,
+                offset: None,
+                set_operation: None,
+            };
+
+            let result = eliminate_unused_tables(&stmt);
+            // Both tables should be kept since both are in SELECT
+            assert!(matches!(result.from, Some(FromClause::Join { .. })));
+        }
+
+        #[test]
+        fn table_in_equijoin_not_eliminated() {
+            // Table in equijoin should not be eliminated
+            let stmt = SelectStmt {
+                with_clause: None,
+                distinct: false,
+                select_list: vec![SelectItem::Expression {
+                    expr: make_column_ref(Some("t1"), "col1"),
+                    alias: None,
+                }],
+                into_table: None,
+                into_variables: None,
+                from: Some(make_cross_join(
+                    make_table("table1", Some("t1")),
+                    make_table("table2", Some("t2")),
+                )),
+                where_clause: Some(Expression::BinaryOp {
+                    op: BinaryOperator::Equal,
+                    left: Box::new(make_column_ref(Some("t1"), "id")),
+                    right: Box::new(make_column_ref(Some("t2"), "id")),
+                }),
+                group_by: None,
+                having: None,
+                order_by: None,
+                limit: None,
+                offset: None,
+                set_operation: None,
+            };
+
+            let result = eliminate_unused_tables(&stmt);
+            // Both tables should be kept since they're in equijoin
+            assert!(matches!(result.from, Some(FromClause::Join { .. })));
+        }
+
+        #[test]
+        fn unused_table_with_filter_eliminated() {
+            // Table not in SELECT and not in equijoin should be eliminated
+            // with its filter converted to EXISTS
+            let stmt = SelectStmt {
+                with_clause: None,
+                distinct: false,
+                select_list: vec![SelectItem::Expression {
+                    expr: make_column_ref(Some("t1"), "col1"),
+                    alias: None,
+                }],
+                into_table: None,
+                into_variables: None,
+                from: Some(make_cross_join(
+                    make_table("table1", Some("t1")),
+                    make_table("date_dim", Some("d")),
+                )),
+                where_clause: Some(Expression::BinaryOp {
+                    op: BinaryOperator::Equal,
+                    left: Box::new(make_column_ref(Some("d"), "d_year")),
+                    right: Box::new(Expression::Literal(SqlValue::Integer(2000))),
+                }),
+                group_by: None,
+                having: None,
+                order_by: None,
+                limit: None,
+                offset: None,
+                set_operation: None,
+            };
+
+            let result = eliminate_unused_tables(&stmt);
+
+            // FROM should now only have table1
+            match &result.from {
+                Some(FromClause::Table { name, .. }) => {
+                    assert_eq!(name, "table1");
+                }
+                _ => panic!("Expected single table, got: {:?}", result.from),
+            }
+
+            // WHERE should contain EXISTS check
+            match &result.where_clause {
+                Some(Expression::Exists { negated, .. }) => {
+                    assert!(!negated);
+                }
+                _ => panic!("Expected EXISTS clause, got: {:?}", result.where_clause),
+            }
+        }
+
+        #[test]
+        fn select_literal_subquery_unchanged() {
+            // SELECT 1 FROM ... subqueries should not be optimized
+            let stmt = SelectStmt {
+                with_clause: None,
+                distinct: false,
+                select_list: vec![SelectItem::Expression {
+                    expr: Expression::Literal(SqlValue::Integer(1)),
+                    alias: None,
+                }],
+                into_table: None,
+                into_variables: None,
+                from: Some(make_cross_join(
+                    make_table("table1", Some("t1")),
+                    make_table("table2", Some("t2")),
+                )),
+                where_clause: None,
+                group_by: None,
+                having: None,
+                order_by: None,
+                limit: None,
+                offset: None,
+                set_operation: None,
+            };
+
+            let result = eliminate_unused_tables(&stmt);
+            // Should be unchanged (both tables kept)
+            assert!(matches!(result.from, Some(FromClause::Join { .. })));
+        }
+
+        #[test]
+        fn no_from_clause_unchanged() {
+            let stmt = SelectStmt {
+                with_clause: None,
+                distinct: false,
+                select_list: vec![SelectItem::Expression {
+                    expr: Expression::Literal(SqlValue::Integer(42)),
+                    alias: None,
+                }],
+                into_table: None,
+                into_variables: None,
+                from: None,
+                where_clause: None,
+                group_by: None,
+                having: None,
+                order_by: None,
+                limit: None,
+                offset: None,
+                set_operation: None,
+            };
+
+            let result = eliminate_unused_tables(&stmt);
+            assert!(result.from.is_none());
+        }
+
+        #[test]
+        fn select_star_references_all_tables() {
+            // SELECT * should reference all tables, preventing elimination
+            let stmt = SelectStmt {
+                with_clause: None,
+                distinct: false,
+                select_list: vec![SelectItem::Wildcard { alias: None }],
+                into_table: None,
+                into_variables: None,
+                from: Some(make_cross_join(
+                    make_table("table1", Some("t1")),
+                    make_table("table2", Some("t2")),
+                )),
+                where_clause: None,
+                group_by: None,
+                having: None,
+                order_by: None,
+                limit: None,
+                offset: None,
+                set_operation: None,
+            };
+
+            let result = eliminate_unused_tables(&stmt);
+            // Both tables should be kept due to SELECT *
+            assert!(matches!(result.from, Some(FromClause::Join { .. })));
+        }
+    }
+
+    mod helper_function_tests {
+        use super::*;
+        use vibesql_ast::{BinaryOperator, Expression, SelectItem};
+        use vibesql_types::SqlValue;
+
+        #[test]
+        fn flatten_and_chain_single() {
+            let expr = Expression::Literal(SqlValue::Integer(1));
+            let result = flatten_and_chain(&expr);
+            assert_eq!(result.len(), 1);
+        }
+
+        #[test]
+        fn flatten_and_chain_multiple() {
+            let expr = Expression::BinaryOp {
+                op: BinaryOperator::And,
+                left: Box::new(Expression::Literal(SqlValue::Integer(1))),
+                right: Box::new(Expression::BinaryOp {
+                    op: BinaryOperator::And,
+                    left: Box::new(Expression::Literal(SqlValue::Integer(2))),
+                    right: Box::new(Expression::Literal(SqlValue::Integer(3))),
+                }),
+            };
+            let result = flatten_and_chain(&expr);
+            assert_eq!(result.len(), 3);
+        }
+
+        #[test]
+        fn combine_predicates_empty() {
+            let preds: Vec<Expression> = vec![];
+            let result = combine_predicates(preds);
+            assert!(matches!(result, Expression::Literal(SqlValue::Boolean(true))));
+        }
+
+        #[test]
+        fn combine_predicates_single() {
+            let preds = vec![Expression::Literal(SqlValue::Integer(42))];
+            let result = combine_predicates(preds);
+            assert!(matches!(result, Expression::Literal(SqlValue::Integer(42))));
+        }
+
+        #[test]
+        fn combine_predicates_multiple() {
+            let preds = vec![
+                Expression::Literal(SqlValue::Integer(1)),
+                Expression::Literal(SqlValue::Integer(2)),
+            ];
+            let result = combine_predicates(preds);
+            assert!(matches!(result, Expression::BinaryOp { op: BinaryOperator::And, .. }));
+        }
+
+        #[test]
+        fn collect_unqualified_columns_finds_refs() {
+            let select_list = vec![
+                SelectItem::Expression {
+                    expr: Expression::ColumnRef {
+                        table: None,
+                        column: "col1".to_string(),
+                    },
+                    alias: None,
+                },
+                SelectItem::Expression {
+                    expr: Expression::ColumnRef {
+                        table: Some("t1".to_string()),
+                        column: "col2".to_string(),
+                    },
+                    alias: None,
+                },
+            ];
+            let result = collect_unqualified_columns(&select_list);
+            assert!(result.contains("col1"));
+            assert!(!result.contains("col2")); // Qualified column should not be included
+        }
+
+        #[test]
+        fn has_unqualified_column_ref_detects_unqualified() {
+            let qualified = Expression::ColumnRef {
+                table: Some("t1".to_string()),
+                column: "col1".to_string(),
+            };
+            assert!(!has_unqualified_column_ref(&qualified));
+
+            let unqualified = Expression::ColumnRef {
+                table: None,
+                column: "col1".to_string(),
+            };
+            assert!(has_unqualified_column_ref(&unqualified));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for `derive_prefix_from_table_name()` function
- Add unit tests for `find_common_prefix()` function  
- Add integration tests for `eliminate_unused_tables()` optimization pass
- Add tests for helper functions (`flatten_and_chain`, `combine_predicates`, etc.)

**28 new tests** covering:
- Short aliases (2-3 chars like `ss`, `ws`)
- Dimension tables (`date_dim` → `d_`)
- Multi-word tables (`customer_address` → `ca_`)
- Single word tables (`customer` → `c_`)
- Edge cases (empty strings, no common prefix, partial matches)
- Table elimination scenarios (SELECT refs, equijoins, wildcards, subqueries)

## Test plan

- [x] All 28 new unit tests pass
- [x] `cargo test -p vibesql-executor table_elimination::tests` passes

Closes #3565

🤖 Generated with [Claude Code](https://claude.com/claude-code)