### PR TITLE
feat(executor): Wire skip-scan planning into query execution

### DIFF
--- a/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
@@ -919,3 +919,389 @@ fn where_clause_fully_satisfied_by_index(
         _ => false,
     }
 }
+
+/// Execute a skip-scan index operation
+///
+/// Skip-scan enables using a composite index when the WHERE clause filters on
+/// non-prefix columns. It works by:
+/// 1. Getting distinct values of the prefix column(s)
+/// 2. For each prefix value, seeking to (prefix, filter_value) in the index
+/// 3. Returning matching rows
+///
+/// # Arguments
+/// * `table_name` - Name of the table being queried
+/// * `index_name` - Name of the index to use
+/// * `alias` - Optional table alias
+/// * `where_clause` - WHERE clause predicate (required for skip-scan)
+/// * `skip_scan_info` - Skip-scan configuration from planning phase
+/// * `database` - Database reference
+/// * `cte_results` - CTE context for subqueries
+///
+/// # Performance
+/// Cost = O(prefix_cardinality × log n + k) vs O(n) for table scan
+/// Beneficial when prefix columns have low cardinality and filter is selective.
+pub(crate) fn execute_skip_scan(
+    table_name: &str,
+    index_name: &str,
+    alias: Option<&String>,
+    where_clause: &Expression,
+    skip_scan_info: &crate::optimizer::index_planner::SkipScanInfo,
+    database: &Database,
+    cte_results: &HashMap<String, CteResult>,
+) -> Result<super::super::FromResult, ExecutorError> {
+    // Get table and index
+    let table = database
+        .get_table(table_name)
+        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+
+    let _index_metadata = database
+        .get_index(index_name)
+        .ok_or_else(|| ExecutorError::IndexNotFound(index_name.to_string()))?;
+
+    let index_data = database
+        .get_index_data(index_name)
+        .ok_or_else(|| ExecutorError::IndexNotFound(index_name.to_string()))?;
+
+    // Extract the filter value from the WHERE clause for the filter column
+    let filter_column = &skip_scan_info.filter_column;
+    let filter_column_idx = skip_scan_info.skip_columns; // The column index in the composite key
+
+    // Extract predicate from WHERE clause for the filter column
+    let skip_scan_predicate = extract_skip_scan_predicate(where_clause, filter_column);
+
+    // Execute skip-scan based on predicate type
+    let matching_row_indices: Vec<usize> = match skip_scan_predicate {
+        SkipScanPredicate::Equality(value) => {
+            if std::env::var("SKIP_SCAN_DEBUG").is_ok() {
+                eprintln!(
+                    "[SKIP_SCAN] Executing equality skip-scan: index={}, filter_col={}, filter_col_idx={}, value={:?}",
+                    index_name, filter_column, filter_column_idx, value
+                );
+            }
+            index_data.skip_scan_equality(filter_column_idx, &value)
+        }
+        SkipScanPredicate::Range { lower, inclusive_lower, upper, inclusive_upper } => {
+            if std::env::var("SKIP_SCAN_DEBUG").is_ok() {
+                eprintln!(
+                    "[SKIP_SCAN] Executing range skip-scan: index={}, filter_col={}, filter_col_idx={}, lower={:?}, upper={:?}",
+                    index_name, filter_column, filter_column_idx, lower, upper
+                );
+            }
+            index_data.skip_scan_range(
+                filter_column_idx,
+                lower.as_ref(),
+                inclusive_lower,
+                upper.as_ref(),
+                inclusive_upper,
+            )
+        }
+        SkipScanPredicate::None => {
+            // No suitable predicate found - fall back to empty result
+            // This shouldn't happen if planning was done correctly
+            if std::env::var("SKIP_SCAN_DEBUG").is_ok() {
+                eprintln!(
+                    "[SKIP_SCAN] Warning: No predicate extracted for filter column '{}', returning empty",
+                    filter_column
+                );
+            }
+            vec![]
+        }
+    };
+
+    if std::env::var("SKIP_SCAN_DEBUG").is_ok() {
+        eprintln!(
+            "[SKIP_SCAN] Found {} matching rows from skip-scan",
+            matching_row_indices.len()
+        );
+    }
+
+    // Build schema
+    let effective_name = alias.cloned().unwrap_or_else(|| table_name.to_string());
+    let schema = CombinedSchema::from_table(effective_name.clone(), table.schema.clone());
+
+    // Fetch matching rows
+    // Issue #3790: Use get_row() which returns None for deleted rows
+    let row_refs: Vec<&Row> =
+        matching_row_indices.iter().filter_map(|idx| table.get_row(*idx)).collect();
+
+    // Skip-scan doesn't fully satisfy WHERE clause, so we need to apply post-filtering
+    // This handles any additional predicates not covered by the skip-scan
+    let predicate_plan = PredicatePlan::from_where_clause(Some(where_clause), &schema)
+        .map_err(ExecutorError::InvalidWhereClause)?;
+
+    // Apply WHERE filtering
+    let filtered_row_refs = apply_where_filter_for_skip_scan(
+        row_refs,
+        &schema,
+        &predicate_plan,
+        table_name,
+        database,
+        cte_results,
+    )?;
+
+    // Clone only the filtered rows
+    let rows: Vec<Row> = filtered_row_refs.into_iter().cloned().collect();
+
+    // Skip-scan doesn't provide sorted output
+    Ok(super::super::FromResult::from_rows(schema, rows))
+}
+
+/// Predicate type extracted for skip-scan execution
+#[derive(Debug)]
+enum SkipScanPredicate {
+    /// Equality: filter_col = value
+    Equality(vibesql_types::SqlValue),
+    /// Range: filter_col > lower AND/OR filter_col < upper
+    Range {
+        lower: Option<vibesql_types::SqlValue>,
+        inclusive_lower: bool,
+        upper: Option<vibesql_types::SqlValue>,
+        inclusive_upper: bool,
+    },
+    /// No suitable predicate found
+    None,
+}
+
+/// Extract predicate for skip-scan filter column from WHERE clause
+fn extract_skip_scan_predicate(where_clause: &Expression, filter_column: &str) -> SkipScanPredicate {
+    use super::selection::is_column_reference;
+    use vibesql_ast::BinaryOperator;
+
+    match where_clause {
+        Expression::BinaryOp { left, op, right } => {
+            match op {
+                BinaryOperator::Equal => {
+                    // col = value or value = col
+                    if is_column_reference(left, filter_column) {
+                        if let Expression::Literal(value) = right.as_ref() {
+                            return SkipScanPredicate::Equality(value.clone());
+                        }
+                    }
+                    if is_column_reference(right, filter_column) {
+                        if let Expression::Literal(value) = left.as_ref() {
+                            return SkipScanPredicate::Equality(value.clone());
+                        }
+                    }
+                }
+                BinaryOperator::GreaterThan => {
+                    if is_column_reference(left, filter_column) {
+                        if let Expression::Literal(value) = right.as_ref() {
+                            return SkipScanPredicate::Range {
+                                lower: Some(value.clone()),
+                                inclusive_lower: false,
+                                upper: None,
+                                inclusive_upper: false,
+                            };
+                        }
+                    }
+                    if is_column_reference(right, filter_column) {
+                        if let Expression::Literal(value) = left.as_ref() {
+                            return SkipScanPredicate::Range {
+                                lower: None,
+                                inclusive_lower: false,
+                                upper: Some(value.clone()),
+                                inclusive_upper: false,
+                            };
+                        }
+                    }
+                }
+                BinaryOperator::GreaterThanOrEqual => {
+                    if is_column_reference(left, filter_column) {
+                        if let Expression::Literal(value) = right.as_ref() {
+                            return SkipScanPredicate::Range {
+                                lower: Some(value.clone()),
+                                inclusive_lower: true,
+                                upper: None,
+                                inclusive_upper: false,
+                            };
+                        }
+                    }
+                    if is_column_reference(right, filter_column) {
+                        if let Expression::Literal(value) = left.as_ref() {
+                            return SkipScanPredicate::Range {
+                                lower: None,
+                                inclusive_lower: false,
+                                upper: Some(value.clone()),
+                                inclusive_upper: true,
+                            };
+                        }
+                    }
+                }
+                BinaryOperator::LessThan => {
+                    if is_column_reference(left, filter_column) {
+                        if let Expression::Literal(value) = right.as_ref() {
+                            return SkipScanPredicate::Range {
+                                lower: None,
+                                inclusive_lower: false,
+                                upper: Some(value.clone()),
+                                inclusive_upper: false,
+                            };
+                        }
+                    }
+                    if is_column_reference(right, filter_column) {
+                        if let Expression::Literal(value) = left.as_ref() {
+                            return SkipScanPredicate::Range {
+                                lower: Some(value.clone()),
+                                inclusive_lower: false,
+                                upper: None,
+                                inclusive_upper: false,
+                            };
+                        }
+                    }
+                }
+                BinaryOperator::LessThanOrEqual => {
+                    if is_column_reference(left, filter_column) {
+                        if let Expression::Literal(value) = right.as_ref() {
+                            return SkipScanPredicate::Range {
+                                lower: None,
+                                inclusive_lower: false,
+                                upper: Some(value.clone()),
+                                inclusive_upper: true,
+                            };
+                        }
+                    }
+                    if is_column_reference(right, filter_column) {
+                        if let Expression::Literal(value) = left.as_ref() {
+                            return SkipScanPredicate::Range {
+                                lower: Some(value.clone()),
+                                inclusive_lower: true,
+                                upper: None,
+                                inclusive_upper: false,
+                            };
+                        }
+                    }
+                }
+                BinaryOperator::And => {
+                    // Try to find predicates on the filter column in both sides
+                    let left_pred = extract_skip_scan_predicate(left, filter_column);
+                    let right_pred = extract_skip_scan_predicate(right, filter_column);
+
+                    // Merge range predicates if both are ranges
+                    match (left_pred, right_pred) {
+                        (SkipScanPredicate::Equality(v), SkipScanPredicate::None) => {
+                            return SkipScanPredicate::Equality(v);
+                        }
+                        (SkipScanPredicate::None, SkipScanPredicate::Equality(v)) => {
+                            return SkipScanPredicate::Equality(v);
+                        }
+                        (SkipScanPredicate::Range { lower: l1, inclusive_lower: il1, upper: u1, inclusive_upper: iu1 },
+                         SkipScanPredicate::Range { lower: l2, inclusive_lower: il2, upper: u2, inclusive_upper: iu2 }) => {
+                            // Merge ranges: take the more restrictive bounds
+                            let (lower, inclusive_lower) = match (l1, l2) {
+                                (Some(v1), Some(v2)) => {
+                                    // Take the larger lower bound (more restrictive)
+                                    if v1 >= v2 { (Some(v1), il1) } else { (Some(v2), il2) }
+                                }
+                                (Some(v), None) | (None, Some(v)) => (Some(v), il1 || il2),
+                                (None, None) => (None, false),
+                            };
+                            let (upper, inclusive_upper) = match (u1, u2) {
+                                (Some(v1), Some(v2)) => {
+                                    // Take the smaller upper bound (more restrictive)
+                                    if v1 <= v2 { (Some(v1), iu1) } else { (Some(v2), iu2) }
+                                }
+                                (Some(v), None) | (None, Some(v)) => (Some(v), iu1 || iu2),
+                                (None, None) => (None, false),
+                            };
+                            return SkipScanPredicate::Range { lower, inclusive_lower, upper, inclusive_upper };
+                        }
+                        (r @ SkipScanPredicate::Range { .. }, SkipScanPredicate::None) => return r,
+                        (SkipScanPredicate::None, r @ SkipScanPredicate::Range { .. }) => return r,
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+        Expression::Between { expr, low, high, negated: false, .. } => {
+            if is_column_reference(expr, filter_column) {
+                if let (Expression::Literal(low_val), Expression::Literal(high_val)) =
+                    (low.as_ref(), high.as_ref())
+                {
+                    return SkipScanPredicate::Range {
+                        lower: Some(low_val.clone()),
+                        inclusive_lower: true,
+                        upper: Some(high_val.clone()),
+                        inclusive_upper: true,
+                    };
+                }
+            }
+        }
+        _ => {}
+    }
+
+    SkipScanPredicate::None
+}
+
+/// Apply WHERE filter for skip-scan results
+///
+/// Similar to apply_where_filter_zerocopy but simplified for skip-scan use case.
+fn apply_where_filter_for_skip_scan<'a>(
+    row_refs: Vec<&'a Row>,
+    schema: &CombinedSchema,
+    predicate_plan: &PredicatePlan,
+    table_name: &str,
+    database: &Database,
+    cte_results: &HashMap<String, CteResult>,
+) -> Result<Vec<&'a Row>, ExecutorError> {
+    use crate::evaluator::compiled::CompiledPredicate;
+    use crate::evaluator::CombinedExpressionEvaluator;
+    use crate::select::scan::predicates::combine_predicates_with_and;
+
+    // Get table statistics for selectivity-based ordering
+    let table_stats_owned = database.get_table(table_name).map(|table| {
+        table.get_statistics().cloned().unwrap_or_else(|| {
+            vibesql_storage::statistics::TableStatistics::estimate_from_schema(
+                table.row_count(),
+                &table.schema,
+            )
+        })
+    });
+
+    // Get predicates ordered by selectivity
+    let ordered_preds = predicate_plan.get_table_filters_ordered(table_name, table_stats_owned.as_ref());
+
+    // If no table-local predicates, return all rows
+    if ordered_preds.is_empty() {
+        return Ok(row_refs);
+    }
+
+    // Combine ordered predicates with AND
+    let combined_where = combine_predicates_with_and(ordered_preds);
+
+    // Try compiled predicate path
+    let compiled = CompiledPredicate::compile(&combined_where, schema);
+    if compiled.is_fully_compiled() {
+        let mut filtered = Vec::with_capacity(row_refs.len() / 2);
+        for row_ref in row_refs {
+            if compiled.evaluate(row_ref).unwrap_or(false) {
+                filtered.push(row_ref);
+            }
+        }
+        return Ok(filtered);
+    }
+
+    // Fallback: Use full expression evaluator
+    let evaluator = if cte_results.is_empty() {
+        CombinedExpressionEvaluator::with_database(schema, database)
+    } else {
+        CombinedExpressionEvaluator::with_database_and_cte(schema, database, cte_results)
+    };
+
+    let mut filtered = Vec::new();
+    for row_ref in row_refs {
+        evaluator.clear_cse_cache();
+        let include_row = match evaluator.eval(&combined_where, row_ref)? {
+            vibesql_types::SqlValue::Boolean(true) => true,
+            vibesql_types::SqlValue::Boolean(false) | vibesql_types::SqlValue::Null => false,
+            vibesql_types::SqlValue::Integer(0) => false,
+            vibesql_types::SqlValue::Integer(_) => true,
+            _ => false,
+        };
+        if include_row {
+            filtered.push(row_ref);
+        }
+    }
+
+    Ok(filtered)
+}

--- a/crates/vibesql-executor/src/select/scan/index_scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/mod.rs
@@ -24,5 +24,8 @@ pub(crate) mod selection;
 
 // Re-export public APIs
 pub(crate) use execution::execute_index_scan;
+pub(crate) use execution::execute_skip_scan;
 pub(crate) use selection::cost_based_index_selection;
+pub(crate) use selection::select_index_scan_method;
+pub(crate) use selection::IndexScanChoice;
 // predicate types are accessed directly via predicate::* for better type clarity

--- a/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
@@ -2,6 +2,7 @@
 //!
 //! Determines when and which index to use for query optimization.
 //! Supports both rule-based (simple) and cost-based (statistics-aware) selection.
+//! Also includes skip-scan optimization for queries filtering on non-prefix columns.
 
 use vibesql_ast::Expression;
 use vibesql_catalog::TableSchema;
@@ -9,6 +10,38 @@ use vibesql_storage::{
     statistics::{AccessMethod, CostEstimator},
     Database,
 };
+
+use crate::optimizer::index_planner::{IndexPlanner, SkipScanInfo};
+
+/// Result of index selection, distinguishing between regular and skip-scan
+#[derive(Debug, Clone)]
+pub(crate) enum IndexScanChoice {
+    /// Regular index scan using prefix columns
+    Regular {
+        index_name: String,
+        sorted_columns: Option<Vec<(String, vibesql_ast::OrderDirection)>>,
+    },
+    /// Skip-scan using non-prefix column filter
+    SkipScan {
+        index_name: String,
+        skip_scan_info: SkipScanInfo,
+    },
+}
+
+impl IndexScanChoice {
+    /// Get the index name regardless of scan type
+    pub fn index_name(&self) -> &str {
+        match self {
+            IndexScanChoice::Regular { index_name, .. } => index_name,
+            IndexScanChoice::SkipScan { index_name, .. } => index_name,
+        }
+    }
+
+    /// Check if this is a skip-scan choice
+    pub fn is_skip_scan(&self) -> bool {
+        matches!(self, IndexScanChoice::SkipScan { .. })
+    }
+}
 
 /// Check if any ORDER BY column is nullable
 ///
@@ -744,6 +777,76 @@ pub(crate) fn estimate_selectivity(
         }
         _ => 0.33, // Default fallback for unsupported expressions
     }
+}
+
+/// Unified index selection that returns IndexScanChoice
+///
+/// This function first tries regular index selection, and if no suitable index is found,
+/// it attempts skip-scan optimization as a fallback. Skip-scan enables using composite
+/// indexes when the WHERE clause filters on non-prefix columns.
+///
+/// # Arguments
+/// * `table_name` - Name of the table being queried
+/// * `where_clause` - Optional WHERE clause predicate
+/// * `order_by` - Optional ORDER BY clause
+/// * `database` - Database reference for accessing statistics and indexes
+///
+/// # Returns
+/// - `Some(IndexScanChoice::Regular {...})` if a regular index scan should be used
+/// - `Some(IndexScanChoice::SkipScan {...})` if skip-scan is beneficial
+/// - `None` if table scan is more appropriate
+///
+/// # Example
+/// ```text
+/// // Query: SELECT * FROM sales WHERE date = '2024-01-01'
+/// // Index: (region, date) - a composite index
+/// //
+/// // Regular index selection fails (no filter on 'region' prefix column)
+/// // Skip-scan is considered: iterate through distinct 'region' values,
+/// // for each region, seek to entries with date = '2024-01-01'
+/// //
+/// // If skip-scan cost < table scan cost, returns IndexScanChoice::SkipScan
+/// ```
+pub(crate) fn select_index_scan_method(
+    table_name: &str,
+    where_clause: Option<&Expression>,
+    order_by: Option<&[vibesql_ast::OrderByItem]>,
+    database: &Database,
+) -> Option<IndexScanChoice> {
+    // First, try regular cost-based index selection
+    if let Some((index_name, sorted_columns)) =
+        cost_based_index_selection(table_name, where_clause, order_by, database)
+    {
+        return Some(IndexScanChoice::Regular { index_name, sorted_columns });
+    }
+
+    // If regular index selection failed and we have a WHERE clause,
+    // try skip-scan optimization
+    if let Some(where_expr) = where_clause {
+        let planner = IndexPlanner::new(database);
+        if let Some(plan) = planner.plan_skip_scan(table_name, where_expr) {
+            if plan.is_skip_scan {
+                if let Some(skip_info) = plan.skip_scan_info {
+                    if std::env::var("SKIP_SCAN_DEBUG").is_ok() {
+                        eprintln!(
+                            "[SKIP_SCAN] Selected skip-scan for table={}, index={}, filter_col={}, prefix_cardinality={}",
+                            table_name,
+                            plan.index_name,
+                            skip_info.filter_column,
+                            skip_info.prefix_cardinality
+                        );
+                    }
+                    return Some(IndexScanChoice::SkipScan {
+                        index_name: plan.index_name,
+                        skip_scan_info: skip_info,
+                    });
+                }
+            }
+        }
+    }
+
+    // No index or skip-scan option found
+    None
 }
 
 #[cfg(test)]

