### PR TITLE
feat(benchmark): Add ENGINE_FILTER for runtime engine selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VibeSQL Makefile
 # Convenience targets for common development tasks
 
-.PHONY: all all-fg logs status build build-all build-wasm build-python test test-unit test-workspace test-sqllogictest test-sqllogictest-halting fuzz fuzz-parser fuzz-expr fuzz-type-convert fuzz-query fuzz-type-coercion fuzz-differential fuzz-list benchmark benchmark-quick benchmark-smoke benchmark-all benchmark-tpch benchmark-tpch-quick benchmark-tpch-profile benchmark-tpcc benchmark-tpcds benchmark-tpcds-all benchmark-sysbench clean help analyze-tests analyze-benchmarks analyze profile-tpch profile-tpcc profile-sysbench profile-select profile-query bench-storage bench-executor bench-types website mysql-start mysql-stop mysql-status strip-quarantine
+.PHONY: all all-fg logs status build build-all build-wasm build-python test test-unit test-workspace test-sqllogictest test-sqllogictest-halting fuzz fuzz-parser fuzz-expr fuzz-type-convert fuzz-query fuzz-type-coercion fuzz-differential fuzz-list benchmark benchmark-quick benchmark-smoke benchmark-all benchmark-tpch benchmark-tpch-quick benchmark-tpch-profile benchmark-tpcc benchmark-tpcds benchmark-tpcds-all benchmark-sysbench benchmark-vibesql benchmark-sqlite benchmark-duckdb benchmark-servers clean help analyze-tests analyze-benchmarks analyze profile-tpch profile-tpcc profile-sysbench profile-select profile-query bench-storage bench-executor bench-types website mysql-start mysql-stop mysql-status strip-quarantine
 
 # Default target: show help
 .DEFAULT_GOAL := help
@@ -99,6 +99,12 @@ help:
 	@echo "  make benchmark-tpcds     - Run TPC-DS benchmark suite (isolated, memory-safe)"
 	@echo "  make benchmark-tpcds-all - Run TPC-DS with all engines simultaneously (may OOM)"
 	@echo "  make benchmark-sysbench  - Run Sysbench OLTP benchmarks"
+	@echo ""
+	@echo "Per-engine benchmark targets (eliminate redundant testing):"
+	@echo "  make benchmark-vibesql   - Run all benchmarks for VibeSQL only (~1 hour)"
+	@echo "  make benchmark-sqlite    - Run all benchmarks for SQLite only (~1.5 hours)"
+	@echo "  make benchmark-duckdb    - Run all benchmarks for DuckDB only (~2 hours)"
+	@echo "  make benchmark-servers   - Run server benchmarks (VibeSQL-server + MySQL)"
 	@echo ""
 	@echo "Profiling targets (uses samply, no sudo required):"
 	@echo "  make profile-tpch       - Profile TPC-H queries (opens Firefox Profiler)"
@@ -326,6 +332,33 @@ benchmark-tpcds-all:
 # Run Sysbench OLTP benchmark
 benchmark-sysbench:
 	@./scripts/bench --test=sysbench
+
+#
+# Per-Engine Benchmark Targets
+# Run all benchmark types for a single engine (eliminates redundant testing)
+#
+
+# Run all benchmarks for VibeSQL only (~1 hour)
+benchmark-vibesql:
+	@echo "Running all benchmarks for VibeSQL only..."
+	@./scripts/bench --test=all --engine=vibesql
+
+# Run all benchmarks for SQLite only (~1.5 hours)
+benchmark-sqlite:
+	@echo "Running all benchmarks for SQLite only..."
+	@./scripts/bench --test=all --engine=sqlite
+
+# Run all benchmarks for DuckDB only (~2 hours)
+benchmark-duckdb:
+	@echo "Running all benchmarks for DuckDB only..."
+	@./scripts/bench --test=all --engine=duckdb
+
+# Run all server benchmarks (VibeSQL-server + MySQL)
+# MySQL is only tested in server mode, not embedded mode
+benchmark-servers:
+	@echo "Running server benchmarks (VibeSQL-server + MySQL)..."
+	@./scripts/bench --test=tpch-server --engine=vibesql,mysql
+	@./scripts/bench --test=sysbench --engine=mysql
 
 #
 # Analysis Targets

--- a/crates/vibesql-executor/benches/TPCH_README.md
+++ b/crates/vibesql-executor/benches/TPCH_README.md
@@ -32,6 +32,35 @@ DuckDB (Rust)  = SQL Engine only (via duckdb-rs)
 
 This gives you **true SQL engine performance** without language binding artifacts.
 
