### PR TITLE
feat(l10n): Add Italian (it) translations

### DIFF
--- a/crates/vibesql-l10n/resources/it/catalog.ftl
+++ b/crates/vibesql-l10n/resources/it/catalog.ftl
@@ -1,0 +1,117 @@
+# VibeSQL Catalog Error Messages - Italian (it)
+# This file contains all error messages for the vibesql-catalog crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+catalog-table-already-exists = La tabella '{ $name }' esiste già
+catalog-table-not-found = Tabella '{ $table_name }' non trovata
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+catalog-column-already-exists = La colonna '{ $name }' esiste già
+catalog-column-not-found = Colonna '{ $column_name }' non trovata nella tabella '{ $table_name }'
+
+# =============================================================================
+# Schema Errors
+# =============================================================================
+
+catalog-schema-already-exists = Lo schema '{ $name }' esiste già
+catalog-schema-not-found = Schema '{ $name }' non trovato
+catalog-schema-not-empty = Lo schema '{ $name }' non è vuoto
+
+# =============================================================================
+# Role Errors
+# =============================================================================
+
+catalog-role-already-exists = Il ruolo '{ $name }' esiste già
+catalog-role-not-found = Ruolo '{ $name }' non trovato
+
+# =============================================================================
+# Domain Errors
+# =============================================================================
+
+catalog-domain-already-exists = Il dominio '{ $name }' esiste già
+catalog-domain-not-found = Dominio '{ $name }' non trovato
+catalog-domain-in-use = Il dominio '{ $domain_name }' è ancora in uso da { $count } colonna/e: { $columns }
+
+# =============================================================================
+# Sequence Errors
+# =============================================================================
+
+catalog-sequence-already-exists = La sequenza '{ $name }' esiste già
+catalog-sequence-not-found = Sequenza '{ $name }' non trovata
+catalog-sequence-in-use = La sequenza '{ $sequence_name }' è ancora in uso da { $count } colonna/e: { $columns }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+catalog-type-already-exists = Il tipo '{ $name }' esiste già
+catalog-type-not-found = Tipo '{ $name }' non trovato
+catalog-type-in-use = Il tipo '{ $name }' è ancora in uso da una o più tabelle
+
+# =============================================================================
+# Collation and Character Set Errors
+# =============================================================================
+
+catalog-collation-already-exists = La collazione '{ $name }' esiste già
+catalog-collation-not-found = Collazione '{ $name }' non trovata
+catalog-character-set-already-exists = Il set di caratteri '{ $name }' esiste già
+catalog-character-set-not-found = Set di caratteri '{ $name }' non trovato
+catalog-translation-already-exists = La traduzione '{ $name }' esiste già
+catalog-translation-not-found = Traduzione '{ $name }' non trovata
+
+# =============================================================================
+# View Errors
+# =============================================================================
+
+catalog-view-already-exists = La vista '{ $name }' esiste già
+catalog-view-not-found = Vista '{ $name }' non trovata
+catalog-view-in-use = La vista o tabella '{ $view_name }' è ancora in uso da { $count } vista/e: { $views }
+
+# =============================================================================
+# Trigger Errors
+# =============================================================================
+
+catalog-trigger-already-exists = Il trigger '{ $name }' esiste già
+catalog-trigger-not-found = Trigger '{ $name }' non trovato
+
+# =============================================================================
+# Assertion Errors
+# =============================================================================
+
+catalog-assertion-already-exists = L'asserzione '{ $name }' esiste già
+catalog-assertion-not-found = Asserzione '{ $name }' non trovata
+
+# =============================================================================
+# Function and Procedure Errors
+# =============================================================================
+
+catalog-function-already-exists = La funzione '{ $name }' esiste già
+catalog-function-not-found = Funzione '{ $name }' non trovata
+catalog-procedure-already-exists = La procedura '{ $name }' esiste già
+catalog-procedure-not-found = Procedura '{ $name }' non trovata
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+catalog-constraint-already-exists = Il vincolo '{ $name }' esiste già
+catalog-constraint-not-found = Vincolo '{ $name }' non trovato
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+catalog-index-already-exists = L'indice '{ $index_name }' sulla tabella '{ $table_name }' esiste già
+catalog-index-not-found = Indice '{ $index_name }' sulla tabella '{ $table_name }' non trovato
+
+# =============================================================================
+# Foreign Key Errors
+# =============================================================================
+
+catalog-circular-foreign-key = Rilevata dipendenza circolare di chiave esterna per la tabella '{ $table_name }': { $message }

