### PR TITLE
fix(executor): Implement SQLite type affinity rules for mixed-type comparisons

### DIFF
--- a/crates/vibesql-executor/src/evaluator/operators/comparison/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/comparison/mod.rs
@@ -197,6 +197,37 @@ where
         _ => {} // Fall through to regular comparison logic
     }
 
+    // SQLite affinity rules: TEXT values are always greater than INTEGER/REAL
+    // NULL < INTEGER < REAL < TEXT < BLOB (type ordering)
+    // When comparing incompatible types, use type order rather than throwing errors
+    let is_string = |v: &SqlValue| matches!(v, Varchar(_) | Character(_));
+    let is_numeric = |v: &SqlValue| {
+        matches!(
+            v,
+            Integer(_) | Smallint(_) | Bigint(_) | Float(_) | Real(_) | Double(_) | Numeric(_)
+        )
+    };
+
+    // String compared to numeric: String is always greater
+    if is_string(left) && is_numeric(right) {
+        // "string" compared to number: string > number in type order
+        // For "string < number": false (string is greater)
+        // For "string > number": true
+        // For "string = number": false
+        // We use Greater ordering since TEXT > INTEGER/REAL
+        return Ok(Boolean(predicate(std::cmp::Ordering::Greater)));
+    }
+
+    // Numeric compared to string: Numeric is always less
+    if is_numeric(left) && is_string(right) {
+        // number compared to "string": number < string in type order
+        // For "number < string": true
+        // For "number > string": false
+        // For "number = string": false
+        // We use Less ordering since INTEGER/REAL < TEXT
+        return Ok(Boolean(predicate(std::cmp::Ordering::Less)));
+    }
+
     match (left, right) {
         // Integer comparisons
         (Integer(a), Integer(b)) => Ok(Boolean(predicate(a.cmp(b)))),

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/comparison.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/comparison.rs
@@ -10,9 +10,18 @@ use super::{
         filter::ColumnPredicate,
         simd_ops::{self, PackedMask},
     },
-    conversion::{value_to_date_i32, value_to_f64, value_to_timestamp_i64},
+    conversion::{is_string_value, value_to_date_i32, value_to_f64, value_to_timestamp_i64},
 };
 use crate::errors::ExecutorError;
