### PR TITLE
fix(executor): Normalize table names to lowercase for case-insensitive lookups

### DIFF
--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -12,10 +12,12 @@ pub struct CombinedSchema {
 
 impl CombinedSchema {
     /// Create a new combined schema from a single table
+    ///
+    /// Note: Table name is normalized to lowercase for case-insensitive lookups
     pub fn from_table(table_name: String, schema: vibesql_catalog::TableSchema) -> Self {
         let total_columns = schema.columns.len();
         let mut table_schemas = HashMap::new();
-        // Use lowercase table name for consistent lookups in predicate decomposition
+        // Use lowercase table name for consistent case-insensitive lookups
         table_schemas.insert(table_name.to_lowercase(), (0, schema));
         CombinedSchema { table_schemas, total_columns }
     }
@@ -108,17 +110,27 @@ impl SchemaBuilder {
     }
 
     /// Create a schema builder initialized with an existing CombinedSchema
+    ///
+    /// Note: Table names are normalized to lowercase for case-insensitive lookups
     pub fn from_schema(schema: CombinedSchema) -> Self {
         let column_offset = schema.total_columns;
-        SchemaBuilder { table_schemas: schema.table_schemas, column_offset }
+        // Normalize all table names to lowercase for case-insensitive lookups
+        let table_schemas = schema
+            .table_schemas
+            .into_iter()
+            .map(|(name, value)| (name.to_lowercase(), value))
+            .collect();
+        SchemaBuilder { table_schemas, column_offset }
     }
 
     /// Add a table to the schema
     ///
     /// This is an O(1) operation - columns are not copied, just indexed
+    /// Note: Table names are normalized to lowercase for case-insensitive lookups
     pub fn add_table(&mut self, name: String, schema: vibesql_catalog::TableSchema) -> &mut Self {
         let num_columns = schema.columns.len();
-        self.table_schemas.insert(name, (self.column_offset, schema));
+        // Use lowercase for consistent case-insensitive lookups
+        self.table_schemas.insert(name.to_lowercase(), (self.column_offset, schema));
         self.column_offset += num_columns;
         self
     }

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -175,7 +175,7 @@ pub(super) fn build_combined_schema(
     let mut combined = CombinedSchema { table_schemas: HashMap::new(), total_columns: 0 };
 
     for (table_name, alias, _batch, schema) in batches {
-        let name = alias.as_ref().unwrap_or(table_name).clone();
+        let name = alias.as_ref().unwrap_or(table_name).to_lowercase();
         combined.table_schemas.insert(name, (combined.total_columns, schema.clone()));
         combined.total_columns += schema.columns.len();
     }
@@ -190,7 +190,8 @@ pub(super) fn is_column_in_tables(column: &str, tables: &[&str], schema: &Combin
 
 /// Check if a column exists in a specific table
 pub(super) fn is_column_in_table(column: &str, table: &str, schema: &CombinedSchema) -> bool {
-    if let Some((_, table_schema)) = schema.table_schemas.get(table) {
+    // Use lowercase for consistent table lookup
+    if let Some((_, table_schema)) = schema.table_schemas.get(&table.to_lowercase()) {
         table_schema.columns.iter().any(|c| c.name.eq_ignore_ascii_case(column))
     } else {
         false

--- a/crates/vibesql-executor/src/select/iterator/join.rs
+++ b/crates/vibesql-executor/src/select/iterator/join.rs
@@ -113,9 +113,10 @@ impl<'schema, I: RowIterator> LazyNestedLoopJoin<'schema, I> {
         let mut right_total = 0;
 
         // Add all right-side tables with adjusted start indices
+        // Use lowercase for consistent case-insensitive lookups
         for (table_name, (start_idx, schema)) in right_schema.table_schemas.iter() {
             let adjusted_start = left_total + start_idx;
-            table_schemas.insert(table_name.clone(), (adjusted_start, schema.clone()));
+            table_schemas.insert(table_name.to_lowercase(), (adjusted_start, schema.clone()));
             right_total += schema.columns.len();
         }
 

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -152,7 +152,8 @@ pub(super) fn build_reordered_schema(
 
         if let Some(schema) = table_schema {
             let col_count = schema.columns.len();
-            new_table_schemas.insert(table_name.clone(), (current_position, schema));
+            // Use lowercase for consistent case-insensitive lookups
+            new_table_schemas.insert(table_name.to_lowercase(), (current_position, schema));
             current_position += col_count;
         }
     }


### PR DESCRIPTION
## Summary

- Fix TPC-DS Q6 `ColumnNotFound` error caused by case sensitivity in table name lookups
- Normalize all table names to lowercase in `CombinedSchema` HashMap keys
- Fixed multiple code paths: `from_schema`, `add_table`, `build_combined_schema`, `build_reordered_schema`, and `LazyNestedLoopJoin` constructor

## Root Cause

The SQL parser normalizes identifiers to uppercase (per SQL standard), but `CombinedSchema` stores table names as HashMap keys. When looking up columns like `j.i_current_price`, the lookup used uppercase `"J"` but the key was lowercase `"j"`, causing a mismatch.

## Test plan

- [x] TPC-DS Q6 passes (the failing query)
- [x] All 99 TPC-DS queries pass at scale factor 0.001
- [x] All library and executor tests pass

Closes #3633

🤖 Generated with [Claude Code](https://claude.com/claude-code)