--- a/crates/vibesql-l10n/resources/it/cli.ftl
+++ b/crates/vibesql-l10n/resources/it/cli.ftl
@@ -1,0 +1,210 @@
+# VibeSQL CLI Localization - Italian (it)
+# This file contains all user-facing strings for the VibeSQL command-line interface.
+
+# =============================================================================
+# REPL Banner and Basic Messages
+# =============================================================================
+
+cli-banner = VibeSQL v{ $version } - Database con conformità FULL allo standard SQL:1999
+cli-help-hint = Digita \help per la guida, \quit per uscire
+cli-goodbye = Arrivederci!
+
+# =============================================================================
+# Command Help Text (Clap Arguments)
+# =============================================================================
+
+cli-about = VibeSQL - Database con conformità FULL allo standard SQL:1999
+
+cli-long-about = Interfaccia a riga di comando di VibeSQL
+
+    MODALITÀ D'USO:
+      REPL interattivo:      vibesql (--database <FILE>)
+      Esegui comando:        vibesql -c "SELECT * FROM users"
+      Esegui file:           vibesql -f script.sql
+      Esegui da stdin:       cat data.sql | vibesql
+      Genera tipi:           vibesql codegen --schema schema.sql --output types.ts
+
+    REPL INTERATTIVO:
+      Quando avviato senza -c, -f o input da pipe, VibeSQL entra in un REPL
+      interattivo con supporto readline, cronologia comandi e meta-comandi come:
+        \d (tabella)  - Descrivi tabella o elenca tutte le tabelle
+        \dt           - Elenca tabelle
+        \f <formato>  - Imposta formato output
+        \copy         - Importa/esporta CSV/JSON
+        \help         - Mostra tutti i comandi REPL
+
+    SOTTOCOMANDI:
+      codegen           Genera tipi TypeScript dallo schema del database
+
+    CONFIGURAZIONE:
+      Le impostazioni possono essere configurate in ~/.vibesqlrc (formato TOML).
+      Sezioni: display, database, history, query
+
+    ESEMPI:
+      # Avvia REPL interattivo con database in memoria
+      vibesql
+
+      # Usa file database persistente
+      vibesql --database mydata.db
+
+      # Esegui singolo comando
+      vibesql -c "CREATE TABLE users (id INT, name VARCHAR(100))"
+
+      # Esegui file script SQL
+      vibesql -f schema.sql -v
+
+      # Importa dati da CSV
+      echo "\copy users FROM 'data.csv'" | vibesql --database mydata.db
+
+      # Esporta risultati query come JSON
+      vibesql -d mydata.db -c "SELECT * FROM users" --format json
+
+      # Genera tipi TypeScript da un file schema
+      vibesql codegen --schema schema.sql --output src/types.ts
+
+      # Genera tipi TypeScript da un database in esecuzione
+      vibesql codegen --database mydata.db --output src/types.ts
+
+# Argument help strings
+arg-database-help = Percorso file database (se non specificato, usa database in memoria)
+arg-file-help = Esegui comandi SQL da file
+arg-command-help = Esegui comando SQL direttamente ed esci
+arg-stdin-help = Leggi comandi SQL da stdin (rilevato automaticamente quando in pipe)
+arg-verbose-help = Mostra output dettagliato durante l'esecuzione di file/stdin
+arg-format-help = Formato output per i risultati delle query
+arg-lang-help = Imposta la lingua di visualizzazione (es. en-US, es, ja)
+
+# =============================================================================
+# Codegen Subcommand
+# =============================================================================
+
+codegen-about = Genera tipi TypeScript dallo schema del database
+
+codegen-long-about = Genera definizioni di tipi TypeScript dallo schema di un database VibeSQL.
+
+    Questo comando crea interfacce TypeScript per tutte le tabelle nel database,
+    insieme a oggetti metadati per il controllo dei tipi a runtime e supporto IDE.
+
+    SORGENTI INPUT:
+      --database <FILE>  Genera da un file database esistente
+      --schema <FILE>    Genera da un file schema SQL (istruzioni CREATE TABLE)
+
+    OUTPUT:
+      --output <FILE>    Scrivi i tipi generati in questo file (default: types.ts)
+
+    OPZIONI:
+      --camel-case       Converti nomi colonne in camelCase
+      --no-metadata      Salta la generazione dell'oggetto metadati delle tabelle
+
+    ESEMPI:
+      # Da un file database
+      vibesql codegen --database mydata.db --output src/db/types.ts
+
+      # Da un file schema SQL
+      vibesql codegen --schema schema.sql --output src/db/types.ts
+
+      # Con nomi proprietà in camelCase
+      vibesql codegen --schema schema.sql --output types.ts --camel-case
+
+codegen-schema-help = File schema SQL contenente istruzioni CREATE TABLE
+codegen-output-help = Percorso file output per il TypeScript generato
+codegen-camel-case-help = Converti nomi colonne in camelCase
+codegen-no-metadata-help = Salta la generazione dell'oggetto metadati delle tabelle
+
+codegen-from-schema = Generazione tipi TypeScript dal file schema: { $path }
+codegen-from-database = Generazione tipi TypeScript dal database: { $path }
+codegen-written = Tipi TypeScript scritti in: { $path }
+codegen-error-no-source = Deve essere specificato --database o --schema.
+    Usa 'vibesql codegen --help' per informazioni sull'utilizzo.
+
+# =============================================================================
+# Meta-commands Help (\help output)
+# =============================================================================
+
+help-title = Meta-comandi:
+help-describe = \d (tabella)    - Descrivi tabella o elenca tutte le tabelle
+help-tables = \dt             - Elenca tabelle
+help-schemas = \ds             - Elenca schemi
+help-indexes = \di             - Elenca indici
+help-roles = \du             - Elenca ruoli/utenti
+help-format = \f <formato>    - Imposta formato output (table, json, csv, markdown, html)
+help-timing = \timing         - Attiva/disattiva misurazione tempo query
+help-copy-to = \copy <tabella> TO <file>   - Esporta tabella in file CSV/JSON
+help-copy-from = \copy <tabella> FROM <file> - Importa file CSV in tabella
+help-save = \save (file)    - Salva database in file dump SQL
+help-errors = \errors         - Mostra cronologia errori recenti
+help-help = \h, \help      - Mostra questa guida
+help-quit = \q, \quit      - Esci
+
+help-sql-title = Introspezione SQL:
+help-show-tables = SHOW TABLES                  - Elenca tutte le tabelle
+help-show-databases = SHOW DATABASES               - Elenca tutti gli schemi/database
+help-show-columns = SHOW COLUMNS FROM <tabella>  - Mostra colonne della tabella
+help-show-index = SHOW INDEX FROM <tabella>    - Mostra indici della tabella
+help-show-create = SHOW CREATE TABLE <tabella>  - Mostra istruzione CREATE TABLE
+help-describe-sql = DESCRIBE <tabella>           - Alias per SHOW COLUMNS
+
+help-examples-title = Esempi:
+help-example-create = CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100));
+help-example-insert = INSERT INTO users VALUES (1, 'Alice'), (2, 'Bob');
+help-example-select = SELECT * FROM users;
+help-example-show-tables = SHOW TABLES;
+help-example-show-columns = SHOW COLUMNS FROM users;
+help-example-describe = DESCRIBE users;
+help-example-format-json = \f json
+help-example-format-md = \f markdown
+help-example-copy-to = \copy users TO '/tmp/users.csv'
+help-example-copy-from = \copy users FROM '/tmp/users.csv'
+help-example-copy-json = \copy users TO '/tmp/users.json'
+help-example-errors = \errors
+
+# =============================================================================
+# Status Messages
+# =============================================================================
+
+format-changed = Formato output impostato a: { $format }
+database-saved = Database salvato in: { $path }
+no-database-file = Errore: Nessun file database specificato. Usa \save <nomefile> o avvia con il flag --database
+
+# =============================================================================
+# Error Display
+# =============================================================================
+
+no-errors = Nessun errore in questa sessione.
+recent-errors = Errori recenti:
+
+# =============================================================================
+# Script Execution Messages
+# =============================================================================
+
+script-no-statements = Nessuna istruzione SQL trovata nello script
+script-executing = Esecuzione istruzione { $current } di { $total }...
+script-error = Errore nell'esecuzione dell'istruzione { $index }: { $error }
+script-summary-title = === Riepilogo Esecuzione Script ===
+script-total = Istruzioni totali: { $count }
+script-successful = Riuscite: { $count }
+script-failed = Fallite: { $count }
+script-failed-error = { $count } istruzioni fallite
+
+# =============================================================================
+# Output Formatting
+# =============================================================================
+
+rows-with-time = { $count } righe nel risultato ({ $time }s)
+rows-count = { $count } righe
+
+# =============================================================================
+# Warnings
+# =============================================================================
+
+warning-config-load = Avviso: Impossibile caricare il file di configurazione: { $error }
+warning-auto-save-failed = Avviso: Salvataggio automatico del database fallito: { $error }
+warning-save-on-exit-failed = Avviso: Salvataggio del database all'uscita fallito: { $error }
+
+# =============================================================================
+# File Operations
+# =============================================================================
+
+file-read-error = Lettura del file '{ $path }' fallita: { $error }
+stdin-read-error = Lettura da stdin fallita: { $error }
+database-load-error = Caricamento database fallito: { $error }

