### PR TITLE
feat(sql): Add VALUES clause as table constructor (SQL:1999)

### DIFF
--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -856,6 +856,21 @@ impl ToSql for FromClause {
                 }
                 result
             }
+            FromClause::Values { rows, alias, column_aliases } => {
+                let rows_sql: Vec<String> = rows
+                    .iter()
+                    .map(|row| {
+                        let cols: Vec<String> = row.iter().map(|e| e.to_sql()).collect();
+                        format!("({})", cols.join(", "))
+                    })
+                    .collect();
+                let mut result =
+                    format!("(VALUES {}) AS {}", rows_sql.join(", "), format_identifier(alias));
+                if let Some(cols) = column_aliases {
+                    result.push_str(&format!(" ({})", cols.join(", ")));
+                }
+                result
+            }
         }
     }
 }

--- a/crates/vibesql-ast/src/select.rs
+++ b/crates/vibesql-ast/src/select.rs
@@ -258,6 +258,17 @@ pub enum FromClause {
         /// Optional column renaming for derived table columns
         column_aliases: Option<Vec<String>>,
     },
+    /// VALUES clause as table constructor (SQL:1999)
+    /// Example: FROM (VALUES(1,'a'), (2,'b')) AS t(x, y)
+    /// Example: WITH t AS (VALUES(1),(2),(3)) SELECT * FROM t
+    Values {
+        /// Each inner Vec is a row, each Expression is a column value
+        rows: Vec<Vec<Expression>>,
+        /// Alias for the VALUES table (required)
+        alias: String,
+        /// Optional column renaming
+        column_aliases: Option<Vec<String>>,
+    },
 }
 
 /// JOIN types

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -854,6 +854,13 @@ fn walk_from_clause<V: ExpressionVisitor>(visitor: &mut V, from: &FromClause) {
                 walk_expression(visitor, cond);
             }
         }
+        FromClause::Values { rows, .. } => {
+            for row in rows {
+                for expr in row {
+                    walk_expression(visitor, expr);
+                }
+            }
+        }
     }
 }
 
@@ -1031,6 +1038,14 @@ fn transform_from_clause<V: ExpressionMutVisitor>(visitor: &mut V, from: FromCla
             join_type,
             condition: condition.map(|c| transform_expression(visitor, c)),
             natural,
+        },
+        FromClause::Values { rows, alias, column_aliases } => FromClause::Values {
+            rows: rows
+                .into_iter()
+                .map(|row| row.into_iter().map(|e| transform_expression(visitor, e)).collect())
+                .collect(),
+            alias,
+            column_aliases,
         },
     }
 }

--- a/crates/vibesql-catalog/src/store/advanced/views.rs
+++ b/crates/vibesql-catalog/src/store/advanced/views.rs
@@ -183,6 +183,8 @@ impl super::super::Catalog {
                     || self.does_from_clause_reference_table(right, table_name)
             }
             FromClause::Subquery { query, .. } => self.select_references_table(query, table_name),
+            // VALUES clauses don't reference any tables
+            FromClause::Values { .. } => false,
         }
     }
 }

--- a/crates/vibesql-executor/src/cache/parameterized.rs
+++ b/crates/vibesql-executor/src/cache/parameterized.rs
@@ -253,6 +253,14 @@ impl LiteralExtractor {
             vibesql_ast::FromClause::Table { .. } => {
                 // No literals in table references
             }
+            vibesql_ast::FromClause::Values { rows, .. } => {
+                // Extract literals from VALUES expressions
+                for row in rows {
+                    for expr in row {
+                        Self::extract_from_expression(expr, literals);
+                    }
+                }
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/cache/prepared_statement/bind/mutation.rs
+++ b/crates/vibesql-executor/src/cache/prepared_statement/bind/mutation.rs
@@ -210,6 +210,14 @@ fn bind_from_clause_mut(from: &mut FromClause, params: &[SqlValue]) {
             }
         }
         FromClause::Subquery { query, .. } => bind_select_mut(query, params),
+        FromClause::Values { rows, .. } => {
+            // Bind parameters in VALUES expressions
+            for row in rows {
+                for expr in row {
+                    bind_expression_mut(expr, params);
+                }
+            }
+        }
     }
 }
 
@@ -576,6 +584,14 @@ fn bind_from_clause_named_mut(from: &mut FromClause, params: &HashMap<String, Sq
             }
         }
         FromClause::Subquery { query, .. } => bind_select_named_mut(query, params),
