### PR TITLE
feat(i18n): Add Dutch translations (nl)

### DIFF
--- a/crates/vibesql-l10n/resources/nl/catalog.ftl
+++ b/crates/vibesql-l10n/resources/nl/catalog.ftl
@@ -1,0 +1,117 @@
+# VibeSQL Catalog Error Messages - Dutch (Nederlands)
+# This file contains all error messages for the vibesql-catalog crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+catalog-table-already-exists = Tabel '{ $name }' bestaat al
+catalog-table-not-found = Tabel '{ $table_name }' niet gevonden
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+catalog-column-already-exists = Kolom '{ $name }' bestaat al
+catalog-column-not-found = Kolom '{ $column_name }' niet gevonden in tabel '{ $table_name }'
+
+# =============================================================================
+# Schema Errors
+# =============================================================================
+
+catalog-schema-already-exists = Schema '{ $name }' bestaat al
+catalog-schema-not-found = Schema '{ $name }' niet gevonden
+catalog-schema-not-empty = Schema '{ $name }' is niet leeg
+
+# =============================================================================
+# Role Errors
+# =============================================================================
+
+catalog-role-already-exists = Rol '{ $name }' bestaat al
+catalog-role-not-found = Rol '{ $name }' niet gevonden
+
+# =============================================================================
+# Domain Errors
+# =============================================================================
+
+catalog-domain-already-exists = Domein '{ $name }' bestaat al
+catalog-domain-not-found = Domein '{ $name }' niet gevonden
+catalog-domain-in-use = Domein '{ $domain_name }' is nog in gebruik door { $count } kolom(men): { $columns }
+
+# =============================================================================
+# Sequence Errors
+# =============================================================================
+
+catalog-sequence-already-exists = Sequentie '{ $name }' bestaat al
+catalog-sequence-not-found = Sequentie '{ $name }' niet gevonden
+catalog-sequence-in-use = Sequentie '{ $sequence_name }' is nog in gebruik door { $count } kolom(men): { $columns }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+catalog-type-already-exists = Type '{ $name }' bestaat al
+catalog-type-not-found = Type '{ $name }' niet gevonden
+catalog-type-in-use = Type '{ $name }' is nog in gebruik door een of meer tabellen
+
+# =============================================================================
+# Collation and Character Set Errors
+# =============================================================================
+
+catalog-collation-already-exists = Collatie '{ $name }' bestaat al
+catalog-collation-not-found = Collatie '{ $name }' niet gevonden
+catalog-character-set-already-exists = Tekenset '{ $name }' bestaat al
+catalog-character-set-not-found = Tekenset '{ $name }' niet gevonden
+catalog-translation-already-exists = Vertaling '{ $name }' bestaat al
+catalog-translation-not-found = Vertaling '{ $name }' niet gevonden
+
+# =============================================================================
+# View Errors
+# =============================================================================
+
+catalog-view-already-exists = View '{ $name }' bestaat al
+catalog-view-not-found = View '{ $name }' niet gevonden
+catalog-view-in-use = View of tabel '{ $view_name }' is nog in gebruik door { $count } view(s): { $views }
+
+# =============================================================================
+# Trigger Errors
+# =============================================================================
+
+catalog-trigger-already-exists = Trigger '{ $name }' bestaat al
+catalog-trigger-not-found = Trigger '{ $name }' niet gevonden
+
+# =============================================================================
+# Assertion Errors
+# =============================================================================
+
+catalog-assertion-already-exists = Assertie '{ $name }' bestaat al
+catalog-assertion-not-found = Assertie '{ $name }' niet gevonden
+
+# =============================================================================
+# Function and Procedure Errors
+# =============================================================================
+
+catalog-function-already-exists = Functie '{ $name }' bestaat al
+catalog-function-not-found = Functie '{ $name }' niet gevonden
+catalog-procedure-already-exists = Procedure '{ $name }' bestaat al
+catalog-procedure-not-found = Procedure '{ $name }' niet gevonden
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+catalog-constraint-already-exists = Constraint '{ $name }' bestaat al
+catalog-constraint-not-found = Constraint '{ $name }' niet gevonden
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+catalog-index-already-exists = Index '{ $index_name }' op tabel '{ $table_name }' bestaat al
+catalog-index-not-found = Index '{ $index_name }' op tabel '{ $table_name }' niet gevonden
+
+# =============================================================================
+# Foreign Key Errors
+# =============================================================================
+
+catalog-circular-foreign-key = Circulaire foreign key-afhankelijkheid gedetecteerd voor tabel '{ $table_name }': { $message }

