### PR TITLE
docs(bench): Add SCALE_FACTOR to tpch_profiling --help output

### DIFF
--- a/crates/vibesql-executor/benches/tpch_profiling.rs
+++ b/crates/vibesql-executor/benches/tpch_profiling.rs
@@ -128,6 +128,7 @@ fn main() {
         eprintln!("\nArguments:");
         eprintln!("  QUERY    Optional query to run (Q1-Q22). If not specified, runs all queries.");
         eprintln!("\nEnvironment Variables:");
+        eprintln!("  SCALE_FACTOR              Scale factor for data size (default: 0.01)");
         eprintln!("  QUERY_TIMEOUT_SECS        Timeout per query in seconds (default: 30)");
         eprintln!("  QUERY_FILTER              Comma-separated list of queries (e.g., Q1,Q6,Q9)");
         eprintln!("  JOIN_REORDER_VERBOSE      Enable verbose join reordering logs");


### PR DESCRIPTION
## Summary

- Add SCALE_FACTOR environment variable documentation to `tpch_profiling` `--help` output

Closes #3613

## Test plan

- [ ] Verify help output displays correctly: run `cargo test -p vibesql-executor --bench tpch_profiling -- --help`
- [ ] Confirm documentation style matches other env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)