### PR TITLE
fix(executor): Support window functions in CASE and IS NULL expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -393,6 +393,10 @@ path = "tests/regression/issue_2852.rs"
 name = "issue_3807"
 path = "tests/regression/issue_3807.rs"
 
+[[test]]
+name = "issue_3809"
+path = "tests/regression/issue_3809.rs"
+
 # Parser tests - SQL parsing and syntax
 [[test]]
 name = "coverage_improvements"

--- a/crates/vibesql-executor/src/select/projection.rs
+++ b/crates/vibesql-executor/src/select/projection.rs
@@ -131,6 +131,23 @@ pub(super) fn evaluate_expression_with_windows(
             let new_expr = Expression::UnaryOp { expr: Box::new(inner_substituted), op: *op };
             evaluator.eval(&new_expr, row)
         }
+        Expression::Case { .. } => {
+            // Substitute window functions in CASE expressions before evaluating
+            let substituted = substitute_window_functions(expr, row, window_mapping)?;
+            evaluator.eval(&substituted, row)
+        }
+        Expression::Function { .. } => {
+            // Substitute window functions in function arguments before evaluating
+            let substituted = substitute_window_functions(expr, row, window_mapping)?;
+            evaluator.eval(&substituted, row)
+        }
+        Expression::IsNull { expr: inner, negated } => {
+            // Substitute window functions in IS NULL expressions
+            let inner_substituted = substitute_window_functions(inner, row, window_mapping)?;
+            let new_expr =
+                Expression::IsNull { expr: Box::new(inner_substituted), negated: *negated };
+            evaluator.eval(&new_expr, row)
+        }
         _ => {
             // For non-window expressions, use the regular evaluator
             evaluator.eval(expr, row)
@@ -227,6 +244,10 @@ fn substitute_window_functions(
                 when_clauses: subst_when?,
                 else_result: subst_else,
             })
+        }
+        Expression::IsNull { expr: inner, negated } => {
+            let inner_sub = substitute_window_functions(inner, row, window_mapping)?;
+            Ok(Expression::IsNull { expr: Box::new(inner_sub), negated: *negated })
         }
         // For all other expressions (literals, column refs, etc.), no substitution needed
         _ => Ok(expr.clone()),

--- a/crates/vibesql-executor/src/select/window/collection.rs
+++ b/crates/vibesql-executor/src/select/window/collection.rs
@@ -53,7 +53,10 @@ fn collect_from_expression(
                 collect_from_expression(arg, select_index, window_functions)?;
             }
         }
-        Expression::Case { when_clauses, else_result, .. } => {
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                collect_from_expression(op, select_index, window_functions)?;
+            }
             for when_clause in when_clauses {
                 for cond in &when_clause.conditions {
                     collect_from_expression(cond, select_index, window_functions)?;
@@ -63,6 +66,9 @@ fn collect_from_expression(
             if let Some(else_expr) = else_result {
                 collect_from_expression(else_expr, select_index, window_functions)?;
             }
+        }
+        Expression::IsNull { expr, .. } => {
+            collect_from_expression(expr, select_index, window_functions)?;
         }
         _ => {}
     }

--- a/crates/vibesql-executor/src/select/window/detection.rs
+++ b/crates/vibesql-executor/src/select/window/detection.rs
@@ -19,12 +19,15 @@ pub(in crate::select) fn expression_has_window_function(expr: &Expression) -> bo
         }
         Expression::UnaryOp { expr, .. } => expression_has_window_function(expr),
         Expression::Function { args, .. } => args.iter().any(expression_has_window_function),
-        Expression::Case { when_clauses, else_result, .. } => {
-            when_clauses.iter().any(|when_clause| {
-                when_clause.conditions.iter().any(expression_has_window_function)
-                    || expression_has_window_function(&when_clause.result)
-            }) || else_result.as_ref().is_some_and(|e| expression_has_window_function(e))
+        Expression::Case { operand, when_clauses, else_result } => {
+            operand.as_ref().is_some_and(|e| expression_has_window_function(e))
+                || when_clauses.iter().any(|when_clause| {
+                    when_clause.conditions.iter().any(expression_has_window_function)
+                        || expression_has_window_function(&when_clause.result)
+                })
+                || else_result.as_ref().is_some_and(|e| expression_has_window_function(e))
         }
+        Expression::IsNull { expr, .. } => expression_has_window_function(expr),
         _ => false,
     }
 }

