### PR TITLE
feat(functions): Support SQLite min/max scalar functions

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/mod.rs
@@ -89,6 +89,10 @@ pub(super) fn eval_scalar_function(
         "DEGREES" => numeric::degrees(args),
         "GREATEST" => numeric::greatest(args),
         "LEAST" => numeric::least(args),
+        // SQLite-compatible scalar MIN/MAX (multi-argument form)
+        // These return NULL if any argument is NULL, unlike LEAST/GREATEST
+        "MIN" => numeric::scalar_min(args),
+        "MAX" => numeric::scalar_max(args),
         "FORMAT" => numeric::format(args),
 
         // Vector functions

--- a/crates/vibesql-executor/src/evaluator/functions/numeric/comparison.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/numeric/comparison.rs
@@ -1,11 +1,175 @@
 //! Comparison functions
 //!
-//! Implements GREATEST and LEAST functions.
+//! Implements GREATEST and LEAST functions, plus SQLite-compatible scalar MIN/MAX.
 
 use vibesql_types::SqlValue;
 
 use super::exponential::numeric_to_f64;
 use crate::errors::ExecutorError;
+
+/// SQLite-compatible scalar MIN(val1, val2, ...) - Returns minimum value
+/// Returns NULL if ANY argument is NULL (SQLite semantics)
+pub fn scalar_min(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    if args.is_empty() {
+        return Err(ExecutorError::UnsupportedFeature(
+            "MIN requires at least one argument".to_string(),
+        ));
+    }
+
+    // SQLite semantics: return NULL if any argument is NULL
+    for arg in args {
+        if matches!(arg, SqlValue::Null) {
+            return Ok(SqlValue::Null);
+        }
+    }
+
+    let mut min_val = &args[0];
+    for arg in &args[1..] {
+        // Compare values - use type-aware comparison
+        match (min_val, arg) {
+            (SqlValue::Integer(a), SqlValue::Integer(b)) => {
+                if b < a {
+                    min_val = arg;
+                }
+            }
+            (SqlValue::Double(a), SqlValue::Double(b)) => {
+                if b < a {
+                    min_val = arg;
+                }
+            }
+            // String types (Character/Varchar)
+            (SqlValue::Character(a), SqlValue::Character(b))
+            | (SqlValue::Varchar(a), SqlValue::Varchar(b))
+            | (SqlValue::Character(a), SqlValue::Varchar(b))
+            | (SqlValue::Varchar(a), SqlValue::Character(b)) => {
+                if b < a {
+                    min_val = arg;
+                }
+            }
+            // Mixed numeric types - compare as f64
+            (a, b) if is_numeric(a) && is_numeric(b) => {
+                let a_f64 = numeric_to_f64(a)?;
+                let b_f64 = numeric_to_f64(b)?;
+                if b_f64 < a_f64 {
+                    min_val = arg;
+                }
+            }
+            // SQLite type affinity comparison order: NULL < INTEGER/REAL < TEXT < BLOB
+            (a, b) => {
+                if type_order(b) < type_order(a) {
+                    min_val = arg;
+                } else if type_order(b) == type_order(a) {
+                    // Same type category, compare as strings
+                    let a_str = a.to_string();
+                    let b_str = b.to_string();
+                    if b_str < a_str {
+                        min_val = arg;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(min_val.clone())
+}
+
+/// SQLite-compatible scalar MAX(val1, val2, ...) - Returns maximum value
+/// Returns NULL if ANY argument is NULL (SQLite semantics)
+pub fn scalar_max(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    if args.is_empty() {
+        return Err(ExecutorError::UnsupportedFeature(
+            "MAX requires at least one argument".to_string(),
+        ));
+    }
+
+    // SQLite semantics: return NULL if any argument is NULL
+    for arg in args {
+        if matches!(arg, SqlValue::Null) {
+            return Ok(SqlValue::Null);
+        }
+    }
+
+    let mut max_val = &args[0];
+    for arg in &args[1..] {
+        // Compare values - use type-aware comparison
+        match (max_val, arg) {
+            (SqlValue::Integer(a), SqlValue::Integer(b)) => {
+                if b > a {
+                    max_val = arg;
+                }
+            }
+            (SqlValue::Double(a), SqlValue::Double(b)) => {
+                if b > a {
+                    max_val = arg;
+                }
+            }
+            // String types (Character/Varchar)
+            (SqlValue::Character(a), SqlValue::Character(b))
+            | (SqlValue::Varchar(a), SqlValue::Varchar(b))
+            | (SqlValue::Character(a), SqlValue::Varchar(b))
+            | (SqlValue::Varchar(a), SqlValue::Character(b)) => {
+                if b > a {
+                    max_val = arg;
+                }
+            }
+            // Mixed numeric types - compare as f64
+            (a, b) if is_numeric(a) && is_numeric(b) => {
+                let a_f64 = numeric_to_f64(a)?;
+                let b_f64 = numeric_to_f64(b)?;
+                if b_f64 > a_f64 {
+                    max_val = arg;
+                }
+            }
+            // SQLite type affinity comparison order: NULL < INTEGER/REAL < TEXT < BLOB
+            (a, b) => {
+                if type_order(b) > type_order(a) {
+                    max_val = arg;
+                } else if type_order(b) == type_order(a) {
+                    // Same type category, compare as strings
+                    let a_str = a.to_string();
+                    let b_str = b.to_string();
+                    if b_str > a_str {
+                        max_val = arg;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(max_val.clone())
+}
+
+/// Check if a value is numeric
+fn is_numeric(val: &SqlValue) -> bool {
+    matches!(
+        val,
+        SqlValue::Integer(_)
+            | SqlValue::Smallint(_)
+            | SqlValue::Bigint(_)
+            | SqlValue::Unsigned(_)
+            | SqlValue::Numeric(_)
+            | SqlValue::Float(_)
+            | SqlValue::Real(_)
+            | SqlValue::Double(_)
+    )
+}
+
+/// SQLite type ordering for comparison: NULL < INTEGER/REAL < TEXT
+fn type_order(val: &SqlValue) -> u8 {
+    match val {
+        SqlValue::Null => 0,
+        SqlValue::Integer(_)
+        | SqlValue::Smallint(_)
+        | SqlValue::Bigint(_)
+        | SqlValue::Unsigned(_)
+        | SqlValue::Numeric(_)
+        | SqlValue::Float(_)
+        | SqlValue::Real(_)
+        | SqlValue::Double(_) => 1,
+        SqlValue::Character(_) | SqlValue::Varchar(_) => 2,
+        _ => 3, // Other types (Date, Time, etc.)
+    }
+}
 
 /// GREATEST(val1, val2, ...) - Returns greatest value
 pub fn greatest(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {

--- a/crates/vibesql-executor/src/evaluator/functions/numeric/exponential.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/numeric/exponential.rs
@@ -12,6 +12,8 @@ pub fn numeric_to_f64(val: &SqlValue) -> Result<f64, ExecutorError> {
         SqlValue::Integer(n) => Ok(*n as f64),
         SqlValue::Bigint(n) => Ok(*n as f64),
         SqlValue::Smallint(n) => Ok(*n as f64),
+        SqlValue::Unsigned(n) => Ok(*n as f64),
+        SqlValue::Numeric(f) => Ok(*f),
         SqlValue::Float(f) => Ok(*f as f64),
         SqlValue::Double(f) => Ok(*f),
         SqlValue::Real(f) => Ok(*f as f64),

--- a/crates/vibesql-executor/src/evaluator/functions/numeric/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/numeric/mod.rs
@@ -30,7 +30,7 @@ mod trigonometric;
 
 // Re-export all public functions
 pub(super) use basic::{abs, mod_fn as mod_func, pi, sign};
-pub(super) use comparison::{greatest, least};
+pub(super) use comparison::{greatest, least, scalar_max, scalar_min};
 pub(super) use decimal::format;
 pub(super) use exponential::{exp, ln, log10, power, sqrt};
 pub(super) use rounding::{ceil, floor, round, truncate};

--- a/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
@@ -24,9 +24,16 @@ impl SelectExecutor<'_> {
             // New AggregateFunction variant
             vibesql_ast::Expression::AggregateFunction { .. } => true,
             // Old Function variant (backwards compatibility for aggregates)
+            // Note: MIN/MAX with >1 argument are scalar functions (SQLite compatibility)
             vibesql_ast::Expression::Function { name, args, .. } => {
+                let name_upper = name.to_uppercase();
                 // Check if this is an aggregate function name
-                if matches!(name.to_uppercase().as_str(), "COUNT" | "SUM" | "AVG" | "MIN" | "MAX") {
+                let is_aggregate = match name_upper.as_str() {
+                    "COUNT" | "SUM" | "AVG" => true,
+                    "MIN" | "MAX" => args.len() <= 1, // multi-arg min/max are scalar functions
+                    _ => false,
+                };
+                if is_aggregate {
                     return true;
                 }
                 // Otherwise, check if any arguments contain aggregates

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/function.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/function.rs
@@ -23,7 +23,14 @@ pub(super) fn evaluate(
     };
 
     // Check if this is actually an aggregate function (backwards compatibility)
-    if matches!(name.to_uppercase().as_str(), "COUNT" | "SUM" | "AVG" | "MIN" | "MAX") {
+    // Note: MIN/MAX with >1 argument are scalar functions (SQLite compatibility)
+    let name_upper = name.to_uppercase();
+    let is_aggregate = match name_upper.as_str() {
+        "COUNT" | "SUM" | "AVG" => true,
+        "MIN" | "MAX" => args.len() <= 1, // multi-arg min/max are scalar functions
+        _ => false,
+    };
+    if is_aggregate {
         // Convert to AggregateFunction variant and evaluate
         let agg_expr = vibesql_ast::Expression::AggregateFunction {
             name: name.clone(),

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -844,10 +844,13 @@ impl<'arena> ArenaParser<'arena> {
         self.advance(); // consume function name
         self.expect_token(Token::LParen)?;
 
-        // Check for aggregate functions with DISTINCT
-        let is_aggregate = matches!(name_upper.as_str(), "COUNT" | "SUM" | "AVG" | "MIN" | "MAX");
+        // Check if this might be an aggregate function (before we know argument count)
+        // Note: MIN/MAX with multiple arguments are scalar functions (like LEAST/GREATEST)
+        // while MIN/MAX with a single argument are aggregate functions
+        let might_be_aggregate =
+            matches!(name_upper.as_str(), "COUNT" | "SUM" | "AVG" | "MIN" | "MAX");
 
-        if is_aggregate {
+        if might_be_aggregate {
             let distinct = self.try_consume_keyword(Keyword::Distinct);
             self.try_consume_keyword(Keyword::All); // ALL is default
 
@@ -864,11 +867,30 @@ impl<'arena> ArenaParser<'arena> {
                 return self.parse_window_function(name_sym, args);
             }
 
-            return Ok(Expression::Extended(self.arena.alloc(ExtendedExpr::AggregateFunction {
-                name: name_sym,
-                distinct,
-                args,
-            })));
+            // Determine if this is truly an aggregate function
+            // MIN/MAX with >1 argument are scalar functions (SQLite compatibility)
+            let is_aggregate = match name_upper.as_str() {
+                "COUNT" | "SUM" | "AVG" => true,
+                "MIN" | "MAX" => args.len() <= 1 && !distinct,
+                _ => false,
+            };
+
+            if is_aggregate {
+                return Ok(Expression::Extended(
+                    self.arena.alloc(ExtendedExpr::AggregateFunction {
+                        name: name_sym,
+                        distinct,
+                        args,
+                    }),
+                ));
+            } else {
+                // Multi-argument MIN/MAX - treat as scalar function
+                return Ok(Expression::Extended(self.arena.alloc(ExtendedExpr::Function {
+                    name: name_sym,
+                    args,
+                    character_unit: None,
+                })));
+            }
         }
 
         // Regular function

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -113,13 +113,15 @@ impl Parser {
             return Ok(Some(self.parse_extract_function()?));
         }
 
-        // Check if this is an aggregate function
+        // Check if this might be an aggregate function (before we know argument count)
+        // Note: MIN/MAX with multiple arguments are scalar functions (like LEAST/GREATEST)
+        // while MIN/MAX with a single argument are aggregate functions
         let function_name_upper = first.to_uppercase();
-        let is_aggregate =
+        let might_be_aggregate =
             matches!(function_name_upper.as_str(), "COUNT" | "SUM" | "AVG" | "MIN" | "MAX");
 
-        // Parse optional DISTINCT or ALL for aggregate functions
-        let distinct = if is_aggregate {
+        // Parse optional DISTINCT or ALL for potential aggregate functions
+        let distinct = if might_be_aggregate {
             if matches!(self.peek(), Token::Keyword(Keyword::Distinct)) {
                 self.advance(); // consume DISTINCT
                 true
@@ -186,6 +188,14 @@ impl Parser {
                 over: window_spec,
             }));
         }
+
+        // Determine if this is truly an aggregate function
+        // MIN/MAX with >1 argument are scalar functions (SQLite compatibility)
+        let is_aggregate = match function_name_upper.as_str() {
+            "COUNT" | "SUM" | "AVG" => true,
+            "MIN" | "MAX" => args.len() <= 1 && !distinct, // multi-arg or DISTINCT with >1 arg = scalar
+            _ => false,
+        };
 
         // Return appropriate expression type
         if is_aggregate {

--- a/crates/vibesql-parser/src/tests/aggregates.rs
+++ b/crates/vibesql-parser/src/tests/aggregates.rs
@@ -135,6 +135,51 @@ fn test_parse_min_max_functions() {
 }
 
 #[test]
+fn test_parse_scalar_min_max_functions() {
+    // Multi-argument MIN/MAX should be parsed as regular (scalar) functions, not aggregates
+    let result = Parser::parse_sql("SELECT min(11, 22), max(1, 2, 3);");
+    assert!(result.is_ok(), "Failed to parse scalar min/max: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            assert_eq!(select.select_list.len(), 2);
+
+            // Check min(11, 22) - should be a scalar Function, not AggregateFunction
+            match &select.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                    vibesql_ast::Expression::Function { name, args, .. } => {
+                        assert_eq!(name.to_uppercase(), "MIN");
+                        assert_eq!(args.len(), 2, "min(11, 22) should have 2 arguments");
+                    }
+                    vibesql_ast::Expression::AggregateFunction { .. } => {
+                        panic!("Multi-argument min should be parsed as scalar Function, not AggregateFunction");
+                    }
+                    _ => panic!("Expected scalar Function, got {:?}", expr),
+                },
+                _ => panic!("Expected expression"),
+            }
+
+            // Check max(1, 2, 3) - should be a scalar Function, not AggregateFunction
+            match &select.select_list[1] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                    vibesql_ast::Expression::Function { name, args, .. } => {
+                        assert_eq!(name.to_uppercase(), "MAX");
+                        assert_eq!(args.len(), 3, "max(1, 2, 3) should have 3 arguments");
+                    }
+                    vibesql_ast::Expression::AggregateFunction { .. } => {
+                        panic!("Multi-argument max should be parsed as scalar Function, not AggregateFunction");
+                    }
+                    _ => panic!("Expected scalar Function, got {:?}", expr),
+                },
+                _ => panic!("Expected expression"),
+            }
+        }
+        _ => panic!("Expected SELECT"),
+    }
+}
+
+#[test]
 fn test_parse_aggregate_with_alias() {
     let result = Parser::parse_sql("SELECT COUNT(*) AS total FROM users;");
     assert!(result.is_ok());

--- a/tests/functions/functions.rs
+++ b/tests/functions/functions.rs
@@ -157,3 +157,139 @@ fn test_e2e_coalesce_and_nullif() {
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].values[0], SqlValue::Null, "NULLIF('Alice', 'Alice') should return NULL");
 }
+
+// ========================================================================
+// SQLite-compatible scalar MIN/MAX Tests (multi-argument form)
+// ========================================================================
+
+#[test]
+fn test_e2e_scalar_min_max() {
+    // Test SQLite-compatible multi-argument MIN/MAX functions
+    let schema = TableSchema::new(
+        "TEST1".to_string(),
+        vec![
+            ColumnSchema::new("F1".to_string(), DataType::Integer, false),
+            ColumnSchema::new("F2".to_string(), DataType::Integer, false),
+        ],
+    );
+
+    let mut db = Database::new();
+    db.create_table(schema).unwrap();
+
+    db.insert_row("TEST1", Row::new(vec![SqlValue::Integer(11), SqlValue::Integer(22)])).unwrap();
+    db.insert_row("TEST1", Row::new(vec![SqlValue::Integer(33), SqlValue::Integer(44)])).unwrap();
+
+    // Test 1: Basic scalar MIN with literals
+    let results = execute_select(&db, "SELECT min(11, 22)").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Integer(11), "min(11, 22) should return 11");
+
+    // Test 2: Basic scalar MAX with literals
+    let results = execute_select(&db, "SELECT max(11, 22)").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Integer(22), "max(11, 22) should return 22");
+
+    // Test 3: Scalar MIN/MAX with three arguments
+    let results = execute_select(&db, "SELECT min(1, 2, 3)").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Integer(1), "min(1, 2, 3) should return 1");
+
+    let results = execute_select(&db, "SELECT max(1, 2, 3)").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Integer(3), "max(1, 2, 3) should return 3");
+
+    // Test 4: Scalar MIN/MAX with floating point values
+    // Note: Numeric literals like 1.1 are parsed as Numeric, not Double
+    let results = execute_select(&db, "SELECT min(1.1, 2.2)").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Numeric(1.1), "min(1.1, 2.2) should return 1.1");
+
+    let results = execute_select(&db, "SELECT max(1.1, 2.2)").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Numeric(2.2), "max(1.1, 2.2) should return 2.2");
+
+    // Test 5: Scalar MIN/MAX with column references
+    let results = execute_select(&db, "SELECT min(f1, f2) FROM test1").unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].values[0], SqlValue::Integer(11), "min(11, 22) should return 11");
+    assert_eq!(results[1].values[0], SqlValue::Integer(33), "min(33, 44) should return 33");
+
+    let results = execute_select(&db, "SELECT max(f1, f2) FROM test1").unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].values[0], SqlValue::Integer(22), "max(11, 22) should return 22");
+    assert_eq!(results[1].values[0], SqlValue::Integer(44), "max(33, 44) should return 44");
+
+    // Test 6: Combined *, min, max in SELECT
+    let results = execute_select(&db, "SELECT *, min(f1, f2), max(f1, f2) FROM test1").unwrap();
+    assert_eq!(results.len(), 2);
+    // Row 1: f1=11, f2=22, min=11, max=22
+    assert_eq!(results[0].values[0], SqlValue::Integer(11));
+    assert_eq!(results[0].values[1], SqlValue::Integer(22));
+    assert_eq!(results[0].values[2], SqlValue::Integer(11));
+    assert_eq!(results[0].values[3], SqlValue::Integer(22));
+    // Row 2: f1=33, f2=44, min=33, max=44
+    assert_eq!(results[1].values[0], SqlValue::Integer(33));
+    assert_eq!(results[1].values[1], SqlValue::Integer(44));
+    assert_eq!(results[1].values[2], SqlValue::Integer(33));
+    assert_eq!(results[1].values[3], SqlValue::Integer(44));
+
+    // Test 7: Single-argument MIN/MAX should still work as aggregate
+    let results = execute_select(&db, "SELECT min(f1) FROM test1").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Integer(11), "min(f1) aggregate should return 11");
+
+    let results = execute_select(&db, "SELECT max(f1) FROM test1").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Integer(33), "max(f1) aggregate should return 33");
+}
+
+#[test]
+fn test_e2e_scalar_min_max_null_semantics() {
+    // Test SQLite NULL semantics: scalar min/max return NULL if ANY argument is NULL
+    let schema = TableSchema::new(
+        "NULLTEST".to_string(),
+        vec![
+            ColumnSchema::new("A".to_string(), DataType::Integer, true),
+            ColumnSchema::new("B".to_string(), DataType::Integer, true),
+        ],
+    );
+
+    let mut db = Database::new();
+    db.create_table(schema).unwrap();
+
+    db.insert_row("NULLTEST", Row::new(vec![SqlValue::Integer(1), SqlValue::Null])).unwrap();
+    db.insert_row("NULLTEST", Row::new(vec![SqlValue::Null, SqlValue::Integer(2)])).unwrap();
+    db.insert_row("NULLTEST", Row::new(vec![SqlValue::Integer(3), SqlValue::Integer(4)])).unwrap();
+
+    // Test 1: Scalar MIN with NULL argument returns NULL
+    let results = execute_select(&db, "SELECT min(a, b) FROM nulltest WHERE a = 1").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Null, "min(1, NULL) should return NULL");
+
+    let results = execute_select(&db, "SELECT min(a, b) FROM nulltest WHERE b = 2").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Null, "min(NULL, 2) should return NULL");
+
+    // Test 2: Scalar MAX with NULL argument returns NULL
+    let results = execute_select(&db, "SELECT max(a, b) FROM nulltest WHERE a = 1").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Null, "max(1, NULL) should return NULL");
+
+    // Test 3: Scalar MIN/MAX without NULLs works normally
+    let results = execute_select(&db, "SELECT min(a, b) FROM nulltest WHERE a = 3").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Integer(3), "min(3, 4) should return 3");
+
+    let results = execute_select(&db, "SELECT max(a, b) FROM nulltest WHERE a = 3").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Integer(4), "max(3, 4) should return 4");
+
+    // Test 4: Aggregate MIN/MAX should skip NULLs (different behavior)
+    let results = execute_select(&db, "SELECT min(a) FROM nulltest").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Integer(1), "Aggregate min should skip NULLs");
+
+    let results = execute_select(&db, "SELECT max(b) FROM nulltest").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].values[0], SqlValue::Integer(4), "Aggregate max should skip NULLs");
+}


### PR DESCRIPTION
## Summary
- Implement SQLite-compatible scalar MIN/MAX functions (multi-argument form)
- Parser now detects multi-arg MIN/MAX as scalar functions vs aggregate (single-arg)
- Added `scalar_min`/`scalar_max` with SQLite NULL semantics (return NULL if ANY arg is NULL)
- Updated aggregate detection in executor to recognize argument-count distinction

## Test plan
- [x] Added integration tests for scalar MIN/MAX with literals and column references
- [x] Added tests for NULL semantics (return NULL if any argument is NULL)
- [x] Verified aggregate MIN/MAX still works correctly (single argument form)
- [x] All existing tests pass (`cargo test --workspace`)

Closes #4326

🤖 Generated with [Claude Code](https://claude.com/claude-code)