### PR TITLE
fix(parser): Support qualified wildcard (t1.*) in arena parser

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -207,6 +207,28 @@ impl<'arena> ArenaParser<'arena> {
             return Ok(SelectItem::Wildcard { alias: None });
         }
 
+        // Check for qualified wildcard (table.* or alias.*)
+        // Must check BEFORE parsing as expression to avoid losing the qualifier.
+        // The expression parser would parse "table.*" as Expression::Wildcard, losing the table name.
+        let saved_position = self.position;
+        if let Token::Identifier(qualifier) | Token::DelimitedIdentifier(qualifier) = self.peek() {
+            let qualifier = qualifier.clone();
+            self.advance();
+
+            if matches!(self.peek(), Token::Symbol('.')) {
+                self.advance(); // consume dot
+
+                if matches!(self.peek(), Token::Symbol('*')) {
+                    self.advance(); // consume asterisk
+                    let qualifier_sym = self.intern(&qualifier);
+                    return Ok(SelectItem::QualifiedWildcard { qualifier: qualifier_sym, alias: None });
+                }
+            }
+
+            // Not a qualified wildcard, backtrack
+            self.position = saved_position;
+        }
+
         // Record start position before parsing expression
         let start_pos = self.position;
 

--- a/crates/vibesql-parser/src/lib.rs
+++ b/crates/vibesql-parser/src/lib.rs
@@ -155,4 +155,24 @@ mod arena_fallback_tests {
         assert!(result.is_ok());
         assert!(matches!(result.unwrap(), Statement::CreateTable(_)));
     }
+
+    #[test]
+    fn test_arena_fallback_qualified_wildcard() {
+        let result = parse_with_arena_fallback("SELECT t1.* FROM t1");
+        assert!(result.is_ok());
+        if let Statement::Select(select) = result.unwrap() {
+            assert_eq!(select.select_list.len(), 1);
+            match &select.select_list[0] {
+                vibesql_ast::SelectItem::QualifiedWildcard { qualifier, alias: _ } => {
+                    assert_eq!(qualifier, "t1");
+                }
+                other => panic!(
+                    "Expected QualifiedWildcard, got {:?}",
+                    other
+                ),
+            }
+        } else {
+            panic!("Expected SELECT statement");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Fixed arena parser to correctly handle qualified wildcard expressions like `SELECT t1.* FROM t1`
- The expression parser was incorrectly consuming `t1.*` as `Expression::Wildcard`, losing the table qualifier
- Added a check for qualified wildcards BEFORE calling `parse_expression()` in `parse_select_item()`
- Added test case for the arena fallback parsing path

## Test plan
- [x] `cargo test --release -p vibesql-parser` - all 1114 tests pass
- [x] Verified `SELECT t1.* FROM t1` now works correctly
- [x] Tested multiple qualified wildcards: `SELECT t1.*, t2.* FROM t1, t2`
- [x] Tested mixed: `SELECT t1.*, t2.c FROM t1, t2`

Closes #4430

🤖 Generated with [Claude Code](https://claude.com/claude-code)