### PR TITLE
feat(i18n): Add Polish translations (pl)

### DIFF
--- a/crates/vibesql-l10n/resources/pl/catalog.ftl
+++ b/crates/vibesql-l10n/resources/pl/catalog.ftl
@@ -1,0 +1,117 @@
+# VibeSQL Catalog Error Messages - Polski (Polish)
+# This file contains all error messages for the vibesql-catalog crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+catalog-table-already-exists = Tabela '{ $name }' już istnieje
+catalog-table-not-found = Nie znaleziono tabeli '{ $table_name }'
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+catalog-column-already-exists = Kolumna '{ $name }' już istnieje
+catalog-column-not-found = Nie znaleziono kolumny '{ $column_name }' w tabeli '{ $table_name }'
+
+# =============================================================================
+# Schema Errors
+# =============================================================================
+
+catalog-schema-already-exists = Schemat '{ $name }' już istnieje
+catalog-schema-not-found = Nie znaleziono schematu '{ $name }'
+catalog-schema-not-empty = Schemat '{ $name }' nie jest pusty
+
+# =============================================================================
+# Role Errors
+# =============================================================================
+
+catalog-role-already-exists = Rola '{ $name }' już istnieje
+catalog-role-not-found = Nie znaleziono roli '{ $name }'
+
+# =============================================================================
+# Domain Errors
+# =============================================================================
+
+catalog-domain-already-exists = Domena '{ $name }' już istnieje
+catalog-domain-not-found = Nie znaleziono domeny '{ $name }'
+catalog-domain-in-use = Domena '{ $domain_name }' jest nadal używana przez { $count } kolumn(y): { $columns }
+
+# =============================================================================
+# Sequence Errors
+# =============================================================================
+
+catalog-sequence-already-exists = Sekwencja '{ $name }' już istnieje
+catalog-sequence-not-found = Nie znaleziono sekwencji '{ $name }'
+catalog-sequence-in-use = Sekwencja '{ $sequence_name }' jest nadal używana przez { $count } kolumn(y): { $columns }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+catalog-type-already-exists = Typ '{ $name }' już istnieje
+catalog-type-not-found = Nie znaleziono typu '{ $name }'
+catalog-type-in-use = Typ '{ $name }' jest nadal używany przez jedną lub więcej tabel
+
+# =============================================================================
+# Collation and Character Set Errors
+# =============================================================================
+
+catalog-collation-already-exists = Zestawienie '{ $name }' już istnieje
+catalog-collation-not-found = Nie znaleziono zestawienia '{ $name }'
+catalog-character-set-already-exists = Zestaw znaków '{ $name }' już istnieje
+catalog-character-set-not-found = Nie znaleziono zestawu znaków '{ $name }'
+catalog-translation-already-exists = Translacja '{ $name }' już istnieje
+catalog-translation-not-found = Nie znaleziono translacji '{ $name }'
+
+# =============================================================================
+# View Errors
+# =============================================================================
+
+catalog-view-already-exists = Widok '{ $name }' już istnieje
+catalog-view-not-found = Nie znaleziono widoku '{ $name }'
+catalog-view-in-use = Widok lub tabela '{ $view_name }' jest nadal używany przez { $count } widok(ów): { $views }
+
+# =============================================================================
+# Trigger Errors
+# =============================================================================
+
+catalog-trigger-already-exists = Wyzwalacz '{ $name }' już istnieje
+catalog-trigger-not-found = Nie znaleziono wyzwalacza '{ $name }'
+
+# =============================================================================
+# Assertion Errors
+# =============================================================================
+
+catalog-assertion-already-exists = Asercja '{ $name }' już istnieje
+catalog-assertion-not-found = Nie znaleziono asercji '{ $name }'
+
+# =============================================================================
+# Function and Procedure Errors
+# =============================================================================
+
+catalog-function-already-exists = Funkcja '{ $name }' już istnieje
+catalog-function-not-found = Nie znaleziono funkcji '{ $name }'
+catalog-procedure-already-exists = Procedura '{ $name }' już istnieje
+catalog-procedure-not-found = Nie znaleziono procedury '{ $name }'
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+catalog-constraint-already-exists = Ograniczenie '{ $name }' już istnieje
+catalog-constraint-not-found = Nie znaleziono ograniczenia '{ $name }'
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+catalog-index-already-exists = Indeks '{ $index_name }' na tabeli '{ $table_name }' już istnieje
+catalog-index-not-found = Nie znaleziono indeksu '{ $index_name }' na tabeli '{ $table_name }'
+
+# =============================================================================
+# Foreign Key Errors
+# =============================================================================
+
+catalog-circular-foreign-key = Wykryto cykliczną zależność klucza obcego dla tabeli '{ $table_name }': { $message }

