### PR TITLE
feat(parser): Support SQLite-style typeless column definitions

### DIFF
--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -1,6 +1,7 @@
 //! CREATE TABLE parsing
 
 use super::super::*;
+use vibesql_types::DataType;
 
 impl Parser {
     /// Parse CREATE TABLE statement
@@ -62,8 +63,14 @@ impl Parser {
                 _ => return Err(ParseError { message: "Expected column name".to_string() }),
             };
 
-            // Parse data type
-            let data_type = self.parse_data_type()?;
+            // Parse data type (optional for SQLite compatibility)
+            // SQLite allows typeless columns with BLOB affinity
+            let data_type = if self.is_column_constraint_or_separator() {
+                // No data type specified - use BLOB affinity (SQLite default)
+                DataType::BinaryLargeObject
+            } else {
+                self.parse_data_type()?
+            };
 
             // Parse optional DEFAULT clause (before COMMENT, per MySQL standard)
             let default_value = if self.peek_keyword(Keyword::Default) {
@@ -145,5 +152,38 @@ impl Parser {
             table_constraints,
             table_options,
         })
+    }
+
+    /// Check if the current token indicates a column constraint or column separator
+    /// rather than a data type. This enables SQLite-style typeless column definitions.
+    ///
+    /// Returns true if the next token is:
+    /// - A column separator: `,` or `)`
+    /// - A column constraint keyword: `NULL`, `NOT`, `PRIMARY`, `UNIQUE`, `CHECK`,
+    ///   `REFERENCES`, `AUTO_INCREMENT`, `AUTOINCREMENT`, `KEY`, `CONSTRAINT`
+    /// - A column modifier: `DEFAULT`, `COMMENT`
+    fn is_column_constraint_or_separator(&self) -> bool {
+        match self.peek() {
+            // Column separators
+            Token::Comma | Token::RParen => true,
+
+            // Column constraint keywords
+            Token::Keyword(Keyword::Null) => true,
+            Token::Keyword(Keyword::Not) => true,
+            Token::Keyword(Keyword::Primary) => true,
+            Token::Keyword(Keyword::Unique) => true,
+            Token::Keyword(Keyword::Check) => true,
+            Token::Keyword(Keyword::References) => true,
+            Token::Keyword(Keyword::AutoIncrement) => true,
+            Token::Keyword(Keyword::Key) => true,
+            Token::Keyword(Keyword::Constraint) => true,
+
+            // Column modifiers (appear after data type normally)
+            Token::Keyword(Keyword::Default) => true,
+            Token::Keyword(Keyword::Comment) => true,
+
+            // Not a constraint/separator - likely a data type
+            _ => false,
+        }
     }
 }

--- a/crates/vibesql-parser/src/tests/create_table/mod.rs
+++ b/crates/vibesql-parser/src/tests/create_table/mod.rs
@@ -11,3 +11,4 @@ mod storage_format;
 mod string_types;
 mod temporal_types;
 mod text_types;
+mod typeless_columns;

