### PR TITLE
feat(statistics): Prefer actual avg_row_bytes over schema-based estimates

### DIFF
--- a/crates/vibesql-storage/src/database/index_ops.rs
+++ b/crates/vibesql-storage/src/database/index_ops.rs
@@ -1043,10 +1043,24 @@ impl Database {
         // Check if table uses native columnar storage
         let is_native_columnar = table.is_native_columnar();
 
-        // Estimate average row size from schema
-        let column_types: Vec<_> =
-            table.schema.columns.iter().map(|col| col.data_type.clone()).collect();
-        let avg_row_size = crate::statistics::estimate_row_size(&column_types);
+        // Get average row size: prefer actual statistics over schema-based heuristics
+        //
+        // When statistics are available (from ANALYZE), use the actual avg_row_bytes
+        // which accounts for real string fill ratios, NULL prevalence, and actual
+        // BLOB sizes. This provides more accurate WAL cost estimation.
+        //
+        // Fall back to schema-based estimation when no statistics are available.
+        // See issue #3980 for details.
+        let avg_row_size = table
+            .get_statistics()
+            .and_then(|stats| stats.avg_row_bytes)
+            .map(|bytes| bytes as usize)
+            .unwrap_or_else(|| {
+                // Fall back to schema-based estimation
+                let column_types: Vec<_> =
+                    table.schema.columns.iter().map(|col| col.data_type.clone()).collect();
+                crate::statistics::estimate_row_size(&column_types)
+            });
 
         Some(crate::statistics::TableIndexInfo::new(
             hash_index_count,
@@ -1230,5 +1244,134 @@ mod tests {
 
         // Should have 3 hash indexes: 1 PK + 2 unique constraints
         assert_eq!(info.hash_index_count, 3);
+    }
+
+    // ============================================================================
+    // avg_row_size Statistics Tests (Issue #3980)
+    // ============================================================================
+
+    #[test]
+    fn test_get_table_index_info_uses_schema_estimate_without_stats() {
+        let mut db = Database::new();
+
+        // Create a table with VARCHAR columns
+        let schema = TableSchema::with_primary_key(
+            "items".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "name".to_string(),
+                    DataType::Varchar { max_length: Some(100) },
+                    false,
+                ),
+            ],
+            vec!["id".to_string()],
+        );
+        db.create_table(schema).unwrap();
+
+        // Without ANALYZE, should use schema-based estimation
+        let info = db.get_table_index_info("items").unwrap();
+
+        // avg_row_size should be computed from schema heuristics
+        // INTEGER (4) + VARCHAR(100) estimate (32) + overhead (8) = 44, min 64
+        assert!(
+            info.avg_row_size >= 64,
+            "Schema-based avg_row_size should be at least base size: {}",
+            info.avg_row_size
+        );
+    }
+
+    #[test]
+    fn test_get_table_index_info_prefers_actual_statistics() {
+        let mut db = Database::new();
+
+        // Create a table with VARCHAR columns
+        let schema = TableSchema::with_primary_key(
+            "items".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "description".to_string(),
+                    DataType::Varchar { max_length: Some(1000) },
+                    false,
+                ),
+            ],
+            vec!["id".to_string()],
+        );
+        db.create_table(schema).unwrap();
+
+        // Insert rows with LONG strings (filling the VARCHAR)
+        for i in 0..10 {
+            let long_description = "x".repeat(800); // Much longer than schema heuristic
+            let row = Row::new(vec![
+                SqlValue::Integer(i),
+                SqlValue::Varchar(long_description.into()),
+            ]);
+            db.insert_row("items", row).unwrap();
+        }
+
+        // Get info WITHOUT statistics - uses schema heuristic
+        let info_without_stats = db.get_table_index_info("items").unwrap();
+        let schema_estimate = info_without_stats.avg_row_size;
+
+        // Run ANALYZE to compute actual statistics
+        db.get_table_mut("items").unwrap().analyze();
+
+        // Get info WITH statistics - should prefer actual avg_row_bytes
+        let info_with_stats = db.get_table_index_info("items").unwrap();
+        let actual_estimate = info_with_stats.avg_row_size;
+
+        // Actual statistics should show larger row size due to long strings
+        // Schema heuristic: VARCHAR(1000) → min(500, 32) = 32 bytes
+        // Actual data: 800 bytes per string
+        assert!(
+            actual_estimate > schema_estimate,
+            "Actual statistics ({}) should show larger row size than schema heuristic ({}) for long strings",
+            actual_estimate,
+            schema_estimate
+        );
+    }
+
+    #[test]
+    fn test_get_table_index_info_statistics_vs_schema_short_strings() {
+        let mut db = Database::new();
+
+        // Create a table with VARCHAR columns
+        let schema = TableSchema::with_primary_key(
+            "items".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "code".to_string(),
+                    DataType::Varchar { max_length: Some(100) },
+                    false,
+                ),
+            ],
+            vec!["id".to_string()],
+        );
+        db.create_table(schema).unwrap();
+
+        // Insert rows with SHORT strings (much shorter than heuristic)
+        for i in 0..10 {
+            let short_code = format!("A{}", i); // 2-3 chars, much shorter than 32-byte heuristic
+            let row = Row::new(vec![
+                SqlValue::Integer(i),
+                SqlValue::Varchar(short_code.into()),
+            ]);
+            db.insert_row("items", row).unwrap();
+        }
+
+        // Run ANALYZE to compute actual statistics
+        db.get_table_mut("items").unwrap().analyze();
+
+        // Get info WITH statistics
+        let info = db.get_table_index_info("items").unwrap();
+
+        // Should have valid avg_row_size (from actual statistics)
+        assert!(
+            info.avg_row_size > 0,
+            "avg_row_size should be positive: {}",
+            info.avg_row_size
+        );
     }
 }

