### PR TITLE
feat(i18n): Add Portuguese translations (pt-BR)

### DIFF
--- a/crates/vibesql-l10n/resources/pt-BR/catalog.ftl
+++ b/crates/vibesql-l10n/resources/pt-BR/catalog.ftl
@@ -1,0 +1,117 @@
+# VibeSQL Mensagens de Erro do Catálogo - Português Brasileiro (pt-BR)
+# Este arquivo contém todas as mensagens de erro do crate vibesql-catalog.
+
+# =============================================================================
+# Erros de Tabela
+# =============================================================================
+
+catalog-table-already-exists = Tabela '{ $name }' já existe
+catalog-table-not-found = Tabela '{ $table_name }' não encontrada
+
+# =============================================================================
+# Erros de Coluna
+# =============================================================================
+
+catalog-column-already-exists = Coluna '{ $name }' já existe
+catalog-column-not-found = Coluna '{ $column_name }' não encontrada na tabela '{ $table_name }'
+
+# =============================================================================
+# Erros de Schema
+# =============================================================================
+
+catalog-schema-already-exists = Schema '{ $name }' já existe
+catalog-schema-not-found = Schema '{ $name }' não encontrado
+catalog-schema-not-empty = Schema '{ $name }' não está vazio
+
+# =============================================================================
+# Erros de Role
+# =============================================================================
+
+catalog-role-already-exists = Role '{ $name }' já existe
+catalog-role-not-found = Role '{ $name }' não encontrada
+
+# =============================================================================
+# Erros de Domain
+# =============================================================================
+
+catalog-domain-already-exists = Domain '{ $name }' já existe
+catalog-domain-not-found = Domain '{ $name }' não encontrado
+catalog-domain-in-use = Domain '{ $domain_name }' ainda está em uso por { $count } coluna(s): { $columns }
+
+# =============================================================================
+# Erros de Sequence
+# =============================================================================
+
+catalog-sequence-already-exists = Sequence '{ $name }' já existe
+catalog-sequence-not-found = Sequence '{ $name }' não encontrada
+catalog-sequence-in-use = Sequence '{ $sequence_name }' ainda está em uso por { $count } coluna(s): { $columns }
+
+# =============================================================================
+# Erros de Tipo
+# =============================================================================
+
+catalog-type-already-exists = Tipo '{ $name }' já existe
+catalog-type-not-found = Tipo '{ $name }' não encontrado
+catalog-type-in-use = Tipo '{ $name }' ainda está em uso por uma ou mais tabelas
+
+# =============================================================================
+# Erros de Collation e Character Set
+# =============================================================================
+
+catalog-collation-already-exists = Collation '{ $name }' já existe
+catalog-collation-not-found = Collation '{ $name }' não encontrada
+catalog-character-set-already-exists = Character set '{ $name }' já existe
+catalog-character-set-not-found = Character set '{ $name }' não encontrado
+catalog-translation-already-exists = Translation '{ $name }' já existe
+catalog-translation-not-found = Translation '{ $name }' não encontrada
+
+# =============================================================================
+# Erros de View
+# =============================================================================
+
+catalog-view-already-exists = View '{ $name }' já existe
+catalog-view-not-found = View '{ $name }' não encontrada
+catalog-view-in-use = View ou tabela '{ $view_name }' ainda está em uso por { $count } view(s): { $views }
+
+# =============================================================================
+# Erros de Trigger
+# =============================================================================
+
+catalog-trigger-already-exists = Trigger '{ $name }' já existe
+catalog-trigger-not-found = Trigger '{ $name }' não encontrado
+
+# =============================================================================
+# Erros de Assertion
+# =============================================================================
+
+catalog-assertion-already-exists = Assertion '{ $name }' já existe
+catalog-assertion-not-found = Assertion '{ $name }' não encontrada
+
+# =============================================================================
+# Erros de Function e Procedure
+# =============================================================================
+
+catalog-function-already-exists = Function '{ $name }' já existe
+catalog-function-not-found = Function '{ $name }' não encontrada
+catalog-procedure-already-exists = Procedure '{ $name }' já existe
+catalog-procedure-not-found = Procedure '{ $name }' não encontrada
+
+# =============================================================================
+# Erros de Constraint
+# =============================================================================
+
+catalog-constraint-already-exists = Constraint '{ $name }' já existe
+catalog-constraint-not-found = Constraint '{ $name }' não encontrada
+
+# =============================================================================
+# Erros de Índice
+# =============================================================================
+
+catalog-index-already-exists = Índice '{ $index_name }' na tabela '{ $table_name }' já existe
+catalog-index-not-found = Índice '{ $index_name }' na tabela '{ $table_name }' não encontrado
+
+# =============================================================================
+# Erros de Foreign Key
+# =============================================================================
+
+catalog-circular-foreign-key = Dependência circular de foreign key detectada para tabela '{ $table_name }': { $message }

