### PR TITLE
feat(storage): Add Database::get_table_index_info() helper for DML cost estimation

### DIFF
--- a/crates/vibesql-storage/src/database/index_ops.rs
+++ b/crates/vibesql-storage/src/database/index_ops.rs
@@ -994,4 +994,235 @@ impl Database {
 
         Ok(delete_result.deleted_count > 0)
     }
+
+    // ============================================================================
+    // Table Index Info for DML Cost Estimation
+    // ============================================================================
+
+    /// Get table index information for DML cost estimation
+    ///
+    /// This method collects all the metadata needed by `CostEstimator::estimate_insert()`,
+    /// `estimate_update()`, and `estimate_delete()` to compute accurate DML operation costs.
+    ///
+    /// # Arguments
+    /// * `table_name` - Name of the table to get index info for
+    ///
+    /// # Returns
+    /// * `Some(TableIndexInfo)` - Index information if table exists
+    /// * `None` - If table doesn't exist
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let info = db.get_table_index_info("users")?;
+    /// let insert_cost = cost_estimator.estimate_insert(&info);
+    /// ```
+    pub fn get_table_index_info(
+        &self,
+        table_name: &str,
+    ) -> Option<crate::statistics::TableIndexInfo> {
+        // Get the table
+        let table = self.get_table(table_name)?;
+
+        // Count hash indexes: 1 for PK (if exists) + 1 per unique constraint
+        let has_primary_key = table.schema.primary_key.is_some();
+        let unique_constraint_count = table.schema.unique_constraints.len();
+        let hash_index_count =
+            if has_primary_key { 1 } else { 0 } + unique_constraint_count;
+
+        // Count B-tree indexes (user-defined indexes managed at Database level)
+        let btree_index_count = self.list_indexes_for_table(table_name).len();
+
+        // Calculate deleted ratio
+        let total_rows = table.physical_row_count();
+        let deleted_ratio = if total_rows > 0 {
+            table.deleted_count() as f64 / total_rows as f64
+        } else {
+            0.0
+        };
+
+        // Check if table uses native columnar storage
+        let is_native_columnar = table.is_native_columnar();
+
+        Some(crate::statistics::TableIndexInfo::new(
+            hash_index_count,
+            btree_index_count,
+            is_native_columnar,
+            deleted_ratio,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibesql_catalog::{ColumnSchema, TableSchema};
+    use vibesql_types::{DataType, SqlValue};
+
+    #[test]
+    fn test_get_table_index_info_basic() {
+        let mut db = Database::new();
+
+        // Create a table with primary key and one unique constraint
+        let schema = TableSchema::with_all_constraints(
+            "users".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new("email".to_string(), DataType::Varchar { max_length: Some(100) }, false),
+                ColumnSchema::new("name".to_string(), DataType::Varchar { max_length: Some(100) }, true),
+            ],
+            Some(vec!["id".to_string()]),
+            vec![vec!["email".to_string()]],
+        );
+        db.create_table(schema).unwrap();
+
+        // Get table index info
+        let info = db.get_table_index_info("users").unwrap();
+
+        // Should have 2 hash indexes: 1 PK + 1 unique constraint
+        assert_eq!(info.hash_index_count, 2);
+        // No B-tree indexes yet
+        assert_eq!(info.btree_index_count, 0);
+        // Not native columnar
+        assert!(!info.is_native_columnar);
+        // No deleted rows
+        assert_eq!(info.deleted_ratio, 0.0);
+    }
+
+    #[test]
+    fn test_get_table_index_info_with_btree_index() {
+        use vibesql_ast::IndexColumn;
+
+        let mut db = Database::new();
+
+        // Create a table with primary key
+        let schema = TableSchema::with_primary_key(
+            "products".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new("name".to_string(), DataType::Varchar { max_length: Some(100) }, false),
+                ColumnSchema::new("price".to_string(), DataType::Decimal { precision: 10, scale: 2 }, false),
+            ],
+            vec!["id".to_string()],
+        );
+        db.create_table(schema).unwrap();
+
+        // Create a B-tree index on price
+        db.create_index(
+            "idx_products_price".to_string(),
+            "products".to_string(),
+            false,
+            vec![IndexColumn {
+                column_name: "price".to_string(),
+                direction: vibesql_ast::OrderDirection::Asc,
+                prefix_length: None,
+            }],
+        ).unwrap();
+
+        // Get table index info
+        let info = db.get_table_index_info("products").unwrap();
+
+        // Should have 1 hash index (PK)
+        assert_eq!(info.hash_index_count, 1);
+        // Should have 1 B-tree index
+        assert_eq!(info.btree_index_count, 1);
+    }
+
+    #[test]
+    fn test_get_table_index_info_with_deleted_rows() {
+        let mut db = Database::new();
+
+        // Create a table with primary key
+        let schema = TableSchema::with_primary_key(
+            "items".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new("name".to_string(), DataType::Varchar { max_length: Some(100) }, false),
+            ],
+            vec!["id".to_string()],
+        );
+        db.create_table(schema).unwrap();
+
+        // Insert 10 rows
+        for i in 0..10 {
+            let row = Row::new(vec![
+                SqlValue::Integer(i),
+                SqlValue::Varchar(format!("Item {}", i)),
+            ]);
+            db.insert_row("items", row).unwrap();
+        }
+
+        // Get initial info - no deleted rows
+        let info = db.get_table_index_info("items").unwrap();
+        assert_eq!(info.deleted_ratio, 0.0);
+
+        // Delete 3 rows (30% deletion)
+        db.delete_by_pk_fast("items", &[SqlValue::Integer(0)]).unwrap();
+        db.delete_by_pk_fast("items", &[SqlValue::Integer(1)]).unwrap();
+        db.delete_by_pk_fast("items", &[SqlValue::Integer(2)]).unwrap();
+
+        // Get updated info - should show deleted ratio
+        let info = db.get_table_index_info("items").unwrap();
+        // 3 deleted out of 10 = 0.3
+        assert!((info.deleted_ratio - 0.3).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_get_table_index_info_nonexistent_table() {
+        let db = Database::new();
+
+        // Should return None for nonexistent table
+        let info = db.get_table_index_info("nonexistent");
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn test_get_table_index_info_no_primary_key() {
+        let mut db = Database::new();
+
+        // Create a table without primary key
+        let schema = TableSchema::new(
+            "logs".to_string(),
+            vec![
+                ColumnSchema::new("message".to_string(), DataType::Varchar { max_length: Some(500) }, false),
+                ColumnSchema::new("level".to_string(), DataType::Integer, false),
+            ],
+        );
+        db.create_table(schema).unwrap();
+
+        // Get table index info
+        let info = db.get_table_index_info("logs").unwrap();
+
+        // Should have 0 hash indexes (no PK, no unique constraints)
+        assert_eq!(info.hash_index_count, 0);
+        // No B-tree indexes
+        assert_eq!(info.btree_index_count, 0);
+    }
+
+    #[test]
+    fn test_get_table_index_info_multiple_unique_constraints() {
+        let mut db = Database::new();
+
+        // Create a table with PK and multiple unique constraints
+        let schema = TableSchema::with_all_constraints(
+            "accounts".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new("email".to_string(), DataType::Varchar { max_length: Some(100) }, false),
+                ColumnSchema::new("username".to_string(), DataType::Varchar { max_length: Some(50) }, false),
+                ColumnSchema::new("phone".to_string(), DataType::Varchar { max_length: Some(20) }, true),
+            ],
+            Some(vec!["id".to_string()]),
+            vec![
+                vec!["email".to_string()],
+                vec!["username".to_string()],
+            ],
+        );
+        db.create_table(schema).unwrap();
+
+        // Get table index info
+        let info = db.get_table_index_info("accounts").unwrap();
+
+        // Should have 3 hash indexes: 1 PK + 2 unique constraints
+        assert_eq!(info.hash_index_count, 3);
+    }
 }

--- a/crates/vibesql-storage/src/lib.rs
+++ b/crates/vibesql-storage/src/lib.rs
@@ -45,7 +45,7 @@ pub use query_buffer_pool::{
     QueryBufferPool, QueryBufferPoolStats, RowBufferGuard, ValueBufferGuard,
 };
 pub use row::Row;
-pub use statistics::{ColumnStatistics, TableStatistics};
+pub use statistics::{ColumnStatistics, TableIndexInfo, TableStatistics};
 pub use table::{DeleteResult, Table};
 pub use wal::{
     DurabilityConfig, DurabilityMode, Lsn, PersistenceConfig, PersistenceEngine, PersistenceStats,

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -644,6 +644,15 @@ impl Table {
         self.rows.len()
     }
 
+    /// Get count of deleted (logically removed) rows
+    ///
+    /// This is used for DML cost estimation, as tables with many deleted rows
+    /// may have degraded performance for UPDATE/DELETE operations.
+    #[inline]
+    pub fn deleted_count(&self) -> usize {
+        self.deleted_count
+    }
+
     /// Get table statistics, computing if necessary
     ///
     /// Statistics are computed lazily on first access and cached.


### PR DESCRIPTION
## Summary

- Adds `Database::get_table_index_info()` method that collects table index metadata needed by `CostEstimator::estimate_insert/update/delete()`
- Returns `TableIndexInfo` struct with hash_index_count, btree_index_count, is_native_columnar, and deleted_ratio
- Adds `Table::deleted_count()` public accessor for delete tracking
- Exports `TableIndexInfo` from vibesql-storage lib.rs
- Includes 6 comprehensive unit tests

## Test plan

- [x] All existing storage crate tests pass (505+ tests)
- [x] 6 new unit tests for `get_table_index_info()`:
  - Basic test with PK and unique constraint
  - Test with B-tree index
  - Test with deleted rows (deleted ratio calculation)
  - Test for nonexistent table (returns None)
  - Test for table without primary key
  - Test with multiple unique constraints

Closes #3898

🤖 Generated with [Claude Code](https://claude.com/claude-code)