### PR TITLE
feat(benchmarks): Add parallel multi-client execution to Sysbench benchmark

### DIFF
--- a/crates/vibesql-executor/benches/sysbench_benchmark.rs
+++ b/crates/vibesql-executor/benches/sysbench_benchmark.rs
@@ -85,8 +85,6 @@ use mysql::prelude::*;
 use mysql::PooledConn;
 #[cfg(feature = "sqlite-comparison")]
 use rusqlite::Connection as SqliteConn;
-#[cfg(feature = "duckdb-comparison")]
-use sysbench::schema::load_duckdb;
 #[cfg(feature = "mysql-comparison")]
 use sysbench::schema::load_mysql;
 


### PR DESCRIPTION
## Summary

- Add support for running Sysbench workloads with multiple parallel clients using rayon
- `SYSBENCH_CLIENTS` environment variable controls client count (default: 1)
- `SYSBENCH_SHOW_CLIENTS` shows per-client results when set
- Parallel execution for VibeSQL, SQLite, and DuckDB comparison engines
- MySQL remains single-threaded with warning when parallel mode is enabled

## Implementation Details

Each parallel client:
- Gets its own database instance (avoids contention)
- Uses a unique RNG seed for different random sequences
- Partitions write operations by client ID to avoid conflicts

## Test plan

- [x] Verify single-client mode works as before (`SYSBENCH_CLIENTS=1`)
- [x] Test parallel execution with 4 clients
- [x] Test with SQLite comparison enabled
- [x] Verify comparison summary shows client count
- [x] Test all workloads: point-select, insert, update-index, update-non-index, delete, range

Example run:
```bash
SYSBENCH_TABLE_SIZE=10000 SYSBENCH_DURATION_SECS=5 SYSBENCH_WARMUP_SECS=2 SYSBENCH_CLIENTS=4 \
  cargo bench --bench sysbench_benchmark --features sqlite-comparison
```

Closes #4096

🤖 Generated with [Claude Code](https://claude.com/claude-code)