### PR TITLE
docs: Convert ignore doctests to text for cleaner test output

### DIFF
--- a/crates/vibesql-executor/src/debug_output.rs
+++ b/crates/vibesql-executor/src/debug_output.rs
@@ -337,7 +337,7 @@ pub fn debug_event(category: Category, event: &'static str, tag: &'static str) -
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```text
 /// debug_emit!(
 ///     optimizer, "join_reorder", "JOIN_REORDER",
 ///     text: "Optimal order: {:?}", optimal_order,

--- a/crates/vibesql-l10n/src/detection.rs
+++ b/crates/vibesql-l10n/src/detection.rs
@@ -28,7 +28,7 @@ const AVAILABLE_LOCALES: &[&str] = &["en-US", "es", "pt-BR", "zh-CN", "ja", "de"
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```text
 /// use vibesql_l10n::detect_locale;
 ///
 /// let locale = detect_locale();

--- a/crates/vibesql-l10n/src/lib.rs
+++ b/crates/vibesql-l10n/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! # Usage
 //!
-//! ```rust,ignore
+//! ```text
 //! use vibesql_l10n::{init, format, vibe_msg};
 //!
 //! // Initialize with system locale detection
@@ -150,7 +150,7 @@ fn create_bundle(locale_str: &str) -> Result<FluentBundle<FluentResource>, L10nE
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```text
 /// use vibesql_l10n::init;
 ///
 /// // Use system locale
@@ -195,7 +195,7 @@ pub fn init(locale: Option<&str>) -> Result<(), L10nError> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```text
 /// use vibesql_l10n::format;
 /// use fluent::FluentArgs;
 ///
