### PR TITLE
i18n: Translate missing benchmark strings for de, fr, it, nl

### DIFF
--- a/web-demo/src/i18n/resources/de.ftl
+++ b/web-demo/src/i18n/resources/de.ftl
@@ -392,8 +392,8 @@ bench-tpcc-disc-btree = Zweckgebaute Indexstruktur optimiert für In-Memory-Arbe
 bench-tpcc-disc-prepared = Abfragepläne werden einmal kompiliert und wiederverwendet
 bench-tpcc-disc-scaling-title = Weitere Skalierung
 bench-tpcc-disc-scaling = Aktuelle Ergebnisse sind single-threaded. VibeSQLs Architektur unterstützt Multi-Thread-Transaktionsverarbeitung, und wir erwarten nahezu lineare Skalierung mit der Hinzufügung paralleler Ausführungsunterstützung. Unser Ziel ist 500K+ TPS auf moderner Multi-Core-Hardware.
-bench-tpcc-disc-duckdb-title = Why DuckDB Lags on OLTP
-bench-tpcc-disc-duckdb = DuckDB achieves only ~385 TPS on TPC-C (60x slower than VibeSQL, 12x slower than SQLite). This is expected: DuckDB is an <strong>analytical (OLAP) database</strong> optimized for large batch operations, not single-row transactions. Its columnar storage format excels at scanning millions of rows but adds overhead for point lookups and small updates that dominate OLTP workloads like TPC-C.
+bench-tpcc-disc-duckdb-title = Warum DuckDB bei OLTP zurückbleibt
+bench-tpcc-disc-duckdb = DuckDB erreicht nur ~385 TPS bei TPC-C (60x langsamer als VibeSQL, 12x langsamer als SQLite). Dies ist zu erwarten: DuckDB ist eine <strong>analytische (OLAP) Datenbank</strong>, die für große Batch-Operationen optimiert ist, nicht für Einzelzeilen-Transaktionen. Ihr spaltenorientiertes Speicherformat exzelliert beim Scannen von Millionen Zeilen, verursacht aber Overhead für Punktabfragen und kleine Updates, die OLTP-Arbeitslasten wie TPC-C dominieren.
 
 # Sysbench Eingebettet spezifisch
 bench-sysbench-embedded-name = Sysbench (Eingebettet)
@@ -421,8 +421,8 @@ bench-sysbench-emb-disc-nonindex = Vollständige Tabellenscans für nicht-indizi
 bench-sysbench-emb-disc-deletes = Unsere Tombstone-basierte Löschung hat Bereinigungsoverhead; Kompaktierungsverbesserungen sind geplant
 bench-sysbench-emb-disc-duckdb-title = DuckDB-Vergleich
 bench-sysbench-emb-disc-duckdb = DuckDB ist für analytische Arbeitslasten optimiert, nicht für Mikrooperationen. Seine 100-1000x langsameren Ergebnisse hier spiegeln architektonische Entscheidungen wider (spaltenorientierte Speicherung, vektorisierte Ausführung), die Einzelzeilenlatenz gegen Massendurchsatz eintauschen. VibeSQL zielt auf beide Anwendungsfälle.
-bench-sysbench-emb-disc-architecture-title = Architectural Trade-offs
-bench-sysbench-emb-disc-architecture = VibeSQL's hybrid architecture targets both OLTP and OLAP workloads. Our B-tree storage provides SQLite-competitive point lookup performance, while columnar execution handles analytical queries efficiently. This differs from pure OLAP databases like DuckDB that optimize exclusively for bulk operations at the cost of single-row latency.
+bench-sysbench-emb-disc-architecture-title = Architektonische Kompromisse
+bench-sysbench-emb-disc-architecture = VibeSQLs hybride Architektur zielt sowohl auf OLTP- als auch OLAP-Arbeitslasten ab. Unsere B-Tree-Speicherung bietet SQLite-wettbewerbsfähige Punktabfrageleistung, während die spaltenorientierte Ausführung analytische Abfragen effizient verarbeitet. Dies unterscheidet sich von reinen OLAP-Datenbanken wie DuckDB, die ausschließlich für Massenoperationen optimieren und dabei Einzelzeilen-Latenz opfern.
 
 # Sysbench Server spezifisch
 bench-sysbench-server-name = Sysbench (Server)

--- a/web-demo/src/i18n/resources/fr.ftl
+++ b/web-demo/src/i18n/resources/fr.ftl
@@ -405,8 +405,8 @@ bench-tpcc-disc-btree = Structure d'index construite sur mesure optimisée pour 
 bench-tpcc-disc-prepared = Les plans de requêtes sont compilés une fois et réutilisés
 bench-tpcc-disc-scaling-title = Passage à l'Échelle
 bench-tpcc-disc-scaling = Les résultats actuels sont mono-thread. L'architecture de VibeSQL supporte le traitement transactionnel multi-thread, et nous nous attendons à un passage à l'échelle quasi-linéaire à mesure que nous ajoutons le support d'exécution parallèle. Notre objectif est d'atteindre plus de 500K TPS sur du matériel multi-cœur moderne.