--- a/crates/vibesql-l10n/resources/nl/cli.ftl
+++ b/crates/vibesql-l10n/resources/nl/cli.ftl
@@ -1,0 +1,211 @@
+# VibeSQL CLI Localization - Dutch (Nederlands)
+# This file contains all user-facing strings for the VibeSQL command-line interface.
+
+# =============================================================================
+# REPL Banner and Basic Messages
+# =============================================================================
+
+cli-banner = VibeSQL v{ $version } - SQL:1999 VOLLEDIG Compliant Database
+cli-help-hint = Typ \help voor hulp, \quit om af te sluiten
+cli-goodbye = Tot ziens!
+
+# =============================================================================
+# Command Help Text (Clap Arguments)
+# =============================================================================
+
+cli-about = VibeSQL - SQL:1999 VOLLEDIG Compliant Database
+
+cli-long-about = VibeSQL opdrachtregelinterface
+
+    GEBRUIKSMODI:
+      Interactieve REPL:    vibesql (--database <BESTAND>)
+      Opdracht uitvoeren:   vibesql -c "SELECT * FROM users"
+      Bestand uitvoeren:    vibesql -f script.sql
+      Uitvoeren via stdin:  cat data.sql | vibesql
+      Types genereren:      vibesql codegen --schema schema.sql --output types.ts
+
+    INTERACTIEVE REPL:
+      Wanneer gestart zonder -c, -f, of gepipete invoer, gaat VibeSQL naar een
+      interactieve REPL met readline-ondersteuning, opdrachtgeschiedenis en
+      meta-opdrachten zoals:
+        \d (tabel)  - Beschrijf tabel of toon alle tabellen
+        \dt         - Toon tabellen
+        \f <format> - Stel uitvoerformaat in
+        \copy       - Importeer/exporteer CSV/JSON
+        \help       - Toon alle REPL-opdrachten
+
+    SUBOPDRACHTEN:
+      codegen           Genereer TypeScript-types uit databaseschema
+
+    CONFIGURATIE:
+      Instellingen kunnen worden geconfigureerd in ~/.vibesqlrc (TOML-formaat).
+      Secties: display, database, history, query
+
+    VOORBEELDEN:
+      # Start interactieve REPL met in-memory database
+      vibesql
+
+      # Gebruik persistent databasebestand
+      vibesql --database mydata.db
+
+      # Voer enkele opdracht uit
+      vibesql -c "CREATE TABLE users (id INT, name VARCHAR(100))"
+
+      # Voer SQL-scriptbestand uit
+      vibesql -f schema.sql -v
+
+      # Importeer gegevens uit CSV
+      echo "\copy users FROM 'data.csv'" | vibesql --database mydata.db
+
+      # Exporteer queryresultaten als JSON
+      vibesql -d mydata.db -c "SELECT * FROM users" --format json
+
+      # Genereer TypeScript-types uit schemabestand
+      vibesql codegen --schema schema.sql --output src/types.ts
+
+      # Genereer TypeScript-types uit draaiende database
+      vibesql codegen --database mydata.db --output src/types.ts
+
+# Argument help strings
+arg-database-help = Databasebestandspad (indien niet opgegeven, wordt in-memory database gebruikt)
+arg-file-help = Voer SQL-opdrachten uit vanuit bestand
+arg-command-help = Voer SQL-opdracht direct uit en sluit af
+arg-stdin-help = Lees SQL-opdrachten van stdin (automatisch gedetecteerd bij piping)
+arg-verbose-help = Toon gedetailleerde uitvoer tijdens bestand/stdin-uitvoering
+arg-format-help = Uitvoerformaat voor queryresultaten
+arg-lang-help = Stel de weergavetaal in (bijv. en-US, es, ja)
+
+# =============================================================================
+# Codegen Subcommand
+# =============================================================================
+
+codegen-about = Genereer TypeScript-types uit databaseschema
+
+codegen-long-about = Genereer TypeScript-typedefinities uit een VibeSQL-databaseschema.
+
+    Deze opdracht maakt TypeScript-interfaces voor alle tabellen in de database,
+    samen met metadata-objecten voor runtime typecontrole en IDE-ondersteuning.
+
+    INVOERBRONNEN:
+      --database <BESTAND>  Genereer uit een bestaand databasebestand
+      --schema <BESTAND>    Genereer uit een SQL-schemabestand (CREATE TABLE-statements)
+
+    UITVOER:
+      --output <BESTAND>    Schrijf gegenereerde types naar dit bestand (standaard: types.ts)
+
+    OPTIES:
+      --camel-case       Converteer kolomnamen naar camelCase
+      --no-metadata      Sla het genereren van het tabellen-metadata-object over
+
+    VOORBEELDEN:
+      # Vanuit een databasebestand
+      vibesql codegen --database mydata.db --output src/db/types.ts
+
+      # Vanuit een SQL-schemabestand
+      vibesql codegen --schema schema.sql --output src/db/types.ts
+
+      # Met camelCase eigenschapnamen
+      vibesql codegen --schema schema.sql --output types.ts --camel-case
+
+codegen-schema-help = SQL-schemabestand met CREATE TABLE-statements
+codegen-output-help = Uitvoerbestandspad voor gegenereerd TypeScript
+codegen-camel-case-help = Converteer kolomnamen naar camelCase
+codegen-no-metadata-help = Sla het genereren van tabel-metadata-object over
+
+codegen-from-schema = TypeScript-types genereren uit schemabestand: { $path }
+codegen-from-database = TypeScript-types genereren uit database: { $path }
+codegen-written = TypeScript-types geschreven naar: { $path }
+codegen-error-no-source = --database of --schema moet worden opgegeven.
+    Gebruik 'vibesql codegen --help' voor gebruiksinformatie.
+
+# =============================================================================
+# Meta-commands Help (\help output)
+# =============================================================================
+
+help-title = Meta-opdrachten:
+help-describe = \d (tabel)      - Beschrijf tabel of toon alle tabellen
+help-tables = \dt             - Toon tabellen
+help-schemas = \ds             - Toon schema's
+help-indexes = \di             - Toon indexen
+help-roles = \du             - Toon rollen/gebruikers
+help-format = \f <format>     - Stel uitvoerformaat in (table, json, csv, markdown, html)
+help-timing = \timing         - Schakel querytiming in/uit
+help-copy-to = \copy <tabel> TO <bestand>   - Exporteer tabel naar CSV/JSON-bestand
+help-copy-from = \copy <tabel> FROM <bestand> - Importeer CSV-bestand in tabel
+help-save = \save (bestand) - Sla database op naar SQL-dumpbestand
+help-errors = \errors         - Toon recente foutgeschiedenis
+help-help = \h, \help      - Toon deze hulp
+help-quit = \q, \quit      - Afsluiten
+
+help-sql-title = SQL-introspectie:
+help-show-tables = SHOW TABLES                  - Toon alle tabellen
+help-show-databases = SHOW DATABASES               - Toon alle schema's/databases
+help-show-columns = SHOW COLUMNS FROM <tabel>    - Toon tabelkolommen
+help-show-index = SHOW INDEX FROM <tabel>      - Toon tabelindexen
+help-show-create = SHOW CREATE TABLE <tabel>    - Toon CREATE TABLE-statement
+help-describe-sql = DESCRIBE <tabel>             - Alias voor SHOW COLUMNS
+
+help-examples-title = Voorbeelden:
+help-example-create = CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100));
+help-example-insert = INSERT INTO users VALUES (1, 'Alice'), (2, 'Bob');
+help-example-select = SELECT * FROM users;
+help-example-show-tables = SHOW TABLES;
+help-example-show-columns = SHOW COLUMNS FROM users;
+help-example-describe = DESCRIBE users;
+help-example-format-json = \f json
+help-example-format-md = \f markdown
+help-example-copy-to = \copy users TO '/tmp/users.csv'
+help-example-copy-from = \copy users FROM '/tmp/users.csv'
+help-example-copy-json = \copy users TO '/tmp/users.json'
+help-example-errors = \errors
+
+# =============================================================================
+# Status Messages
+# =============================================================================
+
+format-changed = Uitvoerformaat ingesteld op: { $format }
+database-saved = Database opgeslagen naar: { $path }
+no-database-file = Fout: Geen databasebestand opgegeven. Gebruik \save <bestandsnaam> of start met --database vlag
+
+# =============================================================================
+# Error Display
+# =============================================================================
+
+no-errors = Geen fouten in deze sessie.
+recent-errors = Recente fouten:
+
+# =============================================================================
+# Script Execution Messages
+# =============================================================================
+
+script-no-statements = Geen SQL-statements gevonden in script
+script-executing = Statement { $current } van { $total } uitvoeren...
+script-error = Fout bij uitvoeren van statement { $index }: { $error }
+script-summary-title = === Samenvatting Scriptuitvoering ===
+script-total = Totaal statements: { $count }
+script-successful = Succesvol: { $count }
+script-failed = Mislukt: { $count }
+script-failed-error = { $count } statements mislukt
+
+# =============================================================================
+# Output Formatting
+# =============================================================================
+
+rows-with-time = { $count } rijen in set ({ $time }s)
+rows-count = { $count } rijen
+
+# =============================================================================
+# Warnings
+# =============================================================================
+
+warning-config-load = Waarschuwing: Kon configuratiebestand niet laden: { $error }
+warning-auto-save-failed = Waarschuwing: Automatisch opslaan van database mislukt: { $error }
+warning-save-on-exit-failed = Waarschuwing: Opslaan van database bij afsluiten mislukt: { $error }
+
+# =============================================================================
+# File Operations
+# =============================================================================
+
+file-read-error = Lezen van bestand '{ $path }' mislukt: { $error }
+stdin-read-error = Lezen van stdin mislukt: { $error }
+database-load-error = Laden van database mislukt: { $error }

