### PR TITLE
feat(l10n): Add Vietnamese (vi) translations

### DIFF
--- a/crates/vibesql-l10n/resources/vi/catalog.ftl
+++ b/crates/vibesql-l10n/resources/vi/catalog.ftl
@@ -1,0 +1,117 @@
+# VibeSQL Catalog Error Messages - Vietnamese (Tiếng Việt)
+# This file contains all error messages for the vibesql-catalog crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+catalog-table-already-exists = Bảng '{ $name }' đã tồn tại
+catalog-table-not-found = Không tìm thấy bảng '{ $table_name }'
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+catalog-column-already-exists = Cột '{ $name }' đã tồn tại
+catalog-column-not-found = Không tìm thấy cột '{ $column_name }' trong bảng '{ $table_name }'
+
+# =============================================================================
+# Schema Errors
+# =============================================================================
+
+catalog-schema-already-exists = Schema '{ $name }' đã tồn tại
+catalog-schema-not-found = Không tìm thấy schema '{ $name }'
+catalog-schema-not-empty = Schema '{ $name }' không trống
+
+# =============================================================================
+# Role Errors
+# =============================================================================
+
+catalog-role-already-exists = Vai trò '{ $name }' đã tồn tại
+catalog-role-not-found = Không tìm thấy vai trò '{ $name }'
+
+# =============================================================================
+# Domain Errors
+# =============================================================================
+
+catalog-domain-already-exists = Domain '{ $name }' đã tồn tại
+catalog-domain-not-found = Không tìm thấy domain '{ $name }'
+catalog-domain-in-use = Domain '{ $domain_name }' vẫn đang được sử dụng bởi { $count } cột: { $columns }
+
+# =============================================================================
+# Sequence Errors
+# =============================================================================
+
+catalog-sequence-already-exists = Sequence '{ $name }' đã tồn tại
+catalog-sequence-not-found = Không tìm thấy sequence '{ $name }'
+catalog-sequence-in-use = Sequence '{ $sequence_name }' vẫn đang được sử dụng bởi { $count } cột: { $columns }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+catalog-type-already-exists = Kiểu '{ $name }' đã tồn tại
+catalog-type-not-found = Không tìm thấy kiểu '{ $name }'
+catalog-type-in-use = Kiểu '{ $name }' vẫn đang được sử dụng bởi một hoặc nhiều bảng
+
+# =============================================================================
+# Collation and Character Set Errors
+# =============================================================================
+
+catalog-collation-already-exists = Collation '{ $name }' đã tồn tại
+catalog-collation-not-found = Không tìm thấy collation '{ $name }'
+catalog-character-set-already-exists = Bộ ký tự '{ $name }' đã tồn tại
+catalog-character-set-not-found = Không tìm thấy bộ ký tự '{ $name }'
+catalog-translation-already-exists = Bản dịch '{ $name }' đã tồn tại
+catalog-translation-not-found = Không tìm thấy bản dịch '{ $name }'
+
+# =============================================================================
+# View Errors
+# =============================================================================
+
+catalog-view-already-exists = View '{ $name }' đã tồn tại
+catalog-view-not-found = Không tìm thấy view '{ $name }'
+catalog-view-in-use = View hoặc bảng '{ $view_name }' vẫn đang được sử dụng bởi { $count } view: { $views }
+
+# =============================================================================
+# Trigger Errors
+# =============================================================================
+
+catalog-trigger-already-exists = Trigger '{ $name }' đã tồn tại
+catalog-trigger-not-found = Không tìm thấy trigger '{ $name }'
+
+# =============================================================================
+# Assertion Errors
+# =============================================================================
+
+catalog-assertion-already-exists = Assertion '{ $name }' đã tồn tại
+catalog-assertion-not-found = Không tìm thấy assertion '{ $name }'
+
+# =============================================================================
+# Function and Procedure Errors
+# =============================================================================
+
+catalog-function-already-exists = Hàm '{ $name }' đã tồn tại
+catalog-function-not-found = Không tìm thấy hàm '{ $name }'
+catalog-procedure-already-exists = Thủ tục '{ $name }' đã tồn tại
+catalog-procedure-not-found = Không tìm thấy thủ tục '{ $name }'
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+catalog-constraint-already-exists = Ràng buộc '{ $name }' đã tồn tại
+catalog-constraint-not-found = Không tìm thấy ràng buộc '{ $name }'
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+catalog-index-already-exists = Index '{ $index_name }' trên bảng '{ $table_name }' đã tồn tại
+catalog-index-not-found = Không tìm thấy index '{ $index_name }' trên bảng '{ $table_name }'
+
+# =============================================================================
+# Foreign Key Errors
+# =============================================================================
+
+catalog-circular-foreign-key = Phát hiện phụ thuộc khóa ngoại vòng cho bảng '{ $table_name }': { $message }