--- a/tests/regression/issue_3809.rs
+++ b/tests/regression/issue_3809.rs
@@ -1,0 +1,141 @@
+//! Test for issue #3809: Window functions inside CASE expressions fail
+//!
+//! This test reproduces the bug where window functions work correctly in direct
+//! SELECT columns but fail when nested inside CASE expressions with the error:
+//! "Window functions require window mapping context"
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+/// Helper to execute SELECT and return rows
+fn select_rows(db: &Database, sql: &str) -> Vec<Row> {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor.execute(&select_stmt).unwrap()
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+/// Helper to create the test table
+fn create_test_table(db: &mut Database) {
+    let schema = TableSchema::new(
+        "T".to_string(),
+        vec![ColumnSchema::new("X".to_string(), DataType::Integer, false)],
+    );
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("T").unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(1)])).unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(2)])).unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(3)])).unwrap();
+}
+
+#[test]
+fn test_window_function_in_case_expression() {
+    let mut db = Database::new();
+    create_test_table(&mut db);
+
+    // Test 1: Basic window function works (sanity check)
+    let rows = select_rows(&db, "SELECT x, LAG(x) OVER (ORDER BY x) as prev FROM t");
+    assert_eq!(rows.len(), 3);
+
+    // Test 2: Window function in CASE WHEN condition - this was failing
+    let rows = select_rows(
+        &db,
+        "SELECT x,
+            CASE
+                WHEN LAG(x) OVER (ORDER BY x) IS NULL THEN 'first'
+                ELSE 'not_first'
+            END as position
+        FROM t",
+    );
+    assert_eq!(rows.len(), 3);
+    // First row should have 'first', others should have 'not_first'
+    assert_eq!(rows[0].values[1], vibesql_types::SqlValue::Varchar("first".to_string()));
+    assert_eq!(rows[1].values[1], vibesql_types::SqlValue::Varchar("not_first".to_string()));
+    assert_eq!(rows[2].values[1], vibesql_types::SqlValue::Varchar("not_first".to_string()));
+
+    // Test 3: Window function in CASE THEN/ELSE result expressions
+    let rows = select_rows(
+        &db,
+        "SELECT x,
+            CASE
+                WHEN x > 1 THEN x - LAG(x) OVER (ORDER BY x)
+                ELSE NULL
+            END as diff
+        FROM t",
+    );
+    assert_eq!(rows.len(), 3);
+    // First row: x=1, x > 1 is false, so NULL
+    assert_eq!(rows[0].values[1], vibesql_types::SqlValue::Null);
+    // Second row: x=2, diff = 2 - 1 = 1
+    assert_eq!(rows[1].values[1], vibesql_types::SqlValue::Integer(1));
+    // Third row: x=3, diff = 3 - 2 = 1
+    assert_eq!(rows[2].values[1], vibesql_types::SqlValue::Integer(1));
+
+    // Test 4: Multiple window functions in same CASE
+    let rows = select_rows(
+        &db,
+        "SELECT x,
+            CASE
+                WHEN LAG(x) OVER (ORDER BY x) IS NULL THEN NULL
+                ELSE x - LAG(x) OVER (ORDER BY x)
+            END as diff
+        FROM t",
+    );
+    assert_eq!(rows.len(), 3);
+    // This is the pattern from the issue
+    assert_eq!(rows[0].values[1], vibesql_types::SqlValue::Null);
+    assert_eq!(rows[1].values[1], vibesql_types::SqlValue::Integer(1));
+    assert_eq!(rows[2].values[1], vibesql_types::SqlValue::Integer(1));
+}
+
+#[test]
+fn test_window_function_in_is_null() {
+    let mut db = Database::new();
+
+    // Create a 2-row table for this test
+    let schema = TableSchema::new(
+        "T".to_string(),
+        vec![ColumnSchema::new("X".to_string(), DataType::Integer, false)],
+    );
+    db.create_table(schema).unwrap();
+    let table = db.get_table_mut("T").unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(1)])).unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(2)])).unwrap();
+
+    // Test: IS NULL with window function
+    let rows = select_rows(
+        &db,
+        "SELECT x, LAG(x) OVER (ORDER BY x) IS NULL as is_first FROM t",
+    );
+    assert_eq!(rows.len(), 2);
+    // First row: LAG is NULL, so IS NULL = true
+    assert_eq!(rows[0].values[1], vibesql_types::SqlValue::Boolean(true));
+    // Second row: LAG = 1, so IS NULL = false
+    assert_eq!(rows[1].values[1], vibesql_types::SqlValue::Boolean(false));
+}
+
+#[test]
+fn test_window_function_in_nested_function() {
+    let mut db = Database::new();
+    create_test_table(&mut db);
+
+    // Test: COALESCE with window function
+    let rows = select_rows(
+        &db,
+        "SELECT x, COALESCE(LAG(x) OVER (ORDER BY x), 0) as prev_or_zero FROM t",
+    );
+    assert_eq!(rows.len(), 3);
+    // First row: LAG is NULL, COALESCE returns 0
+    assert_eq!(rows[0].values[1], vibesql_types::SqlValue::Integer(0));
+    // Second row: LAG = 1
+    assert_eq!(rows[1].values[1], vibesql_types::SqlValue::Integer(1));
+    // Third row: LAG = 2
+    assert_eq!(rows[2].values[1], vibesql_types::SqlValue::Integer(2));
+}


### PR DESCRIPTION
## Summary

- Fixes window functions failing with "Window functions require window mapping context" when nested inside CASE expressions or IS NULL predicates
- Adds handling for IsNull expressions in detection, collection, and projection phases
- Adds proper CASE and Function expression handling in projection to ensure window function substitution

## Test plan

- [x] Added regression test `tests/regression/issue_3809.rs` with test cases for:
  - Window functions in CASE WHEN conditions
  - Window functions in CASE THEN/ELSE results
  - Window functions wrapped in IS NULL predicates
  - Window functions inside COALESCE and other functions
- [x] Verified existing window function tests still pass
- [x] Verified executor crate tests pass

Closes #3809

🤖 Generated with [Claude Code](https://claude.com/claude-code)