### PR TITLE
fix(executor): Apply window functions to aggregate queries for AVG(SUM(...)) patterns

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -4,6 +4,7 @@
 mod detection;
 
 mod evaluation;
+mod window;
 
 use std::collections::HashMap;
 
@@ -319,6 +320,18 @@ impl SelectExecutor<'_> {
                 }
             }
         }
+
+        // Apply window functions that wrap aggregates (e.g., AVG(SUM(x)) OVER (...))
+        // This must happen after GROUP BY but before ORDER BY
+        let result_rows = if window::has_aggregate_window_functions(&expanded_select_list) {
+            window::apply_window_functions_to_aggregates(
+                result_rows,
+                &expanded_select_list,
+                self.database,
+            )?
+        } else {
+            result_rows
+        };
 
         // Apply ORDER BY if present
         let result_rows = if let Some(order_by) = &stmt.order_by {

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -1,0 +1,259 @@
+//! Window function evaluation for aggregate queries
+//!
+//! This module handles window functions that wrap aggregates, like AVG(SUM(x)) OVER (...).
+//! After GROUP BY processing computes the inner aggregates, this module applies the
+//! outer window function over the aggregated rows.
+
+use vibesql_ast::{Expression, SelectItem, WindowFunctionSpec, WindowSpec};
+use vibesql_catalog::ColumnSchema;
+use vibesql_storage::Row;
+use vibesql_types::{DataType, SqlValue};
+
+use crate::{
+    errors::ExecutorError,
+    evaluator::{
+        window::{
+            calculate_frame, evaluate_avg_window, evaluate_count_window, evaluate_max_window,
+            evaluate_min_window, evaluate_sum_window, partition_rows, sort_partition,
+        },
+        CombinedExpressionEvaluator,
+    },
+    schema::CombinedSchema,
+};
+
+/// Information about a window function that needs post-aggregation evaluation
+struct AggregateWindowFunction {
+    /// Index in the SELECT list / result row
+    select_index: usize,
+    /// The outer window function name (e.g., "AVG" in AVG(SUM(x)))
+    outer_func_name: String,
+    /// The window specification (PARTITION BY, ORDER BY, frame)
+    window_spec: WindowSpec,
+}
+
+/// Check if the SELECT list contains window functions that wrap aggregates
+pub(super) fn has_aggregate_window_functions(select_list: &[SelectItem]) -> bool {
+    select_list.iter().any(|item| {
+        if let SelectItem::Expression { expr, .. } = item {
+            is_aggregate_window_function(expr)
+        } else {
+            false
+        }
+    })
+}
+
+/// Check if an expression is a window function wrapping an aggregate
+fn is_aggregate_window_function(expr: &Expression) -> bool {
+    matches!(
+        expr,
+        Expression::WindowFunction {
+            function: WindowFunctionSpec::Aggregate { .. },
+            ..
+        }
+    )
+}
+
+/// Collect aggregate window functions from the SELECT list
+fn collect_aggregate_window_functions(select_list: &[SelectItem]) -> Vec<AggregateWindowFunction> {
+    let mut result = Vec::new();
+
+    for (idx, item) in select_list.iter().enumerate() {
+        if let SelectItem::Expression { expr, .. } = item {
+            if let Expression::WindowFunction {
+                function: WindowFunctionSpec::Aggregate { name, .. },
+                over,
+            } = expr
+            {
+                result.push(AggregateWindowFunction {
+                    select_index: idx,
+                    outer_func_name: name.clone(),
+                    window_spec: over.clone(),
+                });
+            }
+        }
+    }
+
+    result
+}
+
+/// Apply window functions to aggregated rows
+///
+/// This is called after GROUP BY processing. At this point, the result rows contain
+/// the inner aggregate values (e.g., for AVG(SUM(x)), each row has the SUM(x) value).
+/// This function applies the outer window function (AVG) over these values.
+pub(super) fn apply_window_functions_to_aggregates(
+    mut rows: Vec<Row>,
+    select_list: &[SelectItem],
+    database: &vibesql_storage::Database,
+) -> Result<Vec<Row>, ExecutorError> {
+    let window_funcs = collect_aggregate_window_functions(select_list);
+
+    if window_funcs.is_empty() {
+        return Ok(rows);
+    }
+
+    // Build a schema for the aggregate result rows
+    // Each column corresponds to a SELECT list item
+    let result_schema = build_aggregate_result_schema(select_list);
+    let evaluator = CombinedExpressionEvaluator::with_database(&result_schema, database);
+
+    // Process each window function
+    for win_func in &window_funcs {
+        // The window function's argument (e.g., SUM(x)) has already been evaluated
+        // and is stored at the same column index. We need to read this value from
+        // each row and apply the outer window function.
+
+        // For partition/order expressions, we need to map them to column indices
+        // in the aggregate result schema. Create column reference expressions.
+        let partition_exprs: Option<Vec<Expression>> = win_func.window_spec.partition_by.as_ref().map(
+            |exprs| {
+                exprs.iter().map(|e| map_expr_to_result_column(e, select_list)).collect::<Vec<_>>()
+            },
+        );
+
+        // Partition the rows
+        let eval_fn = |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
+            evaluator.clear_cse_cache();
+            evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
+        };
+
+        let mut partitions = partition_rows(rows.clone(), &partition_exprs, eval_fn);
+
+        // Sort each partition
+        let order_by_items: Option<Vec<vibesql_ast::OrderByItem>> =
+            win_func.window_spec.order_by.as_ref().map(|items| {
+                items
+                    .iter()
+                    .map(|item| vibesql_ast::OrderByItem {
+                        expr: map_expr_to_result_column(&item.expr, select_list),
+                        direction: item.direction.clone(),
+                    })
+                    .collect::<Vec<_>>()
+            });
+
+        let order_by_ref = order_by_items.clone();
+
+        for partition in &mut partitions {
+            sort_partition(partition, &order_by_ref);
+        }
+
+        // Compute window function values for each partition
+        let mut results_with_indices: Vec<(usize, SqlValue)> = Vec::new();
+
+        for partition in &partitions {
+            // The argument column is at select_index
+            let arg_col_idx = win_func.select_index;
+
+            // Create an expression that references this column
+            let arg_expr = Expression::ColumnRef {
+                table: Some("result".to_string()),
+                column: format!("col{}", arg_col_idx),
+            };
+
+            // Evaluate the window function for each row in the partition
+            for row_idx in 0..partition.len() {
+                let frame = calculate_frame(
+                    partition,
+                    row_idx,
+                    &order_by_ref,
+                    &win_func.window_spec.frame,
+                );
+
+                let eval_fn = |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
+                    evaluator.clear_cse_cache();
+                    evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
+                };
+
+                let value = match win_func.outer_func_name.to_uppercase().as_str() {
+                    "COUNT" => evaluate_count_window(partition, &frame, Some(&arg_expr), eval_fn),
+                    "SUM" => evaluate_sum_window(partition, &frame, &arg_expr, eval_fn),
+                    "AVG" => evaluate_avg_window(partition, &frame, &arg_expr, eval_fn),
+                    "MIN" => evaluate_min_window(partition, &frame, &arg_expr, eval_fn),
+                    "MAX" => evaluate_max_window(partition, &frame, &arg_expr, eval_fn),
+                    other => {
+                        return Err(ExecutorError::UnsupportedExpression(format!(
+                            "Unsupported aggregate window function: {}",
+                            other
+                        )))
+                    }
+                };
+
+                results_with_indices.push((partition.original_indices[row_idx], value));
+            }
+        }
+
+        // Sort by original index
+        results_with_indices.sort_by_key(|(idx, _)| *idx);
+
+        // Update the rows with window function results
+        for (row_idx, value) in results_with_indices {
+            rows[row_idx].values[win_func.select_index] = value;
+        }
+    }
+
+    Ok(rows)
+}
+
+/// Build a schema for aggregate result rows
+///
+/// Uses consistent column naming: col0, col1, col2, ... so column references work correctly.
+fn build_aggregate_result_schema(select_list: &[SelectItem]) -> CombinedSchema {
+    let mut columns = Vec::new();
+
+    for idx in 0..select_list.len() {
+        // Use consistent naming pattern: col0, col1, col2, ...
+        let column_name = format!("col{}", idx);
+
+        columns.push(ColumnSchema::new(
+            column_name,
+            DataType::Varchar { max_length: Some(255) }, // Placeholder type
+            true,
+        ));
+    }
+
+    let table_schema = vibesql_catalog::TableSchema::new("result".to_string(), columns);
+
+    let mut table_schemas = std::collections::HashMap::new();
+    table_schemas.insert("result".to_string(), (0, table_schema.clone()));
+
+    CombinedSchema { table_schemas, total_columns: table_schema.columns.len() }
+}
+
+/// Map an expression to a column reference in the result schema
+///
+/// For expressions that appear in the SELECT list, we create a ColumnRef
+/// that references the computed value. For others, we return the expression as-is.
+fn map_expr_to_result_column(expr: &Expression, select_list: &[SelectItem]) -> Expression {
+    // Try to find this expression in the SELECT list
+    for (idx, item) in select_list.iter().enumerate() {
+        if let SelectItem::Expression { expr: select_expr, alias } = item {
+            // Check if expressions match
+            if expressions_match(expr, select_expr) {
+                let col_name = alias.clone().unwrap_or_else(|| format!("col{}", idx));
+                return Expression::ColumnRef { table: Some("result".to_string()), column: col_name };
+            }
+
+            // Also check if expr matches an alias
+            if let Some(alias) = alias {
+                if let Expression::ColumnRef { column, table: None } = expr {
+                    if column.eq_ignore_ascii_case(alias) {
+                        return Expression::ColumnRef {
+                            table: Some("result".to_string()),
+                            column: alias.clone(),
+                        };
+                    }
+                }
+            }
+        }
+    }
+
+    // Expression not in SELECT list - return as-is
+    // This might cause evaluation issues if the expression references source columns
+    expr.clone()
+}
+
+/// Check if two expressions are equivalent
+fn expressions_match(expr1: &Expression, expr2: &Expression) -> bool {
+    // Simple structural comparison
+    format!("{:?}", expr1) == format!("{:?}", expr2)
+}

