### PR TITLE
feat: Add missing type variants to type_coercion fuzzer

### DIFF
--- a/fuzz/fuzz_targets/type_coercion.rs
+++ b/fuzz/fuzz_targets/type_coercion.rs
@@ -13,7 +13,7 @@
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use vibesql_types::SqlValue;
+use vibesql_types::{Date, Interval, SqlValue, Time, Timestamp};
 
 /// A fuzzable representation of SqlValue for structured input
 #[derive(Arbitrary, Debug)]
@@ -29,6 +29,31 @@ enum FuzzValue {
     Character(String),
     Varchar(String),
     Boolean(bool),
+    // Date/Time types with bounded/valid values
+    Date {
+        year: i32,
+        month: u8,
+        day: u8,
+    },
+    Time {
+        hour: u8,
+        minute: u8,
+        second: u8,
+        nanosecond: u32,
+    },
+    Timestamp {
+        year: i32,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        nanosecond: u32,
+    },
+    // Interval as a simple duration in days
+    IntervalDays(i32),
+    // Vector with bounded dimensions
+    Vector(Vec<f32>),
     Null,
 }
 
@@ -46,6 +71,54 @@ impl From<&FuzzValue> for SqlValue {
             FuzzValue::Character(v) => SqlValue::Character(v.clone()),
             FuzzValue::Varchar(v) => SqlValue::Varchar(v.clone()),
             FuzzValue::Boolean(v) => SqlValue::Boolean(*v),
+            FuzzValue::Date { year, month, day } => {
+                // Normalize month and day to valid ranges
+                let norm_month = ((*month as u32 - 1) % 12) as u8 + 1;
+                let norm_day = ((*day as u32 - 1) % 31) as u8 + 1;
+                // Date::new validates ranges, but we've already normalized them
+                match Date::new(*year, norm_month, norm_day) {
+                    Ok(date) => SqlValue::Date(date),
+                    Err(_) => SqlValue::Null, // Fallback to NULL on any error
+                }
+            }
+            FuzzValue::Time { hour, minute, second, nanosecond } => {
+                // Normalize time components to valid ranges
+                let norm_hour = *hour % 24;
+                let norm_minute = *minute % 60;
+                let norm_second = *second % 60;
+                let norm_nanosecond = *nanosecond % 1_000_000_000;
+                match Time::new(norm_hour, norm_minute, norm_second, norm_nanosecond) {
+                    Ok(time) => SqlValue::Time(time),
+                    Err(_) => SqlValue::Null,
+                }
+            }
+            FuzzValue::Timestamp { year, month, day, hour, minute, second, nanosecond } => {
+                // Normalize all components
+                let norm_month = ((*month as u32 - 1) % 12) as u8 + 1;
+                let norm_day = ((*day as u32 - 1) % 31) as u8 + 1;
+                let norm_hour = *hour % 24;
+                let norm_minute = *minute % 60;
+                let norm_second = *second % 60;
+                let norm_nanosecond = *nanosecond % 1_000_000_000;
+
+                match (
+                    Date::new(*year, norm_month, norm_day),
+                    Time::new(norm_hour, norm_minute, norm_second, norm_nanosecond),
+                ) {
+                    (Ok(date), Ok(time)) => SqlValue::Timestamp(Timestamp::new(date, time)),
+                    _ => SqlValue::Null,
+                }
+            }
+            FuzzValue::IntervalDays(days) => {
+                // Create a simple interval from days
+                let interval_str = format!("{} DAY", days);
+                SqlValue::Interval(Interval::new(interval_str))
+            }
+            FuzzValue::Vector(v) => {
+                // Limit vector dimensions to 1024 for fuzzing efficiency
+                let bounded_vec: Vec<f32> = v.iter().take(1024).copied().collect();
+                SqlValue::Vector(bounded_vec)
+            }
             FuzzValue::Null => SqlValue::Null,
         }
     }
@@ -125,11 +198,8 @@ fuzz_target!(|input: TypeCoercionInput| {
     );
 
     // 7. Test is_null
-    if matches!(input.value1, FuzzValue::Null) {
-        assert!(v1.is_null(), "is_null failed for Null variant");
-    } else {
-        assert!(!v1.is_null(), "is_null returned true for non-Null");
-    }
+    let is_null_fuzz = matches!(input.value1, FuzzValue::Null);
+    assert_eq!(v1.is_null(), is_null_fuzz, "is_null inconsistent for {:?}", input.value1);
 
     // 8. Test type_name and get_type - should never panic
     let _ = v1.type_name();


### PR DESCRIPTION
Adds support for all 16 SqlValue variants in the type_coercion fuzz target:
- Date variant with year, month, day components
- Time variant with hour, minute, second, nanosecond components  
- Timestamp variant combining Date and Time
- Interval variant as a simple day-based duration
- Vector variant with bounded dimensions (max 1024)

All generated values are validated and normalized to valid ranges. Closes #3578