### PR TITLE
feat(executor): Add column-to-column predicate support for columnar filtering

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/filter/evaluation.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/evaluation.rs
@@ -1,5 +1,5 @@
 use super::comparison::compare_values;
-use super::predicates::{ColumnPredicate, PredicateTree};
+use super::predicates::{ColumnPredicate, CompareOp, PredicateTree};
 use vibesql_types::SqlValue;
 
 /// Evaluate a predicate tree on a row
@@ -49,6 +49,15 @@ where
             false
         }
         PredicateTree::Leaf(predicate) => {
+            // Handle ColumnCompare specially - needs two column values
+            if let ColumnPredicate::ColumnCompare { left_column_idx, op, right_column_idx } =
+                predicate
+            {
+                let left_val = get_value(*left_column_idx);
+                let right_val = get_value(*right_column_idx);
+                return evaluate_column_compare(*op, left_val, right_val);
+            }
+
             // Get the column value and evaluate the leaf predicate
             let column_idx = match predicate {
                 ColumnPredicate::LessThan { column_idx, .. }
@@ -60,6 +69,7 @@ where
                 | ColumnPredicate::Between { column_idx, .. }
                 | ColumnPredicate::Like { column_idx, .. }
                 | ColumnPredicate::InList { column_idx, .. } => *column_idx,
+                ColumnPredicate::ColumnCompare { .. } => unreachable!(), // Handled above
             };
 
             if let Some(value) = get_value(column_idx) {
@@ -69,6 +79,40 @@ where
                 false
             }
         }
+    }
+}
+
+/// Evaluate a column-to-column comparison
+///
+/// Returns true if left op right is satisfied.
+/// Returns false if either value is NULL (per SQL standard).
+pub fn evaluate_column_compare(
+    op: CompareOp,
+    left: Option<&SqlValue>,
+    right: Option<&SqlValue>,
+) -> bool {
+    use std::cmp::Ordering;
+
+    // NULL handling: any comparison with NULL returns false
+    let (left_val, right_val) = match (left, right) {
+        (Some(l), Some(r)) => (l, r),
+        _ => return false,
+    };
+
+    // Both values are NULL
+    if matches!(left_val, SqlValue::Null) || matches!(right_val, SqlValue::Null) {
+        return false;
+    }
+
+    let cmp_result = compare_values(left_val, right_val);
+
+    match op {
+        CompareOp::LessThan => cmp_result.equals(Ordering::Less),
+        CompareOp::GreaterThan => cmp_result.equals(Ordering::Greater),
+        CompareOp::LessThanOrEqual => cmp_result.matches(&[Ordering::Less, Ordering::Equal]),
+        CompareOp::GreaterThanOrEqual => cmp_result.matches(&[Ordering::Greater, Ordering::Equal]),
+        CompareOp::Equal => cmp_result.equals(Ordering::Equal),
+        CompareOp::NotEqual => cmp_result.matches(&[Ordering::Less, Ordering::Greater]),
     }
 }
 
@@ -133,6 +177,13 @@ pub fn evaluate_predicate(predicate: &ColumnPredicate, value: &SqlValue) -> bool
             } else {
                 matches
             }
+        }
+        // ColumnCompare should be handled by evaluate_column_compare, not here
+        // This case is included for exhaustiveness but shouldn't be reached in normal use
+        ColumnPredicate::ColumnCompare { .. } => {
+            // Cannot evaluate column-to-column with single value
+            // Return false as fallback (this path shouldn't be hit)
+            false
         }
     }
 }

--- a/crates/vibesql-executor/src/select/columnar/filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/mod.rs
@@ -13,9 +13,9 @@ use crate::errors::ExecutorError;
 
 // Re-export public types and functions
 pub(super) use comparison::parse_date_string;
-pub use evaluation::{evaluate_predicate, evaluate_predicate_tree};
+pub use evaluation::{evaluate_column_compare, evaluate_predicate, evaluate_predicate_tree};
 pub use predicates::{
-    extract_column_predicates, extract_predicate_tree, ColumnPredicate, PredicateTree,
+    extract_column_predicates, extract_predicate_tree, ColumnPredicate, CompareOp, PredicateTree,
 };
 
 /// Apply a filter to row indices based on a predicate tree
