### PR TITLE
refactor(executor): Consolidate batch size constants

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/vectorized.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/vectorized.rs
@@ -7,6 +7,7 @@
 
 use crate::errors::ExecutorError;
 use crate::schema::CombinedSchema;
+use crate::select::vectorized::DEFAULT_BATCH_SIZE;
 use vibesql_ast::Expression;
 use vibesql_storage::Row;
 use vibesql_types::SqlValue;
@@ -75,8 +76,8 @@ fn try_vectorized_binary_aggregate(
         let mut count = 0;
 
         // Batch processing: accumulate products in batches for better cache locality
-        const BATCH_SIZE: usize = 1024;
-        let mut batch_products = Vec::with_capacity(BATCH_SIZE);
+        // DEFAULT_BATCH_SIZE (1024) provides good throughput while fitting in cache
+        let mut batch_products = Vec::with_capacity(DEFAULT_BATCH_SIZE);
 
         for row_idx in 0..rows.len() {
             // Check filter
@@ -98,7 +99,7 @@ fn try_vectorized_binary_aggregate(
                 count += 1;
 
                 // Process batch when full
-                if batch_products.len() >= BATCH_SIZE {
+                if batch_products.len() >= DEFAULT_BATCH_SIZE {
                     sum += batch_products.iter().sum::<f64>();
                     batch_products.clear();
                 }

--- a/crates/vibesql-executor/src/select/columnar/filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/mod.rs
@@ -10,6 +10,7 @@ mod evaluation;
 mod predicates;
 
 use crate::errors::ExecutorError;
+use crate::select::vectorized::{DEFAULT_BATCH_SIZE, SMALL_BATCH_SIZE};
 
 // Re-export public types and functions
 pub(super) use comparison::parse_date_string;
@@ -45,12 +46,10 @@ where
     let mut bitmap = vec![false; row_count];
 
     // Process in batches for better cache locality and potential auto-vectorization
-    // Batch size of 256 chosen to fit in L1 cache (~32KB for row indices + column data)
+    // SMALL_BATCH_SIZE (256) chosen to fit in L1 cache (~32KB for row indices + column data)
     // This helps with issue #2397: SQLLogicTest queries scanning 1000-row tables
-    const BATCH_SIZE: usize = 256;
-
-    for batch_start in (0..row_count).step_by(BATCH_SIZE) {
-        let batch_end = (batch_start + BATCH_SIZE).min(row_count);
+    for batch_start in (0..row_count).step_by(SMALL_BATCH_SIZE) {
+        let batch_end = (batch_start + SMALL_BATCH_SIZE).min(row_count);
 
         // Evaluate batch - compiler can potentially auto-vectorize inner loops
         for row_idx in batch_start..batch_end {
@@ -216,14 +215,12 @@ pub fn apply_columnar_filter_simd_streaming(
 
     // Batch size tuned for L2 cache efficiency (~256KB)
     // With selective extraction, we use fewer columns so batches are smaller.
-    // We can potentially use larger batches, but 1024 is still reasonable.
-    const BATCH_SIZE: usize = 1024;
-
+    // DEFAULT_BATCH_SIZE (1024) provides good balance of throughput and memory.
     let mut matching_indices = Vec::with_capacity(rows.len() / 4); // Estimate 25% selectivity
 
     // Process rows in streaming batches
-    for batch_start in (0..rows.len()).step_by(BATCH_SIZE) {
-        let batch_end = (batch_start + BATCH_SIZE).min(rows.len());
+    for batch_start in (0..rows.len()).step_by(DEFAULT_BATCH_SIZE) {
+        let batch_end = (batch_start + DEFAULT_BATCH_SIZE).min(rows.len());
         let batch_slice = &rows[batch_start..batch_end];
 
         // Convert only the referenced columns to columnar format

--- a/crates/vibesql-executor/src/select/columnar/simd_aggregate.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_aggregate.rs
@@ -10,6 +10,7 @@ use super::aggregate::AggregateOp;
 use super::scan::ColumnarScan;
 use super::simd_ops;
 use crate::errors::ExecutorError;
+use crate::select::vectorized::DEFAULT_BATCH_SIZE;
 use vibesql_types::SqlValue;
 
 // Re-export optimized SIMD operations from simd_ops module
@@ -64,9 +65,8 @@ pub fn simd_aggregate_i64(
     op: AggregateOp,
     filter_bitmap: Option<&[bool]>,
 ) -> Result<SqlValue, ExecutorError> {
-    const BATCH_SIZE: usize = 1024; // Process 1K values at a time
-
-    let mut batch = Vec::with_capacity(BATCH_SIZE);
+    // DEFAULT_BATCH_SIZE (1024) provides good SIMD throughput while fitting in cache
+    let mut batch = Vec::with_capacity(DEFAULT_BATCH_SIZE);
     let mut original_type: Option<SqlValue> = None;
     let mut count = 0i64;
 
@@ -117,7 +117,7 @@ pub fn simd_aggregate_i64(
             count += 1;
 
             // Process batch when full
-            if batch.len() >= BATCH_SIZE {
+            if batch.len() >= DEFAULT_BATCH_SIZE {
                 match op {
                     AggregateOp::Sum | AggregateOp::Avg => {
                         sum += simd_sum_i64(&batch);
@@ -212,9 +212,8 @@ pub fn simd_aggregate_f64(
     op: AggregateOp,
     filter_bitmap: Option<&[bool]>,
 ) -> Result<SqlValue, ExecutorError> {
-    const BATCH_SIZE: usize = 1024; // Process 1K values at a time
-
-    let mut batch = Vec::with_capacity(BATCH_SIZE);
+    // DEFAULT_BATCH_SIZE (1024) provides good SIMD throughput while fitting in cache
+    let mut batch = Vec::with_capacity(DEFAULT_BATCH_SIZE);
     let mut count = 0i64;
 
     // Accumulators for different operations
@@ -252,7 +251,7 @@ pub fn simd_aggregate_f64(
             count += 1;
 
             // Process batch when full
-            if batch.len() >= BATCH_SIZE {
+            if batch.len() >= DEFAULT_BATCH_SIZE {
                 match op {
                     AggregateOp::Sum | AggregateOp::Avg => {
                         sum += simd_sum_f64(&batch);

--- a/crates/vibesql-executor/src/select/vectorized/batch.rs
+++ b/crates/vibesql-executor/src/select/vectorized/batch.rs
@@ -34,6 +34,10 @@ pub const JOIN_BATCH_SIZE: usize = 512;
 /// Assumes ~8 bytes per value, 4 columns: 32KB / (8 * 4) = 1024 rows
 pub const L1_CACHE_BATCH_SIZE: usize = 1024;
 
+/// Small batch size for tight loops where instruction cache locality matters
+/// Used for bitmap evaluation where keeping predicates hot in I-cache is beneficial
+pub const SMALL_BATCH_SIZE: usize = 256;
+
 /// Batch size optimized for L2 cache (256KB typical)
 /// Allows larger batches for better SIMD throughput
 pub const L2_CACHE_BATCH_SIZE: usize = 2048;

--- a/crates/vibesql-executor/src/select/vectorized/mod.rs
+++ b/crates/vibesql-executor/src/select/vectorized/mod.rs
@@ -23,15 +23,11 @@ pub mod filter;
 pub mod predicate;
 
 pub use arithmetic::evaluate_arithmetic_simd;
-pub use batch::{record_batch_to_rows, rows_to_record_batch};
+pub use batch::{
+    record_batch_to_rows, rows_to_record_batch, DEFAULT_BATCH_SIZE, SMALL_BATCH_SIZE,
+};
 pub use filter::filter_record_batch_simd;
 pub use predicate::apply_where_filter_vectorized;
-
-/// Default chunk size for vectorized SIMD operations
-/// 2048 is the DuckDB standard - fits well in L1/L2 cache (2048 * 8 bytes = 16KB)
-/// while providing good SIMD utilization and reduced loop overhead
-#[allow(dead_code)]
-pub const DEFAULT_CHUNK_SIZE: usize = 2048;
 
 /// Threshold for using vectorized evaluation
 /// Increased proportionally with chunk size - below this, row-by-row


### PR DESCRIPTION
## Summary

- Remove dead `DEFAULT_CHUNK_SIZE` constant from `vectorized/mod.rs` (was marked `#[allow(dead_code)]`)
- Add `SMALL_BATCH_SIZE` (256) constant for tight loop batching operations
- Replace hardcoded `const BATCH_SIZE` in `columnar/filter/mod.rs` with centralized imports
- Replace hardcoded `const BATCH_SIZE` in `columnar/simd_aggregate.rs` with centralized imports
- Replace hardcoded `const BATCH_SIZE` in `aggregate/expression/vectorized.rs` with centralized imports
- Update docstring in `predicate.rs` that referenced the removed constant

## Test plan

- [x] All unit tests pass (`cargo test --lib`)
- [x] TPC-H Q1 columnar tests pass
- [x] TPC-H Q6 columnar tests pass
- [x] Code compiles with no warnings

Closes #4148

🤖 Generated with [Claude Code](https://claude.com/claude-code)