+
+/// Helper to apply null mask and return result with given constant value
+fn apply_null_mask_constant(nulls: Option<&[bool]>, len: usize, constant: bool) -> Vec<bool> {
+    if let Some(null_mask) = nulls {
+        null_mask.iter().map(|&is_null| !is_null && constant).collect()
+    } else {
+        vec![constant; len]
+    }
+}
 
 /// Evaluate predicate on i64 column using SIMD
 pub fn evaluate_predicate_i64_simd(
@@ -22,6 +31,10 @@ pub fn evaluate_predicate_i64_simd(
 ) -> Result<Vec<bool>, ExecutorError> {
     let mut result = match predicate {
         ColumnPredicate::LessThan { value, .. } => {
+            // SQLite affinity: INTEGER < TEXT is always true
+            if is_string_value(value) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), true));
+            }
             if let SqlValue::Integer(threshold) = value {
                 simd_ops::lt_i64(values, *threshold)
             } else if let SqlValue::Bigint(threshold) = value {
@@ -41,6 +54,10 @@ pub fn evaluate_predicate_i64_simd(
         }
 
         ColumnPredicate::GreaterThan { value, .. } => {
+            // SQLite affinity: INTEGER > TEXT is always false
+            if is_string_value(value) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), false));
+            }
             if let SqlValue::Integer(threshold) = value {
                 simd_ops::gt_i64(values, *threshold)
             } else if let SqlValue::Bigint(threshold) = value {
@@ -58,6 +75,10 @@ pub fn evaluate_predicate_i64_simd(
         }
 
         ColumnPredicate::Equal { value, .. } => {
+            // SQLite affinity: INTEGER = TEXT is always false
+            if is_string_value(value) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), false));
+            }
             if let SqlValue::Integer(target) = value {
                 simd_ops::eq_i64(values, *target)
             } else if let SqlValue::Bigint(target) = value {
@@ -75,6 +96,12 @@ pub fn evaluate_predicate_i64_simd(
         }
 
         ColumnPredicate::Between { low, high, .. } => {
+            // SQLite affinity: INTEGER BETWEEN TEXT AND TEXT is always false
+            // (since INTEGER < TEXT, so INTEGER >= TEXT is false)
+            if is_string_value(low) || is_string_value(high) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), false));
+            }
+
             // Try integer bounds first for optimal i64 SIMD path
             let low_i64 = match low {
                 SqlValue::Integer(v) => Some(*v),
@@ -109,6 +136,10 @@ pub fn evaluate_predicate_i64_simd(
         }
 
         ColumnPredicate::GreaterThanOrEqual { value, .. } => {
+            // SQLite affinity: INTEGER >= TEXT is always false
+            if is_string_value(value) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), false));
+            }
             if let SqlValue::Integer(threshold) = value {
                 simd_ops::ge_i64(values, *threshold)
             } else if let SqlValue::Bigint(threshold) = value {
@@ -126,6 +157,10 @@ pub fn evaluate_predicate_i64_simd(
         }
 
         ColumnPredicate::LessThanOrEqual { value, .. } => {
+            // SQLite affinity: INTEGER <= TEXT is always true
+            if is_string_value(value) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), true));
+            }
             if let SqlValue::Integer(threshold) = value {
                 simd_ops::le_i64(values, *threshold)
             } else if let SqlValue::Bigint(threshold) = value {
@@ -143,6 +178,10 @@ pub fn evaluate_predicate_i64_simd(
         }
 
         ColumnPredicate::NotEqual { value, .. } => {
+            // SQLite affinity: INTEGER <> TEXT is always true
+            if is_string_value(value) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), true));
+            }
             if let SqlValue::Integer(target) = value {
                 simd_ops::ne_i64(values, *target)
             } else if let SqlValue::Bigint(target) = value {
@@ -347,6 +386,10 @@ pub fn evaluate_predicate_f64_simd(
 ) -> Result<Vec<bool>, ExecutorError> {
     let mut result = match predicate {
         ColumnPredicate::LessThan { value, .. } => {
+            // SQLite affinity: REAL < TEXT is always true
+            if is_string_value(value) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), true));
+            }
             let threshold =
                 value_to_f64(value).ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
                     operation: "comparison".to_string(),
@@ -357,6 +400,10 @@ pub fn evaluate_predicate_f64_simd(
         }
 
         ColumnPredicate::GreaterThan { value, .. } => {
+            // SQLite affinity: REAL > TEXT is always false
+            if is_string_value(value) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), false));
+            }
             let threshold =
                 value_to_f64(value).ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
                     operation: "comparison".to_string(),
@@ -367,6 +414,10 @@ pub fn evaluate_predicate_f64_simd(
         }
 
         ColumnPredicate::GreaterThanOrEqual { value, .. } => {
+            // SQLite affinity: REAL >= TEXT is always false
+            if is_string_value(value) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), false));
+            }
             let threshold =
                 value_to_f64(value).ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
                     operation: "comparison".to_string(),
@@ -377,6 +428,10 @@ pub fn evaluate_predicate_f64_simd(
         }
 
         ColumnPredicate::LessThanOrEqual { value, .. } => {
+            // SQLite affinity: REAL <= TEXT is always true
+            if is_string_value(value) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), true));
+            }
             let threshold =
                 value_to_f64(value).ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
                     operation: "comparison".to_string(),
@@ -387,6 +442,10 @@ pub fn evaluate_predicate_f64_simd(
         }
 
         ColumnPredicate::Equal { value, .. } => {
+            // SQLite affinity: REAL = TEXT is always false
+            if is_string_value(value) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), false));
+            }
             let target =
                 value_to_f64(value).ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
                     operation: "comparison".to_string(),
@@ -397,6 +456,10 @@ pub fn evaluate_predicate_f64_simd(
         }
 
         ColumnPredicate::Between { low, high, .. } => {
+            // SQLite affinity: REAL BETWEEN TEXT AND TEXT is always false
+            if is_string_value(low) || is_string_value(high) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), false));
+            }
             let low_f64 = value_to_f64(low).ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
                 operation: "BETWEEN".to_string(),
                 left_type: "Float64".to_string(),
