### PR TITLE
feat(server): Add environment variable support for API keys and auth methods

### DIFF
--- a/crates/vibesql-server/src/config.rs
+++ b/crates/vibesql-server/src/config.rs
@@ -235,6 +235,8 @@ impl Config {
     /// | `VIBESQL_HTTP_HOST` | `http.host` |
     /// | `VIBESQL_HTTP_PORT` | `http.port` |
     /// | `VIBESQL_HTTP_AUTH_ENABLED` | `http.auth.enabled` |
+    /// | `VIBESQL_HTTP_AUTH_METHODS` | `http.auth.methods` |
+    /// | `VIBESQL_HTTP_AUTH_API_KEYS` | `http.auth.api_keys.keys` |
     /// | `VIBESQL_HTTP_AUTH_JWT_SECRET` | `http.auth.jwt.secret` |
     /// | `VIBESQL_HTTP_AUTH_JWT_ISSUER` | `http.auth.jwt.issuer` |
     /// | `VIBESQL_HTTP_AUTH_JWT_AUDIENCE` | `http.auth.jwt.audience` |
@@ -296,6 +298,30 @@ impl Config {
         // HTTP Auth configuration
         if let Ok(val) = env::var("VIBESQL_HTTP_AUTH_ENABLED") {
             self.http.auth.enabled = parse_bool(&val);
+        }
+        if let Ok(val) = env::var("VIBESQL_HTTP_AUTH_METHODS") {
+            let methods: Vec<HttpAuthMethod> = val
+                .split(',')
+                .filter_map(|s| match s.trim().to_lowercase().as_str() {
+                    "api_key" => Some(HttpAuthMethod::ApiKey),
+                    "basic" => Some(HttpAuthMethod::Basic),
+                    "jwt" => Some(HttpAuthMethod::Jwt),
+                    _ => None,
+                })
+                .collect();
+            if !methods.is_empty() {
+                self.http.auth.methods = methods;
+            }
+        }
+        if let Ok(val) = env::var("VIBESQL_HTTP_AUTH_API_KEYS") {
+            let keys: Vec<String> = val
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            if !keys.is_empty() {
+                self.http.auth.api_keys.keys = keys;
+            }
         }
 
         // JWT configuration
@@ -657,6 +683,148 @@ enabled = false
         config.apply_env_overrides();
         assert!(!config.http.auth.enabled);
         env::remove_var("VIBESQL_HTTP_AUTH_ENABLED");
+    }
+
+    #[test]
+    fn test_env_override_http_auth_methods() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        // Default methods are api_key and basic
+        assert_eq!(config.http.auth.methods.len(), 2);
+        assert!(config.http.auth.methods.contains(&HttpAuthMethod::ApiKey));
+        assert!(config.http.auth.methods.contains(&HttpAuthMethod::Basic));
+
+        env::set_var("VIBESQL_HTTP_AUTH_METHODS", "jwt,api_key");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.methods.len(), 2);
+        assert!(config.http.auth.methods.contains(&HttpAuthMethod::Jwt));
+        assert!(config.http.auth.methods.contains(&HttpAuthMethod::ApiKey));
+        assert!(!config.http.auth.methods.contains(&HttpAuthMethod::Basic));
+        env::remove_var("VIBESQL_HTTP_AUTH_METHODS");
+    }
+
+    #[test]
+    fn test_env_override_http_auth_methods_case_insensitive() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+
+        env::set_var("VIBESQL_HTTP_AUTH_METHODS", "JWT, API_KEY, BASIC");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.methods.len(), 3);
+        assert!(config.http.auth.methods.contains(&HttpAuthMethod::Jwt));
+        assert!(config.http.auth.methods.contains(&HttpAuthMethod::ApiKey));
+        assert!(config.http.auth.methods.contains(&HttpAuthMethod::Basic));
+        env::remove_var("VIBESQL_HTTP_AUTH_METHODS");
+    }
+
+    #[test]
+    fn test_env_override_http_auth_methods_invalid_ignored() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+
+        // Invalid methods should be silently ignored
+        env::set_var("VIBESQL_HTTP_AUTH_METHODS", "jwt,invalid_method,basic,unknown");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.methods.len(), 2);
+        assert!(config.http.auth.methods.contains(&HttpAuthMethod::Jwt));
+        assert!(config.http.auth.methods.contains(&HttpAuthMethod::Basic));
+        env::remove_var("VIBESQL_HTTP_AUTH_METHODS");
+    }
+
+    #[test]
+    fn test_env_override_http_auth_methods_empty_preserves_default() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        let original_methods = config.http.auth.methods.clone();
+
+        // Empty value should preserve default
+        env::set_var("VIBESQL_HTTP_AUTH_METHODS", "");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.methods, original_methods);
+        env::remove_var("VIBESQL_HTTP_AUTH_METHODS");
+    }
+
+    #[test]
+    fn test_env_override_http_auth_methods_all_invalid_preserves_default() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        let original_methods = config.http.auth.methods.clone();
+
+        // All invalid values should preserve default
+        env::set_var("VIBESQL_HTTP_AUTH_METHODS", "invalid,unknown,bad");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.methods, original_methods);
+        env::remove_var("VIBESQL_HTTP_AUTH_METHODS");
+    }
+
+    #[test]
+    fn test_env_override_http_auth_api_keys() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        assert!(config.http.auth.api_keys.keys.is_empty());
+
+        env::set_var("VIBESQL_HTTP_AUTH_API_KEYS", "key1,key2,key3");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.api_keys.keys.len(), 3);
+        assert!(config.http.auth.api_keys.keys.contains(&"key1".to_string()));
+        assert!(config.http.auth.api_keys.keys.contains(&"key2".to_string()));
+        assert!(config.http.auth.api_keys.keys.contains(&"key3".to_string()));
+        env::remove_var("VIBESQL_HTTP_AUTH_API_KEYS");
+    }
+
+    #[test]
+    fn test_env_override_http_auth_api_keys_trims_whitespace() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+
+        env::set_var("VIBESQL_HTTP_AUTH_API_KEYS", " key1 , key2 , key3 ");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.api_keys.keys.len(), 3);
+        assert!(config.http.auth.api_keys.keys.contains(&"key1".to_string()));
+        assert!(config.http.auth.api_keys.keys.contains(&"key2".to_string()));
+        assert!(config.http.auth.api_keys.keys.contains(&"key3".to_string()));
+        env::remove_var("VIBESQL_HTTP_AUTH_API_KEYS");
+    }
+
+    #[test]
+    fn test_env_override_http_auth_api_keys_empty_values_ignored() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+
+        // Empty values between commas should be ignored
+        env::set_var("VIBESQL_HTTP_AUTH_API_KEYS", "key1,,key2,  ,key3");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.api_keys.keys.len(), 3);
+        assert!(config.http.auth.api_keys.keys.contains(&"key1".to_string()));
+        assert!(config.http.auth.api_keys.keys.contains(&"key2".to_string()));
+        assert!(config.http.auth.api_keys.keys.contains(&"key3".to_string()));
+        env::remove_var("VIBESQL_HTTP_AUTH_API_KEYS");
+    }
+
+    #[test]
+    fn test_env_override_http_auth_api_keys_empty_preserves_default() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        // Pre-populate with a key
+        config.http.auth.api_keys.keys = vec!["original-key".to_string()];
+
+        // Empty value should preserve existing keys
+        env::set_var("VIBESQL_HTTP_AUTH_API_KEYS", "");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.api_keys.keys, vec!["original-key".to_string()]);
+        env::remove_var("VIBESQL_HTTP_AUTH_API_KEYS");
+    }
+
+    #[test]
+    fn test_env_override_http_auth_api_keys_single_key() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+
+        env::set_var("VIBESQL_HTTP_AUTH_API_KEYS", "single-key");
+        config.apply_env_overrides();
+        assert_eq!(config.http.auth.api_keys.keys.len(), 1);
+        assert_eq!(config.http.auth.api_keys.keys[0], "single-key");
+        env::remove_var("VIBESQL_HTTP_AUTH_API_KEYS");
     }
 
     #[test]

