### PR TITLE
feat(parser): Support VALUES as a standalone statement

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -396,6 +396,11 @@ impl<'a, 'arena> Converter<'a, 'arena> {
             limit: stmt.limit,
             offset: stmt.offset,
             set_operation: stmt.set_operation.as_ref().map(|so| self.convert_set_operation(so)),
+            values: stmt.values.as_ref().map(|rows| {
+                rows.iter()
+                    .map(|row| row.iter().map(|e| self.convert_expression(e)).collect())
+                    .collect()
+            }),
         }
     }
 

--- a/crates/vibesql-ast/src/arena/select.rs
+++ b/crates/vibesql-ast/src/arena/select.rs
@@ -31,6 +31,8 @@ pub struct SelectStmt<'arena> {
     pub limit: Option<usize>,
     pub offset: Option<usize>,
     pub set_operation: Option<SetOperation<'arena>>,
+    /// VALUES clause for standalone VALUES statements (SQL:1999)
+    pub values: Option<BumpVec<'arena, BumpVec<'arena, Expression<'arena>>>>,
 }
 
 /// GROUP BY clause structure

--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -739,49 +739,63 @@ impl ToSql for SelectStmt {
             result.push_str(&format!("WITH {} ", cte_strs.join(", ")));
         }
 
-        // SELECT
-        result.push_str("SELECT ");
+        // Check if this is a VALUES statement
+        if let Some(rows) = &self.values {
+            // VALUES clause
+            result.push_str("VALUES");
+            let row_strs: Vec<String> = rows
+                .iter()
+                .map(|row| {
+                    let exprs: Vec<String> = row.iter().map(|e| e.to_sql()).collect();
+                    format!("({})", exprs.join(", "))
+                })
+                .collect();
+            result.push_str(&row_strs.join(", "));
+        } else {
+            // SELECT
+            result.push_str("SELECT ");
 
-        // DISTINCT
-        if self.distinct {
-            result.push_str("DISTINCT ");
+            // DISTINCT
+            if self.distinct {
+                result.push_str("DISTINCT ");
+            }
+
+            // Select list
+            let items: Vec<String> = self.select_list.iter().map(|i| i.to_sql()).collect();
+            result.push_str(&items.join(", "));
+
+            // INTO clause (DDL)
+            if let Some(table) = &self.into_table {
+                result.push_str(&format!(" INTO {}", format_identifier(table)));
+            }
+
+            // INTO variables (procedural)
+            if let Some(vars) = &self.into_variables {
+                result.push_str(&format!(" INTO {}", vars.join(", ")));
+            }
+
+            // FROM
+            if let Some(from) = &self.from {
+                result.push_str(&format!(" FROM {}", from.to_sql()));
+            }
+
+            // WHERE
+            if let Some(where_clause) = &self.where_clause {
+                result.push_str(&format!(" WHERE {}", where_clause.to_sql()));
+            }
+
+            // GROUP BY
+            if let Some(group_by) = &self.group_by {
+                result.push_str(&format!(" GROUP BY {}", group_by.to_sql()));
+            }
+
+            // HAVING
+            if let Some(having) = &self.having {
+                result.push_str(&format!(" HAVING {}", having.to_sql()));
+            }
         }
 
-        // Select list
-        let items: Vec<String> = self.select_list.iter().map(|i| i.to_sql()).collect();
-        result.push_str(&items.join(", "));
-
-        // INTO clause (DDL)
-        if let Some(table) = &self.into_table {
-            result.push_str(&format!(" INTO {}", format_identifier(table)));
-        }
-
-        // INTO variables (procedural)
-        if let Some(vars) = &self.into_variables {
-            result.push_str(&format!(" INTO {}", vars.join(", ")));
-        }
-
-        // FROM
-        if let Some(from) = &self.from {
-            result.push_str(&format!(" FROM {}", from.to_sql()));
-        }
-
-        // WHERE
-        if let Some(where_clause) = &self.where_clause {
-            result.push_str(&format!(" WHERE {}", where_clause.to_sql()));
-        }
-
-        // GROUP BY
-        if let Some(group_by) = &self.group_by {
-            result.push_str(&format!(" GROUP BY {}", group_by.to_sql()));
-        }
-
-        // HAVING
-        if let Some(having) = &self.having {
-            result.push_str(&format!(" HAVING {}", having.to_sql()));
-        }
-
-        // ORDER BY
+        // ORDER BY (applies to both SELECT and VALUES)
         if let Some(order_by) = &self.order_by {
             let items: Vec<String> = order_by.iter().map(|o| o.to_sql()).collect();
             result.push_str(&format!(" ORDER BY {}", items.join(", ")));
@@ -1105,6 +1119,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
         assert_eq!(stmt.to_sql(), "SELECT id FROM users");
     }
@@ -1142,6 +1157,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
         assert_eq!(stmt.to_sql(), "SELECT id, name FROM users WHERE active = 1");
     }
@@ -1172,6 +1188,7 @@ mod tests {
             limit: Some(10),
             offset: None,
             set_operation: None,
+            values: None,
         };
         assert_eq!(stmt.to_sql(), "SELECT DISTINCT name FROM users ORDER BY name ASC LIMIT 10");
     }

--- a/crates/vibesql-ast/src/select.rs
+++ b/crates/vibesql-ast/src/select.rs
@@ -30,6 +30,10 @@ pub struct CommonTableExpr {
 // ============================================================================
 
 /// SELECT statement structure
+///
+/// This can represent either a traditional SELECT statement or a standalone VALUES clause.
+/// When `values` is Some, this represents a VALUES clause (e.g., `VALUES(1),(2),(3)`).
+/// When `values` is None, this is a traditional SELECT statement.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SelectStmt {
     /// Optional WITH clause containing CTEs
@@ -51,6 +55,10 @@ pub struct SelectStmt {
     pub offset: Option<usize>,
     /// Set operation (UNION, INTERSECT, EXCEPT) combining this query with another
     pub set_operation: Option<SetOperation>,
+    /// VALUES clause for standalone VALUES statements (SQL:1999)
+    /// When this is Some, the statement represents a VALUES clause like `VALUES(1),(2),(3)`
+    /// Each inner Vec is a row of expressions
+    pub values: Option<Vec<Vec<Expression>>>,
 }
 
 // ============================================================================

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1042,6 +1042,11 @@ pub fn transform_select<V: ExpressionMutVisitor>(visitor: &mut V, stmt: SelectSt
             all: op.all,
             right: Box::new(transform_select(visitor, *op.right)),
         }),
+        values: stmt.values.map(|rows| {
+            rows.into_iter()
+                .map(|row| row.into_iter().map(|e| transform_expression(visitor, e)).collect())
+                .collect()
+        }),
     }
 }
 
@@ -1511,6 +1516,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         let stmt = Statement::Select(Box::new(select));

--- a/crates/vibesql-ast/tests/complex_expressions.rs
+++ b/crates/vibesql-ast/tests/complex_expressions.rs
@@ -59,6 +59,7 @@ fn test_scalar_subquery() {
     let subquery = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Expression {
             expr: Expression::Function {
@@ -95,6 +96,7 @@ fn test_in_expression() {
     let subquery = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Expression {
             expr: Expression::ColumnRef { table: None, column: "department_id".to_string() },
@@ -131,6 +133,7 @@ fn test_not_in_expression() {
     let subquery = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard { alias: None }],
         into_table: None,

--- a/crates/vibesql-ast/tests/select_stmt.rs
+++ b/crates/vibesql-ast/tests/select_stmt.rs
@@ -10,6 +10,7 @@ fn test_select_star() {
     let select = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard { alias: None }],
         into_table: None,
@@ -35,6 +36,7 @@ fn test_select_with_columns() {
     let select = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             SelectItem::Expression {
@@ -65,6 +67,7 @@ fn test_select_with_alias() {
     let select = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Expression {
             expr: Expression::ColumnRef { table: None, column: "id".to_string() },
@@ -92,6 +95,7 @@ fn test_select_from_table() {
     let select = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard { alias: None }],
         into_table: None,
@@ -120,6 +124,7 @@ fn test_select_with_where() {
     let select = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard { alias: None }],
         into_table: None,
@@ -149,6 +154,7 @@ fn test_select_with_order_by() {
     let select = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard { alias: None }],
         into_table: None,
@@ -182,6 +188,7 @@ fn test_select_distinct() {
     let select = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: true,
         select_list: vec![SelectItem::Expression {
             expr: Expression::ColumnRef { table: None, column: "country".to_string() },
@@ -209,6 +216,7 @@ fn test_select_with_group_by() {
     let select = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Expression {
             expr: Expression::Function {
@@ -243,6 +251,7 @@ fn test_select_with_having() {
     let select = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard { alias: None }],
         into_table: None,
@@ -278,6 +287,7 @@ fn test_select_with_limit() {
     let select = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard { alias: None }],
         into_table: None,
@@ -302,6 +312,7 @@ fn test_select_with_offset() {
     let select = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard { alias: None }],
         into_table: None,
@@ -326,6 +337,7 @@ fn test_order_by_desc() {
     let select = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard { alias: None }],
         into_table: None,
@@ -492,6 +504,7 @@ fn test_from_subquery() {
     let subquery = SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![SelectItem::Wildcard { alias: None }],
         into_table: None,

--- a/crates/vibesql-ast/tests/statements.rs
+++ b/crates/vibesql-ast/tests/statements.rs
@@ -21,6 +21,7 @@ fn test_create_select_statement() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     }));
 
     match stmt {

--- a/crates/vibesql-executor/src/advanced_objects/assertions.rs
+++ b/crates/vibesql-executor/src/advanced_objects/assertions.rs
@@ -93,6 +93,7 @@ impl AssertionChecker {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         // Execute the SELECT

--- a/crates/vibesql-executor/src/cache/parameterized.rs
+++ b/crates/vibesql-executor/src/cache/parameterized.rs
@@ -574,6 +574,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }));
 
         let literals = LiteralExtractor::extract(&stmt);
@@ -614,6 +615,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }));
 
         let literals = LiteralExtractor::extract(&stmt);

--- a/crates/vibesql-executor/src/cache/query_signature.rs
+++ b/crates/vibesql-executor/src/cache/query_signature.rs
@@ -1107,6 +1107,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }));
 
         // SELECT col0 FROM tab WHERE col1 > 10 (different literal)
@@ -1135,6 +1136,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }));
 
         let sig1 = QuerySignature::from_ast(&stmt1);
@@ -1177,6 +1179,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }));
 
         // SELECT col0 FROM tab WHERE col1 < 5 (different operator)
