### PR TITLE
feat(storage): Implement WAL infrastructure for async persistence

### DIFF
--- a/crates/vibesql-storage/src/lib.rs
+++ b/crates/vibesql-storage/src/lib.rs
@@ -21,6 +21,7 @@ pub mod query_buffer_pool;
 pub mod row;
 pub mod statistics;
 pub mod table;
+pub mod wal;
 
 pub use backend::{StorageBackend, StorageFile};
 pub use blob::{BlobId, BlobMetadata, BlobStorageConfig, BlobStorageService};

--- a/crates/vibesql-storage/src/wal/entry.rs
+++ b/crates/vibesql-storage/src/wal/entry.rs
@@ -1,0 +1,536 @@
+// ============================================================================
+// WAL Entry Types
+// ============================================================================
+//
+// Defines the Write-Ahead Log entry structure and operation types for
+// capturing database changes for async persistence.
+
+use std::io::{Read, Write};
+
+use vibesql_types::SqlValue;
+
+use crate::persistence::binary::{
+    io::{read_bool, read_u32, read_u64, write_bool, write_u32, write_u64},
+    value::{read_sql_value, write_sql_value},
+};
+use crate::StorageError;
+
+/// Log Sequence Number - monotonically increasing identifier for WAL entries
+pub type Lsn = u64;
+
+/// WAL entry representing a single operation to be persisted
+#[derive(Debug, Clone, PartialEq)]
+pub struct WalEntry {
+    /// Log sequence number - unique, monotonically increasing
+    pub lsn: Lsn,
+    /// Timestamp when the entry was created (milliseconds since epoch)
+    pub timestamp_ms: u64,
+    /// The operation to perform
+    pub op: WalOp,
+}
+
+/// Operations that can be recorded in the WAL
+#[derive(Debug, Clone, PartialEq)]
+pub enum WalOp {
+    // DML Operations
+    /// Insert a row into a table
+    Insert {
+        table_id: u32,
+        row_id: u64,
+        values: Vec<SqlValue>,
+    },
+    /// Update a row in a table
+    Update {
+        table_id: u32,
+        row_id: u64,
+        old_values: Vec<SqlValue>,
+        new_values: Vec<SqlValue>,
+    },
+    /// Delete a row from a table
+    Delete {
+        table_id: u32,
+        row_id: u64,
+        old_values: Vec<SqlValue>,
+    },
+
+    // DDL Operations
+    /// Create a new table
+    CreateTable {
+        table_id: u32,
+        table_name: String,
+        /// Serialized schema (using existing binary format)
+        schema_data: Vec<u8>,
+    },
+    /// Drop a table
+    DropTable { table_id: u32, table_name: String },
+    /// Create an index
+    CreateIndex {
+        index_id: u32,
+        index_name: String,
+        table_id: u32,
+        column_indices: Vec<u32>,
+        is_unique: bool,
+    },
+    /// Drop an index
+    DropIndex { index_id: u32, index_name: String },
+
+    // Transaction Operations
+    /// Begin a transaction
+    TxnBegin { txn_id: u64 },
+    /// Commit a transaction
+    TxnCommit { txn_id: u64 },
+    /// Rollback a transaction
+    TxnRollback { txn_id: u64 },
+
+    // Checkpoint Operations
+    /// Begin a checkpoint
+    CheckpointBegin { checkpoint_id: u64 },
+    /// Complete a checkpoint (all data up to this LSN is persisted)
+    CheckpointComplete { checkpoint_id: u64, lsn: Lsn },
+}
+
+/// Operation type tags for binary serialization
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WalOpTag {
+    Insert = 0x01,
+    Update = 0x02,
+    Delete = 0x03,
+    CreateTable = 0x10,
+    DropTable = 0x11,
+    CreateIndex = 0x12,
+    DropIndex = 0x13,
+    TxnBegin = 0x20,
+    TxnCommit = 0x21,
+    TxnRollback = 0x22,
+    CheckpointBegin = 0x30,
+    CheckpointComplete = 0x31,
+}
+
+impl WalOpTag {
+    pub fn from_u8(tag: u8) -> Result<Self, StorageError> {
+        match tag {
+            0x01 => Ok(WalOpTag::Insert),
+            0x02 => Ok(WalOpTag::Update),
+            0x03 => Ok(WalOpTag::Delete),
+            0x10 => Ok(WalOpTag::CreateTable),
+            0x11 => Ok(WalOpTag::DropTable),
+            0x12 => Ok(WalOpTag::CreateIndex),
+            0x13 => Ok(WalOpTag::DropIndex),
+            0x20 => Ok(WalOpTag::TxnBegin),
+            0x21 => Ok(WalOpTag::TxnCommit),
+            0x22 => Ok(WalOpTag::TxnRollback),
+            0x30 => Ok(WalOpTag::CheckpointBegin),
+            0x31 => Ok(WalOpTag::CheckpointComplete),
+            _ => Err(StorageError::IoError(format!("Unknown WAL op tag: 0x{:02X}", tag))),
+        }
+    }
+}
+
+impl WalEntry {
+    /// Create a new WAL entry
+    pub fn new(lsn: Lsn, timestamp_ms: u64, op: WalOp) -> Self {
+        Self { lsn, timestamp_ms, op }
+    }
+
+    /// Serialize the entry to bytes
+    pub fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), StorageError> {
+        write_u64(writer, self.lsn)?;
+        write_u64(writer, self.timestamp_ms)?;
+        self.op.serialize(writer)?;
+        Ok(())
+    }
+
+    /// Deserialize an entry from bytes
+    pub fn deserialize<R: Read>(reader: &mut R) -> Result<Self, StorageError> {
+        let lsn = read_u64(reader)?;
+        let timestamp_ms = read_u64(reader)?;
+        let op = WalOp::deserialize(reader)?;
+        Ok(Self { lsn, timestamp_ms, op })
+    }
+}
+
+impl WalOp {
+    /// Serialize the operation to bytes
+    pub fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), StorageError> {
+        match self {
+            WalOp::Insert { table_id, row_id, values } => {
+                writer
+                    .write_all(&[WalOpTag::Insert as u8])
+                    .map_err(|e| StorageError::IoError(e.to_string()))?;
+                write_u32(writer, *table_id)?;
+                write_u64(writer, *row_id)?;
+                write_sql_values(writer, values)?;
+            }
+            WalOp::Update { table_id, row_id, old_values, new_values } => {
+                writer
+                    .write_all(&[WalOpTag::Update as u8])
+                    .map_err(|e| StorageError::IoError(e.to_string()))?;
+                write_u32(writer, *table_id)?;
+                write_u64(writer, *row_id)?;
+                write_sql_values(writer, old_values)?;
+                write_sql_values(writer, new_values)?;
+            }
+            WalOp::Delete { table_id, row_id, old_values } => {
+                writer
+                    .write_all(&[WalOpTag::Delete as u8])
+                    .map_err(|e| StorageError::IoError(e.to_string()))?;
+                write_u32(writer, *table_id)?;
+                write_u64(writer, *row_id)?;
+                write_sql_values(writer, old_values)?;
+            }
+            WalOp::CreateTable { table_id, table_name, schema_data } => {
+                writer
+                    .write_all(&[WalOpTag::CreateTable as u8])
+                    .map_err(|e| StorageError::IoError(e.to_string()))?;
+                write_u32(writer, *table_id)?;
+                write_string(writer, table_name)?;
+                write_bytes(writer, schema_data)?;
+            }
+            WalOp::DropTable { table_id, table_name } => {
+                writer
+                    .write_all(&[WalOpTag::DropTable as u8])
+                    .map_err(|e| StorageError::IoError(e.to_string()))?;
+                write_u32(writer, *table_id)?;
+                write_string(writer, table_name)?;
+            }
+            WalOp::CreateIndex { index_id, index_name, table_id, column_indices, is_unique } => {
+                writer
+                    .write_all(&[WalOpTag::CreateIndex as u8])
+                    .map_err(|e| StorageError::IoError(e.to_string()))?;
+                write_u32(writer, *index_id)?;
+                write_string(writer, index_name)?;
+                write_u32(writer, *table_id)?;
+                write_u32(writer, column_indices.len() as u32)?;
+                for &idx in column_indices {
+                    write_u32(writer, idx)?;
+                }
+                write_bool(writer, *is_unique)?;
+            }
+            WalOp::DropIndex { index_id, index_name } => {
+                writer
+                    .write_all(&[WalOpTag::DropIndex as u8])
+                    .map_err(|e| StorageError::IoError(e.to_string()))?;
+                write_u32(writer, *index_id)?;
+                write_string(writer, index_name)?;
+            }
+            WalOp::TxnBegin { txn_id } => {
+                writer
+                    .write_all(&[WalOpTag::TxnBegin as u8])
+                    .map_err(|e| StorageError::IoError(e.to_string()))?;
+                write_u64(writer, *txn_id)?;
+            }
+            WalOp::TxnCommit { txn_id } => {
+                writer
+                    .write_all(&[WalOpTag::TxnCommit as u8])
+                    .map_err(|e| StorageError::IoError(e.to_string()))?;
+                write_u64(writer, *txn_id)?;
+            }
+            WalOp::TxnRollback { txn_id } => {
+                writer
+                    .write_all(&[WalOpTag::TxnRollback as u8])
+                    .map_err(|e| StorageError::IoError(e.to_string()))?;
+                write_u64(writer, *txn_id)?;
+            }
+            WalOp::CheckpointBegin { checkpoint_id } => {
+                writer
+                    .write_all(&[WalOpTag::CheckpointBegin as u8])
+                    .map_err(|e| StorageError::IoError(e.to_string()))?;
+                write_u64(writer, *checkpoint_id)?;
+            }
+            WalOp::CheckpointComplete { checkpoint_id, lsn } => {
+                writer
+                    .write_all(&[WalOpTag::CheckpointComplete as u8])
+                    .map_err(|e| StorageError::IoError(e.to_string()))?;
+                write_u64(writer, *checkpoint_id)?;
+                write_u64(writer, *lsn)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Deserialize an operation from bytes
+    pub fn deserialize<R: Read>(reader: &mut R) -> Result<Self, StorageError> {
+        let mut tag_buf = [0u8; 1];
+        reader.read_exact(&mut tag_buf).map_err(|e| StorageError::IoError(e.to_string()))?;
+        let tag = WalOpTag::from_u8(tag_buf[0])?;
+
+        match tag {
+            WalOpTag::Insert => {
+                let table_id = read_u32(reader)?;
+                let row_id = read_u64(reader)?;
+                let values = read_sql_values(reader)?;
+                Ok(WalOp::Insert { table_id, row_id, values })
+            }
+            WalOpTag::Update => {
+                let table_id = read_u32(reader)?;
+                let row_id = read_u64(reader)?;
+                let old_values = read_sql_values(reader)?;
+                let new_values = read_sql_values(reader)?;
+                Ok(WalOp::Update { table_id, row_id, old_values, new_values })
+            }
+            WalOpTag::Delete => {
+                let table_id = read_u32(reader)?;
+                let row_id = read_u64(reader)?;
+                let old_values = read_sql_values(reader)?;
+                Ok(WalOp::Delete { table_id, row_id, old_values })
+            }
+            WalOpTag::CreateTable => {
+                let table_id = read_u32(reader)?;
+                let table_name = read_string(reader)?;
+                let schema_data = read_bytes(reader)?;
+                Ok(WalOp::CreateTable { table_id, table_name, schema_data })
+            }
+            WalOpTag::DropTable => {
+                let table_id = read_u32(reader)?;
+                let table_name = read_string(reader)?;
+                Ok(WalOp::DropTable { table_id, table_name })
+            }
+            WalOpTag::CreateIndex => {
+                let index_id = read_u32(reader)?;
+                let index_name = read_string(reader)?;
+                let table_id = read_u32(reader)?;
+                let num_columns = read_u32(reader)? as usize;
+                let mut column_indices = Vec::with_capacity(num_columns);
+                for _ in 0..num_columns {
+                    column_indices.push(read_u32(reader)?);
+                }
+                let is_unique = read_bool(reader)?;
+                Ok(WalOp::CreateIndex { index_id, index_name, table_id, column_indices, is_unique })
+            }
+            WalOpTag::DropIndex => {
+                let index_id = read_u32(reader)?;
+                let index_name = read_string(reader)?;
+                Ok(WalOp::DropIndex { index_id, index_name })
+            }
+            WalOpTag::TxnBegin => {
+                let txn_id = read_u64(reader)?;
+                Ok(WalOp::TxnBegin { txn_id })
+            }
+            WalOpTag::TxnCommit => {
+                let txn_id = read_u64(reader)?;
+                Ok(WalOp::TxnCommit { txn_id })
+            }
+            WalOpTag::TxnRollback => {
+                let txn_id = read_u64(reader)?;
+                Ok(WalOp::TxnRollback { txn_id })
+            }
+            WalOpTag::CheckpointBegin => {
+                let checkpoint_id = read_u64(reader)?;
+                Ok(WalOp::CheckpointBegin { checkpoint_id })
+            }
+            WalOpTag::CheckpointComplete => {
+                let checkpoint_id = read_u64(reader)?;
+                let lsn = read_u64(reader)?;
+                Ok(WalOp::CheckpointComplete { checkpoint_id, lsn })
+            }
+        }
+    }
+}
+
+// Helper functions for serialization
+
+fn write_sql_values<W: Write>(writer: &mut W, values: &[SqlValue]) -> Result<(), StorageError> {
+    write_u32(writer, values.len() as u32)?;
+    for value in values {
+        write_sql_value(writer, value)?;
+    }
+    Ok(())
+}
+
+fn read_sql_values<R: Read>(reader: &mut R) -> Result<Vec<SqlValue>, StorageError> {
+    let len = read_u32(reader)? as usize;
+    let mut values = Vec::with_capacity(len);
+    for _ in 0..len {
+        values.push(read_sql_value(reader)?);
+    }
+    Ok(values)
+}
+
+fn write_string<W: Write>(writer: &mut W, s: &str) -> Result<(), StorageError> {
+    let bytes = s.as_bytes();
+    write_u32(writer, bytes.len() as u32)?;
+    writer.write_all(bytes).map_err(|e| StorageError::IoError(e.to_string()))
+}
+
+fn read_string<R: Read>(reader: &mut R) -> Result<String, StorageError> {
+    let len = read_u32(reader)? as usize;
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf).map_err(|e| StorageError::IoError(e.to_string()))?;
+    String::from_utf8(buf).map_err(|e| StorageError::IoError(format!("Invalid UTF-8: {}", e)))
+}
+
+fn write_bytes<W: Write>(writer: &mut W, data: &[u8]) -> Result<(), StorageError> {
+    write_u32(writer, data.len() as u32)?;
+    writer.write_all(data).map_err(|e| StorageError::IoError(e.to_string()))
+}
+
+fn read_bytes<R: Read>(reader: &mut R) -> Result<Vec<u8>, StorageError> {
+    let len = read_u32(reader)? as usize;
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf).map_err(|e| StorageError::IoError(e.to_string()))?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wal_entry_roundtrip_insert() {
+        let entry = WalEntry::new(
+            1,
+            1234567890,
+            WalOp::Insert {
+                table_id: 42,
+                row_id: 100,
+                values: vec![
+                    SqlValue::Integer(1),
+                    SqlValue::Varchar("test".to_string()),
+                    SqlValue::Boolean(true),
+                ],
+            },
+        );
+
+        let mut buf = Vec::new();
+        entry.serialize(&mut buf).unwrap();
+
+        let mut reader = &buf[..];
+        let decoded = WalEntry::deserialize(&mut reader).unwrap();
+
+        assert_eq!(entry, decoded);
+    }
+
+    #[test]
+    fn test_wal_entry_roundtrip_update() {
+        let entry = WalEntry::new(
+            2,
+            1234567891,
+            WalOp::Update {
+                table_id: 42,
+                row_id: 100,
+                old_values: vec![SqlValue::Integer(1), SqlValue::Varchar("old".to_string())],
+                new_values: vec![SqlValue::Integer(2), SqlValue::Varchar("new".to_string())],
+            },
+        );
+
+        let mut buf = Vec::new();
+        entry.serialize(&mut buf).unwrap();
+
+        let mut reader = &buf[..];
+        let decoded = WalEntry::deserialize(&mut reader).unwrap();
+
+        assert_eq!(entry, decoded);
+    }
+
+    #[test]
+    fn test_wal_entry_roundtrip_delete() {
+        let entry = WalEntry::new(
+            3,
+            1234567892,
+            WalOp::Delete {
+                table_id: 42,
+                row_id: 100,
+                old_values: vec![SqlValue::Integer(1), SqlValue::Null],
+            },
+        );
+
+        let mut buf = Vec::new();
+        entry.serialize(&mut buf).unwrap();
+
+        let mut reader = &buf[..];
+        let decoded = WalEntry::deserialize(&mut reader).unwrap();
+
+        assert_eq!(entry, decoded);
+    }
+
+    #[test]
+    fn test_wal_entry_roundtrip_create_table() {
+        let entry = WalEntry::new(
+            4,
+            1234567893,
+            WalOp::CreateTable {
+                table_id: 1,
+                table_name: "users".to_string(),
+                schema_data: vec![0x01, 0x02, 0x03, 0x04],
+            },
+        );
+
+        let mut buf = Vec::new();
+        entry.serialize(&mut buf).unwrap();
+
+        let mut reader = &buf[..];
+        let decoded = WalEntry::deserialize(&mut reader).unwrap();
+
+        assert_eq!(entry, decoded);
+    }
+
+    #[test]
+    fn test_wal_entry_roundtrip_create_index() {
+        let entry = WalEntry::new(
+            5,
+            1234567894,
+            WalOp::CreateIndex {
+                index_id: 10,
+                index_name: "idx_users_email".to_string(),
+                table_id: 1,
+                column_indices: vec![2, 3],
+                is_unique: true,
+            },
+        );
+
+        let mut buf = Vec::new();
+        entry.serialize(&mut buf).unwrap();
+
+        let mut reader = &buf[..];
+        let decoded = WalEntry::deserialize(&mut reader).unwrap();
+
+        assert_eq!(entry, decoded);
+    }
+
+    #[test]
+    fn test_wal_entry_roundtrip_transaction_ops() {
+        let entries = vec![
+            WalEntry::new(6, 1234567895, WalOp::TxnBegin { txn_id: 1000 }),
+            WalEntry::new(7, 1234567896, WalOp::TxnCommit { txn_id: 1000 }),
+            WalEntry::new(8, 1234567897, WalOp::TxnRollback { txn_id: 1001 }),
+        ];
+
+        for entry in entries {
+            let mut buf = Vec::new();
+            entry.serialize(&mut buf).unwrap();
+
+            let mut reader = &buf[..];
+            let decoded = WalEntry::deserialize(&mut reader).unwrap();
+
+            assert_eq!(entry, decoded);
+        }
+    }
+
+    #[test]
+    fn test_wal_entry_roundtrip_checkpoint() {
+        let entries = vec![
+            WalEntry::new(9, 1234567898, WalOp::CheckpointBegin { checkpoint_id: 1 }),
+            WalEntry::new(10, 1234567899, WalOp::CheckpointComplete { checkpoint_id: 1, lsn: 8 }),
+        ];
+
+        for entry in entries {
+            let mut buf = Vec::new();
+            entry.serialize(&mut buf).unwrap();
+
+            let mut reader = &buf[..];
+            let decoded = WalEntry::deserialize(&mut reader).unwrap();
+
+            assert_eq!(entry, decoded);
+        }
+    }
+
+    #[test]
+    fn test_wal_op_tag_from_u8() {
+        assert_eq!(WalOpTag::from_u8(0x01).unwrap(), WalOpTag::Insert);
+        assert_eq!(WalOpTag::from_u8(0x02).unwrap(), WalOpTag::Update);
+        assert_eq!(WalOpTag::from_u8(0x03).unwrap(), WalOpTag::Delete);
+        assert_eq!(WalOpTag::from_u8(0x10).unwrap(), WalOpTag::CreateTable);
+        assert!(WalOpTag::from_u8(0xFF).is_err());
+    }
+}