--- a/crates/vibesql-l10n/resources/nl/executor.ftl
+++ b/crates/vibesql-l10n/resources/nl/executor.ftl
@@ -1,0 +1,187 @@
+# VibeSQL Executor Error Messages - Dutch (Nederlands)
+# This file contains all error messages for the vibesql-executor crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+executor-table-not-found = Tabel '{ $name }' niet gevonden
+executor-table-already-exists = Tabel '{ $name }' bestaat al
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+executor-column-not-found-simple = Kolom '{ $column_name }' niet gevonden in tabel '{ $table_name }'
+executor-column-not-found-searched = Kolom '{ $column_name }' niet gevonden (doorzochte tabellen: { $searched_tables })
+executor-column-not-found-with-available = Kolom '{ $column_name }' niet gevonden (doorzochte tabellen: { $searched_tables }). Beschikbare kolommen: { $available_columns }
+executor-invalid-table-qualifier = Ongeldige tabelkwalificatie '{ $qualifier }' voor kolom '{ $column }'. Beschikbare tabellen: { $available_tables }
+executor-column-already-exists = Kolom '{ $name }' bestaat al
+executor-column-index-out-of-bounds = Kolomindex { $index } buiten bereik
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+executor-index-not-found = Index '{ $name }' niet gevonden
+executor-index-already-exists = Index '{ $name }' bestaat al
+executor-invalid-index-definition = Ongeldige indexdefinitie: { $message }
+
+# =============================================================================
+# Trigger Errors
+# =============================================================================
+
+executor-trigger-not-found = Trigger '{ $name }' niet gevonden
+executor-trigger-already-exists = Trigger '{ $name }' bestaat al
+
+# =============================================================================
+# Schema Errors
+# =============================================================================
+
+executor-schema-not-found = Schema '{ $name }' niet gevonden
+executor-schema-already-exists = Schema '{ $name }' bestaat al
+executor-schema-not-empty = Kan schema '{ $name }' niet verwijderen: schema is niet leeg
+
+# =============================================================================
+# Role and Permission Errors
+# =============================================================================
+
+executor-role-not-found = Rol '{ $name }' niet gevonden
+executor-permission-denied = Toegang geweigerd: rol '{ $role }' mist { $privilege } privilege op { $object }
+executor-dependent-privileges-exist = Afhankelijke privileges bestaan: { $message }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+executor-type-not-found = Type '{ $name }' niet gevonden
+executor-type-already-exists = Type '{ $name }' bestaat al
+executor-type-in-use = Kan type '{ $name }' niet verwijderen: type is nog in gebruik
+executor-type-mismatch = Type komt niet overeen: { $left } { $op } { $right }
+executor-type-error = Typefout: { $message }
+executor-cast-error = Kan { $from_type } niet converteren naar { $to_type }
+executor-type-conversion-error = Kan { $from } niet converteren naar { $to }
+
+# =============================================================================
+# Expression and Query Errors
+# =============================================================================
+
+executor-division-by-zero = Deling door nul
+executor-invalid-where-clause = Ongeldige WHERE-clausule: { $message }
+executor-unsupported-expression = Niet-ondersteunde expressie: { $message }
+executor-unsupported-feature = Niet-ondersteunde functie: { $message }
+executor-parse-error = Parseerfout: { $message }
+
+# =============================================================================
+# Subquery Errors
+# =============================================================================
+
+executor-subquery-returned-multiple-rows = Scalaire subquery retourneerde { $actual } rijen, verwacht { $expected }
+executor-subquery-column-count-mismatch = Subquery retourneerde { $actual } kolommen, verwacht { $expected }
+executor-column-count-mismatch = Afgeleide kolommenlijst heeft { $provided } kolommen maar query produceert { $expected } kolommen
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+executor-constraint-violation = Constraintschending: { $message }
+executor-multiple-primary-keys = Meerdere PRIMARY KEY-constraints zijn niet toegestaan
+executor-cannot-drop-column = Kan kolom niet verwijderen: { $message }
+executor-constraint-not-found = Constraint '{ $constraint_name }' niet gevonden in tabel '{ $table_name }'
+
+# =============================================================================
+# Resource Limit Errors
+# =============================================================================
+
+executor-expression-depth-exceeded = Expressiedieptelimiet overschreden: { $depth } > { $max_depth } (voorkomt stack overflow)
+executor-query-timeout-exceeded = Querytime-out overschreden: { $elapsed_seconds }s > { $max_seconds }s
+executor-row-limit-exceeded = Rijverwerkingslimiet overschreden: { $rows_processed } > { $max_rows }
+executor-memory-limit-exceeded = Geheugenlimiet overschreden: { $used_gb } GB > { $max_gb } GB
+
+# =============================================================================
+# Procedural/Variable Errors
+# =============================================================================
+
+executor-variable-not-found-simple = Variabele '{ $variable_name }' niet gevonden
+executor-variable-not-found-with-available = Variabele '{ $variable_name }' niet gevonden. Beschikbare variabelen: { $available_variables }
+executor-label-not-found = Label '{ $name }' niet gevonden
+
+# =============================================================================
+# SELECT INTO Errors
+# =============================================================================
+
+executor-select-into-row-count = Procedurele SELECT INTO moet precies { $expected } rij retourneren, kreeg { $actual } rij{ $plural }
+executor-select-into-column-count = Procedurele SELECT INTO kolomaantal komt niet overeen: { $expected } variabele{ $expected_plural } maar query retourneerde { $actual } kolom{ $actual_plural }
+
+# =============================================================================
+# Procedure and Function Errors
+# =============================================================================
+
+executor-procedure-not-found-simple = Procedure '{ $procedure_name }' niet gevonden in schema '{ $schema_name }'
+executor-procedure-not-found-with-available = Procedure '{ $procedure_name }' niet gevonden in schema '{ $schema_name }'
+    .available = Beschikbare procedures: { $available_procedures }
+executor-procedure-not-found-with-suggestion = Procedure '{ $procedure_name }' niet gevonden in schema '{ $schema_name }'
+    .available = Beschikbare procedures: { $available_procedures }
+    .suggestion = Bedoelde u '{ $suggestion }'?
+
+executor-function-not-found-simple = Functie '{ $function_name }' niet gevonden in schema '{ $schema_name }'
+executor-function-not-found-with-available = Functie '{ $function_name }' niet gevonden in schema '{ $schema_name }'
+    .available = Beschikbare functies: { $available_functions }
+executor-function-not-found-with-suggestion = Functie '{ $function_name }' niet gevonden in schema '{ $schema_name }'
+    .available = Beschikbare functies: { $available_functions }
+    .suggestion = Bedoelde u '{ $suggestion }'?
+
+executor-parameter-count-mismatch = { $routine_type } '{ $routine_name }' verwacht { $expected } parameter{ $expected_plural } ({ $parameter_signature }), kreeg { $actual } argument{ $actual_plural }
+executor-parameter-type-mismatch = Parameter '{ $parameter_name }' verwacht { $expected_type }, kreeg { $actual_type } '{ $actual_value }'
+executor-argument-count-mismatch = Argumentaantal komt niet overeen: verwacht { $expected }, kreeg { $actual }
+
+executor-recursion-limit-exceeded = Maximale recursiediepte ({ $max_depth }) overschreden: { $message }
+executor-recursion-call-stack = Aanroepstack:
+executor-function-must-return = Functie moet een waarde retourneren
+executor-invalid-control-flow = Ongeldige controlestroom: { $message }
+executor-invalid-function-body = Ongeldige functiebody: { $message }
+executor-function-read-only-violation = Functie alleen-lezen schending: { $message }
+
+# =============================================================================
+# EXTRACT Errors
+# =============================================================================
+
+executor-invalid-extract-field = Kan { $field } niet extraheren uit { $value_type } waarde
+
+# =============================================================================
+# Columnar/Arrow Errors
+# =============================================================================
+
+executor-arrow-downcast-error = Downcasten van Arrow-array naar { $expected_type } mislukt ({ $context })
+executor-columnar-type-mismatch-binary = Incompatibele types voor { $operation }: { $left_type } vs { $right_type }
+executor-columnar-type-mismatch-unary = Incompatibel type voor { $operation }: { $left_type }
+executor-simd-operation-failed = SIMD { $operation } mislukt: { $reason }
+executor-columnar-column-not-found = Kolomindex { $column_index } buiten bereik (batch heeft { $batch_columns } kolommen)
+executor-columnar-column-not-found-by-name = Kolom niet gevonden: { $column_name }
+executor-columnar-length-mismatch = Kolomlengte komt niet overeen in { $context }: verwacht { $expected }, kreeg { $actual }
+executor-unsupported-array-type = Niet-ondersteund arraytype voor { $operation }: { $array_type }
+
+# =============================================================================
+# Spatial Errors
+# =============================================================================
+
+executor-spatial-geometry-error = { $function_name }: { $message }
+executor-spatial-operation-failed = { $function_name }: { $message }
+executor-spatial-argument-error = { $function_name } verwacht { $expected }, kreeg { $actual }
+
+# =============================================================================
+# Cursor Errors
+# =============================================================================
+
+executor-cursor-already-exists = Cursor '{ $name }' bestaat al
+executor-cursor-not-found = Cursor '{ $name }' niet gevonden
+executor-cursor-already-open = Cursor '{ $name }' is al geopend
+executor-cursor-not-open = Cursor '{ $name }' is niet geopend
+executor-cursor-not-scrollable = Cursor '{ $name }' is niet scrollbaar (SCROLL niet opgegeven)
+
+# =============================================================================
+# Storage and General Errors
+# =============================================================================
+
+executor-storage-error = Opslagfout: { $message }
+executor-other = { $message }

