### PR TITLE
feat(server): Add partial event type for SSE selective column updates

### DIFF
--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -881,6 +881,34 @@ async fn subscribe_stream(
                         Event::default().event("delta").data(event_data)
                     );
                 }
+                SubscriptionUpdate::Partial { updates, .. } => {
+                    // Send partial updates (only changed columns + PK columns)
+                    let partial_updates: Vec<serde_json::Value> = updates
+                        .iter()
+                        .map(|partial| {
+                            json!({
+                                "columns": partial.column_indices,
+                                "old": partial.old_values.iter().map(super::types::sql_value_to_json).collect::<Vec<_>>(),
+                                "new": partial.new_values.iter().map(super::types::sql_value_to_json).collect::<Vec<_>>(),
+                            })
+                        })
+                        .collect();
+
+                    let event_data = match serde_json::to_string(&json!({
+                        "type": "partial",
+                        "updates": partial_updates,
+                    })) {
+                        Ok(data) => data,
+                        Err(e) => {
+                            error!("Failed to serialize partial event: {}", e);
+                            continue;
+                        }
+                    };
+
+                    yield Ok::<_, Box<dyn std::error::Error + Send + Sync>>(
+                        Event::default().event("partial").data(event_data)
+                    );
+                }
                 SubscriptionUpdate::Error { message, .. } => {
                     let event_data = match serde_json::to_string(&SseEvent {
                         event_type: "error".to_string(),

--- a/crates/vibesql-server/src/subscription/manager.rs
+++ b/crates/vibesql-server/src/subscription/manager.rs
@@ -15,8 +15,8 @@ use vibesql_storage::change_events::RecvError;
 use vibesql_storage::Database;
 
 use super::{
-    classify_error_str, compute_delta_with_pk, extract_table_refs, hash_rows, Subscription,
-    SubscriptionConfig, SubscriptionError, SubscriptionErrorKind, SubscriptionId,
+    classify_error_str, compute_delta_with_pk, extract_table_refs, hash_rows, PartialRowDelta,
+    Subscription, SubscriptionConfig, SubscriptionError, SubscriptionErrorKind, SubscriptionId,
     SubscriptionUpdate,
 };
 
@@ -746,7 +746,7 @@ impl SubscriptionManager {
                             "Results changed, notifying subscriber"
                         );
 
-                        // Determine whether to send Delta or Full update
+                        // Determine whether to send Delta, Partial, or Full update
                         let update = if let Some(ref old_rows) = subscription.last_result {
                             // We have previous results - compute delta using PK columns
                             if let Some(delta) = compute_delta_with_pk(
@@ -755,7 +755,11 @@ impl SubscriptionManager {
                                 &result_rows,
                                 &subscription.pk_columns,
                             ) {
-                                // Log delta statistics
+                                // Check if we can use Partial updates (selective column updates)
+                                // Conditions:
+                                // 1. Subscription is selective_eligible (confident PK detection)
+                                // 2. Delta has only updates (no inserts or deletes)
+                                // 3. Updates exist
                                 if let SubscriptionUpdate::Delta {
                                     ref inserts,
                                     ref updates,
@@ -763,15 +767,57 @@ impl SubscriptionManager {
                                     ..
                                 } = delta
                                 {
-                                    debug!(
-                                        subscription_id = %id,
-                                        inserts = inserts.len(),
-                                        updates = updates.len(),
-                                        deletes = deletes.len(),
-                                        "Sending delta update"
-                                    );
+                                    if subscription.selective_eligible
+                                        && inserts.is_empty()
+                                        && deletes.is_empty()
+                                        && !updates.is_empty()
+                                    {
+                                        // Convert to Partial updates
+                                        let partial_updates: Vec<PartialRowDelta> = updates
+                                            .iter()
+                                            .filter_map(|(old_row, new_row)| {
+                                                PartialRowDelta::from_rows(
+                                                    old_row,
+                                                    new_row,
+                                                    &subscription.pk_columns,
+                                                )
+                                            })
+                                            .collect();
+
+                                        if !partial_updates.is_empty() {
+                                            debug!(
+                                                subscription_id = %id,
+                                                partial_updates = partial_updates.len(),
+                                                "Sending partial update (selective columns)"
+                                            );
+                                            SubscriptionUpdate::Partial {
+                                                subscription_id: id,
+                                                updates: partial_updates,
+                                            }
+                                        } else {
+                                            // Fall back to delta if partial conversion failed
+                                            debug!(
+                                                subscription_id = %id,
+                                                updates = updates.len(),
+                                                "Sending delta update (partial conversion failed)"
+                                            );
+                                            delta
+                                        }
+                                    } else {
+                                        // Log delta statistics and send as-is
+                                        debug!(
+                                            subscription_id = %id,
+                                            inserts = inserts.len(),
+                                            updates = updates.len(),
+                                            deletes = deletes.len(),
+                                            selective_eligible = subscription.selective_eligible,
+                                            "Sending delta update"
+                                        );
+                                        delta
+                                    }
+                                } else {
+                                    delta
                                 }
-                                delta
                             } else {
                                 // No delta (shouldn't happen if hash changed, but be safe)
                                 SubscriptionUpdate::Full { subscription_id: id, rows: result_rows.clone() }

--- a/crates/vibesql-server/src/subscription/mod.rs
+++ b/crates/vibesql-server/src/subscription/mod.rs
@@ -492,6 +492,79 @@ impl Subscription {
 }
 
 // ============================================================================
+// Partial Row Delta (for selective column updates)
+// ============================================================================
+
+/// A partial row update containing only changed columns plus primary key columns
+///
+/// Used for efficient updates when only a subset of columns have changed.
+/// The `column_indices` field indicates which columns are present in `values`.
+#[derive(Debug, Clone)]
+pub struct PartialRowDelta {
+    /// Indices of columns that are included in this partial update
+    /// (primary key columns + changed columns, sorted)
+    pub column_indices: Vec<usize>,
+    /// Old values for the included columns
+    pub old_values: Vec<vibesql_types::SqlValue>,
+    /// New values for the included columns
+    pub new_values: Vec<vibesql_types::SqlValue>,
+}
+
+impl PartialRowDelta {
+    /// Create a new partial row delta from old and new rows
+    ///
+    /// # Arguments
+    /// * `old_row` - The previous row values
+    /// * `new_row` - The current row values
+    /// * `pk_columns` - Primary key column indices (always included)
+    ///
+    /// # Returns
+    /// * `Some(PartialRowDelta)` if the rows differ
+    /// * `None` if the rows are identical
+    pub fn from_rows(
+        old_row: &crate::Row,
+        new_row: &crate::Row,
+        pk_columns: &[usize],
+    ) -> Option<Self> {
+        if old_row.values.len() != new_row.values.len() {
+            return None;
+        }
+
+        // Find changed columns
+        let mut changed_columns = Vec::new();
+        for (idx, (old_val, new_val)) in
+            old_row.values.iter().zip(new_row.values.iter()).enumerate()
+        {
+            if old_val != new_val {
+                changed_columns.push(idx);
+            }
+        }
+
+        // If no columns changed, return None
+        if changed_columns.is_empty() {
+            return None;
+        }
+
+        // Build included columns: PK columns + changed columns, sorted
+        let mut column_indices: Vec<usize> = pk_columns.to_vec();
+        for &idx in &changed_columns {
+            if !column_indices.contains(&idx) {
+                column_indices.push(idx);
+            }
+        }
+        column_indices.sort_unstable();
+
+        // Extract values for included columns
+        let old_values: Vec<vibesql_types::SqlValue> =
+            column_indices.iter().map(|&idx| old_row.values[idx].clone()).collect();
+        let new_values: Vec<vibesql_types::SqlValue> =
+            column_indices.iter().map(|&idx| new_row.values[idx].clone()).collect();
+
+        Some(Self { column_indices, old_values, new_values })
+    }
+}
+
+// ============================================================================
 // Subscription Update
 // ============================================================================
 
@@ -539,6 +612,21 @@ pub enum SubscriptionUpdate {
         /// Error message describing what went wrong
         message: String,
     },
+
+    /// Partial row updates (selective column updates)
+    ///
+    /// Sent when a subscription is eligible for selective column updates and
+    /// only a subset of columns have changed. Contains only the changed columns
+    /// plus the primary key columns, reducing bandwidth for wide tables.
+    ///
+    /// This is more efficient than Delta for tables with many columns where
+    /// only a few columns change at a time.
+    Partial {
+        /// The subscription ID this update is for
+        subscription_id: SubscriptionId,
+        /// Partial row updates, each containing only changed columns + PK columns
+        updates: Vec<PartialRowDelta>,
+    },
 }
 
 impl SubscriptionUpdate {
@@ -548,6 +636,7 @@ impl SubscriptionUpdate {
             SubscriptionUpdate::Full { subscription_id, .. } => *subscription_id,
             SubscriptionUpdate::Delta { subscription_id, .. } => *subscription_id,
             SubscriptionUpdate::Error { subscription_id, .. } => *subscription_id,
+            SubscriptionUpdate::Partial { subscription_id, .. } => *subscription_id,
         }
     }
 }
@@ -2222,5 +2311,218 @@ mod tests {
         assert_eq!(partial.values.len(), 2);
         assert_eq!(partial.values[0], Some(b"1".to_vec()));
         assert_eq!(partial.values[1], Some(b"Alice".to_vec())); // Changed from NULL
+    }
+
+    // ========================================================================
+    // Tests for PartialRowDelta
+    // ========================================================================
+
+    #[test]
+    fn test_partial_row_delta_from_rows_single_column_change() {
+        use vibesql_types::SqlValue;
+
+        let old_row = crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Alice".to_string()),
+                SqlValue::Integer(100),
+            ],
+        };
+        let new_row = crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Alice".to_string()),
+                SqlValue::Integer(150),
+            ],
+        };
+
+        let pk_columns = vec![0];
+        let delta = PartialRowDelta::from_rows(&old_row, &new_row, &pk_columns);
+
+        assert!(delta.is_some());
+        let delta = delta.unwrap();
+
+        // Should include PK (0) + changed column (2)
+        assert_eq!(delta.column_indices, vec![0, 2]);
+        assert_eq!(delta.old_values, vec![SqlValue::Integer(1), SqlValue::Integer(100)]);
+        assert_eq!(delta.new_values, vec![SqlValue::Integer(1), SqlValue::Integer(150)]);
+    }
+
+    #[test]
+    fn test_partial_row_delta_from_rows_multiple_column_changes() {
+        use vibesql_types::SqlValue;
+
+        let old_row = crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Alice".to_string()),
+                SqlValue::Integer(100),
+                SqlValue::Varchar("active".to_string()),
+            ],
+        };
+        let new_row = crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Bob".to_string()),
+                SqlValue::Integer(100),
+                SqlValue::Varchar("inactive".to_string()),
+            ],
+        };
+
+        let pk_columns = vec![0];
+        let delta = PartialRowDelta::from_rows(&old_row, &new_row, &pk_columns);
+
+        assert!(delta.is_some());
+        let delta = delta.unwrap();
+
+        // Should include PK (0) + changed columns (1, 3)
+        assert_eq!(delta.column_indices, vec![0, 1, 3]);
+        assert_eq!(
+            delta.old_values,
+            vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Alice".to_string()),
+                SqlValue::Varchar("active".to_string())
+            ]
+        );
+        assert_eq!(
+            delta.new_values,
+            vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Bob".to_string()),
+                SqlValue::Varchar("inactive".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_partial_row_delta_from_rows_no_changes() {
+        use vibesql_types::SqlValue;
+
+        let row = crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+        };
+
+        let pk_columns = vec![0];
+        let delta = PartialRowDelta::from_rows(&row, &row, &pk_columns);
+
+        assert!(delta.is_none(), "Should return None when rows are identical");
+    }
+
+    #[test]
+    fn test_partial_row_delta_from_rows_pk_column_changed() {
+        use vibesql_types::SqlValue;
+
+        let old_row = crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+        };
+        let new_row = crate::Row {
+            values: vec![SqlValue::Integer(2), SqlValue::Varchar("Alice".to_string())],
+        };
+
+        let pk_columns = vec![0];
+        let delta = PartialRowDelta::from_rows(&old_row, &new_row, &pk_columns);
+
+        assert!(delta.is_some());
+        let delta = delta.unwrap();
+
+        // PK column changed, should only include column 0
+        assert_eq!(delta.column_indices, vec![0]);
+        assert_eq!(delta.old_values, vec![SqlValue::Integer(1)]);
+        assert_eq!(delta.new_values, vec![SqlValue::Integer(2)]);
+    }
+
+    #[test]
+    fn test_partial_row_delta_from_rows_null_handling() {
+        use vibesql_types::SqlValue;
+
+        let old_row = crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+        };
+        let new_row = crate::Row { values: vec![SqlValue::Integer(1), SqlValue::Null] };
+
+        let pk_columns = vec![0];
+        let delta = PartialRowDelta::from_rows(&old_row, &new_row, &pk_columns);
+
+        assert!(delta.is_some());
+        let delta = delta.unwrap();
+
+        // Should include PK (0) + changed column (1)
+        assert_eq!(delta.column_indices, vec![0, 1]);
+        assert_eq!(delta.new_values, vec![SqlValue::Integer(1), SqlValue::Null]);
+    }
+
+    #[test]
+    fn test_partial_row_delta_from_rows_composite_pk() {
+        use vibesql_types::SqlValue;
+
+        let old_row = crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Integer(100),
+                SqlValue::Varchar("old".to_string()),
+            ],
+        };
+        let new_row = crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Integer(100),
+                SqlValue::Varchar("new".to_string()),
+            ],
+        };
+
+        let pk_columns = vec![0, 1]; // Composite PK
+        let delta = PartialRowDelta::from_rows(&old_row, &new_row, &pk_columns);
+
+        assert!(delta.is_some());
+        let delta = delta.unwrap();
+
+        // Should include PK columns (0, 1) + changed column (2)
+        assert_eq!(delta.column_indices, vec![0, 1, 2]);
+        assert_eq!(
+            delta.old_values,
+            vec![
+                SqlValue::Integer(1),
+                SqlValue::Integer(100),
+                SqlValue::Varchar("old".to_string())
+            ]
+        );
+        assert_eq!(
+            delta.new_values,
+            vec![
+                SqlValue::Integer(1),
+                SqlValue::Integer(100),
+                SqlValue::Varchar("new".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_partial_row_delta_from_rows_different_column_count() {
+        use vibesql_types::SqlValue;
+
+        let old_row = crate::Row {
+            values: vec![SqlValue::Integer(1), SqlValue::Varchar("Alice".to_string())],
+        };
+        let new_row = crate::Row {
+            values: vec![
+                SqlValue::Integer(1),
+                SqlValue::Varchar("Alice".to_string()),
+                SqlValue::Integer(100),
+            ],
+        };
+
+        let pk_columns = vec![0];
+        let delta = PartialRowDelta::from_rows(&old_row, &new_row, &pk_columns);
+
+        assert!(delta.is_none(), "Should return None when column counts differ");
+    }
+
+    #[test]
+    fn test_subscription_update_partial_subscription_id() {
+        let test_id = SubscriptionId::new();
+        let update = SubscriptionUpdate::Partial { subscription_id: test_id, updates: vec![] };
+
+        assert_eq!(update.subscription_id(), test_id);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `SubscriptionUpdate::Partial` variant for efficient selective column updates in SSE subscriptions
- Introduces `PartialRowDelta` struct to hold only changed columns + PK columns
- Updates subscription manager to emit Partial updates for selective-eligible subscriptions when only row updates occur (no inserts/deletes)
- Adds "partial" event type to SSE response stream with efficient JSON format

## Implementation

When a subscription is marked as `selective_eligible` (confident PK detection) and a Delta update contains only updates (no inserts/deletes), the manager now converts the updates to `SubscriptionUpdate::Partial` format. This sends only the changed columns plus primary key columns, reducing bandwidth for wide tables.

### SSE Event Format

```json
{
  "type": "partial",
  "updates": [
    {
      "columns": [0, 2],       // PK column (0) + changed column (2)
      "old": [1, 100],         // Previous values for included columns
      "new": [1, 150]          // New values for included columns
    }
  ]
}
```

### Changes

- `crates/vibesql-server/src/subscription/mod.rs`: Add `PartialRowDelta` struct and `SubscriptionUpdate::Partial` variant
- `crates/vibesql-server/src/subscription/manager.rs`: Emit Partial updates for selective-eligible subscriptions
- `crates/vibesql-server/src/http/rest.rs`: Handle Partial events in SSE response stream
- `crates/vibesql-server/src/connection.rs`: Remove duplicate function definition

## Test plan

- [ ] Run `cargo test -p vibesql-server -- partial` to verify all partial update tests pass
- [ ] Verify selective-eligible subscriptions emit partial updates on column changes
- [ ] Verify subscriptions with inserts/deletes still emit delta updates
- [ ] Verify non-selective-eligible subscriptions still emit delta updates

Closes #3940

🤖 Generated with [Claude Code](https://claude.com/claude-code)