### PR TITLE
perf(executor): Implement Bloom filter for join optimization

### DIFF
--- a/crates/vibesql-executor/src/select/join/bloom_filter.rs
+++ b/crates/vibesql-executor/src/select/join/bloom_filter.rs
@@ -1,0 +1,393 @@
+//! Bloom filter implementation for hash join optimization
+//!
+//! A Bloom filter is a probabilistic data structure that can quickly determine
+//! whether an element is definitely NOT in a set (no false negatives) or
+//! POSSIBLY in a set (with configurable false positive rate).
+//!
+//! This implementation is used to optimize hash joins by quickly rejecting
+//! probe-side rows that cannot possibly match any build-side rows, avoiding
+//! expensive hash table lookups.
+//!
+//! # How It Works
+//!
+//! During hash join:
+//! 1. **Build phase**: While building the hash table, also populate a Bloom filter
+//!    with the join keys
+//! 2. **Probe phase**: Before probing the hash table, check the Bloom filter
+//!    - If Bloom filter says "definitely not present" → skip the row (no hash lookup)
+//!    - If Bloom filter says "maybe present" → do the actual hash lookup
+//!
+//! # Performance Benefits
+//!
+//! - Bloom filter check is O(1) with excellent cache behavior
+//! - For selective joins (where most probe rows don't match), this eliminates
+//!   most hash table lookups
+//! - Memory overhead is small (typically 10 bits per element for 1% false positive rate)
+//!
+//! # References
+//!
+//! - SQLite uses this optimization via `WHERE_BLOOMFILTER` flag
+//! - See: `docs/reference/sqlite/src/whereInt.h` line 661
+
+use std::hash::{Hash, Hasher};
+
+use ahash::AHasher;
+
+/// Bloom filter for join optimization
+///
+/// Uses double hashing to generate multiple hash indices from a single hash value,
+/// avoiding the need to compute multiple independent hash functions.
+///
+/// # Algorithm
+///
+/// For k hash functions, we compute:
+/// - h1 = lower 32 bits of hash
+/// - h2 = upper 32 bits of hash
+/// - index_i = (h1 + i * h2) % num_bits for i in 0..k
+///
+/// This provides good distribution while only computing one hash.
+#[derive(Debug, Clone)]
+pub struct BloomFilter {
+    /// Bit array stored as u64 words for efficient operations
+    bits: Vec<u64>,
+    /// Number of hash functions (k)
+    num_hashes: u8,
+    /// Number of bits in the filter (m)
+    num_bits: usize,
+}
+
+impl BloomFilter {
+    /// Create a new Bloom filter sized for the expected number of elements
+    /// with the target false positive rate.
+    ///
+    /// # Arguments
+    ///
+    /// * `expected_elements` - Expected number of elements to insert
+    /// * `false_positive_rate` - Target false positive rate (e.g., 0.01 for 1%)
+    ///
+    /// # Panics
+    ///
+    /// Panics if `false_positive_rate` is not in the range (0.0, 1.0).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Create filter for 10,000 elements with 1% false positive rate
+    /// let filter = BloomFilter::new(10_000, 0.01);
+    /// ```
+    pub fn new(expected_elements: usize, false_positive_rate: f64) -> Self {
+        assert!(
+            false_positive_rate > 0.0 && false_positive_rate < 1.0,
+            "false_positive_rate must be in (0.0, 1.0)"
+        );
+
+        // Handle edge case of zero elements
+        let n = expected_elements.max(1) as f64;
+        let p = false_positive_rate;
+
+        // Optimal number of bits: m = -n * ln(p) / (ln(2)^2)
+        let ln2_sq = std::f64::consts::LN_2 * std::f64::consts::LN_2;
+        let m = (-n * p.ln() / ln2_sq).ceil() as usize;
+
+        // Ensure at least 64 bits and round up to next u64 boundary
+        let num_bits = m.max(64);
+        let num_words = (num_bits + 63) / 64;
+        let num_bits = num_words * 64;
+
+        // Optimal number of hash functions: k = (m/n) * ln(2)
+        let k = ((num_bits as f64 / n) * std::f64::consts::LN_2).round() as u8;
+        let num_hashes = k.clamp(1, 16); // Limit to reasonable range
+
+        Self { bits: vec![0u64; num_words], num_hashes, num_bits }
+    }
+
+    /// Create a Bloom filter with explicit parameters.
+    ///
+    /// This is useful for testing or when you want precise control over the filter size.
+    ///
+    /// # Arguments
+    ///
+    /// * `num_bits` - Number of bits in the filter (will be rounded up to multiple of 64)
+    /// * `num_hashes` - Number of hash functions to use
+    #[allow(dead_code)]
+    pub fn with_params(num_bits: usize, num_hashes: u8) -> Self {
+        let num_bits = num_bits.max(64);
+        let num_words = (num_bits + 63) / 64;
+        let num_bits = num_words * 64;
+        let num_hashes = num_hashes.clamp(1, 16);
+
+        Self { bits: vec![0u64; num_words], num_hashes, num_bits }
+    }
+
+    /// Insert a value into the Bloom filter.
+    ///
+    /// After insertion, `might_contain` will always return `true` for this value.
+    #[inline]
+    pub fn insert<T: Hash>(&mut self, value: &T) {
+        let hash = self.compute_hash(value);
+        self.insert_hash(hash);
+    }
+
+    /// Insert a pre-computed hash value into the Bloom filter.
+    ///
+    /// This is useful when you already have a hash value (e.g., from the hash table).
+    #[inline]
+    pub fn insert_hash(&mut self, hash: u64) {
+        let (h1, h2) = self.split_hash(hash);
+
+        for i in 0..self.num_hashes as u64 {
+            let bit_index = self.get_bit_index(h1, h2, i);
+            let word_index = bit_index / 64;
+            let bit_offset = bit_index % 64;
+            self.bits[word_index] |= 1u64 << bit_offset;
+        }
+    }
+
+    /// Check if a value might be in the set.
+    ///
+    /// Returns:
+    /// - `false` if the value is definitely NOT in the set (no false negatives)
+    /// - `true` if the value MIGHT be in the set (possible false positive)
+    #[inline]
+    pub fn might_contain<T: Hash>(&self, value: &T) -> bool {
+        let hash = self.compute_hash(value);
+        self.might_contain_hash(hash)
+    }
+
+    /// Check if a pre-computed hash value might be in the set.
+    #[inline]
+    pub fn might_contain_hash(&self, hash: u64) -> bool {
+        let (h1, h2) = self.split_hash(hash);
+
+        for i in 0..self.num_hashes as u64 {
+            let bit_index = self.get_bit_index(h1, h2, i);
+            let word_index = bit_index / 64;
+            let bit_offset = bit_index % 64;
+            if (self.bits[word_index] & (1u64 << bit_offset)) == 0 {
+                return false; // Definitely not in set
+            }
+        }
+        true // Might be in set
+    }
+
+    /// Get the memory usage of this Bloom filter in bytes.
+    #[allow(dead_code)]
+    pub fn memory_bytes(&self) -> usize {
+        self.bits.len() * 8
+    }
+
+    /// Get the number of bits in the filter.
+    #[allow(dead_code)]
+    pub fn num_bits(&self) -> usize {
+        self.num_bits
+    }
+
+    /// Get the number of hash functions used.
+    #[allow(dead_code)]
+    pub fn num_hashes(&self) -> u8 {
+        self.num_hashes
+    }
+
+    /// Compute hash using AHash (already a dependency in the crate).
+    #[inline]
+    fn compute_hash<T: Hash>(&self, value: &T) -> u64 {
+        let mut hasher = AHasher::default();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Split a 64-bit hash into two 32-bit values for double hashing.
+    #[inline]
+    fn split_hash(&self, hash: u64) -> (u64, u64) {
+        let h1 = hash & 0xFFFF_FFFF;
+        let h2 = hash >> 32;
+        // Ensure h2 is odd to guarantee full period when used as increment
+        (h1, h2 | 1)
+    }
+
+    /// Get the bit index for the i-th hash function using double hashing.
+    #[inline]
+    fn get_bit_index(&self, h1: u64, h2: u64, i: u64) -> usize {
+        let combined = h1.wrapping_add(i.wrapping_mul(h2));
+        (combined % self.num_bits as u64) as usize
+    }
+}
+
+/// Statistics about Bloom filter effectiveness during a join operation.
+#[derive(Debug, Default, Clone)]
+pub struct BloomFilterStats {
+    /// Number of rows checked against the Bloom filter
+    pub rows_checked: u64,
+    /// Number of rows rejected by the Bloom filter (true negatives)
+    pub rows_rejected: u64,
+    /// Number of rows that passed the Bloom filter check
+    pub rows_passed: u64,
+}
+
+impl BloomFilterStats {
+    /// Create new empty statistics.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that a row was rejected by the Bloom filter.
+    #[inline]
+    pub fn record_rejected(&mut self) {
+        self.rows_checked += 1;
+        self.rows_rejected += 1;
+    }
+
+    /// Record that a row passed the Bloom filter check.
+    #[inline]
+    pub fn record_passed(&mut self) {
+        self.rows_checked += 1;
+        self.rows_passed += 1;
+    }
+
+    /// Get the rejection rate (fraction of rows rejected by Bloom filter).
+    #[allow(dead_code)]
+    pub fn rejection_rate(&self) -> f64 {
+        if self.rows_checked == 0 {
+            0.0
+        } else {
+            self.rows_rejected as f64 / self.rows_checked as f64
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bloom_filter_no_false_negatives() {
+        let mut filter = BloomFilter::new(1000, 0.01);
+
+        // Insert values 0..1000
+        for i in 0..1000i64 {
+            filter.insert(&i);
+        }
+
+        // All inserted values should be found (no false negatives)
+        for i in 0..1000i64 {
+            assert!(filter.might_contain(&i), "False negative for {}", i);
+        }
+    }
+
+    #[test]
+    fn test_bloom_filter_false_positive_rate() {
+        let n = 10_000;
+        let target_fpr = 0.01;
+        let mut filter = BloomFilter::new(n, target_fpr);
+
+        // Insert n values
+        for i in 0..n as i64 {
+            filter.insert(&i);
+        }
+
+        // Check n values that were NOT inserted
+        let mut false_positives = 0;
+        let test_range = n as i64..(2 * n as i64);
+        for i in test_range.clone() {
+            if filter.might_contain(&i) {
+                false_positives += 1;
+            }
+        }
+
+        let actual_fpr = false_positives as f64 / n as f64;
+
+        // Allow 3x the target rate to account for variance
+        assert!(
+            actual_fpr < target_fpr * 3.0,
+            "False positive rate {} is too high (target {})",
+            actual_fpr,
+            target_fpr
+        );
+    }
+
+    #[test]
+    fn test_bloom_filter_with_strings() {
+        let mut filter = BloomFilter::new(100, 0.01);
+
+        let values = vec!["apple", "banana", "cherry", "date", "elderberry"];
+        for v in &values {
+            filter.insert(v);
+        }
+
+        for v in &values {
+            assert!(filter.might_contain(v), "False negative for {}", v);
+        }
+
+        // "fig" was not inserted, might be a false positive
+        // We don't assert on this since it's probabilistic
+    }
+
+    #[test]
+    fn test_bloom_filter_empty() {
+        let filter = BloomFilter::new(100, 0.01);
+
+        // Empty filter should reject everything
+        for i in 0..100i64 {
+            assert!(!filter.might_contain(&i), "Empty filter should reject {}", i);
+        }
+    }
+
+    #[test]
+    fn test_bloom_filter_small() {
+        // Test with very small filter
+        let mut filter = BloomFilter::with_params(64, 3);
+
+        filter.insert(&42i64);
+        assert!(filter.might_contain(&42i64));
+    }
+
+    #[test]
+    fn test_bloom_filter_hash_insert() {
+        let mut filter = BloomFilter::new(100, 0.01);
+
+        // Test hash-based insert/query
+        let hash = 0x123456789ABCDEF0u64;
+        filter.insert_hash(hash);
+        assert!(filter.might_contain_hash(hash));
+    }
+
+    #[test]
+    fn test_bloom_filter_stats() {
+        let mut stats = BloomFilterStats::new();
+
+        stats.record_rejected();
+        stats.record_rejected();
+        stats.record_passed();
+
+        assert_eq!(stats.rows_checked, 3);
+        assert_eq!(stats.rows_rejected, 2);
+        assert_eq!(stats.rows_passed, 1);
+        assert!((stats.rejection_rate() - 0.666).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_bloom_filter_memory() {
+        // 10K elements with 1% FPR should use ~12KB (9.6 bits/element)
+        let filter = BloomFilter::new(10_000, 0.01);
+        let memory = filter.memory_bytes();
+
+        // Should be roughly 10K * 10 bits / 8 = 12.5KB
+        // Allow some variance due to rounding
+        assert!(memory >= 10_000, "Memory {} is too small", memory);
+        assert!(memory <= 20_000, "Memory {} is too large", memory);
+    }
+
+    #[test]
+    fn test_bloom_filter_sizing() {
+        // Verify optimal sizing
+        let filter = BloomFilter::new(1000, 0.01);
+
+        // For n=1000, p=0.01:
+        // m = -n * ln(p) / (ln(2)^2) ≈ 9585 bits ≈ 1198 bytes
+        // k = (m/n) * ln(2) ≈ 6.6 ≈ 7 hash functions
+        assert!(filter.num_bits() >= 9000);
+        assert!(filter.num_bits() <= 15000);
+        assert!(filter.num_hashes() >= 5);
+        assert!(filter.num_hashes() <= 10);
+    }
+}

--- a/crates/vibesql-executor/src/select/join/hash_join/columnar/hash_table.rs
+++ b/crates/vibesql-executor/src/select/join/hash_join/columnar/hash_table.rs
@@ -1,11 +1,24 @@
 //! Hash table structures for columnar join operations
 //!
 //! This module provides hash table implementations optimized for columnar data:
-//! - `ColumnarHashTable`: Single-column hash table
+//! - `ColumnarHashTable`: Single-column hash table with optional Bloom filter
 //! - `CompositeIntHashTable`: Multi-column integer hash table
+//!
+//! # Bloom Filter Optimization
+//!
+//! The hash tables can optionally build a Bloom filter alongside the main hash
+//! structure. During probe, the Bloom filter can quickly reject keys that are
+//! definitely not in the table, avoiding expensive hash table lookups.
 
 use crate::errors::ExecutorError;
 use crate::select::columnar::ColumnArray;
+use crate::select::join::BloomFilter;
+
+/// Minimum number of build-side rows to enable Bloom filter optimization.
+const BLOOM_FILTER_MIN_ROWS: usize = 100;
+
+/// Target false positive rate for Bloom filter (1%).
+const BLOOM_FILTER_FPR: f64 = 0.01;
 
 /// Hash table for columnar join operations
 ///
@@ -17,6 +30,12 @@ use crate::select::columnar::ColumnArray;
 /// - No per-bucket Vec allocation
 /// - Entries are stored contiguously
 /// - Better cache utilization during probe
+///
+/// # Bloom Filter Optimization
+///
+/// When the table has enough rows (>= BLOOM_FILTER_MIN_ROWS), a Bloom filter
+/// is built alongside the hash table. Use `bloom_might_contain_*` methods to
+/// quickly reject probe keys before doing full hash table lookups.
 pub struct ColumnarHashTable {
     /// Number of hash buckets (power of 2)
     bucket_count: usize,
@@ -24,6 +43,8 @@ pub struct ColumnarHashTable {
     buckets: Vec<u32>,
     /// Entry array: entries[i] = (row_index, next_entry_index)
     entries: Vec<(u32, u32)>,
+    /// Optional Bloom filter for quick rejection of non-matching keys
+    bloom_filter: Option<BloomFilter>,
 }
 
 impl ColumnarHashTable {
@@ -43,11 +64,24 @@ impl ColumnarHashTable {
         // Pre-allocate entries
         let mut entries = Vec::with_capacity(row_count);
 
+        // Create Bloom filter if we have enough rows
+        let bloom_disabled = std::env::var("VIBESQL_DISABLE_BLOOM_FILTER").is_ok();
+        let mut bloom_filter = if !bloom_disabled && row_count >= BLOOM_FILTER_MIN_ROWS {
+            Some(BloomFilter::new(row_count, BLOOM_FILTER_FPR))
+        } else {
+            None
+        };
+
         // Build hash table
         for (row_idx, &value) in values.iter().enumerate() {
             // Simple hash for i64: mix the bits
             let hash = Self::hash_i64(value);
             let bucket_idx = (hash as usize) & bucket_mask;
+
+            // Insert into Bloom filter
+            if let Some(ref mut bf) = bloom_filter {
+                bf.insert_hash(hash);
+            }
 
             // Insert into linked list at this bucket
             let prev_head = buckets[bucket_idx];
@@ -55,7 +89,7 @@ impl ColumnarHashTable {
             buckets[bucket_idx] = entries.len() as u32 - 1;
         }
 
-        Self { bucket_count, buckets, entries }
+        Self { bucket_count, buckets, entries, bloom_filter }
     }
 
     /// Build a hash table from a string column
@@ -67,16 +101,29 @@ impl ColumnarHashTable {
         let mut buckets = vec![u32::MAX; bucket_count];
         let mut entries = Vec::with_capacity(row_count);
 
+        // Create Bloom filter if we have enough rows
+        let bloom_disabled = std::env::var("VIBESQL_DISABLE_BLOOM_FILTER").is_ok();
+        let mut bloom_filter = if !bloom_disabled && row_count >= BLOOM_FILTER_MIN_ROWS {
+            Some(BloomFilter::new(row_count, BLOOM_FILTER_FPR))
+        } else {
+            None
+        };
+
         for (row_idx, value) in values.iter().enumerate() {
             let hash = Self::hash_string(value);
             let bucket_idx = (hash as usize) & bucket_mask;
+
+            // Insert into Bloom filter
+            if let Some(ref mut bf) = bloom_filter {
+                bf.insert_hash(hash);
+            }
 
             let prev_head = buckets[bucket_idx];
             entries.push((row_idx as u32, prev_head));
             buckets[bucket_idx] = entries.len() as u32 - 1;
         }
 
-        Self { bucket_count, buckets, entries }
+        Self { bucket_count, buckets, entries, bloom_filter }
     }
 
     /// Build hash table from a ColumnArray
@@ -102,16 +149,29 @@ impl ColumnarHashTable {
         let mut buckets = vec![u32::MAX; bucket_count];
         let mut entries = Vec::with_capacity(row_count);
 
+        // Create Bloom filter if we have enough rows
+        let bloom_disabled = std::env::var("VIBESQL_DISABLE_BLOOM_FILTER").is_ok();
+        let mut bloom_filter = if !bloom_disabled && row_count >= BLOOM_FILTER_MIN_ROWS {
+            Some(BloomFilter::new(row_count, BLOOM_FILTER_FPR))
+        } else {
+            None
+        };
+
         for (row_idx, &value) in values.iter().enumerate() {
             let hash = Self::hash_i64(value as i64);
             let bucket_idx = (hash as usize) & bucket_mask;
+
+            // Insert into Bloom filter
+            if let Some(ref mut bf) = bloom_filter {
+                bf.insert_hash(hash);
+            }
 
             let prev_head = buckets[bucket_idx];
             entries.push((row_idx as u32, prev_head));
             buckets[bucket_idx] = entries.len() as u32 - 1;
         }
 
-        Self { bucket_count, buckets, entries }
+        Self { bucket_count, buckets, entries, bloom_filter }
     }
 
     /// Build from f64 values
@@ -123,16 +183,29 @@ impl ColumnarHashTable {
         let mut buckets = vec![u32::MAX; bucket_count];
         let mut entries = Vec::with_capacity(row_count);
 
+        // Create Bloom filter if we have enough rows
+        let bloom_disabled = std::env::var("VIBESQL_DISABLE_BLOOM_FILTER").is_ok();
+        let mut bloom_filter = if !bloom_disabled && row_count >= BLOOM_FILTER_MIN_ROWS {
+            Some(BloomFilter::new(row_count, BLOOM_FILTER_FPR))
+        } else {
+            None
+        };
+
         for (row_idx, &value) in values.iter().enumerate() {
             let hash = Self::hash_f64(value);
             let bucket_idx = (hash as usize) & bucket_mask;
+
+            // Insert into Bloom filter
+            if let Some(ref mut bf) = bloom_filter {
+                bf.insert_hash(hash);
+            }
 
             let prev_head = buckets[bucket_idx];
             entries.push((row_idx as u32, prev_head));
             buckets[bucket_idx] = entries.len() as u32 - 1;
         }
 
-        Self { bucket_count, buckets, entries }
+        Self { bucket_count, buckets, entries, bloom_filter }
     }
 
     /// Probe the hash table with an i64 key, returning matching row indices
@@ -197,6 +270,34 @@ impl ColumnarHashTable {
             hash = hash.wrapping_mul(FNV_PRIME);
         }
         hash
+    }
+
+    /// Check if an i64 key might be in the hash table using the Bloom filter.
+    ///
+    /// Returns `true` if the key MIGHT be in the table (possible false positive).
+    /// Returns `false` if the key is DEFINITELY NOT in the table.
+    /// Returns `true` if no Bloom filter is available (conservative).
+    #[inline]
+    pub fn bloom_might_contain_i64(&self, key: i64) -> bool {
+        match &self.bloom_filter {
+            Some(bf) => bf.might_contain_hash(Self::hash_i64(key)),
+            None => true, // No Bloom filter, assume might contain
+        }
+    }
+
+    /// Check if a string key might be in the hash table using the Bloom filter.
+    #[inline]
+    pub fn bloom_might_contain_string(&self, key: &str) -> bool {
+        match &self.bloom_filter {
+            Some(bf) => bf.might_contain_hash(Self::hash_string(key)),
+            None => true, // No Bloom filter, assume might contain
+        }
+    }
+
+    /// Returns true if this hash table has a Bloom filter enabled.
+    #[inline]
+    pub fn has_bloom_filter(&self) -> bool {
+        self.bloom_filter.is_some()
     }
 }
 

--- a/crates/vibesql-executor/src/select/join/hash_join/columnar/probe.rs
+++ b/crates/vibesql-executor/src/select/join/hash_join/columnar/probe.rs
@@ -21,6 +21,11 @@ pub(crate) fn is_null(nulls: &Option<std::sync::Arc<Vec<bool>>>, idx: usize) -> 
 ///
 /// NULL handling: NULL keys never match in equi-joins (NULL = NULL is NULL, not true).
 /// Both left and right NULL keys are skipped during probe.
+///
+/// # Bloom Filter Optimization
+///
+/// This function uses the Bloom filter (if available) to quickly reject probe keys
+/// that cannot possibly match any build-side keys, avoiding expensive hash table lookups.
 pub(crate) fn probe_columnar(
     hash_table: &ColumnarHashTable,
     left_key: &ColumnArray,
@@ -39,6 +44,12 @@ pub(crate) fn probe_columnar(
                 if is_null(left_nulls, left_idx) {
                     continue;
                 }
+
+                // BLOOM FILTER OPTIMIZATION: Quick rejection of non-matching keys
+                if !hash_table.bloom_might_contain_i64(key) {
+                    continue; // Definitely no match
+                }
+
                 for right_idx in hash_table.probe_i64(key, right_values) {
                     // Skip NULL right keys
                     if is_null(right_nulls, right_idx as usize) {
@@ -58,6 +69,12 @@ pub(crate) fn probe_columnar(
                 if is_null(left_nulls, left_idx) {
                     continue;
                 }
+
+                // BLOOM FILTER OPTIMIZATION: Quick rejection of non-matching keys
+                if !hash_table.bloom_might_contain_string(key) {
+                    continue; // Definitely no match
+                }
+
                 for right_idx in hash_table.probe_string(key, right_values) {
                     // Skip NULL right keys
                     if is_null(right_nulls, right_idx as usize) {
@@ -80,6 +97,12 @@ pub(crate) fn probe_columnar(
 }
 
 /// Probe phase for LEFT OUTER join: find matches and preserve unmatched left rows
+///
+/// # Bloom Filter Optimization
+///
+/// Uses the Bloom filter to quickly reject non-matching keys. Unlike inner join,
+/// left outer join preserves unmatched rows, so Bloom filter rejection doesn't
+/// affect correctness - it just avoids unnecessary hash table lookups.
 pub(crate) fn probe_columnar_left_outer(
     hash_table: &ColumnarHashTable,
     left_key: &ColumnArray,
@@ -99,6 +122,11 @@ pub(crate) fn probe_columnar_left_outer(
                     continue; // Will be handled as unmatched
                 }
 
+                // BLOOM FILTER OPTIMIZATION: Quick rejection of non-matching keys
+                if !hash_table.bloom_might_contain_i64(key) {
+                    continue; // Definitely no match, will be output as unmatched
+                }
+
                 let mut found_match = false;
                 for right_idx in hash_table.probe_i64(key, right_values) {
                     left_indices.push(left_idx as u32);
@@ -115,6 +143,11 @@ pub(crate) fn probe_columnar_left_outer(
                 let is_null = left_nulls.as_ref().map(|n| n[left_idx]).unwrap_or(false);
                 if is_null {
                     continue;
+                }
+
+                // BLOOM FILTER OPTIMIZATION: Quick rejection of non-matching keys
+                if !hash_table.bloom_might_contain_string(key) {
+                    continue; // Definitely no match, will be output as unmatched
                 }
 
                 let mut found_match = false;
@@ -147,6 +180,12 @@ pub(crate) fn probe_columnar_left_outer(
 }
 
 /// Probe phase for RIGHT OUTER join: find matches and preserve unmatched right rows
+///
+/// # Bloom Filter Optimization
+///
+/// Uses the Bloom filter to quickly reject non-matching keys. Unlike inner join,
+/// right outer join preserves unmatched rows, so Bloom filter rejection doesn't
+/// affect correctness - it just avoids unnecessary hash table lookups.
 pub(crate) fn probe_columnar_right_outer(
     hash_table: &ColumnarHashTable,
     right_key: &ColumnArray,
@@ -165,6 +204,11 @@ pub(crate) fn probe_columnar_right_outer(
                     continue;
                 }
 
+                // BLOOM FILTER OPTIMIZATION: Quick rejection of non-matching keys
+                if !hash_table.bloom_might_contain_i64(key) {
+                    continue; // Definitely no match, will be output as unmatched
+                }
+
                 let mut found_match = false;
                 for left_idx in hash_table.probe_i64(key, left_values) {
                     left_indices.push(left_idx);
@@ -181,6 +225,11 @@ pub(crate) fn probe_columnar_right_outer(
                 let is_null = right_nulls.as_ref().map(|n| n[right_idx]).unwrap_or(false);
                 if is_null {
                     continue;
+                }
+
+                // BLOOM FILTER OPTIMIZATION: Quick rejection of non-matching keys
+                if !hash_table.bloom_might_contain_string(key) {
+                    continue; // Definitely no match, will be output as unmatched
                 }
 
                 let mut found_match = false;

--- a/crates/vibesql-executor/src/select/join/hash_join_iterator.rs
+++ b/crates/vibesql-executor/src/select/join/hash_join_iterator.rs
@@ -2,12 +2,25 @@
 //!
 //! This module implements an iterator-based hash join that provides O(N+M)
 //! performance while maintaining lazy evaluation for the left (probe) side.
+//!
+//! # Bloom Filter Optimization
+//!
+//! This implementation uses a Bloom filter to quickly reject probe-side rows
+//! that cannot possibly match any build-side rows. This optimization is
+//! inspired by SQLite's `WHERE_BLOOMFILTER` optimization.
+//!
+//! Benefits:
+//! - Bloom filter check is O(1) with excellent cache behavior
+//! - For selective joins, eliminates most hash table lookups
+//! - Memory overhead is small (~10 bits per build-side element)
 
 #![allow(clippy::manual_is_multiple_of)]
 
-use ahash::AHashMap;
+use std::hash::{Hash, Hasher};
 
-use super::{combine_rows, FromResult};
+use ahash::{AHashMap, AHasher};
+
+use super::{combine_rows, BloomFilter, FromResult};
 use crate::{
     errors::ExecutorError,
     schema::CombinedSchema,
@@ -15,24 +28,47 @@ use crate::{
     timeout::{TimeoutContext, CHECK_INTERVAL},
 };
 
+/// Minimum number of build-side rows to enable Bloom filter optimization.
+/// For small tables, the overhead of maintaining the Bloom filter may exceed benefits.
+const BLOOM_FILTER_MIN_ROWS: usize = 100;
+
+/// Target false positive rate for Bloom filter (1%).
+/// Lower rates require more memory but provide better filtering.
+const BLOOM_FILTER_FPR: f64 = 0.01;
+
+/// Hash a SqlValue for use in Bloom filter.
+/// Uses AHash for fast, high-quality hashing.
+#[inline]
+fn hash_sql_value(value: &vibesql_types::SqlValue) -> u64 {
+    let mut hasher = AHasher::default();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
 /// Hash join iterator that lazily produces joined rows
 ///
 /// This implementation uses a hash join algorithm with:
 /// - Lazy left (probe) side: rows consumed on-demand from iterator
 /// - Materialized right (build) side: all rows hashed into HashMap
+/// - Bloom filter for quick rejection of non-matching probe rows
 ///
 /// Algorithm:
-/// 1. Build phase: Materialize right side into hash table (one-time cost)
-/// 2. Probe phase: Stream left rows, hash lookup for matches (O(1) per row)
+/// 1. Build phase: Materialize right side into hash table AND Bloom filter (one-time cost)
+/// 2. Probe phase: For each left row:
+///    a. Check Bloom filter - if negative, skip immediately (no hash lookup)
+///    b. If Bloom filter positive, do actual hash table lookup
 ///
 /// Performance: O(N + M) where N=left rows, M=right rows
+/// For selective joins, Bloom filter reduces constant factor significantly.
 ///
-/// Memory: O(M) for right side hash table + O(K) for current matches
+/// Memory: O(M) for right side hash table + O(M * 10 bits) for Bloom filter
 pub struct HashJoinIterator<L: RowIterator> {
     /// Lazy probe side (left)
     left: L,
     /// Materialized build side (right) - hash table mapping join key to rows
     right_hash_table: AHashMap<vibesql_types::SqlValue, Vec<vibesql_storage::Row>>,
+    /// Bloom filter for quick rejection of non-matching keys (None if disabled)
+    bloom_filter: Option<BloomFilter>,
     /// Combined schema for output rows
     schema: CombinedSchema,
     /// Column index in left table for join key
@@ -53,6 +89,9 @@ pub struct HashJoinIterator<L: RowIterator> {
     timeout_ctx: TimeoutContext,
     /// Iteration counter for periodic timeout checks
     iteration_count: usize,
+    /// Count of rows rejected by Bloom filter (for debugging/profiling)
+    #[allow(dead_code)]
+    bloom_rejections: usize,
 }
 
 impl<L: RowIterator> HashJoinIterator<L> {
@@ -102,11 +141,24 @@ impl<L: RowIterator> HashJoinIterator<L> {
 
         // Build phase: Create hash table from right side
         // This is the one-time materialization cost
+        let right_rows = right.into_rows();
+        let num_build_rows = right_rows.len();
+
         let mut hash_table: AHashMap<vibesql_types::SqlValue, Vec<vibesql_storage::Row>> =
             AHashMap::new();
+
+        // Create Bloom filter if we have enough rows to benefit
+        // Check environment variable for disabling (useful for A/B testing)
+        let bloom_disabled = std::env::var("VIBESQL_DISABLE_BLOOM_FILTER").is_ok();
+        let mut bloom_filter = if !bloom_disabled && num_build_rows >= BLOOM_FILTER_MIN_ROWS {
+            Some(BloomFilter::new(num_build_rows, BLOOM_FILTER_FPR))
+        } else {
+            None
+        };
+
         let mut build_iterations = 0;
 
-        for row in right.into_rows() {
+        for row in right_rows {
             // Check timeout periodically during build phase
             build_iterations += 1;
             if build_iterations % CHECK_INTERVAL == 0 {
@@ -117,6 +169,13 @@ impl<L: RowIterator> HashJoinIterator<L> {
 
             // Skip NULL values - they never match in equi-joins
             if key != vibesql_types::SqlValue::Null {
+                // Insert into Bloom filter before hash table
+                if let Some(ref mut bf) = bloom_filter {
+                    // Hash the SqlValue and insert into Bloom filter
+                    let hash = hash_sql_value(&key);
+                    bf.insert_hash(hash);
+                }
+
                 hash_table.entry(key).or_default().push(row);
             }
         }
@@ -124,6 +183,7 @@ impl<L: RowIterator> HashJoinIterator<L> {
         Ok(Self {
             left,
             right_hash_table: hash_table,
+            bloom_filter,
             schema: combined_schema,
             left_col_idx,
             right_col_idx,
@@ -133,6 +193,7 @@ impl<L: RowIterator> HashJoinIterator<L> {
             right_col_count,
             timeout_ctx,
             iteration_count: 0,
+            bloom_rejections: 0,
         })
     }
 
@@ -178,6 +239,19 @@ impl<L: RowIterator> Iterator for HashJoinIterator<L> {
                         continue;
                     }
 
+                    // BLOOM FILTER OPTIMIZATION:
+                    // Quick check to see if this key MIGHT be in the build side.
+                    // If the Bloom filter says "definitely not present", skip the
+                    // expensive hash table lookup entirely.
+                    if let Some(ref bf) = self.bloom_filter {
+                        let hash = hash_sql_value(key);
+                        if !bf.might_contain_hash(hash) {
+                            // Bloom filter says definitely no match - skip this row
+                            self.bloom_rejections += 1;
+                            continue;
+                        }
+                    }
+
                     // Lookup matches in hash table
                     if let Some(matches) = self.right_hash_table.get(key) {
                         // Found matches - set up for iteration
@@ -188,6 +262,7 @@ impl<L: RowIterator> Iterator for HashJoinIterator<L> {
                     } else {
                         // No matches for this left row
                         // For INNER JOIN, skip this row
+                        // (This can happen due to Bloom filter false positives)
                         continue;
                     }
                 }

--- a/crates/vibesql-executor/src/select/join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/mod.rs
@@ -7,6 +7,7 @@ use crate::{
     schema::CombinedSchema, timeout::TimeoutContext,
 };
 
+mod bloom_filter;
 mod expression_mapper;
 mod hash_anti_join;
 pub(crate) mod hash_join;
@@ -16,6 +17,9 @@ mod join_analyzer;
 mod nested_loop;
 pub mod reorder;
 pub mod search;
+
+// Re-export Bloom filter for use in hash join implementations
+pub(crate) use bloom_filter::BloomFilter;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary

- Implement Bloom filter data structure for probabilistic membership testing
- Integrate Bloom filter into row-based `HashJoinIterator`
- Integrate Bloom filter into columnar hash join (`ColumnarHashTable`)
- Add Bloom filter quick-rejection to inner, left outer, and right outer join probes

## Problem

Hash joins spend significant time doing hash table lookups for probe-side keys that don't match any build-side keys. This is especially costly for selective joins where most probe rows don't have matches.

## Solution

Add a Bloom filter that's built alongside the hash table during the build phase. During probe, the Bloom filter can quickly reject keys that are definitely not in the build side, avoiding expensive hash table lookups.

**Algorithm:**
1. **Build phase**: Insert all build-side join keys into both the hash table AND a Bloom filter
2. **Probe phase**: For each probe key:
   - Check Bloom filter first (O(1), cache-friendly)
   - If "definitely not present" → skip immediately
   - If "maybe present" → do actual hash table lookup

## Performance Characteristics

- Bloom filter check is O(1) with excellent cache behavior
- Memory overhead: ~10 bits per build-side element (for 1% false positive rate)
- Only enabled for tables with >= 100 rows (avoids overhead for small joins)
- Expected benefit: Significant speedup for selective joins (TPC-H Q3, Q10, etc.)

## Test plan

- [x] All existing Bloom filter unit tests pass (9 tests)
- [x] All hash join iterator tests pass (6 tests)
- [x] All columnar hash join tests pass (4 tests)
- [x] All join-related tests pass (103 tests)
- [ ] Run TPC-H benchmarks with/without Bloom filter to measure improvement

## A/B Testing

Set `VIBESQL_DISABLE_BLOOM_FILTER=1` environment variable to disable the optimization for comparison:

```bash
# With Bloom filter (default)
SCALE_FACTOR=0.01 PROFILING_ITERATIONS=3 ./target/release/deps/tpch_profiling-* Q3

# Without Bloom filter
VIBESQL_DISABLE_BLOOM_FILTER=1 SCALE_FACTOR=0.01 PROFILING_ITERATIONS=3 ./target/release/deps/tpch_profiling-* Q3
```

Closes #4075

🤖 Generated with [Claude Code](https://claude.com/claude-code)