### PR TITLE
feat(cli): Add raw output format for TCL test compatibility

### DIFF
--- a/crates/vibesql-cli/src/commands.rs
+++ b/crates/vibesql-cli/src/commands.rs
@@ -68,6 +68,7 @@ impl MetaCommand {
                         "csv" => Some(MetaCommand::SetFormat(OutputFormat::Csv)),
                         "markdown" | "md" => Some(MetaCommand::SetFormat(OutputFormat::Markdown)),
                         "html" => Some(MetaCommand::SetFormat(OutputFormat::Html)),
+                        "raw" => Some(MetaCommand::SetFormat(OutputFormat::Raw)),
                         _ => None,
                     }
                 } else {
@@ -156,6 +157,7 @@ impl MetaCommand {
                         "csv" => Some(MetaCommand::SetFormat(OutputFormat::Csv)),
                         "markdown" => Some(MetaCommand::SetFormat(OutputFormat::Markdown)),
                         "html" => Some(MetaCommand::SetFormat(OutputFormat::Html)),
+                        "raw" => Some(MetaCommand::SetFormat(OutputFormat::Raw)),
                         _ => None,
                     }
                 } else {
@@ -277,6 +279,10 @@ mod tests {
             MetaCommand::parse("\\f html"),
             Some(MetaCommand::SetFormat(OutputFormat::Html))
         ));
+        assert!(matches!(
+            MetaCommand::parse("\\f raw"),
+            Some(MetaCommand::SetFormat(OutputFormat::Raw))
+        ));
     }
 
     #[test]