--- a/crates/vibesql-l10n/resources/vi/cli.ftl
+++ b/crates/vibesql-l10n/resources/vi/cli.ftl
@@ -1,0 +1,210 @@
+# VibeSQL CLI Localization - Vietnamese (Tiếng Việt)
+# This file contains all user-facing strings for the VibeSQL command-line interface.
+
+# =============================================================================
+# REPL Banner and Basic Messages
+# =============================================================================
+
+cli-banner = VibeSQL v{ $version } - Cơ sở dữ liệu tuân thủ SQL:1999 FULL
+cli-help-hint = Gõ \help để xem trợ giúp, \quit để thoát
+cli-goodbye = Tạm biệt!
+
+# =============================================================================
+# Command Help Text (Clap Arguments)
+# =============================================================================
+
+cli-about = VibeSQL - Cơ sở dữ liệu tuân thủ SQL:1999 FULL
+
+cli-long-about = Giao diện dòng lệnh VibeSQL
+
+    CHẾ ĐỘ SỬ DỤNG:
+      REPL tương tác:         vibesql (--database <FILE>)
+      Thực thi lệnh:          vibesql -c "SELECT * FROM users"
+      Thực thi file:          vibesql -f script.sql
+      Thực thi từ stdin:      cat data.sql | vibesql
+      Tạo kiểu TypeScript:    vibesql codegen --schema schema.sql --output types.ts
+
+    REPL TƯƠNG TÁC:
+      Khi khởi động không có -c, -f, hoặc input qua pipe, VibeSQL vào chế độ REPL
+      tương tác với hỗ trợ readline, lịch sử lệnh và các meta-command như:
+        \d (table)  - Mô tả bảng hoặc liệt kê tất cả bảng
+        \dt         - Liệt kê các bảng
+        \f <format> - Đặt định dạng đầu ra
+        \copy       - Nhập/xuất CSV/JSON
+        \help       - Hiển thị tất cả lệnh REPL
+
+    SUBCOMMANDS:
+      codegen           Tạo kiểu TypeScript từ schema cơ sở dữ liệu
+
+    CẤU HÌNH:
+      Cài đặt có thể được cấu hình trong ~/.vibesqlrc (định dạng TOML).
+      Các phần: display, database, history, query
+
+    VÍ DỤ:
+      # Khởi động REPL tương tác với cơ sở dữ liệu trong bộ nhớ
+      vibesql
+
+      # Sử dụng file cơ sở dữ liệu lưu trữ
+      vibesql --database mydata.db
+
+      # Thực thi một lệnh đơn
+      vibesql -c "CREATE TABLE users (id INT, name VARCHAR(100))"
+
+      # Chạy file script SQL
+      vibesql -f schema.sql -v
+
+      # Nhập dữ liệu từ CSV
+      echo "\copy users FROM 'data.csv'" | vibesql --database mydata.db
+
+      # Xuất kết quả truy vấn dạng JSON
+      vibesql -d mydata.db -c "SELECT * FROM users" --format json
+
+      # Tạo kiểu TypeScript từ file schema
+      vibesql codegen --schema schema.sql --output src/types.ts
+
+      # Tạo kiểu TypeScript từ cơ sở dữ liệu đang chạy
+      vibesql codegen --database mydata.db --output src/types.ts
+
+# Argument help strings
+arg-database-help = Đường dẫn file cơ sở dữ liệu (nếu không chỉ định, sử dụng cơ sở dữ liệu trong bộ nhớ)
+arg-file-help = Thực thi lệnh SQL từ file
+arg-command-help = Thực thi lệnh SQL trực tiếp và thoát
+arg-stdin-help = Đọc lệnh SQL từ stdin (tự động phát hiện khi pipe)
+arg-verbose-help = Hiển thị đầu ra chi tiết khi thực thi file/stdin
+arg-format-help = Định dạng đầu ra cho kết quả truy vấn
+arg-lang-help = Đặt ngôn ngữ hiển thị (ví dụ: en-US, es, ja, vi)
+
+# =============================================================================
+# Codegen Subcommand
+# =============================================================================
+
+codegen-about = Tạo kiểu TypeScript từ schema cơ sở dữ liệu
+
+codegen-long-about = Tạo định nghĩa kiểu TypeScript từ schema cơ sở dữ liệu VibeSQL.
+
+    Lệnh này tạo các interface TypeScript cho tất cả các bảng trong cơ sở dữ liệu,
+    cùng với các đối tượng metadata để kiểm tra kiểu runtime và hỗ trợ IDE.
+
+    NGUỒN ĐẦU VÀO:
+      --database <FILE>  Tạo từ file cơ sở dữ liệu hiện có
+      --schema <FILE>    Tạo từ file schema SQL (câu lệnh CREATE TABLE)
+
+    ĐẦU RA:
+      --output <FILE>    Ghi các kiểu được tạo vào file này (mặc định: types.ts)
+
+    TÙY CHỌN:
+      --camel-case       Chuyển tên cột sang camelCase
+      --no-metadata      Bỏ qua tạo đối tượng metadata bảng
+
+    VÍ DỤ:
+      # Từ file cơ sở dữ liệu
+      vibesql codegen --database mydata.db --output src/db/types.ts
+
+      # Từ file schema SQL
+      vibesql codegen --schema schema.sql --output src/db/types.ts
+
+      # Với tên thuộc tính camelCase
+      vibesql codegen --schema schema.sql --output types.ts --camel-case
+
+codegen-schema-help = File schema SQL chứa các câu lệnh CREATE TABLE
+codegen-output-help = Đường dẫn file đầu ra cho TypeScript được tạo
+codegen-camel-case-help = Chuyển tên cột sang camelCase
+codegen-no-metadata-help = Bỏ qua tạo đối tượng metadata bảng
+
+codegen-from-schema = Đang tạo kiểu TypeScript từ file schema: { $path }
+codegen-from-database = Đang tạo kiểu TypeScript từ cơ sở dữ liệu: { $path }
+codegen-written = Đã ghi kiểu TypeScript vào: { $path }
+codegen-error-no-source = Phải chỉ định --database hoặc --schema.
+    Sử dụng 'vibesql codegen --help' để xem thông tin sử dụng.
+
+# =============================================================================
+# Meta-commands Help (\help output)
+# =============================================================================
+
+help-title = Meta-commands:
+help-describe = \d (table)      - Mô tả bảng hoặc liệt kê tất cả bảng
+help-tables = \dt             - Liệt kê các bảng
+help-schemas = \ds             - Liệt kê các schema
+help-indexes = \di             - Liệt kê các index
+help-roles = \du             - Liệt kê các vai trò/người dùng
+help-format = \f <format>     - Đặt định dạng đầu ra (table, json, csv, markdown, html)
+help-timing = \timing         - Bật/tắt đo thời gian truy vấn
+help-copy-to = \copy <table> TO <file>   - Xuất bảng ra file CSV/JSON
+help-copy-from = \copy <table> FROM <file> - Nhập file CSV vào bảng
+help-save = \save (file)    - Lưu cơ sở dữ liệu ra file SQL dump
+help-errors = \errors         - Hiển thị lịch sử lỗi gần đây
+help-help = \h, \help      - Hiển thị trợ giúp này
+help-quit = \q, \quit      - Thoát
+
+help-sql-title = Truy vấn SQL:
+help-show-tables = SHOW TABLES                  - Liệt kê tất cả bảng
+help-show-databases = SHOW DATABASES               - Liệt kê tất cả schema/database
+help-show-columns = SHOW COLUMNS FROM <table>    - Hiển thị các cột của bảng
+help-show-index = SHOW INDEX FROM <table>      - Hiển thị các index của bảng
+help-show-create = SHOW CREATE TABLE <table>    - Hiển thị câu lệnh CREATE TABLE
+help-describe-sql = DESCRIBE <table>             - Tương đương SHOW COLUMNS
+
+help-examples-title = Ví dụ:
+help-example-create = CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100));
+help-example-insert = INSERT INTO users VALUES (1, 'Alice'), (2, 'Bob');
+help-example-select = SELECT * FROM users;
+help-example-show-tables = SHOW TABLES;
+help-example-show-columns = SHOW COLUMNS FROM users;
+help-example-describe = DESCRIBE users;
+help-example-format-json = \f json
+help-example-format-md = \f markdown
+help-example-copy-to = \copy users TO '/tmp/users.csv'
+help-example-copy-from = \copy users FROM '/tmp/users.csv'
+help-example-copy-json = \copy users TO '/tmp/users.json'
+help-example-errors = \errors
+
+# =============================================================================
+# Status Messages
+# =============================================================================
+
+format-changed = Đã đặt định dạng đầu ra thành: { $format }
+database-saved = Đã lưu cơ sở dữ liệu vào: { $path }
+no-database-file = Lỗi: Chưa chỉ định file cơ sở dữ liệu. Sử dụng \save <filename> hoặc khởi động với cờ --database
+
+# =============================================================================
+# Error Display
+# =============================================================================
+
+no-errors = Không có lỗi trong phiên này.
+recent-errors = Các lỗi gần đây:
+
+# =============================================================================
+# Script Execution Messages
+# =============================================================================
+
+script-no-statements = Không tìm thấy câu lệnh SQL trong script
+script-executing = Đang thực thi câu lệnh { $current } trên { $total }...
+script-error = Lỗi khi thực thi câu lệnh { $index }: { $error }
+script-summary-title = === Tóm tắt thực thi Script ===
+script-total = Tổng số câu lệnh: { $count }
+script-successful = Thành công: { $count }
+script-failed = Thất bại: { $count }
+script-failed-error = { $count } câu lệnh thất bại
+
+# =============================================================================
+# Output Formatting
+# =============================================================================
+
+rows-with-time = { $count } hàng trong tập kết quả ({ $time }s)
+rows-count = { $count } hàng
+
+# =============================================================================
+# Warnings
+# =============================================================================
+
+warning-config-load = Cảnh báo: Không thể tải file cấu hình: { $error }
+warning-auto-save-failed = Cảnh báo: Không thể tự động lưu cơ sở dữ liệu: { $error }
+warning-save-on-exit-failed = Cảnh báo: Không thể lưu cơ sở dữ liệu khi thoát: { $error }
+
+# =============================================================================
+# File Operations
+# =============================================================================
+
+file-read-error = Không thể đọc file '{ $path }': { $error }
+stdin-read-error = Không thể đọc từ stdin: { $error }
+database-load-error = Không thể tải cơ sở dữ liệu: { $error }

