### PR TITLE
fix(storage): Make ROWID 1-indexed like SQLite

### DIFF
--- a/crates/vibesql-executor/src/tests/rowid_tests.rs
+++ b/crates/vibesql-executor/src/tests/rowid_tests.rs
@@ -95,13 +95,13 @@ fn test_select_rowid() {
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 2);
 
-    // First row should have rowid 0
-    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(0));
+    // First row should have rowid 1 (SQLite ROWIDs are 1-indexed)
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(1));
     assert_eq!(result[0].values[1], vibesql_types::SqlValue::Integer(10));
     assert_eq!(result[0].values[2], vibesql_types::SqlValue::Integer(20));
 
-    // Second row should have rowid 1
-    assert_eq!(result[1].values[0], vibesql_types::SqlValue::Bigint(1));
+    // Second row should have rowid 2
+    assert_eq!(result[1].values[0], vibesql_types::SqlValue::Bigint(2));
     assert_eq!(result[1].values[1], vibesql_types::SqlValue::Integer(30));
     assert_eq!(result[1].values[2], vibesql_types::SqlValue::Integer(40));
 }
@@ -158,7 +158,7 @@ fn test_select_underscore_rowid() {
 
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(0));
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(1));
 }
 
 /// Test that oid alias works the same as rowid
@@ -213,7 +213,7 @@ fn test_select_oid() {
 
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(0));
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(1));
 }
 
 /// Test that ROWID is case-insensitive
@@ -268,7 +268,7 @@ fn test_rowid_case_insensitive() {
 
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(0));
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(1));
 }
 
 /// Test that a real column named 'rowid' takes precedence over the pseudo-column
@@ -397,6 +397,6 @@ fn test_rowid_with_table_alias() {
 
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(0));
-    assert_eq!(result[1].values[0], vibesql_types::SqlValue::Bigint(1));
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(1));
+    assert_eq!(result[1].values[0], vibesql_types::SqlValue::Bigint(2));
 }

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -532,7 +532,8 @@ impl Table {
             if !self.deleted[idx] {
                 let mut cloned = row.clone();
                 // Set row_id for ROWID pseudo-column support (SQLite compatibility)
-                cloned.row_id = Some(idx as u64);
+                // SQLite ROWIDs are 1-indexed, so we add 1 to the physical index
+                cloned.row_id = Some((idx + 1) as u64);
                 result.push(cloned);
             }
         }


### PR DESCRIPTION
## Summary
- Changes ROWID generation to be 1-indexed instead of 0-indexed, matching SQLite's behavior
- Updates `scan_live_vec()` in storage layer to add 1 to the physical row index when setting row_id
- Updates all ROWID test assertions to expect 1-based values

## Test plan
- [x] All ROWID unit tests updated and passing (10/10)
- [x] Manual verification: `SELECT rowid FROM t` now returns 1, 2, ... instead of 0, 1, ...
- [x] Release build compiles successfully

Closes #4368

🤖 Generated with [Claude Code](https://claude.com/claude-code)