### PR TITLE
refactor(order): Extract common column position resolution logic

### DIFF
--- a/crates/vibesql-executor/benches/sysbench_benchmark.rs
+++ b/crates/vibesql-executor/benches/sysbench_benchmark.rs
@@ -178,6 +178,7 @@ fn bind_delete(stmt: &DeleteStmt, params: &[SqlValue]) -> DeleteStmt {
 fn bind_update(stmt: &UpdateStmt, params: &[SqlValue]) -> UpdateStmt {
     UpdateStmt {
         table_name: stmt.table_name.clone(),
+            quoted: false,
         assignments: stmt
             .assignments
             .iter()

--- a/crates/vibesql-executor/src/delete/tests/basic.rs
+++ b/crates/vibesql-executor/src/delete/tests/basic.rs
@@ -13,7 +13,7 @@ fn test_delete_all_rows() {
     setup_test_table(&mut db);
 
     // DELETE FROM users;
-    let stmt = DeleteStmt { only: false, table_name: "users".to_string(), where_clause: None };
+    let stmt = DeleteStmt { only: false, table_name: "users".to_string(), quoted: false, where_clause: None };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(deleted, 3);
@@ -31,6 +31,7 @@ fn test_delete_with_simple_where() {
     let stmt = DeleteStmt {
         only: false,
         table_name: "users".to_string(),
+        quoted: false,
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
@@ -65,6 +66,7 @@ fn test_delete_with_boolean_where() {
     let stmt = DeleteStmt {
         only: false,
         table_name: "users".to_string(),
+        quoted: false,
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef { table: None, column: "active".to_string() }),
             op: BinaryOperator::Equal,
@@ -97,6 +99,7 @@ fn test_delete_multiple_rows() {
     let stmt = DeleteStmt {
         only: false,
         table_name: "users".to_string(),
+        quoted: false,
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
             op: BinaryOperator::GreaterThan,

--- a/crates/vibesql-executor/src/delete/tests/edge_cases.rs
+++ b/crates/vibesql-executor/src/delete/tests/edge_cases.rs
@@ -13,7 +13,7 @@ fn test_delete_table_not_found() {
     let mut db = Database::new();
 
     let stmt =
-        DeleteStmt { only: false, table_name: "nonexistent".to_string(), where_clause: None };
+        DeleteStmt { only: false, table_name: "nonexistent".to_string(), quoted: false, where_clause: None };
 
     let result = DeleteExecutor::execute(&stmt, &mut db);
     assert!(result.is_err());
@@ -29,6 +29,7 @@ fn test_delete_no_matching_rows() {
     let stmt = DeleteStmt {
         only: false,
         table_name: "users".to_string(),
+        quoted: false,
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
@@ -57,7 +58,7 @@ fn test_delete_from_empty_table() {
 
     // DELETE FROM empty_users;
     let stmt =
-        DeleteStmt { only: false, table_name: "empty_users".to_string(), where_clause: None };
+        DeleteStmt { only: false, table_name: "empty_users".to_string(), quoted: false, where_clause: None };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(deleted, 0);
@@ -72,6 +73,7 @@ fn test_delete_column_not_found() {
     let stmt = DeleteStmt {
         only: false,
         table_name: "users".to_string(),
+        quoted: false,
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef {
                 table: None,

--- a/crates/vibesql-executor/src/delete/tests/subqueries.rs
+++ b/crates/vibesql-executor/src/delete/tests/subqueries.rs
@@ -212,6 +212,7 @@ mod in_subquery {
         let stmt = DeleteStmt {
             only: false,
             table_name: "employees".to_string(),
+            quoted: false,
             where_clause: Some(WhereClause::Condition(Expression::In {
                 expr: Box::new(Expression::ColumnRef {
                     table: None,
@@ -273,6 +274,7 @@ mod in_subquery {
         let stmt = DeleteStmt {
             only: false,
             table_name: "employees".to_string(),
+            quoted: false,
             where_clause: Some(WhereClause::Condition(Expression::In {
                 expr: Box::new(Expression::ColumnRef {
                     table: None,
@@ -345,6 +347,7 @@ mod scalar_subquery {
         let stmt = DeleteStmt {
             only: false,
             table_name: "employees".to_string(),
+            quoted: false,
             where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef { table: None, column: "salary".to_string() }),
                 op: vibesql_ast::BinaryOperator::LessThan,
@@ -416,6 +419,7 @@ mod scalar_subquery {
         let stmt = DeleteStmt {
             only: false,
             table_name: "items".to_string(),
+            quoted: false,
             where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
                 op: vibesql_ast::BinaryOperator::Equal,
@@ -477,6 +481,7 @@ mod scalar_subquery {
         let stmt = DeleteStmt {
             only: false,
             table_name: "employees".to_string(),
+            quoted: false,
             where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef { table: None, column: "salary".to_string() }),
                 op: vibesql_ast::BinaryOperator::GreaterThan,
@@ -538,6 +543,7 @@ mod empty_subquery {
         let stmt = DeleteStmt {
             only: false,
             table_name: "employees".to_string(),
+            quoted: false,
             where_clause: Some(WhereClause::Condition(Expression::In {
                 expr: Box::new(Expression::ColumnRef {
                     table: None,
@@ -615,6 +621,7 @@ mod complex_subquery {
         let stmt = DeleteStmt {
             only: false,
             table_name: "orders".to_string(),
+            quoted: false,
             where_clause: Some(WhereClause::Condition(Expression::In {
                 expr: Box::new(Expression::ColumnRef {
                     table: None,

--- a/crates/vibesql-executor/src/delete/tests/truncate_optimization.rs
+++ b/crates/vibesql-executor/src/delete/tests/truncate_optimization.rs
@@ -43,7 +43,7 @@ fn test_truncate_optimization_basic() {
 
     // DELETE FROM large_table (no WHERE) - should use TRUNCATE fast path
     let stmt =
-        DeleteStmt { only: false, table_name: "large_table".to_string(), where_clause: None };
+        DeleteStmt { only: false, table_name: "large_table".to_string(), quoted: false, where_clause: None };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(deleted, 1000);
@@ -110,7 +110,7 @@ fn test_truncate_blocked_by_fk_reference() {
     // DELETE FROM parent (no WHERE)
     // Should NOT use TRUNCATE because child references exist
     // Should fail with FK constraint violation
-    let stmt = DeleteStmt { only: false, table_name: "parent".to_string(), where_clause: None };
+    let stmt = DeleteStmt { only: false, table_name: "parent".to_string(), quoted: false, where_clause: None };
 
     let result = DeleteExecutor::execute(&stmt, &mut db);
     assert!(result.is_err());
@@ -174,7 +174,7 @@ fn test_truncate_allowed_when_no_fk_references() {
     // DELETE FROM parent (no WHERE)
     // Cannot use TRUNCATE because FK constraint exists (even though no child rows reference it)
     // This is conservative but correct - we don't scan child table to check
-    let stmt = DeleteStmt { only: false, table_name: "parent".to_string(), where_clause: None };
+    let stmt = DeleteStmt { only: false, table_name: "parent".to_string(), quoted: false, where_clause: None };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(deleted, 100);
@@ -229,7 +229,7 @@ fn test_truncate_blocked_by_delete_trigger() {
     // Should NOT use TRUNCATE because DELETE trigger exists
     // Should use row-by-row deletion (which currently doesn't execute triggers, but that's
     // separate)
-    let stmt = DeleteStmt { only: false, table_name: "test_table".to_string(), where_clause: None };
+    let stmt = DeleteStmt { only: false, table_name: "test_table".to_string(), quoted: false, where_clause: None };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(deleted, 10);
@@ -282,7 +282,7 @@ fn test_truncate_allowed_with_insert_trigger() {
 
     // DELETE FROM test_table (no WHERE)
     // Should use TRUNCATE because only INSERT trigger exists (not DELETE)
-    let stmt = DeleteStmt { only: false, table_name: "test_table".to_string(), where_clause: None };
+    let stmt = DeleteStmt { only: false, table_name: "test_table".to_string(), quoted: false, where_clause: None };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(deleted, 100);
@@ -322,7 +322,7 @@ fn test_truncate_performance() {
     }
 
     let stmt =
-        DeleteStmt { only: false, table_name: "large_table".to_string(), where_clause: None };
+        DeleteStmt { only: false, table_name: "large_table".to_string(), quoted: false, where_clause: None };
 
     // Time the deletion
     let start = std::time::Instant::now();

--- a/crates/vibesql-executor/src/select/order.rs
+++ b/crates/vibesql-executor/src/select/order.rs
@@ -10,6 +10,177 @@ use super::grouping::compare_sql_values;
 use super::parallel::ParallelConfig;
 use crate::{errors::ExecutorError, evaluator::CombinedExpressionEvaluator, schema::CombinedSchema};
 
+/// Result of extracting a column position from an ORDER BY expression
+#[derive(Debug, Clone, Copy)]
+enum ColumnPositionResult {
+    /// A valid positive column position (1-indexed)
+    Position(i64),
+    /// A negative column position (always invalid, but we track it for error reporting)
+    Negative(i64),
+    /// Not a column position expression
+    NotAPosition,
+}
+
+/// Extracts a numeric column position from an ORDER BY expression.
+///
+/// Handles:
+/// - `ORDER BY N` - Integer literal → Position(N)
+/// - `ORDER BY +N` - Unary plus with integer → Position(N) (#4418)
+/// - `ORDER BY -N` - Unary minus with integer → Negative(N)
+/// - Other expressions → NotAPosition
+fn extract_column_position(expr: &vibesql_ast::Expression) -> ColumnPositionResult {
+    match expr {
+        // Direct integer literal: ORDER BY 1, ORDER BY 2, etc.
+        vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) => {
+            ColumnPositionResult::Position(*pos)
+        }
+        // Unary operator with integer
+        vibesql_ast::Expression::UnaryOp { op, expr } => {
+            if let vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) =
+                expr.as_ref()
+            {
+                match op {
+                    // ORDER BY +N: treat as ORDER BY N (#4418)
+                    vibesql_ast::UnaryOperator::Plus => ColumnPositionResult::Position(*pos),
+                    // ORDER BY -N: always invalid
+                    vibesql_ast::UnaryOperator::Minus => ColumnPositionResult::Negative(*pos),
+                    _ => ColumnPositionResult::NotAPosition,
+                }
+            } else {
+                ColumnPositionResult::NotAPosition
+            }
+        }
+        _ => ColumnPositionResult::NotAPosition,
+    }
+}
+
+/// Validates a column position and returns an error if out of range.
+fn validate_column_position(
+    pos: i64,
+    column_count: usize,
+    term_index: usize,
+) -> Result<usize, ExecutorError> {
+    if pos <= 0 || (pos as usize) > column_count {
+        return Err(ExecutorError::OrderByOutOfRange {
+            term_position: term_index + 1, // Convert to 1-indexed for error message
+            column_number: pos,
+            select_list_len: column_count,
+        });
+    }
+    Ok((pos as usize) - 1) // Convert to 0-indexed
+}
+
+/// Resolves a column position to a column name for aggregate queries.
+///
+/// For aggregate queries, we simply look up the alias/expression at the given position
+/// in the SELECT list without wildcard expansion (aggregates don't typically use wildcards).
+fn resolve_position_to_column_name(
+    idx: usize,
+    select_list: &[vibesql_ast::SelectItem],
+) -> Option<String> {
+    if let vibesql_ast::SelectItem::Expression { expr, alias, .. } = &select_list[idx] {
+        Some(if let Some(alias_name) = alias {
+            alias_name.clone()
+        } else if let vibesql_ast::Expression::ColumnRef { column, .. } = expr {
+            column.clone()
+        } else {
+            format!("col{}", idx + 1)
+        })
+    } else {
+        None
+    }
+}
+
+/// Result of resolving a column position with wildcard expansion
+enum ResolvedPosition<'a> {
+    /// The expression at the position (for regular SELECT items)
+    Expression(&'a vibesql_ast::Expression),
+    /// A column name resolved from a wildcard expansion
+    ColumnName(String),
+    /// Position not found (shouldn't happen if validation passed)
+    NotFound,
+}
+
+/// Resolves a column position to an expression or column name, handling wildcard expansion.
+///
+/// This handles SELECT lists that may contain wildcards (`*`) or qualified wildcards (`table.*`)
+/// which expand to multiple columns. The position is 0-indexed.
+fn resolve_position_with_wildcards<'a>(
+    target_col: usize,
+    select_list: &'a [vibesql_ast::SelectItem],
+    schema: Option<&CombinedSchema>,
+) -> ResolvedPosition<'a> {
+    let mut current_col = 0;
+
+    for item in select_list {
+        match item {
+            vibesql_ast::SelectItem::Wildcard { .. } => {
+                // Count how many columns this wildcard expands to
+                let wildcard_cols = if let Some(s) = schema {
+                    s.table_schemas.values().map(|(_, ts)| ts.columns.len()).sum()
+                } else {
+                    1
+                };
+
+                if target_col < current_col + wildcard_cols {
+                    // The position is within this wildcard's expanded columns
+                    if let Some(s) = schema {
+                        let offset_in_wildcard = target_col - current_col;
+                        // Collect all columns from all tables in schema order
+                        let mut all_columns: Vec<(usize, String)> = Vec::new();
+                        for (start_idx, table_schema) in s.table_schemas.values() {
+                            for (i, col) in table_schema.columns.iter().enumerate() {
+                                all_columns.push((start_idx + i, col.name.clone()));
+                            }
+                        }
+                        all_columns.sort_by_key(|(idx, _)| *idx);
+
+                        if offset_in_wildcard < all_columns.len() {
+                            return ResolvedPosition::ColumnName(
+                                all_columns[offset_in_wildcard].1.clone(),
+                            );
+                        }
+                    }
+                    return ResolvedPosition::NotFound;
+                }
+                current_col += wildcard_cols;
+            }
+            vibesql_ast::SelectItem::QualifiedWildcard { qualifier, .. } => {
+                // Count how many columns this qualified wildcard expands to
+                let qualified_cols = if let Some(s) = schema {
+                    s.get_table(qualifier).map(|(_, ts)| ts.columns.len()).unwrap_or(1)
+                } else {
+                    1
+                };
+
+                if target_col < current_col + qualified_cols {
+                    // The position is within this qualified wildcard's columns
+                    if let Some(s) = schema {
+                        if let Some((_, table_schema)) = s.get_table(qualifier) {
+                            let offset = target_col - current_col;
+                            if offset < table_schema.columns.len() {
+                                return ResolvedPosition::ColumnName(
+                                    table_schema.columns[offset].name.clone(),
+                                );
+                            }
+                        }
+                    }
+                    return ResolvedPosition::NotFound;
+                }
+                current_col += qualified_cols;
+            }
+            vibesql_ast::SelectItem::Expression { expr, .. } => {
+                if target_col == current_col {
+                    return ResolvedPosition::Expression(expr);
+                }
+                current_col += 1;
+            }
+        }
+    }
+
+    ResolvedPosition::NotFound
+}
+
 /// Row with optional sort keys for ORDER BY
 pub(super) type RowWithSortKeys =
     (vibesql_storage::Row, Option<Vec<(vibesql_types::SqlValue, vibesql_ast::OrderDirection)>>);
@@ -189,78 +360,24 @@ pub(crate) fn resolve_order_by_for_aggregates(
     // Validate numeric column positions at the TOP LEVEL ONLY
     // (nested integer literals like `WHERE x = 0` are not column positions)
 
-    // Check for numeric column position (ORDER BY 1, 2, 3, etc.)
-    if let vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) = order_expr {
-        // Validate the column position
-        if *pos <= 0 || (*pos as usize) > column_count {
-            return Err(ExecutorError::OrderByOutOfRange {
-                term_position: term_index + 1, // Convert to 1-indexed for error message
-                column_number: *pos,
-                select_list_len: column_count,
-            });
-        }
-        let idx = (*pos as usize) - 1;
-        if let vibesql_ast::SelectItem::Expression { expr, alias, .. } = &select_list[idx] {
-            // Return a ColumnRef to the alias name (or derive from expression)
-            let col_name = if let Some(alias_name) = alias {
-                alias_name.clone()
-            } else if let vibesql_ast::Expression::ColumnRef { column, .. } = expr {
-                column.clone()
-            } else {
-                format!("col{}", idx + 1)
-            };
-            return Ok(vibesql_ast::Expression::ColumnRef { table: None, column: col_name });
-        }
-    }
-
-    // Check for positive unary operator with numeric column position (ORDER BY +1 parsed as UnaryOp { Plus, Integer(1) })
-    // Treat +N the same as N (#4418)
-    if let vibesql_ast::Expression::UnaryOp {
-        op: vibesql_ast::UnaryOperator::Plus,
-        expr,
-    } = order_expr
-    {
-        if let vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) =
-            expr.as_ref()
-        {
-            // Validate the column position
-            if *pos <= 0 || (*pos as usize) > column_count {
-                return Err(ExecutorError::OrderByOutOfRange {
-                    term_position: term_index + 1, // Convert to 1-indexed for error message
-                    column_number: *pos,
-                    select_list_len: column_count,
-                });
-            }
-            let idx = (*pos as usize) - 1;
-            if let vibesql_ast::SelectItem::Expression { expr, alias, .. } = &select_list[idx] {
-                // Return a ColumnRef to the alias name (or derive from expression)
-                let col_name = if let Some(alias_name) = alias {
-                    alias_name.clone()
-                } else if let vibesql_ast::Expression::ColumnRef { column, .. } = expr {
-                    column.clone()
-                } else {
-                    format!("col{}", idx + 1)
-                };
+    // Check for numeric column position (ORDER BY N, ORDER BY +N, ORDER BY -N)
+    match extract_column_position(order_expr) {
+        ColumnPositionResult::Position(pos) => {
+            let idx = validate_column_position(pos, column_count, term_index)?;
+            if let Some(col_name) = resolve_position_to_column_name(idx, select_list) {
                 return Ok(vibesql_ast::Expression::ColumnRef { table: None, column: col_name });
             }
         }
-    }
-
-    // Check for negative numeric column position (ORDER BY -1 parsed as UnaryOp { Minus, Integer(1) })
-    if let vibesql_ast::Expression::UnaryOp {
-        op: vibesql_ast::UnaryOperator::Minus,
-        expr,
-    } = order_expr
-    {
-        if let vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) =
-            expr.as_ref()
-        {
+        ColumnPositionResult::Negative(pos) => {
             // Negative column positions are always invalid
             return Err(ExecutorError::OrderByOutOfRange {
                 term_position: term_index + 1,
-                column_number: -*pos,
+                column_number: -pos,
                 select_list_len: column_count,
             });
+        }
+        ColumnPositionResult::NotAPosition => {
+            // Not a column position, continue to other resolution logic
         }
     }
 
@@ -489,214 +606,37 @@ pub(crate) fn resolve_order_by_alias<'a>(
     // Count actual columns after wildcard expansion (#4413)
     let column_count = count_select_columns(select_list, schema);
 
-    // Check for numeric column position (ORDER BY 1, 2, 3, etc.)
-    if let vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) = order_expr {
-        // Validate the column position against expanded column count
-        if *pos <= 0 || (*pos as usize) > column_count {
-            return Err(ExecutorError::OrderByOutOfRange {
-                term_position: term_index + 1, // Convert to 1-indexed for error message
-                column_number: *pos,
-                select_list_len: column_count,
-            });
-        }
+    // Check for numeric column position (ORDER BY N, ORDER BY +N, ORDER BY -N)
+    match extract_column_position(order_expr) {
+        ColumnPositionResult::Position(pos) => {
+            let idx = validate_column_position(pos, column_count, term_index)?;
 
-        // Map the 1-based position to the corresponding select_list item
-        // accounting for wildcard expansion
-        let target_col = (*pos as usize) - 1; // 0-indexed target column position
-        let mut current_col = 0;
-
-        for item in select_list {
-            match item {
-                vibesql_ast::SelectItem::Wildcard { .. } => {
-                    // Count how many columns this wildcard expands to
-                    let wildcard_cols = if let Some(s) = schema {
-                        s.table_schemas.values().map(|(_, ts)| ts.columns.len()).sum()
-                    } else {
-                        1
-                    };
-
-                    if target_col < current_col + wildcard_cols {
-                        // The position is within this wildcard's expanded columns
-                        // Return a ColumnRef to the N-th column from the schema
-                        if let Some(s) = schema {
-                            let offset_in_wildcard = target_col - current_col;
-                            // Collect all columns from all tables in schema order
-                            let mut all_columns: Vec<(usize, String)> = Vec::new();
-                            for (start_idx, table_schema) in s.table_schemas.values() {
-                                for (i, col) in table_schema.columns.iter().enumerate() {
-                                    all_columns.push((start_idx + i, col.name.clone()));
-                                }
-                            }
-                            all_columns.sort_by_key(|(idx, _)| *idx);
-
-                            if offset_in_wildcard < all_columns.len() {
-                                let col_name = all_columns[offset_in_wildcard].1.clone();
-                                return Ok(Cow::Owned(vibesql_ast::Expression::ColumnRef {
-                                    table: None,
-                                    column: col_name,
-                                }));
-                            }
-                        }
-                        // Fallback: shouldn't reach here if schema is available
-                        break;
-                    }
-                    current_col += wildcard_cols;
+            // Resolve the position, handling wildcard expansion
+            match resolve_position_with_wildcards(idx, select_list, schema) {
+                ResolvedPosition::Expression(expr) => {
+                    return Ok(Cow::Borrowed(expr));
                 }
-                vibesql_ast::SelectItem::QualifiedWildcard { qualifier, .. } => {
-                    // Count how many columns this qualified wildcard expands to
-                    let qualified_cols = if let Some(s) = schema {
-                        s.get_table(qualifier).map(|(_, ts)| ts.columns.len()).unwrap_or(1)
-                    } else {
-                        1
-                    };
-
-                    if target_col < current_col + qualified_cols {
-                        // The position is within this qualified wildcard's columns
-                        if let Some(s) = schema {
-                            if let Some((_, table_schema)) = s.get_table(qualifier) {
-                                let offset = target_col - current_col;
-                                if offset < table_schema.columns.len() {
-                                    let col_name = table_schema.columns[offset].name.clone();
-                                    return Ok(Cow::Owned(vibesql_ast::Expression::ColumnRef {
-                                        table: None,
-                                        column: col_name,
-                                    }));
-                                }
-                            }
-                        }
-                        break;
-                    }
-                    current_col += qualified_cols;
+                ResolvedPosition::ColumnName(col_name) => {
+                    return Ok(Cow::Owned(vibesql_ast::Expression::ColumnRef {
+                        table: None,
+                        column: col_name,
+                    }));
                 }
-                vibesql_ast::SelectItem::Expression { expr, .. } => {
-                    if target_col == current_col {
-                        // This is a regular expression, return it directly
-                        return Ok(Cow::Borrowed(expr));
-                    }
-                    current_col += 1;
+                ResolvedPosition::NotFound => {
+                    // Fallback: shouldn't reach here if validation passed
                 }
             }
         }
-
-        // Fallback: return original expression (shouldn't reach here normally)
-    }
-
-    // Check for positive unary operator with numeric column position (ORDER BY +1 parsed as UnaryOp { Plus, Integer(1) })
-    // Treat +N the same as N (#4418)
-    if let vibesql_ast::Expression::UnaryOp {
-        op: vibesql_ast::UnaryOperator::Plus,
-        expr,
-    } = order_expr
-    {
-        if let vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) =
-            expr.as_ref()
-        {
-            // Validate the column position against expanded column count
-            if *pos <= 0 || (*pos as usize) > column_count {
-                return Err(ExecutorError::OrderByOutOfRange {
-                    term_position: term_index + 1, // Convert to 1-indexed for error message
-                    column_number: *pos,
-                    select_list_len: column_count,
-                });
-            }
-
-            // Map the 1-based position to the corresponding select_list item
-            // accounting for wildcard expansion
-            let target_col = (*pos as usize) - 1; // 0-indexed target column position
-            let mut current_col = 0;
-
-            for item in select_list {
-                match item {
-                    vibesql_ast::SelectItem::Wildcard { .. } => {
-                        // Count how many columns this wildcard expands to
-                        let wildcard_cols = if let Some(s) = schema {
-                            s.table_schemas.values().map(|(_, ts)| ts.columns.len()).sum()
-                        } else {
-                            1
-                        };
-
-                        if target_col < current_col + wildcard_cols {
-                            // The position is within this wildcard's expanded columns
-                            // Return a ColumnRef to the N-th column from the schema
-                            if let Some(s) = schema {
-                                let offset_in_wildcard = target_col - current_col;
-                                // Collect all columns from all tables in schema order
-                                let mut all_columns: Vec<(usize, String)> = Vec::new();
-                                for (start_idx, table_schema) in s.table_schemas.values() {
-                                    for (i, col) in table_schema.columns.iter().enumerate() {
-                                        all_columns.push((start_idx + i, col.name.clone()));
-                                    }
-                                }
-                                all_columns.sort_by_key(|(idx, _)| *idx);
-
-                                if offset_in_wildcard < all_columns.len() {
-                                    let col_name = all_columns[offset_in_wildcard].1.clone();
-                                    return Ok(Cow::Owned(vibesql_ast::Expression::ColumnRef {
-                                        table: None,
-                                        column: col_name,
-                                    }));
-                                }
-                            }
-                            // Fallback: shouldn't reach here if schema is available
-                            break;
-                        }
-                        current_col += wildcard_cols;
-                    }
-                    vibesql_ast::SelectItem::QualifiedWildcard { qualifier, .. } => {
-                        // Count how many columns this qualified wildcard expands to
-                        let qualified_cols = if let Some(s) = schema {
-                            s.get_table(qualifier).map(|(_, ts)| ts.columns.len()).unwrap_or(1)
-                        } else {
-                            1
-                        };
-
-                        if target_col < current_col + qualified_cols {
-                            // The position is within this qualified wildcard's columns
-                            if let Some(s) = schema {
-                                if let Some((_, table_schema)) = s.get_table(qualifier) {
-                                    let offset = target_col - current_col;
-                                    if offset < table_schema.columns.len() {
-                                        let col_name = table_schema.columns[offset].name.clone();
-                                        return Ok(Cow::Owned(vibesql_ast::Expression::ColumnRef {
-                                            table: None,
-                                            column: col_name,
-                                        }));
-                                    }
-                                }
-                            }
-                            break;
-                        }
-                        current_col += qualified_cols;
-                    }
-                    vibesql_ast::SelectItem::Expression { expr, .. } => {
-                        if target_col == current_col {
-                            // This is a regular expression, return it directly
-                            return Ok(Cow::Borrowed(expr));
-                        }
-                        current_col += 1;
-                    }
-                }
-            }
-
-            // Fallback: return original expression (shouldn't reach here normally)
-        }
-    }
-
-    // Check for negative numeric column position (ORDER BY -1 parsed as UnaryOp { Minus, Integer(1) })
-    if let vibesql_ast::Expression::UnaryOp {
-        op: vibesql_ast::UnaryOperator::Minus,
-        expr,
-    } = order_expr
-    {
-        if let vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) =
-            expr.as_ref()
-        {
+        ColumnPositionResult::Negative(pos) => {
             // Negative column positions are always invalid
             return Err(ExecutorError::OrderByOutOfRange {
                 term_position: term_index + 1,
-                column_number: -*pos,
+                column_number: -pos,
                 select_list_len: column_count,
             });
+        }
+        ColumnPositionResult::NotAPosition => {
+            // Not a column position, continue to other resolution logic
         }
     }
 

--- a/crates/vibesql-executor/src/tests/auto_increment_tests.rs
+++ b/crates/vibesql-executor/src/tests/auto_increment_tests.rs
@@ -48,6 +48,7 @@ fn test_auto_increment_basic_inserts() {
     // Insert without specifying id - should auto-generate 1
     let insert1 = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec!["username".to_string()],
         source: InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
             SqlValue::Varchar(arcstr::ArcStr::from("alice")),
@@ -61,6 +62,7 @@ fn test_auto_increment_basic_inserts() {
     // Insert without specifying id - should auto-generate 2
     let insert2 = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec!["username".to_string()],
         source: InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
             SqlValue::Varchar(arcstr::ArcStr::from("bob")),
@@ -168,6 +170,7 @@ fn test_last_insert_rowid_basic() {
     // Insert first row - should auto-generate id=1
     let insert1 = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec!["username".to_string()],
         source: InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
             SqlValue::Varchar(arcstr::ArcStr::from("alice")),
@@ -184,6 +187,7 @@ fn test_last_insert_rowid_basic() {
     // Insert second row - should auto-generate id=2
     let insert2 = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec!["username".to_string()],
         source: InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
             SqlValue::Varchar(arcstr::ArcStr::from("bob")),
@@ -238,6 +242,7 @@ fn test_last_insert_rowid_multi_row_insert() {
     // Multi-row insert - per MySQL semantics, LAST_INSERT_ID returns the FIRST generated ID
     let multi_insert = InsertStmt {
         table_name: "items".to_string(),
+        quoted: false,
         columns: vec!["name".to_string()],
         source: InsertSource::Values(vec![
             vec![vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
@@ -308,6 +313,7 @@ fn test_last_insert_rowid_no_auto_increment() {
     // Insert with explicit ID - no auto-generation
     let insert1 = InsertStmt {
         table_name: "manual".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "name".to_string()],
         source: InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(100)),
@@ -365,6 +371,7 @@ fn test_last_insert_rowid_via_select() {
     // Insert a row
     let insert1 = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec!["name".to_string()],
         source: InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
             SqlValue::Varchar(arcstr::ArcStr::from("alice")),

--- a/crates/vibesql-executor/src/tests/not_operator_tests.rs
+++ b/crates/vibesql-executor/src/tests/not_operator_tests.rs
@@ -234,6 +234,7 @@ fn test_not_in_delete_where() {
     let stmt = vibesql_ast::DeleteStmt {
         only: false,
         table_name: "tab0".to_string(),
+        quoted: false,
         where_clause: Some(vibesql_ast::WhereClause::Condition(vibesql_ast::Expression::UnaryOp {
             op: vibesql_ast::UnaryOperator::Not,
             expr: Box::new(vibesql_ast::Expression::BinaryOp {

--- a/crates/vibesql-executor/src/tests/transaction_tests.rs
+++ b/crates/vibesql-executor/src/tests/transaction_tests.rs
@@ -120,6 +120,7 @@ fn test_transaction_insert_commit() {
     // Insert a row
     let insert_stmt = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
@@ -155,6 +156,7 @@ fn test_transaction_insert_rollback() {
     // Insert a row
     let insert_stmt = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
@@ -186,6 +188,7 @@ fn test_transaction_multiple_operations_commit() {
     // Insert initial data outside transaction
     let insert_stmt1 = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
@@ -203,6 +206,7 @@ fn test_transaction_multiple_operations_commit() {
     // Insert another row
     let insert_stmt2 = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(2)),
@@ -233,6 +237,7 @@ fn test_transaction_multiple_operations_rollback() {
     // Insert initial data outside transaction
     let insert_stmt1 = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
@@ -250,6 +255,7 @@ fn test_transaction_multiple_operations_rollback() {
     // Insert another row
     let insert_stmt2 = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(2)),
@@ -288,6 +294,7 @@ fn test_transaction_isolation() {
         .unwrap();
     let insert_stmt = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
@@ -326,6 +333,7 @@ fn test_transaction_nested_operations() {
     for i in 1..=5 {
         let insert_stmt = InsertStmt {
             table_name: "users".to_string(),
+            quoted: false,
             columns: vec![],
             source: vibesql_ast::InsertSource::Values(vec![vec![
                 vibesql_ast::Expression::Literal(SqlValue::Integer(i)),
@@ -360,6 +368,7 @@ fn test_transaction_empty_rollback() {
     // Insert data outside transaction
     let insert_stmt = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
@@ -392,6 +401,7 @@ fn test_multiple_transactions() {
         .unwrap();
     let insert_stmt1 = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
@@ -408,6 +418,7 @@ fn test_multiple_transactions() {
         .unwrap();
     let insert_stmt2 = InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(2)),

--- a/crates/vibesql-executor/src/tests/triggers/conditions.rs
+++ b/crates/vibesql-executor/src/tests/triggers/conditions.rs
@@ -69,6 +69,7 @@ fn test_when_clause_filters_firing() {
     // Insert row with amount=50 (should NOT fire)
     let insert1 = vibesql_ast::InsertStmt {
         table_name: "TRANSACTIONS".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "amount".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -85,6 +86,7 @@ fn test_when_clause_filters_firing() {
     // Insert row with amount=150 (should fire)
     let insert2 = vibesql_ast::InsertStmt {
         table_name: "TRANSACTIONS".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "amount".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),

--- a/crates/vibesql-executor/src/tests/triggers/coordination.rs
+++ b/crates/vibesql-executor/src/tests/triggers/coordination.rs
@@ -47,6 +47,7 @@ fn test_multiple_triggers_fire_in_order() {
     // Insert a row - should fire both triggers
     let insert = vibesql_ast::InsertStmt {
         table_name: "USERS".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -88,6 +89,7 @@ fn test_trigger_with_multiple_statements() {
     // Insert a row - should fire trigger with both statements
     let insert = vibesql_ast::InsertStmt {
         table_name: "USERS".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -130,6 +132,7 @@ fn test_before_trigger_executes_first() {
     // Initialize counter to 0
     let init_insert = vibesql_ast::InsertStmt {
         table_name: "COUNTER".to_string(),
+        quoted: false,
         columns: vec!["value".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
             vibesql_types::SqlValue::Integer(0),
@@ -155,6 +158,7 @@ fn test_before_trigger_executes_first() {
     // Insert a row
     let insert = vibesql_ast::InsertStmt {
         table_name: "USERS".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),

--- a/crates/vibesql-executor/src/tests/triggers/delete.rs
+++ b/crates/vibesql-executor/src/tests/triggers/delete.rs
@@ -17,6 +17,7 @@ fn test_after_delete_trigger_fires() {
     // Insert a user first
     let insert = vibesql_ast::InsertStmt {
         table_name: "USERS".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -48,6 +49,7 @@ fn test_after_delete_trigger_fires() {
     let delete = vibesql_ast::DeleteStmt {
         only: false,
         table_name: "USERS".to_string(),
+        quoted: false,
         where_clause: Some(vibesql_ast::WhereClause::Condition(
             vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Equal,
@@ -76,6 +78,7 @@ fn test_before_delete_trigger_fires() {
     // Insert a user first
     let insert = vibesql_ast::InsertStmt {
         table_name: "USERS".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -107,6 +110,7 @@ fn test_before_delete_trigger_fires() {
     let delete = vibesql_ast::DeleteStmt {
         only: false,
         table_name: "USERS".to_string(),
+        quoted: false,
         where_clause: Some(vibesql_ast::WhereClause::Condition(
             vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Equal,

--- a/crates/vibesql-executor/src/tests/triggers/error_handling.rs
+++ b/crates/vibesql-executor/src/tests/triggers/error_handling.rs
@@ -31,6 +31,7 @@ fn test_trigger_failure_causes_rollback() {
     // Try to insert - should fail due to trigger error
     let insert = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -97,6 +98,7 @@ fn test_recursion_prevention() {
     // Try to insert - should fail with recursion depth error
     let insert = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),

--- a/crates/vibesql-executor/src/tests/triggers/insert.rs
+++ b/crates/vibesql-executor/src/tests/triggers/insert.rs
@@ -32,6 +32,7 @@ fn test_after_insert_trigger_fires() {
     // Insert a row - should fire trigger
     let insert = vibesql_ast::InsertStmt {
         table_name: "USERS".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -72,6 +73,7 @@ fn test_after_insert_trigger_fires_for_each_row() {
     // Insert 3 rows - should fire trigger 3 times
     let insert = vibesql_ast::InsertStmt {
         table_name: "USERS".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![
             vec![
@@ -126,6 +128,7 @@ fn test_before_insert_trigger_fires() {
     // Insert a row - should fire trigger
     let insert = vibesql_ast::InsertStmt {
         table_name: "USERS".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -17,6 +17,7 @@ fn test_after_update_trigger_fires() {
     // Insert a user first
     let insert = vibesql_ast::InsertStmt {
         table_name: "USERS".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -47,6 +48,7 @@ fn test_after_update_trigger_fires() {
     // Update the user - should fire trigger
     let update = vibesql_ast::UpdateStmt {
         table_name: "USERS".to_string(),
+        quoted: false,
         assignments: vec![vibesql_ast::Assignment {
             column: "username".to_string(),
             value: vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -81,6 +83,7 @@ fn test_before_update_trigger_fires() {
     // Insert a user first
     let insert = vibesql_ast::InsertStmt {
         table_name: "USERS".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -111,6 +114,7 @@ fn test_before_update_trigger_fires() {
     // Update the user - should fire trigger
     let update = vibesql_ast::UpdateStmt {
         table_name: "USERS".to_string(),
+        quoted: false,
         assignments: vec![vibesql_ast::Assignment {
             column: "username".to_string(),
             value: vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(

--- a/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
@@ -112,6 +112,7 @@ fn create_table_with_fk(
 fn insert_row(db: &mut Database, table_name: &str, values: Vec<SqlValue>) {
     let stmt = InsertStmt {
         table_name: table_name.to_string(),
+        quoted: false,
         columns: vec![],
         source: InsertSource::Values(vec![values.into_iter().map(Expression::Literal).collect()]),
         conflict_clause: None,

--- a/crates/vibesql-executor/src/tests/truncate_table_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_table_tests.rs
@@ -354,6 +354,7 @@ fn test_truncate_resets_auto_increment() {
     for val in ["a", "b", "c"] {
         let insert = InsertStmt {
             table_name: "auto_inc_test".to_string(),
+            quoted: false,
             columns: vec!["data".to_string()],
             source: InsertSource::Values(vec![vec![Expression::Literal(SqlValue::Varchar(
                 arcstr::ArcStr::from(val),
@@ -382,6 +383,7 @@ fn test_truncate_resets_auto_increment() {
     // Insert new row - should get id = 1, not 4
     let insert = InsertStmt {
         table_name: "auto_inc_test".to_string(),
+        quoted: false,
         columns: vec!["data".to_string()],
         source: InsertSource::Values(vec![vec![Expression::Literal(SqlValue::Varchar(
             arcstr::ArcStr::from("d"),
@@ -446,6 +448,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
     for i in 1..=10 {
         let insert = InsertStmt {
             table_name: "multi_test".to_string(),
+            quoted: false,
             columns: vec!["value".to_string()],
             source: InsertSource::Values(vec![vec![Expression::Literal(SqlValue::Integer(
                 i * 100,
@@ -472,6 +475,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
     // Insert new row - should get id = 1, not 11
     let insert = InsertStmt {
         table_name: "multi_test".to_string(),
+        quoted: false,
         columns: vec!["value".to_string()],
         source: InsertSource::Values(vec![vec![Expression::Literal(SqlValue::Integer(9999))]]),
         conflict_clause: None,

--- a/crates/vibesql-executor/tests/alter_table_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/alter_table_columnar_cache_tests.rs
@@ -33,6 +33,7 @@ fn setup_test_table(db: &mut Database) {
 fn insert_row(db: &mut Database, id: i64, name: &str, value: i64) {
     let stmt = vibesql_ast::InsertStmt {
         table_name: "test_table".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(id)),
@@ -340,6 +341,7 @@ fn test_alter_column_drop_not_null_invalidates_cache() {
     // Insert data
     let stmt = vibesql_ast::InsertStmt {
         table_name: "test_table".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
@@ -428,6 +430,7 @@ fn test_alter_column_drop_default_invalidates_cache() {
     // Insert data
     let stmt = vibesql_ast::InsertStmt {
         table_name: "test_table".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),

--- a/crates/vibesql-executor/tests/common/insert_constraint_fixtures.rs
+++ b/crates/vibesql-executor/tests/common/insert_constraint_fixtures.rs
@@ -304,6 +304,7 @@ pub fn build_insert_values(
 ) -> vibesql_ast::InsertStmt {
     vibesql_ast::InsertStmt {
         table_name: table_name.to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![values
             .into_iter()
@@ -323,6 +324,7 @@ pub fn build_insert_columns(
 ) -> vibesql_ast::InsertStmt {
     vibesql_ast::InsertStmt {
         table_name: table_name.to_string(),
+        quoted: false,
         columns: columns.iter().map(|s| s.to_string()).collect(),
         source: vibesql_ast::InsertSource::Values(vec![values
             .into_iter()

--- a/crates/vibesql-executor/tests/duplicate_key_update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/duplicate_key_update_columnar_cache_tests.rs
@@ -29,6 +29,7 @@ fn setup_products_table(db: &mut Database) {
 fn insert_product(db: &mut Database, id: i64, name: &str, stock: i64) {
     let stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(id)),
@@ -45,6 +46,7 @@ fn insert_product(db: &mut Database, id: i64, name: &str, stock: i64) {
 fn upsert_product(db: &mut Database, id: i64, name: &str, stock: i64) {
     let stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(id)),
@@ -204,6 +206,7 @@ fn test_on_duplicate_key_update_unique_constraint_invalidates_cache() {
     let insert = |db: &mut Database, id: i64, name: &str, score: i64| {
         let stmt = vibesql_ast::InsertStmt {
             table_name: "users".to_string(),
+        quoted: false,
             columns: vec![],
             source: vibesql_ast::InsertSource::Values(vec![vec![
                 vibesql_ast::Expression::Literal(SqlValue::Integer(id)),
@@ -225,6 +228,7 @@ fn test_on_duplicate_key_update_unique_constraint_invalidates_cache() {
     // ON DUPLICATE KEY UPDATE with same name (unique key conflict) - should update existing row
     let upsert_stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(3)), // Different id
@@ -306,6 +310,7 @@ fn test_on_duplicate_key_update_arithmetic_invalidates_cache() {
     // ON DUPLICATE KEY UPDATE with arithmetic: stock = stock + VALUES(stock)
     let upsert_stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),

--- a/crates/vibesql-executor/tests/index_ordering_tests.rs
+++ b/crates/vibesql-executor/tests/index_ordering_tests.rs
@@ -39,6 +39,7 @@ fn test_index_ordering() {
     // Insert data
     let insert_stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
             vec![

--- a/crates/vibesql-executor/tests/insert_basic_tests.rs
+++ b/crates/vibesql-executor/tests/insert_basic_tests.rs
@@ -11,6 +11,7 @@ fn test_basic_insert() {
     // INSERT INTO users VALUES (1, 'Alice')
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![], // No columns specified
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -38,6 +39,7 @@ fn test_multi_row_insert() {
     // INSERT INTO users VALUES (1, 'Alice'), (2, 'Bob')
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
             vec![
@@ -72,6 +74,7 @@ fn test_insert_with_column_list() {
     // INSERT INTO users (name, id) VALUES ('Alice', 1)
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec!["name".to_string(), "id".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -116,6 +119,7 @@ fn test_insert_null_value() {
     // INSERT INTO users VALUES (1, NULL)
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -137,6 +141,7 @@ fn test_insert_type_mismatch() {
     // INSERT INTO users VALUES ('not_a_number', 'Alice')
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -163,6 +168,7 @@ fn test_insert_column_count_mismatch() {
     // INSERT INTO users VALUES (1)  -- Missing name column
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
             vibesql_types::SqlValue::Integer(1),
@@ -182,6 +188,7 @@ fn test_insert_table_not_found() {
     // INSERT INTO nonexistent VALUES (1, 'Alice')
     let stmt = vibesql_ast::InsertStmt {
         table_name: "nonexistent".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -206,6 +213,7 @@ fn test_insert_column_not_found() {
     // INSERT INTO users (id, invalid_col) VALUES (1, 'Alice')
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "invalid_col".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -231,6 +239,7 @@ fn test_insert_not_null_constraint_violation() {
     // id column is NOT NULL, so this should fail
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),

--- a/crates/vibesql-executor/tests/insert_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/insert_columnar_cache_tests.rs
@@ -29,6 +29,7 @@ fn setup_products_table(db: &mut Database) {
 fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
     let stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(id)),
@@ -155,6 +156,7 @@ fn test_multi_row_insert_invalidates_cache() {
     // Multi-row INSERT
     let stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
             vec![
@@ -233,6 +235,7 @@ fn test_insert_select_invalidates_cache() {
     let insert_source = |db: &mut Database, id: i64, name: &str, price: i64| {
         let stmt = vibesql_ast::InsertStmt {
             table_name: "source_products".to_string(),
+        quoted: false,
             columns: vec![],
             source: vibesql_ast::InsertSource::Values(vec![vec![
                 vibesql_ast::Expression::Literal(SqlValue::Integer(id)),
@@ -277,6 +280,7 @@ fn test_insert_select_invalidates_cache() {
 
     let insert_stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
         conflict_clause: None,

--- a/crates/vibesql-executor/tests/insert_default_tests.rs
+++ b/crates/vibesql-executor/tests/insert_default_tests.rs
@@ -27,6 +27,7 @@ fn test_character_varying_column_with_length() {
     // INSERT INTO test_cv VALUES (1, 'Test description')
     let stmt = vibesql_ast::InsertStmt {
         table_name: "test_cv".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -71,6 +72,7 @@ fn test_character_varying_column_without_length() {
     // INSERT INTO test_cv_nolen VALUES (1, 'Unlimited length text')
     let stmt = vibesql_ast::InsertStmt {
         table_name: "test_cv_nolen".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -119,6 +121,7 @@ fn test_insert_with_default_value() {
     // INSERT INTO users (id, name) VALUES (DEFAULT, 'Alice')
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "name".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Default,
@@ -165,6 +168,7 @@ fn test_insert_default_no_default_value_defined() {
     // INSERT INTO users (id, name) VALUES (DEFAULT, 'Alice')
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "name".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Default,

--- a/crates/vibesql-executor/tests/insert_duplicate_key_update_tests.rs
+++ b/crates/vibesql-executor/tests/insert_duplicate_key_update_tests.rs
@@ -35,6 +35,7 @@ fn test_on_duplicate_key_update_basic() {
     // Initial INSERT: INSERT INTO products VALUES (1, 'Widget', 10)
     let initial_stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -54,6 +55,7 @@ fn test_on_duplicate_key_update_basic() {
     // VALUES(stock)
     let upsert_stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -91,6 +93,7 @@ fn test_on_duplicate_key_update_with_arithmetic() {
     // Initial INSERT
     let initial_stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -108,6 +111,7 @@ fn test_on_duplicate_key_update_with_arithmetic() {
     // Upsert with arithmetic: stock = stock + VALUES(stock)
     let upsert_stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -151,6 +155,7 @@ fn test_on_duplicate_key_update_no_conflict() {
     // INSERT with ON DUPLICATE KEY UPDATE - no conflict, should insert normally
     let upsert_stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),

--- a/crates/vibesql-executor/tests/insert_multi_row_tests.rs
+++ b/crates/vibesql-executor/tests/insert_multi_row_tests.rs
@@ -12,6 +12,7 @@ fn test_multi_row_insert_atomic_success() {
     // All should succeed
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
             vec![
@@ -53,6 +54,7 @@ fn test_multi_row_insert_atomic_failure() {
     // Second row violates NOT NULL constraint on id, should fail atomically
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
             vec![
@@ -95,6 +97,7 @@ fn test_multi_row_insert_with_column_list() {
     // INSERT INTO users (name, id) VALUES ('Alice', 1), ('Bob', 2)
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec!["name".to_string(), "id".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![
             vec![
@@ -130,6 +133,7 @@ fn test_multi_row_insert_type_mismatch() {
     // Second row has type mismatch, should fail atomically
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
             vec![
@@ -197,6 +201,7 @@ fn test_multi_row_insert_various_data_types() {
     //   (3, NULL, NULL, NULL)
     let stmt = vibesql_ast::InsertStmt {
         table_name: "test_types".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
             vec![
@@ -260,6 +265,7 @@ fn test_multi_row_insert_primary_key_violation() {
     // Second row violates PRIMARY KEY, should fail atomically
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
             vec![
@@ -296,6 +302,7 @@ fn test_single_row_insert_no_transaction() {
     // Single row INSERT should work without implicit transaction
     let stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),

--- a/crates/vibesql-executor/tests/insert_select_tests.rs
+++ b/crates/vibesql-executor/tests/insert_select_tests.rs
@@ -11,6 +11,7 @@ fn test_insert_from_select_basic() {
     // First insert some data to select from
     let insert_stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -66,6 +67,7 @@ fn test_insert_from_select_basic() {
 
     let insert_select_stmt = vibesql_ast::InsertStmt {
         table_name: "users_backup".to_string(),
+        quoted: false,
         columns: vec![], // No explicit columns, use all
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
         conflict_clause: None,
@@ -87,6 +89,7 @@ fn test_insert_from_select_with_where() {
     // Insert multiple users
     let insert_stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
             vec![
@@ -157,6 +160,7 @@ fn test_insert_from_select_with_where() {
 
     let insert_select_stmt = vibesql_ast::InsertStmt {
         table_name: "active_users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
         conflict_clause: None,
@@ -178,6 +182,7 @@ fn test_insert_from_select_column_mismatch() {
     // Insert some data
     let insert_stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -238,6 +243,7 @@ fn test_insert_from_select_column_mismatch() {
 
     let insert_select_stmt = vibesql_ast::InsertStmt {
         table_name: "wrong_table".to_string(),
+        quoted: false,
         columns: vec![], // Should match all columns
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
         conflict_clause: None,
@@ -274,6 +280,7 @@ fn test_insert_from_select_with_aggregates() {
     // Insert sales data
     let insert_stmt = vibesql_ast::InsertStmt {
         table_name: "sales".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
             vec![
@@ -351,6 +358,7 @@ fn test_insert_from_select_with_aggregates() {
 
     let insert_select_stmt = vibesql_ast::InsertStmt {
         table_name: "summary".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
         conflict_clause: None,

--- a/crates/vibesql-executor/tests/replace_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/replace_columnar_cache_tests.rs
@@ -29,6 +29,7 @@ fn setup_products_table(db: &mut Database) {
 fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
     let stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(id)),
@@ -45,6 +46,7 @@ fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
 fn replace_product(db: &mut Database, id: i64, name: &str, price: i64) {
     let stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(id)),
@@ -193,6 +195,7 @@ fn test_replace_unique_constraint_invalidates_cache() {
     let insert = |db: &mut Database, id: i64, name: &str, score: i64| {
         let stmt = vibesql_ast::InsertStmt {
             table_name: "users".to_string(),
+        quoted: false,
             columns: vec![],
             source: vibesql_ast::InsertSource::Values(vec![vec![
                 vibesql_ast::Expression::Literal(SqlValue::Integer(id)),
@@ -214,6 +217,7 @@ fn test_replace_unique_constraint_invalidates_cache() {
     // REPLACE with same name (unique key conflict) - should delete old row and insert new
     let replace_stmt = vibesql_ast::InsertStmt {
         table_name: "users".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(3)), // Different id

--- a/crates/vibesql-executor/tests/transaction_tests.rs
+++ b/crates/vibesql-executor/tests/transaction_tests.rs
@@ -28,6 +28,7 @@ fn test_basic_savepoint() {
     // Insert initial row
     let insert_stmt = vibesql_ast::InsertStmt {
         table_name: "accounts".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "balance".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
@@ -45,6 +46,7 @@ fn test_basic_savepoint() {
     // Insert another row
     let insert_stmt2 = vibesql_ast::InsertStmt {
         table_name: "accounts".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "balance".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(2)),
@@ -93,6 +95,7 @@ fn test_nested_savepoints() {
     // Insert initial row
     let insert_stmt = vibesql_ast::InsertStmt {
         table_name: "accounts".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "balance".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
@@ -110,6 +113,7 @@ fn test_nested_savepoints() {
     // Insert second row
     let insert_stmt2 = vibesql_ast::InsertStmt {
         table_name: "accounts".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "balance".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(2)),
@@ -127,6 +131,7 @@ fn test_nested_savepoints() {
     // Insert third row
     let insert_stmt3 = vibesql_ast::InsertStmt {
         table_name: "accounts".to_string(),
+        quoted: false,
         columns: vec!["id".to_string(), "balance".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(3)),

--- a/crates/vibesql-executor/tests/truncate_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/truncate_columnar_cache_tests.rs
@@ -30,6 +30,7 @@ fn setup_products_table(db: &mut Database) {
 fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
     let stmt = vibesql_ast::InsertStmt {
         table_name: "products".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(id)),
@@ -250,6 +251,7 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
     // Insert data into parent using InsertExecutor
     let parent_stmt = vibesql_ast::InsertStmt {
         table_name: "categories".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
@@ -265,6 +267,7 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
     // Insert data into child using InsertExecutor
     let child_stmt1 = vibesql_ast::InsertStmt {
         table_name: "items".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(1)),
@@ -278,6 +281,7 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
 
     let child_stmt2 = vibesql_ast::InsertStmt {
         table_name: "items".to_string(),
+        quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(2)),

--- a/crates/vibesql-executor/tests/update_basic_tests.rs
+++ b/crates/vibesql-executor/tests/update_basic_tests.rs
@@ -13,6 +13,7 @@ fn test_update_all_rows() {
 
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(50000)),
@@ -37,6 +38,7 @@ fn test_update_with_where_clause() {
 
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(60000)),
@@ -72,6 +74,7 @@ fn test_update_multiple_columns() {
 
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![
             Assignment {
                 column: "salary".to_string(),
@@ -107,6 +110,7 @@ fn test_update_with_expression() {
     // Give everyone a 10% raise: salary = salary * 110 DIV 100
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::BinaryOp {
@@ -143,6 +147,7 @@ fn test_update_table_not_found() {
 
     let stmt = UpdateStmt {
         table_name: "nonexistent".to_string(),
+        quoted: false,
         assignments: vec![],
         where_clause: None,
     };
@@ -159,6 +164,7 @@ fn test_update_column_not_found() {
 
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "nonexistent_column".to_string(),
             value: Expression::Literal(SqlValue::Integer(123)),
@@ -178,6 +184,7 @@ fn test_update_no_matching_rows() {
 
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(99999)),

--- a/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
@@ -53,6 +53,7 @@ fn test_update_invalidates_columnar_cache() {
     // Execute UPDATE - give Alice a raise
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(55000)),
@@ -117,6 +118,7 @@ fn test_update_invalidates_prewarmed_cache() {
     // UPDATE to change Bob's salary
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(75000)),
@@ -155,6 +157,7 @@ fn test_update_all_rows_invalidates_cache() {
     // UPDATE all rows - give everyone the same salary
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(60000)),
@@ -187,6 +190,7 @@ fn test_update_no_match_does_not_invalidate_cache() {
     // UPDATE with WHERE clause that matches no rows
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(999999)),
@@ -224,6 +228,7 @@ fn test_multiple_updates_invalidate_cache() {
     // First UPDATE
     let stmt1 = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(50000)),
@@ -247,6 +252,7 @@ fn test_multiple_updates_invalidate_cache() {
     // Second UPDATE
     let stmt2 = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(55000)),
@@ -286,6 +292,7 @@ fn test_update_multiple_columns_invalidates_cache() {
     // UPDATE multiple columns at once
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![
             Assignment {
                 column: "salary".to_string(),

--- a/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
@@ -19,6 +19,7 @@ fn test_update_check_constraint_passes() {
     // Update to valid price (should succeed)
     let stmt = UpdateStmt {
         table_name: "products".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "price".to_string(),
             value: Expression::Literal(SqlValue::Integer(100)),
@@ -41,6 +42,7 @@ fn test_update_check_constraint_violation() {
     // Try to update to negative price (should fail)
     let stmt = UpdateStmt {
         table_name: "products".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "price".to_string(),
             value: Expression::Literal(SqlValue::Integer(-10)),
@@ -70,6 +72,7 @@ fn test_update_check_constraint_with_null() {
     // Update to NULL (should succeed - NULL is treated as UNKNOWN which passes CHECK)
     let stmt = UpdateStmt {
         table_name: "products".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "price".to_string(),
             value: Expression::Literal(SqlValue::Null),
@@ -96,6 +99,7 @@ fn test_update_check_constraint_with_expression() {
     // Update bonus to still be less than salary (should succeed)
     let stmt1 = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "bonus".to_string(),
             value: Expression::Literal(SqlValue::Integer(15000)),
@@ -108,6 +112,7 @@ fn test_update_check_constraint_with_expression() {
     // Try to update bonus to be >= salary (should fail)
     let stmt2 = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "bonus".to_string(),
             value: Expression::Literal(SqlValue::Integer(60000)),

--- a/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
@@ -171,6 +171,7 @@ pub fn create_update_with_id_clause(
 ) -> vibesql_ast::UpdateStmt {
     vibesql_ast::UpdateStmt {
         table_name: table_name.to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: column.to_string(),
             value: Expression::Literal(value),

--- a/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
@@ -161,6 +161,7 @@ fn test_update_unique_constraint_composite() {
     // Try to update Bob to have the same first_name and last_name as Alice (should fail)
     let stmt = UpdateStmt {
         table_name: "users".to_string(),
+        quoted: false,
         assignments: vec![
             Assignment {
                 column: "first_name".to_string(),

--- a/crates/vibesql-executor/tests/update_default_tests.rs
+++ b/crates/vibesql-executor/tests/update_default_tests.rs
@@ -30,6 +30,7 @@ fn test_update_with_default_value() {
     // UPDATE users SET name = DEFAULT WHERE id = 1
     let stmt = UpdateStmt {
         table_name: "users".to_string(),
+        quoted: false,
         assignments: vec![Assignment { column: "name".to_string(), value: Expression::Default }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             op: BinaryOperator::Equal,
@@ -75,6 +76,7 @@ fn test_update_default_no_default_value_defined() {
     // UPDATE users SET name = DEFAULT WHERE id = 1
     let stmt = UpdateStmt {
         table_name: "users".to_string(),
+        quoted: false,
         assignments: vec![Assignment { column: "name".to_string(), value: Expression::Default }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             op: BinaryOperator::Equal,

--- a/crates/vibesql-executor/tests/update_onepass_tests.rs
+++ b/crates/vibesql-executor/tests/update_onepass_tests.rs
@@ -102,6 +102,7 @@ fn test_onepass_multiple_literal_assignments() {
     // UPDATE items SET name = 'Updated', price = 999, quantity = 50 WHERE id = 1
     let stmt = UpdateStmt {
         table_name: "items".to_string(),
+        quoted: false,
         assignments: vec![
             Assignment {
                 column: "name".to_string(),
@@ -147,6 +148,7 @@ fn test_onepass_single_literal_assignment() {
     // UPDATE items SET price = 777 WHERE id = 2
     let stmt = UpdateStmt {
         table_name: "items".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "price".to_string(),
             value: Expression::Literal(SqlValue::Integer(777)),
@@ -174,6 +176,7 @@ fn test_onepass_pk_not_found_returns_zero() {
     // UPDATE items SET price = 999 WHERE id = 999 (non-existent)
     let stmt = UpdateStmt {
         table_name: "items".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "price".to_string(),
             value: Expression::Literal(SqlValue::Integer(999)),
@@ -210,6 +213,7 @@ fn test_onepass_not_null_constraint_enforced() {
     // Try to set NOT NULL column to NULL
     let stmt = UpdateStmt {
         table_name: "required".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "required_field".to_string(),
             value: Expression::Literal(SqlValue::Null),
@@ -238,6 +242,7 @@ fn test_composite_pk_update_both_columns_specified() {
     // UPDATE order_items SET quantity = 99 WHERE order_id = 1 AND item_id = 1
     let stmt = UpdateStmt {
         table_name: "order_items".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "quantity".to_string(),
             value: Expression::Literal(SqlValue::Integer(99)),
@@ -286,6 +291,7 @@ fn test_composite_pk_update_reversed_order() {
     // (columns in reverse order from PK definition)
     let stmt = UpdateStmt {
         table_name: "order_items".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "price".to_string(),
             value: Expression::Literal(SqlValue::Integer(500)),
@@ -329,6 +335,7 @@ fn test_composite_pk_partial_match_uses_scan() {
     // Only one PK column specified - should update multiple rows
     let stmt = UpdateStmt {
         table_name: "order_items".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "quantity".to_string(),
             value: Expression::Literal(SqlValue::Integer(1)),
@@ -359,6 +366,7 @@ fn test_composite_pk_not_found_returns_zero() {
     // UPDATE order_items SET quantity = 999 WHERE order_id = 99 AND item_id = 99
     let stmt = UpdateStmt {
         table_name: "order_items".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "quantity".to_string(),
             value: Expression::Literal(SqlValue::Integer(999)),
@@ -396,6 +404,7 @@ fn test_composite_pk_multiple_columns_updated() {
     // UPDATE order_items SET quantity = 100, price = 1000 WHERE order_id = 2 AND item_id = 1
     let stmt = UpdateStmt {
         table_name: "order_items".to_string(),
+        quoted: false,
         assignments: vec![
             Assignment {
                 column: "quantity".to_string(),

--- a/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
@@ -59,6 +59,7 @@ fn test_update_with_subquery_multiple_rows_error() {
 
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::ScalarSubquery(subquery),
@@ -139,6 +140,7 @@ fn test_update_with_subquery_multiple_columns_error() {
 
     let stmt = UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::ScalarSubquery(subquery),

--- a/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
@@ -119,6 +119,7 @@ fn create_update_stmt(
 ) -> UpdateStmt {
     UpdateStmt {
         table_name: table_name.to_string(),
+        quoted: false,
         assignments: vec![Assignment { column: column.to_string(), value }],
         where_clause,
     }
@@ -130,6 +131,7 @@ fn create_multi_column_update_stmt(
 ) -> UpdateStmt {
     UpdateStmt {
         table_name: table_name.to_string(),
+        quoted: false,
         assignments: assignments
             .into_iter()
             .map(|(col, val)| Assignment { column: col.to_string(), value: val })

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
@@ -59,6 +59,7 @@ fn test_update_where_scalar_subquery_equal() {
     // UPDATE employees SET salary = 55000 WHERE salary = (SELECT min_salary FROM config)
     let stmt = vibesql_ast::UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(55000)),
@@ -137,6 +138,7 @@ fn test_update_where_scalar_subquery_less_than() {
     // UPDATE employees SET bonus = 5000 WHERE salary < (SELECT AVG(salary) FROM employees)
     let stmt = vibesql_ast::UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "bonus".to_string(),
             value: Expression::Literal(SqlValue::Integer(5000)),
@@ -209,6 +211,7 @@ fn test_update_where_subquery_returns_null() {
     // UPDATE employees SET salary = 60000 WHERE salary < (SELECT max_salary FROM config)
     let stmt = vibesql_ast::UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(60000)),
@@ -291,6 +294,7 @@ fn test_update_where_subquery_with_aggregate() {
     // UPDATE items SET discounted = TRUE WHERE price = (SELECT MAX(price) FROM items)
     let stmt = vibesql_ast::UpdateStmt {
         table_name: "items".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "discounted".to_string(),
             value: Expression::Literal(SqlValue::Boolean(true)),
@@ -408,6 +412,7 @@ fn test_update_where_and_set_both_use_subqueries() {
     // dept_id FROM active_depts)
     let stmt = vibesql_ast::UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::ScalarSubquery(set_subquery),

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
@@ -74,6 +74,7 @@ fn test_update_where_in_subquery() {
     // UPDATE employees SET salary = 80000 WHERE dept_id IN (SELECT dept_id FROM active_depts)
     let stmt = vibesql_ast::UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(80000)),
@@ -158,6 +159,7 @@ fn test_update_where_not_in_subquery() {
     // UPDATE employees SET active = FALSE WHERE dept_id NOT IN (SELECT dept_id FROM active_depts)
     let stmt = vibesql_ast::UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "active".to_string(),
             value: Expression::Literal(SqlValue::Boolean(false)),
@@ -235,6 +237,7 @@ fn test_update_where_subquery_empty_result() {
     // UPDATE employees SET active = FALSE WHERE dept_id IN (SELECT dept_id FROM inactive_depts)
     let stmt = vibesql_ast::UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "active".to_string(),
             value: Expression::Literal(SqlValue::Boolean(false)),
@@ -327,6 +330,7 @@ fn test_update_where_complex_subquery_condition() {
     // budget > 80000)
     let stmt = vibesql_ast::UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "salary".to_string(),
             value: Expression::Literal(SqlValue::Integer(70000)),
@@ -415,6 +419,7 @@ fn test_update_where_multiple_rows_in_subquery() {
     // UPDATE employees SET active = FALSE WHERE dept_id IN (SELECT dept_id FROM active_depts)
     let stmt = vibesql_ast::UpdateStmt {
         table_name: "employees".to_string(),
+        quoted: false,
         assignments: vec![Assignment {
             column: "active".to_string(),
             value: Expression::Literal(SqlValue::Boolean(false)),


### PR DESCRIPTION
## Summary

Consolidates duplicated ORDER BY column position handling into reusable helper functions, reducing code duplication introduced in #4418.

### New Helper Functions

- **`extract_column_position()`**: Extracts numeric position from `N`, `+N`, or `-N` expressions
- **`validate_column_position()`**: Validates position is in valid range (1..column_count)
- **`resolve_position_to_column_name()`**: Resolves position for aggregate queries (simpler path)
- **`resolve_position_with_wildcards()`**: Handles wildcard expansion for non-aggregate queries

### Before vs After

| Function | Before | After |
|----------|--------|-------|
| `resolve_order_by_for_aggregates` | ~80 lines of position handling | ~15 lines using helpers |
| `resolve_order_by_alias` | ~200 lines of position handling | ~25 lines using helpers |

**Note**: This PR includes the #4418 fix as a dependency since this refactor builds on those changes.

Closes #4425

## Test plan

- [x] All 4 `issue_4418` regression tests pass
- [x] Additional regression tests (`issue_3809`, `issue_4237`, `issue_2599`) pass
- [x] Manual verification that `SELECT * FROM t5 ORDER BY +2` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)