### PR TITLE
fix(executor): Support alias references in ORDER BY expressions

### DIFF
--- a/crates/vibesql-executor/src/select/order.rs
+++ b/crates/vibesql-executor/src/select/order.rs
@@ -582,13 +582,15 @@ fn expressions_equal(a: &vibesql_ast::Expression, b: &vibesql_ast::Expression) -
 
 /// Resolve ORDER BY expression that might be a SELECT list alias or column position
 ///
-/// Handles four cases:
+/// Handles these cases:
 /// 1. Numeric literal (e.g., ORDER BY 1, 2, 3) - returns the expression from that position in
 ///    SELECT list
 /// 2. Simple column reference that matches a SELECT list alias - returns the SELECT list expression
 /// 3. Simple column reference that matches an aliased column's original name - returns a ColumnRef
 ///    to the alias
-/// 4. Otherwise - returns the original ORDER BY expression
+/// 4. Complex expressions containing alias references (e.g., ORDER BY -x, ORDER BY abs(x)) -
+///    recursively resolves alias references within the expression (#4436)
+/// 5. Otherwise - returns the original ORDER BY expression
 ///
 /// Returns an error if a numeric column position is out of range (0 or > column count)
 ///
@@ -675,8 +677,176 @@ pub(crate) fn resolve_order_by_alias<'a>(
         }
     }
 
+    // For complex expressions (UnaryOp, BinaryOp, Function calls, etc.), recursively resolve
+    // alias references within the expression (#4436)
+    // This handles cases like: ORDER BY -x, ORDER BY abs(x), ORDER BY 10-x
+    if let Some(resolved) = resolve_aliases_in_expression(order_expr, select_list) {
+        return Ok(Cow::Owned(resolved));
+    }
+
     // Not an alias or column position, use the original expression
     Ok(Cow::Borrowed(order_expr))
