### PR TITLE
refactor(profiling): Remove redundant debug env vars per audit

### DIFF
--- a/crates/vibesql-executor/src/select/executor/nonagg/simd.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/simd.rs
@@ -25,18 +25,9 @@ pub(super) fn try_simd_filter(
     where_expr: &vibesql_ast::Expression,
     schema: &crate::schema::CombinedSchema,
 ) -> Result<(Vec<vibesql_storage::Row>, bool), ExecutorError> {
-    let simd_debug = std::env::var("SIMD_DEBUG").is_ok();
-
     // Only use SIMD for datasets >= threshold
     if rows.len() < VECTORIZE_THRESHOLD {
-        if simd_debug {
-            eprintln!("[SIMD] Skipping: {} rows < {} threshold", rows.len(), VECTORIZE_THRESHOLD);
-        }
         return Ok((rows, false));
-    }
-
-    if simd_debug {
-        eprintln!("[SIMD] Attempting SIMD filter on {} rows", rows.len());
     }
 
     // Extract column names from combined schema (in order)
@@ -50,16 +41,8 @@ pub(super) fn try_simd_filter(
     // Try to convert rows to RecordBatch
     // If this fails (e.g., unsupported types), fall back to row-based filtering
     let batch = match rows_to_record_batch(&rows, &column_names) {
-        Ok(batch) => {
-            if simd_debug {
-                eprintln!("[SIMD] Successfully converted to RecordBatch");
-            }
-            batch
-        }
-        Err(e) => {
-            if simd_debug {
-                eprintln!("[SIMD] Failed to convert to RecordBatch: {}", e);
-            }
+        Ok(batch) => batch,
+        Err(_) => {
             // Conversion failed (unsupported types, etc.) - fall back to row-based
             return Ok((rows, false));
         }
@@ -68,20 +51,8 @@ pub(super) fn try_simd_filter(
     // Apply SIMD filter
     // If this fails (e.g., complex predicates), fall back to row-based filtering
     let filtered_batch = match filter_record_batch_simd(&batch, where_expr) {
-        Ok(filtered) => {
-            if simd_debug {
-                eprintln!(
-                    "[SIMD] Filter succeeded: {} rows -> {} rows",
-                    batch.num_rows(),
-                    filtered.num_rows()
-                );
-            }
-            filtered
-        }
-        Err(e) => {
-            if simd_debug {
-                eprintln!("[SIMD] Filter failed: {}", e);
-            }
+        Ok(filtered) => filtered,
+        Err(_) => {
             // SIMD filter failed (complex predicate, etc.) - fall back to row-based
             return Ok((rows, false));
         }
@@ -89,10 +60,6 @@ pub(super) fn try_simd_filter(
 
     // Convert filtered RecordBatch back to rows
     let filtered_rows = record_batch_to_rows(&filtered_batch)?;
-
-    if simd_debug {
-        eprintln!("[SIMD] SIMD path completed successfully");
-    }
 
     Ok((filtered_rows, true))
 }

--- a/crates/vibesql-executor/src/select/scan/join_scan.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan.rs
@@ -97,12 +97,6 @@ where
     // When left side is small, use index lookups on right table instead of scanning all rows
     if matches!(join_type, vibesql_ast::JoinType::Semi) {
         let left_row_count = left_result.as_slice().len();
-        if std::env::var("INL_DEBUG").is_ok() {
-            eprintln!(
-                "[INL] SEMI join detected, left_row_count={}, threshold={}",
-                left_row_count, INL_THRESHOLD
-            );
-        }
         if left_row_count > 0 && left_row_count < INL_THRESHOLD {
             if let Some(result) =
                 try_index_nested_loop_semi_join(&left_result, right, condition, database)?
@@ -379,15 +373,6 @@ fn extract_right_only_predicates(
         return None;
     }
 
-    // Debug output
-    if std::env::var("JOIN_SCAN_DEBUG").is_ok() {
-        eprintln!(
-            "[JOIN_SCAN] Extracted {} right-only predicates for tables {:?}",
-            right_only_predicates.len(),
-            right_tables
-        );
-    }
-
     // Combine predicates with AND
     combine_with_and(right_only_predicates)
 }
@@ -478,17 +463,6 @@ fn filter_out_nullable_side_predicates(
         })
         .collect();
 
-    // Debug output
-    if std::env::var("JOIN_SCAN_DEBUG").is_ok() {
-        let original_count = flatten_conjuncts(where_expr).len();
-        eprintln!(
-            "[JOIN_SCAN] filter_out_nullable_side_predicates: kept {}/{} predicates, nullable tables: {:?}",
-            kept_predicates.len(),
-            original_count,
-            nullable_tables
-        );
-    }
-
     // Combine remaining predicates with AND (returns None if empty)
     combine_with_and(kept_predicates)
 }
@@ -572,71 +546,32 @@ fn try_index_nested_loop_semi_join(
     condition: &Option<vibesql_ast::Expression>,
     database: &vibesql_storage::Database,
 ) -> Result<Option<super::FromResult>, ExecutorError> {
-    let debug = std::env::var("INL_DEBUG").is_ok();
-
-    if debug {
-        eprintln!("[INL] try_index_nested_loop_semi_join called");
-    }
-
     // Must have a join condition
     let cond = match condition {
         Some(c) => c,
-        None => {
-            if debug {
-                eprintln!("[INL] No condition, returning None");
-            }
-            return Ok(None);
-        }
+        None => return Ok(None),
     };
 
     // Right side must be a simple table (not a join or subquery)
     let (right_table_name, _right_alias) = match right_from {
         vibesql_ast::FromClause::Table { name, alias, .. } => (name.clone(), alias.clone()),
-        _ => {
-            if debug {
-                eprintln!("[INL] Right side is not a simple table");
-            }
-            return Ok(None); // Complex right side, can't use INL
-        }
+        _ => return Ok(None), // Complex right side, can't use INL
     };
-
-    if debug {
-        eprintln!("[INL] Right table: {}", right_table_name);
-    }
 
     // Get the right table
     let right_table = match database.get_table(&right_table_name) {
         Some(t) => t,
-        None => {
-            if debug {
-                eprintln!("[INL] Table not found: {}", right_table_name);
-            }
-            return Ok(None);
-        }
+        None => return Ok(None),
     };
 
     // Parse the join condition to extract:
     // 1. The equi-join columns (left_col = right_col)
     // 2. Additional filter predicates on the right table
     let (equi_join, right_filters) =
-        match parse_semi_join_condition(cond, left_result, &right_table_name, debug) {
+        match parse_semi_join_condition(cond, left_result, &right_table_name) {
             Some(parsed) => parsed,
-            None => {
-                if debug {
-                    eprintln!("[INL] parse_semi_join_condition returned None");
-                }
-                return Ok(None);
-            }
+            None => return Ok(None),
         };
-
-    if debug {
-        eprintln!(
-            "[INL] Parsed condition: left_col={}, right_col={}, has_right_filters={}",
-            equi_join.left_col,
-            equi_join.right_col,
-            right_filters.is_some()
-        );
-    }
 
     // Check if the right table has a usable index for point lookups
     // We need an index that starts with the join key column
@@ -653,26 +588,13 @@ fn try_index_nested_loop_semi_join(
     let constant_prefix =
         extract_constant_prefix_for_pk(&right_filters, &pk_columns, &equi_join.right_col);
 
-    if debug {
-        eprintln!("[INL] PK columns: {:?}, constant_prefix: {:?}", pk_columns, constant_prefix);
-    }
-
     // Build the index lookup key template
     // For Stock-Level: key = [s_w_id (from filter), s_i_id (from join)]
     let lookup_key_template =
         match build_lookup_key_template(&pk_columns, &equi_join.right_col, &constant_prefix) {
             Some(template) => template,
-            None => {
-                if debug {
-                    eprintln!("[INL] Cannot build lookup key template, falling back to hash join");
-                }
-                return Ok(None);
-            }
+            None => return Ok(None),
         };
-
-    if debug {
-        eprintln!("[INL] Using INL with lookup_key_template: {:?}", lookup_key_template);
-    }
 
     // Get the primary key index
     let pk_index = match right_table.primary_key_index() {
@@ -745,14 +667,6 @@ fn try_index_nested_loop_semi_join(
         }
     }
 
-    if debug {
-        eprintln!(
-            "[INL] Found {} matching keys out of {} distinct left keys",
-            matching_keys.len(),
-            seen_keys.len()
-        );
-    }
-
     // Build result: all left rows whose join key is in matching_keys
     let result_rows: Vec<vibesql_storage::Row> = left_slice
         .iter()
@@ -777,20 +691,11 @@ fn parse_semi_join_condition(
     cond: &vibesql_ast::Expression,
     left_result: &super::FromResult,
     right_table_name: &str,
-    debug: bool,
 ) -> Option<(EquiJoinInfo, Option<vibesql_ast::Expression>)> {
     let conjuncts = flatten_conjuncts(cond);
 
-    if debug {
-        eprintln!("[INL] Parsing condition with {} conjuncts", conjuncts.len());
-    }
-
     let left_tables: HashSet<String> =
         left_result.schema.table_schemas.keys().map(|s| s.to_uppercase()).collect();
-
-    if debug {
-        eprintln!("[INL] Left tables: {:?}", left_tables);
-    }
 
     let right_table_upper = right_table_name.to_uppercase();
 
@@ -798,10 +703,6 @@ fn parse_semi_join_condition(
     let mut right_only_preds: Vec<vibesql_ast::Expression> = Vec::new();
 
     for pred in conjuncts {
-        if debug {
-            eprintln!("[INL] Analyzing predicate: {:?}", pred);
-        }
-
         // Check if this is an equi-join predicate (col1 = col2)
         if let vibesql_ast::Expression::BinaryOp {
             left,
@@ -819,14 +720,6 @@ fn parse_semi_join_condition(
                 let right_tbl_upper = right_tbl.as_ref().map(|s| s.to_uppercase());
 
                 let left_col_upper = left_col.to_uppercase();
-                let _right_col_upper = right_col.to_uppercase();
-
-                if debug {
-                    eprintln!(
-                        "[INL] Found column=column eq: left=({:?}, {}), right=({:?}, {})",
-                        left_tbl_upper, left_col, right_tbl_upper, right_col
-                    );
-                }
 
                 // Check if left_col is from left tables and right_col is from right table
                 // When table qualifier is None, check if column exists in any left table's schema
@@ -837,13 +730,6 @@ fn parse_semi_join_condition(
                         });
                 let right_is_right =
                     right_tbl_upper.as_ref().map(|t| t == &right_table_upper).unwrap_or(true);
-
-                if debug {
-                    eprintln!(
-                        "[INL] left_is_left={}, right_is_right={}",
-                        left_is_left, right_is_right
-                    );
-                }
 
                 if left_is_left && right_is_right && equi_join.is_none() {
                     equi_join = Some(EquiJoinInfo {
@@ -872,10 +758,6 @@ fn parse_semi_join_condition(
         // Check if this predicate references only the right table
         // (We'll add it to right_only_preds)
         right_only_preds.push(pred);
-    }
-
-    if debug && equi_join.is_none() {
-        eprintln!("[INL] No equi-join predicate found");
     }
 
     equi_join.map(|ej| {

--- a/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
@@ -707,15 +707,7 @@ fn identify_semi_join_target_table(
         .collect();
 
     // Find column references in the condition that belong to inner tables
-    let target = find_inner_table_in_condition(condition, &table_names);
-
-    if std::env::var("SEMI_JOIN_DEBUG").is_ok() {
-        eprintln!("[SEMI_JOIN_DEBUG] Condition: {:?}", condition);
-        eprintln!("[SEMI_JOIN_DEBUG] Inner tables: {:?}", table_names);
-        eprintln!("[SEMI_JOIN_DEBUG] Target table: {:?}", target);
-    }
-
-    target
+    find_inner_table_in_condition(condition, &table_names)
 }
 
 /// Find which inner table is referenced in the semi-join condition

--- a/docs/performance/CPU_PROFILING.md
+++ b/docs/performance/CPU_PROFILING.md
@@ -289,19 +289,16 @@ VibeSQL includes extensive built-in profiling via environment variables. These p
 | `VIBESQL_PROFILE=1` | Enable general query profiling output |
 | `JOIN_PROFILE=1` | Profile join execution with timing breakdown |
 | `JOIN_REORDER_VERBOSE=1` | Log join reordering decisions and costs |
-| `TABLE_SCAN_DEBUG=1` | Debug table scan operations |
-| `COLUMNAR_DEBUG=1` | Debug columnar execution path |
-| `SIMD_DEBUG=1` | Debug SIMD vectorization |
+| `TABLE_SCAN_DEBUG=1` | Log index vs table scan path selection |
+| `COLUMNAR_DEBUG=1` | Log columnar filter optimization decisions |
 
 ### Index Operations
 
 | Variable | Description |
 |----------|-------------|
-| `INDEX_SELECT_DEBUG=1` | Debug index selection decisions |
+| `INDEX_SELECT_DEBUG=1` | Log index selection decisions with selectivity |
 | `RANGE_SCAN_PROFILE=1` | Profile range scan timing |
 | `RANGE_QUERY_BREAKDOWN=1` | Detailed range query timing |
-| `INL_DEBUG=1` | Debug index nested loop joins |
-| `JOIN_SCAN_DEBUG=1` | Debug join scan operations |
 
 ### DML Operations
 
@@ -310,7 +307,7 @@ VibeSQL includes extensive built-in profiling via environment variables. These p
 | `DELETE_PROFILE=1` | Collect delete timing statistics |
 | `DELETE_PROFILE_VERBOSE=1` | Per-delete timing breakdown |
 | `DELETE_PROFILE_SUMMARY=1` | Aggregate summary on thread exit |
-| `DML_COST_DEBUG=1` | Log DML cost estimation |
+| `DML_COST_DEBUG=1` | Log DML cost estimation decisions |
 
 ### Query Optimization
 
@@ -318,7 +315,6 @@ VibeSQL includes extensive built-in profiling via environment variables. These p
 |----------|-------------|
 | `SUBQUERY_TRANSFORM_VERBOSE=1` | Log subquery-to-join transformations |
 | `TABLE_ELIM_VERBOSE=1` | Log table elimination decisions |
-| `SEMI_JOIN_DEBUG=1` | Debug semi-join execution |
 
 ### Benchmark Controls
 
@@ -340,7 +336,7 @@ JOIN_PROFILE=1 JOIN_REORDER_VERBOSE=1 \
   ./target/release/deps/tpch_profiling-* Q13
 
 # Debug index selection for TPC-C
-INDEX_SELECT_DEBUG=1 INL_DEBUG=1 \
+INDEX_SELECT_DEBUG=1 \
   TPCC_SCALE_FACTOR=1 TPCC_DURATION_SECS=5 \
   ./target/release/deps/tpcc_benchmark-*
 ```

--- a/docs/performance/PROFILING_AUDIT.md
+++ b/docs/performance/PROFILING_AUDIT.md
@@ -1,0 +1,366 @@
+# Profiling Environment Variables Audit
+
+This document audits the custom profiling environment variables in VibeSQL to determine which provide unique value vs. which are redundant with samply CPU profiling.
+
+**Issue**: #4051
+**Parent Epic**: #4050 (Rationalize profiling infrastructure)
+
+## Audit Methodology
+
+For each environment variable, we evaluated:
+1. **What it logs** - The specific information output
+2. **Semantic vs Debug** - Does it explain WHY decisions were made, or just WHAT happened?
+3. **Redundancy with samply** - Can a CPU profiler (flamegraph) provide equivalent insight?
+4. **Active usage** - Is it used in benchmarks or debugging workflows?
+
+## Categorization Summary
+
+| Category | Count | Recommendation |
+|----------|-------|----------------|
+| **KEEP - Semantic** | 4 | Essential for understanding optimizer decisions |
+| **KEEP - Phase Timing** | 6 | Provides structured timing samply can't replicate |
+| **REMOVE - Debug Spam** | 4 | Function entry/exit, redundant with CPU profiling |
+| **CONSOLIDATE** | 3 | Merge into unified patterns |
+
+---
+
+## KEEP: Semantic Logging (4 vars)
+
+These variables explain **WHY** the optimizer made specific decisions - information that CPU profiling cannot provide.
+
+### `JOIN_REORDER_VERBOSE`
+
+**Location**: `crates/vibesql-executor/src/select/scan/reorder/optimizer.rs`, `predicates.rs`
+**Usage Count**: 15+ locations
+**Added**: For TPC-H Q19 optimization (#3243)
+
+**What it logs**:
+- Schema-based column mapping results
+- WHERE clause predicates and extracted equijoins
+- Table-local predicates for cardinality estimation
+- Original vs optimal join order comparison
+- Optimizer time budget and search decisions
+
+**Example output**:
+```
+[JOIN_REORDER] Schema-based column mapping: 45 columns resolved from 6 tables
+[JOIN_REORDER] Extracted 3 WHERE equijoins
+[JOIN_REORDER] Original order: ["lineitem", "orders", "customer"]
+[JOIN_REORDER] Optimal order:  ["customer", "orders", "lineitem"]
+```
+
+**Verdict**: **KEEP** - Essential for debugging join optimization. Explains the reasoning behind join order choices with cost estimates.
+
+---
+
+### `SUBQUERY_TRANSFORM_VERBOSE`
+
+**Location**: `crates/vibesql-executor/src/optimizer/subquery_to_join/`
+**Usage Count**: 8+ locations
+**Added**: For subquery-to-join optimization
+
+**What it logs**:
+- Self-join detection and alias creation
+- Column reference rewriting decisions
+- Derived table creation for aggregate subqueries
+- Final transformed FROM clause structure
+
+**Example output**:
+```
+[SUBQUERY_TRANSFORM] Self-join detected: table=item, new_alias=__subquery_item
+[SUBQUERY_TRANSFORM] Converting aggregate IN subquery to derived table semi-join
+[SUBQUERY_TRANSFORM] Derived table alias: __in_agg_0
+```
+
+**Verdict**: **KEEP** - Critical for understanding subquery optimization. Explains how IN/EXISTS are transformed to SEMI/ANTI joins.
+
+---
+
+### `TABLE_ELIM_VERBOSE`
+
+**Location**: `crates/vibesql-executor/src/optimizer/table_elimination.rs`
+**Usage Count**: 1 location
+**Added**: For table elimination optimization
+
+**What it logs**:
+- Which tables were eliminated and why
+- Foreign key relationships used for elimination
+- Before/after table counts
+
+**Verdict**: **KEEP** - Important for understanding query simplification decisions.
+
+---
+
+### `DML_COST_DEBUG`
+
+**Location**: `crates/vibesql-executor/src/delete/executor.rs`, `update/mod.rs`
+**Usage Count**: 4 locations
+**Added**: For DML cost estimation
+
+**What it logs**:
+- Row count thresholds for chunked operations
+- Index impact analysis (hash vs btree count)
+- Early compaction recommendations
+- Cost model reasoning
+
+**Example output**:
+```
+DML_COST_DEBUG: DELETE on orders - 1500 rows qualifies for chunked delete
+DML_COST_DEBUG: UPDATE 100 rows in lineitem - estimated_cost: 4.50 (hash_indexes: 2, btree_indexes: 1)
+```
+
+**Verdict**: **KEEP** - Explains cost model decisions for DML operations.
+
+---
+
+## KEEP: Structured Phase Timing (6 vars)
+
+These variables provide granular timing breakdowns that CPU profiling cannot replicate because they measure logical phases, not just function call stacks.
+
+### `DELETE_PROFILE` / `DELETE_PROFILE_VERBOSE` / `DELETE_PROFILE_SUMMARY`
+
+**Location**: `crates/vibesql-storage/src/database/index_ops.rs`
+**Added**: Dec 2025 (#3873)
+
+**What it logs**:
+- Per-operation timing: pk_lookup, value_clone, wal, index_update, row_remove, cache
+- Percentage breakdown of each phase
+- Aggregate statistics on thread exit
+
+**Example output**:
+```
+DELETE_PROFILE: total=45.2us | pk_lookup=12.1us (27%) | value_clone=3.2us (7%) |
+  wal=8.5us (19%) | index_update=15.3us (34%) | row_remove=4.8us (11%) | cache=1.3us (3%)
+```
+
+**Verdict**: **KEEP** - Well-designed instrumentation. Shows which DELETE sub-operation is the bottleneck. Samply can show function time but not these logical phases.
+
+---
+
+### `JOIN_PROFILE`
+
+**Location**: `crates/vibesql-executor/src/select/scan/reorder/optimizer.rs`
+**Added**: Nov 2025 (#2971)
+
+**What it logs**:
+- Per-join timing in multi-way joins
+- Intermediate result sizes
+- Hash vs nested-loop decision
+
+**Verdict**: **KEEP** - Shows join execution phases that span multiple functions.
+
+---
+
+### `RANGE_SCAN_PROFILE`
+
+**Location**: `crates/vibesql-executor/src/select/scan/index_scan/execution.rs`
+**Added**: Dec 2025 (#3830)
+
+**What it logs**:
+- Range scan setup time
+- Key iteration time
+- Row fetch time
+
+**Verdict**: **KEEP** - Shows index scan sub-phases.
+
+---
+
+### `RANGE_QUERY_BREAKDOWN`
+
+**Location**: Storage crate
+**Added**: For sysbench analysis
+
+**What it logs**:
+- Detailed range query timing
+
+**Verdict**: **KEEP** - Granular timing for range operations.
+
+---
+
+## REMOVE: Debug Spam (4 vars)
+
+These variables log function entry/exit or trace information that can be obtained more effectively with samply CPU profiling.
+
+### `SIMD_DEBUG`
+
+**Location**: `crates/vibesql-executor/src/select/executor/nonagg/simd.rs`
+**Usage Count**: 1 location (6 log points)
+**Added**: Nov 2025 (#2551) for SIMD date optimization investigation
+
+**What it logs**:
+```
+[SIMD] Skipping: 50 rows < 100 threshold
+[SIMD] Attempting SIMD filter on 1000 rows
+[SIMD] Successfully converted to RecordBatch
+```
+
+**Analysis**: This is pure trace logging - it tells you that SIMD was attempted but not why it succeeded/failed in a meaningful way. Samply shows if time is spent in SIMD code paths.
+
+**Verdict**: **REMOVE** - Function entry/exit logging. Use samply to see if SIMD paths are hot.
+
+---
+
+### `INL_DEBUG`
+
+**Location**: `crates/vibesql-executor/src/select/scan/join_scan.rs`
+**Usage Count**: 2 locations (10+ log points)
+
+**What it logs**:
+```
+[INL] SEMI join detected, left_row_count=5, threshold=100
+[INL] try_index_nested_loop_semi_join called
+[INL] Right table: stock
+[INL] No condition, returning None
+```
+
+**Analysis**: Traces through index nested loop decision logic. Most messages are "entering function X" or "condition Y was false". The actual decision is "did INL happen or not" which samply shows clearly.
+
+**Verdict**: **REMOVE** - Function trace logging. Samply shows if INL code paths execute.
+
+---
+
+### `JOIN_SCAN_DEBUG`
+
+**Location**: `crates/vibesql-executor/src/select/scan/join_scan.rs`
+**Usage Count**: 2 locations
+
+**What it logs**:
+```
+[JOIN_SCAN] Extracted 2 right-only predicates for tables ["orders"]
+[JOIN_SCAN] filter_out_nullable_side_predicates: kept 3/4 predicates
+```
+
+**Analysis**: Traces predicate extraction. Useful for debugging specific bugs but not for general performance analysis. The decision (which predicates were extracted) can be inferred from query plans.
+
+**Verdict**: **REMOVE** - Debugging trace, not needed for performance work.
+
+---
+
+### `SEMI_JOIN_DEBUG`
+
+**Location**: `crates/vibesql-executor/src/select/scan/reorder/optimizer.rs`
+**Usage Count**: 1 location
+
+**What it logs**:
+```
+[SEMI_JOIN_DEBUG] Condition: BinaryOp { ... }
+[SEMI_JOIN_DEBUG] Inner tables: ["stock"]
+[SEMI_JOIN_DEBUG] Target table: Some("stock")
+```
+
+**Analysis**: Traces semi-join target table resolution. Very low-level debugging.
+
+**Verdict**: **REMOVE** - Low-level debugging, use for specific bug investigation only.
+
+---
+
+## CONSOLIDATE: Mixed Value (3 vars)
+
+These provide some useful information but could be improved or consolidated.
+
+### `INDEX_SELECT_DEBUG`
+
+**Location**: `crates/vibesql-executor/src/select/scan/index_scan/selection.rs`
+**Usage Count**: 10 locations
+
+**What it logs**:
+```
+[INDEX_SELECT] table=stock, index=idx_stock_item, first_col=s_i_id, can_use_for_where=true
+[INDEX_SELECT] idx_stock_item selectivity=0.0033, access_method=IndexScan, is_index_scan=true
+[INDEX_SELECT] selected best_index=idx_stock_item for table=stock
+```
+
+**Analysis**: This is borderline - it explains the index selection decision (semantic) but also has many trace-level messages. The selectivity and access_method logs are valuable; the "skipping X" messages are trace spam.
+
+**Verdict**: **CONSOLIDATE** - Split into:
+- Keep decision logging (rename to `INDEX_SELECT_VERBOSE`)
+- Remove trace messages
+
+---
+
+### `TABLE_SCAN_DEBUG`
+
+**Location**: `crates/vibesql-executor/src/select/scan/table.rs`
+**Usage Count**: 2 locations
+
+**What it logs**:
+```
+[TABLE_SCAN] Using index scan: table=orders, index=idx_orders_cust
+[TABLE_SCAN] Falling back to table scan: table=nation, available_indexes=["pk_nation"]
+```
+
+**Analysis**: These two messages are actually useful - they show WHEN index vs table scan was chosen. But the name suggests debug spam.
+
+**Verdict**: **CONSOLIDATE** - Rename to `SCAN_PATH_VERBOSE` to clarify it shows scan path selection.
+
+---
+
+### `COLUMNAR_DEBUG`
+
+**Location**: `crates/vibesql-executor/src/select/scan/table.rs`
+**Usage Count**: 3 locations
+
+**What it logs**:
+```
+[COLUMNAR_DEBUG] orders (alias=o) table: has_filters=true
+[COLUMNAR_DEBUG] orders table: extracted 2 predicates for 6000 rows
+[COLUMNAR_DEBUG] orders table: extract_column_predicates returned None, using generic path
+```
+
+**Analysis**: Mildly useful - shows columnar optimization decisions. Could be merged with TABLE_SCAN_DEBUG.
+
+**Verdict**: **CONSOLIDATE** - Merge with `SCAN_PATH_VERBOSE`.
+
+---
+
+## Recommendations
+
+### Immediate Actions (This PR)
+
+1. **Remove 4 debug variables**:
+   - `SIMD_DEBUG` - Use samply for SIMD performance analysis
+   - `INL_DEBUG` - Use samply to see if INL paths are hot
+   - `JOIN_SCAN_DEBUG` - Low-level debugging only
+   - `SEMI_JOIN_DEBUG` - Low-level debugging only
+
+2. **Keep 10 variables unchanged**:
+   - `JOIN_REORDER_VERBOSE` - Essential semantic logging
+   - `SUBQUERY_TRANSFORM_VERBOSE` - Essential semantic logging
+   - `TABLE_ELIM_VERBOSE` - Essential semantic logging
+   - `DML_COST_DEBUG` - Essential semantic logging
+   - `DELETE_PROFILE` family (3) - Well-designed phase timing
+   - `JOIN_PROFILE` - Phase timing
+   - `RANGE_SCAN_PROFILE` - Phase timing
+   - `RANGE_QUERY_BREAKDOWN` - Phase timing
+
+### Follow-up Issues
+
+1. **Consolidate INDEX_SELECT_DEBUG** (#TBD):
+   - Split valuable selectivity logging from trace spam
+   - Rename to `INDEX_SELECT_VERBOSE`
+
+2. **Consolidate scan path logging** (#TBD):
+   - Merge `TABLE_SCAN_DEBUG` and `COLUMNAR_DEBUG`
+   - Create unified `SCAN_PATH_VERBOSE`
+
+3. **Document naming convention** (#TBD):
+   - `*_VERBOSE` = Semantic decision logging (keep)
+   - `*_PROFILE` = Phase timing instrumentation (keep)
+   - `*_DEBUG` = Reserved for temporary debugging (remove after use)
+
+---
+
+## Appendix: Control Variables (Not Audited)
+
+These are configuration/control variables, not profiling instrumentation:
+
+| Variable | Purpose |
+|----------|---------|
+| `SCALE_FACTOR` | TPC-H/TPC-DS scale |
+| `QUERY_FILTER` | Run specific queries |
+| `SKIP_SLOW` | Skip slow queries |
+| `VALIDATE` | Enable result validation |
+| `TABLE_ELIM_DISABLED` | Disable optimization |
+| `JOIN_REORDER_DISABLED` | Disable optimization |
+| `VIBESQL_DISABLE_COLUMNAR*` | Feature toggles |
+| `JOIN_REORDER_TIME_BUDGET_MS` | Tuning parameter |


### PR DESCRIPTION
## Summary

- Audits ~25 custom profiling environment variables
- Removes 4 redundant debug variables (replaced by samply CPU profiling)
- Keeps 10+ high-value semantic logging and phase timing variables
- Documents audit methodology in PROFILING_AUDIT.md

## Changes

### Removed Variables (redundant with samply)
- `SIMD_DEBUG` - trace logging for SIMD filter path
- `INL_DEBUG` - trace logging for index nested loop joins  
- `JOIN_SCAN_DEBUG` - trace logging for join predicate extraction
- `SEMI_JOIN_DEBUG` - trace logging for semi-join target resolution

### Kept Variables (unique value)
**Semantic logging** (explain WHY decisions were made):
- `JOIN_REORDER_VERBOSE` - explains join order choices with costs
- `SUBQUERY_TRANSFORM_VERBOSE` - explains subquery-to-join transformations
- `TABLE_ELIM_VERBOSE` - explains table elimination decisions
- `DML_COST_DEBUG` - explains DML cost model reasoning

**Phase timing** (structured breakdowns samply can't replicate):
- `DELETE_PROFILE` family - pk_lookup, wal, index_update phases
- `JOIN_PROFILE` - join execution phases
- `RANGE_SCAN_PROFILE` - range scan phases

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --release --package vibesql-executor` passes
- [x] All doc tests pass

Closes #4051

🤖 Generated with [Claude Code](https://claude.com/claude-code)