--- a/crates/vibesql-storage/src/statistics/table.rs
+++ b/crates/vibesql-storage/src/statistics/table.rs
@@ -24,6 +24,17 @@ pub struct TableStatistics {
     /// Sampling metadata (Phase 5.2)
     /// None if no sampling was used (small table)
     pub sample_metadata: Option<SampleMetadata>,
+
+    /// Average row size in bytes (computed from sampled data)
+    ///
+    /// This provides actual row size measurements that account for:
+    /// - Real string/varchar fill ratios (not heuristic estimates)
+    /// - Actual NULL prevalence
+    /// - True BLOB/CLOB sizes
+    ///
+    /// Used by DML cost estimation to scale WAL write costs.
+    /// None if statistics were estimated from schema (no actual data sampled).
+    pub avg_row_bytes: Option<f64>,
 }
 
 impl TableStatistics {
@@ -124,6 +135,7 @@ impl TableStatistics {
             last_updated: SystemTime::now(),
             is_stale: true, // Clearly marked as estimates
             sample_metadata: None,
+            avg_row_bytes: None, // No actual data sampled
         }
     }
 
@@ -181,12 +193,22 @@ impl TableStatistics {
             columns.insert(column.name.clone(), col_stats);
         }
 
+        // Compute average row size from sampled data
+        let avg_row_bytes = if sampled_rows.is_empty() {
+            None
+        } else {
+            let total_bytes: usize =
+                sampled_rows.iter().map(|row| row.estimated_size_bytes()).sum();
+            Some(total_bytes as f64 / sampled_rows.len() as f64)
+        };
+
         TableStatistics {
             row_count: total_rows,
             columns,
             last_updated: SystemTime::now(),
             is_stale: false,
             sample_metadata,
+            avg_row_bytes,
         }
     }
 
@@ -250,6 +272,7 @@ impl TableStatistics {
             last_updated: SystemTime::now(),
             is_stale: true, // Mark as stale since these are estimates
             sample_metadata: None,
+            avg_row_bytes: None, // No actual data sampled
         }
     }
 