--- a/crates/vibesql-storage/src/wal/format.rs
+++ b/crates/vibesql-storage/src/wal/format.rs
@@ -1,0 +1,135 @@
+// ============================================================================
+// WAL File Format
+// ============================================================================
+//
+// Defines the WAL file format constants and header structure.
+//
+// File Structure:
+// ┌────────────────────────────────────────┐
+// │ WAL Header (32 bytes)                  │
+// │ - Magic: "VWAL" (4 bytes)              │
+// │ - Version: u32                         │
+// │ - Created: u64 timestamp               │
+// │ - Reserved: 16 bytes                   │
+// ├────────────────────────────────────────┤
+// │ Entry 1: [len:u32][crc:u32][data:...]  │
+// ├────────────────────────────────────────┤
+// │ Entry 2: [len:u32][crc:u32][data:...]  │
+// ├────────────────────────────────────────┤
+// │ ...                                    │
+// └────────────────────────────────────────┘
+
+use std::io::Read;
+
+use crate::persistence::binary::io::{read_u32, read_u64};
+use crate::StorageError;
+
+/// Magic number for WAL files: "VWAL"
+pub const WAL_MAGIC: &[u8; 4] = b"VWAL";
+
+/// Current WAL format version
+pub const WAL_VERSION: u32 = 1;
+
+/// Size of the WAL header in bytes
+pub const WAL_HEADER_SIZE: usize = 32;
+
+/// WAL file header
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalHeader {
+    /// Format version
+    pub version: u32,
+    /// Creation timestamp (milliseconds since epoch)
+    pub created_ms: u64,
+}
+
+impl WalHeader {
+    /// Read and validate WAL header from a reader
+    pub fn read<R: Read>(reader: &mut R) -> Result<Self, StorageError> {
+        // Read magic number
+        let mut magic = [0u8; 4];
+        reader.read_exact(&mut magic).map_err(|e| StorageError::IoError(e.to_string()))?;
+
+        if &magic != WAL_MAGIC {
+            return Err(StorageError::IoError(format!(
+                "Invalid WAL file: expected magic 'VWAL', got '{}'",
+                String::from_utf8_lossy(&magic)
+            )));
+        }
+
+        // Read version
+        let version = read_u32(reader)?;
+        if version > WAL_VERSION {
+            return Err(StorageError::IoError(format!(
+                "Unsupported WAL version: {} (current: {})",
+                version, WAL_VERSION
+            )));
+        }
+
+        // Read creation timestamp
+        let created_ms = read_u64(reader)?;
+
+        // Skip reserved bytes
+        let mut reserved = [0u8; 16];
+        reader.read_exact(&mut reserved).map_err(|e| StorageError::IoError(e.to_string()))?;
+
+        Ok(Self { version, created_ms })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::persistence::binary::io::{write_u32, write_u64};
+
+    fn create_valid_header() -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(WAL_MAGIC);
+        write_u32(&mut buf, WAL_VERSION).unwrap();
+        write_u64(&mut buf, 1234567890).unwrap();
+        buf.extend_from_slice(&[0u8; 16]); // reserved
+        buf
+    }
+
+    #[test]
+    fn test_read_valid_header() {
+        let buf = create_valid_header();
+        let mut reader = Cursor::new(buf);
+
+        let header = WalHeader::read(&mut reader).unwrap();
+        assert_eq!(header.version, WAL_VERSION);
+        assert_eq!(header.created_ms, 1234567890);
+    }
+
+    #[test]
+    fn test_invalid_magic() {
+        let mut buf = create_valid_header();
+        buf[0..4].copy_from_slice(b"XXXX");
+        let mut reader = Cursor::new(buf);
+
+        let result = WalHeader::read(&mut reader);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid WAL file"));
+    }
+
+    #[test]
+    fn test_unsupported_version() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(WAL_MAGIC);
+        write_u32(&mut buf, WAL_VERSION + 100).unwrap(); // Future version
+        write_u64(&mut buf, 1234567890).unwrap();
+        buf.extend_from_slice(&[0u8; 16]);
+        let mut reader = Cursor::new(buf);
+
+        let result = WalHeader::read(&mut reader);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unsupported WAL version"));
+    }
+
+    #[test]
+    fn test_header_size() {
+        let buf = create_valid_header();
+        assert_eq!(buf.len(), WAL_HEADER_SIZE);
+    }
+}

