### PR TITLE
docs: Document partial update efficiency metrics

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -1,0 +1,248 @@
+# VibeSQL Server Metrics
+
+VibeSQL exposes Prometheus-compatible metrics via OpenTelemetry for monitoring server health, query performance, and subscription efficiency.
+
+## Metrics Reference
+
+### Connection Metrics
+
+| Metric | Type | Unit | Labels | Description |
+|--------|------|------|--------|-------------|
+| `vibesql_server_connections_total` | Counter | connection | - | Total connections accepted |
+| `vibesql_server_connection_errors_total` | Counter | error | `error_type` | Connection failures by error type |
+| `vibesql_server_connection_duration_seconds` | Histogram | seconds | - | Connection lifetime distribution |
+
+### Query Metrics
+
+| Metric | Type | Unit | Labels | Description |
+|--------|------|------|--------|-------------|
+| `vibesql_server_queries_total` | Counter | query | `statement_type`, `success` | Queries executed by statement type |
+| `vibesql_server_query_duration_seconds` | Histogram | seconds | `statement_type`, `success` | Query execution latency |
+| `vibesql_server_query_errors_total` | Counter | error | `error_type`, `statement_type` | Query errors by error type |
+| `vibesql_server_query_rows_affected` | Histogram | row | `statement_type`, `success` | Rows affected distribution |
+
+### Protocol Metrics
+
+| Metric | Type | Unit | Labels | Description |
+|--------|------|------|--------|-------------|
+| `vibesql_server_messages_received_total` | Counter | message | `message_type` | PostgreSQL protocol messages received |
+| `vibesql_server_messages_sent_total` | Counter | message | `message_type` | PostgreSQL protocol messages sent |
+| `vibesql_server_bytes_received_total` | Counter | bytes | - | Total bytes received |
+| `vibesql_server_bytes_sent_total` | Counter | bytes | - | Total bytes sent |
+
+### Subscription Metrics
+
+| Metric | Type | Unit | Labels | Description |
+|--------|------|------|--------|-------------|
+| `vibesql_subscription_updates_total` | Counter | update | `type`, `row_count` | Subscription updates sent by type |
+| `vibesql_selective_update_columns_sent` | Histogram | column | - | Number of columns sent in selective updates |
+| `vibesql_selective_update_changed_ratio` | Histogram | ratio (0-1) | - | Ratio of changed columns to total columns |
+| `vibesql_subscriptions_selective_eligible` | Gauge | subscription | - | Active subscriptions eligible for selective updates |
+
+**Subscription Update Types** (`type` label values):
+- `full` - Complete result set refresh
+- `delta_insert` - New rows added
+- `delta_update` - Existing rows modified
+- `delta_delete` - Rows removed
+- `selective` - Partial column update (only changed columns sent)
+
+### Partial Update Efficiency Metrics
+
+These metrics track the effectiveness of partial/selective updates, which reduce bandwidth by only sending changed columns.
+
+| Metric | Type | Unit | Labels | Description |
+|--------|------|------|--------|-------------|
+| `vibesql_partial_update_fallbacks_total` | Counter | fallback | `reason` | Times partial update was skipped |
+| `vibesql_partial_update_bytes_saved` | Histogram | bytes | - | Estimated bytes saved per partial update |
+| `vibesql_partial_update_efficiency` | Gauge | ratio (0-1) | - | Rolling average of column efficiency |
+
+**Fallback Reasons** (`reason` label values):
+- `disabled` - Selective updates disabled in configuration
+- `threshold_exceeded` - Too many columns changed (exceeded threshold)
+- `row_count_mismatch` - Old and new row counts differ
+- `pk_mismatch` - Cannot find matching old row by primary key
+- `no_changes` - No column changes detected
+
+## Understanding Partial Update Efficiency
+
+The partial update system optimizes bandwidth for subscriptions by only sending columns that have changed, rather than full rows.
+
+**Efficiency Calculation:**
+```
+efficiency = 1 - (columns_sent / total_columns)
+```
+
+- **1.0 (100%)** - No columns sent (all unchanged)
+- **0.7 (70%)** - Only 30% of columns sent
+- **0.0 (0%)** - All columns sent (full row update)
+
+Higher efficiency means more bandwidth saved.
+
+## PromQL Examples
+
+### Query Performance
+
+```promql
+# Average query latency by statement type (last 5 minutes)
+rate(vibesql_server_query_duration_seconds_sum[5m])
+  / rate(vibesql_server_query_duration_seconds_count[5m])
+
+# Query error rate
+sum(rate(vibesql_server_query_errors_total[5m]))
+  / sum(rate(vibesql_server_queries_total[5m])) * 100
+
+# 95th percentile query latency
+histogram_quantile(0.95,
+  sum(rate(vibesql_server_query_duration_seconds_bucket[5m])) by (le))
+```
+
+### Connection Health
+
+```promql
+# Active connections (approximation based on connection rate and duration)
+rate(vibesql_server_connections_total[5m])
+  * avg(vibesql_server_connection_duration_seconds)
+
+# Connection error rate
+rate(vibesql_server_connection_errors_total[5m])
+  / rate(vibesql_server_connections_total[5m]) * 100
+```
+
+### Subscription Efficiency
+
+```promql
+# Partial update efficiency (should be high, closer to 1.0 is better)
+vibesql_partial_update_efficiency
+
+# Fallback rate by reason (lower is better)
+sum by (reason) (rate(vibesql_partial_update_fallbacks_total[5m]))
+
+# Total fallback rate as percentage of selective-eligible subscriptions
+sum(rate(vibesql_partial_update_fallbacks_total[5m]))
+  / vibesql_subscriptions_selective_eligible * 100
+
+# Average bytes saved per partial update
+rate(vibesql_partial_update_bytes_saved_sum[5m])
+  / rate(vibesql_partial_update_bytes_saved_count[5m])
+
+# Subscription update breakdown by type
+sum by (type) (rate(vibesql_subscription_updates_total[5m]))
+
+# Selective update ratio (selective updates / total updates)
+sum(rate(vibesql_subscription_updates_total{type="selective"}[5m]))
+  / sum(rate(vibesql_subscription_updates_total[5m])) * 100
+```
+
+### Bandwidth Monitoring
+
+```promql
+# Network throughput
+rate(vibesql_server_bytes_sent_total[5m])
+rate(vibesql_server_bytes_received_total[5m])
+
+# Estimated bandwidth savings from partial updates (bytes/sec)
+rate(vibesql_partial_update_bytes_saved_sum[5m])
+```
+
+## Alerting Guidelines
+
+### Recommended Alerts
+
+#### High Query Error Rate
+```yaml
+alert: VibeSQL_HighQueryErrorRate
+expr: |
+  sum(rate(vibesql_server_query_errors_total[5m]))
+  / sum(rate(vibesql_server_queries_total[5m])) > 0.05
+for: 5m
+labels:
+  severity: warning
+annotations:
+  summary: "High query error rate (>5%)"
+```
+
+#### High Query Latency
+```yaml
+alert: VibeSQL_HighQueryLatency
+expr: |
+  histogram_quantile(0.95,
+    sum(rate(vibesql_server_query_duration_seconds_bucket[5m])) by (le)) > 1.0
+for: 5m
+labels:
+  severity: warning
+annotations:
+  summary: "95th percentile query latency exceeds 1 second"
+```
+
+#### Low Partial Update Efficiency
+```yaml
+alert: VibeSQL_LowPartialUpdateEfficiency
+expr: vibesql_partial_update_efficiency < 0.3
+for: 10m
+labels:
+  severity: info
+annotations:
+  summary: "Partial update efficiency below 30%"
+  description: "Most updates are sending majority of columns. Consider reviewing query patterns."
+```
+
+#### High Partial Update Fallback Rate
+```yaml
+alert: VibeSQL_HighPartialUpdateFallbacks
+expr: |
+  sum(rate(vibesql_partial_update_fallbacks_total[5m]))
+  / (vibesql_subscriptions_selective_eligible + 1) > 0.5
+for: 5m
+labels:
+  severity: warning
+annotations:
+  summary: "High partial update fallback rate"
+  description: "More than 50% of updates falling back to full updates. Check reason label for cause."
+```
+
+#### No Selective-Eligible Subscriptions
+```yaml
+alert: VibeSQL_NoSelectiveEligibleSubscriptions
+expr: vibesql_subscriptions_selective_eligible == 0
+for: 15m
+labels:
+  severity: info
+annotations:
+  summary: "No subscriptions eligible for selective updates"
+  description: "Ensure tables have primary keys defined for selective update eligibility."
+```
+
+### Suggested Thresholds
+
+| Metric | Warning | Critical | Notes |
+|--------|---------|----------|-------|
+| Query error rate | >5% | >20% | Investigate error types |
+| P95 query latency | >1s | >5s | Check slow queries |
+| Connection error rate | >1% | >10% | Check server resources |
+| Partial update efficiency | <0.3 | <0.1 | Review update patterns |
+| Fallback rate (per eligible) | >0.5/s | >2.0/s | Check fallback reasons |
+
+## Grafana Dashboard
+
+Example dashboard panels for VibeSQL monitoring:
+
+1. **Overview Row**
+   - Total queries/sec (counter)
+   - Active connections (gauge)
+   - Error rate (percentage)
+
+2. **Query Performance Row**
+   - Query latency heatmap
+   - Queries by statement type
+   - Error breakdown by type
+
+3. **Subscription Efficiency Row**
+   - Partial update efficiency gauge
+   - Update type distribution pie chart
+   - Fallback reasons over time
+   - Bytes saved rate
+
+4. **Network Row**
+   - Bytes sent/received
+   - Messages by type
+   - Bandwidth savings from partial updates


### PR DESCRIPTION
## Summary

- Add comprehensive observability metrics documentation at `docs/observability/metrics.md`
- Document all VibeSQL server metrics: connection, query, protocol, subscription, and partial update efficiency
- Include PromQL examples for common monitoring scenarios
- Add alerting guidelines with recommended thresholds

Closes #3956

## Test plan

- [x] All metric names in docs match `metrics.rs` exactly
- [x] PromQL examples are syntactically valid
- [ ] Documentation renders correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)