--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -42,6 +42,8 @@ Configuration values are resolved in this order (highest to lowest priority):
 | `VIBESQL_HTTP_HOST` | `http.host` | `0.0.0.0` |
 | `VIBESQL_HTTP_PORT` | `http.port` | `8080` |
 | `VIBESQL_HTTP_AUTH_ENABLED` | `http.auth.enabled` | `true` |
+| `VIBESQL_HTTP_AUTH_METHODS` | `http.auth.methods` | `api_key,jwt,basic` |
+| `VIBESQL_HTTP_AUTH_API_KEYS` | `http.auth.api_keys.keys` | `key1,key2,key3` |
 | `VIBESQL_HTTP_AUTH_JWT_SECRET` | `http.auth.jwt.secret` | `your-secret-key` |
 | `VIBESQL_HTTP_AUTH_JWT_ISSUER` | `http.auth.jwt.issuer` | `vibesql` |
 | `VIBESQL_HTTP_AUTH_JWT_AUDIENCE` | `http.auth.jwt.audience` | `vibesql-api` |
@@ -53,6 +55,20 @@ Boolean environment variables accept the following values (case-insensitive):
 - **True**: `true`, `1`, `yes`, `on`
 - **False**: any other value (e.g., `false`, `0`, `no`, `off`)
 
