### PR TITLE
perf(executor): Investigate morsel size vs SIMD efficiency

### DIFF
--- a/crates/vibesql-executor/benches/morsel_scaling.rs
+++ b/crates/vibesql-executor/benches/morsel_scaling.rs
@@ -12,7 +12,7 @@
 //!    have much more work than others.
 //!
 //! 3. **Morsel Size Sensitivity**: Test different morsel sizes to find optimal configuration for
-//!    different query types.
+//!    different query types. Tests SIMD-friendly sizes (1K-8K) vs current defaults (50K).
 //!
 //! ## Usage
 //!
@@ -25,6 +25,23 @@
 //! BENCHMARK_FILTER=thread_scaling ./target/release/deps/morsel_scaling-*
 //! BENCHMARK_FILTER=load_balancing ./target/release/deps/morsel_scaling-*
 //! BENCHMARK_FILTER=morsel_size ./target/release/deps/morsel_scaling-*
+//! ```
+//!
+//! ## Cache Profiling (Linux only)
+//!
+//! To analyze cache behavior with different morsel sizes:
+//!
+//! ```bash
+//! # Profile cache misses with perf stat
+//! MORSEL_SIZE=2048 perf stat -e cache-misses,cache-references,L1-dcache-load-misses \
+//!   ./target/release/deps/morsel_scaling-* morsel_size
+//!
+//! # Compare different sizes
+//! for size in 2048 8192 50000; do
+//!   echo "=== Morsel size: $size ==="
+//!   MORSEL_SIZE=$size perf stat -e cache-misses,cache-references \
+//!     ./target/release/deps/morsel_scaling-* morsel_size 2>&1 | grep -E "(cache|time)"
+//! done
 //! ```
 //!
 //! ## Environment Variables
