### PR TITLE
feat(server): Use PartialRowUpdate for selective column updates in subscription deltas

### DIFF
--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -6,10 +6,11 @@ use crate::protocol::{
 };
 use crate::registry::DatabaseRegistry;
 use crate::session::{ExecutionResult, Session};
+use crate::protocol::PartialRowUpdate;
 use crate::subscription::{
-    compute_delta_with_pk, detect_pk_columns_from_stmt, extract_table_refs,
-    filter::SubscriptionFilter, hash_rows, SubscriptionId, SubscriptionManager,
-    SubscriptionUpdate,
+    compute_delta_with_pk, create_partial_row_update, detect_pk_columns_from_stmt,
+    extract_table_refs, filter::SubscriptionFilter, hash_rows, SelectiveColumnConfig,
+    SubscriptionId, SubscriptionManager, SubscriptionUpdate,
 };
 use crate::Row;
 use anyhow::Result;
@@ -578,6 +579,8 @@ impl ConnectionHandler {
     /// Send delta updates to a subscription
     ///
     /// The wire protocol sends separate messages for inserts, updates, and deletes.
+    /// For UPDATE operations, we use PartialRowUpdate to send only changed columns
+    /// plus PK columns, reducing wire traffic for wide tables.
     async fn send_delta_updates(
         &mut self,
         subscription_id: &[u8; 16],
@@ -595,27 +598,60 @@ impl ConnectionHandler {
                 .await?;
             }
 
-            // Send updates
-            // Note: The current delta computation doesn't detect updates (they appear as delete+insert)
-            // but we support the wire format for future enhancements
+            // Send updates using partial row format when beneficial
             if !updates.is_empty() {
-                // For updates, we send the new values
-                let wire_rows: Vec<Vec<Option<Vec<u8>>>> = updates
-                    .iter()
-                    .map(|(_, new_row)| {
-                        new_row
-                            .values
-                            .iter()
-                            .map(|v| Some(v.to_string().as_bytes().to_vec()))
-                            .collect()
-                    })
-                    .collect();
-                self.send_subscription_data(
-                    subscription_id,
-                    SubscriptionUpdateType::DeltaUpdate,
-                    wire_rows,
-                )
-                .await?;
+                // Get PK columns for this subscription
+                let pk_columns = self.subscription_manager.get_pk_columns_by_wire_id(subscription_id);
+
+                // Create config for selective column updates
+                let config = SelectiveColumnConfig {
+                    enabled: true,
+                    pk_columns: pk_columns.clone(),
+                    ..Default::default()
+                };
+
+                // Separate updates into partial and full based on threshold
+                let mut partial_updates: Vec<PartialRowUpdate> = Vec::new();
+                let mut full_updates: Vec<Vec<Option<Vec<u8>>>> = Vec::new();
+
+                for (old_row, new_row) in updates {
+                    // Convert rows to wire format
+                    let old_wire: Vec<Option<Vec<u8>>> = old_row
+                        .values
+                        .iter()
+                        .map(|v| Some(v.to_string().as_bytes().to_vec()))
+                        .collect();
+                    let new_wire: Vec<Option<Vec<u8>>> = new_row
+                        .values
+                        .iter()
+                        .map(|v| Some(v.to_string().as_bytes().to_vec()))
+                        .collect();
+
+                    // Try to create a partial update
+                    if let Some(partial) =
+                        create_partial_row_update(&old_wire, &new_wire, &pk_columns, &config)
+                    {
+                        partial_updates.push(partial);
+                    } else {
+                        // Fall back to full row update
+                        full_updates.push(new_wire);
+                    }
+                }
+
+                // Send partial updates via SubscriptionPartialData (0xF7)
+                if !partial_updates.is_empty() {
+                    self.send_subscription_partial_data(subscription_id, partial_updates).await?;
+                }
+
+                // Send any full updates via regular DeltaUpdate
+                if !full_updates.is_empty() {
+                    self.send_subscription_data(
+                        subscription_id,
+                        SubscriptionUpdateType::DeltaUpdate,
+                        full_updates,
+                    )
+                    .await?;
+                }
             }
 
             // Send inserts last
@@ -1298,6 +1334,25 @@ impl ConnectionHandler {
         }
 
         BackendMessage::SubscriptionData { subscription_id: *subscription_id, update_type, rows }
+            .encode(&mut self.write_buf);
+        self.flush_write_buffer().await
+    }
+
+    /// Send subscription partial data message (for selective column updates)
+    ///
+    /// Uses the SubscriptionPartialData (0xF7) message format to send only
+    /// changed columns plus primary key columns, reducing wire traffic.
+    async fn send_subscription_partial_data(
+        &mut self,
+        subscription_id: &[u8; 16],
+        rows: Vec<PartialRowUpdate>,
+    ) -> Result<()> {
+        // Record subscription update metrics
+        if let Some(metrics) = self.observability.metrics() {
+            metrics.record_subscription_update("selective", rows.len() as u64);
+        }
+
+        BackendMessage::SubscriptionPartialData { subscription_id: *subscription_id, rows }
             .encode(&mut self.write_buf);
         self.flush_write_buffer().await
     }

--- a/crates/vibesql-server/src/subscription/mod.rs
+++ b/crates/vibesql-server/src/subscription/mod.rs
@@ -1789,4 +1789,130 @@ mod tests {
 
         assert_eq!(partial.present_column_count(), 3);
     }
+
+    #[test]
+    fn test_delta_updates_produce_partial_row_updates() {
+        use vibesql_types::SqlValue;
+
+        // Test that delta computation with updates can produce partial row updates
+        // This verifies the integration between compute_delta_with_pk and create_partial_row_update
+
+        let test_id = SubscriptionId::new();
+
+        // Create old and new rows where only one column changes
+        // Row format: [id, name, balance]
+        // id=1: name unchanged, balance changes from 100 to 150
+        let old = vec![crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Alice".to_string()),
+                SqlValue::Integer(100),
+            ],
+        }];
+        let new = vec![crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Alice".to_string()),
+                SqlValue::Integer(150),
+            ],
+        }];
+
+        let pk_columns = vec![0]; // First column is PK
+        let delta = compute_delta_with_pk(test_id, &old, &new, &pk_columns);
+
+        // Verify we got an update (not delete+insert)
+        if let SubscriptionUpdate::Delta { updates, inserts, deletes, .. } = delta.unwrap() {
+            assert!(inserts.is_empty(), "Should not have inserts");
+            assert!(deletes.is_empty(), "Should not have deletes");
+            assert_eq!(updates.len(), 1, "Should have one update");
+
+            // Now verify that create_partial_row_update works with this update
+            let (old_row, new_row) = &updates[0];
+
+            // Convert to wire format (as connection.rs does)
+            let old_wire: Vec<Option<Vec<u8>>> =
+                old_row.values.iter().map(|v| Some(v.to_string().as_bytes().to_vec())).collect();
+            let new_wire: Vec<Option<Vec<u8>>> =
+                new_row.values.iter().map(|v| Some(v.to_string().as_bytes().to_vec())).collect();
+
+            let config =
+                SelectiveColumnConfig { enabled: true, pk_columns: vec![0], ..Default::default() };
+
+            let partial = create_partial_row_update(&old_wire, &new_wire, &[0], &config);
+
+            // Should produce a partial update since only 1 of 3 columns changed
+            assert!(partial.is_some(), "Should produce partial row update");
+
+            let partial = partial.unwrap();
+            assert_eq!(partial.total_columns, 3);
+
+            // Should include PK (column 0) and changed column (column 2)
+            assert!(partial.is_column_present(0), "PK column should be present");
+            assert!(!partial.is_column_present(1), "Unchanged column should not be present");
+            assert!(partial.is_column_present(2), "Changed column should be present");
+
+            // Verify values
+            assert_eq!(partial.values.len(), 2); // PK + changed column
+            assert_eq!(partial.values[0], Some(b"1".to_vec())); // PK value
+            assert_eq!(partial.values[1], Some(b"150".to_vec())); // New balance
+        } else {
+            panic!("Expected Delta, got something else");
+        }
+    }
+
+    #[test]
+    fn test_delta_updates_fallback_to_full_row_when_too_many_changes() {
+        use vibesql_types::SqlValue;
+
+        // Test that when too many columns change, create_partial_row_update returns None
+
+        let test_id = SubscriptionId::new();
+
+        // Create old and new rows where most non-PK columns change
+        // Row format: [id, name, email]
+        let old = vec![crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Alice".to_string()),
+                SqlValue::Varchar("alice@old.com".to_string()),
+            ],
+        }];
+        let new = vec![crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Bob".to_string()),
+                SqlValue::Varchar("bob@new.com".to_string()),
+            ],
+        }];
+
+        let pk_columns = vec![0];
+        let delta = compute_delta_with_pk(test_id, &old, &new, &pk_columns);
+
+        if let SubscriptionUpdate::Delta { updates, .. } = delta.unwrap() {
+            assert_eq!(updates.len(), 1);
+
+            let (old_row, new_row) = &updates[0];
+
+            let old_wire: Vec<Option<Vec<u8>>> =
+                old_row.values.iter().map(|v| Some(v.to_string().as_bytes().to_vec())).collect();
+            let new_wire: Vec<Option<Vec<u8>>> =
+                new_row.values.iter().map(|v| Some(v.to_string().as_bytes().to_vec())).collect();
+
+            // Use config with low threshold (max 30% of columns can change)
+            let config = SelectiveColumnConfig {
+                enabled: true,
+                pk_columns: vec![0],
+                max_changed_columns_ratio: 0.3,
+                ..Default::default()
+            };
+
+            // 2 of 3 columns changed (66%), which exceeds 30% threshold
+            let partial = create_partial_row_update(&old_wire, &new_wire, &[0], &config);
+
+            // Should NOT produce partial update due to too many changes
+            assert!(partial.is_none(), "Should fall back to full row when too many columns change");
+        } else {
+            panic!("Expected Delta");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Modified `send_delta_updates()` in connection.rs to use `PartialRowUpdate` format for UPDATE operations
- Added `send_subscription_partial_data()` helper method for sending `SubscriptionPartialData` (0xF7) messages
- Respects `SelectiveColumnConfig` thresholds - falls back to full row when too many columns change
- PK columns are always included in partial updates for client-side row identification

## Benefits

- Reduced wire traffic for updates that only change a few columns
- More efficient for wide tables with many columns
- Client can apply targeted updates without full row replacement

## Test plan

- [x] Added `test_delta_updates_produce_partial_row_updates` - verifies partial updates work correctly
- [x] Added `test_delta_updates_fallback_to_full_row_when_too_many_changes` - verifies threshold behavior
- [x] All 331 vibesql-server lib tests pass

Closes #3903

🤖 Generated with [Claude Code](https://claude.com/claude-code)