--- a/crates/vibesql-l10n/resources/vi/executor.ftl
+++ b/crates/vibesql-l10n/resources/vi/executor.ftl
@@ -1,0 +1,187 @@
+# VibeSQL Executor Error Messages - Vietnamese (Tiếng Việt)
+# This file contains all error messages for the vibesql-executor crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+executor-table-not-found = Không tìm thấy bảng '{ $name }'
+executor-table-already-exists = Bảng '{ $name }' đã tồn tại
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+executor-column-not-found-simple = Không tìm thấy cột '{ $column_name }' trong bảng '{ $table_name }'
+executor-column-not-found-searched = Không tìm thấy cột '{ $column_name }' (các bảng đã tìm kiếm: { $searched_tables })
+executor-column-not-found-with-available = Không tìm thấy cột '{ $column_name }' (các bảng đã tìm kiếm: { $searched_tables }). Các cột có sẵn: { $available_columns }
+executor-invalid-table-qualifier = Định danh bảng không hợp lệ '{ $qualifier }' cho cột '{ $column }'. Các bảng có sẵn: { $available_tables }
+executor-column-already-exists = Cột '{ $name }' đã tồn tại
+executor-column-index-out-of-bounds = Chỉ số cột { $index } vượt quá giới hạn
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+executor-index-not-found = Không tìm thấy index '{ $name }'
+executor-index-already-exists = Index '{ $name }' đã tồn tại
+executor-invalid-index-definition = Định nghĩa index không hợp lệ: { $message }
+
+# =============================================================================
+# Trigger Errors
+# =============================================================================
+
+executor-trigger-not-found = Không tìm thấy trigger '{ $name }'
+executor-trigger-already-exists = Trigger '{ $name }' đã tồn tại
+
+# =============================================================================
+# Schema Errors
+# =============================================================================
+
+executor-schema-not-found = Không tìm thấy schema '{ $name }'
+executor-schema-already-exists = Schema '{ $name }' đã tồn tại
+executor-schema-not-empty = Không thể xóa schema '{ $name }': schema không trống
+
+# =============================================================================
+# Role and Permission Errors
+# =============================================================================
+
+executor-role-not-found = Không tìm thấy vai trò '{ $name }'
+executor-permission-denied = Từ chối quyền: vai trò '{ $role }' thiếu quyền { $privilege } trên { $object }
+executor-dependent-privileges-exist = Tồn tại quyền phụ thuộc: { $message }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+executor-type-not-found = Không tìm thấy kiểu '{ $name }'
+executor-type-already-exists = Kiểu '{ $name }' đã tồn tại
+executor-type-in-use = Không thể xóa kiểu '{ $name }': kiểu vẫn đang được sử dụng
+executor-type-mismatch = Không khớp kiểu: { $left } { $op } { $right }
+executor-type-error = Lỗi kiểu: { $message }
+executor-cast-error = Không thể chuyển đổi { $from_type } sang { $to_type }
+executor-type-conversion-error = Không thể chuyển đổi { $from } sang { $to }
+
+# =============================================================================
+# Expression and Query Errors
+# =============================================================================
+
+executor-division-by-zero = Chia cho số không
+executor-invalid-where-clause = Mệnh đề WHERE không hợp lệ: { $message }
+executor-unsupported-expression = Biểu thức không được hỗ trợ: { $message }
+executor-unsupported-feature = Tính năng không được hỗ trợ: { $message }
+executor-parse-error = Lỗi phân tích cú pháp: { $message }
+
+# =============================================================================
+# Subquery Errors
+# =============================================================================
+
+executor-subquery-returned-multiple-rows = Subquery vô hướng trả về { $actual } hàng, mong đợi { $expected }
+executor-subquery-column-count-mismatch = Subquery trả về { $actual } cột, mong đợi { $expected }
+executor-column-count-mismatch = Danh sách cột dẫn xuất có { $provided } cột nhưng truy vấn tạo ra { $expected } cột
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+executor-constraint-violation = Vi phạm ràng buộc: { $message }
+executor-multiple-primary-keys = Không cho phép nhiều ràng buộc PRIMARY KEY
+executor-cannot-drop-column = Không thể xóa cột: { $message }
+executor-constraint-not-found = Không tìm thấy ràng buộc '{ $constraint_name }' trong bảng '{ $table_name }'
+
+# =============================================================================
+# Resource Limit Errors
+# =============================================================================
+
+executor-expression-depth-exceeded = Vượt quá giới hạn độ sâu biểu thức: { $depth } > { $max_depth } (ngăn tràn ngăn xếp)
+executor-query-timeout-exceeded = Vượt quá thời gian chờ truy vấn: { $elapsed_seconds }s > { $max_seconds }s
+executor-row-limit-exceeded = Vượt quá giới hạn xử lý hàng: { $rows_processed } > { $max_rows }
+executor-memory-limit-exceeded = Vượt quá giới hạn bộ nhớ: { $used_gb } GB > { $max_gb } GB
+
+# =============================================================================
+# Procedural/Variable Errors
+# =============================================================================
+
+executor-variable-not-found-simple = Không tìm thấy biến '{ $variable_name }'
+executor-variable-not-found-with-available = Không tìm thấy biến '{ $variable_name }'. Các biến có sẵn: { $available_variables }
+executor-label-not-found = Không tìm thấy nhãn '{ $name }'
+
+# =============================================================================
+# SELECT INTO Errors
+# =============================================================================
+
+executor-select-into-row-count = SELECT INTO thủ tục phải trả về đúng { $expected } hàng, nhận được { $actual } hàng{ $plural }
+executor-select-into-column-count = Số cột SELECT INTO thủ tục không khớp: { $expected } biến{ $expected_plural } nhưng truy vấn trả về { $actual } cột{ $actual_plural }
+
+# =============================================================================
+# Procedure and Function Errors
+# =============================================================================
+
+executor-procedure-not-found-simple = Không tìm thấy thủ tục '{ $procedure_name }' trong schema '{ $schema_name }'
+executor-procedure-not-found-with-available = Không tìm thấy thủ tục '{ $procedure_name }' trong schema '{ $schema_name }'
+    .available = Các thủ tục có sẵn: { $available_procedures }
+executor-procedure-not-found-with-suggestion = Không tìm thấy thủ tục '{ $procedure_name }' trong schema '{ $schema_name }'
+    .available = Các thủ tục có sẵn: { $available_procedures }
+    .suggestion = Có phải bạn muốn nói '{ $suggestion }'?
+
+executor-function-not-found-simple = Không tìm thấy hàm '{ $function_name }' trong schema '{ $schema_name }'
+executor-function-not-found-with-available = Không tìm thấy hàm '{ $function_name }' trong schema '{ $schema_name }'
+    .available = Các hàm có sẵn: { $available_functions }
+executor-function-not-found-with-suggestion = Không tìm thấy hàm '{ $function_name }' trong schema '{ $schema_name }'
+    .available = Các hàm có sẵn: { $available_functions }
+    .suggestion = Có phải bạn muốn nói '{ $suggestion }'?
+
+executor-parameter-count-mismatch = { $routine_type } '{ $routine_name }' mong đợi { $expected } tham số{ $expected_plural } ({ $parameter_signature }), nhận được { $actual } đối số{ $actual_plural }
+executor-parameter-type-mismatch = Tham số '{ $parameter_name }' mong đợi { $expected_type }, nhận được { $actual_type } '{ $actual_value }'
+executor-argument-count-mismatch = Số đối số không khớp: mong đợi { $expected }, nhận được { $actual }
+
+executor-recursion-limit-exceeded = Vượt quá độ sâu đệ quy tối đa ({ $max_depth }): { $message }
+executor-recursion-call-stack = Ngăn xếp gọi:
+executor-function-must-return = Hàm phải trả về giá trị
+executor-invalid-control-flow = Luồng điều khiển không hợp lệ: { $message }
+executor-invalid-function-body = Thân hàm không hợp lệ: { $message }
+executor-function-read-only-violation = Vi phạm chỉ đọc của hàm: { $message }
+
+# =============================================================================
+# EXTRACT Errors
+# =============================================================================
+
+executor-invalid-extract-field = Không thể trích xuất { $field } từ giá trị kiểu { $value_type }
+
+# =============================================================================
+# Columnar/Arrow Errors
+# =============================================================================
+
+executor-arrow-downcast-error = Không thể chuyển đổi mảng Arrow sang { $expected_type } ({ $context })
+executor-columnar-type-mismatch-binary = Kiểu không tương thích cho { $operation }: { $left_type } vs { $right_type }
+executor-columnar-type-mismatch-unary = Kiểu không tương thích cho { $operation }: { $left_type }
+executor-simd-operation-failed = SIMD { $operation } thất bại: { $reason }
+executor-columnar-column-not-found = Chỉ số cột { $column_index } vượt quá giới hạn (batch có { $batch_columns } cột)
+executor-columnar-column-not-found-by-name = Không tìm thấy cột: { $column_name }
+executor-columnar-length-mismatch = Độ dài cột không khớp trong { $context }: mong đợi { $expected }, nhận được { $actual }
+executor-unsupported-array-type = Kiểu mảng không được hỗ trợ cho { $operation }: { $array_type }
+
+# =============================================================================
+# Spatial Errors
+# =============================================================================
+
+executor-spatial-geometry-error = { $function_name }: { $message }
+executor-spatial-operation-failed = { $function_name }: { $message }
+executor-spatial-argument-error = { $function_name } mong đợi { $expected }, nhận được { $actual }
+
+# =============================================================================
+# Cursor Errors
+# =============================================================================
+
+executor-cursor-already-exists = Con trỏ '{ $name }' đã tồn tại
+executor-cursor-not-found = Không tìm thấy con trỏ '{ $name }'
+executor-cursor-already-open = Con trỏ '{ $name }' đã được mở
+executor-cursor-not-open = Con trỏ '{ $name }' chưa được mở
+executor-cursor-not-scrollable = Con trỏ '{ $name }' không thể cuộn (SCROLL không được chỉ định)
+
+# =============================================================================
+# Storage and General Errors
+# =============================================================================
+
+executor-storage-error = Lỗi lưu trữ: { $message }
+executor-other = { $message }

