### PR TITLE
feat(wal): Wire transaction durability hint through to commit

### DIFF
--- a/crates/vibesql-storage/src/database/core.rs
+++ b/crates/vibesql-storage/src/database/core.rs
@@ -8,7 +8,7 @@ use super::operations::Operations;
 use super::transactions::TransactionChange;
 use crate::change_events::{ChangeEvent, ChangeEventReceiver, ChangeEventSender};
 use crate::columnar_cache::ColumnarCache;
-use crate::wal::{PersistenceEngine, TransactionDurability, WalOp};
+use crate::wal::{DurabilityMode, PersistenceEngine, TransactionDurability, WalOp};
 use crate::{QueryBufferPool, Row, StorageError, Table};
 use std::collections::HashMap;
 
@@ -67,34 +67,46 @@ impl Database {
     /// See [`TransactionDurability`] for available options.
     pub fn begin_transaction_with_durability(
         &mut self,
-        _durability: TransactionDurability,
+        durability: TransactionDurability,
     ) -> Result<(), StorageError> {
         let catalog = &self.catalog.clone();
-        self.lifecycle.transaction_manager_mut().begin_transaction(catalog, &self.tables)?;
+        self.lifecycle
+            .transaction_manager_mut()
+            .begin_transaction_with_durability(catalog, &self.tables, durability)?;
 
         // Emit WAL entry for persistence
         if let Some(txn_id) = self.transaction_id() {
             self.emit_wal_op(WalOp::TxnBegin { txn_id });
         }
 
-        // TODO: Store durability hint in transaction manager for use at commit time
-        // For now, the durability hint is parsed and passed through but not yet
-        // wired to the actual WAL sync behavior. This requires additional changes
-        // to the transaction manager to store the hint and use it at commit.
-
         Ok(())
     }
 
     /// Commit the current transaction
     pub fn commit_transaction(&mut self) -> Result<(), StorageError> {
-        // Get transaction ID before committing (it will be cleared after)
+        // Get transaction ID and durability hint before committing (they will be cleared after)
         let txn_id = self.transaction_id();
+        let durability_hint = self.lifecycle.transaction_manager().get_durability();
 
         self.lifecycle.transaction_manager_mut().commit_transaction()?;
 
         // Emit WAL entry for persistence
         if let Some(txn_id) = txn_id {
             self.emit_wal_op(WalOp::TxnCommit { txn_id });
+        }
+
+        // Apply durability-based sync at commit time
+        if let Some(hint) = durability_hint {
+            let db_mode = self
+                .persistence_engine
+                .as_ref()
+                .map(|e| e.durability_mode())
+                .unwrap_or(DurabilityMode::Lazy);
+
+            let resolved_mode = hint.resolve(db_mode);
+            if resolved_mode.sync_on_commit() {
+                self.sync_persistence()?;
+            }
         }
 
         Ok(())
@@ -1552,5 +1564,251 @@ mod tests {
 
         // Persistence stats should still be None
         assert!(db.persistence_stats().is_none());
+    }
+
+    // ============================================================================
+    // Transaction Durability Hint Tests
+    // ============================================================================
+
+    #[test]
+    fn test_begin_transaction_with_default_durability() {
+        use crate::wal::TransactionDurability;
+
+        let mut db = Database::new();
+
+        db.begin_transaction_with_durability(TransactionDurability::Default).unwrap();
+        assert!(db.in_transaction());
+
+        // Verify the durability hint is stored
+        let durability = db.lifecycle.transaction_manager().get_durability();
+        assert_eq!(durability, Some(TransactionDurability::Default));
+
+        db.rollback_transaction().unwrap();
+    }
+
+    #[test]
+    fn test_begin_transaction_with_force_durable() {
+        use crate::wal::TransactionDurability;
+
+        let mut db = Database::new();
+
+        db.begin_transaction_with_durability(TransactionDurability::ForceDurable).unwrap();
+        assert!(db.in_transaction());
+
+        // Verify the durability hint is stored
+        let durability = db.lifecycle.transaction_manager().get_durability();
+        assert_eq!(durability, Some(TransactionDurability::ForceDurable));
+
+        db.rollback_transaction().unwrap();
+    }
+
+    #[test]
+    fn test_begin_transaction_with_allow_lazy() {
+        use crate::wal::TransactionDurability;
+
+        let mut db = Database::new();
+
+        db.begin_transaction_with_durability(TransactionDurability::AllowLazy).unwrap();
+        assert!(db.in_transaction());
+
+        // Verify the durability hint is stored
+        let durability = db.lifecycle.transaction_manager().get_durability();
+        assert_eq!(durability, Some(TransactionDurability::AllowLazy));
+
+        db.rollback_transaction().unwrap();
+    }
+
+    #[test]
+    fn test_begin_transaction_with_force_volatile() {
+        use crate::wal::TransactionDurability;
+
+        let mut db = Database::new();
+
+        db.begin_transaction_with_durability(TransactionDurability::ForceVolatile).unwrap();
+        assert!(db.in_transaction());
+
+        // Verify the durability hint is stored
+        let durability = db.lifecycle.transaction_manager().get_durability();
+        assert_eq!(durability, Some(TransactionDurability::ForceVolatile));
+
+        db.rollback_transaction().unwrap();
+    }
+
+    #[test]
+    fn test_durability_hint_cleared_on_commit() {
+        use crate::wal::TransactionDurability;
+
+        let mut db = Database::new();
+
+        db.begin_transaction_with_durability(TransactionDurability::ForceDurable).unwrap();
+        assert!(db.in_transaction());
+
+        db.commit_transaction().unwrap();
+        assert!(!db.in_transaction());
+
+        // Durability hint should be None after commit
+        let durability = db.lifecycle.transaction_manager().get_durability();
+        assert_eq!(durability, None);
+    }
+
+    #[test]
+    fn test_durability_hint_cleared_on_rollback() {
+        use crate::wal::TransactionDurability;
+
+        let mut db = Database::new();
+
+        db.begin_transaction_with_durability(TransactionDurability::ForceDurable).unwrap();
+        assert!(db.in_transaction());
+
+        db.rollback_transaction().unwrap();
+        assert!(!db.in_transaction());
+
+        // Durability hint should be None after rollback
+        let durability = db.lifecycle.transaction_manager().get_durability();
+        assert_eq!(durability, None);
+    }
+
+    #[test]
+    fn test_force_durable_triggers_sync() {
+        use std::io::Cursor;
+        use vibesql_catalog::{ColumnSchema, TableSchema};
+        use vibesql_types::DataType;
+        use crate::wal::{PersistenceConfig, PersistenceEngine, TransactionDurability};
+
+        let mut db = Database::new();
+
+        // Enable persistence in lazy mode (default - no sync on commit)
+        let buf = Vec::new();
+        let cursor = Cursor::new(buf);
+        let engine = PersistenceEngine::with_writer(cursor, PersistenceConfig::lazy()).unwrap();
+        db.enable_persistence(engine);
+
+        // Create a table
+        let schema = TableSchema::new(
+            "test".to_string(),
+            vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+        );
+        db.create_table(schema).unwrap();
+
+        // Begin transaction with ForceDurable hint
+        db.begin_transaction_with_durability(TransactionDurability::ForceDurable).unwrap();
+
+        // Insert a row
+        let row = crate::Row::new(vec![SqlValue::Integer(1)]);
+        db.insert_row("test", row).unwrap();
+
+        // Commit - should trigger sync because ForceDurable overrides lazy mode
+        db.commit_transaction().unwrap();
+
+        // Check stats - explicit_flushes should have been triggered by sync
+        let stats = db.persistence_stats().unwrap();
+        assert!(stats.explicit_flushes >= 1, "ForceDurable should trigger an explicit flush on commit");
+    }
+
+    #[test]
+    fn test_default_durability_respects_lazy_mode() {
+        use std::io::Cursor;
+        use vibesql_catalog::{ColumnSchema, TableSchema};
+        use vibesql_types::DataType;
+        use crate::wal::{PersistenceConfig, PersistenceEngine, TransactionDurability};
+
+        let mut db = Database::new();
+
+        // Enable persistence in lazy mode
+        let buf = Vec::new();
+        let cursor = Cursor::new(buf);
+        let engine = PersistenceEngine::with_writer(cursor, PersistenceConfig::lazy()).unwrap();
+        db.enable_persistence(engine);
+
+        // Create a table
+        let schema = TableSchema::new(
+            "test".to_string(),
+            vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+        );
+        db.create_table(schema).unwrap();
+
+        // Get initial stats after table creation
+        let initial_stats = db.persistence_stats().unwrap();
+        let initial_explicit_flushes = initial_stats.explicit_flushes;
+
+        // Begin transaction with Default hint (should follow lazy mode - no sync on commit)
+        db.begin_transaction_with_durability(TransactionDurability::Default).unwrap();
+
+        // Insert a row
+        let row = crate::Row::new(vec![SqlValue::Integer(1)]);
+        db.insert_row("test", row).unwrap();
+
+        // Commit - should NOT trigger sync in lazy mode with default durability
+        db.commit_transaction().unwrap();
+
+        // Check stats - no new explicit_flushes should have been triggered
+        let final_stats = db.persistence_stats().unwrap();
+        assert_eq!(
+            final_stats.explicit_flushes,
+            initial_explicit_flushes,
+            "Default durability in lazy mode should not trigger explicit flush on commit"
+        );
+    }
+
+    #[test]
+    fn test_durability_hint_no_panic_without_persistence() {
+        use crate::wal::TransactionDurability;
+
+        // Create database WITHOUT persistence enabled
+        let mut db = Database::new();
+
+        // Begin transaction with ForceDurable hint
+        db.begin_transaction_with_durability(TransactionDurability::ForceDurable).unwrap();
+        assert!(db.in_transaction());
+
+        // Commit should not panic even though ForceDurable requests sync
+        // (sync is a no-op when persistence is not enabled)
+        db.commit_transaction().unwrap();
+        assert!(!db.in_transaction());
+    }
+
+    #[test]
+    fn test_allow_lazy_downgrades_durable_mode() {
+        use std::io::Cursor;
+        use vibesql_catalog::{ColumnSchema, TableSchema};
+        use vibesql_types::DataType;
+        use crate::wal::{PersistenceConfig, PersistenceEngine, TransactionDurability};
+
+        let mut db = Database::new();
+
+        // Enable persistence in durable mode (sync on every commit by default)
+        let buf = Vec::new();
+        let cursor = Cursor::new(buf);
+        let engine = PersistenceEngine::with_writer(cursor, PersistenceConfig::durable()).unwrap();
+        db.enable_persistence(engine);
+
+        // Create a table
+        let schema = TableSchema::new(
+            "test".to_string(),
+            vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+        );
+        db.create_table(schema).unwrap();
+
+        // Get initial stats after table creation
+        let initial_stats = db.persistence_stats().unwrap();
+        let initial_explicit_flushes = initial_stats.explicit_flushes;
+
+        // Begin transaction with AllowLazy hint (should downgrade durable to lazy)
+        db.begin_transaction_with_durability(TransactionDurability::AllowLazy).unwrap();
+
+        // Insert a row
+        let row = crate::Row::new(vec![SqlValue::Integer(1)]);
+        db.insert_row("test", row).unwrap();
+
+        // Commit - AllowLazy should prevent sync even in durable mode
+        db.commit_transaction().unwrap();
+
+        // Check stats - no new explicit_flushes should have been triggered
+        let final_stats = db.persistence_stats().unwrap();
+        assert_eq!(
+            final_stats.explicit_flushes,
+            initial_explicit_flushes,
+            "AllowLazy should downgrade durable mode and not trigger explicit flush on commit"
+        );
     }
 }

--- a/crates/vibesql-storage/src/database/transactions.rs
+++ b/crates/vibesql-storage/src/database/transactions.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashMap;
 
+use crate::wal::TransactionDurability;
 use crate::{Row, StorageError, Table};
 
 /// A single change made during a transaction
@@ -40,6 +41,8 @@ pub enum TransactionState {
         savepoints: Vec<Savepoint>,
         /// All changes made since transaction start (for incremental undo)
         changes: Vec<TransactionChange>,
+        /// Durability hint for this transaction
+        durability: TransactionDurability,
     },
 }
 
