### PR TITLE
feat(bench): Add SCALE_FACTOR env var support to tpch_profiling

### DIFF
--- a/crates/vibesql-executor/benches/tpch_profiling.rs
+++ b/crates/vibesql-executor/benches/tpch_profiling.rs
@@ -176,10 +176,14 @@ fn main() {
         std::process::exit(1);
     }
 
+    // Get scale factor from env (default 0.01)
+    let scale_factor: f64 =
+        env::var("SCALE_FACTOR").ok().and_then(|s| s.parse().ok()).unwrap_or(0.01);
+
     // Load database
-    eprintln!("\nLoading TPC-H database (SF 0.01)...");
+    eprintln!("\nLoading TPC-H database (SF {})...", scale_factor);
     let load_start = Instant::now();
-    let db = load_vibesql(0.01);
+    let db = load_vibesql(scale_factor);
     eprintln!("Database loaded in {:?}", load_start.elapsed());
 
     // Run selected queries


### PR DESCRIPTION
## Summary
- Add SCALE_FACTOR environment variable support to tpch_profiling benchmark
- Allows testing TPC-H queries at different scale factors (0.01, 0.1, 1.0, etc.)
- Defaults to 0.01 for backward compatibility

## Test Results

### TPC-H SF=0.01 (baseline)
- **Result**: 22/22 queries pass
- **Total time**: ~1.6s for all queries
- All queries complete well under 30s timeout

### TPC-H SF=0.1 (10x larger)
- **Result**: 21/22 queries pass
- **Memory**: ~530MB RSS
- **Q9 timeout**: Takes >50s at this scale factor
- Other notable times: Q7 (312ms), Q19 (344ms), Q18 (133ms)

### TPC-H SF=1.0 (100x larger)
- **Blocker**: Data generation is extremely slow (>17 minutes just to load)
- CPU-bound at 100%, ~6.7GB RAM during load
- Blocked by data generation bottleneck, not query execution

### TPC-DS SF=0.01 (10x larger than SF=0.001)
- **Blocker**: Hangs during index creation phase
- Data loading completes successfully (117,450 inventory rows, 28,804 store_sales rows)
- Process becomes unresponsive at "Creating indexes..." step

## Follow-up Issues Needed
1. **TPC-H Q9 optimization**: Timeout at SF=0.1 indicates join ordering issues
2. **TPC-DS index creation bug**: Investigate hang at SF=0.01
3. **TPC-H data generation**: Consider pre-generated data or optimized generators

## Test plan
- [x] Verify SCALE_FACTOR env var works with tpch_profiling
- [x] Test TPC-H at SF=0.01 (baseline)
- [x] Test TPC-H at SF=0.1
- [ ] TPC-DS blocked by index creation bug

Closes #3599

🤖 Generated with [Claude Code](https://claude.com/claude-code)