### PR TITLE
feat(tcl): Implement execsql2 command for column name tests

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -184,6 +184,41 @@ proc execsql_with_headers {sql {db ""}} {
     return [parse_result_with_headers $result]
 }
 
+proc execsql2 {sql {db ""}} {
+    # Execute SQL and return results with column names interleaved:
+    # {colname1 value1 colname2 value2 ...} for each row, all in a flat list
+    # This is used by SQLite tests to verify column name handling
+
+    # Skip SQLite-specific statements we don't support
+    set sql_upper [string toupper [string trim $sql]]
+    if {[string match "PRAGMA*" $sql_upper]} {
+        return {}
+    }
+
+    if {$::db_file eq ""} {
+        set result [exec echo $sql | $::vibesql_path 2>@1]
+    } else {
+        set result [exec echo $sql | $::vibesql_path $::db_file 2>@1]
+    }
+
+    # Parse with headers
+    set parsed [parse_result_with_headers $result]
+    set headers [lindex $parsed 0]
+    set rows [lindex $parsed 1]
+
+    # Interleave column names with values
+    set output {}
+    foreach row $rows {
+        set idx 0
+        foreach col $headers {
+            lappend output $col [lindex $row $idx]
+            incr idx
+        }
+    }
+
+    return $output
+}
+
 proc catchsql {sql {db ""}} {
     # Execute SQL and catch errors, return {errorcode result}
     if {[catch {execsql $sql $db} result]} {


### PR DESCRIPTION
## Summary

- Add `execsql2` proc to the TCL test shim
- Returns results with column names interleaved: `{col1 val1 col2 val2 ...}`
- Enables running SQLite's select1-6.x tests that verify column name handling
- Reuses existing `parse_result_with_headers` function

## Test Plan

- [x] Manual test with custom TCL test file passes
- [x] `select1-6.3` passes (quoted alias preserves case)
- [x] No more "invalid command name execsql2" errors in select1.test

**Note:** Some 6.x tests still fail due to column name case sensitivity (VibeSQL returns `F1` instead of `f1`), but this is a separate issue from the missing `execsql2` command.

Closes #4365

🤖 Generated with [Claude Code](https://claude.com/claude-code)