--- a/crates/vibesql-l10n/resources/it/executor.ftl
+++ b/crates/vibesql-l10n/resources/it/executor.ftl
@@ -1,0 +1,187 @@
+# VibeSQL Executor Error Messages - Italian (it)
+# This file contains all error messages for the vibesql-executor crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+executor-table-not-found = Tabella '{ $name }' non trovata
+executor-table-already-exists = La tabella '{ $name }' esiste già
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+executor-column-not-found-simple = Colonna '{ $column_name }' non trovata nella tabella '{ $table_name }'
+executor-column-not-found-searched = Colonna '{ $column_name }' non trovata (tabelle cercate: { $searched_tables })
+executor-column-not-found-with-available = Colonna '{ $column_name }' non trovata (tabelle cercate: { $searched_tables }). Colonne disponibili: { $available_columns }
+executor-invalid-table-qualifier = Qualificatore di tabella '{ $qualifier }' non valido per la colonna '{ $column }'. Tabelle disponibili: { $available_tables }
+executor-column-already-exists = La colonna '{ $name }' esiste già
+executor-column-index-out-of-bounds = Indice colonna { $index } fuori dai limiti
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+executor-index-not-found = Indice '{ $name }' non trovato
+executor-index-already-exists = L'indice '{ $name }' esiste già
+executor-invalid-index-definition = Definizione indice non valida: { $message }
+
+# =============================================================================
+# Trigger Errors
+# =============================================================================
+
+executor-trigger-not-found = Trigger '{ $name }' non trovato
+executor-trigger-already-exists = Il trigger '{ $name }' esiste già
+
+# =============================================================================
+# Schema Errors
+# =============================================================================
+
+executor-schema-not-found = Schema '{ $name }' non trovato
+executor-schema-already-exists = Lo schema '{ $name }' esiste già
+executor-schema-not-empty = Impossibile eliminare lo schema '{ $name }': lo schema non è vuoto
+
+# =============================================================================
+# Role and Permission Errors
+# =============================================================================
+
+executor-role-not-found = Ruolo '{ $name }' non trovato
+executor-permission-denied = Permesso negato: il ruolo '{ $role }' non ha il privilegio { $privilege } su { $object }
+executor-dependent-privileges-exist = Esistono privilegi dipendenti: { $message }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+executor-type-not-found = Tipo '{ $name }' non trovato
+executor-type-already-exists = Il tipo '{ $name }' esiste già
+executor-type-in-use = Impossibile eliminare il tipo '{ $name }': il tipo è ancora in uso
+executor-type-mismatch = Tipo non corrispondente: { $left } { $op } { $right }
+executor-type-error = Errore di tipo: { $message }
+executor-cast-error = Impossibile convertire { $from_type } in { $to_type }
+executor-type-conversion-error = Impossibile convertire { $from } in { $to }
+
+# =============================================================================
+# Expression and Query Errors
+# =============================================================================
+
+executor-division-by-zero = Divisione per zero
+executor-invalid-where-clause = Clausola WHERE non valida: { $message }
+executor-unsupported-expression = Espressione non supportata: { $message }
+executor-unsupported-feature = Funzionalità non supportata: { $message }
+executor-parse-error = Errore di parsing: { $message }
+
+# =============================================================================
+# Subquery Errors
+# =============================================================================
+
+executor-subquery-returned-multiple-rows = La subquery scalare ha restituito { $actual } righe, prevista { $expected }
+executor-subquery-column-count-mismatch = La subquery ha restituito { $actual } colonne, previste { $expected }
+executor-column-count-mismatch = La lista colonne derivata ha { $provided } colonne ma la query produce { $expected } colonne
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+executor-constraint-violation = Violazione del vincolo: { $message }
+executor-multiple-primary-keys = Non sono ammessi vincoli PRIMARY KEY multipli
+executor-cannot-drop-column = Impossibile eliminare la colonna: { $message }
+executor-constraint-not-found = Vincolo '{ $constraint_name }' non trovato nella tabella '{ $table_name }'
+
+# =============================================================================
+# Resource Limit Errors
+# =============================================================================
+
+executor-expression-depth-exceeded = Limite di profondità espressione superato: { $depth } > { $max_depth } (previene overflow dello stack)
+executor-query-timeout-exceeded = Timeout query superato: { $elapsed_seconds }s > { $max_seconds }s
+executor-row-limit-exceeded = Limite di elaborazione righe superato: { $rows_processed } > { $max_rows }
+executor-memory-limit-exceeded = Limite di memoria superato: { $used_gb } GB > { $max_gb } GB
+
+# =============================================================================
+# Procedural/Variable Errors
+# =============================================================================
+
+executor-variable-not-found-simple = Variabile '{ $variable_name }' non trovata
+executor-variable-not-found-with-available = Variabile '{ $variable_name }' non trovata. Variabili disponibili: { $available_variables }
+executor-label-not-found = Etichetta '{ $name }' non trovata
+
+# =============================================================================
+# SELECT INTO Errors
+# =============================================================================
+
+executor-select-into-row-count = SELECT INTO procedurale deve restituire esattamente { $expected } riga, ottenute { $actual } righ{ $plural }
+executor-select-into-column-count = Numero colonne SELECT INTO procedurale non corrispondente: { $expected } variabil{ $expected_plural } ma la query ha restituito { $actual } colonn{ $actual_plural }
+
+# =============================================================================
+# Procedure and Function Errors
+# =============================================================================
+
+executor-procedure-not-found-simple = Procedura '{ $procedure_name }' non trovata nello schema '{ $schema_name }'
+executor-procedure-not-found-with-available = Procedura '{ $procedure_name }' non trovata nello schema '{ $schema_name }'
+    .available = Procedure disponibili: { $available_procedures }
+executor-procedure-not-found-with-suggestion = Procedura '{ $procedure_name }' non trovata nello schema '{ $schema_name }'
+    .available = Procedure disponibili: { $available_procedures }
+    .suggestion = Forse intendevi '{ $suggestion }'?
+
+executor-function-not-found-simple = Funzione '{ $function_name }' non trovata nello schema '{ $schema_name }'
+executor-function-not-found-with-available = Funzione '{ $function_name }' non trovata nello schema '{ $schema_name }'
+    .available = Funzioni disponibili: { $available_functions }
+executor-function-not-found-with-suggestion = Funzione '{ $function_name }' non trovata nello schema '{ $schema_name }'
+    .available = Funzioni disponibili: { $available_functions }
+    .suggestion = Forse intendevi '{ $suggestion }'?
+
+executor-parameter-count-mismatch = { $routine_type } '{ $routine_name }' richiede { $expected } parametr{ $expected_plural } ({ $parameter_signature }), ricevuti { $actual } argoment{ $actual_plural }
+executor-parameter-type-mismatch = Il parametro '{ $parameter_name }' richiede { $expected_type }, ricevuto { $actual_type } '{ $actual_value }'
+executor-argument-count-mismatch = Numero argomenti non corrispondente: previsti { $expected }, ricevuti { $actual }
+
+executor-recursion-limit-exceeded = Profondità massima di ricorsione ({ $max_depth }) superata: { $message }
+executor-recursion-call-stack = Stack delle chiamate:
+executor-function-must-return = La funzione deve restituire un valore
+executor-invalid-control-flow = Flusso di controllo non valido: { $message }
+executor-invalid-function-body = Corpo della funzione non valido: { $message }
+executor-function-read-only-violation = Violazione sola lettura della funzione: { $message }
+
+# =============================================================================
+# EXTRACT Errors
+# =============================================================================
+
+executor-invalid-extract-field = Impossibile estrarre { $field } da valore di tipo { $value_type }
+
+# =============================================================================
+# Columnar/Arrow Errors
+# =============================================================================
+
+executor-arrow-downcast-error = Impossibile eseguire downcast dell'array Arrow a { $expected_type } ({ $context })
+executor-columnar-type-mismatch-binary = Tipi incompatibili per { $operation }: { $left_type } vs { $right_type }
+executor-columnar-type-mismatch-unary = Tipo incompatibile per { $operation }: { $left_type }
+executor-simd-operation-failed = Operazione SIMD { $operation } fallita: { $reason }
+executor-columnar-column-not-found = Indice colonna { $column_index } fuori dai limiti (il batch ha { $batch_columns } colonne)
+executor-columnar-column-not-found-by-name = Colonna non trovata: { $column_name }
+executor-columnar-length-mismatch = Lunghezza colonna non corrispondente in { $context }: prevista { $expected }, ottenuta { $actual }
+executor-unsupported-array-type = Tipo array non supportato per { $operation }: { $array_type }
+
+# =============================================================================
+# Spatial Errors
+# =============================================================================
+
+executor-spatial-geometry-error = { $function_name }: { $message }
+executor-spatial-operation-failed = { $function_name }: { $message }
+executor-spatial-argument-error = { $function_name } richiede { $expected }, ricevuto { $actual }
+
+# =============================================================================
+# Cursor Errors
+# =============================================================================
+
+executor-cursor-already-exists = Il cursore '{ $name }' esiste già
+executor-cursor-not-found = Cursore '{ $name }' non trovato
+executor-cursor-already-open = Il cursore '{ $name }' è già aperto
+executor-cursor-not-open = Il cursore '{ $name }' non è aperto
+executor-cursor-not-scrollable = Il cursore '{ $name }' non è scorrevole (SCROLL non specificato)
+
+# =============================================================================
+# Storage and General Errors
+# =============================================================================
+
+executor-storage-error = Errore di archiviazione: { $message }
+executor-other = { $message }