@@ -412,6 +475,10 @@ pub fn evaluate_predicate_f64_simd(
         }
 
         ColumnPredicate::NotEqual { value, .. } => {
+            // SQLite affinity: REAL <> TEXT is always true
+            if is_string_value(value) {
+                return Ok(apply_null_mask_constant(nulls, values.len(), true));
+            }
             let target =
                 value_to_f64(value).ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
                     operation: "comparison".to_string(),

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/conversion.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/conversion.rs
@@ -7,6 +7,11 @@ use vibesql_types::SqlValue;
 
 use super::super::filter::parse_date_string;
 
+/// Check if a SqlValue is a string type (TEXT in SQLite terms)
+pub fn is_string_value(value: &SqlValue) -> bool {
+    matches!(value, SqlValue::Character(_) | SqlValue::Varchar(_))
+}
+
 /// Convert SqlValue to f64 for numeric comparisons
 pub fn value_to_f64(value: &SqlValue) -> Option<f64> {
     match value {

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/string.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/string.rs
@@ -25,6 +25,20 @@ pub fn evaluate_predicate_string_batch(
             // Extract target string
             let target = match value {
                 SqlValue::Character(s) | SqlValue::Varchar(s) => &**s,
+                // SQLite affinity: TEXT vs INTEGER/REAL equality is always false
+                // Different types never match in equality comparison
+                SqlValue::Integer(_)
+                | SqlValue::Bigint(_)
+                | SqlValue::Real(_)
+                | SqlValue::Numeric(_)
+                | SqlValue::Smallint(_) => {
+                    // Return all false - no matches, respecting NULL handling
+                    return Ok(if let Some(null_mask) = nulls {
+                        null_mask.iter().map(|&is_null| !is_null && false).collect()
+                    } else {
+                        vec![false; values.len()]
+                    });
+                }
                 _ => {
                     return Err(ExecutorError::ColumnarTypeMismatch {
                         operation: "string equality".to_string(),
@@ -39,6 +53,19 @@ pub fn evaluate_predicate_string_batch(
         ColumnPredicate::LessThan { value, .. } => {
             let target = match value {
                 SqlValue::Character(s) | SqlValue::Varchar(s) => &**s,
+                // SQLite affinity: TEXT is always GREATER than INTEGER/REAL
+                // So "string < number" is always false
+                SqlValue::Integer(_)
+                | SqlValue::Bigint(_)
+                | SqlValue::Real(_)
+                | SqlValue::Numeric(_)
+                | SqlValue::Smallint(_) => {
+                    return Ok(if let Some(null_mask) = nulls {
+                        null_mask.iter().map(|&is_null| !is_null && false).collect()
+                    } else {
+                        vec![false; values.len()]
+                    });
+                }
                 _ => {
                     return Err(ExecutorError::ColumnarTypeMismatch {
                         operation: "string comparison".to_string(),
@@ -53,6 +80,19 @@ pub fn evaluate_predicate_string_batch(
         ColumnPredicate::GreaterThan { value, .. } => {
             let target = match value {
                 SqlValue::Character(s) | SqlValue::Varchar(s) => &**s,
+                // SQLite affinity: TEXT is always GREATER than INTEGER/REAL
+                // So "string > number" is always true (for non-null values)
+                SqlValue::Integer(_)
+                | SqlValue::Bigint(_)
+                | SqlValue::Real(_)
+                | SqlValue::Numeric(_)
+                | SqlValue::Smallint(_) => {
+                    return Ok(if let Some(null_mask) = nulls {
+                        null_mask.iter().map(|&is_null| !is_null).collect()
+                    } else {
+                        vec![true; values.len()]
+                    });
+                }
                 _ => {
                     return Err(ExecutorError::ColumnarTypeMismatch {
                         operation: "string comparison".to_string(),
@@ -67,6 +107,19 @@ pub fn evaluate_predicate_string_batch(
         ColumnPredicate::LessThanOrEqual { value, .. } => {
             let target = match value {
                 SqlValue::Character(s) | SqlValue::Varchar(s) => &**s,
+                // SQLite affinity: TEXT is always GREATER than INTEGER/REAL
+                // So "string <= number" is always false
+                SqlValue::Integer(_)
+                | SqlValue::Bigint(_)
+                | SqlValue::Real(_)
+                | SqlValue::Numeric(_)
+                | SqlValue::Smallint(_) => {
+                    return Ok(if let Some(null_mask) = nulls {
+                        null_mask.iter().map(|&is_null| !is_null && false).collect()
+                    } else {
+                        vec![false; values.len()]
+                    });
+                }
                 _ => {
                     return Err(ExecutorError::ColumnarTypeMismatch {
                         operation: "string comparison".to_string(),
@@ -81,6 +134,19 @@ pub fn evaluate_predicate_string_batch(
         ColumnPredicate::GreaterThanOrEqual { value, .. } => {
             let target = match value {
                 SqlValue::Character(s) | SqlValue::Varchar(s) => &**s,
+                // SQLite affinity: TEXT is always GREATER than INTEGER/REAL
+                // So "string >= number" is always true (for non-null values)
+                SqlValue::Integer(_)
+                | SqlValue::Bigint(_)
+                | SqlValue::Real(_)
+                | SqlValue::Numeric(_)
+                | SqlValue::Smallint(_) => {
+                    return Ok(if let Some(null_mask) = nulls {
+                        null_mask.iter().map(|&is_null| !is_null).collect()
+                    } else {
+                        vec![true; values.len()]
+                    });
+                }
                 _ => {
                     return Err(ExecutorError::ColumnarTypeMismatch {
                         operation: "string comparison".to_string(),
@@ -95,6 +161,19 @@ pub fn evaluate_predicate_string_batch(
         ColumnPredicate::NotEqual { value, .. } => {
             let target = match value {
                 SqlValue::Character(s) | SqlValue::Varchar(s) => &**s,
+                // SQLite affinity: TEXT vs INTEGER/REAL are always not equal
+                // So "string <> number" is always true (for non-null values)
+                SqlValue::Integer(_)
+                | SqlValue::Bigint(_)
+                | SqlValue::Real(_)
+                | SqlValue::Numeric(_)
+                | SqlValue::Smallint(_) => {
+                    return Ok(if let Some(null_mask) = nulls {
+                        null_mask.iter().map(|&is_null| !is_null).collect()
+                    } else {
+                        vec![true; values.len()]
+                    });
+                }
                 _ => {
                     return Err(ExecutorError::ColumnarTypeMismatch {
                         operation: "string comparison".to_string(),
@@ -127,6 +206,31 @@ pub fn evaluate_predicate_string_batch(
         }
 
         ColumnPredicate::Between { low, high, .. } => {
+            // Helper to check if a value is numeric
+            let is_numeric = |v: &SqlValue| {
+                matches!(
+                    v,
+                    SqlValue::Integer(_)
+                        | SqlValue::Bigint(_)
+                        | SqlValue::Real(_)
+                        | SqlValue::Numeric(_)
+                        | SqlValue::Smallint(_)
+                )
+            };
+
+            // SQLite affinity: TEXT is always GREATER than INTEGER/REAL
+            // For "string BETWEEN low_num AND high_num":
+            //   - string >= low_num is true (text > numbers)
+            //   - string <= high_num is false (text > numbers)
+            //   - Result: true AND false = false
+            if is_numeric(low) && is_numeric(high) {
+                return Ok(if let Some(null_mask) = nulls {
+                    null_mask.iter().map(|&is_null| !is_null && false).collect()
+                } else {
+                    vec![false; values.len()]
+                });
+            }
+
             // String BETWEEN - compare lexicographically
             let low_str = match low {
                 SqlValue::Character(s) | SqlValue::Varchar(s) => &**s,


### PR DESCRIPTION
## Summary

- Implements SQLite type affinity rules for mixed-type comparisons
- String (TEXT) values are always greater than INTEGER/REAL in type ordering
- Comparisons between strings and numbers now work correctly instead of throwing errors
- Fixes issue where `SELECT count(*) FROM t WHERE text_col = 5` would error instead of returning 0

## Test Plan

- [x] Verified original issue is fixed: `WHERE b=5` on text column returns 0 rows
- [x] All comparison operators work correctly for string vs number
- [x] All unit tests pass
- [x] TCL select1 tests improved (select1-2.5.x tests now pass)

Closes #4444

🤖 Generated with [Claude Code](https://claude.com/claude-code)