### PR TITLE
feat(executor): Use full table.column format for result column headers

### DIFF
--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -180,15 +180,15 @@ fn test_select_column_names_and_values_issue_3810() {
 
 #[test]
 fn test_select_column_names_from_table() {
-    // Verify column names are derived correctly preserving original case (SQLite compatibility)
+    // Verify column names include table prefix (full_column_names format)
     let mut executor = SqlExecutor::new(None).unwrap();
     executor.execute("CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(50))").unwrap();
     executor.execute("INSERT INTO users VALUES (1, 'Alice')").unwrap();
 
     let result = executor.execute("SELECT id, name FROM users").unwrap();
 
-    // Column names should match the table schema (lowercase per SQL:1999)
-    assert_eq!(result.columns, vec!["id", "name"]);
+    // Column names include table prefix (full_column_names format)
+    assert_eq!(result.columns, vec!["users.id", "users.name"]);
 
     // Values should be display format
     assert_eq!(result.rows[0][0], Some("1".to_string()));
@@ -197,15 +197,15 @@ fn test_select_column_names_from_table() {
 
 #[test]
 fn test_select_wildcard_column_names() {
-    // Verify SELECT * returns actual column names
+    // Verify SELECT * returns column names with table prefix
     let mut executor = SqlExecutor::new(None).unwrap();
     executor.execute("CREATE TABLE products (sku VARCHAR(20) PRIMARY KEY, price INT)").unwrap();
     executor.execute("INSERT INTO products VALUES ('ABC123', 99)").unwrap();
 
     let result = executor.execute("SELECT * FROM products").unwrap();
 
-    // Column names should be actual column names from table (lowercase per SQL:1999)
-    assert_eq!(result.columns, vec!["sku", "price"]);
+    // Column names include table prefix (full_column_names format)
+    assert_eq!(result.columns, vec!["products.sku", "products.price"]);
     assert_eq!(result.rows[0][0], Some("ABC123".to_string()));
     assert_eq!(result.rows[0][1], Some("99".to_string()));
 }

--- a/crates/vibesql-executor/src/advanced_objects/views.rs
+++ b/crates/vibesql-executor/src/advanced_objects/views.rs
@@ -12,11 +12,12 @@ pub fn execute_create_view(stmt: &CreateViewStmt, db: &mut Database) -> Result<(
 
     // If no explicit column list is provided, derive column names from the query
     // This ensures views with SELECT * preserve original column names
+    // Use simple column names (without table prefix) for view schema compatibility
     let columns = if stmt.columns.is_none() {
         // Execute the query once to derive column names
         use crate::select::SelectExecutor;
         let executor = SelectExecutor::new(db);
-        let result = executor.execute_with_columns(&stmt.query)?;
+        let result = executor.execute_with_simple_columns(&stmt.query)?;
         Some(result.columns)
     } else {
         stmt.columns.clone()

--- a/crates/vibesql-executor/src/readonly.rs
+++ b/crates/vibesql-executor/src/readonly.rs
@@ -269,7 +269,8 @@ mod tests {
         let result = db.query("SELECT name FROM users WHERE id = 2").unwrap();
         assert_eq!(result.rows.len(), 1);
         assert_eq!(result.columns.len(), 1);
-        assert_eq!(result.columns[0].to_lowercase(), "name");
+        // Column names now include table prefix (full_column_names format)
+        assert_eq!(result.columns[0].to_lowercase(), "users.name");
         assert_eq!(result.rows[0].values[0], SqlValue::Varchar(arcstr::ArcStr::from("Bob")));
     }
 

--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -310,6 +310,57 @@ impl CombinedSchema {
         // Fallback: return the input column name if not found in schema
         column.to_string()
     }
+
+    /// Get the fully qualified column name with original table name prefix.
+    ///
+    /// This follows SQLite's `full_column_names=ON` behavior where column names
+    /// in results are prefixed with the original table name from the schema.
+    ///
+    /// For example, if a table was created as `CREATE TABLE test1(f1 int)` and
+    /// queried with `SELECT a.f1 FROM test1 a`, this returns `test1.f1` (using
+    /// the original table name "test1", not the alias "a").
+    ///
+    /// # Arguments
+    /// * `table` - Optional table alias/name for qualified references
+    /// * `column` - Column name to look up (case-insensitive)
+    ///
+    /// # Returns
+    /// The fully qualified column name in `table.column` format, or just the
+    /// column name if the table is not found.
+    pub fn get_full_column_name(&self, table: Option<&str>, column: &str) -> String {
+        if let Some(table_name) = table {
+            // Qualified column reference (table.column)
+            let key = TableKey::new(table_name);
+            if let Some((_start_index, schema)) = self.table_schemas.get(&key) {
+                if let Some(idx) = schema.get_column_index(column) {
+                    // Use the original table name from the schema
+                    return format!("{}.{}", schema.name, schema.columns[idx].name);
+                }
+            }
+        } else {
+            // Unqualified column reference - search all tables
+            // Find the match with the lowest start_index (leftmost table)
+            let mut best_match: Option<(usize, String, String)> = None;
+            for (start_index, schema) in self.table_schemas.values() {
+                if let Some(idx) = schema.get_column_index(column) {
+                    let table_name = schema.name.clone();
+                    let col_name = schema.columns[idx].name.clone();
+                    match &best_match {
+                        None => best_match = Some((*start_index, table_name, col_name)),
+                        Some((current_start, _, _)) if *start_index < *current_start => {
+                            best_match = Some((*start_index, table_name, col_name));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            if let Some((_, table_name, col_name)) = best_match {
+                return format!("{}.{}", table_name, col_name);
+            }
+        }
+        // Fallback: return the input column name if not found in schema
+        column.to_string()
+    }
 }
 
 /// Builder for incrementally constructing a CombinedSchema

--- a/crates/vibesql-executor/src/select/executor/columns.rs
+++ b/crates/vibesql-executor/src/select/executor/columns.rs
@@ -5,10 +5,39 @@ use crate::{errors::ExecutorError, schema::CombinedSchema, select::join::FromRes
 
 impl SelectExecutor<'_> {
     /// Derive column names from SELECT list
+    ///
+    /// Column names follow SQLite's `full_column_names=ON` behavior:
+    /// - For wildcards (`SELECT *`), columns are prefixed with the table alias/name
+    ///   from the FROM clause (e.g., `a.f1` when using `FROM test1 a`)
+    /// - For explicit column references, columns are prefixed with the original
+    ///   table name from the schema (e.g., `test1.f1` even when using alias `a`)
+    /// - Explicit aliases always take precedence
     pub(super) fn derive_column_names(
         &self,
         select_list: &[vibesql_ast::SelectItem],
         from_result: Option<&FromResult>,
+    ) -> Result<Vec<String>, ExecutorError> {
+        self.derive_column_names_internal(select_list, from_result, true)
+    }
+
+    /// Derive simple column names (without table prefix) for internal use
+    ///
+    /// This is used when column names are needed for schema purposes (e.g., view creation)
+    /// where the table prefix would cause issues with column lookups.
+    pub(super) fn derive_simple_column_names(
+        &self,
+        select_list: &[vibesql_ast::SelectItem],
+        from_result: Option<&FromResult>,
+    ) -> Result<Vec<String>, ExecutorError> {
+        self.derive_column_names_internal(select_list, from_result, false)
+    }
+
+    /// Internal implementation that can optionally include table prefixes
+    fn derive_column_names_internal(
+        &self,
+        select_list: &[vibesql_ast::SelectItem],
+        from_result: Option<&FromResult>,
+        include_table_prefix: bool,
     ) -> Result<Vec<String>, ExecutorError> {
         let mut column_names = Vec::new();
         let schema = from_result.map(|fr| &fr.schema);
@@ -21,10 +50,17 @@ impl SelectExecutor<'_> {
                         // Get all column names in order from the combined schema
                         let mut table_columns: Vec<(usize, String)> = Vec::new();
 
-                        for (start_index, schema) in from_res.schema.table_schemas.values() {
-                            for (col_idx, col_schema) in schema.columns.iter().enumerate() {
-                                table_columns
-                                    .push((start_index + col_idx, col_schema.name.clone()));
+                        for (table_key, (start_index, table_schema)) in
+                            &from_res.schema.table_schemas
+                        {
+                            for (col_idx, col_schema) in table_schema.columns.iter().enumerate() {
+                                let col_name = if include_table_prefix {
+                                    // Use the table key (alias or table name) as the prefix
+                                    format!("{}.{}", table_key.as_str(), col_schema.name.clone())
+                                } else {
+                                    col_schema.name.clone()
+                                };
+                                table_columns.push((start_index + col_idx, col_name));
                             }
                         }
 
@@ -59,20 +95,26 @@ impl SelectExecutor<'_> {
                         // TableKey lookup is case-insensitive
                         let result = from_res.schema.get_table(qualifier).cloned();
 
-                        if let Some((_start_index, schema)) = result {
+                        if let Some((_start_index, table_schema)) = result {
                             // Apply derived column list if present
                             if let Some(derived_cols) = alias {
-                                if derived_cols.len() != schema.columns.len() {
+                                if derived_cols.len() != table_schema.columns.len() {
                                     return Err(ExecutorError::ColumnCountMismatch {
-                                        expected: schema.columns.len(),
+                                        expected: table_schema.columns.len(),
                                         provided: derived_cols.len(),
                                     });
                                 }
                                 column_names.extend(derived_cols.clone());
                             } else {
                                 // Add all column names from this table in order
-                                for col_schema in &schema.columns {
-                                    column_names.push(col_schema.name.clone());
+                                for col_schema in &table_schema.columns {
+                                    let col_name = if include_table_prefix {
+                                        // Use the qualifier (alias or table name) as the prefix
+                                        format!("{}.{}", qualifier, col_schema.name.clone())
+                                    } else {
+                                        col_schema.name.clone()
+                                    };
+                                    column_names.push(col_name);
                                 }
                             }
                         } else {
@@ -84,16 +126,23 @@ impl SelectExecutor<'_> {
                         ));
                     }
                 }
-                vibesql_ast::SelectItem::Expression { expr, alias, source_text , .. } => {
+                vibesql_ast::SelectItem::Expression { expr, alias, source_text, .. } => {
                     // If there's an alias, use it
                     if let Some(alias_name) = alias {
                         column_names.push(alias_name.clone());
+                    } else if matches!(expr, vibesql_ast::Expression::ColumnRef { .. }) {
+                        // For simple column references, use full table.column format
+                        // when include_table_prefix is true
+                        column_names
+                            .push(derive_expression_name_impl(expr, schema, include_table_prefix));
                     } else if let Some(src) = source_text {
-                        // Use original source text for column name (SQLite compatibility)
+                        // For complex expressions, use original source text
+                        // (e.g., "f1+F2" preserves the exact expression text)
                         column_names.push(src.clone());
                     } else {
                         // Derive name from the expression, using schema to preserve original case
-                        column_names.push(derive_expression_name_impl(expr, schema));
+                        column_names
+                            .push(derive_expression_name_impl(expr, schema, include_table_prefix));
                     }
                 }
             }
@@ -101,7 +150,6 @@ impl SelectExecutor<'_> {
 
         Ok(column_names)
     }
-
 }
 
 /// Helper function to derive a column name from an expression
@@ -109,21 +157,31 @@ impl SelectExecutor<'_> {
 /// # Arguments
 /// * `expr` - The expression to derive a name from
 /// * `schema` - Optional schema to use for resolving original column names.
-///   When provided, ColumnRef expressions will use the schema's column name
-///   (preserving original case) instead of the parsed identifier (which is
-///   uppercased for unquoted identifiers).
+///   When provided, ColumnRef expressions will use the schema's full column name
+///   (table.column format with original table name) instead of the parsed identifier.
+/// * `include_table_prefix` - Whether to include the table prefix for column references
 fn derive_expression_name_impl(
     expr: &vibesql_ast::Expression,
     schema: Option<&CombinedSchema>,
+    include_table_prefix: bool,
 ) -> String {
     match expr {
         vibesql_ast::Expression::ColumnRef { table, column } => {
-            // Use schema to get the original column name (preserves case from CREATE TABLE)
-            // SQLite returns schema column names, not query identifier case
-            if let Some(s) = schema {
-                s.get_original_column_name(table.as_deref(), column)
+            if include_table_prefix {
+                // Use schema to get the full column name (table.column format)
+                // with original table name from schema, not the query alias
+                if let Some(s) = schema {
+                    s.get_full_column_name(table.as_deref(), column)
+                } else {
+                    column.clone()
+                }
             } else {
-                column.clone()
+                // Use schema to get just the original column name (preserves case)
+                if let Some(s) = schema {
+                    s.get_original_column_name(table.as_deref(), column)
+                } else {
+                    column.clone()
+                }
             }
         }
         vibesql_ast::Expression::Function { name, args, character_unit: _ } => {
@@ -132,7 +190,7 @@ fn derive_expression_name_impl(
                 "*".to_string()
             } else {
                 args.iter()
-                    .map(|e| derive_expression_name_impl(e, schema))
+                    .map(|e| derive_expression_name_impl(e, schema, include_table_prefix))
                     .collect::<Vec<_>>()
                     .join(", ")
             };
@@ -145,7 +203,7 @@ fn derive_expression_name_impl(
                 "*".to_string()
             } else {
                 args.iter()
-                    .map(|e| derive_expression_name_impl(e, schema))
+                    .map(|e| derive_expression_name_impl(e, schema, include_table_prefix))
                     .collect::<Vec<_>>()
                     .join(", ")
             };
@@ -155,7 +213,7 @@ fn derive_expression_name_impl(
             // For binary operations, create descriptive name
             format!(
                 "({} {} {})",
-                derive_expression_name_impl(left, schema),
+                derive_expression_name_impl(left, schema, include_table_prefix),
                 match op {
                     vibesql_ast::BinaryOperator::Plus => "+",
                     vibesql_ast::BinaryOperator::Minus => "-",
@@ -172,7 +230,7 @@ fn derive_expression_name_impl(
                     vibesql_ast::BinaryOperator::Concat => "||",
                     _ => "?",
                 },
-                derive_expression_name_impl(right, schema)
+                derive_expression_name_impl(right, schema, include_table_prefix)
             )
         }
         vibesql_ast::Expression::Literal(val) => {

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -322,8 +322,51 @@ impl SelectExecutor<'_> {
             None
         };
 
-        // Derive column names from the SELECT list
+        // Derive column names from the SELECT list (with table prefix for display)
         let columns = self.derive_column_names(&stmt.select_list, from_result.as_ref())?;
+
+        // Execute the query to get rows
+        let rows = self.execute(stmt)?;
+
+        Ok(SelectResult { columns, rows })
+    }
+
+    /// Execute SELECT statement and return results with simple column names
+    ///
+    /// This is similar to `execute_with_columns` but returns column names without
+    /// table prefixes. This is used for internal purposes like view creation
+    /// where the full table.column format would cause column lookup issues.
+    pub fn execute_with_simple_columns(
+        &self,
+        stmt: &vibesql_ast::SelectStmt,
+    ) -> Result<SelectResult, ExecutorError> {
+        // Execute the FROM clause to get combined schema
+        let from_result = if let Some(from_clause) = &stmt.from {
+            let mut cte_results = if let Some(with_clause) = &stmt.with_clause {
+                execute_ctes(with_clause, |query, cte_ctx| self.execute_with_ctes(query, cte_ctx))?
+            } else {
+                HashMap::new()
+            };
+            // If we have access to outer query's CTEs (for subqueries/derived tables), merge them
+            if let Some(outer_cte_ctx) = self.cte_context {
+                for (name, result) in outer_cte_ctx {
+                    cte_results.entry(name.clone()).or_insert_with(|| result.clone());
+                }
+            }
+            Some(self.execute_from_with_where(
+                from_clause,
+                &cte_results,
+                stmt.where_clause.as_ref(),
+                stmt.order_by.as_deref(),
+                stmt.limit,
+                Some(&stmt.select_list),
+            )?)
+        } else {
+            None
+        };
+
+        // Derive column names from the SELECT list (without table prefix)
+        let columns = self.derive_simple_column_names(&stmt.select_list, from_result.as_ref())?;
 
         // Execute the query to get rows
         let rows = self.execute(stmt)?;

--- a/crates/vibesql-executor/src/tests/join_aggregation.rs
+++ b/crates/vibesql-executor/src/tests/join_aggregation.rs
@@ -204,8 +204,11 @@ fn test_inner_join_with_group_by_count() {
     // Should have 3 departments with employees
     assert_eq!(result.rows.len(), 3);
 
-    // Verify column names
-    assert_eq!(result.columns, vec!["dept_name".to_string(), "emp_count".to_string()]);
+    // Verify column names (now include table prefix per full_column_names format)
+    assert_eq!(
+        result.columns,
+        vec!["departments.dept_name".to_string(), "emp_count".to_string()]
+    );
 
     // Verify the results (Engineering: 2, Sales: 2, HR: 1)
     // Order is not guaranteed without ORDER BY, so we'll find each department

--- a/crates/vibesql-executor/tests/column_names_tests.rs
+++ b/crates/vibesql-executor/tests/column_names_tests.rs
@@ -44,8 +44,8 @@ fn test_column_names_simple_select() {
     let stmt = vibesql_parser::Parser::parse_sql("SELECT id, name FROM employees").unwrap();
     if let vibesql_ast::Statement::Select(select_stmt) = stmt {
         let result = executor.execute_with_columns(&select_stmt).unwrap();
-        // SQL:1999 normalizes unquoted identifiers to lowercase
-        assert_eq!(result.columns, vec!["id", "name"]);
+        // Column names include table prefix (full_column_names format)
+        assert_eq!(result.columns, vec!["employees.id", "employees.name"]);
         assert_eq!(result.rows.len(), 3);
     } else {
         panic!("Expected SELECT statement");
@@ -79,8 +79,16 @@ fn test_column_names_star_expansion() {
     let stmt = vibesql_parser::Parser::parse_sql("SELECT * FROM employees").unwrap();
     if let vibesql_ast::Statement::Select(select_stmt) = stmt {
         let result = executor.execute_with_columns(&select_stmt).unwrap();
-        // SQL:1999 normalizes unquoted identifiers to lowercase
-        assert_eq!(result.columns, vec!["id", "name", "department", "salary"]);
+        // Column names include table prefix (full_column_names format)
+        assert_eq!(
+            result.columns,
+            vec![
+                "employees.id",
+                "employees.name",
+                "employees.department",
+                "employees.salary"
+            ]
+        );
         assert_eq!(result.rows.len(), 3);
     } else {
         panic!("Expected SELECT statement");
@@ -135,8 +143,8 @@ fn test_column_names_mixed() {
     if let vibesql_ast::Statement::Select(select_stmt) = stmt {
         let result = executor.execute_with_columns(&select_stmt).unwrap();
         assert_eq!(result.columns.len(), 3);
-        // SQL:1999 normalizes unquoted identifiers to lowercase
-        assert_eq!(result.columns[0], "id");
+        // Column names include table prefix (full_column_names format)
+        assert_eq!(result.columns[0], "employees.id");
         assert_eq!(result.columns[1], "emp_name");
         // Third column is an expression
         assert!(result.columns[2].contains("salary") || result.columns[2].contains("*"));


### PR DESCRIPTION
## Summary

- Implements SQLite's `full_column_names=ON` behavior for SELECT query result column headers
- Column names now include the source table name as a prefix (e.g., `test1.f1` instead of just `f1`)
- For wildcards, uses the table alias/name from FROM clause (e.g., `a.f1` for `FROM test1 a`)
- Aliases still take precedence as expected

## Test plan

- [x] Verified column naming works correctly for single table queries
- [x] Verified multi-table queries show correct table prefixes
- [x] Verified aliases (AS) override the table prefix
- [x] Verified expressions preserve source text format
- [x] Verified view creation uses simple column names (no prefix)
- [x] All executor tests pass (2099 tests)
- [x] All CLI tests pass (112 tests)
- [x] TCL tests select1-6.1.1, select1-6.9.10, select1-6.9.12 now pass

Closes #4412

🤖 Generated with [Claude Code](https://claude.com/claude-code)