### PR TITLE
fix(executor): Validate predicate pushdown in covering index scan (#1618)

### DIFF
--- a/crates/vibesql-executor/src/select/scan/index_scan/covering.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/covering.rs
@@ -248,6 +248,24 @@ pub(in crate::select) fn try_covering_index_scan(
         None => return Ok(None),
     };
 
+    // Issue #1618: If there's a WHERE clause, we must be able to push it down to this index.
+    // Otherwise, we'd return wrong results (0 rows when predicate doesn't match index columns).
+    // A covering scan without predicate pushdown would require post-filtering which defeats
+    // the purpose and can silently return incorrect results.
+    if let Some(expr) = where_clause {
+        let prefix_with_range = extract_prefix_with_trailing_range(expr, &index_column_names);
+        let prefix_only = if prefix_with_range.is_none() {
+            extract_prefix_equality_predicates(expr, &index_column_names)
+        } else {
+            None
+        };
+
+        // If neither predicate extraction worked, this index can't be used for covering scan
+        if prefix_with_range.is_none() && prefix_only.is_none() {
+            return Ok(None);
+        }
+    }
+
     // Execute covering scan
     let result = execute_covering_index_scan(
         table_name,


### PR DESCRIPTION
## Summary
- Fixes covering index scan returning 0 rows when WHERE clause predicate cannot be pushed down to the index
- Adds validation in `try_covering_index_scan` to ensure the WHERE clause can be extracted as a prefix/range predicate before using covering scan
- If predicate extraction fails, returns `None` so the caller falls back to regular execution path that properly filters rows

## Problem
Query `SELECT pk FROM tab1 WHERE col0 > 250` was returning 0 rows instead of 3.

Root cause: The optimizer was selecting the `PK_TAB1` index (which covers the `pk` column needed for SELECT), but the WHERE clause (`col0 > 250`) couldn't be pushed down to this index. The covering scan code was returning empty results instead of falling back to a path that would properly filter the data.

## Test plan
- [x] `cargo test --release -p vibesql --test issue_1618` - Passes (all 3 cycles)
- [x] `cargo test --release -p vibesql-executor` - All 1826 tests pass

Closes #1618

🤖 Generated with [Claude Code](https://claude.com/claude-code)