### PR TITLE
feat(l10n): Add Thai (th) translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Demo](https://img.shields.io/badge/demo-live-success)](https://rjwalters.github.io/vibesql/)
 [![sqltest](https://img.shields.io/endpoint?url=https://rjwalters.github.io/vibesql/badges/sql1999-conformance.json)](https://rjwalters.github.io/vibesql/conformance.html)
 [![SQLLogicTest](https://img.shields.io/endpoint?url=https://rjwalters.github.io/vibesql/badges/sqllogictest.json)](https://rjwalters.github.io/vibesql/conformance.html#SQLlogicTest)
-[![i18n](https://img.shields.io/badge/i18n-13%20languages-blue)](docs/CONTRIBUTING_TRANSLATIONS.md)
+[![i18n](https://img.shields.io/badge/i18n-18%20languages-blue)](docs/CONTRIBUTING_TRANSLATIONS.md)
 
 **SQL:1999 compliant database in Rust, 100% AI-generated**
 

--- a/crates/vibesql-l10n/resources/th/catalog.ftl
+++ b/crates/vibesql-l10n/resources/th/catalog.ftl
@@ -1,0 +1,117 @@
+# VibeSQL Catalog Error Messages - Thai (ภาษาไทย)
+# This file contains all error messages for the vibesql-catalog crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+catalog-table-already-exists = ตาราง '{ $name }' มีอยู่แล้ว
+catalog-table-not-found = ไม่พบตาราง '{ $table_name }'
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+catalog-column-already-exists = คอลัมน์ '{ $name }' มีอยู่แล้ว
+catalog-column-not-found = ไม่พบคอลัมน์ '{ $column_name }' ในตาราง '{ $table_name }'
+
+# =============================================================================
+# Schema Errors
+# =============================================================================
+
+catalog-schema-already-exists = Schema '{ $name }' มีอยู่แล้ว
+catalog-schema-not-found = ไม่พบ Schema '{ $name }'
+catalog-schema-not-empty = Schema '{ $name }' ไม่ว่าง
+
+# =============================================================================
+# Role Errors
+# =============================================================================
+
+catalog-role-already-exists = Role '{ $name }' มีอยู่แล้ว
+catalog-role-not-found = ไม่พบ Role '{ $name }'
+
+# =============================================================================
+# Domain Errors
+# =============================================================================
+
+catalog-domain-already-exists = Domain '{ $name }' มีอยู่แล้ว
+catalog-domain-not-found = ไม่พบ Domain '{ $name }'
+catalog-domain-in-use = Domain '{ $domain_name }' ยังถูกใช้งานโดย { $count } คอลัมน์: { $columns }
+
+# =============================================================================
+# Sequence Errors
+# =============================================================================
+
+catalog-sequence-already-exists = Sequence '{ $name }' มีอยู่แล้ว
+catalog-sequence-not-found = ไม่พบ Sequence '{ $name }'
+catalog-sequence-in-use = Sequence '{ $sequence_name }' ยังถูกใช้งานโดย { $count } คอลัมน์: { $columns }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+catalog-type-already-exists = ประเภท '{ $name }' มีอยู่แล้ว
+catalog-type-not-found = ไม่พบประเภท '{ $name }'
+catalog-type-in-use = ประเภท '{ $name }' ยังถูกใช้งานโดยตารางหนึ่งหรือมากกว่า
+
+# =============================================================================
+# Collation and Character Set Errors
+# =============================================================================
+
+catalog-collation-already-exists = Collation '{ $name }' มีอยู่แล้ว
+catalog-collation-not-found = ไม่พบ Collation '{ $name }'
+catalog-character-set-already-exists = Character set '{ $name }' มีอยู่แล้ว
+catalog-character-set-not-found = ไม่พบ Character set '{ $name }'
+catalog-translation-already-exists = Translation '{ $name }' มีอยู่แล้ว
+catalog-translation-not-found = ไม่พบ Translation '{ $name }'
+
+# =============================================================================
+# View Errors
+# =============================================================================
+
+catalog-view-already-exists = View '{ $name }' มีอยู่แล้ว
+catalog-view-not-found = ไม่พบ View '{ $name }'
+catalog-view-in-use = View หรือตาราง '{ $view_name }' ยังถูกใช้งานโดย { $count } view(s): { $views }
+
+# =============================================================================
+# Trigger Errors
+# =============================================================================
+
+catalog-trigger-already-exists = Trigger '{ $name }' มีอยู่แล้ว
+catalog-trigger-not-found = ไม่พบ Trigger '{ $name }'
+
+# =============================================================================
+# Assertion Errors
+# =============================================================================
+
+catalog-assertion-already-exists = Assertion '{ $name }' มีอยู่แล้ว
+catalog-assertion-not-found = ไม่พบ Assertion '{ $name }'
+
+# =============================================================================
+# Function and Procedure Errors
+# =============================================================================
+
+catalog-function-already-exists = Function '{ $name }' มีอยู่แล้ว
+catalog-function-not-found = ไม่พบ Function '{ $name }'
+catalog-procedure-already-exists = Procedure '{ $name }' มีอยู่แล้ว
+catalog-procedure-not-found = ไม่พบ Procedure '{ $name }'
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+catalog-constraint-already-exists = Constraint '{ $name }' มีอยู่แล้ว
+catalog-constraint-not-found = ไม่พบ Constraint '{ $name }'
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+catalog-index-already-exists = Index '{ $index_name }' บนตาราง '{ $table_name }' มีอยู่แล้ว
+catalog-index-not-found = ไม่พบ Index '{ $index_name }' บนตาราง '{ $table_name }'
+
+# =============================================================================
+# Foreign Key Errors
+# =============================================================================
+
+catalog-circular-foreign-key = ตรวจพบ circular foreign key dependency สำหรับตาราง '{ $table_name }': { $message }

--- a/crates/vibesql-l10n/resources/th/cli.ftl
+++ b/crates/vibesql-l10n/resources/th/cli.ftl
@@ -1,0 +1,210 @@
+# VibeSQL CLI Localization - Thai (ภาษาไทย)
+# This file contains all user-facing strings for the VibeSQL command-line interface.
+
+# =============================================================================
+# REPL Banner and Basic Messages
+# =============================================================================
+
+cli-banner = VibeSQL v{ $version } - ฐานข้อมูลที่รองรับ SQL:1999 FULL Compliance
+cli-help-hint = พิมพ์ \help เพื่อดูความช่วยเหลือ, \quit เพื่อออก
+cli-goodbye = ลาก่อน!
+
+# =============================================================================
+# Command Help Text (Clap Arguments)
+# =============================================================================
+
+cli-about = VibeSQL - ฐานข้อมูลที่รองรับ SQL:1999 FULL Compliance
+
+cli-long-about = อินเทอร์เฟซบรรทัดคำสั่ง VibeSQL
+
+    โหมดการใช้งาน:
+      REPL แบบโต้ตอบ:     vibesql (--database <FILE>)
+      รันคำสั่ง:           vibesql -c "SELECT * FROM users"
+      รันไฟล์:            vibesql -f script.sql
+      รันจาก stdin:       cat data.sql | vibesql
+      สร้างประเภท:        vibesql codegen --schema schema.sql --output types.ts
+
+    REPL แบบโต้ตอบ:
+      เมื่อเริ่มต้นโดยไม่มี -c, -f, หรือ piped input, VibeSQL จะเข้าสู่ REPL แบบโต้ตอบ
+      พร้อมการรองรับ readline, ประวัติคำสั่ง และ meta-commands เช่น:
+        \d (table)  - อธิบายตารางหรือแสดงรายการตารางทั้งหมด
+        \dt         - แสดงรายการตาราง
+        \f <format> - ตั้งค่ารูปแบบผลลัพธ์
+        \copy       - นำเข้า/ส่งออก CSV/JSON
+        \help       - แสดงคำสั่ง REPL ทั้งหมด
+
+    SUBCOMMANDS:
+      codegen           สร้างประเภท TypeScript จาก schema ฐานข้อมูล
+
+    การกำหนดค่า:
+      ตั้งค่าได้ใน ~/.vibesqlrc (รูปแบบ TOML)
+      ส่วน: display, database, history, query
+
+    ตัวอย่าง:
+      # เริ่ม REPL แบบโต้ตอบกับฐานข้อมูลในหน่วยความจำ
+      vibesql
+
+      # ใช้ไฟล์ฐานข้อมูลแบบถาวร
+      vibesql --database mydata.db
+
+      # รันคำสั่งเดียว
+      vibesql -c "CREATE TABLE users (id INT, name VARCHAR(100))"
+
+      # รันไฟล์สคริปต์ SQL
+      vibesql -f schema.sql -v
+
+      # นำเข้าข้อมูลจาก CSV
+      echo "\copy users FROM 'data.csv'" | vibesql --database mydata.db
+
+      # ส่งออกผลลัพธ์เป็น JSON
+      vibesql -d mydata.db -c "SELECT * FROM users" --format json
+
+      # สร้างประเภท TypeScript จากไฟล์ schema
+      vibesql codegen --schema schema.sql --output src/types.ts
+
+      # สร้างประเภท TypeScript จากฐานข้อมูลที่ทำงานอยู่
+      vibesql codegen --database mydata.db --output src/types.ts
+
+# Argument help strings
+arg-database-help = พาธไฟล์ฐานข้อมูล (หากไม่ระบุ จะใช้ฐานข้อมูลในหน่วยความจำ)
+arg-file-help = รันคำสั่ง SQL จากไฟล์
+arg-command-help = รันคำสั่ง SQL โดยตรงและออก
+arg-stdin-help = อ่านคำสั่ง SQL จาก stdin (ตรวจจับอัตโนมัติเมื่อ piped)
+arg-verbose-help = แสดงผลลัพธ์ละเอียดระหว่างการรันไฟล์/stdin
+arg-format-help = รูปแบบผลลัพธ์สำหรับการ query
+arg-lang-help = ตั้งค่าภาษาที่แสดง (เช่น en-US, es, ja, th)
+
+# =============================================================================
+# Codegen Subcommand
+# =============================================================================
+
+codegen-about = สร้างประเภท TypeScript จาก schema ฐานข้อมูล
+
+codegen-long-about = สร้างคำจำกัดความประเภท TypeScript จาก schema ฐานข้อมูล VibeSQL
+
+    คำสั่งนี้สร้าง TypeScript interfaces สำหรับตารางทั้งหมดในฐานข้อมูล
+    พร้อมกับ metadata objects สำหรับการตรวจสอบประเภทและการรองรับ IDE
+
+    แหล่งข้อมูล:
+      --database <FILE>  สร้างจากไฟล์ฐานข้อมูลที่มีอยู่
+      --schema <FILE>    สร้างจากไฟล์ SQL schema (คำสั่ง CREATE TABLE)
+
+    ผลลัพธ์:
+      --output <FILE>    เขียนประเภทที่สร้างไปยังไฟล์นี้ (ค่าเริ่มต้น: types.ts)
+
+    ตัวเลือก:
+      --camel-case       แปลงชื่อคอลัมน์เป็น camelCase
+      --no-metadata      ข้ามการสร้าง tables metadata object
+
+    ตัวอย่าง:
+      # จากไฟล์ฐานข้อมูล
+      vibesql codegen --database mydata.db --output src/db/types.ts
+
+      # จากไฟล์ SQL schema
+      vibesql codegen --schema schema.sql --output src/db/types.ts
+
+      # กับชื่อ property เป็น camelCase
+      vibesql codegen --schema schema.sql --output types.ts --camel-case
+
+codegen-schema-help = ไฟล์ SQL schema ที่มีคำสั่ง CREATE TABLE
+codegen-output-help = พาธไฟล์ผลลัพธ์สำหรับ TypeScript ที่สร้าง
+codegen-camel-case-help = แปลงชื่อคอลัมน์เป็น camelCase
+codegen-no-metadata-help = ข้ามการสร้าง table metadata object
+
+codegen-from-schema = กำลังสร้างประเภท TypeScript จากไฟล์ schema: { $path }
+codegen-from-database = กำลังสร้างประเภท TypeScript จากฐานข้อมูล: { $path }
+codegen-written = เขียนประเภท TypeScript ไปยัง: { $path }
+codegen-error-no-source = ต้องระบุ --database หรือ --schema
+    ใช้ 'vibesql codegen --help' สำหรับข้อมูลการใช้งาน
+
+# =============================================================================
+# Meta-commands Help (\help output)
+# =============================================================================
+
+help-title = Meta-commands:
+help-describe = \d (table)      - อธิบายตารางหรือแสดงรายการตารางทั้งหมด
+help-tables = \dt             - แสดงรายการตาราง
+help-schemas = \ds             - แสดงรายการ schemas
+help-indexes = \di             - แสดงรายการ indexes
+help-roles = \du             - แสดงรายการ roles/users
+help-format = \f <format>     - ตั้งค่ารูปแบบผลลัพธ์ (table, json, csv, markdown, html)
+help-timing = \timing         - สลับการแสดงเวลา query
+help-copy-to = \copy <table> TO <file>   - ส่งออกตารางไปยังไฟล์ CSV/JSON
+help-copy-from = \copy <table> FROM <file> - นำเข้าไฟล์ CSV ไปยังตาราง
+help-save = \save (file)    - บันทึกฐานข้อมูลเป็น SQL dump file
+help-errors = \errors         - แสดงประวัติข้อผิดพลาดล่าสุด
+help-help = \h, \help      - แสดงความช่วยเหลือนี้
+help-quit = \q, \quit      - ออก
+
+help-sql-title = SQL Introspection:
+help-show-tables = SHOW TABLES                  - แสดงรายการตารางทั้งหมด
+help-show-databases = SHOW DATABASES               - แสดงรายการ schemas/databases ทั้งหมด
+help-show-columns = SHOW COLUMNS FROM <table>    - แสดงคอลัมน์ของตาราง
+help-show-index = SHOW INDEX FROM <table>      - แสดง indexes ของตาราง
+help-show-create = SHOW CREATE TABLE <table>    - แสดงคำสั่ง CREATE TABLE
+help-describe-sql = DESCRIBE <table>             - ชื่อย่อของ SHOW COLUMNS
+
+help-examples-title = ตัวอย่าง:
+help-example-create = CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100));
+help-example-insert = INSERT INTO users VALUES (1, 'Alice'), (2, 'Bob');
+help-example-select = SELECT * FROM users;
+help-example-show-tables = SHOW TABLES;
+help-example-show-columns = SHOW COLUMNS FROM users;
+help-example-describe = DESCRIBE users;
+help-example-format-json = \f json
+help-example-format-md = \f markdown
+help-example-copy-to = \copy users TO '/tmp/users.csv'
+help-example-copy-from = \copy users FROM '/tmp/users.csv'
+help-example-copy-json = \copy users TO '/tmp/users.json'
+help-example-errors = \errors
+
+# =============================================================================
+# Status Messages
+# =============================================================================
+
+format-changed = ตั้งค่ารูปแบบผลลัพธ์เป็น: { $format }
+database-saved = บันทึกฐานข้อมูลไปยัง: { $path }
+no-database-file = ข้อผิดพลาด: ไม่ได้ระบุไฟล์ฐานข้อมูล ใช้ \save <filename> หรือเริ่มต้นด้วย --database flag
+
+# =============================================================================
+# Error Display
+# =============================================================================
+
+no-errors = ไม่มีข้อผิดพลาดใน session นี้
+recent-errors = ข้อผิดพลาดล่าสุด:
+
+# =============================================================================
+# Script Execution Messages
+# =============================================================================
+
+script-no-statements = ไม่พบคำสั่ง SQL ในสคริปต์
+script-executing = กำลังรันคำสั่งที่ { $current } จาก { $total }...
+script-error = ข้อผิดพลาดในการรันคำสั่งที่ { $index }: { $error }
+script-summary-title = === สรุปการรันสคริปต์ ===
+script-total = คำสั่งทั้งหมด: { $count }
+script-successful = สำเร็จ: { $count }
+script-failed = ล้มเหลว: { $count }
+script-failed-error = { $count } คำสั่งล้มเหลว
+
+# =============================================================================
+# Output Formatting
+# =============================================================================
+
+rows-with-time = { $count } แถวในผลลัพธ์ ({ $time } วินาที)
+rows-count = { $count } แถว
+
+# =============================================================================
+# Warnings
+# =============================================================================
+
+warning-config-load = คำเตือน: ไม่สามารถโหลดไฟล์การตั้งค่า: { $error }
+warning-auto-save-failed = คำเตือน: การบันทึกอัตโนมัติล้มเหลว: { $error }
+warning-save-on-exit-failed = คำเตือน: การบันทึกเมื่อออกล้มเหลว: { $error }
+
+# =============================================================================
+# File Operations
+# =============================================================================
+
+file-read-error = ไม่สามารถอ่านไฟล์ '{ $path }': { $error }
+stdin-read-error = ไม่สามารถอ่านจาก stdin: { $error }
+database-load-error = ไม่สามารถโหลดฐานข้อมูล: { $error }

--- a/crates/vibesql-l10n/resources/th/executor.ftl
+++ b/crates/vibesql-l10n/resources/th/executor.ftl
@@ -1,0 +1,187 @@
+# VibeSQL Executor Error Messages - Thai (ภาษาไทย)
+# This file contains all error messages for the vibesql-executor crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+executor-table-not-found = ไม่พบตาราง '{ $name }'
+executor-table-already-exists = ตาราง '{ $name }' มีอยู่แล้ว
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+executor-column-not-found-simple = ไม่พบคอลัมน์ '{ $column_name }' ในตาราง '{ $table_name }'
+executor-column-not-found-searched = ไม่พบคอลัมน์ '{ $column_name }' (ค้นหาในตาราง: { $searched_tables })
+executor-column-not-found-with-available = ไม่พบคอลัมน์ '{ $column_name }' (ค้นหาในตาราง: { $searched_tables }) คอลัมน์ที่มี: { $available_columns }
+executor-invalid-table-qualifier = Table qualifier '{ $qualifier }' ไม่ถูกต้องสำหรับคอลัมน์ '{ $column }' ตารางที่มี: { $available_tables }
+executor-column-already-exists = คอลัมน์ '{ $name }' มีอยู่แล้ว
+executor-column-index-out-of-bounds = ดัชนีคอลัมน์ { $index } เกินขอบเขต
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+executor-index-not-found = ไม่พบ Index '{ $name }'
+executor-index-already-exists = Index '{ $name }' มีอยู่แล้ว
+executor-invalid-index-definition = คำจำกัดความ Index ไม่ถูกต้อง: { $message }
+
+# =============================================================================
+# Trigger Errors
+# =============================================================================
+
+executor-trigger-not-found = ไม่พบ Trigger '{ $name }'
+executor-trigger-already-exists = Trigger '{ $name }' มีอยู่แล้ว
+
+# =============================================================================
+# Schema Errors
+# =============================================================================
+
+executor-schema-not-found = ไม่พบ Schema '{ $name }'
+executor-schema-already-exists = Schema '{ $name }' มีอยู่แล้ว
+executor-schema-not-empty = ไม่สามารถลบ schema '{ $name }': schema ไม่ว่าง
+
+# =============================================================================
+# Role and Permission Errors
+# =============================================================================
+
+executor-role-not-found = ไม่พบ Role '{ $name }'
+executor-permission-denied = ปฏิเสธการอนุญาต: role '{ $role }' ไม่มีสิทธิ์ { $privilege } บน { $object }
+executor-dependent-privileges-exist = มีสิทธิ์ที่ขึ้นอยู่กับ: { $message }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+executor-type-not-found = ไม่พบประเภท '{ $name }'
+executor-type-already-exists = ประเภท '{ $name }' มีอยู่แล้ว
+executor-type-in-use = ไม่สามารถลบประเภท '{ $name }': ประเภทยังถูกใช้งานอยู่
+executor-type-mismatch = ประเภทไม่ตรงกัน: { $left } { $op } { $right }
+executor-type-error = ข้อผิดพลาดประเภท: { $message }
+executor-cast-error = ไม่สามารถแปลง { $from_type } เป็น { $to_type }
+executor-type-conversion-error = ไม่สามารถแปลง { $from } เป็น { $to }
+
+# =============================================================================
+# Expression and Query Errors
+# =============================================================================
+
+executor-division-by-zero = หารด้วยศูนย์
+executor-invalid-where-clause = WHERE clause ไม่ถูกต้อง: { $message }
+executor-unsupported-expression = Expression ที่ไม่รองรับ: { $message }
+executor-unsupported-feature = ฟีเจอร์ที่ไม่รองรับ: { $message }
+executor-parse-error = ข้อผิดพลาดการแยกวิเคราะห์: { $message }
+
+# =============================================================================
+# Subquery Errors
+# =============================================================================
+
+executor-subquery-returned-multiple-rows = Scalar subquery คืนค่า { $actual } แถว คาดหวัง { $expected }
+executor-subquery-column-count-mismatch = Subquery คืนค่า { $actual } คอลัมน์ คาดหวัง { $expected }
+executor-column-count-mismatch = Derived column list มี { $provided } คอลัมน์ แต่ query สร้าง { $expected } คอลัมน์
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+executor-constraint-violation = ละเมิด Constraint: { $message }
+executor-multiple-primary-keys = ไม่อนุญาตให้มี PRIMARY KEY constraints หลายตัว
+executor-cannot-drop-column = ไม่สามารถลบคอลัมน์: { $message }
+executor-constraint-not-found = ไม่พบ Constraint '{ $constraint_name }' ในตาราง '{ $table_name }'
+
+# =============================================================================
+# Resource Limit Errors
+# =============================================================================
+
+executor-expression-depth-exceeded = เกินขีดจำกัดความลึกของ expression: { $depth } > { $max_depth } (ป้องกัน stack overflow)
+executor-query-timeout-exceeded = เกินเวลาที่กำหนดสำหรับ query: { $elapsed_seconds } วินาที > { $max_seconds } วินาที
+executor-row-limit-exceeded = เกินขีดจำกัดการประมวลผลแถว: { $rows_processed } > { $max_rows }
+executor-memory-limit-exceeded = เกินขีดจำกัดหน่วยความจำ: { $used_gb } GB > { $max_gb } GB
+
+# =============================================================================
+# Procedural/Variable Errors
+# =============================================================================
+
+executor-variable-not-found-simple = ไม่พบตัวแปร '{ $variable_name }'
+executor-variable-not-found-with-available = ไม่พบตัวแปร '{ $variable_name }' ตัวแปรที่มี: { $available_variables }
+executor-label-not-found = ไม่พบ Label '{ $name }'
+
+# =============================================================================
+# SELECT INTO Errors
+# =============================================================================
+
+executor-select-into-row-count = Procedural SELECT INTO ต้องคืนค่า { $expected } แถวพอดี ได้รับ { $actual } แถว{ $plural }
+executor-select-into-column-count = จำนวนคอลัมน์ SELECT INTO ไม่ตรงกัน: { $expected } ตัวแปร{ $expected_plural } แต่ query คืนค่า { $actual } คอลัมน์{ $actual_plural }
+
+# =============================================================================
+# Procedure and Function Errors
+# =============================================================================
+
+executor-procedure-not-found-simple = ไม่พบ Procedure '{ $procedure_name }' ใน schema '{ $schema_name }'
+executor-procedure-not-found-with-available = ไม่พบ Procedure '{ $procedure_name }' ใน schema '{ $schema_name }'
+    .available = Procedures ที่มี: { $available_procedures }
+executor-procedure-not-found-with-suggestion = ไม่พบ Procedure '{ $procedure_name }' ใน schema '{ $schema_name }'
+    .available = Procedures ที่มี: { $available_procedures }
+    .suggestion = หมายถึง '{ $suggestion }' หรือไม่?
+
+executor-function-not-found-simple = ไม่พบ Function '{ $function_name }' ใน schema '{ $schema_name }'
+executor-function-not-found-with-available = ไม่พบ Function '{ $function_name }' ใน schema '{ $schema_name }'
+    .available = Functions ที่มี: { $available_functions }
+executor-function-not-found-with-suggestion = ไม่พบ Function '{ $function_name }' ใน schema '{ $schema_name }'
+    .available = Functions ที่มี: { $available_functions }
+    .suggestion = หมายถึง '{ $suggestion }' หรือไม่?
+
+executor-parameter-count-mismatch = { $routine_type } '{ $routine_name }' คาดหวัง { $expected } พารามิเตอร์{ $expected_plural } ({ $parameter_signature }) ได้รับ { $actual } อาร์กิวเมนต์{ $actual_plural }
+executor-parameter-type-mismatch = พารามิเตอร์ '{ $parameter_name }' คาดหวัง { $expected_type } ได้รับ { $actual_type } '{ $actual_value }'
+executor-argument-count-mismatch = จำนวนอาร์กิวเมนต์ไม่ตรงกัน: คาดหวัง { $expected } ได้รับ { $actual }
+
+executor-recursion-limit-exceeded = เกินความลึก recursion สูงสุด ({ $max_depth }): { $message }
+executor-recursion-call-stack = Call stack:
+executor-function-must-return = Function ต้องคืนค่า
+executor-invalid-control-flow = Control flow ไม่ถูกต้อง: { $message }
+executor-invalid-function-body = Function body ไม่ถูกต้อง: { $message }
+executor-function-read-only-violation = ละเมิด Function read-only: { $message }
+
+# =============================================================================
+# EXTRACT Errors
+# =============================================================================
+
+executor-invalid-extract-field = ไม่สามารถแยก { $field } จากค่าประเภท { $value_type }
+
+# =============================================================================
+# Columnar/Arrow Errors
+# =============================================================================
+
+executor-arrow-downcast-error = ไม่สามารถ downcast Arrow array เป็น { $expected_type } ({ $context })
+executor-columnar-type-mismatch-binary = ประเภทไม่เข้ากันสำหรับ { $operation }: { $left_type } กับ { $right_type }
+executor-columnar-type-mismatch-unary = ประเภทไม่เข้ากันสำหรับ { $operation }: { $left_type }
+executor-simd-operation-failed = SIMD { $operation } ล้มเหลว: { $reason }
+executor-columnar-column-not-found = ดัชนีคอลัมน์ { $column_index } เกินขอบเขต (batch มี { $batch_columns } คอลัมน์)
+executor-columnar-column-not-found-by-name = ไม่พบคอลัมน์: { $column_name }
+executor-columnar-length-mismatch = ความยาวคอลัมน์ไม่ตรงกันใน { $context }: คาดหวัง { $expected } ได้รับ { $actual }
+executor-unsupported-array-type = ประเภท array ที่ไม่รองรับสำหรับ { $operation }: { $array_type }
+
+# =============================================================================
+# Spatial Errors
+# =============================================================================
+
+executor-spatial-geometry-error = { $function_name }: { $message }
+executor-spatial-operation-failed = { $function_name }: { $message }
+executor-spatial-argument-error = { $function_name } คาดหวัง { $expected } ได้รับ { $actual }
+
+# =============================================================================
+# Cursor Errors
+# =============================================================================
+
+executor-cursor-already-exists = Cursor '{ $name }' มีอยู่แล้ว
+executor-cursor-not-found = ไม่พบ Cursor '{ $name }'
+executor-cursor-already-open = Cursor '{ $name }' เปิดอยู่แล้ว
+executor-cursor-not-open = Cursor '{ $name }' ไม่ได้เปิด
+executor-cursor-not-scrollable = Cursor '{ $name }' ไม่สามารถเลื่อนได้ (ไม่ได้ระบุ SCROLL)
+
+# =============================================================================
+# Storage and General Errors
+# =============================================================================
+
+executor-storage-error = ข้อผิดพลาด Storage: { $message }
+executor-other = { $message }

--- a/crates/vibesql-l10n/resources/th/parser.ftl
+++ b/crates/vibesql-l10n/resources/th/parser.ftl
@@ -1,0 +1,55 @@
+# VibeSQL Parser/Lexer Localization - Thai (ภาษาไทย)
+# This file contains all user-facing strings for lexer and parser errors.
+
+# =============================================================================
+# Lexer Error Header
+# =============================================================================
+
+lexer-error-at-position = ข้อผิดพลาด Lexer ที่ตำแหน่ง { $position }: { $message }
+
+# =============================================================================
+# String Literal Errors
+# =============================================================================
+
+lexer-unterminated-string = String literal ไม่ถูกปิด
+
+# =============================================================================
+# Identifier Errors
+# =============================================================================
+
+lexer-unterminated-delimited-identifier = Delimited identifier ไม่ถูกปิด
+lexer-empty-delimited-identifier = ไม่อนุญาตให้ใช้ delimited identifier ว่าง
+
+# =============================================================================
+# Number Literal Errors
+# =============================================================================
+
+lexer-invalid-scientific-notation = Scientific notation ไม่ถูกต้อง: คาดหวังตัวเลขหลัง 'E'
+
+# =============================================================================
+# Placeholder Errors
+# =============================================================================
+
+lexer-expected-digit-after-dollar = คาดหวังตัวเลขหลัง '$' สำหรับ numbered placeholder
+lexer-invalid-numbered-placeholder = Numbered placeholder ไม่ถูกต้อง: ${ $placeholder }
+lexer-numbered-placeholder-zero = Numbered placeholder ต้องเป็น $1 หรือสูงกว่า (ไม่มี $0)
+lexer-expected-identifier-after-colon = คาดหวัง identifier หลัง ':' สำหรับ named placeholder
+
+# =============================================================================
+# Variable Errors
+# =============================================================================
+
+lexer-expected-variable-after-at-at = คาดหวังชื่อตัวแปรหลัง @@
+lexer-expected-variable-after-at = คาดหวังชื่อตัวแปรหลัง @
+
+# =============================================================================
+# Operator Errors
+# =============================================================================
+
+lexer-unexpected-pipe = อักขระไม่คาดคิด: '|' (หมายถึง '||' หรือไม่?)
+
+# =============================================================================
+# General Errors
+# =============================================================================
+
+lexer-unexpected-character = อักขระไม่คาดคิด: '{ $character }'

--- a/crates/vibesql-l10n/resources/th/storage.ftl
+++ b/crates/vibesql-l10n/resources/th/storage.ftl
@@ -1,0 +1,68 @@
+# VibeSQL Storage Error Messages - Thai (ภาษาไทย)
+# This file contains all error messages for the vibesql-storage crate.
+
+# =============================================================================
+# Table Errors
+# =============================================================================
+
+storage-table-not-found = ไม่พบตาราง '{ $name }'
+
+# =============================================================================
+# Column Errors
+# =============================================================================
+
+storage-column-count-mismatch = จำนวนคอลัมน์ไม่ตรงกัน: คาดหวัง { $expected } ได้รับ { $actual }
+storage-column-index-out-of-bounds = ดัชนีคอลัมน์ { $index } เกินขอบเขต
+storage-column-not-found = ไม่พบคอลัมน์ '{ $column_name }' ในตาราง '{ $table_name }'
+
+# =============================================================================
+# Index Errors
+# =============================================================================
+
+storage-index-already-exists = Index '{ $name }' มีอยู่แล้ว
+storage-index-not-found = ไม่พบ Index '{ $name }'
+storage-invalid-index-column = { $message }
+
+# =============================================================================
+# Constraint Errors
+# =============================================================================
+
+storage-null-constraint-violation = ละเมิด NOT NULL constraint: คอลัมน์ '{ $column }' ไม่สามารถเป็น NULL
+storage-unique-constraint-violation = { $message }
+
+# =============================================================================
+# Type Errors
+# =============================================================================
+
+storage-type-mismatch = ประเภทไม่ตรงกันในคอลัมน์ '{ $column }': คาดหวัง { $expected } ได้รับ { $actual }
+
+# =============================================================================
+# Transaction and Catalog Errors
+# =============================================================================
+
+storage-catalog-error = ข้อผิดพลาด Catalog: { $message }
+storage-transaction-error = ข้อผิดพลาด Transaction: { $message }
+storage-row-not-found = ไม่พบแถว
+
+# =============================================================================
+# I/O and Page Errors
+# =============================================================================
+
+storage-io-error = ข้อผิดพลาด I/O: { $message }
+storage-invalid-page-size = ขนาดหน้าไม่ถูกต้อง: คาดหวัง { $expected } ได้รับ { $actual }
+storage-invalid-page-id = Page ID ไม่ถูกต้อง: { $page_id }
+storage-lock-error = ข้อผิดพลาด Lock: { $message }
+
+# =============================================================================
+# Memory Errors
+# =============================================================================
+
+storage-memory-budget-exceeded = เกินงบประมาณหน่วยความจำ: ใช้ { $used } ไบต์ งบประมาณคือ { $budget } ไบต์
+storage-no-index-to-evict = ไม่มี index ที่สามารถลบออกได้ (indexes ทั้งหมดเป็น disk-backed แล้ว)
+
+# =============================================================================
+# General Errors
+# =============================================================================
+
+storage-not-implemented = ยังไม่ได้ implement: { $message }
+storage-other = { $message }

--- a/crates/vibesql-l10n/src/lib.rs
+++ b/crates/vibesql-l10n/src/lib.rs
@@ -982,4 +982,94 @@ mod tests {
         assert!(result.contains("\\help"));
         assert!(result.contains("hjälp"));
     }
+
+    #[test]
+    fn test_thai_locale() {
+        init(Some("th")).unwrap();
+
+        let goodbye = format("cli-goodbye", None);
+        assert_eq!(goodbye, "ลาก่อน!");
+
+        let mut args = FluentArgs::new();
+        args.set("count", 5);
+        let result = format("rows-count", Some(&args));
+        assert!(result.contains("5"));
+        assert!(result.contains("แถว"));
+    }
+
+    #[test]
+    fn test_thai_parser_messages() {
+        init(Some("th")).unwrap();
+
+        let result = format("lexer-unterminated-string", None);
+        assert_eq!(result, "String literal ไม่ถูกปิด");
+
+        let result = vibe_msg!("lexer-unexpected-character", character = "~");
+        assert!(result.contains("~"));
+        assert!(result.contains("อักขระไม่คาดคิด"));
+    }
+
+    #[test]
+    fn test_thai_resources_embedded() {
+        // Check that Thai resources are embedded
+        let files: Vec<_> = Resources::iter().collect();
+        assert!(files.iter().any(|f| f.starts_with("th/")), "Thai resources not found in: {:?}", files);
+        assert!(files.iter().any(|f| f == "th/cli.ftl"), "th/cli.ftl not found");
+        assert!(files.iter().any(|f| f == "th/parser.ftl"), "th/parser.ftl not found");
+        assert!(files.iter().any(|f| f == "th/executor.ftl"), "th/executor.ftl not found");
+        assert!(files.iter().any(|f| f == "th/storage.ftl"), "th/storage.ftl not found");
+        assert!(files.iter().any(|f| f == "th/catalog.ftl"), "th/catalog.ftl not found");
+    }
+
+    #[test]
+    fn test_thai_executor_messages() {
+        init(Some("th")).unwrap();
+
+        let result = vibe_msg!("executor-table-not-found", name = "users");
+        assert!(result.contains("users"));
+        assert!(result.contains("ไม่พบตาราง"));
+
+        let result = vibe_msg!("executor-division-by-zero");
+        assert_eq!(result, "หารด้วยศูนย์");
+    }
+
+    #[test]
+    fn test_thai_storage_messages() {
+        init(Some("th")).unwrap();
+
+        let result = vibe_msg!("storage-table-not-found", name = "users");
+        assert!(result.contains("users"));
+        assert!(result.contains("ไม่พบตาราง"));
+
+        let result = format("storage-row-not-found", None);
+        assert_eq!(result, "ไม่พบแถว");
+    }
+
+    #[test]
+    fn test_thai_catalog_messages() {
+        init(Some("th")).unwrap();
+
+        let result = vibe_msg!("catalog-table-already-exists", name = "orders");
+        assert!(result.contains("orders"));
+        assert!(result.contains("มีอยู่แล้ว"));
+
+        let result = vibe_msg!("catalog-schema-not-found", name = "myschema");
+        assert!(result.contains("myschema"));
+        assert!(result.contains("ไม่พบ Schema"));
+    }
+
+    #[test]
+    fn test_thai_script_handling() {
+        init(Some("th")).unwrap();
+
+        // Test messages with Thai script are correctly handled
+        let result = vibe_msg!("executor-schema-not-empty", name = "สาธารณะ");
+        assert!(result.contains("สาธารณะ"));
+        assert!(result.contains("ไม่สามารถลบ"));
+
+        // Test the help hint with Thai characters
+        let result = format("cli-help-hint", None);
+        assert!(result.contains("\\help"));
+        assert!(result.contains("ความช่วยเหลือ"));
+    }
 }


### PR DESCRIPTION
## Summary
- Add complete Thai (th) language support for VibeSQL
- Include translations for all 5 Fluent (.ftl) files: cli, parser, executor, storage, catalog
- Add 7 unit tests to validate Thai locale functionality
- Update README i18n badge to reflect 16 supported languages

## Test Plan
- [x] All 7 new Thai locale tests pass
- [x] All 62 l10n tests pass
- [x] Translations cover all message keys matching en-US baseline

Closes #3766

🤖 Generated with [Claude Code](https://claude.com/claude-code)