--- a/crates/vibesql-l10n/resources/pl/cli.ftl
+++ b/crates/vibesql-l10n/resources/pl/cli.ftl
@@ -1,0 +1,210 @@
+# VibeSQL CLI Localization - Polski (Polish)
+# This file contains all user-facing strings for the VibeSQL command-line interface.
+
+# =============================================================================
+# REPL Banner and Basic Messages
+# =============================================================================
+
+cli-banner = VibeSQL v{ $version } - Baza danych z pełną zgodnością SQL:1999
+cli-help-hint = Wpisz \help aby uzyskać pomoc, \quit aby wyjść
+cli-goodbye = Do widzenia!
+
+# =============================================================================
+# Command Help Text (Clap Arguments)
+# =============================================================================
+
+cli-about = VibeSQL - Baza danych z pełną zgodnością SQL:1999
+
+cli-long-about = Interfejs wiersza poleceń VibeSQL
+
+    TRYBY UŻYCIA:
+      Interaktywny REPL:  vibesql (--database <PLIK>)
+      Wykonaj polecenie:  vibesql -c "SELECT * FROM users"
+      Wykonaj plik:       vibesql -f skrypt.sql
+      Wykonaj ze stdin:   cat dane.sql | vibesql
+      Generuj typy:       vibesql codegen --schema schema.sql --output types.ts
+
+    INTERAKTYWNY REPL:
+      Po uruchomieniu bez -c, -f lub wejścia z potoku, VibeSQL wchodzi w tryb
+      interaktywnego REPL z obsługą readline, historią poleceń i meta-poleceniami:
+        \d (tabela)  - Opisz tabelę lub wyświetl wszystkie tabele
+        \dt          - Wyświetl tabele
+        \f <format>  - Ustaw format wyjściowy
+        \copy        - Importuj/eksportuj CSV/JSON
+        \help        - Pokaż wszystkie polecenia REPL
+
+    PODKOMENDY:
+      codegen           Generuj typy TypeScript ze schematu bazy danych
+
+    KONFIGURACJA:
+      Ustawienia można skonfigurować w ~/.vibesqlrc (format TOML).
+      Sekcje: display, database, history, query
+
+    PRZYKŁADY:
+      # Uruchom interaktywny REPL z bazą w pamięci
+      vibesql
+
+      # Użyj trwałego pliku bazy danych
+      vibesql --database mojedane.db
+
+      # Wykonaj pojedyncze polecenie
+      vibesql -c "CREATE TABLE users (id INT, name VARCHAR(100))"
+
+      # Uruchom plik skryptu SQL
+      vibesql -f schema.sql -v
+
+      # Importuj dane z CSV
+      echo "\copy users FROM 'dane.csv'" | vibesql --database mojedane.db
+
+      # Eksportuj wyniki zapytania jako JSON
+      vibesql -d mojedane.db -c "SELECT * FROM users" --format json
+
+      # Generuj typy TypeScript z pliku schematu
+      vibesql codegen --schema schema.sql --output src/types.ts
+
+      # Generuj typy TypeScript z działającej bazy danych
+      vibesql codegen --database mojedane.db --output src/types.ts
+
+# Argument help strings
+arg-database-help = Ścieżka do pliku bazy danych (jeśli nie podano, używana jest baza w pamięci)
+arg-file-help = Wykonaj polecenia SQL z pliku
+arg-command-help = Wykonaj polecenie SQL bezpośrednio i zakończ
+arg-stdin-help = Odczytaj polecenia SQL ze standardowego wejścia (wykrywane automatycznie przy potoku)
+arg-verbose-help = Pokaż szczegółowe informacje podczas wykonywania pliku/stdin
+arg-format-help = Format wyjściowy dla wyników zapytań
+arg-lang-help = Ustaw język wyświetlania (np. en-US, es, ja, pl)
+
+# =============================================================================
+# Codegen Subcommand
+# =============================================================================
+
+codegen-about = Generuj typy TypeScript ze schematu bazy danych
+
+codegen-long-about = Generuj definicje typów TypeScript ze schematu bazy danych VibeSQL.
+
+    To polecenie tworzy interfejsy TypeScript dla wszystkich tabel w bazie danych,
+    wraz z obiektami metadanych do sprawdzania typów w czasie wykonania i wsparcia IDE.
+
+    ŹRÓDŁA WEJŚCIOWE:
+      --database <PLIK>  Generuj z istniejącego pliku bazy danych
+      --schema <PLIK>    Generuj z pliku schematu SQL (instrukcje CREATE TABLE)
+
+    WYJŚCIE:
+      --output <PLIK>    Zapisz wygenerowane typy do tego pliku (domyślnie: types.ts)
+
+    OPCJE:
+      --camel-case       Konwertuj nazwy kolumn na camelCase
+      --no-metadata      Pomiń generowanie obiektu metadanych tabel
+
+    PRZYKŁADY:
+      # Z pliku bazy danych
+      vibesql codegen --database mojedane.db --output src/db/types.ts
+
+      # Z pliku schematu SQL
+      vibesql codegen --schema schema.sql --output src/db/types.ts
+
+      # Z nazwami właściwości w camelCase
+      vibesql codegen --schema schema.sql --output types.ts --camel-case
+
+codegen-schema-help = Plik schematu SQL zawierający instrukcje CREATE TABLE
+codegen-output-help = Ścieżka pliku wyjściowego dla wygenerowanego TypeScript
+codegen-camel-case-help = Konwertuj nazwy kolumn na camelCase
+codegen-no-metadata-help = Pomiń generowanie obiektu metadanych tabel
+
+codegen-from-schema = Generowanie typów TypeScript z pliku schematu: { $path }
+codegen-from-database = Generowanie typów TypeScript z bazy danych: { $path }
+codegen-written = Typy TypeScript zapisane do: { $path }
+codegen-error-no-source = Należy podać --database lub --schema.
+    Użyj 'vibesql codegen --help' aby uzyskać informacje o użyciu.
+
+# =============================================================================
+# Meta-commands Help (\help output)
+# =============================================================================
+
+help-title = Meta-polecenia:
+help-describe = \d (tabela)     - Opisz tabelę lub wyświetl wszystkie tabele
+help-tables = \dt             - Wyświetl tabele
+help-schemas = \ds             - Wyświetl schematy
+help-indexes = \di             - Wyświetl indeksy
+help-roles = \du             - Wyświetl role/użytkowników
+help-format = \f <format>     - Ustaw format wyjściowy (table, json, csv, markdown, html)
+help-timing = \timing         - Przełącz pomiar czasu zapytań
+help-copy-to = \copy <tabela> TO <plik>   - Eksportuj tabelę do pliku CSV/JSON
+help-copy-from = \copy <tabela> FROM <plik> - Importuj plik CSV do tabeli
+help-save = \save (plik)    - Zapisz bazę danych do pliku zrzutu SQL
+help-errors = \errors         - Pokaż ostatnią historię błędów
+help-help = \h, \help      - Pokaż tę pomoc
+help-quit = \q, \quit      - Wyjdź
+
+help-sql-title = Introspekcja SQL:
+help-show-tables = SHOW TABLES                  - Wyświetl wszystkie tabele
+help-show-databases = SHOW DATABASES               - Wyświetl wszystkie schematy/bazy danych
+help-show-columns = SHOW COLUMNS FROM <tabela>   - Pokaż kolumny tabeli
+help-show-index = SHOW INDEX FROM <tabela>     - Pokaż indeksy tabeli
+help-show-create = SHOW CREATE TABLE <tabela>   - Pokaż instrukcję CREATE TABLE
+help-describe-sql = DESCRIBE <tabela>            - Alias dla SHOW COLUMNS
+
+help-examples-title = Przykłady:
+help-example-create = CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100));
+help-example-insert = INSERT INTO users VALUES (1, 'Alicja'), (2, 'Robert');
+help-example-select = SELECT * FROM users;
+help-example-show-tables = SHOW TABLES;
+help-example-show-columns = SHOW COLUMNS FROM users;
+help-example-describe = DESCRIBE users;
+help-example-format-json = \f json
+help-example-format-md = \f markdown
+help-example-copy-to = \copy users TO '/tmp/users.csv'
+help-example-copy-from = \copy users FROM '/tmp/users.csv'
+help-example-copy-json = \copy users TO '/tmp/users.json'
+help-example-errors = \errors
+
+# =============================================================================
+# Status Messages
+# =============================================================================
+
+format-changed = Format wyjściowy ustawiony na: { $format }
+database-saved = Baza danych zapisana do: { $path }
+no-database-file = Błąd: Nie podano pliku bazy danych. Użyj \save <nazwa_pliku> lub uruchom z flagą --database
+
+# =============================================================================
+# Error Display
+# =============================================================================
+
+no-errors = Brak błędów w tej sesji.
+recent-errors = Ostatnie błędy:
+
+# =============================================================================
+# Script Execution Messages
+# =============================================================================
+
+script-no-statements = Nie znaleziono instrukcji SQL w skrypcie
+script-executing = Wykonywanie instrukcji { $current } z { $total }...
+script-error = Błąd wykonywania instrukcji { $index }: { $error }
+script-summary-title = === Podsumowanie wykonania skryptu ===
+script-total = Łączna liczba instrukcji: { $count }
+script-successful = Udane: { $count }
+script-failed = Nieudane: { $count }
+script-failed-error = { $count } instrukcji nie powiodło się
+
+# =============================================================================
+# Output Formatting
+# =============================================================================
+
+rows-with-time = { $count } wierszy w zbiorze ({ $time }s)
+rows-count = { $count } wierszy
+
+# =============================================================================
+# Warnings
+# =============================================================================
+
+warning-config-load = Ostrzeżenie: Nie można załadować pliku konfiguracji: { $error }
+warning-auto-save-failed = Ostrzeżenie: Nie udało się automatycznie zapisać bazy danych: { $error }
+warning-save-on-exit-failed = Ostrzeżenie: Nie udało się zapisać bazy danych przy wyjściu: { $error }
+
+# =============================================================================
+# File Operations
+# =============================================================================
+
+file-read-error = Nie udało się odczytać pliku '{ $path }': { $error }
+stdin-read-error = Nie udało się odczytać ze standardowego wejścia: { $error }
+database-load-error = Nie udało się załadować bazy danych: { $error }

