### PR TITLE
perf(executor): Selective column extraction for columnar filtering

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/batch/builder.rs
+++ b/crates/vibesql-executor/src/select/columnar/batch/builder.rs
@@ -81,6 +81,60 @@ impl ColumnarBatch {
         Ok(Self { row_count, columns, column_names: None })
     }
 
+    /// Convert selected columns from row-oriented storage to columnar batch
+    ///
+    /// This is an optimized version of `from_rows` that only extracts the
+    /// specified columns. This is critical for predicate evaluation on wide
+    /// tables where only a few columns are referenced by the WHERE clause.
+    ///
+    /// # Arguments
+    ///
+    /// * `rows` - The rows to convert
+    /// * `column_indices` - Which column indices to extract (must be sorted)
+    ///
+    /// # Returns
+    ///
+    /// A sparse columnar batch where `column(i)` returns the data for
+    /// `column_indices[i]`. The caller must map original column indices
+    /// to batch positions using the `column_indices` array.
+    ///
+    /// # Performance
+    ///
+    /// For a table with 16 columns where only 1 column is needed:
+    /// - `from_rows`: extracts all 16 columns (100% work)
+    /// - `from_rows_selective`: extracts only 1 column (6% work)
+    pub fn from_rows_selective(
+        rows: &[Row],
+        column_indices: &[usize],
+    ) -> Result<Self, ExecutorError> {
+        if rows.is_empty() || column_indices.is_empty() {
+            return Ok(Self::new(0));
+        }
+
+        let row_count = rows.len();
+
+        // Infer column types from first row for only the selected columns
+        let column_types: Vec<ColumnType> = column_indices
+            .iter()
+            .map(|&col_idx| {
+                rows[0]
+                    .get(col_idx)
+                    .map(Self::infer_type_from_value)
+                    .unwrap_or(ColumnType::Mixed)
+            })
+            .collect();
+
+        // Create column arrays for only the selected columns
+        let mut columns = Vec::with_capacity(column_indices.len());
+
+        for (batch_idx, &col_idx) in column_indices.iter().enumerate() {
+            let column = Self::extract_column(rows, col_idx, &column_types[batch_idx])?;
+            columns.push(column);
+        }
+
+        Ok(Self { row_count, columns, column_names: None })
+    }
+
     /// Extract a single column from rows into a typed array
     pub(crate) fn extract_column(
         rows: &[Row],
@@ -255,18 +309,26 @@ impl ColumnarBatch {
         let mut types = Vec::with_capacity(first_row.len());
 
         for i in 0..first_row.len() {
-            let col_type = match first_row.get(i) {
-                Some(SqlValue::Integer(_)) => ColumnType::Int64,
-                Some(SqlValue::Double(_)) => ColumnType::Float64,
-                Some(SqlValue::Varchar(_)) => ColumnType::String,
-                Some(SqlValue::Date(_)) => ColumnType::Date,
-                Some(SqlValue::Boolean(_)) => ColumnType::Boolean,
-                _ => ColumnType::Mixed,
-            };
+            let col_type = first_row
+                .get(i)
+                .map(Self::infer_type_from_value)
+                .unwrap_or(ColumnType::Mixed);
             types.push(col_type);
         }
 
         types
+    }
+
+    /// Infer column type from a single SqlValue
+    fn infer_type_from_value(value: &SqlValue) -> ColumnType {
+        match value {
+            SqlValue::Integer(_) => ColumnType::Int64,
+            SqlValue::Double(_) => ColumnType::Float64,
+            SqlValue::Varchar(_) => ColumnType::String,
+            SqlValue::Date(_) => ColumnType::Date,
+            SqlValue::Boolean(_) => ColumnType::Boolean,
+            _ => ColumnType::Mixed,
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/columnar/filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/mod.rs
@@ -15,7 +15,8 @@ use crate::errors::ExecutorError;
 pub(super) use comparison::parse_date_string;
 pub use evaluation::{evaluate_column_compare, evaluate_predicate, evaluate_predicate_tree};
 pub use predicates::{
-    extract_column_predicates, extract_predicate_tree, ColumnPredicate, CompareOp, PredicateTree,
+    collect_referenced_columns, extract_column_predicates, extract_predicate_tree,
+    remap_predicates, ColumnPredicate, CompareOp, PredicateTree,
 };
 
 /// Apply a filter to row indices based on a predicate tree
@@ -203,9 +204,19 @@ pub fn apply_columnar_filter_simd_streaming(
         return Ok(vec![]);
     }
 
+    // OPTIMIZATION: Selective column extraction (#4XXX)
+    // Instead of extracting all columns (expensive for wide tables),
+    // only extract the columns referenced by predicates.
+    //
+    // For lineitem (16 columns) with filter on L_RETURNFLAG:
+    // - Old: Extract 16 columns × N rows = 16N values
+    // - New: Extract 1 column × N rows = 1N values (16x reduction)
+    let referenced_columns = collect_referenced_columns(predicates);
+    let remapped_predicates = remap_predicates(predicates, &referenced_columns);
+
     // Batch size tuned for L2 cache efficiency (~256KB)
-    // With ~16 columns of 8 bytes each = 128 bytes/row
-    // 1024 rows = ~128KB per batch, leaving room for predicates
+    // With selective extraction, we use fewer columns so batches are smaller.
+    // We can potentially use larger batches, but 1024 is still reasonable.
     const BATCH_SIZE: usize = 1024;
 
     let mut matching_indices = Vec::with_capacity(rows.len() / 4); // Estimate 25% selectivity
@@ -215,11 +226,12 @@ pub fn apply_columnar_filter_simd_streaming(
         let batch_end = (batch_start + BATCH_SIZE).min(rows.len());
         let batch_slice = &rows[batch_start..batch_end];
 
-        // Convert batch to columnar format for SIMD processing
-        let batch = ColumnarBatch::from_rows(batch_slice)?;
+        // Convert only the referenced columns to columnar format
+        // This is the key optimization - extracting 1-2 columns instead of 16
+        let batch = ColumnarBatch::from_rows_selective(batch_slice, &referenced_columns)?;
 
-        // Create filter mask using SIMD operations
-        let filter_mask = create_filter_mask_simd(&batch, predicates)?;
+        // Create filter mask using SIMD operations with remapped predicates
+        let filter_mask = create_filter_mask_simd(&batch, &remapped_predicates)?;
 
         // Collect matching indices
         for (local_idx, &passes) in filter_mask.iter().enumerate() {

--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -80,6 +80,129 @@ pub enum ColumnPredicate {
     },
 }
 
+impl ColumnPredicate {
+    /// Get all column indices referenced by this predicate
+    ///
+    /// Returns a vec (typically 1-2 elements) containing the column indices
+    /// that need to be extracted for evaluating this predicate.
+    pub fn referenced_columns(&self) -> Vec<usize> {
+        match self {
+            ColumnPredicate::LessThan { column_idx, .. }
+            | ColumnPredicate::GreaterThan { column_idx, .. }
+            | ColumnPredicate::GreaterThanOrEqual { column_idx, .. }
+            | ColumnPredicate::LessThanOrEqual { column_idx, .. }
+            | ColumnPredicate::Equal { column_idx, .. }
+            | ColumnPredicate::NotEqual { column_idx, .. }
+            | ColumnPredicate::Between { column_idx, .. }
+            | ColumnPredicate::Like { column_idx, .. }
+            | ColumnPredicate::InList { column_idx, .. } => vec![*column_idx],
+            ColumnPredicate::ColumnCompare { left_column_idx, right_column_idx, .. } => {
+                vec![*left_column_idx, *right_column_idx]
+            }
+        }
+    }
+}
+
+/// Collect all unique column indices referenced by a slice of predicates
+///
+/// Returns a sorted, deduplicated list of column indices that need to be
+/// extracted for evaluating the predicates. This enables selective column
+/// extraction optimization - only extracting needed columns instead of all.
+pub fn collect_referenced_columns(predicates: &[ColumnPredicate]) -> Vec<usize> {
+    let mut columns: Vec<usize> = predicates
+        .iter()
+        .flat_map(|p| p.referenced_columns())
+        .collect();
+    columns.sort_unstable();
+    columns.dedup();
+    columns
+}
+
+/// Remap predicates to use new column indices
+///
+/// Given predicates that reference columns in the original table and a mapping
+/// from original column indices to new (sparse batch) positions, returns new
+/// predicates with remapped column indices.
+///
+/// # Arguments
+///
+/// * `predicates` - Original predicates with original column indices
+/// * `column_mapping` - Sorted array where `column_mapping[new_idx] = old_idx`
+///
+/// # Returns
+///
+/// New predicates where each `column_idx` has been replaced with its position
+/// in `column_mapping`. Panics if any column_idx is not found in the mapping.
+///
+/// # Example
+///
+/// ```text
+/// Original predicates: [Equal { column_idx: 14, value: 'R' }]
+/// Column mapping: [14]  (only column 14 was extracted)
+/// Remapped predicates: [Equal { column_idx: 0, value: 'R' }]
+/// ```
+pub fn remap_predicates(predicates: &[ColumnPredicate], column_mapping: &[usize]) -> Vec<ColumnPredicate> {
+    predicates.iter().map(|p| remap_predicate(p, column_mapping)).collect()
+}
+
+fn remap_predicate(predicate: &ColumnPredicate, column_mapping: &[usize]) -> ColumnPredicate {
+    // Find new index for a column - binary search since mapping is sorted
+    let find_new_idx = |old_idx: usize| -> usize {
+        column_mapping
+            .binary_search(&old_idx)
+            .expect("Column index not found in mapping - this is a bug")
+    };
+
+    match predicate {
+        ColumnPredicate::LessThan { column_idx, value } => {
+            ColumnPredicate::LessThan { column_idx: find_new_idx(*column_idx), value: value.clone() }
+        }
+        ColumnPredicate::GreaterThan { column_idx, value } => {
+            ColumnPredicate::GreaterThan { column_idx: find_new_idx(*column_idx), value: value.clone() }
+        }
+        ColumnPredicate::GreaterThanOrEqual { column_idx, value } => {
+            ColumnPredicate::GreaterThanOrEqual { column_idx: find_new_idx(*column_idx), value: value.clone() }
+        }
+        ColumnPredicate::LessThanOrEqual { column_idx, value } => {
+            ColumnPredicate::LessThanOrEqual { column_idx: find_new_idx(*column_idx), value: value.clone() }
+        }
+        ColumnPredicate::Equal { column_idx, value } => {
+            ColumnPredicate::Equal { column_idx: find_new_idx(*column_idx), value: value.clone() }
+        }
+        ColumnPredicate::NotEqual { column_idx, value } => {
+            ColumnPredicate::NotEqual { column_idx: find_new_idx(*column_idx), value: value.clone() }
+        }
+        ColumnPredicate::Between { column_idx, low, high } => {
+            ColumnPredicate::Between {
+                column_idx: find_new_idx(*column_idx),
+                low: low.clone(),
+                high: high.clone(),
+            }
+        }
+        ColumnPredicate::Like { column_idx, pattern, negated } => {
+            ColumnPredicate::Like {
+                column_idx: find_new_idx(*column_idx),
+                pattern: pattern.clone(),
+                negated: *negated,
+            }
+        }
+        ColumnPredicate::InList { column_idx, values, negated } => {
+            ColumnPredicate::InList {
+                column_idx: find_new_idx(*column_idx),
+                values: values.clone(),
+                negated: *negated,
+            }
+        }
+        ColumnPredicate::ColumnCompare { left_column_idx, op, right_column_idx } => {
+            ColumnPredicate::ColumnCompare {
+                left_column_idx: find_new_idx(*left_column_idx),
+                op: *op,
+                right_column_idx: find_new_idx(*right_column_idx),
+            }
+        }
+    }
+}
+
 /// Extract column predicates as a tree from a WHERE clause expression
 ///
 /// This converts AST expressions into a predicate tree that can be evaluated

--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 
-use super::predicates::{apply_table_local_predicates, apply_table_local_predicates_ref};
+use super::predicates::apply_table_local_predicates;
 use crate::{
     errors::ExecutorError,
     evaluator::CombinedExpressionEvaluator,
@@ -321,10 +321,6 @@ pub(crate) fn execute_table_scan(
     let table_schema = apply_column_aliases(table.schema.clone(), column_aliases)?;
     let schema = CombinedSchema::from_table(effective_name.clone(), table_schema);
 
-    // Get live rows from table (excludes deleted rows from deletion bitmap)
-    // Issue #3790: Must use scan_live_vec() instead of scan() to filter deleted rows
-    let live_rows = table.scan_live_vec();
-
     // Check if we need to apply table-local predicates (Phase 1 optimization)
     // NOTE: Skip predicate pushdown for correlated subqueries (when outer_row/outer_schema exist)
     // because the predicates may reference outer columns that aren't available during table scan.
@@ -335,6 +331,8 @@ pub(crate) fn execute_table_scan(
         if is_correlated {
             // Return unfiltered rows for correlated subqueries
             // Filtering will happen later with full outer row context
+            // Issue #3790: Must use scan_live_vec() to filter deleted rows
+            let live_rows = table.scan_live_vec();
             use crate::select::from_iterator::FromIterator;
             return Ok(super::FromResult::from_iterator(
                 schema,
@@ -370,17 +368,28 @@ pub(crate) fn execute_table_scan(
             if let Some(column_predicates) =
                 crate::select::columnar::extract_column_predicates(where_expr, &schema)
             {
+                // OPTIMIZATION: Avoid double-cloning rows
+                // Before: scan_live_vec() clones ALL rows, then filter clones passing rows again
+                // After: scan() returns &[Row] references, filter returns indices,
+                //        then we clone ONLY the rows that pass (and aren't deleted)
+                //
+                // For lineitem (60K rows, 20K pass filter):
+                // - Before: 60K clones + 20K clones = 80K clones
+                // - After: 20K clones only = 75% reduction in cloning
+                let all_rows = table.scan();
+
                 if crate::profiling::is_scan_debug_enabled() {
                     eprintln!(
                         "[SCAN_PATH] {} table: extracted {} columnar predicates for {} rows",
                         table_name,
                         column_predicates.len(),
-                        live_rows.len()
+                        all_rows.len()
                     );
                 }
+
                 // For native columnar tables, use SIMD filtering on typed columns
                 // This avoids SqlValue overhead by working directly on i64/f64/String arrays
-                if table.is_native_columnar() && live_rows.len() >= SIMD_COLUMNAR_THRESHOLD {
+                if table.is_native_columnar() && all_rows.len() >= SIMD_COLUMNAR_THRESHOLD {
                     if let Ok(filtered_rows) = filter_with_simd_columnar(table, &column_predicates)
                     {
                         return Ok(super::FromResult::from_rows(schema, filtered_rows));
@@ -390,11 +399,11 @@ pub(crate) fn execute_table_scan(
 
                 // For row-oriented tables, use cached columnar filter with late materialization
                 // Issue #4136: Use database columnar cache for SIMD filtering, clone only passing rows
-                if live_rows.len() >= SIMD_COLUMNAR_THRESHOLD {
+                if all_rows.len() >= SIMD_COLUMNAR_THRESHOLD {
                     if let Ok(filtered_rows) = filter_with_cached_columnar(
                         database,
                         table_name,
-                        &live_rows,
+                        all_rows,
                         &column_predicates,
                     ) {
                         return Ok(super::FromResult::from_rows(schema, filtered_rows));
@@ -404,9 +413,15 @@ pub(crate) fn execute_table_scan(
 
                 // For smaller tables or if cached columnar fails, use direct row filtering
                 let indices =
-                    crate::select::columnar::apply_columnar_filter(&live_rows, &column_predicates)?;
-                let filtered_rows: Vec<_> =
-                    indices.into_iter().filter_map(|idx| live_rows.get(idx).cloned()).collect();
+                    crate::select::columnar::apply_columnar_filter(all_rows, &column_predicates)?;
+
+                // Clone only the rows that pass the filter AND aren't deleted
+                // This is the key optimization: we skip cloning rows that don't pass
+                let filtered_rows: Vec<_> = indices
+                    .into_iter()
+                    .filter(|&idx| !table.is_row_deleted(idx))
+                    .filter_map(|idx| all_rows.get(idx).cloned())
+                    .collect();
                 return Ok(super::FromResult::from_rows(schema, filtered_rows));
             }
 
@@ -416,10 +431,12 @@ pub(crate) fn execute_table_scan(
                     table_name);
             }
             // Fall back to generic predicate evaluation for complex expressions
+            // Must use scan_live_vec() here since apply_table_local_predicates expects owned rows
             // Note: Use effective_name (alias) for filter lookup since PredicatePlan uses schema table names
             // Issue #3562: Pass CTE context so IN subqueries can reference CTEs
-            let filtered_rows = apply_table_local_predicates_ref(
-                &live_rows,
+            let live_rows = table.scan_live_vec();
+            let filtered_rows = apply_table_local_predicates(
+                live_rows,
                 schema.clone(),
                 &predicate_plan,
                 &effective_name,
@@ -433,7 +450,9 @@ pub(crate) fn execute_table_scan(
     }
 
     // No table-local predicates or no WHERE clause: return live rows
-    // Issue #3790: live_rows already filters deleted rows via scan_live_vec()
+    // Issue #3790: Must filter deleted rows via scan_live_vec()
+    let live_rows = table.scan_live_vec();
+
     #[cfg(feature = "parallel")]
     let rows = parallel_scan_materialize(&live_rows);
 


### PR DESCRIPTION
## Summary
- Extract only columns referenced by predicates instead of all columns during columnar filtering
- Defer row cloning until after filtering to reduce memory allocations
- Add predicate column tracking utilities for sparse batch optimization

## Key Optimizations

**Selective Column Extraction**: For a 16-column table with a filter on 1 column:
- Before: Extract 16 columns × N rows
- After: Extract 1 column × N rows (16x reduction)

**Deferred Row Cloning**: For 60K rows where 20K pass filter:
- Before: 60K clones (scan_live_vec) + 20K clones (filter output) = 80K clones
- After: 20K clones only (75% reduction)

## Test plan
- [ ] Existing tests pass
- [ ] TPC-H queries with selective filters show improved scan times
- [ ] No correctness regressions in filtered results

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #4135