--- a/crates/vibesql-l10n/resources/pt-BR/cli.ftl
+++ b/crates/vibesql-l10n/resources/pt-BR/cli.ftl
@@ -1,0 +1,210 @@
+# VibeSQL CLI Localização - Português Brasileiro (pt-BR)
+# Este arquivo contém todas as strings visíveis ao usuário da interface de linha de comando.
+
+# =============================================================================
+# Banner do REPL e Mensagens Básicas
+# =============================================================================
+
+cli-banner = VibeSQL v{ $version } - Banco de Dados com Conformidade COMPLETA ao SQL:1999
+cli-help-hint = Digite \help para ajuda, \quit para sair
+cli-goodbye = Até logo!
+
+# =============================================================================
+# Texto de Ajuda dos Comandos (Argumentos Clap)
+# =============================================================================
+
+cli-about = VibeSQL - Banco de Dados com Conformidade COMPLETA ao SQL:1999
+
+cli-long-about = Interface de linha de comando do VibeSQL
+
+    MODOS DE USO:
+      REPL Interativo:       vibesql (--database <ARQUIVO>)
+      Executar Comando:      vibesql -c "SELECT * FROM usuarios"
+      Executar Arquivo:      vibesql -f script.sql
+      Executar via stdin:    cat dados.sql | vibesql
+      Gerar Tipos:           vibesql codegen --schema schema.sql --output types.ts
+
+    REPL INTERATIVO:
+      Quando iniciado sem -c, -f ou entrada por pipe, o VibeSQL entra em um REPL
+      interativo com suporte a readline, histórico de comandos e meta-comandos como:
+        \d (tabela)  - Descrever tabela ou listar todas as tabelas
+        \dt          - Listar tabelas
+        \f <formato> - Definir formato de saída
+        \copy        - Importar/exportar CSV/JSON
+        \help        - Mostrar todos os comandos do REPL
+
+    SUBCOMANDOS:
+      codegen           Gerar tipos TypeScript a partir do esquema do banco de dados
+
+    CONFIGURAÇÃO:
+      As configurações podem ser definidas em ~/.vibesqlrc (formato TOML).
+      Seções: display, database, history, query
+
+    EXEMPLOS:
+      # Iniciar REPL interativo com banco de dados em memória
+      vibesql
+
+      # Usar arquivo de banco de dados persistente
+      vibesql --database meusdados.db
+
+      # Executar um único comando
+      vibesql -c "CREATE TABLE usuarios (id INT, nome VARCHAR(100))"
+
+      # Executar arquivo de script SQL
+      vibesql -f schema.sql -v
+
+      # Importar dados de CSV
+      echo "\copy usuarios FROM 'dados.csv'" | vibesql --database meusdados.db
+
+      # Exportar resultados da consulta como JSON
+      vibesql -d meusdados.db -c "SELECT * FROM usuarios" --format json
+
+      # Gerar tipos TypeScript a partir de um arquivo de esquema
+      vibesql codegen --schema schema.sql --output src/types.ts
+
+      # Gerar tipos TypeScript a partir de um banco de dados em execução
+      vibesql codegen --database meusdados.db --output src/types.ts
+
+# Strings de ajuda dos argumentos
+arg-database-help = Caminho do arquivo de banco de dados (se não especificado, usa banco de dados em memória)
+arg-file-help = Executar comandos SQL de um arquivo
+arg-command-help = Executar comando SQL diretamente e sair
+arg-stdin-help = Ler comandos SQL do stdin (detectado automaticamente quando usado pipe)
+arg-verbose-help = Mostrar saída detalhada durante a execução de arquivo/stdin
+arg-format-help = Formato de saída para resultados de consultas
+arg-lang-help = Definir o idioma de exibição (ex., en-US, es, pt-BR)
+
+# =============================================================================
+# Subcomando Codegen
+# =============================================================================
+
+codegen-about = Gerar tipos TypeScript a partir do esquema do banco de dados
+
+codegen-long-about = Gerar definições de tipos TypeScript a partir de um esquema de banco de dados VibeSQL.
+
+    Este comando cria interfaces TypeScript para todas as tabelas no banco de dados,
+    junto com objetos de metadados para verificação de tipos em tempo de execução e suporte a IDE.
+
+    FONTES DE ENTRADA:
+      --database <ARQUIVO>  Gerar a partir de um arquivo de banco de dados existente
+      --schema <ARQUIVO>    Gerar a partir de um arquivo de esquema SQL (instruções CREATE TABLE)
+
+    SAÍDA:
+      --output <ARQUIVO>    Gravar tipos gerados neste arquivo (padrão: types.ts)
+
+    OPÇÕES:
+      --camel-case          Converter nomes de colunas para camelCase
+      --no-metadata         Ignorar geração do objeto de metadados das tabelas
+
+    EXEMPLOS:
+      # A partir de um arquivo de banco de dados
+      vibesql codegen --database meusdados.db --output src/db/types.ts
+
+      # A partir de um arquivo de esquema SQL
+      vibesql codegen --schema schema.sql --output src/db/types.ts
+
+      # Com nomes de propriedades em camelCase
+      vibesql codegen --schema schema.sql --output types.ts --camel-case
+
+codegen-schema-help = Arquivo de esquema SQL contendo instruções CREATE TABLE
+codegen-output-help = Caminho do arquivo de saída para TypeScript gerado
+codegen-camel-case-help = Converter nomes de colunas para camelCase
+codegen-no-metadata-help = Ignorar geração do objeto de metadados das tabelas
+
+codegen-from-schema = Gerando tipos TypeScript a partir do arquivo de esquema: { $path }
+codegen-from-database = Gerando tipos TypeScript a partir do banco de dados: { $path }
+codegen-written = Tipos TypeScript gravados em: { $path }
+codegen-error-no-source = É necessário especificar --database ou --schema.
+    Use 'vibesql codegen --help' para informações de uso.
+
+# =============================================================================
+# Ajuda dos Meta-comandos (saída do \help)
+# =============================================================================
+
+help-title = Meta-comandos:
+help-describe = \d (tabela)     - Descrever tabela ou listar todas as tabelas
+help-tables = \dt             - Listar tabelas
+help-schemas = \ds             - Listar esquemas
+help-indexes = \di             - Listar índices
+help-roles = \du             - Listar roles/usuários
+help-format = \f <formato>    - Definir formato de saída (table, json, csv, markdown, html)
+help-timing = \timing         - Alternar tempo de consulta
+help-copy-to = \copy <tabela> TO <arquivo>   - Exportar tabela para arquivo CSV/JSON
+help-copy-from = \copy <tabela> FROM <arquivo> - Importar arquivo CSV para tabela
+help-save = \save (arquivo) - Salvar banco de dados em arquivo de dump SQL
+help-errors = \errors         - Mostrar histórico de erros recentes
+help-help = \h, \help      - Mostrar esta ajuda
+help-quit = \q, \quit      - Sair
+
+help-sql-title = Introspecção SQL:
+help-show-tables = SHOW TABLES                  - Listar todas as tabelas
+help-show-databases = SHOW DATABASES               - Listar todos os esquemas/bancos de dados
+help-show-columns = SHOW COLUMNS FROM <tabela>   - Mostrar colunas da tabela
+help-show-index = SHOW INDEX FROM <tabela>     - Mostrar índices da tabela
+help-show-create = SHOW CREATE TABLE <tabela>   - Mostrar instrução CREATE TABLE
+help-describe-sql = DESCRIBE <tabela>            - Alias para SHOW COLUMNS
+
+help-examples-title = Exemplos:
+help-example-create = CREATE TABLE usuarios (id INT PRIMARY KEY, nome VARCHAR(100));
+help-example-insert = INSERT INTO usuarios VALUES (1, 'Alice'), (2, 'Roberto');
+help-example-select = SELECT * FROM usuarios;
+help-example-show-tables = SHOW TABLES;
+help-example-show-columns = SHOW COLUMNS FROM usuarios;
+help-example-describe = DESCRIBE usuarios;
+help-example-format-json = \f json
+help-example-format-md = \f markdown
+help-example-copy-to = \copy usuarios TO '/tmp/usuarios.csv'
+help-example-copy-from = \copy usuarios FROM '/tmp/usuarios.csv'
+help-example-copy-json = \copy usuarios TO '/tmp/usuarios.json'
+help-example-errors = \errors
+
+# =============================================================================
+# Mensagens de Status
+# =============================================================================
+
+format-changed = Formato de saída definido para: { $format }
+database-saved = Banco de dados salvo em: { $path }
+no-database-file = Erro: Nenhum arquivo de banco de dados especificado. Use \save <nome_arquivo> ou inicie com a flag --database
+
+# =============================================================================
+# Exibição de Erros
+# =============================================================================
+
+no-errors = Nenhum erro nesta sessão.
+recent-errors = Erros recentes:
+
+# =============================================================================
+# Mensagens de Execução de Script
+# =============================================================================
+
+script-no-statements = Nenhuma instrução SQL encontrada no script
+script-executing = Executando instrução { $current } de { $total }...
+script-error = Erro ao executar instrução { $index }: { $error }
+script-summary-title = === Resumo da Execução do Script ===
+script-total = Total de instruções: { $count }
+script-successful = Bem-sucedidas: { $count }
+script-failed = Falhas: { $count }
+script-failed-error = { $count } instruções falharam
+
+# =============================================================================
+# Formatação de Saída
+# =============================================================================
+
+rows-with-time = { $count } linhas no conjunto ({ $time }s)
+rows-count = { $count } linhas
+
+# =============================================================================
+# Avisos
+# =============================================================================
+
+warning-config-load = Aviso: Não foi possível carregar o arquivo de configuração: { $error }
+warning-auto-save-failed = Aviso: Falha ao salvar automaticamente o banco de dados: { $error }
+warning-save-on-exit-failed = Aviso: Falha ao salvar o banco de dados ao sair: { $error }
+
+# =============================================================================
+# Operações de Arquivo
+# =============================================================================
+
+file-read-error = Falha ao ler arquivo '{ $path }': { $error }
+stdin-read-error = Falha ao ler do stdin: { $error }
+database-load-error = Falha ao carregar banco de dados: { $error }