--- a/crates/vibesql-l10n/resources/it/parser.ftl
+++ b/crates/vibesql-l10n/resources/it/parser.ftl
@@ -1,0 +1,55 @@
+# VibeSQL Parser/Lexer Localization - Italian (it)
+# This file contains all user-facing strings for lexer and parser errors.
+
+# =============================================================================
+# Lexer Error Header
+# =============================================================================
+
+lexer-error-at-position = Errore del lexer alla posizione { $position }: { $message }
+
+# =============================================================================
+# String Literal Errors
+# =============================================================================
+
+lexer-unterminated-string = Stringa letterale non terminata
+
+# =============================================================================
+# Identifier Errors
+# =============================================================================
+
+lexer-unterminated-delimited-identifier = Identificatore delimitato non terminato
+lexer-empty-delimited-identifier = L'identificatore delimitato vuoto non è consentito
+
+# =============================================================================
+# Number Literal Errors
+# =============================================================================
+
+lexer-invalid-scientific-notation = Notazione scientifica non valida: previste cifre dopo 'E'
+
+# =============================================================================
+# Placeholder Errors
+# =============================================================================
+
+lexer-expected-digit-after-dollar = Prevista cifra dopo '$' per placeholder numerato
+lexer-invalid-numbered-placeholder = Placeholder numerato non valido: ${ $placeholder }
+lexer-numbered-placeholder-zero = Il placeholder numerato deve essere $1 o superiore (non $0)
+lexer-expected-identifier-after-colon = Previsto identificatore dopo ':' per placeholder nominato
+
+# =============================================================================
+# Variable Errors
+# =============================================================================
+
+lexer-expected-variable-after-at-at = Previsto nome variabile dopo @@
+lexer-expected-variable-after-at = Previsto nome variabile dopo @
+
+# =============================================================================
+# Operator Errors
+# =============================================================================
+
+lexer-unexpected-pipe = Carattere inatteso: '|' (forse intendevi '||'?)
+
+# =============================================================================
+# General Errors
+# =============================================================================
+
+lexer-unexpected-character = Carattere inatteso: '{ $character }'

