### PR TITLE
fix(parser): Support single-quoted strings as column aliases

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/mod.rs
+++ b/crates/vibesql-parser/src/arena_parser/mod.rs
@@ -631,9 +631,12 @@ impl<'arena> ArenaParser<'arena> {
     }
 
     /// Parse an identifier or keyword as an alias name, returning a Symbol.
+    ///
+    /// SQLite also allows single-quoted strings as aliases (e.g., `SELECT 1 AS 'a'`).
+    /// In this context, the string literal is treated as an identifier name.
     fn parse_alias_name_symbol(&mut self) -> Result<Symbol, ParseError> {
         match self.peek() {
-            Token::Identifier(name) => {
+            Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
                 let name = name.clone();
                 self.advance();
                 Ok(self.intern(&name))
@@ -643,6 +646,12 @@ impl<'arena> ArenaParser<'arena> {
                 let name = kw.to_string();
                 self.advance();
                 Ok(self.intern(&name))
+            }
+            Token::String(s) => {
+                // SQLite compatibility: single-quoted strings can be used as aliases
+                let alias = s.clone();
+                self.advance();
+                Ok(self.intern(&alias))
             }
             _ => Err(ParseError { message: self.peek().syntax_error() })
         }

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -256,15 +256,10 @@ impl<'arena> ArenaParser<'arena> {
             let _ = t; // silence warning
         }
 
-        // Check for alias
+        // Check for alias - supports identifiers, delimited identifiers, keywords, and
+        // single-quoted strings (SQLite compatibility: SELECT 1 AS 'a')
         let alias = if self.try_consume_keyword(Keyword::As) {
-            if let Token::Identifier(name) = self.peek() {
-                let name = name.clone();
-                self.advance();
-                Some(self.intern(&name))
-            } else {
-                return Err(ParseError { message: "Expected alias after AS".to_string() });
-            }
+            Some(self.parse_alias_name_symbol()?)
         } else if let Token::Identifier(name) = self.peek() {
             // Implicit alias (no AS keyword)
             let name = name.clone();

--- a/crates/vibesql-parser/src/parser/helpers.rs
+++ b/crates/vibesql-parser/src/parser/helpers.rs
@@ -93,6 +93,9 @@ impl Parser {
     /// Parse an identifier or keyword as an alias name.
     /// In SQL, keywords can be used as aliases after AS (e.g., `d_year AS year`).
     /// This is standard SQL behavior supported by most databases.
+    ///
+    /// SQLite also allows single-quoted strings as aliases (e.g., `SELECT 1 AS 'a'`).
+    /// In this context, the string literal is treated as an identifier name.
     pub(super) fn parse_alias_name(&mut self) -> Result<String, ParseError> {
         match self.peek() {
             Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
@@ -105,6 +108,13 @@ impl Parser {
                 let name = kw.to_string();
                 self.advance();
                 Ok(name)
+            }
+            Token::String(s) => {
+                // SQLite compatibility: single-quoted strings can be used as aliases
+                // e.g., SELECT 1 AS 'a' - the 'a' is treated as an identifier
+                let alias = s.clone();
+                self.advance();
+                Ok(alias)
             }
             _ => Err(ParseError { message: self.peek().syntax_error() })
         }

--- a/crates/vibesql-parser/src/tests/select/filters.rs
+++ b/crates/vibesql-parser/src/tests/select/filters.rs
@@ -107,6 +107,46 @@ fn test_parse_select_mixed_aliases() {
     }
 }
 
+/// SQLite compatibility: single-quoted strings can be used as column aliases
+/// e.g., SELECT 1 AS 'a' - the 'a' is treated as an identifier, not a string literal
+#[test]
+fn test_parse_select_with_single_quoted_alias() {
+    let result = Parser::parse_sql("SELECT 1 AS 'a', 'hello' AS 'b', 2 AS 'c';");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            assert_eq!(select.select_list.len(), 3);
+
+            // First column: 1 AS 'a'
+            match &select.select_list[0] {
+                vibesql_ast::SelectItem::Expression { alias, .. } => {
+                    assert_eq!(alias.as_ref().unwrap(), "a");
+                }
+                _ => panic!("Expected Expression select item"),
+            }
+
+            // Second column: 'hello' AS 'b'
+            match &select.select_list[1] {
+                vibesql_ast::SelectItem::Expression { alias, .. } => {
+                    assert_eq!(alias.as_ref().unwrap(), "b");
+                }
+                _ => panic!("Expected Expression select item"),
+            }
+
+            // Third column: 2 AS 'c'
+            match &select.select_list[2] {
+                vibesql_ast::SelectItem::Expression { alias, .. } => {
+                    assert_eq!(alias.as_ref().unwrap(), "c");
+                }
+                _ => panic!("Expected Expression select item"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
 #[test]
 fn test_parse_precedence() {
     // Test that 1 + 2 * 3 parses as 1 + (2 * 3)


### PR DESCRIPTION
## Summary

- Adds SQLite-compatible support for single-quoted strings as column aliases
- `SELECT 1 AS 'a', 'hello' AS 'b'` now works correctly with column names `a` and `b`
- Also adds `Token::DelimitedIdentifier` support to arena parser's alias handling for consistency

## Test plan

- [x] New parser test: `test_parse_select_with_single_quoted_alias`
- [x] All 1115 parser tests pass
- [x] Manual verification: `SELECT 1 AS 'a', 'hello' AS 'b', 2 AS 'c'` returns columns `a`, `b`, `c`
- [x] Release build succeeds

Closes #4437

🤖 Generated with [Claude Code](https://claude.com/claude-code)