### PR TITLE
feat(server): Detect primary key columns for selective subscription updates

### DIFF
--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -7,8 +7,8 @@ use crate::protocol::{
 use crate::registry::DatabaseRegistry;
 use crate::session::{ExecutionResult, Session};
 use crate::subscription::{
-    compute_delta, extract_table_refs, filter::SubscriptionFilter, hash_rows, SubscriptionId,
-    SubscriptionManager, SubscriptionUpdate,
+    compute_delta, detect_pk_columns_from_stmt, extract_table_refs, filter::SubscriptionFilter,
+    hash_rows, SubscriptionId, SubscriptionManager, SubscriptionUpdate,
 };
 use crate::Row;
 use anyhow::Result;
@@ -759,6 +759,17 @@ impl ConnectionHandler {
         // Extract table dependencies from the query
         let table_dependencies = table_extractor::extract_tables_from_statement(&parsed);
 
+        // Detect primary key columns for selective updates
+        // This enables bandwidth-efficient delta updates by knowing which columns identify rows
+        let pk_detection = {
+            let db = session.shared_database().read().await;
+            detect_pk_columns_from_stmt(&parsed, &db)
+        };
+        debug!(
+            "PK detection for subscription query: {:?} (confident: {})",
+            pk_detection.pk_column_indices, pk_detection.confident
+        );
+
         // Generate a wire subscription ID (UUID) for the wire protocol
         let wire_subscription_id = *uuid::Uuid::new_v4().as_bytes();
 
@@ -780,6 +791,12 @@ impl ConnectionHandler {
             self.send_subscription_error(&error_id, &format!("{}", e)).await?;
             return Ok(());
         }
+
+        // Store detected PK columns in the subscription for selective updates
+        self.subscription_manager.update_pk_columns_by_wire_id(
+            &wire_subscription_id,
+            pk_detection.pk_column_indices.clone(),
+        );
 
         // Execute the query to get initial data
         match session.execute(query).await {

--- a/crates/vibesql-server/src/subscription/manager.rs
+++ b/crates/vibesql-server/src/subscription/manager.rs
@@ -553,6 +553,30 @@ impl SubscriptionManager {
         }
     }
 
+    /// Update the primary key columns for a subscription by wire ID
+    ///
+    /// This is called after PK detection to set the actual PK column indices
+    /// for selective column updates.
+    pub fn update_pk_columns_by_wire_id(&self, wire_id: &[u8; 16], pk_columns: Vec<usize>) {
+        if let Some(id) = self.wire_id_index.get(wire_id).map(|r| *r) {
+            if let Some(mut sub) = self.subscriptions.get_mut(&id) {
+                sub.pk_columns = pk_columns;
+            }
+        }
+    }
+
+    /// Get the primary key columns for a subscription by wire ID
+    ///
+    /// Returns the PK column indices, or default [0] if not found.
+    pub fn get_pk_columns_by_wire_id(&self, wire_id: &[u8; 16]) -> Vec<usize> {
+        if let Some(id) = self.wire_id_index.get(wire_id).map(|r| *r) {
+            if let Some(sub) = self.subscriptions.get(&id) {
+                return sub.pk_columns.clone();
+            }
+        }
+        vec![0] // default
+    }
+
     /// Get the number of active subscriptions
     pub fn subscription_count(&self) -> usize {
         self.subscriptions.len()

--- a/crates/vibesql-server/src/subscription/mod.rs
+++ b/crates/vibesql-server/src/subscription/mod.rs
@@ -45,6 +45,7 @@
 pub mod error;
 pub mod filter;
 mod manager;
+pub mod pk_detector;
 mod router;
 pub mod session;
 mod table_dependencies;
@@ -59,6 +60,7 @@ use tokio::sync::mpsc;
 
 pub use error::{classify_error, classify_error_str, SubscriptionErrorKind};
 pub use manager::SubscriptionManager;
+pub use pk_detector::{detect_pk_columns, detect_pk_columns_from_stmt, PkDetectionResult};
 pub use router::{ChangeRouter, SubscriptionUpdate as RouterUpdate};
 pub use session::{SessionSubscription, SessionSubscriptionId, SessionSubscriptionManager};
 pub use table_dependencies::extract_table_dependencies;
@@ -319,6 +321,10 @@ pub struct Subscription {
     /// Optional filter expression (SQL WHERE clause) to apply to updates
     /// Only rows matching the filter will be included in subscription updates
     pub filter: Option<String>,
+    /// Primary key column indices in the result set
+    /// Used for selective column updates to always include PK columns
+    /// Default: [0] (assumes first column is PK if not detected)
+    pub pk_columns: Vec<usize>,
 }
 
 impl Subscription {
@@ -354,6 +360,7 @@ impl Subscription {
             connection_id: None,
             wire_subscription_id: None,
             filter: None,
+            pk_columns: vec![0], // default: assume first column is PK
         }
     }
 
@@ -380,6 +387,7 @@ impl Subscription {
             connection_id: None,
             wire_subscription_id: None,
             filter: None,
+            pk_columns: vec![0], // default: assume first column is PK
         }
     }
 
@@ -395,6 +403,33 @@ impl Subscription {
         wire_subscription_id: [u8; 16],
         filter: Option<String>,
         config: &SubscriptionConfig,
+    ) -> Self {
+        Self::for_connection_with_pk(
+            query,
+            tables,
+            notify_tx,
+            connection_id,
+            wire_subscription_id,
+            filter,
+            config,
+            vec![0], // default: assume first column is PK
+        )
+    }
+
+    /// Create a new subscription for a specific connection with custom PK columns
+    ///
+    /// This associates the subscription with a connection ID for tracking
+    /// and cleanup when the connection closes. It also allows specifying
+    /// which columns are primary keys for selective column updates.
+    pub fn for_connection_with_pk(
+        query: String,
+        tables: HashSet<String>,
+        notify_tx: mpsc::Sender<SubscriptionUpdate>,
+        connection_id: String,
+        wire_subscription_id: [u8; 16],
+        filter: Option<String>,
+        config: &SubscriptionConfig,
+        pk_columns: Vec<usize>,
     ) -> Self {
         Self {
             id: SubscriptionId::new(),
@@ -412,7 +447,15 @@ impl Subscription {
             connection_id: Some(connection_id),
             wire_subscription_id: Some(wire_subscription_id),
             filter,
+            pk_columns,
         }
+    }
+
+    /// Set the primary key columns for this subscription
+    ///
+    /// Used after detection to update the subscription with actual PK columns.
+    pub fn set_pk_columns(&mut self, pk_columns: Vec<usize>) {
+        self.pk_columns = pk_columns;
     }
 }
 

--- a/crates/vibesql-server/src/subscription/pk_detector.rs
+++ b/crates/vibesql-server/src/subscription/pk_detector.rs
@@ -1,0 +1,452 @@
+//! Primary Key Column Detection for Subscription Updates
+//!
+//! This module provides functionality to detect which columns in a query's result set
+//! are primary key columns. This information is used for selective column updates,
+//! where we need to always include PK columns to identify rows.
+//!
+//! # Design
+//!
+//! For simple single-table queries (SELECT ... FROM table), we:
+//! 1. Parse the query to extract the table name and SELECT list
+//! 2. Query the database schema to find which columns are PKs
+//! 3. Map those PK column names to positions in the result set
+//!
+//! For complex queries (joins, subqueries, etc.), we fall back to the default
+//! behavior of assuming column 0 is the PK, as correctly mapping PKs across
+//! joins requires more sophisticated analysis.
+
+use std::collections::HashSet;
+
+use vibesql_ast::{Expression, FromClause, SelectItem, SelectStmt, Statement};
+use vibesql_storage::Database;
+
+/// Result of PK column detection
+#[derive(Debug, Clone)]
+pub struct PkDetectionResult {
+    /// Indices of columns that are primary keys in the result set
+    pub pk_column_indices: Vec<usize>,
+    /// Whether detection was confident (single table, no complex joins)
+    pub confident: bool,
+    /// Tables involved in the query
+    pub tables: HashSet<String>,
+}
+
+impl Default for PkDetectionResult {
+    fn default() -> Self {
+        Self {
+            pk_column_indices: vec![0], // Default: assume first column is PK
+            confident: false,
+            tables: HashSet::new(),
+        }
+    }
+}
+
+/// Detect primary key columns in a query result set
+///
+/// # Arguments
+/// * `sql` - The SQL query string
+/// * `db` - Reference to the database for schema lookup
+///
+/// # Returns
+/// * `PkDetectionResult` with the detected PK column indices
+pub fn detect_pk_columns(sql: &str, db: &Database) -> PkDetectionResult {
+    // Parse the query
+    let stmt = match vibesql_parser::Parser::parse_sql(sql) {
+        Ok(stmt) => stmt,
+        Err(_) => return PkDetectionResult::default(),
+    };
+
+    detect_pk_columns_from_stmt(&stmt, db)
+}
+
+/// Detect primary key columns from a parsed statement
+pub fn detect_pk_columns_from_stmt(stmt: &Statement, db: &Database) -> PkDetectionResult {
+    match stmt {
+        Statement::Select(select) => detect_pk_from_select(select, db),
+        _ => PkDetectionResult::default(),
+    }
+}
+
+/// Detect PK columns from a SELECT statement
+fn detect_pk_from_select(select: &SelectStmt, db: &Database) -> PkDetectionResult {
+    // Don't handle set operations (UNION, etc.) - too complex
+    if select.set_operation.is_some() {
+        return PkDetectionResult::default();
+    }
+
+    // Extract the FROM clause
+    let from = match &select.from {
+        Some(from) => from,
+        None => return PkDetectionResult::default(),
+    };
+
+    // Check if this is a simple single-table query
+    let (table_name, table_alias) = match extract_single_table(from) {
+        Some(info) => info,
+        None => {
+            // Multi-table query (join) - try to detect PKs from all tables
+            return detect_pk_from_join(select, from, db);
+        }
+    };
+
+    // Get the table schema
+    let table = match db.get_table(&table_name) {
+        Some(t) => t,
+        None => return PkDetectionResult::default(),
+    };
+
+    // Get PK column indices from schema
+    let pk_indices = match table.schema.get_primary_key_indices() {
+        Some(indices) => indices,
+        None => return PkDetectionResult::default(),
+    };
+
+    // Get PK column names
+    let pk_column_names: Vec<String> = pk_indices
+        .iter()
+        .filter_map(|&idx| table.schema.columns.get(idx).map(|c| c.name.to_lowercase()))
+        .collect();
+
+    if pk_column_names.is_empty() {
+        return PkDetectionResult::default();
+    }
+
+    // Map PK column names to result set positions
+    let result_pk_indices = map_columns_to_result_positions(
+        &select.select_list,
+        &pk_column_names,
+        table.schema.columns.iter().map(|c| c.name.to_string()).collect(),
+        table_alias.as_deref(),
+    );
+
+    let mut tables = HashSet::new();
+    tables.insert(table_name);
+
+    if result_pk_indices.is_empty() {
+        // PKs not in result set - use default
+        PkDetectionResult { pk_column_indices: vec![0], confident: false, tables }
+    } else {
+        PkDetectionResult { pk_column_indices: result_pk_indices, confident: true, tables }
+    }
+}
+
+/// Extract table name and alias from a simple single-table FROM clause
+fn extract_single_table(from: &FromClause) -> Option<(String, Option<String>)> {
+    match from {
+        FromClause::Table { name, alias, .. } => {
+            Some((name.to_lowercase(), alias.clone()))
+        }
+        FromClause::Join { .. } => None, // Join means multiple tables
+        FromClause::Subquery { .. } => None, // Subquery is complex
+    }
+}
+
+/// Detect PK columns from a JOIN query
+///
+/// For joins, we try to find the PK of the "primary" table (first table in FROM).
+/// This is a best-effort approach - for complex queries, we fall back to defaults.
+fn detect_pk_from_join(
+    select: &SelectStmt,
+    from: &FromClause,
+    db: &Database,
+) -> PkDetectionResult {
+    // Collect all tables and their aliases
+    let tables_info = collect_join_tables(from);
+
+    if tables_info.is_empty() {
+        return PkDetectionResult::default();
+    }
+
+    let mut tables = HashSet::new();
+    for (table_name, _) in &tables_info {
+        tables.insert(table_name.clone());
+    }
+
+    // For now, try to use the first table's PK
+    // More sophisticated logic could be added later
+    let (first_table, first_alias) = &tables_info[0];
+
+    let table = match db.get_table(first_table) {
+        Some(t) => t,
+        None => return PkDetectionResult { pk_column_indices: vec![0], confident: false, tables },
+    };
+
+    let pk_indices = match table.schema.get_primary_key_indices() {
+        Some(indices) => indices,
+        None => return PkDetectionResult { pk_column_indices: vec![0], confident: false, tables },
+    };
+
+    let pk_column_names: Vec<String> = pk_indices
+        .iter()
+        .filter_map(|&idx| table.schema.columns.get(idx).map(|c| c.name.to_lowercase()))
+        .collect();
+
+    if pk_column_names.is_empty() {
+        return PkDetectionResult { pk_column_indices: vec![0], confident: false, tables };
+    }
+
+    // Try to map with table alias for qualified references
+    let result_pk_indices = map_columns_to_result_positions(
+        &select.select_list,
+        &pk_column_names,
+        table.schema.columns.iter().map(|c| c.name.to_string()).collect(),
+        first_alias.as_deref(),
+    );
+
+    if result_pk_indices.is_empty() {
+        PkDetectionResult { pk_column_indices: vec![0], confident: false, tables }
+    } else {
+        // Not fully confident for joins since we only handle first table
+        PkDetectionResult { pk_column_indices: result_pk_indices, confident: false, tables }
+    }
+}
+
+/// Collect all tables from a JOIN clause
+fn collect_join_tables(from: &FromClause) -> Vec<(String, Option<String>)> {
+    let mut tables = Vec::new();
+    collect_join_tables_recursive(from, &mut tables);
+    tables
+}
+
+fn collect_join_tables_recursive(from: &FromClause, tables: &mut Vec<(String, Option<String>)>) {
+    match from {
+        FromClause::Table { name, alias, .. } => {
+            tables.push((name.to_lowercase(), alias.clone()));
+        }
+        FromClause::Join { left, right, .. } => {
+            collect_join_tables_recursive(left, tables);
+            collect_join_tables_recursive(right, tables);
+        }
+        FromClause::Subquery { .. } => {
+            // Can't easily extract table info from subqueries
+        }
+    }
+}
+
+/// Map column names to their positions in a SELECT list
+///
+/// Handles:
+/// - SELECT * (expands to all columns)
+/// - SELECT col1, col2 (specific columns)
+/// - SELECT t.col1 (qualified column references)
+/// - SELECT col1 AS alias (aliases - we match on original name)
+fn map_columns_to_result_positions(
+    select_list: &[SelectItem],
+    pk_column_names: &[String],
+    all_table_columns: Vec<String>,
+    table_alias: Option<&str>,
+) -> Vec<usize> {
+    let mut result_indices = Vec::new();
+    let mut current_pos = 0;
+
+    for item in select_list {
+        match item {
+            SelectItem::Wildcard { alias: _ } => {
+                // SELECT * - all columns from all tables in order
+                for (idx, col_name) in all_table_columns.iter().enumerate() {
+                    if pk_column_names.contains(&col_name.to_lowercase()) {
+                        result_indices.push(current_pos + idx);
+                    }
+                }
+                current_pos += all_table_columns.len();
+            }
+            SelectItem::QualifiedWildcard { qualifier, alias: _ } => {
+                // SELECT t.* - all columns from specific table
+                // Only expand if qualifier matches our table alias
+                let qualifier_matches = table_alias
+                    .map(|alias| alias.eq_ignore_ascii_case(qualifier))
+                    .unwrap_or(false);
+
+                if qualifier_matches {
+                    for (idx, col_name) in all_table_columns.iter().enumerate() {
+                        if pk_column_names.contains(&col_name.to_lowercase()) {
+                            result_indices.push(current_pos + idx);
+                        }
+                    }
+                    current_pos += all_table_columns.len();
+                } else {
+                    // Unknown qualifier - skip (can't determine column count)
+                    // This could happen with joins - we'd need to know all table schemas
+                    current_pos += 1; // Assume at least one column
+                }
+            }
+            SelectItem::Expression { expr, alias: _ } => {
+                // Check if this expression is a column reference
+                if let Some(col_name) = extract_column_name(expr, table_alias) {
+                    if pk_column_names.contains(&col_name.to_lowercase()) {
+                        result_indices.push(current_pos);
+                    }
+                }
+                current_pos += 1;
+            }
+        }
+    }
+
+    result_indices
+}
+
+/// Extract column name from an expression (if it's a simple column reference)
+fn extract_column_name(expr: &Expression, table_alias: Option<&str>) -> Option<String> {
+    match expr {
+        Expression::ColumnRef { table, column } => {
+            // For qualified references (t.col), check if table matches our alias
+            if let Some(tbl) = table {
+                if let Some(alias) = table_alias {
+                    if !tbl.eq_ignore_ascii_case(alias) {
+                        return None; // Different table
+                    }
+                }
+            }
+            Some(column.clone())
+        }
+        _ => None, // Not a simple column reference
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibesql_catalog::{ColumnSchema, TableSchema};
+    use vibesql_types::DataType;
+
+    fn create_test_db() -> Database {
+        let mut db = Database::new();
+
+        // Create users table with id as PK
+        let user_columns = vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("name".to_string(), DataType::Varchar { max_length: Some(100) }, true),
+            ColumnSchema::new("email".to_string(), DataType::Varchar { max_length: Some(255) }, true),
+        ];
+        let user_schema = TableSchema::with_primary_key(
+            "users".to_string(),
+            user_columns,
+            vec!["id".to_string()],
+        );
+        db.create_table(user_schema).unwrap();
+
+        // Create orders table with composite PK (order_id, user_id)
+        let order_columns = vec![
+            ColumnSchema::new("order_id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("user_id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("amount".to_string(), DataType::Integer, true),
+            ColumnSchema::new("status".to_string(), DataType::Varchar { max_length: Some(50) }, true),
+        ];
+        let order_schema = TableSchema::with_primary_key(
+            "orders".to_string(),
+            order_columns,
+            vec!["order_id".to_string(), "user_id".to_string()],
+        );
+        db.create_table(order_schema).unwrap();
+
+        db
+    }
+
+    #[test]
+    fn test_simple_select_star() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT * FROM users", &db);
+
+        assert!(result.confident);
+        assert_eq!(result.pk_column_indices, vec![0]); // id is first column
+        assert!(result.tables.contains("users"));
+    }
+
+    #[test]
+    fn test_select_specific_columns_with_pk() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT name, id, email FROM users", &db);
+
+        assert!(result.confident);
+        assert_eq!(result.pk_column_indices, vec![1]); // id is second in select list
+    }
+
+    #[test]
+    fn test_select_without_pk() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT name, email FROM users", &db);
+
+        // PK not in result set - should fall back to column 0
+        assert!(!result.confident);
+        assert_eq!(result.pk_column_indices, vec![0]);
+    }
+
+    #[test]
+    fn test_composite_pk() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT * FROM orders", &db);
+
+        assert!(result.confident);
+        // order_id (0) and user_id (1) are composite PK
+        assert_eq!(result.pk_column_indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_composite_pk_partial_select() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT order_id, amount, status FROM orders", &db);
+
+        // Only order_id is in select list, user_id is missing
+        assert!(result.confident);
+        assert_eq!(result.pk_column_indices, vec![0]); // only order_id at position 0
+    }
+
+    #[test]
+    fn test_nonexistent_table() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT * FROM nonexistent", &db);
+
+        assert!(!result.confident);
+        assert_eq!(result.pk_column_indices, vec![0]); // default
+    }
+
+    #[test]
+    fn test_join_query() {
+        let db = create_test_db();
+        let result = detect_pk_columns(
+            "SELECT u.id, u.name, o.order_id FROM users u JOIN orders o ON u.id = o.user_id",
+            &db,
+        );
+
+        // Join queries are not fully confident, but should try to detect first table's PK
+        assert!(!result.confident);
+        assert!(result.tables.contains("users"));
+        assert!(result.tables.contains("orders"));
+    }
+
+    #[test]
+    fn test_aliased_table() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT u.id, u.name FROM users u", &db);
+
+        assert!(result.confident);
+        assert_eq!(result.pk_column_indices, vec![0]); // u.id is first
+    }
+
+    #[test]
+    fn test_invalid_sql() {
+        let db = create_test_db();
+        let result = detect_pk_columns("INVALID SQL", &db);
+
+        assert!(!result.confident);
+        assert_eq!(result.pk_column_indices, vec![0]); // default
+    }
+
+    #[test]
+    fn test_case_insensitive_table_name() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT * FROM USERS", &db);
+
+        assert!(result.confident);
+        assert_eq!(result.pk_column_indices, vec![0]);
+    }
+
+    #[test]
+    fn test_select_with_alias() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT id AS user_id, name FROM users", &db);
+
+        assert!(result.confident);
+        assert_eq!(result.pk_column_indices, vec![0]); // id (aliased as user_id) is first
+    }
+}


### PR DESCRIPTION
## Summary
- Add automatic detection of primary key columns from database schema for subscription queries
- Enable bandwidth-efficient delta updates by correctly identifying which columns uniquely identify rows
- Integrate PK detection into the subscription lifecycle

## Changes
- Add `pk_detector` module with `detect_pk_columns()` and `detect_pk_columns_from_stmt()` functions
- Handle edge cases: single tables, joins, SELECT *, specific columns, table aliases, composite PKs
- Add `pk_columns` field to `Subscription` struct with `update_pk_columns_by_wire_id()` and `get_pk_columns_by_wire_id()` manager methods
- Integrate PK detection in connection handler's `handle_subscribe()`

## Test plan
- [x] All existing tests pass (297 tests)
- [x] Added 11 unit tests for PK detection covering:
  - Simple SELECT * queries
  - SELECT with specific columns
  - Queries without PK in result set
  - Composite primary keys
  - Table aliases
  - JOIN queries
  - Case insensitivity
  - Invalid SQL handling

Closes #3845

🤖 Generated with [Claude Code](https://claude.com/claude-code)