--- a/crates/vibesql-l10n/resources/it/storage.ftl
+++ b/crates/vibesql-l10n/resources/it/storage.ftl
@@ -1,0 +1,68 @@
+# VibeSQL Storage Error Messages - Italian (it)
+# This file contains all error messages for the vibesql-storage crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+storage-table-not-found = Tabella '{ $name }' non trovata
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+storage-column-count-mismatch = Numero colonne non corrispondente: previste { $expected }, ottenute { $actual }
+storage-column-index-out-of-bounds = Indice colonna { $index } fuori dai limiti
+storage-column-not-found = Colonna '{ $column_name }' non trovata nella tabella '{ $table_name }'
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+storage-index-already-exists = L'indice '{ $name }' esiste già
+storage-index-not-found = Indice '{ $name }' non trovato
+storage-invalid-index-column = { $message }
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+storage-null-constraint-violation = Violazione vincolo NOT NULL: la colonna '{ $column }' non può essere NULL
+storage-unique-constraint-violation = { $message }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+storage-type-mismatch = Tipo non corrispondente nella colonna '{ $column }': previsto { $expected }, ottenuto { $actual }
+
+# =============================================================================
+# Transaction and Catalog Errors
+# =============================================================================
+
+storage-catalog-error = Errore del catalogo: { $message }
+storage-transaction-error = Errore della transazione: { $message }
+storage-row-not-found = Riga non trovata
+
+# =============================================================================
+# I/O and Page Errors
+# =============================================================================
+
+storage-io-error = Errore I/O: { $message }
+storage-invalid-page-size = Dimensione pagina non valida: prevista { $expected }, ottenuta { $actual }
+storage-invalid-page-id = ID pagina non valido: { $page_id }
+storage-lock-error = Errore di lock: { $message }
+
+# =============================================================================
+# Memory Errors
+# =============================================================================
+
+storage-memory-budget-exceeded = Budget di memoria superato: in uso { $used } byte, budget di { $budget } byte
+storage-no-index-to-evict = Nessun indice disponibile per l'eviction (tutti gli indici sono già su disco)
+
+# =============================================================================
+# General Errors
+# =============================================================================
+
+storage-not-implemented = Non implementato: { $message }
+storage-other = { $message }


### PR DESCRIPTION
## Summary

- Add complete Italian (it) translations for vibesql-l10n
- Create 5 translation files: cli.ftl, catalog.ftl, executor.ftl, parser.ftl, storage.ftl
- Achieve 100% translation coverage (232/232 messages)

## Test plan

- [x] Run `cargo run -p vibesql-l10n --bin check-translations -- --locale it` - passes with 100% coverage
- [x] Run `cargo run -p vibesql-l10n --bin check-ftl` - all files valid, 0 errors

Closes #3749

🤖 Generated with [Claude Code](https://claude.com/claude-code)