### PR TITLE
perf(indexes): Skip unaffected user-defined indexes during UPDATE

### DIFF
--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -315,12 +315,12 @@ impl UpdateExecutor {
                 .update_row_selective(*index, new_row.clone(), changed_columns)
                 .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
 
-            index_updates.push((*index, old_row.clone(), new_row.clone()));
+            index_updates.push((*index, old_row.clone(), new_row.clone(), changed_columns.clone()));
         }
 
         // Fire AFTER UPDATE triggers for all updated rows
         if has_triggers {
-            for (_index, old_row, new_row) in &index_updates {
+            for (_index, old_row, new_row, _changed_columns) in &index_updates {
                 crate::TriggerFirer::execute_after_triggers(
                     database,
                     &stmt.table_name,
@@ -332,8 +332,9 @@ impl UpdateExecutor {
         }
 
         // Now update user-defined indexes after releasing table borrow
-        for (index, old_row, new_row) in index_updates {
-            database.update_indexes_for_update(&stmt.table_name, &old_row, &new_row, index);
+        // Pass changed_columns to skip indexes that don't involve any modified columns
+        for (index, old_row, new_row, changed_columns) in index_updates {
+            database.update_indexes_for_update(&stmt.table_name, &old_row, &new_row, index, Some(&changed_columns));
         }
 
         // Invalidate columnar cache since table data has changed
@@ -549,7 +550,8 @@ impl UpdateExecutor {
         }
 
         // Update user-defined indexes FIRST (while we still have both row references)
-        database.update_indexes_for_update(&stmt.table_name, &old_row, &new_row, row_index);
+        // Pass changed_columns to skip indexes that don't involve any modified columns
+        database.update_indexes_for_update(&stmt.table_name, &old_row, &new_row, row_index, Some(&changed_columns));
 
         // Apply the update directly (transfers ownership of new_row, no clone needed)
         let table_mut = database

--- a/crates/vibesql-storage/src/database/core.rs
+++ b/crates/vibesql-storage/src/database/core.rs
@@ -556,13 +556,14 @@ impl Database {
         let table_mut = self.get_table_mut(table_name).unwrap();
         table_mut.update_row_selective(row_index, new_row.clone(), &changed_columns)?;
 
-        // Update user-defined indexes
+        // Update user-defined indexes (pass changed_columns to skip unaffected indexes)
         self.operations.update_indexes_for_update(
             &self.catalog,
             &resolved_name,
             &old_row,
             &new_row,
             row_index,
+            Some(&changed_columns),
         );
 
         // Emit WAL entry for persistence

--- a/crates/vibesql-storage/src/database/index_ops.rs
+++ b/crates/vibesql-storage/src/database/index_ops.rs
@@ -46,12 +46,21 @@ impl Database {
     }
 
     /// Update user-defined indexes for update operation
+    ///
+    /// # Arguments
+    /// * `table_name` - Name of the table being updated
+    /// * `old_row` - Row data before the update
+    /// * `new_row` - Row data after the update
+    /// * `row_index` - Index of the row in the table
+    /// * `changed_columns` - Optional set of column indices that were modified.
+    ///   If provided, indexes that don't involve any changed columns will be skipped.
     pub fn update_indexes_for_update(
         &mut self,
         table_name: &str,
         old_row: &Row,
         new_row: &Row,
         row_index: usize,
+        changed_columns: Option<&std::collections::HashSet<usize>>,
     ) {
         self.operations.update_indexes_for_update(
             &self.catalog,
@@ -59,6 +68,7 @@ impl Database {
             old_row,
             new_row,
             row_index,
+            changed_columns,
         );
     }
 

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance.rs
@@ -323,6 +323,16 @@ impl IndexManager {
     }
 
     /// Update user-defined indexes for update operation
+    ///
+    /// # Arguments
+    /// * `table_name` - Name of the table being updated
+    /// * `table_schema` - Schema of the table
+    /// * `old_row` - Row data before the update
+    /// * `new_row` - Row data after the update
+    /// * `row_index` - Index of the row in the table
+    /// * `changed_columns` - Optional set of column indices that were modified.
+    ///   If provided, indexes that don't involve any changed columns will be skipped.
+    ///   If None, all indexes are processed (backward compatible).
     pub fn update_indexes_for_update(
         &mut self,
         table_name: &str,
@@ -330,12 +340,27 @@ impl IndexManager {
         old_row: &Row,
         new_row: &Row,
         row_index: usize,
+        changed_columns: Option<&std::collections::HashSet<usize>>,
     ) {
         for (index_name, metadata) in &self.indexes {
             // Case-insensitive comparison for table name matching
             // SQL parser normalizes identifiers to uppercase, but table/index metadata
             // may store the original case from DDL statements
             if metadata.table_name.eq_ignore_ascii_case(table_name) {
+                // OPTIMIZATION: Skip indexes that don't involve any changed columns
+                // This avoids building key vectors and comparing them for unaffected indexes
+                if let Some(changed) = changed_columns {
+                    let index_affected = metadata.columns.iter().any(|col| {
+                        table_schema
+                            .get_column_index(&col.column_name)
+                            .map(|idx| changed.contains(&idx))
+                            .unwrap_or(false)
+                    });
+                    if !index_affected {
+                        continue; // Skip this index - none of its columns were changed
+                    }
+                }
+
                 if let Some(index_data) = self.index_data.get_mut(index_name) {
                     // Build keys from old and new rows
                     // Normalize numeric types to ensure consistent comparison

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -456,6 +456,15 @@ impl Operations {
     }
 
     /// Update user-defined indexes for update operation
+    ///
+    /// # Arguments
+    /// * `catalog` - Database catalog for schema lookup
+    /// * `table_name` - Name of the table being updated
+    /// * `old_row` - Row data before the update
+    /// * `new_row` - Row data after the update
+    /// * `row_index` - Index of the row in the table
+    /// * `changed_columns` - Optional set of column indices that were modified.
+    ///   If provided, indexes that don't involve any changed columns will be skipped.
     pub fn update_indexes_for_update(
         &mut self,
         catalog: &vibesql_catalog::Catalog,
@@ -463,6 +472,7 @@ impl Operations {
         old_row: &Row,
         new_row: &Row,
         row_index: usize,
+        changed_columns: Option<&std::collections::HashSet<usize>>,
     ) {
         if let Some(table_schema) = catalog.get_table(table_name) {
             self.index_manager.update_indexes_for_update(
@@ -471,6 +481,7 @@ impl Operations {
                 old_row,
                 new_row,
                 row_index,
+                changed_columns,
             );
         }
 


### PR DESCRIPTION
## Summary
- Add selective index maintenance for user-defined indexes during UPDATE operations
- Skip indexes entirely when none of their columns are being modified
- Pass changed_columns through the update_indexes_for_update call chain

## Details
This optimization mirrors what the internal index manager already does for primary key and unique constraint indexes. When updating rows, we now check if any of an index's columns are in the set of changed columns before processing that index.

For tables with multiple user-defined indexes where only some columns are being updated, this avoids:
- Building key vectors for unaffected indexes
- Comparing old/new key values
- Any HashMap/BTreeMap operations

**Note**: The specific sysbench `update-index` benchmark (which updates the indexed `k` column) won't show improvement since that index must still be updated. This optimization helps scenarios with multiple indexes where only a subset of indexed columns are modified.

## Test plan
- [x] All UPDATE tests pass
- [x] All index tests pass  
- [x] Code compiles without errors
- [x] Ran sysbench benchmark (no regression)

Closes #3797

🤖 Generated with [Claude Code](https://claude.com/claude-code)