+        FromClause::Values { rows, .. } => {
+            // Bind parameters in VALUES expressions
+            for row in rows {
+                for expr in row {
+                    bind_expression_named_mut(expr, params);
+                }
+            }
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/cache/query_signature.rs
+++ b/crates/vibesql-executor/src/cache/query_signature.rs
@@ -209,6 +209,20 @@ impl QuerySignature {
                 Self::hash_select(query, hasher);
                 alias.hash(hasher);
             }
+            vibesql_ast::FromClause::Values { rows, alias, column_aliases } => {
+                "VALUES".hash(hasher);
+                rows.len().hash(hasher);
+                if let Some(first_row) = rows.first() {
+                    first_row.len().hash(hasher);
+                }
+                for row in rows {
+                    for expr in row {
+                        Self::hash_expression(expr, hasher);
+                    }
+                }
+                alias.hash(hasher);
+                column_aliases.hash(hasher);
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/cache/table_extractor.rs
+++ b/crates/vibesql-executor/src/cache/table_extractor.rs
@@ -78,6 +78,9 @@ fn extract_from_from_clause(from: &vibesql_ast::FromClause, tables: &mut HashSet
             let subquery_tables = extract_tables_from_select(query);
             tables.extend(subquery_tables);
         }
+        vibesql_ast::FromClause::Values { .. } => {
+            // VALUES clauses don't reference any tables
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -56,6 +56,10 @@ fn extract_table_names_recursive(from: &FromClause, tables: &mut Vec<String>) {
             // Derived tables are referenced by their alias
             tables.push(alias.clone());
         }
+        FromClause::Values { alias, .. } => {
+            // VALUES clauses are referenced by their alias
+            tables.push(alias.clone());
+        }
     }
 }
 
@@ -179,6 +183,12 @@ fn is_from_clause_correlated(
             // Extract their tables and check recursively
             let nested_tables = extract_table_names_from_from_clause(query.from.as_ref());
             is_select_stmt_correlated_impl(query, outer_schema, &nested_tables)
+        }
+        FromClause::Values { rows, .. } => {
+            // VALUES clauses can contain expressions that reference outer columns
+            rows.iter().any(|row| {
+                row.iter().any(|expr| is_expression_correlated(expr, outer_schema, subquery_tables))
+            })
         }
     }
 }

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
@@ -89,6 +89,9 @@ fn extract_table_names_recursive(from: &vibesql_ast::FromClause, tables: &mut Ve
         vibesql_ast::FromClause::Subquery { alias, .. } => {
             tables.push(alias.clone());
         }
+        vibesql_ast::FromClause::Values { alias, .. } => {
+            tables.push(alias.clone());
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
@@ -166,5 +166,17 @@ fn count_columns_in_from_clause(
                 "Subqueries in FROM clause within IN predicates are not yet supported for schema validation".to_string(),
             ))
         }
+        vibesql_ast::FromClause::Values { rows, column_aliases, .. } => {
+            // VALUES clause column count is determined by either:
+            // 1. The column_aliases if provided, or
+            // 2. The number of expressions in the first row
+            if let Some(aliases) = column_aliases {
+                Ok(aliases.len())
+            } else if let Some(first_row) = rows.first() {
+                Ok(first_row.len())
+            } else {
+                Ok(0) // Empty VALUES clause
+            }
+        }
     }
 }

--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -254,6 +254,18 @@ impl ExplainExecutor {
 
                 Ok(subquery_node)
             }
+            vibesql_ast::FromClause::Values { rows, alias, column_aliases } => {
+                let mut values_node = PlanNode::new("Values");
+                values_node.object = Some(format!("AS {}", alias));
+
+                values_node.details.push(format!("{} row(s)", rows.len()));
+
+                if let Some(aliases) = column_aliases {
+                    values_node.details.push(format!("Columns: {}", aliases.join(", ")));
+                }
+
+                Ok(values_node)
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/insert/bulk_transfer.rs
+++ b/crates/vibesql-executor/src/insert/bulk_transfer.rs
@@ -69,6 +69,7 @@ fn extract_simple_table_select(select_stmt: &SelectStmt) -> Option<String> {
         FromClause::Table { name, .. } => name.clone(),
         FromClause::Join { .. } => return None, // No joins
         FromClause::Subquery { .. } => return None, // No subqueries
+        FromClause::Values { .. } => return None, // No VALUES clauses
     };
 
     // No WHERE, GROUP BY, HAVING, DISTINCT, LIMIT, OFFSET

--- a/crates/vibesql-executor/src/optimizer/adaptive/query.rs
+++ b/crates/vibesql-executor/src/optimizer/adaptive/query.rs
@@ -87,7 +87,7 @@ pub(super) fn has_selective_projection(query: &SelectStmt) -> bool {
 pub(super) fn is_single_table(query: &SelectStmt) -> bool {
     match &query.from {
         Some(FromClause::Table { .. }) => true,
-        Some(FromClause::Join { .. }) | Some(FromClause::Subquery { .. }) => false,
+        Some(FromClause::Join { .. }) | Some(FromClause::Subquery { .. }) | Some(FromClause::Values { .. }) => false,
         None => false, // No FROM clause (e.g., SELECT 1)
     }
 }

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
@@ -235,6 +235,11 @@ fn extract_table_prefixes(from: &vibesql_ast::FromClause) -> Vec<char> {
                     prefixes.push(c.to_ascii_lowercase());
                 }
             }
+            vibesql_ast::FromClause::Values { alias, .. } => {
+                if let Some(c) = alias.chars().next() {
+                    prefixes.push(c.to_ascii_lowercase());
+                }
+            }
         }
     }
     let mut prefixes = Vec::new();