@@ -93,6 +93,19 @@ where
     // Evaluate each row against all predicates (AND logic)
     for row_idx in 0..row_count {
         for predicate in predicates.iter() {
+            // Handle ColumnCompare specially - needs two column values
+            if let ColumnPredicate::ColumnCompare { left_column_idx, op, right_column_idx } =
+                predicate
+            {
+                let left_val = get_value(row_idx, *left_column_idx);
+                let right_val = get_value(row_idx, *right_column_idx);
+                if !evaluate_column_compare(*op, left_val, right_val) {
+                    bitmap[row_idx] = false;
+                    break;
+                }
+                continue;
+            }
+
             let column_idx = match predicate {
                 ColumnPredicate::LessThan { column_idx, .. } => *column_idx,
                 ColumnPredicate::GreaterThan { column_idx, .. } => *column_idx,
@@ -103,6 +116,7 @@ where
                 ColumnPredicate::Between { column_idx, .. } => *column_idx,
                 ColumnPredicate::Like { column_idx, .. } => *column_idx,
                 ColumnPredicate::InList { column_idx, .. } => *column_idx,
+                ColumnPredicate::ColumnCompare { .. } => unreachable!(), // Handled above
             };
 
             if let Some(value) = get_value(row_idx, column_idx) {

--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -3,6 +3,17 @@ use crate::schema::CombinedSchema;
 use vibesql_ast::{BinaryOperator, Expression, UnaryOperator};
 use vibesql_types::{SqlMode, SqlValue};
 
+/// Comparison operator for column-to-column predicates
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompareOp {
+    LessThan,
+    GreaterThan,
+    LessThanOrEqual,
+    GreaterThanOrEqual,
+    Equal,
+    NotEqual,
+}
+
 /// A predicate tree representing complex logical expressions
 ///
 /// Supports nested AND/OR combinations for efficient columnar evaluation.
@@ -59,6 +70,14 @@ pub enum ColumnPredicate {
 
     /// column IN (value1, value2, ...)
     InList { column_idx: usize, values: Vec<SqlValue>, negated: bool },
+
+    /// column1 op column2 (column-to-column comparison)
+    /// Used for predicates like `l_commitdate < l_receiptdate` in TPC-H Q4
+    ColumnCompare {
+        left_column_idx: usize,
+        op: CompareOp,
+        right_column_idx: usize,
+    },
 }
 
 /// Extract column predicates as a tree from a WHERE clause expression
@@ -277,6 +296,31 @@ fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<
                 }
             }
 
+            // Try: column op column (column-to-column comparison)
+            // This handles predicates like `l_commitdate < l_receiptdate` in TPC-H Q4
+            if let (
+                Expression::ColumnRef { table: t1, column: c1 },
+                Expression::ColumnRef { table: t2, column: c2 },
+            ) = (left.as_ref(), right.as_ref())
+            {
+                let left_idx = schema.get_column_index(t1.as_deref(), c1)?;
+                let right_idx = schema.get_column_index(t2.as_deref(), c2)?;
+                let compare_op = match op {
+                    BinaryOperator::LessThan => CompareOp::LessThan,
+                    BinaryOperator::GreaterThan => CompareOp::GreaterThan,
+                    BinaryOperator::LessThanOrEqual => CompareOp::LessThanOrEqual,
+                    BinaryOperator::GreaterThanOrEqual => CompareOp::GreaterThanOrEqual,
+                    BinaryOperator::Equal => CompareOp::Equal,
+                    BinaryOperator::NotEqual => CompareOp::NotEqual,
+                    _ => return None,
+                };
+                return Some(PredicateTree::Leaf(ColumnPredicate::ColumnCompare {
+                    left_column_idx: left_idx,
+                    op: compare_op,
+                    right_column_idx: right_idx,
+                }));
+            }
+
             None
         }
 
@@ -434,7 +478,37 @@ fn extract_predicates_recursive(
                 }
             }
 
-            // Skip cross-table predicates (column op column) - not a failure
+            // Try: column op column (column-to-column comparison within same table)
+            // This handles predicates like `l_commitdate < l_receiptdate` in TPC-H Q4
+            if let (
+                Expression::ColumnRef { table: t1, column: c1 },
+                Expression::ColumnRef { table: t2, column: c2 },
+            ) = (left.as_ref(), right.as_ref())
+            {
+                // Only add if BOTH columns are in schema (same-table comparison)
+                if let (Some(left_idx), Some(right_idx)) = (
+                    schema.get_column_index(t1.as_deref(), c1),
+                    schema.get_column_index(t2.as_deref(), c2),
+                ) {
+                    let compare_op = match op {
+                        BinaryOperator::LessThan => CompareOp::LessThan,
+                        BinaryOperator::GreaterThan => CompareOp::GreaterThan,
+                        BinaryOperator::LessThanOrEqual => CompareOp::LessThanOrEqual,
+                        BinaryOperator::GreaterThanOrEqual => CompareOp::GreaterThanOrEqual,
+                        BinaryOperator::Equal => CompareOp::Equal,
+                        BinaryOperator::NotEqual => CompareOp::NotEqual,
+                        _ => return Some(()), // Skip unsupported operator
+                    };
+                    predicates.push(ColumnPredicate::ColumnCompare {
+                        left_column_idx: left_idx,
+                        op: compare_op,
+                        right_column_idx: right_idx,
+                    });
+                }
+                return Some(());
+            }
+
+            // Skip other unsupported expressions
             Some(())
         }
 
