### PR TITLE
fix(cli): Show actual column names and values in table output

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -62,20 +62,18 @@ impl SqlExecutor {
 
         match statement {
             vibesql_ast::Statement::Select(select_stmt) => {
-                // Execute SELECT and format results
+                // Execute SELECT and format results with column names
                 let executor = vibesql_executor::SelectExecutor::new(&self.db);
-                match executor.execute(&select_stmt) {
-                    Ok(rows) => {
-                        result.row_count = rows.len();
-                        // Convert rows to string representation
-                        if !rows.is_empty() {
-                            // Get column names from the select statement
-                            result.columns = vec!["Column".to_string(); rows[0].values.len()];
-                            for row in rows {
-                                let row_strs: Vec<String> =
-                                    row.values.iter().map(|v| format!("{:?}", v)).collect();
-                                result.rows.push(row_strs);
-                            }
+                match executor.execute_with_columns(&select_stmt) {
+                    Ok(select_result) => {
+                        result.row_count = select_result.rows.len();
+                        // Use column names from the executor result
+                        result.columns = select_result.columns;
+                        // Convert rows to string representation using Display trait
+                        for row in select_result.rows {
+                            let row_strs: Vec<String> =
+                                row.values.iter().map(|v| format!("{}", v)).collect();
+                            result.rows.push(row_strs);
                         }
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -147,9 +147,62 @@ fn test_multi_column_select_order() {
     assert_eq!(result.rows[0].len(), 2, "Should return 2 columns");
 
     // Values should be in the same order as specified in SELECT: 74 first, then 50
-    // Note: Values are formatted as debug strings like "Integer(74)"
-    assert_eq!(result.rows[0][0], "Integer(74)", "First column should be 74");
-    assert_eq!(result.rows[0][1], "Integer(50)", "Second column should be 50");
+    // Values are displayed using Display trait, not Debug (fix for #3810)
+    assert_eq!(result.rows[0][0], "74", "First column should be 74");
+    assert_eq!(result.rows[0][1], "50", "Second column should be 50");
+}
+
+#[test]
+fn test_select_column_names_and_values_issue_3810() {
+    // Regression test for issue #3810
+    // SELECT should show actual column names/aliases, not generic "Column"
+    // SELECT should show actual values, not typed representation like "Integer(1)"
+    let mut executor = SqlExecutor::new(None).unwrap();
+    let result = executor.execute("SELECT 1 as my_column, 'hello' as greeting").unwrap();
+
+    // Column names should be the aliases, not "Column"
+    // Note: SQL standard normalizes unquoted identifiers to uppercase
+    assert_eq!(result.columns, vec!["MY_COLUMN", "GREETING"]);
+
+    // Values should be display format, not debug format
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0][0], "1", "Integer value should display as '1', not 'Integer(1)'");
+    assert_eq!(
+        result.rows[0][1], "hello",
+        "Varchar value should display as 'hello', not 'Varchar(\"hello\")'"
+    );
+}
+
+#[test]
+fn test_select_column_names_from_table() {
+    // Verify column names are derived correctly from table columns
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(50))").unwrap();
+    executor.execute("INSERT INTO users VALUES (1, 'Alice')").unwrap();
+
+    let result = executor.execute("SELECT id, name FROM users").unwrap();
+
+    // Column names should match the table schema
+    assert_eq!(result.columns, vec!["ID", "NAME"]);
+
+    // Values should be display format
+    assert_eq!(result.rows[0][0], "1");
+    assert_eq!(result.rows[0][1], "Alice");
+}
+
+#[test]
+fn test_select_wildcard_column_names() {
+    // Verify SELECT * returns actual column names
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE products (sku VARCHAR(20) PRIMARY KEY, price INT)").unwrap();
+    executor.execute("INSERT INTO products VALUES ('ABC123', 99)").unwrap();
+
+    let result = executor.execute("SELECT * FROM products").unwrap();
+
+    // Column names should be actual column names from table
+    assert_eq!(result.columns, vec!["SKU", "PRICE"]);
+    assert_eq!(result.rows[0][0], "ABC123");
+    assert_eq!(result.rows[0][1], "99");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Fixed CLI table output showing generic "Column" headers instead of actual column names/aliases
- Fixed CLI table output showing Debug format (e.g., "Integer(1)") instead of Display format (e.g., "1")

## Changes

- Use `execute_with_columns()` instead of `execute()` to get column names from SELECT results
- Use Display trait (`{}`) instead of Debug trait (`{:?}`) for value formatting
- Added regression tests for the fix

## Before

```
+------------+------------------+
| Column     | Column           |
+------------+------------------+
| Integer(1) | Varchar("hello") |
+------------+------------------+
```

## After

```
+-----------+----------+
| MY_COLUMN | GREETING |
+-----------+----------+
| 1         | hello    |
+-----------+----------+
```

## Test plan

- [x] Added test `test_select_column_names_and_values_issue_3810` for the exact reproduction case
- [x] Added test `test_select_column_names_from_table` for column names from table schema
- [x] Added test `test_select_wildcard_column_names` for SELECT * case
- [x] Updated existing test `test_multi_column_select_order` to expect new format
- [x] All 97 CLI tests pass

Closes #3810

🤖 Generated with [Claude Code](https://claude.com/claude-code)