### PR TITLE
fix(types): Allow BLOB columns to accept any value type

### DIFF
--- a/crates/vibesql-executor/src/insert/validation.rs
+++ b/crates/vibesql-executor/src/insert/validation.rs
@@ -174,6 +174,12 @@ pub fn coerce_value(
             Ok(SqlValue::Varchar(arcstr::ArcStr::from(s.trim_end()))) // Remove trailing spaces
         }
 
+        // BinaryLargeObject (BLOB) accepts any value type
+        // This implements SQLite's type affinity behavior where untyped columns
+        // (which default to BLOB affinity) can store values of any type.
+        // The value is stored as-is without conversion.
+        (_, DataType::BinaryLargeObject) => Ok(value),
+
         // Type mismatch
         _ => Err(ExecutorError::UnsupportedExpression(format!(
             "Type mismatch: expected {:?}, got {:?}",

--- a/crates/vibesql-storage/src/table/normalization.rs
+++ b/crates/vibesql-storage/src/table/normalization.rs
@@ -306,16 +306,12 @@ impl<'a> RowNormalizer<'a> {
                     });
                 }
             }
-            // Binary types - Note: No SqlValue::Blob variant exists yet
+            // Binary types - implements SQLite's BLOB affinity
             DataType::BinaryLargeObject => {
-                // For now, accept Varchar as a placeholder until BLOB is implemented
-                if !matches!(value, SqlValue::Varchar(_)) {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "BLOB".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
-                }
+                // BLOB affinity accepts any value type.
+                // This implements SQLite's flexible typing where untyped columns
+                // (which default to BLOB affinity) can store values of any type.
+                // The value is stored as-is without conversion.
             }
             DataType::Bit { .. } => {
                 // BIT type: For now, accept Varchar or Integer as placeholder until proper BIT type


### PR DESCRIPTION
## Summary

- Implements SQLite's type affinity behavior where untyped columns (which default to BLOB affinity) can store values of any type
- Previously, INSERT statements into untyped columns failed with: `Type mismatch: expected BinaryLargeObject, got Integer(1)`
- This fix affects ~40% of TCL test failures that use patterns like `CREATE TABLE t(a); INSERT INTO t VALUES(1);`

## Changes

1. **INSERT validation** (`crates/vibesql-executor/src/insert/validation.rs`):
   - Added wildcard match `(_, DataType::BinaryLargeObject) => Ok(value)` to accept any value type for BLOB columns

2. **Storage normalization** (`crates/vibesql-storage/src/table/normalization.rs`):
   - Updated `DataType::BinaryLargeObject` case to accept any value type instead of only VARCHAR

## Test plan

- [x] Manual testing of untyped column INSERT operations
- [x] Existing parser tests for typeless columns pass (12 tests)
- [x] Storage normalization tests pass (9 tests)
- [x] Full cargo test suite passes
- [x] TCL tests now execute INSERT into untyped columns successfully

Closes #4304

🤖 Generated with [Claude Code](https://claude.com/claude-code)