### PR TITLE
feat(storage): Serialize TableIdentifier quoted flag in binary catalog format

### DIFF
--- a/crates/vibesql-catalog/src/schema.rs
+++ b/crates/vibesql-catalog/src/schema.rs
@@ -97,9 +97,9 @@ impl Schema {
         self.drop_table_by_identifier(&identifier)
     }
 
-    /// List all table names in this schema
+    /// List all table names in this schema (returns canonical names)
     pub fn list_tables(&self) -> Vec<String> {
-        self.tables.values().map(|t| t.name.clone()).collect()
+        self.tables.keys().cloned().collect()
     }
 
     /// Get the TableIdentifier for a table by its canonical name

--- a/crates/vibesql-catalog/src/store/tables.rs
+++ b/crates/vibesql-catalog/src/store/tables.rs
@@ -305,6 +305,19 @@ impl super::Catalog {
             schema.table_exists_by_identifier(identifier)
         })
     }
+
+    /// Get the TableIdentifier for a table by its canonical name.
+    ///
+    /// Returns the identifier that was used when the table was created,
+    /// which includes the `quoted` flag for SQL:1999 case-sensitivity semantics.
+    ///
+    /// The canonical_name should be the canonical form of the table name
+    /// (as returned by `list_tables()`).
+    pub fn get_table_identifier(&self, canonical_name: &str) -> Option<&TableIdentifier> {
+        self.schemas
+            .get(&self.current_schema)
+            .and_then(|schema| schema.get_table_identifier(canonical_name))
+    }
 }
 
 #[cfg(test)]

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -84,6 +84,15 @@ pub fn write_catalog<W: Write>(writer: &mut W, db: &Database) -> Result<(), Stor
                     write_string(writer, col)?;
                 }
             }
+
+            // Write quoted flag for TableIdentifier (v4+)
+            // This enables SQL:1999 case-sensitivity to be preserved across save/load
+            let quoted = db
+                .catalog
+                .get_table_identifier(table_name)
+                .map(|id| id.is_quoted())
+                .unwrap_or(false);
+            write_bool(writer, quoted)?;
         }
     }
 
@@ -309,18 +318,24 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
             None
         };
 
-        table_schemas.push((table_name, columns, primary_key));
+        // Read quoted flag for TableIdentifier (v4+)
+        // For older versions, default to unquoted (case-insensitive)
+        let quoted = if version >= 4 { read_bool(reader)? } else { false };
+
+        table_schemas.push((table_name, columns, primary_key, quoted));
     }
 
     // Create tables
-    for (table_name, columns, primary_key) in table_schemas {
+    for (table_name, columns, primary_key, quoted) in table_schemas {
         let schema = if let Some(pk_cols) = primary_key {
-            vibesql_catalog::TableSchema::with_primary_key(table_name, columns, pk_cols)
+            vibesql_catalog::TableSchema::with_primary_key(table_name.clone(), columns, pk_cols)
         } else {
-            vibesql_catalog::TableSchema::new(table_name, columns)
+            vibesql_catalog::TableSchema::new(table_name.clone(), columns)
         };
 
-        db.create_table(schema)
+        // Use TableIdentifier to preserve case-sensitivity semantics
+        let identifier = vibesql_catalog::TableIdentifier::from_canonical(table_name, quoted);
+        db.create_table_with_identifier(schema, identifier)
             .map_err(|e| StorageError::NotImplemented(format!("Failed to create table: {}", e)))?;
     }
 

--- a/crates/vibesql-storage/src/persistence/binary/format.rs
+++ b/crates/vibesql-storage/src/persistence/binary/format.rs
@@ -16,7 +16,8 @@ pub const MAGIC: &[u8; 5] = b"VBSQL";
 /// - v1: Initial binary format
 /// - v2: Added sequence persistence and column default_value expressions
 /// - v3: Added primary key and unique constraints persistence
-pub const VERSION: u8 = 3;
+/// - v4: Added quoted flag for TableIdentifier (SQL:1999 case-sensitivity)
+pub const VERSION: u8 = 4;
 
 /// Type tags for binary serialization
 #[repr(u8)]

--- a/crates/vibesql-storage/src/persistence/json.rs
+++ b/crates/vibesql-storage/src/persistence/json.rs
@@ -275,6 +275,7 @@ impl Database {
             .collect();
 
         // Views - serialize view definitions
+        // Use view_def.name to preserve original case (list_views returns normalized keys)
         let views = self
             .catalog
             .list_views()
@@ -285,7 +286,7 @@ impl Database {
                         .sql_definition
                         .clone()
                         .unwrap_or_else(|| format!("{:#?}", view_def.query));
-                    JsonView { name: view_name, definition }
+                    JsonView { name: view_def.name.clone(), definition }
                 })
             })
             .collect();