+### List Values
+
+Some environment variables accept comma-separated lists:
+
+- **`VIBESQL_HTTP_AUTH_METHODS`**: Comma-separated list of authentication methods.
+  - Valid values: `api_key`, `basic`, `jwt` (case-insensitive)
+  - Invalid values are silently ignored
+  - Example: `api_key,jwt` or `API_KEY, JWT, BASIC`
+
+- **`VIBESQL_HTTP_AUTH_API_KEYS`**: Comma-separated list of valid API keys.
+  - Values are trimmed of whitespace
+  - Empty values are ignored
+  - Example: `secret-key-1,secret-key-2,secret-key-3`
+
 ### Example: Docker Deployment
 
 ```bash
@@ -63,6 +79,8 @@ docker run -d \
   -e VIBESQL_LOG_LEVEL=info \
   -e VIBESQL_HTTP_ENABLED=true \
   -e VIBESQL_HTTP_PORT=8080 \
+  -e VIBESQL_HTTP_AUTH_METHODS=api_key,jwt \
+  -e VIBESQL_HTTP_AUTH_API_KEYS=secret-key-1,secret-key-2 \
   vibesql-server
 ```
 
@@ -92,9 +110,15 @@ spec:
         configMapKeyRef:
           name: vibesql-config
           key: log-level
-    # JWT configuration - inject secrets securely
     - name: VIBESQL_HTTP_AUTH_ENABLED
       value: "true"
+    - name: VIBESQL_HTTP_AUTH_METHODS
+      value: "api_key,jwt"
+    - name: VIBESQL_HTTP_AUTH_API_KEYS
+      valueFrom:
+        secretKeyRef:
+          name: vibesql-secrets
+          key: api-keys
     - name: VIBESQL_HTTP_AUTH_JWT_SECRET
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
## Summary

- Add `VIBESQL_HTTP_AUTH_METHODS` environment variable for comma-separated list of allowed auth methods (`api_key`, `basic`, `jwt`)
- Add `VIBESQL_HTTP_AUTH_API_KEYS` environment variable for comma-separated list of valid API keys
- Update documentation with new environment variables and examples
- Add comprehensive tests for comma-separated parsing and edge cases

## Test plan

- [x] Run `cargo test -p vibesql-server config::` - all 33 config tests pass
- [x] Verify comma-separated parsing works correctly
- [x] Verify invalid method names are silently ignored
- [x] Verify empty values preserve defaults
- [x] Verify whitespace trimming works correctly

Closes #4026

🤖 Generated with [Claude Code](https://claude.com/claude-code)