### PR TITLE
fix(order): Handle ORDER BY +N as column position

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -419,6 +419,10 @@ path = "tests/regression/issue_having_null.rs"
 name = "issue_4236_group_by_expression"
 path = "tests/regression/issue_4236_group_by_expression.rs"
 
+[[test]]
+name = "issue_4418"
+path = "tests/regression/issue_4418.rs"
+
 # Parser tests - SQL parsing and syntax
 [[test]]
 name = "coverage_improvements"

--- a/crates/vibesql-executor/src/select/order.rs
+++ b/crates/vibesql-executor/src/select/order.rs
@@ -213,6 +213,39 @@ pub(crate) fn resolve_order_by_for_aggregates(
         }
     }
 
+    // Check for positive unary operator with numeric column position (ORDER BY +1 parsed as UnaryOp { Plus, Integer(1) })
+    // Treat +N the same as N (#4418)
+    if let vibesql_ast::Expression::UnaryOp {
+        op: vibesql_ast::UnaryOperator::Plus,
+        expr,
+    } = order_expr
+    {
+        if let vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) =
+            expr.as_ref()
+        {
+            // Validate the column position
+            if *pos <= 0 || (*pos as usize) > column_count {
+                return Err(ExecutorError::OrderByOutOfRange {
+                    term_position: term_index + 1, // Convert to 1-indexed for error message
+                    column_number: *pos,
+                    select_list_len: column_count,
+                });
+            }
+            let idx = (*pos as usize) - 1;
+            if let vibesql_ast::SelectItem::Expression { expr, alias, .. } = &select_list[idx] {
+                // Return a ColumnRef to the alias name (or derive from expression)
+                let col_name = if let Some(alias_name) = alias {
+                    alias_name.clone()
+                } else if let vibesql_ast::Expression::ColumnRef { column, .. } = expr {
+                    column.clone()
+                } else {
+                    format!("col{}", idx + 1)
+                };
+                return Ok(vibesql_ast::Expression::ColumnRef { table: None, column: col_name });
+            }
+        }
+    }
+
     // Check for negative numeric column position (ORDER BY -1 parsed as UnaryOp { Minus, Integer(1) })
     if let vibesql_ast::Expression::UnaryOp {
         op: vibesql_ast::UnaryOperator::Minus,
@@ -546,6 +579,107 @@ pub(crate) fn resolve_order_by_alias<'a>(
         }
 
         // Fallback: return original expression (shouldn't reach here normally)
+    }
+
+    // Check for positive unary operator with numeric column position (ORDER BY +1 parsed as UnaryOp { Plus, Integer(1) })
+    // Treat +N the same as N (#4418)
+    if let vibesql_ast::Expression::UnaryOp {
+        op: vibesql_ast::UnaryOperator::Plus,
+        expr,
+    } = order_expr
+    {
+        if let vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) =
+            expr.as_ref()
+        {
+            // Validate the column position against expanded column count
+            if *pos <= 0 || (*pos as usize) > column_count {
+                return Err(ExecutorError::OrderByOutOfRange {
+                    term_position: term_index + 1, // Convert to 1-indexed for error message
+                    column_number: *pos,
+                    select_list_len: column_count,
+                });
+            }
+
+            // Map the 1-based position to the corresponding select_list item
+            // accounting for wildcard expansion
+            let target_col = (*pos as usize) - 1; // 0-indexed target column position
+            let mut current_col = 0;
+
+            for item in select_list {
+                match item {
+                    vibesql_ast::SelectItem::Wildcard { .. } => {
+                        // Count how many columns this wildcard expands to
+                        let wildcard_cols = if let Some(s) = schema {
+                            s.table_schemas.values().map(|(_, ts)| ts.columns.len()).sum()
+                        } else {
+                            1
+                        };
+
+                        if target_col < current_col + wildcard_cols {
+                            // The position is within this wildcard's expanded columns
+                            // Return a ColumnRef to the N-th column from the schema
+                            if let Some(s) = schema {
+                                let offset_in_wildcard = target_col - current_col;
+                                // Collect all columns from all tables in schema order
+                                let mut all_columns: Vec<(usize, String)> = Vec::new();
+                                for (start_idx, table_schema) in s.table_schemas.values() {
+                                    for (i, col) in table_schema.columns.iter().enumerate() {
+                                        all_columns.push((start_idx + i, col.name.clone()));
+                                    }
+                                }
+                                all_columns.sort_by_key(|(idx, _)| *idx);
+
+                                if offset_in_wildcard < all_columns.len() {
+                                    let col_name = all_columns[offset_in_wildcard].1.clone();
+                                    return Ok(Cow::Owned(vibesql_ast::Expression::ColumnRef {
+                                        table: None,
+                                        column: col_name,
+                                    }));
+                                }
+                            }
+                            // Fallback: shouldn't reach here if schema is available
+                            break;
+                        }
+                        current_col += wildcard_cols;
+                    }
+                    vibesql_ast::SelectItem::QualifiedWildcard { qualifier, .. } => {
+                        // Count how many columns this qualified wildcard expands to
+                        let qualified_cols = if let Some(s) = schema {
+                            s.get_table(qualifier).map(|(_, ts)| ts.columns.len()).unwrap_or(1)
+                        } else {
+                            1
+                        };
+
+                        if target_col < current_col + qualified_cols {
+                            // The position is within this qualified wildcard's columns
+                            if let Some(s) = schema {
+                                if let Some((_, table_schema)) = s.get_table(qualifier) {
+                                    let offset = target_col - current_col;
+                                    if offset < table_schema.columns.len() {
+                                        let col_name = table_schema.columns[offset].name.clone();
+                                        return Ok(Cow::Owned(vibesql_ast::Expression::ColumnRef {
+                                            table: None,
+                                            column: col_name,
+                                        }));
+                                    }
+                                }
+                            }
+                            break;
+                        }
+                        current_col += qualified_cols;
+                    }
+                    vibesql_ast::SelectItem::Expression { expr, .. } => {
+                        if target_col == current_col {
+                            // This is a regular expression, return it directly
+                            return Ok(Cow::Borrowed(expr));
+                        }
+                        current_col += 1;
+                    }
+                }
+            }
+
+            // Fallback: return original expression (shouldn't reach here normally)
+        }
     }
 
     // Check for negative numeric column position (ORDER BY -1 parsed as UnaryOp { Minus, Integer(1) })

