### PR TITLE
fix(testing): Use --format raw in TCL test runner for SQLite compatibility

### DIFF
--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -106,10 +106,11 @@ class VibeSQL:
     def execute(self, sql: str) -> tuple[bool, str, str]:
         """
         Execute SQL and return (success, stdout, stderr).
+        Uses --format raw for TCL-compatible output (space-separated values).
         """
         try:
             result = subprocess.run(
-                [self.vibesql_path, self._db_file.name, "-c", sql],
+                [self.vibesql_path, self._db_file.name, "-c", sql, "--format", "raw"],
                 capture_output=True,
                 text=True,
                 timeout=self.timeout,
@@ -432,7 +433,7 @@ def save_to_database(summary: RunSummary, db_path: str, vibesql_path: str):
     """Save run results to the database."""
     # First, get the next run_id
     result = subprocess.run(
-        [vibesql_path, db_path, "-c", "SELECT COALESCE(MAX(run_id), 0) + 1 FROM tcl_test_runs"],
+        [vibesql_path, db_path, "-c", "SELECT COALESCE(MAX(run_id), 0) + 1 FROM tcl_test_runs", "--format", "raw"],
         capture_output=True,
         text=True,
     )
@@ -478,7 +479,7 @@ def save_to_database(summary: RunSummary, db_path: str, vibesql_path: str):
 
     # Get next result ID
     result = subprocess.run(
-        [vibesql_path, db_path, "-c", "SELECT COALESCE(MAX(id), 0) FROM tcl_test_results"],
+        [vibesql_path, db_path, "-c", "SELECT COALESCE(MAX(id), 0) FROM tcl_test_results", "--format", "raw"],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
## Summary

- Fixes TCL test runner output format compatibility with SQLite test harness
- Uses `--format raw` flag for space-separated output without headers/borders
- Eliminates format-related test failures (tests passing for correct query execution)

## Problem

The TCL test runner was producing output mismatches because VibeSQL outputs formatted ASCII tables by default, while SQLite TCL tests expect space-separated values:

**Before (table format):**
```
+-----+
| X   |
+-----+
| 123 |
+-----+
1 rows
```

**After (raw format):**
```
123
```

## Changes

1. Added `--format raw` to the `execute()` method in `tcl_runner.py`
2. Added `--format raw` to database queries in `save_to_database()` function

## Test plan

- [x] Build succeeds
- [x] Raw format output verified: `SELECT 123` → `123`
- [x] Multi-column output verified: `SELECT 1, 2, 3` → `1 2 3`
- [x] TCL test `select4-2.5` now passes (the exact example from issue)
- [x] Database result parsing works with raw format

Closes #4243

🤖 Generated with [Claude Code](https://claude.com/claude-code)