@@ -394,6 +400,10 @@ mod tests {
         assert!(matches!(
             MetaCommand::parse(".mode html"),
             Some(MetaCommand::SetFormat(OutputFormat::Html))
+        ));
+        assert!(matches!(
+            MetaCommand::parse(".mode raw"),
+            Some(MetaCommand::SetFormat(OutputFormat::Raw))
         ));
         // SQLite aliases
         assert!(matches!(

--- a/crates/vibesql-cli/src/formatter.rs
+++ b/crates/vibesql-cli/src/formatter.rs
@@ -10,6 +10,10 @@ pub enum OutputFormat {
     Csv,
     Markdown,
     Html,
+    /// Raw output format: space-separated values, one row per line.
+    /// NULL values are represented as empty strings.
+    /// Compatible with SQLite TCL test harness expectations.
+    Raw,
 }
 
 pub struct ResultFormatter {
@@ -32,9 +36,14 @@ impl ResultFormatter {
             OutputFormat::Csv => self.print_csv(result),
             OutputFormat::Markdown => self.print_markdown(result),
             OutputFormat::Html => self.print_html(result),
+            OutputFormat::Raw => {
+                // Raw format: no timing info, just raw values
+                self.print_raw(result);
+                return;
+            }
         }
 
-        // Print timing if available
+        // Print timing if available (not for raw format)
         if let Some(time_ms) = result.execution_time_ms {
             println!("{}", vibe_msg!("rows-with-time", count = result.row_count as i64, time = format!("{:.3}", time_ms / 1000.0)));
         } else {
@@ -155,6 +164,28 @@ impl ResultFormatter {
             .replace('"', "&quot;")
             .replace('\'', "&#39;")
     }
+
+    /// Print results in raw format for SQLite TCL test compatibility.
+    /// - Space-separated values within each row
+    /// - One row per line
+    /// - NULL values output as empty strings
+    /// - No headers, no borders, no row count
+    fn print_raw(&self, result: &QueryResult) {
+        for row in &result.rows {
+            let values: Vec<&str> = row
+                .iter()
+                .map(|val| {
+                    // SQLite TCL tests expect NULL to be empty string
+                    if val == "NULL" || val.is_empty() {
+                        ""
+                    } else {
+                        val.as_str()
+                    }
+                })
+                .collect();
+            println!("{}", values.join(" "));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -209,5 +240,45 @@ mod tests {
         // These should handle empty results gracefully
         formatter.print_markdown(&result);
         formatter.print_html(&result);
+    }
+
+    #[test]
+    fn test_raw_format() {
+        let mut formatter = ResultFormatter::new();
+        formatter.set_format(OutputFormat::Raw);
+        let result = create_test_result();
+
+        // Just verify it doesn't panic - output goes to stdout
+        formatter.print_raw(&result);
+    }
+
+    #[test]
+    fn test_raw_format_with_nulls() {
+        let mut formatter = ResultFormatter::new();
+        formatter.set_format(OutputFormat::Raw);
+        let result = QueryResult {
+            columns: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            rows: vec![
+                vec!["1".to_string(), "NULL".to_string(), "3".to_string()],
+                vec!["".to_string(), "test".to_string(), "NULL".to_string()],
+            ],
+            row_count: 2,
+            execution_time_ms: None,
+        };
+
+        // Just verify it doesn't panic - output goes to stdout
+        // NULL values should be converted to empty strings
+        formatter.print_raw(&result);
+    }
+
+    #[test]
+    fn test_raw_format_empty_result() {
+        let mut formatter = ResultFormatter::new();
+        formatter.set_format(OutputFormat::Raw);
+        let result =
+            QueryResult { columns: vec![], rows: vec![], row_count: 0, execution_time_ms: None };
+
+        // Should handle empty results gracefully
+        formatter.print_raw(&result);
     }
 }

--- a/crates/vibesql-cli/src/main.rs
+++ b/crates/vibesql-cli/src/main.rs
@@ -109,7 +109,7 @@ struct Args {
     verbose: bool,
 
     /// Output format for query results
-    #[arg(long, value_parser = ["table", "json", "csv", "markdown", "html"], value_name = "FORMAT")]
+    #[arg(long, value_parser = ["table", "json", "csv", "markdown", "html", "raw"], value_name = "FORMAT")]
     format: Option<String>,
 
     /// Set the display language (e.g., en-US, es, ja)
@@ -283,6 +283,7 @@ fn parse_format(format_str: &str) -> Option<OutputFormat> {
         "csv" => Some(OutputFormat::Csv),
         "markdown" => Some(OutputFormat::Markdown),
         "html" => Some(OutputFormat::Html),
+        "raw" => Some(OutputFormat::Raw),
         _ => None,
     }
 }

--- a/crates/vibesql-cli/src/repl.rs
+++ b/crates/vibesql-cli/src/repl.rs
@@ -159,6 +159,7 @@ impl Repl {
                     crate::formatter::OutputFormat::Csv => "csv",
                     crate::formatter::OutputFormat::Markdown => "markdown",
                     crate::formatter::OutputFormat::Html => "html",
+                    crate::formatter::OutputFormat::Raw => "raw",
                 };
                 println!("{}", vibe_msg!("format-changed", format = format_name));
             }


### PR DESCRIPTION
## Summary

- Add `--format raw` option to the CLI that outputs space-separated values with one row per line
- NULL values are represented as empty strings for SQLite TCL test compatibility  
- No headers, borders, or row counts in raw output mode

Closes #4219

## Changes

- `crates/vibesql-cli/src/formatter.rs`: Add `OutputFormat::Raw` variant and `print_raw()` method
- `crates/vibesql-cli/src/main.rs`: Add "raw" to CLI argument parser
- `crates/vibesql-cli/src/commands.rs`: Support `\f raw` and `.mode raw` REPL commands
- `crates/vibesql-cli/src/repl.rs`: Handle Raw format in format name display

## Usage

```bash
# Command line
vibesql --format raw -c "SELECT 1 AS a, 2 AS b, 3 AS c"
# Output: 1 2 3

# Multiple rows with NULL
vibesql --format raw -c "SELECT 1, NULL, 'hello' UNION ALL SELECT 4, 5, NULL"
# Output:
# 1  hello
# 4 5 

# REPL
\f raw
.mode raw
```

## Test plan

- [x] Unit tests for raw format added in `formatter.rs`
- [x] Command parsing tests for `\f raw` and `.mode raw`
- [x] Manual testing with various SELECT queries
- [x] All 114 vibesql-cli tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)