### PR TITLE
refactor(server): Migrate wire protocol to unified SubscriptionManager

### DIFF
--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -7,8 +7,8 @@ use crate::protocol::{
 use crate::registry::DatabaseRegistry;
 use crate::session::{ExecutionResult, Session};
 use crate::subscription::{
-    compute_delta, extract_table_refs, hash_rows, SessionSubscriptionManager, SubscriptionId,
-    SubscriptionManager, SubscriptionUpdate,
+    compute_delta, extract_table_refs, hash_rows, SubscriptionId, SubscriptionManager,
+    SubscriptionUpdate,
 };
 use crate::Row;
 use anyhow::Result;
@@ -50,11 +50,10 @@ pub struct ConnectionHandler {
     active_connections: Arc<AtomicUsize>,
     /// Database registry for shared database instances across connections
     database_registry: DatabaseRegistry,
-    /// Session-level subscription manager for real-time query subscriptions
-    subscription_manager: SessionSubscriptionManager,
-    /// Global subscription manager for processing storage change events
-    #[allow(dead_code)]
-    global_subscription_manager: Arc<SubscriptionManager>,
+    /// Unique identifier for this connection (for subscription tracking)
+    connection_id: String,
+    /// Global subscription manager for processing storage change events and tracking subscriptions
+    subscription_manager: Arc<SubscriptionManager>,
     /// Broadcast sender for notifying other connections about mutations
     mutation_broadcast_tx: broadcast::Sender<TableMutationNotification>,
     /// Broadcast receiver for receiving mutation notifications from other connections
@@ -80,7 +79,7 @@ impl ConnectionHandler {
         password_store: Option<Arc<PasswordStore>>,
         active_connections: Arc<AtomicUsize>,
         database_registry: DatabaseRegistry,
-        global_subscription_manager: Arc<SubscriptionManager>,
+        subscription_manager: Arc<SubscriptionManager>,
         mutation_broadcast_tx: broadcast::Sender<TableMutationNotification>,
     ) -> Self {
         // Split the TCP stream for async select! usage
@@ -89,6 +88,10 @@ impl ConnectionHandler {
 
         // Subscribe to the broadcast channel to receive notifications from other connections
         let mutation_broadcast_rx = mutation_broadcast_tx.subscribe();
+
+        // Generate a unique connection ID for subscription tracking
+        let connection_id = uuid::Uuid::new_v4().to_string();
+
         Self {
             read_half,
             write_half,
@@ -102,8 +105,8 @@ impl ConnectionHandler {
             connection_start: Instant::now(),
             active_connections,
             database_registry,
-            subscription_manager: SessionSubscriptionManager::new(),
-            global_subscription_manager,
+            connection_id,
+            subscription_manager,
             mutation_broadcast_tx,
             mutation_broadcast_rx,
         }
@@ -311,7 +314,8 @@ impl ConnectionHandler {
                 match self.handle_client_message(msg).await? {
                     ClientMessageResult::Continue => {}
                     ClientMessageResult::Terminate => {
-                        self.subscription_manager.clear();
+                        self.subscription_manager
+                            .unsubscribe_all_for_connection(&self.connection_id);
                         return Ok(());
                     }
                 }
@@ -330,7 +334,7 @@ impl ConnectionHandler {
                 notification = self.mutation_broadcast_rx.recv() => {
                     match notification {
                         Ok(n) => {
-                            if self.subscription_manager.subscription_count() > 0 {
+                            if self.subscription_manager.connection_subscription_count(&self.connection_id) > 0 {
                                 self.handle_cross_connection_notification(&n.affected_tables).await;
                             }
                         }
@@ -363,7 +367,8 @@ impl ConnectionHandler {
         }
 
         // Clean up subscriptions when connection closes
-        self.subscription_manager.clear();
+        self.subscription_manager
+            .unsubscribe_all_for_connection(&self.connection_id);
 
         Ok(())
     }
@@ -385,7 +390,7 @@ impl ConnectionHandler {
 
             FrontendMessage::Unsubscribe { subscription_id } => {
                 debug!("Unsubscribe: {:?}", subscription_id);
-                self.subscription_manager.unsubscribe(&subscription_id);
+                self.subscription_manager.unsubscribe_by_wire_id(&subscription_id);
                 // No response needed per protocol spec
                 Ok(ClientMessageResult::Continue)
             }
@@ -409,16 +414,12 @@ impl ConnectionHandler {
     /// This method supports delta updates to reduce network bandwidth when
     /// only a small portion of the result set has changed.
     async fn handle_cross_connection_notification(&mut self, affected_tables: &HashSet<String>) {
-        // Collect subscriptions that need updating along with their previous state
+        // Collect subscriptions for THIS connection that need updating
         let subscriptions_to_update: Vec<([u8; 16], String, u64, Option<Vec<Row>>)> = affected_tables
             .iter()
             .flat_map(|table| {
                 self.subscription_manager
-                    .get_subscriptions_for_table_with_details(table)
-                    .map(|(id, sub)| {
-                        (*id, sub.query.clone(), sub.last_result_hash, sub.last_result.clone())
-                    })
-                    .collect::<Vec<_>>()
+                    .get_affected_subscriptions_for_connection(table, &self.connection_id)
             })
             .collect();
 
@@ -528,7 +529,7 @@ impl ConnectionHandler {
                         }
 
                         // Update stored result for next delta computation
-                        self.subscription_manager.update_result(
+                        self.subscription_manager.update_result_by_wire_id(
                             &subscription_id,
                             new_hash,
                             new_rows,
@@ -705,7 +706,7 @@ impl ConnectionHandler {
     ///
     /// Parses the query, extracts table dependencies, executes the query,
     /// registers the subscription, and sends the initial data to the client.
-    async fn handle_subscribe(&mut self, query: &str, params: Vec<Option<Vec<u8>>>) -> Result<()> {
+    async fn handle_subscribe(&mut self, query: &str, _params: Vec<Option<Vec<u8>>>) -> Result<()> {
         let session = self.session.as_mut().ok_or_else(|| anyhow::anyhow!("No session"))?;
 
         // Parse the query to extract table dependencies
@@ -722,20 +723,26 @@ impl ConnectionHandler {
         // Extract table dependencies from the query
         let table_dependencies = table_extractor::extract_tables_from_statement(&parsed);
 
-        // Register the subscription first (to get the ID)
-        let subscription_id = match self.subscription_manager.subscribe(
+        // Generate a wire subscription ID (UUID) for the wire protocol
+        let wire_subscription_id = *uuid::Uuid::new_v4().as_bytes();
+
+        // Create a dummy channel - wire protocol sends data directly through TCP socket,
+        // not through the subscription manager's channel-based notification system
+        let (notify_tx, _notify_rx) = tokio::sync::mpsc::channel(1);
+
+        // Register the subscription with the global subscription manager
+        if let Err(e) = self.subscription_manager.subscribe_for_connection(
             query.to_string(),
-            params,
-            table_dependencies,
+            notify_tx,
+            self.connection_id.clone(),
+            wire_subscription_id,
+            table_dependencies.clone(),
         ) {
-            Ok(id) => id,
-            Err(e) => {
-                // Send subscription error with a dummy subscription ID (subscription failed before registration)
-                let error_id = [0u8; 16];
-                self.send_subscription_error(&error_id, &format!("{}", e)).await?;
-                return Ok(());
-            }
-        };
+            // Send subscription error with a dummy subscription ID (subscription failed before registration)
+            let error_id = [0u8; 16];
+            self.send_subscription_error(&error_id, &format!("{}", e)).await?;
+            return Ok(());
+        }
 
         // Execute the query to get initial data
         match session.execute(query).await {
@@ -746,8 +753,8 @@ impl ConnectionHandler {
 
                 // Compute hash and store result for future delta computation
                 let result_hash = hash_rows(&result_rows);
-                self.subscription_manager.update_result(
-                    &subscription_id,
+                self.subscription_manager.update_result_by_wire_id(
+                    &wire_subscription_id,
                     result_hash,
                     result_rows.clone(),
                 );
@@ -762,7 +769,7 @@ impl ConnectionHandler {
 
                 // Send initial subscription data
                 self.send_subscription_data(
-                    &subscription_id,
+                    &wire_subscription_id,
                     SubscriptionUpdateType::Full,
                     wire_rows,
                 )
@@ -770,17 +777,17 @@ impl ConnectionHandler {
             }
             Ok(_) => {
                 // Non-SELECT query - send error and remove subscription
-                self.subscription_manager.unsubscribe(&subscription_id);
+                self.subscription_manager.unsubscribe_by_wire_id(&wire_subscription_id);
                 self.send_subscription_error(
-                    &subscription_id,
+                    &wire_subscription_id,
                     "Only SELECT queries can be subscribed to",
                 )
                 .await?;
             }
             Err(e) => {
                 // Query execution failed - remove subscription and send error
-                self.subscription_manager.unsubscribe(&subscription_id);
-                self.send_subscription_error(&subscription_id, &format!("Execution error: {}", e))
+                self.subscription_manager.unsubscribe_by_wire_id(&wire_subscription_id);
+                self.send_subscription_error(&wire_subscription_id, &format!("Execution error: {}", e))
                     .await?;
             }
         }
@@ -808,16 +815,12 @@ impl ConnectionHandler {
             return;
         }
 
-        // Collect subscriptions that need updating along with their previous state
+        // Collect subscriptions for THIS connection that need updating
         let subscriptions_to_update: Vec<([u8; 16], String, u64, Option<Vec<Row>>)> = affected_tables
             .iter()
             .flat_map(|table| {
                 self.subscription_manager
-                    .get_subscriptions_for_table_with_details(table)
-                    .map(|(id, sub)| {
-                        (*id, sub.query.clone(), sub.last_result_hash, sub.last_result.clone())
-                    })
-                    .collect::<Vec<_>>()
+                    .get_affected_subscriptions_for_connection(table, &self.connection_id)
             })
             .collect();
 
@@ -919,7 +922,7 @@ impl ConnectionHandler {
                         }
 
                         // Update stored result for next delta computation
-                        self.subscription_manager.update_result(
+                        self.subscription_manager.update_result_by_wire_id(
                             &subscription_id,
                             new_hash,
                             new_rows,

--- a/crates/vibesql-server/src/subscription/manager.rs
+++ b/crates/vibesql-server/src/subscription/manager.rs
@@ -301,9 +301,9 @@ impl SubscriptionManager {
         // Register subscription
         self.subscriptions.insert(id, subscription);
 
-        // Index by tables
+        // Index by tables (lowercase for case-insensitive matching)
         for table in table_dependencies {
-            self.table_index.entry(table).or_default().insert(id);
+            self.table_index.entry(table.to_lowercase()).or_default().insert(id);
         }
 
         // Index by connection
@@ -441,6 +441,113 @@ impl SubscriptionManager {
             .get(connection_id)
             .map(|c| c.load(Ordering::Acquire))
             .unwrap_or(0)
+    }
+
+    /// Get affected subscription details for wire protocol
+    ///
+    /// This method finds all subscriptions that depend on the given table and returns
+    /// their details needed for wire protocol notifications.
+    ///
+    /// # Arguments
+    ///
+    /// * `table` - The table name to find affected subscriptions for
+    ///
+    /// # Returns
+    ///
+    /// Vector of (wire_subscription_id, query, last_result_hash, last_result) for
+    /// each affected subscription that has a wire ID.
+    pub fn get_affected_subscriptions_for_wire_protocol(
+        &self,
+        table: &str,
+    ) -> Vec<([u8; 16], String, u64, Option<Vec<crate::Row>>)> {
+        let table_lower = table.to_lowercase();
+        let subscription_ids: Vec<SubscriptionId> = self
+            .table_index
+            .get(&table_lower)
+            .map(|ids| ids.iter().copied().collect())
+            .unwrap_or_default();
+
+        subscription_ids
+            .into_iter()
+            .filter_map(|id| {
+                self.subscriptions.get(&id).and_then(|sub| {
+                    sub.wire_subscription_id.map(|wire_id| {
+                        (wire_id, sub.query.clone(), sub.last_result_hash, sub.last_result.clone())
+                    })
+                })
+            })
+            .collect()
+    }
+
+    /// Get affected subscription details for wire protocol filtered by connection
+    ///
+    /// This method finds subscriptions for a specific connection that depend on the
+    /// given table and returns their details needed for wire protocol notifications.
+    ///
+    /// # Arguments
+    ///
+    /// * `table` - The table name to find affected subscriptions for
+    /// * `connection_id` - The connection ID to filter by
+    ///
+    /// # Returns
+    ///
+    /// Vector of (wire_subscription_id, query, last_result_hash, last_result) for
+    /// each affected subscription that belongs to the specified connection.
+    pub fn get_affected_subscriptions_for_connection(
+        &self,
+        table: &str,
+        connection_id: &str,
+    ) -> Vec<([u8; 16], String, u64, Option<Vec<crate::Row>>)> {
+        let table_lower = table.to_lowercase();
+        let subscription_ids: Vec<SubscriptionId> = self
+            .table_index
+            .get(&table_lower)
+            .map(|ids| ids.iter().copied().collect())
+            .unwrap_or_default();
+
+        subscription_ids
+            .into_iter()
+            .filter_map(|id| {
+                self.subscriptions.get(&id).and_then(|sub| {
+                    // Only include subscriptions that belong to this connection
+                    if sub.connection_id.as_deref() == Some(connection_id) {
+                        sub.wire_subscription_id.map(|wire_id| {
+                            (
+                                wire_id,
+                                sub.query.clone(),
+                                sub.last_result_hash,
+                                sub.last_result.clone(),
+                            )
+                        })
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect()
+    }
+
+    /// Update the stored result for a subscription by wire ID
+    ///
+    /// This is used by wire protocol to store results for delta computation.
+    ///
+    /// # Arguments
+    ///
+    /// * `wire_id` - The wire protocol subscription ID (UUID bytes)
+    /// * `result_hash` - Hash of the new result set
+    /// * `result` - The new result set
+    pub fn update_result_by_wire_id(
+        &self,
+        wire_id: &[u8; 16],
+        result_hash: u64,
+        result: Vec<crate::Row>,
+    ) {
+        if let Some(id) = self.wire_id_index.get(wire_id).map(|r| *r) {
+            if let Some(mut sub) = self.subscriptions.get_mut(&id) {
+                sub.last_result_hash = result_hash;
+                sub.last_result = Some(result);
+            }
+        }
     }
 
     /// Get the number of active subscriptions
@@ -1557,5 +1664,269 @@ mod tests {
         // Get all metrics when no subscriptions exist
         let all_metrics = manager.get_all_metrics();
         assert!(all_metrics.is_empty());
+    }
+
+    // ========================================================================
+    // Tests for connection tracking methods
+    // ========================================================================
+
+    #[test]
+    fn test_subscribe_for_connection() {
+        let manager = SubscriptionManager::new();
+        let (tx, _rx) = mpsc::channel(16);
+
+        let connection_id = "conn-1".to_string();
+        let wire_id: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let tables: HashSet<String> = ["users".to_string()].into_iter().collect();
+
+        let result = manager.subscribe_for_connection(
+            "SELECT * FROM users".to_string(),
+            tx,
+            connection_id.clone(),
+            wire_id,
+            tables,
+        );
+
+        assert!(result.is_ok());
+        let id = result.unwrap();
+
+        // Verify subscription was registered
+        assert_eq!(manager.subscription_count(), 1);
+        assert_eq!(manager.connection_subscription_count(&connection_id), 1);
+
+        // Verify wire ID index works
+        let found_id = manager.find_subscription_by_wire_id(&wire_id);
+        assert_eq!(found_id, Some(id));
+    }
+
+    #[test]
+    fn test_subscribe_for_connection_limit_enforcement() {
+        use crate::subscription::SubscriptionConfig;
+
+        let config = SubscriptionConfig {
+            max_per_connection: 2,
+            max_global: 10,
+            ..Default::default()
+        };
+        let manager = SubscriptionManager::with_config(config);
+        let connection_id = "conn-1".to_string();
+
+        // Create 2 subscriptions (at the limit)
+        for i in 0..2 {
+            let (tx, _rx) = mpsc::channel(16);
+            let mut wire_id = [0u8; 16];
+            wire_id[0] = i;
+            let tables: HashSet<String> = ["users".to_string()].into_iter().collect();
+
+            let result = manager.subscribe_for_connection(
+                format!("SELECT {} FROM users", i),
+                tx,
+                connection_id.clone(),
+                wire_id,
+                tables,
+            );
+            assert!(result.is_ok(), "Subscription {} should succeed", i);
+        }
+
+        assert_eq!(manager.connection_subscription_count(&connection_id), 2);
+
+        // Third subscription should fail (connection limit)
+        let (tx, _rx) = mpsc::channel(16);
+        let wire_id = [2u8; 16];
+        let tables: HashSet<String> = ["users".to_string()].into_iter().collect();
+
+        let result = manager.subscribe_for_connection(
+            "SELECT 3 FROM users".to_string(),
+            tx,
+            connection_id.clone(),
+            wire_id,
+            tables,
+        );
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            crate::subscription::SubscriptionError::ConnectionLimitExceeded { current, max } => {
+                assert_eq!(current, 2);
+                assert_eq!(max, 2);
+            }
+            e => panic!("Expected ConnectionLimitExceeded, got {:?}", e),
+        }
+    }
+
+    #[test]
+    fn test_unsubscribe_by_wire_id() {
+        let manager = SubscriptionManager::new();
+        let (tx, _rx) = mpsc::channel(16);
+
+        let connection_id = "conn-1".to_string();
+        let wire_id: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let tables: HashSet<String> = ["users".to_string()].into_iter().collect();
+
+        manager
+            .subscribe_for_connection(
+                "SELECT * FROM users".to_string(),
+                tx,
+                connection_id.clone(),
+                wire_id,
+                tables,
+            )
+            .unwrap();
+
+        assert_eq!(manager.subscription_count(), 1);
+        assert_eq!(manager.connection_subscription_count(&connection_id), 1);
+
+        // Unsubscribe by wire ID
+        manager.unsubscribe_by_wire_id(&wire_id);
+
+        assert_eq!(manager.subscription_count(), 0);
+        assert_eq!(manager.connection_subscription_count(&connection_id), 0);
+
+        // Wire ID should no longer be found
+        assert!(manager.find_subscription_by_wire_id(&wire_id).is_none());
+    }
+
+    #[test]
+    fn test_unsubscribe_all_for_connection() {
+        let manager = SubscriptionManager::new();
+        let connection_id1 = "conn-1".to_string();
+        let connection_id2 = "conn-2".to_string();
+
+        // Create subscriptions for connection 1
+        for i in 0..3 {
+            let (tx, _rx) = mpsc::channel(16);
+            let mut wire_id = [0u8; 16];
+            wire_id[0] = i;
+            let tables: HashSet<String> = ["users".to_string()].into_iter().collect();
+
+            manager
+                .subscribe_for_connection(
+                    format!("SELECT {} FROM users", i),
+                    tx,
+                    connection_id1.clone(),
+                    wire_id,
+                    tables,
+                )
+                .unwrap();
+        }
+
+        // Create subscriptions for connection 2
+        for i in 0..2 {
+            let (tx, _rx) = mpsc::channel(16);
+            let mut wire_id = [10u8; 16];
+            wire_id[0] = i + 10;
+            let tables: HashSet<String> = ["orders".to_string()].into_iter().collect();
+
+            manager
+                .subscribe_for_connection(
+                    format!("SELECT {} FROM orders", i),
+                    tx,
+                    connection_id2.clone(),
+                    wire_id,
+                    tables,
+                )
+                .unwrap();
+        }
+
+        assert_eq!(manager.subscription_count(), 5);
+        assert_eq!(manager.connection_subscription_count(&connection_id1), 3);
+        assert_eq!(manager.connection_subscription_count(&connection_id2), 2);
+
+        // Unsubscribe all for connection 1
+        manager.unsubscribe_all_for_connection(&connection_id1);
+
+        assert_eq!(manager.subscription_count(), 2);
+        assert_eq!(manager.connection_subscription_count(&connection_id1), 0);
+        assert_eq!(manager.connection_subscription_count(&connection_id2), 2);
+    }
+
+    #[test]
+    fn test_connection_subscription_count() {
+        let manager = SubscriptionManager::new();
+        let connection_id = "conn-1".to_string();
+
+        // Initially zero
+        assert_eq!(manager.connection_subscription_count(&connection_id), 0);
+
+        // Add a subscription
+        let (tx, _rx) = mpsc::channel(16);
+        let wire_id: [u8; 16] = [1u8; 16];
+        let tables: HashSet<String> = ["users".to_string()].into_iter().collect();
+
+        manager
+            .subscribe_for_connection(
+                "SELECT * FROM users".to_string(),
+                tx,
+                connection_id.clone(),
+                wire_id,
+                tables,
+            )
+            .unwrap();
+
+        assert_eq!(manager.connection_subscription_count(&connection_id), 1);
+
+        // Non-existent connection should return 0
+        assert_eq!(manager.connection_subscription_count("non-existent"), 0);
+    }
+
+    #[test]
+    fn test_get_affected_subscriptions_for_wire_protocol() {
+        let manager = SubscriptionManager::new();
+        let connection_id = "conn-1".to_string();
+
+        // Create a subscription for "users" table
+        let (tx, _rx) = mpsc::channel(16);
+        let wire_id: [u8; 16] = [1u8; 16];
+        let tables: HashSet<String> = ["users".to_string()].into_iter().collect();
+
+        manager
+            .subscribe_for_connection(
+                "SELECT * FROM users".to_string(),
+                tx,
+                connection_id.clone(),
+                wire_id,
+                tables,
+            )
+            .unwrap();
+
+        // Query for affected subscriptions
+        let affected = manager.get_affected_subscriptions_for_wire_protocol("users");
+        assert_eq!(affected.len(), 1);
+        assert_eq!(affected[0].0, wire_id);
+        assert_eq!(affected[0].1, "SELECT * FROM users");
+
+        // Query for non-existent table
+        let affected = manager.get_affected_subscriptions_for_wire_protocol("orders");
+        assert!(affected.is_empty());
+    }
+
+    #[test]
+    fn test_update_result_by_wire_id() {
+        let manager = SubscriptionManager::new();
+        let connection_id = "conn-1".to_string();
+
+        let (tx, _rx) = mpsc::channel(16);
+        let wire_id: [u8; 16] = [1u8; 16];
+        let tables: HashSet<String> = ["users".to_string()].into_iter().collect();
+
+        manager
+            .subscribe_for_connection(
+                "SELECT * FROM users".to_string(),
+                tx,
+                connection_id.clone(),
+                wire_id,
+                tables,
+            )
+            .unwrap();
+
+        // Update the result
+        let rows = vec![crate::Row { values: vec![vibesql_types::SqlValue::Integer(42)] }];
+        manager.update_result_by_wire_id(&wire_id, 12345, rows.clone());
+
+        // Verify the result was stored
+        let affected = manager.get_affected_subscriptions_for_wire_protocol("users");
+        assert_eq!(affected.len(), 1);
+        assert_eq!(affected[0].2, 12345); // last_result_hash
+        assert!(affected[0].3.is_some()); // last_result
+        assert_eq!(affected[0].3.as_ref().unwrap().len(), 1);
     }
 }

--- a/crates/vibesql-server/src/subscription/session.rs
+++ b/crates/vibesql-server/src/subscription/session.rs
@@ -1,4 +1,11 @@
-//! Session-level subscription management
+//! Session-level subscription management (deprecated)
+//!
+//! **DEPRECATED**: This module is deprecated. Use `SubscriptionManager` with
+//! connection tracking methods instead:
+//! - `subscribe_for_connection()` - Subscribe for a specific connection
+//! - `unsubscribe_by_wire_id()` - Unsubscribe by wire protocol ID
+//! - `unsubscribe_all_for_connection()` - Clean up all subscriptions for a connection
+//! - `connection_subscription_count()` - Get subscription count for a connection
 //!
 //! This module provides a per-connection subscription manager that tracks
 //! subscriptions for a single client session. Unlike the global SubscriptionManager,
@@ -33,6 +40,13 @@ pub struct SessionSubscription {
 }
 
 /// Manages subscriptions for a single connection/session
+///
+/// **DEPRECATED**: Use `SubscriptionManager` with connection tracking methods instead.
+/// See module documentation for migration guide.
+#[deprecated(
+    since = "0.2.0",
+    note = "Use SubscriptionManager with subscribe_for_connection() instead"
+)]
 #[derive(Debug)]
 pub struct SessionSubscriptionManager {
     /// Active subscriptions by ID


### PR DESCRIPTION
## Summary
- Migrate wire protocol in ConnectionHandler to use SubscriptionManager instead of SessionSubscriptionManager
- Add connection_id to ConnectionHandler for unique identification and connection-scoped subscription lookups
- Fix table name case normalization issue where table index stored UPPERCASE but lookups used lowercase
- Deprecate SessionSubscriptionManager with note to use `subscribe_for_connection()` instead
- Add comprehensive unit tests for connection tracking methods

## Changes
- **connection.rs**: Use `subscribe_for_connection()`, `unsubscribe_by_wire_id()`, and `unsubscribe_all_for_connection()` 
- **manager.rs**: Add `get_affected_subscriptions_for_connection()` and `update_result_by_wire_id()` methods; fix lowercase table indexing
- **session.rs**: Add deprecation notice to `SessionSubscriptionManager`

## Test plan
- [x] All 10 e2e subscription tests pass
- [x] All 31 subscription manager unit tests pass (including 7 new connection tracking tests)
- [x] Full vibesql-server test suite passes

Closes #3840

🤖 Generated with [Claude Code](https://claude.com/claude-code)