### PR TITLE
feat(bench): Sort wheel files by mtime when selecting latest build

### DIFF
--- a/scripts/bench
+++ b/scripts/bench
@@ -673,10 +673,11 @@ def ensure_python_bindings():
         print(f"⚠ Failed to build Python bindings: {result.stderr}")
         return False
 
-    # Find and install the wheel
+    # Find and install the wheel (select most recent by mtime)
     wheels = list(Path("target/wheels").glob("vibesql-*.whl"))
     if wheels:
-        wheel_path = wheels[0]
+        wheel_path = max(wheels, key=lambda w: w.stat().st_mtime)
+        print(f"  Installing wheel: {wheel_path.name}")
         result = subprocess.run(
             ["pip3", "install", "--force-reinstall", "--quiet", str(wheel_path)],
             cwd=Path(__file__).parent.parent


### PR DESCRIPTION
## Summary

- Sort wheel files by modification time when selecting which wheel to install
- Use `max(wheels, key=lambda w: w.stat().st_mtime)` to select the most recent build
- Add debug message showing which wheel was selected

## Test plan

- [ ] Verify Python syntax is valid (done via `py_compile`)
- [ ] Manual verification when multiple wheels exist in `target/wheels/`

Closes #3612

🤖 Generated with [Claude Code](https://claude.com/claude-code)