### PR TITLE
feat(subscription): Add debug logging for PK detection failures

### DIFF
--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -735,6 +735,10 @@ impl ConnectionHandler {
 
         // Check if selective updates are enabled in effective config
         if !selective_config.enabled {
+            debug!(
+                "Selective update skipped for subscription {:?}: disabled in config",
+                subscription_id
+            );
             if let Some(metrics) = self.observability.metrics() {
                 metrics.record_partial_update_fallback("disabled");
             }
@@ -743,6 +747,12 @@ impl ConnectionHandler {
 
         // Row counts must match for selective updates (no inserts/deletes)
         if old_rows.len() != new_rows.len() {
+            debug!(
+                "Selective update skipped for subscription {:?}: row count mismatch (old={}, new={})",
+                subscription_id,
+                old_rows.len(),
+                new_rows.len()
+            );
             if let Some(metrics) = self.observability.metrics() {
                 metrics.record_partial_update_fallback("row_count_mismatch");
             }
@@ -802,6 +812,11 @@ impl ConnectionHandler {
             } else {
                 // Can't find matching old row - this is an insert, not an update
                 // Fall back to regular updates
+                debug!(
+                    "Selective update skipped for subscription {:?}: cannot match row by PK (pk_columns={:?})",
+                    subscription_id,
+                    pk_columns
+                );
                 if let Some(metrics) = self.observability.metrics() {
                     metrics.record_partial_update_fallback("pk_mismatch");
                 }
@@ -811,6 +826,11 @@ impl ConnectionHandler {
 
         // Record threshold exceeded fallbacks if any
         if threshold_exceeded_count > 0 {
+            debug!(
+                "Selective update: {} rows exceeded change threshold for subscription {:?}",
+                threshold_exceeded_count,
+                subscription_id
+            );
             if let Some(metrics) = self.observability.metrics() {
                 for _ in 0..threshold_exceeded_count {
                     metrics.record_partial_update_fallback("threshold_exceeded");
@@ -820,6 +840,10 @@ impl ConnectionHandler {
 
         // If no partial updates were generated, nothing changed
         if partial_updates.is_empty() {
+            debug!(
+                "Selective update skipped for subscription {:?}: no column changes detected",
+                subscription_id
+            );
             if let Some(metrics) = self.observability.metrics() {
                 metrics.record_partial_update_fallback("no_changes");
             }
@@ -1010,10 +1034,21 @@ impl ConnectionHandler {
             let db = session.shared_database().read().await;
             detect_pk_columns_from_stmt(&parsed, &db)
         };
-        debug!(
-            "PK detection for subscription query: {:?} (confident: {})",
-            pk_detection.pk_column_indices, pk_detection.confident
-        );
+        if pk_detection.confident {
+            debug!(
+                "PK detection confident for subscription: pk_columns={:?}, tables={:?}",
+                pk_detection.pk_column_indices,
+                pk_detection.tables
+            );
+        } else {
+            debug!(
+                "PK detection not confident for subscription: reason={}, pk_columns={:?}, tables={:?}, query={}",
+                pk_detection.reason.map(|r| r.to_string()).unwrap_or_else(|| "unknown".to_string()),
+                pk_detection.pk_column_indices,
+                pk_detection.tables,
+                query
+            );
+        }
 
         // Generate a wire subscription ID (UUID) for the wire protocol
         let wire_subscription_id = *uuid::Uuid::new_v4().as_bytes();

--- a/crates/vibesql-server/src/subscription/mod.rs
+++ b/crates/vibesql-server/src/subscription/mod.rs
@@ -60,7 +60,9 @@ use tokio::sync::mpsc;
 
 pub use error::{classify_error, classify_error_str, SubscriptionErrorKind};
 pub use manager::SubscriptionManager;
-pub use pk_detector::{detect_pk_columns, detect_pk_columns_from_stmt, PkDetectionResult};
+pub use pk_detector::{
+    detect_pk_columns, detect_pk_columns_from_stmt, PkDetectionFailureReason, PkDetectionResult,
+};
 pub use router::{ChangeRouter, SubscriptionUpdate as RouterUpdate};
 pub use table_dependencies::extract_table_dependencies;
 pub use table_extract::extract_table_refs;

--- a/crates/vibesql-server/src/subscription/pk_detector.rs
+++ b/crates/vibesql-server/src/subscription/pk_detector.rs
@@ -20,6 +20,42 @@ use std::collections::HashSet;
 use vibesql_ast::{Expression, FromClause, SelectItem, SelectStmt, Statement};
 use vibesql_storage::Database;
 
+/// Reasons why PK detection was not confident
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PkDetectionFailureReason {
+    /// Query could not be parsed
+    ParseError,
+    /// Query has a set operation (UNION, INTERSECT, etc.)
+    SetOperation,
+    /// Query has no FROM clause
+    NoFromClause,
+    /// Query involves multiple tables (join)
+    MultipleTablesInQuery,
+    /// The referenced table was not found in the database
+    TableNotFound,
+    /// The table has no primary key defined
+    NoPrimaryKeyOnTable,
+    /// PK columns are not in the query's result set
+    PkColumnsNotInResultSet,
+    /// Query has a subquery in FROM clause
+    SubqueryInFrom,
+}
+
+impl std::fmt::Display for PkDetectionFailureReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ParseError => write!(f, "query parse error"),
+            Self::SetOperation => write!(f, "query contains set operation (UNION/INTERSECT/EXCEPT)"),
+            Self::NoFromClause => write!(f, "query has no FROM clause"),
+            Self::MultipleTablesInQuery => write!(f, "query involves multiple tables (join)"),
+            Self::TableNotFound => write!(f, "table not found in database"),
+            Self::NoPrimaryKeyOnTable => write!(f, "table has no primary key defined"),
+            Self::PkColumnsNotInResultSet => write!(f, "PK columns not present in SELECT list"),
+            Self::SubqueryInFrom => write!(f, "FROM clause contains subquery"),
+        }
+    }
+}
+
 /// Result of PK column detection
 #[derive(Debug, Clone)]
 pub struct PkDetectionResult {
@@ -29,6 +65,8 @@ pub struct PkDetectionResult {
     pub confident: bool,
     /// Tables involved in the query
     pub tables: HashSet<String>,
+    /// Reason for lack of confidence (set when confident is false)
+    pub reason: Option<PkDetectionFailureReason>,
 }
 
 impl Default for PkDetectionResult {
@@ -37,6 +75,29 @@ impl Default for PkDetectionResult {
             pk_column_indices: vec![0], // Default: assume first column is PK
             confident: false,
             tables: HashSet::new(),
+            reason: None,
+        }
+    }
+}
+
+impl PkDetectionResult {
+    /// Create a default result with a specific failure reason
+    fn with_reason(reason: PkDetectionFailureReason) -> Self {
+        Self {
+            pk_column_indices: vec![0],
+            confident: false,
+            tables: HashSet::new(),
+            reason: Some(reason),
+        }
+    }
+
+    /// Create a default result with a specific failure reason and tables
+    fn with_reason_and_tables(reason: PkDetectionFailureReason, tables: HashSet<String>) -> Self {
+        Self {
+            pk_column_indices: vec![0],
+            confident: false,
+            tables,
+            reason: Some(reason),
         }
     }
 }
@@ -53,7 +114,7 @@ pub fn detect_pk_columns(sql: &str, db: &Database) -> PkDetectionResult {
     // Parse the query
     let stmt = match vibesql_parser::Parser::parse_sql(sql) {
         Ok(stmt) => stmt,
-        Err(_) => return PkDetectionResult::default(),
+        Err(_) => return PkDetectionResult::with_reason(PkDetectionFailureReason::ParseError),
     };
 
     detect_pk_columns_from_stmt(&stmt, db)
@@ -71,13 +132,13 @@ pub fn detect_pk_columns_from_stmt(stmt: &Statement, db: &Database) -> PkDetecti
 fn detect_pk_from_select(select: &SelectStmt, db: &Database) -> PkDetectionResult {
     // Don't handle set operations (UNION, etc.) - too complex
     if select.set_operation.is_some() {
-        return PkDetectionResult::default();
+        return PkDetectionResult::with_reason(PkDetectionFailureReason::SetOperation);
     }
 
     // Extract the FROM clause
     let from = match &select.from {
         Some(from) => from,
-        None => return PkDetectionResult::default(),
+        None => return PkDetectionResult::with_reason(PkDetectionFailureReason::NoFromClause),
     };
 
     // Check if this is a simple single-table query
@@ -89,16 +150,29 @@ fn detect_pk_from_select(select: &SelectStmt, db: &Database) -> PkDetectionResul
         }
     };
 
+    let mut tables = HashSet::new();
+    tables.insert(table_name.clone());
+
     // Get the table schema
     let table = match db.get_table(&table_name) {
         Some(t) => t,
-        None => return PkDetectionResult::default(),
+        None => {
+            return PkDetectionResult::with_reason_and_tables(
+                PkDetectionFailureReason::TableNotFound,
+                tables,
+            );
+        }
     };
 
     // Get PK column indices from schema
     let pk_indices = match table.schema.get_primary_key_indices() {
         Some(indices) => indices,
-        None => return PkDetectionResult::default(),
+        None => {
+            return PkDetectionResult::with_reason_and_tables(
+                PkDetectionFailureReason::NoPrimaryKeyOnTable,
+                tables,
+            );
+        }
     };
 
     // Get PK column names
@@ -108,7 +182,10 @@ fn detect_pk_from_select(select: &SelectStmt, db: &Database) -> PkDetectionResul
         .collect();
 
     if pk_column_names.is_empty() {
-        return PkDetectionResult::default();
+        return PkDetectionResult::with_reason_and_tables(
+            PkDetectionFailureReason::NoPrimaryKeyOnTable,
+            tables,
+        );
     }
 
     // Map PK column names to result set positions
@@ -119,14 +196,21 @@ fn detect_pk_from_select(select: &SelectStmt, db: &Database) -> PkDetectionResul
         table_alias.as_deref(),
     );
 
-    let mut tables = HashSet::new();
-    tables.insert(table_name);
-
     if result_pk_indices.is_empty() {
         // PKs not in result set - use default
-        PkDetectionResult { pk_column_indices: vec![0], confident: false, tables }
+        PkDetectionResult {
+            pk_column_indices: vec![0],
+            confident: false,
+            tables,
+            reason: Some(PkDetectionFailureReason::PkColumnsNotInResultSet),
+        }
     } else {
-        PkDetectionResult { pk_column_indices: result_pk_indices, confident: true, tables }
+        PkDetectionResult {
+            pk_column_indices: result_pk_indices,
+            confident: true,
+            tables,
+            reason: None,
+        }
     }
 }
 
@@ -151,10 +235,15 @@ fn detect_pk_from_join(
     db: &Database,
 ) -> PkDetectionResult {
     // Collect all tables and their aliases
-    let tables_info = collect_join_tables(from);
+    let (tables_info, has_subquery) = collect_join_tables(from);
 
     if tables_info.is_empty() {
-        return PkDetectionResult::default();
+        let reason = if has_subquery {
+            PkDetectionFailureReason::SubqueryInFrom
+        } else {
+            PkDetectionFailureReason::MultipleTablesInQuery
+        };
+        return PkDetectionResult::with_reason(reason);
     }
 
     let mut tables = HashSet::new();
@@ -168,12 +257,26 @@ fn detect_pk_from_join(
 
     let table = match db.get_table(first_table) {
         Some(t) => t,
-        None => return PkDetectionResult { pk_column_indices: vec![0], confident: false, tables },
+        None => {
+            return PkDetectionResult {
+                pk_column_indices: vec![0],
+                confident: false,
+                tables,
+                reason: Some(PkDetectionFailureReason::TableNotFound),
+            };
+        }
     };
 
     let pk_indices = match table.schema.get_primary_key_indices() {
         Some(indices) => indices,
-        None => return PkDetectionResult { pk_column_indices: vec![0], confident: false, tables },
+        None => {
+            return PkDetectionResult {
+                pk_column_indices: vec![0],
+                confident: false,
+                tables,
+                reason: Some(PkDetectionFailureReason::NoPrimaryKeyOnTable),
+            };
+        }
     };
 
     let pk_column_names: Vec<String> = pk_indices
@@ -182,7 +285,12 @@ fn detect_pk_from_join(
         .collect();
 
     if pk_column_names.is_empty() {
-        return PkDetectionResult { pk_column_indices: vec![0], confident: false, tables };
+        return PkDetectionResult {
+            pk_column_indices: vec![0],
+            confident: false,
+            tables,
+            reason: Some(PkDetectionFailureReason::NoPrimaryKeyOnTable),
+        };
     }
 
     // Try to map with table alias for qualified references
@@ -194,31 +302,48 @@ fn detect_pk_from_join(
     );
 
     if result_pk_indices.is_empty() {
-        PkDetectionResult { pk_column_indices: vec![0], confident: false, tables }
+        PkDetectionResult {
+            pk_column_indices: vec![0],
+            confident: false,
+            tables,
+            reason: Some(PkDetectionFailureReason::PkColumnsNotInResultSet),
+        }
     } else {
         // Not fully confident for joins since we only handle first table
-        PkDetectionResult { pk_column_indices: result_pk_indices, confident: false, tables }
+        PkDetectionResult {
+            pk_column_indices: result_pk_indices,
+            confident: false,
+            tables,
+            reason: Some(PkDetectionFailureReason::MultipleTablesInQuery),
+        }
     }
 }
 
 /// Collect all tables from a JOIN clause
-fn collect_join_tables(from: &FromClause) -> Vec<(String, Option<String>)> {
+/// Returns (tables, has_subquery) tuple
+fn collect_join_tables(from: &FromClause) -> (Vec<(String, Option<String>)>, bool) {
     let mut tables = Vec::new();
-    collect_join_tables_recursive(from, &mut tables);
-    tables
+    let mut has_subquery = false;
+    collect_join_tables_recursive(from, &mut tables, &mut has_subquery);
+    (tables, has_subquery)
 }
 
-fn collect_join_tables_recursive(from: &FromClause, tables: &mut Vec<(String, Option<String>)>) {
+fn collect_join_tables_recursive(
+    from: &FromClause,
+    tables: &mut Vec<(String, Option<String>)>,
+    has_subquery: &mut bool,
+) {
     match from {
         FromClause::Table { name, alias, .. } => {
             tables.push((name.to_lowercase(), alias.clone()));
         }
         FromClause::Join { left, right, .. } => {
-            collect_join_tables_recursive(left, tables);
-            collect_join_tables_recursive(right, tables);
+            collect_join_tables_recursive(left, tables, has_subquery);
+            collect_join_tables_recursive(right, tables, has_subquery);
         }
         FromClause::Subquery { .. } => {
             // Can't easily extract table info from subqueries
+            *has_subquery = true;
         }
     }
 }
@@ -448,5 +573,89 @@ mod tests {
 
         assert!(result.confident);
         assert_eq!(result.pk_column_indices, vec![0]); // id (aliased as user_id) is first
+    }
+
+    // Tests for PkDetectionFailureReason
+    #[test]
+    fn test_reason_parse_error() {
+        let db = create_test_db();
+        let result = detect_pk_columns("INVALID SQL", &db);
+
+        assert!(!result.confident);
+        assert_eq!(result.reason, Some(PkDetectionFailureReason::ParseError));
+    }
+
+    #[test]
+    fn test_reason_table_not_found() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT * FROM nonexistent_table", &db);
+
+        assert!(!result.confident);
+        assert_eq!(result.reason, Some(PkDetectionFailureReason::TableNotFound));
+    }
+
+    #[test]
+    fn test_reason_pk_columns_not_in_result_set() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT name, email FROM users", &db);
+
+        assert!(!result.confident);
+        assert_eq!(result.reason, Some(PkDetectionFailureReason::PkColumnsNotInResultSet));
+    }
+
+    #[test]
+    fn test_reason_multiple_tables_in_query() {
+        let db = create_test_db();
+        let result = detect_pk_columns(
+            "SELECT u.id, o.order_id FROM users u JOIN orders o ON u.id = o.user_id",
+            &db,
+        );
+
+        assert!(!result.confident);
+        assert_eq!(result.reason, Some(PkDetectionFailureReason::MultipleTablesInQuery));
+    }
+
+    #[test]
+    fn test_reason_no_from_clause() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT 1 + 1", &db);
+
+        assert!(!result.confident);
+        assert_eq!(result.reason, Some(PkDetectionFailureReason::NoFromClause));
+    }
+
+    #[test]
+    fn test_reason_set_operation() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT id FROM users UNION SELECT order_id FROM orders", &db);
+
+        assert!(!result.confident);
+        assert_eq!(result.reason, Some(PkDetectionFailureReason::SetOperation));
+    }
+
+    #[test]
+    fn test_confident_query_has_no_reason() {
+        let db = create_test_db();
+        let result = detect_pk_columns("SELECT * FROM users", &db);
+
+        assert!(result.confident);
+        assert_eq!(result.reason, None);
+    }
+
+    #[test]
+    fn test_failure_reason_display() {
+        // Test Display implementation
+        assert_eq!(
+            PkDetectionFailureReason::ParseError.to_string(),
+            "query parse error"
+        );
+        assert_eq!(
+            PkDetectionFailureReason::TableNotFound.to_string(),
+            "table not found in database"
+        );
+        assert_eq!(
+            PkDetectionFailureReason::MultipleTablesInQuery.to_string(),
+            "query involves multiple tables (join)"
+        );
     }
 }

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -63,6 +63,39 @@ These metrics track the effectiveness of partial/selective updates, which reduce
 - `pk_mismatch` - Cannot find matching old row by primary key
 - `no_changes` - No column changes detected
 
+### Debug Logging for PK Detection
+
+When running with `RUST_LOG=debug` or `RUST_LOG=vibesql_server=debug`, additional debug messages are logged to help diagnose why subscriptions fall back to full updates instead of selective updates.
+
+**PK Detection Logs** (at subscription creation):
+```
+PK detection confident for subscription: pk_columns=[0], tables={"users"}
+PK detection not confident for subscription: reason=<reason>, pk_columns=[0], tables={"users"}, query=SELECT ...
+```
+
+**PK Detection Failure Reasons**:
+| Reason | Description |
+|--------|-------------|
+| `query parse error` | SQL query could not be parsed |
+| `query contains set operation (UNION/INTERSECT/EXCEPT)` | Query uses UNION, INTERSECT, or EXCEPT |
+| `query has no FROM clause` | Query does not reference any table |
+| `query involves multiple tables (join)` | Query joins multiple tables |
+| `table not found in database` | Referenced table does not exist |
+| `table has no primary key defined` | Table lacks a PRIMARY KEY constraint |
+| `PK columns not present in SELECT list` | Primary key columns not included in SELECT |
+| `FROM clause contains subquery` | Query uses a subquery in the FROM clause |
+
+**Selective Update Fallback Logs** (at update time):
+```
+Selective update skipped for subscription <id>: disabled in config
+Selective update skipped for subscription <id>: row count mismatch (old=X, new=Y)
+Selective update skipped for subscription <id>: cannot match row by PK (pk_columns=[...])
+Selective update: N rows exceeded change threshold for subscription <id>
+Selective update skipped for subscription <id>: no column changes detected
+```
+
+These logs help operators understand why subscriptions are sending full data updates (0xF2) instead of selective column updates (0xF7).
+
 ## Understanding Partial Update Efficiency
 
 The partial update system optimizes bandwidth for subscriptions by only sending columns that have changed, rather than full rows.


### PR DESCRIPTION
## Summary

- Add `PkDetectionFailureReason` enum with 8 reason variants to explain why PK detection fails
- Add `reason` field to `PkDetectionResult` populated in all code paths returning `confident: false`
- Add debug logs at subscription creation time with PK detection status and reason
- Add debug logs when selective updates are skipped with specific fallback reasons
- Document all log messages in observability docs

## Background

From #3943 investigation: When 0xF2 (full update) is sent instead of 0xF7 (selective update), there was no clear way for operators to understand why PK detection failed. This makes debugging subscription performance issues difficult.

## Changes

### New enum `PkDetectionFailureReason`

| Reason | Description |
|--------|-------------|
| `ParseError` | SQL query could not be parsed |
| `SetOperation` | Query uses UNION, INTERSECT, or EXCEPT |
| `NoFromClause` | Query does not reference any table |
| `MultipleTablesInQuery` | Query joins multiple tables |
| `TableNotFound` | Referenced table does not exist |
| `NoPrimaryKeyOnTable` | Table lacks a PRIMARY KEY constraint |
| `PkColumnsNotInResultSet` | Primary key columns not in SELECT |
| `SubqueryInFrom` | FROM clause contains subquery |

### Debug log examples

**At subscription creation:**
```
PK detection confident for subscription: pk_columns=[0], tables={"users"}
PK detection not confident for subscription: reason=table has no primary key defined, pk_columns=[0], tables={"messages"}, query=SELECT * FROM messages
```

**At update time:**
```
Selective update skipped for subscription <id>: row count mismatch (old=5, new=7)
Selective update skipped for subscription <id>: cannot match row by PK (pk_columns=[0, 1])
```

## Test plan

- [x] All 19 pk_detector unit tests pass (including 8 new tests for reasons)
- [x] All 351 vibesql-server library tests pass
- [x] Code compiles successfully

Closes #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)