### PR TITLE
fix(server): Fix connection closure after ~150-190 queries

### DIFF
--- a/crates/vibesql-executor/benches/sysbench_server.rs
+++ b/crates/vibesql-executor/benches/sysbench_server.rs
@@ -18,21 +18,6 @@
 //! This benchmark uses vibesql-server with PostgreSQL wire protocol, connecting
 //! via tokio-postgres, to provide an equivalent client-server comparison.
 //!
-//! ## Known Limitations
-//!
-//! vibesql-server has a connection handling issue where connections are closed after
-//! approximately 150-190 table queries (varies by table size). This appears to be a
-//! protocol handling bug in the server. Until fixed, the benchmark:
-//! - Uses a small default table size (50 rows) to maximize benchmark runtime
-//! - Skips warmup phase to preserve queries for actual measurement
-//! - Reports partial results when connection is lost
-//!
-//! Total query budget per connection: ~150-190 table queries
-//! - Schema creation: 2 queries (CREATE TABLE, CREATE INDEX)
-//! - Data loading: N queries (one INSERT per row)
-//! - Verification: 1 query (SELECT COUNT)
-//! - Remaining for benchmark: ~145-187 - N queries
-//!
 //! ## Usage
 //!
 //! ```bash
@@ -47,7 +32,7 @@
 //!
 //! ## Environment Variables
 //!
-//! - `SYSBENCH_TABLE_SIZE` - Number of rows (default: 50, max ~150 due to server bug)
+//! - `SYSBENCH_TABLE_SIZE` - Number of rows (default: 10000)
 //! - `SYSBENCH_DURATION_SECS` - Benchmark duration in seconds (default: 30)
 //! - `SYSBENCH_WARMUP_SECS` - Warmup duration in seconds (default: 5)
 //! - `MYSQL_URL` - MySQL connection string (optional)
@@ -77,9 +62,7 @@ use mysql::prelude::*;
 use mysql::{Pool, PooledConn};
 
 /// Default table size for sysbench tests
-/// NOTE: vibesql-server has a connection limit bug (~190 table queries per connection).
-/// With 50 rows, we get ~137 queries for benchmarking (190 - 3 schema - 50 INSERT).
-const DEFAULT_TABLE_SIZE: usize = 50;
+const DEFAULT_TABLE_SIZE: usize = 10000;
 
 /// Range size for range queries (sysbench default is 100)
 const RANGE_SIZE: usize = 100;
