### PR TITLE
fix(storage): Add case-insensitive table lookup for correlated subqueries

### DIFF
--- a/crates/vibesql-executor/src/tests/scalar_subquery_correlated_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_correlated_tests.rs
@@ -3,8 +3,173 @@
 //! Tests for scalar subqueries that reference columns from the outer query:
 //! - Basic correlated subqueries with outer references
 //! - Correlated subqueries with aggregation
+//! - Case sensitivity handling (#4111)
 
 use super::super::*;
+
+/// Test for issue #4111: Column resolution in correlated subqueries with case mismatch
+/// The parser uppercases identifiers (e.g., j -> J, i_current_price -> I_CURRENT_PRICE)
+/// while the schema may store lowercase column names. This test verifies that column
+/// lookups work correctly with case-insensitive matching.
+///
+/// Reproduces TPC-DS Q6 pattern:
+/// ```sql
+/// SELECT AVG(j.i_current_price)
+/// FROM item j
+/// WHERE j.i_category = i.i_category
+/// ```
+#[test]
+fn test_correlated_subquery_uppercase_identifiers_issue_4111() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Create table with LOWERCASE column names (simulating TPC-DS data loader)
+    let schema = vibesql_catalog::TableSchema::new(
+        "item".to_string(), // lowercase table name
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "i_item_sk".to_string(), // lowercase
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "i_current_price".to_string(), // lowercase - the problematic column
+                vibesql_types::DataType::DoublePrecision,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "i_category".to_string(), // lowercase
+                vibesql_types::DataType::Varchar { max_length: Some(50) },
+                false,
+            ),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    // Insert test data
+    db.insert_row(
+        "item",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(1),
+            vibesql_types::SqlValue::Double(10.00), // 10.00
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Electronics")),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "item",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(2),
+            vibesql_types::SqlValue::Double(20.00), // 20.00
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Electronics")),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "item",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(3),
+            vibesql_types::SqlValue::Double(30.00), // 30.00
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Books")),
+        ]),
+    )
+    .unwrap();
+
+    // Build correlated subquery with UPPERCASE identifiers (as parser would produce):
+    // SELECT AVG(J.I_CURRENT_PRICE) FROM ITEM J WHERE J.I_CATEGORY = I.I_CATEGORY
+    let subquery = Box::new(vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Expression {
+            expr: vibesql_ast::Expression::AggregateFunction {
+                name: "AVG".to_string(),
+                distinct: false,
+                args: vec![vibesql_ast::Expression::ColumnRef {
+                    table: Some("J".to_string()), // UPPERCASE alias
+                    column: "I_CURRENT_PRICE".to_string(), // UPPERCASE column - this was failing
+                }],
+            },
+            alias: None,
+        }],
+        from: Some(vibesql_ast::FromClause::Table {
+            name: "ITEM".to_string(), // UPPERCASE table
+            alias: Some("J".to_string()), // UPPERCASE alias
+            column_aliases: None,
+        }),
+        where_clause: Some(vibesql_ast::Expression::BinaryOp {
+            left: Box::new(vibesql_ast::Expression::ColumnRef {
+                table: Some("J".to_string()), // UPPERCASE alias
+                column: "I_CATEGORY".to_string(), // UPPERCASE column
+            }),
+            op: vibesql_ast::BinaryOperator::Equal,
+            right: Box::new(vibesql_ast::Expression::ColumnRef {
+                table: Some("I".to_string()), // UPPERCASE outer alias
+                column: "I_CATEGORY".to_string(), // UPPERCASE column
+            }),
+        }),
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    });
+
+    // Build main query: SELECT I_ITEM_SK FROM ITEM I WHERE I.I_CURRENT_PRICE > (correlated subquery)
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Expression {
+            expr: vibesql_ast::Expression::ColumnRef {
+                table: Some("I".to_string()),
+                column: "I_ITEM_SK".to_string(),
+            },
+            alias: None,
+        }],
+        from: Some(vibesql_ast::FromClause::Table {
+            name: "ITEM".to_string(),
+            alias: Some("I".to_string()),
+            column_aliases: None,
+        }),
+        where_clause: Some(vibesql_ast::Expression::BinaryOp {
+            left: Box::new(vibesql_ast::Expression::ColumnRef {
+                table: Some("I".to_string()),
+                column: "I_CURRENT_PRICE".to_string(),
+            }),
+            op: vibesql_ast::BinaryOperator::GreaterThan,
+            right: Box::new(vibesql_ast::Expression::ScalarSubquery(subquery)),
+        }),
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let executor = SelectExecutor::new(&db);
+    let result = executor.execute(&stmt);
+
+    // The test verifies that column resolution works despite case mismatch
+    assert!(
+        result.is_ok(),
+        "Correlated subquery should resolve J.I_CURRENT_PRICE despite lowercase schema columns. Error: {:?}",
+        result.err()
+    );
+
+    let rows = result.unwrap();
+    // Electronics avg = 15.00, so item 2 (20.00 > 15.00) passes
+    // Books avg = 30.00, so item 3 (30.00 > 30.00) fails (not strictly greater)
+    assert_eq!(rows.len(), 1, "Only item with price > category avg should be returned");
+    assert_eq!(
+        rows[0].get(0).unwrap(),
+        &vibesql_types::SqlValue::Integer(2),
+        "Item 2 should be returned (20.00 > 15.00 avg for Electronics)"
+    );
+}
 
 #[test]
 fn test_correlated_subquery_basic() {

--- a/crates/vibesql-storage/src/database/core.rs
+++ b/crates/vibesql-storage/src/database/core.rs
@@ -234,9 +234,18 @@ impl Database {
         }
 
         // Try uppercase normalization (for unquoted identifiers from the parser)
-        let normalized_name = name.to_uppercase();
-        if normalized_name != name {
-            if let Some(table) = self.tables.get(&normalized_name) {
+        let uppercase_name = name.to_uppercase();
+        if uppercase_name != name {
+            if let Some(table) = self.tables.get(&uppercase_name) {
+                return Some(table);
+            }
+        }
+
+        // Try lowercase normalization (for case-insensitive matching when table
+        // was created with lowercase but query uses uppercase identifiers)
+        let lowercase_name = name.to_lowercase();
+        if lowercase_name != name && lowercase_name != uppercase_name {
+            if let Some(table) = self.tables.get(&lowercase_name) {
                 return Some(table);
             }
         }
@@ -252,9 +261,19 @@ impl Database {
             }
 
             // Try uppercase with schema prefix
-            let qualified_name_normalized = format!("{}.{}", current_schema, normalized_name);
-            if qualified_name_normalized != qualified_name_original {
-                return self.tables.get(&qualified_name_normalized);
+            let qualified_name_uppercase = format!("{}.{}", current_schema, uppercase_name);
+            if qualified_name_uppercase != qualified_name_original {
+                if let Some(table) = self.tables.get(&qualified_name_uppercase) {
+                    return Some(table);
+                }
+            }
+
+            // Try lowercase with schema prefix
+            let qualified_name_lowercase = format!("{}.{}", current_schema, lowercase_name);
+            if qualified_name_lowercase != qualified_name_original
+                && qualified_name_lowercase != qualified_name_uppercase
+            {
+                return self.tables.get(&qualified_name_lowercase);
             }
         }
 
@@ -269,9 +288,19 @@ impl Database {
         }
 
         // Try uppercase normalization (for unquoted identifiers from the parser)
-        let normalized_name = name.to_uppercase();
-        if normalized_name != name && self.tables.contains_key(&normalized_name) {
-            return self.tables.get_mut(&normalized_name);
+        let uppercase_name = name.to_uppercase();
+        if uppercase_name != name && self.tables.contains_key(&uppercase_name) {
+            return self.tables.get_mut(&uppercase_name);
+        }
+
+        // Try lowercase normalization (for case-insensitive matching when table
+        // was created with lowercase but query uses uppercase identifiers)
+        let lowercase_name = name.to_lowercase();
+        if lowercase_name != name
+            && lowercase_name != uppercase_name
+            && self.tables.contains_key(&lowercase_name)
+        {
+            return self.tables.get_mut(&lowercase_name);
         }
 
         // Try with schema qualification
@@ -285,9 +314,20 @@ impl Database {
             }
 
             // Try uppercase with schema prefix
-            let qualified_name_normalized = format!("{}.{}", current_schema, normalized_name);
-            if qualified_name_normalized != qualified_name_original {
-                return self.tables.get_mut(&qualified_name_normalized);
+            let qualified_name_uppercase = format!("{}.{}", current_schema, uppercase_name);
+            if qualified_name_uppercase != qualified_name_original
+                && self.tables.contains_key(&qualified_name_uppercase)
+            {
+                return self.tables.get_mut(&qualified_name_uppercase);
+            }
+
+            // Try lowercase with schema prefix
+            let qualified_name_lowercase = format!("{}.{}", current_schema, lowercase_name);
+            if qualified_name_lowercase != qualified_name_original
+                && qualified_name_lowercase != qualified_name_uppercase
+                && self.tables.contains_key(&qualified_name_lowercase)
+            {
+                return self.tables.get_mut(&qualified_name_lowercase);
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #4111: TPC-DS Q6 failing with "Column 'I_CURRENT_PRICE' not found (searched tables: J)"

- The SQL parser uppercases unquoted identifiers per SQL:1999 standard (e.g., `j` → `J`, `i_current_price` → `I_CURRENT_PRICE`)
- Tables created via TPC-DS data loaders use lowercase names in the schema
- `Database::get_table()` was only trying uppercase normalization, not lowercase
- When looking up table `ITEM` (uppercase from parser) against stored table `item` (lowercase), the lookup failed

## Changes

- Added lowercase normalization fallback in `get_table()` and `get_table_mut()` in `crates/vibesql-storage/src/database/core.rs`
- Try lowercase both with and without schema qualification  
- Added regression test `test_correlated_subquery_uppercase_identifiers_issue_4111` that builds AST with uppercase identifiers and verifies resolution works

## Test plan

- [x] New test `test_correlated_subquery_uppercase_identifiers_issue_4111` passes
- [x] All existing `vibesql-storage` tests pass
- [x] All existing `vibesql-executor` tests pass
- [x] TPC-DS Q6 benchmark runs successfully (was failing before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)