### PR TITLE
fix(server): Add feature gates to blob storage HTTP tests

### DIFF
--- a/crates/vibesql-server/Cargo.toml
+++ b/crates/vibesql-server/Cargo.toml
@@ -9,6 +9,15 @@ description = "Network server with PostgreSQL wire protocol for VibeSQL"
 keywords = ["sql", "database", "server", "postgresql", "network"]
 categories = ["database", "network-programming"]
 
+[features]
+default = ["storage-all"]
+# Re-export storage features for conditional compilation in tests
+opendal = ["vibesql-storage/opendal"]
+storage-memory = ["vibesql-storage/storage-memory"]
+# storage-all enables all storage backends and also enables the local feature flags
+# so that #[cfg(feature = "...")] checks work correctly in tests
+storage-all = ["vibesql-storage/storage-all", "opendal", "storage-memory"]
+
 [lib]
 name = "vibesql_server"
 path = "src/lib.rs"
@@ -23,7 +32,7 @@ doc = false  # Binaries don't need documentation
 vibesql-types = { version = "0.1.2", path = "../vibesql-types" }
 vibesql-ast = { version = "0.1.2", path = "../vibesql-ast" }
 vibesql-catalog = { version = "0.1.2", path = "../vibesql-catalog" }
-vibesql-storage = { version = "0.1.2", path = "../vibesql-storage", features = ["storage-all"] }
+vibesql-storage = { version = "0.1.2", path = "../vibesql-storage" }
 vibesql-executor = { version = "0.1.2", path = "../vibesql-executor" }
 vibesql-parser = { version = "0.1.2", path = "../vibesql-parser" }
 

--- a/crates/vibesql-server/src/http/storage.rs
+++ b/crates/vibesql-server/src/http/storage.rs
@@ -240,7 +240,9 @@ async fn delete_blob(
     }
 }
 
-#[cfg(test)]
+/// Tests for blob storage HTTP handlers.
+/// These tests require the memory storage backend to be enabled.
+#[cfg(all(test, feature = "opendal", feature = "storage-memory"))]
 mod tests {
     use super::*;
     use axum::{body::Body, http::Request};


### PR DESCRIPTION
## Summary
- Add `[features]` section to `vibesql-server/Cargo.toml` that re-exports storage features from `vibesql-storage`
- Add feature gates (`#[cfg(all(test, feature = "opendal", feature = "storage-memory"))]`) to HTTP storage test module
- Tests now only compile and run when required features are enabled

## Problem
The `test_upload_blob_success` test in `crates/vibesql-server/src/http/storage.rs` was failing during `make test-ignored` with a 500 status error because the memory storage backend wasn't properly initialized when features weren't activated.

## Solution
Re-export storage features through `vibesql-server/Cargo.toml` and gate the test module with the appropriate feature flags, matching the existing pattern in `vibesql-storage/src/blob/service.rs`.

## Test plan
- [x] `cargo test --package vibesql-server --lib` - all 245 tests pass
- [x] `cargo test --package vibesql-server --lib --features storage-all http::storage::tests` - 5 storage tests pass
- [x] `cargo test --package vibesql-server --lib --no-default-features http::storage::tests` - 0 tests (compiled out)

Closes #3653

🤖 Generated with [Claude Code](https://claude.com/claude-code)