### PR TITLE
fix(parser): Use SQLite-compatible syntax error format (#4414)

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/ddl.rs
+++ b/crates/vibesql-parser/src/arena_parser/ddl.rs
@@ -399,9 +399,7 @@ impl<'arena> ArenaParser<'arena> {
                 self.advance();
                 Ok(self.intern(&name))
             }
-            _ => {
-                Err(ParseError { message: format!("Expected table name, found {:?}", self.peek()) })
-            }
+            _ => Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 
@@ -413,9 +411,7 @@ impl<'arena> ArenaParser<'arena> {
                 self.advance();
                 Ok(self.intern(&name))
             }
-            _ => Err(ParseError {
-                message: format!("Expected column name, found {:?}", self.peek()),
-            }),
+            _ => Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 
@@ -783,11 +779,7 @@ impl<'arena> ArenaParser<'arena> {
                 self.expect_token(Token::RParen)?;
                 TableConstraintKind::Check { expr: self.arena.alloc(expr) }
             }
-            _ => {
-                return Err(ParseError {
-                    message: format!("Expected constraint type, found {:?}", self.peek()),
-                })
-            }
+            _ => return Err(ParseError { message: self.peek().syntax_error() })
         };
 
         Ok(TableConstraint { name, kind })
@@ -1057,9 +1049,7 @@ impl<'arena> ArenaParser<'arena> {
                     }),
                 }
             }
-            _ => Err(ParseError {
-                message: format!("Expected PRAGMA value, found {:?}", self.peek()),
-            }),
+            _ => Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 }

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -531,7 +531,7 @@ impl<'arena> ArenaParser<'arena> {
             return Ok(first_expr);
         }
 
-        Err(ParseError { message: format!("Expected expression, found {:?}", self.peek()) })
+        Err(ParseError { message: self.peek().syntax_error() })
     }
 
     /// Parse literal values.
@@ -1007,11 +1007,7 @@ impl<'arena> ArenaParser<'arena> {
             Token::Keyword(Keyword::Interval) => "INTERVAL".to_string(),
             Token::Keyword(Keyword::Character) => "CHARACTER".to_string(),
             Token::Keyword(Keyword::Boolean) => "BOOLEAN".to_string(),
-            _ => {
-                return Err(ParseError {
-                    message: format!("Expected data type, found {:?}", self.peek()),
-                })
-            }
+            _ => return Err(ParseError { message: self.peek().syntax_error() })
         };
         self.advance();
 

--- a/crates/vibesql-parser/src/arena_parser/mod.rs
+++ b/crates/vibesql-parser/src/arena_parser/mod.rs
@@ -232,7 +232,7 @@ impl<'arena> ArenaParser<'arena> {
                 Ok(Statement::ReleaseSavepoint(stmt))
             }
 
-            _ => Err(ParseError { message: format!("Unexpected token: {:?}", self.peek()) }),
+            _ => Err(ParseError { message: self.peek().syntax_error() }),
         }
     }
 
@@ -518,9 +518,7 @@ impl<'arena> ArenaParser<'arena> {
             self.advance();
             Ok(())
         } else {
-            Err(ParseError {
-                message: format!("Expected keyword {:?}, found {:?}", keyword, self.peek()),
-            })
+            Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 
@@ -545,7 +543,7 @@ impl<'arena> ArenaParser<'arena> {
             self.advance();
             Ok(())
         } else {
-            Err(ParseError { message: format!("Expected {:?}, found {:?}", expected, self.peek()) })
+            Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 
@@ -578,9 +576,7 @@ impl<'arena> ArenaParser<'arena> {
                 self.advance();
                 Ok(self.intern(&name))
             }
-            _ => {
-                Err(ParseError { message: format!("Expected identifier, found {:?}", self.peek()) })
-            }
+            _ => Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 
@@ -648,9 +644,7 @@ impl<'arena> ArenaParser<'arena> {
                 self.advance();
                 Ok(self.intern(&name))
             }
-            _ => {
-                Err(ParseError { message: format!("Expected alias name, found {:?}", self.peek()) })
-            }
+            _ => Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -430,11 +430,7 @@ impl<'arena> ArenaParser<'arena> {
                 self.advance();
                 (self.intern(&name), true)
             }
-            _ => {
-                return Err(ParseError {
-                    message: format!("Expected table name, found {:?}", self.peek()),
-                });
-            }
+            _ => return Err(ParseError { message: self.peek().syntax_error() })
         };
 
         // Check for alias

--- a/crates/vibesql-parser/src/parser/expressions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/mod.rs
@@ -82,6 +82,6 @@ impl Parser {
             return Ok(expr);
         }
 
-        Err(ParseError { message: format!("Expected expression, found {:?}", self.peek()) })
+        Err(ParseError { message: self.peek().syntax_error() })
     }
 }

--- a/crates/vibesql-parser/src/parser/helpers.rs
+++ b/crates/vibesql-parser/src/parser/helpers.rs
@@ -51,9 +51,7 @@ impl Parser {
             self.advance();
             Ok(())
         } else {
-            Err(ParseError {
-                message: format!("Expected keyword {:?}, found {:?}", keyword, self.peek()),
-            })
+            Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 
@@ -68,7 +66,7 @@ impl Parser {
             self.advance();
             Ok(())
         } else {
-            Err(ParseError { message: format!("Expected {:?}, found {:?}", expected, self.peek()) })
+            Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 
@@ -88,9 +86,7 @@ impl Parser {
                     ),
                 })
             }