--- a/crates/vibesql-l10n/resources/pt-BR/executor.ftl
+++ b/crates/vibesql-l10n/resources/pt-BR/executor.ftl
@@ -1,0 +1,187 @@
+# VibeSQL Mensagens de Erro do Executor - Português Brasileiro (pt-BR)
+# Este arquivo contém todas as mensagens de erro do crate vibesql-executor.
+
+# =============================================================================
+# Erros de Tabela
+# =============================================================================
+
+executor-table-not-found = Tabela '{ $name }' não encontrada
+executor-table-already-exists = Tabela '{ $name }' já existe
+
+# =============================================================================
+# Erros de Coluna
+# =============================================================================
+
+executor-column-not-found-simple = Coluna '{ $column_name }' não encontrada na tabela '{ $table_name }'
+executor-column-not-found-searched = Coluna '{ $column_name }' não encontrada (tabelas pesquisadas: { $searched_tables })
+executor-column-not-found-with-available = Coluna '{ $column_name }' não encontrada (tabelas pesquisadas: { $searched_tables }). Colunas disponíveis: { $available_columns }
+executor-invalid-table-qualifier = Qualificador de tabela '{ $qualifier }' inválido para coluna '{ $column }'. Tabelas disponíveis: { $available_tables }
+executor-column-already-exists = Coluna '{ $name }' já existe
+executor-column-index-out-of-bounds = Índice de coluna { $index } fora dos limites
+
+# =============================================================================
+# Erros de Índice
+# =============================================================================
+
+executor-index-not-found = Índice '{ $name }' não encontrado
+executor-index-already-exists = Índice '{ $name }' já existe
+executor-invalid-index-definition = Definição de índice inválida: { $message }
+
+# =============================================================================
+# Erros de Trigger
+# =============================================================================
+
+executor-trigger-not-found = Trigger '{ $name }' não encontrado
+executor-trigger-already-exists = Trigger '{ $name }' já existe
+
+# =============================================================================
+# Erros de Schema
+# =============================================================================
+
+executor-schema-not-found = Schema '{ $name }' não encontrado
+executor-schema-already-exists = Schema '{ $name }' já existe
+executor-schema-not-empty = Não é possível remover o schema '{ $name }': schema não está vazio
+
+# =============================================================================
+# Erros de Role e Permissão
+# =============================================================================
+
+executor-role-not-found = Role '{ $name }' não encontrada
+executor-permission-denied = Permissão negada: role '{ $role }' não possui privilégio { $privilege } em { $object }
+executor-dependent-privileges-exist = Privilégios dependentes existem: { $message }
+
+# =============================================================================
+# Erros de Tipo
+# =============================================================================
+
+executor-type-not-found = Tipo '{ $name }' não encontrado
+executor-type-already-exists = Tipo '{ $name }' já existe
+executor-type-in-use = Não é possível remover o tipo '{ $name }': tipo ainda está em uso
+executor-type-mismatch = Incompatibilidade de tipos: { $left } { $op } { $right }
+executor-type-error = Erro de tipo: { $message }
+executor-cast-error = Não é possível converter { $from_type } para { $to_type }
+executor-type-conversion-error = Não é possível converter { $from } para { $to }
+
+# =============================================================================
+# Erros de Expressão e Consulta
+# =============================================================================
+
+executor-division-by-zero = Divisão por zero
+executor-invalid-where-clause = Cláusula WHERE inválida: { $message }
+executor-unsupported-expression = Expressão não suportada: { $message }
+executor-unsupported-feature = Recurso não suportado: { $message }
+executor-parse-error = Erro de análise: { $message }
+
+# =============================================================================
+# Erros de Subconsulta
+# =============================================================================
+
+executor-subquery-returned-multiple-rows = Subconsulta escalar retornou { $actual } linhas, esperada { $expected }
+executor-subquery-column-count-mismatch = Subconsulta retornou { $actual } colunas, esperadas { $expected }
+executor-column-count-mismatch = Lista de colunas derivadas possui { $provided } colunas, mas a consulta produz { $expected } colunas
+
+# =============================================================================
+# Erros de Restrição
+# =============================================================================
+
+executor-constraint-violation = Violação de restrição: { $message }
+executor-multiple-primary-keys = Múltiplas restrições PRIMARY KEY não são permitidas
+executor-cannot-drop-column = Não é possível remover coluna: { $message }
+executor-constraint-not-found = Restrição '{ $constraint_name }' não encontrada na tabela '{ $table_name }'
+
+# =============================================================================
+# Erros de Limite de Recursos
+# =============================================================================
+
+executor-expression-depth-exceeded = Limite de profundidade de expressão excedido: { $depth } > { $max_depth } (previne estouro de pilha)
+executor-query-timeout-exceeded = Tempo limite da consulta excedido: { $elapsed_seconds }s > { $max_seconds }s
+executor-row-limit-exceeded = Limite de processamento de linhas excedido: { $rows_processed } > { $max_rows }
+executor-memory-limit-exceeded = Limite de memória excedido: { $used_gb } GB > { $max_gb } GB
+
+# =============================================================================
+# Erros de Procedimento/Variável
+# =============================================================================
+
+executor-variable-not-found-simple = Variável '{ $variable_name }' não encontrada
+executor-variable-not-found-with-available = Variável '{ $variable_name }' não encontrada. Variáveis disponíveis: { $available_variables }
+executor-label-not-found = Rótulo '{ $name }' não encontrado
+
+# =============================================================================
+# Erros de SELECT INTO
+# =============================================================================
+
+executor-select-into-row-count = SELECT INTO procedural deve retornar exatamente { $expected } linha, obtidas { $actual } linha{ $plural }
+executor-select-into-column-count = Incompatibilidade de contagem de colunas no SELECT INTO procedural: { $expected } variável{ $expected_plural } mas a consulta retornou { $actual } coluna{ $actual_plural }
+
+# =============================================================================
+# Erros de Procedure e Function
+# =============================================================================
+
+executor-procedure-not-found-simple = Procedure '{ $procedure_name }' não encontrada no schema '{ $schema_name }'
+executor-procedure-not-found-with-available = Procedure '{ $procedure_name }' não encontrada no schema '{ $schema_name }'
+    .available = Procedures disponíveis: { $available_procedures }
+executor-procedure-not-found-with-suggestion = Procedure '{ $procedure_name }' não encontrada no schema '{ $schema_name }'
+    .available = Procedures disponíveis: { $available_procedures }
+    .suggestion = Você quis dizer '{ $suggestion }'?
+
+executor-function-not-found-simple = Function '{ $function_name }' não encontrada no schema '{ $schema_name }'
+executor-function-not-found-with-available = Function '{ $function_name }' não encontrada no schema '{ $schema_name }'
+    .available = Functions disponíveis: { $available_functions }
+executor-function-not-found-with-suggestion = Function '{ $function_name }' não encontrada no schema '{ $schema_name }'
+    .available = Functions disponíveis: { $available_functions }
+    .suggestion = Você quis dizer '{ $suggestion }'?
+
+executor-parameter-count-mismatch = { $routine_type } '{ $routine_name }' espera { $expected } parâmetro{ $expected_plural } ({ $parameter_signature }), recebidos { $actual } argumento{ $actual_plural }
+executor-parameter-type-mismatch = Parâmetro '{ $parameter_name }' espera { $expected_type }, recebido { $actual_type } '{ $actual_value }'
+executor-argument-count-mismatch = Incompatibilidade na contagem de argumentos: esperados { $expected }, recebidos { $actual }
+
+executor-recursion-limit-exceeded = Profundidade máxima de recursão ({ $max_depth }) excedida: { $message }
+executor-recursion-call-stack = Pilha de chamadas:
+executor-function-must-return = Function deve retornar um valor
+executor-invalid-control-flow = Fluxo de controle inválido: { $message }
+executor-invalid-function-body = Corpo de function inválido: { $message }
+executor-function-read-only-violation = Violação de somente leitura da function: { $message }
+
+# =============================================================================
+# Erros de EXTRACT
+# =============================================================================
+
+executor-invalid-extract-field = Não é possível extrair { $field } de valor do tipo { $value_type }
+
+# =============================================================================
+# Erros Columnar/Arrow
+# =============================================================================
+
+executor-arrow-downcast-error = Falha ao fazer downcast do array Arrow para { $expected_type } ({ $context })
+executor-columnar-type-mismatch-binary = Tipos incompatíveis para { $operation }: { $left_type } vs { $right_type }
+executor-columnar-type-mismatch-unary = Tipo incompatível para { $operation }: { $left_type }
+executor-simd-operation-failed = Operação SIMD { $operation } falhou: { $reason }
+executor-columnar-column-not-found = Índice de coluna { $column_index } fora dos limites (lote tem { $batch_columns } colunas)
+executor-columnar-column-not-found-by-name = Coluna não encontrada: { $column_name }
+executor-columnar-length-mismatch = Incompatibilidade de comprimento de coluna em { $context }: esperado { $expected }, obtido { $actual }
+executor-unsupported-array-type = Tipo de array não suportado para { $operation }: { $array_type }
+
+# =============================================================================
+# Erros Espaciais
+# =============================================================================
+
+executor-spatial-geometry-error = { $function_name }: { $message }
+executor-spatial-operation-failed = { $function_name }: { $message }
+executor-spatial-argument-error = { $function_name } espera { $expected }, recebido { $actual }
+
+# =============================================================================
+# Erros de Cursor
+# =============================================================================
+
+executor-cursor-already-exists = Cursor '{ $name }' já existe
+executor-cursor-not-found = Cursor '{ $name }' não encontrado
+executor-cursor-already-open = Cursor '{ $name }' já está aberto
+executor-cursor-not-open = Cursor '{ $name }' não está aberto
+executor-cursor-not-scrollable = Cursor '{ $name }' não é rolável (SCROLL não especificado)
+
+# =============================================================================
+# Erros de Storage e Gerais
+# =============================================================================
+
+executor-storage-error = Erro de armazenamento: { $message }
+executor-other = { $message }