@@ -725,5 +799,110 @@ mod tests {
 
         let tree = extract_predicate_tree(&expr, &schema);
         assert!(tree.is_none());
+    }
+
+    #[test]
+    fn test_column_to_column_comparison() {
+        let schema = create_test_schema();
+
+        // col0 < col1 (column-to-column comparison)
+        let expr = Expression::BinaryOp {
+            left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            op: BinaryOperator::LessThan,
+            right: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+        };
+
+        let tree = extract_predicate_tree(&expr, &schema);
+        assert!(tree.is_some());
+
+        match tree.unwrap() {
+            PredicateTree::Leaf(ColumnPredicate::ColumnCompare {
+                left_column_idx,
+                op,
+                right_column_idx,
+            }) => {
+                assert_eq!(left_column_idx, 0);
+                assert_eq!(op, CompareOp::LessThan);
+                assert_eq!(right_column_idx, 1);
+            }
+            _ => panic!("Expected ColumnCompare predicate"),
+        }
+    }
+
+    #[test]
+    fn test_column_to_column_all_operators() {
+        let schema = create_test_schema();
+
+        let operators = [
+            (BinaryOperator::LessThan, CompareOp::LessThan),
+            (BinaryOperator::GreaterThan, CompareOp::GreaterThan),
+            (BinaryOperator::LessThanOrEqual, CompareOp::LessThanOrEqual),
+            (BinaryOperator::GreaterThanOrEqual, CompareOp::GreaterThanOrEqual),
+            (BinaryOperator::Equal, CompareOp::Equal),
+            (BinaryOperator::NotEqual, CompareOp::NotEqual),
+        ];
+
+        for (binary_op, expected_compare_op) in operators {
+            let expr = Expression::BinaryOp {
+                left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+                op: binary_op,
+                right: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+            };
+
+            let tree = extract_predicate_tree(&expr, &schema);
+            assert!(tree.is_some(), "Should extract predicate for operator {:?}", binary_op);
+
+            match tree.unwrap() {
+                PredicateTree::Leaf(ColumnPredicate::ColumnCompare { op, .. }) => {
+                    assert_eq!(op, expected_compare_op, "Operator mismatch for {:?}", binary_op);
+                }
+                _ => panic!("Expected ColumnCompare predicate for {:?}", binary_op),
+            }
+        }
+    }
+
+    #[test]
+    fn test_column_to_column_legacy_path() {
+        let schema = create_test_schema();
+
+        // col0 < col1 AND col0 > 5 (mix of column-to-column and column-to-value)
+        let expr = Expression::BinaryOp {
+            left: Box::new(Expression::BinaryOp {
+                left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+                op: BinaryOperator::LessThan,
+                right: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+            }),
+            op: BinaryOperator::And,
+            right: Box::new(Expression::BinaryOp {
+                left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+                op: BinaryOperator::GreaterThan,
+                right: Box::new(Expression::Literal(SqlValue::Integer(5))),
+            }),
+        };
+
+        let predicates = extract_column_predicates(&expr, &schema);
+        assert!(predicates.is_some());
+
+        let predicates = predicates.unwrap();
+        assert_eq!(predicates.len(), 2);
+
+        // First predicate should be column-to-column
+        match &predicates[0] {
+            ColumnPredicate::ColumnCompare { left_column_idx, op, right_column_idx } => {
+                assert_eq!(*left_column_idx, 0);
+                assert_eq!(*op, CompareOp::LessThan);
+                assert_eq!(*right_column_idx, 1);
+            }
+            _ => panic!("Expected ColumnCompare predicate"),
+        }
+
+        // Second predicate should be column-to-value
+        match &predicates[1] {
+            ColumnPredicate::GreaterThan { column_idx, value } => {
+                assert_eq!(*column_idx, 0);
+                assert_eq!(*value, SqlValue::Integer(5));
+            }
+            _ => panic!("Expected GreaterThan predicate"),
+        }
     }
 }

--- a/crates/vibesql-executor/src/select/columnar/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/mod.rs
@@ -449,6 +449,26 @@ fn evaluate_predicate(row: &Row, predicate: &ColumnPredicate) -> bool {
                 matches
             }
         }
