### PR TITLE
ci: Update TPC-H query checksums after Q7/Q8/Q9 modifications

### DIFF
--- a/scripts/benchmark_query_checksums.json
+++ b/scripts/benchmark_query_checksums.json
@@ -120,8 +120,8 @@
     "TPCH_Q4": "67041b331bd6a174",
     "TPCH_Q5": "d9f268de380c7b64",
     "TPCH_Q6": "33943d3efaa815d3",
-    "TPCH_Q7": "6dae4d4fa81b8da9",
-    "TPCH_Q8": "31cc3a9d55d54f19",
-    "TPCH_Q9": "3d634a05a9518b79"
+    "TPCH_Q7": "e1fc69480ceaa447",
+    "TPCH_Q8": "a04a4eadf25dfb6b",
+    "TPCH_Q9": "1a68dc81dbde0a41"
   }
 }


### PR DESCRIPTION
## Summary

Update expected hashes in `benchmark_query_checksums.json` to reflect intentional query modifications from commit `fbf3b8fc` (cross-database compatibility fixes for TPC-H Q7/Q8/Q9).

## Changes

- Updated checksum for `TPCH_Q7`: `6dae4d4fa81b8da9` → `e1fc69480ceaa447`
- Updated checksum for `TPCH_Q8`: `31cc3a9d55d54f19` → `a04a4eadf25dfb6b`
- Updated checksum for `TPCH_Q9`: `3d634a05a9518b79` → `1a68dc81dbde0a41`

## Test Plan

- [x] `python3 scripts/verify_benchmark_queries.py` passes with "All 121 benchmark queries verified successfully."
- [x] Only the 3 expected queries changed (Q7, Q8, Q9)

Closes #4115