### PR TITLE
fix(optimizer): Extract equijoin predicates for comma-separated tables in semi-join

### DIFF
--- a/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
@@ -928,6 +928,23 @@ where
         );
     }
 
+    // Build column_to_table map for schema-based equijoin extraction
+    let table_names: Vec<String> = table_refs
+        .iter()
+        .map(|t| t.alias.as_ref().unwrap_or(&t.name).to_lowercase())
+        .collect();
+    let column_to_table =
+        utils::build_column_to_table_map(database, &table_names, &table_refs, cte_results);
+
+    // Track accumulated tables (starts with target table)
+    let target_alias = table_refs[target_idx]
+        .alias
+        .as_ref()
+        .unwrap_or(&table_refs[target_idx].name)
+        .to_lowercase();
+    let mut accumulated_tables: HashSet<String> = HashSet::new();
+    accumulated_tables.insert(target_alias);
+
     // Start with the filtered result
     let mut accumulated = filtered_result;
 
@@ -947,34 +964,93 @@ where
         )?;
         let table_scan_time = table_start.elapsed();
 
+        let new_table_alias = table_ref
+            .alias
+            .as_ref()
+            .unwrap_or(&table_ref.name)
+            .to_lowercase();
+
         if profile {
-            let alias = table_ref.alias.as_ref().unwrap_or(&table_ref.name);
             eprintln!(
                 "[SEMI_JOIN_REORDER] Scanned '{}': {} rows in {:?}",
-                alias,
+                new_table_alias,
                 table_result.data.as_slice().len(),
                 table_scan_time
             );
         }
 
-        // Join with accumulated result using WHERE clause predicates
+        // Extract equijoin predicates from WHERE clause that connect accumulated tables to new table
+        let equijoins = if let Some(where_expr) = where_clause {
+            // Build table set including accumulated tables and the new table
+            let mut join_table_set = accumulated_tables.clone();
+            join_table_set.insert(new_table_alias.clone());
+
+            // Extract equijoins that reference both sides
+            let all_equijoins = predicates::extract_where_equijoins_with_schema(
+                where_expr,
+                &join_table_set,
+                &column_to_table,
+            );
+
+            // Filter to only include equijoins that connect accumulated tables to the new table
+            let applicable_equijoins: Vec<_> = all_equijoins
+                .into_iter()
+                .filter(|eq| {
+                    let mut referenced = HashSet::new();
+                    graph::extract_referenced_tables_with_schema(
+                        eq,
+                        &mut referenced,
+                        &join_table_set,
+                        &column_to_table,
+                    );
+                    // Keep if references the new table AND at least one accumulated table
+                    referenced.contains(&new_table_alias)
+                        && referenced.iter().any(|t| accumulated_tables.contains(t))
+                })
+                .collect();
+
+            if profile && !applicable_equijoins.is_empty() {
+                eprintln!(
+                    "[SEMI_JOIN_REORDER] Found {} equijoin predicates for joining '{}'",
+                    applicable_equijoins.len(),
+                    new_table_alias
+                );
+            }
+
+            applicable_equijoins
+        } else {
+            Vec::new()
+        };
+
+        // Use Inner join with equijoins if available, otherwise Cross join
+        let (join_type, join_condition) = if !equijoins.is_empty() {
+            (vibesql_ast::JoinType::Inner, None)
+        } else {
+            (vibesql_ast::JoinType::Cross, None)
+        };
+
+        // Join with accumulated result using extracted equijoin predicates
         let join_start = std::time::Instant::now();
         accumulated = crate::select::join::nested_loop_join(
             accumulated,
             table_result,
-            &vibesql_ast::JoinType::Cross,
-            &None, // No explicit condition - handled by WHERE clause
+            &join_type,
+            &join_condition,
             false,
             database,
-            &[], // WHERE equijoins will be evaluated during join
+            &equijoins,
             &timeout_ctx,
             cte_results,
         )?;
         let join_time = join_start.elapsed();
 
