### PR TITLE
i18n: Translate benchmark strings for Eastern European and Slavic languages

### DIFF
--- a/web-demo/src/i18n/resources/pl.ftl
+++ b/web-demo/src/i18n/resources/pl.ftl
@@ -420,8 +420,8 @@ bench-sysbench-emb-disc-nonindex = Full table scans for non-indexed columns need
 bench-sysbench-emb-disc-deletes = Our tombstone-based deletion has cleanup overhead; compaction improvements are planned
 bench-sysbench-emb-disc-duckdb-title = DuckDB Comparison
 bench-sysbench-emb-disc-duckdb = DuckDB is optimized for analytical workloads, not micro-operations. Its 100-1000x slower results here reflect architectural choices (columnar storage, vectorized execution) that trade single-row latency for bulk throughput. VibeSQL targets both use cases.
-bench-sysbench-emb-disc-architecture-title = Architectural Trade-offs
-bench-sysbench-emb-disc-architecture = VibeSQL's hybrid architecture targets both OLTP and OLAP workloads. Our B-tree storage provides SQLite-competitive point lookup performance, while columnar execution handles analytical queries efficiently. This differs from pure OLAP databases like DuckDB that optimize exclusively for bulk operations at the cost of single-row latency.
+bench-sysbench-emb-disc-architecture-title = Kompromisy architektoniczne
+bench-sysbench-emb-disc-architecture = Hybrydowa architektura VibeSQL jest ukierunkowana zarówno na obciążenia OLTP, jak i OLAP. Nasze B-tree zapewnia wydajność wyszukiwania punktowego na poziomie SQLite, podczas gdy kolumnowe wykonywanie efektywnie obsługuje zapytania analityczne. To różni się od czystych baz danych OLAP, takich jak DuckDB, które optymalizują wyłącznie pod kątem operacji masowych kosztem opóźnień pojedynczych wierszy.
 
 # Sysbench Server specific
 bench-sysbench-server-name = Sysbench (Server)
@@ -601,8 +601,8 @@ conformance-generate-coverage = # Generate coverage report
 conformance-open-coverage = # Open coverage report
 
 bench-table-query = Query
-bench-tpcc-disc-duckdb = DuckDB achieves only ~385 TPS on TPC-C (60x slower than VibeSQL, 12x slower than SQLite). This is expected: DuckDB is an <strong>analytical (OLAP) database</strong> optimized for large batch operations, not single-row transactions. Its columnar storage format excels at scanning millions of rows but adds overhead for point lookups and small updates that dominate OLTP workloads like TPC-C.
-bench-tpcc-disc-duckdb-title = Why DuckDB Lags on OLTP
+bench-tpcc-disc-duckdb-title = Dlaczego DuckDB pozostaje w tyle w OLTP
+bench-tpcc-disc-duckdb = DuckDB osiąga jedynie ~385 TPS w TPC-C (60x wolniej niż VibeSQL, 12x wolniej niż SQLite). Jest to oczekiwane: DuckDB to <strong>analityczna (OLAP) baza danych</strong> zoptymalizowana pod kątem dużych operacji wsadowych, a nie transakcji na pojedynczych wierszach. Jej kolumnowy format przechowywania doskonale radzi sobie ze skanowaniem milionów wierszy, ale dodaje narzut dla wyszukiwań punktowych i małych aktualizacji, które dominują w obciążeniach OLTP takich jak TPC-C.
 bench-tpcc-transactions-label = transactions executed
 
 # Conformance page (English placeholders)

--- a/web-demo/src/i18n/resources/ru.ftl
+++ b/web-demo/src/i18n/resources/ru.ftl
@@ -420,8 +420,8 @@ bench-sysbench-emb-disc-nonindex = Full table scans for non-indexed columns need
 bench-sysbench-emb-disc-deletes = Our tombstone-based deletion has cleanup overhead; compaction improvements are planned
 bench-sysbench-emb-disc-duckdb-title = DuckDB Comparison
 bench-sysbench-emb-disc-duckdb = DuckDB is optimized for analytical workloads, not micro-operations. Its 100-1000x slower results here reflect architectural choices (columnar storage, vectorized execution) that trade single-row latency for bulk throughput. VibeSQL targets both use cases.
