### PR TITLE
feat(wasm): Add runtime locale switching for web demo

### DIFF
--- a/crates/vibesql-wasm-bindings/src/lib.rs
+++ b/crates/vibesql-wasm-bindings/src/lib.rs
@@ -36,6 +36,24 @@ fn detect_browser_locale() -> Option<String> {
         .and_then(|w| w.navigator().language())
 }
 
+/// Sets the locale for localized error messages at runtime.
+///
+/// This allows changing the language without reloading the page.
+/// Supported locales include: en-US, es, pt-BR, zh-CN, ja, de, fr, ko,
+/// id, sv, th, vi.
+#[cfg(feature = "i18n")]
+#[wasm_bindgen]
+pub fn set_locale(locale: &str) {
+    let _ = vibesql_l10n::init(Some(locale));
+}
+
+/// Gets the currently active locale code.
+#[cfg(feature = "i18n")]
+#[wasm_bindgen]
+pub fn get_locale() -> String {
+    vibesql_l10n::current_locale().to_string()
+}
+
 /// Result of a query execution
 #[derive(Serialize, Deserialize)]
 #[wasm_bindgen(getter_with_clone)]

--- a/web-demo/src/db/types.ts
+++ b/web-demo/src/db/types.ts
@@ -65,4 +65,10 @@ export interface WasmModule {
     new (): Database
     newWithPersistence(): Promise<Database>
   }
+
+  /** Set the locale for localized error messages (optional, requires i18n feature) */
+  set_locale?: (locale: string) => void
+
+  /** Get the current locale (optional, requires i18n feature) */
+  get_locale?: () => string
 }


### PR DESCRIPTION
## Summary
- Expose `set_locale()` and `get_locale()` functions via WASM bindings
- Enable runtime language switching in the web demo without page reload
- Update TypeScript types to include optional locale functions

## Test plan
- [ ] Build WASM with `./scripts/build-wasm.sh`
- [ ] Run web demo and verify locale selector changes error message language
- [ ] Verify `get_locale()` returns current locale code

🤖 Generated with [Claude Code](https://claude.com/claude-code)