### PR TITLE
fix(groupby): Add timeout checking to parallel GROUP BY path

### DIFF
--- a/crates/vibesql-executor/src/select/grouping/hash.rs
+++ b/crates/vibesql-executor/src/select/grouping/hash.rs
@@ -3,6 +3,8 @@ use ahash::AHashMap;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+use crate::timeout::TimeoutContext;
+
 /// Grouped rows: (group key values, rows in group)
 pub type GroupedRows = Vec<(Vec<vibesql_types::SqlValue>, Vec<vibesql_storage::Row>)>;
 
@@ -30,8 +32,9 @@ pub fn group_rows<'a>(
         if config.should_parallelize_aggregate(rows.len()) {
             // Get components needed for thread-local evaluators
             let components = evaluator.get_parallel_components();
+            let timeout_ctx = TimeoutContext::from_executor(executor);
 
-            return group_rows_parallel(rows, group_by_exprs, components);
+            return group_rows_parallel(rows, group_by_exprs, components, &timeout_ctx);
         }
     }
 
@@ -90,16 +93,22 @@ fn group_rows_sequential<'a>(
 ///
 /// Thread safety is achieved by creating fresh evaluators per thread,
 /// avoiding the `Send` constraint on `RefCell`/`Rc` in `CombinedExpressionEvaluator`.
+///
+/// Timeout is checked before and after parallel processing (Issue #4151).
 #[cfg(feature = "parallel")]
 fn group_rows_parallel<'a>(
     rows: &[vibesql_storage::Row],
     group_by_exprs: &[vibesql_ast::Expression],
     components: crate::evaluator::parallel::ParallelComponents<'a>,
+    timeout_ctx: &TimeoutContext,
 ) -> Result<GroupedRows, crate::errors::ExecutorError> {
     use crate::evaluator::CombinedExpressionEvaluator;
 
     let (schema, database, outer_row, outer_schema, window_mapping, cte_context, enable_cse) =
         components;
+
+    // Check timeout before parallel execution (can't check mid-parallel easily)
+    timeout_ctx.check()?;
 
     // Get number of threads for chunking
     let num_threads = rayon::current_num_threads();
@@ -145,6 +154,9 @@ fn group_rows_parallel<'a>(
             Ok(local_groups)
         })
         .collect();
+
+    // Check timeout after parallel phase
+    timeout_ctx.check()?;
 
     // Check for errors from any thread
     let mut validated_results: Vec<AHashMap<Vec<vibesql_types::SqlValue>, Vec<vibesql_storage::Row>>> =

--- a/crates/vibesql-executor/src/select/grouping/parallel_sink.rs
+++ b/crates/vibesql-executor/src/select/grouping/parallel_sink.rs
@@ -37,6 +37,8 @@ use crate::errors::ExecutorError;
 use crate::evaluator::CombinedExpressionEvaluator;
 #[cfg(feature = "parallel")]
 use crate::schema::CombinedSchema;
+#[cfg(feature = "parallel")]
+use crate::timeout::TimeoutContext;
 
 /// Thread-local state for parallel aggregation
 ///
@@ -61,6 +63,8 @@ impl ThreadLocalAggregationState {
 /// 1. **Sink**: Each thread processes a chunk of rows with its own evaluator
 /// 2. **Combine**: Thread-local group maps are merged using accumulator.combine()
 /// 3. **Finalize**: Final aggregation results are returned
+///
+/// Timeout is checked before and after parallel processing (Issue #4151).
 ///
 /// # Arguments
 /// * `rows` - Input rows to group and aggregate
@@ -88,6 +92,12 @@ pub fn parallel_group_aggregate<'a>(
         // Fall back to sequential for small datasets
         return sequential_group_aggregate(rows, group_by_exprs, aggregate_infos, schema, database);
     }
+
+    // Use default timeout context (proper propagation from SelectExecutor is a future improvement)
+    let timeout_ctx = TimeoutContext::new_default();
+
+    // Check timeout before parallel execution (can't check mid-parallel easily)
+    timeout_ctx.check()?;
 
     // Get number of threads for chunking
     let num_threads = rayon::current_num_threads();
@@ -135,6 +145,9 @@ pub fn parallel_group_aggregate<'a>(
                 Ok(state.groups)
             })
             .collect();
+
+    // Check timeout after parallel phase
+    timeout_ctx.check()?;
 
     // Check for errors from any thread
     let mut thread_results: Vec<AHashMap<Vec<SqlValue>, Vec<AggregateAccumulator>>> =


### PR DESCRIPTION
## Summary

- Add timeout checking before/after parallel execution in `group_rows_parallel()` using `TimeoutContext` from executor
- Add timeout checking before/after parallel execution in `parallel_group_aggregate()` using default `TimeoutContext`
- Follow established pattern from `hash_join/build.rs` for timeout checking at phase boundaries

## Test plan

- [x] All executor unit tests pass (400+ tests)
- [x] Code compiles with `--features parallel`
- [x] Release build succeeds

Closes #4151

🤖 Generated with [Claude Code](https://claude.com/claude-code)