### PR TITLE
feat: Enable differential assertion checks in differential_sqlite fuzz target

### DIFF
--- a/fuzz/fuzz_targets/differential_sqlite.rs
+++ b/fuzz/fuzz_targets/differential_sqlite.rs
@@ -267,32 +267,30 @@ fuzz_target!(|data: &[u8]| {
         // Both succeeded - compare results
         (Some(sqlite_rows), Some(vibesql_rows)) => {
             // Compare row count
-            if sqlite_rows.len() != vibesql_rows.len() {
-                // Row count mismatch is interesting but might be due to ordering
-                // For now, just verify both return some rows or both return empty
-                if (sqlite_rows.is_empty()) != (vibesql_rows.is_empty()) {
-                    // One returned rows, other didn't - this is a bug
-                    // For fuzzing, we report this as a potential issue by panicking
-                    // In practice, you might want to log these instead
-                    // panic!(
-                    //     "Row count mismatch: SQLite={}, VibeSQL={} for query: {}",
-                    //     sqlite_rows.len(), vibesql_rows.len(), sql
-                    // );
-                }
-            }
+             if sqlite_rows.len() != vibesql_rows.len() {
+                 // Row count mismatch is interesting but might be due to ordering
+                 // For now, just verify both return some rows or both return empty
+                 if (sqlite_rows.is_empty()) != (vibesql_rows.is_empty()) {
+                     // One returned rows, other didn't - this is a bug
+                     panic!(
+                         "Row count mismatch: SQLite={}, VibeSQL={} for query: {}",
+                         sqlite_rows.len(), vibesql_rows.len(), sql
+                     );
+                 }
+             }
 
             // Compare column count for first row
-            if let (Some(sqlite_first), Some(vibesql_first)) =
-                (sqlite_rows.first(), vibesql_rows.first())
-            {
-                if sqlite_first.len() != vibesql_first.len() {
-                    // Column count mismatch - likely a semantic difference
-                    // panic!(
-                    //     "Column count mismatch: SQLite={}, VibeSQL={} for query: {}",
-                    //     sqlite_first.len(), vibesql_first.len(), sql
-                    // );
-                }
-            }
+             if let (Some(sqlite_first), Some(vibesql_first)) =
+                 (sqlite_rows.first(), vibesql_rows.first())
+             {
+                 if sqlite_first.len() != vibesql_first.len() {
+                     // Column count mismatch - likely a semantic difference
+                     panic!(
+                         "Column count mismatch: SQLite={}, VibeSQL={} for query: {}",
+                         sqlite_first.len(), vibesql_first.len(), sql
+                     );
+                 }
+             }
         }
 
         // Both failed - expected for invalid queries


### PR DESCRIPTION
## Summary

Enables the previously commented-out differential testing assertions in the `differential_sqlite` fuzz target.

## Changes

- Uncommented row count mismatch panic assertion
- Uncommented column count mismatch panic assertion  
- Updated fuzz/Cargo.toml with complete dependency list for all fuzz targets
- Added missing query_executor and type_coercion fuzz targets
- Added differential_sqlite binary target configuration

## Rationale

These assertions were temporarily disabled during the initial rollout of PR #3575 to avoid false positives while establishing confidence in the differential testing infrastructure. Now that the fuzzer has been running successfully and we have a good corpus, we can safely enable these assertions to catch actual semantic bugs.

The assertions panic when:
1. One database returns rows but the other doesn't (row count mismatch)
2. The databases return different column counts (column count mismatch)

## Testing

- [x] Code compiles without errors
- [x] Fuzz target builds successfully
- Ready for extended fuzzing runs to validate false positive rate

Closes #3577