### PR TITLE
fix(errors): Match SQLite aggregate error message formats exactly

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -53,7 +53,13 @@ pub enum ExecutorError {
     },
     /// Misuse of aggregate function (SQLite-compatible error)
     /// e.g., aggregate in WHERE clause or nested aggregates
+    /// Format: "misuse of aggregate function X()"
     MisuseOfAggregate {
+        function_name: String,
+    },
+    /// Misuse of aggregate in ORDER BY or other execution contexts (SQLite-compatible)
+    /// Format: "misuse of aggregate: X()" (note the colon, not "function")
+    MisuseOfAggregateContext {
         function_name: String,
     },
     /// Misuse of aliased aggregate (SQLite-compatible error)
@@ -490,6 +496,11 @@ impl std::fmt::Display for ExecutorError {
             ExecutorError::MisuseOfAggregate { function_name } => {
                 // SQLite-compatible error message format
                 write!(f, "misuse of aggregate function {}()", function_name)
+            }
+            ExecutorError::MisuseOfAggregateContext { function_name } => {
+                // SQLite-compatible error message format for ORDER BY and execution contexts
+                // Note: uses colon instead of "function" to match SQLite's expr.c format
+                write!(f, "misuse of aggregate: {}()", function_name)
             }
             ExecutorError::MisuseOfAliasedAggregate { alias_name } => {
                 // SQLite-compatible error message format

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -363,9 +363,11 @@ impl CombinedExpressionEvaluator<'_> {
 
             // Aggregate functions - should be evaluated in aggregation context
             vibesql_ast::Expression::AggregateFunction { name, .. } => {
-                // SQLite-compatible error message for aggregate misuse
-                // Preserve original case to match SQLite behavior
-                Err(ExecutorError::MisuseOfAggregate { function_name: name.clone() })
+                // SQLite-compatible error message for aggregate misuse in execution context
+                // This error occurs when an aggregate is evaluated outside of aggregation,
+                // such as in ORDER BY clauses of non-aggregate queries.
+                // Uses "misuse of aggregate: X()" format (with colon) to match SQLite's expr.c
+                Err(ExecutorError::MisuseOfAggregateContext { function_name: name.clone() })
             }
 
             // Full-text search

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -276,9 +276,11 @@ impl ExpressionEvaluator<'_> {
             )),
 
             vibesql_ast::Expression::AggregateFunction { name, .. } => {
-                // SQLite-compatible error message for aggregate misuse
-                // Preserve original case to match SQLite behavior
-                Err(ExecutorError::MisuseOfAggregate { function_name: name.clone() })
+                // SQLite-compatible error message for aggregate misuse in execution context
+                // This error occurs when an aggregate is evaluated outside of aggregation,
+                // such as in ORDER BY clauses of non-aggregate queries.
+                // Uses "misuse of aggregate: X()" format (with colon) to match SQLite's expr.c
+                Err(ExecutorError::MisuseOfAggregateContext { function_name: name.clone() })
             }
 
             // NEXT VALUE FOR sequence expression

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
@@ -130,9 +130,10 @@ pub(super) fn evaluate(
     // This counts distinct combinations of values
     if name.to_uppercase() == "COUNT" && args.len() > 1 {
         if !distinct {
-            return Err(ExecutorError::UnsupportedExpression(
-                "Multi-argument COUNT requires DISTINCT".to_string(),
-            ));
+            // SQLite-compatible error message
+            return Err(ExecutorError::WrongNumberOfArguments {
+                function_name: name.clone(),
+            });
         }
 
         // Evaluate all arguments for each row and accumulate as tuples

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -49,6 +49,11 @@ impl SelectExecutor<'_> {
         // Must happen before any fast paths or strategy selection
         super::validation::validate_aggregate_arguments(&stmt.select_list)?;
 
+        // Validate no nested aggregates (issue #4439)
+        // This catches errors like SUM(MIN(x)) before any execution
+        // Uses "misuse of aggregate function X()" format to match SQLite's resolve.c
+        super::validation::validate_no_nested_aggregates(&stmt.select_list)?;
+
         #[cfg(feature = "profile-q6")]
         let execute_start = std::time::Instant::now();
 

--- a/crates/vibesql-executor/src/select/executor/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/validation.rs
@@ -192,7 +192,7 @@ fn is_aggregate_function(name: &str) -> bool {
 /// Returns Some((function_name, arg_count)) if there's an error, None otherwise
 fn check_aggregate_arg_count(expr: &Expression) -> Option<String> {
     match expr {
-        Expression::AggregateFunction { name, args, .. } => {
+        Expression::AggregateFunction { name, args, distinct } => {
             let upper = name.to_uppercase();
             let arg_count = args.len();
 
@@ -208,9 +208,13 @@ fn check_aggregate_arg_count(expr: &Expression) -> Option<String> {
 
             match upper.as_str() {
                 "COUNT" => {
-                    // Multi-arg count without DISTINCT is an error
-                    // But this is checked elsewhere, so skip here
-                    None
+                    // Multi-arg COUNT without DISTINCT is an error
+                    // SQLite: "wrong number of arguments to function count()"
+                    if arg_count > 1 && !*distinct {
+                        Some(name.clone())
+                    } else {
+                        None
+                    }
                 }
                 "MIN" | "MAX" => {
                     if has_wildcard || arg_count == 0 {
@@ -438,6 +442,100 @@ fn find_aggregate_in_expression(expr: &Expression) -> Option<String> {
     }
 }
 
+/// Find nested aggregate function in an expression
+///
+/// A nested aggregate is when one aggregate's arguments contain another aggregate,
+/// e.g., `SUM(MIN(x))`. This is invalid in SQL.
+///
+/// Returns Some(inner_aggregate_name) if found, None otherwise.
+fn find_nested_aggregate(expr: &Expression) -> Option<String> {
+    match expr {
+        Expression::AggregateFunction { args, .. } => {
+            // Check if any argument contains an aggregate function
+            for arg in args {
+                if let Some(inner_name) = find_aggregate_in_expression(arg) {
+                    return Some(inner_name);
+                }
+            }
+            None
+        }
+        Expression::Function { name, args, .. } => {
+            // Check if this function is a built-in aggregate with nested aggregate args
+            if is_aggregate_function(name) {
+                let upper = name.to_uppercase();
+                // Multi-arg MIN/MAX are scalar functions, not aggregates
+                let is_scalar_minmax = matches!(upper.as_str(), "MIN" | "MAX") && args.len() > 1;
+                if !is_scalar_minmax {
+                    // This is an aggregate - check for nested aggregates in args
+                    for arg in args {
+                        if let Some(inner_name) = find_aggregate_in_expression(arg) {
+                            return Some(inner_name);
+                        }
+                    }
+                }
+            }
+            // Check arguments recursively (for non-aggregate functions)
+            for arg in args {
+                if let Some(found) = find_nested_aggregate(arg) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Expression::BinaryOp { left, right, .. } => {
+            find_nested_aggregate(left).or_else(|| find_nested_aggregate(right))
+        }
+        Expression::UnaryOp { expr, .. } => find_nested_aggregate(expr),
+        Expression::Cast { expr, .. } => find_nested_aggregate(expr),
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                if let Some(found) = find_nested_aggregate(op) {
+                    return Some(found);
+                }
+            }
+            for case_when in when_clauses {
+                for cond in &case_when.conditions {
+                    if let Some(found) = find_nested_aggregate(cond) {
+                        return Some(found);
+                    }
+                }
+                if let Some(found) = find_nested_aggregate(&case_when.result) {
+                    return Some(found);
+                }
+            }
+            if let Some(else_expr) = else_result {
+                find_nested_aggregate(else_expr)
+            } else {
+                None
+            }
+        }
+        Expression::IsNull { expr, .. } => find_nested_aggregate(expr),
+        Expression::Between { expr, low, high, .. } => find_nested_aggregate(expr)
+            .or_else(|| find_nested_aggregate(low))
+            .or_else(|| find_nested_aggregate(high)),
+        Expression::InList { expr, values, .. } => {
+            if let Some(found) = find_nested_aggregate(expr) {
+                return Some(found);
+            }
+            for val in values {
+                if let Some(found) = find_nested_aggregate(val) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Expression::Conjunction(children) | Expression::Disjunction(children) => {
+            for child in children {
+                if let Some(found) = find_nested_aggregate(child) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
 /// Validate a single column reference against the schema (and optionally outer schema)
 fn validate_column_ref(
     col_ref: &ColumnReference,
@@ -635,6 +733,24 @@ pub fn validate_aggregate_arguments(select_list: &[SelectItem]) -> Result<(), Ex
         if let SelectItem::Expression { expr, .. } = item {
             if let Some(agg_name) = check_aggregate_arg_count(expr) {
                 return Err(ExecutorError::WrongNumberOfArguments { function_name: agg_name });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate that there are no nested aggregate functions in the SELECT list
+///
+/// Nested aggregates like `SUM(MIN(x))` are invalid in SQL.
+/// Returns an error with SQLite-compatible message if nested aggregates are found.
+///
+/// Note: This uses the "misuse of aggregate function X()" format (with "function")
+/// as SQLite detects this during name resolution, not during execution.
+pub fn validate_no_nested_aggregates(select_list: &[SelectItem]) -> Result<(), ExecutorError> {
+    for item in select_list {
+        if let SelectItem::Expression { expr, .. } = item {
+            if let Some(inner_agg_name) = find_nested_aggregate(expr) {
+                return Err(ExecutorError::MisuseOfAggregate { function_name: inner_agg_name });
             }
         }
     }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -144,7 +144,25 @@ proc translate_error_to_sqlite {vibesql_error} {
         return "misuse of aggregate function"
     }
 
-    # "misuse of aggregate function min()" for aggregate in wrong context
+    # SQLite-compatible aggregate error messages
+    # VibeSQL now produces these exact formats, so pass through if already correct:
+
+    # "misuse of aggregate: X()" - for execution context errors (ORDER BY, etc.)
+    if {[regexp -nocase {^misuse of aggregate:\s*([A-Za-z_]+)\(\)$} $error_msg -> func_name]} {
+        return "misuse of aggregate: [string tolower $func_name]()"
+    }
+
+    # "misuse of aggregate function X()" - for name resolution errors (nested aggregates, WHERE)
+    if {[regexp -nocase {^misuse of aggregate function\s*([A-Za-z_]+)\(\)$} $error_msg -> func_name]} {
+        return "misuse of aggregate function [string tolower $func_name]()"
+    }
+
+    # "misuse of aliased aggregate X" - for aliased aggregate misuse in HAVING
+    if {[regexp -nocase {^misuse of aliased aggregate\s+([A-Za-z_][A-Za-z0-9_]*)$} $error_msg -> alias_name]} {
+        return "misuse of aliased aggregate $alias_name"
+    }
+
+    # Legacy fallback: transform other aggregate misuse errors
     if {[regexp -nocase {aggregate.*misuse|misuse.*aggregate|cannot use aggregate} $error_msg]} {
         # Try to extract function name
         if {[regexp -nocase {(min|max|sum|avg|count|total|group_concat)} $error_msg -> func_name]} {
@@ -153,16 +171,7 @@ proc translate_error_to_sqlite {vibesql_error} {
         return "misuse of aggregate function"
     }
 
-    # Misuse of aliased aggregate:
-    # "misuse of aliased aggregate m" or "misuse of aliased aggregate cn"
-    if {[regexp -nocase {alias.*aggregate|aggregate.*alias} $error_msg -> alias_name]} {
-        if {[regexp -nocase {['"]?([a-z_][a-z0-9_]*)['"]?\s*$} $error_msg -> alias_name]} {
-            return "misuse of aliased aggregate [string tolower $alias_name]"
-        }
-        return "misuse of aliased aggregate"
-    }
-
-    # Aggregate in ORDER BY: "misuse of aggregate: min()"
+    # Legacy: Aggregate in ORDER BY context (for old error messages)
     if {[regexp -nocase {aggregate.*ORDER BY|ORDER BY.*aggregate} $error_msg]} {
         if {[regexp -nocase {(min|max|sum|avg|count)} $error_msg -> func_name]} {
             return "misuse of aggregate: [string tolower $func_name]()"


### PR DESCRIPTION
## Summary
- Matches SQLite's exact aggregate error message formats for TCL test compatibility
- Adds `MisuseOfAggregateContext` error variant for execution context errors (ORDER BY)
- Validates nested aggregates like `SUM(MIN(x))` during parsing, not execution
- Updates TCL shim to pass through SQLite-compatible formats

## Changes
| Scenario | SQLite Message | VibeSQL (Before) | VibeSQL (After) |
|----------|----------------|------------------|-----------------|
| `count(f1,f2)` | `wrong number of arguments to function count()` | `Unsupported expression: Multi-argument COUNT requires DISTINCT` | ✅ Match |
| `SUM(min(f1))` | `misuse of aggregate function min()` | `misuse of aggregate: min()` | ✅ Match |
| `ORDER BY min(f1)` | `misuse of aggregate: min()` | `misuse of aggregate function min()` | ✅ Match |
| `HAVING max(m+5)` (m is alias) | `misuse of aliased aggregate m` | ✅ Already matched | ✅ Match |

## Test plan
- [x] Manual tests for all 4 error scenarios
- [x] TCL test select1.test: aggregate error tests now pass (select1-2.20, select1-2.21, select1-2.22, select1-3.9, select1-4.4, select1-4.5)
- [x] Release build succeeds
- [x] Library compiles without errors

Closes #4439

🤖 Generated with [Claude Code](https://claude.com/claude-code)