@@ -65,11 +68,21 @@ impl TransactionManager {
         }
     }
 
-    /// Begin a new transaction
+    /// Begin a new transaction with default durability
     pub fn begin_transaction(
         &mut self,
         catalog: &vibesql_catalog::Catalog,
         tables: &HashMap<String, Table>,
+    ) -> Result<(), StorageError> {
+        self.begin_transaction_with_durability(catalog, tables, TransactionDurability::Default)
+    }
+
+    /// Begin a new transaction with a specific durability hint
+    pub fn begin_transaction_with_durability(
+        &mut self,
+        catalog: &vibesql_catalog::Catalog,
+        tables: &HashMap<String, Table>,
+        durability: TransactionDurability,
     ) -> Result<(), StorageError> {
         match self.transaction_state {
             TransactionState::None => {
@@ -86,6 +99,7 @@ impl TransactionManager {
                     original_tables,
                     savepoints: Vec::new(),
                     changes: Vec::new(),
+                    durability,
                 };
                 Ok(())
             }
@@ -139,6 +153,14 @@ impl TransactionManager {
     pub fn transaction_id(&self) -> Option<u64> {
         match &self.transaction_state {
             TransactionState::Active { id, .. } => Some(*id),
+            TransactionState::None => None,
+        }
+    }
+
+    /// Get the durability hint for the current transaction (if any)
+    pub fn get_durability(&self) -> Option<TransactionDurability> {
+        match &self.transaction_state {
+            TransactionState::Active { durability, .. } => Some(*durability),
             TransactionState::None => None,
         }
     }


### PR DESCRIPTION
## Summary

- Wire the transaction durability hint from `BEGIN TRANSACTION WITH DURABILITY = <mode>` through to actual WAL sync behavior at commit time
- Complete the feature added in PR #3732 by connecting the parsed hint to the storage layer
- Add `durability` field to `TransactionState::Active` and `get_durability()` method to `TransactionManager`
- Update `commit_transaction()` to apply sync based on resolved durability mode

## Behavior

| Durability Hint | In Lazy DB Mode | In Durable DB Mode |
|-----------------|-----------------|-------------------|
| `DURABLE` | Forces sync on commit | Sync on commit |
| `LAZY` | Batched sync | Downgrades to batched |
| `VOLATILE` | No sync | No sync |
| `DEFAULT` | Batched sync | Sync on commit |

## Test plan

- [x] Unit tests verify durability hint is stored and retrieved correctly
- [x] Unit tests verify `ForceDurable` triggers sync in lazy mode
- [x] Unit tests verify `AllowLazy` downgrades durable mode
- [x] Unit tests verify no panic when persistence is disabled
- [x] All 477 storage crate tests pass
- [x] Full workspace test suite passes

Closes #3739

🤖 Generated with [Claude Code](https://claude.com/claude-code)