@@ -264,5 +269,6 @@ fn from_clause_contains_table(from: &vibesql_ast::FromClause, table_name: &str) 
                 || from_clause_contains_table(right, table_name)
         }
         vibesql_ast::FromClause::Subquery { alias, .. } => alias == table_name,
+        vibesql_ast::FromClause::Values { alias, .. } => alias == table_name,
     }
 }

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/detection.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/detection.rs
@@ -125,5 +125,9 @@ fn from_clause_has_in_subquery(from: &vibesql_ast::FromClause) -> bool {
                 || condition.as_ref().is_some_and(expression_has_in_subquery)
         }
         vibesql_ast::FromClause::Subquery { query, .. } => has_in_subqueries(query),
+        vibesql_ast::FromClause::Values { rows, .. } => {
+            // Check if any expressions in VALUES rows contain IN subqueries
+            rows.iter().any(|row| row.iter().any(expression_has_in_subquery))
+        }
     }
 }

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
@@ -368,5 +368,20 @@ pub(super) fn rewrite_from_clause(
                 column_aliases: None,
             }
         }
+        vibesql_ast::FromClause::Values { rows, alias, column_aliases } => {
+            // Rewrite expressions in VALUES rows
+            vibesql_ast::FromClause::Values {
+                rows: rows
+                    .iter()
+                    .map(|row| {
+                        row.iter()
+                            .map(|expr| rewrite_expression(expr, rewrite_subquery_fn))
+                            .collect()
+                    })
+                    .collect(),
+                alias: alias.clone(),
+                column_aliases: column_aliases.clone(),
+            }
+        }
     }
 }

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
@@ -168,6 +168,9 @@ fn extract_table_names(from: &Option<vibesql_ast::FromClause>) -> Vec<String> {
             vibesql_ast::FromClause::Subquery { alias, .. } => {
                 tables.push(alias.clone());
             }
+            vibesql_ast::FromClause::Values { alias, .. } => {
+                tables.push(alias.clone());
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/helpers.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/helpers.rs
@@ -21,6 +21,9 @@ pub(super) fn collect_table_names(from: &FromClause, names: &mut Vec<String>) {
         FromClause::Subquery { alias, .. } => {
             names.push(alias.clone());
         }
+        FromClause::Values { alias, .. } => {
+            names.push(alias.clone());
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/optimizer/table_elimination.rs
+++ b/crates/vibesql-executor/src/optimizer/table_elimination.rs
@@ -317,8 +317,9 @@ fn flatten_from_clause(from: &FromClause, tables: &mut Vec<TableInfo>) {
             flatten_from_clause(left, tables);
             flatten_from_clause(right, tables);
         }
-        // Skip subqueries - they can't be eliminated
+        // Skip subqueries and VALUES - they can't be eliminated
         FromClause::Subquery { .. } => {}
+        FromClause::Values { .. } => {}
     }
 }
 
@@ -544,6 +545,9 @@ fn extract_join_on_tables(
         }
         FromClause::Subquery { .. } => {
             // Subqueries are opaque - don't examine their internals
+        }
+        FromClause::Values { .. } => {
+            // VALUES clauses are opaque - don't examine their internals
         }
     }
 }
