### PR TITLE
docs(observability): Add vibesql_subscriptions_active to metrics documentation

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -37,6 +37,7 @@ VibeSQL exposes Prometheus-compatible metrics via OpenTelemetry for monitoring s
 | `vibesql_subscription_updates_total` | Counter | update | `type`, `row_count` | Subscription updates sent by type |
 | `vibesql_selective_update_columns_sent` | Histogram | column | - | Number of columns sent in selective updates |
 | `vibesql_selective_update_changed_ratio` | Histogram | ratio (0-1) | - | Ratio of changed columns to total columns |
+| `vibesql_subscriptions_active` | Gauge | subscription | - | Total number of active subscriptions |
 | `vibesql_subscriptions_selective_eligible` | Gauge | subscription | - | Active subscriptions eligible for selective updates |
 
 **Subscription Update Types** (`type` label values):


### PR DESCRIPTION
## Summary

- Add `vibesql_subscriptions_active` gauge metric to the Subscription Metrics table in `docs/observability/metrics.md`

This metric was added in PR #4015 but was only referenced in the PromQL example (line 205), not documented in the Subscription Metrics table.

## Test plan

- [x] Verify `vibesql_subscriptions_active` appears in Subscription Metrics table
- [x] Verify description matches implementation in `crates/vibesql-server/src/observability/metrics.rs` ("Total number of active subscriptions")

Closes #4019

🤖 Generated with [Claude Code](https://claude.com/claude-code)