### PR TITLE
fix(types): Support mixed type columns through implicit type coercion

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/aggregate/functions.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/functions.rs
@@ -5,6 +5,8 @@
 
 #![allow(clippy::collapsible_else_if)]
 
+use std::sync::Arc;
+
 use vibesql_types::SqlValue;
 
 use super::{
@@ -350,9 +352,42 @@ pub(super) fn compute_batch_sum(
     }
 }
 
-/// Compute COUNT aggregate directly on a ColumnarBatch
-pub(super) fn compute_batch_count(batch: &ColumnarBatch) -> Result<SqlValue, ExecutorError> {
-    Ok(SqlValue::Integer(batch.row_count() as i64))
+/// Compute COUNT aggregate directly on a ColumnarBatch column
+///
+/// Counts non-NULL values in the specified column. This is different from COUNT(*)
+/// which counts all rows regardless of NULL values.
+pub(super) fn compute_batch_count(
+    batch: &ColumnarBatch,
+    column_idx: usize,
+) -> Result<SqlValue, ExecutorError> {
+    let column = batch.column(column_idx).ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+        column_index: column_idx,
+        batch_columns: batch.column_count(),
+    })?;
+
+    // Helper to count non-null values given array length and optional null mask
+    fn count_non_null(len: usize, nulls: Option<&Arc<Vec<bool>>>) -> usize {
+        if let Some(null_mask) = nulls {
+            len - null_mask.iter().filter(|&&is_null| is_null).count()
+        } else {
+            len
+        }
+    }
+
+    let count = match column {
+        ColumnArray::Int64(values, nulls) => count_non_null(values.len(), nulls.as_ref()),
+        ColumnArray::Int32(values, nulls) => count_non_null(values.len(), nulls.as_ref()),
+        ColumnArray::Float64(values, nulls) => count_non_null(values.len(), nulls.as_ref()),
+        ColumnArray::Float32(values, nulls) => count_non_null(values.len(), nulls.as_ref()),
+        ColumnArray::String(values, nulls) => count_non_null(values.len(), nulls.as_ref()),
+        ColumnArray::FixedString(values, nulls) => count_non_null(values.len(), nulls.as_ref()),
+        ColumnArray::Boolean(values, nulls) => count_non_null(values.len(), nulls.as_ref()),
+        ColumnArray::Date(values, nulls) => count_non_null(values.len(), nulls.as_ref()),
+        ColumnArray::Timestamp(values, nulls) => count_non_null(values.len(), nulls.as_ref()),
+        ColumnArray::Mixed(values) => values.iter().filter(|v| !v.is_null()).count(),
+    };
+
+    Ok(SqlValue::Integer(count as i64))
 }
 
 /// Compute AVG aggregate directly on a ColumnarBatch column
