### PR TITLE
feat(testing): Add SQLite TCL test suite support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -528,6 +528,49 @@ When debugging performance issues, see **[docs/performance/CPU_PROFILING.md](doc
 - **samply** (`make profile-tpch Q=X`) for CPU profiling / flame graphs
 - **Environment variables** (`JOIN_REORDER_VERBOSE=1`, etc.) for optimizer decision logging
 
+### SQLite TCL Test Suite
+
+VibeSQL runs SQLite's canonical TCL test suite for conformance testing. The test suite contains 1,174 test files covering core SQL functionality.
+
+#### Running TCL Tests
+
+```bash
+# Run Priority 1 tests (core SQL: select, where, join, etc.)
+make test-tcl
+
+# Run all 1,174 TCL test files
+make test-tcl-all
+
+# Run a specific test file
+make test-tcl-file FILE=select1.test
+
+# Show test status
+make test-tcl-status
+
+# Parse a test file to see extracted tests
+./scripts/tcltest parse select1.test
+```
+
+#### Priority Levels
+
+- **Priority 1** (core SQL): `select`, `insert`, `update`, `delete`, `where`, `join`, `aggregate`, `func`, `orderby`, `index`
+- **Priority 2** (advanced): `window`, `cte`, `trigger`, `fkey`, `collate`, `subquery`, `union`, `view`
+- **Priority 3** (SQLite-specific): `wal`, `vacuum`, `attach`, `vtab`, `fts` (may not apply to VibeSQL)
+
+#### Test Infrastructure
+
+- **Parser**: `scripts/tcl_parser.py` - Extracts `do_execsql_test` and `do_catchsql_test` patterns
+- **Runner**: `scripts/tcl_runner.py` - Executes tests against VibeSQL
+- **CLI**: `scripts/tcltest` - Unified command-line interface
+- **Results**: `~/.vibesql/test_results/tcl_test_results.vbsql`
+
+#### Exporting Results
+
+```bash
+# Export TCL results to website format
+python3 scripts/export_tcl_results.py --verbose
+```
+
 ### Benchmarking and Website Updates
 
 VibeSQL uses a dogfooded SQLite-compatible database (`~/.vibesql/test_results/benchmark_results.vbsql`) to store all benchmark results. The web demo at https://rjwalters.github.io/vibesql/ displays this data.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VibeSQL Makefile
 # Convenience targets for common development tasks
 
-.PHONY: all all-fg logs status build build-all build-wasm build-python test test-unit test-workspace test-sqllogictest test-sqllogictest-halting fuzz fuzz-parser fuzz-expr fuzz-type-convert fuzz-query fuzz-type-coercion fuzz-differential fuzz-list benchmark benchmark-quick benchmark-smoke benchmark-all benchmark-embedded-all benchmark-server-all benchmark-tpch benchmark-tpch-quick benchmark-tpch-profile benchmark-tpch-server benchmark-tpcc benchmark-tpcc-server benchmark-tpcds benchmark-sysbench benchmark-sysbench-server benchmark-vibesql benchmark-sqlite benchmark-duckdb clean help analyze-tests analyze-benchmarks analyze profile-tpch profile-tpcc profile-sysbench profile-select profile-query bench-storage bench-executor bench-types website mysql-start mysql-stop mysql-status strip-quarantine
+.PHONY: all all-fg logs status build build-all build-wasm build-python test test-unit test-workspace test-sqllogictest test-sqllogictest-halting test-tcl test-tcl-all test-tcl-file test-tcl-status fuzz fuzz-parser fuzz-expr fuzz-type-convert fuzz-query fuzz-type-coercion fuzz-differential fuzz-list benchmark benchmark-quick benchmark-smoke benchmark-all benchmark-embedded-all benchmark-server-all benchmark-tpch benchmark-tpch-quick benchmark-tpch-profile benchmark-tpch-server benchmark-tpcc benchmark-tpcc-server benchmark-tpcds benchmark-sysbench benchmark-sysbench-server benchmark-vibesql benchmark-sqlite benchmark-duckdb clean help analyze-tests analyze-benchmarks analyze profile-tpch profile-tpcc profile-sysbench profile-select profile-query bench-storage bench-executor bench-types website mysql-start mysql-stop mysql-status strip-quarantine
 
 # Default target: show help
 .DEFAULT_GOAL := help
@@ -76,6 +76,10 @@ help:
 	@echo "  make test-workspace     - Run all workspace tests (unit + integration + sqllogictest)"
 	@echo "  make test-sqllogictest  - Run SQLLogicTest standalone (with JSON output)"
 	@echo "  make test-sqllogictest-halting - Run SQLLogicTest, stop on first failure"
+	@echo "  make test-tcl           - Run SQLite TCL tests (Priority 1 - core SQL)"
+	@echo "  make test-tcl-all       - Run all SQLite TCL tests (1174 files)"
+	@echo "  make test-tcl-file FILE=X - Run specific TCL test file"
+	@echo "  make test-tcl-status    - Show TCL test status"
 	@echo ""
 	@echo "Fuzzing targets:"
 	@echo "  make fuzz               - Run all fuzz targets (5 min each)"
@@ -211,6 +215,30 @@ test-sqllogictest-halting:
 	@echo "Running SQLLogicTest suite (fail-fast mode)..."
 	@echo "Will stop on first test file failure for easier debugging"
 	./scripts/sqllogictest run --fail-fast
+
+# Run SQLite TCL test suite (Priority 1 - core SQL tests)
+# This is the canonical SQLite conformance test suite
+test-tcl:
+	@echo "Running SQLite TCL test suite (Priority 1 - core SQL)..."
+	@echo "Tests: select, insert, update, delete, where, join, aggregate, func"
+	./scripts/tcltest run --priority 1 --verbose
+
+# Run all SQLite TCL tests (all priorities)
+test-tcl-all:
+	@echo "Running full SQLite TCL test suite (all 1174 files)..."
+	./scripts/tcltest run --verbose
+
+# Run specific TCL test file
+test-tcl-file:
+	@if [ -z "$(FILE)" ]; then \
+		echo "Usage: make test-tcl-file FILE=select1.test"; \
+		exit 1; \
+	fi
+	./scripts/tcltest test $(FILE)
+
+# Show TCL test status
+test-tcl-status:
+	./scripts/tcltest status
 
 #
 # Fuzzing Targets

--- a/scripts/export_tcl_results.py
+++ b/scripts/export_tcl_results.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+Export TCL test results to website data format.
+
+Reads test results from the TCL test database and exports conformance data
+for the web demo.
+
+Usage:
+    python scripts/export_tcl_results.py
+    python scripts/export_tcl_results.py --output web-demo/public/conformance/
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# Default paths
+RESULTS_DB = os.path.expanduser("~/.vibesql/test_results/tcl_test_results.vbsql")
+VIBESQL_BIN = "./target/release/vibesql"
+
+
+def get_repo_root() -> Path:
+    """Get the repository root directory."""
+    return Path(__file__).parent.parent
+
+
+def query_db(sql: str, db_path: str = RESULTS_DB) -> List[str]:
+    """Query the database and return results as lines."""
+    try:
+        result = subprocess.run(
+            [VIBESQL_BIN, db_path, "-c", sql],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return []
+        # Skip header lines and return data
+        lines = result.stdout.strip().split('\n')
+        # Find the data lines (after the table header)
+        data_lines = []
+        in_data = False
+        for line in lines:
+            if line.startswith('+'):
+                if in_data:
+                    break  # End of data
+                in_data = True
+                continue
+            if in_data and line.startswith('|'):
+                # Parse pipe-delimited row
+                parts = [p.strip() for p in line.split('|')[1:-1]]
+                data_lines.append(parts)
+        return data_lines
+    except Exception as e:
+        print(f"Error querying database: {e}", file=sys.stderr)
+        return []
+
+
+def get_latest_run() -> Optional[Dict]:
+    """Get the latest test run info."""
+    rows = query_db("""
+        SELECT run_id, started_at, completed_at, git_commit,
+               total_files, total_tests, passed, failed, skipped, parse_errors
+        FROM tcl_test_runs
+        ORDER BY run_id DESC
+        LIMIT 1
+    """)
+
+    if not rows:
+        return None
+
+    row = rows[0]
+    return {
+        "run_id": int(row[0]) if row[0] else 0,
+        "started_at": row[1],
+        "completed_at": row[2],
+        "git_commit": row[3],
+        "total_files": int(row[4]) if row[4] else 0,
+        "total_tests": int(row[5]) if row[5] else 0,
+        "passed": int(row[6]) if row[6] else 0,
+        "failed": int(row[7]) if row[7] else 0,
+        "skipped": int(row[8]) if row[8] else 0,
+        "parse_errors": int(row[9]) if row[9] else 0,
+    }
+
+
+def get_results_by_file(run_id: int) -> List[Dict]:
+    """Get test results grouped by file."""
+    rows = query_db(f"""
+        SELECT file_path,
+               COUNT(*) as total,
+               SUM(CASE WHEN status = 'passed' THEN 1 ELSE 0 END) as passed,
+               SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
+               SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END) as skipped
+        FROM tcl_test_results
+        WHERE run_id = {run_id}
+        GROUP BY file_path
+        ORDER BY file_path
+    """)
+
+    return [
+        {
+            "file": row[0].split('/')[-1] if '/' in row[0] else row[0],
+            "path": row[0],
+            "total": int(row[1]) if row[1] else 0,
+            "passed": int(row[2]) if row[2] else 0,
+            "failed": int(row[3]) if row[3] else 0,
+            "skipped": int(row[4]) if row[4] else 0,
+        }
+        for row in rows
+    ]
+
+
+def get_results_by_category(run_id: int) -> Dict[str, Dict]:
+    """Get test results grouped by category (test file prefix)."""
+    rows = query_db(f"""
+        SELECT file_path,
+               status,
+               COUNT(*) as count
+        FROM tcl_test_results
+        WHERE run_id = {run_id}
+        GROUP BY file_path, status
+    """)
+
+    # Group by category (file name prefix like 'select', 'where', etc.)
+    categories: Dict[str, Dict] = {}
+
+    for row in rows:
+        file_path = row[0]
+        status = row[1]
+        count = int(row[2]) if row[2] else 0
+
+        # Extract category from filename
+        filename = file_path.split('/')[-1] if '/' in file_path else file_path
+        # Remove .test extension and trailing numbers
+        import re
+        category = re.sub(r'\d*\.test$', '', filename)
+        if not category:
+            category = "other"
+
+        if category not in categories:
+            categories[category] = {
+                "total": 0,
+                "passed": 0,
+                "failed": 0,
+                "skipped": 0,
+            }
+
+        categories[category]["total"] += count
+        if status == "passed":
+            categories[category]["passed"] += count
+        elif status == "failed":
+            categories[category]["failed"] += count
+        elif status == "skipped":
+            categories[category]["skipped"] += count
+
+    # Calculate pass rates
+    for cat in categories.values():
+        testable = cat["total"] - cat["skipped"]
+        cat["pass_rate"] = round(cat["passed"] / testable * 100, 1) if testable > 0 else 0.0
+
+    return categories
+
+
+def get_failure_patterns(run_id: int, limit: int = 20) -> List[Dict]:
+    """Get common failure patterns."""
+    rows = query_db(f"""
+        SELECT error_message,
+               COUNT(*) as count
+        FROM tcl_test_results
+        WHERE run_id = {run_id}
+        AND status = 'failed'
+        AND error_message IS NOT NULL
+        GROUP BY error_message
+        ORDER BY count DESC
+        LIMIT {limit}
+    """)
+
+    return [
+        {
+            "error": row[0][:100] if row[0] else "Unknown",
+            "count": int(row[1]) if row[1] else 0,
+        }
+        for row in rows
+    ]
+
+
+def get_run_history(limit: int = 10) -> List[Dict]:
+    """Get recent test run history."""
+    rows = query_db(f"""
+        SELECT run_id, started_at, git_commit,
+               total_tests, passed, failed, skipped
+        FROM tcl_test_runs
+        ORDER BY run_id DESC
+        LIMIT {limit}
+    """)
+
+    return [
+        {
+            "run_id": int(row[0]) if row[0] else 0,
+            "date": row[1],
+            "commit": row[2],
+            "total": int(row[3]) if row[3] else 0,
+            "passed": int(row[4]) if row[4] else 0,
+            "failed": int(row[5]) if row[5] else 0,
+            "skipped": int(row[6]) if row[6] else 0,
+            "pass_rate": round(int(row[4]) / (int(row[3]) - int(row[6])) * 100, 1)
+                if row[3] and row[6] and int(row[3]) > int(row[6]) else 0.0,
+        }
+        for row in rows
+    ]
+
+
+def export_tcl_results(output_dir: Optional[Path] = None, verbose: bool = False) -> Dict:
+    """Export TCL test results to JSON format."""
+    if output_dir is None:
+        output_dir = get_repo_root() / "web-demo" / "public" / "conformance"
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Check if database exists
+    if not os.path.exists(RESULTS_DB):
+        print(f"TCL results database not found: {RESULTS_DB}", file=sys.stderr)
+        print("Run: make test-tcl to generate test results", file=sys.stderr)
+        return {}
+
+    # Get latest run
+    latest_run = get_latest_run()
+    if not latest_run:
+        print("No test runs found in database", file=sys.stderr)
+        return {}
+
+    run_id = latest_run["run_id"]
+
+    if verbose:
+        print(f"Exporting run {run_id} from {latest_run['started_at']}")
+
+    # Build export data
+    export_data = {
+        "version": "1.0",
+        "generated_at": datetime.now().isoformat(),
+        "latest_run": latest_run,
+        "summary": {
+            "total_tests": latest_run["total_tests"],
+            "passed": latest_run["passed"],
+            "failed": latest_run["failed"],
+            "skipped": latest_run["skipped"],
+            "pass_rate": round(latest_run["passed"] / (latest_run["total_tests"] - latest_run["skipped"]) * 100, 1)
+                if latest_run["total_tests"] > latest_run["skipped"] else 0.0,
+        },
+        "categories": get_results_by_category(run_id),
+        "by_file": get_results_by_file(run_id),
+        "failure_patterns": get_failure_patterns(run_id),
+        "history": get_run_history(),
+    }
+
+    # Write JSON file
+    output_file = output_dir / "tcl_results.json"
+    with open(output_file, 'w') as f:
+        json.dump(export_data, f, indent=2)
+
+    if verbose:
+        print(f"Exported to: {output_file}")
+        print(f"  Pass rate: {export_data['summary']['pass_rate']}%")
+        print(f"  Categories: {len(export_data['categories'])}")
+
+    return export_data
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Export TCL test results to website format")
+    parser.add_argument("--output", "-o", help="Output directory", default=None)
+    parser.add_argument("--verbose", "-v", action="store_true")
+
+    args = parser.parse_args()
+
+    output_dir = Path(args.output) if args.output else None
+    result = export_tcl_results(output_dir, args.verbose)
+
+    if not result:
+        return 1
+
+    print(f"TCL test results exported: {result['summary']['pass_rate']}% pass rate")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tcl_parser.py
+++ b/scripts/tcl_parser.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""
+TCL Test Parser for SQLite TCL Test Suite
+
+Parses SQLite's TCL test files and extracts test cases that can be
+executed against VibeSQL. Focuses on the common test patterns:
+
+- do_execsql_test: Execute SQL and compare output
+- do_catchsql_test: Execute SQL and expect specific error
+- do_test with execsql: General test with SQL execution
+- execsql blocks: Standalone SQL execution (setup)
+
+This is a "hybrid" approach that parses simple patterns while skipping
+tests with complex TCL logic that would require a full TCL interpreter.
+"""
+
+import re
+import sys
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+
+class TestType(Enum):
+    EXECSQL = "execsql"           # do_execsql_test
+    CATCHSQL = "catchsql"         # do_catchsql_test
+    GENERAL = "general"           # do_test with execsql
+    SETUP = "setup"               # standalone execsql (no assertion)
+    SKIPPED = "skipped"           # complex TCL logic, skipped
+
+
+@dataclass
+class ParsedTest:
+    """Represents a single parsed test case from a TCL file."""
+    name: str
+    test_type: TestType
+    sql: str
+    expected_output: Optional[str] = None
+    expected_error: Optional[str] = None
+    error_code: Optional[int] = None
+    line_number: int = 0
+    skip_reason: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "type": self.test_type.value,
+            "sql": self.sql,
+            "expected_output": self.expected_output,
+            "expected_error": self.expected_error,
+            "error_code": self.error_code,
+            "line_number": self.line_number,
+            "skip_reason": self.skip_reason,
+        }
+
+
+@dataclass
+class ParsedFile:
+    """Represents all parsed content from a single TCL test file."""
+    file_path: str
+    tests: list[ParsedTest] = field(default_factory=list)
+    setup_sql: list[str] = field(default_factory=list)
+    skipped_count: int = 0
+    parse_errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "file_path": self.file_path,
+            "tests": [t.to_dict() for t in self.tests],
+            "setup_sql": self.setup_sql,
+            "skipped_count": self.skipped_count,
+            "parse_errors": self.parse_errors,
+            "stats": {
+                "total_tests": len(self.tests),
+                "execsql_tests": len([t for t in self.tests if t.test_type == TestType.EXECSQL]),
+                "catchsql_tests": len([t for t in self.tests if t.test_type == TestType.CATCHSQL]),
+                "skipped_tests": len([t for t in self.tests if t.test_type == TestType.SKIPPED]),
+            }
+        }
+
+
+class TclTestParser:
+    """
+    Parser for SQLite TCL test files.
+
+    Handles common test patterns while gracefully skipping complex TCL logic.
+    """
+
+    # Patterns for different test types
+    DO_EXECSQL_PATTERN = re.compile(
+        r'do_execsql_test\s+(\S+)\s*\{([^}]*)\}\s*\{([^}]*)\}',
+        re.DOTALL
+    )
+
+    DO_CATCHSQL_PATTERN = re.compile(
+        r'do_catchsql_test\s+(\S+)\s*\{([^}]*)\}\s*\{(\d+)\s+\{([^}]*)\}\}',
+        re.DOTALL
+    )
+
+    # Simpler catchsql pattern: {1 {error message}}
+    DO_CATCHSQL_SIMPLE_PATTERN = re.compile(
+        r'do_catchsql_test\s+(\S+)\s*\{([^}]*)\}\s*\{(\d+)\s+([^}]+)\}',
+        re.DOTALL
+    )
+
+    DO_TEST_PATTERN = re.compile(
+        r'do_test\s+(\S+)\s*\{([^}]*)\}\s*\{([^}]*)\}',
+        re.DOTALL
+    )
+
+    EXECSQL_BLOCK_PATTERN = re.compile(
+        r'execsql\s*\{([^}]*)\}',
+        re.DOTALL
+    )
+
+    # Patterns indicating complex TCL logic we should skip
+    COMPLEX_PATTERNS = [
+        r'\$\w+',           # TCL variables
+        r'\[.*\]',          # TCL command substitution
+        r'foreach\s+',      # Loops
+        r'for\s*\{',        # For loops
+        r'while\s*\{',      # While loops
+        r'if\s*\{',         # If statements (in test body)
+        r'proc\s+',         # Procedure definitions
+        r'expr\s*\{',       # Expressions
+        r'db\s+eval',       # Direct db calls
+        r'db\s+close',      # DB operations
+        r'file\s+',         # File operations
+        r'sqlite3\s+',      # SQLite3 command
+        r'catchsql',        # Nested catchsql
+    ]
+
+    # Patterns to skip entire test files
+    SKIP_FILE_PATTERNS = [
+        r'malloc',          # Memory allocation tests
+        r'corrupt',         # Corruption tests
+        r'crash',           # Crash recovery tests
+        r'thread',          # Threading tests
+        r'shell',           # Shell tests
+        r'fts[0-9]',        # Full-text search (not supported)
+        r'rtree',           # R-tree (not supported)
+        r'wal',             # WAL tests (SQLite-specific)
+        r'journal',         # Journal tests (SQLite-specific)
+        r'vacuum',          # Vacuum tests
+        r'attach',          # Attach database
+        r'vtab',            # Virtual tables
+        r'intarray',        # Int array extension
+    ]
+
+    def __init__(self, verbose: bool = False):
+        self.verbose = verbose
+        self._complex_regex = re.compile('|'.join(self.COMPLEX_PATTERNS))
+        self._skip_file_regex = re.compile('|'.join(self.SKIP_FILE_PATTERNS), re.IGNORECASE)
+
+    def should_skip_file(self, file_path: str) -> Optional[str]:
+        """Check if entire file should be skipped based on filename."""
+        filename = Path(file_path).stem.lower()
+        match = self._skip_file_regex.search(filename)
+        if match:
+            return f"File type '{match.group()}' not applicable to VibeSQL"
+        return None
+
+    def _has_complex_tcl(self, code: str) -> bool:
+        """Check if code contains complex TCL that we can't parse."""
+        return bool(self._complex_regex.search(code))
+
+    def _clean_sql(self, sql: str) -> str:
+        """Clean SQL extracted from TCL blocks."""
+        # Remove leading/trailing whitespace
+        sql = sql.strip()
+        # Remove TCL comments (lines starting with #)
+        lines = [l for l in sql.split('\n') if not l.strip().startswith('#')]
+        sql = '\n'.join(lines)
+        return sql.strip()
+
+    def _parse_expected_output(self, output: str) -> str:
+        """Parse expected output from TCL format to normalized format."""
+        output = output.strip()
+        # TCL lists use spaces as separators
+        # Multi-row results may have newlines
+        return output
+
+    def _extract_execsql_from_do_test(self, body: str) -> Optional[str]:
+        """Extract SQL from a do_test body that uses execsql."""
+        # Look for execsql { ... } pattern
+        match = self.EXECSQL_BLOCK_PATTERN.search(body)
+        if match:
+            return self._clean_sql(match.group(1))
+        return None
+
+    def parse_file(self, file_path: str) -> ParsedFile:
+        """Parse a single TCL test file."""
+        result = ParsedFile(file_path=file_path)
+
+        # Check if we should skip the entire file
+        skip_reason = self.should_skip_file(file_path)
+        if skip_reason:
+            result.parse_errors.append(f"Skipped: {skip_reason}")
+            return result
+
+        try:
+            with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
+                content = f.read()
+        except Exception as e:
+            result.parse_errors.append(f"Error reading file: {e}")
+            return result
+
+        # Track line numbers for each match
+        lines = content.split('\n')
+
+        # Parse do_execsql_test
+        for match in self.DO_EXECSQL_PATTERN.finditer(content):
+            name = match.group(1)
+            sql = self._clean_sql(match.group(2))
+            expected = self._parse_expected_output(match.group(3))
+
+            # Calculate line number
+            line_num = content[:match.start()].count('\n') + 1
+
+            # Check for complex TCL
+            if self._has_complex_tcl(sql):
+                result.tests.append(ParsedTest(
+                    name=name,
+                    test_type=TestType.SKIPPED,
+                    sql=sql,
+                    line_number=line_num,
+                    skip_reason="Complex TCL in SQL block"
+                ))
+                result.skipped_count += 1
+            else:
+                result.tests.append(ParsedTest(
+                    name=name,
+                    test_type=TestType.EXECSQL,
+                    sql=sql,
+                    expected_output=expected,
+                    line_number=line_num
+                ))
+
+        # Parse do_catchsql_test
+        for match in self.DO_CATCHSQL_PATTERN.finditer(content):
+            name = match.group(1)
+            sql = self._clean_sql(match.group(2))
+            error_code = int(match.group(3))
+            error_msg = match.group(4).strip()
+            line_num = content[:match.start()].count('\n') + 1
+
+            if self._has_complex_tcl(sql):
+                result.tests.append(ParsedTest(
+                    name=name,
+                    test_type=TestType.SKIPPED,
+                    sql=sql,
+                    line_number=line_num,
+                    skip_reason="Complex TCL in SQL block"
+                ))
+                result.skipped_count += 1
+            else:
+                result.tests.append(ParsedTest(
+                    name=name,
+                    test_type=TestType.CATCHSQL,
+                    sql=sql,
+                    error_code=error_code,
+                    expected_error=error_msg,
+                    line_number=line_num
+                ))
+
+        # Try simpler catchsql pattern
+        for match in self.DO_CATCHSQL_SIMPLE_PATTERN.finditer(content):
+            name = match.group(1)
+            # Skip if already parsed
+            if any(t.name == name for t in result.tests):
+                continue
+
+            sql = self._clean_sql(match.group(2))
+            error_code = int(match.group(3))
+            error_msg = match.group(4).strip()
+            line_num = content[:match.start()].count('\n') + 1
+
+            if self._has_complex_tcl(sql):
+                result.tests.append(ParsedTest(
+                    name=name,
+                    test_type=TestType.SKIPPED,
+                    sql=sql,
+                    line_number=line_num,
+                    skip_reason="Complex TCL in SQL block"
+                ))
+                result.skipped_count += 1
+            else:
+                result.tests.append(ParsedTest(
+                    name=name,
+                    test_type=TestType.CATCHSQL,
+                    sql=sql,
+                    error_code=error_code,
+                    expected_error=error_msg,
+                    line_number=line_num
+                ))
+
+        # Parse do_test with execsql (more complex)
+        for match in self.DO_TEST_PATTERN.finditer(content):
+            name = match.group(1)
+            body = match.group(2)
+            expected = match.group(3).strip()
+            line_num = content[:match.start()].count('\n') + 1
+
+            # Skip if already parsed as execsql_test or catchsql_test
+            if any(t.name == name for t in result.tests):
+                continue
+
+            # Try to extract SQL from the body
+            sql = self._extract_execsql_from_do_test(body)
+
+            if sql is None:
+                # Complex test body, skip
+                result.tests.append(ParsedTest(
+                    name=name,
+                    test_type=TestType.SKIPPED,
+                    sql="",
+                    line_number=line_num,
+                    skip_reason="Complex do_test body without simple execsql"
+                ))
+                result.skipped_count += 1
+            elif self._has_complex_tcl(sql) or self._has_complex_tcl(body):
+                result.tests.append(ParsedTest(
+                    name=name,
+                    test_type=TestType.SKIPPED,
+                    sql=sql,
+                    line_number=line_num,
+                    skip_reason="Complex TCL in test body"
+                ))
+                result.skipped_count += 1
+            else:
+                result.tests.append(ParsedTest(
+                    name=name,
+                    test_type=TestType.GENERAL,
+                    sql=sql,
+                    expected_output=expected,
+                    line_number=line_num
+                ))
+
+        # Extract standalone execsql blocks for setup
+        # Look for execsql that are NOT inside do_test/do_execsql_test
+        for match in self.EXECSQL_BLOCK_PATTERN.finditer(content):
+            # Check if this is inside a test block
+            start = match.start()
+            preceding = content[max(0, start-100):start]
+            if 'do_test' in preceding or 'do_execsql_test' in preceding:
+                continue
+
+            sql = self._clean_sql(match.group(1))
+            if sql and not self._has_complex_tcl(sql):
+                result.setup_sql.append(sql)
+
+        # Sort tests by line number
+        result.tests.sort(key=lambda t: t.line_number)
+
+        if self.verbose:
+            print(f"Parsed {file_path}: {len(result.tests)} tests, {result.skipped_count} skipped")
+
+        return result
+
+
+def parse_directory(dir_path: str, patterns: list[str] = None, verbose: bool = False) -> list[ParsedFile]:
+    """Parse all TCL test files in a directory."""
+    parser = TclTestParser(verbose=verbose)
+    results = []
+
+    dir_path = Path(dir_path)
+    if patterns:
+        files = []
+        for pattern in patterns:
+            files.extend(dir_path.glob(pattern))
+    else:
+        files = list(dir_path.glob("*.test"))
+
+    for file_path in sorted(files):
+        result = parser.parse_file(str(file_path))
+        results.append(result)
+
+    return results
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Parse SQLite TCL test files")
+    parser.add_argument("path", help="File or directory to parse")
+    parser.add_argument("--pattern", "-p", action="append",
+                       help="Glob pattern(s) for files (e.g., 'select*.test')")
+    parser.add_argument("--output", "-o", help="Output JSON file")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument("--stats-only", action="store_true",
+                       help="Only show statistics, not full output")
+
+    args = parser.parse_args()
+
+    path = Path(args.path)
+
+    if path.is_file():
+        parser = TclTestParser(verbose=args.verbose)
+        results = [parser.parse_file(str(path))]
+    elif path.is_dir():
+        results = parse_directory(str(path), args.pattern, args.verbose)
+    else:
+        print(f"Error: {path} is not a file or directory", file=sys.stderr)
+        sys.exit(1)
+
+    # Calculate totals
+    total_tests = sum(len(r.tests) for r in results)
+    total_execsql = sum(len([t for t in r.tests if t.test_type == TestType.EXECSQL]) for r in results)
+    total_catchsql = sum(len([t for t in r.tests if t.test_type == TestType.CATCHSQL]) for r in results)
+    total_general = sum(len([t for t in r.tests if t.test_type == TestType.GENERAL]) for r in results)
+    total_skipped = sum(r.skipped_count for r in results)
+    total_setup = sum(len(r.setup_sql) for r in results)
+
+    if args.stats_only:
+        print(f"Files parsed:     {len(results)}")
+        print(f"Total tests:      {total_tests}")
+        print(f"  - execsql:      {total_execsql}")
+        print(f"  - catchsql:     {total_catchsql}")
+        print(f"  - general:      {total_general}")
+        print(f"  - skipped:      {total_skipped}")
+        print(f"Setup statements: {total_setup}")
+        if total_tests > 0:
+            parse_rate = (total_tests - total_skipped) / total_tests * 100
+            print(f"Parse rate:       {parse_rate:.1f}%")
+    else:
+        output = {
+            "files": [r.to_dict() for r in results],
+            "summary": {
+                "files_parsed": len(results),
+                "total_tests": total_tests,
+                "execsql_tests": total_execsql,
+                "catchsql_tests": total_catchsql,
+                "general_tests": total_general,
+                "skipped_tests": total_skipped,
+                "setup_statements": total_setup,
+                "parse_rate": (total_tests - total_skipped) / total_tests * 100 if total_tests > 0 else 0,
+            }
+        }
+
+        if args.output:
+            with open(args.output, 'w') as f:
+                json.dump(output, f, indent=2)
+            print(f"Output written to {args.output}")
+        else:
+            print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""
+TCL Test Runner for VibeSQL
+
+Executes parsed TCL tests against VibeSQL and records results.
+Works with tcl_parser.py to parse test files first.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+# Import our parser
+sys.path.insert(0, str(Path(__file__).parent))
+from tcl_parser import TclTestParser, ParsedTest, ParsedFile, TestType
+
+
+@dataclass
+class TestResult:
+    """Result of running a single test."""
+    test_name: str
+    file_path: str
+    test_type: str
+    status: str  # 'passed', 'failed', 'skipped', 'error'
+    sql: str
+    expected_output: Optional[str] = None
+    actual_output: Optional[str] = None
+    error_message: Optional[str] = None
+    execution_time_ms: float = 0.0
+    line_number: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "test_name": self.test_name,
+            "file_path": self.file_path,
+            "test_type": self.test_type,
+            "status": self.status,
+            "sql": self.sql,
+            "expected_output": self.expected_output,
+            "actual_output": self.actual_output,
+            "error_message": self.error_message,
+            "execution_time_ms": self.execution_time_ms,
+            "line_number": self.line_number,
+        }
+
+
+@dataclass
+class RunSummary:
+    """Summary of a test run."""
+    started_at: str
+    completed_at: str = ""
+    git_commit: str = ""
+    total_files: int = 0
+    total_tests: int = 0
+    passed: int = 0
+    failed: int = 0
+    skipped: int = 0
+    parse_errors: int = 0
+    results: list[TestResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "git_commit": self.git_commit,
+            "total_files": self.total_files,
+            "total_tests": self.total_tests,
+            "passed": self.passed,
+            "failed": self.failed,
+            "skipped": self.skipped,
+            "parse_errors": self.parse_errors,
+            "pass_rate": (self.passed / self.total_tests * 100) if self.total_tests > 0 else 0,
+            "results": [r.to_dict() for r in self.results],
+        }
+
+
+class VibeSQL:
+    """Interface to VibeSQL for test execution."""
+
+    def __init__(self, vibesql_path: str, timeout: float = 5.0):
+        self.vibesql_path = vibesql_path
+        self.timeout = timeout
+        self._db_file = None
+
+    def __enter__(self):
+        # Create a temporary database file
+        self._db_file = tempfile.NamedTemporaryFile(suffix='.vbsql', delete=False)
+        self._db_file.close()
+        return self
+
+    def __exit__(self, *args):
+        # Clean up temporary database
+        if self._db_file and os.path.exists(self._db_file.name):
+            os.unlink(self._db_file.name)
+
+    def execute(self, sql: str) -> tuple[bool, str, str]:
+        """
+        Execute SQL and return (success, stdout, stderr).
+        """
+        try:
+            result = subprocess.run(
+                [self.vibesql_path, self._db_file.name, "-c", sql],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+            return (result.returncode == 0, result.stdout.strip(), result.stderr.strip())
+        except subprocess.TimeoutExpired:
+            return (False, "", f"Timeout after {self.timeout}s")
+        except Exception as e:
+            return (False, "", str(e))
+
+    def execute_setup(self, sql_statements: list[str]) -> tuple[bool, str]:
+        """Execute setup SQL statements."""
+        for sql in sql_statements:
+            success, _, stderr = self.execute(sql)
+            if not success:
+                return (False, f"Setup failed: {stderr}")
+        return (True, "")
+
+
+def normalize_output(output: str) -> str:
+    """Normalize output for comparison."""
+    # Strip whitespace
+    output = output.strip()
+    # Normalize whitespace within
+    output = re.sub(r'\s+', ' ', output)
+    # Remove trailing whitespace on each line
+    lines = [l.strip() for l in output.split('\n')]
+    return ' '.join(lines)
+
+
+def compare_outputs(expected: str, actual: str) -> bool:
+    """Compare expected and actual output, handling TCL format quirks."""
+    expected_norm = normalize_output(expected)
+    actual_norm = normalize_output(actual)
+
+    if expected_norm == actual_norm:
+        return True
+
+    # Handle numeric comparisons (e.g., 1.0 vs 1)
+    try:
+        exp_parts = expected_norm.split()
+        act_parts = actual_norm.split()
+
+        if len(exp_parts) != len(act_parts):
+            return False
+
+        for e, a in zip(exp_parts, act_parts):
+            # Try numeric comparison
+            try:
+                if float(e) != float(a):
+                    return False
+            except ValueError:
+                if e != a:
+                    return False
+
+        return True
+    except:
+        return False
+
+
+class TclTestRunner:
+    """Runs TCL tests against VibeSQL."""
+
+    def __init__(self, vibesql_path: str, verbose: bool = False, timeout: float = 5.0):
+        self.vibesql_path = vibesql_path
+        self.verbose = verbose
+        self.timeout = timeout
+        self.parser = TclTestParser(verbose=verbose)
+
+    def run_single_test(self, test: ParsedTest, vibesql: VibeSQL, file_path: str) -> TestResult:
+        """Run a single test and return the result."""
+        start_time = time.time()
+
+        # Handle skipped tests
+        if test.test_type == TestType.SKIPPED:
+            return TestResult(
+                test_name=test.name,
+                file_path=file_path,
+                test_type=test.test_type.value,
+                status="skipped",
+                sql=test.sql,
+                error_message=test.skip_reason,
+                line_number=test.line_number,
+            )
+
+        # Execute the SQL
+        success, stdout, stderr = vibesql.execute(test.sql)
+        elapsed_ms = (time.time() - start_time) * 1000
+
+        # Check result based on test type
+        if test.test_type == TestType.CATCHSQL:
+            # For catchsql tests, we expect an error
+            if test.error_code == 0:
+                # Expect success
+                if not success:
+                    return TestResult(
+                        test_name=test.name,
+                        file_path=file_path,
+                        test_type=test.test_type.value,
+                        status="failed",
+                        sql=test.sql,
+                        expected_output=test.expected_error or "success",
+                        actual_output=stderr,
+                        error_message=f"Expected success but got error: {stderr}",
+                        execution_time_ms=elapsed_ms,
+                        line_number=test.line_number,
+                    )
+                else:
+                    return TestResult(
+                        test_name=test.name,
+                        file_path=file_path,
+                        test_type=test.test_type.value,
+                        status="passed",
+                        sql=test.sql,
+                        expected_output="success",
+                        actual_output=stdout,
+                        execution_time_ms=elapsed_ms,
+                        line_number=test.line_number,
+                    )
+            else:
+                # Expect error with specific message
+                if success:
+                    return TestResult(
+                        test_name=test.name,
+                        file_path=file_path,
+                        test_type=test.test_type.value,
+                        status="failed",
+                        sql=test.sql,
+                        expected_output=f"error: {test.expected_error}",
+                        actual_output=stdout,
+                        error_message="Expected error but query succeeded",
+                        execution_time_ms=elapsed_ms,
+                        line_number=test.line_number,
+                    )
+                else:
+                    # Check if error message matches
+                    # Be lenient - just check if the key part of the error is present
+                    expected_error = (test.expected_error or "").lower()
+                    actual_error = stderr.lower()
+
+                    # Extract key error keywords
+                    if expected_error and any(keyword in actual_error for keyword in expected_error.split()[:3]):
+                        return TestResult(
+                            test_name=test.name,
+                            file_path=file_path,
+                            test_type=test.test_type.value,
+                            status="passed",
+                            sql=test.sql,
+                            expected_output=test.expected_error,
+                            actual_output=stderr,
+                            execution_time_ms=elapsed_ms,
+                            line_number=test.line_number,
+                        )
+                    else:
+                        return TestResult(
+                            test_name=test.name,
+                            file_path=file_path,
+                            test_type=test.test_type.value,
+                            status="failed",
+                            sql=test.sql,
+                            expected_output=f"error: {test.expected_error}",
+                            actual_output=f"error: {stderr}",
+                            error_message=f"Error message mismatch",
+                            execution_time_ms=elapsed_ms,
+                            line_number=test.line_number,
+                        )
+
+        else:
+            # For execsql and general tests, compare output
+            if not success:
+                return TestResult(
+                    test_name=test.name,
+                    file_path=file_path,
+                    test_type=test.test_type.value,
+                    status="failed",
+                    sql=test.sql,
+                    expected_output=test.expected_output,
+                    actual_output=stderr,
+                    error_message=f"Query failed: {stderr}",
+                    execution_time_ms=elapsed_ms,
+                    line_number=test.line_number,
+                )
+
+            expected = test.expected_output or ""
+            if compare_outputs(expected, stdout):
+                return TestResult(
+                    test_name=test.name,
+                    file_path=file_path,
+                    test_type=test.test_type.value,
+                    status="passed",
+                    sql=test.sql,
+                    expected_output=expected,
+                    actual_output=stdout,
+                    execution_time_ms=elapsed_ms,
+                    line_number=test.line_number,
+                )
+            else:
+                return TestResult(
+                    test_name=test.name,
+                    file_path=file_path,
+                    test_type=test.test_type.value,
+                    status="failed",
+                    sql=test.sql,
+                    expected_output=expected,
+                    actual_output=stdout,
+                    error_message="Output mismatch",
+                    execution_time_ms=elapsed_ms,
+                    line_number=test.line_number,
+                )
+
+    def run_file(self, file_path: str) -> list[TestResult]:
+        """Run all tests in a single TCL file."""
+        results = []
+
+        # Parse the file
+        parsed = self.parser.parse_file(file_path)
+
+        if parsed.parse_errors:
+            for error in parsed.parse_errors:
+                results.append(TestResult(
+                    test_name="parse_error",
+                    file_path=file_path,
+                    test_type="parse",
+                    status="error",
+                    sql="",
+                    error_message=error,
+                ))
+            if not parsed.tests:
+                return results
+
+        # Create a fresh database for this file
+        with VibeSQL(self.vibesql_path, timeout=self.timeout) as vibesql:
+            # Run setup SQL first
+            for sql in parsed.setup_sql:
+                success, error = vibesql.execute_setup([sql])
+                if not success:
+                    if self.verbose:
+                        print(f"  Setup warning: {error}")
+
+            # Run each test
+            for test in parsed.tests:
+                result = self.run_single_test(test, vibesql, file_path)
+                results.append(result)
+
+                if self.verbose:
+                    status_icon = "✓" if result.status == "passed" else "✗" if result.status == "failed" else "○"
+                    print(f"  {status_icon} {test.name}: {result.status}")
+
+        return results
+
+    def run_files(self, file_paths: list[str], parallel: bool = False) -> RunSummary:
+        """Run tests from multiple files."""
+        summary = RunSummary(
+            started_at=datetime.now().isoformat(),
+            total_files=len(file_paths),
+        )
+
+        # Get git commit
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            summary.git_commit = result.stdout.strip()
+        except:
+            pass
+
+        if parallel:
+            # Parallel execution
+            with ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
+                futures = {executor.submit(self.run_file, f): f for f in file_paths}
+                for future in as_completed(futures):
+                    file_path = futures[future]
+                    try:
+                        results = future.result()
+                        for result in results:
+                            summary.results.append(result)
+                            summary.total_tests += 1
+                            if result.status == "passed":
+                                summary.passed += 1
+                            elif result.status == "failed":
+                                summary.failed += 1
+                            elif result.status == "skipped":
+                                summary.skipped += 1
+                            elif result.status == "error":
+                                summary.parse_errors += 1
+                    except Exception as e:
+                        summary.parse_errors += 1
+                        print(f"Error processing {file_path}: {e}")
+        else:
+            # Sequential execution
+            for i, file_path in enumerate(file_paths):
+                if self.verbose:
+                    print(f"[{i+1}/{len(file_paths)}] {Path(file_path).name}")
+
+                try:
+                    results = self.run_file(file_path)
+                    for result in results:
+                        summary.results.append(result)
+                        summary.total_tests += 1
+                        if result.status == "passed":
+                            summary.passed += 1
+                        elif result.status == "failed":
+                            summary.failed += 1
+                        elif result.status == "skipped":
+                            summary.skipped += 1
+                        elif result.status == "error":
+                            summary.parse_errors += 1
+                except Exception as e:
+                    summary.parse_errors += 1
+                    print(f"Error processing {file_path}: {e}")
+
+        summary.completed_at = datetime.now().isoformat()
+        return summary
+
+
+def save_to_database(summary: RunSummary, db_path: str, vibesql_path: str):
+    """Save run results to the database."""
+    # First, get the next run_id
+    result = subprocess.run(
+        [vibesql_path, db_path, "-c", "SELECT COALESCE(MAX(run_id), 0) + 1 FROM tcl_test_runs"],
+        capture_output=True,
+        text=True,
+    )
+    try:
+        # Parse output - look for the number in the result
+        lines = [l.strip() for l in result.stdout.strip().split('\n') if l.strip()]
+        run_id = int(lines[-1])
+    except (ValueError, IndexError):
+        run_id = 1
+
+    # Create run record
+    run_sql = f"""
+        INSERT INTO tcl_test_runs (
+            run_id, started_at, completed_at, git_commit,
+            total_files, total_tests, passed, failed, skipped, parse_errors
+        ) VALUES (
+            {run_id}, '{summary.started_at}', '{summary.completed_at}', '{summary.git_commit}',
+            {summary.total_files}, {summary.total_tests},
+            {summary.passed}, {summary.failed}, {summary.skipped}, {summary.parse_errors}
+        );
+    """
+
+    try:
+        subprocess.run(
+            [vibesql_path, db_path, "-c", run_sql],
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Warning: Failed to save run summary: {e.stderr}")
+        return
+
+    # Helper to escape SQL strings
+    def escape_sql(s: str, max_len: int = 1000) -> str:
+        if not s:
+            return ""
+        # Replace single quotes with doubled quotes
+        s = s.replace("'", "''")
+        # Remove newlines and other control chars that might break the INSERT
+        s = s.replace('\n', ' ').replace('\r', ' ').replace('\t', ' ')
+        # Truncate
+        return s[:max_len]
+
+    # Get next result ID
+    result = subprocess.run(
+        [vibesql_path, db_path, "-c", "SELECT COALESCE(MAX(id), 0) FROM tcl_test_results"],
+        capture_output=True,
+        text=True,
+    )
+    try:
+        lines = [l.strip() for l in result.stdout.strip().split('\n') if l.strip()]
+        next_id = int(lines[-1]) + 1
+    except (ValueError, IndexError):
+        next_id = 1
+
+    # Insert results one at a time to avoid batch issues
+    for r in summary.results:
+        sql_escaped = escape_sql(r.sql, 1000)
+        expected = escape_sql(r.expected_output, 1000)
+        actual = escape_sql(r.actual_output, 1000)
+        error = escape_sql(r.error_message, 500)
+        file_path = escape_sql(r.file_path, 500)
+        test_name = escape_sql(r.test_name, 200)
+
+        insert_sql = f"""
+            INSERT INTO tcl_test_results (
+                id, run_id, file_path, test_name, test_type, status,
+                sql_text, expected_output, actual_output, error_message,
+                execution_time_ms, line_number
+            ) VALUES (
+                {next_id},
+                {run_id},
+                '{file_path}',
+                '{test_name}',
+                '{r.test_type}',
+                '{r.status}',
+                '{sql_escaped}',
+                '{expected}',
+                '{actual}',
+                '{error}',
+                {r.execution_time_ms},
+                {r.line_number}
+            );
+        """
+        next_id += 1
+
+        try:
+            subprocess.run(
+                [vibesql_path, db_path, "-c", insert_sql],
+                capture_output=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            # Silently skip problematic records
+            pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run TCL tests against VibeSQL")
+    parser.add_argument("--file", "-f", help="Single file to test")
+    parser.add_argument("--files", nargs="+", help="Multiple files to test")
+    parser.add_argument("--vibesql", required=True, help="Path to VibeSQL binary")
+    parser.add_argument("--results-db", help="Path to results database")
+    parser.add_argument("--output", "-o", help="Output JSON file")
+    parser.add_argument("--parallel", action="store_true", help="Run tests in parallel")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument("--timeout", type=float, default=5.0, help="Per-test timeout in seconds")
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.vibesql):
+        print(f"Error: VibeSQL binary not found: {args.vibesql}", file=sys.stderr)
+        sys.exit(1)
+
+    runner = TclTestRunner(
+        vibesql_path=args.vibesql,
+        verbose=args.verbose,
+        timeout=args.timeout,
+    )
+
+    # Determine files to run
+    if args.file:
+        file_paths = [args.file]
+    elif args.files:
+        file_paths = args.files
+    else:
+        print("Error: No files specified", file=sys.stderr)
+        sys.exit(1)
+
+    # Run tests
+    summary = runner.run_files(file_paths, parallel=args.parallel)
+
+    # Print summary
+    print()
+    print("=" * 50)
+    print(f"Total tests: {summary.total_tests}")
+    print(f"Passed:      {summary.passed} ({summary.passed/summary.total_tests*100:.1f}%)" if summary.total_tests > 0 else "Passed: 0")
+    print(f"Failed:      {summary.failed}")
+    print(f"Skipped:     {summary.skipped}")
+    print(f"Errors:      {summary.parse_errors}")
+    print("=" * 50)
+
+    # Save to database if specified
+    if args.results_db:
+        save_to_database(summary, args.results_db, args.vibesql)
+        print(f"Results saved to: {args.results_db}")
+
+    # Output JSON if specified
+    if args.output:
+        with open(args.output, 'w') as f:
+            json.dump(summary.to_dict(), f, indent=2)
+        print(f"JSON output: {args.output}")
+
+    # Exit with error if there were failures
+    if summary.failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tcltest
+++ b/scripts/tcltest
@@ -1,0 +1,463 @@
+#!/usr/bin/env bash
+#
+# SQLite TCL Test Suite Runner for VibeSQL
+#
+# Runs SQLite's TCL test files against VibeSQL, tracking results
+# in a database for conformance reporting.
+#
+# Usage:
+#   ./scripts/tcltest <command> [options]
+#
+# Commands:
+#   test <file>              Test a single TCL file
+#   run [options]            Run the full test suite
+#   analyze                  Analyze failure patterns
+#   status                   Show quick summary
+#
+# Examples:
+#   ./scripts/tcltest test select1.test
+#   ./scripts/tcltest run --pattern "select*.test"
+#   ./scripts/tcltest run --priority 1
+#   ./scripts/tcltest status
+#
+
+set -euo pipefail
+
+# Get repository root
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Print colored output
+print_error() { echo -e "${RED}❌ $1${NC}" >&2; }
+print_success() { echo -e "${GREEN}✓ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
+print_info() { echo -e "${BLUE}ℹ $1${NC}"; }
+
+# Paths
+TCL_TEST_DIR="docs/reference/sqlite/test"
+RESULTS_DIR="$HOME/.vibesql/test_results"
+RESULTS_DB="$RESULTS_DIR/tcl_test_results.vbsql"
+VIBESQL_BIN="./target/release/vibesql"
+
+# Check if VibeSQL is built
+check_vibesql() {
+    if [ ! -f "$VIBESQL_BIN" ]; then
+        print_error "VibeSQL not built. Run: cargo build --release"
+        exit 1
+    fi
+}
+
+# Check if TCL test directory exists
+check_tcl_tests() {
+    if [ ! -d "$TCL_TEST_DIR" ]; then
+        print_error "TCL test directory not found: $TCL_TEST_DIR"
+        echo ""
+        echo "Make sure the SQLite submodule is initialized:"
+        echo "  git submodule update --init --recursive"
+        exit 1
+    fi
+}
+
+# Initialize results database
+init_results_db() {
+    mkdir -p "$RESULTS_DIR"
+
+    # Create the results database if it doesn't exist
+    if [ ! -f "$RESULTS_DB" ]; then
+        print_info "Initializing results database: $RESULTS_DB"
+        "$VIBESQL_BIN" "$RESULTS_DB" -c "
+            CREATE TABLE IF NOT EXISTS tcl_test_runs (
+                run_id INTEGER PRIMARY KEY,
+                started_at TEXT NOT NULL,
+                completed_at TEXT,
+                git_commit TEXT,
+                total_files INTEGER DEFAULT 0,
+                total_tests INTEGER DEFAULT 0,
+                passed INTEGER DEFAULT 0,
+                failed INTEGER DEFAULT 0,
+                skipped INTEGER DEFAULT 0,
+                parse_errors INTEGER DEFAULT 0
+            );
+
+            CREATE TABLE IF NOT EXISTS tcl_test_results (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                file_path TEXT NOT NULL,
+                test_name TEXT NOT NULL,
+                test_type TEXT NOT NULL,
+                status TEXT NOT NULL,
+                sql_text TEXT,
+                expected_output TEXT,
+                actual_output TEXT,
+                error_message TEXT,
+                execution_time_ms REAL,
+                line_number INTEGER,
+                FOREIGN KEY (run_id) REFERENCES tcl_test_runs(run_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_tcl_results_run ON tcl_test_results(run_id);
+            CREATE INDEX IF NOT EXISTS idx_tcl_results_file ON tcl_test_results(file_path);
+            CREATE INDEX IF NOT EXISTS idx_tcl_results_status ON tcl_test_results(status);
+        "
+    fi
+}
+
+# Show main help
+show_help() {
+    cat << 'EOF'
+SQLite TCL Test Suite Runner for VibeSQL
+
+Usage:
+  ./scripts/tcltest <command> [options]
+
+Commands:
+  test <file>              Test a single TCL file
+  run [options]            Run TCL test suite
+  parse <file>             Parse TCL file and show extracted tests
+  analyze                  Analyze failure patterns
+  status                   Show quick pass rate summary
+
+Options for 'run':
+  --pattern GLOB           Run only files matching pattern (e.g., "select*.test")
+  --priority N             Run priority level N tests (1=core, 2=advanced, 3=sqlite-specific)
+  --limit N                Limit to N files
+  --parallel               Run tests in parallel
+  --verbose                Show detailed output
+
+Examples:
+  # Test a specific file
+  ./scripts/tcltest test select1.test
+
+  # Parse and show tests in a file
+  ./scripts/tcltest parse select1.test
+
+  # Run all Priority 1 (core SQL) tests
+  ./scripts/tcltest run --priority 1
+
+  # Run just SELECT tests
+  ./scripts/tcltest run --pattern "select*.test"
+
+  # Quick status
+  ./scripts/tcltest status
+
+Priority Levels:
+  1 - Core SQL: select, insert, update, delete, where, join, aggregate, func
+  2 - Advanced: window, cte, trigger, fkey, collate
+  3 - SQLite-specific: wal, vacuum, attach, vtab, fts (likely to fail/skip)
+
+Environment Variables:
+  TCLTEST_VERBOSE          Enable verbose output
+  TCLTEST_TIMEOUT          Per-test timeout in seconds (default: 5)
+EOF
+}
+
+# Get priority patterns
+get_priority_patterns() {
+    local priority="$1"
+    case "$priority" in
+        1)
+            echo "select*.test,insert*.test,update*.test,delete*.test,where*.test,join*.test,aggregate*.test,func*.test,orderby*.test,index*.test,between*.test,in*.test"
+            ;;
+        2)
+            echo "window*.test,cte*.test,trigger*.test,fkey*.test,collate*.test,autoincr*.test,cast*.test,coalesce*.test,expr*.test,like*.test,null*.test,subquery*.test,union*.test,view*.test"
+            ;;
+        3)
+            echo "wal*.test,vacuum*.test,attach*.test,vtab*.test,fts*.test,rtree*.test,json*.test"
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
+
+# Parse command: parse and show tests in a file
+cmd_parse() {
+    if [ $# -eq 0 ] || [ "$1" = "--help" ]; then
+        cat << 'EOF'
+Parse a TCL test file and show extracted tests
+
+Usage:
+  ./scripts/tcltest parse <file>
+
+Arguments:
+  <file>    Path to test file relative to docs/reference/sqlite/test/
+
+Examples:
+  ./scripts/tcltest parse select1.test
+  ./scripts/tcltest parse where1.test
+EOF
+        exit 0
+    fi
+
+    local test_file="$1"
+    local full_path="$TCL_TEST_DIR/$test_file"
+
+    if [ ! -f "$full_path" ]; then
+        print_error "Test file not found: $full_path"
+        exit 1
+    fi
+
+    python3 scripts/tcl_parser.py "$full_path"
+}
+
+# Test command: run a single file
+cmd_test() {
+    if [ $# -eq 0 ] || [ "$1" = "--help" ]; then
+        cat << 'EOF'
+Test a single TCL test file against VibeSQL
+
+Usage:
+  ./scripts/tcltest test <file>
+
+Arguments:
+  <file>    Path to test file relative to docs/reference/sqlite/test/
+
+Examples:
+  ./scripts/tcltest test select1.test
+  ./scripts/tcltest test where1.test
+EOF
+        exit 0
+    fi
+
+    check_vibesql
+    check_tcl_tests
+
+    local test_file="$1"
+    local full_path="$TCL_TEST_DIR/$test_file"
+
+    if [ ! -f "$full_path" ]; then
+        print_error "Test file not found: $full_path"
+        echo ""
+        echo "Available test files (sample):"
+        ls "$TCL_TEST_DIR"/*.test 2>/dev/null | head -10 | xargs -I{} basename {}
+        exit 1
+    fi
+
+    print_info "Testing: $test_file"
+    echo ""
+
+    # Run the test using Python runner
+    python3 scripts/tcl_runner.py --file "$full_path" --vibesql "$VIBESQL_BIN"
+}
+
+# Run command: execute test suite
+cmd_run() {
+    local pattern=""
+    local priority=""
+    local limit=""
+    local parallel=false
+    local verbose=false
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --help)
+                cat << 'EOF'
+Run the TCL test suite against VibeSQL
+
+Usage:
+  ./scripts/tcltest run [options]
+
+Options:
+  --pattern GLOB           Run only files matching pattern
+  --priority N             Run priority level N tests (1, 2, or 3)
+  --limit N                Limit to N files
+  --parallel               Run tests in parallel
+  --verbose                Show detailed output
+
+Examples:
+  # Run Priority 1 tests (core SQL)
+  ./scripts/tcltest run --priority 1
+
+  # Run SELECT tests only
+  ./scripts/tcltest run --pattern "select*.test"
+
+  # Run first 10 files
+  ./scripts/tcltest run --limit 10
+EOF
+                exit 0
+                ;;
+            --pattern)
+                pattern="$2"
+                shift 2
+                ;;
+            --priority)
+                priority="$2"
+                shift 2
+                ;;
+            --limit)
+                limit="$2"
+                shift 2
+                ;;
+            --parallel)
+                parallel=true
+                shift
+                ;;
+            --verbose)
+                verbose=true
+                shift
+                ;;
+            *)
+                print_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    check_vibesql
+    check_tcl_tests
+    init_results_db
+
+    # Build file list
+    local files=()
+
+    if [ -n "$priority" ]; then
+        local patterns
+        patterns=$(get_priority_patterns "$priority")
+        IFS=',' read -ra pattern_array <<< "$patterns"
+        for p in "${pattern_array[@]}"; do
+            for f in "$TCL_TEST_DIR"/$p; do
+                [ -f "$f" ] && files+=("$f")
+            done
+        done
+    elif [ -n "$pattern" ]; then
+        for f in "$TCL_TEST_DIR"/$pattern; do
+            [ -f "$f" ] && files+=("$f")
+        done
+    else
+        for f in "$TCL_TEST_DIR"/*.test; do
+            [ -f "$f" ] && files+=("$f")
+        done
+    fi
+
+    # Apply limit
+    if [ -n "$limit" ]; then
+        files=("${files[@]:0:$limit}")
+    fi
+
+    local file_count=${#files[@]}
+    print_info "Running TCL test suite"
+    echo "Files to test: $file_count"
+    if [ -n "$pattern" ]; then
+        echo "Pattern: $pattern"
+    fi
+    if [ -n "$priority" ]; then
+        echo "Priority: $priority"
+    fi
+    echo ""
+
+    # Build Python command
+    local py_args=(
+        "scripts/tcl_runner.py"
+        "--vibesql" "$VIBESQL_BIN"
+        "--results-db" "$RESULTS_DB"
+    )
+
+    if $verbose; then
+        py_args+=("--verbose")
+    fi
+
+    if $parallel; then
+        py_args+=("--parallel")
+    fi
+
+    # Add files
+    py_args+=("--files" "${files[@]}")
+
+    python3 "${py_args[@]}"
+
+    print_success "Test run complete"
+    echo "Results database: $RESULTS_DB"
+}
+
+# Status command: quick summary
+cmd_status() {
+    check_vibesql
+    init_results_db
+
+    echo "=== TCL Test Suite Status ==="
+    echo ""
+    echo "Results database: $RESULTS_DB"
+    echo ""
+
+    # Query the database for latest run
+    "$VIBESQL_BIN" "$RESULTS_DB" -c "
+        SELECT
+            started_at as latest_run,
+            total_tests,
+            passed,
+            failed,
+            skipped,
+            ROUND(100.0 * passed / NULLIF(total_tests - skipped, 0), 1) as pass_rate
+        FROM tcl_test_runs
+        ORDER BY run_id DESC
+        LIMIT 1
+    " 2>/dev/null || print_warning "No test runs yet. Run: ./scripts/tcltest run"
+}
+
+# Analyze command: failure pattern analysis
+cmd_analyze() {
+    check_vibesql
+    init_results_db
+
+    echo "=== TCL Test Failure Analysis ==="
+    echo ""
+
+    # Query for failure patterns
+    "$VIBESQL_BIN" "$RESULTS_DB" -c "
+        SELECT
+            SUBSTR(error_message, 1, 60) as error_pattern,
+            COUNT(*) as count,
+            GROUP_CONCAT(DISTINCT SUBSTR(file_path, -30)) as sample_files
+        FROM tcl_test_results
+        WHERE status = 'failed'
+        AND run_id = (SELECT MAX(run_id) FROM tcl_test_runs)
+        GROUP BY SUBSTR(error_message, 1, 60)
+        ORDER BY count DESC
+        LIMIT 20
+    " 2>/dev/null || print_warning "No failure data yet. Run: ./scripts/tcltest run"
+}
+
+# Main command router
+main() {
+    if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+        show_help
+        exit 0
+    fi
+
+    local command="$1"
+    shift
+
+    case "$command" in
+        test)
+            cmd_test "$@"
+            ;;
+        parse)
+            cmd_parse "$@"
+            ;;
+        run)
+            cmd_run "$@"
+            ;;
+        status)
+            cmd_status "$@"
+            ;;
+        analyze)
+            cmd_analyze "$@"
+            ;;
+        *)
+            print_error "Unknown command: $command"
+            echo ""
+            echo "Run './scripts/tcltest --help' for usage"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Implements infrastructure for running SQLite's canonical TCL test suite against VibeSQL as a first-class conformance test.

- Add TCL test parser (`scripts/tcl_parser.py`) that extracts `do_execsql_test` and `do_catchsql_test` patterns
- Add test runner (`scripts/tcl_runner.py`) that executes tests against VibeSQL
- Add unified CLI (`scripts/tcltest`) for running, analyzing, and reporting results
- Add website export script (`scripts/export_tcl_results.py`)
- Add Makefile targets: `test-tcl`, `test-tcl-all`, `test-tcl-file`, `test-tcl-status`
- Document usage in CLAUDE.md

### Parser Stats

The parser achieves ~90% parse rate on Priority 1 (core SQL) test files:
- **select*.test**: 124 tests, 90.3% parsed
- **where*.test**: 285 tests, 89.8% parsed

Tests that require complex TCL logic (variables, loops, conditionals) are automatically skipped.

### Priority Levels

1. **Priority 1** (core SQL): `select`, `insert`, `update`, `delete`, `where`, `join`, `aggregate`, `func`
2. **Priority 2** (advanced): `window`, `cte`, `trigger`, `fkey`, `collate`
3. **Priority 3** (SQLite-specific): `wal`, `vacuum`, `attach`, `vtab`, `fts`

## Test plan

- [x] `make test-tcl-file FILE=select1.test` runs and reports results
- [x] Results saved to `~/.vibesql/test_results/tcl_test_results.vbsql`
- [x] `./scripts/tcltest status` shows pass rate
- [x] Parser correctly extracts tests from TCL files

Closes #4214

🤖 Generated with [Claude Code](https://claude.com/claude-code)