### PR TITLE
fix(catalog): Return original view names from list_views()

### DIFF
--- a/crates/vibesql-catalog/src/store/advanced/views.rs
+++ b/crates/vibesql-catalog/src/store/advanced/views.rs
@@ -43,9 +43,9 @@ impl super::super::Catalog {
         self.views.get(&key)
     }
 
-    /// List all VIEW names
+    /// List all VIEW names (returns original names, not normalized keys)
     pub fn list_views(&self) -> Vec<String> {
-        self.views.keys().cloned().collect()
+        self.views.values().map(|v| v.name.clone()).collect()
     }
 
     /// Drop a VIEW with specified behavior


### PR DESCRIPTION
## Summary

- Fixes `list_views()` to return original `ViewDefinition.name` values instead of normalized HashMap keys
- Root cause was PR #4396 (SQL:1999 case-sensitivity) which normalizes keys to uppercase, but the old code returned keys instead of stored names

## Root Cause

After #4396, view names are stored with uppercase keys for case-insensitive lookup:
- `create_view("active_users")` stores key `"ACTIVE_USERS"` → `ViewDefinition { name: "active_users", ... }`
- Old `list_views()` returned `self.views.keys()` → `["ACTIVE_USERS"]`
- Tests expected `"active_users"` but got `"ACTIVE_USERS"`

## Fix

Changed `list_views()` to return `view.name` from stored `ViewDefinition`, consistent with `list_tables()` which returns `table.name`.

## Test plan

- [x] `cargo test -p vibesql-storage test_json_view_preservation` passes
- [x] `cargo test -p vibesql-catalog` passes (49 tests)
- [x] `cargo test -p vibesql-storage` passes (564 tests)
- [x] `cargo test -p vibesql-executor view` passes (15 tests)
- [x] `cargo build --workspace` compiles cleanly

Closes #4407

🤖 Generated with [Claude Code](https://claude.com/claude-code)