### PR TITLE
fix(storage): SELECT queries filter deleted rows from deletion bitmap

### DIFF
--- a/crates/vibesql-executor/src/select/executor/arena_execution.rs
+++ b/crates/vibesql-executor/src/select/executor/arena_execution.rs
@@ -185,9 +185,10 @@ impl SelectExecutor<'_> {
         let evaluator =
             ArenaExpressionEvaluator::with_database(&schema, params, self.database, interner);
 
-        // Scan table and filter
+        // Scan table and filter (only live rows)
+        // Issue #3790: Use scan_live() to filter out deleted rows
         let mut results = Vec::new();
-        for row in table.scan() {
+        for (_, row) in table.scan_live() {
             // Apply WHERE clause filter
             if let Some(where_clause) = &stmt.where_clause {
                 let filter_result = evaluator.eval(where_clause, row)?;

--- a/crates/vibesql-executor/src/select/executor/fast_path.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path.rs
@@ -637,10 +637,10 @@ impl SelectExecutor<'_> {
         };
 
         // Fetch the single row
-        let all_rows = table.scan();
-        let row = match all_rows.get(row_idx) {
+        // Issue #3790: Use get_row() which returns None for deleted rows
+        let row = match table.get_row(row_idx) {
             Some(r) => r.clone(),
-            None => return Ok(Some(vec![])), // Invalid row index
+            None => return Ok(Some(vec![])), // Row deleted or invalid index
         };
 
         // Build schema for projection
@@ -801,9 +801,9 @@ impl SelectExecutor<'_> {
             }
 
             // Fetch the rows
-            let all_rows = table.scan();
+            // Issue #3790: Use get_row() which returns None for deleted rows
             let rows: Vec<Row> =
-                row_indices.iter().filter_map(|&idx| all_rows.get(idx).cloned()).collect();
+                row_indices.iter().filter_map(|&idx| table.get_row(idx).cloned()).collect();
 
             // Build schema for projection and filtering
             let effective_name = alias.cloned().unwrap_or_else(|| table_name.to_string());

--- a/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
@@ -361,17 +361,15 @@ pub(crate) fn execute_index_scan(
             false
         };
 
-    // Fetch rows from table (zero-copy - returns references)
-    let all_rows = table.scan();
-
     // Build schema early (needed for WHERE filtering)
     let effective_name = alias.cloned().unwrap_or_else(|| table_name.to_string());
     let schema = CombinedSchema::from_table(effective_name, table.schema.clone());
 
     // Zero-copy optimization: Work with row references until the final step
     // This avoids cloning rows that will be filtered out by the WHERE clause
+    // Issue #3790: Use get_row() which returns None for deleted rows
     let row_refs: Vec<&Row> =
-        matching_row_indices.iter().filter_map(|idx| all_rows.get(*idx)).collect();
+        matching_row_indices.iter().filter_map(|idx| table.get_row(*idx)).collect();
 
     // Apply WHERE clause predicates if needed (zero-copy filtering)
     // Performance optimization: Skip WHERE clause evaluation if the index already

--- a/crates/vibesql-executor/src/select/scan/join_scan.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan.rs
@@ -700,8 +700,6 @@ fn try_index_nested_loop_semi_join(
         AHashSet::with_capacity(left_slice.len());
     let mut matching_keys: AHashSet<vibesql_types::SqlValue> = AHashSet::new();
 
-    let all_rows = right_table.scan();
-
     for left_row in left_slice {
         let join_key = &left_row.values[left_col_idx];
 
@@ -726,11 +724,12 @@ fn try_index_nested_loop_semi_join(
             .collect();
 
         // Do point lookup
+        // Issue #3790: Use get_row() which returns None for deleted rows
         if let Some(&row_idx) = pk_index.get(&lookup_key) {
-            if row_idx >= all_rows.len() {
-                continue;
-            }
-            let right_row = &all_rows[row_idx];
+            let right_row = match right_table.get_row(row_idx) {
+                Some(row) => row,
+                None => continue, // Row deleted or invalid
+            };
 
             // Apply residual filter if any
             let passes = if let (Some(filter), Some(eval)) = (&residual_filter, &evaluator) {

--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -248,8 +248,9 @@ pub(crate) fn execute_table_scan(
     let effective_name = alias.cloned().unwrap_or_else(|| table_name.to_string());
     let schema = CombinedSchema::from_table(effective_name.clone(), table.schema.clone());
 
-    // Get row slice from table (zero-copy reference)
-    let row_slice = table.scan();
+    // Get live rows from table (excludes deleted rows from deletion bitmap)
+    // Issue #3790: Must use scan_live_vec() instead of scan() to filter deleted rows
+    let live_rows = table.scan_live_vec();
 
     // Check if we need to apply table-local predicates (Phase 1 optimization)
     // NOTE: Skip predicate pushdown for correlated subqueries (when outer_row/outer_schema exist)
@@ -261,11 +262,10 @@ pub(crate) fn execute_table_scan(
         if is_correlated {
             // Return unfiltered rows for correlated subqueries
             // Filtering will happen later with full outer row context
-            let rows = row_slice.to_vec();
             use crate::select::from_iterator::FromIterator;
             return Ok(super::FromResult::from_iterator(
                 schema,
-                FromIterator::from_table_scan(rows),
+                FromIterator::from_table_scan(live_rows),
             ));
         }
 
@@ -302,12 +302,12 @@ pub(crate) fn execute_table_scan(
                         "[COLUMNAR_DEBUG] {} table: extracted {} predicates for {} rows",
                         table_name,
                         column_predicates.len(),
-                        row_slice.len()
+                        live_rows.len()
                     );
                 }
                 // For native columnar tables, use SIMD filtering on typed columns
                 // This avoids SqlValue overhead by working directly on i64/f64/String arrays
-                if table.is_native_columnar() && row_slice.len() >= SIMD_COLUMNAR_THRESHOLD {
+                if table.is_native_columnar() && live_rows.len() >= SIMD_COLUMNAR_THRESHOLD {
                     if let Ok(filtered_rows) = filter_with_simd_columnar(table, &column_predicates)
                     {
                         return Ok(super::FromResult::from_rows(schema, filtered_rows));
@@ -317,9 +317,9 @@ pub(crate) fn execute_table_scan(
 
                 // For row-oriented tables, use bitmap-based filtering
                 let indices =
-                    crate::select::columnar::apply_columnar_filter(row_slice, &column_predicates)?;
+                    crate::select::columnar::apply_columnar_filter(&live_rows, &column_predicates)?;
                 let filtered_rows: Vec<_> =
-                    indices.into_iter().filter_map(|idx| row_slice.get(idx).cloned()).collect();
+                    indices.into_iter().filter_map(|idx| live_rows.get(idx).cloned()).collect();
                 return Ok(super::FromResult::from_rows(schema, filtered_rows));
             }
 
@@ -332,7 +332,7 @@ pub(crate) fn execute_table_scan(
             // Note: Use effective_name (alias) for filter lookup since PredicatePlan uses schema table names
             // Issue #3562: Pass CTE context so IN subqueries can reference CTEs
             let filtered_rows = apply_table_local_predicates_ref(
-                row_slice,
+                &live_rows,
                 schema.clone(),
                 &predicate_plan,
                 &effective_name,
@@ -345,13 +345,13 @@ pub(crate) fn execute_table_scan(
         }
     }
 
-    // No table-local predicates or no WHERE clause: clone rows for iterator
-    // TODO: Future optimization - use zero-copy iterator over row slice
+    // No table-local predicates or no WHERE clause: return live rows
+    // Issue #3790: live_rows already filters deleted rows via scan_live_vec()
     #[cfg(feature = "parallel")]
-    let rows = parallel_scan_materialize(row_slice);
+    let rows = parallel_scan_materialize(&live_rows);
 
     #[cfg(not(feature = "parallel"))]
-    let rows = row_slice.to_vec();
+    let rows = live_rows;
 
     use crate::select::from_iterator::FromIterator;
     Ok(super::FromResult::from_iterator(schema, FromIterator::from_table_scan(rows)))
@@ -466,10 +466,8 @@ fn try_primary_key_lookup(
             // in case there are additional predicates beyond the PK columns.
             // Example: SELECT * FROM stock WHERE s_w_id = 1 AND s_i_id = 123 AND s_quantity < 10
             // The PK lookup finds the row, but we must also check s_quantity < 10.
-            let all_rows = table.scan();
-            if row_idx < all_rows.len() {
-                let row = &all_rows[row_idx];
-
+            // Issue #3790: Use get_row() which returns None for deleted rows
+            if let Some(row) = table.get_row(row_idx) {
                 // Evaluate the full WHERE clause on this row
                 // Issue #3562: Pass CTE context so IN subqueries can reference CTEs
                 let evaluator = if cte_results.is_empty() {
@@ -487,7 +485,7 @@ fn try_primary_key_lookup(
                     Err(_) => vec![], // Evaluation error - treat as no match
                 }
             } else {
-                vec![] // Index points to invalid row (shouldn't happen)
+                vec![] // Row is deleted or index invalid
             }
         }
         None => vec![], // No matching row

--- a/crates/vibesql-executor/tests/delete_tests.rs
+++ b/crates/vibesql-executor/tests/delete_tests.rs
@@ -427,3 +427,67 @@ fn test_delete_exists_with_select_multiple_columns() {
         panic!("Expected DELETE statement");
     }
 }
+
+/// Test that SELECT queries return only non-deleted rows after deletion bitmap marks rows as deleted.
+///
+/// This test verifies the fix for issue #3790:
+/// - DELETE marks rows as deleted in the bitmap (O(1) operation)
+/// - SELECT must filter out deleted rows using scan_live(), not scan()
+///
+/// Without the fix, SELECT returns all rows including deleted ones.
+#[test]
+fn test_select_excludes_deleted_rows_after_delete() {
+    use vibesql_executor::SelectExecutor;
+
+    let mut db = setup_customers_orders_db();
+
+    // Initial state: 4 customers (Alice, Bob, Charlie, Diana)
+    let select_stmt = Parser::parse_sql("SELECT * FROM customers").unwrap();
+    let rows = if let vibesql_ast::Statement::Select(ref select) = select_stmt {
+        SelectExecutor::new(&db).execute(select).unwrap()
+    } else {
+        panic!("Expected SELECT statement");
+    };
+    assert_eq!(rows.len(), 4, "Should have 4 customers initially");
+
+    // Delete Alice and Bob (customers with orders)
+    let delete_sql = "DELETE FROM customers WHERE EXISTS (SELECT 1 FROM orders WHERE customer_id = customers.id)";
+    let stmt = Parser::parse_sql(delete_sql).unwrap();
+    if let vibesql_ast::Statement::Delete(delete_stmt) = stmt {
+        let deleted = DeleteExecutor::execute(&delete_stmt, &mut db).unwrap();
+        assert_eq!(deleted, 2, "Should delete 2 customers");
+    }
+
+    // SELECT * FROM customers should only return Charlie and Diana (2 rows)
+    // Bug: Without fix, this returns all 4 rows (including deleted Alice and Bob)
+    let select_stmt = Parser::parse_sql("SELECT * FROM customers").unwrap();
+    let rows = if let vibesql_ast::Statement::Select(ref select) = select_stmt {
+        SelectExecutor::new(&db).execute(select).unwrap()
+    } else {
+        panic!("Expected SELECT statement");
+    };
+
+    assert_eq!(
+        rows.len(),
+        2,
+        "SELECT should return only 2 non-deleted customers (Charlie, Diana), got {}",
+        rows.len()
+    );
+
+    // Verify the remaining customers are Charlie (id=3) and Diana (id=4)
+    let ids: Vec<i64> = rows
+        .iter()
+        .filter_map(|row| {
+            if let SqlValue::Integer(id) = row.get(0).unwrap() {
+                Some(*id)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(ids.contains(&3), "Charlie (id=3) should be in results");
+    assert!(ids.contains(&4), "Diana (id=4) should be in results");
+    assert!(!ids.contains(&1), "Alice (id=1) was deleted, should NOT be in results");
+    assert!(!ids.contains(&2), "Bob (id=2) was deleted, should NOT be in results");
+}

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -497,6 +497,35 @@ impl Table {
             .filter(|(idx, _)| !self.deleted[*idx])
     }
 
+    /// Scan only live (non-deleted) rows, returning an owned Vec.
+    ///
+    /// This method provides an efficient way to get all live rows as a Vec<Row>
+    /// for executor paths that need owned data. Unlike `scan()` which returns
+    /// all rows including deleted ones, this method filters out deleted rows.
+    ///
+    /// # Performance
+    /// O(n) time and space where n is the number of live rows.
+    /// Pre-allocates the exact capacity needed based on `row_count()`.
+    ///
+    /// # Returns
+    /// A Vec containing clones of all non-deleted rows.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// // For SELECT queries that need a Vec<Row>
+    /// let rows = table.scan_live_vec();
+    /// ```
+    #[inline]
+    pub fn scan_live_vec(&self) -> Vec<Row> {
+        let mut result = Vec::with_capacity(self.row_count());
+        for (idx, row) in self.rows.iter().enumerate() {
+            if !self.deleted[idx] {
+                result.push(row.clone());
+            }
+        }
+        result
+    }
+
     /// Get a single row by index position (O(1) access)
     ///
     /// Returns None if the row is deleted or index is out of bounds.


### PR DESCRIPTION
## Summary
- Update all SELECT executor paths to filter out deleted rows that are marked in the deletion bitmap but not yet compacted
- Add `scan_live_vec()` method to Table for efficient live row retrieval as Vec
- Add regression test verifying SELECT excludes deleted rows

## Problem
After implementing the deletion bitmap in #3779, `DELETE` operations mark rows as deleted in a bitmap but don't physically remove them. However, `SELECT` queries were still using `table.scan()` which returns all rows including deleted ones.

## Solution
Update all SELECT code paths to use deletion-aware methods:
- `scan_live_vec()` - returns only live (non-deleted) rows as a Vec
- `scan_live()` - iterator over live rows with indices
- `get_row(idx)` - returns None for deleted rows

## Files Changed
- `crates/vibesql-storage/src/table/mod.rs` - Add `scan_live_vec()` method
- `crates/vibesql-executor/src/select/scan/table.rs` - Main table scan path
- `crates/vibesql-executor/src/select/executor/fast_path.rs` - Fast path optimization
- `crates/vibesql-executor/src/select/executor/arena_execution.rs` - Arena execution
- `crates/vibesql-executor/src/select/scan/join_scan.rs` - Join scan  
- `crates/vibesql-executor/src/select/scan/index_scan/execution.rs` - Index scan
- `crates/vibesql-executor/tests/delete_tests.rs` - Regression test

## Test plan
- [x] Added `test_select_excludes_deleted_rows_after_delete` regression test
- [x] All existing delete tests pass
- [x] All executor tests pass
- [x] Release build succeeds

Closes #3790

🤖 Generated with [Claude Code](https://claude.com/claude-code)