### PR TITLE
feat(parser): Support schema-qualified table names in INSERT/UPDATE/DELETE

### DIFF
--- a/crates/vibesql-parser/src/parser/delete.rs
+++ b/crates/vibesql-parser/src/parser/delete.rs
@@ -9,30 +9,17 @@ impl Parser {
         // Check for optional ONLY keyword
         let only = self.try_consume_keyword(Keyword::Only);
 
-        // Check for optional left parenthesis
+        // Check for optional left parenthesis (for DELETE FROM ONLY (table_name) syntax)
         let has_paren = matches!(self.peek(), Token::LParen);
         if has_paren {
             self.advance(); // consume '('
         }
 
-        // Parse table name and track if quoted (for SQL:1999 case-sensitive lookups)
-        let (table_name, quoted) = match self.peek() {
-            Token::Identifier(name) => {
-                let table = name.clone();
-                self.advance();
-                (table, false)
-            }
-            Token::DelimitedIdentifier(name) => {
-                let table = name.clone();
-                self.advance();
-                (table, true)
-            }
-            _ => {
-                return Err(ParseError {
-                    message: "Expected table name after DELETE FROM".to_string(),
-                })
-            }
-        };
+        // Parse table name with optional schema qualifier and quoted flag
+        // Supports: tablename, "TableName", schema.table, "schema"."table"
+        let table_ref = self.parse_table_ref()?;
+        let table_name = table_ref.name;
+        let quoted = table_ref.quoted;
 
         // If we had opening paren, expect closing paren
         if has_paren {

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -25,24 +25,11 @@ impl Parser {
 
         self.expect_keyword(Keyword::Into)?;
 
-        // Parse table name and track if quoted (for SQL:1999 case-sensitive lookups)
-        let (table_name, quoted) = match self.peek() {
-            Token::Identifier(name) => {
-                let table = name.clone();
-                self.advance();
-                (table, false)
-            }
-            Token::DelimitedIdentifier(name) => {
-                let table = name.clone();
-                self.advance();
-                (table, true)
-            }
-            _ => {
-                return Err(ParseError {
-                    message: "Expected table name after INSERT INTO".to_string(),
-                })
-            }
-        };
+        // Parse table name with optional schema qualifier and quoted flag
+        // Supports: tablename, "TableName", schema.table, "schema"."table"
+        let table_ref = self.parse_table_ref()?;
+        let table_name = table_ref.name;
+        let quoted = table_ref.quoted;
 
         // Parse column list (optional in SQL, but we'll require it for now)
         let columns = if matches!(self.peek(), Token::LParen) {
@@ -152,24 +139,11 @@ impl Parser {
         self.expect_keyword(Keyword::Replace)?;
         self.expect_keyword(Keyword::Into)?;
 
-        // Parse table name and track if quoted (for SQL:1999 case-sensitive lookups)
-        let (table_name, quoted) = match self.peek() {
-            Token::Identifier(name) => {
-                let table = name.clone();
-                self.advance();
-                (table, false)
-            }
-            Token::DelimitedIdentifier(name) => {
-                let table = name.clone();
-                self.advance();
-                (table, true)
-            }
-            _ => {
-                return Err(ParseError {
-                    message: "Expected table name after REPLACE INTO".to_string(),
-                })
-            }
-        };
+        // Parse table name with optional schema qualifier and quoted flag
+        // Supports: tablename, "TableName", schema.table, "schema"."table"
+        let table_ref = self.parse_table_ref()?;
+        let table_name = table_ref.name;
+        let quoted = table_ref.quoted;
 
         // Parse column list (optional)
         let columns = if matches!(self.peek(), Token::LParen) {

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -5,22 +5,11 @@ impl Parser {
     pub(super) fn parse_update_statement(&mut self) -> Result<vibesql_ast::UpdateStmt, ParseError> {
         self.expect_keyword(Keyword::Update)?;
 
-        // Parse table name and track if quoted (for SQL:1999 case-sensitive lookups)
-        let (table_name, quoted) = match self.peek() {
-            Token::Identifier(name) => {
-                let table = name.clone();
-                self.advance();
-                (table, false)
-            }
-            Token::DelimitedIdentifier(name) => {
-                let table = name.clone();
-                self.advance();
-                (table, true)
-            }
-            _ => {
-                return Err(ParseError { message: "Expected table name after UPDATE".to_string() })
-            }
-        };
+        // Parse table name with optional schema qualifier and quoted flag
+        // Supports: tablename, "TableName", schema.table, "schema"."table"
+        let table_ref = self.parse_table_ref()?;
+        let table_name = table_ref.name;
+        let quoted = table_ref.quoted;
 
         // Parse SET keyword
         self.expect_keyword(Keyword::Set)?;

--- a/crates/vibesql-parser/src/tests/dml_schema_qualified.rs
+++ b/crates/vibesql-parser/src/tests/dml_schema_qualified.rs
@@ -1,0 +1,83 @@
+//! Tests for schema-qualified table names in DML statements
+
+use crate::Parser;
+use vibesql_ast::Statement;
+
+#[test]
+fn test_insert_schema_qualified_quoted() {
+    let sql = r#"INSERT INTO "mySchema"."users" VALUES (1)"#;
+    let stmt = Parser::parse_sql(sql).unwrap();
+    match stmt {
+        Statement::Insert(insert) => {
+            assert_eq!(insert.table_name, "mySchema.users");
+            assert!(insert.quoted);
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_insert_schema_qualified_unquoted() {
+    let sql = r#"INSERT INTO myschema.users VALUES (1)"#;
+    let stmt = Parser::parse_sql(sql).unwrap();
+    match stmt {
+        Statement::Insert(insert) => {
+            assert_eq!(insert.table_name, "myschema.users");
+            assert!(!insert.quoted);
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_update_schema_qualified_quoted() {
+    let sql = r#"UPDATE "mySchema"."users" SET id = 2"#;
+    let stmt = Parser::parse_sql(sql).unwrap();
+    match stmt {
+        Statement::Update(update) => {
+            assert_eq!(update.table_name, "mySchema.users");
+            assert!(update.quoted);
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_delete_schema_qualified_quoted() {
+    let sql = r#"DELETE FROM "mySchema"."users""#;
+    let stmt = Parser::parse_sql(sql).unwrap();
+    match stmt {
+        Statement::Delete(delete) => {
+            assert_eq!(delete.table_name, "mySchema.users");
+            assert!(delete.quoted);
+        }
+        _ => panic!("Expected DELETE statement"),
+    }
+}
+
+#[test]
+fn test_insert_mixed_quoted_unquoted() {
+    // Quoted schema, unquoted table
+    let sql = r#"INSERT INTO "mySchema".users VALUES (1)"#;
+    let stmt = Parser::parse_sql(sql).unwrap();
+    match stmt {
+        Statement::Insert(insert) => {
+            assert_eq!(insert.table_name, "mySchema.users");
+            assert!(insert.quoted); // quoted if any part is quoted
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_replace_schema_qualified() {
+    let sql = r#"REPLACE INTO "mySchema"."users" VALUES (1)"#;
+    let stmt = Parser::parse_sql(sql).unwrap();
+    match stmt {
+        Statement::Insert(insert) => {
+            assert_eq!(insert.table_name, "mySchema.users");
+            assert!(insert.quoted);
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}

--- a/crates/vibesql-parser/src/tests/mod.rs
+++ b/crates/vibesql-parser/src/tests/mod.rs
@@ -52,3 +52,4 @@ mod update;
 mod values_statement;
 mod view;
 mod window_functions;
+mod dml_schema_qualified;


### PR DESCRIPTION
## Summary

- Refactor INSERT, UPDATE, and DELETE parsers to use the existing `parse_table_ref()` helper
- Enable schema-qualified table names (e.g., `"mySchema"."users"`) in all DML statements
- Add comprehensive tests for schema-qualified DML parsing

## Changes

The parsers for INSERT, UPDATE, and DELETE were manually parsing table names, which didn't support schema-qualified identifiers. This PR refactors them to use `parse_table_ref()`, which already handles:

- Simple table names: `users`
- Quoted identifiers: `"Users"`
- Schema-qualified names: `schema.table`
- Quoted schema-qualified: `"mySchema"."users"`
- Mixed quoting: `"mySchema".users`

## Test plan

- [x] All 1107 parser tests pass
- [x] Added 6 new tests for schema-qualified DML parsing
- [x] Doc tests pass
- [x] Verified pre-existing test failures on main are unrelated to this change

Closes #4428

🤖 Generated with [Claude Code](https://claude.com/claude-code)