--- a/crates/vibesql-l10n/resources/pl/executor.ftl
+++ b/crates/vibesql-l10n/resources/pl/executor.ftl
@@ -1,0 +1,187 @@
+# VibeSQL Executor Error Messages - Polski (Polish)
+# This file contains all error messages for the vibesql-executor crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+executor-table-not-found = Nie znaleziono tabeli '{ $name }'
+executor-table-already-exists = Tabela '{ $name }' już istnieje
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+executor-column-not-found-simple = Nie znaleziono kolumny '{ $column_name }' w tabeli '{ $table_name }'
+executor-column-not-found-searched = Nie znaleziono kolumny '{ $column_name }' (przeszukane tabele: { $searched_tables })
+executor-column-not-found-with-available = Nie znaleziono kolumny '{ $column_name }' (przeszukane tabele: { $searched_tables }). Dostępne kolumny: { $available_columns }
+executor-invalid-table-qualifier = Nieprawidłowy kwalifikator tabeli '{ $qualifier }' dla kolumny '{ $column }'. Dostępne tabele: { $available_tables }
+executor-column-already-exists = Kolumna '{ $name }' już istnieje
+executor-column-index-out-of-bounds = Indeks kolumny { $index } poza zakresem
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+executor-index-not-found = Nie znaleziono indeksu '{ $name }'
+executor-index-already-exists = Indeks '{ $name }' już istnieje
+executor-invalid-index-definition = Nieprawidłowa definicja indeksu: { $message }
+
+# =============================================================================
+# Trigger Errors
+# =============================================================================
+
+executor-trigger-not-found = Nie znaleziono wyzwalacza '{ $name }'
+executor-trigger-already-exists = Wyzwalacz '{ $name }' już istnieje
+
+# =============================================================================
+# Schema Errors
+# =============================================================================
+
+executor-schema-not-found = Nie znaleziono schematu '{ $name }'
+executor-schema-already-exists = Schemat '{ $name }' już istnieje
+executor-schema-not-empty = Nie można usunąć schematu '{ $name }': schemat nie jest pusty
+
+# =============================================================================
+# Role and Permission Errors
+# =============================================================================
+
+executor-role-not-found = Nie znaleziono roli '{ $name }'
+executor-permission-denied = Odmowa dostępu: rola '{ $role }' nie ma uprawnienia { $privilege } do { $object }
+executor-dependent-privileges-exist = Istnieją zależne uprawnienia: { $message }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+executor-type-not-found = Nie znaleziono typu '{ $name }'
+executor-type-already-exists = Typ '{ $name }' już istnieje
+executor-type-in-use = Nie można usunąć typu '{ $name }': typ jest nadal używany
+executor-type-mismatch = Niezgodność typów: { $left } { $op } { $right }
+executor-type-error = Błąd typu: { $message }
+executor-cast-error = Nie można rzutować { $from_type } na { $to_type }
+executor-type-conversion-error = Nie można przekonwertować { $from } na { $to }
+
+# =============================================================================
+# Expression and Query Errors
+# =============================================================================
+
+executor-division-by-zero = Dzielenie przez zero
+executor-invalid-where-clause = Nieprawidłowa klauzula WHERE: { $message }
+executor-unsupported-expression = Nieobsługiwane wyrażenie: { $message }
+executor-unsupported-feature = Nieobsługiwana funkcjonalność: { $message }
+executor-parse-error = Błąd parsowania: { $message }
+
+# =============================================================================
+# Subquery Errors
+# =============================================================================
+
+executor-subquery-returned-multiple-rows = Podzapytanie skalarne zwróciło { $actual } wierszy, oczekiwano { $expected }
+executor-subquery-column-count-mismatch = Podzapytanie zwróciło { $actual } kolumn, oczekiwano { $expected }
+executor-column-count-mismatch = Lista kolumn pochodnych ma { $provided } kolumn, ale zapytanie produkuje { $expected } kolumn
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+executor-constraint-violation = Naruszenie ograniczenia: { $message }
+executor-multiple-primary-keys = Wiele ograniczeń PRIMARY KEY jest niedozwolonych
+executor-cannot-drop-column = Nie można usunąć kolumny: { $message }
+executor-constraint-not-found = Nie znaleziono ograniczenia '{ $constraint_name }' w tabeli '{ $table_name }'
+
+# =============================================================================
+# Resource Limit Errors
+# =============================================================================
+
+executor-expression-depth-exceeded = Przekroczono limit głębokości wyrażenia: { $depth } > { $max_depth } (zapobiega przepełnieniu stosu)
+executor-query-timeout-exceeded = Przekroczono limit czasu zapytania: { $elapsed_seconds }s > { $max_seconds }s
+executor-row-limit-exceeded = Przekroczono limit przetwarzania wierszy: { $rows_processed } > { $max_rows }
+executor-memory-limit-exceeded = Przekroczono limit pamięci: { $used_gb } GB > { $max_gb } GB
+
+# =============================================================================
+# Procedural/Variable Errors
+# =============================================================================
+
+executor-variable-not-found-simple = Nie znaleziono zmiennej '{ $variable_name }'
+executor-variable-not-found-with-available = Nie znaleziono zmiennej '{ $variable_name }'. Dostępne zmienne: { $available_variables }
+executor-label-not-found = Nie znaleziono etykiety '{ $name }'
+
+# =============================================================================
+# SELECT INTO Errors
+# =============================================================================
+
+executor-select-into-row-count = Proceduralne SELECT INTO musi zwrócić dokładnie { $expected } wiersz, otrzymano { $actual } wiersz{ $plural }
+executor-select-into-column-count = Niezgodność liczby kolumn w proceduralnym SELECT INTO: { $expected } zmienn{ $expected_plural }, ale zapytanie zwróciło { $actual } kolumn{ $actual_plural }
+
+# =============================================================================
+# Procedure and Function Errors
+# =============================================================================
+
+executor-procedure-not-found-simple = Nie znaleziono procedury '{ $procedure_name }' w schemacie '{ $schema_name }'
+executor-procedure-not-found-with-available = Nie znaleziono procedury '{ $procedure_name }' w schemacie '{ $schema_name }'
+    .available = Dostępne procedury: { $available_procedures }
+executor-procedure-not-found-with-suggestion = Nie znaleziono procedury '{ $procedure_name }' w schemacie '{ $schema_name }'
+    .available = Dostępne procedury: { $available_procedures }
+    .suggestion = Czy chodziło o '{ $suggestion }'?
+
+executor-function-not-found-simple = Nie znaleziono funkcji '{ $function_name }' w schemacie '{ $schema_name }'
+executor-function-not-found-with-available = Nie znaleziono funkcji '{ $function_name }' w schemacie '{ $schema_name }'
+    .available = Dostępne funkcje: { $available_functions }
+executor-function-not-found-with-suggestion = Nie znaleziono funkcji '{ $function_name }' w schemacie '{ $schema_name }'
+    .available = Dostępne funkcje: { $available_functions }
+    .suggestion = Czy chodziło o '{ $suggestion }'?
+
+executor-parameter-count-mismatch = { $routine_type } '{ $routine_name }' oczekuje { $expected } parametr{ $expected_plural } ({ $parameter_signature }), otrzymano { $actual } argument{ $actual_plural }
+executor-parameter-type-mismatch = Parametr '{ $parameter_name }' oczekuje { $expected_type }, otrzymano { $actual_type } '{ $actual_value }'
+executor-argument-count-mismatch = Niezgodność liczby argumentów: oczekiwano { $expected }, otrzymano { $actual }
+
+executor-recursion-limit-exceeded = Przekroczono maksymalną głębokość rekurencji ({ $max_depth }): { $message }
+executor-recursion-call-stack = Stos wywołań:
+executor-function-must-return = Funkcja musi zwrócić wartość
+executor-invalid-control-flow = Nieprawidłowy przepływ sterowania: { $message }
+executor-invalid-function-body = Nieprawidłowe ciało funkcji: { $message }
+executor-function-read-only-violation = Naruszenie trybu tylko do odczytu funkcji: { $message }
+
+# =============================================================================
+# EXTRACT Errors
+# =============================================================================
+
+executor-invalid-extract-field = Nie można wyodrębnić { $field } z wartości typu { $value_type }
+
+# =============================================================================
+# Columnar/Arrow Errors
+# =============================================================================
+
+executor-arrow-downcast-error = Nie udało się rzutować tablicy Arrow na { $expected_type } ({ $context })
+executor-columnar-type-mismatch-binary = Niekompatybilne typy dla { $operation }: { $left_type } vs { $right_type }
+executor-columnar-type-mismatch-unary = Niekompatybilny typ dla { $operation }: { $left_type }
+executor-simd-operation-failed = Operacja SIMD { $operation } nie powiodła się: { $reason }
+executor-columnar-column-not-found = Indeks kolumny { $column_index } poza zakresem (partia ma { $batch_columns } kolumn)
+executor-columnar-column-not-found-by-name = Nie znaleziono kolumny: { $column_name }
+executor-columnar-length-mismatch = Niezgodność długości kolumny w { $context }: oczekiwano { $expected }, otrzymano { $actual }
+executor-unsupported-array-type = Nieobsługiwany typ tablicy dla { $operation }: { $array_type }
+
+# =============================================================================
+# Spatial Errors
+# =============================================================================
+
+executor-spatial-geometry-error = { $function_name }: { $message }
+executor-spatial-operation-failed = { $function_name }: { $message }
+executor-spatial-argument-error = { $function_name } oczekuje { $expected }, otrzymano { $actual }
+
+# =============================================================================
+# Cursor Errors
+# =============================================================================
+
+executor-cursor-already-exists = Kursor '{ $name }' już istnieje
+executor-cursor-not-found = Nie znaleziono kursora '{ $name }'
+executor-cursor-already-open = Kursor '{ $name }' jest już otwarty
+executor-cursor-not-open = Kursor '{ $name }' nie jest otwarty
+executor-cursor-not-scrollable = Kursor '{ $name }' nie jest przewijalny (nie określono SCROLL)
+
+# =============================================================================
+# Storage and General Errors
+# =============================================================================
+
+executor-storage-error = Błąd przechowywania: { $message }
+executor-other = { $message }

