### PR TITLE
fix(columnar): Add constant folding before predicate extraction in columnar join

### DIFF
--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
@@ -14,13 +14,14 @@ use super::join_helpers::{
 use crate::{
     errors::ExecutorError,
     evaluator::CombinedExpressionEvaluator,
+    optimizer::optimize_expression,
     schema::CombinedSchema,
     select::{
         columnar, cte::CteResult, executor::builder::SelectExecutor,
         join::hash_join::columnar as columnar_join, projection::project_row_combined,
     },
 };
-use vibesql_ast::{FromClause, SelectItem};
+use vibesql_ast::{Expression, FromClause, SelectItem};
 
 impl SelectExecutor<'_> {
     /// Try to execute a multi-table JOIN query using columnar hash join (Phase 4)
@@ -64,9 +65,23 @@ impl SelectExecutor<'_> {
             return Ok(None);
         }
 
-        // Only handle queries without CTEs or set operations
+        // Only handle queries without CTEs, set operations, or DISTINCT
+        // DISTINCT requires deduplication which the columnar path doesn't support yet
         if !cte_results.is_empty() || stmt.set_operation.is_some() {
             log::debug!("Columnar join: skipping - has CTEs or set operations");
+            return Ok(None);
+        }
+
+        // DISTINCT queries need special handling - fall back to row-oriented
+        if stmt.distinct {
+            log::debug!("Columnar join: skipping - DISTINCT not supported");
+            return Ok(None);
+        }
+
+        // LIMIT/OFFSET queries need special handling - fall back to row-oriented
+        // TODO: Add LIMIT support to columnar join path
+        if stmt.limit.is_some() || stmt.offset.is_some() {
+            log::debug!("Columnar join: skipping - LIMIT/OFFSET not supported");
             return Ok(None);
         }
 
@@ -194,8 +209,24 @@ impl SelectExecutor<'_> {
             };
 
         // Apply remaining WHERE predicates (non-join conditions) using SIMD filtering
-        let predicates = stmt
-            .where_clause
+        // First, constant-fold the WHERE clause to handle expressions like `BETWEEN 1 AND 1+2`
+        // which need to become `BETWEEN 1 AND 3` for the predicate extractor to recognize them
+        let folded_where = if let Some(where_expr) = &stmt.where_clause {
+            // Create evaluator for constant folding
+            // SAFETY: combined_schema lives for the duration of this function call
+            let schema_ref: &'static CombinedSchema =
+                unsafe { std::mem::transmute(&combined_schema) };
+            let evaluator = CombinedExpressionEvaluator::with_database(schema_ref, self.database);
+
+            match optimize_expression(where_expr, &evaluator) {
+                Ok(folded) => Some(folded),
+                Err(_) => Some(where_expr.clone()), // Fall back to original if folding fails
+            }
+        } else {
+            None
+        };
+
+        let predicates = folded_where
             .as_ref()
             .and_then(|where_expr| extract_non_join_predicates(where_expr, &combined_schema))
             .unwrap_or_default();


### PR DESCRIPTION
## Summary

- Fixes incorrect results from columnar join execution for queries with BETWEEN expressions containing arithmetic (e.g., `BETWEEN 1 AND 1+2`)
- Adds constant folding to WHERE clause before predicate extraction so expressions are simplified to literals
- Adds fallbacks to row-oriented execution for DISTINCT and LIMIT/OFFSET queries not yet supported in columnar path

## Root Cause

The columnar join predicate extractor (`predicates.rs:228-241`) only recognizes BETWEEN expressions with literal bounds:

```rust
Expression::Between { expr: inner, low, high, negated: false, symmetric: false } => {
    if let (Expression::Literal(low_val), Expression::Literal(high_val)) =
        (low.as_ref(), high.as_ref())  // Only matches literals!
    {
```

When TPC-DS Q69 uses `d1.d_moy BETWEEN 1 AND 1+2`, the `1+2` is not matched, causing the predicate to be silently dropped. The SIMD filter then returns too many rows.

## Fix

Add constant folding to the WHERE clause before predicate extraction in the columnar join path. This transforms `BETWEEN 1 AND 1+2` into `BETWEEN 1 AND 3`, which the extractor can now handle correctly.

Also discovered that columnar join didn't handle DISTINCT or LIMIT/OFFSET queries - added fallbacks for correctness.

## Test plan

- [x] TPC-DS Q69 returns correct 17 rows (was 27)
- [x] All unit tests pass
- [x] Verified with SQLite comparison testing

Closes #3730

🤖 Generated with [Claude Code](https://claude.com/claude-code)