### PR TITLE
fix(tpcds): Remove cartesian product bug from Q69 query

### DIFF
--- a/crates/vibesql-executor/benches/tpcds/queries.rs
+++ b/crates/vibesql-executor/benches/tpcds/queries.rs
@@ -2501,8 +2501,11 @@ ORDER BY i_category, i_class, i_brand, sumsales DESC
 LIMIT 100
 "#;
 
-// TPC-DS Q69: Customer analysis with address
-// Tests: NOT EXISTS, multiple subqueries
+// TPC-DS Q69: Customer analysis - store buyers who don't buy web
+// Tests: EXISTS, NOT EXISTS, correlated subqueries (store vs web sales)
+// This is a simplified version of official Q69 that tests EXISTS/NOT EXISTS pattern
+// without the third catalog_sales clause that causes memory explosion.
+// Full TPC-DS spec also uses customer_demographics with GROUP BY.
 pub const TPCDS_Q69: &str = r#"
 SELECT
     c_customer_id,
@@ -2512,10 +2515,9 @@ SELECT
     c_birth_country,
     c_login,
     c_email_address
-FROM customer c, customer_address ca, date_dim
+FROM customer c, customer_address ca
 WHERE c.c_current_addr_sk = ca.ca_address_sk
     AND ca_state IN ('KY', 'GA', 'NM')
-    AND d_year = 2000
     AND EXISTS (
         SELECT 1
         FROM store_sales, date_dim d2


### PR DESCRIPTION
## Summary

- Removed `date_dim` from outer FROM clause which was causing a cartesian product (missing join condition)
- Updated Q69 to properly test EXISTS/NOT EXISTS correlated subquery pattern
- Query now passes validation against DuckDB at SF=0.001 (returns 22 rows as expected)

The original Q69 had `date_dim` in the outer FROM with only a filter (`d_year = 2000`) but no join condition, multiplying the result by ~365 rows and causing incorrect results.

## Test plan

- [x] Run `VALIDATE=1 QUERY_FILTER=Q69 SCALE_FACTOR=0.001 ./target/release/deps/tpcds_runner-*` 
- [x] Verify Q69 returns 22 rows matching DuckDB expected count
- [x] Confirm query completes without MemoryLimitExceeded error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3655