+        ColumnPredicate::ColumnCompare { left_column_idx, op, right_column_idx } => {
+            // Column-to-column comparison
+            let left_val = row.get(*left_column_idx);
+            let right_val = row.get(*right_column_idx);
+            match (left_val, right_val) {
+                (Some(l), Some(r)) => {
+                    use std::cmp::Ordering;
+                    let cmp = compare_values(l, r);
+                    match op {
+                        filter::CompareOp::LessThan => cmp == Ordering::Less,
+                        filter::CompareOp::GreaterThan => cmp == Ordering::Greater,
+                        filter::CompareOp::LessThanOrEqual => cmp != Ordering::Greater,
+                        filter::CompareOp::GreaterThanOrEqual => cmp != Ordering::Less,
+                        filter::CompareOp::Equal => cmp == Ordering::Equal,
+                        filter::CompareOp::NotEqual => cmp != Ordering::Equal,
+                    }
+                }
+                _ => false, // NULL comparison returns false
+            }
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/comparison.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/comparison.rs
@@ -181,6 +181,15 @@ pub fn evaluate_predicate_i64_simd(
             }
             result
         }
+
+        // ColumnCompare is handled at higher level in simd_filter/mod.rs
+        ColumnPredicate::ColumnCompare { .. } => {
+            return Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "column-to-column comparison".to_string(),
+                left_type: "Int64".to_string(),
+                right_type: Some("Should be handled in simd_filter/mod.rs".to_string()),
+            });
+        }
     };
 
     // Apply NULL mask: NULLs always fail predicates
@@ -302,6 +311,15 @@ pub fn evaluate_predicate_i32_simd(
             }
             result
         }
+
+        // ColumnCompare is handled at higher level in simd_filter/mod.rs
+        ColumnPredicate::ColumnCompare { .. } => {
+            return Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "column-to-column comparison".to_string(),
+                left_type: "Date".to_string(),
+                right_type: Some("Should be handled in simd_filter/mod.rs".to_string()),
+            });
+        }
     };
 
     // Apply NULL mask: NULLs always fail predicates
@@ -421,6 +439,15 @@ pub fn evaluate_predicate_f64_simd(
                 result.iter_mut().for_each(|v| *v = !*v);
             }
             result
+        }
+
+        // ColumnCompare is handled at higher level in simd_filter/mod.rs
+        ColumnPredicate::ColumnCompare { .. } => {
+            return Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "column-to-column comparison".to_string(),
+                left_type: "Float64".to_string(),
+                right_type: Some("Should be handled in simd_filter/mod.rs".to_string()),
+            });
         }
     };
 
@@ -610,6 +637,15 @@ pub fn evaluate_predicate_i64_packed(
             }
             result
         }
+
+        // ColumnCompare is handled at higher level in simd_filter/mod.rs
+        ColumnPredicate::ColumnCompare { .. } => {
+            return Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "column-to-column comparison".to_string(),
+                left_type: "Int64".to_string(),
+                right_type: Some("Should be handled in simd_filter/mod.rs".to_string()),
+            });
+        }
     };
 
     // Apply NULL mask: NULLs always fail predicates
@@ -729,6 +765,15 @@ pub fn evaluate_predicate_i32_packed(
             }
             result
         }
+
+        // ColumnCompare is handled at higher level in simd_filter/mod.rs
+        ColumnPredicate::ColumnCompare { .. } => {
+            return Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "column-to-column comparison".to_string(),
+                left_type: "Date".to_string(),
+                right_type: Some("Should be handled in simd_filter/mod.rs".to_string()),
+            });
+        }
     };
 
     // Apply NULL mask
@@ -846,6 +891,15 @@ pub fn evaluate_predicate_f64_packed(
                 result = result.not();
             }
             result
+        }
+
+        // ColumnCompare is handled at higher level in simd_filter/mod.rs
+        ColumnPredicate::ColumnCompare { .. } => {
+            return Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "column-to-column comparison".to_string(),
+                left_type: "Float64".to_string(),
+                right_type: Some("Should be handled in simd_filter/mod.rs".to_string()),
+            });
         }
     };
 

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/mod.rs
@@ -15,7 +15,7 @@ mod mask;
 mod string;
 
 use super::batch::{ColumnArray, ColumnarBatch};
-use super::filter::ColumnPredicate;
+use super::filter::{evaluate_column_compare, ColumnPredicate, CompareOp};
 use super::simd_ops::{self, PackedMask};
 use crate::errors::ExecutorError;
 use vibesql_types::SqlValue;
@@ -46,6 +46,9 @@ fn predicate_contains_null(predicate: &ColumnPredicate) -> bool {
         ColumnPredicate::InList { values, .. } => {
             values.iter().any(|v| matches!(v, SqlValue::Null))
         }
+        // Column-to-column comparisons don't have literal NULLs
+        // (NULL columns are handled during evaluation)
+        ColumnPredicate::ColumnCompare { .. } => false,
     }
 }
 
