### PR TITLE
refactor(storage): Remove table-level columnar cache to eliminate duplication

### DIFF
--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -1028,11 +1028,9 @@ impl Table {
         };
 
         // For native columnar tables, rebuild columnar data
-        // For row tables, invalidate the cache
+        // (Row tables use Database::columnar_cache which is invalidated by executors)
         if self.native_columnar.is_some() {
             let _ = self.rebuild_native_columnar();
-        } else {
-            *self.columnar_cache.write().unwrap() = None;
         }
 
         DeleteResult::new(deleted, compacted)


### PR DESCRIPTION
## Summary

Consolidates the two-level columnar cache architecture by removing the table-level cache (`Table.columnar_cache`) in favor of the database-level cache (`Database.columnar_cache`).

## Problem

The codebase had two separate columnar caches that stored the same data:
1. **Table-level cache** (`Table.columnar_cache`): Per-table `RwLock<Option<ColumnarTable>>` used by `Table::scan_columnar()`
2. **Database-level cache** (`Database.columnar_cache`): `Arc<ColumnarCache>` with LRU eviction used by `Database::get_columnar()`

This caused:
- Duplicate memory usage
- Error-prone dual-invalidation requirement (every mutation site must invalidate both caches)
- Unclear ownership of columnar data

## Solution (Option A from #3892)

Remove the table-level cache entirely. All columnar caching now goes through `Database::get_columnar()`.

### Changes

- Remove `columnar_cache` field from `Table` struct  
- Update `Table::scan_columnar()` to perform fresh conversion each time (caching now handled by `Database::get_columnar()`)
- Remove table-level cache invalidation from mutation methods
- Update documentation to reflect new caching architecture

## Benefits

1. **Single source of truth** - Only one cache to manage
2. **No duplicate memory** - Columnar data stored in one place
3. **Simpler invalidation** - Executors only need to call `database.invalidate_columnar_cache()`
4. **Retains LRU eviction** - Database-level cache provides memory management with Arc-based sharing

## Test plan

- [x] `cargo check -p vibesql-storage` passes
- [x] `cargo test -p vibesql-storage` passes (484 tests)
- [x] `cargo check -p vibesql-executor` passes
- [x] `cargo test -p vibesql-executor --test columnar_storage_tests` passes (11 tests)
- [x] `cargo test -p vibesql-executor --lib` passes (1831 tests)

Closes #3892

🤖 Generated with [Claude Code](https://claude.com/claude-code)