### PR TITLE
fix(parser): Use SQLite-compatible (subquery-N) naming format

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -406,7 +406,7 @@ impl<'arena> ArenaParser<'arena> {
             } else {
                 // Auto-generate unique alias for SQLite compatibility
                 let generated = format!(
-                    "__derived_{}",
+                    "(subquery-{})",
                     ARENA_DERIVED_TABLE_COUNTER.fetch_add(1, Ordering::Relaxed)
                 );
                 self.intern(&generated)

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -147,7 +147,7 @@ impl Parser {
                         _ => {
                             // Auto-generate unique alias for SQLite compatibility
                             format!(
-                                "__derived_{}",
+                                "(subquery-{})",
                                 DERIVED_TABLE_COUNTER.fetch_add(1, Ordering::Relaxed)
                             )
                         }

--- a/crates/vibesql-parser/src/tests/subquery.rs
+++ b/crates/vibesql-parser/src/tests/subquery.rs
@@ -235,10 +235,10 @@ fn test_parse_derived_table_without_alias() {
             // FROM clause should be a Subquery with auto-generated alias
             match &select.from {
                 Some(vibesql_ast::FromClause::Subquery { alias, .. }) => {
-                    // Alias should start with __derived_
+                    // Alias should start with (subquery-
                     assert!(
-                        alias.starts_with("__derived_"),
-                        "Expected auto-generated alias starting with __derived_, got: {}",
+                        alias.starts_with("(subquery-"),
+                        "Expected auto-generated alias starting with (subquery-, got: {}",
                         alias
                     );
                 }
@@ -281,7 +281,7 @@ fn test_parse_derived_table_comma_join_without_alias() {
                     match right.as_ref() {
                         vibesql_ast::FromClause::Subquery { alias, .. } => {
                             assert!(
-                                alias.starts_with("__derived_"),
+                                alias.starts_with("(subquery-"),
                                 "Expected auto-generated alias, got: {}",
                                 alias
                             );
@@ -316,9 +316,9 @@ fn test_parse_multiple_derived_tables_without_aliases() {
                         _ => panic!("Expected Subquery on right side"),
                     };
 
-                    // Both should start with __derived_ and be unique
-                    assert!(left_alias.starts_with("__derived_"));
-                    assert!(right_alias.starts_with("__derived_"));
+                    // Both should start with (subquery- and be unique
+                    assert!(left_alias.starts_with("(subquery-"));
+                    assert!(right_alias.starts_with("(subquery-"));
                     assert_ne!(left_alias, right_alias, "Aliases should be unique");
                 }
                 _ => panic!("Expected Join in FROM clause"),
@@ -339,12 +339,12 @@ fn test_parse_nested_derived_tables_without_aliases() {
             match &select.from {
                 Some(vibesql_ast::FromClause::Subquery { query, alias, .. }) => {
                     // Outer subquery should have auto-generated alias
-                    assert!(alias.starts_with("__derived_"));
+                    assert!(alias.starts_with("(subquery-"));
 
                     // Inner subquery should also have auto-generated alias
                     match &query.from {
                         Some(vibesql_ast::FromClause::Subquery { alias: inner_alias, .. }) => {
-                            assert!(inner_alias.starts_with("__derived_"));
+                            assert!(inner_alias.starts_with("(subquery-"));
                         }
                         _ => panic!("Expected nested Subquery"),
                     }
@@ -368,7 +368,7 @@ fn test_parse_derived_table_with_limit_without_alias() {
                 Some(vibesql_ast::FromClause::Join { right, .. }) => {
                     match right.as_ref() {
                         vibesql_ast::FromClause::Subquery { query, alias, .. } => {
-                            assert!(alias.starts_with("__derived_"));
+                            assert!(alias.starts_with("(subquery-"));
                             // Verify LIMIT is parsed
                             assert!(query.limit.is_some());
                         }


### PR DESCRIPTION
## Summary

- Change anonymous subquery naming from `__derived_N` to `(subquery-N)` to match SQLite's behavior
- Updates both parsers (standard and arena-based)
- Updates affected test assertions

## Test plan

- [x] All 1107 parser tests pass
- [x] Manual verification shows correct output: `(subquery-0).5` instead of `__derived_0.5`
- [x] TCL test select1-6.9.7 now passes

Closes #4420

🤖 Generated with [Claude Code](https://claude.com/claude-code)