--- a/crates/vibesql-parser/src/tests/create_table/typeless_columns.rs
+++ b/crates/vibesql-parser/src/tests/create_table/typeless_columns.rs
@@ -1,0 +1,266 @@
+//! Tests for SQLite-style typeless column definitions
+//!
+//! SQLite allows column definitions without explicit data types. When no type
+//! is specified, the column has BLOB affinity (any value can be stored).
+
+use super::super::*;
+
+// ========================================================================
+// SQLite-style Typeless Column Tests
+// ========================================================================
+
+#[test]
+fn test_parse_create_table_single_typeless_column() {
+    // CREATE TABLE t1(x); - simplest case
+    let result = Parser::parse_sql("CREATE TABLE t1(x);");
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "T1");
+            assert_eq!(create.columns.len(), 1);
+            assert_eq!(create.columns[0].name, "X");
+            // Typeless columns default to BLOB affinity
+            assert_eq!(
+                create.columns[0].data_type,
+                vibesql_types::DataType::BinaryLargeObject
+            );
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_multiple_typeless_columns() {
+    // CREATE TABLE t1(a, b, c); - multiple typeless columns
+    let result = Parser::parse_sql("CREATE TABLE t1(a, b, c);");
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "T1");
+            assert_eq!(create.columns.len(), 3);
+            assert_eq!(create.columns[0].name, "A");
+            assert_eq!(create.columns[1].name, "B");
+            assert_eq!(create.columns[2].name, "C");
+            // All columns default to BLOB affinity
+            for col in &create.columns {
+                assert_eq!(col.data_type, vibesql_types::DataType::BinaryLargeObject);
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_typeless_with_primary_key() {
+    // CREATE TABLE t1(x PRIMARY KEY); - typeless with constraint
+    let result = Parser::parse_sql("CREATE TABLE t1(x PRIMARY KEY);");
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "T1");
+            assert_eq!(create.columns.len(), 1);
+            assert_eq!(create.columns[0].name, "X");
+            assert_eq!(
+                create.columns[0].data_type,
+                vibesql_types::DataType::BinaryLargeObject
+            );
+            // Should have PRIMARY KEY constraint
+            assert!(create.columns[0]
+                .constraints
+                .iter()
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::PrimaryKey)));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_typeless_with_not_null() {
+    // CREATE TABLE t1(x NOT NULL); - typeless with NOT NULL constraint
+    let result = Parser::parse_sql("CREATE TABLE t1(x NOT NULL);");
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].data_type, vibesql_types::DataType::BinaryLargeObject);
+            assert!(!create.columns[0].nullable); // NOT NULL means not nullable
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_typeless_with_unique() {
+    // CREATE TABLE t1(x UNIQUE); - typeless with UNIQUE constraint
+    let result = Parser::parse_sql("CREATE TABLE t1(x UNIQUE);");
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].data_type, vibesql_types::DataType::BinaryLargeObject);
+            assert!(create.columns[0]
+                .constraints
+                .iter()
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Unique)));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_typeless_with_default() {
+    // CREATE TABLE t1(x DEFAULT 0); - typeless with DEFAULT
+    let result = Parser::parse_sql("CREATE TABLE t1(x DEFAULT 0);");
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].data_type, vibesql_types::DataType::BinaryLargeObject);
+            assert!(create.columns[0].default_value.is_some());
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_mixed_typed_and_typeless() {
+    // CREATE TABLE t1(a INTEGER, b, c TEXT); - mixed typed and typeless
+    let result = Parser::parse_sql("CREATE TABLE t1(a INTEGER, b, c TEXT);");
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 3);
+            // First column has INTEGER type
+            assert_eq!(create.columns[0].name, "A");
+            assert_eq!(create.columns[0].data_type, vibesql_types::DataType::Integer);
+            // Second column is typeless -> BLOB
+            assert_eq!(create.columns[1].name, "B");
+            assert_eq!(create.columns[1].data_type, vibesql_types::DataType::BinaryLargeObject);
+            // Third column has TEXT type (maps to VARCHAR)
+            assert_eq!(create.columns[2].name, "C");
+            assert_eq!(
+                create.columns[2].data_type,
+                vibesql_types::DataType::Varchar { max_length: None }
+            );
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_typeless_with_multiple_constraints() {
+    // CREATE TABLE t1(x PRIMARY KEY NOT NULL UNIQUE);
+    let result = Parser::parse_sql("CREATE TABLE t1(x PRIMARY KEY NOT NULL UNIQUE);");
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].data_type, vibesql_types::DataType::BinaryLargeObject);
+            assert!(!create.columns[0].nullable);
+            let constraints = &create.columns[0].constraints;
+            assert!(constraints
+                .iter()
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::PrimaryKey)));
+            assert!(constraints.iter().any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::NotNull)));
+            assert!(constraints.iter().any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Unique)));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_typeless_with_check_constraint() {
+    // CREATE TABLE t1(x CHECK(x > 0));
+    let result = Parser::parse_sql("CREATE TABLE t1(x CHECK(x > 0));");
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].data_type, vibesql_types::DataType::BinaryLargeObject);
+            assert!(create.columns[0]
+                .constraints
+                .iter()
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Check(_))));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_typeless_with_references() {
+    // CREATE TABLE t1(x REFERENCES other(id));
+    let result = Parser::parse_sql("CREATE TABLE t1(x REFERENCES other(id));");
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].data_type, vibesql_types::DataType::BinaryLargeObject);
+            assert!(create.columns[0].constraints.iter().any(|c| matches!(
+                &c.kind,
+                vibesql_ast::ColumnConstraintKind::References { table, column, .. }
+                    if table == "OTHER" && column == "ID"
+            )));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_complex_sqlite_pattern() {
+    // Real-world SQLite pattern from test suite
+    let result = Parser::parse_sql(
+        "CREATE TABLE t1(w, x, y, z, PRIMARY KEY(w, x));",
+    );
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 4);
+            // All columns are typeless
+            for col in &create.columns {
+                assert_eq!(col.data_type, vibesql_types::DataType::BinaryLargeObject);
+            }
+            // Should have table-level PRIMARY KEY constraint
+            assert!(!create.table_constraints.is_empty());
+            assert!(create.table_constraints.iter().any(|c| matches!(
+                &c.kind,
+                vibesql_ast::TableConstraintKind::PrimaryKey { columns } if columns.len() == 2
+            )));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_create_table_typeless_with_autoincrement() {
+    // CREATE TABLE t1(x AUTOINCREMENT);
+    let result = Parser::parse_sql("CREATE TABLE t1(x AUTOINCREMENT);");
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].data_type, vibesql_types::DataType::BinaryLargeObject);
+            assert!(create.columns[0]
+                .constraints
+                .iter()
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::AutoIncrement)));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}