--- a/crates/vibesql-l10n/resources/nl/parser.ftl
+++ b/crates/vibesql-l10n/resources/nl/parser.ftl
@@ -1,0 +1,55 @@
+# VibeSQL Parser/Lexer Localization - Dutch (Nederlands)
+# This file contains all user-facing strings for lexer and parser errors.
+
+# =============================================================================
+# Lexer Error Header
+# =============================================================================
+
+lexer-error-at-position = Lexerfout op positie { $position }: { $message }
+
+# =============================================================================
+# String Literal Errors
+# =============================================================================
+
+lexer-unterminated-string = Niet-afgesloten string-literal
+
+# =============================================================================
+# Identifier Errors
+# =============================================================================
+
+lexer-unterminated-delimited-identifier = Niet-afgesloten gescheiden identificatie
+lexer-empty-delimited-identifier = Lege gescheiden identificatie is niet toegestaan
+
+# =============================================================================
+# Number Literal Errors
+# =============================================================================
+
+lexer-invalid-scientific-notation = Ongeldige wetenschappelijke notatie: cijfers verwacht na 'E'
+
+# =============================================================================
+# Placeholder Errors
+# =============================================================================
+
+lexer-expected-digit-after-dollar = Cijfer verwacht na '$' voor genummerde placeholder
+lexer-invalid-numbered-placeholder = Ongeldige genummerde placeholder: ${ $placeholder }
+lexer-numbered-placeholder-zero = Genummerde placeholder moet $1 of hoger zijn (geen $0)
+lexer-expected-identifier-after-colon = Identificatie verwacht na ':' voor benoemde placeholder
+
+# =============================================================================
+# Variable Errors
+# =============================================================================
+
+lexer-expected-variable-after-at-at = Variabelenaam verwacht na @@
+lexer-expected-variable-after-at = Variabelenaam verwacht na @
+
+# =============================================================================
+# Operator Errors
+# =============================================================================
+
+lexer-unexpected-pipe = Onverwacht teken: '|' (bedoelde u '||'?)
+
+# =============================================================================
+# General Errors
+# =============================================================================
+
+lexer-unexpected-character = Onverwacht teken: '{ $character }'