+## Engine Selection
+
+### Runtime Engine Filtering
+
+Use the `ENGINE_FILTER` environment variable to run only specific engines without recompiling:
+
+```bash
+# Run VibeSQL only (fastest iteration)
+ENGINE_FILTER=vibesql ./target/release/deps/tpch_benchmark-*
+
+# Run VibeSQL and SQLite only
+ENGINE_FILTER=vibesql,sqlite ./target/release/deps/tpch_benchmark-*
+
+# Run all embedded engines
+ENGINE_FILTER=vibesql,sqlite,duckdb ./target/release/deps/tpch_benchmark-*
+```
+
+This eliminates redundant data loading and significantly reduces benchmark runtime.
+
+### MySQL Note
+
+MySQL is a client-server database and is tested separately via the server benchmark:
+```bash
+# Use server benchmark for MySQL comparison
+make benchmark-servers
+```
+
+For embedded engine comparisons (VibeSQL, SQLite, DuckDB), use the standard benchmark targets.
+
 ## Quick Start
 
 ### Run All TPC-H Benchmarks

--- a/crates/vibesql-executor/benches/harness/mod.rs
+++ b/crates/vibesql-executor/benches/harness/mod.rs
@@ -8,8 +8,11 @@
 //! - Reports min/max/avg/median statistics
 //! - Supports warmup phases
 //! - Produces consistent output for parsing by scripts/bench
+//! - Runtime engine selection via ENGINE_FILTER
 //!
 //! Environment Variables:
+//!   ENGINE_FILTER - Comma-separated list of engines to run (default: all)
+//!                   Valid values: vibesql, sqlite, duckdb, mysql, all
 //!   WARMUP_ITERATIONS - Number of warmup runs (default: 3)
 //!   BENCHMARK_ITERATIONS - Number of timed runs (default: 10)
 //!   BENCHMARK_TIMEOUT_SECS - Timeout per query (default: 30)
@@ -357,6 +360,131 @@ pub fn format_duration(d: Duration) -> String {
         format!("{:.2}ms", d.as_secs_f64() * 1000.0)
     } else {
         format!("{:.2}us", d.as_secs_f64() * 1_000_000.0)
+    }
+}
+
+/// Engine filter for runtime selection of which engines to benchmark.
+///
+/// This allows running only specific engines without recompiling the benchmark binary.
+/// The filter is parsed from the `ENGINE_FILTER` environment variable.
+///
+/// # Usage
+///
+/// ```bash
+/// # Run only VibeSQL
+/// ENGINE_FILTER=vibesql ./target/release/deps/tpch_benchmark-*
+///
+/// # Run VibeSQL and SQLite
+/// ENGINE_FILTER=vibesql,sqlite ./target/release/deps/tpch_benchmark-*
+///
+/// # Run all engines (default when ENGINE_FILTER is not set)
+/// ./target/release/deps/tpch_benchmark-*
+/// ```
+#[derive(Debug, Clone)]
+pub struct EngineFilter {
+    pub vibesql: bool,
+    pub sqlite: bool,
+    pub duckdb: bool,
+    pub mysql: bool,
+}
+
+impl EngineFilter {
+    /// Parse ENGINE_FILTER environment variable.
+    /// If not set, all compiled engines are enabled.
+    pub fn from_env() -> Self {
+        match env::var("ENGINE_FILTER") {
+            Ok(filter) => {
+                let engines: Vec<String> = filter
+                    .split(',')
+                    .map(|s| s.trim().to_lowercase())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+
+                // If filter is empty or "all", enable all
+                if engines.is_empty() || engines.iter().any(|e| e == "all") {
+                    return Self::all();
+                }
+
+                Self {
+                    vibesql: engines.iter().any(|e| e == "vibesql"),
+                    sqlite: engines.iter().any(|e| e == "sqlite"),
+                    duckdb: engines.iter().any(|e| e == "duckdb"),
+                    mysql: engines.iter().any(|e| e == "mysql"),
+                }
+            }
+            Err(_) => Self::all(),
+        }
+    }
+
+    /// Enable all engines (default when no filter is set)
+    pub fn all() -> Self {
+        Self {
+            vibesql: true,
+            sqlite: true,
+            duckdb: true,
+            mysql: true,
+        }
+    }
+
+    /// Enable only VibeSQL
+    pub fn vibesql_only() -> Self {
+        Self {
+            vibesql: true,
+            sqlite: false,
+            duckdb: false,
+            mysql: false,
+        }
+    }
+
+    /// Returns a comma-separated list of enabled engines for display
+    pub fn enabled_list(&self) -> String {
+        let mut engines = Vec::new();
+        if self.vibesql {
+            engines.push("vibesql");
+        }
+        if self.sqlite {
+            engines.push("sqlite");
+        }
+        if self.duckdb {
+            engines.push("duckdb");
+        }
+        if self.mysql {
+            engines.push("mysql");
+        }
+        if engines.is_empty() {
+            "none".to_string()
+        } else {
+            engines.join(", ")
+        }
+    }
+
+    /// Returns true if any engine is enabled
+    pub fn any_enabled(&self) -> bool {
+        self.vibesql || self.sqlite || self.duckdb || self.mysql
+    }
+
+    /// Returns the number of enabled engines
+    pub fn count(&self) -> usize {
+        let mut count = 0;
+        if self.vibesql {
+            count += 1;
+        }
+        if self.sqlite {
+            count += 1;
+        }
+        if self.duckdb {
+            count += 1;
+        }
+        if self.mysql {
+            count += 1;
+        }
+        count
+    }
+}
+
+impl Default for EngineFilter {
+    fn default() -> Self {
+        Self::from_env()
     }
 }
 

