### PR TITLE
fix(persistence): Include PRIMARY KEY in SQL dump for INSERT OR REPLACE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -403,6 +403,10 @@ name = "issue_3809"
 path = "tests/regression/issue_3809.rs"
 
 [[test]]
+name = "issue_4237"
+path = "tests/regression/issue_4237.rs"
+
+[[test]]
 name = "issue_having_null"
 path = "tests/regression/issue_having_null.rs"
 

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -100,6 +100,13 @@ impl Database {
                     }
                 }
 
+                // Add PRIMARY KEY constraint if present
+                if let Some(pk_cols) = &schema.primary_key {
+                    write!(writer, ", PRIMARY KEY ({})", pk_cols.join(", ")).map_err(|e| {
+                        StorageError::NotImplemented(format!("Write error: {}", e))
+                    })?;
+                }
+
                 writeln!(writer, ");")
                     .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
 
@@ -132,10 +139,15 @@ impl Database {
             }
         }
 
-        // Export indexes
+        // Export indexes (skip auto-generated PK indexes which are recreated by PRIMARY KEY constraint)
         writeln!(writer, "-- Indexes")
             .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
         for index_name in self.list_indexes() {
+            // Skip primary key indexes - these are automatically created by the PRIMARY KEY constraint
+            // PK indexes follow the naming convention "PK_<table_name>"
+            if index_name.starts_with("PK_") {
+                continue;
+            }
             let metadata = self.get_index(&index_name).unwrap();
             write!(writer, "CREATE")
                 .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;

--- a/scripts/process_test_results.py
+++ b/scripts/process_test_results.py
@@ -175,13 +175,8 @@ VALUES ({run_id}, TIMESTAMP '{timestamp}', TIMESTAMP '{timestamp}', {total}, {pa
     for file_path in tested_files.get('passed', []):
         category, subcategory = categorize_test_file(file_path)
 
-        # Workaround: DELETE + INSERT instead of INSERT OR REPLACE
-        # (INSERT OR REPLACE has a bug in VibeSQL where it fails on existing rows)
         statements.append(f"""
-DELETE FROM test_files WHERE file_path = {sql_escape(file_path)};
-""")
-        statements.append(f"""
-INSERT INTO test_files (file_path, category, subcategory, status, last_tested, last_passed)
+INSERT OR REPLACE INTO test_files (file_path, category, subcategory, status, last_tested, last_passed)
 VALUES ({sql_escape(file_path)}, {sql_escape(category)}, {sql_escape(subcategory)}, 'PASS', TIMESTAMP '{timestamp}', TIMESTAMP '{timestamp}');
 """)
 
@@ -209,13 +204,8 @@ VALUES ({abs(hash(f'{run_id}_{file_path}'))}, {run_id}, {sql_escape(file_path)},
         # Get error message from lookup, or NULL if not available
         error_message = error_lookup.get(file_path, None)
 
-        # Workaround: DELETE + INSERT instead of INSERT OR REPLACE
-        # (INSERT OR REPLACE has a bug in VibeSQL where it fails on existing rows)
         statements.append(f"""
-DELETE FROM test_files WHERE file_path = {sql_escape(file_path)};
-""")
-        statements.append(f"""
-INSERT INTO test_files (file_path, category, subcategory, status, last_tested, last_passed)
+INSERT OR REPLACE INTO test_files (file_path, category, subcategory, status, last_tested, last_passed)
 VALUES ({sql_escape(file_path)}, {sql_escape(category)}, {sql_escape(subcategory)}, 'FAIL', TIMESTAMP '{timestamp}', NULL);
 """)
 
@@ -230,13 +220,8 @@ VALUES ({abs(hash(f'{run_id}_{file_path}'))}, {run_id}, {sql_escape(file_path)},
     for file_path in timed_out_files:
         category, subcategory = categorize_test_file(file_path)
 
-        # Workaround: DELETE + INSERT instead of INSERT OR REPLACE
-        # (INSERT OR REPLACE has a bug in VibeSQL where it fails on existing rows)
         statements.append(f"""
-DELETE FROM test_files WHERE file_path = {sql_escape(file_path)};
-""")
-        statements.append(f"""
-INSERT INTO test_files (file_path, category, subcategory, status, last_tested, last_passed)
+INSERT OR REPLACE INTO test_files (file_path, category, subcategory, status, last_tested, last_passed)
 VALUES ({sql_escape(file_path)}, {sql_escape(category)}, {sql_escape(subcategory)}, 'TIMEOUT', TIMESTAMP '{timestamp}', NULL);
 """)
 

--- a/tests/regression/issue_4237.rs
+++ b/tests/regression/issue_4237.rs
@@ -1,0 +1,180 @@
+//! Test for Issue #4237: INSERT OR REPLACE fails on persisted databases
+//!
+//! This regression test ensures that INSERT OR REPLACE correctly replaces
+//! existing rows when the database is saved to disk (as SQL dump) and reloaded.
+//!
+//! Root cause: The SQL dump generation (`save_sql_dump`) did not include the
+//! PRIMARY KEY constraint in the CREATE TABLE statement. Instead, it only
+//! created a UNIQUE INDEX named "PK_<table>". When the database was reloaded,
+//! the table had no PRIMARY KEY metadata, so `handle_replace_conflicts()`
+//! couldn't detect conflicts and the INSERT OR REPLACE failed with a
+//! unique constraint violation.
+//!
+//! Fix: Modified `save_sql_dump` to:
+//! 1. Include PRIMARY KEY constraint in CREATE TABLE statement
+//! 2. Skip auto-generated PK indexes (PK_*) to avoid duplicate index creation
+
+use std::fs;
+use vibesql_executor::{CreateTableExecutor, InsertExecutor, SelectExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::{SqlValue, StringValue};
+
+/// Helper to execute SQL and return results
+fn execute(db: &mut Database, sql: &str) -> Result<Vec<Vec<SqlValue>>, String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("Parse error: {}", e))?;
+    match stmt {
+        vibesql_ast::Statement::Select(select_stmt) => {
+            let executor = SelectExecutor::new(db);
+            let rows =
+                executor.execute(&select_stmt).map_err(|e| format!("Execution error: {}", e))?;
+            Ok(rows.into_iter().map(|r| r.values.into_vec()).collect())
+        }
+        vibesql_ast::Statement::CreateTable(create_stmt) => {
+            CreateTableExecutor::execute(&create_stmt, db)
+                .map_err(|e| format!("Create table error: {}", e))?;
+            Ok(vec![])
+        }
+        vibesql_ast::Statement::Insert(insert_stmt) => {
+            InsertExecutor::execute(db, &insert_stmt).map_err(|e| format!("Insert error: {}", e))?;
+            Ok(vec![])
+        }
+        _ => Err("Unsupported statement type".to_string()),
+    }
+}
+
+/// Test that INSERT OR REPLACE works correctly after SQL dump save/reload
+#[test]
+fn test_insert_or_replace_persists_across_sql_dump() {
+    // Create database with PRIMARY KEY table
+    let mut db = Database::new();
+
+    execute(&mut db, "CREATE TABLE test_files (file_path VARCHAR(500) PRIMARY KEY, status VARCHAR(20) NOT NULL)").unwrap();
+
+    // First INSERT OR REPLACE
+    execute(
+        &mut db,
+        "INSERT OR REPLACE INTO test_files (file_path, status) VALUES ('test.file', 'PASS')",
+    )
+    .unwrap();
+
+    // Verify initial insert
+    let rows = execute(&mut db, "SELECT file_path, status FROM test_files").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][1], SqlValue::Varchar(StringValue::from("PASS")));
+
+    // Save database as SQL dump
+    let path = "/tmp/test_issue_4237.sql";
+    db.save_sql_dump(path).unwrap();
+
+    // Verify the SQL dump contains PRIMARY KEY
+    let dump_content = fs::read_to_string(path).unwrap();
+    assert!(
+        dump_content.contains("PRIMARY KEY"),
+        "SQL dump should contain PRIMARY KEY constraint"
+    );
+
+    // Reload database from SQL dump (simulates opening existing database file)
+    // We need to use the CLI's load_sql_dump functionality here
+    // For this test, we'll just re-parse and execute the dump
+
+    // Create a fresh database and execute the dump statements
+    let mut db2 = Database::new();
+
+    // Parse and execute each statement from the dump
+    for line in dump_content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("--") {
+            continue;
+        }
+        // Only process statements ending with semicolon
+        if trimmed.ends_with(';') {
+            let sql = trimmed.trim_end_matches(';');
+            // Skip empty statements
+            if sql.trim().is_empty() {
+                continue;
+            }
+            match execute(&mut db2, sql) {
+                Ok(_) => {}
+                Err(e) => panic!("Failed to execute dump statement '{}': {}", sql, e),
+            }
+        }
+    }
+
+    // Verify the loaded data
+    let rows = execute(&mut db2, "SELECT file_path, status FROM test_files").unwrap();
+    assert_eq!(rows.len(), 1, "Should have 1 row after loading dump");
+
+    // THIS IS THE BUG BEING TESTED:
+    // INSERT OR REPLACE should work after loading from SQL dump
+    execute(
+        &mut db2,
+        "INSERT OR REPLACE INTO test_files (file_path, status) VALUES ('test.file', 'FAIL')",
+    )
+    .expect("INSERT OR REPLACE should succeed after loading from SQL dump");
+
+    // Verify the replacement worked
+    let rows = execute(&mut db2, "SELECT file_path, status FROM test_files").unwrap();
+    assert_eq!(rows.len(), 1, "Should still have 1 row after REPLACE");
+    assert_eq!(
+        rows[0][1],
+        SqlValue::Varchar(StringValue::from("FAIL")),
+        "Status should be updated to FAIL"
+    );
+
+    // Cleanup
+    let _ = fs::remove_file(path);
+}
+
+/// Test that SQL dump correctly includes composite PRIMARY KEY
+#[test]
+fn test_composite_primary_key_in_sql_dump() {
+    let mut db = Database::new();
+
+    execute(
+        &mut db,
+        "CREATE TABLE composite_pk (a INTEGER, b VARCHAR(50), c TEXT, PRIMARY KEY (a, b))",
+    )
+    .unwrap();
+
+    // Save and check the dump
+    let path = "/tmp/test_issue_4237_composite.sql";
+    db.save_sql_dump(path).unwrap();
+
+    let dump_content = fs::read_to_string(path).unwrap();
+    assert!(
+        dump_content.contains("PRIMARY KEY (A, B)"),
+        "SQL dump should contain composite PRIMARY KEY: {}",
+        dump_content
+    );
+
+    // Cleanup
+    let _ = fs::remove_file(path);
+}
+
+/// Test that PK_ indexes are not duplicated in SQL dump
+#[test]
+fn test_pk_indexes_not_duplicated_in_dump() {
+    let mut db = Database::new();
+
+    execute(&mut db, "CREATE TABLE test (id INTEGER PRIMARY KEY, val TEXT)").unwrap();
+
+    // Save and check the dump
+    let path = "/tmp/test_issue_4237_pk_dup.sql";
+    db.save_sql_dump(path).unwrap();
+
+    let dump_content = fs::read_to_string(path).unwrap();
+
+    // Should have PRIMARY KEY in CREATE TABLE
+    assert!(dump_content.contains("PRIMARY KEY"), "Should have PRIMARY KEY in table definition");
+
+    // Should NOT have separate CREATE INDEX PK_TEST
+    assert!(
+        !dump_content.contains("CREATE UNIQUE INDEX PK_"),
+        "Should not have separate PK_ index: {}",
+        dump_content
+    );
+
+    // Cleanup
+    let _ = fs::remove_file(path);
+}


### PR DESCRIPTION
## Summary

- Fixes INSERT OR REPLACE failing with unique constraint violation after database reload
- SQL dump now properly includes PRIMARY KEY constraints in CREATE TABLE statements
- Skips auto-generated PK_ indexes to avoid duplicate index creation on reload

## Root Cause

The SQL dump generation (`save_sql_dump`) was not including PRIMARY KEY constraints in the CREATE TABLE statement. Instead, it only created a UNIQUE INDEX named "PK_<table>". When the database was reloaded from the SQL dump, the table had no PRIMARY KEY metadata, so `handle_replace_conflicts()` couldn't detect conflicts and the INSERT OR REPLACE failed.

## Test plan

- [x] Added regression test `tests/regression/issue_4237.rs` with 3 test cases
- [x] All existing persistence tests pass
- [x] Verified `process_test_results.py` works with the fix
- [x] Manual testing confirms INSERT OR REPLACE works after save/reload

Closes #4237

🤖 Generated with [Claude Code](https://claude.com/claude-code)