-            _ => Err(ParseError {
-                message: format!("Expected identifier, found {:?}", self.peek())
-            }),
+            _ => Err(ParseError { message: self.peek().syntax_error() }),
         }
     }
 
@@ -110,9 +106,7 @@ impl Parser {
                 self.advance();
                 Ok(name)
             }
-            _ => {
-                Err(ParseError { message: format!("Expected alias name, found {:?}", self.peek()) })
-            }
+            _ => Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 
@@ -233,9 +227,7 @@ impl Parser {
                     message: format!("Expected integer, found '{}'", num_str),
                 })
             }
-            _ => Err(ParseError {
-                message: format!("Expected integer literal, found {:?}", self.peek()),
-            }),
+            _ => Err(ParseError { message: self.peek().syntax_error() }),
         }
     }
 
@@ -290,9 +282,7 @@ impl Parser {
 
         // Expect closing parenthesis
         if self.peek() != &Token::RParen {
-            return Err(ParseError {
-                message: format!("Expected ')' after column alias list, found {:?}", self.peek()),
-            });
+            return Err(ParseError { message: self.peek().syntax_error() });
         }
         self.advance(); // Consume ')'
 

--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -721,9 +721,7 @@ impl Parser {
                     }),
                 }
             }
-            _ => Err(ParseError {
-                message: format!("Expected PRAGMA value, found {:?}", self.peek()),
-            }),
+            _ => Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 }

--- a/crates/vibesql-parser/src/parser/introspection.rs
+++ b/crates/vibesql-parser/src/parser/introspection.rs
@@ -12,9 +12,7 @@ impl Parser {
                 self.advance();
                 Ok(string_val)
             }
-            _ => Err(ParseError {
-                message: format!("Expected string literal, found {:?}", self.peek()),
-            }),
+            _ => Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -397,9 +397,7 @@ impl Parser {
                 let pragma_stmt = self.parse_pragma_statement()?;
                 Ok(vibesql_ast::Statement::Pragma(pragma_stmt))
             }
-            _ => {
-                Err(ParseError { message: format!("Expected statement, found {:?}", self.peek()) })
-            }
+            _ => Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 

--- a/crates/vibesql-parser/src/parser/prepared.rs
+++ b/crates/vibesql-parser/src/parser/prepared.rs
@@ -222,9 +222,7 @@ impl Parser {
                 self.advance();
                 Ok(s)
             }
-            _ => Err(ParseError {
-                message: format!("Expected string literal, found {:?}", self.peek()),
-            }),
+            _ => Err(ParseError { message: self.peek().syntax_error() })
         }
     }
 }

--- a/crates/vibesql-parser/src/token.rs
+++ b/crates/vibesql-parser/src/token.rs
@@ -108,6 +108,23 @@ impl Token {
             Token::Eof => String::new(),
         }
     }
+
+    /// Generate a SQLite-compatible syntax error message for this token.
+    ///
+    /// SQLite uses the format: `near "TOKEN": syntax error`
+    /// where TOKEN is the actual text that caused the error.
+    ///
+    /// Special cases:
+    /// - EOF (end of input) is reported as `;` (SQLite convention)
+    /// - Keywords are reported in uppercase
+    pub fn syntax_error(&self) -> String {
+        let token_text = match self {
+            Token::Eof => ";".to_string(),
+            Token::Keyword(kw) => kw.to_string().to_uppercase(),
+            _ => self.to_sql(),
+        };
+        format!("near \"{}\": syntax error", token_text)
+    }
 }
 
 impl fmt::Display for Token {

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -209,9 +209,13 @@ proc translate_error_to_sqlite {vibesql_error} {
         return "CHECK constraint failed"
     }
 
-    # Syntax/parse errors - try to preserve some context
+    # Syntax/parse errors - parser now produces SQLite-compatible format directly
+    # Format: "Parse error: near "X": syntax error" -> "near "X": syntax error"
+    if {[regexp -nocase {^Parse error: (near .+: syntax error)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
+    # Fallback for other parse errors (e.g., descriptive messages like "Expected identifier")
     if {[regexp -nocase {^Parse error: (.+)$} $error_msg -> parse_msg]} {
-        # Return simplified parse error
         return "near \"$parse_msg\": syntax error"
     }
 


### PR DESCRIPTION
## Summary
- Add `Token::syntax_error()` method that generates SQLite-compatible error format: `near "TOKEN": syntax error`
- Update all parser error sites to use the new format instead of debug format
- Update TCL test shim to pass through the new format directly

**Before:** `Parse error: Expected expression, found Keyword(Where)`  
**After:** `Parse error: near "WHERE": syntax error`

## Test plan
- [x] All 1107 parser tests pass
- [x] Manual testing confirms new error format
- [x] TCL select1.test pass rate improved from 54.8% to 58.0% (6 more tests pass)

Closes #4414

🤖 Generated with [Claude Code](https://claude.com/claude-code)