--- a/crates/vibesql-l10n/resources/vi/parser.ftl
+++ b/crates/vibesql-l10n/resources/vi/parser.ftl
@@ -1,0 +1,55 @@
+# VibeSQL Parser/Lexer Localization - Vietnamese (Tiếng Việt)
+# This file contains all user-facing strings for lexer and parser errors.
+
+# =============================================================================
+# Lexer Error Header
+# =============================================================================
+
+lexer-error-at-position = Lỗi lexer tại vị trí { $position }: { $message }
+
+# =============================================================================
+# String Literal Errors
+# =============================================================================
+
+lexer-unterminated-string = Chuỗi ký tự chưa kết thúc
+
+# =============================================================================
+# Identifier Errors
+# =============================================================================
+
+lexer-unterminated-delimited-identifier = Định danh phân cách chưa kết thúc
+lexer-empty-delimited-identifier = Không cho phép định danh phân cách rỗng
+
+# =============================================================================
+# Number Literal Errors
+# =============================================================================
+
+lexer-invalid-scientific-notation = Ký hiệu khoa học không hợp lệ: mong đợi các chữ số sau 'E'
+
+# =============================================================================
+# Placeholder Errors
+# =============================================================================
+
+lexer-expected-digit-after-dollar = Mong đợi chữ số sau '$' cho placeholder đánh số
+lexer-invalid-numbered-placeholder = Placeholder đánh số không hợp lệ: ${ $placeholder }
+lexer-numbered-placeholder-zero = Placeholder đánh số phải là $1 trở lên (không có $0)
+lexer-expected-identifier-after-colon = Mong đợi định danh sau ':' cho placeholder có tên
+
+# =============================================================================
+# Variable Errors
+# =============================================================================
+
+lexer-expected-variable-after-at-at = Mong đợi tên biến sau @@
+lexer-expected-variable-after-at = Mong đợi tên biến sau @
+
+# =============================================================================
+# Operator Errors
+# =============================================================================
+
+lexer-unexpected-pipe = Ký tự không mong đợi: '|' (có phải bạn muốn nói '||'?)
+
+# =============================================================================
+# General Errors
+# =============================================================================
+
+lexer-unexpected-character = Ký tự không mong đợi: '{ $character }'

