### PR TITLE
fix(server): Enable subscription e2e tests with same-connection notifications (#3816)

### DIFF
--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -6,7 +6,7 @@ use crate::protocol::{
 };
 use crate::registry::DatabaseRegistry;
 use crate::session::{ExecutionResult, Session};
-use crate::subscription::{SessionSubscriptionManager, SubscriptionManager};
+use crate::subscription::{extract_table_refs, SessionSubscriptionManager, SubscriptionManager};
 use anyhow::Result;
 use bytes::BytesMut;
 use std::collections::HashMap;
@@ -349,7 +349,20 @@ impl ConnectionHandler {
                     metrics.record_query(query_duration, stmt_type, true, rows_affected);
                 }
 
+                // Check if this was a mutation that might affect subscriptions
+                let is_mutation = matches!(
+                    &result,
+                    ExecutionResult::Insert { .. }
+                        | ExecutionResult::Update { .. }
+                        | ExecutionResult::Delete { .. }
+                );
+
                 self.send_query_result(result).await?;
+
+                // Notify affected subscriptions after mutations
+                if is_mutation {
+                    self.notify_affected_subscriptions(query).await;
+                }
 
                 // Return appropriate transaction status
                 let txn_status = self.get_transaction_status();
@@ -461,6 +474,100 @@ impl ConnectionHandler {
         }
 
         Ok(())
+    }
+
+    /// Notify affected subscriptions after a mutation (INSERT/UPDATE/DELETE)
+    ///
+    /// This method parses the mutation query to extract the affected table,
+    /// finds all subscriptions that depend on that table, re-executes their
+    /// queries, and sends updated results to the client.
+    async fn notify_affected_subscriptions(&mut self, mutation_query: &str) {
+        // Parse the mutation query to extract affected tables
+        let affected_tables = match vibesql_parser::Parser::parse_sql(mutation_query) {
+            Ok(stmt) => extract_table_refs(&stmt),
+            Err(e) => {
+                debug!("Failed to parse mutation query for subscription update: {}", e);
+                return;
+            }
+        };
+
+        if affected_tables.is_empty() {
+            return;
+        }
+
+        // Collect subscriptions that need updating
+        // We collect (subscription_id, query) pairs to avoid borrowing issues
+        let subscriptions_to_update: Vec<([u8; 16], String)> = affected_tables
+            .iter()
+            .flat_map(|table| {
+                self.subscription_manager
+                    .get_subscriptions_for_table_with_details(table)
+                    .map(|(id, sub)| (*id, sub.query.clone()))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        if subscriptions_to_update.is_empty() {
+            return;
+        }
+
+        // De-duplicate subscriptions (a subscription may depend on multiple affected tables)
+        let mut seen = std::collections::HashSet::new();
+        let unique_subscriptions: Vec<_> = subscriptions_to_update
+            .into_iter()
+            .filter(|(id, _)| seen.insert(*id))
+            .collect();
+
+        debug!(
+            "Notifying {} subscriptions after mutation affecting tables: {:?}",
+            unique_subscriptions.len(),
+            affected_tables
+        );
+
+        // Re-execute each subscription query and send updates
+        for (subscription_id, query) in unique_subscriptions {
+            if let Some(session) = &mut self.session {
+                match session.execute(&query).await {
+                    Ok(ExecutionResult::Select { rows, .. }) => {
+                        // Convert rows to wire format
+                        let wire_rows: Vec<Vec<Option<Vec<u8>>>> = rows
+                            .iter()
+                            .map(|row| {
+                                row.values
+                                    .iter()
+                                    .map(|v| Some(v.to_string().as_bytes().to_vec()))
+                                    .collect()
+                            })
+                            .collect();
+
+                        // Send full update (could optimize to send delta in the future)
+                        if let Err(e) = self
+                            .send_subscription_data(
+                                &subscription_id,
+                                SubscriptionUpdateType::Full,
+                                wire_rows,
+                            )
+                            .await
+                        {
+                            warn!("Failed to send subscription update: {}", e);
+                        }
+                    }
+                    Ok(_) => {
+                        // Non-SELECT result - shouldn't happen for a subscription query
+                        warn!("Subscription query returned non-SELECT result");
+                    }
+                    Err(e) => {
+                        // Query failed - send error to subscriber
+                        if let Err(send_err) = self
+                            .send_subscription_error(&subscription_id, &format!("Query error: {}", e))
+                            .await
+                        {
+                            warn!("Failed to send subscription error: {}", send_err);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Send query result to client

--- a/crates/vibesql-server/src/subscription/session.rs
+++ b/crates/vibesql-server/src/subscription/session.rs
@@ -91,9 +91,9 @@ impl SessionSubscriptionManager {
             table_dependencies: table_dependencies.clone(),
         };
 
-        // Update table -> subscription index
+        // Update table -> subscription index (normalize to lowercase for case-insensitive matching)
         for table in &table_dependencies {
-            self.table_to_subscriptions.entry(table.clone()).or_default().insert(id);
+            self.table_to_subscriptions.entry(table.to_lowercase()).or_default().insert(id);
         }
 
         self.subscriptions.insert(id, subscription);
@@ -139,12 +139,13 @@ impl SessionSubscriptionManager {
         subscription_id: &SessionSubscriptionId,
     ) -> Option<SessionSubscription> {
         if let Some(subscription) = self.subscriptions.remove(subscription_id) {
-            // Clean up table -> subscription index
+            // Clean up table -> subscription index (use lowercase to match how we stored it)
             for table in &subscription.table_dependencies {
-                if let Some(sub_ids) = self.table_to_subscriptions.get_mut(table) {
+                let table_lower = table.to_lowercase();
+                if let Some(sub_ids) = self.table_to_subscriptions.get_mut(&table_lower) {
                     sub_ids.remove(subscription_id);
                     if sub_ids.is_empty() {
-                        self.table_to_subscriptions.remove(table);
+                        self.table_to_subscriptions.remove(&table_lower);
                     }
                 }
             }
@@ -154,13 +155,30 @@ impl SessionSubscriptionManager {
         }
     }
 
-    /// Get all subscription IDs that depend on a given table
-    #[allow(dead_code)]
+    /// Get all subscription IDs that depend on a given table (case-insensitive)
     pub fn get_subscriptions_for_table(&self, table: &str) -> Vec<SessionSubscriptionId> {
         self.table_to_subscriptions
-            .get(table)
+            .get(&table.to_lowercase())
             .map(|ids| ids.iter().copied().collect())
             .unwrap_or_default()
+    }
+
+    /// Get subscriptions that depend on a given table (case-insensitive)
+    ///
+    /// Returns an iterator over (subscription_id, subscription) pairs for all
+    /// subscriptions that depend on the given table. This is used to notify
+    /// subscribers when a table is mutated.
+    pub fn get_subscriptions_for_table_with_details(
+        &self,
+        table: &str,
+    ) -> impl Iterator<Item = (&SessionSubscriptionId, &SessionSubscription)> {
+        let table_lower = table.to_lowercase();
+        self.table_to_subscriptions
+            .get(&table_lower)
+            .into_iter()
+            .flat_map(|ids| {
+                ids.iter().filter_map(|id| self.subscriptions.get(id).map(|sub| (id, sub)))
+            })
     }
 
     /// Get a subscription by ID

--- a/crates/vibesql-server/tests/e2e_subscription_tests.rs
+++ b/crates/vibesql-server/tests/e2e_subscription_tests.rs
@@ -14,13 +14,9 @@ const MSG_SUBSCRIPTION_DATA: u8 = 0xF2;
 const MSG_READY_FOR_QUERY: u8 = b'Z';
 
 /// Helper to send a subscription request for a query
-async fn send_subscribe(client: &mut TestClient, query: &str) -> std::io::Result<[u8; 16]> {
-    // Generate a subscription ID (16 bytes based on query hash)
-    let mut sub_id = [0u8; 16];
-    for (i, b) in query.as_bytes().iter().enumerate() {
-        sub_id[i % 16] = sub_id[i % 16].wrapping_add(*b);
-    }
-
+/// Note: The returned ID is a placeholder. Use `extract_subscription_id` on the
+/// SubscriptionData response to get the real server-generated ID.
+async fn send_subscribe(client: &mut TestClient, query: &str) -> std::io::Result<()> {
     let mut buf = BytesMut::new();
 
     // Build message body: query string (null-terminated) + param count (i16)
@@ -38,7 +34,22 @@ async fn send_subscribe(client: &mut TestClient, query: &str) -> std::io::Result
 
     client.stream_write_all(&buf).await?;
     client.stream_flush().await?;
-    Ok(sub_id)
+    Ok(())
+}
+
+/// Extract subscription ID from SubscriptionData message bytes
+/// The ID is at bytes 0-16 of the payload (after msg_type byte and length i32 which are not in payload)
+fn extract_subscription_id(messages: &[common::ParsedMessage]) -> Option<[u8; 16]> {
+    for msg in messages {
+        if msg.msg_type == MSG_SUBSCRIPTION_DATA && msg.payload.len() >= 16 {
+            let mut id = [0u8; 16];
+            // Payload starts after msg_type (1 byte) + length (4 bytes)
+            // So subscription_id is at the start of payload
+            id.copy_from_slice(&msg.payload[0..16]);
+            return Some(id);
+        }
+    }
+    None
 }
 
 /// Helper to send an unsubscribe request
@@ -59,7 +70,6 @@ async fn send_unsubscribe(client: &mut TestClient, sub_id: [u8; 16]) -> std::io:
 
 /// test_subscribe_receives_initial_data - Subscribe returns current query results
 #[tokio::test]
-#[ignore = "Subscription protocol not fully implemented - see issue #XXXX"]
 async fn test_subscribe_receives_initial_data() {
     let server = start_test_server().await;
     let mut client = TestClient::connect(server.addr()).await.expect("Failed to connect");
@@ -85,8 +95,7 @@ async fn test_subscribe_receives_initial_data() {
 
     // Subscribe to the table
     let select_query = format!("SELECT * FROM {}", table_name);
-    let _sub_id =
-        send_subscribe(&mut client, &select_query).await.expect("Failed to send subscribe");
+    send_subscribe(&mut client, &select_query).await.expect("Failed to send subscribe");
 
     // Read subscription response (should include initial data)
     let data = client
@@ -105,7 +114,6 @@ async fn test_subscribe_receives_initial_data() {
 
 /// test_insert_triggers_subscription_update - INSERT causes subscriber notification
 #[tokio::test]
-#[ignore = "Subscription protocol not fully implemented - see issue #XXXX"]
 async fn test_insert_triggers_subscription_update() {
     let server = start_test_server().await;
     let mut client = TestClient::connect(server.addr()).await.expect("Failed to connect");
@@ -124,8 +132,7 @@ async fn test_insert_triggers_subscription_update() {
 
     // Subscribe to empty table
     let select_query = format!("SELECT * FROM {}", table_name);
-    let _sub_id =
-        send_subscribe(&mut client, &select_query).await.expect("Failed to send subscribe");
+    send_subscribe(&mut client, &select_query).await.expect("Failed to send subscribe");
     let _ = client
         .read_until_message_type(MSG_SUBSCRIPTION_DATA)
         .await
@@ -154,7 +161,6 @@ async fn test_insert_triggers_subscription_update() {
 
 /// test_update_triggers_subscription_update - UPDATE causes subscriber notification
 #[tokio::test]
-#[ignore = "Subscription protocol not fully implemented - see issue #XXXX"]
 async fn test_update_triggers_subscription_update() {
     let server = start_test_server().await;
     let mut client = TestClient::connect(server.addr()).await.expect("Failed to connect");
@@ -179,8 +185,7 @@ async fn test_update_triggers_subscription_update() {
 
     // Subscribe
     let select_query = format!("SELECT * FROM {} WHERE id = 1", table_name);
-    let _sub_id =
-        send_subscribe(&mut client, &select_query).await.expect("Failed to send subscribe");
+    send_subscribe(&mut client, &select_query).await.expect("Failed to send subscribe");
     let _ = client
         .read_until_message_type(MSG_SUBSCRIPTION_DATA)
         .await
@@ -209,7 +214,6 @@ async fn test_update_triggers_subscription_update() {
 
 /// test_delete_triggers_subscription_update - DELETE causes subscriber notification
 #[tokio::test]
-#[ignore = "Subscription protocol not fully implemented - see issue #XXXX"]
 async fn test_delete_triggers_subscription_update() {
     let server = start_test_server().await;
     let mut client = TestClient::connect(server.addr()).await.expect("Failed to connect");
@@ -234,8 +238,7 @@ async fn test_delete_triggers_subscription_update() {
 
     // Subscribe
     let select_query = format!("SELECT * FROM {}", table_name);
-    let _sub_id =
-        send_subscribe(&mut client, &select_query).await.expect("Failed to send subscribe");
+    send_subscribe(&mut client, &select_query).await.expect("Failed to send subscribe");
     let _ = client
         .read_until_message_type(MSG_SUBSCRIPTION_DATA)
         .await
@@ -264,7 +267,6 @@ async fn test_delete_triggers_subscription_update() {
 
 /// test_unsubscribe_stops_updates - After unsubscribe, no more notifications
 #[tokio::test]
-#[ignore = "Subscription protocol not fully implemented - see issue #XXXX"]
 async fn test_unsubscribe_stops_updates() {
     let server = start_test_server().await;
     let mut client = TestClient::connect(server.addr()).await.expect("Failed to connect");
@@ -289,12 +291,13 @@ async fn test_unsubscribe_stops_updates() {
 
     // Subscribe
     let select_query = format!("SELECT * FROM {}", table_name);
-    let sub_id =
-        send_subscribe(&mut client, &select_query).await.expect("Failed to send subscribe");
-    let _ = client
+    send_subscribe(&mut client, &select_query).await.expect("Failed to send subscribe");
+    let data = client
         .read_until_message_type(MSG_SUBSCRIPTION_DATA)
         .await
         .expect("Failed to read subscription response");
+    let messages = parse_backend_messages(&data);
+    let sub_id = extract_subscription_id(&messages).expect("Failed to extract subscription ID");
 
     // Unsubscribe - no response expected per protocol spec, just continue
     send_unsubscribe(&mut client, sub_id).await.expect("Failed to send unsubscribe");
@@ -326,7 +329,6 @@ async fn test_unsubscribe_stops_updates() {
 
 /// test_subscription_ignores_unrelated_tables - Changes to table B don't notify table A subscribers
 #[tokio::test]
-#[ignore = "Subscription protocol not fully implemented - see issue #XXXX"]
 async fn test_subscription_ignores_unrelated_tables() {
     let server = start_test_server().await;
     let mut client = TestClient::connect(server.addr()).await.expect("Failed to connect");
@@ -359,7 +361,7 @@ async fn test_subscription_ignores_unrelated_tables() {
         client.read_until_message_type(b'Z').await.expect("Failed to read insert user response");
 
     // Subscribe to users table
-    let _sub_id = send_subscribe(&mut client, "SELECT * FROM sub_users_unrel")
+    send_subscribe(&mut client, "SELECT * FROM sub_users_unrel")
         .await
         .expect("Failed to send subscribe");
     let _ = client
@@ -396,8 +398,11 @@ async fn test_subscription_ignores_unrelated_tables() {
 // ============================================================================
 
 /// test_multiple_subscribers_same_query - Both clients receive updates
+/// NOTE: This test requires cross-connection subscription notifications, which
+/// requires integrating with the global SubscriptionManager and storage change events.
+/// Currently, subscriptions only receive updates for mutations on the same connection.
 #[tokio::test]
-#[ignore = "Subscription protocol not fully implemented - see issue #XXXX"]
+#[ignore = "Cross-connection subscription notifications not yet implemented"]
 async fn test_multiple_subscribers_same_query() {
     let server = start_test_server().await;
 
@@ -427,15 +432,13 @@ async fn test_multiple_subscribers_same_query() {
 
     // Both clients subscribe to the same query
     let query = "SELECT * FROM sub_shared_users";
-    let _sub_id1 =
-        send_subscribe(&mut client1, query).await.expect("Failed to send subscribe from client1");
+    send_subscribe(&mut client1, query).await.expect("Failed to send subscribe from client1");
     let _ = client1
         .read_until_message_type(MSG_SUBSCRIPTION_DATA)
         .await
         .expect("Failed to read subscription response");
 
-    let _sub_id2 =
-        send_subscribe(&mut client2, query).await.expect("Failed to send subscribe from client2");
+    send_subscribe(&mut client2, query).await.expect("Failed to send subscribe from client2");
     let _ = client2
         .read_until_message_type(MSG_SUBSCRIPTION_DATA)
         .await
@@ -476,7 +479,6 @@ async fn test_multiple_subscribers_same_query() {
 
 /// test_subscription_survives_empty_result - Subscription works even if query returns no rows
 #[tokio::test]
-#[ignore = "Subscription protocol not fully implemented - see issue #XXXX"]
 async fn test_subscription_survives_empty_result() {
     let server = start_test_server().await;
     let mut client = TestClient::connect(server.addr()).await.expect("Failed to connect");
@@ -493,7 +495,7 @@ async fn test_subscription_survives_empty_result() {
     let _ = client.read_until_message_type(b'Z').await.expect("Failed to read create response");
 
     // Subscribe to empty result set
-    let _sub_id = send_subscribe(&mut client, "SELECT * FROM sub_empty_users")
+    send_subscribe(&mut client, "SELECT * FROM sub_empty_users")
         .await
         .expect("Failed to send subscribe");
 
@@ -531,7 +533,6 @@ async fn test_subscription_survives_empty_result() {
 
 /// test_rapid_mutations - Many quick changes don't cause issues
 #[tokio::test]
-#[ignore = "Subscription protocol not fully implemented - see issue #XXXX"]
 async fn test_rapid_mutations() {
     let server = start_test_server().await;
     let mut client = TestClient::connect(server.addr()).await.expect("Failed to connect");
@@ -548,7 +549,7 @@ async fn test_rapid_mutations() {
     let _ = client.read_until_message_type(b'Z').await.expect("Failed to read create response");
 
     // Subscribe
-    let _sub_id = send_subscribe(&mut client, "SELECT * FROM sub_counter_test")
+    send_subscribe(&mut client, "SELECT * FROM sub_counter_test")
         .await
         .expect("Failed to send subscribe");
     let _ = client
@@ -583,7 +584,6 @@ async fn test_rapid_mutations() {
 
 /// test_subscription_cleanup_on_disconnect - Subscriptions removed when client disconnects
 #[tokio::test]
-#[ignore = "Subscription protocol not fully implemented - see issue #XXXX"]
 async fn test_subscription_cleanup_on_disconnect() {
     let server = start_test_server().await;
     let mut client = TestClient::connect(server.addr()).await.expect("Failed to connect");
@@ -600,7 +600,7 @@ async fn test_subscription_cleanup_on_disconnect() {
     let _ = client.read_until_message_type(b'Z').await.expect("Failed to read create response");
 
     // Subscribe
-    let _sub_id = send_subscribe(&mut client, "SELECT * FROM sub_disconnect_test")
+    send_subscribe(&mut client, "SELECT * FROM sub_disconnect_test")
         .await
         .expect("Failed to send subscribe");
     let _ = client


### PR DESCRIPTION
## Summary

- Implements same-connection subscription notifications for mutations
- Fixes case sensitivity in table name matching for subscriptions
- Updates e2e tests to use server-generated subscription IDs
- Enables 9/10 subscription tests (1 requires cross-connection notifications)

## Test plan

- [x] Run `cargo test --release -p vibesql-server --test e2e_subscription_tests` - 9 pass, 1 ignored
- [x] Verify tests pass after merging main

Closes #3816

🤖 Generated with [Claude Code](https://claude.com/claude-code)