### PR TITLE
fix(tcl): Convert NULL to empty string for SQLite TCL compatibility

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -329,7 +329,14 @@ proc parse_result {output} {
             }
             set vals [split $content "|"]
             foreach v $vals {
-                lappend data [string trim $v]
+                set trimmed [string trim $v]
+                # SQLite TCL interface represents NULL as empty string
+                # VibeSQL displays NULL as "NULL" text, convert for compatibility
+                if {$trimmed eq "NULL"} {
+                    lappend data ""
+                } else {
+                    lappend data $trimmed
+                }
             }
         }
     }
@@ -365,7 +372,15 @@ proc parse_result_with_headers {output} {
         if {[regexp {^\|(.+)\|$} $line -> content]} {
             set vals {}
             foreach v [split $content "|"] {
-                lappend vals [string trim $v]
+                set trimmed [string trim $v]
+                # SQLite TCL interface represents NULL as empty string
+                # VibeSQL displays NULL as "NULL" text, convert for compatibility
+                # (Don't convert in header row)
+                if {$separator_count >= 2 && $trimmed eq "NULL"} {
+                    lappend vals ""
+                } else {
+                    lappend vals $trimmed
+                }
             }
 
             if {$separator_count < 2} {


### PR DESCRIPTION
## Summary

- Fix TCL test failures caused by NULL value display mismatch
- Update `parse_result` and `parse_result_with_headers` in TCL shim to convert "NULL" to empty string
- select1-2.0 test now passes (was failing due to NULL comparison)

## Problem

The SQLite TCL test interface represents NULL values as empty TCL list elements (`{}`), but VibeSQL displays them as the literal string "NULL". This caused tests like `select1-2.0` to fail:

**Expected**: `{abc {} {} xyz 11 22 33 44}`  
**Got**: `{abc NULL NULL xyz 11 22 33 44}`

## Solution

Updated the TCL shim's `parse_result` and `parse_result_with_headers` functions to convert the string "NULL" to an empty string when parsing VibeSQL's tabular output. This only affects the TCL test interface - the actual CLI output formats (table, CSV, JSON, raw) continue to show "NULL" appropriately.

## Test plan

- [x] Verified select1-2.0 now passes
- [x] Verified other output formats still display NULL
- [x] Ran select1.test - same pass rate (81/188) but select1-2.0 now passes

Closes #4364

🤖 Generated with [Claude Code](https://claude.com/claude-code)