### PR TITLE
feat(parser): Support legacy comma-join ON syntax

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -307,16 +307,31 @@ impl<'arena> ArenaParser<'arena> {
             } else if self.try_consume_keyword(Keyword::Join) {
                 Some(JoinType::Inner)
             } else if self.try_consume(&Token::Comma) {
+                // Comma normally represents CROSS JOIN, but we need to check for
+                // SQLite's legacy syntax: FROM t1, t2 ON condition (treated as INNER JOIN)
                 Some(JoinType::Cross)
             } else {
                 None
             };
 
-            if let Some(jt) = join_type {
+            // Track if this was originally a comma-join (for legacy ON support)
+            let was_comma_join = matches!(join_type, Some(JoinType::Cross))
+                && !matches!(self.peek(), Token::Keyword(Keyword::Natural));
+
+            if let Some(mut jt) = join_type {
                 let natural = self.try_consume_keyword(Keyword::Natural);
                 let right = self.parse_table_reference()?;
 
-                let (condition, using_columns) = if jt != JoinType::Cross && !natural {
+                // For comma-joins, check for legacy ON clause (SQLite compatibility)
+                // If found, treat as INNER JOIN instead of CROSS JOIN
+                let (condition, using_columns) = if was_comma_join && !natural {
+                    if self.try_consume_keyword(Keyword::On) {
+                        jt = JoinType::Inner; // Convert to INNER JOIN
+                        (Some(self.parse_expression()?), None)
+                    } else {
+                        (None, None)
+                    }
+                } else if jt != JoinType::Cross && !natural {
                     if self.try_consume_keyword(Keyword::On) {
                         (Some(self.parse_expression()?), None)
                     } else if self.try_consume_keyword(Keyword::Using) {

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -16,10 +16,20 @@ impl Parser {
         while self.is_join_keyword() || self.peek() == &Token::Comma {
             let (join_type, right, condition, using_columns, natural) =
                 if self.peek() == &Token::Comma {
-                    // Comma represents CROSS JOIN
+                    // Comma normally represents CROSS JOIN, but SQLite's legacy syntax
+                    // allows "FROM t1, t2 ON condition" which behaves like INNER JOIN
                     self.advance(); // Consume comma
                     let right = self.parse_table_reference()?;
-                    (vibesql_ast::JoinType::Cross, right, None, None, false)
+
+                    // Check for legacy ON clause after comma-join
+                    // SQLite allows: FROM t1, t2 ON t1.a=t2.b (treated as INNER JOIN)
+                    if self.peek_keyword(Keyword::On) {
+                        self.consume_keyword(Keyword::On)?;
+                        let condition = self.parse_expression()?;
+                        (vibesql_ast::JoinType::Inner, right, Some(condition), None, false)
+                    } else {
+                        (vibesql_ast::JoinType::Cross, right, None, None, false)
+                    }
                 } else {
                     let (join_type, natural) = self.parse_join_type()?;
 

--- a/crates/vibesql-parser/src/tests/joins.rs
+++ b/crates/vibesql-parser/src/tests/joins.rs
@@ -396,3 +396,80 @@ fn test_parse_natural_cross_join_complex() {
     );
     assert!(result.is_ok(), "Parse failed: {:?}", result.err());
 }
+
+// ========================================================================
+// Legacy Comma-Join ON Syntax Tests (#4369)
+// ========================================================================
+
+#[test]
+fn test_parse_legacy_comma_join_on() {
+    // SQLite legacy syntax: FROM t1, t2 ON condition behaves like INNER JOIN
+    let result = Parser::parse_sql("SELECT * FROM t1, t2 ON t1.a = t2.b;");
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
+            vibesql_ast::FromClause::Join { join_type, condition, natural, .. } => {
+                // Legacy comma-join with ON should be treated as INNER JOIN
+                assert_eq!(*join_type, vibesql_ast::JoinType::Inner);
+                assert!(!*natural);
+                assert!(condition.is_some(), "Expected ON condition");
+            }
+            _ => panic!("Expected JOIN"),
+        },
+        _ => panic!("Expected SELECT"),
+    }
+}
+
+#[test]
+fn test_parse_legacy_comma_join_on_multiple_tables() {
+    // Multiple comma-joins with ON clauses
+    let result = Parser::parse_sql("SELECT * FROM t1, t2 ON t1.a = t2.b, t3 ON t2.c = t3.d;");
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            match select.from.as_ref().unwrap() {
+                vibesql_ast::FromClause::Join {
+                    join_type, left, condition, ..
+                } => {
+                    // Outermost join (t1,t2) JOIN t3
+                    assert_eq!(*join_type, vibesql_ast::JoinType::Inner);
+                    assert!(condition.is_some());
+
+                    // Inner join should also be Inner with condition
+                    match left.as_ref() {
+                        vibesql_ast::FromClause::Join { join_type: inner_type, condition: inner_cond, .. } => {
+                            assert_eq!(*inner_type, vibesql_ast::JoinType::Inner);
+                            assert!(inner_cond.is_some());
+                        }
+                        _ => panic!("Expected nested JOIN"),
+                    }
+                }
+                _ => panic!("Expected JOIN"),
+            }
+        }
+        _ => panic!("Expected SELECT"),
+    }
+}
+
+#[test]
+fn test_parse_comma_without_on_still_cross_join() {
+    // Plain comma without ON should still be CROSS JOIN
+    let result = Parser::parse_sql("SELECT * FROM t1, t2;");
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
+            vibesql_ast::FromClause::Join { join_type, condition, .. } => {
+                assert_eq!(*join_type, vibesql_ast::JoinType::Cross);
+                assert!(condition.is_none());
+            }
+            _ => panic!("Expected JOIN"),
+        },
+        _ => panic!("Expected SELECT"),
+    }
+}


### PR DESCRIPTION
## Summary
- Adds support for SQLite's legacy comma-join ON syntax: `FROM t1, t2 ON condition`
- When ON clause follows a comma-separated table, treats it as INNER JOIN instead of CROSS JOIN
- Updated both regular parser and arena parser for consistency

## Test plan
- [x] Parser tests added for comma-join ON syntax (3 new tests)
- [x] All 1105 parser tests pass
- [x] Verified SQL behavior matches SQLite:
  - `FROM t1, t2 ON t1.a=t2.b` returns 3 rows (INNER JOIN behavior)
  - `FROM t1 INNER JOIN t2 ON t1.a=t2.b` returns same 3 rows
  - `FROM t1, t2` returns 9 rows (CROSS JOIN, unchanged)

Closes #4369

🤖 Generated with [Claude Code](https://claude.com/claude-code)