--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -210,25 +210,51 @@ pub(crate) fn execute_table_scan(
     }
 
     // Check if we should use an index scan (with cost-based selection)
-    if let Some((index_name, sorted_columns)) =
-        super::index_scan::cost_based_index_selection(table_name, where_clause, order_by, database)
+    // This now includes skip-scan as a fallback option when regular index scan isn't available
+    if let Some(scan_choice) =
+        super::index_scan::select_index_scan_method(table_name, where_clause, order_by, database)
     {
-        // Use index scan for potentially better performance
-        if crate::profiling::is_scan_debug_enabled() {
-            eprintln!("[SCAN_PATH] Using index scan: table={}, index={}", table_name, index_name);
+        match scan_choice {
+            super::index_scan::IndexScanChoice::Regular { index_name, sorted_columns } => {
+                // Use regular index scan for potentially better performance
+                if crate::profiling::is_scan_debug_enabled() {
+                    eprintln!("[SCAN_PATH] Using index scan: table={}, index={}", table_name, index_name);
+                }
+                // Pass limit for LIMIT pushdown optimization when ORDER BY is satisfied by index (#3253)
+                // Issue #3562: Pass CTE context so IN subqueries can reference CTEs
+                return super::index_scan::execute_index_scan(
+                    table_name,
+                    &index_name,
+                    alias,
+                    where_clause,
+                    sorted_columns,
+                    limit,
+                    database,
+                    cte_results,
+                );
+            }
+            super::index_scan::IndexScanChoice::SkipScan { index_name, skip_scan_info } => {
+                // Use skip-scan for non-prefix column filtering
+                if crate::profiling::is_scan_debug_enabled() {
+                    eprintln!(
+                        "[SCAN_PATH] Using skip-scan: table={}, index={}, filter_col={}",
+                        table_name, index_name, skip_scan_info.filter_column
+                    );
+                }
+                // Skip-scan requires a WHERE clause (guaranteed by selection)
+                if let Some(where_expr) = where_clause {
+                    return super::index_scan::execute_skip_scan(
+                        table_name,
+                        &index_name,
+                        alias,
+                        where_expr,
+                        &skip_scan_info,
+                        database,
+                        cte_results,
+                    );
+                }
+            }
         }
-        // Pass limit for LIMIT pushdown optimization when ORDER BY is satisfied by index (#3253)
-        // Issue #3562: Pass CTE context so IN subqueries can reference CTEs
-        return super::index_scan::execute_index_scan(
-            table_name,
-            &index_name,
-            alias,
-            where_clause,
-            sorted_columns,
-            limit,
-            database,
-            cte_results,
-        );
     }
 
     // Debug: Log when table scan is used instead of index


### PR DESCRIPTION
## Summary

- Connects the skip-scan infrastructure from PR #4081 into the actual query execution path
- Enables queries filtering on non-prefix columns of composite indexes to automatically use skip-scan optimization when cost-effective
- Adds unified index selection that tries regular index scan first, then falls back to skip-scan

## Changes

- **selection.rs**: Added `IndexScanChoice` enum and `select_index_scan_method()` function for unified scan method selection
- **execution.rs**: Added `execute_skip_scan()` with predicate extraction supporting equality and range predicates
- **table.rs**: Updated `scan_table_or_derived()` to use unified selection and route to appropriate execution path
- **mod.rs**: Re-exported new public APIs

## Test plan

- [x] All 1859 executor tests pass
- [x] All 558 storage tests pass
- [ ] Manual testing with queries that filter on non-prefix columns

Closes #4082

🤖 Generated with [Claude Code](https://claude.com/claude-code)