--- a/crates/vibesql-l10n/resources/pl/parser.ftl
+++ b/crates/vibesql-l10n/resources/pl/parser.ftl
@@ -1,0 +1,55 @@
+# VibeSQL Parser/Lexer Localization - Polski (Polish)
+# This file contains all user-facing strings for lexer and parser errors.
+
+# =============================================================================
+# Lexer Error Header
+# =============================================================================
+
+lexer-error-at-position = Błąd leksera na pozycji { $position }: { $message }
+
+# =============================================================================
+# String Literal Errors
+# =============================================================================
+
+lexer-unterminated-string = Niezakończony literał znakowy
+
+# =============================================================================
+# Identifier Errors
+# =============================================================================
+
+lexer-unterminated-delimited-identifier = Niezakończony identyfikator ograniczony
+lexer-empty-delimited-identifier = Pusty identyfikator ograniczony jest niedozwolony
+
+# =============================================================================
+# Number Literal Errors
+# =============================================================================
+
+lexer-invalid-scientific-notation = Nieprawidłowa notacja naukowa: oczekiwano cyfr po 'E'
+
+# =============================================================================
+# Placeholder Errors
+# =============================================================================
+
+lexer-expected-digit-after-dollar = Oczekiwano cyfry po '$' dla numerowanego symbolu zastępczego
+lexer-invalid-numbered-placeholder = Nieprawidłowy numerowany symbol zastępczy: ${ $placeholder }
+lexer-numbered-placeholder-zero = Numerowany symbol zastępczy musi być $1 lub wyższy (brak $0)
+lexer-expected-identifier-after-colon = Oczekiwano identyfikatora po ':' dla nazwanego symbolu zastępczego
+
+# =============================================================================
+# Variable Errors
+# =============================================================================
+
+lexer-expected-variable-after-at-at = Oczekiwano nazwy zmiennej po @@
+lexer-expected-variable-after-at = Oczekiwano nazwy zmiennej po @
+
+# =============================================================================
+# Operator Errors
+# =============================================================================
+
+lexer-unexpected-pipe = Nieoczekiwany znak: '|' (czy chodziło o '||'?)
+
+# =============================================================================
+# General Errors
+# =============================================================================
+
+lexer-unexpected-character = Nieoczekiwany znak: '{ $character }'

