### PR TITLE
feat(server): Wire up partial/full update sent counters for efficiency stats

### DIFF
--- a/crates/vibesql-server/src/connection.rs
+++ b/crates/vibesql-server/src/connection.rs
@@ -919,6 +919,11 @@ impl ConnectionHandler {
             return false;
         }
 
+        // Record successful partial update sent
+        if let Some(metrics) = self.observability.metrics() {
+            metrics.record_partial_update_sent();
+        }
+
         debug!(
             "Sent selective column update (0xF7) for subscription {:?}",
             subscription_id
@@ -1670,6 +1675,11 @@ impl ConnectionHandler {
                 SubscriptionUpdateType::SelectiveUpdate => "selective",
             };
             metrics.record_subscription_update(type_str, rows.len() as u64);
+
+            // Record full update sent for efficiency stats
+            if matches!(update_type, SubscriptionUpdateType::Full) {
+                metrics.record_full_update_sent();
+            }
         }
 
         BackendMessage::SubscriptionData { subscription_id: *subscription_id, update_type, rows }

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -889,6 +889,10 @@ async fn subscribe_stream(
                         is_first_event = false;
                         "initial"
                     } else {
+                        // Record full update sent for efficiency stats (non-initial updates only)
+                        if let Some(ref metrics) = state.metrics {
+                            metrics.record_full_update_sent();
+                        }
                         "update"
                     };
 
@@ -949,6 +953,11 @@ async fn subscribe_stream(
                     );
                 }
                 SubscriptionUpdate::Partial { updates, .. } => {
+                    // Record partial update sent for efficiency stats
+                    if let Some(ref metrics) = state.metrics {
+                        metrics.record_partial_update_sent();
+                    }
+
                     // Send partial updates (only changed columns + PK columns)
                     let partial_updates: Vec<serde_json::Value> = updates
                         .iter()


### PR DESCRIPTION
## Summary

- Wire up `record_partial_update_sent()` and `record_full_update_sent()` methods added in PR #3986
- The `/stats/subscriptions/efficiency` endpoint now returns accurate counts for `partial_updates_sent` and `full_updates_sent`

## Changes

- **connection.rs**: Call `record_partial_update_sent()` after sending selective column updates
- **connection.rs**: Call `record_full_update_sent()` in `send_subscription_data()` when full updates are sent
- **rest.rs**: Call `record_partial_update_sent()` for HTTP SSE partial updates
- **rest.rs**: Call `record_full_update_sent()` for HTTP SSE full updates (non-initial only)

## Test plan

- [x] `cargo check -p vibesql-server` passes
- [x] `cargo test -p vibesql-server` passes (all 62 tests)
- [x] Existing metrics unit tests in `metrics.rs` verify counters work correctly

Closes #4004

🤖 Generated with [Claude Code](https://claude.com/claude-code)