--- a/crates/vibesql-storage/src/persistence/tests/binary_persistence.rs
+++ b/crates/vibesql-storage/src/persistence/tests/binary_persistence.rs
@@ -1,0 +1,212 @@
+// ============================================================================
+// Binary Persistence Tests
+// ============================================================================
+//
+// Tests for binary format serialization/deserialization, including:
+// - TableIdentifier quoted flag persistence (SQL:1999 case-sensitivity)
+// - Backward compatibility with older format versions
+
+use vibesql_catalog::{ColumnSchema, TableIdentifier, TableSchema};
+use vibesql_types::{DataType, SqlValue};
+
+use crate::Database;
+
+/// Test that the quoted flag for TableIdentifier is persisted correctly
+/// through a save/load roundtrip.
+#[test]
+fn test_quoted_table_identifier_roundtrip() {
+    let mut db = Database::new();
+
+    // Create a table with a quoted identifier (case-sensitive)
+    let schema = TableSchema::new(
+        "MyTable".to_string(),
+        vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+    );
+    let identifier = TableIdentifier::quoted("MyTable");
+    db.create_table_with_identifier(schema, identifier).unwrap();
+
+    // Verify the identifier is marked as quoted
+    let original_identifier = db.catalog.get_table_identifier("MyTable").unwrap();
+    assert!(original_identifier.is_quoted(), "Original table should be quoted");
+    assert_eq!(original_identifier.canonical(), "MyTable");
+
+    // Save and load using binary format
+    let path = "/tmp/test_quoted_identifier.vbsql";
+    db.save_binary(path).unwrap();
+
+    let loaded_db = Database::load_binary(path).unwrap();
+
+    // Verify the quoted flag was preserved
+    let loaded_identifier = loaded_db.catalog.get_table_identifier("MyTable").unwrap();
+    assert!(
+        loaded_identifier.is_quoted(),
+        "Loaded table should still be quoted after roundtrip"
+    );
+    assert_eq!(loaded_identifier.canonical(), "MyTable");
+
+    // Cleanup
+    std::fs::remove_file(path).ok();
+}
+
+/// Test that unquoted tables remain unquoted through roundtrip
+#[test]
+fn test_unquoted_table_identifier_roundtrip() {
+    let mut db = Database::new();
+
+    // Create a table with an unquoted identifier (case-insensitive)
+    let schema = TableSchema::new(
+        "users".to_string(),
+        vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+    );
+    let identifier = TableIdentifier::unquoted("users");
+    db.create_table_with_identifier(schema, identifier).unwrap();
+
+    // Verify the identifier is NOT quoted
+    let original_identifier = db.catalog.get_table_identifier("users").unwrap();
+    assert!(
+        !original_identifier.is_quoted(),
+        "Original table should be unquoted"
+    );
+    assert_eq!(original_identifier.canonical(), "users");
+
+    // Save and load using binary format
+    let path = "/tmp/test_unquoted_identifier.vbsql";
+    db.save_binary(path).unwrap();
+
+    let loaded_db = Database::load_binary(path).unwrap();
+
+    // Verify the unquoted flag was preserved
+    let loaded_identifier = loaded_db.catalog.get_table_identifier("users").unwrap();
+    assert!(
+        !loaded_identifier.is_quoted(),
+        "Loaded table should still be unquoted after roundtrip"
+    );
+    assert_eq!(loaded_identifier.canonical(), "users");
+
+    // Cleanup
+    std::fs::remove_file(path).ok();
+}
+
+/// Test that both quoted and unquoted tables can coexist and be persisted correctly
+#[test]
+fn test_mixed_quoted_unquoted_tables_roundtrip() {
+    let mut db = Database::new();
+
+    // Create an unquoted table (case-insensitive)
+    let schema1 = TableSchema::new(
+        "users".to_string(),
+        vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+    );
+    db.create_table_with_identifier(schema1, TableIdentifier::unquoted("users"))
+        .unwrap();
+
+    // Create a quoted table (case-sensitive)
+    let schema2 = TableSchema::new(
+        "UserProfiles".to_string(),
+        vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+    );
+    db.create_table_with_identifier(schema2, TableIdentifier::quoted("UserProfiles"))
+        .unwrap();
+
+    // Save and load
+    let path = "/tmp/test_mixed_identifiers.vbsql";
+    db.save_binary(path).unwrap();
+
+    let loaded_db = Database::load_binary(path).unwrap();
+
+    // Verify both tables preserved their quoted flags
+    let users_id = loaded_db.catalog.get_table_identifier("users").unwrap();
+    assert!(!users_id.is_quoted(), "users should remain unquoted");
+
+    let profiles_id = loaded_db.catalog.get_table_identifier("UserProfiles").unwrap();
+    assert!(profiles_id.is_quoted(), "UserProfiles should remain quoted");
+
+    // Cleanup
+    std::fs::remove_file(path).ok();
+}
+
+/// Test that tables with data preserve quoted flag
+#[test]
+fn test_quoted_table_with_data_roundtrip() {
+    let mut db = Database::new();
+
+    // Create a quoted table with data
+    let schema = TableSchema::new(
+        "CaseSensitiveTable".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new(
+                "name".to_string(),
+                DataType::Varchar { max_length: Some(100) },
+                true,
+            ),
+        ],
+    );
+    db.create_table_with_identifier(schema, TableIdentifier::quoted("CaseSensitiveTable"))
+        .unwrap();
+
+    // Insert data
+    let table = db.get_table_mut("CaseSensitiveTable").unwrap();
+    table
+        .insert(crate::Row::new(vec![
+            SqlValue::Integer(1),
+            SqlValue::Varchar(arcstr::ArcStr::from("Alice")),
+        ]))
+        .unwrap();
+    table
+        .insert(crate::Row::new(vec![
+            SqlValue::Integer(2),
+            SqlValue::Varchar(arcstr::ArcStr::from("Bob")),
+        ]))
+        .unwrap();
+
+    // Save and load
+    let path = "/tmp/test_quoted_with_data.vbsql";
+    db.save_binary(path).unwrap();
+
+    let loaded_db = Database::load_binary(path).unwrap();
+
+    // Verify quoted flag preserved
+    let identifier = loaded_db
+        .catalog
+        .get_table_identifier("CaseSensitiveTable")
+        .unwrap();
+    assert!(identifier.is_quoted());
+
+    // Verify data preserved
+    let loaded_table = loaded_db.get_table("CaseSensitiveTable").unwrap();
+    assert_eq!(loaded_table.row_count(), 2);
+
+    // Cleanup
+    std::fs::remove_file(path).ok();
+}
+
+/// Test legacy behavior: tables created without identifier use default (unquoted)
+#[test]
+fn test_legacy_table_creation_defaults_to_unquoted() {
+    let mut db = Database::new();
+
+    // Create table using legacy method (no explicit identifier)
+    let schema = TableSchema::new(
+        "legacy_table".to_string(),
+        vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+    );
+    db.create_table(schema).unwrap();
+
+    // Should default to unquoted
+    let identifier = db.catalog.get_table_identifier("legacy_table").unwrap();
+    assert!(!identifier.is_quoted(), "Legacy tables should default to unquoted");
+
+    // Save and load
+    let path = "/tmp/test_legacy_table.vbsql";
+    db.save_binary(path).unwrap();
+
+    let loaded_db = Database::load_binary(path).unwrap();
+
+    // Verify still unquoted after load
+    let loaded_id = loaded_db.catalog.get_table_identifier("legacy_table").unwrap();
+    assert!(!loaded_id.is_quoted());
+
+    // Cleanup
+    std::fs::remove_file(path).ok();
+}