+        // Add new table to accumulated set
+        accumulated_tables.insert(new_table_alias.clone());
+
         if profile {
             eprintln!(
-                "[SEMI_JOIN_REORDER] After join: {} rows in {:?}",
+                "[SEMI_JOIN_REORDER] After join with '{}': {} rows in {:?}",
+                new_table_alias,
                 accumulated.data.as_slice().len(),
                 join_time
             );

--- a/tests/sqllogictest-files/select/semi_join_comma_tables.slt
+++ b/tests/sqllogictest-files/select/semi_join_comma_tables.slt
@@ -1,0 +1,125 @@
+# Semi-join reordering with comma-separated tables (issue #3728)
+#
+# This test ensures that when using comma-separated tables in FROM clause
+# with EXISTS/NOT EXISTS subqueries, the equijoin predicates from WHERE
+# are properly applied instead of creating cartesian products.
+
+# Setup test tables
+statement ok
+CREATE TABLE customer (c_customer_sk INTEGER PRIMARY KEY, c_current_addr_sk INTEGER, c_current_cdemo_sk INTEGER)
+
+statement ok
+CREATE TABLE customer_address (ca_address_sk INTEGER PRIMARY KEY, ca_state VARCHAR(10))
+
+statement ok
+CREATE TABLE customer_demographics (cd_demo_sk INTEGER PRIMARY KEY, cd_gender VARCHAR(1), cd_marital_status VARCHAR(1))
+
+statement ok
+CREATE TABLE store_sales (ss_customer_sk INTEGER, ss_sold_date_sk INTEGER)
+
+statement ok
+CREATE TABLE date_dim (d_date_sk INTEGER PRIMARY KEY, d_year INTEGER)
+
+# Insert test data
+statement ok
+INSERT INTO customer VALUES
+    (1, 101, 201),
+    (2, 102, 202),
+    (3, 103, 203)
+
+statement ok
+INSERT INTO customer_address VALUES
+    (101, 'KS'),
+    (102, 'NY'),
+    (103, 'AZ')
+
+statement ok
+INSERT INTO customer_demographics VALUES
+    (201, 'M', 'S'),
+    (202, 'F', 'M'),
+    (203, 'M', 'M')
+
+statement ok
+INSERT INTO store_sales VALUES
+    (1, 1001),
+    (1, 1002),
+    (3, 1001)
+
+statement ok
+INSERT INTO date_dim VALUES
+    (1001, 2000),
+    (1002, 2001)
+
+# Test 1: Simple comma-separated tables with EXISTS
+# This should NOT create a cartesian product - customer 2 is excluded by state filter,
+# customer 1 is included (has sales in 2000, state KS), customer 3 is included (has sales, state AZ)
+query TT rowsort
+SELECT cd.cd_gender, cd.cd_marital_status
+FROM customer c, customer_address ca, customer_demographics cd
+WHERE c.c_current_addr_sk = ca.ca_address_sk
+    AND cd.cd_demo_sk = c.c_current_cdemo_sk
+    AND ca.ca_state IN ('KS', 'AZ', 'NE')
+    AND EXISTS (
+        SELECT 1
+        FROM store_sales ss, date_dim d
+        WHERE c.c_customer_sk = ss.ss_customer_sk
+            AND ss.ss_sold_date_sk = d.d_date_sk
+            AND d.d_year = 2000
+    )
+----
+M M
+M S
+
+# Test 2: Verify correct behavior with NOT EXISTS
+# Customer 2 is excluded (NY state), customers 1 and 3 have sales,
+# so with NOT EXISTS, only customers without sales in 2000 would match.
+# But all our customers with KS/AZ/NE states do have sales in 2000, so empty result.
+query TT rowsort
+SELECT cd.cd_gender, cd.cd_marital_status
+FROM customer c, customer_address ca, customer_demographics cd
+WHERE c.c_current_addr_sk = ca.ca_address_sk
+    AND cd.cd_demo_sk = c.c_current_cdemo_sk
+    AND ca.ca_state IN ('KS', 'AZ', 'NE')
+    AND NOT EXISTS (
+        SELECT 1
+        FROM store_sales ss, date_dim d
+        WHERE c.c_customer_sk = ss.ss_customer_sk
+            AND ss.ss_sold_date_sk = d.d_date_sk
+            AND d.d_year = 2000
+    )
+----
+
+# Test 3: Same query using explicit JOINs (for comparison)
+# Should produce identical results to Test 1
+query TT rowsort
+SELECT cd.cd_gender, cd.cd_marital_status
+FROM customer c
+JOIN customer_address ca ON c.c_current_addr_sk = ca.ca_address_sk
+JOIN customer_demographics cd ON cd.cd_demo_sk = c.c_current_cdemo_sk
+WHERE ca.ca_state IN ('KS', 'AZ', 'NE')
+    AND EXISTS (
+        SELECT 1
+        FROM store_sales ss
+        JOIN date_dim d ON ss.ss_sold_date_sk = d.d_date_sk
+        WHERE c.c_customer_sk = ss.ss_customer_sk
+            AND d.d_year = 2000
+    )
+----
+M M
+M S
+
+# Cleanup
+statement ok
+DROP TABLE date_dim
+
+statement ok
+DROP TABLE store_sales
+
+statement ok
+DROP TABLE customer_demographics
+
+statement ok
+DROP TABLE customer_address
+
+statement ok
+DROP TABLE customer


### PR DESCRIPTION
## Summary

Fixes semi-join reordering optimization creating cartesian products when using comma-separated tables (SQL-92 style implicit joins) in FROM clause with EXISTS/NOT EXISTS subqueries.

### Changes:
- Extract equijoin predicates from WHERE clause that connect accumulated tables to remaining tables
- Use Inner join with equijoins instead of Cross join for remaining table joins
- Track accumulated table set as we build the join result
- Also fixes pre-existing issue where window.rs was not using TableKey type after recent schema refactoring

## Test plan

- [x] Build succeeds
- [x] All executor tests pass
- [x] Added sqllogictest test file for comma-separated tables with semi-join
- [ ] Verify Q69 TPC-DS performance improvement

Closes #3728

🤖 Generated with [Claude Code](https://claude.com/claude-code)