--- a/tests/regression/issue_4418.rs
+++ b/tests/regression/issue_4418.rs
@@ -1,0 +1,104 @@
+//! Test for issue #4418: ORDER BY +N not recognized as column position
+//!
+//! When using `ORDER BY +N` (positive unary operator with numeric column position),
+//! VibeSQL should treat it the same as `ORDER BY N` - as a column position reference.
+//! The `+` is a unary positive operator that doesn't change the value.
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+/// Helper to execute SELECT and return rows
+fn select_rows(db: &Database, sql: &str) -> Vec<Row> {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor.execute(&select_stmt).unwrap()
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+/// Helper to create the test table (matches select1.test t5 table)
+fn create_test_table(db: &mut Database) {
+    let schema = TableSchema::new(
+        "t5".to_string(),
+        vec![
+            ColumnSchema::new("a".to_string(), DataType::Integer, false),
+            ColumnSchema::new("b".to_string(), DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("t5").unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(10)])).unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(2), SqlValue::Integer(9)])).unwrap();
+}
+
+#[test]
+fn test_order_by_positive_unary_position() {
+    let mut db = Database::new();
+    create_test_table(&mut db);
+
+    // Test 1: ORDER BY N works (sanity check)
+    let rows = select_rows(&db, "SELECT * FROM t5 ORDER BY 2");
+    assert_eq!(rows.len(), 2);
+    // Should be sorted by column b (the 2nd column) ascending: 9, 10
+    assert_eq!(rows[0].values[0], SqlValue::Integer(2)); // a=2, b=9
+    assert_eq!(rows[0].values[1], SqlValue::Integer(9));
+    assert_eq!(rows[1].values[0], SqlValue::Integer(1)); // a=1, b=10
+    assert_eq!(rows[1].values[1], SqlValue::Integer(10));
+
+    // Test 2: ORDER BY +N should work the same as ORDER BY N
+    // This was the failing case from select1-4.9.2
+    let rows = select_rows(&db, "SELECT * FROM t5 ORDER BY +2");
+    assert_eq!(rows.len(), 2);
+    // Should be sorted by column b (the 2nd column) ascending: 9, 10
+    assert_eq!(rows[0].values[0], SqlValue::Integer(2)); // a=2, b=9
+    assert_eq!(rows[0].values[1], SqlValue::Integer(9));
+    assert_eq!(rows[1].values[0], SqlValue::Integer(1)); // a=1, b=10
+    assert_eq!(rows[1].values[1], SqlValue::Integer(10));
+}
+
+#[test]
+fn test_order_by_positive_unary_first_column() {
+    let mut db = Database::new();
+    create_test_table(&mut db);
+
+    // Test ORDER BY +1 (first column)
+    let rows = select_rows(&db, "SELECT * FROM t5 ORDER BY +1");
+    assert_eq!(rows.len(), 2);
+    // Should be sorted by column a ascending: 1, 2
+    assert_eq!(rows[0].values[0], SqlValue::Integer(1));
+    assert_eq!(rows[1].values[0], SqlValue::Integer(2));
+}
+
+#[test]
+fn test_order_by_positive_unary_descending() {
+    let mut db = Database::new();
+    create_test_table(&mut db);
+
+    // Test ORDER BY +2 DESC
+    let rows = select_rows(&db, "SELECT * FROM t5 ORDER BY +2 DESC");
+    assert_eq!(rows.len(), 2);
+    // Should be sorted by column b descending: 10, 9
+    assert_eq!(rows[0].values[0], SqlValue::Integer(1)); // a=1, b=10
+    assert_eq!(rows[0].values[1], SqlValue::Integer(10));
+    assert_eq!(rows[1].values[0], SqlValue::Integer(2)); // a=2, b=9
+    assert_eq!(rows[1].values[1], SqlValue::Integer(9));
+}
+
+#[test]
+fn test_order_by_positive_unary_with_alias() {
+    let mut db = Database::new();
+    create_test_table(&mut db);
+
+    // Test ORDER BY +1 with aliased columns
+    let rows = select_rows(&db, "SELECT a AS x, b AS y FROM t5 ORDER BY +2");
+    assert_eq!(rows.len(), 2);
+    // Should be sorted by y (column b) ascending: 9, 10
+    assert_eq!(rows[0].values[1], SqlValue::Integer(9));
+    assert_eq!(rows[1].values[1], SqlValue::Integer(10));
+}


### PR DESCRIPTION
## Summary
- Fixes issue where `ORDER BY +N` was not recognized as a column position reference
- The unary `+` operator is now correctly handled, treating `+N` the same as `N`
- Adds handling in both `resolve_order_by_alias` and `resolve_order_by_for_aggregates` functions

Closes #4418

## Test plan
- [x] Added regression test `issue_4418.rs` with 4 test cases covering:
  - Basic `ORDER BY +N` functionality
  - First column reference (`ORDER BY +1`)
  - Descending order (`ORDER BY +N DESC`)
  - With aliased columns
- [x] Manual verification that `SELECT * FROM t5 ORDER BY +2` now correctly sorts by the second column

🤖 Generated with [Claude Code](https://claude.com/claude-code)