--- a/crates/vibesql-l10n/resources/pt-BR/parser.ftl
+++ b/crates/vibesql-l10n/resources/pt-BR/parser.ftl
@@ -1,0 +1,55 @@
+# VibeSQL Parser/Lexer Localização - Português Brasileiro (pt-BR)
+# Este arquivo contém todas as strings visíveis ao usuário de erros do lexer e parser.
+
+# =============================================================================
+# Cabeçalho de Erro do Lexer
+# =============================================================================
+
+lexer-error-at-position = Erro do lexer na posição { $position }: { $message }
+
+# =============================================================================
+# Erros de Literais de String
+# =============================================================================
+
+lexer-unterminated-string = Literal de string não terminado
+
+# =============================================================================
+# Erros de Identificadores
+# =============================================================================
+
+lexer-unterminated-delimited-identifier = Identificador delimitado não terminado
+lexer-empty-delimited-identifier = Identificador delimitado vazio não é permitido
+
+# =============================================================================
+# Erros de Literais Numéricos
+# =============================================================================
+
+lexer-invalid-scientific-notation = Notação científica inválida: esperados dígitos após 'E'
+
+# =============================================================================
+# Erros de Marcadores de Posição
+# =============================================================================
+
+lexer-expected-digit-after-dollar = Esperado dígito após '$' para marcador de posição numerado
+lexer-invalid-numbered-placeholder = Marcador de posição numerado inválido: ${ $placeholder }
+lexer-numbered-placeholder-zero = Marcador de posição numerado deve ser $1 ou superior (não $0)
+lexer-expected-identifier-after-colon = Esperado identificador após ':' para marcador de posição nomeado
+
+# =============================================================================
+# Erros de Variáveis
+# =============================================================================
+
+lexer-expected-variable-after-at-at = Esperado nome de variável após @@
+lexer-expected-variable-after-at = Esperado nome de variável após @
+
+# =============================================================================
+# Erros de Operadores
+# =============================================================================
+
+lexer-unexpected-pipe = Caractere inesperado: '|' (você quis dizer '||'?)
+
+# =============================================================================
+# Erros Gerais
+# =============================================================================
+
+lexer-unexpected-character = Caractere inesperado: '{ $character }'

