### PR TITLE
fix(server): Update axum route parameter syntax for v0.7 compatibility

### DIFF
--- a/crates/vibesql-server/src/http/crud.rs
+++ b/crates/vibesql-server/src/http/crud.rs
@@ -6,12 +6,12 @@
 //! ## API Design
 //!
 //! ```text
-//! GET    /api/tables/:table/rows          # SELECT * FROM :table
-//! GET    /api/tables/:table/rows/:id      # SELECT * FROM :table WHERE pk = :id
-//! POST   /api/tables/:table/rows          # INSERT INTO :table ...
-//! PUT    /api/tables/:table/rows/:id      # Full UPDATE (all columns)
-//! PATCH  /api/tables/:table/rows/:id      # Partial UPDATE (specified columns only)
-//! DELETE /api/tables/:table/rows/:id      # DELETE FROM :table WHERE pk = :id
+//! GET    /api/tables/{table}/rows          # SELECT * FROM {table}
+//! GET    /api/tables/{table}/rows/{id}     # SELECT * FROM {table} WHERE pk = {id}
+//! POST   /api/tables/{table}/rows          # INSERT INTO {table} ...
+//! PUT    /api/tables/{table}/rows/{id}     # Full UPDATE (all columns)
+//! PATCH  /api/tables/{table}/rows/{id}     # Partial UPDATE (specified columns only)
+//! DELETE /api/tables/{table}/rows/{id}     # DELETE FROM {table} WHERE pk = {id}
 //! ```
 //!
 //! ## Query Parameters (GET collection)

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -84,14 +84,14 @@ pub fn create_http_router(
         .route("/api/query", post(execute_query))
         .route("/api/subscribe", get(subscribe_stream))
         .route("/api/tables", get(list_tables))
-        .route("/api/tables/:table_name", get(get_table_info))
+        .route("/api/tables/{table_name}", get(get_table_info))
         // CRUD endpoints for auto-generated RESTful access
-        .route("/api/tables/:table_name/rows", get(super::crud::list_rows))
-        .route("/api/tables/:table_name/rows", post(super::crud::create_row))
-        .route("/api/tables/:table_name/rows/:id", get(super::crud::get_row))
-        .route("/api/tables/:table_name/rows/:id", put(super::crud::update_row))
-        .route("/api/tables/:table_name/rows/:id", patch(super::crud::patch_row))
-        .route("/api/tables/:table_name/rows/:id", delete(super::crud::delete_row))
+        .route("/api/tables/{table_name}/rows", get(super::crud::list_rows))
+        .route("/api/tables/{table_name}/rows", post(super::crud::create_row))
+        .route("/api/tables/{table_name}/rows/{id}", get(super::crud::get_row))
+        .route("/api/tables/{table_name}/rows/{id}", put(super::crud::update_row))
+        .route("/api/tables/{table_name}/rows/{id}", patch(super::crud::patch_row))
+        .route("/api/tables/{table_name}/rows/{id}", delete(super::crud::delete_row))
         // GraphQL endpoint
         .route("/api/graphql", post(graphql_handler))
         .with_state(state);


### PR DESCRIPTION
## Summary

- Updates axum route parameter syntax from `:param` to `{param}` to fix server crash on startup
- Axum v0.7 changed route parameter syntax and the old Express.js style (`:param`) now causes a panic
- Updates documentation comments in `crud.rs` to match the new syntax

Closes #3850

## Test plan

- [x] Server compiles without errors
- [x] All 256 server tests pass
- [x] Verified the route syntax matches axum v0.7 requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)