### PR TITLE
feat(server): Add selective column updates for subscriptions

### DIFF
--- a/crates/vibesql-server/PROTOCOL.md
+++ b/crates/vibesql-server/PROTOCOL.md
@@ -22,17 +22,18 @@ Standard PostgreSQL clients (psql, libpq, etc.) work normally with VibeSQL serve
 
 ## Message Overview
 
-VibeSQL adds subscription message types in the custom range (0xF0-0xF6), chosen to avoid collision with PostgreSQL protocol messages (which use ASCII letters):
+VibeSQL adds subscription message types in the custom range (0xF0-0xF7), chosen to avoid collision with PostgreSQL protocol messages (which use ASCII letters):
 
 | Code | Direction | Name | Description |
 |------|-----------|------|-------------|
 | `0xF0` (240) | Frontend | Subscribe | Subscribe to query updates |
 | `0xF1` (241) | Frontend | Unsubscribe | Cancel subscription |
-| `0xF2` (242) | Backend | SubscriptionData | Query result update |
+| `0xF2` (242) | Backend | SubscriptionData | Query result update (full rows) |
 | `0xF3` (243) | Backend | SubscriptionError | Subscription error |
 | `0xF4` (244) | Backend | SubscriptionAck | Acknowledge subscription creation |
 | `0xF5` (245) | Frontend | SubscriptionPause | Temporarily pause updates |
 | `0xF6` (246) | Frontend | SubscriptionResume | Resume paused subscription |
+| `0xF7` (247) | Backend | SubscriptionPartialData | Selective column update |
 
 ## Protocol Messages
 
