### PR TITLE
feat(l10n): Add Indonesian (id) translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Demo](https://img.shields.io/badge/demo-live-success)](https://rjwalters.github.io/vibesql/)
 [![sqltest](https://img.shields.io/endpoint?url=https://rjwalters.github.io/vibesql/badges/sql1999-conformance.json)](https://rjwalters.github.io/vibesql/conformance.html)
 [![SQLLogicTest](https://img.shields.io/endpoint?url=https://rjwalters.github.io/vibesql/badges/sqllogictest.json)](https://rjwalters.github.io/vibesql/conformance.html#SQLlogicTest)
-[![i18n](https://img.shields.io/badge/i18n-12%20languages-blue)](docs/CONTRIBUTING_TRANSLATIONS.md)
+[![i18n](https://img.shields.io/badge/i18n-13%20languages-blue)](docs/CONTRIBUTING_TRANSLATIONS.md)
 
 **SQL:1999 compliant database in Rust, 100% AI-generated**
 

--- a/crates/vibesql-l10n/resources/id/catalog.ftl
+++ b/crates/vibesql-l10n/resources/id/catalog.ftl
@@ -1,0 +1,117 @@
+# VibeSQL Catalog Error Messages - Indonesian (id)
+# This file contains all error messages for the vibesql-catalog crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+catalog-table-already-exists = Tabel '{ $name }' sudah ada
+catalog-table-not-found = Tabel '{ $table_name }' tidak ditemukan
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+catalog-column-already-exists = Kolom '{ $name }' sudah ada
+catalog-column-not-found = Kolom '{ $column_name }' tidak ditemukan dalam tabel '{ $table_name }'
+
+# =============================================================================
+# Schema Errors
+# =============================================================================
+
+catalog-schema-already-exists = Skema '{ $name }' sudah ada
+catalog-schema-not-found = Skema '{ $name }' tidak ditemukan
+catalog-schema-not-empty = Skema '{ $name }' tidak kosong
+
+# =============================================================================
+# Role Errors
+# =============================================================================
+
+catalog-role-already-exists = Peran '{ $name }' sudah ada
+catalog-role-not-found = Peran '{ $name }' tidak ditemukan
+
+# =============================================================================
+# Domain Errors
+# =============================================================================
+
+catalog-domain-already-exists = Domain '{ $name }' sudah ada
+catalog-domain-not-found = Domain '{ $name }' tidak ditemukan
+catalog-domain-in-use = Domain '{ $domain_name }' masih digunakan oleh { $count } kolom: { $columns }
+
+# =============================================================================
+# Sequence Errors
+# =============================================================================
+
+catalog-sequence-already-exists = Urutan '{ $name }' sudah ada
+catalog-sequence-not-found = Urutan '{ $name }' tidak ditemukan
+catalog-sequence-in-use = Urutan '{ $sequence_name }' masih digunakan oleh { $count } kolom: { $columns }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+catalog-type-already-exists = Tipe '{ $name }' sudah ada
+catalog-type-not-found = Tipe '{ $name }' tidak ditemukan
+catalog-type-in-use = Tipe '{ $name }' masih digunakan oleh satu atau lebih tabel
+
+# =============================================================================
+# Collation and Character Set Errors
+# =============================================================================
+
+catalog-collation-already-exists = Kolasi '{ $name }' sudah ada
+catalog-collation-not-found = Kolasi '{ $name }' tidak ditemukan
+catalog-character-set-already-exists = Set karakter '{ $name }' sudah ada
+catalog-character-set-not-found = Set karakter '{ $name }' tidak ditemukan
+catalog-translation-already-exists = Terjemahan '{ $name }' sudah ada
+catalog-translation-not-found = Terjemahan '{ $name }' tidak ditemukan
+
+# =============================================================================
+# View Errors
+# =============================================================================
+
+catalog-view-already-exists = View '{ $name }' sudah ada
+catalog-view-not-found = View '{ $name }' tidak ditemukan
+catalog-view-in-use = View atau tabel '{ $view_name }' masih digunakan oleh { $count } view: { $views }
+
+# =============================================================================
+# Trigger Errors
+# =============================================================================
+
+catalog-trigger-already-exists = Trigger '{ $name }' sudah ada
+catalog-trigger-not-found = Trigger '{ $name }' tidak ditemukan
+
+# =============================================================================
+# Assertion Errors
+# =============================================================================
+
+catalog-assertion-already-exists = Asersi '{ $name }' sudah ada
+catalog-assertion-not-found = Asersi '{ $name }' tidak ditemukan
+
+# =============================================================================
+# Function and Procedure Errors
+# =============================================================================
+
+catalog-function-already-exists = Fungsi '{ $name }' sudah ada
+catalog-function-not-found = Fungsi '{ $name }' tidak ditemukan
+catalog-procedure-already-exists = Prosedur '{ $name }' sudah ada
+catalog-procedure-not-found = Prosedur '{ $name }' tidak ditemukan
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+catalog-constraint-already-exists = Batasan '{ $name }' sudah ada
+catalog-constraint-not-found = Batasan '{ $name }' tidak ditemukan
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+catalog-index-already-exists = Indeks '{ $index_name }' pada tabel '{ $table_name }' sudah ada
+catalog-index-not-found = Indeks '{ $index_name }' pada tabel '{ $table_name }' tidak ditemukan
+
+# =============================================================================
+# Foreign Key Errors
+# =============================================================================
+
+catalog-circular-foreign-key = Ketergantungan kunci asing melingkar terdeteksi untuk tabel '{ $table_name }': { $message }

--- a/crates/vibesql-l10n/resources/id/cli.ftl
+++ b/crates/vibesql-l10n/resources/id/cli.ftl
@@ -1,0 +1,210 @@
+# VibeSQL CLI Localization - Indonesian (id)
+# This file contains all user-facing strings for the VibeSQL command-line interface.
+
+# =============================================================================
+# REPL Banner and Basic Messages
+# =============================================================================
+
+cli-banner = VibeSQL v{ $version } - Database dengan Kepatuhan PENUH SQL:1999
+cli-help-hint = Ketik \help untuk bantuan, \quit untuk keluar
+cli-goodbye = Sampai jumpa!
+
+# =============================================================================
+# Command Help Text (Clap Arguments)
+# =============================================================================
+
+cli-about = VibeSQL - Database dengan Kepatuhan PENUH SQL:1999
+
+cli-long-about = Antarmuka baris perintah VibeSQL
+
+    MODE PENGGUNAAN:
+      REPL interaktif:       vibesql (--database <FILE>)
+      Jalankan perintah:     vibesql -c "SELECT * FROM users"
+      Jalankan file:         vibesql -f script.sql
+      Jalankan dari stdin:   cat data.sql | vibesql
+      Hasilkan tipe:         vibesql codegen --schema schema.sql --output types.ts
+
+    REPL INTERAKTIF:
+      Ketika dijalankan tanpa -c, -f, atau input pipa, VibeSQL masuk ke REPL
+      interaktif dengan dukungan readline, riwayat perintah, dan meta-perintah seperti:
+        \d (tabel)    - Jelaskan tabel atau daftar semua tabel
+        \dt           - Daftar tabel
+        \f <format>   - Atur format output
+        \copy         - Impor/ekspor CSV/JSON
+        \help         - Tampilkan semua perintah REPL
+
+    SUBPERINTAH:
+      codegen           Hasilkan tipe TypeScript dari skema database
+
+    KONFIGURASI:
+      Pengaturan dapat dikonfigurasi di ~/.vibesqlrc (format TOML).
+      Bagian: display, database, history, query
+
+    CONTOH:
+      # Mulai REPL interaktif dengan database di memori
+      vibesql
+
+      # Gunakan file database persisten
+      vibesql --database mydata.db
+
+      # Jalankan perintah tunggal
+      vibesql -c "CREATE TABLE users (id INT, name VARCHAR(100))"
+
+      # Jalankan file skrip SQL
+      vibesql -f schema.sql -v
+
+      # Impor data dari CSV
+      echo "\copy users FROM 'data.csv'" | vibesql --database mydata.db
+
+      # Ekspor hasil query sebagai JSON
+      vibesql -d mydata.db -c "SELECT * FROM users" --format json
+
+      # Hasilkan tipe TypeScript dari file skema
+      vibesql codegen --schema schema.sql --output src/types.ts
+
+      # Hasilkan tipe TypeScript dari database yang berjalan
+      vibesql codegen --database mydata.db --output src/types.ts
+
+# Argument help strings
+arg-database-help = Path file database (jika tidak ditentukan, gunakan database di memori)
+arg-file-help = Jalankan perintah SQL dari file
+arg-command-help = Jalankan perintah SQL langsung dan keluar
+arg-stdin-help = Baca perintah SQL dari stdin (terdeteksi otomatis saat di-pipe)
+arg-verbose-help = Tampilkan output detail selama eksekusi file/stdin
+arg-format-help = Format output untuk hasil query
+arg-lang-help = Atur bahasa tampilan (mis. en-US, es, ja)
+
+# =============================================================================
+# Codegen Subcommand
+# =============================================================================
+
+codegen-about = Hasilkan tipe TypeScript dari skema database
+
+codegen-long-about = Hasilkan definisi tipe TypeScript dari skema database VibeSQL.
+
+    Perintah ini membuat antarmuka TypeScript untuk semua tabel di database,
+    bersama dengan objek metadata untuk pemeriksaan tipe runtime dan dukungan IDE.
+
+    SUMBER INPUT:
+      --database <FILE>  Hasilkan dari file database yang ada
+      --schema <FILE>    Hasilkan dari file skema SQL (pernyataan CREATE TABLE)
+
+    OUTPUT:
+      --output <FILE>    Tulis tipe yang dihasilkan ke file ini (default: types.ts)
+
+    OPSI:
+      --camel-case       Konversi nama kolom ke camelCase
+      --no-metadata      Lewati pembuatan objek metadata tabel
+
+    CONTOH:
+      # Dari file database
+      vibesql codegen --database mydata.db --output src/db/types.ts
+
+      # Dari file skema SQL
+      vibesql codegen --schema schema.sql --output src/db/types.ts
+
+      # Dengan nama properti camelCase
+      vibesql codegen --schema schema.sql --output types.ts --camel-case
+
+codegen-schema-help = File skema SQL yang berisi pernyataan CREATE TABLE
+codegen-output-help = Path file output untuk TypeScript yang dihasilkan
+codegen-camel-case-help = Konversi nama kolom ke camelCase
+codegen-no-metadata-help = Lewati pembuatan objek metadata tabel
+
+codegen-from-schema = Menghasilkan tipe TypeScript dari file skema: { $path }
+codegen-from-database = Menghasilkan tipe TypeScript dari database: { $path }
+codegen-written = Tipe TypeScript ditulis ke: { $path }
+codegen-error-no-source = Harus menentukan --database atau --schema.
+    Gunakan 'vibesql codegen --help' untuk informasi penggunaan.
+
+# =============================================================================
+# Meta-commands Help (\help output)
+# =============================================================================
+
+help-title = Meta-perintah:
+help-describe = \d (tabel)      - Jelaskan tabel atau daftar semua tabel
+help-tables = \dt             - Daftar tabel
+help-schemas = \ds             - Daftar skema
+help-indexes = \di             - Daftar indeks
+help-roles = \du             - Daftar peran/pengguna
+help-format = \f <format>     - Atur format output (table, json, csv, markdown, html)
+help-timing = \timing         - Aktifkan/nonaktifkan pengukuran waktu query
+help-copy-to = \copy <tabel> TO <file>   - Ekspor tabel ke file CSV/JSON
+help-copy-from = \copy <tabel> FROM <file> - Impor file CSV ke tabel
+help-save = \save (file)    - Simpan database ke file dump SQL
+help-errors = \errors         - Tampilkan riwayat kesalahan terkini
+help-help = \h, \help      - Tampilkan bantuan ini
+help-quit = \q, \quit      - Keluar
+
+help-sql-title = Introspeksi SQL:
+help-show-tables = SHOW TABLES                  - Daftar semua tabel
+help-show-databases = SHOW DATABASES               - Daftar semua skema/database
+help-show-columns = SHOW COLUMNS FROM <tabel>    - Tampilkan kolom tabel
+help-show-index = SHOW INDEX FROM <tabel>      - Tampilkan indeks tabel
+help-show-create = SHOW CREATE TABLE <tabel>    - Tampilkan pernyataan CREATE TABLE
+help-describe-sql = DESCRIBE <tabel>             - Alias untuk SHOW COLUMNS
+
+help-examples-title = Contoh:
+help-example-create = CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100));
+help-example-insert = INSERT INTO users VALUES (1, 'Alice'), (2, 'Bob');
+help-example-select = SELECT * FROM users;
+help-example-show-tables = SHOW TABLES;
+help-example-show-columns = SHOW COLUMNS FROM users;
+help-example-describe = DESCRIBE users;
+help-example-format-json = \f json
+help-example-format-md = \f markdown
+help-example-copy-to = \copy users TO '/tmp/users.csv'
+help-example-copy-from = \copy users FROM '/tmp/users.csv'
+help-example-copy-json = \copy users TO '/tmp/users.json'
+help-example-errors = \errors
+
+# =============================================================================
+# Status Messages
+# =============================================================================
+
+format-changed = Format output diatur ke: { $format }
+database-saved = Database disimpan ke: { $path }
+no-database-file = Kesalahan: Tidak ada file database yang ditentukan. Gunakan \save <namafile> atau mulai dengan flag --database
+
+# =============================================================================
+# Error Display
+# =============================================================================
+
+no-errors = Tidak ada kesalahan dalam sesi ini.
+recent-errors = Kesalahan terkini:
+
+# =============================================================================
+# Script Execution Messages
+# =============================================================================
+
+script-no-statements = Tidak ada pernyataan SQL yang ditemukan dalam skrip
+script-executing = Menjalankan pernyataan { $current } dari { $total }...
+script-error = Kesalahan menjalankan pernyataan { $index }: { $error }
+script-summary-title = === Ringkasan Eksekusi Skrip ===
+script-total = Total pernyataan: { $count }
+script-successful = Berhasil: { $count }
+script-failed = Gagal: { $count }
+script-failed-error = { $count } pernyataan gagal
+
+# =============================================================================
+# Output Formatting
+# =============================================================================
+
+rows-with-time = { $count } baris dalam hasil ({ $time }s)
+rows-count = { $count } baris
+
+# =============================================================================
+# Warnings
+# =============================================================================
+
+warning-config-load = Peringatan: Tidak dapat memuat file konfigurasi: { $error }
+warning-auto-save-failed = Peringatan: Gagal menyimpan database secara otomatis: { $error }
+warning-save-on-exit-failed = Peringatan: Gagal menyimpan database saat keluar: { $error }
+
+# =============================================================================
+# File Operations
+# =============================================================================
+
+file-read-error = Gagal membaca file '{ $path }': { $error }
+stdin-read-error = Gagal membaca dari stdin: { $error }
+database-load-error = Gagal memuat database: { $error }

--- a/crates/vibesql-l10n/resources/id/executor.ftl
+++ b/crates/vibesql-l10n/resources/id/executor.ftl
@@ -1,0 +1,187 @@
+# VibeSQL Executor Error Messages - Indonesian (id)
+# This file contains all error messages for the vibesql-executor crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+executor-table-not-found = Tabel '{ $name }' tidak ditemukan
+executor-table-already-exists = Tabel '{ $name }' sudah ada
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+executor-column-not-found-simple = Kolom '{ $column_name }' tidak ditemukan dalam tabel '{ $table_name }'
+executor-column-not-found-searched = Kolom '{ $column_name }' tidak ditemukan (tabel yang dicari: { $searched_tables })
+executor-column-not-found-with-available = Kolom '{ $column_name }' tidak ditemukan (tabel yang dicari: { $searched_tables }). Kolom yang tersedia: { $available_columns }
+executor-invalid-table-qualifier = Kualifier tabel '{ $qualifier }' tidak valid untuk kolom '{ $column }'. Tabel yang tersedia: { $available_tables }
+executor-column-already-exists = Kolom '{ $name }' sudah ada
+executor-column-index-out-of-bounds = Indeks kolom { $index } di luar batas
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+executor-index-not-found = Indeks '{ $name }' tidak ditemukan
+executor-index-already-exists = Indeks '{ $name }' sudah ada
+executor-invalid-index-definition = Definisi indeks tidak valid: { $message }
+
+# =============================================================================
+# Trigger Errors
+# =============================================================================
+
+executor-trigger-not-found = Trigger '{ $name }' tidak ditemukan
+executor-trigger-already-exists = Trigger '{ $name }' sudah ada
+
+# =============================================================================
+# Schema Errors
+# =============================================================================
+
+executor-schema-not-found = Skema '{ $name }' tidak ditemukan
+executor-schema-already-exists = Skema '{ $name }' sudah ada
+executor-schema-not-empty = Tidak dapat menghapus skema '{ $name }': skema tidak kosong
+
+# =============================================================================
+# Role and Permission Errors
+# =============================================================================
+
+executor-role-not-found = Peran '{ $name }' tidak ditemukan
+executor-permission-denied = Izin ditolak: peran '{ $role }' tidak memiliki hak { $privilege } pada { $object }
+executor-dependent-privileges-exist = Hak dependen ada: { $message }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+executor-type-not-found = Tipe '{ $name }' tidak ditemukan
+executor-type-already-exists = Tipe '{ $name }' sudah ada
+executor-type-in-use = Tidak dapat menghapus tipe '{ $name }': tipe masih digunakan
+executor-type-mismatch = Ketidakcocokan tipe: { $left } { $op } { $right }
+executor-type-error = Kesalahan tipe: { $message }
+executor-cast-error = Tidak dapat mengkonversi { $from_type } ke { $to_type }
+executor-type-conversion-error = Tidak dapat mengkonversi { $from } ke { $to }
+
+# =============================================================================
+# Expression and Query Errors
+# =============================================================================
+
+executor-division-by-zero = Pembagian dengan nol
+executor-invalid-where-clause = Klausa WHERE tidak valid: { $message }
+executor-unsupported-expression = Ekspresi tidak didukung: { $message }
+executor-unsupported-feature = Fitur tidak didukung: { $message }
+executor-parse-error = Kesalahan parsing: { $message }
+
+# =============================================================================
+# Subquery Errors
+# =============================================================================
+
+executor-subquery-returned-multiple-rows = Subquery skalar mengembalikan { $actual } baris, diharapkan { $expected }
+executor-subquery-column-count-mismatch = Subquery mengembalikan { $actual } kolom, diharapkan { $expected }
+executor-column-count-mismatch = Daftar kolom turunan memiliki { $provided } kolom tetapi query menghasilkan { $expected } kolom
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+executor-constraint-violation = Pelanggaran batasan: { $message }
+executor-multiple-primary-keys = Batasan PRIMARY KEY ganda tidak diperbolehkan
+executor-cannot-drop-column = Tidak dapat menghapus kolom: { $message }
+executor-constraint-not-found = Batasan '{ $constraint_name }' tidak ditemukan dalam tabel '{ $table_name }'
+
+# =============================================================================
+# Resource Limit Errors
+# =============================================================================
+
+executor-expression-depth-exceeded = Batas kedalaman ekspresi terlampaui: { $depth } > { $max_depth } (mencegah stack overflow)
+executor-query-timeout-exceeded = Batas waktu query terlampaui: { $elapsed_seconds }s > { $max_seconds }s
+executor-row-limit-exceeded = Batas pemrosesan baris terlampaui: { $rows_processed } > { $max_rows }
+executor-memory-limit-exceeded = Batas memori terlampaui: { $used_gb } GB > { $max_gb } GB
+
+# =============================================================================
+# Procedural/Variable Errors
+# =============================================================================
+
+executor-variable-not-found-simple = Variabel '{ $variable_name }' tidak ditemukan
+executor-variable-not-found-with-available = Variabel '{ $variable_name }' tidak ditemukan. Variabel yang tersedia: { $available_variables }
+executor-label-not-found = Label '{ $name }' tidak ditemukan
+
+# =============================================================================
+# SELECT INTO Errors
+# =============================================================================
+
+executor-select-into-row-count = SELECT INTO prosedural harus mengembalikan tepat { $expected } baris, mendapat { $actual } baris
+executor-select-into-column-count = Ketidakcocokan jumlah kolom SELECT INTO prosedural: { $expected } variabel tetapi query mengembalikan { $actual } kolom
+
+# =============================================================================
+# Procedure and Function Errors
+# =============================================================================
+
+executor-procedure-not-found-simple = Prosedur '{ $procedure_name }' tidak ditemukan dalam skema '{ $schema_name }'
+executor-procedure-not-found-with-available = Prosedur '{ $procedure_name }' tidak ditemukan dalam skema '{ $schema_name }'
+    .available = Prosedur yang tersedia: { $available_procedures }
+executor-procedure-not-found-with-suggestion = Prosedur '{ $procedure_name }' tidak ditemukan dalam skema '{ $schema_name }'
+    .available = Prosedur yang tersedia: { $available_procedures }
+    .suggestion = Apakah Anda maksud '{ $suggestion }'?
+
+executor-function-not-found-simple = Fungsi '{ $function_name }' tidak ditemukan dalam skema '{ $schema_name }'
+executor-function-not-found-with-available = Fungsi '{ $function_name }' tidak ditemukan dalam skema '{ $schema_name }'
+    .available = Fungsi yang tersedia: { $available_functions }
+executor-function-not-found-with-suggestion = Fungsi '{ $function_name }' tidak ditemukan dalam skema '{ $schema_name }'
+    .available = Fungsi yang tersedia: { $available_functions }
+    .suggestion = Apakah Anda maksud '{ $suggestion }'?
+
+executor-parameter-count-mismatch = { $routine_type } '{ $routine_name }' mengharapkan { $expected } parameter ({ $parameter_signature }), mendapat { $actual } argumen
+executor-parameter-type-mismatch = Parameter '{ $parameter_name }' mengharapkan { $expected_type }, mendapat { $actual_type } '{ $actual_value }'
+executor-argument-count-mismatch = Ketidakcocokan jumlah argumen: diharapkan { $expected }, mendapat { $actual }
+
+executor-recursion-limit-exceeded = Kedalaman rekursi maksimum ({ $max_depth }) terlampaui: { $message }
+executor-recursion-call-stack = Stack panggilan:
+executor-function-must-return = Fungsi harus mengembalikan nilai
+executor-invalid-control-flow = Alur kontrol tidak valid: { $message }
+executor-invalid-function-body = Badan fungsi tidak valid: { $message }
+executor-function-read-only-violation = Pelanggaran fungsi hanya-baca: { $message }
+
+# =============================================================================
+# EXTRACT Errors
+# =============================================================================
+
+executor-invalid-extract-field = Tidak dapat mengekstrak { $field } dari nilai tipe { $value_type }
+
+# =============================================================================
+# Columnar/Arrow Errors
+# =============================================================================
+
+executor-arrow-downcast-error = Gagal menurunkan array Arrow ke { $expected_type } ({ $context })
+executor-columnar-type-mismatch-binary = Tipe tidak kompatibel untuk { $operation }: { $left_type } vs { $right_type }
+executor-columnar-type-mismatch-unary = Tipe tidak kompatibel untuk { $operation }: { $left_type }
+executor-simd-operation-failed = Operasi SIMD { $operation } gagal: { $reason }
+executor-columnar-column-not-found = Indeks kolom { $column_index } di luar batas (batch memiliki { $batch_columns } kolom)
+executor-columnar-column-not-found-by-name = Kolom tidak ditemukan: { $column_name }
+executor-columnar-length-mismatch = Ketidakcocokan panjang kolom dalam { $context }: diharapkan { $expected }, mendapat { $actual }
+executor-unsupported-array-type = Tipe array tidak didukung untuk { $operation }: { $array_type }
+
+# =============================================================================
+# Spatial Errors
+# =============================================================================
+
+executor-spatial-geometry-error = { $function_name }: { $message }
+executor-spatial-operation-failed = { $function_name }: { $message }
+executor-spatial-argument-error = { $function_name } mengharapkan { $expected }, mendapat { $actual }
+
+# =============================================================================
+# Cursor Errors
+# =============================================================================
+
+executor-cursor-already-exists = Kursor '{ $name }' sudah ada
+executor-cursor-not-found = Kursor '{ $name }' tidak ditemukan
+executor-cursor-already-open = Kursor '{ $name }' sudah terbuka
+executor-cursor-not-open = Kursor '{ $name }' tidak terbuka
+executor-cursor-not-scrollable = Kursor '{ $name }' tidak dapat di-scroll (SCROLL tidak ditentukan)
+
+# =============================================================================
+# Storage and General Errors
+# =============================================================================
+
+executor-storage-error = Kesalahan penyimpanan: { $message }
+executor-other = { $message }

--- a/crates/vibesql-l10n/resources/id/parser.ftl
+++ b/crates/vibesql-l10n/resources/id/parser.ftl
@@ -1,0 +1,55 @@
+# VibeSQL Parser/Lexer Localization - Indonesian (id)
+# This file contains all user-facing strings for lexer and parser errors.
+
+# =============================================================================
+# Lexer Error Header
+# =============================================================================
+
+lexer-error-at-position = Kesalahan lexer pada posisi { $position }: { $message }
+
+# =============================================================================
+# String Literal Errors
+# =============================================================================
+
+lexer-unterminated-string = Literal string tidak diakhiri
+
+# =============================================================================
+# Identifier Errors
+# =============================================================================
+
+lexer-unterminated-delimited-identifier = Identifier dibatasi tidak diakhiri
+lexer-empty-delimited-identifier = Identifier dibatasi kosong tidak diperbolehkan
+
+# =============================================================================
+# Number Literal Errors
+# =============================================================================
+
+lexer-invalid-scientific-notation = Notasi ilmiah tidak valid: digit diharapkan setelah 'E'
+
+# =============================================================================
+# Placeholder Errors
+# =============================================================================
+
+lexer-expected-digit-after-dollar = Digit diharapkan setelah '$' untuk placeholder bernomor
+lexer-invalid-numbered-placeholder = Placeholder bernomor tidak valid: ${ $placeholder }
+lexer-numbered-placeholder-zero = Placeholder bernomor harus $1 atau lebih tinggi (bukan $0)
+lexer-expected-identifier-after-colon = Identifier diharapkan setelah ':' untuk placeholder bernama
+
+# =============================================================================
+# Variable Errors
+# =============================================================================
+
+lexer-expected-variable-after-at-at = Nama variabel diharapkan setelah @@
+lexer-expected-variable-after-at = Nama variabel diharapkan setelah @
+
+# =============================================================================
+# Operator Errors
+# =============================================================================
+
+lexer-unexpected-pipe = Karakter tidak terduga: '|' (apakah Anda maksud '||'?)
+
+# =============================================================================
+# General Errors
+# =============================================================================
+
+lexer-unexpected-character = Karakter tidak terduga: '{ $character }'

--- a/crates/vibesql-l10n/resources/id/storage.ftl
+++ b/crates/vibesql-l10n/resources/id/storage.ftl
@@ -1,0 +1,68 @@
+# VibeSQL Storage Error Messages - Indonesian (id)
+# This file contains all error messages for the vibesql-storage crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+storage-table-not-found = Tabel '{ $name }' tidak ditemukan
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+storage-column-count-mismatch = Ketidakcocokan jumlah kolom: diharapkan { $expected }, mendapat { $actual }
+storage-column-index-out-of-bounds = Indeks kolom { $index } di luar batas
+storage-column-not-found = Kolom '{ $column_name }' tidak ditemukan dalam tabel '{ $table_name }'
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+storage-index-already-exists = Indeks '{ $name }' sudah ada
+storage-index-not-found = Indeks '{ $name }' tidak ditemukan
+storage-invalid-index-column = { $message }
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+storage-null-constraint-violation = Pelanggaran batasan NOT NULL: kolom '{ $column }' tidak boleh NULL
+storage-unique-constraint-violation = { $message }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+storage-type-mismatch = Ketidakcocokan tipe dalam kolom '{ $column }': diharapkan { $expected }, mendapat { $actual }
+
+# =============================================================================
+# Transaction and Catalog Errors
+# =============================================================================
+
+storage-catalog-error = Kesalahan katalog: { $message }
+storage-transaction-error = Kesalahan transaksi: { $message }
+storage-row-not-found = Baris tidak ditemukan
+
+# =============================================================================
+# I/O and Page Errors
+# =============================================================================
+
+storage-io-error = Kesalahan I/O: { $message }
+storage-invalid-page-size = Ukuran halaman tidak valid: diharapkan { $expected }, mendapat { $actual }
+storage-invalid-page-id = ID halaman tidak valid: { $page_id }
+storage-lock-error = Kesalahan kunci: { $message }
+
+# =============================================================================
+# Memory Errors
+# =============================================================================
+
+storage-memory-budget-exceeded = Anggaran memori terlampaui: menggunakan { $used } byte, anggaran { $budget } byte
+storage-no-index-to-evict = Tidak ada indeks yang tersedia untuk dievakuasi (semua indeks sudah di disk)
+
+# =============================================================================
+# General Errors
+# =============================================================================
+
+storage-not-implemented = Tidak diimplementasikan: { $message }
+storage-other = { $message }

--- a/crates/vibesql-l10n/src/lib.rs
+++ b/crates/vibesql-l10n/src/lib.rs
@@ -817,4 +817,79 @@ mod tests {
         assert!(result.contains("\\help"));
         assert!(result.contains("도움말"));
     }
+
+    #[test]
+    fn test_indonesian_locale() {
+        init(Some("id")).unwrap();
+
+        let goodbye = format("cli-goodbye", None);
+        assert_eq!(goodbye, "Sampai jumpa!");
+
+        let mut args = FluentArgs::new();
+        args.set("count", 5);
+        let result = format("rows-count", Some(&args));
+        assert!(result.contains("5"));
+        assert!(result.contains("baris"));
+    }
+
+    #[test]
+    fn test_indonesian_parser_messages() {
+        init(Some("id")).unwrap();
+
+        let result = format("lexer-unterminated-string", None);
+        assert_eq!(result, "Literal string tidak diakhiri");
+
+        let result = vibe_msg!("lexer-unexpected-character", character = "~");
+        assert!(result.contains("~"));
+        assert!(result.contains("Karakter tidak terduga"));
+    }
+
+    #[test]
+    fn test_indonesian_resources_embedded() {
+        // Check that Indonesian resources are embedded
+        let files: Vec<_> = Resources::iter().collect();
+        assert!(files.iter().any(|f| f.starts_with("id/")), "Indonesian resources not found in: {:?}", files);
+        assert!(files.iter().any(|f| f == "id/cli.ftl"), "id/cli.ftl not found");
+        assert!(files.iter().any(|f| f == "id/parser.ftl"), "id/parser.ftl not found");
+        assert!(files.iter().any(|f| f == "id/executor.ftl"), "id/executor.ftl not found");
+        assert!(files.iter().any(|f| f == "id/storage.ftl"), "id/storage.ftl not found");
+        assert!(files.iter().any(|f| f == "id/catalog.ftl"), "id/catalog.ftl not found");
+    }
+
+    #[test]
+    fn test_indonesian_executor_messages() {
+        init(Some("id")).unwrap();
+
+        let result = vibe_msg!("executor-table-not-found", name = "users");
+        assert!(result.contains("users"));
+        assert!(result.contains("tidak ditemukan"));
+
+        let result = vibe_msg!("executor-division-by-zero");
+        assert_eq!(result, "Pembagian dengan nol");
+    }
+
+    #[test]
+    fn test_indonesian_storage_messages() {
+        init(Some("id")).unwrap();
+
+        let result = vibe_msg!("storage-table-not-found", name = "users");
+        assert!(result.contains("users"));
+        assert!(result.contains("tidak ditemukan"));
+
+        let result = format("storage-row-not-found", None);
+        assert_eq!(result, "Baris tidak ditemukan");
+    }
+
+    #[test]
+    fn test_indonesian_catalog_messages() {
+        init(Some("id")).unwrap();
+
+        let result = vibe_msg!("catalog-table-already-exists", name = "orders");
+        assert!(result.contains("orders"));
+        assert!(result.contains("sudah ada"));
+
+        let result = vibe_msg!("catalog-schema-not-found", name = "myschema");
+        assert!(result.contains("myschema"));
+        assert!(result.contains("tidak ditemukan"));
+    }
 }


### PR DESCRIPTION
## Summary
- Add Indonesian (Bahasa Indonesia) language support with complete translations
- Create all 5 `.ftl` files: cli, parser, executor, storage, catalog
- Add comprehensive tests for Indonesian locale
- Update README badge count from 12 to 13 languages

## Details
- **Language code**: `id`
- **Native name**: Bahasa Indonesia
- **Speakers**: ~270 million
- **Script**: Latin

Closes #3763

## Test plan
- [x] Run l10n tests (`cargo test --package vibesql-l10n`) - all 61 tests pass
- [x] Verify Indonesian resources are properly embedded
- [x] Test key messages render correctly (goodbye, errors, rows count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)