### PR TITLE
feat(benchmarks): Add DuckDB comparison jobs to nightly workflow

### DIFF
--- a/.github/workflows/nightly-benchmarks.yml
+++ b/.github/workflows/nightly-benchmarks.yml
@@ -72,6 +72,108 @@ jobs:
           fi
 
   # ============================================================================
+  # TPC-H with DuckDB Comparison (Separate job due to ~73MB binary size)
+  # ============================================================================
+  tpch-duckdb-comparison:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          df -h
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-key-suffix: nightly-duckdb
+
+      - name: Run TPC-H with DuckDB comparison
+        env:
+          SCALE_FACTOR: "0.1"
+          PROFILING_ITERATIONS: "5"
+        run: |
+          cargo bench --package vibesql-executor --bench tpch_profiling \
+            --features benchmark-comparison,duckdb-comparison \
+            -- 2>&1 | tee tpch_duckdb_output.txt
+
+      - name: Generate comparison JSON
+        if: always()
+        run: |
+          # Extract timing data and generate JSON for web-demo consumption
+          python3 << 'PYEOF'
+          import json
+          import re
+          import sys
+          from datetime import datetime
+
+          results = {
+              "generated_at": datetime.utcnow().isoformat() + "Z",
+              "scale_factor": 0.1,
+              "source": "nightly-benchmark",
+              "benchmarks": []
+          }
+
+          try:
+              with open('tpch_duckdb_output.txt', 'r') as f:
+                  content = f.read()
+
+              # Parse timing output - look for patterns like "Q1: 123.45ms"
+              # or "TOTAL: 123.45ms" lines
+              query_pattern = re.compile(r'=== (Q\d+) ===.*?TOTAL:\s+([\d.]+)\s*(ms|s|us)', re.DOTALL)
+              for match in query_pattern.finditer(content):
+                  query = match.group(1).lower()
+                  time_val = float(match.group(2))
+                  unit = match.group(3)
+                  # Convert to seconds
+                  if unit == 'ms':
+                      time_val /= 1000.0
+                  elif unit == 'us':
+                      time_val /= 1000000.0
+                  results["benchmarks"].append({
+                      "name": f"tpch_{query}_vibesql",
+                      "stats": {"mean": time_val, "status": "passed"}
+                  })
+
+              with open('tpch_duckdb_comparison.json', 'w') as f:
+                  json.dump(results, f, indent=2)
+              print(f"Generated comparison JSON with {len(results['benchmarks'])} entries")
+          except Exception as e:
+              print(f"Warning: Could not generate JSON: {e}", file=sys.stderr)
+              # Create empty results file
+              with open('tpch_duckdb_comparison.json', 'w') as f:
+                  json.dump(results, f, indent=2)
+          PYEOF
+
+      - name: Upload DuckDB comparison results
+        uses: actions/upload-artifact@v5
+        with:
+          name: nightly-tpch-duckdb-comparison
+          path: |
+            tpch_duckdb_output.txt
+            tpch_duckdb_comparison.json
+          retention-days: 30
+
+      - name: Display DuckDB comparison results
+        if: always()
+        run: |
+          echo "## TPC-H DuckDB Comparison Results (SF 0.1)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f tpch_duckdb_output.txt ]; then
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            tail -100 tpch_duckdb_output.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # ============================================================================
   # TPC-C Extended Duration
   # ============================================================================
   tpcc-extended:
@@ -226,6 +328,112 @@ jobs:
           fi
 
   # ============================================================================