@@ -430,5 +453,122 @@ mod tests {
 
         assert_eq!(stats.row_count, 0);
         assert!(stats.is_stale);
+    }
+
+    // ============================================================================
+    // avg_row_bytes Tests (Issue #3980)
+    // ============================================================================
+
+    #[test]
+    fn test_avg_row_bytes_computed_from_actual_data() {
+        let schema = TableSchema::new(
+            "test_table".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "name".to_string(),
+                    DataType::Varchar { max_length: Some(100) },
+                    false,
+                ),
+            ],
+        );
+
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar(arcstr::ArcStr::from("Alice"))]),
+            Row::new(vec![SqlValue::Integer(2), SqlValue::Varchar(arcstr::ArcStr::from("Bob"))]),
+            Row::new(vec![SqlValue::Integer(3), SqlValue::Varchar(arcstr::ArcStr::from("Charlie"))]),
+        ];
+
+        let stats = TableStatistics::compute(&rows, &schema);
+
+        // avg_row_bytes should be computed from actual data
+        assert!(stats.avg_row_bytes.is_some());
+        let avg_bytes = stats.avg_row_bytes.unwrap();
+        // Should be positive and reasonable (Row struct + values)
+        assert!(avg_bytes > 0.0, "avg_row_bytes should be positive: {}", avg_bytes);
+    }
+
+    #[test]
+    fn test_avg_row_bytes_none_for_schema_estimates() {
+        let schema = TableSchema::new(
+            "test_table".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "name".to_string(),
+                    DataType::Varchar { max_length: Some(100) },
+                    false,
+                ),
+            ],
+        );
+
+        // estimate_from_schema should NOT have avg_row_bytes (no actual data)
+        let stats = TableStatistics::estimate_from_schema(1000, &schema);
+        assert!(
+            stats.avg_row_bytes.is_none(),
+            "estimate_from_schema should not have avg_row_bytes"
+        );
+
+        // estimate_from_row_count should NOT have avg_row_bytes
+        let stats = TableStatistics::estimate_from_row_count(1000);
+        assert!(
+            stats.avg_row_bytes.is_none(),
+            "estimate_from_row_count should not have avg_row_bytes"
+        );
+    }
+
+    #[test]
+    fn test_avg_row_bytes_none_for_empty_table() {
+        let schema = TableSchema::new(
+            "empty_table".to_string(),
+            vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+        );
+
+        // Empty table should have avg_row_bytes = None
+        let stats = TableStatistics::compute(&[], &schema);
+        assert!(
+            stats.avg_row_bytes.is_none(),
+            "Empty table should have avg_row_bytes = None"
+        );
+    }
+
+    #[test]
+    fn test_avg_row_bytes_varies_with_string_length() {
+        let schema = TableSchema::new(
+            "test_table".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "data".to_string(),
+                    DataType::Varchar { max_length: Some(1000) },
+                    false,
+                ),
+            ],
+        );
+
+        // Short strings
+        let short_rows = vec![
+            Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar(arcstr::ArcStr::from("a"))]),
+            Row::new(vec![SqlValue::Integer(2), SqlValue::Varchar(arcstr::ArcStr::from("b"))]),
+        ];
+        let short_stats = TableStatistics::compute(&short_rows, &schema);
+
+        // Long strings
+        let long_string = "x".repeat(500);
+        let long_rows = vec![
+            Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar(arcstr::ArcStr::from(&long_string))]),
+            Row::new(vec![SqlValue::Integer(2), SqlValue::Varchar(arcstr::ArcStr::from(&long_string))]),
+        ];
+        let long_stats = TableStatistics::compute(&long_rows, &schema);
+
+        // Long strings should result in larger avg_row_bytes
+        let short_avg = short_stats.avg_row_bytes.unwrap();
+        let long_avg = long_stats.avg_row_bytes.unwrap();
+        assert!(
+            long_avg > short_avg,
+            "Long strings ({}) should have larger avg_row_bytes than short strings ({})",
+            long_avg,
+            short_avg
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `avg_row_bytes` field to `TableStatistics` to capture actual row sizes computed during ANALYZE
- Update `get_table_index_info()` to prefer actual statistics over schema-based heuristics
- Add comprehensive tests for the new functionality

## Background

The DML cost estimation uses `avg_row_size` to scale WAL write costs. Previously, this was always computed from schema heuristics (e.g., VARCHAR(100) → 32 bytes), which don't reflect actual data patterns.

With this change:
- When ANALYZE has been run, we use the actual `avg_row_bytes` computed from sampled data
- When no statistics exist, we fall back to schema-based estimation
- This provides more accurate cost estimates for tables with unusual fill patterns

## Test plan

- [x] New tests for `avg_row_bytes` field in `TableStatistics`
- [x] Tests verifying `get_table_index_info()` prefers statistics over schema estimates
- [x] All existing cost estimation tests pass (33 tests)
- [x] All storage crate tests pass
- [x] No clippy warnings

Closes #3980

🤖 Generated with [Claude Code](https://claude.com/claude-code)