### PR TITLE
feat(parser): Support IS [NOT] DISTINCT FROM syntax (SQL:1999)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,10 @@ name = "is_null_expressions"
 path = "tests/functions/is_null_expressions.rs"
 
 [[test]]
+name = "is_distinct_from"
+path = "tests/functions/is_distinct_from.rs"
+
+[[test]]
 name = "not_is_null_fix"
 path = "tests/functions/not_is_null_fix.rs"
 

--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -138,6 +138,13 @@ impl<'a, 'arena> Converter<'a, 'arena> {
                 expr: Box::new(self.convert_expression(expr)),
                 negated: *negated,
             },
+            arena_expr::Expression::IsDistinctFrom { left, right, negated } => {
+                Expression::IsDistinctFrom {
+                    left: Box::new(self.convert_expression(left)),
+                    right: Box::new(self.convert_expression(right)),
+                    negated: *negated,
+                }
+            }
             arena_expr::Expression::Wildcard => Expression::Wildcard,
             arena_expr::Expression::CurrentDate => Expression::CurrentDate,
             arena_expr::Expression::CurrentTime { precision } => {

--- a/crates/vibesql-ast/src/arena/expression.rs
+++ b/crates/vibesql-ast/src/arena/expression.rs
@@ -83,6 +83,14 @@ pub enum Expression<'arena> {
         negated: bool,
     },
 
+    /// IS DISTINCT FROM / IS NOT DISTINCT FROM (SQL:1999)
+    /// NULL-safe comparison operator.
+    IsDistinctFrom {
+        left: ExprRef<'arena>,
+        right: ExprRef<'arena>,
+        negated: bool, // false = IS DISTINCT FROM, true = IS NOT DISTINCT FROM
+    },
+
     /// Wildcard (*)
     Wildcard,
 

--- a/crates/vibesql-ast/src/expression.rs
+++ b/crates/vibesql-ast/src/expression.rs
@@ -78,6 +78,16 @@ pub enum Expression {
         negated: bool, // false = IS NULL, true = IS NOT NULL
     },
 
+    /// IS DISTINCT FROM / IS NOT DISTINCT FROM (SQL:1999)
+    /// NULL-safe comparison operator:
+    /// - `a IS NOT DISTINCT FROM b`: TRUE when both NULL or both equal non-NULL
+    /// - `a IS DISTINCT FROM b`: TRUE when one is NULL and other isn't, or both non-NULL but unequal
+    IsDistinctFrom {
+        left: Box<Expression>,
+        right: Box<Expression>,
+        negated: bool, // false = IS DISTINCT FROM, true = IS NOT DISTINCT FROM
+    },
+
     /// Wildcard (*)
     Wildcard,
 

--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -353,6 +353,16 @@ impl ToSql for Expression {
                 }
             }
 