--- a/crates/vibesql-l10n/resources/nl/storage.ftl
+++ b/crates/vibesql-l10n/resources/nl/storage.ftl
@@ -1,0 +1,68 @@
+# VibeSQL Storage Error Messages - Dutch (Nederlands)
+# This file contains all error messages for the vibesql-storage crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+storage-table-not-found = Tabel '{ $name }' niet gevonden
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+storage-column-count-mismatch = Kolomaantal komt niet overeen: verwacht { $expected }, kreeg { $actual }
+storage-column-index-out-of-bounds = Kolomindex { $index } buiten bereik
+storage-column-not-found = Kolom '{ $column_name }' niet gevonden in tabel '{ $table_name }'
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+storage-index-already-exists = Index '{ $name }' bestaat al
+storage-index-not-found = Index '{ $name }' niet gevonden
+storage-invalid-index-column = { $message }
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+storage-null-constraint-violation = NOT NULL-constraintschending: kolom '{ $column }' kan niet NULL zijn
+storage-unique-constraint-violation = { $message }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+storage-type-mismatch = Type komt niet overeen in kolom '{ $column }': verwacht { $expected }, kreeg { $actual }
+
+# =============================================================================
+# Transaction and Catalog Errors
+# =============================================================================
+
+storage-catalog-error = Catalogusfout: { $message }
+storage-transaction-error = Transactiefout: { $message }
+storage-row-not-found = Rij niet gevonden
+
+# =============================================================================
+# I/O and Page Errors
+# =============================================================================
+
+storage-io-error = I/O-fout: { $message }
+storage-invalid-page-size = Ongeldige paginagrootte: verwacht { $expected }, kreeg { $actual }
+storage-invalid-page-id = Ongeldig pagina-ID: { $page_id }
+storage-lock-error = Vergrendelingsfout: { $message }
+
+# =============================================================================
+# Memory Errors
+# =============================================================================
+
+storage-memory-budget-exceeded = Geheugenbudget overschreden: gebruikt { $used } bytes, budget is { $budget } bytes
+storage-no-index-to-evict = Geen index beschikbaar om te verwijderen (alle indexen zijn al schijfgebaseerd)
+
+# =============================================================================
+# General Errors
+# =============================================================================
+
+storage-not-implemented = Niet geïmplementeerd: { $message }
+storage-other = { $message }


### PR DESCRIPTION
## Summary
- Add complete Dutch (Nederlands) translations to vibesql-l10n
- 232 messages translated across 5 files (cli, catalog, executor, parser, storage)
- 100% translation coverage verified by check-translations
- All FTL files pass syntax validation

## Test plan
- [x] Run `cargo run -p vibesql-l10n --bin check-translations -- --locale nl` - passes with 100% coverage
- [x] Run `cargo run -p vibesql-l10n --bin check-ftl` - all files valid

Closes #3752

🤖 Generated with [Claude Code](https://claude.com/claude-code)