### PR TITLE
docs(wasm): Fix build instructions in crate README

### DIFF
--- a/crates/vibesql-wasm-bindings/README.md
+++ b/crates/vibesql-wasm-bindings/README.md
@@ -46,13 +46,21 @@ console.log(result.rows);
 
 ## Building
 
-```bash
-# Build the WASM package
-wasm-pack build --target web
+Build from the repository root using the provided script:
 
-# Or for Node.js
-wasm-pack build --target nodejs
+```bash
+# From repository root
+./scripts/build-wasm.sh
+
+# Output location: web-demo/public/pkg/
 ```
+
+The build script handles:
+- macOS LLVM configuration (required for wasm32 target)
+- Size-optimized release settings
+- Correct output directory for the web demo
+
+See [web-demo/README.md](../../web-demo/README.md) for full development setup.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Fixed misleading build instructions in `crates/vibesql-wasm-bindings/README.md`
- Previous instructions suggested `wasm-pack build` directly, which outputs to the wrong location
- Now points to `./scripts/build-wasm.sh` and explains the correct output path (`web-demo/public/pkg/`)

## Context

This addresses the root cause of confusion in #3852 - the crate README was directing users to the wrong build approach.

## Test plan

- [x] Verified links are correct
- [x] Documentation accurately reflects actual build process

🤖 Generated with [Claude Code](https://claude.com/claude-code)