--- a/crates/vibesql-l10n/resources/pt-BR/storage.ftl
+++ b/crates/vibesql-l10n/resources/pt-BR/storage.ftl
@@ -1,0 +1,68 @@
+# VibeSQL Mensagens de Erro de Storage - Português Brasileiro (pt-BR)
+# Este arquivo contém todas as mensagens de erro do crate vibesql-storage.
+
+# =============================================================================
+# Erros de Tabela
+# =============================================================================
+
+storage-table-not-found = Tabela '{ $name }' não encontrada
+
+# =============================================================================
+# Erros de Coluna
+# =============================================================================
+
+storage-column-count-mismatch = Incompatibilidade na contagem de colunas: esperadas { $expected }, obtidas { $actual }
+storage-column-index-out-of-bounds = Índice de coluna { $index } fora dos limites
+storage-column-not-found = Coluna '{ $column_name }' não encontrada na tabela '{ $table_name }'
+
+# =============================================================================
+# Erros de Índice
+# =============================================================================
+
+storage-index-already-exists = Índice '{ $name }' já existe
+storage-index-not-found = Índice '{ $name }' não encontrado
+storage-invalid-index-column = { $message }
+
+# =============================================================================
+# Erros de Restrição
+# =============================================================================
+
+storage-null-constraint-violation = Violação de restrição NOT NULL: coluna '{ $column }' não pode ser NULL
+storage-unique-constraint-violation = { $message }
+
+# =============================================================================
+# Erros de Tipo
+# =============================================================================
+
+storage-type-mismatch = Incompatibilidade de tipo na coluna '{ $column }': esperado { $expected }, obtido { $actual }
+
+# =============================================================================
+# Erros de Transação e Catálogo
+# =============================================================================
+
+storage-catalog-error = Erro de catálogo: { $message }
+storage-transaction-error = Erro de transação: { $message }
+storage-row-not-found = Linha não encontrada
+
+# =============================================================================
+# Erros de E/S e Página
+# =============================================================================
+
+storage-io-error = Erro de E/S: { $message }
+storage-invalid-page-size = Tamanho de página inválido: esperado { $expected }, obtido { $actual }
+storage-invalid-page-id = ID de página inválido: { $page_id }
+storage-lock-error = Erro de bloqueio: { $message }
+
+# =============================================================================
+# Erros de Memória
+# =============================================================================
+
+storage-memory-budget-exceeded = Orçamento de memória excedido: usando { $used } bytes, orçamento é { $budget } bytes
+storage-no-index-to-evict = Nenhum índice disponível para remoção (todos os índices já estão em disco)
+
+# =============================================================================
+# Erros Gerais
+# =============================================================================
+
+storage-not-implemented = Não implementado: { $message }
+storage-other = { $message }

