### PR TITLE
fix(triggers): Fix trigger body parsing and INSTEAD OF triggers on views

### DIFF
--- a/crates/vibesql-executor/src/trigger_ddl.rs
+++ b/crates/vibesql-executor/src/trigger_ddl.rs
@@ -2,7 +2,9 @@
 //!
 //! Handles CREATE TRIGGER, ALTER TRIGGER, and DROP TRIGGER statements
 
-use vibesql_ast::{AlterTriggerAction, AlterTriggerStmt, CreateTriggerStmt, DropTriggerStmt};
+use vibesql_ast::{
+    AlterTriggerAction, AlterTriggerStmt, CreateTriggerStmt, DropTriggerStmt, TriggerTiming,
+};
 use vibesql_catalog::TriggerDefinition;
 use vibesql_storage::Database;
 
@@ -17,9 +19,21 @@ impl TriggerExecutor {
         db: &mut Database,
         stmt: &CreateTriggerStmt,
     ) -> Result<String, ExecutorError> {
-        // Verify the target table exists
-        if !db.catalog.table_exists(&stmt.table_name) {
-            return Err(ExecutorError::TableNotFound(stmt.table_name.clone()));
+        // INSTEAD OF triggers can only be created on views
+        // BEFORE and AFTER triggers can only be created on tables
+        if stmt.timing == TriggerTiming::InsteadOf {
+            // Verify the target view exists
+            if db.catalog.get_view(&stmt.table_name).is_none() {
+                return Err(ExecutorError::Other(format!(
+                    "INSTEAD OF trigger requires a view, but '{}' is not a view",
+                    stmt.table_name
+                )));
+            }
+        } else {
+            // Verify the target table exists
+            if !db.catalog.table_exists(&stmt.table_name) {
+                return Err(ExecutorError::TableNotFound(stmt.table_name.clone()));
+            }
         }
 
         // Create trigger definition from statement

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -157,14 +157,9 @@ impl Parser {
                         message: "Unexpected end of input in trigger action".to_string(),
                     });
                 }
-                Token::Semicolon => {
-                    // Semicolon inside trigger body, not end of statement
-                    sql_parts.push(";".to_string());
-                    self.advance();
-                }
                 token => {
-                    // Collect other tokens
-                    sql_parts.push(format!("{:?}", token));
+                    // Convert token back to valid SQL using to_sql()
+                    sql_parts.push(token.to_sql());
                     self.advance();
                 }
             }

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -198,3 +198,65 @@ fn test_create_trigger_missing_action() {
     let result = Parser::parse_sql(sql);
     assert!(result.is_err(), "Should fail without triggered action");
 }
