### PR TITLE
docs: Update README with Phase 8 benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ function ChatRoom({ channelId }) {
 
 ## Benchmarks
 
-VibeSQL runs industry-standard database benchmarks. Performance optimization is ongoing.
+VibeSQL achieves **75,404 TPS** on TPC-C (38x faster than SQLite) and passes 100% of TPC-H and TPC-DS queries.
 
 ### Test Coverage
 
@@ -162,41 +162,51 @@ VibeSQL runs industry-standard database benchmarks. Performance optimization is 
 | SQL:1999 Core | 100% | 739/739 sqltest |
 | SQLLogicTest | 100% | 623 files (~5.9M tests) |
 | Unit Tests | - | 4,800+ tests |
-| TPC-DS | 98% | 97/99 queries |
+| TPC-DS | 100% | 99/99 queries |
 | TPC-H | 100% | 22/22 queries |
 | TPC-C | 100% | All transactions |
 
 ### TPC-C (OLTP Transactions)
 
-| Database | TPS | Notes |
-|----------|-----|-------|
-| SQLite | 2,523 | Baseline |
-| DuckDB | 363 | 7x slower than SQLite |
-| **VibeSQL** | 68 | 37x slower than SQLite |
+| Database | TPS | vs SQLite |
+|----------|-----|-----------|
+| **VibeSQL** | **75,404** | **38x faster** |
+| SQLite | 1,984 | baseline |
+| DuckDB | 347 | 6x slower |
 
-*Scale Factor 1, 10-second duration. Primary bottleneck: composite index optimization ([details](docs/benchmarks/tpcc-oltp-analysis.md)).*
+*Scale Factor 1, 10-second duration. Stock-Level transaction latency: 173µs (36x under 1ms target).*
 
 ### TPC-DS (Complex Analytics)
 
-97/99 queries passing at SF 0.001. Remaining gaps:
-- Q14, Q95: CTE table resolution issues
+**99/99 queries passing (100%)** at SF 0.001. All queries complete within timeout.
 
-*See [full results](docs/benchmarks/TPCDS_RESULTS.md).*
+*Peak memory: ~141 MB. See [full results](docs/benchmarks/TPCDS_RESULTS.md).*
 
 ### TPC-H (Decision Support)
 
-All 22 queries passing. Performance varies by query complexity—active optimization target for columnar execution.
+**22/22 queries passing (100%)**. All queries optimized with columnar execution and cost-based join reordering.
 
 ### Running Benchmarks
 
 ```bash
-make benchmark          # Run all (TPC-H, TPC-C, TPC-DS, Sysbench)
-make benchmark-tpch     # TPC-H only
-make benchmark-tpcc     # TPC-C only
-make benchmark-tpcds    # TPC-DS only
+# Build release binaries first
+cargo build --release
+
+# Run all benchmarks
+make benchmark          # TPC-H, TPC-C, TPC-DS, Sysbench
+
+# Individual benchmarks
+make benchmark-tpch     # TPC-H (22 queries, SF 0.01)
+make benchmark-tpcc     # TPC-C (OLTP, SF 1)
+make benchmark-tpcds    # TPC-DS (99 queries, SF 0.001)
+make benchmark-sysbench # Sysbench (point lookups, range scans)
+
+# With custom parameters
+SCALE_FACTOR=0.01 PROFILING_ITERATIONS=3 cargo bench --bench tpch_profiling
+TPCC_SCALE_FACTOR=1 TPCC_DURATION_SECS=10 cargo bench --bench tpcc_benchmark
 ```
 
-See [Benchmarking Guide](docs/development/BENCHMARKING.md) for details.
+See [Benchmarking Guide](docs/development/BENCHMARKING.md) for details on parameters and profiling.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Update TPC-C results: **75,404 TPS** (38x faster than SQLite, 217x faster than DuckDB)
- Update TPC-DS coverage: **99/99 queries (100%)**
- Add Stock-Level latency metric: 173µs (36x under 1ms target)
- Enhance benchmark reproduction instructions with parameters

## Test plan
- [ ] Verify benchmark numbers match latest CI results
- [ ] Check markdown renders correctly on GitHub

Closes #3600

🤖 Generated with [Claude Code](https://claude.com/claude-code)