@@ -159,6 +162,12 @@ fn evaluate_predicate_simd_packed(
         return Ok(PackedMask::new_all_clear(batch.row_count()));
     }
 
+    // Handle ColumnCompare specially - needs two columns
+    if let ColumnPredicate::ColumnCompare { left_column_idx, op, right_column_idx } = predicate {
+        let bool_mask = evaluate_column_compare_simd(batch, *left_column_idx, *op, *right_column_idx)?;
+        return Ok(PackedMask::from_bool_slice(&bool_mask));
+    }
+
     let column_idx = match predicate {
         ColumnPredicate::LessThan { column_idx, .. }
         | ColumnPredicate::GreaterThan { column_idx, .. }
@@ -169,6 +178,7 @@ fn evaluate_predicate_simd_packed(
         | ColumnPredicate::Between { column_idx, .. }
         | ColumnPredicate::Like { column_idx, .. }
         | ColumnPredicate::InList { column_idx, .. } => *column_idx,
+        ColumnPredicate::ColumnCompare { .. } => unreachable!(), // Handled above
     };
 
     let column = batch.column(column_idx).ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
@@ -216,6 +226,11 @@ fn evaluate_predicate_simd(
         return Ok(vec![false; batch.row_count()]);
     }
 
+    // Handle ColumnCompare specially - needs two columns
+    if let ColumnPredicate::ColumnCompare { left_column_idx, op, right_column_idx } = predicate {
+        return evaluate_column_compare_simd(batch, *left_column_idx, *op, *right_column_idx);
+    }
+
     let column_idx = match predicate {
         ColumnPredicate::LessThan { column_idx, .. }
         | ColumnPredicate::GreaterThan { column_idx, .. }
@@ -226,6 +241,7 @@ fn evaluate_predicate_simd(
         | ColumnPredicate::Between { column_idx, .. }
         | ColumnPredicate::Like { column_idx, .. }
         | ColumnPredicate::InList { column_idx, .. } => *column_idx,
+        ColumnPredicate::ColumnCompare { .. } => unreachable!(), // Handled above
     };
 
     let column = batch.column(column_idx).ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
@@ -267,6 +283,278 @@ fn evaluate_predicate_simd(
         // Scalar fallback for other column types
         _ => evaluate_predicate_scalar(batch, predicate, column_idx),
     }
+}
+
+/// Evaluate a column-to-column comparison using vectorized operations where possible
+///
+/// This is the main optimization for predicates like `l_commitdate < l_receiptdate` in TPC-H Q4.
+/// For Date columns (i32), this uses a tight scalar loop that the compiler can auto-vectorize.
+fn evaluate_column_compare_simd(
+    batch: &ColumnarBatch,
+    left_column_idx: usize,
+    op: CompareOp,
+    right_column_idx: usize,
+) -> Result<Vec<bool>, ExecutorError> {
+    let row_count = batch.row_count();
+
+    let left_column =
+        batch.column(left_column_idx).ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: left_column_idx,
+            batch_columns: batch.column_count(),
+        })?;
+
+    let right_column =
+        batch.column(right_column_idx).ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+            column_index: right_column_idx,
+            batch_columns: batch.column_count(),
+        })?;
+
+    // Try SIMD path for matching column types
+    match (left_column, right_column) {
+        // Date columns (i32) - common case for TPC-H Q4 (l_commitdate < l_receiptdate)
+        (ColumnArray::Date(left_values, left_nulls), ColumnArray::Date(right_values, right_nulls)) => {
+            evaluate_column_compare_i32_simd(
+                left_values,
+                left_nulls.as_ref().map(|n| n.as_slice()),
+                op,
+                right_values,
+                right_nulls.as_ref().map(|n| n.as_slice()),
+            )
+        }
+
+        // Int64 columns
+        (ColumnArray::Int64(left_values, left_nulls), ColumnArray::Int64(right_values, right_nulls)) => {
+            evaluate_column_compare_i64_simd(
+                left_values,
+                left_nulls.as_ref().map(|n| n.as_slice()),
+                op,
+                right_values,
+                right_nulls.as_ref().map(|n| n.as_slice()),
+            )
+        }
+
+        // Float64 columns
+        (ColumnArray::Float64(left_values, left_nulls), ColumnArray::Float64(right_values, right_nulls)) => {
+            evaluate_column_compare_f64_simd(
+                left_values,
+                left_nulls.as_ref().map(|n| n.as_slice()),
+                op,
+                right_values,
+                right_nulls.as_ref().map(|n| n.as_slice()),
+            )
+        }
+
+        // Timestamp columns (i64)
+        (ColumnArray::Timestamp(left_values, left_nulls), ColumnArray::Timestamp(right_values, right_nulls)) => {
+            evaluate_column_compare_i64_simd(
+                left_values,
+                left_nulls.as_ref().map(|n| n.as_slice()),
+                op,
+                right_values,
+                right_nulls.as_ref().map(|n| n.as_slice()),
+            )
+        }
+
+        // Fallback to scalar evaluation for other types or mismatched types
+        _ => {
+            let mut result = Vec::with_capacity(row_count);
+            for row_idx in 0..row_count {
+                let left_val = batch.get_value(row_idx, left_column_idx)?;
+                let right_val = batch.get_value(row_idx, right_column_idx)?;
+                let passes = evaluate_column_compare(op, Some(&left_val), Some(&right_val));
+                result.push(passes);
+            }
+            Ok(result)
+        }
+    }
+}
+
+/// Evaluate column-to-column comparison for i32 arrays (Date columns)
+/// Uses a tight loop that LLVM can auto-vectorize
+fn evaluate_column_compare_i32_simd(
+    left_values: &[i32],
+    left_nulls: Option<&[bool]>,
+    op: CompareOp,
+    right_values: &[i32],
+    right_nulls: Option<&[bool]>,
+) -> Result<Vec<bool>, ExecutorError> {
+    let len = left_values.len();
+    let mut result = vec![false; len];
+
+    // Pre-compute null masks
+    let has_left_nulls = left_nulls.is_some();
+    let has_right_nulls = right_nulls.is_some();
+
+    match op {
+        CompareOp::LessThan => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] < right_values[i];
+            }
+        }
+        CompareOp::GreaterThan => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] > right_values[i];
+            }
+        }
+        CompareOp::LessThanOrEqual => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] <= right_values[i];
+            }
+        }
+        CompareOp::GreaterThanOrEqual => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] >= right_values[i];
+            }
+        }
+        CompareOp::Equal => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] == right_values[i];
+            }
+        }
+        CompareOp::NotEqual => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] != right_values[i];
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Evaluate column-to-column comparison for i64 arrays
+fn evaluate_column_compare_i64_simd(
+    left_values: &[i64],
+    left_nulls: Option<&[bool]>,
+    op: CompareOp,
+    right_values: &[i64],
+    right_nulls: Option<&[bool]>,
+) -> Result<Vec<bool>, ExecutorError> {
+    let len = left_values.len();
+    let mut result = vec![false; len];
+
+    let has_left_nulls = left_nulls.is_some();
+    let has_right_nulls = right_nulls.is_some();
+
+    match op {
+        CompareOp::LessThan => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] < right_values[i];
+            }
+        }
+        CompareOp::GreaterThan => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] > right_values[i];
+            }
+        }
+        CompareOp::LessThanOrEqual => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] <= right_values[i];
+            }
+        }
+        CompareOp::GreaterThanOrEqual => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] >= right_values[i];
+            }
+        }
+        CompareOp::Equal => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] == right_values[i];
+            }
+        }
+        CompareOp::NotEqual => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] != right_values[i];
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Evaluate column-to-column comparison for f64 arrays
+fn evaluate_column_compare_f64_simd(
+    left_values: &[f64],
+    left_nulls: Option<&[bool]>,
+    op: CompareOp,
+    right_values: &[f64],
+    right_nulls: Option<&[bool]>,
+) -> Result<Vec<bool>, ExecutorError> {
+    let len = left_values.len();
+    let mut result = vec![false; len];
+
+    let has_left_nulls = left_nulls.is_some();
+    let has_right_nulls = right_nulls.is_some();
+
+    match op {
+        CompareOp::LessThan => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] < right_values[i];
+            }
+        }
+        CompareOp::GreaterThan => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] > right_values[i];
+            }
+        }
+        CompareOp::LessThanOrEqual => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] <= right_values[i];
+            }
+        }
+        CompareOp::GreaterThanOrEqual => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] >= right_values[i];
+            }
+        }
+        CompareOp::Equal => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] == right_values[i];
+            }
+        }
+        CompareOp::NotEqual => {
+            for i in 0..len {
+                let is_null = (has_left_nulls && left_nulls.unwrap()[i])
+                    || (has_right_nulls && right_nulls.unwrap()[i]);
+                result[i] = !is_null && left_values[i] != right_values[i];
+            }
+        }
+    }
+
+    Ok(result)
 }
 
 /// Scalar fallback for non-numeric columns
