### PR TITLE
refactor(schema): Introduce TableKey newtype for type-safe case-insensitive table lookups

### DIFF
--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -197,7 +197,7 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
                         table_name: table_str
                             .map(|t| t.to_string())
                             .unwrap_or_else(|| "unknown".to_string()),
-                        searched_tables: self.schema.table_schemas.keys().cloned().collect(),
+                        searched_tables: self.schema.table_names(),
                         available_columns: self.get_available_columns(),
                     })
                 }

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -97,7 +97,7 @@ impl CombinedExpressionEvaluator<'_> {
 
                 // Column not found in either schema - collect diagnostic info
                 let searched_tables: Vec<String> =
-                    self.schema.table_schemas.keys().cloned().collect();
+                    self.schema.table_names();
                 let mut available_columns = Vec::new();
                 for (_start, schema) in self.schema.table_schemas.values() {
                     available_columns.extend(schema.columns.iter().map(|c| c.name.clone()));

--- a/crates/vibesql-executor/src/optimizer/where_pushdown/table_refs.rs
+++ b/crates/vibesql-executor/src/optimizer/where_pushdown/table_refs.rs
@@ -47,7 +47,7 @@ fn extract_tables_recursive_branch(
     match expr {
         vibesql_ast::Expression::ColumnRef { table: Some(table_name), .. } => {
             let normalized = table_name.to_lowercase();
-            if schema.table_schemas.contains_key(&normalized) {
+            if schema.contains_table(&normalized) {
                 tables.insert(normalized);
                 true
             } else {
@@ -62,7 +62,7 @@ fn extract_tables_recursive_branch(
             let mut found = false;
             for (table_name, (_start_idx, table_schema)) in &schema.table_schemas {
                 if table_schema.columns.iter().any(|col| col.name.to_lowercase() == column_lower) {
-                    tables.insert(table_name.clone());
+                    tables.insert(table_name.to_string());
                     found = true;
                 }
             }
@@ -186,7 +186,7 @@ fn extract_column_reference_branch(
         vibesql_ast::Expression::ColumnRef { table, column } => {
             if let Some(table_name) = table {
                 let normalized_table = table_name.to_lowercase();
-                if schema.table_schemas.contains_key(&normalized_table) {
+                if schema.contains_table(&normalized_table) {
                     return Some((normalized_table, column.to_lowercase()));
                 }
             }

--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -1,11 +1,109 @@
+use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+
+/// A normalized table/alias key for case-insensitive lookups.
+/// Always stored as lowercase, making case-insensitive handling impossible to get wrong.
+#[derive(Debug, Clone, Eq)]
+pub struct TableKey(String);
+
+impl TableKey {
+    /// Create a new TableKey, normalizing to lowercase.
+    #[inline]
+    pub fn new(name: impl AsRef<str>) -> Self {
+        TableKey(name.as_ref().to_lowercase())
+    }
+
+    /// Get the normalized key as a string slice.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the TableKey and return the inner String.
+    #[inline]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl PartialEq for TableKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Hash for TableKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl Deref for TableKey {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<str> for TableKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<str> for TableKey {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for TableKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for TableKey {
+    fn from(s: String) -> Self {
+        TableKey::new(s)
+    }
+}
+
+impl From<&str> for TableKey {
+    fn from(s: &str) -> Self {
+        TableKey::new(s)
+    }
+}
+
+impl From<TableKey> for String {
+    fn from(key: TableKey) -> Self {
+        key.0
+    }
+}
+
+impl From<&TableKey> for TableKey {
+    fn from(key: &TableKey) -> Self {
+        key.clone()
+    }
+}
+
+impl From<&String> for TableKey {
+    fn from(s: &String) -> Self {
+        TableKey::new(s)
+    }
+}
 
 /// Represents the combined schema from multiple tables (for JOINs)
 #[derive(Debug, Clone)]
 pub struct CombinedSchema {
-    /// Map from table name to (start_index, TableSchema)
+    /// Map from table name (normalized via TableKey) to (start_index, TableSchema)
     /// start_index is where this table's columns begin in the combined row
-    pub table_schemas: HashMap<String, (usize, vibesql_catalog::TableSchema)>,
+    /// Keys are always lowercase for case-insensitive lookups
+    pub table_schemas: HashMap<TableKey, (usize, vibesql_catalog::TableSchema)>,
     /// Total number of columns across all tables
     pub total_columns: usize,
 }
@@ -13,16 +111,18 @@ pub struct CombinedSchema {
 impl CombinedSchema {
     /// Create a new combined schema from a single table
     ///
-    /// Note: Table name is normalized to lowercase for case-insensitive lookups
+    /// Note: Table name is automatically normalized via TableKey for case-insensitive lookups
     pub fn from_table(table_name: String, schema: vibesql_catalog::TableSchema) -> Self {
         let total_columns = schema.columns.len();
         let mut table_schemas = HashMap::new();
-        // Use lowercase table name for consistent case-insensitive lookups
-        table_schemas.insert(table_name.to_lowercase(), (0, schema));
+        // TableKey automatically normalizes to lowercase
+        table_schemas.insert(TableKey::new(table_name), (0, schema));
         CombinedSchema { table_schemas, total_columns }
     }
 
     /// Create a new combined schema from a derived table (subquery result)
+    ///
+    /// Note: Alias is automatically normalized via TableKey for case-insensitive lookups
     pub fn from_derived_table(
         alias: String,
         column_names: Vec<String>,
@@ -44,22 +144,24 @@ impl CombinedSchema {
 
         let schema = vibesql_catalog::TableSchema::new(alias.clone(), columns);
         let mut table_schemas = HashMap::new();
-        // Use lowercase alias for consistent lookups
-        table_schemas.insert(alias.to_lowercase(), (0, schema));
+        // TableKey automatically normalizes to lowercase
+        table_schemas.insert(TableKey::new(alias), (0, schema));
         CombinedSchema { table_schemas, total_columns }
     }
 
     /// Combine two schemas (for JOIN operations)
+    ///
+    /// Note: Right table name is automatically normalized via TableKey for case-insensitive lookups
     pub fn combine(
         left: CombinedSchema,
-        right_table: String,
+        right_table: impl Into<TableKey>,
         right_schema: vibesql_catalog::TableSchema,
     ) -> Self {
         let mut table_schemas = left.table_schemas;
         let left_total = left.total_columns;
         let right_columns = right_schema.columns.len();
-        // Use lowercase table name for consistent lookups
-        table_schemas.insert(right_table.to_lowercase(), (left_total, right_schema));
+        // TableKey automatically normalizes to lowercase
+        table_schemas.insert(right_table.into(), (left_total, right_schema));
         CombinedSchema { table_schemas, total_columns: left_total + right_columns }
     }
 
@@ -68,17 +170,10 @@ impl CombinedSchema {
     pub fn get_column_index(&self, table: Option<&str>, column: &str) -> Option<usize> {
         if let Some(table_name) = table {
             // Qualified column reference (table.column)
-            // Try exact match first for performance
-            if let Some((start_index, schema)) = self.table_schemas.get(table_name) {
+            // TableKey normalizes to lowercase, so lookup is case-insensitive
+            let key = TableKey::new(table_name);
+            if let Some((start_index, schema)) = self.table_schemas.get(&key) {
                 return schema.get_column_index(column).map(|idx| start_index + idx);
-            }
-
-            // Fall back to case-insensitive table/alias name lookup
-            let table_name_lower = table_name.to_lowercase();
-            for (key, (start_index, schema)) in self.table_schemas.iter() {
-                if key.to_lowercase() == table_name_lower {
-                    return schema.get_column_index(column).map(|idx| start_index + idx);
-                }
             }
             None
         } else {
@@ -91,6 +186,31 @@ impl CombinedSchema {
             None
         }
     }
+
+    /// Get a table schema by name (case-insensitive lookup)
+    pub fn get_table(&self, table_name: &str) -> Option<&(usize, vibesql_catalog::TableSchema)> {
+        self.table_schemas.get(&TableKey::new(table_name))
+    }
+
+    /// Check if a table exists (case-insensitive lookup)
+    pub fn contains_table(&self, table_name: &str) -> bool {
+        self.table_schemas.contains_key(&TableKey::new(table_name))
+    }
+
+    /// Get all table names as strings
+    pub fn table_names(&self) -> Vec<String> {
+        self.table_schemas.keys().map(|k| k.to_string()).collect()
+    }
+
+    /// Insert or update a table in the schema
+    pub fn insert_table(
+        &mut self,
+        name: impl Into<TableKey>,
+        start_index: usize,
+        schema: vibesql_catalog::TableSchema,
+    ) {
+        self.table_schemas.insert(name.into(), (start_index, schema));
+    }
 }
 
 /// Builder for incrementally constructing a CombinedSchema
@@ -99,7 +219,7 @@ impl CombinedSchema {
 /// the column offset as tables are added.
 #[derive(Debug)]
 pub struct SchemaBuilder {
-    table_schemas: HashMap<String, (usize, vibesql_catalog::TableSchema)>,
+    table_schemas: HashMap<TableKey, (usize, vibesql_catalog::TableSchema)>,
     column_offset: usize,
 }
 
@@ -111,26 +231,21 @@ impl SchemaBuilder {
 
     /// Create a schema builder initialized with an existing CombinedSchema
     ///
-    /// Note: Table names are normalized to lowercase for case-insensitive lookups
+    /// Note: Table names are already normalized via TableKey
     pub fn from_schema(schema: CombinedSchema) -> Self {
         let column_offset = schema.total_columns;
-        // Normalize all table names to lowercase for case-insensitive lookups
-        let table_schemas = schema
-            .table_schemas
-            .into_iter()
-            .map(|(name, value)| (name.to_lowercase(), value))
-            .collect();
-        SchemaBuilder { table_schemas, column_offset }
+        // TableKeys are already normalized, just pass them through
+        SchemaBuilder { table_schemas: schema.table_schemas, column_offset }
     }
 
     /// Add a table to the schema
     ///
     /// This is an O(1) operation - columns are not copied, just indexed
-    /// Note: Table names are normalized to lowercase for case-insensitive lookups
-    pub fn add_table(&mut self, name: String, schema: vibesql_catalog::TableSchema) -> &mut Self {
+    /// Note: Table names are automatically normalized via TableKey for case-insensitive lookups
+    pub fn add_table(&mut self, name: impl Into<TableKey>, schema: vibesql_catalog::TableSchema) -> &mut Self {
         let num_columns = schema.columns.len();
-        // Use lowercase for consistent case-insensitive lookups
-        self.table_schemas.insert(name.to_lowercase(), (self.column_offset, schema));
+        // TableKey automatically normalizes to lowercase
+        self.table_schemas.insert(name.into(), (self.column_offset, schema));
         self.column_offset += num_columns;
         self
     }

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -188,12 +188,10 @@ impl SelectExecutor<'_> {
             vibesql_catalog::TableSchema::new("result".to_string(), result_columns);
 
         // Create a CombinedSchema for the result set
-        let mut table_schemas = std::collections::HashMap::new();
-        table_schemas.insert("result".to_string(), (0, result_table_schema.clone()));
-        let result_schema = crate::schema::CombinedSchema {
-            table_schemas,
-            total_columns: result_table_schema.columns.len(),
-        };
+        let result_schema = crate::schema::CombinedSchema::from_table(
+            "result".to_string(),
+            result_table_schema.clone(),
+        );
 
         let result_evaluator =
             CombinedExpressionEvaluator::with_database(&result_schema, self.database);

--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -395,7 +395,7 @@ impl SelectExecutor<'_> {
                             let column_expr = vibesql_ast::Expression::ColumnRef {
                                 table: if schema.table_schemas.len() > 1 {
                                     // Multiple tables: qualify the column
-                                    Some(table_name.clone())
+                                    Some(table_name.to_string())
                                 } else {
                                     // Single table: no need to qualify
                                     None
@@ -412,15 +412,8 @@ impl SelectExecutor<'_> {
                 }
                 vibesql_ast::SelectItem::QualifiedWildcard { qualifier, .. } => {
                     // Expand SELECT table.* to all columns from that specific table
-                    // Try exact match first
-                    let table_result = schema.table_schemas.get(qualifier).cloned().or_else(|| {
-                        // Fall back to case-insensitive lookup without allocation
-                        schema
-                            .table_schemas
-                            .iter()
-                            .find(|(key, _)| key.eq_ignore_ascii_case(qualifier))
-                            .map(|(_key, value)| value.clone())
-                    });
+                    // TableKey lookup is case-insensitive
+                    let table_result = schema.get_table(qualifier).cloned();
 
                     if let Some((_start_idx, table_schema)) = table_result {
                         for column in &table_schema.columns {

--- a/crates/vibesql-executor/src/select/executor/arena_execution.rs
+++ b/crates/vibesql-executor/src/select/executor/arena_execution.rs
@@ -247,9 +247,7 @@ impl SelectExecutor<'_> {
                 ArenaSelectItem::QualifiedWildcard { qualifier, .. } => {
                     // Qualified wildcard (table.*) - expand columns from specific table
                     let qualifier_str = interner.resolve(*qualifier);
-                    if let Some(&(start, ref tbl_schema)) =
-                        schema.table_schemas.get(&qualifier_str.to_lowercase())
-                    {
+                    if let Some(&(start, ref tbl_schema)) = schema.get_table(qualifier_str) {
                         for i in 0..tbl_schema.columns.len() {
                             if let Some(val) = row.get(start + i) {
                                 values.push(val.clone());

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -175,8 +175,8 @@ pub(super) fn build_combined_schema(
     let mut combined = CombinedSchema { table_schemas: HashMap::new(), total_columns: 0 };
 
     for (table_name, alias, _batch, schema) in batches {
-        let name = alias.as_ref().unwrap_or(table_name).to_lowercase();
-        combined.table_schemas.insert(name, (combined.total_columns, schema.clone()));
+        let name = alias.as_ref().unwrap_or(table_name);
+        combined.insert_table(name, combined.total_columns, schema.clone());
         combined.total_columns += schema.columns.len();
     }
 
@@ -190,8 +190,8 @@ pub(super) fn is_column_in_tables(column: &str, tables: &[&str], schema: &Combin
 
 /// Check if a column exists in a specific table
 pub(super) fn is_column_in_table(column: &str, table: &str, schema: &CombinedSchema) -> bool {
-    // Use lowercase for consistent table lookup
-    if let Some((_, table_schema)) = schema.table_schemas.get(&table.to_lowercase()) {
+    // TableKey lookup is case-insensitive
+    if let Some((_, table_schema)) = schema.get_table(table) {
         table_schema.columns.iter().any(|c| c.name.eq_ignore_ascii_case(column))
     } else {
         false

--- a/crates/vibesql-executor/src/select/executor/columns.rs
+++ b/crates/vibesql-executor/src/select/executor/columns.rs
@@ -55,17 +55,8 @@ impl SelectExecutor<'_> {
                     // ...)]
                     if let Some(from_res) = from_result {
                         // Find the table/alias in the schema
-                        // Try exact match first for performance
-                        let result =
-                            from_res.schema.table_schemas.get(qualifier).cloned().or_else(|| {
-                                // Fall back to case-insensitive lookup without allocation
-                                from_res
-                                    .schema
-                                    .table_schemas
-                                    .iter()
-                                    .find(|(key, _)| key.eq_ignore_ascii_case(qualifier))
-                                    .map(|(_, value)| value.clone())
-                            });
+                        // TableKey lookup is case-insensitive
+                        let result = from_res.schema.get_table(qualifier).cloned();
 
                         if let Some((_start_index, schema)) = result {
                             // Apply derived column list if present

--- a/crates/vibesql-executor/src/select/executor/fast_path.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path.rs
@@ -1267,7 +1267,7 @@ impl SelectExecutor<'_> {
                     return Err(ExecutorError::ColumnNotFound {
                         column_name: column.clone(),
                         table_name: table.clone().unwrap_or_else(|| "unknown".to_string()),
-                        searched_tables: schema.table_schemas.keys().cloned().collect(),
+                        searched_tables: schema.table_names(),
                         available_columns,
                     });
                 }
@@ -1313,7 +1313,7 @@ impl SelectExecutor<'_> {
                     .ok_or_else(|| ExecutorError::ColumnNotFound {
                         column_name: column.clone(),
                         table_name: table.clone().unwrap_or_default(),
-                        searched_tables: schema.table_schemas.keys().cloned().collect(),
+                        searched_tables: schema.table_names(),
                         available_columns: vec![],
                     })?,
                 _ => {

--- a/crates/vibesql-executor/src/select/executor/index_optimization/spatial.rs
+++ b/crates/vibesql-executor/src/select/executor/index_optimization/spatial.rs
@@ -176,7 +176,7 @@ fn find_table_for_column(
 ) -> Result<Option<String>, ExecutorError> {
     for (table, (_start_idx, table_schema)) in &schema.table_schemas {
         if table_schema.get_column_index(column_name).is_some() {
-            return Ok(Some(table.clone()));
+            return Ok(Some(table.to_string()));
         }
     }
     Ok(None)

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -301,7 +301,7 @@ fn validate_expression_column_refs(
             }
 
             // Column not found - build error with context
-            let mut searched_tables: Vec<String> = schema.table_schemas.keys().cloned().collect();
+            let mut searched_tables: Vec<String> = schema.table_names();
             let mut available_columns: Vec<String> = schema
                 .table_schemas
                 .values()
@@ -310,7 +310,7 @@ fn validate_expression_column_refs(
 
             // Include outer schema info in error message
             if let Some(outer) = outer_schema {
-                searched_tables.extend(outer.table_schemas.keys().cloned());
+                searched_tables.extend(outer.table_names());
                 available_columns.extend(
                     outer.table_schemas.values().flat_map(|(_, tbl_schema)| {
                         tbl_schema.columns.iter().map(|c| c.name.clone())

--- a/crates/vibesql-executor/src/select/executor/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/validation.rs
@@ -186,7 +186,7 @@ fn validate_column_ref(
         vec![table.clone()]
     } else {
         // If unqualified, list all tables that were searched
-        schema.table_schemas.keys().cloned().collect()
+        schema.table_names()
     };
 
     // Collect available columns for suggestions (from both schemas)
@@ -199,7 +199,7 @@ fn validate_column_ref(
     // Include outer schema tables and columns in error message
     if let Some(outer) = outer_schema {
         if col_ref.table.is_none() {
-            searched_tables.extend(outer.table_schemas.keys().cloned());
+            searched_tables.extend(outer.table_names());
         }
         available_columns.extend(
             outer
@@ -267,9 +267,9 @@ pub fn validate_select_columns_with_context(
 
                 if !table_in_inner && !table_in_outer {
                     let mut available_tables: Vec<String> =
-                        schema.table_schemas.keys().cloned().collect();
+                        schema.table_names();
                     if let Some(outer) = outer_schema {
-                        available_tables.extend(outer.table_schemas.keys().cloned());
+                        available_tables.extend(outer.table_names());
                     }
                     return Err(ExecutorError::InvalidTableQualifier {
                         qualifier: qualifier.clone(),

--- a/crates/vibesql-executor/src/select/filter/pattern.rs
+++ b/crates/vibesql-executor/src/select/filter/pattern.rs
@@ -325,10 +325,7 @@ mod tests {
 
         let schema = TableSchema::new("lineitem".to_string(), columns);
 
-        let mut table_schemas = HashMap::new();
-        table_schemas.insert("lineitem".to_string(), (0, schema));
-
-        CombinedSchema { table_schemas, total_columns: 3 }
+        CombinedSchema::from_table("lineitem".to_string(), schema)
     }
 
     #[test]

--- a/crates/vibesql-executor/src/select/iterator/join.rs
+++ b/crates/vibesql-executor/src/select/iterator/join.rs
@@ -113,10 +113,10 @@ impl<'schema, I: RowIterator> LazyNestedLoopJoin<'schema, I> {
         let mut right_total = 0;
 
         // Add all right-side tables with adjusted start indices
-        // Use lowercase for consistent case-insensitive lookups
-        for (table_name, (start_idx, schema)) in right_schema.table_schemas.iter() {
+        // TableKey already handles case normalization
+        for (table_key, (start_idx, schema)) in right_schema.table_schemas.iter() {
             let adjusted_start = left_total + start_idx;
-            table_schemas.insert(table_name.to_lowercase(), (adjusted_start, schema.clone()));
+            table_schemas.insert(table_key.clone(), (adjusted_start, schema.clone()));
             right_total += schema.columns.len();
         }
 

--- a/crates/vibesql-executor/src/select/join/hash_semi_join.rs
+++ b/crates/vibesql-executor/src/select/join/hash_semi_join.rs
@@ -324,10 +324,10 @@ pub(super) fn partition_filter_predicates(
     right_schema: &CombinedSchema,
 ) -> (Option<vibesql_ast::Expression>, Option<vibesql_ast::Expression>) {
     // Get the set of right-only table names
-    let right_table_names: HashSet<String> = right_schema.table_schemas.keys().cloned().collect();
+    let right_table_names: HashSet<String> = right_schema.table_names().into_iter().collect();
 
     // Get the set of left table names
-    let left_table_names: HashSet<String> = left_schema.table_schemas.keys().cloned().collect();
+    let left_table_names: HashSet<String> = left_schema.table_names().into_iter().collect();
 
     // Flatten the filter into individual conjuncts
     let conjuncts = flatten_conjuncts(filter);

--- a/crates/vibesql-executor/src/select/join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/mod.rs
@@ -1193,7 +1193,7 @@ fn remove_duplicate_columns_for_natural_join(
         for col in &table_schema.columns {
             let lowercase = col.name.to_lowercase();
             left_column_map.entry(lowercase).or_default().push((
-                table_name.clone(),
+                table_name.to_string(),
                 col.name.clone(),
                 col_idx,
             ));

--- a/crates/vibesql-executor/src/select/projection.rs
+++ b/crates/vibesql-executor/src/select/projection.rs
@@ -35,15 +35,8 @@ pub(crate) fn project_row_combined(
             }
             vibesql_ast::SelectItem::QualifiedWildcard { qualifier, .. } => {
                 // SELECT table.* or SELECT alias.* - include columns from specific table/alias
-                // Try exact match first for performance
-                let result = schema.table_schemas.get(qualifier).cloned().or_else(|| {
-                    // Fall back to case-insensitive lookup without allocation
-                    schema
-                        .table_schemas
-                        .iter()
-                        .find(|(key, _)| key.eq_ignore_ascii_case(qualifier))
-                        .map(|(_, value)| value.clone())
-                });
+                // TableKey lookup is case-insensitive
+                let result = schema.get_table(qualifier).cloned();
 
                 if let Some((start_index, table_schema)) = result {
                     let num_columns = table_schema.columns.len();

--- a/crates/vibesql-executor/src/select/scan/join_scan.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan.rs
@@ -158,10 +158,10 @@ where
             .map_err(ExecutorError::InvalidWhereClause)?;
 
         // Extract equijoin conditions that apply to this join
-        let left_schema_tables: std::collections::HashSet<_> =
-            left_result.schema.table_schemas.keys().cloned().collect();
-        let right_schema_tables: std::collections::HashSet<_> =
-            right_result.schema.table_schemas.keys().cloned().collect();
+        let left_schema_tables: std::collections::HashSet<String> =
+            left_result.schema.table_names().into_iter().collect();
+        let right_schema_tables: std::collections::HashSet<String> =
+            right_result.schema.table_names().into_iter().collect();
 
         predicate_plan
             .get_equijoin_conditions()
@@ -224,7 +224,7 @@ fn generate_natural_join_condition(
             left_columns
                 .entry(lowercase_name)
                 .or_default()
-                .push((table_name.clone(), col.name.clone()));
+                .push((table_name.to_string(), col.name.clone()));
         }
     }
 
@@ -239,7 +239,7 @@ fn generate_natural_join_condition(
                     common_columns.push((
                         left_table.clone(),
                         left_col.clone(),
-                        table_name.clone(),
+                        table_name.to_string(),
                         col.name.clone(),
                     ));
                 }

--- a/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
@@ -270,8 +270,7 @@ where
         }
 
         // Record the column count for this table (using table_schemas to get column info)
-        let col_count = if let Some((_, schema)) = table_result.schema.table_schemas.get(table_name)
-        {
+        let col_count = if let Some((_, schema)) = table_result.schema.get_table(table_name) {
             schema.columns.len()
         } else {
             table_result.schema.total_columns

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -130,30 +130,16 @@ pub(super) fn build_reordered_schema(
 
     // Walk through original order and rebuild schema with correct positions
     for table_name in original_order {
-        let table_lower = table_name.to_lowercase();
-
         // Find this table's schema in the current (optimally ordered) schema
-        // Try exact match first, then case-insensitive
+        // get_table handles case-insensitive lookups via TableKey
         let table_schema = current_schema
-            .table_schemas
-            .get(table_name)
-            .or_else(|| {
-                current_schema.table_schemas.iter().find_map(
-                    |(k, v): (&String, &(usize, vibesql_catalog::TableSchema))| {
-                        if k.to_lowercase() == table_lower {
-                            Some(v)
-                        } else {
-                            None
-                        }
-                    },
-                )
-            })
-            .map(|(_, schema): &(usize, vibesql_catalog::TableSchema)| schema.clone());
+            .get_table(table_name)
+            .map(|(_, schema)| schema.clone());
 
         if let Some(schema) = table_schema {
             let col_count = schema.columns.len();
-            // Use lowercase for consistent case-insensitive lookups
-            new_table_schemas.insert(table_name.to_lowercase(), (current_position, schema));
+            // TableKey handles case normalization automatically
+            new_table_schemas.insert(crate::schema::TableKey::new(table_name), (current_position, schema));
             current_position += col_count;
         }
     }


### PR DESCRIPTION
## Summary

Introduces a `TableKey` newtype that normalizes table/alias names to lowercase on construction, making case-insensitive handling impossible to get wrong at compile time.

- Defines `TableKey(String)` in schema.rs with automatic lowercase normalization
- Updates `CombinedSchema` and `SchemaBuilder` to use `HashMap<TableKey, ...>`
- Adds convenience methods: `get_table()`, `contains_table()`, `table_names()`, `insert_table()`
- Updates 21 files with call sites to use the new type-safe API
- Removes manual `.to_lowercase()` calls throughout the codebase

## Test plan

- [x] All unit tests pass (`cargo test --lib`)
- [x] Full test suite passes (`cargo test`)
- [x] Compilation succeeds (`cargo check`)

Closes #3663

🤖 Generated with [Claude Code](https://claude.com/claude-code)