--- a/crates/vibesql-executor/benches/tpch_benchmark.rs
+++ b/crates/vibesql-executor/benches/tpch_benchmark.rs
@@ -16,10 +16,16 @@
 //!
 //! # With MySQL comparison
 //! MYSQL_URL=mysql://user:pass@localhost:3306/tpch ./target/release/deps/tpch_benchmark-*
+//!
+//! # Run only specific engines (runtime filtering)
+//! ENGINE_FILTER=vibesql ./target/release/deps/tpch_benchmark-*
+//! ENGINE_FILTER=vibesql,sqlite ./target/release/deps/tpch_benchmark-*
 //! ```
 //!
 //! ## Environment Variables
 //!
+//! - `ENGINE_FILTER` - Comma-separated list of engines to run (e.g., "vibesql,sqlite")
+//!   Valid values: vibesql, sqlite, duckdb, mysql (default: all compiled engines)
 //! - `WARMUP_ITERATIONS` - Number of warmup runs per query (default: 3)
 //! - `BENCHMARK_ITERATIONS` - Number of timed runs per query (default: 10)
 //! - `BENCHMARK_TIMEOUT_SECS` - Timeout per query (default: 30)
@@ -34,11 +40,23 @@
 //! QUERY_FILTER=Q1,Q6,Q9 ./target/release/deps/tpch_benchmark-*
 //! ./target/release/deps/tpch_benchmark-*            # Run all queries
 //! ```
+//!
+//! ## Engine Selection (Runtime Filtering)
+//!
+//! The ENGINE_FILTER environment variable allows running only specific engines
+//! without recompiling. This eliminates redundant data loading and speeds up
+//! targeted benchmarks.
+//!
+//! ```bash
+//! ENGINE_FILTER=vibesql ./target/release/deps/tpch_benchmark-*    # VibeSQL only
+//! ENGINE_FILTER=sqlite ./target/release/deps/tpch_benchmark-*     # SQLite only
+//! ENGINE_FILTER=vibesql,duckdb ./target/release/deps/tpch_benchmark-*  # Multiple engines
+//! ```
 
 mod harness;
 mod tpch;
 
-use harness::{BenchConfig, BenchResult, BenchStats, Harness};
+use harness::{BenchConfig, BenchResult, BenchStats, EngineFilter, Harness};
 use std::env;
 use std::time::{Duration, Instant};
 use tpch::queries::*;