-bench-tpcc-disc-duckdb-title = Why DuckDB Lags on OLTP
-bench-tpcc-disc-duckdb = DuckDB achieves only ~385 TPS on TPC-C (60x slower than VibeSQL, 12x slower than SQLite). This is expected: DuckDB is an <strong>analytical (OLAP) database</strong> optimized for large batch operations, not single-row transactions. Its columnar storage format excels at scanning millions of rows but adds overhead for point lookups and small updates that dominate OLTP workloads like TPC-C.
+bench-tpcc-disc-duckdb-title = Pourquoi DuckDB est à la traîne sur OLTP
+bench-tpcc-disc-duckdb = DuckDB n'atteint que ~385 TPS sur TPC-C (60x plus lent que VibeSQL, 12x plus lent que SQLite). C'est attendu : DuckDB est une <strong>base de données analytique (OLAP)</strong> optimisée pour les opérations par lots volumineuses, pas pour les transactions mono-ligne. Son format de stockage en colonnes excelle dans le scan de millions de lignes mais ajoute une surcharge pour les recherches ponctuelles et les petites mises à jour qui dominent les charges OLTP comme TPC-C.
 
 # Sysbench Embarqué spécifique
 bench-sysbench-embedded-name = Sysbench (Embarqué)
@@ -434,8 +434,8 @@ bench-sysbench-emb-disc-nonindex = Les scans de table complets pour les colonnes
 bench-sysbench-emb-disc-deletes = Notre suppression basée sur tombstones a une surcharge de nettoyage ; des améliorations de compactage sont planifiées
 bench-sysbench-emb-disc-duckdb-title = Comparaison avec DuckDB
 bench-sysbench-emb-disc-duckdb = DuckDB est optimisé pour les charges analytiques, pas les micro-opérations. Ses résultats 100-1000x plus lents ici reflètent des choix architecturaux (stockage colonnaire, exécution vectorisée) qui échangent la latence mono-ligne contre le débit en masse. VibeSQL cible les deux cas d'usage.
-bench-sysbench-emb-disc-architecture-title = Architectural Trade-offs
-bench-sysbench-emb-disc-architecture = VibeSQL's hybrid architecture targets both OLTP and OLAP workloads. Our B-tree storage provides SQLite-competitive point lookup performance, while columnar execution handles analytical queries efficiently. This differs from pure OLAP databases like DuckDB that optimize exclusively for bulk operations at the cost of single-row latency.
+bench-sysbench-emb-disc-architecture-title = Compromis Architecturaux
+bench-sysbench-emb-disc-architecture = L'architecture hybride de VibeSQL cible à la fois les charges OLTP et OLAP. Notre stockage B-tree offre des performances de recherche ponctuelle compétitives avec SQLite, tandis que l'exécution en colonnes gère efficacement les requêtes analytiques. Ceci diffère des bases de données purement OLAP comme DuckDB qui optimisent exclusivement pour les opérations en masse au détriment de la latence mono-ligne.
 
 # Sysbench Serveur spécifique
 bench-sysbench-server-name = Sysbench (Serveur)

--- a/web-demo/src/i18n/resources/it.ftl
+++ b/web-demo/src/i18n/resources/it.ftl
@@ -430,8 +430,8 @@ bench-sysbench-emb-disc-nonindex = Full table scans for non-indexed columns need
 bench-sysbench-emb-disc-deletes = Our tombstone-based deletion has cleanup overhead; compaction improvements are planned
 bench-sysbench-emb-disc-duckdb-title = DuckDB Comparison
 bench-sysbench-emb-disc-duckdb = DuckDB is optimized for analytical workloads, not micro-operations. Its 100-1000x slower results here reflect architectural choices (columnar storage, vectorized execution) that trade single-row latency for bulk throughput. VibeSQL targets both use cases.
-bench-sysbench-emb-disc-architecture-title = Architectural Trade-offs
-bench-sysbench-emb-disc-architecture = VibeSQL's hybrid architecture targets both OLTP and OLAP workloads. Our B-tree storage provides SQLite-competitive point lookup performance, while columnar execution handles analytical queries efficiently. This differs from pure OLAP databases like DuckDB that optimize exclusively for bulk operations at the cost of single-row latency.
+bench-sysbench-emb-disc-architecture-title = Compromessi Architetturali
+bench-sysbench-emb-disc-architecture = L'architettura ibrida di VibeSQL è progettata sia per carichi di lavoro OLTP che OLAP. Il nostro storage B-tree offre prestazioni di ricerca puntuale competitive con SQLite, mentre l'esecuzione colonnare gestisce efficientemente le query analitiche. Questo si differenzia dai database puramente OLAP come DuckDB che ottimizzano esclusivamente per operazioni di massa a scapito della latenza su singola riga.
 
 # Sysbench Server specific
 bench-sysbench-server-name = Sysbench (Server)
@@ -614,8 +614,8 @@ conformance-generate-coverage = # Generate coverage report
 conformance-open-coverage = # Open coverage report
 
 bench-table-query = Query
