### PR TITLE
fix(join): Preserve multi-table schemas in nested joins

### DIFF
--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -167,6 +167,28 @@ impl CombinedSchema {
         CombinedSchema { table_schemas, total_columns: left_total + right_columns }
     }
 
+    /// Merge two CombinedSchemas (for JOIN operations with nested joins)
+    ///
+    /// Unlike `combine` which adds a single table, this method merges ALL tables
+    /// from the right schema into the left schema. This is essential for nested
+    /// joins like `t1 JOIN (t2 JOIN t3 USING(a)) USING(a)` where the right side
+    /// contains multiple tables that must all remain visible.
+    ///
+    /// The right schema's tables have their start indices adjusted to account
+    /// for the left schema's total column count.
+    pub fn merge(left: CombinedSchema, right: CombinedSchema) -> Self {
+        let mut table_schemas = left.table_schemas;
+        let left_total = left.total_columns;
+
+        // Add all tables from right schema with adjusted start indices
+        for (table_key, (start_index, schema)) in right.table_schemas {
+            let adjusted_start = left_total + start_index;
+            table_schemas.insert(table_key, (adjusted_start, schema));
+        }
+
+        CombinedSchema { table_schemas, total_columns: left_total + right.total_columns }
+    }
+
     /// Look up a column by name (optionally qualified with table name)
     /// Uses case-insensitive matching for table/alias and column names
     pub fn get_column_index(&self, table: Option<&str>, column: &str) -> Option<usize> {

--- a/crates/vibesql-executor/src/select/join/hash_join/inner.rs
+++ b/crates/vibesql-executor/src/select/join/hash_join/inner.rs
@@ -45,26 +45,8 @@ pub(in crate::select::join) fn hash_join_inner(
     // Note: No memory limit check here. Hash join is already O(n+m) time and O(smaller_table)
     // space, which is optimal for equijoins. We cannot predict output size accurately anyway.
 
-    // Extract right table name and schema for combining
-    let right_table_name = right
-        .schema
-        .table_schemas
-        .keys()
-        .next()
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .clone();
-
-    let right_schema = right
-        .schema
-        .table_schemas
-        .get(&right_table_name)
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .1
-        .clone();
-
-    // Combine schemas
-    let combined_schema =
-        CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
+    // Combine schemas using merge to preserve all tables from nested joins
+    let combined_schema = CombinedSchema::merge(left.schema.clone(), right.schema.clone());
 
     // Use as_slice() for zero-cost access without triggering row materialization
     // This avoids the 57% performance bottleneck from premature row collection
@@ -174,26 +156,8 @@ pub(in crate::select::join) fn hash_join_inner_multi(
     left_col_indices: &[usize],
     right_col_indices: &[usize],
 ) -> Result<FromResult, ExecutorError> {
-    // Extract right table name and schema for combining
-    let right_table_name = right
-        .schema
-        .table_schemas
-        .keys()
-        .next()
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .clone();
-
-    let right_schema = right
-        .schema
-        .table_schemas
-        .get(&right_table_name)
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .1
-        .clone();
-
-    // Combine schemas
-    let combined_schema =
-        CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
+    // Combine schemas using merge to preserve all tables from nested joins
+    let combined_schema = CombinedSchema::merge(left.schema.clone(), right.schema.clone());
 
     // Choose build and probe sides (build hash table on smaller table)
     let (build_rows, probe_rows, build_col_indices, probe_col_indices, left_is_build) =

--- a/crates/vibesql-executor/src/select/join/hash_join/outer.rs
+++ b/crates/vibesql-executor/src/select/join/hash_join/outer.rs
@@ -36,30 +36,12 @@ pub(in crate::select::join) fn hash_join_left_outer(
     left_col_idx: usize,
     right_col_idx: usize,
 ) -> Result<FromResult, ExecutorError> {
-    // Extract right table name and schema for combining
-    let right_table_name = right
-        .schema
-        .table_schemas
-        .keys()
-        .next()
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .clone();
+    // Get column counts (handles nested joins with multiple tables)
+    let right_col_count = right.schema.total_columns;
+    let left_col_count = left.schema.total_columns;
 
-    let right_schema = right
-        .schema
-        .table_schemas
-        .get(&right_table_name)
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .1
-        .clone();
-
-    let right_col_count = right_schema.columns.len();
-    let left_col_count: usize =
-        left.schema.table_schemas.values().map(|(_, s)| s.columns.len()).sum();
-
-    // Combine schemas
-    let combined_schema =
-        CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
+    // Combine schemas using merge to preserve all tables from nested joins
+    let combined_schema = CombinedSchema::merge(left.schema.clone(), right.schema.clone());
 
     // Use as_slice() for zero-cost access without triggering row materialization
     let left_slice = left.as_slice();
@@ -202,30 +184,12 @@ pub(in crate::select::join) fn hash_join_left_outer_multi(
     left_col_indices: &[usize],
     right_col_indices: &[usize],
 ) -> Result<FromResult, ExecutorError> {
-    // Extract right table name and schema for combining
-    let right_table_name = right
-        .schema
-        .table_schemas
-        .keys()
-        .next()
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .clone();
+    // Get column counts (handles nested joins with multiple tables)
+    let right_col_count = right.schema.total_columns;
+    let left_col_count = left.schema.total_columns;
 
-    let right_schema = right
-        .schema
-        .table_schemas
-        .get(&right_table_name)
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .1
-        .clone();
-
-    let right_col_count = right_schema.columns.len();
-    let left_col_count: usize =
-        left.schema.table_schemas.values().map(|(_, s)| s.columns.len()).sum();
-
-    // Combine schemas
-    let combined_schema =
-        CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
+    // Combine schemas using merge to preserve all tables from nested joins
+    let combined_schema = CombinedSchema::merge(left.schema.clone(), right.schema.clone());
 
     // Use as_slice() for zero-cost access (we can't swap build/probe for LEFT JOIN)
     let left_slice = left.as_slice();

--- a/crates/vibesql-executor/src/select/join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/mod.rs
@@ -433,30 +433,10 @@ pub(super) fn nested_loop_join(
         // Get column count and right table info once for analysis
         // IMPORTANT: Sum up columns from ALL tables in the left schema,
         // not just the first table, to handle accumulated multi-table joins
-        let left_col_count: usize =
-            left.schema.table_schemas.values().map(|(_, schema)| schema.columns.len()).sum();
+        let left_col_count = left.schema.total_columns;
 
-        let right_table_name = right
-            .schema
-            .table_schemas
-            .keys()
-            .next()
-            .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-            .clone();
-
-        let right_schema = right
-            .schema
-            .table_schemas
-            .get(&right_table_name)
-            .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-            .1
-            .clone();
-
-        // Clone right_table_name before it gets moved into combine()
-        let right_table_name_for_natural = right_table_name.clone();
-
-        let temp_schema =
-            CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
+        // Use merge to preserve all tables from nested joins for column resolution
+        let temp_schema = CombinedSchema::merge(left.schema.clone(), right.schema.clone());
 
         // Phase 3.1: Try ON condition first (preferred for hash join)
         // Now supports multi-column composite keys for better performance
@@ -500,28 +480,12 @@ pub(super) fn nested_loop_join(
                         if let (Some(left_schema), Some(right_schema_orig)) =
                             (left_schema_for_natural, right_schema_for_natural)
                         {
-                            let right_schema_for_removal = CombinedSchema {
-                                table_schemas: vec![(
-                                    right_table_name_for_natural.clone(),
-                                    (
-                                        0,
-                                        right_schema_orig
-                                            .table_schemas
-                                            .values()
-                                            .next()
-                                            .unwrap()
-                                            .1
-                                            .clone(),
-                                    ),
-                                )]
-                                .into_iter()
-                                .collect(),
-                                total_columns: right_schema_orig.total_columns,
-                            };
+                            // Use the original right schema directly to handle nested joins
+                            // with multiple tables (e.g., t1 NATURAL JOIN (t2 JOIN t3))
                             result = remove_duplicate_columns_for_natural_join(
                                 result,
                                 &left_schema,
-                                &right_schema_for_removal,
+                                &right_schema_orig,
                             )?;
                         }
                     }
@@ -557,28 +521,12 @@ pub(super) fn nested_loop_join(
                     if let (Some(left_schema), Some(right_schema_orig)) =
                         (left_schema_for_natural, right_schema_for_natural)
                     {
-                        let right_schema_for_removal = CombinedSchema {
-                            table_schemas: vec![(
-                                right_table_name_for_natural.clone(),
-                                (
-                                    0,
-                                    right_schema_orig
-                                        .table_schemas
-                                        .values()
-                                        .next()
-                                        .unwrap()
-                                        .1
-                                        .clone(),
-                                ),
-                            )]
-                            .into_iter()
-                            .collect(),
-                            total_columns: right_schema_orig.total_columns,
-                        };
+                        // Use the original right schema directly to handle nested joins
+                        // with multiple tables (e.g., t1 NATURAL JOIN (t2 JOIN t3))
                         result = remove_duplicate_columns_for_natural_join(
                             result,
                             &left_schema,
-                            &right_schema_for_removal,
+                            &right_schema_orig,
                         )?;
                     }
                 }
@@ -621,28 +569,12 @@ pub(super) fn nested_loop_join(
                     if let (Some(left_schema), Some(right_schema_orig)) =
                         (left_schema_for_natural, right_schema_for_natural)
                     {
-                        let right_schema_for_removal = CombinedSchema {
-                            table_schemas: vec![(
-                                right_table_name_for_natural.clone(),
-                                (
-                                    0,
-                                    right_schema_orig
-                                        .table_schemas
-                                        .values()
-                                        .next()
-                                        .unwrap()
-                                        .1
-                                        .clone(),
-                                ),
-                            )]
-                            .into_iter()
-                            .collect(),
-                            total_columns: right_schema_orig.total_columns,
-                        };
+                        // Use the original right schema directly to handle nested joins
+                        // with multiple tables (e.g., t1 NATURAL JOIN (t2 JOIN t3))
                         result = remove_duplicate_columns_for_natural_join(
                             result,
                             &left_schema,
-                            &right_schema_for_removal,
+                            &right_schema_orig,
                         )?;
                     }
                 }
@@ -677,28 +609,12 @@ pub(super) fn nested_loop_join(
                     if let (Some(left_schema), Some(right_schema_orig)) =
                         (left_schema_for_natural, right_schema_for_natural)
                     {
-                        let right_schema_for_removal = CombinedSchema {
-                            table_schemas: vec![(
-                                right_table_name_for_natural.clone(),
-                                (
-                                    0,
-                                    right_schema_orig
-                                        .table_schemas
-                                        .values()
-                                        .next()
-                                        .unwrap()
-                                        .1
-                                        .clone(),
-                                ),
-                            )]
-                            .into_iter()
-                            .collect(),
-                            total_columns: right_schema_orig.total_columns,
-                        };
+                        // Use the original right schema directly to handle nested joins
+                        // with multiple tables (e.g., t1 NATURAL JOIN (t2 JOIN t3))
                         result = remove_duplicate_columns_for_natural_join(
                             result,
                             &left_schema,
-                            &right_schema_for_removal,
+                            &right_schema_orig,
                         )?;
                     }
                 }
@@ -760,28 +676,12 @@ pub(super) fn nested_loop_join(
                     if let (Some(left_schema), Some(right_schema_orig)) =
                         (left_schema_for_natural, right_schema_for_natural)
                     {
-                        let right_schema_for_removal = CombinedSchema {
-                            table_schemas: vec![(
-                                right_table_name_for_natural.clone(),
-                                (
-                                    0,
-                                    right_schema_orig
-                                        .table_schemas
-                                        .values()
-                                        .next()
-                                        .unwrap()
-                                        .1
-                                        .clone(),
-                                ),
-                            )]
-                            .into_iter()
-                            .collect(),
-                            total_columns: right_schema_orig.total_columns,
-                        };
+                        // Use the original right schema directly to handle nested joins
+                        // with multiple tables (e.g., t1 NATURAL JOIN (t2 JOIN t3))
                         result = remove_duplicate_columns_for_natural_join(
                             result,
                             &left_schema,
-                            &right_schema_for_removal,
+                            &right_schema_orig,
                         )?;
                     }
                 }
@@ -831,28 +731,12 @@ pub(super) fn nested_loop_join(
                     if let (Some(left_schema), Some(right_schema_orig)) =
                         (left_schema_for_natural, right_schema_for_natural)
                     {
-                        let right_schema_for_removal = CombinedSchema {
-                            table_schemas: vec![(
-                                right_table_name_for_natural.clone(),
-                                (
-                                    0,
-                                    right_schema_orig
-                                        .table_schemas
-                                        .values()
-                                        .next()
-                                        .unwrap()
-                                        .1
-                                        .clone(),
-                                ),
-                            )]
-                            .into_iter()
-                            .collect(),
-                            total_columns: right_schema_orig.total_columns,
-                        };
+                        // Use the original right schema directly to handle nested joins
+                        // with multiple tables (e.g., t1 NATURAL JOIN (t2 JOIN t3))
                         result = remove_duplicate_columns_for_natural_join(
                             result,
                             &left_schema,
-                            &right_schema_for_removal,
+                            &right_schema_orig,
                         )?;
                     }
                 }
@@ -904,28 +788,12 @@ pub(super) fn nested_loop_join(
                     if let (Some(left_schema), Some(right_schema_orig)) =
                         (left_schema_for_natural, right_schema_for_natural)
                     {
-                        let right_schema_for_removal = CombinedSchema {
-                            table_schemas: vec![(
-                                right_table_name_for_natural.clone(),
-                                (
-                                    0,
-                                    right_schema_orig
-                                        .table_schemas
-                                        .values()
-                                        .next()
-                                        .unwrap()
-                                        .1
-                                        .clone(),
-                                ),
-                            )]
-                            .into_iter()
-                            .collect(),
-                            total_columns: right_schema_orig.total_columns,
-                        };
+                        // Use the original right schema directly to handle nested joins
+                        // with multiple tables (e.g., t1 NATURAL JOIN (t2 JOIN t3))
                         result = remove_duplicate_columns_for_natural_join(
                             result,
                             &left_schema,
-                            &right_schema_for_removal,
+                            &right_schema_orig,
                         )?;
                     }
                 }
@@ -939,30 +807,10 @@ pub(super) fn nested_loop_join(
     // This optimization is critical for Q13 (customer LEFT JOIN orders)
     if let vibesql_ast::JoinType::LeftOuter = join_type {
         // Get column count and right table info for analysis
-        let left_col_count: usize =
-            left.schema.table_schemas.values().map(|(_, schema)| schema.columns.len()).sum();
+        let left_col_count = left.schema.total_columns;
 
-        let right_table_name = right
-            .schema
-            .table_schemas
-            .keys()
-            .next()
-            .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-            .clone();
-
-        let right_schema = right
-            .schema
-            .table_schemas
-            .get(&right_table_name)
-            .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-            .1
-            .clone();
-
-        // Clone right_table_name before it gets moved into combine()
-        let right_table_name_for_natural = right_table_name.clone();
-
-        let temp_schema =
-            CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
+        // Use merge to preserve all tables from nested joins for column resolution
+        let temp_schema = CombinedSchema::merge(left.schema.clone(), right.schema.clone());
 
         // Try ON condition for hash join with multi-column support
         // Use multi-column analysis to include ALL equi-join conditions in the hash join
@@ -1015,28 +863,12 @@ pub(super) fn nested_loop_join(
                     if let (Some(left_schema), Some(right_schema_orig)) =
                         (left_schema_for_natural, right_schema_for_natural)
                     {
-                        let right_schema_for_removal = CombinedSchema {
-                            table_schemas: vec![(
-                                right_table_name_for_natural.clone(),
-                                (
-                                    0,
-                                    right_schema_orig
-                                        .table_schemas
-                                        .values()
-                                        .next()
-                                        .unwrap()
-                                        .1
-                                        .clone(),
-                                ),
-                            )]
-                            .into_iter()
-                            .collect(),
-                            total_columns: right_schema_orig.total_columns,
-                        };
+                        // Use the original right schema directly to handle nested joins
+                        // with multiple tables (e.g., t1 NATURAL JOIN (t2 JOIN t3))
                         result = remove_duplicate_columns_for_natural_join(
                             result,
                             &left_schema,
-                            &right_schema_for_removal,
+                            &right_schema_orig,
                         )?;
                     }
                 }
@@ -1049,27 +881,10 @@ pub(super) fn nested_loop_join(
     // Try to use hash join for SEMI/ANTI JOINs with equi-join conditions
     if matches!(join_type, vibesql_ast::JoinType::Semi | vibesql_ast::JoinType::Anti) {
         // Get column count for analysis
-        let left_col_count: usize =
-            left.schema.table_schemas.values().map(|(_, schema)| schema.columns.len()).sum();
+        let left_col_count = left.schema.total_columns;
 
-        let right_table_name = right
-            .schema
-            .table_schemas
-            .keys()
-            .next()
-            .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-            .clone();
-
-        let right_schema = right
-            .schema
-            .table_schemas
-            .get(&right_table_name)
-            .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-            .1
-            .clone();
-
-        let temp_schema =
-            CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
+        // Use merge to preserve all tables from nested joins for column resolution
+        let temp_schema = CombinedSchema::merge(left.schema.clone(), right.schema.clone());
 
         // Try ON condition first - use analyze_compound_equi_join to handle complex conditions
         // This enables hash join optimization for EXISTS subqueries with additional predicates
@@ -1140,27 +955,10 @@ pub(super) fn nested_loop_join(
     if let vibesql_ast::JoinType::Cross = join_type {
         if !additional_equijoins.is_empty() {
             // Get column count and right table info for analysis
-            let left_col_count: usize =
-                left.schema.table_schemas.values().map(|(_, schema)| schema.columns.len()).sum();
+            let left_col_count = left.schema.total_columns;
 
-            let right_table_name = right
-                .schema
-                .table_schemas
-                .keys()
-                .next()
-                .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-                .clone();
-
-            let right_schema = right
-                .schema
-                .table_schemas
-                .get(&right_table_name)
-                .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-                .1
-                .clone();
-
-            let temp_schema =
-                CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
+            // Use merge to preserve all tables from nested joins for column resolution
+            let temp_schema = CombinedSchema::merge(left.schema.clone(), right.schema.clone());
 
             // Try WHERE clause equijoins for hash join
             for (idx, equijoin) in additional_equijoins.iter().enumerate() {

--- a/crates/vibesql-executor/src/select/join/nested_loop.rs
+++ b/crates/vibesql-executor/src/select/join/nested_loop.rs
@@ -540,26 +540,10 @@ pub(super) fn nested_loop_inner_join(
         check_cross_join_size_limit(left_slice.len(), right_slice.len())?;
     }
 
-    // Extract right table name (assume single table for now)
-    let right_table_name = right
-        .schema
-        .table_schemas
-        .keys()
-        .next()
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .clone();
-
-    let right_schema = right
-        .schema
-        .table_schemas
-        .get(&right_table_name)
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .1
-        .clone();
-
-    // Combine schemas
-    let combined_schema =
-        CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
+    // Combine schemas using merge to preserve all tables from nested joins
+    // This handles cases like `t1 JOIN (t2 JOIN t3 USING(a)) USING(a)` where
+    // the right side contains multiple tables that must remain visible
+    let combined_schema = CombinedSchema::merge(left.schema.clone(), right.schema.clone());
 
     // OPTIMIZATION: Analyze condition to see if we can evaluate equijoin before allocation
     // This prevents creating combined_row for pairs that won't match the join condition
@@ -618,28 +602,11 @@ pub(super) fn nested_loop_left_outer_join(
     // Note: No memory check here. Hash join is selected in mod.rs BEFORE this function is called.
     // OUTER JOINs typically preserve at least the left table size, making estimates more reliable.
 
-    // Extract right table name and schema
-    let right_table_name = right
-        .schema
-        .table_schemas
-        .keys()
-        .next()
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .clone();
+    // Get total right column count (handles nested joins with multiple tables)
+    let right_column_count = right.schema.total_columns;
 
-    let right_schema = right
-        .schema
-        .table_schemas
-        .get(&right_table_name)
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .1
-        .clone();
-
-    let right_column_count = right_schema.columns.len();
-
-    // Combine schemas
-    let combined_schema =
-        CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
+    // Combine schemas using merge to preserve all tables from nested joins
+    let combined_schema = CombinedSchema::merge(left.schema.clone(), right.schema.clone());
     let evaluator = CombinedExpressionEvaluator::with_database(&combined_schema, database);
 
     // Use as_slice() for zero-cost access without triggering row materialization
@@ -715,16 +682,8 @@ pub(super) fn nested_loop_right_outer_join(
     // RIGHT OUTER JOIN = LEFT OUTER JOIN with sides swapped
     // Then we need to reorder columns to put left first, right second
 
-    // Get the right column count before moving
-    let right_col_count = right
-        .schema
-        .table_schemas
-        .values()
-        .next()
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .1
-        .columns
-        .len();
+    // Get the right column count (handles nested joins with multiple tables)
+    let right_col_count = right.schema.total_columns;
 
     // Do LEFT OUTER JOIN with swapped sides
     let swapped_result =
@@ -763,37 +722,12 @@ pub(super) fn nested_loop_full_outer_join(
     // Note: Memory check removed - full outer joins are rare and typically used
     // with smaller datasets. Hash join is tried first for equijoins anyway.
 
-    // Extract right table name and schema
-    let right_table_name = right
-        .schema
-        .table_schemas
-        .keys()
-        .next()
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .clone();
+    // Get column counts (handles nested joins with multiple tables)
+    let left_column_count = left.schema.total_columns;
+    let right_column_count = right.schema.total_columns;
 
-    let right_schema = right
-        .schema
-        .table_schemas
-        .get(&right_table_name)
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .1
-        .clone();
-
-    let left_column_count = left
-        .schema
-        .table_schemas
-        .values()
-        .next()
-        .ok_or_else(|| ExecutorError::UnsupportedFeature("Complex JOIN".to_string()))?
-        .1
-        .columns
-        .len();
-    let right_column_count = right_schema.columns.len();
-
-    // Combine schemas
-    let combined_schema =
-        CombinedSchema::combine(left.schema.clone(), right_table_name, right_schema);
+    // Combine schemas using merge to preserve all tables from nested joins
+    let combined_schema = CombinedSchema::merge(left.schema.clone(), right.schema.clone());
     let evaluator = CombinedExpressionEvaluator::with_database(&combined_schema, database);
 
     // Use as_slice() for zero-cost access without triggering row materialization


### PR DESCRIPTION
## Summary

- Fixed column visibility in nested parenthesized joins
- Added `CombinedSchema::merge()` method to properly combine multi-table schemas  
- Updated all join functions to use merge instead of extracting only the first table
- Simplified NATURAL JOIN duplicate column handling

## Problem

Queries like `SELECT e FROM t1 JOIN (t2 JOIN t3 USING(a)) USING(a)` would fail with "Column 'E' not found" because the join code only extracted the first table from the right side, losing columns from inner tables.

## Solution

Added a new `merge()` method to `CombinedSchema` that properly combines two schemas, preserving all tables from both sides with correctly adjusted column indices.

## Test Results

- joinB.test pass rate: 7.4% (38) → 14.3% (73) = **93% improvement**
- No regressions in existing tests

## Test plan

- [x] Build succeeds (`cargo build --release`)
- [x] Executor tests pass (`cargo test --release -p vibesql-executor`)
- [x] joinB.test improvements verified
- [ ] Full CI run

Closes #4283

🤖 Generated with [Claude Code](https://claude.com/claude-code)