### PR TITLE
style(wal): Use is_some_and instead of map_or in checkpoint.rs

### DIFF
--- a/crates/vibesql-storage/src/wal/checkpoint.rs
+++ b/crates/vibesql-storage/src/wal/checkpoint.rs
@@ -258,7 +258,7 @@ impl CheckpointWriter {
         if let Ok(entries) = fs::read_dir(&self.checkpoint_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.extension().map_or(false, |ext| ext == "vchk") {
+                if path.extension().is_some_and(|ext| ext == "vchk") {
                     if let Ok(info) = Self::read_checkpoint_info(&path) {
                         checkpoints.push(info);
                     }


### PR DESCRIPTION
## Summary
- Replace `map_or(false, |ext| ext == "vchk")` with the more idiomatic `is_some_and(|ext| ext == "vchk")` as suggested by clippy

## Test plan
- [x] Code compiles
- [x] Verified clippy no longer produces the warning for this line

Closes #3697

🤖 Generated with [Claude Code](https://claude.com/claude-code)