### PR TITLE
perf(join): Parallelize hash join probe phase

### DIFF
--- a/crates/vibesql-executor/benches/lineitem_scan_profiling.rs
+++ b/crates/vibesql-executor/benches/lineitem_scan_profiling.rs
@@ -173,7 +173,7 @@ fn main() {
 
     #[cfg(not(feature = "duckdb-comparison"))]
     {
-        print_summary_table("VibeSQL", &vibesql_results);
+        harness::print_summary_table("VibeSQL", &vibesql_results);
     }
 
     eprintln!("\n=== Benchmark Complete ===\n");

--- a/crates/vibesql-executor/src/select/join/hash_join/inner.rs
+++ b/crates/vibesql-executor/src/select/join/hash_join/inner.rs
@@ -5,6 +5,12 @@ use super::columnar::{hash_join_indices_columnar, hash_join_indices_columnar_mul
 use super::{batch_combine_rows, FromResult};
 use crate::{errors::ExecutorError, schema::CombinedSchema};
 
+#[cfg(feature = "parallel")]
+use crate::select::parallel::ParallelConfig;
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
 // Note: Memory limit checking removed from hash join.
 // Hash join uses O(smaller_table) memory for the hash table, not O(result_size).
 // The actual join output size depends on data distribution and selectivity,
@@ -86,6 +92,39 @@ pub(in crate::select::join) fn hash_join_inner(
 
         // Probe phase: Collect (build_idx, probe_idx) pairs without materializing rows
         // This defers the expensive row cloning until after we know all matches
+        // Uses parallel probing when row count exceeds threshold (read-only hash table is thread-safe)
+        #[cfg(feature = "parallel")]
+        {
+            let config = ParallelConfig::global();
+            if config.should_parallelize_join(probe_rows.len()) {
+                // Parallel probe - read-only hash table access is thread-safe
+                let pairs: Vec<(usize, usize)> = probe_rows
+                    .par_iter()
+                    .enumerate()
+                    .flat_map(|(probe_idx, probe_row)| {
+                        let key = &probe_row.values[probe_col_idx];
+                        if key == &vibesql_types::SqlValue::Null {
+                            return Vec::new();
+                        }
+                        hash_table
+                            .get(key)
+                            .map(|build_indices| {
+                                build_indices
+                                    .iter()
+                                    .map(|&build_idx| (build_idx, probe_idx))
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default()
+                    })
+                    .collect();
+                return Ok(FromResult::from_rows(
+                    combined_schema,
+                    batch_combine_rows(build_rows, probe_rows, &pairs, left_is_build),
+                ));
+            }
+        }
+
+        // Sequential fallback for small datasets or non-parallel builds
         let estimated_capacity = probe_rows.len().saturating_mul(2).min(100_000);
         let mut pairs: Vec<(usize, usize)> = Vec::with_capacity(estimated_capacity);
 
@@ -179,6 +218,39 @@ pub(in crate::select::join) fn hash_join_inner_multi(
         let hash_table = build_hash_table_composite_parallel(build_rows, build_col_indices);
 
         // Probe phase: Collect (build_idx, probe_idx) pairs
+        // Uses parallel probing when row count exceeds threshold (read-only hash table is thread-safe)
+        #[cfg(feature = "parallel")]
+        {
+            let config = ParallelConfig::global();
+            if config.should_parallelize_join(probe_rows.len()) {
+                // Parallel probe with composite keys
+                let pairs: Vec<(usize, usize)> = probe_rows
+                    .par_iter()
+                    .enumerate()
+                    .flat_map(|(probe_idx, probe_row)| {
+                        let probe_key = CompositeKey::from_row(probe_row, probe_col_indices);
+                        if probe_key.has_null() {
+                            return Vec::new();
+                        }
+                        hash_table
+                            .get(&probe_key)
+                            .map(|build_indices| {
+                                build_indices
+                                    .iter()
+                                    .map(|&build_idx| (build_idx, probe_idx))
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default()
+                    })
+                    .collect();
+                return Ok(FromResult::from_rows(
+                    combined_schema,
+                    batch_combine_rows(build_rows, probe_rows, &pairs, left_is_build),
+                ));
+            }
+        }
+
+        // Sequential fallback for small datasets or non-parallel builds
         let estimated_capacity = probe_rows.len().saturating_mul(2).min(100_000);
         let mut pairs: Vec<(usize, usize)> = Vec::with_capacity(estimated_capacity);
 
@@ -269,6 +341,42 @@ pub(in crate::select::join) fn hash_join_inner_arithmetic(
     }
 
     // Probe phase: For each left row, lookup by left_col value
+    // Uses parallel probing when row count exceeds threshold (read-only hash table is thread-safe)
+    #[cfg(feature = "parallel")]
+    {
+        let config = ParallelConfig::global();
+        if config.should_parallelize_join(left_slice.len()) {
+            // Parallel probe for arithmetic join
+            let pairs: Vec<(usize, usize)> = left_slice
+                .par_iter()
+                .enumerate()
+                .flat_map(|(left_idx, left_row)| {
+                    let value = &left_row.values[left_col_idx];
+                    if let SqlValue::Integer(n) = value {
+                        hash_table
+                            .get(n)
+                            .map(|right_indices| {
+                                right_indices
+                                    .iter()
+                                    .map(|&right_idx| (left_idx, right_idx))
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default()
+                    } else {
+                        Vec::new()
+                    }
+                })
+                .collect();
+
+            // Swap pairs for batch_combine_rows (see comment below)
+            let swapped_pairs: Vec<(usize, usize)> =
+                pairs.into_iter().map(|(left, right)| (right, left)).collect();
+            let result_rows = batch_combine_rows(right_slice, left_slice, &swapped_pairs, false);
+            return Ok(FromResult::from_rows(combined_schema, result_rows));
+        }
+    }
+
+    // Sequential fallback for small datasets or non-parallel builds
     let estimated_capacity = left_slice.len().saturating_mul(2).min(100_000);
     let mut pairs: Vec<(usize, usize)> = Vec::with_capacity(estimated_capacity);
 

--- a/crates/vibesql-executor/src/select/join/hash_join/outer.rs
+++ b/crates/vibesql-executor/src/select/join/hash_join/outer.rs
@@ -2,6 +2,12 @@ use super::build::{build_hash_table_composite_parallel, build_hash_table_paralle
 use super::FromResult;
 use crate::{errors::ExecutorError, schema::CombinedSchema};
 
+#[cfg(feature = "parallel")]
+use crate::select::parallel::ParallelConfig;
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
 /// Create a row with all NULL values
 #[allow(dead_code)]
 pub(crate) fn create_null_row(col_count: usize) -> vibesql_storage::Row {
@@ -66,7 +72,54 @@ pub(in crate::select::join) fn hash_join_left_outer(
     // Pre-compute combined row size for efficient allocation
     let combined_size = left_col_count + right_col_count;
 
-    // Two-phase approach for better allocation:
+    // Parallel probe phase for LEFT OUTER JOIN
+    // Every left row must appear in output (with matches or NULLs)
+    #[cfg(feature = "parallel")]
+    {
+        let config = ParallelConfig::global();
+        if config.should_parallelize_join(left_slice.len()) {
+            // Pre-create null values for unmatched rows (shared across threads via reference)
+            let null_values = vec![vibesql_types::SqlValue::Null; right_col_count];
+
+            let result_rows: Vec<vibesql_storage::Row> = left_slice
+                .par_iter()
+                .flat_map(|left_row| {
+                    let key = &left_row.values[left_col_idx];
+
+                    // For NULL keys in left, emit left + NULLs
+                    if key == &vibesql_types::SqlValue::Null {
+                        let mut combined = Vec::with_capacity(combined_size);
+                        combined.extend_from_slice(&left_row.values);
+                        combined.extend_from_slice(&null_values);
+                        return vec![vibesql_storage::Row::new(combined)];
+                    }
+
+                    if let Some(right_indices) = hash_table.get(key) {
+                        // Found matches - emit all combinations
+                        right_indices
+                            .iter()
+                            .map(|&right_idx| {
+                                let mut combined = Vec::with_capacity(combined_size);
+                                combined.extend_from_slice(&left_row.values);
+                                combined.extend_from_slice(&right_slice[right_idx].values);
+                                vibesql_storage::Row::new(combined)
+                            })
+                            .collect()
+                    } else {
+                        // No match - emit left row with NULLs
+                        let mut combined = Vec::with_capacity(combined_size);
+                        combined.extend_from_slice(&left_row.values);
+                        combined.extend_from_slice(&null_values);
+                        vec![vibesql_storage::Row::new(combined)]
+                    }
+                })
+                .collect();
+
+            return Ok(FromResult::from_rows(combined_schema, result_rows));
+        }
+    }
+
+    // Sequential fallback: Two-phase approach for better allocation
     // Phase 1: Count total rows needed (matched + unmatched)
     let mut match_count = 0usize;
     let mut unmatched_count = 0usize;
@@ -184,6 +237,54 @@ pub(in crate::select::join) fn hash_join_left_outer_multi(
     // Pre-compute combined row size for efficient allocation
     let combined_size = left_col_count + right_col_count;
 
+    // Parallel probe phase for multi-column LEFT OUTER JOIN
+    // Every left row must appear in output (with matches or NULLs)
+    #[cfg(feature = "parallel")]
+    {
+        let config = ParallelConfig::global();
+        if config.should_parallelize_join(left_slice.len()) {
+            // Pre-create null values for unmatched rows
+            let null_values = vec![vibesql_types::SqlValue::Null; right_col_count];
+
+            let result_rows: Vec<vibesql_storage::Row> = left_slice
+                .par_iter()
+                .flat_map(|left_row| {
+                    let probe_key = CompositeKey::from_row(left_row, left_col_indices);
+
+                    // For NULL keys in left (any column is NULL), emit left + NULLs
+                    if probe_key.has_null() {
+                        let mut combined = Vec::with_capacity(combined_size);
+                        combined.extend_from_slice(&left_row.values);
+                        combined.extend_from_slice(&null_values);
+                        return vec![vibesql_storage::Row::new(combined)];
+                    }
+
+                    if let Some(right_indices) = hash_table.get(&probe_key) {
+                        // Found matches - emit all combinations
+                        right_indices
+                            .iter()
+                            .map(|&right_idx| {
+                                let mut combined = Vec::with_capacity(combined_size);
+                                combined.extend_from_slice(&left_row.values);
+                                combined.extend_from_slice(&right_slice[right_idx].values);
+                                vibesql_storage::Row::new(combined)
+                            })
+                            .collect()
+                    } else {
+                        // No match - emit left row with NULLs
+                        let mut combined = Vec::with_capacity(combined_size);
+                        combined.extend_from_slice(&left_row.values);
+                        combined.extend_from_slice(&null_values);
+                        vec![vibesql_storage::Row::new(combined)]
+                    }
+                })
+                .collect();
+
+            return Ok(FromResult::from_rows(combined_schema, result_rows));
+        }
+    }
+
+    // Sequential fallback
     // Create a single null row for reuse (reduces allocations for unmatched rows)
     let null_values = vec![vibesql_types::SqlValue::Null; right_col_count];
 


### PR DESCRIPTION
## Summary

- Adds parallel probing to all hash join implementations (inner, inner_multi, inner_arithmetic, left_outer, left_outer_multi)
- Probe phase is embarrassingly parallel since hash table is read-only
- Uses existing `should_parallelize_join()` threshold from `ParallelConfig`
- All parallel paths feature-gated with `#[cfg(feature = "parallel")]`
- Also fixes minor benchmark bug (missing `harness::` prefix)

## Test plan

- [x] All executor tests pass (1863 tests)
- [x] Build succeeds with parallel feature enabled
- [ ] TPC-H Q3, Q5, Q7 benchmarks (probe-heavy joins) - waiting for CI
- [ ] TPC-H Q13 benchmark (LEFT OUTER JOIN) - waiting for CI

Closes #4130

🤖 Generated with [Claude Code](https://claude.com/claude-code)