### PR TITLE
fix(benchmarks): Fix TPC-H partsupp key generation for small scale factors

### DIFF
--- a/crates/vibesql-executor/benches/tpch/schema.rs
+++ b/crates/vibesql-executor/benches/tpch/schema.rs
@@ -1444,10 +1444,7 @@ fn load_partsupp_vibesql(db: &mut VibeDB, data: &mut TPCHData) {
     // Each part is supplied by 4 suppliers
     for part_key in 1..=data.part_count {
         for j in 0..4 {
-            let supp_key = ((part_key
-                + (j * (data.supplier_count / 4 + (part_key - 1) / data.supplier_count)))
-                % data.supplier_count)
-                + 1;
+            let supp_key = get_valid_supplier_for_part(part_key, data.supplier_count, j);
             let availqty = ((part_key * 17 + j * 31) % 9999) + 1;
             let supplycost = ((part_key * 13 + j * 7) % 100000) as f64 / 100.0 + 1.0;
             let row = Row::new(vec![
@@ -1478,10 +1475,7 @@ fn load_partsupp_sqlite(conn: &SqliteConn, data: &mut TPCHData) {
     // Each part is supplied by 4 suppliers
     for part_key in 1..=data.part_count {
         for j in 0..4 {
-            let supp_key = ((part_key
-                + (j * (data.supplier_count / 4 + (part_key - 1) / data.supplier_count)))
-                % data.supplier_count)
-                + 1;
+            let supp_key = get_valid_supplier_for_part(part_key, data.supplier_count, j);
             let availqty = ((part_key * 17 + j * 31) % 9999) + 1;
             let supplycost = ((part_key * 13 + j * 7) % 100000) as f64 / 100.0 + 1.0;
 
@@ -1504,10 +1498,7 @@ fn load_partsupp_duckdb(conn: &DuckDBConn, data: &mut TPCHData) {
     // Each part is supplied by 4 suppliers
     for part_key in 1..=data.part_count {
         for j in 0..4 {
-            let supp_key = ((part_key
-                + (j * (data.supplier_count / 4 + (part_key - 1) / data.supplier_count)))
-                % data.supplier_count)
-                + 1;
+            let supp_key = get_valid_supplier_for_part(part_key, data.supplier_count, j);
             let availqty = ((part_key * 17 + j * 31) % 9999) + 1;
             let supplycost = ((part_key * 13 + j * 7) % 100000) as f64 / 100.0 + 1.0;
 
@@ -1616,13 +1607,19 @@ fn load_orders_duckdb(conn: &DuckDBConn, data: &mut TPCHData) {
 
 /// Returns one of the 4 valid supplier keys for a given part_key.
 /// This matches the supplier generation logic in load_partsupp.
+///
+/// Uses a formula that guarantees 4 unique suppliers per part at any scale factor.
+/// The base supplier is determined by (part_key - 1) % supplier_count, then
+/// we add evenly-spaced offsets (0, 1/4, 2/4, 3/4 of supplier_count) for each j.
 fn get_valid_supplier_for_part(
     part_key: usize,
     supplier_count: usize,
     supplier_idx: usize,
 ) -> usize {
     let j = supplier_idx % 4; // 0-3
-    ((part_key + (j * (supplier_count / 4 + (part_key - 1) / supplier_count))) % supplier_count) + 1
+    let base = (part_key - 1) % supplier_count;
+    let offset = (j * supplier_count) / 4;
+    ((base + offset) % supplier_count) + 1
 }
 
 fn load_lineitem_vibesql(db: &mut VibeDB, data: &mut TPCHData) {
@@ -1880,10 +1877,7 @@ fn load_part_mysql(conn: &mut PooledConn, data: &mut TPCHData) {
 fn load_partsupp_mysql(conn: &mut PooledConn, data: &mut TPCHData) {
     for part_key in 1..=data.part_count {
         for j in 0..4 {
-            let supp_key = ((part_key
-                + (j * (data.supplier_count / 4 + (part_key - 1) / data.supplier_count)))
-                % data.supplier_count)
-                + 1;
+            let supp_key = get_valid_supplier_for_part(part_key, data.supplier_count, j);
             let availqty = ((part_key * 17 + j * 31) % 9999) + 1;
             let supplycost = ((part_key * 13 + j * 7) % 100000) as f64 / 100.0 + 1.0;
 


### PR DESCRIPTION
## Summary

- Fixed TPC-H partsupp key generation formula that produced duplicate PRIMARY KEY violations at small scale factors
- Updated `get_valid_supplier_for_part()` to use a formula that guarantees 4 unique suppliers per part regardless of scale factor
- Updated all partsupp loaders (VibeSQL, SQLite, DuckDB, MySQL) to use the centralized helper function

## Root Cause

The old formula `((part_key + (j * (supplier_count / 4 + (part_key - 1) / supplier_count))) % supplier_count) + 1` produced duplicate `(ps_partkey, ps_suppkey)` pairs at small scale factors due to integer division causing insufficient step sizes.

At `SCALE_FACTOR=0.001` (`supplier_count=10`), this produced 100 duplicate keys out of 800 rows (12.5% collision rate).

## Fix

New formula evenly spaces 4 suppliers for each part across the range:
```rust
let base = (part_key - 1) % supplier_count;
let offset = (j * supplier_count) / 4;
((base + offset) % supplier_count) + 1
```

## Test plan

- [x] Build compiles with `--features sqlite-comparison`
- [x] TPC-H benchmark with SQLite comparison runs without UNIQUE constraint errors
- [x] Verified all 12 queries complete successfully in comparison mode

Closes #4097

🤖 Generated with [Claude Code](https://claude.com/claude-code)