### PR TITLE
feat(web): Add PostgreSQL regression test badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Demo](https://img.shields.io/badge/demo-live-success)](https://rjwalters.github.io/vibesql/)
 [![sqltest](https://img.shields.io/endpoint?url=https://rjwalters.github.io/vibesql/badges/sql1999-conformance.json)](https://rjwalters.github.io/vibesql/conformance.html)
 [![SQLLogicTest](https://img.shields.io/endpoint?url=https://rjwalters.github.io/vibesql/badges/sqllogictest.json)](https://rjwalters.github.io/vibesql/conformance.html#SQLlogicTest)
+[![PostgreSQL](https://img.shields.io/endpoint?url=https://rjwalters.github.io/vibesql/badges/pgsql-regress.json)](https://rjwalters.github.io/vibesql/conformance.html#postgresql)
 [![i18n](https://img.shields.io/badge/i18n-19%20languages-blue)](docs/CONTRIBUTING_TRANSLATIONS.md)
 
 **SQL:1999 compliant database in Rust, 100% AI-generated**

--- a/scripts/export_website_data.py
+++ b/scripts/export_website_data.py
@@ -980,6 +980,39 @@ def main():
         print(f"  -> {path.name}")
         exported.append(path)
 
+        # Generate pgsql-regress badge
+        pgsql_data = load_pgsql_regress_data()
+        if pgsql_data.get("summary"):
+            summary = pgsql_data["summary"]
+            passed = summary.get("passing", 0)
+            skipped = summary.get("skipped", 0)
+            pass_rate = summary.get("pass_rate", 0)
+
+            if pass_rate == 100:
+                color = "brightgreen"
+            elif pass_rate >= 95:
+                color = "green"
+            elif pass_rate >= 80:
+                color = "yellow"
+            else:
+                color = "red"
+
+            badge = {
+                "schemaVersion": 1,
+                "label": "PostgreSQL",
+                "message": f"{passed}\u2713 {skipped}\u2298 ({pass_rate:.0f}%)",
+                "color": color
+            }
+
+            badges_dir = base_dir / "badges"
+            badges_dir.mkdir(parents=True, exist_ok=True)
+            badge_path = badges_dir / "pgsql-regress.json"
+            with open(badge_path, 'w') as f:
+                json.dump(badge, f, indent=2)
+                f.write('\n')
+            print(f"  PostgreSQL badge: {passed} passed, {skipped} skipped ({pass_rate:.0f}%) -> {badge_path.name}")
+            exported.append(badge_path)
+
     print(f"\nExported {len(exported)} files")
     return 0
 

--- a/web-demo/public/badges/pgsql-regress.json
+++ b/web-demo/public/badges/pgsql-regress.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "PostgreSQL",
+  "message": "59\u2713 4\u2298 (100%)",
+  "color": "brightgreen"
+}


### PR DESCRIPTION
## Summary

- Add `pgsql-regress.json` badge file with shields.io endpoint format
- Add badge generation logic to `export_website_data.py` (runs with `make website`)
- Add PostgreSQL badge to README.md badges section after SQLLogicTest badge

## Implementation Details

The badge displays:
- Passed tests count (✓)
- Skipped tests count (⊘)
- Pass rate percentage

Badge color varies based on pass rate:
- `brightgreen`: 100%
- `green`: 95-99%
- `yellow`: 80-94%
- `red`: <80%

## Test plan

- [x] Verified badge JSON format matches existing badges
- [x] Tested export script generates badge correctly
- [x] Confirmed badge appears in README after SQLLogicTest badge

Closes #4216

🤖 Generated with [Claude Code](https://claude.com/claude-code)