+  # TPC-DS with DuckDB Comparison (Separate job due to binary size)
+  # ============================================================================
+  tpcds-duckdb-comparison:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          df -h
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-key-suffix: nightly-duckdb
+
+      - name: Run TPC-DS with DuckDB comparison
+        env:
+          SCALE_FACTOR: "0.01"
+          VALIDATE: "1"
+        run: |
+          timeout 6000 cargo bench --bench tpcds_runner \
+            --features benchmark-comparison,duckdb-comparison \
+            -- 2>&1 | tee tpcds_duckdb_output.txt || true
+
+      - name: Generate comparison JSON
+        if: always()
+        run: |
+          # Parse TPC-DS output and generate comparison JSON
+          python3 << 'PYEOF'
+          import json
+          import re
+          import sys
+          from datetime import datetime
+
+          results = {
+              "generated_at": datetime.utcnow().isoformat() + "Z",
+              "scale_factor": 0.01,
+              "source": "nightly-benchmark",
+              "benchmark_type": "tpcds",
+              "benchmarks": []
+          }
+
+          try:
+              with open('tpcds_duckdb_output.txt', 'r') as f:
+                  content = f.read()
+
+              # Parse CSV output section if present
+              csv_match = re.search(r'=== CSV Output ===\s*\n(.*?)(?:\n\n|\Z)', content, re.DOTALL)
+              if csv_match:
+                  csv_lines = csv_match.group(1).strip().split('\n')
+                  for line in csv_lines[1:]:  # Skip header
+                      parts = line.split(',')
+                      if len(parts) >= 3:
+                          query = parts[0].strip().lower()
+                          try:
+                              time_ms = float(parts[1].strip())
+                              status = parts[2].strip() if len(parts) > 2 else "passed"
+                              results["benchmarks"].append({
+                                  "name": f"tpcds_{query}_vibesql",
+                                  "stats": {
+                                      "mean": time_ms / 1000.0,  # Convert to seconds
+                                      "status": status
+                                  }
+                              })
+                          except ValueError:
+                              continue
+
+              with open('tpcds_duckdb_comparison.json', 'w') as f:
+                  json.dump(results, f, indent=2)
+              print(f"Generated TPC-DS comparison JSON with {len(results['benchmarks'])} entries")
+          except Exception as e:
+              print(f"Warning: Could not generate JSON: {e}", file=sys.stderr)
+              with open('tpcds_duckdb_comparison.json', 'w') as f:
+                  json.dump(results, f, indent=2)
+          PYEOF
+
+      - name: Upload TPC-DS DuckDB comparison results
+        uses: actions/upload-artifact@v5
+        with:
+          name: nightly-tpcds-duckdb-comparison
+          path: |
+            tpcds_duckdb_output.txt
+            tpcds_duckdb_comparison.json
+          retention-days: 30
+
+      - name: Display TPC-DS DuckDB comparison results
+        if: always()
+        run: |
+          echo "## TPC-DS DuckDB Comparison Results (SF 0.01)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f tpcds_duckdb_output.txt ]; then
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            grep -A 1000 "=== CSV Output ===" tpcds_duckdb_output.txt | head -120 >> $GITHUB_STEP_SUMMARY || tail -100 tpcds_duckdb_output.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # ============================================================================
   # Sysbench Extended
   # ============================================================================
   sysbench-extended:
@@ -360,7 +568,7 @@ jobs:
   # ============================================================================
   summary:
     runs-on: ubuntu-latest
-    needs: [tpch-full, tpcc-extended, tpcds-full, sysbench-extended, sqllogictest-complete]
+    needs: [tpch-full, tpch-duckdb-comparison, tpcc-extended, tpcds-full, tpcds-duckdb-comparison, sysbench-extended, sqllogictest-complete]
     if: always()
     steps:
       - name: Download all artifacts
@@ -379,9 +587,17 @@ jobs:
           echo "| Benchmark | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-----------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| TPC-H Full | ${{ needs.tpch-full.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| TPC-H DuckDB Comparison | ${{ needs.tpch-duckdb-comparison.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| TPC-C Extended | ${{ needs.tpcc-extended.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| TPC-DS Full | ${{ needs.tpcds-full.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| TPC-DS DuckDB Comparison | ${{ needs.tpcds-duckdb-comparison.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Sysbench Extended | ${{ needs.sysbench-extended.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| SQLLogicTest Complete | ${{ needs.sqllogictest-complete.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Comparison Artifacts" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "DuckDB comparison results are available as artifacts:" >> $GITHUB_STEP_SUMMARY
+          echo "- \`nightly-tpch-duckdb-comparison\`: TPC-H comparison data" >> $GITHUB_STEP_SUMMARY
+          echo "- \`nightly-tpcds-duckdb-comparison\`: TPC-DS comparison data" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "All artifacts are available for download (30 day retention)" >> $GITHUB_STEP_SUMMARY

--- a/docs/development/BENCHMARKING.md
+++ b/docs/development/BENCHMARKING.md
@@ -550,6 +550,98 @@ Current support matrix:
 
 ---
 
