### PR TITLE
feat(test): Add native TCL shim for SQLite test suite

### DIFF
--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -3,7 +3,12 @@
 TCL Test Runner for VibeSQL
 
 Executes parsed TCL tests against VibeSQL and records results.
-Works with tcl_parser.py to parse test files first.
+Supports two modes:
+1. Static parsing mode (default): Extract tests from TCL files and execute them
+2. Native TCL mode (--native-tcl): Run test files directly with tclsh and our shim
+
+Use --native-tcl for test files that contain TCL constructs like for loops
+that generate data dynamically.
 """
 
 import argparse
@@ -691,6 +696,77 @@ def save_to_database(summary: RunSummary, db_path: str, vibesql_path: str):
             pass
 
 
+def run_native_tcl(test_file: str, shim_path: str, verbose: bool = False, timeout: float = 60.0) -> tuple[int, int, int, list[str]]:
+    """
+    Run a TCL test file using the native tclsh interpreter with our VibeSQL shim.
+
+    This mode is for test files that use TCL constructs (like for loops) that
+    can't be statically parsed.
+
+    Returns: (passed, failed, skipped, failed_test_names)
+    """
+    cmd = ["tclsh", shim_path, test_file]
+    if verbose:
+        cmd.append("--verbose")
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        output = result.stdout + result.stderr
+
+        # Parse the summary from output
+        # Expected format:
+        # Tests run:    N
+        # Tests passed: N
+        # Tests failed: N
+        # Tests skipped: N
+
+        passed = 0
+        failed = 0
+        skipped = 0
+        failed_tests = []
+
+        for line in output.split('\n'):
+            if 'Tests passed:' in line:
+                match = re.search(r'Tests passed:\s*(\d+)', line)
+                if match:
+                    passed = int(match.group(1))
+            elif 'Tests failed:' in line:
+                match = re.search(r'Tests failed:\s*(\d+)', line)
+                if match:
+                    failed = int(match.group(1))
+            elif 'Tests skipped:' in line:
+                match = re.search(r'Tests skipped:\s*(\d+)', line)
+                if match:
+                    skipped = int(match.group(1))
+
+        # Extract failed test names if present
+        if 'Failed tests:' in output:
+            in_failed_section = False
+            for line in output.split('\n'):
+                if 'Failed tests:' in line:
+                    in_failed_section = True
+                    continue
+                if in_failed_section and line.strip().startswith('-'):
+                    failed_tests.append(line.strip().lstrip('- '))
+
+        if verbose:
+            print(output)
+
+        return passed, failed, skipped, failed_tests
+
+    except subprocess.TimeoutExpired:
+        print(f"Timeout running {test_file}")
+        return 0, 0, 0, ["TIMEOUT"]
+    except Exception as e:
+        print(f"Error running {test_file}: {e}")
+        return 0, 0, 0, [str(e)]
+
+
 def main():
     parser = argparse.ArgumentParser(description="Run TCL tests against VibeSQL")
     parser.add_argument("--file", "-f", help="Single file to test")
@@ -701,18 +777,16 @@ def main():
     parser.add_argument("--parallel", action="store_true", help="Run tests in parallel")
     parser.add_argument("--verbose", "-v", action="store_true")
     parser.add_argument("--timeout", type=float, default=5.0, help="Per-test timeout in seconds")
+    parser.add_argument("--native-tcl", action="store_true",
+                        help="Run tests using native tclsh instead of parsing (for files with TCL loops)")
+    parser.add_argument("--tcl-shim", default=None,
+                        help="Path to TCL shim (default: scripts/tester_vibesql.tcl)")
 
     args = parser.parse_args()
 
     if not os.path.exists(args.vibesql):
         print(f"Error: VibeSQL binary not found: {args.vibesql}", file=sys.stderr)
         sys.exit(1)
-
-    runner = TclTestRunner(
-        vibesql_path=args.vibesql,
-        verbose=args.verbose,
-        timeout=args.timeout,
-    )
 
     # Determine files to run
     if args.file:
@@ -722,6 +796,61 @@ def main():
     else:
         print("Error: No files specified", file=sys.stderr)
         sys.exit(1)
+
+    # Native TCL mode - run with tclsh and our shim
+    if args.native_tcl:
+        # Find the shim
+        script_dir = Path(__file__).parent
+        shim_path = args.tcl_shim or str(script_dir / "tester_vibesql.tcl")
+
+        if not os.path.exists(shim_path):
+            print(f"Error: TCL shim not found: {shim_path}", file=sys.stderr)
+            sys.exit(1)
+
+        total_passed = 0
+        total_failed = 0
+        total_skipped = 0
+        all_failed_tests = []
+
+        for file_path in file_paths:
+            if args.verbose:
+                print(f"\nRunning: {file_path}")
+
+            passed, failed, skipped, failed_tests = run_native_tcl(
+                file_path, shim_path, verbose=args.verbose, timeout=args.timeout
+            )
+            total_passed += passed
+            total_failed += failed
+            total_skipped += skipped
+            all_failed_tests.extend(failed_tests)
+
+        # Print summary
+        total_tests = total_passed + total_failed + total_skipped
+        print()
+        print("=" * 50)
+        print(f"Total tests: {total_tests}")
+        print(f"Passed:      {total_passed} ({total_passed/total_tests*100:.1f}%)" if total_tests > 0 else "Passed: 0")
+        print(f"Failed:      {total_failed}")
+        print(f"Skipped:     {total_skipped}")
+        print("=" * 50)
+
+        if all_failed_tests:
+            print("\nFailed tests:")
+            for t in all_failed_tests[:20]:  # Limit to first 20
+                print(f"  - {t}")
+            if len(all_failed_tests) > 20:
+                print(f"  ... and {len(all_failed_tests) - 20} more")
+
+        if total_failed > 0:
+            sys.exit(1)
+        sys.exit(0)
+
+    # Standard parsing mode
+    runner = TclTestRunner(
+        vibesql_path=args.vibesql,
+        verbose=args.verbose,
+        timeout=args.timeout,
+    )
 
     # Run tests
     summary = runner.run_files(file_paths, parallel=args.parallel)

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1,0 +1,497 @@
+# VibeSQL Test Shim for SQLite TCL Tests
+#
+# This file provides compatibility layer to run SQLite's TCL test files
+# against VibeSQL instead of SQLite. It implements the key testing
+# commands: execsql, catchsql, do_test, do_execsql_test, do_catchsql_test
+#
+# Usage: tclsh tester_vibesql.tcl <test_file.test>
+#
+# NOTE: Unlike SQLite's tester.tcl which maintains a persistent database
+# connection within the TCL process, this shim invokes vibesql as a separate
+# process for each SQL execution. This means :memory: databases cannot work
+# (each process gets a fresh empty memory database). We use temp files instead.
+
+package require Tcl 8.5
+
+# Configuration
+set ::vibesql_path [file normalize "./target/release/vibesql"]
+# Use temp file for persistence - :memory: won't work across process invocations
+set ::db_file [file normalize "/tmp/vibesql_test_[pid].vbsql"]
+set ::verbose 0
+
+# Test counters
+set ::nTest 0
+set ::nPass 0
+set ::nFail 0
+set ::nSkip 0
+set ::failList {}
+
+# SQL statement accumulator for batching
+set ::sql_batch {}
+set ::in_transaction 0
+
+#-----------------------------------------------------------------------------
+# Core SQL execution
+#-----------------------------------------------------------------------------
+
+proc flush_batch {} {
+    # Execute accumulated SQL statements
+    if {[llength $::sql_batch] == 0} return
+
+    set combined [join $::sql_batch ";\n"]
+    set ::sql_batch {}
+
+    if {$::db_file eq ""} {
+        set cmd [list echo $combined | $::vibesql_path]
+    } else {
+        set cmd [list echo $combined | $::vibesql_path $::db_file]
+    }
+
+    if {[catch {exec {*}$cmd 2>@1} result]} {
+        error $result
+    }
+    return $result
+}
+
+proc execsql {sql {db ""}} {
+    # Execute SQL and return results as a TCL list
+
+    # Skip SQLite-specific statements we don't support
+    set sql_upper [string toupper [string trim $sql]]
+    if {[string match "PRAGMA*" $sql_upper]} {
+        return {}  ;# Skip PRAGMA statements
+    }
+    if {[string match "ANALYZE*" $sql_upper]} {
+        return {}  ;# Skip ANALYZE statements
+    }
+    if {[string match "REINDEX*" $sql_upper]} {
+        return {}  ;# Skip REINDEX statements
+    }
+
+    # Handle transaction batching
+    if {$sql_upper eq "BEGIN" || [string match "BEGIN*" $sql_upper]} {
+        set ::in_transaction 1
+        lappend ::sql_batch $sql
+        return {}
+    } elseif {$sql_upper eq "COMMIT" || $sql_upper eq "ROLLBACK"} {
+        lappend ::sql_batch $sql
+        set ::in_transaction 0
+        set result [flush_batch]
+        return [parse_result $result]
+    } elseif {$::in_transaction} {
+        lappend ::sql_batch $sql
+        return {}
+    }
+
+    # Direct execution for non-transaction SQL
+    if {$::db_file eq ""} {
+        set result [exec echo $sql | $::vibesql_path 2>@1]
+    } else {
+        set result [exec echo $sql | $::vibesql_path $::db_file 2>@1]
+    }
+
+    return [parse_result $result]
+}
+
+proc parse_result {output} {
+    # Parse VibeSQL tabular output into TCL list
+    set data {}
+    set lines [split $output "\n"]
+    set header_seen 0
+    set separator_count 0
+
+    foreach line $lines {
+        # Skip empty lines and row count lines
+        if {[string trim $line] eq ""} continue
+        if {[regexp {^\d+ rows?$} $line]} continue
+        if {[regexp {^=+$} $line]} continue
+        if {[regexp {^Error} $line]} {
+            error $line
+        }
+
+        # Count separators - header is between 1st and 2nd separator
+        if {[regexp {^\+[-+]+\+$} $line]} {
+            incr separator_count
+            continue
+        }
+
+        # Extract data from pipe-delimited lines
+        if {[regexp {^\|(.+)\|$} $line -> content]} {
+            # Skip header row (first row, before 2nd separator)
+            if {$separator_count < 2} {
+                continue
+            }
+            set vals [split $content "|"]
+            foreach v $vals {
+                lappend data [string trim $v]
+            }
+        }
+    }
+
+    return $data
+}
+
+proc parse_result_with_headers {output} {
+    # Parse VibeSQL tabular output, returning {headers rows} where rows is list of lists
+    set headers {}
+    set rows {}
+    set lines [split $output "\n"]
+    set separator_count 0
+
+    foreach line $lines {
+        # Skip empty lines and row count lines
+        if {[string trim $line] eq ""} continue
+        if {[regexp {^\d+ rows?$} $line]} continue
+        if {[regexp {^=+$} $line]} continue
+        if {[regexp {^Error} $line]} {
+            error $line
+        }
+
+        # Count separators - header is between 1st and 2nd separator
+        if {[regexp {^\+[-+]+\+$} $line]} {
+            incr separator_count
+            continue
+        }
+
+        # Extract data from pipe-delimited lines
+        if {[regexp {^\|(.+)\|$} $line -> content]} {
+            set vals {}
+            foreach v [split $content "|"] {
+                lappend vals [string trim $v]
+            }
+
+            if {$separator_count < 2} {
+                # This is the header row
+                set headers $vals
+            } else {
+                # This is a data row
+                lappend rows $vals
+            }
+        }
+    }
+
+    return [list $headers $rows]
+}
+
+proc execsql_with_headers {sql {db ""}} {
+    # Execute SQL and return {headers rows} for iteration
+    if {$::db_file eq ""} {
+        set result [exec echo $sql | $::vibesql_path 2>@1]
+    } else {
+        set result [exec echo $sql | $::vibesql_path $::db_file 2>@1]
+    }
+
+    return [parse_result_with_headers $result]
+}
+
+proc catchsql {sql {db ""}} {
+    # Execute SQL and catch errors, return {errorcode result}
+    if {[catch {execsql $sql $db} result]} {
+        # Error occurred
+        return [list 1 $result]
+    } else {
+        return [list 0 $result]
+    }
+}
+
+#-----------------------------------------------------------------------------
+# Test execution commands
+#-----------------------------------------------------------------------------
+
+proc do_test {name script expected} {
+    # Run a test and compare result to expected
+    incr ::nTest
+
+    if {$::verbose} {
+        puts -nonewline "  $name... "
+        flush stdout
+    }
+
+    if {[catch {uplevel 1 $script} result]} {
+        # Script error
+        incr ::nFail
+        lappend ::failList $name
+        if {$::verbose} {
+            puts "FAILED (error: $result)"
+        }
+        return
+    }
+
+    # Normalize for comparison
+    set result_norm [normalize_result $result]
+    set expected_norm [normalize_result $expected]
+
+    if {$result_norm eq $expected_norm} {
+        incr ::nPass
+        if {$::verbose} {
+            puts "ok"
+        }
+    } else {
+        incr ::nFail
+        lappend ::failList $name
+        if {$::verbose} {
+            puts "FAILED"
+            puts "    Expected: $expected"
+            puts "    Got:      $result"
+        }
+    }
+}
+
+proc do_execsql_test {name sql expected} {
+    # Convenience wrapper for SQL execution tests
+    do_test $name [list execsql $sql] $expected
+}
+
+proc do_catchsql_test {name sql expected} {
+    # Test that expects a specific error
+    do_test $name [list catchsql $sql] $expected
+}
+
+proc normalize_result {val} {
+    # Normalize result for comparison
+    # Convert to string and normalize whitespace
+    set val [string trim $val]
+    regsub -all {\s+} $val " " val
+    return $val
+}
+
+#-----------------------------------------------------------------------------
+# Capability checking (stub implementations)
+#-----------------------------------------------------------------------------
+
+proc ifcapable {capability script} {
+    # Skip SQLite-specific capabilities that we don't support
+    set skip_caps {wal vacuum_incr stat4 stat3 compound_select tclvar vtab fts3 fts4 fts5}
+    if {$capability in $skip_caps} {
+        return
+    }
+    uplevel 1 $script
+}
+
+proc capable {capability} {
+    set skip_caps {wal vacuum_incr stat4 stat3}
+    return [expr {$capability ni $skip_caps}]
+}
+
+#-----------------------------------------------------------------------------
+# Database setup
+#-----------------------------------------------------------------------------
+
+proc sqlite3 {db filename args} {
+    # Create/open a database
+    # Note: :memory: is mapped to a temp file because we spawn separate processes
+    # for each SQL execution, and memory databases don't persist across processes.
+    if {$filename eq ":memory:" || $filename eq ""} {
+        # Use temp file instead of :memory: for persistence
+        set ::db_file [file normalize "/tmp/vibesql_test_[pid].vbsql"]
+    } else {
+        set ::db_file [file normalize $filename]
+    }
+
+    # Clean existing db file for fresh start
+    if {[file exists $::db_file]} {
+        file delete -force $::db_file
+    }
+
+    # Create db command alias - if name is not "db" (which already exists)
+    # create an alias to the global db proc
+    if {$db ne "db"} {
+        interp alias {} $db {} db
+    }
+}
+
+proc db {cmd args} {
+    # Default db command - supports multiple call patterns:
+    # db eval SQL                    - returns results as list
+    # db eval SQL varname script     - iterates over rows, setting varname array
+    # db one SQL                     - returns first column of first row
+    switch $cmd {
+        eval {
+            set sql [lindex $args 0]
+            if {[llength $args] == 1} {
+                # Simple case: just return the results
+                return [execsql $sql]
+            } elseif {[llength $args] == 3} {
+                # Iterator case: db eval $sql varname script
+                set varname [lindex $args 1]
+                set script [lindex $args 2]
+
+                # Execute SQL and get column names + data
+                set raw_result [execsql_with_headers $sql]
+                set headers [lindex $raw_result 0]
+                set rows [lindex $raw_result 1]
+
+                # Iterate over each row
+                foreach row $rows {
+                    # Set up the array variable in caller's scope
+                    upvar 1 $varname arr
+                    set idx 0
+                    foreach col $headers {
+                        set arr($col) [lindex $row $idx]
+                        incr idx
+                    }
+                    # Execute the script in caller's scope
+                    uplevel 1 $script
+                }
+                return
+            } else {
+                # Two args case: db eval $sql varname (no script)
+                return [execsql $sql]
+            }
+        }
+        one {
+            # Return single value (first column of first row)
+            set sql [lindex $args 0]
+            set result [execsql $sql]
+            if {[llength $result] > 0} {
+                return [lindex $result 0]
+            }
+            return ""
+        }
+        close {
+            # No-op
+        }
+        nullvalue {
+            # Sets the string used for NULL - ignore
+            return
+        }
+        default {
+            error "Unknown db command: $cmd"
+        }
+    }
+}
+
+#-----------------------------------------------------------------------------
+# Utility commands
+#-----------------------------------------------------------------------------
+
+proc finish_test {} {
+    # Clean up temp database
+    if {$::db_file ne "" && [file exists $::db_file]} {
+        file delete -force $::db_file
+    }
+
+    # Print summary
+    puts ""
+    puts "======================================"
+    puts "Tests run:    $::nTest"
+    puts "Tests passed: $::nPass"
+    puts "Tests failed: $::nFail"
+    puts "Tests skipped: $::nSkip"
+    puts "======================================"
+
+    if {[llength $::failList] > 0} {
+        puts "\nFailed tests:"
+        foreach t $::failList {
+            puts "  - $t"
+        }
+        exit 1
+    }
+    exit 0
+}
+
+proc omit_test {name reason {append 0}} {
+    incr ::nSkip
+    if {$::verbose} {
+        puts "  $name... SKIPPED ($reason)"
+    }
+}
+
+proc reset_db {} {
+    # Reset the database to a clean state
+    if {$::db_file ne "" && [file exists $::db_file]} {
+        file delete -force $::db_file
+    }
+}
+
+proc forcedelete {args} {
+    # Force delete files (SQLite test utility)
+    foreach f $args {
+        catch {file delete -force $f}
+    }
+}
+
+proc file_control_chunksize_test {db size} {
+    # SQLite-specific file control - ignore
+    return
+}
+
+proc sqlite3_memdebug_pending {args} {
+    # SQLite memory debugging - ignore
+    return -1
+}
+
+proc breakpoint {} {
+    # Debug breakpoint - ignore
+    return
+}
+
+proc set_test_counter {counter {value ""}} {
+    switch $counter {
+        NTEST {
+            if {$value ne ""} {set ::nTest $value}
+            return $::nTest
+        }
+        NPASS {
+            if {$value ne ""} {set ::nPass $value}
+            return $::nPass
+        }
+        NFAIL {
+            if {$value ne ""} {set ::nFail $value}
+            return $::nFail
+        }
+    }
+}
+
+#-----------------------------------------------------------------------------
+# Main entry point
+#-----------------------------------------------------------------------------
+
+proc run_test_file {filename} {
+    # Clean any existing temp db
+    if {$::db_file ne "" && [file exists $::db_file]} {
+        file delete -force $::db_file
+    }
+
+    puts "Running: $filename"
+    puts ""
+
+    # Read and preprocess the test file
+    # Replace "source $testdir/tester.tcl" with nothing (we already have our defs)
+    set f [open $filename r]
+    set content [read $f]
+    close $f
+
+    # The test file uses $argv0 and $testdir before sourcing tester.tcl
+    # We need to inject our variable definitions BEFORE those lines
+    # First, set up the variables that will be referenced
+    set testdir [file dirname $filename]
+
+    # Replace the set testdir and source lines with our setup
+    # Common patterns:
+    # set testdir [file dirname $argv0]
+    # source $testdir/tester.tcl
+    regsub {set testdir \[file dirname \$argv0\]} $content "set testdir \"$testdir\"" content
+    regsub {source \$testdir/tester\.tcl} $content "# tester.tcl replaced by vibesql shim" content
+
+    # Execute the modified content
+    if {[catch {eval $content} err]} {
+        puts "Error running test: $err"
+        puts "Error info: $::errorInfo"
+        exit 1
+    }
+
+    finish_test
+}
+
+# Parse command line
+if {$argc > 0} {
+    set test_file [lindex $argv 0]
+    if {[lsearch $argv "--verbose"] >= 0 || [lsearch $argv "-v"] >= 0} {
+        set ::verbose 1
+    }
+    run_test_file $test_file
+} else {
+    puts "Usage: tclsh tester_vibesql.tcl <test_file.test> \[--verbose\]"
+    exit 1
+}


### PR DESCRIPTION
## Summary

- Add `scripts/tester_vibesql.tcl` - a TCL shim that enables running SQLite's TCL test suite against VibeSQL using native `tclsh`
- Add `--native-tcl` mode to `scripts/tcl_runner.py` to invoke the TCL shim

## Background

Issue #4337 reported that 1,472 TCL tests return empty results when values are expected. Investigation revealed the root cause: SQLite TCL tests use TCL `for` loops to generate test data (e.g., inserting 30,000 rows), but the Python TCL parser can only extract statically-defined tests.

## Solution

Instead of trying to parse/expand TCL in Python (overcomplicated), this PR uses native `tclsh` with a VibeSQL compatibility shim that:

- Pipes SQL to `vibesql` via subprocess
- Uses temp files for database persistence (`:memory:` can't work across process invocations)
- Implements key testing commands: `execsql`, `catchsql`, `do_test`, `do_execsql_test`, `db eval`, `db one`
- Skips SQLite-specific features: PRAGMA, tclvar, FTS, etc.

## Results

Testing `select1.test`:
- **188 tests run** (vs 0 with static parsing that couldn't handle TCL constructs)
- **62 tests passed** (33%)
- **126 tests failed** - these reveal real VibeSQL conformance issues:
  - Float formatting (`1.100` vs `1.1`)
  - NULL display (`NULL` vs `{}`)
  - Error message differences
  - Missing SQL features

## Test plan

- [x] Verify existing loop test works with shim
- [x] Run `select1.test` with native TCL mode
- [x] Verify summary parsing works correctly

## Usage

```bash
# Run a TCL test with native shim
python3 scripts/tcl_runner.py --vibesql ./target/release/vibesql --native-tcl --file docs/reference/sqlite/test/select1.test -v

# Or directly with tclsh
tclsh scripts/tester_vibesql.tcl docs/reference/sqlite/test/select1.test --verbose
```

Closes #4337

🤖 Generated with [Claude Code](https://claude.com/claude-code)