### PR TITLE
fix(parser): Allow 'M' keyword as identifier

### DIFF
--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -347,7 +347,10 @@ impl Keyword {
             Keyword::Microsecond |
             // SQLite compatibility: TYPE and SQL are not reserved in SQLite
             // (allows unquoted access to sqlite_master.type and sqlite_master.sql columns)
-            Keyword::Type | Keyword::Sql
+            Keyword::Type | Keyword::Sql |
+            // Vector index parameter: M is only contextual in HNSW WITH clause
+            // SQLite TCL tests commonly use 'm' as a column name
+            Keyword::M
         )
     }
 }

--- a/crates/vibesql-parser/src/tests/select/keyword_as_identifier.rs
+++ b/crates/vibesql-parser/src/tests/select/keyword_as_identifier.rs
@@ -1,0 +1,85 @@
+use super::super::*;
+
+/// Tests for using keywords as identifiers (column names).
+/// Issue #4302: Parser should allow 'M' as column name since it's only
+/// contextually reserved for HNSW vector index configuration.
+
+#[test]
+fn test_column_m_in_select() {
+    // This was failing with: "Parse error: Expected expression, found Keyword(M)"
+    let result = Parser::parse_sql("SELECT m FROM t;");
+    assert!(result.is_ok(), "Failed to parse SELECT m FROM t: {:?}", result);
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            assert_eq!(select.select_list.len(), 1);
+            match &select.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                    vibesql_ast::Expression::ColumnRef { column, .. } => {
+                        assert_eq!(column, "M");
+                    }
+                    _ => panic!("Expected ColumnRef, got {:?}", expr),
+                },
+                _ => panic!("Expected Expression select item"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_column_m_in_where_clause() {
+    // From issue: SELECT k FROM t WHERE (j=1 AND m=1);
+    let result = Parser::parse_sql("SELECT k FROM t WHERE j=1 AND m=1;");
+    assert!(
+        result.is_ok(),
+        "Failed to parse WHERE with m column: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_column_m_in_create_table() {
+    // From issue: CREATE TABLE t(i, j, k, m, n);
+    let result = Parser::parse_sql("CREATE TABLE t(i, j, k, m, n);");
+    assert!(
+        result.is_ok(),
+        "Failed to parse CREATE TABLE with m column: {:?}",
+        result
+    );
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 5);
+            let column_names: Vec<&str> = create.columns.iter().map(|c| c.name.as_str()).collect();
+            assert!(
+                column_names.contains(&"M"),
+                "Column 'M' not found in columns: {:?}",
+                column_names
+            );
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_column_m_uppercase() {
+    let result = Parser::parse_sql("SELECT M FROM t;");
+    assert!(
+        result.is_ok(),
+        "Failed to parse SELECT M FROM t: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_column_m_in_expression() {
+    let result = Parser::parse_sql("SELECT m + 1 FROM t;");
+    assert!(
+        result.is_ok(),
+        "Failed to parse m in expression: {:?}",
+        result
+    );
+}

--- a/crates/vibesql-parser/src/tests/select/mod.rs
+++ b/crates/vibesql-parser/src/tests/select/mod.rs
@@ -5,4 +5,5 @@ mod concat;
 mod derived_columns;
 mod extract;
 mod filters;
+mod keyword_as_identifier;
 mod position;


### PR DESCRIPTION
## Summary

- Make `M` a contextual keyword that can be used as an identifier (column name)
- Fixes ~10% of TCL test failures where SQLite tests use single-letter column names including 'm'
- `M` keyword remains recognized in HNSW vector index WITH clauses for the M parameter

## Test plan

- [x] Added parser tests for 'm' as column name in SELECT, WHERE, CREATE TABLE, and expressions
- [x] Verified all 1065 parser tests pass
- [x] Verified index tests still work correctly

Closes #4302

🤖 Generated with [Claude Code](https://claude.com/claude-code)