### PR TITLE
feat(parser): Support == operator for SQLite compatibility

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -224,6 +224,7 @@ impl<'arena> ArenaParser<'arena> {
                     | MultiCharOperator::GreaterEqual
                     | MultiCharOperator::NotEqual
                     | MultiCharOperator::NotEqualAlt
+                    | MultiCharOperator::DoubleEqual
                     | MultiCharOperator::CosineDistance
                     | MultiCharOperator::NegativeInnerProduct
                     | MultiCharOperator::L2Distance
@@ -242,6 +243,8 @@ impl<'arena> ArenaParser<'arena> {
                     MultiCharOperator::NotEqual | MultiCharOperator::NotEqualAlt => {
                         BinaryOperator::NotEqual
                     }
+                    // SQLite compatibility: == is a synonym for =
+                    MultiCharOperator::DoubleEqual => BinaryOperator::Equal,
                     // Vector distance operators (pgvector compatible)
                     MultiCharOperator::CosineDistance => BinaryOperator::CosineDistance,
                     MultiCharOperator::NegativeInnerProduct => BinaryOperator::NegativeInnerProduct,

--- a/crates/vibesql-parser/src/lexer/operators.rs
+++ b/crates/vibesql-parser/src/lexer/operators.rs
@@ -68,6 +68,11 @@ impl<'a> Lexer<'a> {
                             self.advance();
                             Ok(Token::Operator(MultiCharOperator::NotEqual))
                         }
+                        ('=', '=') => {
+                            // SQLite compatibility: == is a synonym for =
+                            self.advance();
+                            Ok(Token::Operator(MultiCharOperator::DoubleEqual))
+                        }
                         _ => Ok(Token::Symbol(ch)),
                     }
                 } else {

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -310,6 +310,8 @@ impl Parser {
                         MultiCharOperator::NotEqual | MultiCharOperator::NotEqualAlt => {
                             vibesql_ast::BinaryOperator::NotEqual
                         }
+                        // SQLite compatibility: == is a synonym for =
+                        MultiCharOperator::DoubleEqual => vibesql_ast::BinaryOperator::Equal,
                         // Vector distance operators (pgvector compatible)
                         MultiCharOperator::CosineDistance => {
                             vibesql_ast::BinaryOperator::CosineDistance

--- a/crates/vibesql-parser/src/tests/lexer/symbols.rs
+++ b/crates/vibesql-parser/src/tests/lexer/symbols.rs
@@ -55,6 +55,21 @@ fn test_tokenize_multi_char_operators() {
 }
 
 #[test]
+fn test_tokenize_double_equals_sqlite_compat() {
+    // SQLite uses == as a synonym for = (equality)
+    let mut lexer = Lexer::new("==");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::Operator(MultiCharOperator::DoubleEqual));
+
+    // Test in expression context
+    let mut lexer2 = Lexer::new("a==b");
+    let tokens2 = lexer2.tokenize().unwrap();
+    assert_eq!(tokens2[0], Token::Identifier("A".to_string()));
+    assert_eq!(tokens2[1], Token::Operator(MultiCharOperator::DoubleEqual));
+    assert_eq!(tokens2[2], Token::Identifier("B".to_string()));
+}
+
+#[test]
 fn test_tokenize_operators_without_spaces() {
     // Test that >= is tokenized as one operator, not two
     let mut lexer = Lexer::new("age>=18");

--- a/crates/vibesql-parser/src/tests/predicates.rs
+++ b/crates/vibesql-parser/src/tests/predicates.rs
@@ -2,6 +2,62 @@
 
 use super::*;
 
+// ============================================================================
+// SQLite compatibility: == operator
+// ============================================================================
+
+#[test]
+fn test_double_equals_sqlite_compat() {
+    // SQLite uses == as a synonym for = (equality)
+    let sql = "SELECT * FROM users WHERE id == 1";
+    let stmt = Parser::parse_sql(sql).expect("Parse failed");
+
+    if let vibesql_ast::Statement::Select(select) = stmt {
+        assert!(select.where_clause.is_some());
+        let where_expr = select.where_clause.unwrap();
+
+        // Verify it's an equality comparison
+        match where_expr {
+            vibesql_ast::Expression::BinaryOp { op, left, right } => {
+                assert_eq!(op, vibesql_ast::BinaryOperator::Equal, "== should parse as Equal");
+
+                // Check left is 'id'
+                match *left {
+                    vibesql_ast::Expression::ColumnRef { column, .. } => {
+                        assert_eq!(column, "ID");
+                    }
+                    _ => panic!("Expected ColumnRef for left"),
+                }
+
+                // Check right is 1
+                match *right {
+                    vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(val)) => {
+                        assert_eq!(val, 1);
+                    }
+                    _ => panic!("Expected Integer literal for right"),
+                }
+            }
+            _ => panic!("Expected BinaryOp expression"),
+        }
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_double_equals_in_expression() {
+    // Test == in more complex expressions
+    let sql = "SELECT a, b FROM t WHERE a == b AND c == 'test'";
+    let stmt = Parser::parse_sql(sql).expect("Parse failed");
+
+    if let vibesql_ast::Statement::Select(select) = stmt {
+        assert!(select.where_clause.is_some());
+        // If it parses without error, the == operator is working
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
 #[test]
 fn test_between_integer() {
     let sql = "SELECT * FROM users WHERE age BETWEEN 18 AND 65";

--- a/crates/vibesql-parser/src/token.rs
+++ b/crates/vibesql-parser/src/token.rs
@@ -14,6 +14,8 @@ pub enum MultiCharOperator {
     NotEqual,
     /// <> (not equal, SQL standard)
     NotEqualAlt,
+    /// == (equal, SQLite compatibility - synonym for =)
+    DoubleEqual,
     /// || (string concatenation)
     Concat,
     /// <-> (cosine distance - pgvector compatible)
@@ -31,6 +33,7 @@ impl fmt::Display for MultiCharOperator {
             MultiCharOperator::GreaterEqual => write!(f, ">="),
             MultiCharOperator::NotEqual => write!(f, "!="),
             MultiCharOperator::NotEqualAlt => write!(f, "<>"),
+            MultiCharOperator::DoubleEqual => write!(f, "=="),
             MultiCharOperator::Concat => write!(f, "||"),
             MultiCharOperator::CosineDistance => write!(f, "<->"),
             MultiCharOperator::NegativeInnerProduct => write!(f, "<#>"),


### PR DESCRIPTION
## Summary
- Add support for the `==` equality operator (SQLite compatibility)
- Fixes 54 TCL test failures that use SQLite's `==` syntax
- Both standard and arena parsers now correctly treat `==` as equivalent to `=`

## Changes
- Add `DoubleEqual` variant to `MultiCharOperator` enum
- Update lexer to tokenize `==` as `DoubleEqual`
- Update both standard and arena parsers to map `DoubleEqual` to `Equal`
- Add unit tests for lexer and parser

## Investigation Notes
The original issue mentioned `IS DISTINCT FROM` still failing, but investigation revealed:
1. `IS DISTINCT FROM` was already working correctly (implemented in #4250)
2. The actual parse errors (`Expected expression, found Symbol('=')`) were caused by queries using the `==` operator
3. This fix adds `==` support, resolving the remaining parse errors

## Test plan
- [x] Run lexer tests: `cargo test -p vibesql-parser -- test_tokenize_double_equals`
- [x] Run parser tests: `cargo test -p vibesql-parser -- double_equals`
- [x] Run full parser test suite: `cargo test -p vibesql-parser` (1060 tests pass)
- [x] Manual test: `SELECT 1==1, 2==3, 'a'=='a', NULL==NULL;`

Closes #4269

🤖 Generated with [Claude Code](https://claude.com/claude-code)