### PR TITLE
feat(observability): Add metrics for subscription partial update efficiency

### DIFF
--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -735,11 +735,17 @@ impl ConnectionHandler {
         // Check if selective updates are enabled in config
         let config = &self.config.subscriptions.selective_updates;
         if !config.enabled {
+            if let Some(metrics) = self.observability.metrics() {
+                metrics.record_partial_update_fallback("disabled");
+            }
             return false;
         }
 
         // Row counts must match for selective updates (no inserts/deletes)
         if old_rows.len() != new_rows.len() {
+            if let Some(metrics) = self.observability.metrics() {
+                metrics.record_partial_update_fallback("row_count_mismatch");
+            }
             return false;
         }
 
@@ -769,6 +775,7 @@ impl ConnectionHandler {
 
         // Try to create partial row updates for each new row
         let mut partial_updates = Vec::new();
+        let mut threshold_exceeded_count = 0u64;
         for new_row in &new_wire {
             // Extract PK from new row
             let pk_values: Vec<Option<Vec<u8>>> =
@@ -784,19 +791,83 @@ impl ConnectionHandler {
                 {
                     partial_updates.push(partial);
                 } else {
-                    // No changes for this row, skip it
+                    // Check if this was due to threshold exceeded (too many columns changed)
+                    let changed_count = old_row
+                        .iter()
+                        .zip(new_row.iter())
+                        .filter(|(o, n)| o != n)
+                        .count();
+                    if changed_count > 0 {
+                        let ratio = changed_count as f64 / new_row.len() as f64;
+                        if ratio > selective_config.max_changed_columns_ratio {
+                            threshold_exceeded_count += 1;
+                        }
+                    }
                     continue;
                 }
             } else {
                 // Can't find matching old row - this is an insert, not an update
                 // Fall back to regular updates
+                if let Some(metrics) = self.observability.metrics() {
+                    metrics.record_partial_update_fallback("pk_mismatch");
+                }
                 return false;
+            }
+        }
+
+        // Record threshold exceeded fallbacks if any
+        if threshold_exceeded_count > 0 {
+            if let Some(metrics) = self.observability.metrics() {
+                for _ in 0..threshold_exceeded_count {
+                    metrics.record_partial_update_fallback("threshold_exceeded");
+                }
             }
         }
 
         // If no partial updates were generated, nothing changed
         if partial_updates.is_empty() {
+            if let Some(metrics) = self.observability.metrics() {
+                metrics.record_partial_update_fallback("no_changes");
+            }
             return false;
+        }
+
+        // Calculate and record metrics before sending
+        if let Some(metrics) = self.observability.metrics() {
+            let total_columns = if !new_wire.is_empty() { new_wire[0].len() as u64 } else { 0 };
+            let mut total_columns_sent: u64 = 0;
+            let mut total_bytes_full: u64 = 0;
+            let mut total_bytes_partial: u64 = 0;
+
+            for (partial, new_row) in partial_updates.iter().zip(new_wire.iter()) {
+                // Count columns sent in this partial update
+                total_columns_sent += partial.present_column_count() as u64;
+
+                // Estimate bytes for full row vs partial update
+                let full_row_bytes: u64 = new_row
+                    .iter()
+                    .map(|v| v.as_ref().map(|b| b.len() as u64).unwrap_or(0) + 4) // value + length prefix
+                    .sum();
+                let partial_bytes: u64 = partial
+                    .values
+                    .iter()
+                    .map(|v| v.as_ref().map(|b| b.len() as u64).unwrap_or(0) + 4)
+                    .sum::<u64>()
+                    + partial.column_mask.len() as u64
+                    + 2; // mask + total_columns header
+
+                total_bytes_full += full_row_bytes;
+                total_bytes_partial += partial_bytes;
+            }
+
+            // Record column efficiency metrics
+            let total_possible = total_columns * partial_updates.len() as u64;
+            metrics.record_selective_update_columns(total_columns_sent, total_possible);
+
+            // Record bytes saved
+            if total_bytes_full > total_bytes_partial {
+                metrics.record_partial_update_bytes_saved(total_bytes_full - total_bytes_partial);
+            }
         }
 
         // Send the partial updates
@@ -1540,20 +1611,6 @@ impl ConnectionHandler {
             message: message.to_string(),
         }
         .encode(&mut self.write_buf);
-        self.flush_write_buffer().await
-    }
-
-    /// Send subscription partial data (0xF7) for selective column updates
-    ///
-    /// This is more bandwidth-efficient than sending full rows when only
-    /// a few columns have changed.
-    async fn send_subscription_partial_data(
-        &mut self,
-        subscription_id: &[u8; 16],
-        rows: Vec<crate::protocol::messages::PartialRowUpdate>,
-    ) -> Result<()> {
-        BackendMessage::SubscriptionPartialData { subscription_id: *subscription_id, rows }
-            .encode(&mut self.write_buf);
         self.flush_write_buffer().await
     }
 

--- a/crates/vibesql-server/src/observability/metrics.rs
+++ b/crates/vibesql-server/src/observability/metrics.rs
@@ -35,6 +35,13 @@ pub struct ServerMetrics {
     selective_update_changed_ratio: Histogram<f64>,
     subscriptions_selective_eligible: Gauge<u64>,
     subscriptions_selective_eligible_count: Arc<AtomicU64>,
+
+    // Partial update efficiency metrics
+    partial_update_fallbacks_total: Counter<u64>,
+    partial_update_bytes_saved: Histogram<u64>,
+    partial_update_efficiency: Gauge<f64>,
+    partial_update_efficiency_numerator: Arc<AtomicU64>,
+    partial_update_efficiency_denominator: Arc<AtomicU64>,
 }
 
 impl ServerMetrics {
@@ -135,6 +142,27 @@ impl ServerMetrics {
             .build();
         let subscriptions_selective_eligible_count = Arc::new(AtomicU64::new(0));
 
+        // Partial update efficiency metrics
+        let partial_update_fallbacks_total = meter
+            .u64_counter("vibesql_partial_update_fallbacks_total")
+            .with_description("Times partial update was skipped, by reason (threshold_exceeded, disabled, row_count_mismatch, pk_mismatch, no_changes)")
+            .with_unit("{fallback}")
+            .build();
+
+        let partial_update_bytes_saved = meter
+            .u64_histogram("vibesql_partial_update_bytes_saved")
+            .with_description("Estimated bytes saved per partial update compared to full row update")
+            .with_unit("By")
+            .build();
+
+        let partial_update_efficiency = meter
+            .f64_gauge("vibesql_partial_update_efficiency")
+            .with_description("Rolling average of column efficiency (columns_sent / total_columns) for partial updates")
+            .with_unit("1")
+            .build();
+        let partial_update_efficiency_numerator = Arc::new(AtomicU64::new(0));
+        let partial_update_efficiency_denominator = Arc::new(AtomicU64::new(0));
+
         Self {
             connections_total,
             connection_errors_total,
@@ -152,6 +180,11 @@ impl ServerMetrics {
             selective_update_changed_ratio,
             subscriptions_selective_eligible,
             subscriptions_selective_eligible_count,
+            partial_update_fallbacks_total,
+            partial_update_bytes_saved,
+            partial_update_efficiency,
+            partial_update_efficiency_numerator,
+            partial_update_efficiency_denominator,
         }
     }
 
@@ -251,20 +284,6 @@ impl ServerMetrics {
         );
     }
 
-    /// Record selective update column statistics
-    ///
-    /// # Arguments
-    /// * `columns_sent` - Number of columns included in the selective update
-    /// * `total_columns` - Total number of columns in the full row
-    pub fn record_selective_update_columns(&self, columns_sent: u64, total_columns: u64) {
-        self.selective_update_columns_sent.record(columns_sent, &[]);
-
-        if total_columns > 0 {
-            let ratio = columns_sent as f64 / total_columns as f64;
-            self.selective_update_changed_ratio.record(ratio, &[]);
-        }
-    }
-
     /// Increment the count of selective-eligible subscriptions
     ///
     /// Called when a subscription is registered with successfully detected PK columns.
@@ -284,6 +303,68 @@ impl ServerMetrics {
     /// Get the current count of selective-eligible subscriptions
     pub fn selective_eligible_count(&self) -> u64 {
         self.subscriptions_selective_eligible_count.load(Ordering::Relaxed)
+    }
+
+    // Partial update efficiency metrics methods
+
+    /// Record a partial update fallback (when partial update was skipped)
+    ///
+    /// # Arguments
+    /// * `reason` - The reason for fallback: "threshold_exceeded", "disabled",
+    ///              "row_count_mismatch", "pk_mismatch", "no_changes"
+    pub fn record_partial_update_fallback(&self, reason: &str) {
+        self.partial_update_fallbacks_total
+            .add(1, &[KeyValue::new("reason", reason.to_string())]);
+    }
+
+    /// Record bytes saved by a partial update compared to full row update
+    ///
+    /// # Arguments
+    /// * `bytes_saved` - Estimated bytes saved (full_row_size - partial_update_size)
+    pub fn record_partial_update_bytes_saved(&self, bytes_saved: u64) {
+        self.partial_update_bytes_saved.record(bytes_saved, &[]);
+    }
+
+    /// Record selective update columns and update efficiency gauge
+    ///
+    /// This method records both the column-level statistics and updates
+    /// the rolling efficiency gauge.
+    ///
+    /// # Arguments
+    /// * `columns_sent` - Number of columns included in the selective update
+    /// * `total_columns` - Total number of columns in the full row
+    pub fn record_selective_update_columns(&self, columns_sent: u64, total_columns: u64) {
+        self.selective_update_columns_sent.record(columns_sent, &[]);
+
+        if total_columns > 0 {
+            let ratio = columns_sent as f64 / total_columns as f64;
+            self.selective_update_changed_ratio.record(ratio, &[]);
+
+            // Update rolling efficiency (columns saved ratio = 1 - columns_sent/total)
+            // We track cumulative columns_sent and total_columns to compute average
+            self.partial_update_efficiency_numerator.fetch_add(columns_sent, Ordering::Relaxed);
+            self.partial_update_efficiency_denominator.fetch_add(total_columns, Ordering::Relaxed);
+
+            // Compute and record rolling average efficiency
+            let total_sent = self.partial_update_efficiency_numerator.load(Ordering::Relaxed);
+            let total_possible = self.partial_update_efficiency_denominator.load(Ordering::Relaxed);
+            if total_possible > 0 {
+                // Efficiency = ratio of columns NOT sent (i.e., bandwidth saved)
+                let efficiency = 1.0 - (total_sent as f64 / total_possible as f64);
+                self.partial_update_efficiency.record(efficiency, &[]);
+            }
+        }
+    }
+
+    /// Get the current partial update efficiency (columns saved ratio)
+    pub fn partial_update_efficiency(&self) -> f64 {
+        let total_sent = self.partial_update_efficiency_numerator.load(Ordering::Relaxed);
+        let total_possible = self.partial_update_efficiency_denominator.load(Ordering::Relaxed);
+        if total_possible > 0 {
+            1.0 - (total_sent as f64 / total_possible as f64)
+        } else {
+            0.0
+        }
     }
 }
 
@@ -337,5 +418,70 @@ mod tests {
         metrics2.increment_selective_eligible();
         assert_eq!(metrics1.selective_eligible_count(), 2);
         assert_eq!(metrics2.selective_eligible_count(), 2);
+    }
+
+    #[test]
+    fn test_partial_update_efficiency_calculation() {
+        let metrics = create_test_metrics();
+
+        // Initially zero efficiency (no data)
+        assert_eq!(metrics.partial_update_efficiency(), 0.0);
+
+        // Record some selective update columns
+        // 3 columns sent out of 10 total = 70% efficiency (columns saved)
+        metrics.record_selective_update_columns(3, 10);
+        let efficiency = metrics.partial_update_efficiency();
+        assert!((efficiency - 0.7).abs() < 0.001, "Expected ~0.7, got {}", efficiency);
+
+        // Record more: 5 columns sent out of 10 total
+        // Cumulative: 8 sent out of 20 = 60% efficiency
+        metrics.record_selective_update_columns(5, 10);
+        let efficiency = metrics.partial_update_efficiency();
+        assert!((efficiency - 0.6).abs() < 0.001, "Expected ~0.6, got {}", efficiency);
+    }
+
+    #[test]
+    fn test_partial_update_efficiency_shared_across_clones() {
+        let metrics1 = create_test_metrics();
+
+        // Record on first instance
+        metrics1.record_selective_update_columns(2, 10);
+        let eff1 = metrics1.partial_update_efficiency();
+
+        // Clone and verify shared state
+        let metrics2 = metrics1.clone();
+        let eff2 = metrics2.partial_update_efficiency();
+        assert!((eff1 - eff2).abs() < 0.001, "Clones should share efficiency state");
+
+        // Record on clone, both should see updated value
+        metrics2.record_selective_update_columns(2, 10);
+        // Cumulative: 4 sent out of 20 = 80% efficiency
+        let eff_after = metrics1.partial_update_efficiency();
+        assert!((eff_after - 0.8).abs() < 0.001, "Expected ~0.8, got {}", eff_after);
+    }
+
+    #[test]
+    fn test_partial_update_fallback_recording() {
+        // This test verifies the method exists and can be called without panicking.
+        // The actual counter value is tracked in OpenTelemetry and harder to verify.
+        let metrics = create_test_metrics();
+
+        // Should not panic when recording various fallback reasons
+        metrics.record_partial_update_fallback("disabled");
+        metrics.record_partial_update_fallback("threshold_exceeded");
+        metrics.record_partial_update_fallback("row_count_mismatch");
+        metrics.record_partial_update_fallback("pk_mismatch");
+        metrics.record_partial_update_fallback("no_changes");
+    }
+
+    #[test]
+    fn test_partial_update_bytes_saved_recording() {
+        // This test verifies the method exists and can be called without panicking.
+        let metrics = create_test_metrics();
+
+        // Should not panic when recording bytes saved
+        metrics.record_partial_update_bytes_saved(100);
+        metrics.record_partial_update_bytes_saved(500);
+        metrics.record_partial_update_bytes_saved(0);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `vibesql_partial_update_fallbacks_total` counter tracking when partial updates are skipped, with reason labels (disabled, threshold_exceeded, row_count_mismatch, pk_mismatch, no_changes)
- Adds `vibesql_partial_update_bytes_saved` histogram estimating bytes saved by partial updates vs full row updates
- Adds `vibesql_partial_update_efficiency` gauge showing rolling average of column efficiency (ratio of columns NOT sent)
- Wires up metrics recording in connection handler's `try_send_selective_updates()` method

## Test plan
- [x] All existing metrics tests pass
- [x] New tests verify efficiency calculation and metric recording
- [x] `cargo check -p vibesql-server` compiles successfully

Closes #3937

🤖 Generated with [Claude Code](https://claude.com/claude-code)