### PR TITLE
fix(optimizer): Detect equijoins inside OR branches to prevent incorrect table elimination

### DIFF
--- a/crates/vibesql-executor/src/optimizer/table_elimination.rs
+++ b/crates/vibesql-executor/src/optimizer/table_elimination.rs
@@ -406,6 +406,13 @@ fn find_equijoin_tables(
             find_equijoin_tables(left, tables, _table_names, table_prefixes);
             find_equijoin_tables(right, tables, _table_names, table_prefixes);
         }
+        // Also recurse into OR branches to find equijoins
+        // This is critical for queries like TPC-H Q19 where the join condition
+        // (p_partkey = l_partkey) appears inside multiple OR branches
+        Expression::BinaryOp { op: BinaryOperator::Or, left, right } => {
+            find_equijoin_tables(left, tables, _table_names, table_prefixes);
+            find_equijoin_tables(right, tables, _table_names, table_prefixes);
+        }
         Expression::BinaryOp { op: BinaryOperator::Equal, left, right } => {
             // Check if this is a join between two tables
             let mut left_tables = HashSet::new();


### PR DESCRIPTION
## Summary

- Fix TPC-H Q19 failure caused by incorrect table elimination in queries with OR-based join conditions
- The table elimination optimizer's `find_equijoin_tables` function now recurses into OR branches to detect equijoins
- Previously, join conditions like `p_partkey = l_partkey` inside OR branches were not detected, causing tables to be incorrectly eliminated

## Root Cause

For queries like TPC-H Q19:
```sql
SELECT SUM(l_extendedprice * (1 - l_discount)) as revenue
FROM lineitem, part
WHERE
    (p_partkey = l_partkey AND p_brand = 'Brand#12' AND ...)
    OR
    (p_partkey = l_partkey AND p_brand = 'Brand#23' AND ...)
    OR
    (p_partkey = l_partkey AND p_brand = 'Brand#34' AND ...)
```

The `find_equijoin_tables` function only recursed into AND branches:
```rust
Expression::BinaryOp { op: BinaryOperator::And, left, right } => {
    find_equijoin_tables(left, ...);
    find_equijoin_tables(right, ...);
}
// OR branches fell through to `_ => {}` - not recursed!
```

This caused the `part` table to be eliminated since the equijoin `p_partkey = l_partkey` was never detected.

## Fix

Add OR branch handling to recurse into both sides:
```rust
Expression::BinaryOp { op: BinaryOperator::Or, left, right } => {
    find_equijoin_tables(left, ...);
    find_equijoin_tables(right, ...);
}
```

## Test plan

- [x] TPC-H Q19 now passes (was: "Column 'P_PARTKEY' not found")
- [x] TPC-H suite: 20/22 queries pass (Q11, Q15 failures are pre-existing)
- [x] Executor tests: 1772 passed, 5 failed (all 5 failures are pre-existing)
- [x] No regressions introduced

Closes #3585

🤖 Generated with [Claude Code](https://claude.com/claude-code)