### PR TITLE
feat(server): Add gauge metric for selective-eligible subscriptions

### DIFF
--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -315,8 +315,15 @@ impl ConnectionHandler {
                 match self.handle_client_message(msg).await? {
                     ClientMessageResult::Continue => {}
                     ClientMessageResult::Terminate => {
-                        self.subscription_manager
+                        let (_total, selective_eligible) = self.subscription_manager
                             .unsubscribe_all_for_connection(&self.connection_id);
+                        if selective_eligible > 0 {
+                            if let Some(metrics) = self.observability.metrics() {
+                                for _ in 0..selective_eligible {
+                                    metrics.decrement_selective_eligible();
+                                }
+                            }
+                        }
                         return Ok(());
                     }
                 }
@@ -368,8 +375,15 @@ impl ConnectionHandler {
         }
 
         // Clean up subscriptions when connection closes
-        self.subscription_manager
+        let (_total, selective_eligible) = self.subscription_manager
             .unsubscribe_all_for_connection(&self.connection_id);
+        if selective_eligible > 0 {
+            if let Some(metrics) = self.observability.metrics() {
+                for _ in 0..selective_eligible {
+                    metrics.decrement_selective_eligible();
+                }
+            }
+        }
 
         Ok(())
     }
@@ -391,7 +405,12 @@ impl ConnectionHandler {
 
             FrontendMessage::Unsubscribe { subscription_id } => {
                 debug!("Unsubscribe: {:?}", subscription_id);
-                self.subscription_manager.unsubscribe_by_wire_id(&subscription_id);
+                let was_selective_eligible = self.subscription_manager.unsubscribe_by_wire_id(&subscription_id);
+                if was_selective_eligible {
+                    if let Some(metrics) = self.observability.metrics() {
+                        metrics.decrement_selective_eligible();
+                    }
+                }
                 // No response needed per protocol spec
                 Ok(ClientMessageResult::Continue)
             }
@@ -800,10 +819,17 @@ impl ConnectionHandler {
         }
 
         // Store detected PK columns in the subscription for selective updates
-        self.subscription_manager.update_pk_columns_by_wire_id(
+        // Track selective-eligible subscriptions in metrics
+        let newly_eligible = self.subscription_manager.update_pk_columns_with_eligibility_by_wire_id(
             &wire_subscription_id,
             pk_detection.pk_column_indices.clone(),
+            pk_detection.confident,
         );
+        if newly_eligible {
+            if let Some(metrics) = self.observability.metrics() {
+                metrics.increment_selective_eligible();
+            }
+        }
 
         // Execute the query to get initial data
         match session.execute(query).await {
@@ -850,7 +876,12 @@ impl ConnectionHandler {
             }
             Ok(_) => {
                 // Non-SELECT query - send error and remove subscription
-                self.subscription_manager.unsubscribe_by_wire_id(&wire_subscription_id);
+                let was_selective_eligible = self.subscription_manager.unsubscribe_by_wire_id(&wire_subscription_id);
+                if was_selective_eligible {
+                    if let Some(metrics) = self.observability.metrics() {
+                        metrics.decrement_selective_eligible();
+                    }
+                }
                 self.send_subscription_error(
                     &wire_subscription_id,
                     "Only SELECT queries can be subscribed to",
@@ -859,7 +890,12 @@ impl ConnectionHandler {
             }
             Err(e) => {
                 // Query execution failed - remove subscription and send error
-                self.subscription_manager.unsubscribe_by_wire_id(&wire_subscription_id);
+                let was_selective_eligible = self.subscription_manager.unsubscribe_by_wire_id(&wire_subscription_id);
+                if was_selective_eligible {
+                    if let Some(metrics) = self.observability.metrics() {
+                        metrics.decrement_selective_eligible();
+                    }
+                }
                 self.send_subscription_error(&wire_subscription_id, &format!("Execution error: {}", e))
                     .await?;
             }

--- a/crates/vibesql-server/src/observability/metrics.rs
+++ b/crates/vibesql-server/src/observability/metrics.rs
@@ -1,5 +1,7 @@
-use opentelemetry::metrics::{Counter, Histogram, Meter};
+use opentelemetry::metrics::{Counter, Gauge, Histogram, Meter};
 use opentelemetry::KeyValue;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Server metrics collection
@@ -31,6 +33,8 @@ pub struct ServerMetrics {
     subscription_updates_total: Counter<u64>,
     selective_update_columns_sent: Histogram<u64>,
     selective_update_changed_ratio: Histogram<f64>,
+    subscriptions_selective_eligible: Gauge<u64>,
+    subscriptions_selective_eligible_count: Arc<AtomicU64>,
 }
 
 impl ServerMetrics {
@@ -124,6 +128,13 @@ impl ServerMetrics {
             .with_unit("1")
             .build();
 
+        let subscriptions_selective_eligible = meter
+            .u64_gauge("vibesql_subscriptions_selective_eligible")
+            .with_description("Active subscriptions eligible for selective column updates")
+            .with_unit("{subscription}")
+            .build();
+        let subscriptions_selective_eligible_count = Arc::new(AtomicU64::new(0));
+
         Self {
             connections_total,
             connection_errors_total,
@@ -139,6 +150,8 @@ impl ServerMetrics {
             subscription_updates_total,
             selective_update_columns_sent,
             selective_update_changed_ratio,
+            subscriptions_selective_eligible,
+            subscriptions_selective_eligible_count,
         }
     }
 
@@ -250,5 +263,79 @@ impl ServerMetrics {
             let ratio = columns_sent as f64 / total_columns as f64;
             self.selective_update_changed_ratio.record(ratio, &[]);
         }
+    }
+
+    /// Increment the count of selective-eligible subscriptions
+    ///
+    /// Called when a subscription is registered with successfully detected PK columns.
+    pub fn increment_selective_eligible(&self) {
+        let new_value = self.subscriptions_selective_eligible_count.fetch_add(1, Ordering::Relaxed) + 1;
+        self.subscriptions_selective_eligible.record(new_value, &[]);
+    }
+
+    /// Decrement the count of selective-eligible subscriptions
+    ///
+    /// Called when a selective-eligible subscription is unregistered.
+    pub fn decrement_selective_eligible(&self) {
+        let new_value = self.subscriptions_selective_eligible_count.fetch_sub(1, Ordering::Relaxed) - 1;
+        self.subscriptions_selective_eligible.record(new_value, &[]);
+    }
+
+    /// Get the current count of selective-eligible subscriptions
+    pub fn selective_eligible_count(&self) -> u64 {
+        self.subscriptions_selective_eligible_count.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::global;
+
+    fn create_test_metrics() -> ServerMetrics {
+        let meter = global::meter("test_meter");
+        ServerMetrics::new(&meter)
+    }
+
+    #[test]
+    fn test_selective_eligible_increment_decrement() {
+        let metrics = create_test_metrics();
+
+        // Initially zero
+        assert_eq!(metrics.selective_eligible_count(), 0);
+
+        // Increment
+        metrics.increment_selective_eligible();
+        assert_eq!(metrics.selective_eligible_count(), 1);
+
+        // Increment again
+        metrics.increment_selective_eligible();
+        assert_eq!(metrics.selective_eligible_count(), 2);
+
+        // Decrement
+        metrics.decrement_selective_eligible();
+        assert_eq!(metrics.selective_eligible_count(), 1);
+
+        // Decrement again
+        metrics.decrement_selective_eligible();
+        assert_eq!(metrics.selective_eligible_count(), 0);
+    }
+
+    #[test]
+    fn test_selective_eligible_clone() {
+        let metrics1 = create_test_metrics();
+
+        // Increment on first instance
+        metrics1.increment_selective_eligible();
+        assert_eq!(metrics1.selective_eligible_count(), 1);
+
+        // Clone and check shared state
+        let metrics2 = metrics1.clone();
+        assert_eq!(metrics2.selective_eligible_count(), 1);
+
+        // Increment on clone, check both see it
+        metrics2.increment_selective_eligible();
+        assert_eq!(metrics1.selective_eligible_count(), 2);
+        assert_eq!(metrics2.selective_eligible_count(), 2);
     }
 }

--- a/crates/vibesql-server/src/subscription/manager.rs
+++ b/crates/vibesql-server/src/subscription/manager.rs
@@ -324,9 +324,15 @@ impl SubscriptionManager {
     /// # Arguments
     ///
     /// * `id` - The subscription ID to remove
-    pub fn unsubscribe(&self, id: SubscriptionId) {
+    ///
+    /// # Returns
+    ///
+    /// `true` if the removed subscription was selective-eligible, `false` otherwise
+    pub fn unsubscribe(&self, id: SubscriptionId) -> bool {
         if let Some((_, subscription)) = self.subscriptions.remove(&id) {
             debug!(subscription_id = %id, "Removing subscription");
+
+            let was_selective_eligible = subscription.selective_eligible;
 
             // Decrement the atomic counter
             self.subscription_count_atomic.fetch_sub(1, Ordering::Release);
@@ -353,7 +359,10 @@ impl SubscriptionManager {
             if let Some(wire_id) = subscription.wire_subscription_id {
                 self.wire_id_index.remove(&wire_id);
             }
+
+            return was_selective_eligible;
         }
+        false
     }
 
     /// Remove a subscription by its wire protocol ID
@@ -366,11 +375,11 @@ impl SubscriptionManager {
     ///
     /// # Returns
     ///
-    /// `true` if the subscription was found and removed, `false` otherwise
+    /// `true` if the removed subscription was selective-eligible, `false` otherwise.
+    /// Returns `false` if the subscription was not found.
     pub fn unsubscribe_by_wire_id(&self, wire_id: &[u8; 16]) -> bool {
         if let Some((_, id)) = self.wire_id_index.remove(wire_id) {
-            self.unsubscribe(id);
-            true
+            self.unsubscribe(id)
         } else {
             false
         }
@@ -387,14 +396,14 @@ impl SubscriptionManager {
     ///
     /// # Returns
     ///
-    /// Number of subscriptions removed
-    pub fn unsubscribe_all_for_connection(&self, connection_id: &str) -> usize {
+    /// A tuple of (total_removed, selective_eligible_removed)
+    pub fn unsubscribe_all_for_connection(&self, connection_id: &str) -> (usize, usize) {
         let subscription_ids: Vec<SubscriptionId> = if let Some((_, ids)) =
             self.connection_index.remove(connection_id)
         {
             ids.into_iter().collect()
         } else {
-            return 0;
+            return (0, 0);
         };
 
         let count = subscription_ids.len();
@@ -404,16 +413,19 @@ impl SubscriptionManager {
             "Removing all subscriptions for connection"
         );
 
+        let mut selective_eligible_count = 0;
         for id in subscription_ids {
             // Note: unsubscribe will try to remove from connection_index again,
             // but it will be a no-op since we already removed it
-            self.unsubscribe(id);
+            if self.unsubscribe(id) {
+                selective_eligible_count += 1;
+            }
         }
 
         // Clean up the per-connection count entry
         self.connection_subscription_counts.remove(connection_id);
 
-        count
+        (count, selective_eligible_count)
     }
 
     /// Find a subscription by its wire protocol ID
@@ -563,6 +575,26 @@ impl SubscriptionManager {
                 sub.pk_columns = pk_columns;
             }
         }
+    }
+
+    /// Update PK columns with eligibility tracking
+    ///
+    /// Sets the PK columns and marks whether the subscription is eligible
+    /// for selective column updates (based on confident PK detection).
+    ///
+    /// Returns `true` if the subscription is newly marked as selective-eligible.
+    pub fn update_pk_columns_with_eligibility_by_wire_id(
+        &self,
+        wire_id: &[u8; 16],
+        pk_columns: Vec<usize>,
+        confident: bool,
+    ) -> bool {
+        if let Some(id) = self.wire_id_index.get(wire_id).map(|r| *r) {
+            if let Some(mut sub) = self.subscriptions.get_mut(&id) {
+                return sub.set_pk_columns_with_eligibility(pk_columns, confident);
+            }
+        }
+        false
     }
 
     /// Get the primary key columns for a subscription by wire ID

--- a/crates/vibesql-server/src/subscription/mod.rs
+++ b/crates/vibesql-server/src/subscription/mod.rs
@@ -335,6 +335,9 @@ pub struct Subscription {
     /// Used for selective column updates to always include PK columns
     /// Default: [0] (assumes first column is PK if not detected)
     pub pk_columns: Vec<usize>,
+    /// Whether this subscription is eligible for selective column updates
+    /// True when PK columns were confidently detected
+    pub selective_eligible: bool,
 }
 
 impl Subscription {
@@ -371,6 +374,7 @@ impl Subscription {
             wire_subscription_id: None,
             filter: None,
             pk_columns: vec![0], // default: assume first column is PK
+            selective_eligible: false,
         }
     }
 
@@ -398,6 +402,7 @@ impl Subscription {
             wire_subscription_id: None,
             filter: None,
             pk_columns: vec![0], // default: assume first column is PK
+            selective_eligible: false,
         }
     }
 
@@ -458,6 +463,7 @@ impl Subscription {
             wire_subscription_id: Some(wire_subscription_id),
             filter,
             pk_columns,
+            selective_eligible: false,
         }
     }
 
@@ -466,6 +472,22 @@ impl Subscription {
     /// Used after detection to update the subscription with actual PK columns.
     pub fn set_pk_columns(&mut self, pk_columns: Vec<usize>) {
         self.pk_columns = pk_columns;
+    }
+
+    /// Set both PK columns and selective eligibility
+    ///
+    /// Used after PK detection to update the subscription.
+    /// Returns true if the subscription is newly marked as selective-eligible.
+    pub fn set_pk_columns_with_eligibility(
+        &mut self,
+        pk_columns: Vec<usize>,
+        confident: bool,
+    ) -> bool {
+        self.pk_columns = pk_columns;
+        let was_eligible = self.selective_eligible;
+        self.selective_eligible = confident;
+        // Return true if newly eligible (wasn't before, is now)
+        !was_eligible && confident
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `vibesql_subscriptions_selective_eligible` gauge metric to track subscriptions where PK columns were confidently detected
- Add `selective_eligible` field to `Subscription` struct to track eligibility status
- Update subscription lifecycle (register/unregister) to maintain the metric accurately

## Implementation Details

- **ServerMetrics**: Added `subscriptions_selective_eligible` gauge with `increment_selective_eligible()` and `decrement_selective_eligible()` methods using `Arc<AtomicU64>` for thread-safe counting
- **Subscription struct**: Added `selective_eligible: bool` field and `set_pk_columns_with_eligibility()` method
- **SubscriptionManager**: 
  - Added `update_pk_columns_with_eligibility_by_wire_id()` to set PK columns and eligibility atomically
  - Updated `unsubscribe()` and `unsubscribe_by_wire_id()` to return whether the removed subscription was selective-eligible
  - Updated `unsubscribe_all_for_connection()` to return tuple of (total_removed, selective_eligible_removed)
- **Connection handling**: Updated subscription creation/cleanup paths to increment/decrement the metric

## Test plan

- [x] Added unit tests for `increment_selective_eligible`/`decrement_selective_eligible`
- [x] Added unit test for cloned metrics sharing state
- [x] Existing subscription tests pass
- [x] `cargo check` passes

Closes #3901

🤖 Generated with [Claude Code](https://claude.com/claude-code)