### PR DESCRIPTION
## Summary

- Add support for SQLite-style typeless column definitions in CREATE TABLE
- Columns without explicit types default to BLOB affinity
- 12 new parser tests covering various typeless column scenarios

## Changes

**Parser** (`crates/vibesql-parser/src/parser/create/table.rs`):
- Made data type parsing optional after column name
- Added `is_column_constraint_or_separator()` helper to detect when no type is present
- Defaults to `DataType::BinaryLargeObject` (BLOB) when type is omitted

**Tests** (`crates/vibesql-parser/src/tests/create_table/typeless_columns.rs`):
- Added 12 test cases covering:
  - Single typeless column
  - Multiple typeless columns
  - Typeless with various constraints (PRIMARY KEY, NOT NULL, UNIQUE, CHECK, REFERENCES, DEFAULT, AUTOINCREMENT)
  - Mixed typed/typeless columns
  - Complex SQLite patterns with table-level constraints

## SQL Examples Now Supported

```sql
CREATE TABLE t1(x);                    -- BLOB affinity
CREATE TABLE t1(x PRIMARY KEY);        -- BLOB with constraint
CREATE TABLE t1(a, b, c);              -- Multiple typeless
CREATE TABLE t1(a INTEGER, b, c TEXT); -- Mixed typed/typeless
CREATE TABLE t1(w, x, y, z, PRIMARY KEY(w, x)); -- Real SQLite pattern
```

## Test plan

- [x] All 12 new typeless column tests pass
- [x] All 1036 existing parser tests pass
- [x] End-to-end CREATE TABLE + .schema verification works
- [x] Mixed typed/typeless columns work correctly

## Impact

This is the **#1 blocker** for TCL test suite pass rate:
- 6+ tests in `select1.test` blocked
- Estimated 30-50% of Priority 1 TCL tests use typeless columns

Closes #4228

🤖 Generated with [Claude Code](https://claude.com/claude-code)