+            Expression::IsDistinctFrom { left, right, negated } => {
+                let left_sql = left.to_sql();
+                let right_sql = right.to_sql();
+                if *negated {
+                    format!("{} IS NOT DISTINCT FROM {}", left_sql, right_sql)
+                } else {
+                    format!("{} IS DISTINCT FROM {}", left_sql, right_sql)
+                }
+            }
+
             Expression::Wildcard => "*".to_string(),
 
             Expression::Case { operand, when_clauses, else_result } => {

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -255,6 +255,14 @@ pub fn walk_expression<V: ExpressionVisitor>(visitor: &mut V, expr: &Expression)
 
         Expression::IsNull { expr: inner, .. } => walk_expression(visitor, inner),
 
+        Expression::IsDistinctFrom { left, right, .. } => {
+            let result = walk_expression(visitor, left);
+            if result.should_stop() {
+                return VisitResult::Stop;
+            }
+            walk_expression(visitor, right)
+        }
+
         Expression::Wildcard => visitor.visit_wildcard(),
 
         Expression::Case { operand, when_clauses, else_result } => {
@@ -555,6 +563,12 @@ pub fn transform_expression<V: ExpressionMutVisitor>(
         Expression::IsNull { expr: inner, negated } => {
             Expression::IsNull { expr: Box::new(transform_expression(visitor, *inner)), negated }
         }
+
+        Expression::IsDistinctFrom { left, right, negated } => Expression::IsDistinctFrom {
+            left: Box::new(transform_expression(visitor, *left)),
+            right: Box::new(transform_expression(visitor, *right)),
+            negated,
+        },
 
         Expression::Case { operand, when_clauses, else_result } => Expression::Case {
             operand: operand.map(|op| Box::new(transform_expression(visitor, *op))),

--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -470,6 +470,10 @@ impl TableSchema {
             vibesql_ast::Expression::IsNull { expr, .. } => {
                 Self::expression_references_column(expr, column_name)
             }
+            vibesql_ast::Expression::IsDistinctFrom { left, right, .. } => {
+                Self::expression_references_column(left, column_name)
+                    || Self::expression_references_column(right, column_name)
+            }
             vibesql_ast::Expression::Case { operand, when_clauses, else_result } => {
                 // Check operand
                 if let Some(op) = operand {

--- a/crates/vibesql-executor/src/cache/parameterized.rs
+++ b/crates/vibesql-executor/src/cache/parameterized.rs
@@ -366,6 +366,11 @@ impl LiteralExtractor {
                 Self::extract_from_expression(expr, literals);
             }
 
+            Expression::IsDistinctFrom { left, right, .. } => {
+                Self::extract_from_expression(left, literals);
+                Self::extract_from_expression(right, literals);
+            }
+
             Expression::Case { operand, when_clauses, else_result } => {
                 if let Some(ref op) = operand {
                     Self::extract_from_expression(op, literals);

--- a/crates/vibesql-executor/src/cache/prepared_statement/arena_prepared.rs
+++ b/crates/vibesql-executor/src/cache/prepared_statement/arena_prepared.rs
@@ -395,6 +395,10 @@ where
         Expression::IsNull { expr: inner, .. } => {
             visit_arena_expression(inner, visitor);
         }
+        Expression::IsDistinctFrom { left, right, .. } => {
+            visit_arena_expression(left, visitor);
+            visit_arena_expression(right, visitor);
+        }
         // Leaf nodes - no recursion needed
         Expression::Literal(_)
         | Expression::Placeholder(_)

--- a/crates/vibesql-executor/src/cache/prepared_statement/bind/mutation.rs
+++ b/crates/vibesql-executor/src/cache/prepared_statement/bind/mutation.rs
@@ -289,6 +289,11 @@ fn bind_expression_mut(expr: &mut Expression, params: &[SqlValue]) {
             bind_expression_mut(inner, params);
         }
 
+        Expression::IsDistinctFrom { left, right, .. } => {
+            bind_expression_mut(left, params);
+            bind_expression_mut(right, params);
+        }
+
         Expression::Case { operand, when_clauses, else_result } => {
             if let Some(op) = operand {
                 bind_expression_mut(op, params);
@@ -652,6 +657,11 @@ fn bind_expression_named_mut(expr: &mut Expression, params: &HashMap<String, Sql
 
         Expression::IsNull { expr: inner, .. } => {
             bind_expression_named_mut(inner, params);
+        }
+
+        Expression::IsDistinctFrom { left, right, .. } => {
+            bind_expression_named_mut(left, params);
+            bind_expression_named_mut(right, params);
         }
 
         Expression::Case { operand, when_clauses, else_result } => {

--- a/crates/vibesql-executor/src/cache/query_signature.rs
+++ b/crates/vibesql-executor/src/cache/query_signature.rs
@@ -362,6 +362,13 @@ impl QuerySignature {
                 negated.hash(hasher);
             }
 
+            Expression::IsDistinctFrom { left, right, negated } => {
+                "IS_DISTINCT_FROM".hash(hasher);
+                Self::hash_expression(left, hasher);
+                Self::hash_expression(right, hasher);
+                negated.hash(hasher);
+            }
+
             Expression::Wildcard => "WILDCARD".hash(hasher),
 
             Expression::Case { operand, when_clauses, else_result } => {
@@ -758,6 +765,13 @@ impl QuerySignature {
             ArenaExpression::IsNull { expr, negated } => {
                 "IS_NULL".hash(hasher);
                 Self::hash_arena_expression(expr, hasher);
+                negated.hash(hasher);
+            }
+
+            ArenaExpression::IsDistinctFrom { left, right, negated } => {
+                "IS_DISTINCT_FROM".hash(hasher);
+                Self::hash_arena_expression(left, hasher);
+                Self::hash_arena_expression(right, hasher);
                 negated.hash(hasher);
             }
 

--- a/crates/vibesql-executor/src/cache/table_extractor.rs
+++ b/crates/vibesql-executor/src/cache/table_extractor.rs
@@ -141,6 +141,10 @@ fn extract_from_expression(expr: &vibesql_ast::Expression, tables: &mut HashSet<
         vibesql_ast::Expression::IsNull { expr, .. } => {
             extract_from_expression(expr, tables);
         }
+        vibesql_ast::Expression::IsDistinctFrom { left, right, .. } => {
+            extract_from_expression(left, tables);
+            extract_from_expression(right, tables);
+        }
         vibesql_ast::Expression::Cast { expr, .. } => {
             extract_from_expression(expr, tables);
         }

--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -248,6 +248,11 @@ fn is_expression_correlated(
             is_expression_correlated(expr, outer_schema, subquery_tables)
         }
 
+        Expression::IsDistinctFrom { left, right, .. } => {
+            is_expression_correlated(left, outer_schema, subquery_tables)
+                || is_expression_correlated(right, outer_schema, subquery_tables)
+        }
+
         Expression::Case { operand, when_clauses, else_result } => {
             // Check operand
             if let Some(op) = operand {

--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -221,6 +221,14 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
                 Ok(SqlValue::Boolean(if *negated { !is_null } else { is_null }))
             }
 
+            // IS DISTINCT FROM / IS NOT DISTINCT FROM
+            ArenaExpression::IsDistinctFrom { left, right, negated } => {
+                let left_val = self.eval_with_depth(left, row)?;
+                let right_val = self.eval_with_depth(right, row)?;
+                let is_distinct = super::core::values_are_distinct(&left_val, &right_val);
+                Ok(SqlValue::Boolean(if *negated { !is_distinct } else { is_distinct }))
+            }
+
             // Wildcard (*)
             ArenaExpression::Wildcard => Ok(SqlValue::Null),
 

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -253,6 +253,11 @@ impl CombinedExpressionEvaluator<'_> {
                 self.eval_is_null(expr, *negated, row)
             }
 
+            // IS DISTINCT FROM / IS NOT DISTINCT FROM (SQL:1999)
+            vibesql_ast::Expression::IsDistinctFrom { left, right, negated } => {
+                self.eval_is_distinct_from(left, right, *negated, row)
+            }
+
             // Function expressions - handle scalar functions (not aggregates)
             vibesql_ast::Expression::Function { name, args, character_unit } => {
                 self.eval_function(name, args, character_unit, row)

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -375,6 +375,43 @@ impl CombinedExpressionEvaluator<'_> {
         Ok(vibesql_types::SqlValue::Boolean(result))
     }
 
+    /// Evaluate IS [NOT] DISTINCT FROM (SQL:1999)
+    /// NULL-safe comparison:
+    /// - `a IS NOT DISTINCT FROM b`: TRUE when both NULL or both equal non-NULL
+    /// - `a IS DISTINCT FROM b`: TRUE when one is NULL and other isn't, or both non-NULL but unequal
+    pub(super) fn eval_is_distinct_from(
+        &self,
+        left: &vibesql_ast::Expression,
+        right: &vibesql_ast::Expression,
+        negated: bool,
+        row: &vibesql_storage::Row,
+    ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        let left_val = self.eval(left, row)?;
+        let right_val = self.eval(right, row)?;
+
+        let left_null = matches!(left_val, vibesql_types::SqlValue::Null);
+        let right_null = matches!(right_val, vibesql_types::SqlValue::Null);
+
+        // IS DISTINCT FROM semantics:
+        // - Both NULL: NOT distinct (they are considered equal)
+        // - One NULL, one not: distinct
+        // - Both non-NULL: use normal equality comparison
+        let is_distinct = if left_null && right_null {
+            // Both NULL - not distinct
+            false
+        } else if left_null || right_null {
+            // One NULL, one not - distinct
+            true
+        } else {
+            // Both non-NULL - compare values
+            left_val != right_val
+        };
+
+        // IS NOT DISTINCT FROM inverts the result
+        let result = if negated { !is_distinct } else { is_distinct };
+        Ok(vibesql_types::SqlValue::Boolean(result))
+    }
+
     /// Evaluate POSITION expression: POSITION(substring IN string)
     pub(super) fn eval_position(
         &self,

--- a/crates/vibesql-executor/src/evaluator/core.rs
+++ b/crates/vibesql-executor/src/evaluator/core.rs
@@ -140,3 +140,30 @@ pub(crate) fn values_are_equal(
         _ => false, // Type mismatch = not equal
     }
 }
+
+/// Compare two SQL values using IS DISTINCT FROM semantics (SQL:1999)
+/// - NULL IS NOT DISTINCT FROM NULL is TRUE (both NULL = not distinct)
+/// - NULL IS DISTINCT FROM non-NULL is TRUE (one NULL, one not = distinct)
+/// - For non-NULL values, uses regular != comparison
+pub(crate) fn values_are_distinct(
+    left: &vibesql_types::SqlValue,
+    right: &vibesql_types::SqlValue,
+) -> bool {
+    use vibesql_types::SqlValue::*;
+
+    // IS DISTINCT FROM semantics (SQL:1999):
+    // - Both NULL: NOT distinct (they are considered equal)
+    // - One NULL, one not: distinct
+    // - Both non-NULL: use normal inequality comparison
+    match (left, right) {
+        // Both NULL - not distinct
+        (Null, Null) => false,
+
+        // One NULL, one not - distinct
+        (Null, _) | (_, Null) => true,
+
+        // Both non-NULL - compare for inequality
+        // Reuse the values_are_equal logic but invert it
+        _ => !values_are_equal(left, right),
+    }
+}

--- a/crates/vibesql-executor/src/evaluator/expression_hash.rs
+++ b/crates/vibesql-executor/src/evaluator/expression_hash.rs
@@ -128,6 +128,10 @@ impl ExpressionHasher {
 
             vibesql_ast::Expression::IsNull { expr, .. } => Self::is_deterministic(expr),
 
+            vibesql_ast::Expression::IsDistinctFrom { left, right, .. } => {
+                Self::is_deterministic(left) && Self::is_deterministic(right)
+            }
+
             vibesql_ast::Expression::Position { substring, string, .. } => {
                 Self::is_deterministic(substring) && Self::is_deterministic(string)
             }
@@ -256,6 +260,12 @@ impl ExpressionHasher {
 
             vibesql_ast::Expression::IsNull { expr, negated } => {
                 Self::hash_expression(expr, hasher);
+                negated.hash(hasher);
+            }
+
+            vibesql_ast::Expression::IsDistinctFrom { left, right, negated } => {
+                Self::hash_expression(left, hasher);
+                Self::hash_expression(right, hasher);
                 negated.hash(hasher);
             }
 

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -247,6 +247,14 @@ impl ExpressionEvaluator<'_> {
                 Ok(SqlValue::Boolean(result))
             }
 
+            vibesql_ast::Expression::IsDistinctFrom { left, right, negated } => {
+                let left_val = self.eval(left, row)?;
+                let right_val = self.eval(right, row)?;
+                let is_distinct = super::super::core::values_are_distinct(&left_val, &right_val);
+                let result = if *negated { !is_distinct } else { is_distinct };
+                Ok(SqlValue::Boolean(result))
+            }
+
             vibesql_ast::Expression::WindowFunction { .. } => Err(ExecutorError::UnsupportedExpression(
                 "Window functions should be evaluated separately".to_string(),
             )),

--- a/crates/vibesql-executor/src/evaluator/single.rs
+++ b/crates/vibesql-executor/src/evaluator/single.rs
@@ -201,6 +201,16 @@ impl<'a> ExpressionEvaluator<'a> {
         super::core::values_are_equal(left, right)
     }
 
+    /// Compare two SQL values using IS DISTINCT FROM semantics (SQL:1999)
+    ///
+    /// Delegates to the core module's implementation.
+    pub(crate) fn values_are_distinct(
+        left: &vibesql_types::SqlValue,
+        right: &vibesql_types::SqlValue,
+    ) -> bool {
+        super::core::values_are_distinct(left, right)
+    }
+
     /// Helper to execute a closure with incremented depth
     pub(super) fn with_incremented_depth<F, T>(&self, f: F) -> Result<T, ExecutorError>
     where

--- a/crates/vibesql-executor/src/optimizer/expressions.rs
+++ b/crates/vibesql-executor/src/optimizer/expressions.rs
@@ -186,6 +186,26 @@ pub fn optimize_expression(
             }
         }
 
+        // IS DISTINCT FROM/IS NOT DISTINCT FROM - try to fold if both operands are literals
+        Expression::IsDistinctFrom { left, right, negated } => {
+            let left_opt = optimize_expression(left, evaluator)?;
+            let right_opt = optimize_expression(right, evaluator)?;
+
+            if let (Expression::Literal(left_val), Expression::Literal(right_val)) =
+                (&left_opt, &right_opt)
+            {
+                let is_distinct = ExpressionEvaluator::values_are_distinct(left_val, right_val);
+                let result = if *negated { !is_distinct } else { is_distinct };
+                Ok(Expression::Literal(SqlValue::Boolean(result)))
+            } else {
+                Ok(Expression::IsDistinctFrom {
+                    left: Box::new(left_opt),
+                    right: Box::new(right_opt),
+                    negated: *negated,
+                })
+            }
+        }
+
         // Wildcard - cannot optimize
         Expression::Wildcard => Ok(expr.clone()),
 

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
@@ -133,6 +133,10 @@ pub(crate) fn has_external_column_refs(expr: &Expression, subquery: &SelectStmt)
 
         Expression::IsNull { expr, .. } => has_external_column_refs(expr, subquery),
 
+        Expression::IsDistinctFrom { left, right, .. } => {
+            has_external_column_refs(left, subquery) || has_external_column_refs(right, subquery)
+        }
+
         Expression::Case { operand, when_clauses, else_result } => {
             operand.as_ref().is_some_and(|e| has_external_column_refs(e, subquery))
                 || when_clauses.iter().any(|clause| {

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
@@ -121,6 +121,20 @@ pub(super) fn rewrite_expression_with_context(
             negated: *negated,
         },
 
+        Expression::IsDistinctFrom { left, right, negated } => Expression::IsDistinctFrom {
+            left: Box::new(rewrite_expression_with_context(
+                left,
+                rewrite_subquery_fn,
+                outer_tables,
+            )),
+            right: Box::new(rewrite_expression_with_context(
+                right,
+                rewrite_subquery_fn,
+                outer_tables,
+            )),
+            negated: *negated,
+        },
+
         Expression::Case { operand, when_clauses, else_result } => Expression::Case {
             operand: operand.as_ref().map(|e| {
                 Box::new(rewrite_expression_with_context(e, rewrite_subquery_fn, outer_tables))

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -77,6 +77,7 @@ impl SelectExecutor<'_> {
             | vibesql_ast::Expression::InList { .. }
             | vibesql_ast::Expression::Like { .. }
             | vibesql_ast::Expression::IsNull { .. }
+            | vibesql_ast::Expression::IsDistinctFrom { .. }
             | vibesql_ast::Expression::Position { .. }
             | vibesql_ast::Expression::Trim { .. }
             | vibesql_ast::Expression::Extract { .. }
@@ -469,6 +470,29 @@ impl SelectExecutor<'_> {
                 )?;
                 let is_null = matches!(inner_val, vibesql_types::SqlValue::Null);
                 Ok(vibesql_types::SqlValue::Boolean(if *negated { !is_null } else { is_null }))
+            }
+
+            // IsDistinctFrom - evaluate both expressions with grouping context
+            vibesql_ast::Expression::IsDistinctFrom { left, right, negated } => {
+                let left_val = self.evaluate_with_aggregates_and_grouping(
+                    left,
+                    group_rows,
+                    group_key,
+                    evaluator,
+                    grouping_context,
+                )?;
+                let right_val = self.evaluate_with_aggregates_and_grouping(
+                    right,
+                    group_rows,
+                    group_key,
+                    evaluator,
+                    grouping_context,
+                )?;
+                let is_distinct = !crate::evaluator::ExpressionEvaluator::values_are_equal(
+                    &left_val,
+                    &right_val,
+                );
+                Ok(vibesql_types::SqlValue::Boolean(if *negated { !is_distinct } else { is_distinct }))
             }
 
             // For all other expressions, delegate to existing evaluation

--- a/crates/vibesql-executor/src/select/executor/arena_execution.rs
+++ b/crates/vibesql-executor/src/select/executor/arena_execution.rs
@@ -354,6 +354,9 @@ impl SelectExecutor<'_> {
             }
             ArenaExpression::UnaryOp { expr, .. } => self.arena_expr_has_aggregate(expr),
             ArenaExpression::IsNull { expr, .. } => self.arena_expr_has_aggregate(expr),
+            ArenaExpression::IsDistinctFrom { left, right, .. } => {
+                self.arena_expr_has_aggregate(left) || self.arena_expr_has_aggregate(right)
+            }
             ArenaExpression::Conjunction(children) | ArenaExpression::Disjunction(children) => {
                 children.iter().any(|c| self.arena_expr_has_aggregate(c))
             }

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -49,6 +49,10 @@ pub(super) fn validate_where_clause_subqueries(
         Expression::IsNull { expr, .. } => {
             validate_where_clause_subqueries(expr, database, cte_results)
         }
+        Expression::IsDistinctFrom { left, right, .. } => {
+            validate_where_clause_subqueries(left, database, cte_results)?;
+            validate_where_clause_subqueries(right, database, cte_results)
+        }
         Expression::InList { expr, values, .. } => {
             validate_where_clause_subqueries(expr, database, cte_results)?;
             for val in values {
@@ -426,6 +430,12 @@ fn validate_expression_column_refs(
         // IS NULL / IS NOT NULL
         Expression::IsNull { expr, .. } => {
             validate_expression_column_refs(expr, schema, outer_schema, allowed_aliases)
+        }
+
+        // IS DISTINCT FROM / IS NOT DISTINCT FROM
+        Expression::IsDistinctFrom { left, right, .. } => {
+            validate_expression_column_refs(left, schema, outer_schema, allowed_aliases)?;
+            validate_expression_column_refs(right, schema, outer_schema, allowed_aliases)
         }
 
         // IN list

--- a/crates/vibesql-executor/src/select/executor/utils.rs
+++ b/crates/vibesql-executor/src/select/executor/utils.rs
@@ -26,6 +26,10 @@ fn expression_references_column(expr: &vibesql_ast::Expression) -> bool {
 
         vibesql_ast::Expression::IsNull { expr, .. } => expression_references_column(expr),
 
+        vibesql_ast::Expression::IsDistinctFrom { left, right, .. } => {
+            expression_references_column(left) || expression_references_column(right)
+        }
+
         vibesql_ast::Expression::InList { expr, values, .. } => {
             expression_references_column(expr) || values.iter().any(expression_references_column)
         }

--- a/crates/vibesql-executor/src/select/executor/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/validation.rs
@@ -62,6 +62,10 @@ fn extract_column_refs(expr: &Expression, refs: &mut Vec<ColumnReference>) {
         Expression::IsNull { expr, .. } => {
             extract_column_refs(expr, refs);
         }
+        Expression::IsDistinctFrom { left, right, .. } => {
+            extract_column_refs(left, refs);
+            extract_column_refs(right, refs);
+        }
         Expression::Between { expr, low, high, .. } => {
             extract_column_refs(expr, refs);
             extract_column_refs(low, refs);

--- a/crates/vibesql-executor/src/select/join/expression_mapper.rs
+++ b/crates/vibesql-executor/src/select/join/expression_mapper.rs
@@ -201,6 +201,10 @@ impl ExpressionMapper {
             Expression::IsNull { expr: e, .. } => {
                 self.walk_expression(e, tables, columns, resolvable);
             }
+            Expression::IsDistinctFrom { left, right, .. } => {
+                self.walk_expression(left, tables, columns, resolvable);
+                self.walk_expression(right, tables, columns, resolvable);
+            }
             Expression::Case { operand, when_clauses, else_result } => {
                 if let Some(op) = operand {
                     self.walk_expression(op, tables, columns, resolvable);

--- a/crates/vibesql-executor/src/select/window/order_by.rs
+++ b/crates/vibesql-executor/src/select/window/order_by.rs
@@ -82,6 +82,10 @@ fn collect_window_functions_from_expression(
         Expression::IsNull { expr, .. } => {
             collect_window_functions_from_expression(expr, window_functions);
         }
+        Expression::IsDistinctFrom { left, right, .. } => {
+            collect_window_functions_from_expression(left, window_functions);
+            collect_window_functions_from_expression(right, window_functions);
+        }
         Expression::Position { substring, string, character_unit: _ } => {
             collect_window_functions_from_expression(substring, window_functions);
             collect_window_functions_from_expression(string, window_functions);

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -282,14 +282,24 @@ impl<'arena> ArenaParser<'arena> {
             left = Expression::BinaryOp { op, left: left_ref, right: right_ref };
         }
 
-        // Check for IS NULL / IS NOT NULL
+        // Check for IS NULL / IS NOT NULL / IS [NOT] DISTINCT FROM
         if self.peek_keyword(Keyword::Is) {
             self.consume_keyword(Keyword::Is)?;
             let negated = self.try_consume_keyword(Keyword::Not);
-            self.expect_keyword(Keyword::Null)?;
 
-            let left_ref = self.arena.alloc(left);
-            left = Expression::IsNull { expr: left_ref, negated };
+            // Check for DISTINCT FROM (SQL:1999) or NULL
+            if self.peek_keyword(Keyword::Distinct) {
+                self.consume_keyword(Keyword::Distinct)?;
+                self.expect_keyword(Keyword::From)?;
+                let right = self.parse_additive_expression()?;
+                let left_ref = self.arena.alloc(left);
+                let right_ref = self.arena.alloc(right);
+                left = Expression::IsDistinctFrom { left: left_ref, right: right_ref, negated };
+            } else {
+                self.expect_keyword(Keyword::Null)?;
+                let left_ref = self.arena.alloc(left);
+                left = Expression::IsNull { expr: left_ref, negated };
+            }
         }
 
         Ok(left)

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -370,7 +370,7 @@ impl Parser {
             };
         }
 
-        // Check for IS NULL / IS NOT NULL
+        // Check for IS NULL / IS NOT NULL / IS [NOT] DISTINCT FROM
         if self.peek_keyword(Keyword::Is) {
             self.consume_keyword(Keyword::Is)?;
 
@@ -382,10 +382,21 @@ impl Parser {
                 false
             };
 
-            // Expect NULL
-            self.expect_keyword(Keyword::Null)?;
-
-            left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated };
+            // Check for DISTINCT FROM (SQL:1999) or NULL
+            if self.peek_keyword(Keyword::Distinct) {
+                self.consume_keyword(Keyword::Distinct)?;
+                self.expect_keyword(Keyword::From)?;
+                let right = self.parse_additive_expression()?;
+                left = vibesql_ast::Expression::IsDistinctFrom {
+                    left: Box::new(left),
+                    right: Box::new(right),
+                    negated,
+                };
+            } else {
+                // Expect NULL
+                self.expect_keyword(Keyword::Null)?;
+                left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated };
+            }
         }
 
         Ok(left)

--- a/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
+++ b/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
@@ -73,6 +73,7 @@ enum ExprTag {
     Extract = 0x1E,
     Conjunction = 0x1F,
     Disjunction = 0x20,
+    IsDistinctFrom = 0x21,
 }
 
 impl ExprTag {
@@ -111,6 +112,7 @@ impl ExprTag {
             0x1E => Ok(ExprTag::Extract),
             0x1F => Ok(ExprTag::Conjunction),
             0x20 => Ok(ExprTag::Disjunction),
+            0x21 => Ok(ExprTag::IsDistinctFrom),
             _ => {
                 Err(StorageError::NotImplemented(format!("Unknown expression tag: 0x{:02X}", tag)))
             }
@@ -176,6 +178,12 @@ pub fn write_expression<W: Write>(writer: &mut W, expr: &Expression) -> Result<(
         Expression::IsNull { expr, negated } => {
             write_tag!(writer, ExprTag::IsNull);
             write_expression(writer, expr)?;
+            write_bool(writer, *negated)?;
+        }
+        Expression::IsDistinctFrom { left, right, negated } => {
+            write_tag!(writer, ExprTag::IsDistinctFrom);
+            write_expression(writer, left)?;
+            write_expression(writer, right)?;
             write_bool(writer, *negated)?;
         }
         Expression::Wildcard => {
@@ -424,6 +432,12 @@ pub fn read_expression<R: Read>(reader: &mut R) -> Result<Expression, StorageErr
             let expr = Box::new(read_expression(reader)?);
             let negated = read_bool(reader)?;
             Ok(Expression::IsNull { expr, negated })
+        }
+        ExprTag::IsDistinctFrom => {
+            let left = Box::new(read_expression(reader)?);
+            let right = Box::new(read_expression(reader)?);
+            let negated = read_bool(reader)?;
+            Ok(Expression::IsDistinctFrom { left, right, negated })
         }
         ExprTag::Wildcard => Ok(Expression::Wildcard),
         ExprTag::Case => {

--- a/tests/functions/is_distinct_from.rs
+++ b/tests/functions/is_distinct_from.rs
@@ -1,0 +1,196 @@
+// Test for IS [NOT] DISTINCT FROM syntax (SQL:1999)
+// NULL-safe comparison operator for JOIN conditions and predicates.
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+/// Execute a SELECT query end-to-end: parse SQL → execute → return results.
+fn execute_select(db: &Database, sql: &str) -> Result<Vec<Row>, String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("Parse error: {:?}", e))?;
+    let select_stmt = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        other => return Err(format!("Expected SELECT statement, got {:?}", other)),
+    };
+
+    let executor = SelectExecutor::new(db);
+    executor.execute(&select_stmt).map_err(|e| format!("Execution error: {:?}", e))
+}
+
+fn setup_test_db() -> Database {
+    let schema = TableSchema::new(
+        "t1".to_string(),
+        vec![
+            ColumnSchema::new("a".to_string(), DataType::Integer, true),
+            ColumnSchema::new("b".to_string(), DataType::Integer, true),
+        ],
+    );
+
+    let mut db = Database::new();
+    db.create_table(schema).unwrap();
+    // Row 1: a=1, b=1 (equal non-NULL values)
+    db.insert_row("t1", Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(1)])).unwrap();
+    // Row 2: a=1, b=2 (different non-NULL values)
+    db.insert_row("t1", Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(2)])).unwrap();
+    // Row 3: a=NULL, b=NULL (both NULL)
+    db.insert_row("t1", Row::new(vec![SqlValue::Null, SqlValue::Null])).unwrap();
+    // Row 4: a=NULL, b=1 (one NULL, one not)
+    db.insert_row("t1", Row::new(vec![SqlValue::Null, SqlValue::Integer(1)])).unwrap();
+    // Row 5: a=1, b=NULL (one NULL, one not)
+    db.insert_row("t1", Row::new(vec![SqlValue::Integer(1), SqlValue::Null])).unwrap();
+    db
+}
+
+#[test]
+fn test_is_distinct_from_non_null_equal() {
+    let db = setup_test_db();
+    // Two equal non-NULL values: NOT distinct
+    let results = execute_select(&db, "SELECT a, b FROM t1 WHERE a IS DISTINCT FROM b")
+        .expect("Query should succeed");
+    // Should find: (1,2), (NULL,1), (1,NULL) - values that ARE distinct
+    // Should NOT find: (1,1), (NULL,NULL)
+    assert_eq!(results.len(), 3, "Should find 3 rows where a IS DISTINCT FROM b");
+}
+
+#[test]
+fn test_is_not_distinct_from_non_null_equal() {
+    let db = setup_test_db();
+    // Two equal non-NULL values: NOT distinct (so IS NOT DISTINCT returns true)
+    let results = execute_select(&db, "SELECT a, b FROM t1 WHERE a IS NOT DISTINCT FROM b")
+        .expect("Query should succeed");
+    // Should find: (1,1), (NULL,NULL) - values that are NOT distinct
+    assert_eq!(results.len(), 2, "Should find 2 rows where a IS NOT DISTINCT FROM b");
+}
+
+#[test]
+fn test_is_distinct_from_both_null() {
+    let db = setup_test_db();
+    // NULL IS DISTINCT FROM NULL → FALSE (they're considered equal for this comparison)
+    let results = execute_select(&db, "SELECT a FROM t1 WHERE NULL IS DISTINCT FROM NULL")
+        .expect("Query should succeed");
+    assert_eq!(results.len(), 0, "NULL IS DISTINCT FROM NULL should be FALSE");
+}
+
+#[test]
+fn test_is_not_distinct_from_both_null() {
+    let db = setup_test_db();
+    // NULL IS NOT DISTINCT FROM NULL → TRUE (they're considered equal)
+    let results = execute_select(&db, "SELECT a FROM t1 WHERE NULL IS NOT DISTINCT FROM NULL")
+        .expect("Query should succeed");
+    assert_eq!(results.len(), 5, "NULL IS NOT DISTINCT FROM NULL should be TRUE for all rows");
+}
+
+#[test]
+fn test_is_distinct_from_one_null() {
+    let db = setup_test_db();
+    // NULL IS DISTINCT FROM non-NULL → TRUE
+    let results = execute_select(&db, "SELECT a FROM t1 WHERE NULL IS DISTINCT FROM 1")
+        .expect("Query should succeed");
+    assert_eq!(results.len(), 5, "NULL IS DISTINCT FROM 1 should be TRUE for all rows");
+}
+
+#[test]
+fn test_is_not_distinct_from_one_null() {
+    let db = setup_test_db();
+    // NULL IS NOT DISTINCT FROM non-NULL → FALSE
+    let results = execute_select(&db, "SELECT a FROM t1 WHERE NULL IS NOT DISTINCT FROM 1")
+        .expect("Query should succeed");
+    assert_eq!(results.len(), 0, "NULL IS NOT DISTINCT FROM 1 should be FALSE");
+}
+
+#[test]
+fn test_is_distinct_from_non_null_different() {
+    let db = setup_test_db();
+    // 1 IS DISTINCT FROM 2 → TRUE (different values)
+    let results = execute_select(&db, "SELECT a FROM t1 WHERE 1 IS DISTINCT FROM 2")
+        .expect("Query should succeed");
+    assert_eq!(results.len(), 5, "1 IS DISTINCT FROM 2 should be TRUE for all rows");
+}
+
+#[test]
+fn test_is_not_distinct_from_non_null_different() {
+    let db = setup_test_db();
+    // 1 IS NOT DISTINCT FROM 2 → FALSE (different values)
+    let results = execute_select(&db, "SELECT a FROM t1 WHERE 1 IS NOT DISTINCT FROM 2")
+        .expect("Query should succeed");
+    assert_eq!(results.len(), 0, "1 IS NOT DISTINCT FROM 2 should be FALSE");
+}
+
+#[test]
+fn test_is_distinct_from_in_join_condition() {
+    // This test verifies the syntax parses correctly in a JOIN context
+    let schema1 = TableSchema::new(
+        "t1".to_string(),
+        vec![ColumnSchema::new("a".to_string(), DataType::Integer, true)],
+    );
+    let schema2 = TableSchema::new(
+        "t2".to_string(),
+        vec![ColumnSchema::new("b".to_string(), DataType::Integer, true)],
+    );
+
+    let mut db = Database::new();
+    db.create_table(schema1).unwrap();
+    db.create_table(schema2).unwrap();
+    db.insert_row("t1", Row::new(vec![SqlValue::Integer(1)])).unwrap();
+    db.insert_row("t1", Row::new(vec![SqlValue::Null])).unwrap();
+    db.insert_row("t2", Row::new(vec![SqlValue::Integer(1)])).unwrap();
+    db.insert_row("t2", Row::new(vec![SqlValue::Null])).unwrap();
+
+    // IS NOT DISTINCT FROM is commonly used for NULL-safe joins
+    let results =
+        execute_select(&db, "SELECT t1.a, t2.b FROM t1 JOIN t2 ON t1.a IS NOT DISTINCT FROM t2.b")
+            .expect("Query should succeed");
+    // Should match: (1,1) and (NULL,NULL)
+    assert_eq!(results.len(), 2, "Should find 2 matching rows in NULL-safe join");
+}
+
+#[test]
+fn test_is_distinct_from_with_expressions() {
+    let db = setup_test_db();
+    // Test with arithmetic expressions
+    let results = execute_select(&db, "SELECT a FROM t1 WHERE (a + 1) IS NOT DISTINCT FROM (b + 1)")
+        .expect("Query should succeed");
+    // (a+1) IS NOT DISTINCT FROM (b+1) when a=b (for row 1 where a=1,b=1)
+    // For NULL values, NULL+1=NULL, and NULL IS NOT DISTINCT FROM NULL
+    assert_eq!(results.len(), 2, "Should find 2 rows where (a+1) IS NOT DISTINCT FROM (b+1)");
+}
+
+#[test]
+fn test_pretty_print_is_distinct_from() {
+    use vibesql_ast::pretty_print::ToSql;
+
+    let sql = "SELECT * FROM t1 WHERE a IS DISTINCT FROM b";
+    let stmt = Parser::parse_sql(sql).expect("Parse should succeed");
+    let select_stmt = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        _ => panic!("Expected SELECT statement"),
+    };
+
+    let printed = select_stmt.to_sql();
+    assert!(
+        printed.contains("IS DISTINCT FROM"),
+        "Pretty print should contain 'IS DISTINCT FROM': {}",
+        printed
+    );
+}
+
+#[test]
+fn test_pretty_print_is_not_distinct_from() {
+    use vibesql_ast::pretty_print::ToSql;
+
+    let sql = "SELECT * FROM t1 WHERE a IS NOT DISTINCT FROM b";
+    let stmt = Parser::parse_sql(sql).expect("Parse should succeed");
+    let select_stmt = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        _ => panic!("Expected SELECT statement"),
+    };
+
+    let printed = select_stmt.to_sql();
+    assert!(
+        printed.contains("IS NOT DISTINCT FROM"),
+        "Pretty print should contain 'IS NOT DISTINCT FROM': {}",
+        printed
+    );
+}


### PR DESCRIPTION
## Summary
- Add IS DISTINCT FROM / IS NOT DISTINCT FROM operators (SQL:1999)
- NULL-safe comparison for JOIN conditions and predicates
- Addresses 301 TCL test failures

## Changes
- New `IsDistinctFrom` AST variant with `left`, `right`, `negated` fields
- Parsing in both standard and arena parsers
- Evaluation with proper NULL-handling semantics
- Pretty-print and binary persistence support
- Constant folding optimization for literals
- 12 new tests covering all edge cases

## Test plan
- [x] All 12 IS DISTINCT FROM tests pass
- [x] Parser tests pass (1044 tests)
- [x] Executor tests pass
- [x] AST tests pass

Closes #4240

🤖 Generated with [Claude Code](https://claude.com/claude-code)