### PR TITLE
fix(tcl): Distinguish NULL values from literal string 'NULL'

### DIFF
--- a/crates/vibesql-cli/src/data_io.rs
+++ b/crates/vibesql-cli/src/data_io.rs
@@ -17,9 +17,11 @@ impl DataIO {
         // Write header
         write_csv_row(&mut file, &result.columns)?;
 
-        // Write rows
+        // Write rows (NULL values become empty strings in CSV)
         for row in &result.rows {
-            write_csv_row(&mut file, row)?;
+            let values: Vec<String> =
+                row.iter().map(|v| v.clone().unwrap_or_default()).collect();
+            write_csv_row(&mut file, &values)?;
         }
 
         println!("Exported {} rows to '{}'", result.row_count, file_path);
@@ -33,7 +35,12 @@ impl DataIO {
             let mut json_obj = serde_json::Map::new();
             for (i, col) in result.columns.iter().enumerate() {
                 if i < row.len() {
-                    json_obj.insert(col.clone(), serde_json::Value::String(row[i].clone()));
+                    // Use proper JSON null for NULL values
+                    let value = match &row[i] {
+                        Some(s) => serde_json::Value::String(s.clone()),
+                        None => serde_json::Value::Null,
+                    };
+                    json_obj.insert(col.clone(), value);
                 }
             }
             json_rows.push(serde_json::Value::Object(json_obj));

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -18,7 +18,10 @@ pub struct SqlExecutor {
 
 #[derive(Debug, Clone)]
 pub struct QueryResult {
-    pub rows: Vec<Vec<String>>,
+    /// Cell values: None represents SQL NULL, Some(s) represents actual data.
+    /// This distinction is important for output formatting - NULL values should
+    /// be displayed differently than the literal string "NULL".
+    pub rows: Vec<Vec<Option<String>>>,
     pub columns: Vec<String>,
     pub row_count: usize,
     pub execution_time_ms: Option<f64>,
@@ -86,9 +89,19 @@ impl SqlExecutor {
                         // Use column names from the executor result
                         result.columns = select_result.columns;
                         // Convert rows to string representation using Display trait
+                        // NULL values are represented as None to distinguish from the literal string "NULL"
                         for row in select_result.rows {
-                            let row_strs: Vec<String> =
-                                row.values.iter().map(|v| format!("{}", v)).collect();
+                            let row_strs: Vec<Option<String>> = row
+                                .values
+                                .iter()
+                                .map(|v| {
+                                    if v.is_null() {
+                                        None
+                                    } else {
+                                        Some(format!("{}", v))
+                                    }
+                                })
+                                .collect();
                             result.rows.push(row_strs);
                         }
                     }
@@ -234,7 +247,7 @@ impl SqlExecutor {
                         result.columns = vec!["QUERY PLAN".to_string()];
                         // Split output into rows for better display
                         for line in output.lines() {
-                            result.rows.push(vec![line.to_string()]);
+                            result.rows.push(vec![Some(line.to_string())]);
                         }
                         result.row_count = result.rows.len();
                     }
@@ -419,7 +432,8 @@ impl SqlExecutor {
         // Note: WHERE clause filtering would require expression evaluation
         // For now, we support LIKE pattern only
 
-        let rows: Vec<Vec<String>> = filtered_tables.iter().map(|t| vec![t.clone()]).collect();
+        let rows: Vec<Vec<Option<String>>> =
+            filtered_tables.iter().map(|t| vec![Some(t.clone())]).collect();
         let row_count = rows.len();
 
         Ok(QueryResult {
@@ -448,7 +462,8 @@ impl SqlExecutor {
             schemas
         };
 
-        let rows: Vec<Vec<String>> = filtered_schemas.iter().map(|s| vec![s.clone()]).collect();
+        let rows: Vec<Vec<Option<String>>> =
+            filtered_schemas.iter().map(|s| vec![Some(s.clone())]).collect();
         let row_count = rows.len();
 
         Ok(QueryResult {
@@ -471,7 +486,7 @@ impl SqlExecutor {
             .get_table(&normalized_name)
             .ok_or_else(|| anyhow::anyhow!("Table '{}' does not exist", stmt.table_name))?;
 
-        let mut rows: Vec<Vec<String>> = Vec::new();
+        let mut rows: Vec<Vec<Option<String>>> = Vec::new();
 
         for column in &table.schema.columns {
             // Check LIKE pattern if specified
@@ -504,24 +519,24 @@ impl SqlExecutor {
             let row = if stmt.full {
                 // SHOW FULL COLUMNS returns additional fields
                 vec![
-                    column.name.clone(),
-                    display::format_data_type(&column.data_type),
-                    String::new(), // Collation - not yet supported
-                    nullable.to_string(),
-                    key.to_string(),
-                    default_val,
-                    String::new(), // Extra
-                    String::new(), // Privileges
-                    String::new(), // Comment
+                    Some(column.name.clone()),
+                    Some(display::format_data_type(&column.data_type)),
+                    Some(String::new()), // Collation - not yet supported
+                    Some(nullable.to_string()),
+                    Some(key.to_string()),
+                    Some(default_val),
+                    Some(String::new()), // Extra
+                    Some(String::new()), // Privileges
+                    Some(String::new()), // Comment
                 ]
             } else {
                 vec![
-                    column.name.clone(),
-                    display::format_data_type(&column.data_type),
-                    nullable.to_string(),
-                    key.to_string(),
-                    default_val,
-                    String::new(), // Extra
+                    Some(column.name.clone()),
+                    Some(display::format_data_type(&column.data_type)),
+                    Some(nullable.to_string()),
+                    Some(key.to_string()),
+                    Some(default_val),
+                    Some(String::new()), // Extra
                 ]
             };
 
@@ -567,7 +582,7 @@ impl SqlExecutor {
             .ok_or_else(|| anyhow::anyhow!("Table '{}' does not exist", stmt.table_name))?;
 
         let index_names = self.db.list_indexes();
-        let mut rows: Vec<Vec<String>> = Vec::new();
+        let mut rows: Vec<Vec<Option<String>>> = Vec::new();
 
         for index_name in index_names {
             if let Some(index_meta) = self.db.get_index(&index_name) {
@@ -575,18 +590,18 @@ impl SqlExecutor {
                     // Add one row per column in the index
                     for (seq, col) in index_meta.columns.iter().enumerate() {
                         rows.push(vec![
-                            normalized_name.clone(),                               // Table
-                            if index_meta.unique { "0" } else { "1" }.to_string(), // Non_unique
-                            index_meta.index_name.clone(),                         // Key_name
-                            (seq + 1).to_string(),                                 // Seq_in_index
-                            col.column_name.clone(),                               // Column_name
-                            "A".to_string(), // Collation (always Ascending for now)
-                            String::new(),   // Cardinality
-                            String::new(),   // Sub_part
-                            String::new(),   // Packed
-                            String::new(),   // Null
-                            "BTREE".to_string(), // Index_type
-                            String::new(),   // Comment
+                            Some(normalized_name.clone()),                               // Table
+                            Some(if index_meta.unique { "0" } else { "1" }.to_string()), // Non_unique
+                            Some(index_meta.index_name.clone()),                         // Key_name
+                            Some((seq + 1).to_string()), // Seq_in_index
+                            Some(col.column_name.clone()), // Column_name
+                            Some("A".to_string()), // Collation (always Ascending for now)
+                            Some(String::new()),   // Cardinality
+                            Some(String::new()),   // Sub_part
+                            Some(String::new()),   // Packed
+                            Some(String::new()),   // Null
+                            Some("BTREE".to_string()), // Index_type
+                            Some(String::new()),   // Comment
                         ]);
                     }
                 }
@@ -670,7 +685,7 @@ impl SqlExecutor {
 
         Ok(QueryResult {
             columns: vec!["Table".to_string(), "Create Table".to_string()],
-            rows: vec![vec![normalized_name, create_sql]],
+            rows: vec![vec![Some(normalized_name), Some(create_sql)]],
             row_count: 1,
             execution_time_ms: None,
             message: None,

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -148,8 +148,8 @@ fn test_multi_column_select_order() {
 
     // Values should be in the same order as specified in SELECT: 74 first, then 50
     // Values are displayed using Display trait, not Debug (fix for #3810)
-    assert_eq!(result.rows[0][0], "74", "First column should be 74");
-    assert_eq!(result.rows[0][1], "50", "Second column should be 50");
+    assert_eq!(result.rows[0][0], Some("74".to_string()), "First column should be 74");
+    assert_eq!(result.rows[0][1], Some("50".to_string()), "Second column should be 50");
 }
 
 #[test]
@@ -166,9 +166,14 @@ fn test_select_column_names_and_values_issue_3810() {
 
     // Values should be display format, not debug format
     assert_eq!(result.rows.len(), 1);
-    assert_eq!(result.rows[0][0], "1", "Integer value should display as '1', not 'Integer(1)'");
     assert_eq!(
-        result.rows[0][1], "hello",
+        result.rows[0][0],
+        Some("1".to_string()),
+        "Integer value should display as '1', not 'Integer(1)'"
+    );
+    assert_eq!(
+        result.rows[0][1],
+        Some("hello".to_string()),
         "Varchar value should display as 'hello', not 'Varchar(\"hello\")'"
     );
 }
@@ -186,8 +191,8 @@ fn test_select_column_names_from_table() {
     assert_eq!(result.columns, vec!["ID", "NAME"]);
 
     // Values should be display format
-    assert_eq!(result.rows[0][0], "1");
-    assert_eq!(result.rows[0][1], "Alice");
+    assert_eq!(result.rows[0][0], Some("1".to_string()));
+    assert_eq!(result.rows[0][1], Some("Alice".to_string()));
 }
 
 #[test]
@@ -201,8 +206,8 @@ fn test_select_wildcard_column_names() {
 
     // Column names should be actual column names from table
     assert_eq!(result.columns, vec!["SKU", "PRICE"]);
-    assert_eq!(result.rows[0][0], "ABC123");
-    assert_eq!(result.rows[0][1], "99");
+    assert_eq!(result.rows[0][0], Some("ABC123".to_string()));
+    assert_eq!(result.rows[0][1], Some("99".to_string()));
 }
 
 // ============================================================================
@@ -326,7 +331,7 @@ fn test_show_create_table() {
     assert_eq!(result.row_count, 1);
 
     // The CREATE TABLE statement should be in the second column
-    let create_stmt = &result.rows[0][1];
+    let create_stmt = result.rows[0][1].as_ref().expect("CREATE TABLE output should not be NULL");
     assert!(create_stmt.contains("CREATE TABLE"));
     assert!(create_stmt.contains("USERS")); // Table name is normalized to uppercase
 }

--- a/crates/vibesql-cli/src/formatter.rs
+++ b/crates/vibesql-cli/src/formatter.rs
@@ -77,7 +77,13 @@ impl ResultFormatter {
 
         // Add rows
         for row in &result.rows {
-            let cells: Vec<Cell> = row.iter().map(|val| Cell::new(val)).collect();
+            let cells: Vec<Cell> = row
+                .iter()
+                .map(|val| {
+                    // For table display, show "NULL" for actual NULL values
+                    Cell::new(val.as_ref().map(|s| s.as_str()).unwrap_or("NULL"))
+                })
+                .collect();
             table.add_row(Row::new(cells));
         }
 
@@ -90,7 +96,12 @@ impl ResultFormatter {
             let mut json_obj = serde_json::Map::new();
             for (i, col) in result.columns.iter().enumerate() {
                 if i < row.len() {
-                    json_obj.insert(col.clone(), serde_json::Value::String(row[i].clone()));
+                    // For JSON, use proper null for NULL values
+                    let value = match &row[i] {
+                        Some(s) => serde_json::Value::String(s.clone()),
+                        None => serde_json::Value::Null,
+                    };
+                    json_obj.insert(col.clone(), value);
                 }
             }
             json_rows.push(serde_json::Value::Object(json_obj));
@@ -106,7 +117,10 @@ impl ResultFormatter {
 
         // Print rows
         for row in &result.rows {
-            println!("{}", row.join(","));
+            // For CSV, NULL values are empty
+            let values: Vec<&str> =
+                row.iter().map(|val| val.as_ref().map(|s| s.as_str()).unwrap_or("")).collect();
+            println!("{}", values.join(","));
         }
     }
 
@@ -133,7 +147,8 @@ impl ResultFormatter {
         for row in &result.rows {
             print!("|");
             for val in row {
-                print!(" {} |", val);
+                // For markdown, show "NULL" for actual NULL values
+                print!(" {} |", val.as_ref().map(|s| s.as_str()).unwrap_or("NULL"));
             }
             println!();
         }
@@ -161,7 +176,9 @@ impl ResultFormatter {
         for row in &result.rows {
             println!("    <tr>");
             for val in row {
-                println!("      <td>{}</td>", Self::escape_html(val));
+                // For HTML, show "NULL" for actual NULL values
+                let display = val.as_ref().map(|s| s.as_str()).unwrap_or("NULL");
+                println!("      <td>{}</td>", Self::escape_html(display));
             }
             println!("    </tr>");
         }
@@ -189,11 +206,8 @@ impl ResultFormatter {
                 .iter()
                 .map(|val| {
                     // SQLite TCL tests expect NULL to be empty string
-                    if val == "NULL" || val.is_empty() {
-                        ""
-                    } else {
-                        val.as_str()
-                    }
+                    // None represents actual NULL, Some("") is an empty string value
+                    val.as_ref().map(|s| s.as_str()).unwrap_or("")
                 })
                 .collect();
             println!("{}", values.join(" "));
@@ -209,8 +223,8 @@ mod tests {
         QueryResult {
             columns: vec!["id".to_string(), "name".to_string()],
             rows: vec![
-                vec!["1".to_string(), "Alice".to_string()],
-                vec!["2".to_string(), "Bob".to_string()],
+                vec![Some("1".to_string()), Some("Alice".to_string())],
+                vec![Some("2".to_string()), Some("Bob".to_string())],
             ],
             row_count: 2,
             execution_time_ms: None,
@@ -278,8 +292,10 @@ mod tests {
         let result = QueryResult {
             columns: vec!["a".to_string(), "b".to_string(), "c".to_string()],
             rows: vec![
-                vec!["1".to_string(), "NULL".to_string(), "3".to_string()],
-                vec!["".to_string(), "test".to_string(), "NULL".to_string()],
+                // First row: value, NULL (actual), value
+                vec![Some("1".to_string()), None, Some("3".to_string())],
+                // Second row: empty string (not NULL), value, NULL (actual)
+                vec![Some(String::new()), Some("test".to_string()), None],
             ],
             row_count: 2,
             execution_time_ms: None,
@@ -287,7 +303,26 @@ mod tests {
         };
 
         // Just verify it doesn't panic - output goes to stdout
-        // NULL values should be converted to empty strings
+        // NULL values (None) should be converted to empty strings
+        formatter.print_raw(&result);
+    }
+
+    #[test]
+    fn test_raw_format_null_vs_null_string() {
+        let mut formatter = ResultFormatter::new();
+        formatter.set_format(OutputFormat::Raw);
+        let result = QueryResult {
+            columns: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            rows: vec![
+                // Row: actual NULL, literal string "NULL", regular value
+                vec![None, Some("NULL".to_string()), Some("hello".to_string())],
+            ],
+            row_count: 1,
+            execution_time_ms: None,
+            message: None,
+        };
+
+        // NULL (None) should become empty, but "NULL" string (Some("NULL")) should stay "NULL"
         formatter.print_raw(&result);
     }
 

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -282,11 +282,17 @@ proc execsql {sql {db ""}} {
     }
 
     # Direct execution for non-transaction SQL
+    # Use raw format for proper NULL handling:
+    # - Actual NULL values become empty strings
+    # - The literal string 'NULL' remains as "NULL"
+    # This matches SQLite TCL interface behavior
+    set raw_sql ".mode raw\n$sql"
+
     # Use catch to handle process errors and translate them to SQLite format
     if {$::db_file eq ""} {
-        set exec_code [catch {exec echo $sql | $::vibesql_path 2>@1} result]
+        set exec_code [catch {exec echo $raw_sql | $::vibesql_path 2>@1} result]
     } else {
-        set exec_code [catch {exec echo $sql | $::vibesql_path $::db_file 2>@1} result]
+        set exec_code [catch {exec echo $raw_sql | $::vibesql_path $::db_file 2>@1} result]
     }
 
     if {$exec_code != 0} {
@@ -294,11 +300,48 @@ proc execsql {sql {db ""}} {
         error [translate_error_to_sqlite $result]
     }
 
-    return [parse_result $result]
+    return [parse_raw_result $result]
+}
+
+proc parse_raw_result {output} {
+    # Parse VibeSQL raw format output into TCL list
+    # Raw format is space-separated values, one row per line
+    # NULL values are already empty strings, string 'NULL' stays as "NULL"
+    # This matches SQLite TCL interface behavior for NULL representation
+    set data {}
+
+    # Trim trailing newlines to avoid spurious empty elements from split
+    set output [string trimright $output "\n"]
+    set lines [split $output "\n"]
+
+    foreach line $lines {
+        # Skip error lines
+        if {[regexp {^Error} $line]} {
+            error [translate_error_to_sqlite $line]
+        }
+
+        # Handle empty lines (represent rows where all values are NULL)
+        # For a single-column query with NULL, the line will be empty
+        if {$line eq ""} {
+            # Empty line = row with single NULL value = empty string
+            lappend data ""
+            continue
+        }
+
+        # Split by whitespace and add each value to the result
+        # In raw format, values are space-separated on each line
+        foreach val [split $line] {
+            lappend data $val
+        }
+    }
+
+    return $data
 }
 
 proc parse_result {output} {
     # Parse VibeSQL tabular output into TCL list
+    # NOTE: This function is kept for backwards compatibility but parse_raw_result
+    # should be preferred as it correctly handles NULL vs 'NULL' string distinction
     # Errors in output are translated to SQLite-compatible format
     set data {}
     set lines [split $output "\n"]


### PR DESCRIPTION
## Summary
- Changed CLI `QueryResult.rows` from `Vec<Vec<String>>` to `Vec<Vec<Option<String>>>` to properly represent NULL values
- Updated all output formatters (table, JSON, CSV, raw, markdown, HTML) to handle `Option<String>` appropriately
- Modified TCL shim to use raw format for queries, correctly representing NULL as empty lines while preserving the string "NULL"

## Key Behavior Changes
| Format | Actual NULL | String 'NULL' |
|--------|-------------|---------------|
| Table | "NULL" | "NULL" |
| JSON | `null` | `"NULL"` |
| CSV | (empty) | `NULL` |
| Raw | (empty line) | `NULL` |

## Test plan
- [x] Verified inline `SELECT NULL, 'NULL', 'hello'` correctly returns `{} NULL hello`
- [x] Verified table-stored NULL vs 'NULL' string returns `{} NULL`
- [x] All 112 vibesql-cli tests pass
- [x] TCL test runner works with updated shim

Closes #4384

🤖 Generated with [Claude Code](https://claude.com/claude-code)