--- a/crates/vibesql-executor/src/tests/select_window_aggregate.rs
+++ b/crates/vibesql-executor/src/tests/select_window_aggregate.rs
@@ -628,3 +628,192 @@ fn test_tpcds_q12_revenue_ratio_pattern() {
         panic!("Expected SELECT statement");
     }
 }
+
+/// Test AVG(SUM(...)) pattern - minimal reproduction of TPC-DS Q57 issue
+/// This is the exact pattern that fails in Q57:
+/// AVG(SUM(cs_sales_price)) OVER (PARTITION BY ... ORDER BY ... ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING)
+#[test]
+fn test_window_function_avg_sum_nested() {
+    use vibesql_storage::Row;
+    let mut db = Database::new();
+
+    // Create sales table with categories and months
+    let schema = TableSchema::new(
+        "SALES".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new(
+                "CATEGORY".to_string(),
+                DataType::Varchar { max_length: Some(50) },
+                false,
+            ),
+            ColumnSchema::new("MONTH".to_string(), DataType::Integer, false),
+            ColumnSchema::new("AMOUNT".to_string(), DataType::Integer, false),
+        ],
+    );
+
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("SALES").unwrap();
+    // Category A, Month 1: sales 100, 200 = 300 total
+    table
+        .insert(Row::new(vec![
+            SqlValue::Integer(1),
+            SqlValue::Varchar("A".to_string()),
+            SqlValue::Integer(1),
+            SqlValue::Integer(100),
+        ]))
+        .unwrap();
+    table
+        .insert(Row::new(vec![
+            SqlValue::Integer(2),
+            SqlValue::Varchar("A".to_string()),
+            SqlValue::Integer(1),
+            SqlValue::Integer(200),
+        ]))
+        .unwrap();
+    // Category A, Month 2: sales 300 = 300 total
+    table
+        .insert(Row::new(vec![
+            SqlValue::Integer(3),
+            SqlValue::Varchar("A".to_string()),
+            SqlValue::Integer(2),
+            SqlValue::Integer(300),
+        ]))
+        .unwrap();
+    // Category A, Month 3: sales 400 = 400 total
+    table
+        .insert(Row::new(vec![
+            SqlValue::Integer(4),
+            SqlValue::Varchar("A".to_string()),
+            SqlValue::Integer(3),
+            SqlValue::Integer(400),
+        ]))
+        .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // Test AVG(SUM(amount)) - this is the Q57 pattern
+    let query = r#"
+        SELECT
+            category,
+            month,
+            SUM(amount) as total,
+            AVG(SUM(amount)) OVER (PARTITION BY category) as avg_monthly
+        FROM sales
+        GROUP BY category, month
+    "#;
+    let stmt = Parser::parse_sql(query).unwrap();
+
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute(&select_stmt);
+
+        assert!(result.is_ok(), "AVG(SUM()) should work: {:?}", result.err());
+
+        let rows = result.unwrap();
+        // 3 months for category A
+        assert_eq!(rows.len(), 3);
+
+        // Debug output
+        eprintln!("=== AVG(SUM()) test results ===");
+        for (i, row) in rows.iter().enumerate() {
+            eprintln!("Row {}: {:?}", i, row.values);
+        }
+
+        // Month 1: total=300
+        // Month 2: total=300
+        // Month 3: total=400
+        // AVG = (300 + 300 + 400) / 3 = 333.33...
+        for row in &rows {
+            // avg_monthly should be ~333.33 for all rows
+            if let SqlValue::Numeric(avg) = row.values[3] {
+                assert!(
+                    (avg - 333.333).abs() < 1.0,
+                    "Expected avg ~333.33, got {}",
+                    avg
+                );
+            } else {
+                panic!("Expected Numeric for avg_monthly, got {:?}", row.values[3]);
+            }
+        }
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+/// Test AVG(SUM(...)) with frame specification like Q57
+#[test]
+fn test_window_function_avg_sum_with_frame() {
+    use vibesql_storage::Row;
+    let mut db = Database::new();
+
+    // Create sales table with categories and months
+    let schema = TableSchema::new(
+        "SALES".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new(
+                "CATEGORY".to_string(),
+                DataType::Varchar { max_length: Some(50) },
+                false,
+            ),
+            ColumnSchema::new("MONTH".to_string(), DataType::Integer, false),
+            ColumnSchema::new("AMOUNT".to_string(), DataType::Integer, false),
+        ],
+    );
+
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("SALES").unwrap();
+    // 5 months of data for category A
+    for month in 1..=5 {
+        table
+            .insert(Row::new(vec![
+                SqlValue::Integer(month),
+                SqlValue::Varchar("A".to_string()),
+                SqlValue::Integer(month),
+                SqlValue::Integer(month * 100), // 100, 200, 300, 400, 500
+            ]))
+            .unwrap();
+    }
+
+    let executor = SelectExecutor::new(&db);
+
+    // Test AVG(SUM(amount)) with frame - exact Q57 pattern
+    let query = r#"
+        SELECT
+            category,
+            month,
+            SUM(amount) as total,
+            AVG(SUM(amount)) OVER (
+                PARTITION BY category
+                ORDER BY month
+                ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
+            ) as moving_avg
+        FROM sales
+        GROUP BY category, month
+        ORDER BY month
+    "#;
+    let stmt = Parser::parse_sql(query).unwrap();
+
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute(&select_stmt);
+
+        assert!(
+            result.is_ok(),
+            "AVG(SUM()) with frame should work: {:?}",
+            result.err()
+        );
+
+        let rows = result.unwrap();
+        assert_eq!(rows.len(), 5);
+
+        // Month 1: AVG(100, 200) = 150
+        // Month 2: AVG(100, 200, 300) = 200
+        // Month 3: AVG(200, 300, 400) = 300
+        // Month 4: AVG(300, 400, 500) = 400
+        // Month 5: AVG(400, 500) = 450
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes TPC-DS Q57 validation failure caused by window functions with nested aggregate patterns (AVG(SUM(...)) OVER (...))
- Window functions wrapping aggregates were not being evaluated after GROUP BY processing
- Adds new `window.rs` module to handle window function evaluation in aggregate context

## Test plan
- [x] Added unit tests for `AVG(SUM(...))` pattern
- [x] Added unit tests for `AVG(SUM(...))` with frame specification  
- [x] Verified TPC-DS Q57 benchmark passes with validation
- [x] Ran full executor test suite (1795 tests pass)

Closes #3654

🤖 Generated with [Claude Code](https://claude.com/claude-code)