### PR TITLE
fix(executor): Sort UNION results for SQLite compatibility

### DIFF
--- a/crates/vibesql-executor/src/select/set_operations.rs
+++ b/crates/vibesql-executor/src/select/set_operations.rs
@@ -26,15 +26,18 @@ pub(super) fn apply_set_operation(
     match set_op.op {
         vibesql_ast::SetOperator::Union => {
             if set_op.all {
-                // UNION ALL: combine all rows from both queries
+                // UNION ALL: combine all rows from both queries (preserves insertion order)
                 let mut result = left;
                 result.extend(right);
                 Ok(result)
             } else {
-                // UNION (DISTINCT): combine and remove duplicates
+                // UNION (DISTINCT): combine, remove duplicates, and sort
+                // SQLite sorts UNION results by all columns in ascending order
                 let mut result = left;
                 result.extend(right);
-                Ok(apply_distinct(result))
+                let mut result = apply_distinct(result);
+                result.sort_by(|a, b| a.values.cmp(&b.values));
+                Ok(result)
             }
         }
 


### PR DESCRIPTION
## Summary

- UNION (without ALL) now returns results sorted by all columns in ascending order after deduplication
- UNION ALL continues to preserve insertion order (no change)
- Matches SQLite's behavior for UNION operations

## Test plan

- [x] Verified test case from issue: `SELECT 3, 4 UNION SELECT * FROM t3` now returns `1|2` before `3|4`
- [x] Verified UNION ALL preserves insertion order
- [x] TCL test select1-12.6 now passes
- [x] Existing set_operations tests pass
- [x] SQLLogicTest suite passes

Closes #4447

🤖 Generated with [Claude Code](https://claude.com/claude-code)