@@ -99,6 +82,7 @@ async fn start_vibesql_server(
     use vibesql_server::config::{AuthConfig, Config, LoggingConfig, ServerConfig};
     use vibesql_server::connection::ConnectionHandler;
     use vibesql_server::observability::ObservabilityProvider;
+    use vibesql_server::registry::DatabaseRegistry;
     use vibesql_server::subscription::SubscriptionManager;
 
     // Create minimal configuration for benchmark
@@ -130,6 +114,9 @@ async fn start_vibesql_server(
     // Create the global subscription manager (no need for change events in benchmark)
     let subscription_manager = Arc::new(SubscriptionManager::new());
 
+    // Create shared database registry for all connections
+    let database_registry = DatabaseRegistry::new();
+
     // Create observability provider once (disabled for benchmarks)
     let observability = Arc::new(
         ObservabilityProvider::init(&Default::default())
@@ -151,6 +138,7 @@ async fn start_vibesql_server(
                             let config = Arc::clone(&config);
                             let active_connections = Arc::clone(&active_connections);
                             let subscription_manager = Arc::clone(&subscription_manager);
+                            let database_registry = database_registry.clone();
                             let observability = Arc::clone(&observability);
 
                             tokio::spawn(async move {
@@ -161,6 +149,7 @@ async fn start_vibesql_server(
                                     observability,
                                     None, // No password store (trust auth)
                                     active_connections,
+                                    database_registry,
                                     subscription_manager,
                                 );
                                 let _ = handler.handle().await;
@@ -1362,9 +1351,7 @@ fn main() {
         }
         eprintln!("Data loaded in {:?}", load_start.elapsed());
 
-        // Skip warmup and run a quick benchmark directly
-        // vibesql-server has a connection limit bug - table queries fail after ~190 total queries
-        eprintln!("Starting benchmarks (no warmup due to connection limitations)...");
+        eprintln!("Starting benchmarks...");
 
         // Run benchmarks
         let mut results = Vec::new();

--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -255,41 +255,44 @@ impl ConnectionHandler {
     /// Process queries from the client
     async fn process_queries(&mut self) -> Result<()> {
         loop {
-            // Read a message
-            self.read_message().await?;
-
-            // Decode frontend message
-            let msg = FrontendMessage::decode(&mut self.read_buf)?;
+            // Read a complete message, waiting for more data if needed
+            let msg = match self.read_complete_message().await {
+                Ok(msg) => msg,
+                Err(e) => {
+                    // Check if this is a clean connection close
+                    let err_str = e.to_string();
+                    if err_str.contains("Connection closed") {
+                        debug!("Connection closed by client");
+                        break;
+                    }
+                    return Err(e);
+                }
+            };
 
             match msg {
-                Some(FrontendMessage::Query { query }) => {
+                FrontendMessage::Query { query } => {
                     debug!("Query: {}", query);
                     self.execute_query(&query).await?;
                 }
 
-                Some(FrontendMessage::Subscribe { query, params }) => {
+                FrontendMessage::Subscribe { query, params } => {
                     debug!("Subscribe: {}", query);
                     self.handle_subscribe(&query, params).await?;
                 }
 
-                Some(FrontendMessage::Unsubscribe { subscription_id }) => {
+                FrontendMessage::Unsubscribe { subscription_id } => {
                     debug!("Unsubscribe: {:?}", subscription_id);
                     self.subscription_manager.unsubscribe(&subscription_id);
                     // No response needed per protocol spec
                 }
 
-                Some(FrontendMessage::Terminate) => {
+                FrontendMessage::Terminate => {
                     debug!("Client requested termination");
                     break;
                 }
 
-                Some(msg) => {
+                msg => {
                     warn!("Unexpected message: {:?}", msg);
-                }
-
-                None => {
-                    debug!("Connection closed by client");
-                    break;
                 }
             }
         }
@@ -298,6 +301,24 @@ impl ConnectionHandler {
         self.subscription_manager.clear();
 
         Ok(())
+    }
+
+    /// Read a complete frontend message, looping until enough data is available
+    ///
+    /// This is critical for proper PostgreSQL wire protocol handling. TCP may deliver
+    /// messages in fragments, so we must continue reading until we have a complete
+    /// message. Previously, partial reads were incorrectly interpreted as connection
+    /// closure, causing connections to drop after ~150-190 queries.
+    async fn read_complete_message(&mut self) -> Result<FrontendMessage> {
+        loop {
+            // Try to decode a message from the existing buffer
+            if let Some(msg) = FrontendMessage::decode(&mut self.read_buf)? {
+                return Ok(msg);
+            }
+
+            // Need more data - read from the stream
+            self.read_message().await?;
+        }
     }
 
     /// Execute a SQL query


### PR DESCRIPTION
## Summary

- Fixes PostgreSQL wire protocol connection handler incorrectly interpreting partial TCP reads as connection closures
- Introduces `read_complete_message()` helper that properly loops until a complete message is decoded
- Updates sysbench_server benchmark to use the new DatabaseRegistry parameter and removes outdated limitations

## Root Cause

When TCP fragmentation occurred (more likely with larger result sets), the server would:
1. Receive only part of a PostgreSQL message
2. `FrontendMessage::decode()` would return `Ok(None)` indicating "need more data"
3. `process_queries()` would incorrectly interpret this as "connection closed by client" and break out of the loop

## The Fix

The new `read_complete_message()` method properly loops, reading more data from the socket until a complete message can be decoded. This ensures TCP fragmentation is handled correctly regardless of query count or result size.

## Test Results

**Before:** Connections dropped after ~150-190 table queries

**After:** 
```
=== Sysbench Client-Server Benchmark ===
Configuration:
  Table size: 1000 rows
  Duration: 10 seconds

--- VibeSQL Server Results ---
Workload               Operations     Avg Latency      Ops/sec
-------------------- ------------ --------------- ------------
Point Select               206311        47.92 us        20867
```

206,000+ point-select queries ran successfully in 10 seconds with 1000 rows loaded.

## Test plan

- [x] All 245 vibesql-server tests pass
- [x] sysbench_server benchmark runs for full duration with 1000 rows (was limited to ~50 rows before)
- [x] No connection drops during benchmark

Closes #3649

🤖 Generated with [Claude Code](https://claude.com/claude-code)