### PR TITLE
feat(parser): Allow derived tables without explicit aliases (SQLite compat)

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -1,5 +1,7 @@
 //! Arena-allocated SELECT statement parsing.
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use bumpalo::collections::Vec as BumpVec;
 use vibesql_ast::arena::{
     CommonTableExpr, Expression, FromClause, GroupByClause, GroupingElement, GroupingSet, JoinType,
@@ -10,6 +12,10 @@ use super::ArenaParser;
 use crate::keywords::Keyword;
 use crate::token::Token;
 use crate::ParseError;
+
+/// Counter for generating unique derived table aliases when none is provided.
+/// SQLite allows derived tables without aliases, unlike SQL:1999 which requires them.
+static ARENA_DERIVED_TABLE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 impl<'arena> ArenaParser<'arena> {
     /// Parse a SELECT statement.
@@ -345,14 +351,19 @@ impl<'arena> ArenaParser<'arena> {
             let query = self.parse_select_statement()?;
             self.expect_token(Token::RParen)?;
 
-            // Subquery requires alias
+            // Parse optional alias - SQLite allows derived tables without aliases
             self.try_consume_keyword(Keyword::As);
             let alias = if let Token::Identifier(name) = self.peek() {
                 let name = name.clone();
                 self.advance();
                 self.intern(&name)
             } else {
-                return Err(ParseError { message: "Subquery requires alias".to_string() });
+                // Auto-generate unique alias for SQLite compatibility
+                let generated = format!(
+                    "__derived_{}",
+                    ARENA_DERIVED_TABLE_COUNTER.fetch_add(1, Ordering::Relaxed)
+                );
+                self.intern(&generated)
             };
 
             // Parse optional column aliases: (col1, col2, ...)

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -1,4 +1,9 @@
 use super::*;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Counter for generating unique derived table aliases when none is provided.
+/// SQLite allows derived tables without aliases, unlike SQL:1999 which requires them.
+static DERIVED_TABLE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 impl Parser {
     /// Parse FROM clause
@@ -78,7 +83,8 @@ impl Parser {
                         self.consume_keyword(Keyword::As)?;
                     }
 
-                    // Parse alias (required for derived tables) - keywords allowed as aliases
+                    // Parse alias - keywords allowed as aliases
+                    // SQLite allows derived tables without aliases; auto-generate if not provided
                     let alias = match self.peek() {
                         Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
                             let alias = id.clone();
@@ -92,9 +98,11 @@ impl Parser {
                             alias
                         }
                         _ => {
-                            return Err(ParseError {
-                                message: "Derived table must have an alias".to_string(),
-                            })
+                            // Auto-generate unique alias for SQLite compatibility
+                            format!(
+                                "__derived_{}",
+                                DERIVED_TABLE_COUNTER.fetch_add(1, Ordering::Relaxed)
+                            )
                         }
                     };
 

--- a/crates/vibesql-parser/src/tests/subquery.rs
+++ b/crates/vibesql-parser/src/tests/subquery.rs
@@ -218,3 +218,168 @@ fn test_parse_scalar_subquery_in_select() {
         _ => panic!("Expected SELECT statement"),
     }
 }
+
+// ============================================================================
+// Derived Table (Subquery in FROM) Tests - SQLite Compatibility
+// Issue #4229: Allow derived tables without explicit aliases
+// ============================================================================
+
+#[test]
+fn test_parse_derived_table_without_alias() {
+    // SQLite allows derived tables without explicit aliases
+    let sql = "SELECT * FROM (SELECT 1)";
+    let stmt = Parser::parse_sql(sql).unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            // FROM clause should be a Subquery with auto-generated alias
+            match &select.from {
+                Some(vibesql_ast::FromClause::Subquery { alias, .. }) => {
+                    // Alias should start with __derived_
+                    assert!(
+                        alias.starts_with("__derived_"),
+                        "Expected auto-generated alias starting with __derived_, got: {}",
+                        alias
+                    );
+                }
+                _ => panic!("Expected Subquery in FROM clause"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_parse_derived_table_with_explicit_alias() {
+    // Explicit aliases should still work
+    let sql = "SELECT * FROM (SELECT 1) AS subq";
+    let stmt = Parser::parse_sql(sql).unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            match &select.from {
+                Some(vibesql_ast::FromClause::Subquery { alias, .. }) => {
+                    assert_eq!(alias, "SUBQ");
+                }
+                _ => panic!("Expected Subquery in FROM clause"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_parse_derived_table_comma_join_without_alias() {
+    // From select1-17.1: SELECT * FROM t1,(SELECT * FROM t2 WHERE y=2 ORDER BY y,z);
+    let sql = "SELECT * FROM t1, (SELECT * FROM t2 WHERE y=2 ORDER BY y, z)";
+    let stmt = Parser::parse_sql(sql).unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            // Should have a join in FROM clause
+            match &select.from {
+                Some(vibesql_ast::FromClause::Join { right, .. }) => {
+                    // Right side should be the derived table
+                    match right.as_ref() {
+                        vibesql_ast::FromClause::Subquery { alias, .. } => {
+                            assert!(
+                                alias.starts_with("__derived_"),
+                                "Expected auto-generated alias, got: {}",
+                                alias
+                            );
+                        }
+                        _ => panic!("Expected Subquery on right side of join"),
+                    }
+                }
+                _ => panic!("Expected Join in FROM clause"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_parse_multiple_derived_tables_without_aliases() {
+    // Multiple derived tables should get unique auto-generated aliases
+    let sql = "SELECT * FROM (SELECT 1), (SELECT 2)";
+    let stmt = Parser::parse_sql(sql).unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            match &select.from {
+                Some(vibesql_ast::FromClause::Join { left, right, .. }) => {
+                    // Both should have auto-generated aliases
+                    let left_alias = match left.as_ref() {
+                        vibesql_ast::FromClause::Subquery { alias, .. } => alias.clone(),
+                        _ => panic!("Expected Subquery on left side"),
+                    };
+                    let right_alias = match right.as_ref() {
+                        vibesql_ast::FromClause::Subquery { alias, .. } => alias.clone(),
+                        _ => panic!("Expected Subquery on right side"),
+                    };
+
+                    // Both should start with __derived_ and be unique
+                    assert!(left_alias.starts_with("__derived_"));
+                    assert!(right_alias.starts_with("__derived_"));
+                    assert_ne!(left_alias, right_alias, "Aliases should be unique");
+                }
+                _ => panic!("Expected Join in FROM clause"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_parse_nested_derived_tables_without_aliases() {
+    // Nested derived tables: SELECT * FROM (SELECT * FROM (SELECT 1))
+    let sql = "SELECT * FROM (SELECT * FROM (SELECT 1))";
+    let stmt = Parser::parse_sql(sql).unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            match &select.from {
+                Some(vibesql_ast::FromClause::Subquery { query, alias, .. }) => {
+                    // Outer subquery should have auto-generated alias
+                    assert!(alias.starts_with("__derived_"));
+
+                    // Inner subquery should also have auto-generated alias
+                    match &query.from {
+                        Some(vibesql_ast::FromClause::Subquery { alias: inner_alias, .. }) => {
+                            assert!(inner_alias.starts_with("__derived_"));
+                        }
+                        _ => panic!("Expected nested Subquery"),
+                    }
+                }
+                _ => panic!("Expected Subquery in FROM clause"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_parse_derived_table_with_limit_without_alias() {
+    // From select1-17.2: SELECT * FROM t1,(SELECT * FROM t2 ORDER BY y LIMIT 4);
+    let sql = "SELECT * FROM t1, (SELECT * FROM t2 ORDER BY y LIMIT 4)";
+    let stmt = Parser::parse_sql(sql).unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            match &select.from {
+                Some(vibesql_ast::FromClause::Join { right, .. }) => {
+                    match right.as_ref() {
+                        vibesql_ast::FromClause::Subquery { query, alias, .. } => {
+                            assert!(alias.starts_with("__derived_"));
+                            // Verify LIMIT is parsed
+                            assert!(query.limit.is_some());
+                        }
+                        _ => panic!("Expected Subquery on right side"),
+                    }
+                }
+                _ => panic!("Expected Join in FROM clause"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}


### PR DESCRIPTION
## Summary

- Added SQLite compatibility for derived tables (subqueries in FROM clause) without explicit aliases
- Parser now auto-generates unique internal aliases (`__derived_N`) when none is provided
- Implemented in both standard parser and arena parser for consistency

## Test plan

- [x] Parser unit tests pass (all 1030 tests)
- [x] Added 6 new tests covering:
  - Single derived table without alias
  - Explicit alias still works correctly  
  - Comma-joined derived tables
  - Multiple derived tables with unique aliases
  - Nested derived tables
  - Derived tables with LIMIT clause
- [x] Manual testing of patterns from issue:
  - `SELECT * FROM (SELECT 1);` ✓
  - `SELECT * FROM t1, (SELECT * FROM t2 WHERE y=2 ORDER BY y, z);` ✓
  - `SELECT * FROM (SELECT 1), (SELECT 2);` ✓
  - `SELECT * FROM (SELECT * FROM (SELECT 1));` ✓
  - `SELECT * FROM t1, (SELECT * FROM t2 ORDER BY y LIMIT 4);` ✓

Closes #4229

🤖 Generated with [Claude Code](https://claude.com/claude-code)