### PR TITLE
perf(catalog): Optimize column_index_cache for case-insensitive lookups

### DIFF
--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -31,7 +31,7 @@ pub struct TableSchema {
 impl TableSchema {
     pub fn new(name: String, columns: Vec<ColumnSchema>) -> Self {
         let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+            columns.iter().enumerate().map(|(idx, col)| (col.name.to_lowercase(), idx)).collect();
 
         TableSchema {
             name,
@@ -52,7 +52,7 @@ impl TableSchema {
         primary_key: Vec<String>,
     ) -> Self {
         let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+            columns.iter().enumerate().map(|(idx, col)| (col.name.to_lowercase(), idx)).collect();
 
         TableSchema {
             name,
@@ -73,7 +73,7 @@ impl TableSchema {
         unique_constraints: Vec<Vec<String>>,
     ) -> Self {
         let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+            columns.iter().enumerate().map(|(idx, col)| (col.name.to_lowercase(), idx)).collect();
 
         TableSchema {
             name,
@@ -94,7 +94,7 @@ impl TableSchema {
         foreign_keys: Vec<ForeignKeyConstraint>,
     ) -> Self {
         let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+            columns.iter().enumerate().map(|(idx, col)| (col.name.to_lowercase(), idx)).collect();
 
         TableSchema {
             name,
@@ -116,7 +116,7 @@ impl TableSchema {
         unique_constraints: Vec<Vec<String>>,
     ) -> Self {
         let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+            columns.iter().enumerate().map(|(idx, col)| (col.name.to_lowercase(), idx)).collect();
 
         TableSchema {
             name,
@@ -140,7 +140,7 @@ impl TableSchema {
         foreign_keys: Vec<ForeignKeyConstraint>,
     ) -> Self {
         let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+            columns.iter().enumerate().map(|(idx, col)| (col.name.to_lowercase(), idx)).collect();
 
         TableSchema {
             name,
@@ -161,7 +161,7 @@ impl TableSchema {
         storage_format: StorageFormat,
     ) -> Self {
         let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+            columns.iter().enumerate().map(|(idx, col)| (col.name.to_lowercase(), idx)).collect();
 
         TableSchema {
             name,
@@ -186,34 +186,15 @@ impl TableSchema {
     }
 
     /// Get column by name.
-    /// Uses case-insensitive matching for column names.
+    /// Uses case-insensitive matching for column names via lowercase cache keys.
     pub fn get_column(&self, name: &str) -> Option<&ColumnSchema> {
-        // First try exact match for performance
-        if let Some(col) = self.columns.iter().find(|col| col.name == name) {
-            return Some(col);
-        }
-
-        // Fall back to case-insensitive search
-        let name_lower = name.to_lowercase();
-        self.columns.iter().find(|col| col.name.to_lowercase() == name_lower)
+        self.get_column_index(name).map(|idx| &self.columns[idx])
     }
 
     /// Get column index by name.
-    /// Uses case-insensitive matching for column names.
+    /// Uses case-insensitive matching for column names via lowercase cache keys.
     pub fn get_column_index(&self, name: &str) -> Option<usize> {
-        // First try exact match for performance
-        if let Some(idx) = self.column_index_cache.get(name) {
-            return Some(*idx);
-        }
-
-        // Fall back to case-insensitive search
-        let name_lower = name.to_lowercase();
-        for (i, col) in self.columns.iter().enumerate() {
-            if col.name.to_lowercase() == name_lower {
-                return Some(i);
-            }
-        }
-        None
+        self.column_index_cache.get(&name.to_lowercase()).copied()
     }
 
     /// Get number of columns.
@@ -248,8 +229,8 @@ impl TableSchema {
             return Err(crate::CatalogError::ColumnAlreadyExists(column.name));
         }
         let index = self.columns.len();
-        self.columns.push(column.clone());
-        self.column_index_cache.insert(column.name, index);
+        self.column_index_cache.insert(column.name.to_lowercase(), index);
+        self.columns.push(column);
         Ok(())
     }
 
@@ -266,7 +247,7 @@ impl TableSchema {
         // Rebuild the column index cache since indices have shifted
         self.column_index_cache.clear();
         for (idx, col) in self.columns.iter().enumerate() {
-            self.column_index_cache.insert(col.name.clone(), idx);
+            self.column_index_cache.insert(col.name.to_lowercase(), idx);
         }
 
         // Remove from primary key if present


### PR DESCRIPTION
## Summary

- Store lowercase keys in `column_index_cache` so case-insensitive lookups get O(1) hash lookups instead of O(n) linear search
- Simplify `get_column_index` to single cache lookup
- Simplify `get_column` to use `get_column_index`
- Update `add_column` and `remove_column` to use lowercase keys

## Impact

Queries with many column references will benefit from consistent O(1) lookups. Previously, non-exact-case column references (common in SQL where columns may be stored lowercase but queried uppercase from the parser) would always miss the cache and fall back to O(n) linear search.

## Test plan

- [x] All catalog tests pass (36 tests)
- [x] All executor tests pass (1793 tests)

Closes #3664

🤖 Generated with [Claude Code](https://claude.com/claude-code)