--- a/crates/vibesql-l10n/resources/vi/storage.ftl
+++ b/crates/vibesql-l10n/resources/vi/storage.ftl
@@ -1,0 +1,68 @@
+# VibeSQL Storage Error Messages - Vietnamese (Tiếng Việt)
+# This file contains all error messages for the vibesql-storage crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+storage-table-not-found = Không tìm thấy bảng '{ $name }'
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+storage-column-count-mismatch = Số cột không khớp: mong đợi { $expected }, nhận được { $actual }
+storage-column-index-out-of-bounds = Chỉ số cột { $index } vượt quá giới hạn
+storage-column-not-found = Không tìm thấy cột '{ $column_name }' trong bảng '{ $table_name }'
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+storage-index-already-exists = Index '{ $name }' đã tồn tại
+storage-index-not-found = Không tìm thấy index '{ $name }'
+storage-invalid-index-column = { $message }
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+storage-null-constraint-violation = Vi phạm ràng buộc NOT NULL: cột '{ $column }' không thể là NULL
+storage-unique-constraint-violation = { $message }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+storage-type-mismatch = Không khớp kiểu trong cột '{ $column }': mong đợi { $expected }, nhận được { $actual }
+
+# =============================================================================
+# Transaction and Catalog Errors
+# =============================================================================
+
+storage-catalog-error = Lỗi catalog: { $message }
+storage-transaction-error = Lỗi giao dịch: { $message }
+storage-row-not-found = Không tìm thấy hàng
+
+# =============================================================================
+# I/O and Page Errors
+# =============================================================================
+
+storage-io-error = Lỗi I/O: { $message }
+storage-invalid-page-size = Kích thước trang không hợp lệ: mong đợi { $expected }, nhận được { $actual }
+storage-invalid-page-id = ID trang không hợp lệ: { $page_id }
+storage-lock-error = Lỗi khóa: { $message }
+
+# =============================================================================
+# Memory Errors
+# =============================================================================
+
+storage-memory-budget-exceeded = Vượt quá ngân sách bộ nhớ: đang sử dụng { $used } bytes, ngân sách là { $budget } bytes
+storage-no-index-to-evict = Không có index nào để xóa bỏ (tất cả index đã được lưu trên đĩa)
+
+# =============================================================================
+# General Errors
+# =============================================================================
+
+storage-not-implemented = Chưa được triển khai: { $message }
+storage-other = { $message }

