### PR TITLE
feat(http): Integrate HTTP API with shared DatabaseRegistry

### DIFF
--- a/crates/vibesql-server/src/http/crud.rs
+++ b/crates/vibesql-server/src/http/crud.rs
@@ -39,7 +39,7 @@ use std::collections::HashMap;
 
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
     Json,
 };
@@ -47,8 +47,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use tracing::{debug, error};
 
-use super::rest::HttpState;
+use super::rest::{get_database_name, HttpState};
 use super::types::*;
+use crate::registry::SharedDatabase;
 
 /// Query parameters for GET collection endpoint
 #[derive(Debug, Deserialize, Default)]
@@ -361,9 +362,10 @@ fn json_to_sql_literal(val: &JsonValue) -> String {
     }
 }
 
-/// Get the primary key column name for a table
-fn get_primary_key_column(state: &HttpState, table_name: &str) -> Option<String> {
-    let table = state.db.get_table(table_name)?;
+/// Get the primary key column name for a table using shared database
+async fn get_primary_key_column(shared_db: &SharedDatabase, table_name: &str) -> Option<String> {
+    let db = shared_db.read().await;
+    let table = db.get_table(table_name)?;
     let pk = table.schema.primary_key.as_ref()?;
     // For now, support single-column primary keys
     pk.first().cloned()
@@ -385,26 +387,37 @@ fn rows_to_json(columns: &[String], rows: &[Vec<JsonValue>]) -> Vec<HashMap<Stri
 /// GET /api/tables/:table/rows - List all rows with filtering, sorting, pagination
 pub async fn list_rows(
     State(state): State<HttpState>,
+    headers: HeaderMap,
     Path(table_name): Path<String>,
     Query(params): Query<CrudQueryParams>,
 ) -> impl IntoResponse {
     debug!("CRUD: GET /api/tables/{}/rows with params: {:?}", table_name, params);
 
+    // Get the database name from headers
+    let db_name = get_database_name(&headers);
+
+    // Get or create the shared database from the registry
+    let shared_db = state.registry.get_or_create(&db_name).await;
+
     // Check if table exists
-    let table_names = state.db.list_tables();
-    if !table_names.iter().any(|t| t.eq_ignore_ascii_case(&table_name)) {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({ "error": format!("Table '{}' not found", table_name) })),
-        )
-            .into_response();
+    {
+        let db = shared_db.read().await;
+        let table_names = db.list_tables();
+        if !table_names.iter().any(|t| t.eq_ignore_ascii_case(&table_name)) {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": format!("Table '{}' not found", table_name) })),
+            )
+                .into_response();
+        }
     }
 
     // Build and execute SQL
     let sql = build_select_sql(&table_name, &params);
     debug!("CRUD: Executing SQL: {}", sql);
 
-    let mut session = crate::session::Session::new_standalone("http".to_string(), "http_user".to_string());
+    let mut session =
+        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
 
     match session.execute(&sql).await {
         Ok(crate::session::ExecutionResult::Select { rows, columns }) => {
@@ -432,13 +445,20 @@ pub async fn list_rows(
 /// GET /api/tables/:table/rows/:id - Get a single row by primary key
 pub async fn get_row(
     State(state): State<HttpState>,
+    headers: HeaderMap,
     Path((table_name, id)): Path<(String, String)>,
     Query(params): Query<CrudQueryParams>,
 ) -> impl IntoResponse {
     debug!("CRUD: GET /api/tables/{}/rows/{}", table_name, id);
 
+    // Get the database name from headers
+    let db_name = get_database_name(&headers);
+
+    // Get or create the shared database from the registry
+    let shared_db = state.registry.get_or_create(&db_name).await;
+
     // Get primary key column
-    let pk_column = match get_primary_key_column(&state, &table_name) {
+    let pk_column = match get_primary_key_column(&shared_db, &table_name).await {
         Some(pk) => pk,
         None => {
             return (
@@ -456,7 +476,8 @@ pub async fn get_row(
     let sql = build_select_by_pk_sql(&table_name, &pk_column, &id, params.select.as_deref());
     debug!("CRUD: Executing SQL: {}", sql);
 
-    let mut session = crate::session::Session::new_standalone("http".to_string(), "http_user".to_string());
+    let mut session =
+        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
 
     match session.execute(&sql).await {
         Ok(crate::session::ExecutionResult::Select { rows, columns }) => {
@@ -492,6 +513,7 @@ pub async fn get_row(
 /// POST /api/tables/:table/rows - Create a new row
 pub async fn create_row(
     State(state): State<HttpState>,
+    headers: HeaderMap,
     Path(table_name): Path<String>,
     Json(body): Json<CreateRequest>,
 ) -> impl IntoResponse {
@@ -505,21 +527,31 @@ pub async fn create_row(
             .into_response();
     }
 
+    // Get the database name from headers
+    let db_name = get_database_name(&headers);
+
+    // Get or create the shared database from the registry
+    let shared_db = state.registry.get_or_create(&db_name).await;
+
     // Check if table exists
-    let table_names = state.db.list_tables();
-    if !table_names.iter().any(|t| t.eq_ignore_ascii_case(&table_name)) {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({ "error": format!("Table '{}' not found", table_name) })),
-        )
-            .into_response();
+    {
+        let db = shared_db.read().await;
+        let table_names = db.list_tables();
+        if !table_names.iter().any(|t| t.eq_ignore_ascii_case(&table_name)) {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": format!("Table '{}' not found", table_name) })),
+            )
+                .into_response();
+        }
     }
 
     // Build and execute SQL
     let sql = build_insert_sql(&table_name, &body.values);
     debug!("CRUD: Executing SQL: {}", sql);
 
-    let mut session = crate::session::Session::new_standalone("http".to_string(), "http_user".to_string());
+    let mut session =
+        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
 
     match session.execute(&sql).await {
         Ok(crate::session::ExecutionResult::Insert { rows_affected }) => {
@@ -541,6 +573,7 @@ pub async fn create_row(
 /// PUT /api/tables/:table/rows/:id - Full update (replace all columns)
 pub async fn update_row(
     State(state): State<HttpState>,
+    headers: HeaderMap,
     Path((table_name, id)): Path<(String, String)>,
     Json(body): Json<UpdateRequest>,
 ) -> impl IntoResponse {
@@ -554,8 +587,14 @@ pub async fn update_row(
             .into_response();
     }
 
+    // Get the database name from headers
+    let db_name = get_database_name(&headers);
+
+    // Get or create the shared database from the registry
+    let shared_db = state.registry.get_or_create(&db_name).await;
+
     // Get primary key column
-    let pk_column = match get_primary_key_column(&state, &table_name) {
+    let pk_column = match get_primary_key_column(&shared_db, &table_name).await {
         Some(pk) => pk,
         None => {
             return (
@@ -573,7 +612,8 @@ pub async fn update_row(
     let sql = build_update_sql(&table_name, &pk_column, &id, &body.values);
     debug!("CRUD: Executing SQL: {}", sql);
 
-    let mut session = crate::session::Session::new_standalone("http".to_string(), "http_user".to_string());
+    let mut session =
+        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
 
     match session.execute(&sql).await {
         Ok(crate::session::ExecutionResult::Update { rows_affected }) => {
@@ -603,6 +643,7 @@ pub async fn update_row(
 /// PATCH /api/tables/:table/rows/:id - Partial update (only specified columns)
 pub async fn patch_row(
     State(state): State<HttpState>,
+    headers: HeaderMap,
     Path((table_name, id)): Path<(String, String)>,
     Json(body): Json<PatchRequest>,
 ) -> impl IntoResponse {
@@ -616,8 +657,14 @@ pub async fn patch_row(
             .into_response();
     }
 
+    // Get the database name from headers
+    let db_name = get_database_name(&headers);
+
+    // Get or create the shared database from the registry
+    let shared_db = state.registry.get_or_create(&db_name).await;
+
     // Get primary key column
-    let pk_column = match get_primary_key_column(&state, &table_name) {
+    let pk_column = match get_primary_key_column(&shared_db, &table_name).await {
         Some(pk) => pk,
         None => {
             return (
@@ -635,7 +682,8 @@ pub async fn patch_row(
     let sql = build_update_sql(&table_name, &pk_column, &id, &body.values);
     debug!("CRUD: Executing SQL: {}", sql);
 
-    let mut session = crate::session::Session::new_standalone("http".to_string(), "http_user".to_string());
+    let mut session =
+        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
 
     match session.execute(&sql).await {
         Ok(crate::session::ExecutionResult::Update { rows_affected }) => {
@@ -665,12 +713,19 @@ pub async fn patch_row(
 /// DELETE /api/tables/:table/rows/:id - Delete a row
 pub async fn delete_row(
     State(state): State<HttpState>,
+    headers: HeaderMap,
     Path((table_name, id)): Path<(String, String)>,
 ) -> impl IntoResponse {
     debug!("CRUD: DELETE /api/tables/{}/rows/{}", table_name, id);
 
+    // Get the database name from headers
+    let db_name = get_database_name(&headers);
+
+    // Get or create the shared database from the registry
+    let shared_db = state.registry.get_or_create(&db_name).await;
+
     // Get primary key column
-    let pk_column = match get_primary_key_column(&state, &table_name) {
+    let pk_column = match get_primary_key_column(&shared_db, &table_name).await {
         Some(pk) => pk,
         None => {
             return (
@@ -688,7 +743,8 @@ pub async fn delete_row(
     let sql = build_delete_sql(&table_name, &pk_column, &id);
     debug!("CRUD: Executing SQL: {}", sql);
 
-    let mut session = crate::session::Session::new_standalone("http".to_string(), "http_user".to_string());
+    let mut session =
+        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
 
     match session.execute(&sql).await {
         Ok(crate::session::ExecutionResult::Delete { rows_affected }) => {

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{delete, get, patch, post, put},
     Json, Router,
@@ -18,6 +18,7 @@ use vibesql_storage::Database;
 
 use super::graphql;
 use super::types::*;
+use crate::registry::DatabaseRegistry;
 use crate::subscription::{SubscriptionManager, SubscriptionUpdate};
 
 /// Pagination configuration
@@ -43,19 +44,39 @@ impl PaginationParams {
     }
 }
 
+/// Default database name for HTTP API requests
+pub const DEFAULT_DATABASE_NAME: &str = "default";
+
+/// HTTP header for specifying the database name
+pub const DATABASE_HEADER: &str = "X-Database-Name";
+
 /// HTTP server state
 #[derive(Clone)]
 pub struct HttpState {
+    /// Database registry for shared database access
+    pub registry: DatabaseRegistry,
+    /// Legacy database reference for backwards compatibility (e.g., subscriptions, table listing)
     pub db: Arc<Database>,
+    /// Subscription manager for real-time updates
     pub subscription_manager: Arc<SubscriptionManager>,
 }
 
 /// Create the HTTP API router
+///
+/// # Arguments
+/// * `db` - Legacy database reference for backwards compatibility (subscriptions, table listing)
+/// * `registry` - Database registry for shared database access
+/// * `subscription_manager` - Subscription manager for real-time updates
 pub fn create_http_router(
     db: Arc<Database>,
+    registry: DatabaseRegistry,
     subscription_manager: Arc<SubscriptionManager>,
 ) -> Router {
-    let state = HttpState { db: db.clone(), subscription_manager: subscription_manager.clone() };
+    let state = HttpState {
+        registry: registry.clone(),
+        db: db.clone(),
+        subscription_manager: subscription_manager.clone(),
+    };
 
     // Create main router with state
     let main_router = Router::new()
@@ -77,25 +98,45 @@ pub fn create_http_router(
 
     // Create storage sub-router with its own state
     // We nest it after the main router is state-resolved
-    let storage_router = super::storage::create_storage_router(db);
+    let storage_router = super::storage::create_storage_router(db, registry);
 
     main_router.nest("/api/storage", storage_router)
+}
+
+/// Extract database name from request headers, falling back to default
+pub fn get_database_name(headers: &HeaderMap) -> String {
+    headers
+        .get(DATABASE_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| DEFAULT_DATABASE_NAME.to_string())
 }
 
 /// GraphQL endpoint handler with relationship resolution support
 async fn graphql_handler(
     State(state): State<HttpState>,
+    headers: HeaderMap,
     Json(req): Json<graphql::GraphQLRequest>,
 ) -> impl IntoResponse {
     debug!("Received GraphQL request: {}", req.query);
 
-    // First, try to handle introspection queries
-    if let Some(introspection_result) = graphql::try_introspection_query(&state.db, &req.query) {
-        return (
-            StatusCode::OK,
-            Json(graphql::GraphQLResponse { data: Some(introspection_result), errors: None }),
-        )
-            .into_response();
+    // Get the database name from headers
+    let db_name = get_database_name(&headers);
+
+    // Get or create the shared database from the registry
+    let shared_db = state.registry.get_or_create(&db_name).await;
+
+    // For introspection, we need a read lock on the database
+    {
+        let db_guard = shared_db.read().await;
+        let db_arc = std::sync::Arc::new((*db_guard).clone());
+        if let Some(introspection_result) = graphql::try_introspection_query(&db_arc, &req.query) {
+            return (
+                StatusCode::OK,
+                Json(graphql::GraphQLResponse { data: Some(introspection_result), errors: None }),
+            )
+                .into_response();
+        }
     }
 
     // Parse the GraphQL query
@@ -141,9 +182,9 @@ async fn graphql_handler(
 
     debug!("Generated SQL: {}", sql);
 
-    // Create a session and execute the query
+    // Create a session with the shared database
     let mut session =
-        crate::session::Session::new_standalone("graphql".to_string(), "graphql_user".to_string());
+        crate::session::Session::new(db_name.clone(), "graphql_user".to_string(), shared_db.clone());
 
     // Execute the main query
     let result = if params.is_empty() {
@@ -181,7 +222,9 @@ async fn graphql_handler(
                         } = &query_info
                         {
                             // Build schema map from database
-                            let schemas = build_schema_map(&state.db);
+                            let db_guard = shared_db.read().await;
+                            let schemas = build_schema_map(&db_guard);
+                            drop(db_guard);
 
                             if !schemas.is_empty() {
                                 let ctx = graphql::GraphQLExecutionContext::new(&schemas);
@@ -381,7 +424,8 @@ async fn health_check() -> impl IntoResponse {
 
 /// Execute a SQL query with optional pagination
 async fn execute_query(
-    State(_state): State<HttpState>,
+    State(state): State<HttpState>,
+    headers: HeaderMap,
     Json(req): Json<QueryRequest>,
 ) -> impl IntoResponse {
     debug!("Executing query: {} (limit: {:?}, offset: {:?})", req.sql, req.limit, req.offset);
@@ -399,9 +443,15 @@ async fn execute_query(
         }
     };
 
-    // Create a session for query execution
+    // Get the database name from headers
+    let db_name = get_database_name(&headers);
+
+    // Get or create the shared database from the registry
+    let shared_db = state.registry.get_or_create(&db_name).await;
+
+    // Create a session with the shared database
     let mut session =
-        crate::session::Session::new_standalone("http".to_string(), "http_user".to_string());
+        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
 
     // Execute the query
     let result = if params.is_empty() {
@@ -575,11 +625,18 @@ pub struct SseEvent {
 /// Returns a text/event-stream response with real-time updates
 async fn subscribe_stream(
     State(state): State<HttpState>,
+    headers: HeaderMap,
     Query(params): Query<SubscribeQuery>,
 ) -> axum::response::Response {
     use axum::response::sse::{Event, KeepAlive, Sse};
 
     debug!("SSE subscription requested for query: {}", params.query);
+
+    // Get the database name from headers
+    let db_name = get_database_name(&headers);
+
+    // Get or create the shared database from the registry
+    let shared_db = state.registry.get_or_create(&db_name).await;
 
     // Parse optional parameters
     let params_vec = if let Some(params_str) = params.params {
@@ -598,9 +655,9 @@ async fn subscribe_stream(
         vec![]
     };
 
-    // Execute initial query
+    // Execute initial query with the shared database
     let mut session =
-        crate::session::Session::new_standalone("http".to_string(), "http_user".to_string());
+        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
 
     // Execute the initial query
     let result = if params_vec.is_empty() {

--- a/crates/vibesql-server/src/http/storage.rs
+++ b/crates/vibesql-server/src/http/storage.rs
@@ -19,40 +19,45 @@ use tracing::{debug, error};
 use vibesql_storage::{BlobId, BlobStorageConfig, BlobStorageService, Database};
 
 use super::types::*;
+use crate::registry::DatabaseRegistry;
 
 /// State for storage endpoints
 #[derive(Clone)]
 pub struct StorageState {
+    /// Database registry for shared database access
+    pub registry: DatabaseRegistry,
+    /// Legacy database reference for backwards compatibility (blob storage)
     pub db: Arc<RwLock<Database>>,
+    /// Blob storage service
     pub blob_service: Arc<BlobStorageService>,
 }
 
 impl StorageState {
-    /// Create storage state from database
-    pub fn new(db: Arc<Database>) -> Self {
+    /// Create storage state from database and registry
+    pub fn new(db: Arc<Database>, registry: DatabaseRegistry) -> Self {
         // Create blob service with the database reference
         let blob_service = Arc::new(BlobStorageService::new_default(db.clone()));
         // Wrap Database in RwLock for safe concurrent access
         let db_inner = Arc::try_unwrap(db).unwrap_or_else(|arc| (*arc).clone());
         let db = Arc::new(RwLock::new(db_inner));
-        Self { db, blob_service }
+        Self { registry, db, blob_service }
     }
 
     /// Create storage state with custom config
     #[allow(dead_code)]
-    pub fn with_config(config: BlobStorageConfig, db: Arc<Database>) -> Self {
+    pub fn with_config(config: BlobStorageConfig, db: Arc<Database>, registry: DatabaseRegistry) -> Self {
         // Create blob service with the database reference
         let blob_service = Arc::new(BlobStorageService::new(config, db.clone()));
         // Wrap Database in RwLock for safe concurrent access
         let db_inner = Arc::try_unwrap(db).unwrap_or_else(|arc| (*arc).clone());
         let db = Arc::new(RwLock::new(db_inner));
-        Self { db, blob_service }
+        Self { registry, db, blob_service }
     }
 }
 
 /// Create the storage API router
-pub fn create_storage_router(db: Arc<Database>) -> Router {
-    let state = StorageState::new(db);
+pub fn create_storage_router(db: Arc<Database>, registry: DatabaseRegistry) -> Router {
+    let state = StorageState::new(db, registry);
 
     Router::new()
         .route("/upload", post(upload_blob))
@@ -250,11 +255,12 @@ mod tests {
 
     fn create_test_router() -> Router {
         let db = Arc::new(Database::new());
+        let registry = DatabaseRegistry::new();
         let config = BlobStorageConfig {
             backend: "memory".to_string(),
             config: serde_json::json!({}),
         };
-        let state = StorageState::with_config(config, db);
+        let state = StorageState::with_config(config, db, registry);
 
         Router::new()
             .route("/upload", post(upload_blob))

--- a/crates/vibesql-server/src/main.rs
+++ b/crates/vibesql-server/src/main.rs
@@ -128,9 +128,11 @@ async fn main() -> Result<()> {
             .expect("Invalid HTTP address");
         let db_for_http = Arc::clone(&db);
         let subscription_manager_for_http = Arc::clone(&subscription_manager);
+        // Share the database registry with the HTTP server
+        let registry_for_http = database_registry.clone();
 
         tokio::spawn(async move {
-            let app = create_http_router(db_for_http, subscription_manager_for_http);
+            let app = create_http_router(db_for_http, registry_for_http, subscription_manager_for_http);
             let listener = tokio::net::TcpListener::bind(&http_addr)
                 .await
                 .expect("Failed to bind HTTP server");


### PR DESCRIPTION
## Summary
- Integrate HTTP REST API with shared DatabaseRegistry from PR #3658
- HTTP handlers now use the same database instances as wire protocol connections
- Database name can be specified via `X-Database-Name` header (defaults to "default")

## Changes
- Updated `HttpState` to hold `DatabaseRegistry` reference
- All HTTP handlers (query, GraphQL, CRUD, subscriptions) now use the registry
- Storage handlers updated to accept registry parameter
- Removed `Session::new_standalone()` usage in HTTP handlers

## Test plan
- [x] All existing vibesql-server tests pass
- [x] Verified compilation succeeds without warnings
- [x] Existing `test_shared_database_across_sessions` verifies wire protocol sharing

Closes #3660

🤖 Generated with [Claude Code](https://claude.com/claude-code)