### PR TITLE
fix(executor): Add cfg(feature) guard for TimeoutContext import

### DIFF
--- a/crates/vibesql-executor/src/select/grouping/hash.rs
+++ b/crates/vibesql-executor/src/select/grouping/hash.rs
@@ -3,6 +3,7 @@ use ahash::AHashMap;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+#[cfg(feature = "parallel")]
 use crate::timeout::TimeoutContext;
 
 /// Grouped rows: (group key values, rows in group)


### PR DESCRIPTION
## Summary

- Add `#[cfg(feature = "parallel")]` guard to `TimeoutContext` import in `hash.rs`

This fixes an unused import warning when building without the `parallel` feature. The `TimeoutContext` type is only used within `#[cfg(feature = "parallel")]` code blocks.

## Test plan

- [x] Verified build succeeds without `parallel` feature: `cargo build -p vibesql-executor --no-default-features`
- [x] Verified build succeeds with `parallel` feature: `cargo build -p vibesql-executor --features parallel`

Closes #4167

🤖 Generated with [Claude Code](https://claude.com/claude-code)