@@ -226,6 +244,8 @@ fn print_help(program: &str) {
     eprintln!("  {} --help              Show this help", program);
     eprintln!();
     eprintln!("Environment Variables:");
+    eprintln!("  ENGINE_FILTER          Engines to run (e.g., vibesql,sqlite)");
+    eprintln!("                         Valid: vibesql, sqlite, duckdb, mysql, all");
     eprintln!("  WARMUP_ITERATIONS      Warmup runs per query (default: 3)");
     eprintln!("  BENCHMARK_ITERATIONS   Timed runs per query (default: 10)");
     eprintln!("  BENCHMARK_TIMEOUT_SECS Timeout per query (default: 30)");
@@ -239,9 +259,11 @@ fn print_help(program: &str) {
     }
     eprintln!();
     eprintln!("Examples:");
-    eprintln!("  {} Q1,Q6               # Run Q1 and Q6", program);
-    eprintln!("  QUERY_FILTER=Q1,Q6 {}  # Same, via env var", program);
-    eprintln!("  SCALE_FACTOR=0.1 {}    # Use larger dataset", program);
+    eprintln!("  {} Q1,Q6                    # Run Q1 and Q6", program);
+    eprintln!("  QUERY_FILTER=Q1,Q6 {}       # Same, via env var", program);
+    eprintln!("  SCALE_FACTOR=0.1 {}         # Use larger dataset", program);
+    eprintln!("  ENGINE_FILTER=vibesql {}    # VibeSQL only (skip other engines)", program);
+    eprintln!("  ENGINE_FILTER=sqlite {}     # SQLite only", program);
 }
 
 fn main() {
@@ -262,11 +284,15 @@ fn main() {
     let config = BenchConfig::default();
     let harness = Harness::with_config(config.clone());
 
+    // Parse engine filter for runtime selection
+    let engine_filter = EngineFilter::from_env();
+
     eprintln!("Configuration:");
     eprintln!("  Scale factor: {}", scale_factor);
     eprintln!("  Warmup iterations: {}", config.warmup_iterations);
     eprintln!("  Benchmark iterations: {}", config.benchmark_iterations);
     eprintln!("  Timeout: {}s", config.timeout.as_secs());
+    eprintln!("  Engines: {}", engine_filter.enabled_list());
 
     // Get queries to run
     let query_filter = get_query_filter();
@@ -284,29 +310,33 @@ fn main() {
     let mut all_results: Vec<(&str, Vec<BenchStats>)> = Vec::new();
 
     // ========================================
-    // VibeSQL Benchmark
+    // VibeSQL Benchmark (if enabled in filter)
     // ========================================
-    eprintln!("\nLoading VibeSQL database (SF {})...", scale_factor);
-    let load_start = Instant::now();
-    let vibesql_db = load_vibesql(scale_factor);
-    eprintln!("VibeSQL loaded in {:?}", load_start.elapsed());
+    if engine_filter.vibesql {
+        eprintln!("\nLoading VibeSQL database (SF {})...", scale_factor);
+        let load_start = Instant::now();
+        let vibesql_db = load_vibesql(scale_factor);
+        eprintln!("VibeSQL loaded in {:?}", load_start.elapsed());
 
-    let mut vibesql_results = Vec::new();
-    eprintln!("\n--- VibeSQL ---");
+        let mut vibesql_results = Vec::new();
+        eprintln!("\n--- VibeSQL ---");
 
-    for (name, sql) in &queries {
-        let timeout = harness.timeout();
-        let stats = harness.run(name, || run_vibesql_query(&vibesql_db, sql, timeout));
-        stats.print_compact();
-        vibesql_results.push(stats);
+        for (name, sql) in &queries {
+            let timeout = harness.timeout();
+            let stats = harness.run(name, || run_vibesql_query(&vibesql_db, sql, timeout));
+            stats.print_compact();
+            vibesql_results.push(stats);
+        }
+        all_results.push(("VibeSQL", vibesql_results));
+    } else {
+        eprintln!("\nSkipping VibeSQL (filtered out by ENGINE_FILTER)");
     }
-    all_results.push(("VibeSQL", vibesql_results));
 
     // ========================================
-    // SQLite Benchmark (if feature enabled)
+    // SQLite Benchmark (if feature enabled and in filter)
     // ========================================
     #[cfg(feature = "benchmark-comparison")]
-    {
+    if engine_filter.sqlite {
         eprintln!("\nLoading SQLite database...");
         let load_start = Instant::now();
         let sqlite_conn = load_sqlite(scale_factor);
@@ -323,13 +353,16 @@ fn main() {
             sqlite_results.push(stats);
         }
         all_results.push(("SQLite", sqlite_results));
+    } else {
+        #[cfg(feature = "benchmark-comparison")]
+        eprintln!("\nSkipping SQLite (filtered out by ENGINE_FILTER)");
     }
 
     // ========================================
-    // DuckDB Benchmark (if feature enabled)
+    // DuckDB Benchmark (if feature enabled and in filter)
     // ========================================
     #[cfg(feature = "duckdb-comparison")]
-    {
+    if engine_filter.duckdb {
         eprintln!("\nLoading DuckDB database...");
         let load_start = Instant::now();
         let duckdb_conn = load_duckdb(scale_factor);
@@ -344,13 +377,16 @@ fn main() {
             duckdb_results.push(stats);
         }
         all_results.push(("DuckDB", duckdb_results));
+    } else {
+        #[cfg(feature = "duckdb-comparison")]
+        eprintln!("\nSkipping DuckDB (filtered out by ENGINE_FILTER)");
     }
 
     // ========================================
-    // MySQL Benchmark (if feature enabled and MYSQL_URL set)
+    // MySQL Benchmark (if feature enabled, in filter, and MYSQL_URL set)
     // ========================================
     #[cfg(feature = "mysql-comparison")]
-    {
+    if engine_filter.mysql {
         if let Some(mut conn) = load_mysql(scale_factor) {
             let mut mysql_results = Vec::new();
             eprintln!("\n--- MySQL ---");
@@ -364,6 +400,9 @@ fn main() {
         } else {
             eprintln!("\nSkipping MySQL (MYSQL_URL not set)");
         }
+    } else {
+        #[cfg(feature = "mysql-comparison")]
+        eprintln!("\nSkipping MySQL (filtered out by ENGINE_FILTER)");
     }
 
     // Print comparison summary

--- a/scripts/bench
+++ b/scripts/bench
@@ -443,6 +443,11 @@ def run_tpch_comparison(config: BenchConfig) -> int:
         env["BENCHMARK_TIMEOUT_SECS"] = str(config.timeout)
         print(f"  Timeout: {config.timeout}s")
 
+    # Set ENGINE_FILTER for runtime engine selection
+    # This allows running only specific engines even when all are compiled
+    env["ENGINE_FILTER"] = ",".join(config.engines)
+    print(f"  Engine filter: {env['ENGINE_FILTER']}")
+
     # Find and run the benchmark binary
     print(f"\nRunning TPC-H benchmarks (features: {features_str})...")
     import glob


### PR DESCRIPTION
## Summary

Adds the ability to selectively run benchmark engines at runtime without recompiling, eliminating redundant data loading and reducing benchmark time.

### Changes

- **ENGINE_FILTER env var**: Parse comma-separated list of engines (vibesql, sqlite, duckdb, mysql) to run
- **Shared harness module**: Added `EngineFilter` struct to `harness/mod.rs` for reuse across all benchmarks
- **TPC-H benchmark**: Skip data loading for filtered-out engines, reducing runtime significantly
- **scripts/bench**: Pass ENGINE_FILTER based on `--engine` flag
- **Makefile targets**: Added per-engine targets for focused testing:
  - `make benchmark-vibesql` - Run all benchmarks for VibeSQL only
  - `make benchmark-sqlite` - Run all benchmarks for SQLite only
  - `make benchmark-duckdb` - Run all benchmarks for DuckDB only
  - `make benchmark-servers` - Run server benchmarks (VibeSQL-server + MySQL)
- **Documentation**: Updated TPCH_README.md with engine selection guidance

### Usage Examples

```bash
# Run only VibeSQL (skip loading SQLite/DuckDB/MySQL data)
ENGINE_FILTER=vibesql ./target/release/deps/tpch_benchmark-*

# Run VibeSQL and SQLite comparison only
ENGINE_FILTER=vibesql,sqlite ./target/release/deps/tpch_benchmark-*

# Via scripts/bench
./scripts/bench --test=tpch --engine=vibesql

# Via Makefile
make benchmark-vibesql
```

### Test Results

```
=== TPC-H Benchmark ===
Configuration:
  Scale factor: 0.001
  Engines: vibesql    # <-- Only runs VibeSQL
  Queries: ["Q6"]

Loading VibeSQL database (SF 0.001)...
VibeSQL loaded in 18.3ms

--- VibeSQL ---
  Q6                      97.67µs avg

Skipping SQLite (filtered out by ENGINE_FILTER)

=== Done ===
```

## Test plan

- [x] `cargo check --package vibesql-executor --bench tpch_benchmark --features benchmark-comparison` passes
- [x] ENGINE_FILTER=vibesql correctly skips SQLite data loading
- [x] ENGINE_FILTER=vibesql,sqlite runs both engines
- [x] `make help` shows new per-engine targets
- [x] Documentation updated in TPCH_README.md

Closes #4113

🤖 Generated with [Claude Code](https://claude.com/claude-code)