--- a/crates/vibesql-l10n/resources/pl/storage.ftl
+++ b/crates/vibesql-l10n/resources/pl/storage.ftl
@@ -1,0 +1,68 @@
+# VibeSQL Storage Error Messages - Polski (Polish)
+# This file contains all error messages for the vibesql-storage crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+storage-table-not-found = Nie znaleziono tabeli '{ $name }'
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+storage-column-count-mismatch = Niezgodność liczby kolumn: oczekiwano { $expected }, otrzymano { $actual }
+storage-column-index-out-of-bounds = Indeks kolumny { $index } poza zakresem
+storage-column-not-found = Nie znaleziono kolumny '{ $column_name }' w tabeli '{ $table_name }'
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+storage-index-already-exists = Indeks '{ $name }' już istnieje
+storage-index-not-found = Nie znaleziono indeksu '{ $name }'
+storage-invalid-index-column = { $message }
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+storage-null-constraint-violation = Naruszenie ograniczenia NOT NULL: kolumna '{ $column }' nie może być NULL
+storage-unique-constraint-violation = { $message }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+storage-type-mismatch = Niezgodność typu w kolumnie '{ $column }': oczekiwano { $expected }, otrzymano { $actual }
+
+# =============================================================================
+# Transaction and Catalog Errors
+# =============================================================================
+
+storage-catalog-error = Błąd katalogu: { $message }
+storage-transaction-error = Błąd transakcji: { $message }
+storage-row-not-found = Nie znaleziono wiersza
+
+# =============================================================================
+# I/O and Page Errors
+# =============================================================================
+
+storage-io-error = Błąd I/O: { $message }
+storage-invalid-page-size = Nieprawidłowy rozmiar strony: oczekiwano { $expected }, otrzymano { $actual }
+storage-invalid-page-id = Nieprawidłowy identyfikator strony: { $page_id }
+storage-lock-error = Błąd blokady: { $message }
+
+# =============================================================================
+# Memory Errors
+# =============================================================================
+
+storage-memory-budget-exceeded = Przekroczono budżet pamięci: używane { $used } bajtów, budżet wynosi { $budget } bajtów
+storage-no-index-to-evict = Brak indeksu do usunięcia (wszystkie indeksy są już oparte na dysku)
+
+# =============================================================================
+# General Errors
+# =============================================================================
+
+storage-not-implemented = Nie zaimplementowano: { $message }
+storage-other = { $message }


### PR DESCRIPTION
## Summary

- Add complete Polish (pl) translations for vibesql-l10n
- All 232 messages translated with 100% coverage
- Includes: cli.ftl, catalog.ftl, executor.ftl, parser.ftl, storage.ftl

## Test plan

- [x] Run `cargo run -p vibesql-l10n --bin check-translations -- --locale pl` → PASSED (100% coverage)
- [x] Run `cargo run -p vibesql-l10n --bin check-ftl` → PASSED (0 errors, 0 warnings)

Closes #3750

🤖 Generated with [Claude Code](https://claude.com/claude-code)