--- a/crates/vibesql-l10n/src/detection.rs
+++ b/crates/vibesql-l10n/src/detection.rs
@@ -13,7 +13,7 @@
 use std::env;
 
 /// List of available locales (embedded in the binary)
-const AVAILABLE_LOCALES: &[&str] = &["en-US"];
+const AVAILABLE_LOCALES: &[&str] = &["en-US", "es", "pt-BR"];
 
 /// Detect the user's preferred locale from environment variables.
 ///

--- a/crates/vibesql-l10n/src/lib.rs
+++ b/crates/vibesql-l10n/src/lib.rs
@@ -387,4 +387,42 @@ mod tests {
         assert!(files.iter().any(|f| f == "es/cli.ftl"), "es/cli.ftl not found");
         assert!(files.iter().any(|f| f == "es/parser.ftl"), "es/parser.ftl not found");
     }
+
+    #[test]
+    fn test_portuguese_locale() {
+        init(Some("pt-BR")).unwrap();
+
+        let goodbye = format("cli-goodbye", None);
+        assert_eq!(goodbye, "Até logo!");
+
+        let mut args = FluentArgs::new();
+        args.set("count", 5);
+        let result = format("rows-count", Some(&args));
+        assert!(result.contains("5"));
+        assert!(result.contains("linhas"));
+    }
+
+    #[test]
+    fn test_portuguese_parser_messages() {
+        init(Some("pt-BR")).unwrap();
+
+        let result = format("lexer-unterminated-string", None);
+        assert_eq!(result, "Literal de string não terminado");
+
+        let result = vibe_msg!("lexer-unexpected-character", character = "~");
+        assert!(result.contains("~"));
+        assert!(result.contains("Caractere inesperado"));
+    }
+
+    #[test]
+    fn test_portuguese_resources_embedded() {
+        // Check that Portuguese (Brazilian) resources are embedded
+        let files: Vec<_> = Resources::iter().collect();
+        assert!(files.iter().any(|f| f.starts_with("pt-BR/")), "Portuguese resources not found in: {:?}", files);
+        assert!(files.iter().any(|f| f == "pt-BR/cli.ftl"), "pt-BR/cli.ftl not found");
+        assert!(files.iter().any(|f| f == "pt-BR/parser.ftl"), "pt-BR/parser.ftl not found");
+        assert!(files.iter().any(|f| f == "pt-BR/executor.ftl"), "pt-BR/executor.ftl not found");
+        assert!(files.iter().any(|f| f == "pt-BR/storage.ftl"), "pt-BR/storage.ftl not found");
+        assert!(files.iter().any(|f| f == "pt-BR/catalog.ftl"), "pt-BR/catalog.ftl not found");
+    }
 }


### PR DESCRIPTION
## Summary
- Add complete Brazilian Portuguese (pt-BR) translations for VibeSQL
- 5 FTL files with translations for CLI, parser, executor, storage, and catalog messages
- Update AVAILABLE_LOCALES to include "es" and "pt-BR" for automatic locale detection
- Add unit tests for pt-BR locale validation

## Files Created
- `crates/vibesql-l10n/resources/pt-BR/cli.ftl` (~210 strings)
- `crates/vibesql-l10n/resources/pt-BR/parser.ftl` (~15 strings)
- `crates/vibesql-l10n/resources/pt-BR/executor.ftl` (~90 strings)
- `crates/vibesql-l10n/resources/pt-BR/storage.ftl` (~18 strings)
- `crates/vibesql-l10n/resources/pt-BR/catalog.ftl` (~38 strings)

## Test plan
- [x] All existing l10n tests pass
- [x] New pt-BR tests pass (`test_portuguese_locale`, `test_portuguese_parser_messages`, `test_portuguese_resources_embedded`)
- [x] Fallback to English works for missing keys
- [x] Brazilian Portuguese conventions used (not European Portuguese)

Closes #3715

🤖 Generated with [Claude Code](https://claude.com/claude-code)