+
+#[test]
+fn test_create_trigger_body_preserved_as_valid_sql() {
+    use vibesql_ast::TriggerAction;
+
+    let sql = "CREATE TRIGGER my_trigger AFTER INSERT ON my_table FOR EACH ROW BEGIN SELECT 1; END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let stmt = result.unwrap();
+    match stmt {
+        Statement::CreateTrigger(trigger) => {
+            match &trigger.triggered_action {
+                TriggerAction::RawSql(body) => {
+                    // Verify the body contains valid SQL that can be re-parsed
+                    assert!(body.contains("SELECT"), "Body should contain SELECT keyword");
+                    assert!(body.contains("1"), "Body should contain the number 1");
+                    assert!(body.contains("BEGIN"), "Body should contain BEGIN");
+                    assert!(body.contains("END"), "Body should contain END");
+                    // Most importantly: body should NOT contain debug format like "Keyword(Select)"
+                    assert!(
+                        !body.contains("Keyword("),
+                        "Body should NOT contain debug format. Got: {}",
+                        body
+                    );
+                    assert!(
+                        !body.contains("Number("),
+                        "Body should NOT contain debug format. Got: {}",
+                        body
+                    );
+                }
+            }
+        }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+#[test]
+fn test_create_trigger_body_with_string_literal() {
+    use vibesql_ast::TriggerAction;
+
+    let sql = "CREATE TRIGGER my_trigger AFTER INSERT ON my_table BEGIN INSERT INTO log VALUES ('test'); END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let stmt = result.unwrap();
+    match stmt {
+        Statement::CreateTrigger(trigger) => {
+            match &trigger.triggered_action {
+                TriggerAction::RawSql(body) => {
+                    // Verify string literals are properly quoted
+                    assert!(
+                        body.contains("'test'"),
+                        "Body should contain properly quoted string literal. Got: {}",
+                        body
+                    );
+                }
+            }
+        }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}

--- a/crates/vibesql-parser/src/token.rs
+++ b/crates/vibesql-parser/src/token.rs
@@ -81,6 +81,32 @@ pub enum Token {
     Eof,
 }
 
+impl Token {
+    /// Convert token back to valid SQL string.
+    /// This is the inverse of lexing - it produces SQL that can be re-parsed.
+    pub fn to_sql(&self) -> String {
+        match self {
+            Token::Keyword(kw) => kw.to_string(),
+            Token::Identifier(id) => id.clone(),
+            Token::DelimitedIdentifier(id) => format!("\"{}\"", id),
+            Token::Number(n) => n.clone(),
+            Token::String(s) => format!("'{}'", s.replace('\'', "''")),
+            Token::Symbol(c) => c.to_string(),
+            Token::Operator(op) => op.to_string(),
+            Token::SessionVariable(v) => format!("@@{}", v),
+            Token::UserVariable(v) => format!("@{}", v),
+            Token::Placeholder => "?".to_string(),
+            Token::NumberedPlaceholder(n) => format!("${}", n),
+            Token::NamedPlaceholder(name) => format!(":{}", name),
+            Token::Semicolon => ";".to_string(),
+            Token::Comma => ",".to_string(),
+            Token::LParen => "(".to_string(),
+            Token::RParen => ")".to_string(),
+            Token::Eof => String::new(),
+        }
+    }
+}
+
 impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/tests/pgsql/sql/triggers.sql
+++ b/tests/pgsql/sql/triggers.sql
@@ -4,14 +4,6 @@
 -- Adapted from PostgreSQL's src/test/regress/sql/triggers.sql
 -- Modified for VibeSQL's SQLite-compatible trigger syntax
 -- ============================================================================
---
--- KNOWN LIMITATIONS:
--- - VibeSQL's trigger parser stores trigger bodies as debug token format
---   which causes failures when the trigger body is later re-parsed for execution.
---   This is tracked and tests marked accordingly with SKIP directives.
--- - NEW/OLD pseudo-variables work when triggers are created programmatically
---   but fail when parsed from SQL due to the above limitation.
--- ============================================================================
 
 -- ============================================================================
 -- SECTION 1: Basic Table Creation (These always work)
@@ -197,7 +189,6 @@ CREATE VIEW trigtest_view AS
 SELECT id, value, name FROM trigtest WHERE value > 100;
 
 -- TEST: Create INSTEAD OF INSERT trigger - syntax test
--- SKIP: INSTEAD OF triggers on views not fully supported
 CREATE TRIGGER tr_instead_of_test
 INSTEAD OF INSERT ON trigtest_view
 FOR EACH ROW
@@ -205,7 +196,6 @@ BEGIN
 END;
 
 -- TEST: Drop INSTEAD OF trigger
--- SKIP: Previous trigger creation skipped
 DROP TRIGGER tr_instead_of_test;
 
 -- TEST: Drop view
@@ -288,7 +278,6 @@ CREATE TABLE trigger_counter (count INTEGER DEFAULT 0);
 INSERT INTO trigger_counter VALUES (0);
 
 -- TEST: Create trigger with simple SELECT (won't modify state but tests execution path)
--- SKIP: Trigger body parsing stores debug format, not valid SQL
 CREATE TRIGGER tr_simple_exec
 AFTER INSERT ON trigtest
 FOR EACH ROW
@@ -305,7 +294,6 @@ INSERT INTO trigtest (id, value, name) VALUES (1, 100, 'first');
 SELECT id, value, name FROM trigtest WHERE id = 1;
 
 -- TEST: Cleanup simple exec trigger
--- SKIP: Previous trigger creation may have failed
 DROP TRIGGER tr_simple_exec;
 
 -- ============================================================================


### PR DESCRIPTION
## Summary

- Fix trigger body parsing to preserve valid SQL instead of debug format
- Enable INSTEAD OF triggers on views by checking for view existence
- All 63 PostgreSQL trigger regression tests now pass (100%)

## Changes

1. **Trigger body parsing** (`crates/vibesql-parser/src/token.rs`, `crates/vibesql-parser/src/parser/trigger.rs`):
   - Added `Token::to_sql()` method that converts tokens back to valid SQL
   - Replaced `format!("{:?}", token)` with `token.to_sql()` in trigger parser
   - Trigger bodies like `BEGIN SELECT 1; END` are now stored correctly

2. **INSTEAD OF triggers on views** (`crates/vibesql-executor/src/trigger_ddl.rs`):
   - INSTEAD OF triggers now check for view existence instead of table existence
   - BEFORE/AFTER triggers still require tables (per SQL standard)

3. **Tests** (`tests/pgsql/sql/triggers.sql`, `crates/vibesql-parser/src/tests/trigger.rs`):
   - Removed 4 SKIP directives from PostgreSQL trigger tests
   - Added parser tests verifying trigger body preservation

## Test plan

- [x] `cargo test -p vibesql-parser trigger` - all 15 trigger parser tests pass
- [x] `cargo test -p vibesql --test pgsql_regress` - 63/63 tests pass (100%)
- [x] Tests verify trigger bodies don't contain debug format like `Keyword(Select)`

Closes #4233

🤖 Generated with [Claude Code](https://claude.com/claude-code)