+## DuckDB Comparison Benchmarks
+
+### Overview
+
+VibeSQL supports comparison benchmarks against DuckDB for OLAP workloads. DuckDB comparison is kept in separate jobs/features because DuckDB adds ~73MB to the binary size.
+
+### Running Comparisons Locally
+
+```bash
+# TPC-H with SQLite comparison only (default, lighter weight)
+cargo bench --package vibesql-executor --bench tpch_profiling \
+  --features benchmark-comparison
+
+# TPC-H with DuckDB comparison (adds ~73MB to binary)
+cargo bench --package vibesql-executor --bench tpch_profiling \
+  --features benchmark-comparison,duckdb-comparison
+
+# TPC-DS with DuckDB validation mode
+VALIDATE=1 cargo bench --bench tpcds_runner \
+  --features benchmark-comparison,duckdb-comparison
+
+# Run with specific scale factor
+SCALE_FACTOR=0.1 cargo bench --package vibesql-executor --bench tpch_profiling \
+  --features benchmark-comparison,duckdb-comparison
+```
+
+### Feature Flags
+
+| Feature | Description | Binary Size Impact |
+|---------|-------------|-------------------|
+| `benchmark-comparison` | Enable SQLite comparison + in-memory indexes | ~2MB |
+| `sqlite-comparison` | SQLite only (included in benchmark-comparison) | ~2MB |
+| `duckdb-comparison` | Add DuckDB comparison | ~73MB |
+| `mysql-comparison` | Add MySQL comparison (requires MYSQL_URL) | ~1MB |
+
+### CI vs Local Differences
+
+| Aspect | Local | CI (Nightly) |
+|--------|-------|--------------|
+| DuckDB jobs | Optional feature flag | Separate jobs for isolation |
+| MySQL | Requires Docker/server | Uses service container |
+| Scale factor | Configurable | SF=0.1 (TPC-H), SF=0.01 (TPC-DS) |
+| Output format | Console | JSON + text artifacts |
+| Results storage | Local benchmarks.db | GitHub artifacts (30-day retention) |
+
+### Nightly Workflow Structure
+
+The nightly benchmark workflow (`.github/workflows/nightly-benchmarks.yml`) runs:
+
+1. **Standard benchmarks** (SQLite comparison):
+   - `tpch-full`: TPC-H with SQLite
+   - `tpcds-full`: TPC-DS with SQLite
+
+2. **DuckDB comparison jobs** (separate for binary size isolation):
+   - `tpch-duckdb-comparison`: TPC-H vs DuckDB
+   - `tpcds-duckdb-comparison`: TPC-DS vs DuckDB (with validation)
+
+3. **Other benchmarks**:
+   - `tpcc-extended`: TPC-C OLTP workload
+   - `sysbench-extended`: Sysbench OLTP
+   - `sqllogictest-complete`: Full conformance suite
+
+### Comparison Artifacts
+
+Nightly runs produce JSON artifacts suitable for web-demo consumption:
+
+```bash
+# Download artifacts from GitHub Actions
+gh run download <run-id> --name nightly-tpch-duckdb-comparison
+
+# Artifacts include:
+# - tpch_duckdb_output.txt (raw benchmark output)
+# - tpch_duckdb_comparison.json (parsed JSON for web-demo)
+```
+
+JSON format matches web-demo schema:
+```json
+{
+  "generated_at": "2024-12-05T02:00:00Z",
+  "scale_factor": 0.1,
+  "source": "nightly-benchmark",
+  "benchmarks": [
+    {
+      "name": "tpch_q1_vibesql",
+      "stats": { "mean": 0.245, "status": "passed" }
+    }
+  ]
+}
+```
+
+---
+
 ## CI Integration
 
 ### GitHub Actions Workflow


### PR DESCRIPTION
## Summary

- Add separate DuckDB comparison benchmark jobs to the nightly CI workflow
- Generate JSON artifacts for web-demo consumption
- Document comparison benchmark workflow for local vs CI runs

## Changes

### Nightly Workflow (`.github/workflows/nightly-benchmarks.yml`)

Added two new comparison jobs:
- **`tpch-duckdb-comparison`**: Runs TPC-H benchmarks with DuckDB comparison enabled (~73MB binary)
- **`tpcds-duckdb-comparison`**: Runs TPC-DS benchmarks with DuckDB validation mode

Both jobs:
- Use separate cache key (`nightly-duckdb`) to avoid bloating other job caches
- Generate parseable JSON output for web-demo integration
- Upload artifacts with 30-day retention

### Documentation (`docs/development/BENCHMARKING.md`)

Added new "DuckDB Comparison Benchmarks" section covering:
- How to run comparisons locally vs in CI
- Feature flag descriptions and binary size impacts
- Nightly workflow structure
- Comparison artifact format

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Manual workflow dispatch to test jobs run correctly
- [ ] Check artifacts are uploaded with correct format

Closes #3689

🤖 Generated with [Claude Code](https://claude.com/claude-code)