@@ -1205,6 +1208,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }));
 
         let sig1 = QuerySignature::from_ast(&stmt1);

--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -477,6 +477,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         // With the fixed implementation, this is correctly detected as non-correlated
@@ -514,6 +515,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         assert!(is_correlated(&subquery, &outer_schema));
@@ -541,6 +543,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         assert!(!is_correlated(&subquery, &outer_schema));

--- a/crates/vibesql-executor/src/cursor.rs
+++ b/crates/vibesql-executor/src/cursor.rs
@@ -340,6 +340,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }
     }
 

--- a/crates/vibesql-executor/src/delete/tests/subqueries.rs
+++ b/crates/vibesql-executor/src/delete/tests/subqueries.rs
@@ -205,6 +205,7 @@ mod in_subquery {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         });
 
         // DELETE FROM employees WHERE dept_id IN (SELECT dept_id FROM inactive_depts)
@@ -265,6 +266,7 @@ mod in_subquery {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         });
 
         // DELETE FROM employees WHERE dept_id NOT IN (SELECT dept_id FROM active_depts)
@@ -336,6 +338,7 @@ mod scalar_subquery {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         });
 
         // DELETE FROM employees WHERE salary < (SELECT AVG(salary) FROM employees)
@@ -406,6 +409,7 @@ mod scalar_subquery {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         });
 
         // DELETE FROM items WHERE price = (SELECT MAX(price) FROM items)
@@ -466,6 +470,7 @@ mod scalar_subquery {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         });
 
         // DELETE FROM employees WHERE salary > (SELECT threshold FROM config)
@@ -526,6 +531,7 @@ mod empty_subquery {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         });
 
         // DELETE FROM employees WHERE dept_id IN (SELECT dept_id FROM old_depts)
@@ -601,6 +607,7 @@ mod complex_subquery {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         });
 
         // DELETE FROM orders WHERE customer_id IN (SELECT customer_id FROM inactive_customers WHERE

--- a/crates/vibesql-executor/src/insert/bulk_transfer.rs
+++ b/crates/vibesql-executor/src/insert/bulk_transfer.rs
@@ -293,6 +293,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         assert_eq!(extract_simple_table_select(&stmt), Some("source".to_string()));
@@ -318,6 +319,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         assert_eq!(extract_simple_table_select(&stmt), None);
@@ -343,6 +345,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         assert_eq!(extract_simple_table_select(&stmt), None);

--- a/crates/vibesql-executor/src/optimizer/adaptive/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/adaptive/mod.rs
@@ -152,6 +152,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         // Should use row-oriented (wildcard projection, no aggregation)
@@ -206,6 +207,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         // Should use columnar (GROUP BY with aggregation is now supported in Phase 6)
@@ -251,6 +253,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         // Should use columnar (aggregation + arithmetic, no GROUP BY)
@@ -311,6 +314,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         // Should use row-oriented (4 tables > threshold, wildcard)
@@ -344,6 +348,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         assert!(query::has_aggregate_functions(&query_with_count));
@@ -382,6 +387,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         assert!(query::has_arithmetic_expressions(&query_with_arithmetic));
@@ -417,6 +423,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         assert!(query::has_selective_projection(&selective));
@@ -440,6 +447,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         assert!(!query::has_selective_projection(&non_selective));

--- a/crates/vibesql-executor/src/optimizer/adaptive/strategy.rs
+++ b/crates/vibesql-executor/src/optimizer/adaptive/strategy.rs
@@ -350,6 +350,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }
     }
 
@@ -389,6 +390,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }
     }
 
@@ -411,6 +413,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         let cte_results = HashMap::new();

--- a/crates/vibesql-executor/src/optimizer/aggregate_analysis.rs
+++ b/crates/vibesql-executor/src/optimizer/aggregate_analysis.rs
@@ -517,6 +517,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         let analysis = AggregateAnalysis::analyze(&stmt);
@@ -551,6 +552,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         let analysis = AggregateAnalysis::analyze(&stmt);
@@ -590,6 +592,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         };
 
         let analysis = AggregateAnalysis::analyze(&stmt);

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
@@ -211,6 +211,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }
     }
 
@@ -572,6 +573,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }
     }
 

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/exists.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/exists.rs
@@ -244,6 +244,7 @@ fn try_convert_complex_exists_to_join(
         limit: None,
         offset: None,
         set_operation: None,
+        values: None,
     };
 
     // Create the derived table as FromClause::Subquery

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/tests.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/tests.rs
@@ -27,6 +27,7 @@ fn simple_select(table: &str, column: &str) -> SelectStmt {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     }
 }
 
@@ -343,6 +344,7 @@ fn test_exists_self_join_column_qualification() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     // Create correlated EXISTS subquery:
@@ -374,6 +376,7 @@ fn test_exists_self_join_column_qualification() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     stmt.where_clause =
@@ -460,6 +463,7 @@ fn test_not_exists_self_join_column_qualification() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     // Create correlated NOT EXISTS subquery:
@@ -491,6 +495,7 @@ fn test_not_exists_self_join_column_qualification() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     stmt.where_clause = Some(Expression::Exists {
@@ -580,6 +585,7 @@ fn test_conjunction_exists_to_semi_join() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     // Create correlated EXISTS subquery
@@ -604,6 +610,7 @@ fn test_conjunction_exists_to_semi_join() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     // Build Conjunction: [predicate1, predicate2, EXISTS(...)]
@@ -667,6 +674,7 @@ fn test_conjunction_not_exists_to_anti_join() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     // Create correlated NOT EXISTS subquery
@@ -691,6 +699,7 @@ fn test_conjunction_not_exists_to_anti_join() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     // Build Conjunction with NOT EXISTS

--- a/crates/vibesql-executor/src/optimizer/table_elimination.rs
+++ b/crates/vibesql-executor/src/optimizer/table_elimination.rs
@@ -291,6 +291,7 @@ pub fn eliminate_unused_tables(stmt: &SelectStmt) -> SelectStmt {
         limit: stmt.limit,
         offset: stmt.offset,
         set_operation: stmt.set_operation.clone(),
+        values: stmt.values.clone(),
     }
 }
 
@@ -806,6 +807,7 @@ fn build_exists_checks(eliminated: &[EliminatedTable]) -> Vec<Expression> {
                 limit: Some(1),
                 offset: None,
                 set_operation: None,
+                values: None,
             };
 
             Expression::Exists { subquery: Box::new(subquery), negated: false }
@@ -1309,6 +1311,7 @@ mod tests {
                 limit: None,
                 offset: None,
                 set_operation: None,
+                values: None,
             };
 
             let result = eliminate_unused_tables(&stmt);
@@ -1344,6 +1347,7 @@ mod tests {
                 limit: None,
                 offset: None,
                 set_operation: None,
+                values: None,
             };
 
             let result = eliminate_unused_tables(&stmt);
@@ -1378,6 +1382,7 @@ mod tests {
                 limit: None,
                 offset: None,
                 set_operation: None,
+                values: None,
             };
 
             let result = eliminate_unused_tables(&stmt);
@@ -1413,6 +1418,7 @@ mod tests {
                 limit: None,
                 offset: None,
                 set_operation: None,
+                values: None,
             };
 
             let result = eliminate_unused_tables(&stmt);
@@ -1457,6 +1463,7 @@ mod tests {
                 limit: None,
                 offset: None,
                 set_operation: None,
+                values: None,
             };
 
             let result = eliminate_unused_tables(&stmt);
@@ -1483,6 +1490,7 @@ mod tests {
                 limit: None,
                 offset: None,
                 set_operation: None,
+                values: None,
             };
 
             let result = eliminate_unused_tables(&stmt);
@@ -1509,6 +1517,7 @@ mod tests {
                 limit: None,
                 offset: None,
                 set_operation: None,
+                values: None,
             };
 
             let result = eliminate_unused_tables(&stmt);
@@ -1552,6 +1561,7 @@ mod tests {
                 limit: None,
                 offset: None,
                 set_operation: None,
+                values: None,
             };
 
             let result = eliminate_unused_tables(&stmt);
@@ -1599,6 +1609,7 @@ mod tests {
                 limit: None,
                 offset: None,
                 set_operation: None,
+                values: None,
             };
 
             let result = eliminate_unused_tables(&stmt);

--- a/crates/vibesql-executor/src/select/columnar/aggregate/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/mod.rs
@@ -397,6 +397,7 @@ mod tests {
                 limit: None,
                 offset: None,
                 set_operation: None,
+            values: None,
             }))],
         }];
 

