### PR TITLE
feat(server): Add cross-connection subscription notifications

### DIFF
--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -9,15 +9,24 @@ use crate::session::{ExecutionResult, Session};
 use crate::subscription::{extract_table_refs, SessionSubscriptionManager, SubscriptionManager};
 use anyhow::Result;
 use bytes::BytesMut;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
+use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
 use vibesql_executor::cache::table_extractor;
+
+/// Notification sent when a mutation affects tables
+/// This is broadcast to all connections so they can notify their subscriptions
+#[derive(Debug, Clone)]
+pub struct TableMutationNotification {
+    /// Tables that were affected by the mutation
+    pub affected_tables: HashSet<String>,
+}
 
 /// Connection handler for a single client
 pub struct ConnectionHandler {
@@ -38,6 +47,10 @@ pub struct ConnectionHandler {
     /// Global subscription manager for processing storage change events
     #[allow(dead_code)]
     global_subscription_manager: Arc<SubscriptionManager>,
+    /// Broadcast sender for notifying other connections about mutations
+    mutation_broadcast_tx: broadcast::Sender<TableMutationNotification>,
+    /// Broadcast receiver for receiving mutation notifications from other connections
+    mutation_broadcast_rx: broadcast::Receiver<TableMutationNotification>,
 }
 
 impl ConnectionHandler {
@@ -52,7 +65,10 @@ impl ConnectionHandler {
         active_connections: Arc<AtomicUsize>,
         database_registry: DatabaseRegistry,
         global_subscription_manager: Arc<SubscriptionManager>,
+        mutation_broadcast_tx: broadcast::Sender<TableMutationNotification>,
     ) -> Self {
+        // Subscribe to the broadcast channel to receive notifications from other connections
+        let mutation_broadcast_rx = mutation_broadcast_tx.subscribe();
         Self {
             stream,
             peer_addr,
@@ -67,6 +83,8 @@ impl ConnectionHandler {
             database_registry,
             subscription_manager: SessionSubscriptionManager::new(),
             global_subscription_manager,
+            mutation_broadcast_tx,
+            mutation_broadcast_rx,
         }
     }
 
@@ -254,13 +272,76 @@ impl ConnectionHandler {
     }
 
     /// Process queries from the client
+    ///
+    /// This method handles both:
+    /// 1. Client messages from the TCP stream
+    /// 2. Broadcast notifications from other connections about table mutations
+    ///
+    /// This enables cross-connection subscription notifications: when connection A
+    /// mutates a table, connection B's subscriptions on that table are notified.
     async fn process_queries(&mut self) -> Result<()> {
         loop {
-            // Read a complete message, waiting for more data if needed
-            let msg = match self.read_complete_message().await {
-                Ok(msg) => msg,
-                Err(e) => {
-                    // Check if this is a clean connection close
+            // First, drain any pending broadcast notifications without blocking
+            // This ensures we process notifications that arrived while handling previous messages
+            loop {
+                match self.mutation_broadcast_rx.try_recv() {
+                    Ok(notification) => {
+                        if self.subscription_manager.subscription_count() > 0 {
+                            self.handle_cross_connection_notification(&notification.affected_tables)
+                                .await;
+                        }
+                    }
+                    Err(broadcast::error::TryRecvError::Empty) => break,
+                    Err(broadcast::error::TryRecvError::Lagged(n)) => {
+                        debug!("Missed {} broadcast notifications (lagged)", n);
+                    }
+                    Err(broadcast::error::TryRecvError::Closed) => {
+                        warn!("Mutation broadcast channel closed");
+                        break;
+                    }
+                }
+            }
+
+            // Now wait for the next event: either a client message or a broadcast notification
+            // We use a short timeout on the client read to periodically check for broadcasts
+            let msg_result = tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                self.read_complete_message(),
+            )
+            .await;
+
+            match msg_result {
+                Ok(Ok(msg)) => {
+                    // Process the client message
+                    match msg {
+                        FrontendMessage::Query { query } => {
+                            debug!("Query: {}", query);
+                            self.execute_query(&query).await?;
+                        }
+
+                        FrontendMessage::Subscribe { query, params } => {
+                            debug!("Subscribe: {}", query);
+                            self.handle_subscribe(&query, params).await?;
+                        }
+
+                        FrontendMessage::Unsubscribe { subscription_id } => {
+                            debug!("Unsubscribe: {:?}", subscription_id);
+                            self.subscription_manager.unsubscribe(&subscription_id);
+                            // No response needed per protocol spec
+                        }
+
+                        FrontendMessage::Terminate => {
+                            debug!("Client requested termination");
+                            break;
+                        }
+
+                        msg => {
+                            warn!("Unexpected message: {:?}", msg);
+                        }
+                    }
+                }
+                Ok(Err(e)) => {
+                    // Error reading from client
                     let err_str = e.to_string();
                     if err_str.contains("Connection closed") {
                         debug!("Connection closed by client");
@@ -268,32 +349,10 @@ impl ConnectionHandler {
                     }
                     return Err(e);
                 }
-            };
-
-            match msg {
-                FrontendMessage::Query { query } => {
-                    debug!("Query: {}", query);
-                    self.execute_query(&query).await?;
-                }
-
-                FrontendMessage::Subscribe { query, params } => {
-                    debug!("Subscribe: {}", query);
-                    self.handle_subscribe(&query, params).await?;
-                }
-
-                FrontendMessage::Unsubscribe { subscription_id } => {
-                    debug!("Unsubscribe: {:?}", subscription_id);
-                    self.subscription_manager.unsubscribe(&subscription_id);
-                    // No response needed per protocol spec
-                }
-
-                FrontendMessage::Terminate => {
-                    debug!("Client requested termination");
-                    break;
-                }
-
-                msg => {
-                    warn!("Unexpected message: {:?}", msg);
+                Err(_elapsed) => {
+                    // Timeout - no client message, loop back to check for broadcasts
+                    // This is the normal case when client is idle
+                    continue;
                 }
             }
         }
@@ -302,6 +361,85 @@ impl ConnectionHandler {
         self.subscription_manager.clear();
 
         Ok(())
+    }
+
+    /// Handle a cross-connection notification about table mutations
+    ///
+    /// When another connection mutates tables, this method is called to
+    /// check if any of our subscriptions are affected and send updates.
+    async fn handle_cross_connection_notification(&mut self, affected_tables: &HashSet<String>) {
+        // Collect subscriptions that need updating
+        let subscriptions_to_update: Vec<([u8; 16], String)> = affected_tables
+            .iter()
+            .flat_map(|table| {
+                self.subscription_manager
+                    .get_subscriptions_for_table_with_details(table)
+                    .map(|(id, sub)| (*id, sub.query.clone()))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        if subscriptions_to_update.is_empty() {
+            return;
+        }
+
+        // De-duplicate subscriptions (a subscription may depend on multiple affected tables)
+        let mut seen = std::collections::HashSet::new();
+        let unique_subscriptions: Vec<_> = subscriptions_to_update
+            .into_iter()
+            .filter(|(id, _)| seen.insert(*id))
+            .collect();
+
+        debug!(
+            "Cross-connection notification: notifying {} subscriptions for tables: {:?}",
+            unique_subscriptions.len(),
+            affected_tables
+        );
+
+        // Re-execute each subscription query and send updates
+        for (subscription_id, query) in unique_subscriptions {
+            if let Some(session) = &mut self.session {
+                match session.execute(&query).await {
+                    Ok(ExecutionResult::Select { rows, .. }) => {
+                        // Convert rows to wire format
+                        let wire_rows: Vec<Vec<Option<Vec<u8>>>> = rows
+                            .iter()
+                            .map(|row| {
+                                row.values
+                                    .iter()
+                                    .map(|v| Some(v.to_string().as_bytes().to_vec()))
+                                    .collect()
+                            })
+                            .collect();
+
+                        // Send full update
+                        if let Err(e) = self
+                            .send_subscription_data(
+                                &subscription_id,
+                                SubscriptionUpdateType::Full,
+                                wire_rows,
+                            )
+                            .await
+                        {
+                            warn!("Failed to send cross-connection subscription update: {}", e);
+                        }
+                    }
+                    Ok(_) => {
+                        // Non-SELECT result - shouldn't happen for a subscription query
+                        warn!("Subscription query returned non-SELECT result");
+                    }
+                    Err(e) => {
+                        // Query failed - send error to subscriber
+                        if let Err(send_err) = self
+                            .send_subscription_error(&subscription_id, &format!("Query error: {}", e))
+                            .await
+                        {
+                            warn!("Failed to send subscription error: {}", send_err);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Read a complete frontend message, looping until enough data is available
@@ -361,7 +499,11 @@ impl ConnectionHandler {
 
                 // Notify affected subscriptions after mutations
                 if is_mutation {
+                    // First, notify local subscriptions (same connection)
                     self.notify_affected_subscriptions(query).await;
+
+                    // Then, broadcast to other connections for cross-connection notifications
+                    self.broadcast_mutation(query);
                 }
 
                 // Return appropriate transaction status
@@ -567,6 +709,36 @@ impl ConnectionHandler {
                     }
                 }
             }
+        }
+    }
+
+    /// Broadcast a mutation event to all connections
+    ///
+    /// This is called after a mutation (INSERT/UPDATE/DELETE) is executed to notify
+    /// other connections that may have subscriptions on the affected tables.
+    fn broadcast_mutation(&self, mutation_query: &str) {
+        // Parse the mutation query to extract affected tables
+        let affected_tables = match vibesql_parser::Parser::parse_sql(mutation_query) {
+            Ok(stmt) => extract_table_refs(&stmt),
+            Err(e) => {
+                debug!("Failed to parse mutation query for broadcast: {}", e);
+                return;
+            }
+        };
+
+        if affected_tables.is_empty() {
+            return;
+        }
+
+        debug!("Broadcasting mutation affecting tables: {:?}", affected_tables);
+
+        // Broadcast the notification to all connections
+        // Note: This is fire-and-forget. If the channel is full or has no receivers,
+        // it's okay - we've already notified our own connection's subscriptions.
+        let notification = TableMutationNotification { affected_tables };
+        if let Err(e) = self.mutation_broadcast_tx.send(notification) {
+            // No receivers or channel issue - this is fine, just log at debug level
+            debug!("Failed to broadcast mutation notification: {}", e);
         }
     }
 

--- a/crates/vibesql-server/src/lib.rs
+++ b/crates/vibesql-server/src/lib.rs
@@ -20,7 +20,7 @@ pub use config::{
     ApiKeyConfig, AuthConfig, Config, HttpAuthConfig, HttpAuthMethod, HttpConfig, JwtConfig,
     LoggingConfig, ServerConfig,
 };
-pub use connection::ConnectionHandler;
+pub use connection::{ConnectionHandler, TableMutationNotification};
 pub use observability::ObservabilityProvider;
 pub use protocol::{
     BackendMessage, FieldDescription, FrontendMessage, SubscriptionUpdateType, TransactionStatus,

--- a/crates/vibesql-server/src/main.rs
+++ b/crates/vibesql-server/src/main.rs
@@ -6,11 +6,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
+use tokio::sync::broadcast;
 use tracing::{error, info, warn};
 
 use vibesql_server::auth::PasswordStore;
 use vibesql_server::config::Config;
-use vibesql_server::connection::ConnectionHandler;
+use vibesql_server::connection::{ConnectionHandler, TableMutationNotification};
 use vibesql_server::http::create_http_router;
 use vibesql_server::observability::ObservabilityProvider;
 use vibesql_server::protocol::BackendMessage;
@@ -101,6 +102,13 @@ async fn main() -> Result<()> {
     // Create a shared database registry for wire protocol connections
     // Each database name maps to a shared Database instance
     let database_registry = DatabaseRegistry::new();
+
+    // Create a broadcast channel for cross-connection subscription notifications
+    // When one connection mutates data, other connections with subscriptions on
+    // the affected tables need to be notified. The channel capacity should be
+    // large enough to handle bursts of mutations without dropping messages.
+    let (mutation_broadcast_tx, _mutation_broadcast_rx) =
+        broadcast::channel::<TableMutationNotification>(1024);
 
     // Create a shared database for HTTP API and subscriptions
     // TODO: Consider integrating HTTP database into the registry
@@ -208,6 +216,9 @@ async fn main() -> Result<()> {
                             // Clone the database registry for this connection
                             let database_registry = database_registry.clone();
 
+                            // Clone the mutation broadcast sender for this connection
+                            let mutation_broadcast_tx = mutation_broadcast_tx.clone();
+
                             // Spawn a new task for each connection
                             tokio::spawn(async move {
                                 let mut handler = ConnectionHandler::new(
@@ -219,6 +230,7 @@ async fn main() -> Result<()> {
                                     active_connections,
                                     database_registry,
                                     subscription_manager,
+                                    mutation_broadcast_tx,
                                 );
                                 if let Err(e) = handler.handle().await {
                                     error!("Connection error from {}: {}", peer_addr, e);

--- a/crates/vibesql-server/tests/common/mod.rs
+++ b/crates/vibesql-server/tests/common/mod.rs
@@ -6,13 +6,13 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::oneshot;
+use tokio::sync::{broadcast, oneshot};
 
 use vibesql_server::auth::PasswordStore;
 use vibesql_server::config::{
     AuthConfig, Config, HttpAuthConfig, HttpConfig, LoggingConfig, ServerConfig,
 };
-use vibesql_server::connection::ConnectionHandler;
+use vibesql_server::connection::{ConnectionHandler, TableMutationNotification};
 use vibesql_server::observability::{ObservabilityConfig, ObservabilityProvider};
 use vibesql_server::registry::DatabaseRegistry;
 use vibesql_server::subscription::SubscriptionConfig;
@@ -87,6 +87,10 @@ pub async fn start_test_server_with_config(mut config: Config) -> TestServer {
     // Create shared database registry for tests
     let database_registry = DatabaseRegistry::new();
 
+    // Create broadcast channel for cross-connection subscription notifications
+    let (mutation_broadcast_tx, _mutation_broadcast_rx) =
+        broadcast::channel::<TableMutationNotification>(1024);
+
     // Spawn server task
     tokio::spawn(async move {
         loop {
@@ -100,6 +104,7 @@ pub async fn start_test_server_with_config(mut config: Config) -> TestServer {
                             let active_connections = Arc::clone(&active_connections);
                             let database_registry = database_registry.clone();
                             let subscription_manager = Arc::clone(&subscription_manager);
+                            let mutation_broadcast_tx = mutation_broadcast_tx.clone();
 
                             tokio::spawn(async move {
                                 let mut handler = ConnectionHandler::new(
@@ -111,6 +116,7 @@ pub async fn start_test_server_with_config(mut config: Config) -> TestServer {
                                     active_connections,
                                     database_registry,
                                     subscription_manager,
+                                    mutation_broadcast_tx,
                                 );
                                 let _ = handler.handle().await;
                             });

--- a/crates/vibesql-server/tests/e2e_subscription_tests.rs
+++ b/crates/vibesql-server/tests/e2e_subscription_tests.rs
@@ -398,11 +398,10 @@ async fn test_subscription_ignores_unrelated_tables() {
 // ============================================================================
 
 /// test_multiple_subscribers_same_query - Both clients receive updates
-/// NOTE: This test requires cross-connection subscription notifications, which
-/// requires integrating with the global SubscriptionManager and storage change events.
-/// Currently, subscriptions only receive updates for mutations on the same connection.
+///
+/// This test verifies that when multiple clients subscribe to the same query,
+/// mutations from one client notify all subscribers across all connections.
 #[tokio::test]
-#[ignore = "Cross-connection subscription notifications not yet implemented"]
 async fn test_multiple_subscribers_same_query() {
     let server = start_test_server().await;
 

--- a/crates/vibesql-server/tests/transaction_tests.rs
+++ b/crates/vibesql-server/tests/transaction_tests.rs
@@ -55,8 +55,9 @@ impl Drop for TestServer {
 
 /// Run a test server instance.
 async fn run_test_server(port: u16, mut shutdown_rx: oneshot::Receiver<()>) {
+    use tokio::sync::broadcast;
     use vibesql_server::config::Config;
-    use vibesql_server::connection::ConnectionHandler;
+    use vibesql_server::connection::{ConnectionHandler, TableMutationNotification};
     use vibesql_server::observability::ObservabilityProvider;
     use vibesql_server::registry::DatabaseRegistry;
     use vibesql_server::SubscriptionManager;
@@ -82,6 +83,10 @@ async fn run_test_server(port: u16, mut shutdown_rx: oneshot::Receiver<()>) {
     let subscription_manager = Arc::new(SubscriptionManager::new());
     let database_registry = DatabaseRegistry::new();
 
+    // Create broadcast channel for cross-connection subscription notifications
+    let (mutation_broadcast_tx, _mutation_broadcast_rx) =
+        broadcast::channel::<TableMutationNotification>(1024);
+
     loop {
         tokio::select! {
             _ = &mut shutdown_rx => {
@@ -95,6 +100,7 @@ async fn run_test_server(port: u16, mut shutdown_rx: oneshot::Receiver<()>) {
                         let active_connections = Arc::clone(&active_connections);
                         let database_registry = database_registry.clone();
                         let subscription_manager = Arc::clone(&subscription_manager);
+                        let mutation_broadcast_tx = mutation_broadcast_tx.clone();
 
                         tokio::spawn(async move {
                             let mut handler = ConnectionHandler::new(
@@ -106,6 +112,7 @@ async fn run_test_server(port: u16, mut shutdown_rx: oneshot::Receiver<()>) {
                                 active_connections,
                                 database_registry,
                                 subscription_manager,
+                                mutation_broadcast_tx,
                             );
                             let _ = handler.handle().await;
                         });


### PR DESCRIPTION
## Summary
- Implements cross-connection subscription notification broadcasting using a broadcast channel
- When a mutation (INSERT/UPDATE/DELETE) executes on any connection, all other connections with subscriptions on the affected tables are notified
- Uses a 100ms timeout-based polling approach to check for broadcast notifications between client messages

## Key Changes
- Added `TableMutationNotification` type to propagate table mutation events across connections
- Modified `ConnectionHandler` to listen for broadcast notifications and send subscription updates
- Added `broadcast_mutation()` method to broadcast affected tables after mutations
- Added `handle_cross_connection_notification()` to process broadcasts and send updates to affected subscriptions

## Test plan
- [x] `test_multiple_subscribers_same_query` now passes (previously `#[ignore]`)
- [x] All e2e subscription tests pass
- [x] All vibesql-server unit and integration tests pass
- [x] Build compiles without errors

Closes #3822

🤖 Generated with [Claude Code](https://claude.com/claude-code)