--- a/crates/vibesql-storage/src/wal/mod.rs
+++ b/crates/vibesql-storage/src/wal/mod.rs
@@ -1,0 +1,79 @@
+// ============================================================================
+// Write-Ahead Log (WAL)
+// ============================================================================
+//
+// This module provides Write-Ahead Log infrastructure for capturing database
+// changes for async persistence. The WAL enables:
+//
+// 1. Durability: Changes can be recovered after a crash
+// 2. Async persistence: Changes are logged quickly, persisted in background
+// 3. Replication: WAL can be shipped to replicas (future)
+//
+// ## Architecture
+//
+// The WAL is an append-only log file with the following structure:
+//
+// ```text
+// ┌────────────────────────────────────────┐
+// │ WAL Header (32 bytes)                  │
+// │ - Magic: "VWAL" (4 bytes)              │
+// │ - Version: u32                         │
+// │ - Created: u64 timestamp               │
+// │ - Reserved: 16 bytes                   │
+// ├────────────────────────────────────────┤
+// │ Entry 1: [len:u32][crc:u32][data:...]  │
+// ├────────────────────────────────────────┤
+// │ Entry 2: [len:u32][crc:u32][data:...]  │
+// ├────────────────────────────────────────┤
+// │ ...                                    │
+// └────────────────────────────────────────┘
+// ```
+//
+// Each entry contains:
+// - Length prefix (4 bytes): Size of the serialized entry data
+// - CRC32 checksum (4 bytes): For corruption detection
+// - Entry data: Serialized WalEntry
+//
+// ## Usage
+//
+// ```rust,ignore
+// use vibesql_storage::wal::{WalWriter, WalReader, WalEntry, WalOp};
+// use std::io::Cursor;
+//
+// // Create a new WAL file
+// let buf = Vec::new();
+// let cursor = Cursor::new(buf);
+// let mut writer = WalWriter::create(cursor).unwrap();
+//
+// // Append an operation
+// let lsn = writer.append_op(WalOp::Insert {
+//     table_id: 1,
+//     row_id: 100,
+//     values: vec![SqlValue::Integer(42)],
+// }).unwrap();
+//
+// // Read entries back
+// let cursor = Cursor::new(writer.writer.into_inner());
+// let mut reader = WalReader::open(cursor).unwrap();
+// let entries = reader.read_all().unwrap();
+// ```
+//
+// ## Corruption Handling
+//
+// The WAL reader detects corruption through:
+// 1. CRC32 checksums on each entry
+// 2. Length prefixes to detect truncation
+//
+// When corruption is detected, recovery can truncate the WAL at the last
+// valid entry using `find_recovery_point()`.
+
+pub mod entry;
+pub mod format;
+pub mod reader;
+pub mod writer;
+
+// Re-export main types
+pub use entry::{Lsn, WalEntry, WalOp, WalOpTag};
+pub use format::{WalHeader, WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION};
+pub use reader::{find_recovery_point, ReadResult, RecoveryInfo, WalIterator, WalReader};
+pub use writer::{verify_checksum, WalWriter};

