### PR TITLE
perf(columnar): Add LIMIT/OFFSET support to columnar join path

### DIFF
--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -424,7 +424,13 @@ impl SelectExecutor<'_> {
                 if has_joins {
                     if let Some(result) = self.try_columnar_join_execution(stmt, cte_results)? {
                         log::info!("Columnar join execution succeeded");
-                        result
+                        // Apply LIMIT/OFFSET to columnar join results (#3776)
+                        // Skip if set_operation exists - it will be applied later
+                        if stmt.set_operation.is_none() {
+                            apply_limit_offset(result, stmt.limit, stmt.offset)
+                        } else {
+                            result
+                        }
                     } else {
                         log::debug!(
                             "Columnar join execution not applicable, falling back to row-oriented"

--- a/crates/vibesql-executor/src/tests/limit_offset.rs
+++ b/crates/vibesql-executor/src/tests/limit_offset.rs
@@ -133,3 +133,346 @@ fn test_limit_greater_than_result_set() {
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 4);
 }
+
+/// Test LIMIT/OFFSET with INNER JOIN (#3776)
+///
+/// This tests that the columnar join execution path correctly applies
+/// LIMIT and OFFSET to join results.
+#[test]
+fn test_limit_with_inner_join() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Create users table
+    let users_schema = vibesql_catalog::TableSchema::new(
+        "users".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "id".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "name".to_string(),
+                vibesql_types::DataType::Varchar { max_length: Some(100) },
+                true,
+            ),
+        ],
+    );
+    db.create_table(users_schema).unwrap();
+    for i in 1..=4 {
+        db.insert_row(
+            "users",
+            vibesql_storage::Row::new(vec![
+                vibesql_types::SqlValue::Integer(i),
+                vibesql_types::SqlValue::Varchar(format!("User{}", i)),
+            ]),
+        )
+        .unwrap();
+    }
+
+    // Create orders table - each user has 2 orders
+    let orders_schema = vibesql_catalog::TableSchema::new(
+        "orders".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "id".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "user_id".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "amount".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+        ],
+    );
+    db.create_table(orders_schema).unwrap();
+    let mut order_id = 1;
+    for user_id in 1..=4 {
+        for _ in 0..2 {
+            db.insert_row(
+                "orders",
+                vibesql_storage::Row::new(vec![
+                    vibesql_types::SqlValue::Integer(order_id),
+                    vibesql_types::SqlValue::Integer(user_id),
+                    vibesql_types::SqlValue::Integer(order_id * 10),
+                ]),
+            )
+            .unwrap();
+            order_id += 1;
+        }
+    }
+
+    // INNER JOIN produces 8 rows (4 users * 2 orders each)
+    // Test with LIMIT 3
+    let executor = SelectExecutor::new(&db);
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+        from: Some(vibesql_ast::FromClause::Join {
+            left: Box::new(vibesql_ast::FromClause::Table {
+                name: "users".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            right: Box::new(vibesql_ast::FromClause::Table {
+                name: "orders".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            join_type: vibesql_ast::JoinType::Inner,
+            condition: Some(vibesql_ast::Expression::BinaryOp {
+                left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    table: Some("users".to_string()),
+                    column: "id".to_string(),
+                }),
+                op: vibesql_ast::BinaryOperator::Equal,
+                right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    table: Some("orders".to_string()),
+                    column: "user_id".to_string(),
+                }),
+            }),
+            natural: false,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: Some(3),
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 3, "LIMIT 3 should return exactly 3 rows");
+}
+
+/// Test OFFSET with INNER JOIN (#3776)
+#[test]
+fn test_offset_with_inner_join() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Create users table
+    let users_schema = vibesql_catalog::TableSchema::new(
+        "users".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "id".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "name".to_string(),
+                vibesql_types::DataType::Varchar { max_length: Some(100) },
+                true,
+            ),
+        ],
+    );
+    db.create_table(users_schema).unwrap();
+    for i in 1..=4 {
+        db.insert_row(
+            "users",
+            vibesql_storage::Row::new(vec![
+                vibesql_types::SqlValue::Integer(i),
+                vibesql_types::SqlValue::Varchar(format!("User{}", i)),
+            ]),
+        )
+        .unwrap();
+    }
+
+    // Create orders table - each user has 2 orders (8 total)
+    let orders_schema = vibesql_catalog::TableSchema::new(
+        "orders".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "id".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "user_id".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+        ],
+    );
+    db.create_table(orders_schema).unwrap();
+    let mut order_id = 1;
+    for user_id in 1..=4 {
+        for _ in 0..2 {
+            db.insert_row(
+                "orders",
+                vibesql_storage::Row::new(vec![
+                    vibesql_types::SqlValue::Integer(order_id),
+                    vibesql_types::SqlValue::Integer(user_id),
+                ]),
+            )
+            .unwrap();
+            order_id += 1;
+        }
+    }
+
+    // INNER JOIN produces 8 rows, OFFSET 5 should return 3 rows
+    let executor = SelectExecutor::new(&db);
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+        from: Some(vibesql_ast::FromClause::Join {
+            left: Box::new(vibesql_ast::FromClause::Table {
+                name: "users".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            right: Box::new(vibesql_ast::FromClause::Table {
+                name: "orders".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            join_type: vibesql_ast::JoinType::Inner,
+            condition: Some(vibesql_ast::Expression::BinaryOp {
+                left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    table: Some("users".to_string()),
+                    column: "id".to_string(),
+                }),
+                op: vibesql_ast::BinaryOperator::Equal,
+                right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    table: Some("orders".to_string()),
+                    column: "user_id".to_string(),
+                }),
+            }),
+            natural: false,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: Some(5),
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 3, "OFFSET 5 from 8 rows should return 3 rows");
+}
+
+/// Test LIMIT and OFFSET together with INNER JOIN (#3776)
+#[test]
+fn test_limit_offset_with_inner_join() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Create users table
+    let users_schema = vibesql_catalog::TableSchema::new(
+        "users".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "id".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "name".to_string(),
+                vibesql_types::DataType::Varchar { max_length: Some(100) },
+                true,
+            ),
+        ],
+    );
+    db.create_table(users_schema).unwrap();
+    for i in 1..=5 {
+        db.insert_row(
+            "users",
+            vibesql_storage::Row::new(vec![
+                vibesql_types::SqlValue::Integer(i),
+                vibesql_types::SqlValue::Varchar(format!("User{}", i)),
+            ]),
+        )
+        .unwrap();
+    }
+
+    // Create orders table - each user has 2 orders (10 total)
+    let orders_schema = vibesql_catalog::TableSchema::new(
+        "orders".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "id".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "user_id".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+        ],
+    );
+    db.create_table(orders_schema).unwrap();
+    let mut order_id = 1;
+    for user_id in 1..=5 {
+        for _ in 0..2 {
+            db.insert_row(
+                "orders",
+                vibesql_storage::Row::new(vec![
+                    vibesql_types::SqlValue::Integer(order_id),
+                    vibesql_types::SqlValue::Integer(user_id),
+                ]),
+            )
+            .unwrap();
+            order_id += 1;
+        }
+    }
+
+    // INNER JOIN produces 10 rows, LIMIT 3 OFFSET 2 should return rows 3-5
+    let executor = SelectExecutor::new(&db);
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+        from: Some(vibesql_ast::FromClause::Join {
+            left: Box::new(vibesql_ast::FromClause::Table {
+                name: "users".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            right: Box::new(vibesql_ast::FromClause::Table {
+                name: "orders".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            join_type: vibesql_ast::JoinType::Inner,
+            condition: Some(vibesql_ast::Expression::BinaryOp {
+                left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    table: Some("users".to_string()),
+                    column: "id".to_string(),
+                }),
+                op: vibesql_ast::BinaryOperator::Equal,
+                right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    table: Some("orders".to_string()),
+                    column: "user_id".to_string(),
+                }),
+            }),
+            natural: false,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: Some(3),
+        offset: Some(2),
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 3, "LIMIT 3 OFFSET 2 should return exactly 3 rows");
+}


### PR DESCRIPTION
## Summary

- Fix columnar join path to apply LIMIT/OFFSET to query results (#3776)
- Add comprehensive tests for LIMIT, OFFSET, and combined use with JOINs
- Common pattern in web applications for pagination now works correctly

## Changes

The columnar join execution path was not applying LIMIT/OFFSET, causing queries like:
```sql
SELECT * FROM users JOIN orders ON users.id = orders.user_id LIMIT 20 OFFSET 40
```
to return all rows instead of the paginated subset.

### Implementation
- Apply `apply_limit_offset()` after columnar join execution succeeds in `execute.rs:427-433`
- Skip application when `set_operation` is present (handled later in the pipeline)

### Tests Added
- `test_limit_with_inner_join` - LIMIT only with JOIN
- `test_offset_with_inner_join` - OFFSET only with JOIN  
- `test_limit_offset_with_inner_join` - Combined LIMIT and OFFSET with JOIN

## Test plan

- [x] All existing LIMIT/OFFSET tests pass
- [x] All join tests pass
- [x] New tests verify LIMIT, OFFSET, and combined behavior
- [x] `cargo check` passes

Closes #3776

🤖 Generated with [Claude Code](https://claude.com/claude-code)