### PR TITLE
feat(web): Integrate TCL test results into website conformance report

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Demo](https://img.shields.io/badge/demo-live-success)](https://rjwalters.github.io/vibesql/)
 [![sqltest](https://img.shields.io/endpoint?url=https://rjwalters.github.io/vibesql/badges/sql1999-conformance.json)](https://rjwalters.github.io/vibesql/conformance.html)
 [![SQLLogicTest](https://img.shields.io/endpoint?url=https://rjwalters.github.io/vibesql/badges/sqllogictest.json)](https://rjwalters.github.io/vibesql/conformance.html#SQLlogicTest)
+[![TCL Tests](https://img.shields.io/endpoint?url=https://rjwalters.github.io/vibesql/badges/tcl-tests.json)](https://rjwalters.github.io/vibesql/conformance.html#tcl-tests)
 [![PostgreSQL](https://img.shields.io/endpoint?url=https://rjwalters.github.io/vibesql/badges/pgsql-regress.json)](https://rjwalters.github.io/vibesql/conformance.html#postgresql)
 [![i18n](https://img.shields.io/badge/i18n-19%20languages-blue)](docs/CONTRIBUTING_TRANSLATIONS.md)
 

--- a/scripts/export_tcl_results.py
+++ b/scripts/export_tcl_results.py
@@ -270,6 +270,34 @@ def export_tcl_results(output_dir: Optional[Path] = None, verbose: bool = False)
         print(f"  Pass rate: {export_data['summary']['pass_rate']}%")
         print(f"  Categories: {len(export_data['categories'])}")
 
+    # Write badge JSON for shields.io
+    badge_dir = get_repo_root() / "web-demo" / "public" / "badges"
+    badge_dir.mkdir(parents=True, exist_ok=True)
+
+    pass_rate = export_data['summary']['pass_rate']
+    if pass_rate >= 90:
+        color = "brightgreen"
+    elif pass_rate >= 70:
+        color = "green"
+    elif pass_rate >= 50:
+        color = "yellow"
+    else:
+        color = "red"
+
+    badge = {
+        "schemaVersion": 1,
+        "label": "TCL Tests",
+        "message": f"{pass_rate:.1f}%",
+        "color": color
+    }
+
+    badge_file = badge_dir / "tcl-tests.json"
+    with open(badge_file, 'w') as f:
+        json.dump(badge, f, indent=2)
+
+    if verbose:
+        print(f"Badge written to: {badge_file}")
+
     return export_data
 
 

--- a/scripts/export_website_data.py
+++ b/scripts/export_website_data.py
@@ -980,6 +980,17 @@ def main():
         print(f"  -> {path.name}")
         exported.append(path)
 
+        # Export TCL test results
+        try:
+            from export_tcl_results import export_tcl_results
+            tcl_result = export_tcl_results(verbose=args.verbose)
+            if tcl_result:
+                print(f"  TCL Tests: {tcl_result['summary']['pass_rate']}% ({tcl_result['summary']['passed']}/{tcl_result['summary']['total_tests']} tests)")
+                exported.append(base_dir / "conformance" / "tcl_results.json")
+                exported.append(base_dir / "badges" / "tcl-tests.json")
+        except Exception as e:
+            print(f"  TCL export skipped: {e}")
+
         # Generate pgsql-regress badge
         pgsql_data = load_pgsql_regress_data()
         if pgsql_data.get("summary"):

--- a/web-demo/src/components/ConformanceReport.ts
+++ b/web-demo/src/components/ConformanceReport.ts
@@ -11,6 +11,7 @@ import {
   renderExplanation,
   renderFailingTests,
   renderSQLLogicTestResults,
+  renderTCLTestResults,
   renderRunningTestsLocally,
 } from './conformance/section-renderers'
 import { initTimelineChart, updateChartTheme } from './conformance/timeline-chart'
@@ -32,6 +33,7 @@ export class ConformanceReportComponent extends Component<ConformanceReportState
       data: null,
       sltData: null,
       dashboardData: null,
+      tclData: null,
       loading: true,
       error: null,
     })
@@ -70,15 +72,17 @@ export class ConformanceReportComponent extends Component<ConformanceReportState
     try {
       // Try loading new dashboard format first
       const dashboardData = await this.dataProcessor.loadDashboardData()
+      // Always try to load TCL data (optional)
+      const tclData = await this.dataProcessor.loadTCLTestData()
 
       if (dashboardData) {
         // New format available - use it
-        this.setState({ dashboardData, loading: false })
+        this.setState({ dashboardData, tclData, loading: false })
       } else {
         // Fall back to legacy format
         const data = await this.dataProcessor.loadSqltestData()
         const sltData = await this.dataProcessor.loadSQLLogicTestData()
-        this.setState({ data, sltData, loading: false })
+        this.setState({ data, sltData, tclData, loading: false })
       }
     } catch (error) {
       this.setState({
@@ -132,6 +136,7 @@ export class ConformanceReportComponent extends Component<ConformanceReportState
 
   private renderDashboardFormat(dashboardData: DashboardData): void {
     const conformance = dashboardData.conformance!
+    const { tclData } = this.state
     const hasHistory = conformance.history && conformance.history.length > 0
     const hasCategories = conformance.categories && Object.keys(conformance.categories).length > 0
     const hasMilestones = dashboardData.milestones && dashboardData.milestones.length > 0
@@ -140,6 +145,7 @@ export class ConformanceReportComponent extends Component<ConformanceReportState
       <div class="space-y-8">
         ${renderConformanceOverview(conformance)}
         ${hasCategories ? renderCategoryBreakdown(conformance.categories) : ''}
+        ${tclData ? renderTCLTestResults(tclData) : ''}
         ${hasHistory ? renderConformanceTimeline() : ''}
         ${hasMilestones ? renderMilestones(dashboardData.milestones!) : ''}
         ${renderRunningTestsLocally()}
@@ -157,7 +163,7 @@ export class ConformanceReportComponent extends Component<ConformanceReportState
   }
 
   private renderLegacyFormat(): void {
-    const { data, sltData } = this.state
+    const { data, sltData, tclData } = this.state
 
     if (!data) return
 
@@ -169,6 +175,7 @@ export class ConformanceReportComponent extends Component<ConformanceReportState
         ${renderMetadataCard(commit, timestamp, data.pass_rate || 0)}
         ${renderSqltestResults(data)}
         ${sltData ? renderSQLLogicTestResults(sltData) : ''}
+        ${tclData ? renderTCLTestResults(tclData) : ''}
         ${renderExplanation(data, sltData)}
         ${data.error_tests && data.error_tests.length > 0 ? renderFailingTests(data.error_tests) : ''}
         ${renderRunningTestsLocally()}

--- a/web-demo/src/components/conformance/data-processor.ts
+++ b/web-demo/src/components/conformance/data-processor.ts
@@ -1,4 +1,4 @@
-import type { ConformanceData, SQLLogicTestData, DashboardData } from './types'
+import type { ConformanceData, SQLLogicTestData, DashboardData, TCLTestData } from './types'
 
 /**
  * Handles loading and processing of conformance test data
@@ -140,6 +140,29 @@ export class DataProcessor {
     } catch (error) {
       // SQLLogicTest data is optional, continue without it
       console.warn('SQLLogicTest results not available:', error)
+    }
+    return null
+  }
+
+  /**
+   * Load TCL test suite results from conformance directory
+   */
+  async loadTCLTestData(): Promise<TCLTestData | null> {
+    try {
+      const url = `${this.baseUrl}conformance/tcl_results.json?v=${this.cacheBust}`
+      const response = await fetch(url)
+      const contentType = response.headers.get('content-type')
+
+      if (response.ok && contentType && contentType.includes('application/json')) {
+        const data = await response.json()
+        // Validate structure
+        if (data.summary && data.categories) {
+          return data as TCLTestData
+        }
+      }
+    } catch (error) {
+      // TCL data is optional, continue without it
+      console.warn('TCL test results not available:', error)
     }
     return null
   }

--- a/web-demo/src/components/conformance/section-renderers.ts
+++ b/web-demo/src/components/conformance/section-renderers.ts
@@ -4,6 +4,7 @@ import type {
   ErrorTest,
   DashboardConformance,
   DashboardMilestone,
+  TCLTestData,
 } from './types'
 import { getStatusColor, getStatusText, escapeHtml } from './render-utils'
 import { t } from '../../i18n'
@@ -559,11 +560,160 @@ export function renderRunningTestsLocally(): string {
           <div>cargo test --test sqltest_conformance -- --nocapture</div>
           <div class="mt-4 text-green-600 dark:text-green-400">${t('conformance-run-sqllogictest')}</div>
           <div>cargo test --test sqllogictest_suite -- --nocapture</div>
+          <div class="mt-4 text-green-600 dark:text-green-400"># Run SQLite TCL test suite</div>
+          <div>make test-tcl</div>
           <div class="mt-4 text-green-600 dark:text-green-400">${t('conformance-generate-coverage')}</div>
           <div>cargo coverage</div>
           <div class="mt-2 text-green-600 dark:text-green-400">${t('conformance-open-coverage')}</div>
           <div>open target/llvm-cov/html/index.html</div>
         </div>
+      </div>
+    </div>
+  `
+}
+
+/**
+ * Render TCL Test Suite results section
+ */
+export function renderTCLTestResults(tclData: TCLTestData): string {
+  const passRate = (tclData.summary.pass_rate || 0).toFixed(1)
+  const { summary, categories, failure_patterns } = tclData
+
+  // Build category rows sorted by total tests descending
+  const categoryRows = Object.entries(categories)
+    .sort((a, b) => b[1].total - a[1].total)
+    .slice(0, 10) // Show top 10 categories
+    .map(([name, cat]) => {
+      const catPassRate = cat.pass_rate.toFixed(1)
+      const isComplete = cat.pass_rate === 100
+
+      return `
+        <tr class="border-b border-gray-200 dark:border-gray-700 last:border-0">
+          <td class="py-2 px-3 font-medium text-gray-900 dark:text-white font-mono text-sm">${escapeHtml(name)}</td>
+          <td class="py-2 px-3">
+            <span class="font-semibold ${isComplete ? 'text-green-600 dark:text-green-400' : 'text-gray-900 dark:text-white'}">
+              ${catPassRate}%
+            </span>
+          </td>
+          <td class="py-2 px-3 w-1/4">
+            <div class="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+              <div
+                class="h-full ${isComplete ? 'bg-green-500' : 'bg-orange-500'} rounded-full"
+                style="width: ${cat.pass_rate}%"
+              ></div>
+            </div>
+          </td>
+          <td class="py-2 px-3 text-right text-gray-600 dark:text-gray-400 text-sm">
+            ${formatNumber(cat.passed)} / ${formatNumber(cat.total)}
+          </td>
+        </tr>
+      `
+    })
+    .join('')
+
+  // Build failure pattern list
+  const failurePatternsList = failure_patterns
+    .slice(0, 5)
+    .map(
+      fp => `
+      <li class="flex justify-between items-start py-2 border-b border-gray-200 dark:border-gray-700 last:border-0">
+        <span class="text-sm text-gray-700 dark:text-gray-300 font-mono truncate max-w-xs" title="${escapeHtml(fp.error)}">${escapeHtml(fp.error.substring(0, 50))}${fp.error.length > 50 ? '...' : ''}</span>
+        <span class="text-sm font-semibold text-red-600 dark:text-red-400 ml-2">${fp.count}</span>
+      </li>
+    `
+    )
+    .join('')
+
+  return `
+    <div id="tcl-tests" class="bg-white dark:bg-gray-800 rounded-lg shadow-md border border-gray-200 dark:border-gray-700 p-8">
+      <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-6">SQLite TCL Test Suite</h2>
+
+      <p class="text-gray-700 dark:text-gray-300 mb-6">
+        Results from SQLite's canonical
+        <a href="https://www.sqlite.org/testing.html" target="_blank" class="text-blue-600 dark:text-blue-400 hover:underline">TCL test suite</a>
+        containing 1,174 test files. This suite is the gold standard for SQLite compatibility testing.
+      </p>
+
+      <!-- Overall Results -->
+      <div class="bg-gradient-to-br from-orange-500 to-orange-700 rounded-lg shadow-lg p-6 text-white mb-6">
+        <div class="text-sm font-semibold uppercase tracking-wider opacity-90 mb-2">Overall Pass Rate</div>
+        <div class="text-4xl font-bold mb-2">${passRate}%</div>
+        <div class="text-sm opacity-75">${formatNumber(summary.passed)} of ${formatNumber(summary.total_tests)} tests passing</div>
+        <div class="mt-4 bg-white/20 rounded-full h-2 overflow-hidden">
+          <div
+            class="bg-white h-full rounded-full transition-all duration-500"
+            style="width: ${passRate}%"
+          ></div>
+        </div>
+      </div>
+
+      <!-- Summary Cards -->
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+          <div class="text-xs font-semibold uppercase tracking-wider text-gray-600 dark:text-gray-400 mb-2">Passed</div>
+          <div class="text-2xl font-bold text-green-600 dark:text-green-400">${formatNumber(summary.passed)}</div>
+        </div>
+        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+          <div class="text-xs font-semibold uppercase tracking-wider text-gray-600 dark:text-gray-400 mb-2">Failed</div>
+          <div class="text-2xl font-bold text-red-600 dark:text-red-400">${formatNumber(summary.failed)}</div>
+        </div>
+        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+          <div class="text-xs font-semibold uppercase tracking-wider text-gray-600 dark:text-gray-400 mb-2">Skipped</div>
+          <div class="text-2xl font-bold text-gray-600 dark:text-gray-400">${formatNumber(summary.skipped)}</div>
+        </div>
+        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+          <div class="text-xs font-semibold uppercase tracking-wider text-gray-600 dark:text-gray-400 mb-2">Total</div>
+          <div class="text-2xl font-bold text-gray-900 dark:text-white">${formatNumber(summary.total_tests)}</div>
+        </div>
+      </div>
+
+      <!-- Two Column Layout: Categories and Failure Patterns -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <!-- Category Breakdown -->
+        <div>
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Test Categories</h3>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-gray-200 dark:border-gray-700 text-left text-xs text-gray-600 dark:text-gray-400">
+                  <th class="py-2 px-3 font-medium">Category</th>
+                  <th class="py-2 px-3 font-medium">Rate</th>
+                  <th class="py-2 px-3 font-medium">Progress</th>
+                  <th class="py-2 px-3 font-medium text-right">Tests</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${categoryRows}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Failure Patterns -->
+        ${
+          failure_patterns.length > 0
+            ? `
+        <div>
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Common Failures</h3>
+          <ul class="space-y-1">
+            ${failurePatternsList}
+          </ul>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-3">
+            Top ${Math.min(5, failure_patterns.length)} failure patterns by occurrence count
+          </p>
+        </div>
+        `
+            : ''
+        }
+      </div>
+
+      <!-- Info Box -->
+      <div class="mt-6 bg-orange-50 dark:bg-orange-900/20 rounded-lg border border-orange-200 dark:border-orange-800 p-4">
+        <p class="text-sm text-gray-700 dark:text-gray-300">
+          <strong>About TCL Tests:</strong> SQLite's TCL test suite is the canonical conformance test for SQLite compatibility.
+          It tests specific SQLite behaviors, quirks, and edge cases that may not be covered by standard SQL test suites.
+          High pass rates here indicate strong SQLite compatibility for application migration scenarios.
+        </p>
       </div>
     </div>
   `

--- a/web-demo/src/components/conformance/types.ts
+++ b/web-demo/src/components/conformance/types.ts
@@ -79,10 +79,74 @@ export interface DashboardData {
   milestones?: DashboardMilestone[]
 }
 
+// TCL Test Suite types
+
+export interface TCLTestCategory {
+  total: number
+  passed: number
+  failed: number
+  skipped: number
+  pass_rate: number
+}
+
+export interface TCLTestFile {
+  file: string
+  path: string
+  total: number
+  passed: number
+  failed: number
+  skipped: number
+}
+
+export interface TCLFailurePattern {
+  error: string
+  count: number
+}
+
+export interface TCLHistoryEntry {
+  run_id: number
+  date: string
+  commit: string
+  total: number
+  passed: number
+  failed: number
+  skipped: number
+  pass_rate: number
+}
+
+export interface TCLTestData {
+  version: string
+  generated_at: string
+  latest_run: {
+    run_id: number
+    started_at: string
+    completed_at: string
+    git_commit: string
+    total_files: number
+    total_tests: number
+    passed: number
+    failed: number
+    skipped: number
+    parse_errors: number
+  }
+  summary: {
+    total_tests: number
+    passed: number
+    failed: number
+    skipped: number
+    pass_rate: number
+  }
+  categories: Record<string, TCLTestCategory>
+  by_file: TCLTestFile[]
+  failure_patterns: TCLFailurePattern[]
+  history: TCLHistoryEntry[]
+}
+
 export interface ConformanceReportState {
   data: ConformanceData | null
   sltData: SQLLogicTestData | null
   dashboardData: DashboardData | null
+  tclData: TCLTestData | null
   loading: boolean
   error: string | null
 }


### PR DESCRIPTION
## Summary

- Adds TCL test results display to the website conformance page
- Generates shields.io-compatible badge for README
- Integrates with existing `make website` export workflow

## Changes

### Python Export Scripts

- **`scripts/export_tcl_results.py`**: Added badge generation (writes `web-demo/public/badges/tcl-tests.json`)
- **`scripts/export_website_data.py`**: Integrated TCL export call with graceful fallback

### TypeScript/Website

- **`types.ts`**: Added `TCLTestData`, `TCLTestCategory`, `TCLTestFile`, `TCLFailurePattern`, `TCLHistoryEntry` types
- **`section-renderers.ts`**: Added `renderTCLTestResults()` with:
  - Overall pass rate hero card (orange gradient)
  - Summary cards (passed/failed/skipped/total)
  - Category breakdown table (top 10 categories)
  - Common failure patterns list
- **`data-processor.ts`**: Added `loadTCLTestData()` method
- **`ConformanceReport.ts`**: Integrated TCL section into both dashboard and legacy render paths

### Documentation

- **`README.md`**: Added TCL Tests badge alongside other conformance badges

## Test Plan

- [x] TypeScript compiles without conformance-related errors
- [x] Python export script is importable
- [ ] Run `make test-tcl` to generate TCL results database
- [ ] Run `make website` to verify TCL export is called
- [ ] Verify badge JSON file is generated correctly
- [ ] Test website displays TCL section (requires TCL results)
- [ ] Verify graceful fallback when no TCL data exists

## Screenshots

N/A - Requires running TCL tests to generate data for display

Closes #4225

🤖 Generated with [Claude Code](https://claude.com/claude-code)