### PR TITLE
fix: Propagate CTE context to predicate evaluation for IN subqueries

### DIFF
--- a/crates/vibesql-executor/src/select/scan/predicates.rs
+++ b/crates/vibesql-executor/src/select/scan/predicates.rs
@@ -7,9 +7,11 @@
 //! **Phase 1 Optimization**: This module now uses `PredicatePlan` to avoid redundant
 //! WHERE clause decomposition. The plan is computed once at query start and passed through.
 
+use std::collections::HashMap;
+
 use crate::{
     errors::ExecutorError, evaluator::CombinedExpressionEvaluator,
-    optimizer::PredicatePlan, schema::CombinedSchema,
+    optimizer::PredicatePlan, schema::CombinedSchema, select::cte::CteResult,
 };
 
 #[cfg(feature = "parallel")]
@@ -29,6 +31,7 @@ use std::sync::Arc;
 ///
 /// **Phase 1**: Optimized to work with row slices instead of owned vectors.
 /// **Phase 2**: Attempts columnar execution for complex predicates with OR logic.
+/// **Issue #3563**: Now accepts CTE context for WHERE clauses with IN subqueries referencing CTEs.
 pub(crate) fn apply_table_local_predicates_ref(
     rows: &[vibesql_storage::Row],
     schema: CombinedSchema,
@@ -37,6 +40,7 @@ pub(crate) fn apply_table_local_predicates_ref(
     database: &vibesql_storage::Database,
     outer_row: Option<&vibesql_storage::Row>,
     outer_schema: Option<&CombinedSchema>,
+    cte_results: Option<&HashMap<String, CteResult>>,
 ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
     // Get table statistics for selectivity-based ordering
     let table_stats = database
@@ -82,11 +86,23 @@ pub(crate) fn apply_table_local_predicates_ref(
             // If columnar extraction fails, fall through to row-by-row evaluation
         }
 
-        // Create evaluator for filtering with outer context for correlated subqueries
-        let evaluator = if let (Some(outer_row), Some(outer_schema)) = (outer_row, outer_schema) {
-            CombinedExpressionEvaluator::with_database_and_outer_context(&schema, database, outer_row, outer_schema)
-        } else {
-            CombinedExpressionEvaluator::with_database(&schema, database)
+        // Create evaluator for filtering with outer context, CTE context, or both (#3563)
+        // Priority: outer+CTE > outer > CTE > database only
+        let evaluator = match (outer_row, outer_schema, cte_results) {
+            (Some(outer_row), Some(outer_schema), Some(cte_ctx)) if !cte_ctx.is_empty() => {
+                CombinedExpressionEvaluator::with_database_and_outer_context_and_cte(
+                    &schema, database, outer_row, outer_schema, cte_ctx,
+                )
+            }
+            (Some(outer_row), Some(outer_schema), _) => {
+                CombinedExpressionEvaluator::with_database_and_outer_context(
+                    &schema, database, outer_row, outer_schema,
+                )
+            }
+            (_, _, Some(cte_ctx)) if !cte_ctx.is_empty() => {
+                CombinedExpressionEvaluator::with_database_and_cte(&schema, database, cte_ctx)
+            }
+            _ => CombinedExpressionEvaluator::with_database(&schema, database),
         };
 
         // Filter rows, only cloning those that pass
@@ -139,6 +155,7 @@ pub(crate) fn apply_table_local_predicates_ref(
 /// **Phase 1**: Now accepts `PredicatePlan` instead of decomposing WHERE clause internally.
 /// **Phase 2**: Attempts columnar execution for complex predicates with OR logic.
 /// **Phase 4**: Uses cost-based predicate ordering via selectivity estimation.
+/// **Issue #3563**: Now accepts CTE context for WHERE clauses with IN subqueries referencing CTEs.
 ///
 /// **Note**: This version takes owned Vec<Row>. Consider using apply_table_local_predicates_ref
 /// for better performance with large datasets.
@@ -150,6 +167,7 @@ pub(crate) fn apply_table_local_predicates(
     database: &vibesql_storage::Database,
     outer_row: Option<&vibesql_storage::Row>,
     outer_schema: Option<&CombinedSchema>,
+    cte_results: Option<&HashMap<String, CteResult>>,
 ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
     // Get table statistics for selectivity-based ordering
     let table_stats = database
@@ -187,11 +205,23 @@ pub(crate) fn apply_table_local_predicates(
             }
         }
 
-        // Create evaluator for filtering with outer context for correlated subqueries
-        let evaluator = if let (Some(outer_row), Some(outer_schema)) = (outer_row, outer_schema) {
-            CombinedExpressionEvaluator::with_database_and_outer_context(&schema, database, outer_row, outer_schema)
-        } else {
-            CombinedExpressionEvaluator::with_database(&schema, database)
+        // Create evaluator for filtering with outer context, CTE context, or both (#3563)
+        // Priority: outer+CTE > outer > CTE > database only
+        let evaluator = match (outer_row, outer_schema, cte_results) {
+            (Some(outer_row), Some(outer_schema), Some(cte_ctx)) if !cte_ctx.is_empty() => {
+                CombinedExpressionEvaluator::with_database_and_outer_context_and_cte(
+                    &schema, database, outer_row, outer_schema, cte_ctx,
+                )
+            }
+            (Some(outer_row), Some(outer_schema), _) => {
+                CombinedExpressionEvaluator::with_database_and_outer_context(
+                    &schema, database, outer_row, outer_schema,
+                )
+            }
+            (_, _, Some(cte_ctx)) if !cte_ctx.is_empty() => {
+                CombinedExpressionEvaluator::with_database_and_cte(&schema, database, cte_ctx)
+            }
+            _ => CombinedExpressionEvaluator::with_database(&schema, database),
         };
 
         // Check if we should use parallel filtering

--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -75,6 +75,7 @@ pub(crate) fn execute_table_scan(
 
             // Must clone rows for filtering (copy-on-write semantics)
             // Note: Use effective_name (alias) for filter lookup since PredicatePlan uses schema table names
+            // Pass CTE context for WHERE clauses with IN subqueries referencing CTEs (#3563)
             let rows = apply_table_local_predicates(
                 cte_rows.as_ref().clone(),
                 schema.clone(),
@@ -83,6 +84,7 @@ pub(crate) fn execute_table_scan(
                 database,
                 None,  // No outer context for non-correlated predicate pushdown
                 None,
+                Some(cte_results),
             )?;
             return Ok(super::FromResult::from_rows(schema, rows));
         }
@@ -174,6 +176,7 @@ pub(crate) fn execute_table_scan(
                 .map_err(ExecutorError::InvalidWhereClause)?;
 
             // Note: Use effective_name (alias) for filter lookup since PredicatePlan uses schema table names
+            // Pass CTE context for WHERE clauses with IN subqueries referencing CTEs (#3563)
             rows = apply_table_local_predicates(
                 rows,
                 schema.clone(),
@@ -182,6 +185,7 @@ pub(crate) fn execute_table_scan(
                 database,
                 None,  // No outer context for non-correlated predicate pushdown
                 None,
+                Some(cte_results),
             )?;
         }
 
@@ -292,6 +296,7 @@ pub(crate) fn execute_table_scan(
             }
             // Fall back to generic predicate evaluation for complex expressions
             // Note: Use effective_name (alias) for filter lookup since PredicatePlan uses schema table names
+            // Pass CTE context for WHERE clauses with IN subqueries referencing CTEs (#3563)
             let filtered_rows = apply_table_local_predicates_ref(
                 row_slice,
                 schema.clone(),
@@ -300,6 +305,7 @@ pub(crate) fn execute_table_scan(
                 database,
                 None,  // No outer context for predicate pushdown
                 None,
+                Some(cte_results),
             )?;
             return Ok(super::FromResult::from_rows(schema, filtered_rows));
         }

--- a/tests/executor/cte.rs
+++ b/tests/executor/cte.rs
@@ -235,3 +235,44 @@ fn test_cte_used_multiple_times() {
 
     assert_eq!(results.len(), 1); // User 1 joined with user 3
 }
+
+/// Test for issue #3563: CTE visibility in IN subqueries
+///
+/// CTEs should be visible within IN subqueries in the WHERE clause.
+/// Previously this failed with TableNotFound error because the CTE context
+/// was not propagated to the predicate evaluation.
+#[test]
+fn test_cte_visible_in_in_subquery() {
+    let db = create_test_database();
+
+    // Query pattern similar to TPC-DS Q95:
+    // WITH cte AS (...) SELECT ... WHERE col IN (SELECT col FROM cte)
+    let results = execute_query(
+        &db,
+        "WITH high_orders AS (SELECT user_id FROM orders WHERE amount >= 150) \
+         SELECT name FROM users WHERE id IN (SELECT user_id FROM high_orders);",
+    )
+    .unwrap();
+
+    // Users 1 and 2 have orders >= 150 (101->100, 102->200, 103->150)
+    // User 1: orders 101 (100) and 103 (150) - has order >= 150
+    // User 2: order 102 (200) - has order >= 150
+    assert_eq!(results.len(), 2);
+}
+
+/// Test CTE visibility in NOT IN subquery
+#[test]
+fn test_cte_visible_in_not_in_subquery() {
+    let db = create_test_database();
+
+    let results = execute_query(
+        &db,
+        "WITH big_spenders AS (SELECT user_id FROM orders WHERE amount >= 200) \
+         SELECT name FROM users WHERE id NOT IN (SELECT user_id FROM big_spenders);",
+    )
+    .unwrap();
+
+    // User 2 has an order of 200, so they are a big spender
+    // Users 1 and 3 should be returned (3 has no orders)
+    assert_eq!(results.len(), 2);
+}


### PR DESCRIPTION
## Summary
- Fixed issue where CTEs were not visible within IN subqueries in WHERE clauses
- Added `cte_results` parameter to `apply_table_local_predicates` and `apply_table_local_predicates_ref` functions
- CTE context is now properly propagated to the expression evaluator during predicate pushdown
- TPC-DS Q95 (and similar query patterns) now work correctly

## Test plan
- [x] TPC-DS Q95 passes (previously failed with TableNotFound)
- [x] All 11 CTE unit tests pass (including 2 new tests for this issue)
- [x] TPC-DS suite: 98/99 queries passing
- [x] All existing executor tests pass

Closes #3563

🤖 Generated with [Claude Code](https://claude.com/claude-code)