@@ -432,6 +433,109 @@ Breakdown:
   29 3a 4b 5c 6d 7e 8f 90                - Subscription ID bytes 8-15
 ```
 
+### SubscriptionPartialData (0xF7) - Backend Message
+
+Sends selective column updates to the client. This is an optimization for wide tables where only a few columns change frequently. Instead of sending all columns, only changed columns (plus primary key columns for row identification) are included.
+
+**When to Use:**
+- Wide tables with many columns
+- Updates that typically affect only a few columns
+- Bandwidth-constrained environments
+
+**Byte-Level Format:**
+```
+┌──────────┬──────────────┬─────────────────┬─────────────┬───────────┬───────────────────┐
+│  Type    │   Length     │ Subscription ID │ Update Type │ Row Count │ Partial Rows...   │
+│   1B     │   4B (BE)    │    16B (UUID)   │    1B       │  4B (BE)  │    variable       │
+└──────────┴──────────────┴─────────────────┴─────────────┴───────────┴───────────────────┘
+     ↓            ↓               ↓               ↓             ↓              ↓
+   0xF7     Total length     Identifies     SelectiveUpdate  Number      Partial row
+            after type       subscription     (always 4)     of rows     data (below)
+```
+
+**Field Details:**
+
+| Offset | Field | Type | Description |
+|--------|-------|------|-------------|
+| 0 | Message Type | `u8` | `0xF7` (SubscriptionPartialData) |
+| 1-4 | Length | `i32` BE | Total length after type byte |
+| 5-20 | Subscription ID | `[u8; 16]` | UUID identifying this subscription |
+| 21 | Update Type | `u8` | Always `4` (SelectiveUpdate) |
+| 22-25 | Row Count | `i32` BE | Number of partial row updates |
+| 26+ | Partial Rows | Array | Partial row data (see below) |
+
+**Partial Row Encoding:**
+
+Each partial row contains a column presence bitmap followed by values for only the present columns:
+
+```
+┌──────────────────┬─────────────────────────┬──────────────────────────────┐
+│  Total Columns   │    Column Bitmap        │     Present Column Values    │
+│    2B (BE)       │  ceil(columns/8) bytes  │          variable            │
+└──────────────────┴─────────────────────────┴──────────────────────────────┘
+```
+
+- **Total Columns**: The total number of columns in the full schema (for bitmap sizing)
+- **Column Bitmap**: One bit per column. Bit 0 = column 0, Bit 1 = column 1, etc.
+  - Bit = 0: Column not present (unchanged)
+  - Bit = 1: Column present in this update
+- **Present Column Values**: Values for columns with bit=1, in column order
+  - Encoded same as regular column values (4-byte length + data, or -1 for NULL)
+
+**Distinguishing Unchanged from NULL:**
+- Bit = 0: Column unchanged (not sent)
+- Bit = 1, Length = -1: Column changed to NULL
+- Bit = 1, Length >= 0: Column has new value
+
+**Primary Key Handling:**
+Server implementations should always include primary key columns (even if unchanged) to allow clients to identify which row is being updated.
+
+**Example** - Partial update for a 5-column table, updating columns 0 (PK) and 3:
+```
+Byte:  00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16
+       ─────────────────────────────────────────────────────────────────────
+Hex:   F7 00 00 00 2A a1 b2 c3 d4 e5 f6 07 18 29 3a 4b 5c 6d 7e 8f 90 04 00
+       ↑  └────┬────┘ └───────────────────────────┬────────────────┘  ↑  └┬─
+       │       │                                  │                   │   │
+      Type   Length                        Subscription ID         Update Row
+      0xF7    42                             (16 bytes)             Type  Count
+                                                                   4=Sel   1
+
+Hex (continued):
+       17 18 19 1A 1B 1C 1D 1E 1F 20 21 22 23 24 25 26 27 28 29
+       ────────────────────────────────────────────────────────────
+       00 01 00 05 09 00 00 00 01 31 00 00 00 05 76 61 6C 75 65
+       └──┬──┘ ↑  └─┬─┘ └────┬────┘ ↑  └────┬────┘ └──────┬──────┘
+          │   │    │        │      │       │             │
+       Total Bitmap ID Len  "1"  Val Len  "value"
+       Cols=5 09=0b1001     1      5
+             (cols 0,3)
+
+Full Breakdown:
+  F7                                     - Message type: SubscriptionPartialData
+  00 00 00 2A                            - Length: 42 bytes
+  a1 b2 c3 d4 e5 f6 07 18                - Subscription ID bytes 0-7
+  29 3a 4b 5c 6d 7e 8f 90                - Subscription ID bytes 8-15
+  04                                     - Update type: SelectiveUpdate (4)
+  00 00 00 01                            - Row count: 1
+  00 05                                  - Total columns: 5
+  09                                     - Bitmap: 0b00001001 (columns 0 and 3 present)
+  00 00 00 01                            - Column 0 length: 1 byte
+  31                                     - Column 0 value: "1" (PK)
+  00 00 00 05                            - Column 3 length: 5 bytes
+  76 61 6C 75 65                         - Column 3 value: "value"
+```
+
+**Example** - Partial update with NULL:
+```
+Hex:   ... 00 03 05 00 00 00 01 31 FF FF FF FF
+            └┬─┘ ↑  └────┬────┘ ↑  └────┬────┘
+             │   │       │      │       │
+          Total Bitmap  ID Len "1"   NULL (-1)
+          Cols=3 05=0b101       1    (column 2 is NULL)
+                (cols 0,2)
+```
+
 ## Subscription Lifecycle
 
 ### Successful Subscription Flow
@@ -736,6 +840,5 @@ To use subscriptions, a client must:
 
 Potential future enhancements:
 - Filtering expressions for deltas (client-side filters to reduce network traffic)
-- Selective column updates (don't send unchanged columns in SubscriptionData)
 - Delta compression (send only changed rows instead of full result set)
 - Subscription batching (combine multiple subscriptions into single updates)

--- a/crates/vibesql-server/src/protocol/messages.rs
+++ b/crates/vibesql-server/src/protocol/messages.rs
@@ -34,6 +34,71 @@ pub enum SubscriptionUpdateType {
     DeltaInsert = 1,
     DeltaUpdate = 2,
     DeltaDelete = 3,
+    /// Selective column update - only changed columns are sent
+    /// Used with SubscriptionPartialData message
+    SelectiveUpdate = 4,
+}
+
+/// A partial row update containing only changed columns
+///
+/// Used for selective column updates to reduce bandwidth when only
+/// a few columns change in a wide table.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PartialRowUpdate {
+    /// Total number of columns in the full row (for bitmap sizing)
+    pub total_columns: u16,
+    /// Bitmap indicating which columns are present (1 bit per column)
+    /// Bit 0 = column 0, Bit 1 = column 1, etc.
+    /// A set bit means the column value is included in `values`
+    pub column_mask: Vec<u8>,
+    /// Values for columns with set bits in column_mask, in column order
+    /// None = NULL, Some(bytes) = value data
+    pub values: Vec<Option<Vec<u8>>>,
+}
+
+impl PartialRowUpdate {
+    /// Create a new partial row update
+    ///
+    /// # Arguments
+    /// * `total_columns` - Total number of columns in the full row
+    /// * `present_columns` - Indices of columns that are present in this update
+    /// * `values` - Values for the present columns, in same order as present_columns
+    pub fn new(total_columns: u16, present_columns: &[u16], values: Vec<Option<Vec<u8>>>) -> Self {
+        debug_assert_eq!(present_columns.len(), values.len());
+
+        // Create bitmap
+        let bitmap_bytes = (total_columns as usize + 7) / 8;
+        let mut column_mask = vec![0u8; bitmap_bytes];
+
+        for &col_idx in present_columns {
+            if (col_idx as usize) < total_columns as usize {
+                let byte_idx = col_idx as usize / 8;
+                let bit_idx = col_idx as usize % 8;
+                column_mask[byte_idx] |= 1 << bit_idx;
+            }
+        }
+
+        Self { total_columns, column_mask, values }
+    }
+
+    /// Check if a column is present in this update
+    pub fn is_column_present(&self, col_idx: u16) -> bool {
+        if col_idx >= self.total_columns {
+            return false;
+        }
+        let byte_idx = col_idx as usize / 8;
+        let bit_idx = col_idx as usize % 8;
+        if byte_idx < self.column_mask.len() {
+            (self.column_mask[byte_idx] & (1 << bit_idx)) != 0
+        } else {
+            false
+        }
+    }
+
+    /// Get the number of present columns
+    pub fn present_column_count(&self) -> usize {
+        self.column_mask.iter().map(|b| b.count_ones() as usize).sum()
+    }
 }
 
 /// Backend message types (server -> client)
@@ -84,12 +149,35 @@ pub enum BackendMessage {
     /// Subscription error (0xF3) - subscription error notification
     SubscriptionError { subscription_id: [u8; 16], message: String },
 
-    /// Subscription acknowledgment (0xF4) - confirms subscription registration
+/// Subscription acknowledgment (0xF4) - confirms subscription registration
     /// Sent immediately after a subscription is registered, before initial data
     SubscriptionAck {
         subscription_id: [u8; 16],
         /// Number of table dependencies the subscription monitors
         table_count: u16,
+    },
+
+    /// Subscription partial data (0xF7) - selective column update
+    ///
+    /// Used for sending only changed columns in row updates, reducing bandwidth
+    /// for wide tables where only a few columns change frequently.
+    ///
+    /// Wire format:
+    /// - 1 byte: Message type (0xF7)
+    /// - 4 bytes: Length (big-endian)
+    /// - 16 bytes: Subscription ID
+    /// - 1 byte: Update type (always SelectiveUpdate = 4)
+    /// - 4 bytes: Row count (big-endian)
+    /// - For each row:
+    ///   - 2 bytes: Total column count (big-endian)
+    ///   - N bytes: Column presence bitmap (ceil(total_columns / 8) bytes)
+    ///   - For each present column (bit=1):
+    ///     - 4 bytes: Value length (-1 for NULL)
+    ///     - M bytes: Value data (if length >= 0)
+    SubscriptionPartialData {
+        subscription_id: [u8; 16],
+        /// Partial row updates with column bitmaps
+        rows: Vec<PartialRowUpdate>,
     },
 }
 
@@ -323,7 +411,7 @@ impl BackendMessage {
                 put_cstring(buf, message);
             }
 
-            BackendMessage::SubscriptionAck { subscription_id, table_count } => {
+BackendMessage::SubscriptionAck { subscription_id, table_count } => {
                 buf.put_u8(0xF4); // SubscriptionAck
 
                 let len = 4 + 16 + 2; // length + subscription_id + table_count
@@ -331,6 +419,46 @@ impl BackendMessage {
                 buf.put_i32(len as i32);
                 buf.put_slice(subscription_id);
                 buf.put_u16(*table_count);
+            }
+
+            BackendMessage::SubscriptionPartialData { subscription_id, rows } => {
+                buf.put_u8(0xF7); // SubscriptionPartialData
+
+                // Calculate total length
+                // 4 (length field) + 16 (subscription_id) + 1 (update_type) + 4 (row count)
+                let mut len = 4 + 16 + 1 + 4;
+                for row in rows {
+                    // 2 (total_columns) + bitmap bytes + values
+                    len += 2;
+                    len += row.column_mask.len();
+                    for value in &row.values {
+                        len += 4; // value length field
+                        if let Some(v) = value {
+                            len += v.len();
+                        }
+                    }
+                }
+
+                buf.put_i32(len as i32);
+                buf.put_slice(subscription_id);
+                buf.put_u8(SubscriptionUpdateType::SelectiveUpdate as u8);
+                buf.put_i32(rows.len() as i32);
+
+                for row in rows {
+                    buf.put_i16(row.total_columns as i16);
+                    buf.put_slice(&row.column_mask);
+                    for value in &row.values {
+                        match value {
+                            Some(v) => {
+                                buf.put_i32(v.len() as i32);
+                                buf.put_slice(v);
+                            }
+                            None => {
+                                buf.put_i32(-1); // NULL value
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -695,6 +823,103 @@ mod tests {
             Some(FrontendMessage::SubscriptionResume { subscription_id })
             if subscription_id == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
         ));
+    }
+
+    #[test]
+    fn test_subscription_partial_data_encoding() {
+        let mut buf = BytesMut::new();
+        let subscription_id = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+        // Create a partial row update with 4 columns, columns 0 and 2 present
+        let partial_row = PartialRowUpdate::new(
+            4,
+            &[0, 2],
+            vec![Some(b"id1".to_vec()), Some(b"value".to_vec())],
+        );
+
+        let msg = BackendMessage::SubscriptionPartialData {
+            subscription_id,
+            rows: vec![partial_row],
+        };
+        msg.encode(&mut buf);
+
+        // Verify message type (0xF7)
+        assert_eq!(buf[0], 0xF7);
+
+        // Verify subscription_id is at bytes 5-20
+        assert_eq!(&buf[5..21], subscription_id.as_ref());
+
+        // Verify update type is SelectiveUpdate (4)
+        assert_eq!(buf[21], 4);
+
+        // Verify row count is 1
+        let row_count = i32::from_be_bytes([buf[22], buf[23], buf[24], buf[25]]);
+        assert_eq!(row_count, 1);
+
+        // Verify total columns is 4
+        let total_cols = i16::from_be_bytes([buf[26], buf[27]]);
+        assert_eq!(total_cols, 4);
+
+        // Verify column bitmap (1 byte for 4 columns)
+        // Columns 0 and 2: binary 0101 = 5
+        assert_eq!(buf[28], 0b00000101);
+    }
+
+    #[test]
+    fn test_subscription_partial_data_encoding_with_null() {
+        let mut buf = BytesMut::new();
+        let subscription_id = [0u8; 16];
+
+        // Create a partial row update with NULL value
+        let partial_row = PartialRowUpdate::new(
+            3,
+            &[0, 1],
+            vec![Some(b"1".to_vec()), None], // Column 1 is NULL
+        );
+
+        let msg = BackendMessage::SubscriptionPartialData {
+            subscription_id,
+            rows: vec![partial_row],
+        };
+        msg.encode(&mut buf);
+
+        assert_eq!(buf[0], 0xF7);
+
+        // After subscription_id (16 bytes), update_type (1 byte), row_count (4 bytes)
+        // total_columns (2 bytes), column_mask (1 byte for 3 columns)
+        // First value: length (4) + data (1)
+        // Second value: length (-1) for NULL
+
+        // Find the position of the NULL value length (-1)
+        // Position: 1 (type) + 4 (len) + 16 (id) + 1 (update_type) + 4 (row_count)
+        //         + 2 (total_cols) + 1 (bitmap) + 4 (val1_len) + 1 (val1_data) = 34
+        let null_pos = 34;
+        let null_len = i32::from_be_bytes([buf[null_pos], buf[null_pos + 1], buf[null_pos + 2], buf[null_pos + 3]]);
+        assert_eq!(null_len, -1);
+    }
+
+    #[test]
+    fn test_partial_row_update_new() {
+        // Test with 16 columns to verify multi-byte bitmap
+        let partial = PartialRowUpdate::new(
+            16,
+            &[0, 8, 15],
+            vec![Some(b"a".to_vec()), Some(b"b".to_vec()), Some(b"c".to_vec())],
+        );
+
+        assert_eq!(partial.total_columns, 16);
+        assert_eq!(partial.column_mask.len(), 2); // ceil(16/8) = 2 bytes
+
+        // Byte 0: bit 0 set (column 0) = 0x01
+        // Byte 1: bit 0 set (column 8), bit 7 set (column 15) = 0x81
+        assert_eq!(partial.column_mask[0], 0b00000001);
+        assert_eq!(partial.column_mask[1], 0b10000001);
+
+        assert!(partial.is_column_present(0));
+        assert!(!partial.is_column_present(1));
+        assert!(partial.is_column_present(8));
+        assert!(partial.is_column_present(15));
+        assert!(!partial.is_column_present(16)); // Out of range
     }
 
     // =====================================================================

--- a/crates/vibesql-server/src/subscription/mod.rs
+++ b/crates/vibesql-server/src/subscription/mod.rs
@@ -64,6 +64,9 @@ pub use table_dependencies::extract_table_dependencies;
 pub use table_extract::extract_table_refs;
 // SubscriptionMetrics is defined inline in this module and exported directly
 
+// Re-export selective column update types (defined later in this file)
+// SelectiveColumnConfig, ColumnDiff, compute_column_diff, should_use_selective_update, create_partial_row_update
+
 // ============================================================================
 // Subscription Configuration
 // ============================================================================
@@ -652,6 +655,186 @@ pub fn compute_delta(
     Some(SubscriptionUpdate::Delta { subscription_id, inserts, updates, deletes })
 }
 
+// ============================================================================
+// Selective Column Updates
+// ============================================================================
+
+/// Configuration for selective column updates
+#[derive(Debug, Clone)]
+pub struct SelectiveColumnConfig {
+    /// Enable selective column updates
+    pub enabled: bool,
+    /// Column indices that are primary key columns (always included)
+    pub pk_columns: Vec<usize>,
+    /// Minimum columns that must change to use selective update
+    /// If fewer columns change, send full row instead
+    pub min_changed_columns: usize,
+    /// Maximum columns that can change before falling back to full row
+    /// If more columns change, send full row instead (more efficient)
+    pub max_changed_columns_ratio: f64,
+}
+
+impl Default for SelectiveColumnConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            pk_columns: vec![0], // Assume first column is PK by default
+            min_changed_columns: 1,
+            max_changed_columns_ratio: 0.5, // If >50% of columns changed, send full row
+        }
+    }
+}
+
+/// Result of column-level diff computation
+#[derive(Debug, Clone)]
+pub struct ColumnDiff {
+    /// Indices of columns that changed
+    pub changed_columns: Vec<usize>,
+    /// Indices of columns to include (PK + changed)
+    pub included_columns: Vec<usize>,
+}
+
+/// Compute which columns differ between two rows
+///
+/// # Arguments
+/// * `old_row` - The previous row values
+/// * `new_row` - The current row values
+/// * `pk_columns` - Indices of primary key columns (always included even if unchanged)
+///
+/// # Returns
+/// * `Some(ColumnDiff)` if rows have same column count and some columns differ
+/// * `None` if rows have different column counts or are identical
+pub fn compute_column_diff(
+    old_row: &crate::Row,
+    new_row: &crate::Row,
+    pk_columns: &[usize],
+) -> Option<ColumnDiff> {
+    // Rows must have same number of columns
+    if old_row.values.len() != new_row.values.len() {
+        return None;
+    }
+
+    let mut changed_columns = Vec::new();
+
+    // Compare each column
+    for (idx, (old_val, new_val)) in old_row.values.iter().zip(new_row.values.iter()).enumerate() {
+        if old_val != new_val {
+            changed_columns.push(idx);
+        }
+    }
+
+    // If no columns changed, return None
+    if changed_columns.is_empty() {
+        return None;
+    }
+
+    // Build included columns: PK columns + changed columns
+    let mut included_columns: Vec<usize> = pk_columns.to_vec();
+    for &idx in &changed_columns {
+        if !included_columns.contains(&idx) {
+            included_columns.push(idx);
+        }
+    }
+    included_columns.sort_unstable();
+
+    Some(ColumnDiff { changed_columns, included_columns })
+}
+
+/// Determine if selective update should be used based on configuration
+///
+/// Returns true if:
+/// - Selective updates are enabled
+/// - Number of changed columns meets minimum threshold
+/// - Changed column ratio doesn't exceed maximum
+pub fn should_use_selective_update(
+    diff: &ColumnDiff,
+    total_columns: usize,
+    config: &SelectiveColumnConfig,
+) -> bool {
+    if !config.enabled {
+        return false;
+    }
+
+    // Check minimum changed columns
+    if diff.changed_columns.len() < config.min_changed_columns {
+        return false;
+    }
+
+    // Check maximum ratio
+    let changed_ratio = diff.changed_columns.len() as f64 / total_columns as f64;
+    if changed_ratio > config.max_changed_columns_ratio {
+        return false;
+    }
+
+    true
+}
+
+/// Create a partial row update from old and new rows
+///
+/// # Arguments
+/// * `old_row` - The previous row values (wire format)
+/// * `new_row` - The current row values (wire format)
+/// * `pk_columns` - Primary key column indices
+/// * `config` - Selective column configuration
+///
+/// # Returns
+/// * `Some(PartialRowUpdate)` if selective update should be used
+/// * `None` if full row should be sent instead
+pub fn create_partial_row_update(
+    old_row: &[Option<Vec<u8>>],
+    new_row: &[Option<Vec<u8>>],
+    pk_columns: &[usize],
+    config: &SelectiveColumnConfig,
+) -> Option<crate::protocol::messages::PartialRowUpdate> {
+    // Rows must have same number of columns
+    if old_row.len() != new_row.len() {
+        return None;
+    }
+
+    let total_columns = new_row.len();
+    let mut changed_columns = Vec::new();
+
+    // Compare each column
+    for (idx, (old_val, new_val)) in old_row.iter().zip(new_row.iter()).enumerate() {
+        if old_val != new_val {
+            changed_columns.push(idx);
+        }
+    }
+
+    // If no columns changed, return None
+    if changed_columns.is_empty() {
+        return None;
+    }
+
+    // Check if we should use selective update
+    let changed_ratio = changed_columns.len() as f64 / total_columns as f64;
+    if !config.enabled || changed_ratio > config.max_changed_columns_ratio {
+        return None;
+    }
+
+    // Build included columns: PK columns + changed columns, sorted
+    let mut included_columns: Vec<usize> = pk_columns.to_vec();
+    for &idx in &changed_columns {
+        if !included_columns.contains(&idx) {
+            included_columns.push(idx);
+        }
+    }
+    included_columns.sort_unstable();
+
+    // Extract values for included columns
+    let values: Vec<Option<Vec<u8>>> =
+        included_columns.iter().map(|&idx| new_row[idx].clone()).collect();
+
+    // Convert to u16 for protocol
+    let present_columns: Vec<u16> = included_columns.iter().map(|&idx| idx as u16).collect();
+
+    Some(crate::protocol::messages::PartialRowUpdate::new(
+        total_columns as u16,
+        &present_columns,
+        values,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -911,5 +1094,225 @@ mod tests {
             }
             _ => panic!("Expected Delta update"),
         }
+    }
+
+    // ========================================================================
+    // Tests for Selective Column Updates
+    // ========================================================================
+
+    #[test]
+    fn test_compute_column_diff_no_changes() {
+        use vibesql_types::SqlValue;
+
+        let old = crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+        };
+        let new = crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+        };
+
+        let diff = compute_column_diff(&old, &new, &[0]);
+        assert!(diff.is_none());
+    }
+
+    #[test]
+    fn test_compute_column_diff_single_column_change() {
+        use vibesql_types::SqlValue;
+
+        let old = crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+        };
+        let new = crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Bob".to_string())],
+        };
+
+        let diff = compute_column_diff(&old, &new, &[0]).unwrap();
+        assert_eq!(diff.changed_columns, vec![1]);
+        // Included columns should be PK (0) + changed (1)
+        assert_eq!(diff.included_columns, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_compute_column_diff_multiple_columns_change() {
+        use vibesql_types::SqlValue;
+
+        let old = crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Alice".to_string()),
+                SqlValue::Integer(100),
+                SqlValue::Varchar("active".to_string()),
+            ],
+        };
+        let new = crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Bob".to_string()),
+                SqlValue::Integer(100),
+                SqlValue::Varchar("inactive".to_string()),
+            ],
+        };
+
+        let diff = compute_column_diff(&old, &new, &[0]).unwrap();
+        assert_eq!(diff.changed_columns, vec![1, 3]);
+        // Included columns should be PK (0) + changed (1, 3)
+        assert_eq!(diff.included_columns, vec![0, 1, 3]);
+    }
+
+    #[test]
+    fn test_compute_column_diff_pk_column_changed() {
+        use vibesql_types::SqlValue;
+
+        let old = crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+        };
+        let new = crate::Row {
+            values: vec![SqlValue::Integer(2), SqlValue::Varchar("Alice".to_string())],
+        };
+
+        let diff = compute_column_diff(&old, &new, &[0]).unwrap();
+        assert_eq!(diff.changed_columns, vec![0]);
+        // PK is already changed, so included = just [0]
+        assert_eq!(diff.included_columns, vec![0]);
+    }
+
+    #[test]
+    fn test_compute_column_diff_null_handling() {
+        use vibesql_types::SqlValue;
+
+        let old = crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+        };
+        let new = crate::Row { values: vec![SqlValue::Integer(1), SqlValue::Null] };
+
+        let diff = compute_column_diff(&old, &new, &[0]).unwrap();
+        assert_eq!(diff.changed_columns, vec![1]);
+        assert_eq!(diff.included_columns, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_should_use_selective_update_enabled() {
+        let diff = ColumnDiff { changed_columns: vec![1], included_columns: vec![0, 1] };
+
+        let config =
+            SelectiveColumnConfig { enabled: true, pk_columns: vec![0], ..Default::default() };
+
+        assert!(should_use_selective_update(&diff, 10, &config));
+    }
+
+    #[test]
+    fn test_should_use_selective_update_disabled() {
+        let diff = ColumnDiff { changed_columns: vec![1], included_columns: vec![0, 1] };
+
+        let config =
+            SelectiveColumnConfig { enabled: false, pk_columns: vec![0], ..Default::default() };
+
+        assert!(!should_use_selective_update(&diff, 10, &config));
+    }
+
+    #[test]
+    fn test_should_use_selective_update_too_many_changes() {
+        // 6 columns changed out of 10 = 60%, exceeds 50% threshold
+        let diff = ColumnDiff {
+            changed_columns: vec![1, 2, 3, 4, 5, 6],
+            included_columns: vec![0, 1, 2, 3, 4, 5, 6],
+        };
+
+        let config = SelectiveColumnConfig {
+            enabled: true,
+            pk_columns: vec![0],
+            max_changed_columns_ratio: 0.5,
+            ..Default::default()
+        };
+
+        assert!(!should_use_selective_update(&diff, 10, &config));
+    }
+
+    #[test]
+    fn test_create_partial_row_update() {
+        let old_row =
+            vec![Some(b"1".to_vec()), Some(b"Alice".to_vec()), Some(b"100".to_vec())];
+        let new_row =
+            vec![Some(b"1".to_vec()), Some(b"Bob".to_vec()), Some(b"100".to_vec())];
+
+        let config = SelectiveColumnConfig {
+            enabled: true,
+            pk_columns: vec![0],
+            max_changed_columns_ratio: 0.5,
+            ..Default::default()
+        };
+
+        let partial = create_partial_row_update(&old_row, &new_row, &[0], &config).unwrap();
+
+        assert_eq!(partial.total_columns, 3);
+        // Should include columns 0 (PK) and 1 (changed)
+        assert!(partial.is_column_present(0));
+        assert!(partial.is_column_present(1));
+        assert!(!partial.is_column_present(2));
+        assert_eq!(partial.present_column_count(), 2);
+        // Values should be the new values for included columns
+        assert_eq!(partial.values.len(), 2);
+        assert_eq!(partial.values[0], Some(b"1".to_vec()));
+        assert_eq!(partial.values[1], Some(b"Bob".to_vec()));
+    }
+
+    #[test]
+    fn test_create_partial_row_update_null_change() {
+        let old_row = vec![Some(b"1".to_vec()), Some(b"Alice".to_vec())];
+        let new_row = vec![Some(b"1".to_vec()), None];
+
+        let config =
+            SelectiveColumnConfig { enabled: true, pk_columns: vec![0], ..Default::default() };
+
+        let partial = create_partial_row_update(&old_row, &new_row, &[0], &config).unwrap();
+
+        assert_eq!(partial.total_columns, 2);
+        assert!(partial.is_column_present(0));
+        assert!(partial.is_column_present(1));
+        assert_eq!(partial.values.len(), 2);
+        assert_eq!(partial.values[0], Some(b"1".to_vec()));
+        assert_eq!(partial.values[1], None); // NULL value
+    }
+
+    #[test]
+    fn test_create_partial_row_update_no_changes() {
+        let old_row = vec![Some(b"1".to_vec()), Some(b"Alice".to_vec())];
+        let new_row = vec![Some(b"1".to_vec()), Some(b"Alice".to_vec())];
+
+        let config =
+            SelectiveColumnConfig { enabled: true, pk_columns: vec![0], ..Default::default() };
+
+        let partial = create_partial_row_update(&old_row, &new_row, &[0], &config);
+        assert!(partial.is_none());
+    }
+
+    #[test]
+    fn test_partial_row_update_column_mask() {
+        use crate::protocol::messages::PartialRowUpdate;
+
+        // Test with 10 columns, columns 0, 3, 7 present
+        let partial = PartialRowUpdate::new(
+            10,
+            &[0, 3, 7],
+            vec![Some(b"a".to_vec()), Some(b"b".to_vec()), Some(b"c".to_vec())],
+        );
+
+        assert_eq!(partial.total_columns, 10);
+        assert_eq!(partial.column_mask.len(), 2); // ceil(10/8) = 2 bytes
+
+        // Check column presence
+        assert!(partial.is_column_present(0));
+        assert!(!partial.is_column_present(1));
+        assert!(!partial.is_column_present(2));
+        assert!(partial.is_column_present(3));
+        assert!(!partial.is_column_present(4));
+        assert!(!partial.is_column_present(5));
+        assert!(!partial.is_column_present(6));
+        assert!(partial.is_column_present(7));
+        assert!(!partial.is_column_present(8));
+        assert!(!partial.is_column_present(9));
+        assert!(!partial.is_column_present(10)); // Out of range
+
+        assert_eq!(partial.present_column_count(), 3);
     }
 }


### PR DESCRIPTION
## Summary

- Add new `SubscriptionPartialData` (0xF4) backend message type for selective column updates that only sends changed columns
- Add `PartialRowUpdate` struct with column presence bitmap for efficient encoding
- Add `SelectiveColumnConfig` for configuring when to use selective vs full updates
- Add column-level diff computation functions (`compute_column_diff`, `create_partial_row_update`)
- Add comprehensive tests for the new functionality
- Update PROTOCOL.md with full documentation of the new message format

## Wire Format

The new message includes a column presence bitmap where:
- Bit=0 means column unchanged (not sent)
- Bit=1 with length=-1 means column changed to NULL
- Bit=1 with length>=0 means column has new value

Primary key columns are always included for row identification.

## Test plan

- [x] Run `cargo test -p vibesql-server` - all tests pass
- [x] Verify new selective column tests pass
- [x] Verify protocol encoding tests pass
- [ ] Manual testing with a VibeSQL-aware client (future)

Closes #3839

🤖 Generated with [Claude Code](https://claude.com/claude-code)