-bench-sysbench-emb-disc-architecture-title = Architectural Trade-offs
-bench-sysbench-emb-disc-architecture = VibeSQL's hybrid architecture targets both OLTP and OLAP workloads. Our B-tree storage provides SQLite-competitive point lookup performance, while columnar execution handles analytical queries efficiently. This differs from pure OLAP databases like DuckDB that optimize exclusively for bulk operations at the cost of single-row latency.
+bench-sysbench-emb-disc-architecture-title = Архитектурные компромиссы
+bench-sysbench-emb-disc-architecture = Гибридная архитектура VibeSQL ориентирована как на OLTP, так и на OLAP нагрузки. Наше B-tree хранилище обеспечивает производительность точечных запросов на уровне SQLite, в то время как колоночное выполнение эффективно обрабатывает аналитические запросы. Это отличается от чистых OLAP баз данных, таких как DuckDB, которые оптимизированы исключительно для массовых операций в ущерб задержке одиночных строк.
 
 # Sysbench Server specific
 bench-sysbench-server-name = Sysbench (Server)
@@ -604,8 +604,8 @@ conformance-generate-coverage = # Generate coverage report
 conformance-open-coverage = # Open coverage report
 
 bench-table-query = Query
-bench-tpcc-disc-duckdb = DuckDB achieves only ~385 TPS on TPC-C (60x slower than VibeSQL, 12x slower than SQLite). This is expected: DuckDB is an <strong>analytical (OLAP) database</strong> optimized for large batch operations, not single-row transactions. Its columnar storage format excels at scanning millions of rows but adds overhead for point lookups and small updates that dominate OLTP workloads like TPC-C.
-bench-tpcc-disc-duckdb-title = Why DuckDB Lags on OLTP
+bench-tpcc-disc-duckdb-title = Почему DuckDB отстаёт в OLTP
+bench-tpcc-disc-duckdb = DuckDB достигает лишь ~385 TPS в TPC-C (в 60 раз медленнее VibeSQL, в 12 раз медленнее SQLite). Это ожидаемо: DuckDB — это <strong>аналитическая (OLAP) база данных</strong>, оптимизированная для крупных пакетных операций, а не для транзакций с одиночными строками. Её колоночный формат хранения отлично справляется со сканированием миллионов строк, но добавляет накладные расходы для точечных запросов и мелких обновлений, которые преобладают в OLTP-нагрузках типа TPC-C.
 bench-tpcc-transactions-label = transactions executed
 
 # Conformance page (English placeholders)

--- a/web-demo/src/i18n/resources/sv.ftl
+++ b/web-demo/src/i18n/resources/sv.ftl
@@ -417,8 +417,8 @@ bench-sysbench-emb-disc-nonindex = Full table scans for non-indexed columns need
 bench-sysbench-emb-disc-deletes = Our tombstone-based deletion has cleanup overhead; compaction improvements are planned
 bench-sysbench-emb-disc-duckdb-title = DuckDB Comparison
 bench-sysbench-emb-disc-duckdb = DuckDB is optimized for analytical workloads, not micro-operations. Its 100-1000x slower results here reflect architectural choices (columnar storage, vectorized execution) that trade single-row latency for bulk throughput. VibeSQL targets both use cases.
-bench-sysbench-emb-disc-architecture-title = Architectural Trade-offs
-bench-sysbench-emb-disc-architecture = VibeSQL's hybrid architecture targets both OLTP and OLAP workloads. Our B-tree storage provides SQLite-competitive point lookup performance, while columnar execution handles analytical queries efficiently. This differs from pure OLAP databases like DuckDB that optimize exclusively for bulk operations at the cost of single-row latency.
+bench-sysbench-emb-disc-architecture-title = Arkitektoniska avvägningar
+bench-sysbench-emb-disc-architecture = VibeSQLs hybridarkitektur riktar sig mot både OLTP- och OLAP-arbetsbelastningar. Vår B-tree-lagring ger SQLite-konkurrerande prestanda för punktuppslag, medan kolumnär exekvering hanterar analytiska frågor effektivt. Detta skiljer sig från rena OLAP-databaser som DuckDB som optimerar uteslutande för bulkoperationer på bekostnad av enkelradsfördröjning.
 
 # Sysbench Server specific
 bench-sysbench-server-name = Sysbench (Server)
@@ -601,8 +601,8 @@ conformance-generate-coverage = # Generate coverage report
 conformance-open-coverage = # Open coverage report
 
 bench-table-query = Query
-bench-tpcc-disc-duckdb = DuckDB achieves only ~385 TPS on TPC-C (60x slower than VibeSQL, 12x slower than SQLite). This is expected: DuckDB is an <strong>analytical (OLAP) database</strong> optimized for large batch operations, not single-row transactions. Its columnar storage format excels at scanning millions of rows but adds overhead for point lookups and small updates that dominate OLTP workloads like TPC-C.
-bench-tpcc-disc-duckdb-title = Why DuckDB Lags on OLTP
+bench-tpcc-disc-duckdb-title = Varför DuckDB ligger efter i OLTP
+bench-tpcc-disc-duckdb = DuckDB uppnår endast ~385 TPS i TPC-C (60x långsammare än VibeSQL, 12x långsammare än SQLite). Detta är förväntat: DuckDB är en <strong>analytisk (OLAP) databas</strong> optimerad för stora batchoperationer, inte enkelradstransaktioner. Dess kolumnära lagringsformat utmärker sig vid skanning av miljontals rader men lägger till overhead för punktuppslag och små uppdateringar som dominerar OLTP-arbetsbelastningar som TPC-C.
 bench-tpcc-transactions-label = transactions executed
 
 # Conformance page (English placeholders)