+}
+
+/// Recursively resolve alias references within an ORDER BY expression.
+///
+/// This handles complex expressions like:
+/// - `ORDER BY -x` where x is an alias
+/// - `ORDER BY abs(x)` where x is an alias
+/// - `ORDER BY 10-x` where x is an alias
+///
+/// Returns Some(resolved_expression) if any aliases were resolved, None otherwise.
+fn resolve_aliases_in_expression(
+    expr: &vibesql_ast::Expression,
+    select_list: &[vibesql_ast::SelectItem],
+) -> Option<vibesql_ast::Expression> {
+    match expr {
+        // Handle UnaryOp (e.g., -x, +x, NOT x)
+        vibesql_ast::Expression::UnaryOp { op, expr: inner } => {
+            // Try to resolve the inner expression
+            if let Some(resolved_inner) = resolve_alias_or_clone(inner, select_list) {
+                Some(vibesql_ast::Expression::UnaryOp {
+                    op: *op,
+                    expr: Box::new(resolved_inner),
+                })
+            } else {
+                None
+            }
+        }
+
+        // Handle BinaryOp (e.g., 10-x, x+y)
+        vibesql_ast::Expression::BinaryOp { left, op, right } => {
+            let resolved_left = resolve_alias_or_clone(left, select_list);
+            let resolved_right = resolve_alias_or_clone(right, select_list);
+
+            // Only return Some if at least one side was resolved
+            if resolved_left.is_some() || resolved_right.is_some() {
+                Some(vibesql_ast::Expression::BinaryOp {
+                    left: Box::new(resolved_left.unwrap_or_else(|| left.as_ref().clone())),
+                    op: *op,
+                    right: Box::new(resolved_right.unwrap_or_else(|| right.as_ref().clone())),
+                })
+            } else {
+                None
+            }
+        }
+
+        // Handle Function calls (e.g., abs(x), coalesce(x, 0))
+        vibesql_ast::Expression::Function { name, args, character_unit } => {
+            let mut any_resolved = false;
+            let resolved_args: Vec<_> = args
+                .iter()
+                .map(|arg| {
+                    if let Some(resolved) = resolve_alias_or_clone(arg, select_list) {
+                        any_resolved = true;
+                        resolved
+                    } else {
+                        arg.clone()
+                    }
+                })
+                .collect();
+
+            if any_resolved {
+                Some(vibesql_ast::Expression::Function {
+                    name: name.clone(),
+                    args: resolved_args,
+                    character_unit: character_unit.clone(),
+                })
+            } else {
+                None
+            }
+        }
+
+        // Handle CASE expressions
+        vibesql_ast::Expression::Case { operand, when_clauses, else_result } => {
+            let mut any_resolved = false;
+
+            let resolved_operand = operand.as_ref().map(|op| {
+                if let Some(resolved) = resolve_alias_or_clone(op, select_list) {
+                    any_resolved = true;
+                    Box::new(resolved)
+                } else {
+                    op.clone()
+                }
+            });
+
+            let resolved_when_clauses: Vec<_> = when_clauses
+                .iter()
+                .map(|clause| {
+                    let resolved_conditions: Vec<_> = clause
+                        .conditions
+                        .iter()
+                        .map(|cond| {
+                            if let Some(resolved) = resolve_alias_or_clone(cond, select_list) {
+                                any_resolved = true;
+                                resolved
+                            } else {
+                                cond.clone()
+                            }
+                        })
+                        .collect();
+
+                    let resolved_result =
+                        if let Some(resolved) = resolve_alias_or_clone(&clause.result, select_list)
+                        {
+                            any_resolved = true;
+                            resolved
+                        } else {
+                            clause.result.clone()
+                        };
+
+                    vibesql_ast::CaseWhen { conditions: resolved_conditions, result: resolved_result }
+                })
+                .collect();
+
+            let resolved_else = else_result.as_ref().map(|e| {
+                if let Some(resolved) = resolve_alias_or_clone(e, select_list) {
+                    any_resolved = true;
+                    Box::new(resolved)
+                } else {
+                    e.clone()
+                }
+            });
+
+            if any_resolved {
+                Some(vibesql_ast::Expression::Case {
+                    operand: resolved_operand,
+                    when_clauses: resolved_when_clauses,
+                    else_result: resolved_else,
+                })
+            } else {
+                None
+            }
+        }
+
+        // For other expression types, no resolution needed
+        _ => None,
+    }
+}
+
+/// Helper: resolve an alias in an expression, or return None if no alias was found.
+/// Returns Some(resolved_expression) if the expression contains an alias that was resolved.
+fn resolve_alias_or_clone(
+    expr: &vibesql_ast::Expression,
+    select_list: &[vibesql_ast::SelectItem],
+) -> Option<vibesql_ast::Expression> {
+    // Check if this is a simple column reference that matches an alias
+    if let vibesql_ast::Expression::ColumnRef { table: None, column } = expr {
+        // Search for matching alias in SELECT list
+        for item in select_list {
+            if let vibesql_ast::SelectItem::Expression { expr: select_expr, alias: Some(alias_name), .. } =
+                item
+            {
+                if alias_name.eq_ignore_ascii_case(column) {
+                    // Found matching alias, return the SELECT list expression
+                    return Some(select_expr.clone());
+                }
+            }
+        }
+    }
+
+    // Try recursive resolution for complex expressions
+    resolve_aliases_in_expression(expr, select_list)
 }
 
 #[cfg(test)]