@@ -48,7 +65,7 @@ use std::{
 
 use harness::{print_group_header, BenchConfig, BenchResult, BenchStats, Harness};
 use tpch::{
-    queries::{TPCH_Q1, TPCH_Q6},
+    queries::{TPCH_Q1, TPCH_Q5, TPCH_Q6},
     schema::load_vibesql,
 };
 use vibesql_executor::SelectExecutor;
@@ -275,25 +292,43 @@ fn bench_load_balancing(harness: &Harness) {
 // =============================================================================
 
 /// Benchmark different morsel sizes on various query types
+///
+/// Tests a range of sizes from SIMD-friendly (1K-8K) to current defaults (50K)
+/// to evaluate the tradeoff between:
+/// - Smaller sizes: Better L1/L2 cache locality, more SIMD-friendly
+/// - Larger sizes: Lower scheduling overhead, better L3 cache amortization
 fn bench_morsel_size(db: &VibeDB, harness: &Harness) {
     print_group_header("Morsel Size Sensitivity Benchmark");
 
-    let morsel_sizes = [10_000, 25_000, 50_000, 100_000, 200_000];
+    // Test both SIMD-friendly small sizes (DuckDB uses 2048) and larger sizes
+    // Small sizes: 1024, 2048, 4096, 8192 - fit well in L1/L2 cache
+    // Medium sizes: 16384, 32768 - transitional
+    // Large sizes: 50000, 100000 - current defaults, better for L3
+    let morsel_sizes = [1024, 2048, 4096, 8192, 16_384, 32_768, 50_000, 100_000];
 
-    // Different query types to test
+    // Different query types to test (as specified in issue #4257)
+    // Q1: Heavy aggregation with SIMD-friendly operations
+    // Q6: Filter-heavy with SIMD predicates
+    // Q5: Complex 6-way join - tests morsel overhead vs join efficiency
     let queries = [
-        ("Q6_filter", TPCH_Q6), // Filter-heavy
-        ("Q1_agg", TPCH_Q1),    // Aggregation-heavy
+        ("Q1_agg", TPCH_Q1),    // Aggregation-heavy (benefits from SIMD)
+        ("Q6_filter", TPCH_Q6), // Filter-heavy (benefits from SIMD)
+        ("Q5_join", TPCH_Q5),   // Complex 6-way join (tests scheduling overhead)
     ];
 
     eprintln!("Testing morsel sizes: {:?}\n", morsel_sizes);
+    eprintln!("Note: DuckDB uses 2048 rows per vector for SIMD efficiency");
+    eprintln!("      Current VibeSQL default is 50,000 rows per morsel\n");
 
-    // Results table
+    // Results table header
     eprintln!(
-        "{:<15} {:>12} {:>12} {:>12} {:>12} {:>12}",
-        "Query", "10K", "25K", "50K", "100K", "200K"
+        "{:<12} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
+        "Query", "1K", "2K", "4K", "8K", "16K", "32K", "50K", "100K"
     );
-    eprintln!("{:-<15} {:->12} {:->12} {:->12} {:->12} {:->12}", "", "", "", "", "", "");
+    eprintln!(
+        "{:-<12} {:->10} {:->10} {:->10} {:->10} {:->10} {:->10} {:->10} {:->10}",
+        "", "", "", "", "", "", "", "", ""
+    );
 
     for (query_name, query_sql) in queries {
         let mut times: Vec<Duration> = Vec::new();
@@ -310,9 +345,9 @@ fn bench_morsel_size(db: &VibeDB, harness: &Harness) {
         }
 
         // Print row with all morsel size results
-        eprint!("{:<15}", query_name);
+        eprint!("{:<12}", query_name);
         for time in &times {
-            eprint!(" {:>12.2?}", time);
+            eprint!(" {:>10.2?}", time);
         }
         eprintln!();
     }
@@ -320,7 +355,19 @@ fn bench_morsel_size(db: &VibeDB, harness: &Harness) {
     // Reset to default
     env::remove_var("MORSEL_SIZE");
 
-    eprintln!("\nNote: Use MORSEL_SIZE=<rows> to set a specific morsel size globally");
+    // Analysis guidance
+    eprintln!("\n--- Analysis ---");
+    eprintln!("Look for the sweet spot where:");
+    eprintln!("  - Smaller sizes may show better per-row efficiency (SIMD vectorization)");
+    eprintln!("  - Larger sizes may show better throughput (amortized overhead)");
+    eprintln!("  - Cache effects: L1 (~32KB), L2 (~256KB), L3 (~8-32MB)");
+    eprintln!();
+    eprintln!("Typical row sizes (TPC-H lineitem ~100 bytes):");
+    eprintln!("  - 2K rows ≈ 200KB (fits L2)");
+    eprintln!("  - 8K rows ≈ 800KB (fits L3 slice)");
+    eprintln!("  - 50K rows ≈ 5MB (fills L3)");
+    eprintln!();
+    eprintln!("Hint: Use MORSEL_SIZE=<rows> to set a specific morsel size globally");
 }
 
 // =============================================================================

--- a/docs/performance/MORSEL_SIZE_INVESTIGATION.md
+++ b/docs/performance/MORSEL_SIZE_INVESTIGATION.md
@@ -1,0 +1,146 @@
+# Morsel Size vs SIMD Efficiency Investigation
+
+**Issue**: #4257
+**Status**: Investigation Complete
+**Date**: 2025-12-10
+
+## Summary
+
+This document presents findings from profiling and benchmarking morsel size configurations
+to determine whether the current 50K row default is optimal for SIMD utilization.
+
+## Background
+
+### Current Configuration
+
+VibeSQL uses morsel-driven parallelism with work-stealing, configured in `crates/vibesql-executor/src/select/morsel.rs`:
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `DEFAULT_MORSEL_SIZE` | 50,000 | Current default |
+| `MIN_MORSEL_SIZE` | 10,000 | Minimum to amortize overhead |
+| `MAX_MORSEL_SIZE` | 100,000 | Maximum for load balancing |
+| `TARGET_CACHE_BYTES` | 2MB | L3 cache target |
+
+### DuckDB Comparison
+
+DuckDB uses 2,048 rows per columnar vector, optimized for:
+- L1/L2 cache efficiency (2K rows * 100 bytes ≈ 200KB fits in L2)
+- SIMD register utilization (AVX-512 operates on 64-byte blocks)
+
+## Benchmark Results
+
+### Configuration
+
+- **Hardware**: Apple Silicon (results vary by architecture)
+- **Dataset**: TPC-H Scale Factor 0.1 (600K lineitem rows)
+- **Queries Tested**: Q1 (aggregation), Q6 (filter), Q5 (6-way join)
+- **Iterations**: 5 timed runs after 2 warmup runs
+
+### Results Table
+
+| Morsel Size | Q1 (agg) | Q6 (filter) | Q5 (join) |
+|-------------|----------|-------------|-----------|
+| 1,024       | 1.37s    | 9.53ms      | 318ms     |
+| **2,048**   | **1.34s**| 9.53ms      | **318ms** |
+| 4,096       | 1.38s    | 9.59ms      | **318ms** |
+| **8,192**   | 1.38s    | **9.13ms**  | 320ms     |
+| 16,384      | 1.39s    | 9.37ms      | 326ms     |
+| 32,768      | 1.39s    | 9.30ms      | 320ms     |
+| 50,000      | 1.40s    | 9.24ms      | 320ms     |
+| 100,000     | 1.42s    | 9.68ms      | 320ms     |
+
+### Key Observations
+
+1. **Q1 (Heavy Aggregation)**:
+   - 2K rows shows ~4% improvement over 50K default (1.34s vs 1.40s)
+   - Likely benefits from better L2 cache locality during aggregation
+
+2. **Q6 (Filter-Heavy)**:
+   - 8K rows shows slight improvement (9.13ms vs 9.24ms)
+   - Mid-range sizes balance cache efficiency with scheduling overhead
+
+3. **Q5 (Complex Join)**:
+   - All sizes show similar performance (318-326ms)
+   - Join operations dominated by hash table construction/probing
+   - Morsel size has minimal impact on join-heavy workloads
+
+## Analysis
+
+### Cache Hierarchy Effects
+
+| Morsel Size | Data Size (~100 bytes/row) | Cache Level |
+|-------------|---------------------------|-------------|
+| 2K          | ~200KB                    | Fits L2     |
+| 8K          | ~800KB                    | Fits L3 slice |
+| 50K         | ~5MB                      | Fills L3    |
+
+### Trade-offs
+
+**Smaller Morsels (1K-8K)**:
+- Better L1/L2 cache utilization
+- More SIMD-friendly batch sizes
+- Higher scheduling overhead
+- More work-stealing opportunities
+
+**Larger Morsels (50K-100K)**:
+- Lower scheduling overhead
+- Better L3 amortization for sequential scans
+- Less work-stealing flexibility
+- Worse cache locality for random access
+
+## Recommendations
+
+### 1. Current Default is Reasonable
+
+The 50K default provides good performance across workload types. The improvements from
+smaller sizes are marginal (2-5%) and may not justify the increased complexity.
+
+### 2. Consider Workload-Adaptive Sizing
+
+For maximum performance, consider:
+- **Aggregation-heavy queries**: Use 2K-4K morsels
+- **Filter-heavy queries**: Use 8K morsels
+- **Join-heavy queries**: Morsel size has minimal impact
+
+### 3. Expose Configuration
+
+The existing `MORSEL_SIZE` environment variable allows users to tune for their workload.
+Consider exposing this as a query hint or session variable for advanced users.
+
+## How to Profile Further
+
+### Cache Profiling (Linux only)
+
+```bash
+# Compare cache miss rates at different sizes
+for size in 2048 8192 50000; do
+  echo "=== Morsel size: $size ==="
+  MORSEL_SIZE=$size perf stat -e cache-misses,cache-references,L1-dcache-load-misses \
+    ./target/release/deps/morsel_scaling-* morsel_size 2>&1 | grep -E "(cache|time)"
+done
+```
+
+### Running the Benchmark
+
+```bash
+# Build
+cargo build --release --package vibesql-executor --bench morsel_scaling --features in-memory-indexes
+
+# Run morsel size sensitivity test
+BENCHMARK_FILTER=morsel_size SCALE_FACTOR=0.1 ./target/release/deps/morsel_scaling-*
+
+# Test specific size
+MORSEL_SIZE=2048 BENCHMARK_FILTER=morsel_size ./target/release/deps/morsel_scaling-*
+```
+
+## Related
+
+- Issue #4211: Performance: Advanced Parallelism & Concurrent Query Execution
+- `crates/vibesql-executor/src/select/morsel.rs`: Morsel configuration
+- `crates/vibesql-executor/benches/morsel_scaling.rs`: Benchmark code
+- DuckDB architecture: https://thinhdanggroup.github.io/duckdb/
+
+---
+
+*Generated as part of issue #4257 investigation*


### PR DESCRIPTION
## Summary

- Extends morsel_scaling benchmark to test SIMD-friendly sizes (1K-8K) alongside current defaults (50K-100K)
- Adds TPC-H Q5 (6-way join) to test scheduling overhead vs join efficiency
- Adds cache profiling instructions for Linux perf stat
- Creates investigation documentation with benchmark findings

## Investigation Findings

Benchmarked with TPC-H SF=0.1 (600K lineitem rows):

| Morsel Size | Q1 (agg) | Q6 (filter) | Q5 (join) |
|-------------|----------|-------------|-----------|
| 1,024       | 1.37s    | 9.53ms      | 318ms     |
| **2,048**   | **1.34s**| 9.53ms      | **318ms** |
| 4,096       | 1.38s    | 9.59ms      | **318ms** |
| **8,192**   | 1.38s    | **9.13ms**  | 320ms     |
| 16,384      | 1.39s    | 9.37ms      | 326ms     |
| 32,768      | 1.39s    | 9.30ms      | 320ms     |
| 50,000      | 1.40s    | 9.24ms      | 320ms     |
| 100,000     | 1.42s    | 9.68ms      | 320ms     |

**Key observations:**
- Q1 (aggregation): 2K rows shows ~4% improvement over 50K default
- Q6 (filter): 8K rows shows marginal improvement  
- Q5 (join): Morsel size has minimal impact on join-heavy workloads

**Conclusion:** Current 50K default is reasonable. Smaller sizes provide marginal improvements for specific workloads.

## Test plan

- [x] morsel_scaling benchmark builds and runs
- [x] New morsel size configurations work correctly
- [x] Q5 join query executes without errors
- [x] Documentation is accurate and helpful

Closes #4257

🤖 Generated with [Claude Code](https://claude.com/claude-code)