### PR TITLE
feat(server): Add environment variable support for HTTP auth and JWT configuration

### DIFF
--- a/crates/vibesql-server/src/config.rs
+++ b/crates/vibesql-server/src/config.rs
@@ -234,6 +234,11 @@ impl Config {
     /// | `VIBESQL_HTTP_ENABLED` | `http.enabled` |
     /// | `VIBESQL_HTTP_HOST` | `http.host` |
     /// | `VIBESQL_HTTP_PORT` | `http.port` |
+    /// | `VIBESQL_HTTP_AUTH_ENABLED` | `http.auth.enabled` |
+    /// | `VIBESQL_HTTP_AUTH_JWT_SECRET` | `http.auth.jwt.secret` |
+    /// | `VIBESQL_HTTP_AUTH_JWT_ISSUER` | `http.auth.jwt.issuer` |
+    /// | `VIBESQL_HTTP_AUTH_JWT_AUDIENCE` | `http.auth.jwt.audience` |
+    /// | `VIBESQL_HTTP_AUTH_JWT_EXPIRATION` | `http.auth.jwt.expiration_secs` |
     pub fn apply_env_overrides(&mut self) {
         // Server configuration
         if let Ok(val) = env::var("VIBESQL_SERVER_HOST") {
@@ -285,6 +290,27 @@ impl Config {
         if let Ok(val) = env::var("VIBESQL_HTTP_PORT") {
             if let Ok(port) = val.parse() {
                 self.http.port = port;
+            }
+        }
+
+        // HTTP Auth configuration
+        if let Ok(val) = env::var("VIBESQL_HTTP_AUTH_ENABLED") {
+            self.http.auth.enabled = parse_bool(&val);
+        }
+
+        // JWT configuration
+        if let Ok(val) = env::var("VIBESQL_HTTP_AUTH_JWT_SECRET") {
+            self.http.auth.jwt.secret = val;
+        }
+        if let Ok(val) = env::var("VIBESQL_HTTP_AUTH_JWT_ISSUER") {
+            self.http.auth.jwt.issuer = Some(val);
+        }
+        if let Ok(val) = env::var("VIBESQL_HTTP_AUTH_JWT_AUDIENCE") {
+            self.http.auth.jwt.audience = Some(val);
+        }
+        if let Ok(val) = env::var("VIBESQL_HTTP_AUTH_JWT_EXPIRATION") {
+            if let Ok(secs) = val.parse() {
+                self.http.auth.jwt.expiration_secs = secs;
             }
         }
     }
@@ -607,5 +633,90 @@ enabled = false
         env::remove_var("VIBESQL_AUTH_METHOD");
         env::remove_var("VIBESQL_LOG_LEVEL");
         env::remove_var("VIBESQL_HTTP_PORT");
+    }
+
+    #[test]
+    fn test_env_override_http_auth_enabled() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        assert!(!config.http.auth.enabled);
+
+        env::set_var("VIBESQL_HTTP_AUTH_ENABLED", "true");
+        config.apply_env_overrides();
+        assert!(config.http.auth.enabled);
+        env::remove_var("VIBESQL_HTTP_AUTH_ENABLED");
+    }
+
+    #[test]
+    fn test_env_override_http_auth_enabled_false() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        config.http.auth.enabled = true;
+
+        env::set_var("VIBESQL_HTTP_AUTH_ENABLED", "false");
+        config.apply_env_overrides();
+        assert!(!config.http.auth.enabled);
+        env::remove_var("VIBESQL_HTTP_AUTH_ENABLED");
+    }
+
+    #[test]
+    fn test_env_override_jwt_secret() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        assert_eq!(config.http.auth.jwt.secret, "");
+
+        env::set_var("VIBESQL_HTTP_AUTH_JWT_SECRET", "my-super-secret-key");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.jwt.secret, "my-super-secret-key");
+        env::remove_var("VIBESQL_HTTP_AUTH_JWT_SECRET");
+    }
+
+    #[test]
+    fn test_env_override_jwt_issuer() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        assert_eq!(config.http.auth.jwt.issuer, Some("vibesql".to_string()));
+
+        env::set_var("VIBESQL_HTTP_AUTH_JWT_ISSUER", "custom-issuer");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.jwt.issuer, Some("custom-issuer".to_string()));
+        env::remove_var("VIBESQL_HTTP_AUTH_JWT_ISSUER");
+    }
+
+    #[test]
+    fn test_env_override_jwt_audience() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        assert_eq!(config.http.auth.jwt.audience, Some("vibesql-api".to_string()));
+
+        env::set_var("VIBESQL_HTTP_AUTH_JWT_AUDIENCE", "custom-audience");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.jwt.audience, Some("custom-audience".to_string()));
+        env::remove_var("VIBESQL_HTTP_AUTH_JWT_AUDIENCE");
+    }
+
+    #[test]
+    fn test_env_override_jwt_expiration() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        assert_eq!(config.http.auth.jwt.expiration_secs, 3600);
+
+        env::set_var("VIBESQL_HTTP_AUTH_JWT_EXPIRATION", "7200");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.jwt.expiration_secs, 7200);
+        env::remove_var("VIBESQL_HTTP_AUTH_JWT_EXPIRATION");
+    }
+
+    #[test]
+    fn test_env_override_jwt_expiration_invalid() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        assert_eq!(config.http.auth.jwt.expiration_secs, 3600);
+
+        // Invalid expiration should be ignored
+        env::set_var("VIBESQL_HTTP_AUTH_JWT_EXPIRATION", "not_a_number");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.jwt.expiration_secs, 3600);
+        env::remove_var("VIBESQL_HTTP_AUTH_JWT_EXPIRATION");
     }
 }

