### PR TITLE
feat(benchmarks): Migrate 4 benchmarks from Criterion to custom harness

### DIFF
--- a/crates/vibesql-executor/benches/hash_join_parallel.rs
+++ b/crates/vibesql-executor/benches/hash_join_parallel.rs
@@ -7,9 +7,21 @@
 //! - 4-6x speedup on large equi-joins with 4+ cores
 //! - Threshold: parallelization beneficial for 50k+ rows
 //! - Linear scaling up to 4 cores, diminishing returns beyond 8 cores
+//!
+//! Migrated from Criterion to custom harness for deterministic timing.
+//!
+//! Usage:
+//!   cargo bench --bench hash_join_parallel
+//!
+//! Environment variables:
+//!   WARMUP_ITERATIONS - Number of warmup runs (default: 3)
+//!   BENCHMARK_ITERATIONS - Number of timed runs (default: 10)
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+mod harness;
+
+use harness::{print_group_header, BenchResult, Harness};
 use std::hint::black_box;
+use std::time::Instant;
 use vibesql_executor::SelectExecutor;
 use vibesql_parser::Parser;
 use vibesql_storage::Database;
@@ -25,18 +37,18 @@ fn parse_select(sql: &str) -> vibesql_ast::SelectStmt {
 
 /// Setup: Create two tables for join benchmarks
 fn setup_join_tables(db: &mut Database, left_rows: usize, right_rows: usize) {
-    // Create left table (customers)
+    // Create left table (customers) - uppercase for SQL parser normalization
     let left_schema = vibesql_catalog::TableSchema::new(
-        "customers".to_string(),
+        "CUSTOMERS".to_string(),
         vec![
             vibesql_catalog::ColumnSchema {
-                name: "id".to_string(),
+                name: "ID".to_string(),
                 data_type: vibesql_types::DataType::Integer,
                 nullable: false,
                 default_value: None,
             },
             vibesql_catalog::ColumnSchema {
-                name: "name".to_string(),
+                name: "NAME".to_string(),
                 data_type: vibesql_types::DataType::Varchar { max_length: Some(50) },
                 nullable: true,
                 default_value: None,
@@ -45,24 +57,24 @@ fn setup_join_tables(db: &mut Database, left_rows: usize, right_rows: usize) {
     );
     db.create_table(left_schema).unwrap();
 
-    // Create right table (orders)
+    // Create right table (orders) - uppercase for SQL parser normalization
     let right_schema = vibesql_catalog::TableSchema::new(
-        "orders".to_string(),
+        "ORDERS".to_string(),
         vec![
             vibesql_catalog::ColumnSchema {
-                name: "id".to_string(),
+                name: "ID".to_string(),
                 data_type: vibesql_types::DataType::Integer,
                 nullable: false,
                 default_value: None,
             },
             vibesql_catalog::ColumnSchema {
-                name: "customer_id".to_string(),
+                name: "CUSTOMER_ID".to_string(),
                 data_type: vibesql_types::DataType::Integer,
                 nullable: false,
                 default_value: None,
             },
             vibesql_catalog::ColumnSchema {
-                name: "amount".to_string(),
+                name: "AMOUNT".to_string(),
                 data_type: vibesql_types::DataType::Integer,
                 nullable: true,
                 default_value: None,
@@ -77,7 +89,7 @@ fn setup_join_tables(db: &mut Database, left_rows: usize, right_rows: usize) {
             SqlValue::Integer(i as i64),
             SqlValue::Varchar(arcstr::ArcStr::from(format!("customer_{}", i))),
         ]);
-        db.insert_row("customers", row).unwrap();
+        db.insert_row("CUSTOMERS", row).unwrap();
     }
 
     // Insert into right table (orders) - each customer has multiple orders
@@ -88,46 +100,49 @@ fn setup_join_tables(db: &mut Database, left_rows: usize, right_rows: usize) {
             SqlValue::Integer(customer_id),
             SqlValue::Integer((i % 1000) as i64),
         ]);
-        db.insert_row("orders", row).unwrap();
+        db.insert_row("ORDERS", row).unwrap();
     }
 }
+
+const JOIN_SQL: &str = "SELECT c.name, o.amount
+     FROM customers c
+     JOIN orders o ON c.id = o.customer_id;";
 
 /// Benchmark: Hash join scaling with different data sizes
 ///
 /// This measures the speedup from parallel hash table building
 /// as the dataset size increases.
-fn bench_hash_join_scaling(c: &mut Criterion) {
-    let mut group = c.benchmark_group("hash_join_scaling");
+fn bench_hash_join_scaling(harness: &Harness) {
+    print_group_header("Hash Join Scaling");
 
     // Test different dataset sizes to see where parallelization kicks in
     for size in [1_000, 10_000, 50_000, 100_000] {
         let mut db = Database::new();
         setup_join_tables(&mut db, size / 10, size); // 10:1 orders to customers ratio
 
-        group.throughput(Throughput::Elements(size as u64));
-
-        group.bench_with_input(BenchmarkId::new("equi_join", size), &size, |b, _| {
-            b.iter(|| {
-                let stmt = parse_select(
-                    "SELECT c.name, o.amount
-                         FROM customers c
-                         JOIN orders o ON c.id = o.customer_id;",
-                );
-                let executor = SelectExecutor::new(&db);
-                black_box(executor.execute(&stmt).unwrap())
-            });
+        let name = format!("equi_join/{}_rows", size);
+        let stats = harness.run(&name, || {
+            let start = Instant::now();
+            let stmt = parse_select(JOIN_SQL);
+            let executor = SelectExecutor::new(&db);
+            match executor.execute(&stmt) {
+                Ok(rows) => {
+                    black_box(rows);
+                    BenchResult::Ok(start.elapsed())
+                }
+                Err(e) => BenchResult::Error(e.to_string()),
+            }
         });
+        stats.print();
     }
-
-    group.finish();
 }
 
 /// Benchmark: Hash join with different join ratios
 ///
 /// This tests how the parallel build performs with different
 /// cardinalities (1:1, 1:many, many:many).
-fn bench_hash_join_cardinality(c: &mut Criterion) {
-    let mut group = c.benchmark_group("hash_join_cardinality");
+fn bench_hash_join_cardinality(harness: &Harness) {
+    print_group_header("Hash Join Cardinality");
 
     let base_size = 50_000;
 
@@ -136,17 +151,19 @@ fn bench_hash_join_cardinality(c: &mut Criterion) {
         let mut db = Database::new();
         setup_join_tables(&mut db, base_size, base_size);
 
-        group.bench_function("one_to_one", |b| {
-            b.iter(|| {
-                let stmt = parse_select(
-                    "SELECT c.name, o.amount
-                     FROM customers c
-                     JOIN orders o ON c.id = o.customer_id;",
-                );
-                let executor = SelectExecutor::new(&db);
-                black_box(executor.execute(&stmt).unwrap())
-            });
+        let stats = harness.run("one_to_one", || {
+            let start = Instant::now();
+            let stmt = parse_select(JOIN_SQL);
+            let executor = SelectExecutor::new(&db);
+            match executor.execute(&stmt) {
+                Ok(rows) => {
+                    black_box(rows);
+                    BenchResult::Ok(start.elapsed())
+                }
+                Err(e) => BenchResult::Error(e.to_string()),
+            }
         });
+        stats.print();
     }
 
     // 1:10 join (each customer has 10 orders)
@@ -154,28 +171,28 @@ fn bench_hash_join_cardinality(c: &mut Criterion) {
         let mut db = Database::new();
         setup_join_tables(&mut db, base_size / 10, base_size);
 
-        group.bench_function("one_to_many", |b| {
-            b.iter(|| {
-                let stmt = parse_select(
-                    "SELECT c.name, o.amount
-                     FROM customers c
-                     JOIN orders o ON c.id = o.customer_id;",
-                );
-                let executor = SelectExecutor::new(&db);
-                black_box(executor.execute(&stmt).unwrap())
-            });
+        let stats = harness.run("one_to_many", || {
+            let start = Instant::now();
+            let stmt = parse_select(JOIN_SQL);
+            let executor = SelectExecutor::new(&db);
+            match executor.execute(&stmt) {
+                Ok(rows) => {
+                    black_box(rows);
+                    BenchResult::Ok(start.elapsed())
+                }
+                Err(e) => BenchResult::Error(e.to_string()),
+            }
         });
+        stats.print();
     }
-
-    group.finish();
 }
 
 /// Benchmark: Hash join build phase in isolation
 ///
 /// This benchmark focuses specifically on the hash table build phase
 /// by using a minimal probe phase (small right table).
-fn bench_hash_build_phase(c: &mut Criterion) {
-    let mut group = c.benchmark_group("hash_build_phase");
+fn bench_hash_build_phase(harness: &Harness) {
+    print_group_header("Hash Build Phase");
 
     for build_size in [10_000, 50_000, 100_000] {
         let mut db = Database::new();
@@ -183,57 +200,61 @@ fn bench_hash_build_phase(c: &mut Criterion) {
         // Small right table (minimal probe cost)
         setup_join_tables(&mut db, build_size, 100);
 
-        group.throughput(Throughput::Elements(build_size as u64));
-
-        group.bench_with_input(BenchmarkId::new("build_phase", build_size), &build_size, |b, _| {
-            b.iter(|| {
-                let stmt = parse_select(
-                    "SELECT c.name, o.amount
-                         FROM customers c
-                         JOIN orders o ON c.id = o.customer_id;",
-                );
-                let executor = SelectExecutor::new(&db);
-                black_box(executor.execute(&stmt).unwrap())
-            });
+        let name = format!("build_phase/{}_rows", build_size);
+        let stats = harness.run(&name, || {
+            let start = Instant::now();
+            let stmt = parse_select(JOIN_SQL);
+            let executor = SelectExecutor::new(&db);
+            match executor.execute(&stmt) {
+                Ok(rows) => {
+                    black_box(rows);
+                    BenchResult::Ok(start.elapsed())
+                }
+                Err(e) => BenchResult::Error(e.to_string()),
+            }
         });
+        stats.print();
     }
-
-    group.finish();
 }
 
 /// Benchmark: Compare sequential threshold behavior
 ///
 /// This tests the automatic fallback to sequential execution
 /// for small datasets.
-fn bench_threshold_behavior(c: &mut Criterion) {
-    let mut group = c.benchmark_group("threshold_behavior");
+fn bench_threshold_behavior(harness: &Harness) {
+    print_group_header("Threshold Behavior");
 
     // Test sizes around the parallelization threshold
     for size in [1_000, 5_000, 10_000, 20_000, 50_000] {
         let mut db = Database::new();
         setup_join_tables(&mut db, size / 10, size);
 
-        group.bench_with_input(BenchmarkId::new("auto_threshold", size), &size, |b, _| {
-            b.iter(|| {
-                let stmt = parse_select(
-                    "SELECT c.name, o.amount
-                         FROM customers c
-                         JOIN orders o ON c.id = o.customer_id;",
-                );
-                let executor = SelectExecutor::new(&db);
-                black_box(executor.execute(&stmt).unwrap())
-            });
+        let name = format!("auto_threshold/{}_rows", size);
+        let stats = harness.run(&name, || {
+            let start = Instant::now();
+            let stmt = parse_select(JOIN_SQL);
+            let executor = SelectExecutor::new(&db);
+            match executor.execute(&stmt) {
+                Ok(rows) => {
+                    black_box(rows);
+                    BenchResult::Ok(start.elapsed())
+                }
+                Err(e) => BenchResult::Error(e.to_string()),
+            }
         });
+        stats.print();
     }
-
-    group.finish();
 }
 
-criterion_group!(
-    benches,
-    bench_hash_join_scaling,
-    bench_hash_join_cardinality,
-    bench_hash_build_phase,
-    bench_threshold_behavior
-);
-criterion_main!(benches);
+fn main() {
+    eprintln!("\n=== Hash Join Parallel Benchmarks ===\n");
+
+    let harness = Harness::new();
+
+    bench_hash_join_scaling(&harness);
+    bench_hash_join_cardinality(&harness);
+    bench_hash_build_phase(&harness);
+    bench_threshold_behavior(&harness);
+
+    eprintln!("\n=== Benchmark Complete ===\n");
+}

--- a/crates/vibesql-executor/benches/lineitem_scan_profiling.rs
+++ b/crates/vibesql-executor/benches/lineitem_scan_profiling.rs
@@ -5,16 +5,25 @@
 //! - Date predicate filtering cost
 //! - Comparison with DuckDB equivalent operations
 //!
+//! Migrated from Criterion to custom harness for deterministic timing.
+//!
 //! Usage:
-//!   cargo bench --bench lineitem_scan_profiling --features benchmark-comparison
+//!   cargo bench --bench lineitem_scan_profiling
+//!   cargo bench --bench lineitem_scan_profiling --features duckdb-comparison
+//!
+//! Environment variables:
+//!   WARMUP_ITERATIONS - Number of warmup runs (default: 3)
+//!   BENCHMARK_ITERATIONS - Number of timed runs (default: 10)
+//!   SCALE_FACTOR - TPC-H scale factor (default: 0.01)
 //!
 //! Part of issue #2962: Profile lineitem table scan performance
 
+mod harness;
 mod tpch;
 
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use harness::{print_group_header, print_summary_table, BenchResult, Harness};
 use std::hint::black_box;
-use std::time::Duration;
+use std::time::Instant;
 use vibesql_executor::SelectExecutor;
 use vibesql_parser::Parser;
 
@@ -53,31 +62,28 @@ const LINEITEM_DATE_LIMIT_100: &str =
 // VibeSQL Benchmark Functions
 // =============================================================================
 
-fn benchmark_vibesql(c: &mut Criterion, group_name: &str, sql: &str) {
-    let mut group = c.benchmark_group(group_name);
-    group.measurement_time(Duration::from_secs(5));
-
-    let db = load_vibesql(0.01);
-
-    // Get row count for throughput calculation
-    let row_count = db.get_table("lineitem").map(|t| t.row_count()).unwrap_or(0);
-
-    group.throughput(Throughput::Elements(row_count as u64));
-
-    group.bench_function("vibesql", |b| {
-        b.iter(|| {
-            let stmt = Parser::parse_sql(sql).unwrap();
-            if let vibesql_ast::Statement::Select(select) = stmt {
-                let executor = SelectExecutor::new(&db);
-                let result = executor.execute(&select).unwrap();
-                black_box(result.len())
-            } else {
-                0
+fn run_vibesql_benchmark(
+    harness: &Harness,
+    name: &str,
+    db: &vibesql_storage::Database,
+    sql: &str,
+) -> harness::BenchStats {
+    harness.run(name, || {
+        let start = Instant::now();
+        let stmt = Parser::parse_sql(sql).unwrap();
+        if let vibesql_ast::Statement::Select(select) = stmt {
+            let executor = SelectExecutor::new(db);
+            match executor.execute(&select) {
+                Ok(result) => {
+                    black_box(result.len());
+                    BenchResult::Ok(start.elapsed())
+                }
+                Err(e) => BenchResult::Error(e.to_string()),
             }
-        });
-    });
-
-    group.finish();
+        } else {
+            BenchResult::Error("Not a SELECT statement".to_string())
+        }
+    })
 }
 
 // =============================================================================
@@ -85,148 +91,90 @@ fn benchmark_vibesql(c: &mut Criterion, group_name: &str, sql: &str) {
 // =============================================================================
 
 #[cfg(feature = "duckdb-comparison")]
-fn benchmark_duckdb(c: &mut Criterion, group_name: &str, sql: &str) {
-    let mut group = c.benchmark_group(group_name);
-    group.measurement_time(Duration::from_secs(5));
-
-    let conn = load_duckdb(0.01);
-
-    // Get row count for throughput calculation
-    let row_count: i64 = conn
-        .prepare("SELECT COUNT(*) FROM lineitem")
-        .unwrap()
-        .query_row([], |row| row.get(0))
-        .unwrap();
-
-    group.throughput(Throughput::Elements(row_count as u64));
-
-    group.bench_function("duckdb", |b| {
-        b.iter(|| {
-            let mut stmt = conn.prepare(sql).unwrap();
-            let mut rows = stmt.query([]).unwrap();
-            let mut count = 0;
-            while rows.next().unwrap().is_some() {
-                count += 1;
-            }
-            black_box(count)
-        });
-    });
-
-    group.finish();
+fn run_duckdb_benchmark(
+    harness: &Harness,
+    name: &str,
+    conn: &duckdb::Connection,
+    sql: &str,
+) -> harness::BenchStats {
+    harness.run(name, || {
+        let start = Instant::now();
+        let mut stmt = conn.prepare(sql).unwrap();
+        let mut rows = stmt.query([]).unwrap();
+        let mut count = 0;
+        while rows.next().unwrap().is_some() {
+            count += 1;
+        }
+        black_box(count);
+        BenchResult::Ok(start.elapsed())
+    })
 }
 
 // =============================================================================
-// Benchmark Functions
+// Benchmark Runner
 // =============================================================================
 
-fn bench_full_scan_vibesql(c: &mut Criterion) {
-    benchmark_vibesql(c, "lineitem_full_scan", LINEITEM_FULL_SCAN);
+fn main() {
+    eprintln!("\n=== Lineitem Scan Profiling Benchmarks ===\n");
+
+    let scale_factor: f64 = std::env::var("SCALE_FACTOR")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.01);
+
+    eprintln!("Scale factor: {}", scale_factor);
+
+    let harness = Harness::new();
+
+    // Load VibeSQL database
+    eprintln!("\nLoading VibeSQL TPC-H data...");
+    let db = load_vibesql(scale_factor);
+    let row_count = db.get_table("lineitem").map(|t| t.row_count()).unwrap_or(0);
+    eprintln!("Loaded {} lineitem rows\n", row_count);
+
+    // Define benchmarks
+    let benchmarks = [
+        ("full_scan", LINEITEM_FULL_SCAN),
+        ("count", LINEITEM_COUNT),
+        ("date_filter", LINEITEM_DATE_FILTER),
+        ("date_count", LINEITEM_DATE_COUNT),
+        ("single_column", LINEITEM_SINGLE_COLUMN),
+        ("two_columns", LINEITEM_TWO_COLUMNS),
+        ("limit_100", LINEITEM_LIMIT_100),
+        ("date_limit_100", LINEITEM_DATE_LIMIT_100),
+    ];
+
+    // Run VibeSQL benchmarks
+    print_group_header("VibeSQL Lineitem Scans");
+    let mut vibesql_results = Vec::new();
+    for (name, sql) in &benchmarks {
+        let stats = run_vibesql_benchmark(&harness, name, &db, sql);
+        stats.print();
+        vibesql_results.push(stats);
+    }
+
+    // Run DuckDB benchmarks if feature is enabled
+    #[cfg(feature = "duckdb-comparison")]
+    {
+        eprintln!("\nLoading DuckDB TPC-H data...");
+        let conn = load_duckdb(scale_factor);
+
+        print_group_header("DuckDB Lineitem Scans");
+        let mut duckdb_results = Vec::new();
+        for (name, sql) in &benchmarks {
+            let stats = run_duckdb_benchmark(&harness, name, &conn, sql);
+            stats.print();
+            duckdb_results.push(stats);
+        }
+
+        // Print comparison summary
+        harness::print_comparison_table(&[("VibeSQL", vibesql_results), ("DuckDB", duckdb_results)]);
+    }
+
+    #[cfg(not(feature = "duckdb-comparison"))]
+    {
+        print_summary_table("VibeSQL", &vibesql_results);
+    }
+
+    eprintln!("\n=== Benchmark Complete ===\n");
 }
-
-fn bench_count_vibesql(c: &mut Criterion) {
-    benchmark_vibesql(c, "lineitem_count", LINEITEM_COUNT);
-}
-
-fn bench_date_filter_vibesql(c: &mut Criterion) {
-    benchmark_vibesql(c, "lineitem_date_filter", LINEITEM_DATE_FILTER);
-}
-
-fn bench_date_count_vibesql(c: &mut Criterion) {
-    benchmark_vibesql(c, "lineitem_date_count", LINEITEM_DATE_COUNT);
-}
-
-fn bench_single_column_vibesql(c: &mut Criterion) {
-    benchmark_vibesql(c, "lineitem_single_column", LINEITEM_SINGLE_COLUMN);
-}
-
-fn bench_two_columns_vibesql(c: &mut Criterion) {
-    benchmark_vibesql(c, "lineitem_two_columns", LINEITEM_TWO_COLUMNS);
-}
-
-fn bench_limit_100_vibesql(c: &mut Criterion) {
-    benchmark_vibesql(c, "lineitem_limit_100", LINEITEM_LIMIT_100);
-}
-
-fn bench_date_limit_100_vibesql(c: &mut Criterion) {
-    benchmark_vibesql(c, "lineitem_date_limit_100", LINEITEM_DATE_LIMIT_100);
-}
-
-#[cfg(feature = "duckdb-comparison")]
-fn bench_full_scan_duckdb(c: &mut Criterion) {
-    benchmark_duckdb(c, "lineitem_full_scan", LINEITEM_FULL_SCAN);
-}
-
-#[cfg(feature = "duckdb-comparison")]
-fn bench_count_duckdb(c: &mut Criterion) {
-    benchmark_duckdb(c, "lineitem_count", LINEITEM_COUNT);
-}
-
-#[cfg(feature = "duckdb-comparison")]
-fn bench_date_filter_duckdb(c: &mut Criterion) {
-    benchmark_duckdb(c, "lineitem_date_filter", LINEITEM_DATE_FILTER);
-}
-
-#[cfg(feature = "duckdb-comparison")]
-fn bench_date_count_duckdb(c: &mut Criterion) {
-    benchmark_duckdb(c, "lineitem_date_count", LINEITEM_DATE_COUNT);
-}
-
-#[cfg(feature = "duckdb-comparison")]
-fn bench_single_column_duckdb(c: &mut Criterion) {
-    benchmark_duckdb(c, "lineitem_single_column", LINEITEM_SINGLE_COLUMN);
-}
-
-#[cfg(feature = "duckdb-comparison")]
-fn bench_two_columns_duckdb(c: &mut Criterion) {
-    benchmark_duckdb(c, "lineitem_two_columns", LINEITEM_TWO_COLUMNS);
-}
-
-#[cfg(feature = "duckdb-comparison")]
-fn bench_limit_100_duckdb(c: &mut Criterion) {
-    benchmark_duckdb(c, "lineitem_limit_100", LINEITEM_LIMIT_100);
-}
-
-#[cfg(feature = "duckdb-comparison")]
-fn bench_date_limit_100_duckdb(c: &mut Criterion) {
-    benchmark_duckdb(c, "lineitem_date_limit_100", LINEITEM_DATE_LIMIT_100);
-}
-
-// =============================================================================
-// Criterion Benchmark Groups
-// =============================================================================
-
-#[cfg(not(feature = "duckdb-comparison"))]
-criterion_group!(
-    benches,
-    bench_full_scan_vibesql,
-    bench_count_vibesql,
-    bench_date_filter_vibesql,
-    bench_date_count_vibesql,
-    bench_single_column_vibesql,
-    bench_two_columns_vibesql,
-    bench_limit_100_vibesql,
-    bench_date_limit_100_vibesql
-);
-
-#[cfg(feature = "duckdb-comparison")]
-criterion_group!(
-    benches,
-    bench_full_scan_vibesql,
-    bench_full_scan_duckdb,
-    bench_count_vibesql,
-    bench_count_duckdb,
-    bench_date_filter_vibesql,
-    bench_date_filter_duckdb,
-    bench_date_count_vibesql,
-    bench_date_count_duckdb,
-    bench_single_column_vibesql,
-    bench_single_column_duckdb,
-    bench_two_columns_vibesql,
-    bench_two_columns_duckdb,
-    bench_limit_100_vibesql,
-    bench_limit_100_duckdb,
-    bench_date_limit_100_vibesql,
-    bench_date_limit_100_duckdb
-);
-
-criterion_main!(benches);

--- a/crates/vibesql-executor/benches/parallel_sort.rs
+++ b/crates/vibesql-executor/benches/parallel_sort.rs
@@ -2,9 +2,21 @@
 //!
 //! These benchmarks validate the 2-3x speedup claims for parallel sorting
 //! implemented in PR #1594, as part of Phase 1.5 of the PARALLELISM_ROADMAP.md
+//!
+//! Migrated from Criterion to custom harness for deterministic timing.
+//!
+//! Usage:
+//!   cargo bench --bench parallel_sort
+//!
+//! Environment variables:
+//!   WARMUP_ITERATIONS - Number of warmup runs (default: 3)
+//!   BENCHMARK_ITERATIONS - Number of timed runs (default: 10)
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+mod harness;
+
+use harness::{print_group_header, BenchResult, Harness};
 use std::hint::black_box;
+use std::time::Instant;
 use vibesql_executor::SelectExecutor;
 use vibesql_parser::Parser;
 use vibesql_storage::Database;
@@ -75,274 +87,242 @@ fn setup_sort_table(db: &mut Database, row_count: usize, include_nulls: bool) {
     }
 }
 
+/// Setup: Create a table with already sorted data
+fn setup_presorted_table(db: &mut Database, row_count: usize, table_name: &str) {
+    let schema = vibesql_catalog::TableSchema::new(
+        table_name.to_string(),
+        vec![vibesql_catalog::ColumnSchema {
+            name: "ID".to_string(),
+            data_type: vibesql_types::DataType::Integer,
+            nullable: false,
+            default_value: None,
+        }],
+    );
+    db.create_table(schema).unwrap();
+
+    for i in 0..row_count {
+        let row = vibesql_storage::Row::new(vec![vibesql_types::SqlValue::Integer(i as i64)]);
+        db.insert_row(table_name, row).unwrap();
+    }
+}
+
+/// Setup: Create a table with reverse sorted data
+fn setup_reverse_sorted_table(db: &mut Database, row_count: usize, table_name: &str) {
+    let schema = vibesql_catalog::TableSchema::new(
+        table_name.to_string(),
+        vec![vibesql_catalog::ColumnSchema {
+            name: "ID".to_string(),
+            data_type: vibesql_types::DataType::Integer,
+            nullable: false,
+            default_value: None,
+        }],
+    );
+    db.create_table(schema).unwrap();
+
+    for i in 0..row_count {
+        let row = vibesql_storage::Row::new(vec![vibesql_types::SqlValue::Integer(
+            (row_count - i) as i64,
+        )]);
+        db.insert_row(table_name, row).unwrap();
+    }
+}
+
+/// Run a benchmark with a specific thread pool configuration
+fn run_benchmark_with_cores(
+    harness: &Harness,
+    name: &str,
+    db: &Database,
+    sql: &str,
+    cores: usize,
+) -> harness::BenchStats {
+    let pool = rayon::ThreadPoolBuilder::new().num_threads(cores).build().unwrap();
+
+    pool.install(|| {
+        harness.run(name, || {
+            let start = Instant::now();
+            let stmt = parse_select(sql);
+            let executor = SelectExecutor::new(db);
+            let result = executor.execute(&stmt);
+            match result {
+                Ok(rows) => {
+                    black_box(rows);
+                    BenchResult::Ok(start.elapsed())
+                }
+                Err(e) => BenchResult::Error(e.to_string()),
+            }
+        })
+    })
+}
+
 /// Benchmark: Simple integer sort (best case for parallelization)
-fn bench_simple_integer_sort(c: &mut Criterion) {
-    let mut group = c.benchmark_group("simple_integer_sort");
+fn bench_simple_integer_sort(harness: &Harness) {
+    print_group_header("Simple Integer Sort");
 
     for row_count in [1_000, 10_000, 100_000] {
         let mut db = Database::new();
         setup_sort_table(&mut db, row_count, false);
 
-        group.throughput(Throughput::Elements(row_count as u64));
+        eprintln!("\n  Row count: {}", row_count);
 
-        // Benchmark with different core counts
         for cores in [1, 2, 4, 8] {
-            group.bench_with_input(
-                BenchmarkId::new(format!("{}_cores", cores), row_count),
-                &(row_count, cores),
-                |b, &(_, cores)| {
-                    // Create a new thread pool for each benchmark
-                    let pool = rayon::ThreadPoolBuilder::new().num_threads(cores).build().unwrap();
-
-                    pool.install(|| {
-                        b.iter(|| {
-                            let stmt = parse_select("SELECT * FROM sort_test ORDER BY id;");
-                            let executor = SelectExecutor::new(&db);
-                            black_box(executor.execute(&stmt).unwrap())
-                        });
-                    });
-                },
-            );
+            let name = format!("{}_cores/{}_rows", cores, row_count);
+            let stats =
+                run_benchmark_with_cores(harness, &name, &db, "SELECT * FROM sort_test ORDER BY id;", cores);
+            stats.print_compact();
         }
     }
-
-    group.finish();
 }
 
 /// Benchmark: Multi-column sort (more complex comparisons)
-fn bench_multi_column_sort(c: &mut Criterion) {
-    let mut group = c.benchmark_group("multi_column_sort");
+fn bench_multi_column_sort(harness: &Harness) {
+    print_group_header("Multi-Column Sort");
 
     for row_count in [1_000, 10_000, 100_000] {
         let mut db = Database::new();
         setup_sort_table(&mut db, row_count, false);
 
-        group.throughput(Throughput::Elements(row_count as u64));
+        eprintln!("\n  Row count: {}", row_count);
 
         for cores in [1, 2, 4, 8] {
-            group.bench_with_input(
-                BenchmarkId::new(format!("{}_cores", cores), row_count),
-                &(row_count, cores),
-                |b, &(_, cores)| {
-                    let pool = rayon::ThreadPoolBuilder::new().num_threads(cores).build().unwrap();
-
-                    pool.install(|| {
-                        b.iter(|| {
-                            let stmt =
-                                parse_select("SELECT * FROM sort_test ORDER BY category, id DESC;");
-                            let executor = SelectExecutor::new(&db);
-                            black_box(executor.execute(&stmt).unwrap())
-                        });
-                    });
-                },
+            let name = format!("{}_cores/{}_rows", cores, row_count);
+            let stats = run_benchmark_with_cores(
+                harness,
+                &name,
+                &db,
+                "SELECT * FROM sort_test ORDER BY category, id DESC;",
+                cores,
             );
+            stats.print_compact();
         }
     }
-
-    group.finish();
 }
 
 /// Benchmark: String sort (expensive comparisons)
-fn bench_string_sort(c: &mut Criterion) {
-    let mut group = c.benchmark_group("string_sort");
+fn bench_string_sort(harness: &Harness) {
+    print_group_header("String Sort");
 
     for row_count in [1_000, 10_000, 100_000] {
         let mut db = Database::new();
         setup_sort_table(&mut db, row_count, false);
 
-        group.throughput(Throughput::Elements(row_count as u64));
+        eprintln!("\n  Row count: {}", row_count);
 
         for cores in [1, 2, 4, 8] {
-            group.bench_with_input(
-                BenchmarkId::new(format!("{}_cores", cores), row_count),
-                &(row_count, cores),
-                |b, &(_, cores)| {
-                    let pool = rayon::ThreadPoolBuilder::new().num_threads(cores).build().unwrap();
-
-                    pool.install(|| {
-                        b.iter(|| {
-                            let stmt = parse_select("SELECT * FROM sort_test ORDER BY name;");
-                            let executor = SelectExecutor::new(&db);
-                            black_box(executor.execute(&stmt).unwrap())
-                        });
-                    });
-                },
+            let name = format!("{}_cores/{}_rows", cores, row_count);
+            let stats = run_benchmark_with_cores(
+                harness,
+                &name,
+                &db,
+                "SELECT * FROM sort_test ORDER BY name;",
+                cores,
             );
+            stats.print_compact();
         }
     }
-
-    group.finish();
 }
 
 /// Benchmark: Sort with NULLs (worst case for comparisons)
-fn bench_sort_with_nulls(c: &mut Criterion) {
-    let mut group = c.benchmark_group("sort_with_nulls");
+fn bench_sort_with_nulls(harness: &Harness) {
+    print_group_header("Sort with NULLs");
 
     for row_count in [1_000, 10_000, 100_000] {
         let mut db = Database::new();
         setup_sort_table(&mut db, row_count, true); // ~10% NULL values
 
-        group.throughput(Throughput::Elements(row_count as u64));
+        eprintln!("\n  Row count: {}", row_count);
 
         for cores in [1, 2, 4, 8] {
-            group.bench_with_input(
-                BenchmarkId::new(format!("{}_cores", cores), row_count),
-                &(row_count, cores),
-                |b, &(_, cores)| {
-                    let pool = rayon::ThreadPoolBuilder::new().num_threads(cores).build().unwrap();
-
-                    pool.install(|| {
-                        b.iter(|| {
-                            let stmt = parse_select("SELECT * FROM sort_test ORDER BY value;");
-                            let executor = SelectExecutor::new(&db);
-                            black_box(executor.execute(&stmt).unwrap())
-                        });
-                    });
-                },
+            let name = format!("{}_cores/{}_rows", cores, row_count);
+            let stats = run_benchmark_with_cores(
+                harness,
+                &name,
+                &db,
+                "SELECT * FROM sort_test ORDER BY value;",
+                cores,
             );
+            stats.print_compact();
         }
     }
-
-    group.finish();
 }
 
 /// Benchmark: Threshold boundary testing
 /// Tests performance at the threshold boundary to validate threshold values
-fn bench_threshold_boundary(c: &mut Criterion) {
-    let mut group = c.benchmark_group("threshold_boundary");
+fn bench_threshold_boundary(harness: &Harness) {
+    print_group_header("Threshold Boundary (8 cores)");
 
     // Test around the 8-core threshold of 5,000 rows (from parallel.rs:116-121)
     for row_count in [4_500, 5_000, 5_500] {
         let mut db = Database::new();
         setup_sort_table(&mut db, row_count, false);
 
-        group.throughput(Throughput::Elements(row_count as u64));
-
-        // Test with 8 cores (aggressive threshold: 5,000)
         let cores = 8;
-        group.bench_with_input(BenchmarkId::new("8_cores", row_count), &row_count, |b, &_| {
-            let pool = rayon::ThreadPoolBuilder::new().num_threads(cores).build().unwrap();
-
-            pool.install(|| {
-                b.iter(|| {
-                    let stmt = parse_select("SELECT * FROM sort_test ORDER BY id;");
-                    let executor = SelectExecutor::new(&db);
-                    black_box(executor.execute(&stmt).unwrap())
-                });
-            });
-        });
+        let name = format!("8_cores/{}_rows", row_count);
+        let stats =
+            run_benchmark_with_cores(harness, &name, &db, "SELECT * FROM sort_test ORDER BY id;", cores);
+        stats.print();
     }
-
-    group.finish();
 }
 
 /// Benchmark: Already sorted data (best case for sort algorithm)
-fn bench_presorted_data(c: &mut Criterion) {
-    let mut group = c.benchmark_group("presorted_data");
+fn bench_presorted_data(harness: &Harness) {
+    print_group_header("Pre-sorted Data");
 
     for row_count in [10_000, 100_000] {
         let mut db = Database::new();
+        setup_presorted_table(&mut db, row_count, "PRESORTED_TEST");
 
-        // Create table with already sorted data
-        let schema = vibesql_catalog::TableSchema::new(
-            "PRESORTED_TEST".to_string(),
-            vec![vibesql_catalog::ColumnSchema {
-                name: "ID".to_string(),
-                data_type: vibesql_types::DataType::Integer,
-                nullable: false,
-                default_value: None,
-            }],
-        );
-        db.create_table(schema).unwrap();
-
-        for i in 0..row_count {
-            let row = vibesql_storage::Row::new(vec![
-                vibesql_types::SqlValue::Integer(i as i64), // Already sorted
-            ]);
-            db.insert_row("PRESORTED_TEST", row).unwrap();
-        }
-
-        group.throughput(Throughput::Elements(row_count as u64));
+        eprintln!("\n  Row count: {}", row_count);
 
         for cores in [1, 4, 8] {
-            group.bench_with_input(
-                BenchmarkId::new(format!("{}_cores", cores), row_count),
-                &(row_count, cores),
-                |b, &(_, cores)| {
-                    let pool = rayon::ThreadPoolBuilder::new().num_threads(cores).build().unwrap();
-
-                    pool.install(|| {
-                        b.iter(|| {
-                            let stmt = parse_select("SELECT * FROM presorted_test ORDER BY id;");
-                            let executor = SelectExecutor::new(&db);
-                            black_box(executor.execute(&stmt).unwrap())
-                        });
-                    });
-                },
+            let name = format!("{}_cores/{}_rows", cores, row_count);
+            let stats = run_benchmark_with_cores(
+                harness,
+                &name,
+                &db,
+                "SELECT * FROM presorted_test ORDER BY id;",
+                cores,
             );
+            stats.print_compact();
         }
     }
-
-    group.finish();
 }
 
 /// Benchmark: Reverse sorted data (worst case for some sort algorithms)
-fn bench_reverse_sorted_data(c: &mut Criterion) {
-    let mut group = c.benchmark_group("reverse_sorted_data");
+fn bench_reverse_sorted_data(harness: &Harness) {
+    print_group_header("Reverse-sorted Data");
 
     for row_count in [10_000, 100_000] {
         let mut db = Database::new();
+        setup_reverse_sorted_table(&mut db, row_count, "REVERSE_TEST");
 
-        let schema = vibesql_catalog::TableSchema::new(
-            "REVERSE_TEST".to_string(),
-            vec![vibesql_catalog::ColumnSchema {
-                name: "ID".to_string(),
-                data_type: vibesql_types::DataType::Integer,
-                nullable: false,
-                default_value: None,
-            }],
-        );
-        db.create_table(schema).unwrap();
-
-        for i in 0..row_count {
-            let row = vibesql_storage::Row::new(vec![
-                vibesql_types::SqlValue::Integer((row_count - i) as i64), // Reverse sorted
-            ]);
-            db.insert_row("REVERSE_TEST", row).unwrap();
-        }
-
-        group.throughput(Throughput::Elements(row_count as u64));
+        eprintln!("\n  Row count: {}", row_count);
 
         for cores in [1, 4, 8] {
-            group.bench_with_input(
-                BenchmarkId::new(format!("{}_cores", cores), row_count),
-                &(row_count, cores),
-                |b, &(_, cores)| {
-                    let pool = rayon::ThreadPoolBuilder::new().num_threads(cores).build().unwrap();
-
-                    pool.install(|| {
-                        b.iter(|| {
-                            let stmt = parse_select("SELECT * FROM reverse_test ORDER BY id;");
-                            let executor = SelectExecutor::new(&db);
-                            black_box(executor.execute(&stmt).unwrap())
-                        });
-                    });
-                },
+            let name = format!("{}_cores/{}_rows", cores, row_count);
+            let stats = run_benchmark_with_cores(
+                harness,
+                &name,
+                &db,
+                "SELECT * FROM reverse_test ORDER BY id;",
+                cores,
             );
+            stats.print_compact();
         }
     }
-
-    group.finish();
 }
 
-criterion_group!(
-    benches,
-    bench_simple_integer_sort,
-    bench_multi_column_sort,
-    bench_string_sort,
-    bench_sort_with_nulls,
-    bench_threshold_boundary,
-    bench_presorted_data,
-    bench_reverse_sorted_data
-);
-criterion_main!(benches);
+fn main() {
+    eprintln!("\n=== Parallel Sort Benchmarks ===\n");
+
+    let harness = Harness::new();
+
+    bench_simple_integer_sort(&harness);
+    bench_multi_column_sort(&harness);
+    bench_string_sort(&harness);
+    bench_sort_with_nulls(&harness);
+    bench_threshold_boundary(&harness);
+    bench_presorted_data(&harness);
+    bench_reverse_sorted_data(&harness);
+
+    eprintln!("\n=== Benchmark Complete ===\n");
+}

--- a/crates/vibesql-storage/benches/harness.rs
+++ b/crates/vibesql-storage/benches/harness.rs
@@ -1,0 +1,169 @@
+//! Minimal timing harness for storage benchmarks
+//!
+//! A simplified version of the shared harness from vibesql-executor
+//! for storage crate benchmarks.
+
+#![allow(dead_code)]
+
+use std::env;
+use std::time::{Duration, Instant};
+
+/// Default configuration for benchmarks
+pub const DEFAULT_WARMUP_ITERATIONS: usize = 3;
+pub const DEFAULT_BENCHMARK_ITERATIONS: usize = 10;
+
+/// Configuration for a benchmark run
+#[derive(Debug, Clone)]
+pub struct BenchConfig {
+    pub warmup_iterations: usize,
+    pub benchmark_iterations: usize,
+}
+
+impl Default for BenchConfig {
+    fn default() -> Self {
+        Self {
+            warmup_iterations: env::var("WARMUP_ITERATIONS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(DEFAULT_WARMUP_ITERATIONS),
+            benchmark_iterations: env::var("BENCHMARK_ITERATIONS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(DEFAULT_BENCHMARK_ITERATIONS),
+        }
+    }
+}
+
+/// Statistics collected from a benchmark run
+#[derive(Debug, Clone)]
+pub struct BenchStats {
+    pub name: String,
+    pub iterations: usize,
+    pub times: Vec<Duration>,
+    pub min: Duration,
+    pub max: Duration,
+    pub mean: Duration,
+    pub median: Duration,
+    pub stddev: Duration,
+}
+
+impl BenchStats {
+    /// Calculate statistics from a collection of timing samples
+    pub fn from_times(name: &str, times: Vec<Duration>) -> Self {
+        let iterations = times.len();
+        if iterations == 0 {
+            return Self {
+                name: name.to_string(),
+                iterations: 0,
+                times: vec![],
+                min: Duration::ZERO,
+                max: Duration::ZERO,
+                mean: Duration::ZERO,
+                median: Duration::ZERO,
+                stddev: Duration::ZERO,
+            };
+        }
+
+        let mut sorted = times.clone();
+        sorted.sort();
+
+        let min = sorted[0];
+        let max = sorted[iterations - 1];
+        let median = sorted[iterations / 2];
+
+        // Calculate mean
+        let total: Duration = times.iter().sum();
+        let mean = total / iterations as u32;
+
+        // Calculate standard deviation
+        let mean_nanos = mean.as_nanos() as f64;
+        let variance: f64 = times
+            .iter()
+            .map(|t| {
+                let diff = t.as_nanos() as f64 - mean_nanos;
+                diff * diff
+            })
+            .sum::<f64>()
+            / iterations as f64;
+        let stddev = Duration::from_nanos(variance.sqrt() as u64);
+
+        Self { name: name.to_string(), iterations, times, min, max, mean, median, stddev }
+    }
+
+    /// Print statistics in a format compatible with existing benchmark parsers
+    pub fn print(&self) {
+        eprintln!("  {} ({} iterations):", self.name, self.iterations);
+        eprintln!("    Min:    {:>10.2?}", self.min);
+        eprintln!("    Max:    {:>10.2?}", self.max);
+        eprintln!("    Mean:   {:>10.2?}", self.mean);
+        eprintln!("    Median: {:>10.2?}", self.median);
+        eprintln!("    StdDev: {:>10.2?}", self.stddev);
+    }
+
+    /// Print in a compact single-line format for comparison tables
+    pub fn print_compact(&self) {
+        eprintln!(
+            "  {:<30} {:>10.2?} avg ({:>10.2?} - {:>10.2?})",
+            self.name, self.mean, self.min, self.max
+        );
+    }
+}
+
+/// Benchmark harness for running and timing operations
+pub struct Harness {
+    config: BenchConfig,
+}
+
+impl Harness {
+    /// Create a new harness with default configuration (from environment)
+    pub fn new() -> Self {
+        Self { config: BenchConfig::default() }
+    }
+
+    /// Run a benchmark, measuring execution time automatically
+    pub fn run<F, T>(&self, name: &str, mut f: F) -> BenchStats
+    where
+        F: FnMut() -> T,
+    {
+        // Warmup phase
+        for _ in 0..self.config.warmup_iterations {
+            std::hint::black_box(f());
+        }
+
+        // Timed phase
+        let mut times = Vec::with_capacity(self.config.benchmark_iterations);
+
+        for _ in 0..self.config.benchmark_iterations {
+            let start = Instant::now();
+            std::hint::black_box(f());
+            times.push(start.elapsed());
+        }
+
+        BenchStats::from_times(name, times)
+    }
+}
+
+impl Default for Harness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Print a benchmark group header
+pub fn print_group_header(name: &str) {
+    eprintln!("\n=== {} ===", name);
+}
+
+/// Print a benchmark group summary table
+pub fn print_summary_table(results: &[BenchStats]) {
+    eprintln!("\n--- Summary ---");
+    eprintln!("{:<35} {:>12} {:>12} {:>12}", "Benchmark", "Mean", "Min", "Max");
+    eprintln!("{:-<35} {:->12} {:->12} {:->12}", "", "", "", "");
+
+    for stat in results {
+        eprintln!(
+            "{:<35} {:>12.2?} {:>12.2?} {:>12.2?}",
+            stat.name, stat.mean, stat.min, stat.max
+        );
+    }
+}

--- a/crates/vibesql-storage/benches/row_capacity_benchmark.rs
+++ b/crates/vibesql-storage/benches/row_capacity_benchmark.rs
@@ -3,16 +3,18 @@
 //! This benchmark tests different ROW_INLINE_CAPACITY values to find the optimal
 //! trade-off between inline storage and heap allocations.
 //!
+//! Migrated from Criterion to custom harness for deterministic timing.
+//!
 //! Run with:
 //!   cargo bench --package vibesql-storage --bench row_capacity_benchmark
 //!
-//! Or run directly:
-//!   cargo bench --package vibesql-storage --bench row_capacity_benchmark --no-run
-//!   ./target/release/deps/row_capacity_benchmark-*
-//!
-//! The benchmark uses criterion's default sample collection.
+//! Environment variables:
+//!   WARMUP_ITERATIONS - Number of warmup runs (default: 3)
+//!   BENCHMARK_ITERATIONS - Number of timed runs (default: 10)
 
-use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+mod harness;
+
+use harness::{print_group_header, print_summary_table, Harness};
 use smallvec::SmallVec;
 use std::hint::black_box;
 use vibesql_types::SqlValue;
@@ -33,7 +35,7 @@ fn make_value(i: usize) -> SqlValue {
         0 => SqlValue::Integer(i as i64 * 1000),
         1 => SqlValue::Double(i as f64 * 2.5),
         2 => SqlValue::Varchar(arcstr::ArcStr::from(format!("value_{}", i))),
-        3 => SqlValue::Boolean(i.is_multiple_of(2)),
+        3 => SqlValue::Boolean(i % 2 == 0),
         4 => SqlValue::Null,
         _ => unreachable!(),
     }
@@ -84,167 +86,6 @@ fn create_row12(column_count: usize) -> Row12 {
     row
 }
 
-/// Benchmark row creation with different capacities
-fn bench_row_creation(c: &mut Criterion) {
-    let mut group = c.benchmark_group("row_creation");
-
-    for &col_count in &COLUMN_COUNTS {
-        group.throughput(Throughput::Elements(col_count as u64));
-
-        // Capacity 4
-        group.bench_with_input(BenchmarkId::new("capacity_4", col_count), &col_count, |b, &cols| {
-            b.iter(|| black_box(create_row4(cols)));
-        });
-
-        // Capacity 6
-        group.bench_with_input(BenchmarkId::new("capacity_6", col_count), &col_count, |b, &cols| {
-            b.iter(|| black_box(create_row6(cols)));
-        });
-
-        // Capacity 8 (current default)
-        group.bench_with_input(BenchmarkId::new("capacity_8", col_count), &col_count, |b, &cols| {
-            b.iter(|| black_box(create_row8(cols)));
-        });
-
-        // Capacity 10
-        group.bench_with_input(
-            BenchmarkId::new("capacity_10", col_count),
-            &col_count,
-            |b, &cols| {
-                b.iter(|| black_box(create_row10(cols)));
-            },
-        );
-
-        // Capacity 12
-        group.bench_with_input(
-            BenchmarkId::new("capacity_12", col_count),
-            &col_count,
-            |b, &cols| {
-                b.iter(|| black_box(create_row12(cols)));
-            },
-        );
-    }
-
-    group.finish();
-}
-
-/// Benchmark batch row creation (simulates query result processing)
-fn bench_batch_creation(c: &mut Criterion) {
-    let mut group = c.benchmark_group("batch_creation");
-    const BATCH_SIZE: usize = 1000;
-
-    for &col_count in &[4, 8, 12] {
-        group.throughput(Throughput::Elements(BATCH_SIZE as u64));
-
-        // Capacity 4
-        group.bench_with_input(BenchmarkId::new("capacity_4", col_count), &col_count, |b, &cols| {
-            b.iter(|| {
-                let batch: Vec<Row4> = (0..BATCH_SIZE).map(|_| create_row4(cols)).collect();
-                black_box(batch)
-            });
-        });
-
-        // Capacity 8 (current default)
-        group.bench_with_input(BenchmarkId::new("capacity_8", col_count), &col_count, |b, &cols| {
-            b.iter(|| {
-                let batch: Vec<Row8> = (0..BATCH_SIZE).map(|_| create_row8(cols)).collect();
-                black_box(batch)
-            });
-        });
-
-        // Capacity 12
-        group.bench_with_input(
-            BenchmarkId::new("capacity_12", col_count),
-            &col_count,
-            |b, &cols| {
-                b.iter(|| {
-                    let batch: Vec<Row12> = (0..BATCH_SIZE).map(|_| create_row12(cols)).collect();
-                    black_box(batch)
-                });
-            },
-        );
-    }
-
-    group.finish();
-}
-
-/// Benchmark row cloning (important for query processing)
-fn bench_row_clone(c: &mut Criterion) {
-    let mut group = c.benchmark_group("row_clone");
-
-    for &col_count in &COLUMN_COUNTS {
-        // Pre-create rows to clone
-        let row4 = create_row4(col_count);
-        let row8 = create_row8(col_count);
-        let row12 = create_row12(col_count);
-
-        group.bench_with_input(BenchmarkId::new("capacity_4", col_count), &row4, |b, row| {
-            b.iter(|| black_box(row.clone()));
-        });
-
-        group.bench_with_input(BenchmarkId::new("capacity_8", col_count), &row8, |b, row| {
-            b.iter(|| black_box(row.clone()));
-        });
-
-        group.bench_with_input(BenchmarkId::new("capacity_12", col_count), &row12, |b, row| {
-            b.iter(|| black_box(row.clone()));
-        });
-    }
-
-    group.finish();
-}
-
-/// Benchmark row access patterns (simulates filtering)
-fn bench_row_access(c: &mut Criterion) {
-    let mut group = c.benchmark_group("row_access");
-
-    for &col_count in &[4, 8, 16] {
-        // Pre-create rows
-        let row4 = create_row4(col_count);
-        let row8 = create_row8(col_count);
-        let row12 = create_row12(col_count);
-
-        group.bench_with_input(BenchmarkId::new("capacity_4", col_count), &row4, |b, row| {
-            b.iter(|| {
-                // Simulate accessing multiple columns (like in a filter)
-                let mut sum = 0i64;
-                for i in 0..row.len() {
-                    if let SqlValue::Integer(v) = &row[i] {
-                        sum += v;
-                    }
-                }
-                black_box(sum)
-            });
-        });
-
-        group.bench_with_input(BenchmarkId::new("capacity_8", col_count), &row8, |b, row| {
-            b.iter(|| {
-                let mut sum = 0i64;
-                for i in 0..row.len() {
-                    if let SqlValue::Integer(v) = &row[i] {
-                        sum += v;
-                    }
-                }
-                black_box(sum)
-            });
-        });
-
-        group.bench_with_input(BenchmarkId::new("capacity_12", col_count), &row12, |b, row| {
-            b.iter(|| {
-                let mut sum = 0i64;
-                for i in 0..row.len() {
-                    if let SqlValue::Integer(v) = &row[i] {
-                        sum += v;
-                    }
-                }
-                black_box(sum)
-            });
-        });
-    }
-
-    group.finish();
-}
-
 /// Print size information for different capacities
 fn print_size_info() {
     use std::mem::size_of;
@@ -270,13 +111,196 @@ fn print_size_info() {
     eprintln!();
 }
 
-criterion_group!(benches, bench_row_creation, bench_batch_creation, bench_row_clone, bench_row_access);
+/// Benchmark row creation with different capacities
+fn bench_row_creation(harness: &Harness) -> Vec<harness::BenchStats> {
+    print_group_header("Row Creation");
+
+    let mut results = Vec::new();
+
+    for &col_count in &COLUMN_COUNTS {
+        // Capacity 4
+        let name = format!("capacity_4/{}_cols", col_count);
+        let stats = harness.run(&name, || create_row4(col_count));
+        stats.print_compact();
+        results.push(stats);
+
+        // Capacity 6
+        let name = format!("capacity_6/{}_cols", col_count);
+        let stats = harness.run(&name, || create_row6(col_count));
+        stats.print_compact();
+        results.push(stats);
+
+        // Capacity 8 (current default)
+        let name = format!("capacity_8/{}_cols", col_count);
+        let stats = harness.run(&name, || create_row8(col_count));
+        stats.print_compact();
+        results.push(stats);
+
+        // Capacity 10
+        let name = format!("capacity_10/{}_cols", col_count);
+        let stats = harness.run(&name, || create_row10(col_count));
+        stats.print_compact();
+        results.push(stats);
+
+        // Capacity 12
+        let name = format!("capacity_12/{}_cols", col_count);
+        let stats = harness.run(&name, || create_row12(col_count));
+        stats.print_compact();
+        results.push(stats);
+
+        eprintln!(); // Blank line between column counts
+    }
+
+    results
+}
+
+/// Benchmark batch row creation (simulates query result processing)
+fn bench_batch_creation(harness: &Harness) -> Vec<harness::BenchStats> {
+    print_group_header("Batch Creation (1000 rows)");
+    const BATCH_SIZE: usize = 1000;
+
+    let mut results = Vec::new();
+
+    for &col_count in &[4usize, 8, 12] {
+        // Capacity 4
+        let name = format!("capacity_4/{}_cols", col_count);
+        let stats = harness.run(&name, || {
+            let batch: Vec<Row4> = (0..BATCH_SIZE).map(|_| create_row4(col_count)).collect();
+            black_box(batch)
+        });
+        stats.print_compact();
+        results.push(stats);
+
+        // Capacity 8 (current default)
+        let name = format!("capacity_8/{}_cols", col_count);
+        let stats = harness.run(&name, || {
+            let batch: Vec<Row8> = (0..BATCH_SIZE).map(|_| create_row8(col_count)).collect();
+            black_box(batch)
+        });
+        stats.print_compact();
+        results.push(stats);
+
+        // Capacity 12
+        let name = format!("capacity_12/{}_cols", col_count);
+        let stats = harness.run(&name, || {
+            let batch: Vec<Row12> = (0..BATCH_SIZE).map(|_| create_row12(col_count)).collect();
+            black_box(batch)
+        });
+        stats.print_compact();
+        results.push(stats);
+
+        eprintln!(); // Blank line between column counts
+    }
+
+    results
+}
+
+/// Benchmark row cloning (important for query processing)
+fn bench_row_clone(harness: &Harness) -> Vec<harness::BenchStats> {
+    print_group_header("Row Clone");
+
+    let mut results = Vec::new();
+
+    for &col_count in &COLUMN_COUNTS {
+        // Pre-create rows to clone
+        let row4 = create_row4(col_count);
+        let row8 = create_row8(col_count);
+        let row12 = create_row12(col_count);
+
+        let name = format!("capacity_4/{}_cols", col_count);
+        let stats = harness.run(&name, || row4.clone());
+        stats.print_compact();
+        results.push(stats);
+
+        let name = format!("capacity_8/{}_cols", col_count);
+        let stats = harness.run(&name, || row8.clone());
+        stats.print_compact();
+        results.push(stats);
+
+        let name = format!("capacity_12/{}_cols", col_count);
+        let stats = harness.run(&name, || row12.clone());
+        stats.print_compact();
+        results.push(stats);
+
+        eprintln!(); // Blank line between column counts
+    }
+
+    results
+}
+
+/// Benchmark row access patterns (simulates filtering)
+fn bench_row_access(harness: &Harness) -> Vec<harness::BenchStats> {
+    print_group_header("Row Access");
+
+    let mut results = Vec::new();
+
+    for &col_count in &[4usize, 8, 16] {
+        // Pre-create rows
+        let row4 = create_row4(col_count);
+        let row8 = create_row8(col_count);
+        let row12 = create_row12(col_count);
+
+        let name = format!("capacity_4/{}_cols", col_count);
+        let stats = harness.run(&name, || {
+            // Simulate accessing multiple columns (like in a filter)
+            let mut sum = 0i64;
+            for i in 0..row4.len() {
+                if let SqlValue::Integer(v) = &row4[i] {
+                    sum += v;
+                }
+            }
+            black_box(sum)
+        });
+        stats.print_compact();
+        results.push(stats);
+
+        let name = format!("capacity_8/{}_cols", col_count);
+        let stats = harness.run(&name, || {
+            let mut sum = 0i64;
+            for i in 0..row8.len() {
+                if let SqlValue::Integer(v) = &row8[i] {
+                    sum += v;
+                }
+            }
+            black_box(sum)
+        });
+        stats.print_compact();
+        results.push(stats);
+
+        let name = format!("capacity_12/{}_cols", col_count);
+        let stats = harness.run(&name, || {
+            let mut sum = 0i64;
+            for i in 0..row12.len() {
+                if let SqlValue::Integer(v) = &row12[i] {
+                    sum += v;
+                }
+            }
+            black_box(sum)
+        });
+        stats.print_compact();
+        results.push(stats);
+
+        eprintln!(); // Blank line between column counts
+    }
+
+    results
+}
 
 fn main() {
     // Print size info before running benchmarks
     print_size_info();
 
-    // Run criterion benchmarks
-    benches();
-    Criterion::default().configure_from_args().final_summary();
+    eprintln!("=== Row Capacity Benchmarks ===\n");
+
+    let harness = Harness::new();
+
+    let mut all_results = Vec::new();
+    all_results.extend(bench_row_creation(&harness));
+    all_results.extend(bench_batch_creation(&harness));
+    all_results.extend(bench_row_clone(&harness));
+    all_results.extend(bench_row_access(&harness));
+
+    print_summary_table(&all_results);
+
+    eprintln!("\n=== Benchmark Complete ===\n");
 }


### PR DESCRIPTION
## Summary

Migrates 4 selected benchmarks from Criterion to the custom timing harness based on the evaluation in issue #4107:

**Migrated benchmarks:**
- `parallel_sort.rs` (vibesql-executor) - Parallel algorithms benefit from deterministic iteration
- `hash_join_parallel.rs` (vibesql-executor) - Parallel join benchmarks need consistent timing
- `lineitem_scan_profiling.rs` (vibesql-executor) - Profiling-focused, doesn't need statistical analysis
- `row_capacity_benchmark.rs` (vibesql-storage) - Simple structure, easy migration

**Benefits:**
- Reduced compile time (no Criterion proc macros for these benchmarks)
- Deterministic iteration counts via `WARMUP_ITERATIONS` and `BENCHMARK_ITERATIONS` env vars
- Consistent output format with TPC-H/TPC-DS/Sysbench benchmarks

**Remaining 16 benchmarks stay on Criterion** as they benefit from:
- Statistical analysis for micro-operations (sub-millisecond timings)
- Throughput metrics for I/O-bound tests
- Parser comparison features

## Changes

- Converted 4 Criterion benchmarks to use the shared `harness` module
- Added `harness.rs` to vibesql-storage benches for the row_capacity_benchmark
- Fixed table name case sensitivity in hash_join_parallel.rs (uppercase for SQL parser)

## Test Plan

- [x] `cargo bench --bench parallel_sort` runs successfully with timing output
- [x] `cargo bench --bench hash_join_parallel` runs successfully with timing output
- [x] `cargo bench --bench row_capacity_benchmark` runs successfully with timing output
- [x] `cargo check --bench lineitem_scan_profiling` compiles (requires TPC-H data to run)
- [x] All benchmarks compile without errors

Closes #4107