### PR TITLE
feat(server): Expose selective column update configuration in server config

### DIFF
--- a/crates/vibesql-server/src/config.rs
+++ b/crates/vibesql-server/src/config.rs
@@ -231,4 +231,84 @@ mod tests {
         let deserialized: Config = toml::from_str(&toml_str).unwrap();
         assert_eq!(config.server.port, deserialized.server.port);
     }
+
+    #[test]
+    fn test_selective_updates_config_defaults() {
+        let config = Config::default();
+        assert!(config.subscriptions.selective_updates.enabled);
+        assert_eq!(config.subscriptions.selective_updates.min_changed_columns, 1);
+        assert!((config.subscriptions.selective_updates.max_changed_columns_ratio - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_selective_updates_config_from_toml() {
+        let toml_str = r#"
+[server]
+host = "0.0.0.0"
+port = 5432
+max_connections = 100
+ssl_enabled = false
+
+[auth]
+method = "trust"
+
+[logging]
+level = "info"
+
+[subscriptions.selective_updates]
+enabled = false
+min_changed_columns = 2
+max_changed_columns_ratio = 0.75
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(!config.subscriptions.selective_updates.enabled);
+        assert_eq!(config.subscriptions.selective_updates.min_changed_columns, 2);
+        assert!((config.subscriptions.selective_updates.max_changed_columns_ratio - 0.75).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_selective_updates_config_partial_override() {
+        // Test that partial config falls back to defaults for unspecified fields
+        let toml_str = r#"
+[server]
+host = "0.0.0.0"
+port = 5432
+max_connections = 100
+ssl_enabled = false
+
+[auth]
+method = "trust"
+
+[logging]
+level = "info"
+
+[subscriptions.selective_updates]
+enabled = false
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(!config.subscriptions.selective_updates.enabled);
+        // Other fields should use defaults
+        assert_eq!(config.subscriptions.selective_updates.min_changed_columns, 1);
+        assert!((config.subscriptions.selective_updates.max_changed_columns_ratio - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_selective_updates_config_serialization() {
+        let config = Config::default();
+        let toml_str = toml::to_string(&config).unwrap();
+        let deserialized: Config = toml::from_str(&toml_str).unwrap();
+
+        assert_eq!(
+            config.subscriptions.selective_updates.enabled,
+            deserialized.subscriptions.selective_updates.enabled
+        );
+        assert_eq!(
+            config.subscriptions.selective_updates.min_changed_columns,
+            deserialized.subscriptions.selective_updates.min_changed_columns
+        );
+        assert!(
+            (config.subscriptions.selective_updates.max_changed_columns_ratio
+                - deserialized.subscriptions.selective_updates.max_changed_columns_ratio).abs() < 0.001
+        );
+    }
 }

--- a/crates/vibesql-server/src/lib.rs
+++ b/crates/vibesql-server/src/lib.rs
@@ -31,9 +31,9 @@ pub use scheduler::{
 pub use registry::{DatabaseRegistry, SharedDatabase};
 pub use session::{Column, ExecutionResult, Row, Session};
 pub use subscription::{
-    extract_table_dependencies, extract_table_refs, SessionSubscription, SessionSubscriptionId,
-    SessionSubscriptionManager, Subscription, SubscriptionError, SubscriptionId,
-    SubscriptionManager, SubscriptionUpdate,
+    extract_table_dependencies, extract_table_refs, SelectiveColumnConfig, SessionSubscription,
+    SessionSubscriptionId, SessionSubscriptionManager, Subscription, SubscriptionConfig,
+    SubscriptionError, SubscriptionId, SubscriptionManager, SubscriptionUpdate,
 };
 pub use transaction::{
     SessionTransactionManager, TransactionChange, TransactionError, TransactionState,

--- a/crates/vibesql-server/src/subscription/manager.rs
+++ b/crates/vibesql-server/src/subscription/manager.rs
@@ -1623,6 +1623,7 @@ mod tests {
             rate_limit_per_second: 100,
             channel_buffer_size: 128,
             slow_consumer_threshold_percent: 90,
+            selective_updates: Default::default(),
         };
 
         let sub = Subscription::with_config("SELECT * FROM users".to_string(), tables, tx, &config);

--- a/crates/vibesql-server/src/subscription/mod.rs
+++ b/crates/vibesql-server/src/subscription/mod.rs
@@ -117,6 +117,13 @@ pub struct SubscriptionConfig {
     /// When channel depth exceeds this percentage, warn about slow consumer
     #[serde(default = "default_slow_consumer_threshold_percent")]
     pub slow_consumer_threshold_percent: u8,
+
+    /// Configuration for selective column updates
+    ///
+    /// Controls when the server sends partial row updates (only changed columns)
+    /// instead of full rows, reducing bandwidth for wide tables with few changes.
+    #[serde(default)]
+    pub selective_updates: SelectiveColumnConfig,
 }
 
 fn default_max_per_connection() -> usize {
@@ -152,6 +159,7 @@ impl Default for SubscriptionConfig {
             rate_limit_per_second: default_rate_limit_per_second(),
             channel_buffer_size: default_channel_buffer_size(),
             slow_consumer_threshold_percent: default_slow_consumer_threshold_percent(),
+            selective_updates: SelectiveColumnConfig::default(),
         }
     }
 }
@@ -711,27 +719,48 @@ pub fn compute_delta(
 // ============================================================================
 
 /// Configuration for selective column updates
-#[derive(Debug, Clone)]
+///
+/// This config controls when selective column updates (0xF7 messages) are used
+/// instead of full row updates. Selective updates only send changed columns
+/// plus primary key columns, reducing bandwidth for wide tables with few changes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SelectiveColumnConfig {
     /// Enable selective column updates
+    #[serde(default = "default_selective_enabled")]
     pub enabled: bool,
     /// Column indices that are primary key columns (always included)
+    /// This is per-subscription and not configurable via config file
+    #[serde(skip)]
     pub pk_columns: Vec<usize>,
     /// Minimum columns that must change to use selective update
     /// If fewer columns change, send full row instead
+    #[serde(default = "default_min_changed_columns")]
     pub min_changed_columns: usize,
-    /// Maximum columns that can change before falling back to full row
-    /// If more columns change, send full row instead (more efficient)
+    /// Maximum ratio of changed columns before falling back to full row
+    /// E.g., 0.5 means if >50% of columns changed, send full row instead
+    #[serde(default = "default_max_changed_columns_ratio")]
     pub max_changed_columns_ratio: f64,
+}
+
+fn default_selective_enabled() -> bool {
+    true
+}
+
+fn default_min_changed_columns() -> usize {
+    1
+}
+
+fn default_max_changed_columns_ratio() -> f64 {
+    0.5
 }
 
 impl Default for SelectiveColumnConfig {
     fn default() -> Self {
         Self {
-            enabled: true,
+            enabled: default_selective_enabled(),
             pk_columns: vec![0], // Assume first column is PK by default
-            min_changed_columns: 1,
-            max_changed_columns_ratio: 0.5, // If >50% of columns changed, send full row
+            min_changed_columns: default_min_changed_columns(),
+            max_changed_columns_ratio: default_max_changed_columns_ratio(),
         }
     }
 }

--- a/crates/vibesql-server/tests/subscription_tests.rs
+++ b/crates/vibesql-server/tests/subscription_tests.rs
@@ -145,6 +145,7 @@ fn test_subscription_manager_unique_ids() {
         rate_limit_per_second: 200, // High rate limit for test
         channel_buffer_size: 64,
         slow_consumer_threshold_percent: 80,
+        selective_updates: Default::default(),
     };
     let mut manager = SessionSubscriptionManager::with_config(config);
 


### PR DESCRIPTION
## Summary

- Expose `SelectiveColumnConfig` through the server configuration file, allowing operators to tune or disable selective column updates
- Add serde serialization/deserialization support to `SelectiveColumnConfig`
- Add `selective_updates` field to `SubscriptionConfig`
- Export `SelectiveColumnConfig` and `SubscriptionConfig` from the crate for external use
- Add comprehensive tests for config parsing, defaults, partial overrides, and serialization

## Configuration Example

```toml
[subscriptions.selective_updates]
# Enable/disable selective column updates (0xF7 messages)
enabled = true

# Minimum columns that must change to use selective update
# If fewer columns change, send full row instead
min_changed_columns = 1

# Maximum ratio of changed columns before falling back to full row
# E.g., 0.5 means if >50% of columns changed, send full row
max_changed_columns_ratio = 0.5
```

## Test plan

- [x] All existing tests pass
- [x] New config parsing tests verify correct default values
- [x] New config tests verify TOML parsing works correctly
- [x] New tests verify partial config overrides use defaults for unspecified fields
- [x] New tests verify config serialization round-trips correctly

Closes #3857

🤖 Generated with [Claude Code](https://claude.com/claude-code)