### PR TITLE
fix(server): Remove duplicate send_subscription_partial_data method

### DIFF
--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -1543,20 +1543,6 @@ impl ConnectionHandler {
         self.flush_write_buffer().await
     }
 
-    /// Send subscription partial data (0xF7) for selective column updates
-    ///
-    /// This is more bandwidth-efficient than sending full rows when only
-    /// a few columns have changed.
-    async fn send_subscription_partial_data(
-        &mut self,
-        subscription_id: &[u8; 16],
-        rows: Vec<crate::protocol::messages::PartialRowUpdate>,
-    ) -> Result<()> {
-        BackendMessage::SubscriptionPartialData { subscription_id: *subscription_id, rows }
-            .encode(&mut self.write_buf);
-        self.flush_write_buffer().await
-    }
-
     // I/O methods
 
     async fn read_message(&mut self) -> Result<()> {


### PR DESCRIPTION
## Summary
- Fixes duplicate method definition in ConnectionHandler that was causing compilation errors
- PR #3930 accidentally added a second `send_subscription_partial_data` method
- Removes the duplicate while keeping the original which includes observability metrics

Note: Issue #3929 requested test coverage for UPDATE + columnar cache invalidation, but these tests already exist (added by PR #3926). This PR fixes the compilation error discovered while verifying those tests work.

## Test plan
- [x] `cargo test -p vibesql-executor --test update_columnar_cache_tests` - 6/6 tests pass
- [x] Compilation succeeds without duplicate definition error

Closes #3929

🤖 Generated with [Claude Code](https://claude.com/claude-code)