@@ -676,5 +964,171 @@ mod tests {
 
         // All 3 rows should pass all predicates
         assert_eq!(filtered.row_count(), 3, "All rows should pass from_storage_columnar path");
+    }
+
+    /// Test column-to-column comparison for Date columns (TPC-H Q4 pattern)
+    #[test]
+    fn test_simd_filter_column_compare_date() {
+        use vibesql_types::Date;
+
+        // Test case: l_commitdate < l_receiptdate (TPC-H Q4 pattern)
+        // Two date columns where we compare values within the same row
+        let rows = vec![
+            // Row 0: commitdate < receiptdate -> passes
+            Row::new(vec![
+                SqlValue::Date(Date { year: 1994, month: 6, day: 10 }), // commitdate
+                SqlValue::Date(Date { year: 1994, month: 6, day: 20 }), // receiptdate
+            ]),
+            // Row 1: commitdate == receiptdate -> fails
+            Row::new(vec![
+                SqlValue::Date(Date { year: 1994, month: 6, day: 15 }),
+                SqlValue::Date(Date { year: 1994, month: 6, day: 15 }),
+            ]),
+            // Row 2: commitdate > receiptdate -> fails
+            Row::new(vec![
+                SqlValue::Date(Date { year: 1994, month: 6, day: 25 }),
+                SqlValue::Date(Date { year: 1994, month: 6, day: 20 }),
+            ]),
+            // Row 3: commitdate < receiptdate -> passes
+            Row::new(vec![
+                SqlValue::Date(Date { year: 1995, month: 1, day: 5 }),
+                SqlValue::Date(Date { year: 1995, month: 3, day: 10 }),
+            ]),
+        ];
+
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+
+        // Filter: col0 < col1 (commitdate < receiptdate)
+        let predicates = vec![ColumnPredicate::ColumnCompare {
+            left_column_idx: 0,
+            op: CompareOp::LessThan,
+            right_column_idx: 1,
+        }];
+
+        let filtered = simd_filter_batch(&batch, &predicates).unwrap();
+
+        // Should match rows 0 and 3
+        assert_eq!(filtered.row_count(), 2);
+    }
+
+    /// Test column-to-column comparison for Int64 columns
+    #[test]
+    fn test_simd_filter_column_compare_int64() {
+        let rows = vec![
+            // Row 0: 5 < 10 -> passes
+            Row::new(vec![SqlValue::Integer(5), SqlValue::Integer(10)]),
+            // Row 1: 10 < 10 -> fails
+            Row::new(vec![SqlValue::Integer(10), SqlValue::Integer(10)]),
+            // Row 2: 15 < 10 -> fails
+            Row::new(vec![SqlValue::Integer(15), SqlValue::Integer(10)]),
+            // Row 3: 3 < 20 -> passes
+            Row::new(vec![SqlValue::Integer(3), SqlValue::Integer(20)]),
+        ];
+
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+
+        let predicates = vec![ColumnPredicate::ColumnCompare {
+            left_column_idx: 0,
+            op: CompareOp::LessThan,
+            right_column_idx: 1,
+        }];
+
+        let filtered = simd_filter_batch(&batch, &predicates).unwrap();
+
+        // Should match rows 0 and 3
+        assert_eq!(filtered.row_count(), 2);
+    }
+
+    /// Test column-to-column comparison with NULL handling
+    #[test]
+    fn test_simd_filter_column_compare_with_nulls() {
+        use vibesql_types::Date;
+
+        let rows = vec![
+            // Row 0: commitdate < receiptdate -> passes
+            Row::new(vec![
+                SqlValue::Date(Date { year: 1994, month: 6, day: 10 }),
+                SqlValue::Date(Date { year: 1994, month: 6, day: 20 }),
+            ]),
+            // Row 1: NULL < receiptdate -> fails (NULL comparison)
+            Row::new(vec![SqlValue::Null, SqlValue::Date(Date { year: 1994, month: 6, day: 20 })]),
+            // Row 2: commitdate < NULL -> fails (NULL comparison)
+            Row::new(vec![SqlValue::Date(Date { year: 1994, month: 6, day: 10 }), SqlValue::Null]),
+            // Row 3: commitdate < receiptdate -> passes
+            Row::new(vec![
+                SqlValue::Date(Date { year: 1995, month: 1, day: 5 }),
+                SqlValue::Date(Date { year: 1995, month: 3, day: 10 }),
+            ]),
+        ];
+
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+
+        let predicates = vec![ColumnPredicate::ColumnCompare {
+            left_column_idx: 0,
+            op: CompareOp::LessThan,
+            right_column_idx: 1,
+        }];
+
+        let filtered = simd_filter_batch(&batch, &predicates).unwrap();
+
+        // Should match rows 0 and 3 (NULL rows fail)
+        assert_eq!(filtered.row_count(), 2);
+    }
+
+    /// Test different comparison operators for column-to-column
+    #[test]
+    fn test_simd_filter_column_compare_operators() {
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(5), SqlValue::Integer(10)]),
+            Row::new(vec![SqlValue::Integer(10), SqlValue::Integer(10)]),
+            Row::new(vec![SqlValue::Integer(15), SqlValue::Integer(10)]),
+        ];
+
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+
+        // Test Equal
+        let predicates = vec![ColumnPredicate::ColumnCompare {
+            left_column_idx: 0,
+            op: CompareOp::Equal,
+            right_column_idx: 1,
+        }];
+        let filtered = simd_filter_batch(&batch, &predicates).unwrap();
+        assert_eq!(filtered.row_count(), 1); // Only row 1
+
+        // Test GreaterThan
+        let predicates = vec![ColumnPredicate::ColumnCompare {
+            left_column_idx: 0,
+            op: CompareOp::GreaterThan,
+            right_column_idx: 1,
+        }];
+        let filtered = simd_filter_batch(&batch, &predicates).unwrap();
+        assert_eq!(filtered.row_count(), 1); // Only row 2
+
+        // Test GreaterThanOrEqual
+        let predicates = vec![ColumnPredicate::ColumnCompare {
+            left_column_idx: 0,
+            op: CompareOp::GreaterThanOrEqual,
+            right_column_idx: 1,
+        }];
+        let filtered = simd_filter_batch(&batch, &predicates).unwrap();
+        assert_eq!(filtered.row_count(), 2); // Rows 1 and 2
+
+        // Test LessThanOrEqual
+        let predicates = vec![ColumnPredicate::ColumnCompare {
+            left_column_idx: 0,
+            op: CompareOp::LessThanOrEqual,
+            right_column_idx: 1,
+        }];
+        let filtered = simd_filter_batch(&batch, &predicates).unwrap();
+        assert_eq!(filtered.row_count(), 2); // Rows 0 and 1
+
+        // Test NotEqual
+        let predicates = vec![ColumnPredicate::ColumnCompare {
+            left_column_idx: 0,
+            op: CompareOp::NotEqual,
+            right_column_idx: 1,
+        }];
+        let filtered = simd_filter_batch(&batch, &predicates).unwrap();
+        assert_eq!(filtered.row_count(), 2); // Rows 0 and 2
     }
 }

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/string.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/string.rs
@@ -183,6 +183,16 @@ pub fn evaluate_predicate_string_batch(
             }
             result
         }