@@ -544,7 +579,7 @@ pub(super) fn compute_batch_aggregate(
 ) -> Result<SqlValue, ExecutorError> {
     match op {
         AggregateOp::Sum => compute_batch_sum(batch, column_idx),
-        AggregateOp::Count => compute_batch_count(batch),
+        AggregateOp::Count => compute_batch_count(batch, column_idx),
         AggregateOp::Avg => compute_batch_avg(batch, column_idx),
         AggregateOp::Min => compute_batch_min(batch, column_idx),
         AggregateOp::Max => compute_batch_max(batch, column_idx),

--- a/crates/vibesql-executor/src/select/columnar/batch/builder.rs
+++ b/crates/vibesql-executor/src/select/columnar/batch/builder.rs
@@ -133,6 +133,9 @@ impl ColumnarBatch {
     }
 
     /// Extract a single column from rows into a typed array
+    ///
+    /// SQLite allows mixed types in a single column (manifest typing), so this
+    /// function handles type mismatches gracefully by falling back to Mixed type.
     pub(crate) fn extract_column(
         rows: &[Row],
         col_idx: usize,
@@ -155,12 +158,9 @@ impl ColumnarBatch {
                             nulls.push(true);
                             has_nulls = true;
                         }
-                        Some(other) => {
-                            return Err(ExecutorError::ColumnarTypeMismatch {
-                                operation: "extract_column".to_string(),
-                                left_type: "Integer".to_string(),
-                                right_type: Some(format!("{:?}", other)),
-                            });
+                        Some(_other) => {
+                            // Type mismatch - fall back to Mixed type for SQLite compatibility
+                            return Self::extract_column(rows, col_idx, &ColumnType::Mixed);
                         }
                         None => {
                             values.push(0);
@@ -192,12 +192,9 @@ impl ColumnarBatch {
                             nulls.push(true);
                             has_nulls = true;
                         }
-                        Some(other) => {
-                            return Err(ExecutorError::ColumnarTypeMismatch {
-                                operation: "extract_column".to_string(),
-                                left_type: "Double".to_string(),
-                                right_type: Some(format!("{:?}", other)),
-                            });
+                        Some(_other) => {
+                            // Type mismatch - fall back to Mixed type for SQLite compatibility
+                            return Self::extract_column(rows, col_idx, &ColumnType::Mixed);
                         }
                         None => {
                             values.push(0.0);
@@ -229,12 +226,9 @@ impl ColumnarBatch {
                             nulls.push(true);
                             has_nulls = true;
                         }
-                        Some(other) => {
-                            return Err(ExecutorError::ColumnarTypeMismatch {
-                                operation: "extract_column".to_string(),
-                                left_type: "Varchar".to_string(),
-                                right_type: Some(format!("{:?}", other)),
-                            });
+                        Some(_other) => {
+                            // Type mismatch - fall back to Mixed type for SQLite compatibility
+                            return Self::extract_column(rows, col_idx, &ColumnType::Mixed);
                         }
                         None => {
                             values.push(Arc::from(""));
@@ -278,12 +272,9 @@ impl ColumnarBatch {
                             nulls.push(true);
                             has_nulls = true;
                         }
-                        Some(other) => {
-                            return Err(ExecutorError::ColumnarTypeMismatch {
-                                operation: "extract_column".to_string(),
-                                left_type: "Boolean".to_string(),
-                                right_type: Some(format!("{:?}", other)),
-                            });
+                        Some(_other) => {
+                            // Type mismatch - fall back to Mixed type for SQLite compatibility
+                            return Self::extract_column(rows, col_idx, &ColumnType::Mixed);
                         }
                         None => {
                             values.push(0);
@@ -411,6 +402,74 @@ mod tests {
             assert_eq!(nulls.as_slice(), &[false, false, true]);
         } else {
             panic!("Expected Float64 column with nulls");
+        }
+    }
+
+    #[test]
+    fn test_columnar_batch_mixed_types() {
+        // SQLite allows mixed types in a single column (manifest typing)
+        // First row has VARCHAR, subsequent rows have INTEGER
+        let rows = vec![
+            Row::new(vec![
+                SqlValue::Varchar(arcstr::ArcStr::from("abc")),
+                SqlValue::Null,
+            ]),
+            Row::new(vec![SqlValue::Null, SqlValue::Varchar(arcstr::ArcStr::from("xyz"))]),
+            Row::new(vec![SqlValue::Integer(11), SqlValue::Integer(22)]),
+            Row::new(vec![SqlValue::Integer(33), SqlValue::Integer(44)]),
+        ];
+
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+
+        assert_eq!(batch.row_count(), 4);
+        assert_eq!(batch.column_count(), 2);
+
+        // Column 0 should be Mixed due to type mismatch (VARCHAR then INTEGER)
+        let col0 = batch.column(0).unwrap();
+        if let ColumnArray::Mixed(values) = col0 {
+            assert_eq!(values.len(), 4);
+            assert_eq!(values[0], SqlValue::Varchar(arcstr::ArcStr::from("abc")));
+            assert_eq!(values[1], SqlValue::Null);
+            assert_eq!(values[2], SqlValue::Integer(11));
+            assert_eq!(values[3], SqlValue::Integer(33));
+        } else {
+            panic!("Expected Mixed column, got {:?}", col0);
+        }
+
+        // Column 1 should also be Mixed (NULL first, then VARCHAR, then INTEGERs)
+        let col1 = batch.column(1).unwrap();
+        if let ColumnArray::Mixed(values) = col1 {
+            assert_eq!(values.len(), 4);
+            assert_eq!(values[0], SqlValue::Null);
+            assert_eq!(values[1], SqlValue::Varchar(arcstr::ArcStr::from("xyz")));
+            assert_eq!(values[2], SqlValue::Integer(22));
+            assert_eq!(values[3], SqlValue::Integer(44));
+        } else {
+            panic!("Expected Mixed column, got {:?}", col1);
+        }
+    }
+
+    #[test]
+    fn test_columnar_batch_mixed_types_int_first() {
+        // Test case where INTEGER comes first, then VARCHAR
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(11), SqlValue::Integer(22)]),
+            Row::new(vec![
+                SqlValue::Varchar(arcstr::ArcStr::from("abc")),
+                SqlValue::Null,
+            ]),
+        ];
+
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+
+        // Column 0: First row is Integer, second is Varchar -> Mixed
+        let col0 = batch.column(0).unwrap();
+        if let ColumnArray::Mixed(values) = col0 {
+            assert_eq!(values.len(), 2);
+            assert_eq!(values[0], SqlValue::Integer(11));
+            assert_eq!(values[1], SqlValue::Varchar(arcstr::ArcStr::from("abc")));
+        } else {
+            panic!("Expected Mixed column for mixed integer/varchar, got {:?}", col0);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Modified `extract_column` to fall back to Mixed type when type mismatch is detected
- Fixed `compute_batch_count` to properly count non-NULL values in a column
- Added unit tests for mixed type column scenarios

## Test plan
- [x] Unit tests pass for mixed type column creation
- [x] Manual verification that `count(column)` correctly excludes NULLs
- [x] TCL test `select1-2.5.1` now passes (was failing before)

Closes #4431

🤖 Generated with [Claude Code](https://claude.com/claude-code)