### PR TITLE
refactor(columnar): Enhance predicate extractor to handle arithmetic expressions

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -1,6 +1,7 @@
+use crate::evaluator::ExpressionEvaluator;
 use crate::schema::CombinedSchema;
-use vibesql_ast::{BinaryOperator, Expression};
-use vibesql_types::SqlValue;
+use vibesql_ast::{BinaryOperator, Expression, UnaryOperator};
+use vibesql_types::{SqlMode, SqlValue};
 
 /// A predicate tree representing complex logical expressions
 ///
@@ -117,6 +118,67 @@ pub fn extract_column_predicates(
     }
 }
 
+/// Try to fold a constant expression to a literal value
+///
+/// Handles simple arithmetic expressions like `1+2`, `10-5`, `2*3`, etc.
+/// Returns Some(SqlValue) if the expression can be folded to a constant,
+/// or None if it contains column references or other non-constant expressions.
+fn try_fold_constant(expr: &Expression) -> Option<SqlValue> {
+    match expr {
+        // Literals are already folded
+        Expression::Literal(val) => Some(val.clone()),
+
+        // Binary operations on constants
+        Expression::BinaryOp { left, op, right } => {
+            let left_val = try_fold_constant(left)?;
+            let right_val = try_fold_constant(right)?;
+
+            // Use the static evaluator with default SQL mode
+            ExpressionEvaluator::eval_binary_op_static(&left_val, op, &right_val, SqlMode::default())
+                .ok()
+        }
+
+        // Unary operations on constants
+        Expression::UnaryOp { op, expr: inner } => {
+            let inner_val = try_fold_constant(inner)?;
+
+            match op {
+                UnaryOperator::Minus => {
+                    // Negate the value
+                    match inner_val {
+                        SqlValue::Integer(n) => Some(SqlValue::Integer(-n)),
+                        SqlValue::Bigint(n) => Some(SqlValue::Bigint(-n)),
+                        SqlValue::Smallint(n) => Some(SqlValue::Smallint(-n)),
+                        SqlValue::Float(n) => Some(SqlValue::Float(-n)),
+                        SqlValue::Double(n) => Some(SqlValue::Double(-n)),
+                        SqlValue::Real(n) => Some(SqlValue::Real(-n)),
+                        SqlValue::Numeric(n) => Some(SqlValue::Numeric(-n)),
+                        _ => None,
+                    }
+                }
+                UnaryOperator::Plus => Some(inner_val),
+                UnaryOperator::Not => match inner_val {
+                    SqlValue::Boolean(b) => Some(SqlValue::Boolean(!b)),
+                    _ => None,
+                },
+                _ => None,
+            }
+        }
+
+        // Cast expressions can be folded if the inner expression is constant
+        Expression::Cast { expr: inner, data_type } => {
+            let inner_val = try_fold_constant(inner)?;
+            crate::evaluator::casting::cast_value(&inner_val, data_type, &SqlMode::default()).ok()
+        }
+
+        // Parenthesized expressions are represented as the inner expression
+        // (AST doesn't have a Paren variant, so nothing to do here)
+
+        // Everything else (column refs, functions, etc.) cannot be folded
+        _ => None,
+    }
+}
+
 /// Recursively extract predicates as a tree from an expression (handles OR)
 fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<PredicateTree> {
     match expr {
@@ -158,65 +220,61 @@ fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<
             Some(PredicateTree::Or(children))
         }
 
-        // Binary comparison: column op literal
+        // Binary comparison: column op value (value can be literal or foldable expression)
         Expression::BinaryOp { left, op, right } => {
-            // Try: column op literal
-            if let (Expression::ColumnRef { table, column }, Expression::Literal(value)) =
-                (left.as_ref(), right.as_ref())
-            {
-                let column_idx = schema.get_column_index(table.as_deref(), column)?;
-                let predicate = match op {
-                    BinaryOperator::LessThan => {
-                        ColumnPredicate::LessThan { column_idx, value: value.clone() }
-                    }
-                    BinaryOperator::GreaterThan => {
-                        ColumnPredicate::GreaterThan { column_idx, value: value.clone() }
-                    }
-                    BinaryOperator::LessThanOrEqual => {
-                        ColumnPredicate::LessThanOrEqual { column_idx, value: value.clone() }
-                    }
-                    BinaryOperator::GreaterThanOrEqual => {
-                        ColumnPredicate::GreaterThanOrEqual { column_idx, value: value.clone() }
-                    }
-                    BinaryOperator::Equal => {
-                        ColumnPredicate::Equal { column_idx, value: value.clone() }
-                    }
-                    BinaryOperator::NotEqual => {
-                        ColumnPredicate::NotEqual { column_idx, value: value.clone() }
-                    }
-                    _ => return None,
-                };
-                return Some(PredicateTree::Leaf(predicate));
+            // Try: column op value (fold right side if possible)
+            if let Expression::ColumnRef { table, column } = left.as_ref() {
+                if let Some(value) = try_fold_constant(right) {
+                    let column_idx = schema.get_column_index(table.as_deref(), column)?;
+                    let predicate = match op {
+                        BinaryOperator::LessThan => {
+                            ColumnPredicate::LessThan { column_idx, value }
+                        }
+                        BinaryOperator::GreaterThan => {
+                            ColumnPredicate::GreaterThan { column_idx, value }
+                        }
+                        BinaryOperator::LessThanOrEqual => {
+                            ColumnPredicate::LessThanOrEqual { column_idx, value }
+                        }
+                        BinaryOperator::GreaterThanOrEqual => {
+                            ColumnPredicate::GreaterThanOrEqual { column_idx, value }
+                        }
+                        BinaryOperator::Equal => ColumnPredicate::Equal { column_idx, value },
+                        BinaryOperator::NotEqual => {
+                            ColumnPredicate::NotEqual { column_idx, value }
+                        }
+                        _ => return None,
+                    };
+                    return Some(PredicateTree::Leaf(predicate));
+                }
             }
 
-            // Try: literal op column (reverse the comparison)
-            if let (Expression::Literal(value), Expression::ColumnRef { table, column }) =
-                (left.as_ref(), right.as_ref())
-            {
-                let column_idx = schema.get_column_index(table.as_deref(), column)?;
-                let predicate = match op {
-                    BinaryOperator::LessThan => {
-                        ColumnPredicate::GreaterThan { column_idx, value: value.clone() }
-                    }
-                    BinaryOperator::GreaterThan => {
-                        ColumnPredicate::LessThan { column_idx, value: value.clone() }
-                    }
-                    BinaryOperator::LessThanOrEqual => {
-                        ColumnPredicate::GreaterThanOrEqual { column_idx, value: value.clone() }
-                    }
-                    BinaryOperator::GreaterThanOrEqual => {
-                        ColumnPredicate::LessThanOrEqual { column_idx, value: value.clone() }
-                    }
-                    BinaryOperator::Equal => {
-                        ColumnPredicate::Equal { column_idx, value: value.clone() }
-                    }
-                    // NotEqual is symmetric: literal <> column == column <> literal
-                    BinaryOperator::NotEqual => {
-                        ColumnPredicate::NotEqual { column_idx, value: value.clone() }
-                    }
-                    _ => return None,
-                };
-                return Some(PredicateTree::Leaf(predicate));
+            // Try: value op column (reverse the comparison, fold left side if possible)
+            if let Expression::ColumnRef { table, column } = right.as_ref() {
+                if let Some(value) = try_fold_constant(left) {
+                    let column_idx = schema.get_column_index(table.as_deref(), column)?;
+                    let predicate = match op {
+                        BinaryOperator::LessThan => {
+                            ColumnPredicate::GreaterThan { column_idx, value }
+                        }
+                        BinaryOperator::GreaterThan => {
+                            ColumnPredicate::LessThan { column_idx, value }
+                        }
+                        BinaryOperator::LessThanOrEqual => {
+                            ColumnPredicate::GreaterThanOrEqual { column_idx, value }
+                        }
+                        BinaryOperator::GreaterThanOrEqual => {
+                            ColumnPredicate::LessThanOrEqual { column_idx, value }
+                        }
+                        BinaryOperator::Equal => ColumnPredicate::Equal { column_idx, value },
+                        // NotEqual is symmetric: literal <> column == column <> literal
+                        BinaryOperator::NotEqual => {
+                            ColumnPredicate::NotEqual { column_idx, value }
+                        }
+                        _ => return None,
+                    };
+                    return Some(PredicateTree::Leaf(predicate));
+                }
             }
 
             None
@@ -227,16 +285,16 @@ fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<
         // SYMMETRIC BETWEEN falls through to general evaluator which handles bounds swapping
         Expression::Between { expr: inner, low, high, negated: false, symmetric: false } => {
             if let Expression::ColumnRef { table, column } = inner.as_ref() {
-                if let (Expression::Literal(low_val), Expression::Literal(high_val)) =
-                    (low.as_ref(), high.as_ref())
-                {
-                    let column_idx = schema.get_column_index(table.as_deref(), column)?;
-                    return Some(PredicateTree::Leaf(ColumnPredicate::Between {
-                        column_idx,
-                        low: low_val.clone(),
-                        high: high_val.clone(),
-                    }));
-                }
+                // Try to fold bounds to literals (handles arithmetic expressions like 1+2)
+                let low_val = try_fold_constant(low)?;
+                let high_val = try_fold_constant(high)?;
+
+                let column_idx = schema.get_column_index(table.as_deref(), column)?;
+                return Some(PredicateTree::Leaf(ColumnPredicate::Between {
+                    column_idx,
+                    low: low_val,
+                    high: high_val,
+                }));
             }
             None
         }
@@ -262,25 +320,25 @@ fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<
         // IN list: column IN (value1, value2, ...)
         Expression::InList { expr: inner, values, negated } => {
             if let Expression::ColumnRef { table, column } = inner.as_ref() {
-                // Extract all literal values from the IN list
-                let mut literal_values = Vec::with_capacity(values.len());
+                // Extract all values from the IN list (try to fold each to a constant)
+                let mut folded_values = Vec::with_capacity(values.len());
                 for value_expr in values {
-                    if let Expression::Literal(val) = value_expr {
-                        literal_values.push(val.clone());
+                    if let Some(val) = try_fold_constant(value_expr) {
+                        folded_values.push(val);
                     } else {
-                        // Non-literal value in IN list - can't optimize
+                        // Non-foldable value in IN list - can't optimize
                         return None;
                     }
                 }
 
-                if literal_values.is_empty() {
+                if folded_values.is_empty() {
                     return None;
                 }
 
                 let column_idx = schema.get_column_index(table.as_deref(), column)?;
                 return Some(PredicateTree::Leaf(ColumnPredicate::InList {
                     column_idx,
-                    values: literal_values,
+                    values: folded_values,
                     negated: *negated,
                 }));
             }
@@ -312,72 +370,68 @@ fn extract_predicates_recursive(
             Some(())
         }
 
-        // Binary comparison: column op literal
+        // Binary comparison: column op value (value can be literal or foldable expression)
         Expression::BinaryOp { left, op, right } => {
-            // Try: column op literal
-            if let (Expression::ColumnRef { table, column }, Expression::Literal(value)) =
-                (left.as_ref(), right.as_ref())
-            {
-                // Skip if column not in schema (cross-table predicate)
-                if let Some(column_idx) = schema.get_column_index(table.as_deref(), column) {
-                    let predicate = match op {
-                        BinaryOperator::LessThan => {
-                            ColumnPredicate::LessThan { column_idx, value: value.clone() }
-                        }
-                        BinaryOperator::GreaterThan => {
-                            ColumnPredicate::GreaterThan { column_idx, value: value.clone() }
-                        }
-                        BinaryOperator::LessThanOrEqual => {
-                            ColumnPredicate::LessThanOrEqual { column_idx, value: value.clone() }
-                        }
-                        BinaryOperator::GreaterThanOrEqual => {
-                            ColumnPredicate::GreaterThanOrEqual { column_idx, value: value.clone() }
-                        }
-                        BinaryOperator::Equal => {
-                            ColumnPredicate::Equal { column_idx, value: value.clone() }
-                        }
-                        BinaryOperator::NotEqual => {
-                            ColumnPredicate::NotEqual { column_idx, value: value.clone() }
-                        }
-                        _ => return Some(()), // Skip unsupported operator
-                    };
-                    predicates.push(predicate);
+            // Try: column op value (fold right side if possible)
+            if let Expression::ColumnRef { table, column } = left.as_ref() {
+                if let Some(value) = try_fold_constant(right) {
+                    // Skip if column not in schema (cross-table predicate)
+                    if let Some(column_idx) = schema.get_column_index(table.as_deref(), column) {
+                        let predicate = match op {
+                            BinaryOperator::LessThan => {
+                                ColumnPredicate::LessThan { column_idx, value }
+                            }
+                            BinaryOperator::GreaterThan => {
+                                ColumnPredicate::GreaterThan { column_idx, value }
+                            }
+                            BinaryOperator::LessThanOrEqual => {
+                                ColumnPredicate::LessThanOrEqual { column_idx, value }
+                            }
+                            BinaryOperator::GreaterThanOrEqual => {
+                                ColumnPredicate::GreaterThanOrEqual { column_idx, value }
+                            }
+                            BinaryOperator::Equal => ColumnPredicate::Equal { column_idx, value },
+                            BinaryOperator::NotEqual => {
+                                ColumnPredicate::NotEqual { column_idx, value }
+                            }
+                            _ => return Some(()), // Skip unsupported operator
+                        };
+                        predicates.push(predicate);
+                    }
+                    return Some(());
                 }
-                return Some(());
             }
 
-            // Try: literal op column (reverse the comparison)
-            if let (Expression::Literal(value), Expression::ColumnRef { table, column }) =
-                (left.as_ref(), right.as_ref())
-            {
-                // Skip if column not in schema (cross-table predicate)
-                if let Some(column_idx) = schema.get_column_index(table.as_deref(), column) {
-                    let predicate = match op {
-                        // Reverse the comparison: literal < column => column > literal
-                        BinaryOperator::LessThan => {
-                            ColumnPredicate::GreaterThan { column_idx, value: value.clone() }
-                        }
-                        BinaryOperator::GreaterThan => {
-                            ColumnPredicate::LessThan { column_idx, value: value.clone() }
-                        }
-                        BinaryOperator::LessThanOrEqual => {
-                            ColumnPredicate::GreaterThanOrEqual { column_idx, value: value.clone() }
-                        }
-                        BinaryOperator::GreaterThanOrEqual => {
-                            ColumnPredicate::LessThanOrEqual { column_idx, value: value.clone() }
-                        }
-                        BinaryOperator::Equal => {
-                            ColumnPredicate::Equal { column_idx, value: value.clone() }
-                        }
-                        // NotEqual is symmetric: literal <> column == column <> literal
-                        BinaryOperator::NotEqual => {
-                            ColumnPredicate::NotEqual { column_idx, value: value.clone() }
-                        }
-                        _ => return Some(()), // Skip unsupported operator
-                    };
-                    predicates.push(predicate);
+            // Try: value op column (reverse the comparison, fold left side if possible)
+            if let Expression::ColumnRef { table, column } = right.as_ref() {
+                if let Some(value) = try_fold_constant(left) {
+                    // Skip if column not in schema (cross-table predicate)
+                    if let Some(column_idx) = schema.get_column_index(table.as_deref(), column) {
+                        let predicate = match op {
+                            // Reverse the comparison: value < column => column > value
+                            BinaryOperator::LessThan => {
+                                ColumnPredicate::GreaterThan { column_idx, value }
+                            }
+                            BinaryOperator::GreaterThan => {
+                                ColumnPredicate::LessThan { column_idx, value }
+                            }
+                            BinaryOperator::LessThanOrEqual => {
+                                ColumnPredicate::GreaterThanOrEqual { column_idx, value }
+                            }
+                            BinaryOperator::GreaterThanOrEqual => {
+                                ColumnPredicate::LessThanOrEqual { column_idx, value }
+                            }
+                            BinaryOperator::Equal => ColumnPredicate::Equal { column_idx, value },
+                            // NotEqual is symmetric: value <> column == column <> value
+                            BinaryOperator::NotEqual => {
+                                ColumnPredicate::NotEqual { column_idx, value }
+                            }
+                            _ => return Some(()), // Skip unsupported operator
+                        };
+                        predicates.push(predicate);
+                    }
+                    return Some(());
                 }
-                return Some(());
             }
 
             // Skip cross-table predicates (column op column) - not a failure
@@ -388,15 +442,16 @@ fn extract_predicates_recursive(
         // Only support ASYMMETRIC (default) BETWEEN for columnar optimization
         Expression::Between { expr: inner, low, high, negated: false, symmetric: false } => {
             if let Expression::ColumnRef { table, column } = inner.as_ref() {
-                if let (Expression::Literal(low_val), Expression::Literal(high_val)) =
-                    (low.as_ref(), high.as_ref())
+                // Try to fold bounds to literals (handles arithmetic expressions like 1+2)
+                if let (Some(low_val), Some(high_val)) =
+                    (try_fold_constant(low), try_fold_constant(high))
                 {
                     // Skip if column not in schema (cross-table predicate)
                     if let Some(column_idx) = schema.get_column_index(table.as_deref(), column) {
                         predicates.push(ColumnPredicate::Between {
                             column_idx,
-                            low: low_val.clone(),
-                            high: high_val.clone(),
+                            low: low_val,
+                            high: high_val,
                         });
                     }
                     return Some(());
@@ -431,18 +486,18 @@ fn extract_predicates_recursive(
         // IN list: column IN (value1, value2, ...)
         Expression::InList { expr: inner, values, negated } => {
             if let Expression::ColumnRef { table, column } = inner.as_ref() {
-                // Extract all literal values from the IN list
-                let mut literal_values = Vec::with_capacity(values.len());
+                // Extract all values from the IN list (try to fold each to a constant)
+                let mut folded_values = Vec::with_capacity(values.len());
                 for value_expr in values {
-                    if let Expression::Literal(val) = value_expr {
-                        literal_values.push(val.clone());
+                    if let Some(val) = try_fold_constant(value_expr) {
+                        folded_values.push(val);
                     } else {
-                        // Non-literal value in IN list - can't optimize
+                        // Non-foldable value in IN list - can't optimize
                         return Some(());
                     }
                 }
 
-                if literal_values.is_empty() {
+                if folded_values.is_empty() {
                     return Some(());
                 }
 
@@ -450,7 +505,7 @@ fn extract_predicates_recursive(
                 if let Some(column_idx) = schema.get_column_index(table.as_deref(), column) {
                     predicates.push(ColumnPredicate::InList {
                         column_idx,
-                        values: literal_values,
+                        values: folded_values,
                         negated: *negated,
                     });
                 }
@@ -462,5 +517,213 @@ fn extract_predicates_recursive(
 
         // Skip any other expression types - don't fail
         _ => Some(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::CombinedSchema;
+    use vibesql_catalog::{ColumnSchema, TableSchema};
+    use vibesql_types::DataType;
+
+    fn create_test_schema() -> CombinedSchema {
+        let schema = TableSchema::new(
+            "test".to_string(),
+            vec![
+                ColumnSchema::new("col0".to_string(), DataType::Integer, false),
+                ColumnSchema::new("col1".to_string(), DataType::Integer, false),
+            ],
+        );
+        CombinedSchema::from_table("test".to_string(), schema)
+    }
+
+    #[test]
+    fn test_try_fold_constant_literal() {
+        let expr = Expression::Literal(SqlValue::Integer(42));
+        assert_eq!(try_fold_constant(&expr), Some(SqlValue::Integer(42)));
+    }
+
+    #[test]
+    fn test_try_fold_constant_addition() {
+        // 1 + 2 should fold to 3
+        let expr = Expression::BinaryOp {
+            left: Box::new(Expression::Literal(SqlValue::Integer(1))),
+            op: BinaryOperator::Plus,
+            right: Box::new(Expression::Literal(SqlValue::Integer(2))),
+        };
+        assert_eq!(try_fold_constant(&expr), Some(SqlValue::Integer(3)));
+    }
+
+    #[test]
+    fn test_try_fold_constant_nested_arithmetic() {
+        // (1 + 2) * 3 should fold to 9
+        let expr = Expression::BinaryOp {
+            left: Box::new(Expression::BinaryOp {
+                left: Box::new(Expression::Literal(SqlValue::Integer(1))),
+                op: BinaryOperator::Plus,
+                right: Box::new(Expression::Literal(SqlValue::Integer(2))),
+            }),
+            op: BinaryOperator::Multiply,
+            right: Box::new(Expression::Literal(SqlValue::Integer(3))),
+        };
+        assert_eq!(try_fold_constant(&expr), Some(SqlValue::Integer(9)));
+    }
+
+    #[test]
+    fn test_try_fold_constant_unary_minus() {
+        // -5 should fold to -5
+        let expr = Expression::UnaryOp {
+            op: UnaryOperator::Minus,
+            expr: Box::new(Expression::Literal(SqlValue::Integer(5))),
+        };
+        assert_eq!(try_fold_constant(&expr), Some(SqlValue::Integer(-5)));
+    }
+
+    #[test]
+    fn test_try_fold_constant_column_ref_returns_none() {
+        // Column references cannot be folded
+        let expr = Expression::ColumnRef { table: None, column: "x".to_string() };
+        assert_eq!(try_fold_constant(&expr), None);
+    }
+
+    #[test]
+    fn test_between_with_arithmetic_bounds() {
+        let schema = create_test_schema();
+
+        // col0 BETWEEN 1 AND 1+2
+        let expr = Expression::Between {
+            expr: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            low: Box::new(Expression::Literal(SqlValue::Integer(1))),
+            high: Box::new(Expression::BinaryOp {
+                left: Box::new(Expression::Literal(SqlValue::Integer(1))),
+                op: BinaryOperator::Plus,
+                right: Box::new(Expression::Literal(SqlValue::Integer(2))),
+            }),
+            negated: false,
+            symmetric: false,
+        };
+
+        let tree = extract_predicate_tree(&expr, &schema);
+        assert!(tree.is_some());
+
+        match tree.unwrap() {
+            PredicateTree::Leaf(ColumnPredicate::Between { column_idx, low, high }) => {
+                assert_eq!(column_idx, 0);
+                assert_eq!(low, SqlValue::Integer(1));
+                assert_eq!(high, SqlValue::Integer(3)); // 1+2 folded to 3
+            }
+            _ => panic!("Expected Between predicate"),
+        }
+    }
+
+    #[test]
+    fn test_comparison_with_arithmetic_value() {
+        let schema = create_test_schema();
+
+        // col0 < 10 - 3
+        let expr = Expression::BinaryOp {
+            left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            op: BinaryOperator::LessThan,
+            right: Box::new(Expression::BinaryOp {
+                left: Box::new(Expression::Literal(SqlValue::Integer(10))),
+                op: BinaryOperator::Minus,
+                right: Box::new(Expression::Literal(SqlValue::Integer(3))),
+            }),
+        };
+
+        let tree = extract_predicate_tree(&expr, &schema);
+        assert!(tree.is_some());
+
+        match tree.unwrap() {
+            PredicateTree::Leaf(ColumnPredicate::LessThan { column_idx, value }) => {
+                assert_eq!(column_idx, 0);
+                assert_eq!(value, SqlValue::Integer(7)); // 10-3 folded to 7
+            }
+            _ => panic!("Expected LessThan predicate"),
+        }
+    }
+
+    #[test]
+    fn test_reverse_comparison_with_arithmetic() {
+        let schema = create_test_schema();
+
+        // 2*5 > col0 should become col0 < 10
+        let expr = Expression::BinaryOp {
+            left: Box::new(Expression::BinaryOp {
+                left: Box::new(Expression::Literal(SqlValue::Integer(2))),
+                op: BinaryOperator::Multiply,
+                right: Box::new(Expression::Literal(SqlValue::Integer(5))),
+            }),
+            op: BinaryOperator::GreaterThan,
+            right: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+        };
+
+        let tree = extract_predicate_tree(&expr, &schema);
+        assert!(tree.is_some());
+
+        match tree.unwrap() {
+            PredicateTree::Leaf(ColumnPredicate::LessThan { column_idx, value }) => {
+                assert_eq!(column_idx, 0);
+                assert_eq!(value, SqlValue::Integer(10)); // 2*5 folded to 10
+            }
+            _ => panic!("Expected LessThan predicate (reversed from GreaterThan)"),
+        }
+    }
+
+    #[test]
+    fn test_in_list_with_arithmetic_values() {
+        let schema = create_test_schema();
+
+        // col0 IN (1, 1+1, 2+1)
+        let expr = Expression::InList {
+            expr: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            values: vec![
+                Expression::Literal(SqlValue::Integer(1)),
+                Expression::BinaryOp {
+                    left: Box::new(Expression::Literal(SqlValue::Integer(1))),
+                    op: BinaryOperator::Plus,
+                    right: Box::new(Expression::Literal(SqlValue::Integer(1))),
+                },
+                Expression::BinaryOp {
+                    left: Box::new(Expression::Literal(SqlValue::Integer(2))),
+                    op: BinaryOperator::Plus,
+                    right: Box::new(Expression::Literal(SqlValue::Integer(1))),
+                },
+            ],
+            negated: false,
+        };
+
+        let tree = extract_predicate_tree(&expr, &schema);
+        assert!(tree.is_some());
+
+        match tree.unwrap() {
+            PredicateTree::Leaf(ColumnPredicate::InList { column_idx, values, negated }) => {
+                assert_eq!(column_idx, 0);
+                assert!(!negated);
+                assert_eq!(values.len(), 3);
+                assert_eq!(values[0], SqlValue::Integer(1));
+                assert_eq!(values[1], SqlValue::Integer(2)); // 1+1 folded to 2
+                assert_eq!(values[2], SqlValue::Integer(3)); // 2+1 folded to 3
+            }
+            _ => panic!("Expected InList predicate"),
+        }
+    }
+
+    #[test]
+    fn test_between_with_column_bound_returns_none() {
+        let schema = create_test_schema();
+
+        // col0 BETWEEN 1 AND col1 (col1 cannot be folded)
+        let expr = Expression::Between {
+            expr: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            low: Box::new(Expression::Literal(SqlValue::Integer(1))),
+            high: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+            negated: false,
+            symmetric: false,
+        };
+
+        let tree = extract_predicate_tree(&expr, &schema);
+        assert!(tree.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Add constant folding support to the columnar predicate extractor so expressions like `BETWEEN 1 AND 1+2` or `col < 10-3` are properly handled
- Add `try_fold_constant()` helper to evaluate simple arithmetic expressions on literals
- Update BETWEEN, binary comparison, and IN list extraction to fold values
- Add comprehensive tests for all arithmetic folding scenarios

## Test plan

- [x] All new predicate tests pass (10 tests added)
- [x] All existing columnar filter tests pass (22 tests)
- [x] All columnar module tests pass (162 tests)

Closes #3778

🤖 Generated with [Claude Code](https://claude.com/claude-code)