+
+        // ColumnCompare is not supported for string columns in this path
+        // It's handled at a higher level in simd_filter/mod.rs
+        ColumnPredicate::ColumnCompare { .. } => {
+            return Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "column-to-column comparison".to_string(),
+                left_type: "String".to_string(),
+                right_type: Some("Should be handled in simd_filter/mod.rs".to_string()),
+            });
+        }
     };
 
     Ok(result)


### PR DESCRIPTION
## Summary
- Add support for predicates comparing two columns (e.g., `l_commitdate < l_receiptdate`) in the columnar filtering path
- Enable SIMD-accelerated evaluation of column-to-column predicates for Date (i32), Int64, Float64, and Timestamp columns
- Particularly beneficial for TPC-H Q4 performance

## Changes
- Add `CompareOp` enum and `ColumnCompare` variant to `ColumnPredicate`
- Update `extract_tree_recursive()` to detect column-to-column comparisons
- Update `extract_predicates_recursive()` for legacy path compatibility
- Add `evaluate_column_compare()` function for row-by-row evaluation
- Add SIMD-accelerated column compare functions (`evaluate_column_compare_i32_simd`, `evaluate_column_compare_i64_simd`, `evaluate_column_compare_f64_simd`)
- Handle `ColumnCompare` in all predicate evaluation paths (columnar/mod.rs, simd_filter/mod.rs, simd_filter/comparison.rs, simd_filter/string.rs)
- Add comprehensive unit tests for all comparison operators and data types

## Test plan
- [x] All existing vibesql-executor tests pass (1846 tests)
- [x] New unit tests for column-to-column comparisons pass:
  - `test_column_to_column_comparison`
  - `test_column_to_column_legacy_path`
  - `test_column_to_column_all_operators`
  - `test_simd_filter_column_compare_date`
  - `test_simd_filter_column_compare_int64`
  - `test_simd_filter_column_compare_with_nulls`
  - `test_simd_filter_column_compare_operators`
- [x] TPC-H Q4 runs successfully

Closes #4042

🤖 Generated with [Claude Code](https://claude.com/claude-code)