### PR TITLE
feat(http): Add PK detection and selective-eligible metrics to HTTP SSE subscriptions

### DIFF
--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -1543,20 +1543,6 @@ impl ConnectionHandler {
         self.flush_write_buffer().await
     }
 
-    /// Send subscription partial data (0xF7) for selective column updates
-    ///
-    /// This is more bandwidth-efficient than sending full rows when only
-    /// a few columns have changed.
-    async fn send_subscription_partial_data(
-        &mut self,
-        subscription_id: &[u8; 16],
-        rows: Vec<crate::protocol::messages::PartialRowUpdate>,
-    ) -> Result<()> {
-        BackendMessage::SubscriptionPartialData { subscription_id: *subscription_id, rows }
-            .encode(&mut self.write_buf);
-        self.flush_write_buffer().await
-    }
-
     // I/O methods
 
     async fn read_message(&mut self) -> Result<()> {

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -18,8 +18,9 @@ use vibesql_storage::Database;
 
 use super::graphql;
 use super::types::*;
+use crate::observability::ServerMetrics;
 use crate::registry::DatabaseRegistry;
-use crate::subscription::{SubscriptionManager, SubscriptionUpdate};
+use crate::subscription::{detect_pk_columns_from_stmt, SubscriptionManager, SubscriptionUpdate};
 
 /// Pagination configuration
 #[derive(Debug, Clone)]
@@ -59,6 +60,8 @@ pub struct HttpState {
     pub db: Arc<Database>,
     /// Subscription manager for real-time updates
     pub subscription_manager: Arc<SubscriptionManager>,
+    /// Optional server metrics for observability
+    pub metrics: Option<ServerMetrics>,
 }
 
 /// Create the HTTP API router
@@ -67,15 +70,18 @@ pub struct HttpState {
 /// * `db` - Legacy database reference for backwards compatibility (subscriptions, table listing)
 /// * `registry` - Database registry for shared database access
 /// * `subscription_manager` - Subscription manager for real-time updates
+/// * `metrics` - Optional server metrics for observability
 pub fn create_http_router(
     db: Arc<Database>,
     registry: DatabaseRegistry,
     subscription_manager: Arc<SubscriptionManager>,
+    metrics: Option<ServerMetrics>,
 ) -> Router {
     let state = HttpState {
         registry: registry.clone(),
         db: db.clone(),
         subscription_manager: subscription_manager.clone(),
+        metrics,
     };
 
     // Create main router with state
@@ -733,6 +739,37 @@ async fn subscribe_stream(
         }
     };
 
+    // Detect PK columns for selective column updates
+    // Parse the subscription query to detect primary key columns
+    if let Ok(stmt) = vibesql_parser::Parser::parse_sql(&params.query) {
+        // Get the database for PK detection
+        let db_for_pk = state.registry.get_or_create(&db_name).await;
+        let db_guard_pk = db_for_pk.read().await;
+        let pk_detection = detect_pk_columns_from_stmt(&stmt, &db_guard_pk);
+        drop(db_guard_pk);
+
+        debug!(
+            subscription_id = %subscription_id,
+            pk_columns = ?pk_detection.pk_column_indices,
+            confident = pk_detection.confident,
+            "Detected PK columns for HTTP SSE subscription"
+        );
+
+        // Update subscription with PK columns and eligibility
+        let newly_eligible = state.subscription_manager.update_pk_columns_with_eligibility(
+            subscription_id,
+            pk_detection.pk_column_indices,
+            pk_detection.confident,
+        );
+
+        // Track selective-eligible metric
+        if newly_eligible {
+            if let Some(ref metrics) = state.metrics {
+                metrics.increment_selective_eligible();
+            }
+        }
+    }
+
     // Send initial results using the database from the registry
     let columns_clone = columns.clone();
     // Re-get the database from registry and send initial results
@@ -743,7 +780,12 @@ async fn subscribe_stream(
     {
         drop(db_guard);
         error!("Failed to send initial results: {}", e);
-        state.subscription_manager.unsubscribe(subscription_id);
+        let was_selective_eligible = state.subscription_manager.unsubscribe(subscription_id);
+        if was_selective_eligible {
+            if let Some(ref metrics) = state.metrics {
+                metrics.decrement_selective_eligible();
+            }
+        }
 
         let event_data = serde_json::to_string(&SseEvent {
             event_type: "error".to_string(),
@@ -866,7 +908,12 @@ async fn subscribe_stream(
         }
 
         // Clean up subscription when stream ends
-        state.subscription_manager.unsubscribe(subscription_id);
+        let was_selective_eligible = state.subscription_manager.unsubscribe(subscription_id);
+        if was_selective_eligible {
+            if let Some(ref metrics) = state.metrics {
+                metrics.decrement_selective_eligible();
+            }
+        }
     };
 
     // Create SSE response with keepalive

--- a/crates/vibesql-server/src/main.rs
+++ b/crates/vibesql-server/src/main.rs
@@ -139,8 +139,9 @@ async fn main() -> Result<()> {
         // Share the database registry with the HTTP server
         let registry_for_http = database_registry.clone();
 
+        let metrics_for_http = observability.metrics().cloned();
         tokio::spawn(async move {
-            let app = create_http_router(db_for_http, registry_for_http, subscription_manager_for_http);
+            let app = create_http_router(db_for_http, registry_for_http, subscription_manager_for_http, metrics_for_http);
             let listener = tokio::net::TcpListener::bind(&http_addr)
                 .await
                 .expect("Failed to bind HTTP server");

--- a/crates/vibesql-server/src/subscription/manager.rs
+++ b/crates/vibesql-server/src/subscription/manager.rs
@@ -597,6 +597,25 @@ impl SubscriptionManager {
         false
     }
 
+    /// Update PK columns with eligibility tracking by internal subscription ID
+    ///
+    /// Sets the PK columns and marks whether the subscription is eligible
+    /// for selective column updates (based on confident PK detection).
+    /// This variant is used for HTTP SSE subscriptions that don't have wire IDs.
+    ///
+    /// Returns `true` if the subscription is newly marked as selective-eligible.
+    pub fn update_pk_columns_with_eligibility(
+        &self,
+        id: SubscriptionId,
+        pk_columns: Vec<usize>,
+        confident: bool,
+    ) -> bool {
+        if let Some(mut sub) = self.subscriptions.get_mut(&id) {
+            return sub.set_pk_columns_with_eligibility(pk_columns, confident);
+        }
+        false
+    }
+
     /// Get the primary key columns for a subscription by wire ID
     ///
     /// Returns the PK column indices, or default [0] if not found.
@@ -2002,5 +2021,60 @@ mod tests {
         assert_eq!(affected[0].2, 12345); // last_result_hash
         assert!(affected[0].3.is_some()); // last_result
         assert_eq!(affected[0].3.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_update_pk_columns_with_eligibility() {
+        let manager = SubscriptionManager::new();
+        let (tx, _rx) = mpsc::channel(16);
+
+        // Create a basic subscription (non-connection based)
+        let id = manager.subscribe("SELECT * FROM users".to_string(), tx).unwrap();
+
+        // Initially not selective eligible
+        let sub = manager.subscriptions.get(&id).unwrap();
+        assert!(!sub.selective_eligible);
+        assert_eq!(sub.pk_columns, vec![0]); // Default
+        drop(sub);
+
+        // Update PK columns with confident detection
+        let newly_eligible = manager.update_pk_columns_with_eligibility(id, vec![0, 1], true);
+        assert!(newly_eligible, "Should be newly eligible");
+
+        // Verify changes
+        let sub = manager.subscriptions.get(&id).unwrap();
+        assert!(sub.selective_eligible);
+        assert_eq!(sub.pk_columns, vec![0, 1]);
+        drop(sub);
+
+        // Updating again should return false (not newly eligible)
+        let newly_eligible2 = manager.update_pk_columns_with_eligibility(id, vec![0, 1], true);
+        assert!(!newly_eligible2, "Should not be newly eligible since already was");
+
+        // Unsubscribe should return true (was selective eligible)
+        let was_eligible = manager.unsubscribe(id);
+        assert!(was_eligible);
+    }
+
+    #[test]
+    fn test_update_pk_columns_with_eligibility_not_confident() {
+        let manager = SubscriptionManager::new();
+        let (tx, _rx) = mpsc::channel(16);
+
+        let id = manager.subscribe("SELECT * FROM users".to_string(), tx).unwrap();
+
+        // Update with non-confident detection
+        let newly_eligible = manager.update_pk_columns_with_eligibility(id, vec![0, 2], false);
+        assert!(!newly_eligible, "Should not be eligible when not confident");
+
+        // Verify PK columns updated but not selective eligible
+        let sub = manager.subscriptions.get(&id).unwrap();
+        assert!(!sub.selective_eligible);
+        assert_eq!(sub.pk_columns, vec![0, 2]);
+        drop(sub);
+
+        // Unsubscribe should return false (was not selective eligible)
+        let was_eligible = manager.unsubscribe(id);
+        assert!(!was_eligible);
     }
 }

--- a/crates/vibesql-server/tests/common/mod.rs
+++ b/crates/vibesql-server/tests/common/mod.rs
@@ -131,8 +131,9 @@ pub async fn start_test_server_with_config(mut config: Config) -> TestServer {
 
         // Spawn HTTP server
         let db_for_http = Arc::clone(&db);
+        let metrics_for_http = observability.metrics().cloned();
         tokio::spawn(async move {
-            let app = create_http_router(db_for_http, registry_for_http, subscription_manager_for_http);
+            let app = create_http_router(db_for_http, registry_for_http, subscription_manager_for_http, metrics_for_http);
             axum::serve(http_listener, app).await.expect("HTTP server error");
         });
 


### PR DESCRIPTION
## Summary
- Adds primary key column detection to HTTP SSE subscriptions, enabling selective column updates
- Tracks `vibesql_subscriptions_selective_eligible` metric for HTTP SSE subscriptions
- Adds `update_pk_columns_with_eligibility()` method to SubscriptionManager for internal subscription IDs
- Brings HTTP SSE subscriptions to feature parity with wire protocol for PK detection

## Test plan
- [x] Verify `cargo check --package vibesql-server` passes
- [x] Run subscription manager tests: `cargo test --package vibesql-server subscription::manager`
- [x] Run HTTP SSE tests: `cargo test --package vibesql-server --test http_sse_subscription_tests`
- [x] Run all server tests: `cargo test --package vibesql-server`
- [x] Added unit tests for new `update_pk_columns_with_eligibility` method

Closes #3925

🤖 Generated with [Claude Code](https://claude.com/claude-code)