--- a/crates/vibesql-executor/src/select/columnar/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/mod.rs
@@ -932,6 +932,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }));
 
         let aggregates = vec![Expression::AggregateFunction {

--- a/crates/vibesql-executor/src/select/executor/memory_tests.rs
+++ b/crates/vibesql-executor/src/select/executor/memory_tests.rs
@@ -122,6 +122,7 @@ mod integration_tests {
             into_variables: None,
             with_clause: None,
             set_operation: None,
+            values: None,
             distinct: false,
             select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
             from: Some(vibesql_ast::FromClause::Table {
@@ -195,6 +196,7 @@ mod integration_tests {
             into_variables: None,
             with_clause: None,
             set_operation: None,
+            values: None,
             distinct: false,
             select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
             from: Some(vibesql_ast::FromClause::Join {
@@ -235,6 +237,7 @@ mod integration_tests {
             into_variables: None,
             with_clause: None,
             set_operation: None,
+            values: None,
             distinct: false,
             select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
             from: Some(vibesql_ast::FromClause::Join {

--- a/crates/vibesql-executor/src/select/grouping/grouping_sets/expression_utils.rs
+++ b/crates/vibesql-executor/src/select/grouping/grouping_sets/expression_utils.rs
@@ -634,6 +634,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }));
         let subq2 = Expression::ScalarSubquery(Box::new(SelectStmt {
             with_clause: None,
@@ -649,6 +650,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }));
 
         // Subqueries always compare as false (reference inequality)

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -619,6 +619,7 @@ mod tests {
             limit: None,
             offset: None,
             set_operation: None,
+            values: None,
         }
     }
 

--- a/crates/vibesql-executor/src/tests/aggregate_caching.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_caching.rs
@@ -88,6 +88,7 @@ fn test_repeated_count_star_cached() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression { expr: final_expr, alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -161,6 +162,7 @@ fn test_repeated_sum_cached() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression { expr, alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -269,6 +271,7 @@ fn test_cache_cleared_between_groups() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -359,6 +362,7 @@ fn test_distinct_aggregates_not_confused() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {

--- a/crates/vibesql-executor/src/tests/aggregate_count_sum_avg_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_count_sum_avg_tests.rs
@@ -54,6 +54,7 @@ fn test_count_star_no_group_by() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -131,6 +132,7 @@ fn test_sum_no_group_by() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -212,6 +214,7 @@ fn test_count_with_nulls() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -289,6 +292,7 @@ fn test_sum_with_nulls() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -370,6 +374,7 @@ fn test_avg_function() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -451,6 +456,7 @@ fn test_avg_with_nulls() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -535,6 +541,7 @@ fn test_count_column_all_nulls() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -570,6 +577,7 @@ fn test_count_column_all_nulls() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -627,6 +635,7 @@ fn test_count_star_in_simple_case_expression() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Case {
@@ -696,6 +705,7 @@ fn test_count_star_in_searched_case_expression() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Case {
@@ -770,6 +780,7 @@ fn test_count_star_in_arithmetic_expression() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::BinaryOp {
@@ -827,6 +838,7 @@ fn test_count_star_in_case_then_clause() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Case {
@@ -895,6 +907,7 @@ fn test_count_star_in_nested_case_expression() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Case {

--- a/crates/vibesql-executor/src/tests/aggregate_distinct.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_distinct.rs
@@ -90,6 +90,7 @@ fn test_count_distinct_basic() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -132,6 +133,7 @@ fn test_count_distinct_vs_count_all() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -189,6 +191,7 @@ fn test_sum_distinct() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -231,6 +234,7 @@ fn test_sum_distinct_vs_sum_all() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -288,6 +292,7 @@ fn test_avg_distinct() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -330,6 +335,7 @@ fn test_min_distinct() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -372,6 +378,7 @@ fn test_max_distinct() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -434,6 +441,7 @@ fn test_count_distinct_with_nulls() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -494,6 +502,7 @@ fn test_distinct_all_same_value() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -561,6 +570,7 @@ fn test_distinct_empty_table() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {

--- a/crates/vibesql-executor/src/tests/aggregate_edge_case_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_edge_case_tests.rs
@@ -55,6 +55,7 @@ fn test_avg_precision_decimal() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -142,6 +143,7 @@ fn test_sum_mixed_numeric_types() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -233,6 +235,7 @@ fn test_aggregate_with_case_expression() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -308,6 +311,7 @@ fn test_max_with_unary_plus() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -367,6 +371,7 @@ fn test_max_with_unary_minus() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -427,6 +432,7 @@ fn test_count_with_not() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {

--- a/crates/vibesql-executor/src/tests/aggregate_group_by_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_group_by_tests.rs
@@ -69,6 +69,7 @@ fn test_group_by_select_alias() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -187,6 +188,7 @@ fn test_group_by_numeric_position() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -300,6 +302,7 @@ fn test_group_by_with_count() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {

--- a/crates/vibesql-executor/src/tests/aggregate_having_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_having_tests.rs
@@ -134,6 +134,7 @@ fn test_having_clause() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {

--- a/crates/vibesql-executor/src/tests/aggregate_min_max_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_min_max_tests.rs
@@ -54,6 +54,7 @@ fn test_min_function() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -134,6 +135,7 @@ fn test_max_function() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -217,6 +219,7 @@ fn test_min_max_on_strings() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -255,6 +258,7 @@ fn test_min_max_on_strings() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {

--- a/crates/vibesql-executor/src/tests/aggregate_without_from.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_without_from.rs
@@ -16,6 +16,7 @@ fn test_max_constant_without_from() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -50,6 +51,7 @@ fn test_count_star_without_from() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -84,6 +86,7 @@ fn test_aggregate_in_expression_without_from() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::BinaryOp {
@@ -126,6 +129,7 @@ fn test_count_distinct_without_from() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -160,6 +164,7 @@ fn test_multiple_aggregates_without_from() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -218,6 +223,7 @@ fn test_sum_avg_without_from() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {

--- a/crates/vibesql-executor/src/tests/between_predicates.rs
+++ b/crates/vibesql-executor/src/tests/between_predicates.rs
@@ -74,6 +74,7 @@ fn test_between_integer() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -186,6 +187,7 @@ fn test_not_between() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "name".to_string() },
@@ -261,6 +263,7 @@ fn test_between_boundary_inclusive() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -357,6 +360,7 @@ fn test_between_with_column_references() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "VALUE".to_string() },

--- a/crates/vibesql-executor/src/tests/comparison_ops.rs
+++ b/crates/vibesql-executor/src/tests/comparison_ops.rs
@@ -27,6 +27,7 @@ fn test_greater_than_comparison() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -77,6 +78,7 @@ fn test_less_than_comparison() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -129,6 +131,7 @@ fn test_not_equal_comparison() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -182,6 +185,7 @@ fn test_less_than_or_equal_comparison() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {

--- a/crates/vibesql-executor/src/tests/count_star_fast_path.rs
+++ b/crates/vibesql-executor/src/tests/count_star_fast_path.rs
@@ -45,6 +45,7 @@ fn test_count_star_fast_path_simple() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -92,6 +93,7 @@ fn test_count_star_fast_path_empty_table() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -157,6 +159,7 @@ fn test_count_star_with_where_no_fast_path() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -261,6 +264,7 @@ fn test_count_star_with_group_by_no_fast_path() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -327,6 +331,7 @@ fn test_count_star_distinct_no_fast_path() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: true, // DISTINCT specified
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -382,6 +387,7 @@ fn test_count_column_no_fast_path() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -440,6 +446,7 @@ fn test_count_star_with_alias() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -505,6 +512,7 @@ fn test_count_star_multiple_select_items_no_fast_path() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {

--- a/crates/vibesql-executor/src/tests/join_aggregation.rs
+++ b/crates/vibesql-executor/src/tests/join_aggregation.rs
@@ -140,6 +140,7 @@ fn test_inner_join_with_group_by_count() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -248,6 +249,7 @@ fn test_left_join_with_group_by_avg_salary() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -357,6 +359,7 @@ fn test_join_group_by_with_having() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -459,6 +462,7 @@ fn test_join_group_by_multiple_aggregates() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {

--- a/crates/vibesql-executor/src/tests/limit_offset.rs
+++ b/crates/vibesql-executor/src/tests/limit_offset.rs
@@ -9,6 +9,7 @@ fn make_pagination_stmt(limit: Option<usize>, offset: Option<usize>) -> vibesql_
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -216,6 +217,7 @@ fn test_limit_with_inner_join() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -328,6 +330,7 @@ fn test_offset_with_inner_join() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -440,6 +443,7 @@ fn test_limit_offset_with_inner_join() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {

--- a/crates/vibesql-executor/src/tests/natural_join.rs
+++ b/crates/vibesql-executor/src/tests/natural_join.rs
@@ -117,6 +117,7 @@ fn test_natural_join_single_common_column() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {

--- a/crates/vibesql-executor/src/tests/not_operator_tests.rs
+++ b/crates/vibesql-executor/src/tests/not_operator_tests.rs
@@ -61,6 +61,7 @@ fn test_not_in_select_where() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "pk".to_string() },
@@ -142,6 +143,7 @@ fn test_not_with_equality() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "pk".to_string() },
@@ -253,6 +255,7 @@ fn test_not_in_delete_where() {
     let verify_stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -321,6 +324,7 @@ fn test_not_with_null() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "pk".to_string() },

--- a/crates/vibesql-executor/src/tests/operator_edge_cases/binary_arithmetic.rs
+++ b/crates/vibesql-executor/src/tests/operator_edge_cases/binary_arithmetic.rs
@@ -18,6 +18,7 @@ fn test_nested_arithmetic() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::BinaryOp {
@@ -79,6 +80,7 @@ fn test_integer_division_basic() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::BinaryOp {

--- a/crates/vibesql-executor/src/tests/operator_edge_cases/comparison_operators.rs
+++ b/crates/vibesql-executor/src/tests/operator_edge_cases/comparison_operators.rs
@@ -26,6 +26,7 @@ fn test_nested_comparisons() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {

--- a/crates/vibesql-executor/src/tests/operator_edge_cases/operator_test_utils.rs
+++ b/crates/vibesql-executor/src/tests/operator_edge_cases/operator_test_utils.rs
@@ -15,6 +15,7 @@ pub fn create_select_stmt(expr: vibesql_ast::Expression, alias: &str) -> vibesql
     vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr,

--- a/crates/vibesql-executor/src/tests/phase3_join_optimization.rs
+++ b/crates/vibesql-executor/src/tests/phase3_join_optimization.rs
@@ -82,6 +82,7 @@ fn test_hash_join_from_where_equijoin_no_on_clause() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -207,6 +208,7 @@ fn test_hash_join_multiple_equijoins_in_where() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -325,6 +327,7 @@ fn test_cascading_joins_with_where_equijoins() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -490,6 +493,7 @@ fn test_hash_join_with_on_clause_and_where_equijoins() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -634,6 +638,7 @@ fn test_multi_column_hash_join_composite_keys() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -782,6 +787,7 @@ fn test_star_join_select5_pattern() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {

--- a/crates/vibesql-executor/src/tests/predicate_pushdown.rs
+++ b/crates/vibesql-executor/src/tests/predicate_pushdown.rs
@@ -55,6 +55,7 @@ fn test_table_local_predicate_applied_at_scan() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -133,6 +134,7 @@ fn test_multi_table_with_local_predicates() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -281,6 +283,7 @@ fn test_table_local_predicate_with_explicit_join() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -389,6 +392,7 @@ fn test_table_local_predicate_with_multiple_conditions() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {

--- a/crates/vibesql-executor/src/tests/predicate_tests/between_predicate.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/between_predicate.rs
@@ -30,6 +30,7 @@ fn test_between_with_null_expr() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -86,6 +87,7 @@ fn test_not_between() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -141,6 +143,7 @@ fn test_between_boundary_values() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -199,6 +202,7 @@ fn test_not_between_with_null_bound() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -256,6 +260,7 @@ fn test_between_with_null_bound() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -316,6 +321,7 @@ fn test_not_between_with_null_lower_bound() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -378,6 +384,7 @@ fn test_not_negative_literal_between_null_bounds() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {

--- a/crates/vibesql-executor/src/tests/predicate_tests/cast_expression.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/cast_expression.rs
@@ -17,6 +17,7 @@ fn test_cast_integer_to_varchar() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
@@ -52,6 +53,7 @@ fn test_cast_varchar_to_integer() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
@@ -87,6 +89,7 @@ fn test_cast_null() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
@@ -120,6 +123,7 @@ fn test_cast_integer_to_unsigned() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
@@ -155,6 +159,7 @@ fn test_cast_negative_integer_to_unsigned() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
@@ -191,6 +196,7 @@ fn test_cast_varchar_to_unsigned() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
@@ -230,6 +236,7 @@ fn test_cast_float_to_unsigned() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
@@ -266,6 +273,7 @@ fn test_cast_as_signed_positive() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
@@ -304,6 +312,7 @@ fn test_cast_as_signed_negative() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
@@ -346,6 +355,7 @@ fn test_cast_as_signed_from_float() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
@@ -390,6 +400,7 @@ fn test_cast_negative_float_to_signed_rounds() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
@@ -431,6 +442,7 @@ fn test_cast_rounding_edge_cases() {
         let stmt = vibesql_ast::SelectStmt {
             with_clause: None,
             set_operation: None,
+            values: None,
             distinct: false,
             select_list: vec![vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::Cast {

--- a/crates/vibesql-executor/src/tests/predicate_tests/in_predicate.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/in_predicate.rs
@@ -33,6 +33,7 @@ fn test_in_list_basic() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -90,6 +91,7 @@ fn test_not_in_list() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -145,6 +147,7 @@ fn test_in_list_with_null_value() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -200,6 +203,7 @@ fn test_in_list_with_null_in_list() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -256,6 +260,7 @@ fn test_empty_in_list() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -308,6 +313,7 @@ fn test_empty_not_in_list() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -359,6 +365,7 @@ fn test_null_in_empty_subquery() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::In {
@@ -366,6 +373,7 @@ fn test_null_in_empty_subquery() {
                 subquery: Box::new(vibesql_ast::SelectStmt {
                     with_clause: None,
                     set_operation: None,
+            values: None,
                     distinct: false,
                     select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
                     from: Some(vibesql_ast::FromClause::Table {
@@ -425,6 +433,7 @@ fn test_null_not_in_empty_subquery() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::In {
@@ -432,6 +441,7 @@ fn test_null_not_in_empty_subquery() {
                 subquery: Box::new(vibesql_ast::SelectStmt {
                     with_clause: None,
                     set_operation: None,
+            values: None,
                     distinct: false,
                     select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
                     from: Some(vibesql_ast::FromClause::Table {
@@ -490,6 +500,7 @@ fn test_value_in_empty_subquery() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::In {
@@ -499,6 +510,7 @@ fn test_value_in_empty_subquery() {
                 subquery: Box::new(vibesql_ast::SelectStmt {
                     with_clause: None,
                     set_operation: None,
+            values: None,
                     distinct: false,
                     select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
                     from: Some(vibesql_ast::FromClause::Table {

--- a/crates/vibesql-executor/src/tests/predicate_tests/in_subquery_multi_column_validation.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/in_subquery_multi_column_validation.rs
@@ -42,6 +42,7 @@ fn test_in_subquery_wildcard_multi_column_rejected() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -57,6 +58,7 @@ fn test_in_subquery_wildcard_multi_column_rejected() {
             subquery: Box::new(vibesql_ast::SelectStmt {
                 with_clause: None,
                 set_operation: None,
+            values: None,
                 distinct: false,
                 select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }], /* * expands to 2 columns! */
                 from: Some(vibesql_ast::FromClause::Table {
@@ -131,6 +133,7 @@ fn test_in_subquery_explicit_multi_column_rejected() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -146,6 +149,7 @@ fn test_in_subquery_explicit_multi_column_rejected() {
             subquery: Box::new(vibesql_ast::SelectStmt {
                 with_clause: None,
                 set_operation: None,
+            values: None,
                 distinct: false,
                 select_list: vec![
                     vibesql_ast::SelectItem::Expression {
@@ -235,6 +239,7 @@ fn test_in_subquery_single_column_accepted() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -250,6 +255,7 @@ fn test_in_subquery_single_column_accepted() {
             subquery: Box::new(vibesql_ast::SelectStmt {
                 with_clause: None,
                 set_operation: None,
+            values: None,
                 distinct: false,
                 select_list: vec![vibesql_ast::SelectItem::Expression {
                     expr: vibesql_ast::Expression::ColumnRef {
@@ -326,11 +332,13 @@ fn test_scalar_subquery_wildcard_multi_column_rejected() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ScalarSubquery(Box::new(vibesql_ast::SelectStmt {
                 with_clause: None,
                 set_operation: None,
+            values: None,
                 distinct: false,
                 select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }], /* * expands to 2 columns! */
                 from: Some(vibesql_ast::FromClause::Table {

--- a/crates/vibesql-executor/src/tests/predicate_tests/like_predicate.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/like_predicate.rs
@@ -48,6 +48,7 @@ fn test_like_wildcard_percent() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -118,6 +119,7 @@ fn test_like_wildcard_underscore() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -188,6 +190,7 @@ fn test_not_like() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -245,6 +248,7 @@ fn test_like_null_pattern() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -300,6 +304,7 @@ fn test_like_null_value() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {

--- a/crates/vibesql-executor/src/tests/predicate_tests/position_function.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/position_function.rs
@@ -17,6 +17,7 @@ fn test_position_found() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Position {
@@ -55,6 +56,7 @@ fn test_position_not_found() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Position {
@@ -93,6 +95,7 @@ fn test_position_null_substring() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Position {
@@ -131,6 +134,7 @@ fn test_position_null_string() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Position {

--- a/crates/vibesql-executor/src/tests/predicate_tests/trim_function.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/trim_function.rs
@@ -18,6 +18,7 @@ fn test_trim_both_default() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Trim {
@@ -57,6 +58,7 @@ fn test_trim_leading() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Trim {
@@ -96,6 +98,7 @@ fn test_trim_trailing() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Trim {
@@ -135,6 +138,7 @@ fn test_trim_custom_char() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Trim {
@@ -176,6 +180,7 @@ fn test_trim_null_string() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Trim {
@@ -210,6 +215,7 @@ fn test_trim_null_removal_char() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Trim {

--- a/crates/vibesql-executor/src/tests/procedures/edge_cases.rs
+++ b/crates/vibesql-executor/src/tests/procedures/edge_cases.rs
@@ -392,6 +392,7 @@ fn test_procedural_select_into_single_column() {
                 limit: None,
                 offset: None,
                 set_operation: None,
+            values: None,
             })))),
         ],
     );
@@ -474,6 +475,7 @@ fn test_procedural_select_into_multiple_columns() {
                 limit: None,
                 offset: None,
                 set_operation: None,
+            values: None,
             })))),
         ],
     );
@@ -542,6 +544,7 @@ fn test_procedural_select_into_error_no_rows() {
                 limit: None,
                 offset: None,
                 set_operation: None,
+            values: None,
             })))),
         ]),
         sql_security: None,
@@ -616,6 +619,7 @@ fn test_procedural_select_into_error_multiple_rows() {
                 limit: None,
                 offset: None,
                 set_operation: None,
+            values: None,
             })))),
         ],
     );
@@ -689,6 +693,7 @@ fn test_procedural_select_into_error_column_count_mismatch() {
                 limit: None,
                 offset: None,
                 set_operation: None,
+            values: None,
             })))),
         ],
     );

--- a/crates/vibesql-executor/src/tests/quantified_comparison_tests.rs
+++ b/crates/vibesql-executor/src/tests/quantified_comparison_tests.rs
@@ -53,6 +53,7 @@ fn test_all_greater_than_basic() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
@@ -76,6 +77,7 @@ fn test_all_greater_than_basic() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
@@ -153,6 +155,7 @@ fn test_any_less_than_basic() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
@@ -176,6 +179,7 @@ fn test_any_less_than_basic() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
@@ -254,6 +258,7 @@ fn test_some_equals_basic() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
@@ -277,6 +282,7 @@ fn test_some_equals_basic() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
@@ -349,6 +355,7 @@ fn test_all_with_empty_subquery() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
@@ -372,6 +379,7 @@ fn test_all_with_empty_subquery() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
@@ -444,6 +452,7 @@ fn test_any_with_empty_subquery() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
@@ -467,6 +476,7 @@ fn test_any_with_empty_subquery() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
@@ -546,6 +556,7 @@ fn test_all_with_null_in_subquery() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
@@ -569,6 +580,7 @@ fn test_all_with_null_in_subquery() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
@@ -637,6 +649,7 @@ fn test_all_with_null_left_value() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
@@ -660,6 +673,7 @@ fn test_all_with_null_left_value() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },

--- a/crates/vibesql-executor/src/tests/rowid_tests.rs
+++ b/crates/vibesql-executor/src/tests/rowid_tests.rs
@@ -54,6 +54,7 @@ fn test_select_rowid() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -133,6 +134,7 @@ fn test_select_underscore_rowid() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
@@ -187,6 +189,7 @@ fn test_select_oid() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
@@ -241,6 +244,7 @@ fn test_rowid_case_insensitive() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
@@ -308,6 +312,7 @@ fn test_real_rowid_column_takes_precedence() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
@@ -368,6 +373,7 @@ fn test_rowid_with_table_alias() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {

--- a/crates/vibesql-executor/src/tests/scalar_subquery_basic_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_basic_tests.rs
@@ -70,6 +70,7 @@ fn test_scalar_subquery_in_where_clause() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -101,6 +102,7 @@ fn test_scalar_subquery_in_where_clause() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -190,6 +192,7 @@ fn test_scalar_subquery_in_select_list() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -221,6 +224,7 @@ fn test_scalar_subquery_in_select_list() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -300,6 +304,7 @@ fn test_scalar_subquery_returns_null_when_empty() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() },
@@ -333,6 +338,7 @@ fn test_scalar_subquery_returns_null_when_empty() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ScalarSubquery(subquery),

--- a/crates/vibesql-executor/src/tests/scalar_subquery_correlated_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_correlated_tests.rs
@@ -81,6 +81,7 @@ fn test_correlated_subquery_uppercase_identifiers_issue_4111() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -123,6 +124,7 @@ fn test_correlated_subquery_uppercase_identifiers_issue_4111() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
@@ -257,6 +259,7 @@ fn test_correlated_subquery_basic() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -298,6 +301,7 @@ fn test_correlated_subquery_basic() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {

--- a/crates/vibesql-executor/src/tests/scalar_subquery_error_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_error_tests.rs
@@ -40,6 +40,7 @@ fn test_scalar_subquery_error_multiple_rows() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() },
@@ -64,6 +65,7 @@ fn test_scalar_subquery_error_multiple_rows() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ScalarSubquery(subquery),
@@ -135,6 +137,7 @@ fn test_scalar_subquery_error_multiple_columns() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -168,6 +171,7 @@ fn test_scalar_subquery_error_multiple_columns() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ScalarSubquery(subquery),

--- a/crates/vibesql-executor/src/tests/select_basic_projection.rs
+++ b/crates/vibesql-executor/src/tests/select_basic_projection.rs
@@ -47,6 +47,7 @@ fn test_select_star() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -114,6 +115,7 @@ fn test_select_specific_columns() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {

--- a/crates/vibesql-executor/src/tests/select_derived_columns.rs
+++ b/crates/vibesql-executor/src/tests/select_derived_columns.rs
@@ -44,6 +44,7 @@ fn test_select_star_with_derived_columns() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard {
             alias: Some(vec!["C".to_string(), "D".to_string()]),
@@ -107,6 +108,7 @@ fn test_select_qualified_star_with_derived_columns() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::QualifiedWildcard {
             qualifier: "t1".to_string(),
@@ -173,6 +175,7 @@ fn test_derived_columns_count_mismatch() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard {
             alias: Some(vec!["C".to_string(), "D".to_string(), "E".to_string()]),
@@ -243,6 +246,7 @@ fn test_select_distinct_star_with_derived_columns() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: true, // DISTINCT
         select_list: vec![vibesql_ast::SelectItem::Wildcard {
             alias: Some(vec!["C".to_string(), "D".to_string()]),
@@ -306,6 +310,7 @@ fn test_select_star_alias_with_table_alias() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::QualifiedWildcard {
             qualifier: "alias_name".to_string(),
@@ -636,6 +641,7 @@ fn test_select_without_from() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -667,6 +673,7 @@ fn test_select_expression_without_from() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::BinaryOp {

--- a/crates/vibesql-executor/src/tests/select_distinct.rs
+++ b/crates/vibesql-executor/src/tests/select_distinct.rs
@@ -66,6 +66,7 @@ fn test_distinct_removes_duplicate_rows() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: true,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
@@ -177,6 +178,7 @@ fn test_distinct_with_multiple_columns() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: true,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -275,6 +277,7 @@ fn test_distinct_with_null_values() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: true,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
@@ -345,6 +348,7 @@ fn test_distinct_false_preserves_duplicates() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -427,6 +431,7 @@ fn test_distinct_with_where_clause() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: true,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef { table: None, column: "role".to_string() },
@@ -521,6 +526,7 @@ fn test_distinct_with_order_by() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: true,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {

--- a/crates/vibesql-executor/src/tests/select_into_tests.rs
+++ b/crates/vibesql-executor/src/tests/select_into_tests.rs
@@ -74,6 +74,7 @@ fn test_select_into_single_row() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let result = SelectIntoExecutor::execute(&select_stmt, "target", &mut db);
@@ -102,6 +103,7 @@ fn test_select_into_single_row() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
     let rows = executor.execute(&query).unwrap();
     assert_eq!(rows.len(), 1);
@@ -154,6 +156,7 @@ fn test_select_into_no_rows_error() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let result = SelectIntoExecutor::execute(&select_stmt, "target", &mut db);
@@ -221,6 +224,7 @@ fn test_select_into_multiple_rows_error() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let result = SelectIntoExecutor::execute(&select_stmt, "target", &mut db);
@@ -292,6 +296,7 @@ fn test_select_into_with_expressions() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let result = SelectIntoExecutor::execute(&select_stmt, "target", &mut db);
@@ -317,6 +322,7 @@ fn test_select_into_with_expressions() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
     let rows = executor.execute(&query).unwrap();
     assert_eq!(rows.len(), 1);

--- a/crates/vibesql-executor/src/tests/select_joins.rs
+++ b/crates/vibesql-executor/src/tests/select_joins.rs
@@ -87,6 +87,7 @@ fn test_inner_join_two_tables() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -214,6 +215,7 @@ fn test_right_outer_join() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -348,6 +350,7 @@ fn test_full_outer_join() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -485,6 +488,7 @@ fn test_cross_join() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -547,6 +551,7 @@ fn test_cross_join_with_condition_fails() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
@@ -676,6 +681,7 @@ fn test_inner_join_null_values_dont_match() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {

--- a/crates/vibesql-executor/src/tests/select_order_by.rs
+++ b/crates/vibesql-executor/src/tests/select_order_by.rs
@@ -55,6 +55,7 @@ fn test_order_by_single_column_asc() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -148,6 +149,7 @@ fn test_order_by_multiple_columns() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {

--- a/crates/vibesql-executor/src/tests/select_values.rs
+++ b/crates/vibesql-executor/src/tests/select_values.rs
@@ -15,6 +15,7 @@ fn test_values_single_row() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Values {
@@ -56,6 +57,7 @@ fn test_values_multiple_rows() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Values {
@@ -117,6 +119,7 @@ fn test_values_with_column_aliases() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Values {
@@ -155,6 +158,7 @@ fn test_values_with_nulls() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Values {
@@ -199,6 +203,7 @@ fn test_values_with_negative_numbers() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Values {

--- a/crates/vibesql-executor/src/tests/select_where.rs
+++ b/crates/vibesql-executor/src/tests/select_where.rs
@@ -54,6 +54,7 @@ fn test_select_with_where() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -141,6 +142,7 @@ fn test_select_with_and_condition() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -235,6 +237,7 @@ fn test_select_with_or_condition() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -327,6 +330,7 @@ fn test_select_with_null_in_where() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {

--- a/crates/vibesql-executor/src/tests/select_without_from.rs
+++ b/crates/vibesql-executor/src/tests/select_without_from.rs
@@ -14,6 +14,7 @@ fn test_select_literal_integers() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -56,6 +57,7 @@ fn test_select_literal_mixed_types() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -102,6 +104,7 @@ fn test_select_arithmetic_expression() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
@@ -155,6 +158,7 @@ fn test_select_function_call() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
@@ -193,6 +197,7 @@ fn test_select_star_without_from_fails() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: None,
@@ -224,6 +229,7 @@ fn test_column_reference_without_from_fails() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
@@ -261,6 +267,7 @@ fn test_is_null_with_column_reference_fails() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::IsNull {
@@ -301,6 +308,7 @@ fn test_between_with_column_reference_fails() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Between {
@@ -348,6 +356,7 @@ fn test_cast_with_column_reference_fails() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
@@ -388,6 +397,7 @@ fn test_like_with_column_reference_fails() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Like {
@@ -431,6 +441,7 @@ fn test_in_list_with_column_reference_fails() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::InList {
@@ -488,6 +499,7 @@ fn test_hex_literal_in_subquery_without_from() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::In {
@@ -497,6 +509,7 @@ fn test_hex_literal_in_subquery_without_from() {
                 subquery: Box::new(vibesql_ast::SelectStmt {
                     with_clause: None,
                     set_operation: None,
+            values: None,
                     distinct: false,
                     select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
                     from: Some(vibesql_ast::FromClause::Table {
@@ -545,6 +558,7 @@ fn test_hex_literal_simple() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -590,6 +604,7 @@ fn test_binary_literal_in_subquery_without_from() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::In {
@@ -599,6 +614,7 @@ fn test_binary_literal_in_subquery_without_from() {
                 subquery: Box::new(vibesql_ast::SelectStmt {
                     with_clause: None,
                     set_operation: None,
+            values: None,
                     distinct: false,
                     select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
                     from: Some(vibesql_ast::FromClause::Table {
@@ -669,6 +685,7 @@ fn test_in_subquery_multi_column_empty_table_should_error() {
     let stmt = vibesql_ast::SelectStmt {
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -684,6 +701,7 @@ fn test_in_subquery_multi_column_empty_table_should_error() {
             subquery: Box::new(vibesql_ast::SelectStmt {
                 with_clause: None,
                 set_operation: None,
+            values: None,
                 distinct: false,
                 select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
                 from: Some(vibesql_ast::FromClause::Table {

--- a/crates/vibesql-executor/src/tests/subquery_mysql_compat.rs
+++ b/crates/vibesql-executor/src/tests/subquery_mysql_compat.rs
@@ -95,6 +95,7 @@ fn test_mysql_null_in_empty_subquery() {
                 limit: None,
                 offset: None,
                 set_operation: None,
+            values: None,
             }),
             negated: false,
         }),
@@ -104,6 +105,7 @@ fn test_mysql_null_in_empty_subquery() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let executor = crate::SelectExecutor::new(&db);
@@ -183,6 +185,7 @@ fn test_mysql_null_not_in_empty_subquery() {
                 limit: None,
                 offset: None,
                 set_operation: None,
+            values: None,
             }),
             negated: true, // NOT IN
         }),
@@ -192,6 +195,7 @@ fn test_mysql_null_not_in_empty_subquery() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let executor = crate::SelectExecutor::new(&db);
@@ -280,6 +284,7 @@ fn test_mysql_null_in_non_empty_without_null() {
                 limit: None,
                 offset: None,
                 set_operation: None,
+            values: None,
             }),
             negated: false,
         }),
@@ -289,6 +294,7 @@ fn test_mysql_null_in_non_empty_without_null() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let executor = crate::SelectExecutor::new(&db);
@@ -444,6 +450,7 @@ fn test_mysql_triple_nested_subquery() {
                                 limit: None,
                                 offset: None,
                                 set_operation: None,
+            values: None,
                             },
                         ))),
                     }),
@@ -453,6 +460,7 @@ fn test_mysql_triple_nested_subquery() {
                     limit: None,
                     offset: None,
                     set_operation: None,
+            values: None,
                 },
             ))),
         }),
@@ -462,6 +470,7 @@ fn test_mysql_triple_nested_subquery() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let executor = crate::SelectExecutor::new(&db);
@@ -572,6 +581,7 @@ fn test_mysql_exists_short_circuit() {
                 limit: None,
                 offset: None,
                 set_operation: None,
+            values: None,
             }),
             negated: false,
         }),
@@ -581,6 +591,7 @@ fn test_mysql_exists_short_circuit() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let executor = crate::SelectExecutor::new(&db);
@@ -710,6 +721,7 @@ fn test_mysql_scalar_within_exists() {
                             limit: None,
                             offset: None,
                             set_operation: None,
+            values: None,
                         },
                     ))),
                 }),
@@ -719,6 +731,7 @@ fn test_mysql_scalar_within_exists() {
                 limit: None,
                 offset: None,
                 set_operation: None,
+            values: None,
             }),
             negated: false,
         }),
@@ -728,6 +741,7 @@ fn test_mysql_scalar_within_exists() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let executor = crate::SelectExecutor::new(&db);

--- a/crates/vibesql-executor/src/tests/triggers/coordination.rs
+++ b/crates/vibesql-executor/src/tests/triggers/coordination.rs
@@ -188,6 +188,7 @@ fn test_before_trigger_executes_first() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
     let executor = SelectExecutor::new(&db);
     let result = executor.execute(&select).expect("Failed to select counter");
@@ -213,6 +214,7 @@ fn test_before_trigger_executes_first() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
     let user_result = executor.execute(&user_select).expect("Failed to select users");
     assert_eq!(user_result.len(), 1, "User should be inserted after BEFORE trigger");

--- a/crates/vibesql-executor/src/tests/triggers/error_handling.rs
+++ b/crates/vibesql-executor/src/tests/triggers/error_handling.rs
@@ -65,6 +65,7 @@ fn test_trigger_failure_causes_rollback() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
     let executor = SelectExecutor::new(&db);
     let rows = executor.execute(&select).expect("Failed to select");

--- a/crates/vibesql-executor/src/tests/triggers/mod.rs
+++ b/crates/vibesql-executor/src/tests/triggers/mod.rs
@@ -94,6 +94,7 @@ pub(super) fn count_audit_rows(db: &Database) -> usize {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
     let executor = SelectExecutor::new(db);
     let result = executor.execute(&select).expect("Failed to select from audit_log");

--- a/crates/vibesql-executor/tests/case_sensitivity_tests.rs
+++ b/crates/vibesql-executor/tests/case_sensitivity_tests.rs
@@ -274,6 +274,7 @@ fn test_view_lookup_case_insensitive_when_enabled() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
         with_clause: None,
     };
 
@@ -331,6 +332,7 @@ fn test_drop_view_case_insensitive_when_enabled() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
         with_clause: None,
     };
 
@@ -390,6 +392,7 @@ fn test_view_case_sensitive_mode() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
         with_clause: None,
     };
 

--- a/crates/vibesql-executor/tests/index_ordering_tests.rs
+++ b/crates/vibesql-executor/tests/index_ordering_tests.rs
@@ -105,6 +105,7 @@ fn test_index_ordering() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let executor = SelectExecutor::new(&db);

--- a/crates/vibesql-executor/tests/insert_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/insert_columnar_cache_tests.rs
@@ -271,6 +271,7 @@ fn test_insert_select_invalidates_cache() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let insert_stmt = vibesql_ast::InsertStmt {

--- a/crates/vibesql-executor/tests/insert_select_tests.rs
+++ b/crates/vibesql-executor/tests/insert_select_tests.rs
@@ -60,6 +60,7 @@ fn test_insert_from_select_basic() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let insert_select_stmt = vibesql_ast::InsertStmt {
@@ -149,6 +150,7 @@ fn test_insert_from_select_with_where() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let insert_select_stmt = vibesql_ast::InsertStmt {
@@ -228,6 +230,7 @@ fn test_insert_from_select_column_mismatch() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let insert_select_stmt = vibesql_ast::InsertStmt {
@@ -341,6 +344,7 @@ fn test_insert_from_select_with_aggregates() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let insert_select_stmt = vibesql_ast::InsertStmt {

--- a/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
@@ -54,6 +54,7 @@ fn test_update_with_subquery_multiple_rows_error() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     let stmt = UpdateStmt {
@@ -134,6 +135,7 @@ fn test_update_with_subquery_multiple_columns_error() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     let stmt = UpdateStmt {

--- a/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
@@ -73,6 +73,7 @@ fn create_scalar_subquery(table_name: &str, column_name: &str) -> Box<vibesql_as
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     })
 }
 
@@ -106,6 +107,7 @@ fn create_aggregate_subquery(
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     })
 }
 

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
@@ -53,6 +53,7 @@ fn test_update_where_scalar_subquery_equal() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     // UPDATE employees SET salary = 55000 WHERE salary = (SELECT min_salary FROM config)
@@ -130,6 +131,7 @@ fn test_update_where_scalar_subquery_less_than() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     // UPDATE employees SET bonus = 5000 WHERE salary < (SELECT AVG(salary) FROM employees)
@@ -201,6 +203,7 @@ fn test_update_where_subquery_returns_null() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     // UPDATE employees SET salary = 60000 WHERE salary < (SELECT max_salary FROM config)
@@ -282,6 +285,7 @@ fn test_update_where_subquery_with_aggregate() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     // UPDATE items SET discounted = TRUE WHERE price = (SELECT MAX(price) FROM items)
@@ -372,6 +376,7 @@ fn test_update_where_and_set_both_use_subqueries() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     // WHERE subquery
@@ -396,6 +401,7 @@ fn test_update_where_and_set_both_use_subqueries() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     // UPDATE employees SET salary = (SELECT target FROM salary_targets) WHERE dept_id IN (SELECT

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
@@ -68,6 +68,7 @@ fn test_update_where_in_subquery() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     // UPDATE employees SET salary = 80000 WHERE dept_id IN (SELECT dept_id FROM active_depts)
@@ -151,6 +152,7 @@ fn test_update_where_not_in_subquery() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     // UPDATE employees SET active = FALSE WHERE dept_id NOT IN (SELECT dept_id FROM active_depts)
@@ -227,6 +229,7 @@ fn test_update_where_subquery_empty_result() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     // UPDATE employees SET active = FALSE WHERE dept_id IN (SELECT dept_id FROM inactive_depts)
@@ -317,6 +320,7 @@ fn test_update_where_complex_subquery_condition() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     // UPDATE employees SET salary = 70000 WHERE dept_id IN (SELECT dept_id FROM departments WHERE
@@ -405,6 +409,7 @@ fn test_update_where_multiple_rows_in_subquery() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     });
 
     // UPDATE employees SET active = FALSE WHERE dept_id IN (SELECT dept_id FROM active_depts)

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -123,6 +123,7 @@ impl<'arena> ArenaParser<'arena> {
             limit,
             offset,
             set_operation,
+            values: None,
         };
 
         Ok(self.arena.alloc(stmt))

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -110,6 +110,10 @@ impl Parser {
                 let select_stmt = self.parse_select_statement()?;
                 Ok(vibesql_ast::Statement::Select(Box::new(select_stmt)))
             }
+            Token::Keyword(Keyword::Values) => {
+                let select_stmt = self.parse_values_statement()?;
+                Ok(vibesql_ast::Statement::Select(Box::new(select_stmt)))
+            }
             Token::Keyword(Keyword::Insert) => {
                 let insert_stmt = self.parse_insert_statement()?;
                 Ok(vibesql_ast::Statement::Insert(insert_stmt))

--- a/crates/vibesql-parser/src/parser/select/statement.rs
+++ b/crates/vibesql-parser/src/parser/select/statement.rs
@@ -133,24 +133,31 @@ impl Parser {
                 false // Default behavior is DISTINCT
             };
 
-            // Parse the right-hand side SELECT statement
+            // Parse the right-hand side SELECT or VALUES statement
             // Don't allow ORDER BY/LIMIT on the right side - they should only apply to the final
             // result
             //
-            // Standard SQL allows the right-hand SELECT to be wrapped in parentheses:
-            //   SELECT ... UNION ALL (SELECT ...)
-            // This is commonly used in CTEs and TPC-DS queries.
+            // Standard SQL allows the right-hand side to be:
+            //   - A SELECT statement: SELECT ... UNION ALL SELECT ...
+            //   - A VALUES clause: SELECT ... UNION VALUES(1)
+            //   - Parenthesized: SELECT ... UNION ALL (SELECT ...) or SELECT ... UNION (VALUES(1))
             let right = if matches!(self.peek(), Token::LParen) {
                 self.advance(); // consume '('
-                let stmt = self.parse_select_statement_internal(false)?;
+                let stmt = if self.peek_keyword(Keyword::Values) {
+                    self.parse_values_statement_internal(false)?
+                } else {
+                    self.parse_select_statement_internal(false)?
+                };
                 if !matches!(self.peek(), Token::RParen) {
                     return Err(ParseError {
-                        message: "Expected ')' after parenthesized SELECT in set operation"
+                        message: "Expected ')' after parenthesized statement in set operation"
                             .to_string(),
                     });
                 }
                 self.advance(); // consume ')'
                 Box::new(stmt)
+            } else if self.peek_keyword(Keyword::Values) {
+                Box::new(self.parse_values_statement_internal(false)?)
             } else {
                 Box::new(self.parse_select_statement_internal(false)?)
             };
@@ -247,6 +254,7 @@ impl Parser {
             limit,
             offset,
             set_operation,
+            values: None,
         })
     }
 
@@ -326,5 +334,162 @@ impl Parser {
         self.advance(); // consume ')'
 
         Ok(vibesql_ast::CommonTableExpr { name, columns, query })
+    }
+
+    /// Parse a VALUES statement (standalone or in set operations)
+    ///
+    /// Syntax: VALUES(expr, ...) [, (expr, ...), ...] [set_operation] [ORDER BY] [LIMIT] [OFFSET]
+    ///
+    /// Examples:
+    /// - VALUES(1);
+    /// - VALUES(1,2,3);
+    /// - VALUES(1),(2),(3);
+    /// - VALUES(1) UNION VALUES(2);
+    pub(crate) fn parse_values_statement(&mut self) -> Result<vibesql_ast::SelectStmt, ParseError> {
+        self.parse_values_statement_internal(true)
+    }
+
+    /// Internal VALUES parser with control over ORDER BY/LIMIT parsing
+    fn parse_values_statement_internal(
+        &mut self,
+        allow_order_limit: bool,
+    ) -> Result<vibesql_ast::SelectStmt, ParseError> {
+        // Parse the VALUES rows
+        let rows = self.parse_values_rows()?;
+
+        // Parse set operations (UNION, INTERSECT, EXCEPT)
+        let set_operation = if self.peek_keyword(Keyword::Union)
+            || self.peek_keyword(Keyword::Intersect)
+            || self.peek_keyword(Keyword::Except)
+        {
+            let op = if self.peek_keyword(Keyword::Union) {
+                self.consume_keyword(Keyword::Union)?;
+                vibesql_ast::SetOperator::Union
+            } else if self.peek_keyword(Keyword::Intersect) {
+                self.consume_keyword(Keyword::Intersect)?;
+                vibesql_ast::SetOperator::Intersect
+            } else {
+                self.consume_keyword(Keyword::Except)?;
+                vibesql_ast::SetOperator::Except
+            };
+
+            let all = if self.peek_keyword(Keyword::All) {
+                self.consume_keyword(Keyword::All)?;
+                true
+            } else if self.peek_keyword(Keyword::Distinct) {
+                self.consume_keyword(Keyword::Distinct)?;
+                false
+            } else {
+                false
+            };
+
+            // Parse the right-hand side (can be SELECT or VALUES)
+            let right = if matches!(self.peek(), Token::LParen) {
+                self.advance(); // consume '('
+                let stmt = if self.peek_keyword(Keyword::Values) {
+                    self.parse_values_statement_internal(false)?
+                } else {
+                    self.parse_select_statement_internal(false)?
+                };
+                if !matches!(self.peek(), Token::RParen) {
+                    return Err(ParseError {
+                        message: "Expected ')' after parenthesized statement in set operation"
+                            .to_string(),
+                    });
+                }
+                self.advance(); // consume ')'
+                Box::new(stmt)
+            } else if self.peek_keyword(Keyword::Values) {
+                Box::new(self.parse_values_statement_internal(false)?)
+            } else {
+                Box::new(self.parse_select_statement_internal(false)?)
+            };
+
+            Some(vibesql_ast::SetOperation { op, all, right })
+        } else {
+            None
+        };
+
+        // Parse ORDER BY (only if allowed)
+        let order_by = if allow_order_limit && self.peek_keyword(Keyword::Order) {
+            self.consume_keyword(Keyword::Order)?;
+            self.expect_keyword(Keyword::By)?;
+
+            let order_items = self.parse_comma_separated_list(|p| {
+                let expr = p.parse_expression()?;
+
+                let direction = if p.peek_keyword(Keyword::Asc) {
+                    p.consume_keyword(Keyword::Asc)?;
+                    vibesql_ast::OrderDirection::Asc
+                } else if p.peek_keyword(Keyword::Desc) {
+                    p.consume_keyword(Keyword::Desc)?;
+                    vibesql_ast::OrderDirection::Desc
+                } else {
+                    vibesql_ast::OrderDirection::Asc
+                };
+
+                Ok(vibesql_ast::OrderByItem { expr, direction })
+            })?;
+
+            Some(order_items)
+        } else {
+            None
+        };
+
+        // Parse LIMIT
+        let limit = if allow_order_limit && self.peek_keyword(Keyword::Limit) {
+            self.consume_keyword(Keyword::Limit)?;
+            match self.peek() {
+                Token::Number(n) => {
+                    let limit_value = n.parse::<usize>().map_err(|_| ParseError {
+                        message: format!("Invalid LIMIT value: {}", n),
+                    })?;
+                    self.advance();
+                    Some(limit_value)
+                }
+                _ => return Err(ParseError { message: "Expected number after LIMIT".to_string() }),
+            }
+        } else {
+            None
+        };
+
+        // Parse OFFSET
+        let offset = if allow_order_limit && self.peek_keyword(Keyword::Offset) {
+            self.consume_keyword(Keyword::Offset)?;
+            match self.peek() {
+                Token::Number(n) => {
+                    let offset_value = n.parse::<usize>().map_err(|_| ParseError {
+                        message: format!("Invalid OFFSET value: {}", n),
+                    })?;
+                    self.advance();
+                    Some(offset_value)
+                }
+                _ => return Err(ParseError { message: "Expected number after OFFSET".to_string() }),
+            }
+        } else {
+            None
+        };
+
+        // Consume optional semicolon
+        if matches!(self.peek(), Token::Semicolon) {
+            self.advance();
+        }
+
+        Ok(vibesql_ast::SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![],
+            into_table: None,
+            into_variables: None,
+            from: None,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by,
+            limit,
+            offset,
+            set_operation,
+            values: Some(rows),
+        })
     }
 }

--- a/crates/vibesql-parser/src/tests/mod.rs
+++ b/crates/vibesql-parser/src/tests/mod.rs
@@ -48,5 +48,6 @@ mod translation;
 mod trigger;
 mod truncate;
 mod update;
+mod values_statement;
 mod view;
 mod window_functions;

--- a/crates/vibesql-parser/src/tests/values_statement.rs
+++ b/crates/vibesql-parser/src/tests/values_statement.rs
@@ -1,0 +1,195 @@
+//! Tests for standalone VALUES statement parsing (SQL:1999)
+//!
+//! VALUES is a table value constructor that can be used:
+//! 1. As a standalone statement: VALUES(1,2,3);
+//! 2. In set operations: VALUES(1) UNION VALUES(2);
+//! 3. Mixed with SELECT: SELECT * FROM t INTERSECT VALUES(1,2,3);
+
+use crate::Parser;
+use vibesql_ast::{Expression, SelectStmt, SetOperator, Statement};
+use vibesql_types::SqlValue;
+
+fn parse(sql: &str) -> Statement {
+    Parser::parse_sql(sql).expect(&format!("Failed to parse: {}", sql))
+}
+
+fn parse_select(sql: &str) -> SelectStmt {
+    match parse(sql) {
+        Statement::Select(stmt) => *stmt,
+        other => panic!("Expected Select statement, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_values_single_row_single_column() {
+    let stmt = parse_select("VALUES(1);");
+
+    assert!(stmt.values.is_some());
+    let values = stmt.values.unwrap();
+    assert_eq!(values.len(), 1);
+    assert_eq!(values[0].len(), 1);
+    assert_eq!(values[0][0], Expression::Literal(SqlValue::Integer(1)));
+}
+
+#[test]
+fn test_values_single_row_multiple_columns() {
+    let stmt = parse_select("VALUES(1, 2, 3);");
+
+    assert!(stmt.values.is_some());
+    let values = stmt.values.unwrap();
+    assert_eq!(values.len(), 1);
+    assert_eq!(values[0].len(), 3);
+    assert_eq!(values[0][0], Expression::Literal(SqlValue::Integer(1)));
+    assert_eq!(values[0][1], Expression::Literal(SqlValue::Integer(2)));
+    assert_eq!(values[0][2], Expression::Literal(SqlValue::Integer(3)));
+}
+
+#[test]
+fn test_values_multiple_rows() {
+    let stmt = parse_select("VALUES(1),(2),(3);");
+
+    assert!(stmt.values.is_some());
+    let values = stmt.values.unwrap();
+    assert_eq!(values.len(), 3);
+    assert_eq!(values[0][0], Expression::Literal(SqlValue::Integer(1)));
+    assert_eq!(values[1][0], Expression::Literal(SqlValue::Integer(2)));
+    assert_eq!(values[2][0], Expression::Literal(SqlValue::Integer(3)));
+}
+
+#[test]
+fn test_values_multiple_rows_multiple_columns() {
+    let stmt = parse_select("VALUES(1,'a'),(2,'b'),(3,'c');");
+
+    assert!(stmt.values.is_some());
+    let values = stmt.values.unwrap();
+    assert_eq!(values.len(), 3);
+    assert_eq!(values[0].len(), 2);
+    assert_eq!(values[0][0], Expression::Literal(SqlValue::Integer(1)));
+    assert_eq!(
+        values[0][1],
+        Expression::Literal(SqlValue::Varchar("a".into()))
+    );
+    assert_eq!(values[2][0], Expression::Literal(SqlValue::Integer(3)));
+    assert_eq!(
+        values[2][1],
+        Expression::Literal(SqlValue::Varchar("c".into()))
+    );
+}
+
+#[test]
+fn test_values_union_values() {
+    let stmt = parse_select("VALUES(1) UNION VALUES(2);");
+
+    assert!(stmt.values.is_some());
+    let values = stmt.values.as_ref().unwrap();
+    assert_eq!(values.len(), 1);
+    assert_eq!(values[0][0], Expression::Literal(SqlValue::Integer(1)));
+
+    // Check set operation
+    assert!(stmt.set_operation.is_some());
+    let set_op = stmt.set_operation.as_ref().unwrap();
+    assert_eq!(set_op.op, SetOperator::Union);
+    assert!(!set_op.all);
+
+    // Check right side
+    assert!(set_op.right.values.is_some());
+    let right_values = set_op.right.values.as_ref().unwrap();
+    assert_eq!(right_values.len(), 1);
+    assert_eq!(
+        right_values[0][0],
+        Expression::Literal(SqlValue::Integer(2))
+    );
+}
+
+#[test]
+fn test_values_union_all_values() {
+    let stmt = parse_select("VALUES(1),(2) UNION ALL VALUES(3);");
+
+    assert!(stmt.values.is_some());
+    let values = stmt.values.as_ref().unwrap();
+    assert_eq!(values.len(), 2);
+
+    assert!(stmt.set_operation.is_some());
+    let set_op = stmt.set_operation.as_ref().unwrap();
+    assert_eq!(set_op.op, SetOperator::Union);
+    assert!(set_op.all);
+}
+
+#[test]
+fn test_values_intersect_values() {
+    let stmt = parse_select("VALUES(1),(2),(3) INTERSECT VALUES(2);");
+
+    assert!(stmt.values.is_some());
+    assert!(stmt.set_operation.is_some());
+    let set_op = stmt.set_operation.as_ref().unwrap();
+    assert_eq!(set_op.op, SetOperator::Intersect);
+}
+
+#[test]
+fn test_values_except_values() {
+    let stmt = parse_select("VALUES(1),(2),(3) EXCEPT VALUES(2);");
+
+    assert!(stmt.values.is_some());
+    assert!(stmt.set_operation.is_some());
+    let set_op = stmt.set_operation.as_ref().unwrap();
+    assert_eq!(set_op.op, SetOperator::Except);
+}
+
+#[test]
+fn test_select_union_values() {
+    let stmt = parse_select("SELECT 1 UNION VALUES(2);");
+
+    // Left side is a SELECT (no values)
+    assert!(stmt.values.is_none());
+    assert_eq!(stmt.select_list.len(), 1);
+
+    // Right side is VALUES
+    assert!(stmt.set_operation.is_some());
+    let set_op = stmt.set_operation.as_ref().unwrap();
+    assert!(set_op.right.values.is_some());
+}
+
+#[test]
+fn test_select_from_table_intersect_values() {
+    let stmt = parse_select("SELECT * FROM t14 INTERSECT VALUES(1,2,3);");
+
+    // Left side is a SELECT from table
+    assert!(stmt.values.is_none());
+    assert!(stmt.from.is_some());
+
+    // Right side is VALUES
+    assert!(stmt.set_operation.is_some());
+    let set_op = stmt.set_operation.as_ref().unwrap();
+    assert_eq!(set_op.op, SetOperator::Intersect);
+    assert!(set_op.right.values.is_some());
+}
+
+#[test]
+fn test_values_expressions() {
+    let stmt = parse_select("VALUES(1+2, 'hello' || ' world');");
+
+    assert!(stmt.values.is_some());
+    let values = stmt.values.unwrap();
+    assert_eq!(values.len(), 1);
+    assert_eq!(values[0].len(), 2);
+
+    // First expression is 1+2 (binary op)
+    match &values[0][0] {
+        Expression::BinaryOp { .. } => {}
+        other => panic!("Expected BinaryOp, got {:?}", other),
+    }
+
+    // Second expression is string concatenation
+    match &values[0][1] {
+        Expression::BinaryOp { .. } => {}
+        other => panic!("Expected BinaryOp, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_values_without_semicolon() {
+    // Should also parse without trailing semicolon
+    let stmt = parse_select("VALUES(1,2,3)");
+    assert!(stmt.values.is_some());
+    assert_eq!(stmt.values.unwrap().len(), 1);
+}

--- a/crates/vibesql-storage/src/persistence/tests/json_persistence.rs
+++ b/crates/vibesql-storage/src/persistence/tests/json_persistence.rs
@@ -952,6 +952,7 @@ fn test_json_view_preservation() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     // Create view with SQL definition
@@ -1030,6 +1031,7 @@ fn test_json_view_preservation_without_sql_definition() {
         limit: None,
         offset: None,
         set_operation: None,
+            values: None,
     };
 
     let view = ViewDefinition::new("all_products".to_string(), None, select_stmt, false);

--- a/tests/executor/count_star.rs
+++ b/tests/executor/count_star.rs
@@ -31,6 +31,7 @@ fn test_count_star_in_multiplication() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::BinaryOp {
@@ -91,6 +92,7 @@ fn test_count_star_in_addition() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::BinaryOp {
@@ -179,6 +181,7 @@ fn test_count_star_complex_expression() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression { expr: full_expr, alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -261,6 +264,7 @@ fn test_count_star_with_unary_operators() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression { expr: full_expr, alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
@@ -326,6 +330,7 @@ fn test_count_star_with_negative_unary() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression { expr: full_expr, alias: None }],
         from: Some(vibesql_ast::FromClause::Table {

--- a/tests/executor/count_star_without_from.rs
+++ b/tests/executor/count_star_without_from.rs
@@ -16,6 +16,7 @@ fn test_count_star_without_from() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
@@ -61,6 +62,7 @@ fn test_count_star_in_expression_without_from() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::BinaryOp {
@@ -156,6 +158,7 @@ fn test_complex_expression_without_from() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: div,

--- a/tests/regression/issue_990.rs
+++ b/tests/regression/issue_990.rs
@@ -33,6 +33,7 @@ fn test_issue_990_multiple_unary_plus() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::BinaryOp {
@@ -115,6 +116,7 @@ fn test_issue_990_simpler_case() {
         into_variables: None,
         with_clause: None,
         set_operation: None,
+            values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::BinaryOp {


### PR DESCRIPTION
## Summary
- Adds support for VALUES clause as a top-level SQL statement (SQL:1999)
- Enables queries like `VALUES(1);`, `VALUES(1,2,3);`, `VALUES(1),(2),(3);`
- Supports VALUES in set operations: `SELECT 1 UNION VALUES(2)`, `VALUES(1) INTERSECT VALUES(2)`

## Changes
- Add `values` field to `SelectStmt` in AST (owned and arena versions)
- Update parser to handle VALUES as top-level statement in `parse_statement`
- Allow VALUES on right-hand side of set operations (UNION/INTERSECT/EXCEPT)
- Update `pretty_print` to render VALUES statements correctly  
- Update visitor/transform to handle values field
- Add comprehensive parser tests (12 new tests)

## Test plan
- [x] All 1087 parser tests pass
- [x] All 2049 executor library tests pass
- [x] New VALUES statement tests cover:
  - Single row, single/multiple columns
  - Multiple rows
  - Mixed types (integers, strings)
  - UNION/INTERSECT/EXCEPT with VALUES
  - SELECT UNION VALUES mixed operations
  - Expressions in VALUES

Closes #4311

🤖 Generated with [Claude Code](https://claude.com/claude-code)