### PR TITLE
docs(observability): Add vibesql_selective_update_bytes_saved_total to metrics

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -55,6 +55,7 @@ These metrics track the effectiveness of partial/selective updates, which reduce
 | `vibesql_partial_update_fallbacks_total` | Counter | fallback | `reason` | Times partial update was skipped |
 | `vibesql_partial_update_bytes_saved` | Histogram | bytes | - | Estimated bytes saved per partial update |
 | `vibesql_partial_update_efficiency` | Gauge | ratio (0-1) | - | Rolling average of column efficiency |
+| `vibesql_selective_update_bytes_saved_total` | Counter | bytes | - | Total bytes saved by using selective column updates instead of full row updates |
 
 **Fallback Reasons** (`reason` label values):
 - `disabled` - Selective updates disabled in configuration


### PR DESCRIPTION
## Summary

- Add the `vibesql_selective_update_bytes_saved_total` counter metric to the Partial Update Efficiency Metrics documentation table

This metric was added in PR #4017 but was not documented.

## Test plan

- [x] Verify metric description matches implementation in `metrics.rs`
- [x] Verify metric appears in correct section (Partial Update Efficiency Metrics)

Closes #4023

🤖 Generated with [Claude Code](https://claude.com/claude-code)