### PR TITLE
Fix failing test: test_upload_blob_success

### DIFF
--- a/crates/vibesql-server/Cargo.toml
+++ b/crates/vibesql-server/Cargo.toml
@@ -23,7 +23,7 @@ doc = false  # Binaries don't need documentation
 vibesql-types = { version = "0.1.1", path = "../vibesql-types" }
 vibesql-ast = { version = "0.1.1", path = "../vibesql-ast" }
 vibesql-catalog = { version = "0.1.1", path = "../vibesql-catalog" }
-vibesql-storage = { version = "0.1.1", path = "../vibesql-storage" }
+vibesql-storage = { version = "0.1.1", path = "../vibesql-storage", features = ["storage-all"] }
 vibesql-executor = { version = "0.1.1", path = "../vibesql-executor" }
 vibesql-parser = { version = "0.1.1", path = "../vibesql-parser" }
 

--- a/crates/vibesql-server/src/http/storage.rs
+++ b/crates/vibesql-server/src/http/storage.rs
@@ -248,11 +248,21 @@ mod tests {
 
     fn create_test_router() -> Router {
         let db = Arc::new(Database::new());
-        create_storage_router(db)
+        let config = BlobStorageConfig {
+            backend: "memory".to_string(),
+            config: serde_json::json!({}),
+        };
+        let state = StorageState::with_config(config, db);
+
+        Router::new()
+            .route("/upload", post(upload_blob))
+            .route("/{blob_id}", get(download_blob))
+            .route("/{blob_id}", delete(delete_blob))
+            .route("/{blob_id}/metadata", get(get_blob_metadata))
+            .with_state(state)
     }
 
     #[tokio::test]
-    #[ignore = "requires opendal feature with storage backend configured"]
     async fn test_upload_blob_success() {
         // Test that blob upload succeeds and returns CREATED status
         let router = create_test_router();
@@ -320,8 +330,7 @@ mod tests {
             .unwrap();
 
         let response = router.oneshot(request).await.unwrap();
-        // Delete returns 500 for non-existent blobs since storage table may not exist
-        // Future improvement: return 204 for idempotent behavior
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        // Delete is idempotent - deleting non-existent blob returns 204
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
     }
 }

--- a/crates/vibesql-storage/src/blob/service.rs
+++ b/crates/vibesql-storage/src/blob/service.rs
@@ -286,9 +286,11 @@ impl BlobStorageService {
         let path = id.to_path();
 
         if let Some(ref op) = self.operator {
-            op.is_exist(&path)
-                .await
-                .map_err(|e| StorageError::Other(format!("Failed to check blob existence: {}", e)))
+            match op.stat(&path).await {
+                Ok(_) => Ok(true),
+                Err(e) if e.kind() == opendal::ErrorKind::NotFound => Ok(false),
+                Err(e) => Err(StorageError::Other(format!("Failed to check blob existence: {}", e))),
+            }
         } else {
             Err(StorageError::Other(
                 "Storage operator not initialized. Check your configuration.".to_string(),


### PR DESCRIPTION
## Description

This PR fixes the failing test `test_upload_blob_success` by enabling the opendal and memory storage backend features.

## Changes

- Added `storage-all` feature to `vibesql-storage` dependency in vibesql-server to enable all storage backends
- Updated `test_upload_blob_success` to use the in-memory backend instead of relying on uninitialized operators
- Removed the `#[ignore]` attribute since the test now has all required dependencies
- Fixed deprecated opendal API call: replaced `is_exist()` with `stat()` method
- Updated `test_delete_blob_nonexistent` expectation from 500 to 204 (idempotent behavior)

## Testing

- The test now passes locally: `cargo test --release -p vibesql-server test_upload_blob_success --lib`
- All 240 vibesql-server tests pass without failures

Closes #3596