--- a/crates/vibesql-l10n/src/lib.rs
+++ b/crates/vibesql-l10n/src/lib.rs
@@ -1072,4 +1072,94 @@ mod tests {
         assert!(result.contains("\\help"));
         assert!(result.contains("ความช่วยเหลือ"));
     }
+
+    #[test]
+    fn test_vietnamese_locale() {
+        init(Some("vi")).unwrap();
+
+        let goodbye = format("cli-goodbye", None);
+        assert_eq!(goodbye, "Tạm biệt!");
+
+        let mut args = FluentArgs::new();
+        args.set("count", 5);
+        let result = format("rows-count", Some(&args));
+        assert!(result.contains("5"));
+        assert!(result.contains("hàng"));
+    }
+
+    #[test]
+    fn test_vietnamese_parser_messages() {
+        init(Some("vi")).unwrap();
+
+        let result = format("lexer-unterminated-string", None);
+        assert_eq!(result, "Chuỗi ký tự chưa kết thúc");
+
+        let result = vibe_msg!("lexer-unexpected-character", character = "~");
+        assert!(result.contains("~"));
+        assert!(result.contains("Ký tự không mong đợi"));
+    }
+
+    #[test]
+    fn test_vietnamese_resources_embedded() {
+        // Check that Vietnamese resources are embedded
+        let files: Vec<_> = Resources::iter().collect();
+        assert!(files.iter().any(|f| f.starts_with("vi/")), "Vietnamese resources not found in: {:?}", files);
+        assert!(files.iter().any(|f| f == "vi/cli.ftl"), "vi/cli.ftl not found");
+        assert!(files.iter().any(|f| f == "vi/parser.ftl"), "vi/parser.ftl not found");
+        assert!(files.iter().any(|f| f == "vi/executor.ftl"), "vi/executor.ftl not found");
+        assert!(files.iter().any(|f| f == "vi/storage.ftl"), "vi/storage.ftl not found");
+        assert!(files.iter().any(|f| f == "vi/catalog.ftl"), "vi/catalog.ftl not found");
+    }
+
+    #[test]
+    fn test_vietnamese_executor_messages() {
+        init(Some("vi")).unwrap();
+
+        let result = vibe_msg!("executor-table-not-found", name = "users");
+        assert!(result.contains("users"));
+        assert!(result.contains("Không tìm thấy bảng"));
+
+        let result = vibe_msg!("executor-division-by-zero");
+        assert_eq!(result, "Chia cho số không");
+    }
+
+    #[test]
+    fn test_vietnamese_storage_messages() {
+        init(Some("vi")).unwrap();
+
+        let result = vibe_msg!("storage-table-not-found", name = "users");
+        assert!(result.contains("users"));
+        assert!(result.contains("Không tìm thấy bảng"));
+
+        let result = format("storage-row-not-found", None);
+        assert_eq!(result, "Không tìm thấy hàng");
+    }
+
+    #[test]
+    fn test_vietnamese_catalog_messages() {
+        init(Some("vi")).unwrap();
+
+        let result = vibe_msg!("catalog-table-already-exists", name = "orders");
+        assert!(result.contains("orders"));
+        assert!(result.contains("đã tồn tại"));
+
+        let result = vibe_msg!("catalog-schema-not-found", name = "myschema");
+        assert!(result.contains("myschema"));
+        assert!(result.contains("Không tìm thấy schema"));
+    }
+
+    #[test]
+    fn test_vietnamese_diacritics_handling() {
+        init(Some("vi")).unwrap();
+
+        // Test messages with Vietnamese diacritics are correctly handled
+        let result = vibe_msg!("executor-schema-not-empty", name = "công_khai");
+        assert!(result.contains("công_khai"));
+        assert!(result.contains("không trống"));
+
+        // Test the help hint with Vietnamese characters
+        let result = format("cli-help-hint", None);
+        assert!(result.contains("\\help"));
+        assert!(result.contains("trợ giúp"));
+    }
 }


### PR DESCRIPTION
## Summary
- Add Vietnamese (vi) language support with complete translations for all 5 .ftl files
- Add comprehensive tests for Vietnamese locale handling
- Update README badge to show 13 languages

## Details
- **Language code**: `vi`
- **Native name**: Tiếng Việt
- **Speakers**: ~85 million
- **Script**: Latin (with diacritics)

## Files Added
- `crates/vibesql-l10n/resources/vi/catalog.ftl`
- `crates/vibesql-l10n/resources/vi/cli.ftl`
- `crates/vibesql-l10n/resources/vi/executor.ftl`
- `crates/vibesql-l10n/resources/vi/parser.ftl`
- `crates/vibesql-l10n/resources/vi/storage.ftl`

## Test Plan
- [x] All 7 Vietnamese locale tests pass
- [x] Tests verify correct handling of Vietnamese diacritics
- [x] Tests verify all message categories (CLI, parser, executor, storage, catalog)

Closes #3765

🤖 Generated with [Claude Code](https://claude.com/claude-code)