### PR TITLE
fix(parser): Allow keywords as implicit table aliases

### DIFF
--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -248,6 +248,20 @@ impl Parser {
                         }
                         _ => None,
                     }
+                } else if matches!(self.peek(), Token::Keyword(_))
+                    && !self.is_join_keyword()
+                    && !self.is_clause_keyword()
+                {
+                    // Allow non-reserved keywords as implicit aliases (e.g., FROM t m)
+                    // Keywords like M, YEAR, etc. can be used as aliases
+                    match self.peek() {
+                        Token::Keyword(kw) => {
+                            let alias = kw.to_string();
+                            self.advance();
+                            Some(alias)
+                        }
+                        _ => None,
+                    }
                 } else {
                     None
                 };
@@ -277,6 +291,26 @@ impl Parser {
                 | Token::Keyword(Keyword::Cross)
                 | Token::Keyword(Keyword::Full)
                 | Token::Keyword(Keyword::Natural)
+        )
+    }
+
+    /// Check if current token is a clause keyword that cannot be used as implicit alias
+    /// These keywords start new clauses in SELECT statements
+    pub(crate) fn is_clause_keyword(&self) -> bool {
+        matches!(
+            self.peek(),
+            Token::Keyword(Keyword::On)
+                | Token::Keyword(Keyword::Where)
+                | Token::Keyword(Keyword::Group)
+                | Token::Keyword(Keyword::Having)
+                | Token::Keyword(Keyword::Order)
+                | Token::Keyword(Keyword::Limit)
+                | Token::Keyword(Keyword::Offset)
+                | Token::Keyword(Keyword::Union)
+                | Token::Keyword(Keyword::Intersect)
+                | Token::Keyword(Keyword::Except)
+                | Token::Keyword(Keyword::Using)
+                | Token::Keyword(Keyword::For)
         )
     }
 


### PR DESCRIPTION
## Summary

- Fixed CTE self-join queries failing when using keywords as implicit table aliases
- The parser now accepts `Token::Keyword` for implicit aliases (e.g., `FROM agg m` where `m` is tokenized as `Keyword::M`)
- Added `is_clause_keyword()` guard to prevent clause keywords (WHERE, GROUP, etc.) from being misinterpreted as aliases

## Root Cause

The lexer tokenizes `M` as `Keyword::M` (used for HNSW index parameters), but the FROM clause alias parser only matched `Token::Identifier` for implicit aliases. This caused queries like:

```sql
WITH agg AS (...) 
SELECT m.col FROM agg m
```

to fail with "Column not found (searched tables: M)" because `m` wasn't recognized as an alias.

## Test plan

- [x] Verified the failing query from #4387 now works
- [x] Tested that clause keywords (WHERE, GROUP, etc.) still parse correctly  
- [x] `cargo test -p vibesql-parser` passes (1105 tests)
- [x] `cargo test -p vibesql-executor --test '*'` passes

Closes #4387

🤖 Generated with [Claude Code](https://claude.com/claude-code)