-bench-tpcc-disc-duckdb = DuckDB achieves only ~385 TPS on TPC-C (60x slower than VibeSQL, 12x slower than SQLite). This is expected: DuckDB is an <strong>analytical (OLAP) database</strong> optimized for large batch operations, not single-row transactions. Its columnar storage format excels at scanning millions of rows but adds overhead for point lookups and small updates that dominate OLTP workloads like TPC-C.
-bench-tpcc-disc-duckdb-title = Why DuckDB Lags on OLTP
+bench-tpcc-disc-duckdb = DuckDB raggiunge solo ~385 TPS su TPC-C (60x più lento di VibeSQL, 12x più lento di SQLite). Questo è previsto: DuckDB è un <strong>database analitico (OLAP)</strong> ottimizzato per operazioni batch di grandi dimensioni, non per transazioni su singole righe. Il suo formato di archiviazione colonnare eccelle nella scansione di milioni di righe ma aggiunge overhead per le ricerche puntuali e i piccoli aggiornamenti che dominano i carichi di lavoro OLTP come TPC-C.
+bench-tpcc-disc-duckdb-title = Perché DuckDB è in Ritardo su OLTP
 bench-tpcc-transactions-label = transactions executed
 
 # Conformance page (English placeholders)

--- a/web-demo/src/i18n/resources/nl.ftl
+++ b/web-demo/src/i18n/resources/nl.ftl
@@ -430,8 +430,8 @@ bench-sysbench-emb-disc-nonindex = Full table scans for non-indexed columns need
 bench-sysbench-emb-disc-deletes = Our tombstone-based deletion has cleanup overhead; compaction improvements are planned
 bench-sysbench-emb-disc-duckdb-title = DuckDB Comparison
 bench-sysbench-emb-disc-duckdb = DuckDB is optimized for analytical workloads, not micro-operations. Its 100-1000x slower results here reflect architectural choices (columnar storage, vectorized execution) that trade single-row latency for bulk throughput. VibeSQL targets both use cases.
-bench-sysbench-emb-disc-architecture-title = Architectural Trade-offs
-bench-sysbench-emb-disc-architecture = VibeSQL's hybrid architecture targets both OLTP and OLAP workloads. Our B-tree storage provides SQLite-competitive point lookup performance, while columnar execution handles analytical queries efficiently. This differs from pure OLAP databases like DuckDB that optimize exclusively for bulk operations at the cost of single-row latency.
+bench-sysbench-emb-disc-architecture-title = Architecturale Afwegingen
+bench-sysbench-emb-disc-architecture = De hybride architectuur van VibeSQL richt zich op zowel OLTP- als OLAP-workloads. Onze B-tree opslag biedt SQLite-competitieve puntopzoekprestaties, terwijl kolomgeoriënteerde uitvoering analytische queries efficiënt afhandelt. Dit verschilt van pure OLAP-databases zoals DuckDB die exclusief optimaliseren voor bulkoperaties ten koste van latentie op enkele rijen.
 
 # Sysbench Server specific
 bench-sysbench-server-name = Sysbench (Server)
@@ -614,8 +614,8 @@ conformance-generate-coverage = # Generate coverage report
 conformance-open-coverage = # Open coverage report
 
 bench-table-query = Query
-bench-tpcc-disc-duckdb = DuckDB achieves only ~385 TPS on TPC-C (60x slower than VibeSQL, 12x slower than SQLite). This is expected: DuckDB is an <strong>analytical (OLAP) database</strong> optimized for large batch operations, not single-row transactions. Its columnar storage format excels at scanning millions of rows but adds overhead for point lookups and small updates that dominate OLTP workloads like TPC-C.
-bench-tpcc-disc-duckdb-title = Why DuckDB Lags on OLTP
+bench-tpcc-disc-duckdb = DuckDB behaalt slechts ~385 TPS op TPC-C (60x langzamer dan VibeSQL, 12x langzamer dan SQLite). Dit is verwacht: DuckDB is een <strong>analytische (OLAP) database</strong> geoptimaliseerd voor grote batch-operaties, niet voor transacties op enkele rijen. Het kolomgeoriënteerde opslagformaat blinkt uit in het scannen van miljoenen rijen, maar voegt overhead toe voor puntopzoekingen en kleine updates die OLTP-workloads zoals TPC-C domineren.
+bench-tpcc-disc-duckdb-title = Waarom DuckDB Achterloopt op OLTP
 bench-tpcc-transactions-label = transactions executed
 
 # Conformance page (English placeholders)


### PR DESCRIPTION
## Summary
- Translate `bench-tpcc-disc-duckdb-title` and `bench-tpcc-disc-duckdb` into German, French, Italian, and Dutch
- Translate `bench-sysbench-emb-disc-architecture-title` and `bench-sysbench-emb-disc-architecture` into all 4 languages
- All translations preserve HTML markup (`<strong>` tags) and technical terms (TPS, TPC-C, OLTP, OLAP, etc.)

Closes #4259

## Test plan
- [ ] Verify translations render correctly in web demo at each language setting
- [ ] Check HTML formatting is preserved
- [ ] Verify no broken string references in i18n system

🤖 Generated with [Claude Code](https://claude.com/claude-code)