### PR TITLE
refactor(benchmark): Remove redundant nested #[cfg] attributes

### DIFF
--- a/crates/vibesql-executor/benches/tpch_benchmark.rs
+++ b/crates/vibesql-executor/benches/tpch_benchmark.rs
@@ -354,7 +354,6 @@ fn main() {
         }
         all_results.push(("SQLite", sqlite_results));
     } else {
-        #[cfg(feature = "benchmark-comparison")]
         eprintln!("\nSkipping SQLite (filtered out by ENGINE_FILTER)");
     }
 
@@ -378,7 +377,6 @@ fn main() {
         }
         all_results.push(("DuckDB", duckdb_results));
     } else {
-        #[cfg(feature = "duckdb-comparison")]
         eprintln!("\nSkipping DuckDB (filtered out by ENGINE_FILTER)");
     }
 
@@ -401,7 +399,6 @@ fn main() {
             eprintln!("\nSkipping MySQL (MYSQL_URL not set)");
         }
     } else {
-        #[cfg(feature = "mysql-comparison")]
         eprintln!("\nSkipping MySQL (filtered out by ENGINE_FILTER)");
     }
 


### PR DESCRIPTION
## Summary

Remove redundant nested `#[cfg]` attributes inside else branches that are already within cfg-gated if-else blocks in `tpch_benchmark.rs`.

## Changes

- Removed `#[cfg(feature = "benchmark-comparison")]` from SQLite else branch (line 357)
- Removed `#[cfg(feature = "duckdb-comparison")]` from DuckDB else branch (line 381)
- Removed `#[cfg(feature = "mysql-comparison")]` from MySQL else branch (line 404)

## Why This is Safe

The inner `#[cfg]` attributes were redundant because:
1. The outer `#[cfg]` already gates the entire `if-else` block
2. If the feature is disabled, neither branch compiles
3. If the feature is enabled, both branches are included

## Test Plan

- [x] `cargo check --package vibesql-executor` - Verified no compile errors
- [x] `cargo check --package vibesql-executor --features benchmark-comparison` - Verified SQLite code compiles
- [x] `cargo check --package vibesql-executor --features duckdb-comparison` - Verified DuckDB code compiles
- [x] `cargo check --package vibesql-executor --features mysql-comparison` - Verified MySQL code compiles

Closes #4116