### PR TITLE
enhance(compat): Improve sqlite_master SQL column for views and triggers

### DIFF
--- a/crates/vibesql-ast/src/ddl/schema.rs
+++ b/crates/vibesql-ast/src/ddl/schema.rs
@@ -103,6 +103,9 @@ pub struct CreateViewStmt {
     pub or_replace: bool,
     /// Whether this is a temporary view (CREATE TEMP VIEW or CREATE TEMPORARY VIEW)
     pub temporary: bool,
+    /// Original SQL definition for sqlite_master compatibility
+    /// This is populated during parsing to preserve the exact SQL text
+    pub sql_definition: Option<String>,
 }
 
 /// DROP VIEW statement

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -111,7 +111,9 @@ impl SqlExecutor {
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
             }
-            vibesql_ast::Statement::CreateView(view_stmt) => {
+            vibesql_ast::Statement::CreateView(mut view_stmt) => {
+                // Store original SQL for sqlite_master compatibility
+                view_stmt.sql_definition = Some(sql.to_string());
                 match vibesql_executor::advanced_objects::execute_create_view(
                     &view_stmt,
                     &mut self.db,

--- a/crates/vibesql-executor/src/advanced_objects/views.rs
+++ b/crates/vibesql-executor/src/advanced_objects/views.rs
@@ -22,12 +22,22 @@ pub fn execute_create_view(stmt: &CreateViewStmt, db: &mut Database) -> Result<(
         stmt.columns.clone()
     };
 
-    let view = ViewDefinition::new(
-        stmt.view_name.clone(),
-        columns,
-        (*stmt.query).clone(),
-        stmt.with_check_option,
-    );
+    let view = if let Some(ref sql) = stmt.sql_definition {
+        ViewDefinition::new_with_sql(
+            stmt.view_name.clone(),
+            columns,
+            (*stmt.query).clone(),
+            stmt.with_check_option,
+            sql.clone(),
+        )
+    } else {
+        ViewDefinition::new(
+            stmt.view_name.clone(),
+            columns,
+            (*stmt.query).clone(),
+            stmt.with_check_option,
+        )
+    };
 
     if stmt.or_replace {
         // DROP the view if it exists, then CREATE

--- a/crates/vibesql-executor/src/persistence.rs
+++ b/crates/vibesql-executor/src/persistence.rs
@@ -69,7 +69,7 @@ pub fn load_sql_dump<P: AsRef<Path>>(path: P) -> Result<Database, ExecutorError>
         })?;
 
         // Execute the statement
-        execute_statement_for_load(&mut db, statement).map_err(|e| {
+        execute_statement_for_load(&mut db, statement, trimmed).map_err(|e| {
             ExecutorError::Other(format!(
                 "Failed to execute statement {} in {:?}: {}\nStatement: {}",
                 idx + 1,
@@ -90,6 +90,7 @@ pub fn load_sql_dump<P: AsRef<Path>>(path: P) -> Result<Database, ExecutorError>
 fn execute_statement_for_load(
     db: &mut Database,
     statement: vibesql_ast::Statement,
+    original_sql: &str,
 ) -> Result<(), ExecutorError> {
     match statement {
         vibesql_ast::Statement::CreateSchema(schema_stmt) => {
@@ -101,7 +102,9 @@ fn execute_statement_for_load(
         vibesql_ast::Statement::CreateIndex(index_stmt) => {
             CreateIndexExecutor::execute(&index_stmt, db)?;
         }
-        vibesql_ast::Statement::CreateView(view_stmt) => {
+        vibesql_ast::Statement::CreateView(mut view_stmt) => {
+            // Store original SQL for sqlite_master compatibility
+            view_stmt.sql_definition = Some(original_sql.to_string());
             ViewExecutor::execute_create_view(&view_stmt, db)?;
         }
         vibesql_ast::Statement::CreateRole(role_stmt) => {

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -221,7 +221,7 @@ fn generate_create_view_sql(view: &vibesql_catalog::ViewDefinition) -> String {
 
 /// Generate CREATE TRIGGER SQL statement for a trigger
 fn generate_create_trigger_sql(trigger: &vibesql_catalog::TriggerDefinition) -> String {
-    use vibesql_ast::{TriggerEvent, TriggerGranularity, TriggerTiming};
+    use vibesql_ast::{TriggerAction, TriggerEvent, TriggerGranularity, TriggerTiming};
 
     let timing = match trigger.timing {
         TriggerTiming::Before => "BEFORE",
@@ -237,22 +237,25 @@ fn generate_create_trigger_sql(trigger: &vibesql_catalog::TriggerDefinition) -> 
     let event = match &trigger.event {
         TriggerEvent::Insert => "INSERT".to_string(),
         TriggerEvent::Update(None) => "UPDATE".to_string(),
-        TriggerEvent::Update(Some(cols)) => {
-            return format!(
-                "CREATE TRIGGER {} {} UPDATE OF {} ON {} FOR EACH {} ...",
-                trigger.name,
-                timing,
-                cols.join(", "),
-                trigger.table_name,
-                granularity
-            );
-        }
+        TriggerEvent::Update(Some(cols)) => format!("UPDATE OF {}", cols.join(", ")),
         TriggerEvent::Delete => "DELETE".to_string(),
     };
 
+    // Include WHEN clause if present
+    let when_clause = trigger
+        .when_condition
+        .as_ref()
+        .map(|expr| format!(" WHEN ({})", format_expression(expr)))
+        .unwrap_or_default();
+
+    // Include trigger body from TriggerAction
+    let body = match &trigger.triggered_action {
+        TriggerAction::RawSql(sql) => sql.clone(),
+    };
+
     format!(
-        "CREATE TRIGGER {} {} {} ON {} FOR EACH {} ...",
-        trigger.name, timing, event, trigger.table_name, granularity
+        "CREATE TRIGGER {} {} {} ON {} FOR EACH {}{}{}",
+        trigger.name, timing, event, trigger.table_name, granularity, when_clause, body
     )
 }
 
@@ -519,5 +522,125 @@ mod tests {
 
         let sql = generate_create_index_sql(&index);
         assert_eq!(sql, "CREATE UNIQUE INDEX idx_email ON users (email(50))");
+    }
+
+    #[test]
+    fn test_generate_create_trigger_sql_basic() {
+        use vibesql_ast::{TriggerAction, TriggerEvent, TriggerGranularity, TriggerTiming};
+        use vibesql_catalog::TriggerDefinition;
+
+        let trigger = TriggerDefinition {
+            name: "audit_insert".to_string(),
+            table_name: "users".to_string(),
+            timing: TriggerTiming::After,
+            event: TriggerEvent::Insert,
+            granularity: TriggerGranularity::Row,
+            when_condition: None,
+            triggered_action: TriggerAction::RawSql(" BEGIN INSERT INTO audit VALUES (NEW.id); END".to_string()),
+            enabled: true,
+        };
+
+        let sql = generate_create_trigger_sql(&trigger);
+        assert_eq!(
+            sql,
+            "CREATE TRIGGER audit_insert AFTER INSERT ON users FOR EACH ROW BEGIN INSERT INTO audit VALUES (NEW.id); END"
+        );
+    }
+
+    #[test]
+    fn test_generate_create_trigger_sql_with_update_of() {
+        use vibesql_ast::{TriggerAction, TriggerEvent, TriggerGranularity, TriggerTiming};
+        use vibesql_catalog::TriggerDefinition;
+
+        let trigger = TriggerDefinition {
+            name: "track_status_change".to_string(),
+            table_name: "orders".to_string(),
+            timing: TriggerTiming::Before,
+            event: TriggerEvent::Update(Some(vec!["status".to_string(), "updated_at".to_string()])),
+            granularity: TriggerGranularity::Row,
+            when_condition: None,
+            triggered_action: TriggerAction::RawSql(" BEGIN SELECT 1; END".to_string()),
+            enabled: true,
+        };
+
+        let sql = generate_create_trigger_sql(&trigger);
+        assert!(sql.contains("UPDATE OF status, updated_at"));
+        assert!(sql.contains("CREATE TRIGGER track_status_change BEFORE UPDATE OF"));
+    }
+
+    #[test]
+    fn test_generate_create_trigger_sql_instead_of() {
+        use vibesql_ast::{TriggerAction, TriggerEvent, TriggerGranularity, TriggerTiming};
+        use vibesql_catalog::TriggerDefinition;
+
+        let trigger = TriggerDefinition {
+            name: "instead_delete".to_string(),
+            table_name: "my_view".to_string(),
+            timing: TriggerTiming::InsteadOf,
+            event: TriggerEvent::Delete,
+            granularity: TriggerGranularity::Row,
+            when_condition: None,
+            triggered_action: TriggerAction::RawSql(" BEGIN DELETE FROM base_table WHERE id = OLD.id; END".to_string()),
+            enabled: true,
+        };
+
+        let sql = generate_create_trigger_sql(&trigger);
+        assert!(sql.contains("INSTEAD OF DELETE"));
+        assert!(sql.contains("FOR EACH ROW"));
+    }
+
+    /// Create a minimal SelectStmt for testing purposes
+    fn create_minimal_select_stmt() -> vibesql_ast::SelectStmt {
+        vibesql_ast::SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+            into_table: None,
+            into_variables: None,
+            from: None,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+        }
+    }
+
+    #[test]
+    fn test_generate_create_view_sql_with_definition() {
+        use vibesql_catalog::ViewDefinition;
+
+        // Create a view with sql_definition set
+        let view = ViewDefinition::new_with_sql(
+            "active_users".to_string(),
+            Some(vec!["id".to_string(), "name".to_string()]),
+            create_minimal_select_stmt(),
+            false,
+            "CREATE VIEW active_users (id, name) AS SELECT id, name FROM users WHERE active = 1".to_string(),
+        );
+
+        let sql = generate_create_view_sql(&view);
+        assert_eq!(sql, "CREATE VIEW active_users (id, name) AS SELECT id, name FROM users WHERE active = 1");
+    }
+
+    #[test]
+    fn test_generate_create_view_sql_fallback() {
+        use vibesql_catalog::ViewDefinition;
+
+        // Create a view without sql_definition (fallback path)
+        let view = ViewDefinition::new(
+            "test_view".to_string(),
+            Some(vec!["col1".to_string()]),
+            create_minimal_select_stmt(),
+            false,
+        );
+
+        let sql = generate_create_view_sql(&view);
+        // Should contain CREATE VIEW and the view name
+        assert!(sql.contains("CREATE VIEW test_view"));
+        // With column list specified
+        assert!(sql.contains("(col1)"));
     }
 }

--- a/crates/vibesql-executor/src/view_ddl.rs
+++ b/crates/vibesql-executor/src/view_ddl.rs
@@ -27,12 +27,22 @@ impl ViewExecutor {
         }
 
         // Create the view definition
-        let view_def = ViewDefinition::new(
-            stmt.view_name.clone(),
-            stmt.columns.clone(),
-            *stmt.query.clone(),
-            stmt.with_check_option,
-        );
+        let view_def = if let Some(ref sql) = stmt.sql_definition {
+            ViewDefinition::new_with_sql(
+                stmt.view_name.clone(),
+                stmt.columns.clone(),
+                *stmt.query.clone(),
+                stmt.with_check_option,
+                sql.clone(),
+            )
+        } else {
+            ViewDefinition::new(
+                stmt.view_name.clone(),
+                stmt.columns.clone(),
+                *stmt.query.clone(),
+                stmt.with_check_option,
+            )
+        };
 
         // Add to catalog
         database

--- a/crates/vibesql-parser/src/parser/view.rs
+++ b/crates/vibesql-parser/src/parser/view.rs
@@ -100,6 +100,7 @@ impl Parser {
             with_check_option,
             or_replace,
             temporary,
+            sql_definition: None, // Will be populated by the statement executor if needed
         })
     }
 

--- a/crates/vibesql-python-bindings/src/cursor.rs
+++ b/crates/vibesql-python-bindings/src/cursor.rs
@@ -261,7 +261,9 @@ impl Cursor {
 
                 Ok(())
             }
-            vibesql_ast::Statement::CreateView(view_stmt) => {
+            vibesql_ast::Statement::CreateView(mut view_stmt) => {
+                // Store original SQL for sqlite_master compatibility
+                view_stmt.sql_definition = Some(sql.to_string());
                 let mut db = self.db.lock();
                 vibesql_executor::advanced_objects::execute_create_view(&view_stmt, &mut db)
                     .map_err(|e| OperationalError::new_err(format!("Execution error: {:?}", e)))?;

--- a/crates/vibesql-wasm-bindings/src/modules/execute.rs
+++ b/crates/vibesql-wasm-bindings/src/modules/execute.rs
@@ -325,7 +325,9 @@ impl Database {
                 serde_wasm_bindgen::to_value(&result)
                     .map_err(|e| JsValue::from_str(&format!("Serialization error: {:?}", e)))
             }
-            vibesql_ast::Statement::CreateView(stmt) => {
+            vibesql_ast::Statement::CreateView(mut stmt) => {
+                // Store original SQL for sqlite_master compatibility
+                stmt.sql_definition = Some(sql.to_string());
                 vibesql_executor::advanced_objects::execute_create_view(&stmt, &mut self.db)
                     .map_err(|e| JsValue::from_str(&format!("Execution error: {:?}", e)))?;
                 let result = ExecuteResult {


### PR DESCRIPTION
## Summary

Improves the `sql` column in `sqlite_master` to contain valid, executable CREATE statements for triggers and views, enabling better compatibility with tools that parse schema information.

## Changes

### Triggers
- Include the actual trigger body from `TriggerAction::RawSql` instead of `...` placeholder
- Properly format UPDATE OF columns when present  
- Fix trigger SQL generation to produce complete, valid statements

### Views
- Add `sql_definition` field to `CreateViewStmt` AST node
- Store original SQL during view creation in all entry points
- Use stored SQL definition in `sqlite_master` when available

## Key Files Modified

| File | Change |
|------|--------|
| `crates/vibesql-executor/src/sqlite_schema.rs` | Fixed trigger generation, added tests |
| `crates/vibesql-ast/src/ddl/schema.rs` | Added `sql_definition` field to `CreateViewStmt` |
| `crates/vibesql-cli/src/executor/mod.rs` | Store SQL in view creation |
| `crates/vibesql-wasm-bindings/src/modules/execute.rs` | Store SQL in view creation |
| `crates/vibesql-python-bindings/src/cursor.rs` | Store SQL in view creation |
| `crates/vibesql-executor/src/persistence.rs` | Store SQL during database loading |

## Before/After

**Triggers (before):**
```sql
SELECT sql FROM sqlite_master WHERE type='trigger';
-- Returns: CREATE TRIGGER t AFTER INSERT ON users FOR EACH ROW ...
```

**Triggers (after):**
```sql
SELECT sql FROM sqlite_master WHERE type='trigger';
-- Returns: CREATE TRIGGER t AFTER INSERT ON users FOR EACH ROW BEGIN INSERT INTO audit VALUES (NEW.id); END
```

**Views with stored SQL:**
```sql
SELECT sql FROM sqlite_master WHERE type='view';
-- Returns: CREATE VIEW active_users AS SELECT id, name FROM users WHERE active = 1
```

## Test plan

- [x] All 13 sqlite_schema tests pass
- [x] All 1942 executor tests pass
- [x] Added 5 new tests for trigger and view SQL generation:
  - `test_generate_create_trigger_sql_basic`
  - `test_generate_create_trigger_sql_with_update_of`
  - `test_generate_create_trigger_sql_instead_of`
  - `test_generate_create_view_sql_with_definition`
  - `test_generate_create_view_sql_fallback`

Closes #4188

🤖 Generated with [Claude Code](https://claude.com/claude-code)