### PR TITLE
feat(observability): Add vibesql_subscriptions_active gauge metric

### DIFF
--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -316,13 +316,14 @@ impl ConnectionHandler {
                 match self.handle_client_message(msg).await? {
                     ClientMessageResult::Continue => {}
                     ClientMessageResult::Terminate => {
-                        let (_total, selective_eligible) = self.subscription_manager
+                        let (total, selective_eligible) = self.subscription_manager
                             .unsubscribe_all_for_connection(&self.connection_id);
-                        if selective_eligible > 0 {
-                            if let Some(metrics) = self.observability.metrics() {
-                                for _ in 0..selective_eligible {
-                                    metrics.decrement_selective_eligible();
-                                }
+                        if let Some(metrics) = self.observability.metrics() {
+                            for _ in 0..total {
+                                metrics.decrement_subscriptions_active();
+                            }
+                            for _ in 0..selective_eligible {
+                                metrics.decrement_selective_eligible();
                             }
                         }
                         return Ok(());
@@ -376,13 +377,14 @@ impl ConnectionHandler {
         }
 
         // Clean up subscriptions when connection closes
-        let (_total, selective_eligible) = self.subscription_manager
+        let (total, selective_eligible) = self.subscription_manager
             .unsubscribe_all_for_connection(&self.connection_id);
-        if selective_eligible > 0 {
-            if let Some(metrics) = self.observability.metrics() {
-                for _ in 0..selective_eligible {
-                    metrics.decrement_selective_eligible();
-                }
+        if let Some(metrics) = self.observability.metrics() {
+            for _ in 0..total {
+                metrics.decrement_subscriptions_active();
+            }
+            for _ in 0..selective_eligible {
+                metrics.decrement_selective_eligible();
             }
         }
 
@@ -1114,6 +1116,11 @@ impl ConnectionHandler {
             let error_id = [0u8; 16];
             self.send_subscription_error(&error_id, &format!("{}", e)).await?;
             return Ok(());
+        }
+
+        // Track the new subscription in metrics
+        if let Some(metrics) = self.observability.metrics() {
+            metrics.increment_subscriptions_active();
         }
 
         // Store detected PK columns in the subscription for selective updates

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -782,7 +782,13 @@ async fn subscribe_stream(
     // Create subscription via SubscriptionManager
     let (tx, mut rx) = mpsc::channel(32);
     let subscription_id = match state.subscription_manager.subscribe(params.query.clone(), tx) {
-        Ok(id) => id,
+        Ok(id) => {
+            // Track the new subscription in metrics
+            if let Some(ref metrics) = state.metrics {
+                metrics.increment_subscriptions_active();
+            }
+            id
+        }
         Err(e) => {
             error!("Failed to create subscription: {}", e);
             let event_data = serde_json::to_string(&SseEvent {
@@ -848,8 +854,9 @@ async fn subscribe_stream(
         drop(db_guard);
         error!("Failed to send initial results: {}", e);
         let was_selective_eligible = state.subscription_manager.unsubscribe(subscription_id);
-        if was_selective_eligible {
-            if let Some(ref metrics) = state.metrics {
+        if let Some(ref metrics) = state.metrics {
+            metrics.decrement_subscriptions_active();
+            if was_selective_eligible {
                 metrics.decrement_selective_eligible();
             }
         }
@@ -1004,8 +1011,9 @@ async fn subscribe_stream(
 
         // Clean up subscription when stream ends
         let was_selective_eligible = state.subscription_manager.unsubscribe(subscription_id);
-        if was_selective_eligible {
-            if let Some(ref metrics) = state.metrics {
+        if let Some(ref metrics) = state.metrics {
+            metrics.decrement_subscriptions_active();
+            if was_selective_eligible {
                 metrics.decrement_selective_eligible();
             }
         }

--- a/crates/vibesql-server/src/observability/metrics.rs
+++ b/crates/vibesql-server/src/observability/metrics.rs
@@ -33,6 +33,8 @@ pub struct ServerMetrics {
     subscription_updates_total: Counter<u64>,
     selective_update_columns_sent: Histogram<u64>,
     selective_update_changed_ratio: Histogram<f64>,
+    subscriptions_active: Gauge<u64>,
+    subscriptions_active_count: Arc<AtomicU64>,
     subscriptions_selective_eligible: Gauge<u64>,
     subscriptions_selective_eligible_count: Arc<AtomicU64>,
 
@@ -150,6 +152,13 @@ impl ServerMetrics {
             .with_unit("1")
             .build();
 
+        let subscriptions_active = meter
+            .u64_gauge("vibesql_subscriptions_active")
+            .with_description("Total number of active subscriptions")
+            .with_unit("{subscription}")
+            .build();
+        let subscriptions_active_count = Arc::new(AtomicU64::new(0));
+
         let subscriptions_selective_eligible = meter
             .u64_gauge("vibesql_subscriptions_selective_eligible")
             .with_description("Active subscriptions eligible for selective column updates")
@@ -212,6 +221,8 @@ impl ServerMetrics {
             subscription_updates_total,
             selective_update_columns_sent,
             selective_update_changed_ratio,
+            subscriptions_active,
+            subscriptions_active_count,
             subscriptions_selective_eligible,
             subscriptions_selective_eligible_count,
             partial_update_fallbacks_total,
@@ -328,6 +339,27 @@ impl ServerMetrics {
                 KeyValue::new("row_count", row_count as i64),
             ],
         );
+    }
+
+    /// Increment the count of active subscriptions
+    ///
+    /// Called when a subscription is registered.
+    pub fn increment_subscriptions_active(&self) {
+        let new_value = self.subscriptions_active_count.fetch_add(1, Ordering::Relaxed) + 1;
+        self.subscriptions_active.record(new_value, &[]);
+    }
+
+    /// Decrement the count of active subscriptions
+    ///
+    /// Called when a subscription is unregistered.
+    pub fn decrement_subscriptions_active(&self) {
+        let new_value = self.subscriptions_active_count.fetch_sub(1, Ordering::Relaxed) - 1;
+        self.subscriptions_active.record(new_value, &[]);
+    }
+
+    /// Get the current count of active subscriptions
+    pub fn subscriptions_active_count(&self) -> u64 {
+        self.subscriptions_active_count.load(Ordering::Relaxed)
     }
 
     /// Increment the count of selective-eligible subscriptions
@@ -518,6 +550,30 @@ mod tests {
     fn create_test_metrics() -> ServerMetrics {
         let meter = global::meter("test_meter");
         ServerMetrics::new(&meter)
+    }
+
+    #[test]
+    fn test_subscriptions_active_increment_decrement() {
+        let metrics = create_test_metrics();
+
+        // Initially zero
+        assert_eq!(metrics.subscriptions_active_count(), 0);
+
+        // Increment
+        metrics.increment_subscriptions_active();
+        assert_eq!(metrics.subscriptions_active_count(), 1);
+
+        // Increment again
+        metrics.increment_subscriptions_active();
+        assert_eq!(metrics.subscriptions_active_count(), 2);
+
+        // Decrement
+        metrics.decrement_subscriptions_active();
+        assert_eq!(metrics.subscriptions_active_count(), 1);
+
+        // Decrement again
+        metrics.decrement_subscriptions_active();
+        assert_eq!(metrics.subscriptions_active_count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add a `vibesql_subscriptions_active` gauge metric to track the total number of active subscriptions. This metric is needed to calculate the percentage of subscriptions eligible for selective updates.

## Changes

- Added `subscriptions_active` gauge metric with `subscriptions_active_count` atomic counter
- Implemented `increment_subscriptions_active()` and `decrement_subscriptions_active()` methods in ServerMetrics
- Integrated metric tracking in REST API subscription endpoints
- Integrated metric tracking in wire protocol subscription endpoints  
- Added comprehensive unit tests

## Testing

- All existing tests pass
- New unit test for subscriptions_active increment/decrement added
- Verified build succeeds with all changes

Closes #4011