### PR TITLE
fix(storage): Fix missing columnar cache invalidation in REPLACE path

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -297,7 +297,11 @@ impl DeleteExecutor {
             database.rebuild_indexes(&stmt.table_name);
         }
 
-        // Invalidate columnar cache since table data has changed
+        // Invalidate the database-level columnar cache since table data changed.
+        // Note: The table-level cache is already invalidated by delete_by_indices().
+        // Both invalidations are necessary because they manage separate caches:
+        // - Table-level cache: used by Table::scan_columnar() for SIMD filtering
+        // - Database-level cache: used by Database::get_columnar() for cached access
         if delete_result.deleted_count > 0 {
             database.invalidate_columnar_cache(&stmt.table_name);
         }
@@ -424,9 +428,12 @@ fn execute_truncate(database: &mut Database, table_name: &str) -> Result<usize, 
     let row_count = table.row_count();
 
     // Clear all data at once (O(1) operation)
+    // Note: table.clear() invalidates the table-level columnar cache internally
     table.clear();
 
-    // Invalidate columnar cache since table data has changed
+    // Invalidate the database-level columnar cache since table data changed.
+    // Both the table-level (via clear()) and database-level invalidations are
+    // necessary because they manage separate caches at different levels.
     if row_count > 0 {
         database.invalidate_columnar_cache(table_name);
     }

--- a/crates/vibesql-executor/src/insert/replace.rs
+++ b/crates/vibesql-executor/src/insert/replace.rs
@@ -109,5 +109,14 @@ pub fn handle_replace_conflicts(
         db.adjust_indexes_after_delete(table_name, &deleted_indices);
     }
 
+    // Invalidate the database-level columnar cache since table data changed.
+    // Note: The table-level cache is already invalidated by delete_by_indices().
+    // Both invalidations are necessary because they manage separate caches:
+    // - Table-level cache: used by Table::scan_columnar() for SIMD filtering
+    // - Database-level cache: used by Database::get_columnar() for cached access
+    if delete_result.deleted_count > 0 {
+        db.invalidate_columnar_cache(table_name);
+    }
+
     Ok(())
 }

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -337,7 +337,11 @@ impl UpdateExecutor {
             database.update_indexes_for_update(&stmt.table_name, &old_row, &new_row, index, Some(&changed_columns));
         }
 
-        // Invalidate columnar cache since table data has changed
+        // Invalidate the database-level columnar cache since table data changed.
+        // Note: Table-level cache is invalidated by update_row_fast()/update_row_selective().
+        // Both invalidations are necessary because they manage separate caches:
+        // - Table-level cache: used by Table::scan_columnar() for SIMD filtering
+        // - Database-level cache: used by Database::get_columnar() for cached access
         if update_count > 0 {
             database.invalidate_columnar_cache(&stmt.table_name);
         }


### PR DESCRIPTION
## Summary

- Fixed bug in REPLACE path: `handle_replace_conflicts` was not invalidating the database-level columnar cache after calling `delete_by_indices()`, which could cause stale data to be returned by `Database::get_columnar()`
- Added clarifying comments documenting the two-level cache architecture (table-level vs database-level) and why both invalidations are necessary
- Updated comments in DELETE, UPDATE, and REPLACE paths for consistency

## Technical Details

The codebase has two separate columnar caches:

1. **Table-level cache** (`Table.columnar_cache`): A per-table `RwLock<Option<ColumnarTable>>` used by `Table::scan_columnar()` for SIMD filtering operations
2. **Database-level cache** (`Database.columnar_cache`): An `Arc<ColumnarCache>` with LRU eviction used by `Database::get_columnar()` for cached columnar access

Both caches must be invalidated when table data changes:
- Mutation methods like `delete_by_indices()` invalidate the table-level cache internally
- The executor must also call `database.invalidate_columnar_cache()` to invalidate the database-level cache

The original issue suggested these were "duplicate" invalidations, but analysis revealed they are necessary for different purposes.

## Test plan

- [x] `cargo check` passes
- [x] All existing executor tests pass
- [x] Columnar cache tests pass

Closes #3884

🤖 Generated with [Claude Code](https://claude.com/claude-code)