--- a/web-demo/src/i18n/resources/uk.ftl
+++ b/web-demo/src/i18n/resources/uk.ftl
@@ -420,8 +420,8 @@ bench-sysbench-emb-disc-nonindex = Full table scans for non-indexed columns need
 bench-sysbench-emb-disc-deletes = Our tombstone-based deletion has cleanup overhead; compaction improvements are planned
 bench-sysbench-emb-disc-duckdb-title = DuckDB Comparison
 bench-sysbench-emb-disc-duckdb = DuckDB is optimized for analytical workloads, not micro-operations. Its 100-1000x slower results here reflect architectural choices (columnar storage, vectorized execution) that trade single-row latency for bulk throughput. VibeSQL targets both use cases.
-bench-sysbench-emb-disc-architecture-title = Architectural Trade-offs
-bench-sysbench-emb-disc-architecture = VibeSQL's hybrid architecture targets both OLTP and OLAP workloads. Our B-tree storage provides SQLite-competitive point lookup performance, while columnar execution handles analytical queries efficiently. This differs from pure OLAP databases like DuckDB that optimize exclusively for bulk operations at the cost of single-row latency.
+bench-sysbench-emb-disc-architecture-title = Архітектурні компроміси
+bench-sysbench-emb-disc-architecture = Гібридна архітектура VibeSQL орієнтована як на OLTP, так і на OLAP навантаження. Наше B-tree сховище забезпечує продуктивність точкових запитів на рівні SQLite, тоді як колонкове виконання ефективно обробляє аналітичні запити. Це відрізняється від чистих OLAP баз даних, таких як DuckDB, які оптимізовані виключно для масових операцій на шкоду затримці одиночних рядків.
 
 # Sysbench Server specific
 bench-sysbench-server-name = Sysbench (Server)
@@ -601,8 +601,8 @@ conformance-generate-coverage = # Generate coverage report
 conformance-open-coverage = # Open coverage report
 
 bench-table-query = Query
-bench-tpcc-disc-duckdb = DuckDB achieves only ~385 TPS on TPC-C (60x slower than VibeSQL, 12x slower than SQLite). This is expected: DuckDB is an <strong>analytical (OLAP) database</strong> optimized for large batch operations, not single-row transactions. Its columnar storage format excels at scanning millions of rows but adds overhead for point lookups and small updates that dominate OLTP workloads like TPC-C.
-bench-tpcc-disc-duckdb-title = Why DuckDB Lags on OLTP
+bench-tpcc-disc-duckdb-title = Чому DuckDB відстає в OLTP
+bench-tpcc-disc-duckdb = DuckDB досягає лише ~385 TPS в TPC-C (у 60 разів повільніше за VibeSQL, у 12 разів повільніше за SQLite). Це очікувано: DuckDB — це <strong>аналітична (OLAP) база даних</strong>, оптимізована для великих пакетних операцій, а не для транзакцій з одиночними рядками. Її колонковий формат зберігання чудово справляється зі скануванням мільйонів рядків, але додає накладні витрати для точкових запитів і дрібних оновлень, які переважають в OLTP-навантаженнях типу TPC-C.
 bench-tpcc-transactions-label = transactions executed
 
 # Conformance page (English placeholders)


### PR DESCRIPTION
## Summary

- Translate 4 benchmark-related strings to Russian (ru), Polish (pl), Ukrainian (uk), and Swedish (sv)
- Translated strings:
  - `bench-tpcc-disc-duckdb-title`: "Why DuckDB Lags on OLTP"
  - `bench-tpcc-disc-duckdb`: Full explanation about DuckDB's OLTP performance
  - `bench-sysbench-emb-disc-architecture-title`: "Architectural Trade-offs"
  - `bench-sysbench-emb-disc-architecture`: Full explanation about VibeSQL's hybrid architecture

## Test plan

- [ ] Verify translations render correctly in the web demo
- [ ] Check that special characters display properly
- [ ] Confirm HTML tags (`<strong>`) are preserved in translations

Closes #4260

🤖 Generated with [Claude Code](https://claude.com/claude-code)