--- a/crates/vibesql-storage/src/persistence/tests/mod.rs
+++ b/crates/vibesql-storage/src/persistence/tests/mod.rs
@@ -6,10 +6,12 @@
 //
 // - sql_dump: Tests for SQL dump save/load functionality
 // - json_persistence: Tests for JSON serialization/deserialization
+// - binary_persistence: Tests for binary format serialization/deserialization
 //
 // Tests are split from the original monolithic tests.rs file (1,211 lines)
 // into smaller, focused modules for improved maintainability and navigation.
 // ============================================================================
 
+pub mod binary_persistence;
 pub mod json_persistence;
 pub mod sql_dump;


### PR DESCRIPTION
## Summary
- Implements persistence of the `quoted` flag for TableIdentifier in the binary catalog format (v4)
- Enables SQL:1999 case-sensitivity semantics to survive database save/load cycles
- Fixes JSON view serialization regression from #4403 (views were serialized with uppercase normalized keys)

## Changes
- Bump binary format VERSION to 4 with new `quoted` flag field per table
- Add `get_table_identifier` method to Catalog for accessing table identifiers
- Update `list_tables()` to return canonical keys (HashMap keys)
- Fix JSON view serialization to use original view name instead of normalized key
- Add comprehensive tests for quoted table identifier roundtrip persistence

## Backward Compatibility
- Files with version < 4 are loaded with `quoted = false` (unquoted/case-insensitive)
- All existing databases continue to work correctly

## Test plan
- [x] All existing tests pass (569 tests)
- [x] New tests verify quoted table name persistence roundtrip
- [x] New tests verify unquoted table name persistence roundtrip
- [x] Mixed quoted/unquoted tables preserve their flags through save/load
- [x] Tables with data preserve quoted flag through roundtrip
- [x] Legacy tables (created without identifier) default to unquoted

Closes #4404

🤖 Generated with [Claude Code](https://claude.com/claude-code)