### PR TITLE
feat(client-ts): Emit subscription events from Connection class

### DIFF
--- a/packages/vibesql-client-ts/src/connection.ts
+++ b/packages/vibesql-client-ts/src/connection.ts
@@ -19,6 +19,9 @@ import {
   DataRowMessage,
   RowDescriptionMessage,
   CommandCompleteMessage,
+  SubscriptionDataMessage,
+  SubscriptionErrorMessage,
+  SubscriptionPartialDataMessage,
   QueryRow,
   ColumnDescription,
 } from './protocol/messages';
@@ -240,6 +243,21 @@ export class Connection extends EventEmitter {
           } else {
             this.emit('error', new QueryError(errorText));
           }
+          break;
+
+        case 'SubscriptionData':
+          this.emit('subscriptionData', message as SubscriptionDataMessage);
+          break;
+
+        case 'SubscriptionError':
+          this.emit('subscriptionError', message as SubscriptionErrorMessage);
+          break;
+
+        case 'SubscriptionPartialData':
+          this.emit(
+            'subscriptionPartialData',
+            message as SubscriptionPartialDataMessage
+          );
           break;
 
         default:


### PR DESCRIPTION
## Summary

- Add subscription event emissions to `Connection.processMessages()` for `SubscriptionData` (0xF2), `SubscriptionError` (0xF3), and `SubscriptionPartialData` (0xF7) messages
- These events are required by `SubscriptionManager` to receive and process real-time subscription updates
- Import the necessary message types from protocol/messages

## Test plan

- [x] TypeScript tests pass (`pnpm test`)
- [x] Verified `SubscriptionManager` is already set up to listen for these events

Closes #3871

🤖 Generated with [Claude Code](https://claude.com/claude-code)