@@ -1050,6 +1054,7 @@ fn collect_qualified_columns_from_from(
     match from {
         FromClause::Table { .. } => {}
         FromClause::Subquery { .. } => {}
+        FromClause::Values { .. } => {}
         FromClause::Join { left, right, condition, .. } => {
             collect_qualified_columns_from_from(left, table_columns);
             collect_qualified_columns_from_from(right, table_columns);

--- a/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
@@ -165,6 +165,7 @@ impl SelectExecutor<'_> {
             Some(vibesql_ast::FromClause::Table { name, .. }) => name.clone(),
             Some(vibesql_ast::FromClause::Join { .. }) => return None, // JOIN not allowed
             Some(vibesql_ast::FromClause::Subquery { .. }) => return None, // Subquery not allowed
+            Some(vibesql_ast::FromClause::Values { .. }) => return None, // VALUES not allowed
             None => return None,                                       // No FROM clause
         };
 

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -16,7 +16,7 @@ use vibesql_ast::{BinaryOperator, Expression, FromClause, JoinType};
 /// - This enables columnar execution for implicit join syntax (e.g., TPC-H Q19)
 pub(super) fn is_inner_or_cross_join_only(from: &FromClause) -> bool {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } => true,
+        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => true,
         FromClause::Join { left, right, join_type, .. } => {
             matches!(join_type, JoinType::Inner | JoinType::Cross)
                 && is_inner_or_cross_join_only(left)
@@ -31,7 +31,7 @@ pub(super) fn is_inner_or_cross_join_only(from: &FromClause) -> bool {
 /// We detect this case to fall back to regular execution which produces a proper error.
 pub(super) fn has_cross_join_with_on_condition(from: &FromClause) -> bool {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } => false,
+        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => false,
         FromClause::Join { left, right, join_type, condition, .. } => {
             // CROSS JOIN with ON condition is invalid
             if matches!(join_type, JoinType::Cross) && condition.is_some() {
@@ -55,6 +55,9 @@ pub(super) fn flatten_join_tree_simple(from: &FromClause, tables: &mut Vec<Simpl
         FromClause::Subquery { alias, .. } => {
             tables.push((alias.clone(), Some(alias.clone()), true));
         }
+        FromClause::Values { alias, .. } => {
+            tables.push((alias.clone(), Some(alias.clone()), true));
+        }
         FromClause::Join { left, right, .. } => {
             flatten_join_tree_simple(left, tables);
             flatten_join_tree_simple(right, tables);
@@ -74,7 +77,7 @@ pub(super) struct EquiJoinCondition {
 /// Extract join conditions from a FROM clause (ON conditions)
 pub(super) fn extract_join_conditions(from: &FromClause, conditions: &mut Vec<EquiJoinCondition>) {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } => {}
+        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => {}
         FromClause::Join { left, right, condition, join_type, .. } => {
             // Only handle INNER and CROSS joins in columnar path
             // OUTER joins need special handling and are not supported
@@ -251,6 +254,7 @@ pub(super) fn extract_single_table_name(from_clause: &FromClause) -> Option<Stri
         FromClause::Table { name, .. } => Some(name.clone()),
         FromClause::Join { .. } => None, // JOINs not supported in native columnar path
         FromClause::Subquery { .. } => None, // Subqueries not supported
+        FromClause::Values { .. } => None, // VALUES not supported
     }
 }
 
@@ -267,5 +271,6 @@ pub(super) fn extract_table_name_and_alias(from_clause: &FromClause) -> Option<(
         FromClause::Table { name, alias, .. } => Some((name.clone(), alias.clone())),
         FromClause::Join { .. } => None, // JOINs not supported in native columnar path
         FromClause::Subquery { .. } => None, // Subqueries not supported
+        FromClause::Values { .. } => None, // VALUES not supported
     }
 }

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -170,6 +170,18 @@ fn count_columns_in_from_clause(
                 "Subqueries in FROM clause within IN predicates are not yet supported for schema validation".to_string(),
             ))
         }
+        vibesql_ast::FromClause::Values { rows, column_aliases, .. } => {
+            // VALUES clause column count is determined by either:
+            // 1. The column_aliases if provided, or
+            // 2. The number of expressions in the first row
+            if let Some(aliases) = column_aliases {
+                Ok(aliases.len())
+            } else if let Some(first_row) = rows.first() {
+                Ok(first_row.len())
+            } else {
+                Ok(0) // Empty VALUES clause
+            }
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/scan/join_scan.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan.rs
@@ -536,6 +536,10 @@ fn collect_table_names(from: &vibesql_ast::FromClause, tables: &mut Vec<String>)
             // Subquery alias is required (String, not Option<String>)
             tables.push(alias.clone());
         }
+        vibesql_ast::FromClause::Values { alias, .. } => {
+            // VALUES alias is required (String, not Option<String>)
+            tables.push(alias.clone());
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/mod.rs
@@ -21,6 +21,7 @@ mod join_scan;
 mod predicates;
 mod reorder;
 mod table;
+mod values;
 
 /// Execute a FROM clause (table, join, or subquery) and return combined schema and rows
 ///
@@ -156,6 +157,9 @@ where
         }
         vibesql_ast::FromClause::Subquery { query, alias, column_aliases } => {
             derived::execute_derived_table(query, alias, column_aliases.as_ref(), execute_subquery)
+        }
+        vibesql_ast::FromClause::Values { rows, alias, column_aliases } => {
+            values::execute_values(rows, alias, column_aliases.as_ref())
         }
     }
 }

--- a/crates/vibesql-executor/src/select/scan/reorder/graph.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/graph.rs
@@ -48,6 +48,16 @@ pub(super) fn flatten_join_tree(from: &FromClause, tables: &mut Vec<TableRef>) {
                 column_aliases: column_aliases.clone(),
             });
         }
+        FromClause::Values { alias, column_aliases, .. } => {
+            tables.push(TableRef {
+                name: alias.clone(),
+                alias: Some(alias.clone()),
+                is_cte: false,
+                is_subquery: false,
+                subquery: None,
+                column_aliases: column_aliases.clone(),
+            });
+        }
         FromClause::Join { left, right, .. } => {
             flatten_join_tree(left, tables);
             flatten_join_tree(right, tables);
@@ -58,7 +68,7 @@ pub(super) fn flatten_join_tree(from: &FromClause, tables: &mut Vec<TableRef>) {
 /// Extract all join conditions and WHERE predicates from a FROM clause
 pub(super) fn extract_all_conditions(from: &FromClause, conditions: &mut Vec<Expression>) {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } => {
+        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => {
             // No conditions in simple table refs
         }
         FromClause::Join { left, right, condition, .. } => {
@@ -79,7 +89,7 @@ pub(super) fn extract_conditions_with_types(
     conditions: &mut Vec<JoinConditionWithType>,
 ) {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } => {
+        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => {
             // No conditions in simple table refs
         }
         FromClause::Join { left, right, join_type, condition, .. } => {

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -87,6 +87,7 @@ pub(crate) fn count_tables_in_from(from: &FromClause) -> usize {
     match from {
         FromClause::Table { .. } => 1,
         FromClause::Subquery { .. } => 1,
+        FromClause::Values { .. } => 1,
         FromClause::Join { left, right, .. } => {
             count_tables_in_from(left) + count_tables_in_from(right)
         }
@@ -104,7 +105,7 @@ pub(crate) fn count_tables_in_from(from: &FromClause) -> usize {
 /// where the appropriate error is raised (CROSS JOIN does not support ON clause).
 pub(crate) fn all_joins_are_cross(from: &FromClause) -> bool {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } => true,
+        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => true,
         FromClause::Join { left, right, join_type, condition, .. } => {
             // Must be CROSS join type AND have no ON condition
             // CROSS JOIN with ON clause is invalid and should not be reordered

--- a/crates/vibesql-executor/src/select/scan/values.rs
+++ b/crates/vibesql-executor/src/select/scan/values.rs
@@ -1,0 +1,147 @@
+//! VALUES clause execution logic
+//!
+//! Handles execution of VALUES table constructors in FROM clauses
+//! by evaluating expressions and creating a derived table.
+//!
+//! Example: `SELECT * FROM (VALUES(1,'a'), (2,'b')) AS t(x, y)`
+
+use crate::{errors::ExecutorError, schema::CombinedSchema};
+
+/// Evaluate a simple expression to SqlValue
+/// Supports literals and basic expressions. For VALUES clauses,
+/// expressions are typically constants.
+fn evaluate_values_expression(
+    expr: &vibesql_ast::Expression,
+) -> Result<vibesql_types::SqlValue, ExecutorError> {
+    match expr {
+        vibesql_ast::Expression::Literal(val) => Ok(val.clone()),
+        vibesql_ast::Expression::UnaryOp { op, expr } => {
+            let inner_val = evaluate_values_expression(expr)?;
+            match op {
+                vibesql_ast::UnaryOperator::Minus => match inner_val {
+                    vibesql_types::SqlValue::Integer(n) => {
+                        Ok(vibesql_types::SqlValue::Integer(-n))
+                    }
+                    vibesql_types::SqlValue::Bigint(n) => Ok(vibesql_types::SqlValue::Bigint(-n)),
+                    vibesql_types::SqlValue::Smallint(n) => {
+                        Ok(vibesql_types::SqlValue::Smallint(-n))
+                    }
+                    vibesql_types::SqlValue::Numeric(n) => {
+                        Ok(vibesql_types::SqlValue::Numeric(-n))
+                    }
+                    vibesql_types::SqlValue::Double(n) => Ok(vibesql_types::SqlValue::Double(-n)),
+                    vibesql_types::SqlValue::Float(n) => Ok(vibesql_types::SqlValue::Float(-n)),
+                    vibesql_types::SqlValue::Real(n) => Ok(vibesql_types::SqlValue::Real(-n)),
+                    vibesql_types::SqlValue::Null => Ok(vibesql_types::SqlValue::Null),
+                    _ => Err(ExecutorError::TypeError(format!(
+                        "Cannot negate value of type {:?}",
+                        inner_val.get_type()
+                    ))),
+                },
+                vibesql_ast::UnaryOperator::Plus => Ok(inner_val),
+                vibesql_ast::UnaryOperator::Not => match inner_val {
+                    vibesql_types::SqlValue::Boolean(b) => {
+                        Ok(vibesql_types::SqlValue::Boolean(!b))
+                    }
+                    vibesql_types::SqlValue::Null => Ok(vibesql_types::SqlValue::Null),
+                    _ => Err(ExecutorError::TypeError(format!(
+                        "Cannot apply NOT to value of type {:?}",
+                        inner_val.get_type()
+                    ))),
+                },
+                vibesql_ast::UnaryOperator::IsNull => {
+                    Ok(vibesql_types::SqlValue::Boolean(inner_val.is_null()))
+                }
+                vibesql_ast::UnaryOperator::IsNotNull => {
+                    Ok(vibesql_types::SqlValue::Boolean(!inner_val.is_null()))
+                }
+            }
+        }
+        _ => Err(ExecutorError::UnsupportedExpression(format!(
+            "Expression type {:?} not supported in VALUES clause. Only literals are currently supported.",
+            std::any::type_name_of_val(expr)
+        ))),
+    }
+}
+
+/// Execute a VALUES table constructor
+///
+/// Evaluates each expression in each row, validates that all rows have
+/// the same number of columns, and creates a derived table with the results.
+///
+/// # Arguments
+///
+/// * `rows` - The VALUE rows, each containing expressions for columns
+/// * `alias` - The table alias (required)
+/// * `column_aliases` - Optional column name overrides
+pub(crate) fn execute_values(
+    rows: &[Vec<vibesql_ast::Expression>],
+    alias: &str,
+    column_aliases: Option<&Vec<String>>,
+) -> Result<super::FromResult, ExecutorError> {
+    // Handle empty VALUES - return empty result with appropriate schema
+    if rows.is_empty() {
+        let num_columns = column_aliases.map(|ca| ca.len()).unwrap_or(0);
+        let column_names: Vec<String> = column_aliases.cloned().unwrap_or_else(|| {
+            (0..num_columns).map(|i| format!("column{}", i + 1)).collect()
+        });
+        let column_types = vec![vibesql_types::DataType::Null; num_columns];
+        let schema = CombinedSchema::from_derived_table(alias.to_string(), column_names, column_types);
+        return Ok(super::FromResult::from_rows(schema, vec![]));
+    }
+
+    // Determine expected column count from first row
+    let expected_columns = rows[0].len();
+
+    // Evaluate all rows and collect results
+    let mut result_rows = Vec::with_capacity(rows.len());
+    for (row_idx, row_exprs) in rows.iter().enumerate() {
+        // Validate column count matches
+        if row_exprs.len() != expected_columns {
+            return Err(ExecutorError::ColumnCountMismatch {
+                expected: expected_columns,
+                provided: row_exprs.len(),
+            });
+        }
+
+        // Evaluate each expression in the row
+        let mut values = Vec::with_capacity(row_exprs.len());
+        for expr in row_exprs {
+            let value = evaluate_values_expression(expr).map_err(|e| {
+                ExecutorError::TypeError(format!(
+                    "Error evaluating VALUES row {}: {}",
+                    row_idx + 1,
+                    e
+                ))
+            })?;
+            values.push(value);
+        }
+        result_rows.push(vibesql_storage::Row::new(values));
+    }
+
+    // Derive column names
+    let column_names: Vec<String> = if let Some(aliases) = column_aliases {
+        // Validate column alias count matches
+        if aliases.len() != expected_columns {
+            return Err(ExecutorError::ColumnCountMismatch {
+                expected: expected_columns,
+                provided: aliases.len(),
+            });
+        }
+        aliases.clone()
+    } else {
+        // Generate default column names: column1, column2, ...
+        (0..expected_columns).map(|i| format!("column{}", i + 1)).collect()
+    };
+
+    // Infer column types from first row values
+    let column_types: Vec<vibesql_types::DataType> = result_rows
+        .first()
+        .map(|row| row.values.iter().map(|v| v.get_type()).collect())
+        .unwrap_or_else(|| vec![vibesql_types::DataType::Null; expected_columns]);
+
+    // Create schema with table alias
+    let schema = CombinedSchema::from_derived_table(alias.to_string(), column_names, column_types);
+
+    Ok(super::FromResult::from_rows(schema, result_rows))
+}

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -99,6 +99,7 @@ mod select_distinct;
 mod select_into_tests;
 mod select_joins;
 mod select_order_by;
+mod select_values;
 mod select_where;
 mod select_window_aggregate;
 mod select_without_from;

--- a/crates/vibesql-executor/src/tests/select_values.rs
+++ b/crates/vibesql-executor/src/tests/select_values.rs
@@ -1,0 +1,241 @@
+//! VALUES clause tests
+//!
+//! Tests for VALUES table constructor functionality in FROM clauses.
+
+use super::super::*;
+
+/// Test basic VALUES with single row
+#[test]
+fn test_values_single_row() {
+    let db = vibesql_storage::Database::new();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+        from: Some(vibesql_ast::FromClause::Values {
+            rows: vec![vec![
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(3)),
+            ]],
+            alias: "t".to_string(),
+            column_aliases: None,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt);
+    assert!(result.is_ok(), "VALUES query failed: {:?}", result.err());
+
+    let result = result.unwrap();
+    assert_eq!(result.len(), 1, "Expected 1 row");
+    assert_eq!(result[0].values.len(), 3, "Expected 3 columns");
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Integer(1));
+    assert_eq!(result[0].values[1], vibesql_types::SqlValue::Integer(2));
+    assert_eq!(result[0].values[2], vibesql_types::SqlValue::Integer(3));
+}
+
+/// Test VALUES with multiple rows
+#[test]
+fn test_values_multiple_rows() {
+    let db = vibesql_storage::Database::new();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+        from: Some(vibesql_ast::FromClause::Values {
+            rows: vec![
+                vec![
+                    vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+                    vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                        arcstr::ArcStr::from("a"),
+                    )),
+                ],
+                vec![
+                    vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
+                    vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                        arcstr::ArcStr::from("b"),
+                    )),
+                ],
+                vec![
+                    vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(3)),
+                    vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                        arcstr::ArcStr::from("c"),
+                    )),
+                ],
+            ],
+            alias: "t".to_string(),
+            column_aliases: None,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt);
+    assert!(result.is_ok(), "VALUES query failed: {:?}", result.err());
+
+    let result = result.unwrap();
+    assert_eq!(result.len(), 3, "Expected 3 rows");
+
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Integer(1));
+    assert_eq!(
+        result[0].values[1],
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("a"))
+    );
+
+    assert_eq!(result[1].values[0], vibesql_types::SqlValue::Integer(2));
+    assert_eq!(
+        result[1].values[1],
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("b"))
+    );
+
+    assert_eq!(result[2].values[0], vibesql_types::SqlValue::Integer(3));
+    assert_eq!(
+        result[2].values[1],
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("c"))
+    );
+}
+
+/// Test VALUES with column aliases
+#[test]
+fn test_values_with_column_aliases() {
+    let db = vibesql_storage::Database::new();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+        from: Some(vibesql_ast::FromClause::Values {
+            rows: vec![vec![
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
+            ]],
+            alias: "t".to_string(),
+            column_aliases: Some(vec!["x".to_string(), "y".to_string()]),
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt);
+    assert!(result.is_ok(), "VALUES query failed: {:?}", result.err());
+
+    let result = result.unwrap();
+    assert_eq!(result.len(), 1, "Expected 1 row");
+    // Just verify the query executed successfully - column names are in schema
+    assert_eq!(result[0].values.len(), 2, "Expected 2 columns");
+}
+
+/// Test VALUES with NULL values
+#[test]
+fn test_values_with_nulls() {
+    let db = vibesql_storage::Database::new();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+        from: Some(vibesql_ast::FromClause::Values {
+            rows: vec![
+                vec![
+                    vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+                    vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
+                ],
+                vec![
+                    vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
+                    vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
+                ],
+            ],
+            alias: "t".to_string(),
+            column_aliases: None,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt);
+    assert!(result.is_ok(), "VALUES query failed: {:?}", result.err());
+
+    let result = result.unwrap();
+    assert_eq!(result.len(), 2, "Expected 2 rows");
+    assert_eq!(result[0].values[1], vibesql_types::SqlValue::Null);
+    assert_eq!(result[1].values[0], vibesql_types::SqlValue::Null);
+}
+
+/// Test VALUES with negative numbers (unary minus)
+#[test]
+fn test_values_with_negative_numbers() {
+    let db = vibesql_storage::Database::new();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+        from: Some(vibesql_ast::FromClause::Values {
+            rows: vec![vec![
+                vibesql_ast::Expression::UnaryOp {
+                    op: vibesql_ast::UnaryOperator::Minus,
+                    expr: Box::new(vibesql_ast::Expression::Literal(
+                        vibesql_types::SqlValue::Integer(42),
+                    )),
+                },
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(100)),
+            ]],
+            alias: "t".to_string(),
+            column_aliases: None,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt);
+    assert!(result.is_ok(), "VALUES query failed: {:?}", result.err());
+
+    let result = result.unwrap();
+    assert_eq!(result.len(), 1, "Expected 1 row");
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Integer(-42));
+    assert_eq!(result[0].values[1], vibesql_types::SqlValue::Integer(100));
+}

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -48,14 +48,34 @@ impl Parser {
         Ok(left)
     }
 
+    /// Parse VALUES clause rows: VALUES(1,2), (3,4), ...
+    /// Returns Vec<Vec<Expression>> where each inner vec is a row
+    pub(crate) fn parse_values_rows(&mut self) -> Result<Vec<Vec<vibesql_ast::Expression>>, ParseError> {
+        self.expect_keyword(Keyword::Values)?;
+        let mut rows = Vec::new();
+        loop {
+            self.expect_token(Token::LParen)?;
+            let row = self.parse_comma_separated_list(|p| p.parse_expression())?;
+            self.expect_token(Token::RParen)?;
+            rows.push(row);
+
+            if matches!(self.peek(), Token::Comma) {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        Ok(rows)
+    }
+
     /// Parse a single table reference (table name, subquery, or derived table with alias)
     pub(crate) fn parse_table_reference(&mut self) -> Result<vibesql_ast::FromClause, ParseError> {
         match self.peek() {
             Token::LParen => {
-                // Parenthesized expression: could be a subquery or a JOIN expression
+                // Parenthesized expression: could be a subquery, VALUES, or a JOIN expression
                 self.advance(); // Consume '('
 
-                // Check if this is a subquery (starts with SELECT) or a table reference/JOIN
+                // Check if this is a subquery (starts with SELECT), VALUES, or a table reference/JOIN
                 let result = if self.peek_keyword(Keyword::Select) {
                     // Parse the SELECT statement (subquery)
                     let query = Box::new(self.parse_select_statement()?);
@@ -103,6 +123,51 @@ impl Parser {
                     let column_aliases = self.parse_column_alias_list()?;
 
                     vibesql_ast::FromClause::Subquery { query, alias, column_aliases }
+                } else if self.peek_keyword(Keyword::Values) {
+                    // Parse VALUES clause as table constructor
+                    // Example: (VALUES(1,'a'), (2,'b')) AS t(x, y)
+                    let rows = self.parse_values_rows()?;
+
+                    // Expect closing ')'
+                    match self.peek() {
+                        Token::RParen => {
+                            self.advance();
+                        }
+                        _ => {
+                            return Err(ParseError {
+                                message: "Expected ')' after VALUES clause".to_string(),
+                            })
+                        }
+                    }
+
+                    // Parse optional AS keyword
+                    if self.peek_keyword(Keyword::As) {
+                        self.consume_keyword(Keyword::As)?;
+                    }
+
+                    // Parse alias (required for VALUES tables) - keywords allowed as aliases
+                    let alias = match self.peek() {
+                        Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
+                            let alias = id.clone();
+                            self.advance();
+                            alias
+                        }
+                        Token::Keyword(kw) => {
+                            let alias = kw.to_string();
+                            self.advance();
+                            alias
+                        }
+                        _ => {
+                            return Err(ParseError {
+                                message: "VALUES table must have an alias".to_string(),
+                            })
+                        }
+                    };
+
+                    // Parse optional column aliases: AS alias (col1, col2, ...)
+                    let column_aliases = self.parse_column_alias_list()?;
+
+                    vibesql_ast::FromClause::Values { rows, alias, column_aliases }
                 } else {
                     // Parenthesized table reference or JOIN expression
                     // Parse as a FROM clause (which handles JOINs)

--- a/crates/vibesql-server/src/subscription/pk_detector.rs
+++ b/crates/vibesql-server/src/subscription/pk_detector.rs
@@ -222,6 +222,7 @@ fn extract_single_table(from: &FromClause) -> Option<(String, Option<String>)> {
         }
         FromClause::Join { .. } => None, // Join means multiple tables
         FromClause::Subquery { .. } => None, // Subquery is complex
+        FromClause::Values { .. } => None, // VALUES is complex
     }
 }
 
@@ -343,6 +344,10 @@ fn collect_join_tables_recursive(
         }
         FromClause::Subquery { .. } => {
             // Can't easily extract table info from subqueries
+            *has_subquery = true;
+        }
+        FromClause::Values { .. } => {
+            // Can't easily extract table info from VALUES
             *has_subquery = true;
         }
     }

--- a/crates/vibesql-server/src/subscription/table_dependencies.rs
+++ b/crates/vibesql-server/src/subscription/table_dependencies.rs
@@ -121,6 +121,14 @@ fn visit_from_clause(from: &FromClause, tables: &mut HashSet<String>) {
                 visit_expression(cond, tables);
             }
         }
+        FromClause::Values { rows, .. } => {
+            // VALUES clause may contain subqueries in expressions
+            for row in rows {
+                for expr in row {
+                    visit_expression(expr, tables);
+                }
+            }
+        }
     }
 }
 

--- a/crates/vibesql-server/src/subscription/table_extract.rs
+++ b/crates/vibesql-server/src/subscription/table_extract.rs
@@ -44,6 +44,14 @@ impl TableExtractor {
                     walk_expression(self, cond);
                 }
             }
+            FromClause::Values { rows, .. } => {
+                // VALUES clause may contain subqueries in expressions
+                for row in rows {
+                    for expr in row {
+                        walk_expression(self, expr);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Add support for VALUES clause as a table constructor in FROM clauses, implementing SQL:1999 standard syntax like `SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS t(x, y)`
- Implement parser support to detect and parse VALUES keyword within parenthesized FROM expressions
- Add executor support with expression evaluation for VALUES rows including literals, NULL values, and unary operators

## Test plan

- [x] Unit tests for VALUES single row
- [x] Unit tests for VALUES multiple rows  
- [x] Unit tests for VALUES with column aliases
- [x] Unit tests for VALUES with NULL values
- [x] Unit tests for VALUES with negative numbers (unary minus)
- [x] Full test suite passes (cargo test --release)

Closes #4230

🤖 Generated with [Claude Code](https://claude.com/claude-code)