@@ -236,7 +236,7 @@ pub fn format(msg_id: &str, args: Option<&FluentArgs>) -> String {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```text
 /// use vibesql_l10n::current_locale;
 ///
 /// let locale = current_locale();
@@ -252,7 +252,7 @@ pub fn current_locale() -> LanguageIdentifier {
 ///
 /// # Examples
 ///
-/// ```rust,ignore
+/// ```text
 /// use vibesql_l10n::vibe_msg;
 ///
 /// // Simple message without arguments

--- a/crates/vibesql-parser/src/arena_parser/mod.rs
+++ b/crates/vibesql-parser/src/arena_parser/mod.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! For arena-allocated AST (fastest, but requires arena lifetime management):
-//! ```ignore
+//! ```text
 //! use bumpalo::Bump;
 //! use vibesql_parser::arena_parser::ArenaParser;
 //!

--- a/crates/vibesql-python-bindings/src/conversions.rs
+++ b/crates/vibesql-python-bindings/src/conversions.rs
@@ -137,7 +137,7 @@ pub fn convert_params_to_sql_values(
 /// correct formatting for all SQL types.
 ///
 /// # Example
-/// ```ignore
+/// ```text
 /// // Input: "SELECT * FROM users WHERE id = ?"
 /// // Values: [Integer(42)]
 /// // Output: "SELECT * FROM users WHERE id = 42"

--- a/crates/vibesql-server/src/session.rs
+++ b/crates/vibesql-server/src/session.rs
@@ -205,7 +205,7 @@ impl Session {
     /// SQL will return the cached prepared statement without re-parsing.
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// let stmt = session.prepare("SELECT * FROM users WHERE id = ?")?;
     /// let result = session.execute_prepared(&stmt, &[SqlValue::Integer(1)]).await?;
     /// ```

--- a/crates/vibesql-server/src/subscription/manager.rs
+++ b/crates/vibesql-server/src/subscription/manager.rs
@@ -121,7 +121,7 @@ impl SubscriptionManager {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```text
     /// let manager = SubscriptionManager::new();
     /// let (tx, mut rx) = mpsc::channel(16);
     ///

--- a/crates/vibesql-server/src/subscription/mod.rs
+++ b/crates/vibesql-server/src/subscription/mod.rs
@@ -20,7 +20,7 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```text
 //! use vibesql_server::subscription::{SubscriptionManager, ChangeEvent};
 //! use tokio::sync::mpsc;
 //!

--- a/crates/vibesql-server/src/subscription/table_dependencies.rs
+++ b/crates/vibesql-server/src/subscription/table_dependencies.rs
@@ -26,7 +26,7 @@ use vibesql_parser::{ParseError, Parser};
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// use vibesql_server::subscription::extract_table_dependencies;
 ///
 /// // Simple query

--- a/crates/vibesql-server/src/subscription/table_extract.rs
+++ b/crates/vibesql-server/src/subscription/table_extract.rs
@@ -136,7 +136,7 @@ impl ExpressionVisitor for TableExtractor {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```text
 /// use vibesql_parser::Parser;
 /// use vibesql_server::subscription::extract_table_refs;
 ///

--- a/crates/vibesql-storage/src/btree/mod.rs
+++ b/crates/vibesql-storage/src/btree/mod.rs
@@ -35,7 +35,7 @@
 //!
 //! ## Usage Example (once #1473 is integrated):
 //!
-//! ```ignore
+//! ```text
 //! // In CREATE INDEX executor:
 //!
 //! // 1. Collect and sort all rows by index key(s)

--- a/crates/vibesql-storage/src/btree/node/btree_index/delete.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/delete.rs
@@ -41,7 +41,7 @@ impl BTreeIndex {
     /// - All row IDs for the key are removed regardless of count
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// use vibesql_types::SqlValue;
     ///
     /// // Insert duplicate keys
@@ -183,7 +183,7 @@ impl BTreeIndex {
     /// - Batch delete: O(n + log m) for sorted keys in same/adjacent leaves
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// use vibesql_types::SqlValue;
     ///
     /// // Delete multiple index entries in batch

--- a/crates/vibesql-storage/src/btree/node/btree_index/insert.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/insert.rs
@@ -58,7 +58,7 @@ impl BTreeIndex {
     /// - **Duplicate key**: O(log n) to find + O(1) to append to existing Vec
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// use vibesql_types::SqlValue;
     ///
     /// // Insert first occurrence of key 42

--- a/crates/vibesql-storage/src/btree/node/btree_index/mod.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/mod.rs
@@ -83,7 +83,7 @@ impl BTreeIndex {
     /// A new B+ tree index with an empty root
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// use std::sync::Arc;
     /// use vibesql_storage::btree::BTreeIndex;
     /// use vibesql_storage::page::PageManager;

--- a/crates/vibesql-storage/src/btree/node/btree_index/query.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/query.rs
@@ -26,7 +26,7 @@ impl BTreeIndex {
     /// - Total: O(log n + k)
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// use vibesql_types::SqlValue;
     ///
     /// // Insert duplicate keys
@@ -118,7 +118,7 @@ impl BTreeIndex {
     /// - Total: O(log n + m + k)
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// use vibesql_types::SqlValue;
     ///
     /// // Insert some data with duplicates
@@ -233,7 +233,7 @@ impl BTreeIndex {
     /// O(log n) - only finds the first leaf and returns immediately
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// // TPC-C Delivery: find oldest new_order for a district
     /// // Only returns the first (minimum) order ID
     /// let first = index.range_scan_first(

--- a/crates/vibesql-storage/src/columnar/interner.rs
+++ b/crates/vibesql-storage/src/columnar/interner.rs
@@ -8,7 +8,7 @@
 //!
 //! ## Usage
 //!
-//! ```ignore
+//! ```text
 //! let mut interner = StringInterner::new(32); // threshold of 32 distinct values
 //!
 //! let s1 = interner.intern("active");

--- a/crates/vibesql-storage/src/columnar/table.rs
+++ b/crates/vibesql-storage/src/columnar/table.rs
@@ -18,7 +18,7 @@ use super::types::ColumnTypeClass;
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```text
 /// use vibesql_storage::{Row, ColumnarTable};
 /// use vibesql_types::SqlValue;
 ///

--- a/crates/vibesql-storage/src/columnar_cache.rs
+++ b/crates/vibesql-storage/src/columnar_cache.rs
@@ -81,7 +81,7 @@ struct CacheEntry {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```text
 /// use vibesql_storage::columnar_cache::ColumnarCache;
 ///
 /// // Create a cache with 256MB budget
@@ -115,7 +115,7 @@ impl ColumnarCache {
     /// * `max_memory` - Maximum memory budget in bytes
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // 256MB cache
     /// let cache = ColumnarCache::new(256 * 1024 * 1024);
     /// ```

--- a/crates/vibesql-storage/src/database/cache.rs
+++ b/crates/vibesql-storage/src/database/cache.rs
@@ -27,7 +27,7 @@ impl Database {
     /// * `Err(StorageError)` - Conversion failed
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// if let Some(columnar) = db.get_columnar("lineitem")? {
     ///     // Use columnar data for SIMD operations
     /// }
@@ -108,7 +108,7 @@ impl Database {
     /// * `Err(StorageError)` - Conversion failed for a table
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // After loading TPC-H data
     /// let warmed = db.pre_warm_columnar_cache(&["lineitem", "orders"])?;
     /// eprintln!("Pre-warmed {} tables", warmed);
@@ -140,7 +140,7 @@ impl Database {
     /// * `Err(StorageError)` - Conversion failed for a table
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // After loading all benchmark data
     /// let warmed = db.pre_warm_all_columnar()?;
     /// eprintln!("Pre-warmed {} tables", warmed);

--- a/crates/vibesql-storage/src/database/core.rs
+++ b/crates/vibesql-storage/src/database/core.rs
@@ -359,7 +359,7 @@ impl Database {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```text
     /// let rows = vec![
     ///     Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar(arcstr::ArcStr::from("Alice"))]),
     ///     Row::new(vec![SqlValue::Integer(2), SqlValue::Varchar(arcstr::ArcStr::from("Bob"))]),
@@ -436,7 +436,7 @@ impl Database {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```text
     /// // Stream 100K rows in batches of 5000
     /// let rows = (0..100_000).map(|i| Row::new(vec![SqlValue::Integer(i)]));
     /// let count = db.insert_rows_iter("numbers", rows, 5000)?;
@@ -492,7 +492,7 @@ impl Database {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```text
     /// // Update column 'name' for row with id=5
     /// let updated = db.update_row_by_pk(
     ///     "users",
@@ -656,7 +656,7 @@ impl Database {
     /// - Uses direct HashMap lookup on the PK index
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// let row = db.get_row_by_pk("users", &SqlValue::Integer(42))?;
     /// if let Some(row) = row {
     ///     let name = &row.values[1];
@@ -785,7 +785,7 @@ impl Database {
     /// * `capacity` - Maximum number of events to buffer before old events are overwritten
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// let mut db = Database::new();
     /// let mut rx = db.enable_change_events(1024);
     ///
@@ -809,7 +809,7 @@ impl Database {
     /// or None if `enable_change_events()` has not been called.
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Enable broadcasting
     /// db.enable_change_events(1024);
     ///
@@ -878,7 +878,7 @@ impl Database {
     /// * `engine` - A pre-configured PersistenceEngine instance
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// use vibesql_storage::{Database, PersistenceEngine, PersistenceConfig};
     ///
     /// let mut db = Database::new();
@@ -997,7 +997,7 @@ impl Database {
     /// Returns 0 if no auto-generated values have been produced yet.
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Create table with AUTO_INCREMENT
     /// db.execute("CREATE TABLE users (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(100))")?;
     ///

--- a/crates/vibesql-storage/src/database/index_ops.rs
+++ b/crates/vibesql-storage/src/database/index_ops.rs
@@ -490,7 +490,7 @@ impl Database {
     /// - Uses direct B+ tree lookup on the index
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Single-column index lookup
     /// let rows = db.lookup_by_index("idx_users_pk", &[SqlValue::Integer(42)])?;
     ///
@@ -608,7 +608,7 @@ impl Database {
     /// * `Err(StorageError)` - Index not found or other error
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Batch lookup multiple items
     /// let results = db.lookup_by_index_batch("idx_items_pk", &[
     ///     vec![SqlValue::Integer(1)],
@@ -733,7 +733,7 @@ impl Database {
     /// Uses efficient B+ tree range scan: O(log n + k) where n is total keys, k is matches.
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Index on (warehouse_id, district_id, order_id) - 3 columns
     /// // Find all orders for warehouse 1, district 5 (2-column prefix)
     /// let rows = db.lookup_by_index_prefix("idx_orders_pk", &[
@@ -788,7 +788,7 @@ impl Database {
     /// * `Err(StorageError)` - Index not found or other error
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Index on (w_id, d_id, o_id) - find new orders for all 10 districts
     /// let prefixes: Vec<Vec<SqlValue>> = (1..=10)
     ///     .map(|d| vec![SqlValue::Integer(w_id), SqlValue::Integer(d)])
@@ -873,7 +873,7 @@ impl Database {
     /// Note: WAL logging is handled internally by this method.
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Fast delete by PK
     /// let deleted = db.delete_by_pk_fast("users", &[SqlValue::Integer(42)])?;
     /// if deleted {
@@ -1021,7 +1021,7 @@ impl Database {
     /// * `None` - If table doesn't exist
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// let info = db.get_table_index_info("users")?;
     /// let insert_cost = cost_estimator.estimate_insert(&info);
     /// ```

--- a/crates/vibesql-storage/src/database/indexes/prefix_match.rs
+++ b/crates/vibesql-storage/src/database/indexes/prefix_match.rs
@@ -77,7 +77,7 @@ impl IndexData {
     /// So prefix_scan([1, 2]) scans from [1, 2] (inclusive) to [1, 3) (exclusive).
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Index on (w_id, d_id, o_id) - 3 columns
     /// // Find all rows where w_id=1 AND d_id=5 (2-column prefix)
     /// let rows = index_data.prefix_scan(&[SqlValue::Integer(1), SqlValue::Integer(5)]);
@@ -173,7 +173,7 @@ impl IndexData {
     /// O(log n) - only accesses the first matching entry in the BTreeMap range
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // TPC-C Delivery: find oldest new_order for warehouse 1, district 5
     /// // Index: (no_w_id, no_d_id, no_o_id)
     /// // Returns the row with minimum no_o_id for the given warehouse/district
@@ -274,7 +274,7 @@ impl IndexData {
     /// complexity, where n is the number of unique keys and k is matching keys.
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Index on (s_w_id, s_quantity, s_i_id)
     /// // Find all rows where s_w_id = 1 AND s_quantity < 10
     /// let rows = index_data.prefix_bounded_scan(
@@ -402,7 +402,7 @@ impl IndexData {
     /// Vector of row indices matching the prefix and range constraint
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Index on (ol_w_id, ol_d_id, ol_o_id, ol_number)
     /// // Find all rows where ol_w_id = 1 AND ol_d_id = 1 AND ol_o_id >= 2981 AND ol_o_id < 3001
     /// let rows = index_data.prefix_range_scan(
@@ -588,7 +588,7 @@ impl IndexData {
     /// - With limit+reverse: Scan from end, stop after 1 = O(1)
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Find the most recent order for customer (ORDER BY o_id DESC LIMIT 1)
     /// let prefix = vec![SqlValue::Integer(w_id), SqlValue::Integer(d_id), SqlValue::Integer(c_id)];
     /// let rows = index_data.prefix_scan_limit(&prefix, Some(1), true);
@@ -739,7 +739,7 @@ impl IndexData {
     /// Vector of (prefix_index, row_indices) pairs for each prefix that has matches
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Index on (w_id, d_id, o_id) - look up all orders for districts 1-10
     /// let prefixes: Vec<Vec<SqlValue>> = (1..=10)
     ///     .map(|d| vec![SqlValue::Integer(1), SqlValue::Integer(d)])
@@ -778,7 +778,7 @@ impl IndexData {
     /// (e.g., [s_w_id, s_quantity, s_i_id]) that matched the predicate.
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Index on (s_w_id, s_quantity, s_i_id)
     /// // Query: SELECT s_i_id FROM stock WHERE s_w_id = 1 AND s_quantity < 10
     /// // This is a covering index scan - s_i_id is in the index key!

--- a/crates/vibesql-storage/src/database/indexes/range_bounds.rs
+++ b/crates/vibesql-storage/src/database/indexes/range_bounds.rs
@@ -124,7 +124,7 @@ pub fn try_increment_sqlvalue(value: &SqlValue) -> Option<SqlValue> {
 /// we scan from `[prefix]` to `[prefix_incremented]` (exclusive).
 ///
 /// # Example
-/// ```rust,ignore
+/// ```text
 /// // Find all keys starting with [1, 2]
 /// // We scan from Included([1, 2]) to Excluded([1, 3])
 /// let upper = try_increment_sqlvalue_prefix(&vec![SqlValue::Integer(1), SqlValue::Integer(2)]);

--- a/crates/vibesql-storage/src/database/indexes/reverse_scan.rs
+++ b/crates/vibesql-storage/src/database/indexes/reverse_scan.rs
@@ -53,7 +53,7 @@ impl IndexData {
     /// optimal but correct).
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Index on (w_id, d_id, o_id) - 3 columns
     /// // Find all rows where w_id=1 AND d_id=5 in DESCENDING o_id order
     /// let rows = index_data.prefix_scan_reverse(&[SqlValue::Integer(1), SqlValue::Integer(5)]);
@@ -176,7 +176,7 @@ impl IndexData {
     /// returns after finding just the first (highest) matching key.
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Find the most recent order for customer (w_id=1, d_id=2, c_id=3)
     /// // Index on (o_w_id, o_d_id, o_c_id, o_id) - composite index
     /// let rows = index_data.prefix_scan_reverse_limit(

--- a/crates/vibesql-storage/src/progress.rs
+++ b/crates/vibesql-storage/src/progress.rs
@@ -67,7 +67,7 @@ pub fn disable() {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```text
 /// use vibesql_storage::progress::ProgressTracker;
 ///
 /// let mut tracker = ProgressTracker::new("Creating index 'idx_users'", Some(1_000_000));

--- a/crates/vibesql-storage/src/query_buffer_pool.rs
+++ b/crates/vibesql-storage/src/query_buffer_pool.rs
@@ -124,7 +124,7 @@ impl QueryBufferPool {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```text
     /// use vibesql_storage::QueryBufferPool;
     ///
     /// // Run a batch of queries...

--- a/crates/vibesql-storage/src/statistics/cost.rs
+++ b/crates/vibesql-storage/src/statistics/cost.rs
@@ -308,7 +308,7 @@ impl CostEstimator {
     /// * `table_stats` - Statistics for the table being scanned
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// let cost = estimator.estimate_table_scan(&table_stats);
     /// // For 1000 rows: (10 pages * 1.0) + (1000 * 0.01) = 20.0
     /// ```
@@ -397,7 +397,7 @@ impl CostEstimator {
     /// * `index_info` - Information about table indexes
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// let cost = estimator.estimate_insert(100, &table_stats, &index_info);
     /// // For 100 rows with 1 PK and 2 B-tree indexes:
     /// // (100 * 0.1) + (100 * 1 * 0.05) + (100 * 2 * 0.15) + WAL = ~57
@@ -458,7 +458,7 @@ impl CostEstimator {
     ///   Use 1.0 if all indexed columns might change, or a lower value for selective updates
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // Full update (all columns may change)
     /// let cost = estimator.estimate_update(50, &table_stats, &index_info, 1.0);
     ///
@@ -532,7 +532,7 @@ impl CostEstimator {
     /// * `index_info` - Information about table indexes
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// let cost = estimator.estimate_delete(100, &table_stats, &index_info);
     /// // Compaction multiplier is applied if deleted_ratio would exceed 50%
     /// ```

--- a/crates/vibesql-storage/src/statistics/table.rs
+++ b/crates/vibesql-storage/src/statistics/table.rs
@@ -60,7 +60,7 @@ impl TableStatistics {
     /// * `schema` - Table schema with column definitions
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// let stats = TableStatistics::estimate_from_schema(5000, &schema);
     /// // Boolean col: n_distinct = 2
     /// // Integer col: n_distinct = sqrt(5000) ≈ 70
@@ -260,7 +260,7 @@ impl TableStatistics {
     /// - Marked as stale to indicate these are estimates
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// let table_stats = table.get_statistics()
     ///     .cloned()
     ///     .unwrap_or_else(|| TableStatistics::estimate_from_row_count(table.row_count()));

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -137,7 +137,7 @@ impl DeleteResult {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```text
 /// use vibesql_catalog::TableSchema;
 /// use vibesql_storage::Table;
 ///
@@ -341,7 +341,7 @@ impl Table {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```text
     /// let rows = vec![
     ///     Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar(arcstr::ArcStr::from("Alice"))]),
     ///     Row::new(vec![SqlValue::Integer(2), SqlValue::Varchar(arcstr::ArcStr::from("Bob"))]),
@@ -439,7 +439,7 @@ impl Table {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```text
     /// // Stream rows from a file reader
     /// let rows_iter = csv_reader.rows().map(|r| Row::from_csv_record(r));
     /// let count = table.insert_from_iter(rows_iter, 1000)?;
@@ -497,7 +497,7 @@ impl Table {
     /// An iterator yielding `(physical_index, &Row)` pairs for all live rows.
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// for (idx, row) in table.scan_live() {
     ///     // idx is the physical index, can be used with get_row() or delete_by_indices()
     ///     process_row(idx, row);
@@ -525,7 +525,7 @@ impl Table {
     /// A Vec containing clones of all non-deleted rows.
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```text
     /// // For SELECT queries that need a Vec<Row>
     /// let rows = table.scan_live_vec();
     /// ```
@@ -585,7 +585,7 @@ impl Table {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```text
     /// let columnar = table.scan_columnar()?;
     /// // Process with SIMD-accelerated operations
     /// if let Some(ColumnData::Int64 { values, nulls }) = columnar.get_column("quantity") {

--- a/crates/vibesql-storage/src/wal/mod.rs
+++ b/crates/vibesql-storage/src/wal/mod.rs
@@ -36,7 +36,7 @@
 //
 // ## Usage
 //
-// ```rust,ignore
+// ```text
 // use vibesql_storage::wal::{WalWriter, WalReader, WalEntry, WalOp};
 // use std::io::Cursor;
 //

--- a/crates/vibesql-storage/src/wal/recovery.rs
+++ b/crates/vibesql-storage/src/wal/recovery.rs
@@ -745,7 +745,7 @@ fn parse_data_type(s: &str) -> Result<vibesql_types::DataType, StorageError> {
 /// A tuple of (Database, RecoveryStats) on success
 ///
 /// # Example
-/// ```rust,ignore
+/// ```text
 /// use vibesql_storage::wal::recovery::recover;
 ///
 /// let (db, stats) = recover("/path/to/checkpoints", Some("/path/to/wal.log"))?;

--- a/crates/vibesql-types/src/sql_mode/strings.rs
+++ b/crates/vibesql-types/src/sql_mode/strings.rs
@@ -53,7 +53,7 @@ pub trait StringBehavior {
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
+    /// ```text
     /// assert!(!SqlMode::MySQL.default_string_comparison_case_sensitive());
     /// assert!(SqlMode::SQLite.default_string_comparison_case_sensitive());
     /// ```
@@ -63,7 +63,7 @@ pub trait StringBehavior {
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
+    /// ```text
     /// assert_eq!(SqlMode::MySQL.default_collation(), Collation::Utf8GeneralCi);
     /// assert_eq!(SqlMode::SQLite.default_collation(), Collation::Binary);
     /// ```
@@ -73,7 +73,7 @@ pub trait StringBehavior {
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
+    /// ```text
     /// let mysql_collations = SqlMode::MySQL.supported_collations();
     /// assert!(mysql_collations.contains(&Collation::Utf8Binary));
     /// assert!(mysql_collations.contains(&Collation::Utf8GeneralCi));


### PR DESCRIPTION
## Summary

- Convert all `ignore` and `rust,ignore` doctest markers to `text` across 32 files
- Eliminates 72 "ignored" test messages from `cargo test --doc` output
- Aligns with codebase convention (89 existing `text` instances)

## Test plan

- [x] `cargo test --doc` shows 0 ignored tests
- [x] Documentation renders correctly (only marker changed, not content)

Closes #4063

🤖 Generated with [Claude Code](https://claude.com/claude-code)