--- a/tests/regression/issue_4436.rs
+++ b/tests/regression/issue_4436.rs
@@ -1,0 +1,187 @@
+//! Test for issue #4436: ORDER BY alias references in expressions
+//!
+//! When using expressions like `ORDER BY -x` or `ORDER BY abs(x)` where `x` is an alias
+//! defined in the SELECT clause, VibeSQL should resolve the alias and use the underlying
+//! expression for sorting.
+//!
+//! SQLite allows referencing SELECT clause aliases in ORDER BY expressions.
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+/// Helper to execute SELECT and return rows
+fn select_rows(db: &Database, sql: &str) -> Vec<Row> {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor.execute(&select_stmt).unwrap()
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+/// Helper to create the test table (matches select1.test test1 table)
+fn create_test1_table(db: &mut Database) {
+    let schema = TableSchema::new(
+        "test1".to_string(),
+        vec![ColumnSchema::new("f1".to_string(), DataType::Integer, false)],
+    );
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("test1").unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(11)])).unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(33)])).unwrap();
+}
+
+/// Helper to create the t3 table for boolean test
+fn create_t3_table(db: &mut Database) {
+    let schema = TableSchema::new(
+        "t3".to_string(),
+        vec![ColumnSchema::new("a".to_string(), DataType::Integer, false)],
+    );
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("t3").unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(1)])).unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(2)])).unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(3)])).unwrap();
+}
+
+/// Helper to create the t4 table for multi-column alias test
+fn create_t4_table(db: &mut Database) {
+    let schema = TableSchema::new(
+        "t4".to_string(),
+        vec![
+            ColumnSchema::new("a".to_string(), DataType::Integer, false),
+            ColumnSchema::new("b".to_string(), DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("t4").unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(2)])).unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(1)])).unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(2), SqlValue::Integer(3)])).unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(2), SqlValue::Integer(2)])).unwrap();
+}
+
+/// select1-10.2: SELECT f1 AS x FROM test1 ORDER BY -x
+#[test]
+fn test_order_by_negated_alias() {
+    let mut db = Database::new();
+    create_test1_table(&mut db);
+
+    // ORDER BY -x where x is an alias for f1
+    // -11 = -11, -33 = -33
+    // Sorted ascending: -33, -11 → so rows are: 33, 11
+    let rows = select_rows(&db, "SELECT f1 AS x FROM test1 ORDER BY -x");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].values[0], SqlValue::Integer(33));
+    assert_eq!(rows[1].values[0], SqlValue::Integer(11));
+}
+
+/// select1-10.3: SELECT f1-23 AS x FROM test1 ORDER BY abs(x)
+#[test]
+fn test_order_by_function_of_alias() {
+    let mut db = Database::new();
+    create_test1_table(&mut db);
+
+    // f1-23: 11-23=-12, 33-23=10
+    // abs(x): abs(-12)=12, abs(10)=10
+    // Sorted by abs(x) ascending: 10, 12 → rows are: 33-23=10, 11-23=-12
+    let rows = select_rows(&db, "SELECT f1-23 AS x FROM test1 ORDER BY abs(x)");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].values[0], SqlValue::Integer(10)); // 33-23
+    assert_eq!(rows[1].values[0], SqlValue::Integer(-12)); // 11-23
+}
+
+/// select1-10.4: SELECT a=1 AS x FROM t3 ORDER BY x
+/// This tests ordering by a boolean alias result
+#[test]
+fn test_order_by_boolean_alias() {
+    let mut db = Database::new();
+    create_t3_table(&mut db);
+
+    // a=1 returns: TRUE (for a=1), FALSE (for a=2), FALSE (for a=3)
+    // SQLite sorts FALSE (0) before TRUE (1)
+    // Sorted ascending: 0, 0, 1
+    let rows = select_rows(&db, "SELECT a=1 AS x FROM t3 ORDER BY x");
+    assert_eq!(rows.len(), 3);
+    // FALSE (0) values come first, then TRUE (1)
+    assert_eq!(rows[0].values[0], SqlValue::Integer(0)); // a=2 or a=3
+    assert_eq!(rows[1].values[0], SqlValue::Integer(0)); // a=2 or a=3
+    assert_eq!(rows[2].values[0], SqlValue::Integer(1)); // a=1
+}
+
+/// select1-10.6: SELECT a AS x, b AS y FROM t4 ORDER BY x, y
+/// This tests ordering by multiple aliases
+#[test]
+fn test_order_by_multiple_aliases() {
+    let mut db = Database::new();
+    create_t4_table(&mut db);
+
+    // Order by x (a), then y (b)
+    // Expected order: (1,1), (1,2), (2,2), (2,3)
+    let rows = select_rows(&db, "SELECT a AS x, b AS y FROM t4 ORDER BY x, y");
+    assert_eq!(rows.len(), 4);
+    assert_eq!(rows[0].values, vec![SqlValue::Integer(1), SqlValue::Integer(1)]);
+    assert_eq!(rows[1].values, vec![SqlValue::Integer(1), SqlValue::Integer(2)]);
+    assert_eq!(rows[2].values, vec![SqlValue::Integer(2), SqlValue::Integer(2)]);
+    assert_eq!(rows[3].values, vec![SqlValue::Integer(2), SqlValue::Integer(3)]);
+}
+
+/// select1-10.7: SELECT a AS x FROM t4 ORDER BY 10-x
+#[test]
+fn test_order_by_expression_with_alias() {
+    let mut db = Database::new();
+    create_t4_table(&mut db);
+
+    // 10-x values: 10-1=9, 10-1=9, 10-2=8, 10-2=8
+    // Sorted ascending by 10-x: 8, 8, 9, 9
+    // So rows where a=2 come first, then a=1
+    let rows = select_rows(&db, "SELECT a AS x FROM t4 ORDER BY 10-x");
+    assert_eq!(rows.len(), 4);
+    // First two should have x=2 (10-2=8)
+    assert_eq!(rows[0].values[0], SqlValue::Integer(2));
+    assert_eq!(rows[1].values[0], SqlValue::Integer(2));
+    // Last two should have x=1 (10-1=9)
+    assert_eq!(rows[2].values[0], SqlValue::Integer(1));
+    assert_eq!(rows[3].values[0], SqlValue::Integer(1));
+}
+
+/// Test ORDER BY with alias used inside CASE expression
+#[test]
+fn test_order_by_case_with_alias() {
+    let mut db = Database::new();
+    create_t4_table(&mut db);
+
+    // CASE WHEN x > 1 THEN 0 ELSE 1 END
+    // x=1 → 1, x=2 → 0
+    // Sorted ascending: 0, 0, 1, 1
+    let rows = select_rows(&db, "SELECT a AS x FROM t4 ORDER BY CASE WHEN x > 1 THEN 0 ELSE 1 END");
+    assert_eq!(rows.len(), 4);
+    // First two should have x=2 (CASE returns 0)
+    assert_eq!(rows[0].values[0], SqlValue::Integer(2));
+    assert_eq!(rows[1].values[0], SqlValue::Integer(2));
+    // Last two should have x=1 (CASE returns 1)
+    assert_eq!(rows[2].values[0], SqlValue::Integer(1));
+    assert_eq!(rows[3].values[0], SqlValue::Integer(1));
+}
+
+/// Test ORDER BY alias with DESC
+#[test]
+fn test_order_by_alias_expr_desc() {
+    let mut db = Database::new();
+    create_test1_table(&mut db);
+
+    // ORDER BY -x DESC
+    // -11 = -11, -33 = -33
+    // Sorted descending: -11, -33 → rows are: 11, 33
+    let rows = select_rows(&db, "SELECT f1 AS x FROM test1 ORDER BY -x DESC");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].values[0], SqlValue::Integer(11));
+    assert_eq!(rows[1].values[0], SqlValue::Integer(33));
+}


### PR DESCRIPTION
## Summary
- ORDER BY clauses now support alias references within complex expressions like `ORDER BY -x`, `ORDER BY abs(x)`, or `ORDER BY 10-x`
- Adds recursive alias resolution for UnaryOp, BinaryOp, Function calls, and CASE expressions
- Fixes SQLite TCL test compatibility for select1-10.x tests

## Test plan
- [x] Manual testing with vibesql CLI confirms all patterns work
- [x] TCL tests select1-10.2, select1-10.3, select1-10.4 now pass
- [x] Added regression tests in `tests/regression/issue_4436.rs`

Closes #4436

🤖 Generated with [Claude Code](https://claude.com/claude-code)