### PR TITLE
perf(storage): Batch optimize index updates for insert operations

### DIFF
--- a/crates/vibesql-storage/src/database/indexes/index_maintenance.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance.rs
@@ -322,6 +322,106 @@ impl IndexManager {
         }
     }
 
+    /// Batch add rows to user-defined indexes after insert
+    ///
+    /// This is significantly more efficient than calling `add_to_indexes_for_insert` in a loop
+    /// because it:
+    /// 1. Pre-computes column indices once per index (not per row)
+    /// 2. Builds all keys in a single pass per index
+    /// 3. Batch-inserts entries into each index
+    ///
+    /// # Arguments
+    /// * `table_name` - The table name
+    /// * `table_schema` - The table schema (for column lookups)
+    /// * `rows_to_insert` - Vec of (row_index, row) pairs to insert
+    pub fn batch_add_to_indexes_for_insert(
+        &mut self,
+        table_name: &str,
+        table_schema: &vibesql_catalog::TableSchema,
+        rows_to_insert: &[(usize, &Row)],
+    ) {
+        if rows_to_insert.is_empty() {
+            return;
+        }
+
+        // Collect indexes that need updating for this table
+        // Pre-compute column indices once per index (not per row)
+        #[allow(clippy::type_complexity)]
+        let indexes_to_update: Vec<(String, Vec<(usize, Option<u64>)>)> = self
+            .indexes
+            .iter()
+            .filter(|(_, metadata)| metadata.table_name.eq_ignore_ascii_case(table_name))
+            .map(|(index_name, metadata)| {
+                // Pre-compute column indices and prefix lengths for this index
+                let column_info: Vec<(usize, Option<u64>)> = metadata
+                    .columns
+                    .iter()
+                    .map(|col| {
+                        let col_idx = table_schema
+                            .get_column_index(&col.column_name)
+                            .expect("Index column should exist");
+                        (col_idx, col.prefix_length)
+                    })
+                    .collect();
+                (index_name.clone(), column_info)
+            })
+            .collect();
+
+        // Process each index
+        for (index_name, column_info) in indexes_to_update {
+            if let Some(index_data) = self.index_data.get_mut(&index_name) {
+                match index_data {
+                    IndexData::InMemory { data, .. } => {
+                        // Build all keys and insert in batch
+                        for &(row_index, row) in rows_to_insert {
+                            let key_values: Vec<SqlValue> = column_info
+                                .iter()
+                                .map(|&(col_idx, prefix_length)| {
+                                    let value = &row.values[col_idx];
+                                    let truncated = apply_prefix_truncation(value, prefix_length);
+                                    crate::database::indexes::index_operations::normalize_for_comparison(&truncated)
+                                })
+                                .collect();
+
+                            data.entry(key_values).or_default().push(row_index);
+                        }
+                    }
+                    IndexData::DiskBacked { btree, .. } => {
+                        // Acquire lock once and batch insert
+                        match acquire_btree_lock(btree) {
+                            Ok(mut guard) => {
+                                for &(row_index, row) in rows_to_insert {
+                                    let key_values: Vec<SqlValue> = column_info
+                                        .iter()
+                                        .map(|&(col_idx, prefix_length)| {
+                                            let value = &row.values[col_idx];
+                                            let truncated = apply_prefix_truncation(value, prefix_length);
+                                            crate::database::indexes::index_operations::normalize_for_comparison(&truncated)
+                                        })
+                                        .collect();
+                                    if let Err(e) = guard.insert(key_values, row_index) {
+                                        log::warn!(
+                                            "Failed to insert into disk-backed index '{}': {:?}",
+                                            index_name,
+                                            e
+                                        );
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                log::warn!("BTreeIndex lock acquisition failed in batch_add_to_indexes_for_insert: {}", e);
+                            }
+                        }
+                    }
+                    IndexData::IVFFlat { .. } | IndexData::Hnsw { .. } => {
+                        // Vector indexes don't support incremental inserts via this path
+                        // They need to be rebuilt after bulk operations
+                    }
+                }
+            }
+        }
+    }
+
     /// Update user-defined indexes for update operation
     ///
     /// # Arguments

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -246,14 +246,15 @@ impl Operations {
         // Generate row indices for return
         let row_indices: Vec<usize> = (start_index..start_index + count).collect();
 
-        // Update user-defined indexes for all inserted rows (only if we cloned)
-        if let (Some(schema), Some(rows_ref)) = (table_schema, rows_for_indexes) {
-            for (i, row) in rows_ref.iter().enumerate() {
-                let row_index = start_index + i;
-                self.index_manager.add_to_indexes_for_insert(table_name, schema, row, row_index);
-                // Update spatial indexes
-                self.update_spatial_indexes_for_insert(catalog, table_name, row, row_index);
-            }
+        // Update user-defined indexes for all inserted rows using batch optimization
+        // This pre-computes column indices once per index rather than once per row
+        if let Some(rows_ref) = rows_for_indexes {
+            let rows_to_insert: Vec<(usize, &Row)> = rows_ref
+                .iter()
+                .enumerate()
+                .map(|(i, row)| (start_index + i, row))
+                .collect();
+            self.batch_add_to_indexes_for_insert(catalog, table_name, &rows_to_insert);
         }
 
         Ok(row_indices)
@@ -537,6 +538,24 @@ impl Operations {
         for &(row_index, row) in rows_to_delete {
             self.update_spatial_indexes_for_delete(catalog, table_name, row, row_index);
         }
+    }
+
+    /// Batch add to user-defined indexes for insert operation
+    ///
+    /// This is significantly more efficient than calling `add_to_indexes_for_insert` in a loop
+    /// because it pre-computes column indices once per index rather than once per row.
+    pub fn batch_add_to_indexes_for_insert(
+        &mut self,
+        catalog: &vibesql_catalog::Catalog,
+        table_name: &str,
+        rows_to_insert: &[(usize, &Row)],
+    ) {
+        if let Some(table_schema) = catalog.get_table(table_name) {
+            self.index_manager.batch_add_to_indexes_for_insert(table_name, table_schema, rows_to_insert);
+        }
+
+        // Update spatial indexes in batch
+        self.batch_update_spatial_indexes_for_insert(catalog, table_name, rows_to_insert);
     }
 
     /// Rebuild user-defined indexes after bulk operations that change row indices
@@ -1031,6 +1050,55 @@ impl Operations {
             if let Some(mbr) = extract_mbr_from_sql_value(geom_value) {
                 if let Some((_, index)) = self.spatial_indexes.get_mut(&index_name) {
                     index.insert(row_index, mbr);
+                }
+            }
+        }
+    }
+
+    /// Batch update spatial indexes for insert operation
+    ///
+    /// This is more efficient than calling `update_spatial_indexes_for_insert` in a loop
+    /// because it pre-computes column indices once per index rather than once per row.
+    ///
+    /// # Arguments
+    /// * `catalog` - The database catalog
+    /// * `table_name` - The table name
+    /// * `rows_to_insert` - Vec of (row_index, row) pairs to insert
+    fn batch_update_spatial_indexes_for_insert(
+        &mut self,
+        catalog: &vibesql_catalog::Catalog,
+        table_name: &str,
+        rows_to_insert: &[(usize, &Row)],
+    ) {
+        if rows_to_insert.is_empty() {
+            return;
+        }
+
+        let table_schema = match catalog.get_table(table_name) {
+            Some(schema) => schema,
+            None => return,
+        };
+
+        // Pre-compute indexes and column indices once
+        let indexes_to_update: Vec<(String, usize)> = self
+            .spatial_indexes
+            .iter()
+            .filter(|(_, (metadata, _))| metadata.table_name == table_name)
+            .filter_map(|(index_name, (metadata, _))| {
+                table_schema
+                    .get_column_index(&metadata.column_name)
+                    .map(|col_idx| (index_name.clone(), col_idx))
+            })
+            .collect();
+
+        // Process each index
+        for (index_name, col_idx) in indexes_to_update {
+            if let Some((_, index)) = self.spatial_indexes.get_mut(&index_name) {
+                for &(row_index, row) in rows_to_insert {
+                    let geom_value = &row.values[col_idx];
+                    if let Some(mbr) = extract_mbr_from_sql_value(geom_value) {
+                        index.insert(row_index, mbr);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Add `batch_add_to_indexes_for_insert` to IndexManager that pre-computes column indices once per index rather than once per row
- Add `batch_update_spatial_indexes_for_insert` to Operations that follows the same pattern
- Update `insert_rows_batch` to use the new batch methods instead of per-row iteration

This optimization reduces redundant column lookups and schema access when inserting multiple rows into tables with user-defined indexes or spatial indexes.

## Test plan

- [x] All storage package tests pass (`cargo test --package vibesql-storage`)
- [x] All executor package tests pass (`cargo test --package vibesql-executor`)
- [x] Index-related tests pass (`cargo test --package vibesql-storage -- index`)

Closes #3889

🤖 Generated with [Claude Code](https://claude.com/claude-code)