--- a/crates/vibesql-storage/src/wal/reader.rs
+++ b/crates/vibesql-storage/src/wal/reader.rs
@@ -1,0 +1,364 @@
+// ============================================================================
+// WAL Reader
+// ============================================================================
+//
+// Sequential reader for WAL entries with corruption detection.
+
+use std::io::{Read, Seek, SeekFrom};
+
+use crate::persistence::binary::io::read_u32;
+use crate::StorageError;
+
+use super::entry::{Lsn, WalEntry};
+use super::format::{WalHeader, WAL_HEADER_SIZE};
+use super::writer::verify_checksum;
+
+/// Result of reading a WAL entry
+#[derive(Debug)]
+pub enum ReadResult {
+    /// Successfully read an entry
+    Entry(WalEntry),
+    /// Reached end of file (clean EOF)
+    Eof,
+    /// Found corruption (partial write or checksum mismatch)
+    /// Contains the position where corruption was detected
+    Corruption { position: u64 },
+}
+
+/// WAL reader for sequential reading of entries
+pub struct WalReader<R: Read + Seek> {
+    reader: R,
+    /// WAL file header
+    header: WalHeader,
+    /// Current position in the file
+    position: u64,
+    /// Number of entries read
+    entries_read: u64,
+    /// Last LSN seen
+    last_lsn: Option<Lsn>,
+}
+
+impl<R: Read + Seek> WalReader<R> {
+    /// Open a WAL file for reading
+    pub fn open(mut reader: R) -> Result<Self, StorageError> {
+        // Read and validate header
+        let header = WalHeader::read(&mut reader)?;
+
+        Ok(Self {
+            reader,
+            header,
+            position: WAL_HEADER_SIZE as u64,
+            entries_read: 0,
+            last_lsn: None,
+        })
+    }
+
+    /// Read the next entry from the WAL
+    pub fn read_entry(&mut self) -> Result<ReadResult, StorageError> {
+        // Try to read entry length
+        let len = match read_u32(&mut self.reader) {
+            Ok(len) => len,
+            Err(_) => {
+                // Could be clean EOF or partial write
+                return Ok(ReadResult::Eof);
+            }
+        };
+
+        // Read checksum
+        let checksum = match read_u32(&mut self.reader) {
+            Ok(crc) => crc,
+            Err(_) => {
+                // Partial write - length was written but not checksum
+                return Ok(ReadResult::Corruption { position: self.position });
+            }
+        };
+
+        // Read entry data
+        let mut data = vec![0u8; len as usize];
+        if let Err(_) = self.reader.read_exact(&mut data) {
+            // Partial write - header was written but not full data
+            return Ok(ReadResult::Corruption { position: self.position });
+        }
+
+        // Verify checksum
+        if !verify_checksum(&data, checksum) {
+            return Ok(ReadResult::Corruption { position: self.position });
+        }
+
+        // Deserialize entry
+        let mut data_reader = &data[..];
+        let entry = WalEntry::deserialize(&mut data_reader)?;
+
+        // Update state
+        self.position += 4 + 4 + len as u64; // len + crc + data
+        self.entries_read += 1;
+        self.last_lsn = Some(entry.lsn);
+
+        Ok(ReadResult::Entry(entry))
+    }
+
+    /// Read all entries from the WAL
+    /// Returns entries up to the first corruption or EOF
+    pub fn read_all(&mut self) -> Result<Vec<WalEntry>, StorageError> {
+        let mut entries = Vec::new();
+
+        loop {
+            match self.read_entry()? {
+                ReadResult::Entry(entry) => entries.push(entry),
+                ReadResult::Eof => break,
+                ReadResult::Corruption { position: _ } => break,
+            }
+        }
+
+        Ok(entries)
+    }
+
+    /// Get the WAL header
+    pub fn header(&self) -> &WalHeader {
+        &self.header
+    }
+
+    /// Get the number of entries read so far
+    pub fn entries_read(&self) -> u64 {
+        self.entries_read
+    }
+
+    /// Get the last LSN seen
+    pub fn last_lsn(&self) -> Option<Lsn> {
+        self.last_lsn
+    }
+
+    /// Get the current position in the file
+    pub fn position(&self) -> u64 {
+        self.position
+    }
+
+    /// Seek to a specific position in the WAL
+    /// Note: Should only seek to positions after the header
+    pub fn seek_to(&mut self, position: u64) -> Result<(), StorageError> {
+        if position < WAL_HEADER_SIZE as u64 {
+            return Err(StorageError::IoError("Cannot seek before WAL header".to_string()));
+        }
+        self.reader
+            .seek(SeekFrom::Start(position))
+            .map_err(|e| StorageError::IoError(e.to_string()))?;
+        self.position = position;
+        Ok(())
+    }
+
+    /// Reset reader to the beginning of entries (after header)
+    pub fn reset(&mut self) -> Result<(), StorageError> {
+        self.seek_to(WAL_HEADER_SIZE as u64)?;
+        self.entries_read = 0;
+        self.last_lsn = None;
+        Ok(())
+    }
+}
+
+/// Iterator over WAL entries
+pub struct WalIterator<'a, R: Read + Seek> {
+    reader: &'a mut WalReader<R>,
+}
+
+impl<R: Read + Seek> WalReader<R> {
+    /// Create an iterator over WAL entries
+    pub fn iter(&mut self) -> WalIterator<'_, R> {
+        WalIterator { reader: self }
+    }
+}
+
+impl<R: Read + Seek> Iterator for WalIterator<'_, R> {
+    type Item = Result<WalEntry, StorageError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.reader.read_entry() {
+            Ok(ReadResult::Entry(entry)) => Some(Ok(entry)),
+            Ok(ReadResult::Eof) => None,
+            Ok(ReadResult::Corruption { position }) => {
+                Some(Err(StorageError::IoError(format!("WAL corruption at position {}", position))))
+            }
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+/// Find the position of the last valid entry in a potentially corrupted WAL
+/// This is useful for recovering from partial writes
+pub fn find_recovery_point<R: Read + Seek>(reader: R) -> Result<RecoveryInfo, StorageError> {
+    let mut wal_reader = WalReader::open(reader)?;
+    let mut last_valid_position = WAL_HEADER_SIZE as u64;
+    let mut last_lsn = None;
+    let mut entry_count = 0;
+
+    loop {
+        match wal_reader.read_entry()? {
+            ReadResult::Entry(entry) => {
+                last_valid_position = wal_reader.position();
+                last_lsn = Some(entry.lsn);
+                entry_count += 1;
+            }
+            ReadResult::Eof => break,
+            ReadResult::Corruption { position: _ } => break,
+        }
+    }
+
+    Ok(RecoveryInfo { last_valid_position, last_lsn, entry_count })
+}
+
+/// Information about WAL recovery
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveryInfo {
+    /// Position after the last valid entry
+    pub last_valid_position: u64,
+    /// LSN of the last valid entry (None if no valid entries)
+    pub last_lsn: Option<Lsn>,
+    /// Number of valid entries found
+    pub entry_count: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use vibesql_types::SqlValue;
+
+    use super::*;
+    use crate::wal::entry::WalOp;
+    use crate::wal::writer::WalWriter;
+
+    fn create_test_wal() -> Cursor<Vec<u8>> {
+        let buf = Vec::new();
+        let cursor = Cursor::new(buf);
+        let mut writer = WalWriter::create(cursor).unwrap();
+
+        for i in 1..=5 {
+            let entry = WalEntry::new(
+                i,
+                1234567890 + i,
+                WalOp::Insert { table_id: 1, row_id: i, values: vec![SqlValue::Integer(i as i64)] },
+            );
+            writer.append(&entry).unwrap();
+        }
+
+        writer.flush().unwrap();
+        Cursor::new(writer.into_inner().into_inner())
+    }
+
+    #[test]
+    fn test_read_all_entries() {
+        let cursor = create_test_wal();
+        let mut reader = WalReader::open(cursor).unwrap();
+
+        let entries = reader.read_all().unwrap();
+        assert_eq!(entries.len(), 5);
+
+        for (i, entry) in entries.iter().enumerate() {
+            assert_eq!(entry.lsn, (i + 1) as u64);
+        }
+    }
+
+    #[test]
+    fn test_read_entry_by_entry() {
+        let cursor = create_test_wal();
+        let mut reader = WalReader::open(cursor).unwrap();
+
+        for i in 1..=5 {
+            match reader.read_entry().unwrap() {
+                ReadResult::Entry(entry) => {
+                    assert_eq!(entry.lsn, i);
+                }
+                other => panic!("Expected Entry, got {:?}", other),
+            }
+        }
+
+        match reader.read_entry().unwrap() {
+            ReadResult::Eof => {}
+            other => panic!("Expected Eof, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_iterator() {
+        let cursor = create_test_wal();
+        let mut reader = WalReader::open(cursor).unwrap();
+
+        let entries: Vec<_> = reader.iter().collect();
+        assert_eq!(entries.len(), 5);
+        for entry in entries {
+            assert!(entry.is_ok());
+        }
+    }
+
+    #[test]
+    fn test_header_info() {
+        let cursor = create_test_wal();
+        let reader = WalReader::open(cursor).unwrap();
+
+        assert_eq!(reader.header().version, super::super::format::WAL_VERSION);
+    }
+
+    #[test]
+    fn test_recovery_info() {
+        let cursor = create_test_wal();
+        let info = find_recovery_point(cursor).unwrap();
+
+        assert_eq!(info.entry_count, 5);
+        assert_eq!(info.last_lsn, Some(5));
+        assert!(info.last_valid_position > WAL_HEADER_SIZE as u64);
+    }
+
+    #[test]
+    fn test_corruption_detection_truncated_data() {
+        // Create a WAL with entries
+        let mut buf = create_test_wal().into_inner();
+
+        // Truncate in the middle of an entry (corrupt it)
+        buf.truncate(WAL_HEADER_SIZE + 20);
+
+        let cursor = Cursor::new(buf);
+        let mut reader = WalReader::open(cursor).unwrap();
+
+        // First entry should be readable
+        // After that we should hit corruption or partial read
+        let entries = reader.read_all().unwrap();
+        // May have 0 or more entries depending on where truncation happened
+        assert!(entries.len() <= 5);
+    }
+
+    #[test]
+    fn test_corruption_detection_bad_checksum() {
+        // Create a WAL with entries
+        let mut buf = create_test_wal().into_inner();
+
+        // Corrupt the checksum of the second entry
+        // Entry format: [len:4][crc:4][data:...]
+        // After header (32 bytes) and first entry, modify CRC
+        // We'll just flip a bit in the data area to cause checksum mismatch
+        if buf.len() > WAL_HEADER_SIZE + 50 {
+            buf[WAL_HEADER_SIZE + 45] ^= 0xFF; // Flip bits in data
+        }
+
+        let cursor = Cursor::new(buf);
+        let info = find_recovery_point(cursor).unwrap();
+
+        // Should detect corruption and report recovery point
+        assert!(info.entry_count < 5);
+    }
+
+    #[test]
+    fn test_reset() {
+        let cursor = create_test_wal();
+        let mut reader = WalReader::open(cursor).unwrap();
+
+        // Read all entries
+        let entries1 = reader.read_all().unwrap();
+        assert_eq!(entries1.len(), 5);
+
+        // Reset and read again
+        reader.reset().unwrap();
+        let entries2 = reader.read_all().unwrap();
+        assert_eq!(entries2.len(), 5);
+
+        assert_eq!(entries1, entries2);
+    }
+}

--- a/crates/vibesql-storage/src/wal/writer.rs
+++ b/crates/vibesql-storage/src/wal/writer.rs
@@ -1,0 +1,275 @@
+// ============================================================================
+// WAL Writer
+// ============================================================================
+//
+// Append-only writer for WAL entries with CRC32 checksums.
+
+use std::io::{Seek, SeekFrom, Write};
+
+use crate::persistence::binary::io::{write_u32, write_u64};
+use crate::StorageError;
+
+use super::entry::{Lsn, WalEntry};
+use super::format::{WAL_MAGIC, WAL_VERSION};
+
+#[cfg(test)]
+use super::format::WAL_HEADER_SIZE;
+
+/// CRC-32 implementation using the IEEE polynomial
+/// This is a simple, portable implementation that works on both native and WASM
+fn crc32(data: &[u8]) -> u32 {
+    const CRC32_TABLE: [u32; 256] = {
+        let mut table = [0u32; 256];
+        let mut i = 0;
+        while i < 256 {
+            let mut crc = i as u32;
+            let mut j = 0;
+            while j < 8 {
+                if crc & 1 != 0 {
+                    crc = (crc >> 1) ^ 0xEDB88320;
+                } else {
+                    crc >>= 1;
+                }
+                j += 1;
+            }
+            table[i] = crc;
+            i += 1;
+        }
+        table
+    };
+
+    let mut crc = 0xFFFFFFFF;
+    for &byte in data {
+        let index = ((crc ^ byte as u32) & 0xFF) as usize;
+        crc = (crc >> 8) ^ CRC32_TABLE[index];
+    }
+    crc ^ 0xFFFFFFFF
+}
+
+/// WAL writer for appending entries to a WAL file
+pub struct WalWriter<W: Write + Seek> {
+    writer: W,
+    /// Current log sequence number (next to be assigned)
+    next_lsn: Lsn,
+    /// Number of entries written
+    entry_count: u64,
+}
+
+impl<W: Write + Seek> WalWriter<W> {
+    /// Create a new WAL file with header
+    pub fn create(mut writer: W) -> Result<Self, StorageError> {
+        // Write header
+        write_header(&mut writer)?;
+
+        Ok(Self { writer, next_lsn: 1, entry_count: 0 })
+    }
+
+    /// Open an existing WAL file for appending
+    /// Returns the writer positioned at the end, ready to append
+    pub fn open(mut writer: W, next_lsn: Lsn) -> Result<Self, StorageError> {
+        // Seek to end to append
+        writer.seek(SeekFrom::End(0)).map_err(|e| StorageError::IoError(e.to_string()))?;
+
+        Ok(Self { writer, next_lsn, entry_count: 0 })
+    }
+
+    /// Append an entry to the WAL
+    /// Returns the LSN assigned to the entry
+    pub fn append(&mut self, entry: &WalEntry) -> Result<Lsn, StorageError> {
+        // Serialize the entry to a buffer first to calculate length and checksum
+        let mut entry_buf = Vec::new();
+        entry.serialize(&mut entry_buf)?;
+
+        let len = entry_buf.len() as u32;
+        let checksum = crc32(&entry_buf);
+
+        // Write: [len:u32][crc:u32][data:...]
+        write_u32(&mut self.writer, len)?;
+        write_u32(&mut self.writer, checksum)?;
+        self.writer.write_all(&entry_buf).map_err(|e| StorageError::IoError(e.to_string()))?;
+
+        let assigned_lsn = entry.lsn;
+        self.next_lsn = assigned_lsn + 1;
+        self.entry_count += 1;
+
+        Ok(assigned_lsn)
+    }
+
+    /// Append an operation, automatically assigning LSN and timestamp
+    pub fn append_op(&mut self, op: super::entry::WalOp) -> Result<Lsn, StorageError> {
+        let lsn = self.next_lsn;
+        let timestamp_ms = current_timestamp_ms();
+
+        let entry = WalEntry::new(lsn, timestamp_ms, op);
+        self.append(&entry)
+    }
+
+    /// Get the next LSN that will be assigned
+    pub fn next_lsn(&self) -> Lsn {
+        self.next_lsn
+    }
+
+    /// Get the number of entries written
+    pub fn entry_count(&self) -> u64 {
+        self.entry_count
+    }
+
+    /// Flush any buffered writes to the underlying storage
+    pub fn flush(&mut self) -> Result<(), StorageError> {
+        self.writer.flush().map_err(|e| StorageError::IoError(e.to_string()))
+    }
+
+    /// Sync writes to disk (if supported by the underlying writer)
+    /// For maximum durability, this should be called after critical operations
+    pub fn sync(&mut self) -> Result<(), StorageError> {
+        self.flush()
+        // Note: For actual fsync behavior, the underlying writer would need
+        // to be a File. The StorageBackend trait would handle this in Phase 2.
+    }
+
+    /// Consume the writer and return the underlying writer
+    pub fn into_inner(self) -> W {
+        self.writer
+    }
+}
+
+/// Write the WAL file header
+fn write_header<W: Write>(writer: &mut W) -> Result<(), StorageError> {
+    // Magic number (4 bytes)
+    writer.write_all(WAL_MAGIC).map_err(|e| StorageError::IoError(e.to_string()))?;
+
+    // Version (4 bytes)
+    write_u32(writer, WAL_VERSION)?;
+
+    // Created timestamp (8 bytes)
+    write_u64(writer, current_timestamp_ms())?;
+
+    // Reserved (16 bytes)
+    writer.write_all(&[0u8; 16]).map_err(|e| StorageError::IoError(e.to_string()))?;
+
+    Ok(())
+}
+
+/// Get current timestamp in milliseconds since epoch
+fn current_timestamp_ms() -> u64 {
+    // Use instant crate for WASM compatibility
+    use instant::SystemTime;
+    SystemTime::now()
+        .duration_since(instant::SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Verify a CRC32 checksum
+pub fn verify_checksum(data: &[u8], expected: u32) -> bool {
+    crc32(data) == expected
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use vibesql_types::SqlValue;
+
+    use super::*;
+    use crate::wal::entry::WalOp;
+
+    #[test]
+    fn test_create_wal_file() {
+        let buf = Vec::new();
+        let cursor = Cursor::new(buf);
+
+        let writer = WalWriter::create(cursor).unwrap();
+        assert_eq!(writer.next_lsn(), 1);
+        assert_eq!(writer.entry_count(), 0);
+    }
+
+    #[test]
+    fn test_append_entry() {
+        let buf = Vec::new();
+        let cursor = Cursor::new(buf);
+
+        let mut writer = WalWriter::create(cursor).unwrap();
+
+        let entry = WalEntry::new(
+            1,
+            1234567890,
+            WalOp::Insert {
+                table_id: 1,
+                row_id: 100,
+                values: vec![SqlValue::Integer(42)],
+            },
+        );
+
+        let lsn = writer.append(&entry).unwrap();
+        assert_eq!(lsn, 1);
+        assert_eq!(writer.next_lsn(), 2);
+        assert_eq!(writer.entry_count(), 1);
+    }
+
+    #[test]
+    fn test_append_multiple_entries() {
+        let buf = Vec::new();
+        let cursor = Cursor::new(buf);
+
+        let mut writer = WalWriter::create(cursor).unwrap();
+
+        for i in 1..=10 {
+            let entry = WalEntry::new(
+                i,
+                1234567890 + i,
+                WalOp::Insert { table_id: 1, row_id: i, values: vec![SqlValue::Integer(i as i64)] },
+            );
+            let lsn = writer.append(&entry).unwrap();
+            assert_eq!(lsn, i);
+        }
+
+        assert_eq!(writer.next_lsn(), 11);
+        assert_eq!(writer.entry_count(), 10);
+    }
+
+    #[test]
+    fn test_append_op() {
+        let buf = Vec::new();
+        let cursor = Cursor::new(buf);
+
+        let mut writer = WalWriter::create(cursor).unwrap();
+
+        let lsn = writer
+            .append_op(WalOp::Insert {
+                table_id: 1,
+                row_id: 100,
+                values: vec![SqlValue::Varchar("test".to_string())],
+            })
+            .unwrap();
+
+        assert_eq!(lsn, 1);
+        assert_eq!(writer.next_lsn(), 2);
+    }
+
+    #[test]
+    fn test_crc32() {
+        // Test vectors from the CRC-32 IEEE standard
+        assert_eq!(crc32(b"123456789"), 0xCBF43926);
+        assert_eq!(crc32(b""), 0x00000000);
+        assert_eq!(crc32(b"a"), 0xE8B7BE43);
+    }
+
+    #[test]
+    fn test_verify_checksum() {
+        let data = b"test data for checksum";
+        let checksum = crc32(data);
+        assert!(verify_checksum(data, checksum));
+        assert!(!verify_checksum(data, checksum + 1));
+    }
+
+    #[test]
+    fn test_header_size() {
+        let buf = Vec::new();
+        let cursor = Cursor::new(buf);
+
+        let writer = WalWriter::create(cursor).unwrap();
+        let inner = writer.into_inner().into_inner();
+        assert_eq!(inner.len(), WAL_HEADER_SIZE);
+    }
+}


### PR DESCRIPTION
## Summary

- Implement Write-Ahead Log (WAL) infrastructure for Phase 1 of Memory-First Storage Architecture
- Add `WalEntry` struct with LSN, timestamp, and operation types
- Add `WalOp` enum covering all DML, DDL, transaction, and checkpoint operations
- Add `WalWriter` for append-only writes with CRC32 checksums
- Add `WalReader` for sequential reading with corruption detection
- Add `find_recovery_point()` for recovering from partial writes

## Test plan

- [x] All 27 WAL unit tests pass
- [x] Entry serialization/deserialization roundtrips for all operation types
- [x] CRC32 checksum verification
- [x] Corruption detection (truncated data, bad checksum)
- [x] Recovery point detection works correctly
- [x] Full workspace compiles

Closes #3642

🤖 Generated with [Claude Code](https://claude.com/claude-code)