--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -41,6 +41,11 @@ Configuration values are resolved in this order (highest to lowest priority):
 | `VIBESQL_HTTP_ENABLED` | `http.enabled` | `true` |
 | `VIBESQL_HTTP_HOST` | `http.host` | `0.0.0.0` |
 | `VIBESQL_HTTP_PORT` | `http.port` | `8080` |
+| `VIBESQL_HTTP_AUTH_ENABLED` | `http.auth.enabled` | `true` |
+| `VIBESQL_HTTP_AUTH_JWT_SECRET` | `http.auth.jwt.secret` | `your-secret-key` |
+| `VIBESQL_HTTP_AUTH_JWT_ISSUER` | `http.auth.jwt.issuer` | `vibesql` |
+| `VIBESQL_HTTP_AUTH_JWT_AUDIENCE` | `http.auth.jwt.audience` | `vibesql-api` |
+| `VIBESQL_HTTP_AUTH_JWT_EXPIRATION` | `http.auth.jwt.expiration_secs` | `3600` |
 
 ### Boolean Values
 
@@ -87,6 +92,18 @@ spec:
         configMapKeyRef:
           name: vibesql-config
           key: log-level
+    # JWT configuration - inject secrets securely
+    - name: VIBESQL_HTTP_AUTH_ENABLED
+      value: "true"
+    - name: VIBESQL_HTTP_AUTH_JWT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: vibesql-secrets
+          key: jwt-secret
+    - name: VIBESQL_HTTP_AUTH_JWT_ISSUER
+      value: "vibesql"
+    - name: VIBESQL_HTTP_AUTH_JWT_AUDIENCE
+      value: "vibesql-api"
 ```
 
 ## Configuration Format


### PR DESCRIPTION
## Summary

- Add environment variable overrides for HTTP authentication and JWT configuration
- Adds 5 new environment variables:
  - `VIBESQL_HTTP_AUTH_ENABLED` - Enable/disable HTTP authentication
  - `VIBESQL_HTTP_AUTH_JWT_SECRET` - JWT signing secret (critical for production)
  - `VIBESQL_HTTP_AUTH_JWT_ISSUER` - JWT issuer claim
  - `VIBESQL_HTTP_AUTH_JWT_AUDIENCE` - JWT audience claim
  - `VIBESQL_HTTP_AUTH_JWT_EXPIRATION` - JWT expiration in seconds
- Add 7 unit tests covering all new environment variables and edge cases
- Update documentation with new env vars and Kubernetes example for secure secret injection

## Why This Matters

The JWT secret is a sensitive value that should **never** be stored in configuration files in production. This change enables secure secret injection via environment variables, following security best practices for:
- Docker deployments
- Kubernetes Secrets
- Cloud platform secret management systems

## Test plan

- [x] All 7 new environment variable tests pass
- [x] All existing config tests continue to pass (21 total env override tests)
- [x] Clippy passes with no warnings
- [x] Documentation updated with examples

Closes #4021

🤖 Generated with [Claude Code](https://claude.com/claude-code)