### PR TITLE
bench(server): Update TPC-H server benchmark to use extended query protocol (#4458)

### DIFF
--- a/crates/vibesql-server/benches/tpch_server.rs
+++ b/crates/vibesql-server/benches/tpch_server.rs
@@ -205,8 +205,8 @@ impl PostgresExecutor {
     }
 
     async fn query(&self, sql: &str) -> Result<usize, tokio_postgres::Error> {
-        let msgs = self.client.simple_query(sql).await?;
-        Ok(msgs.iter().filter(|m| matches!(m, tokio_postgres::SimpleQueryMessage::Row(_))).count())
+        let rows = self.client.query(sql, &[]).await?;
+        Ok(rows.len())
     }
 }
 


### PR DESCRIPTION
## Summary

- Updated TPC-H server benchmark to use extended query protocol (`client.query(sql, &[])`) instead of simple query protocol (`client.simple_query(sql)`)
- Aligns with TPC-C server benchmark which was updated in #4454
- Creates fair comparison with MySQL which uses prepared statements

## Test plan

- [x] Built benchmark successfully
- [x] Verified all 12 TPC-H queries work with extended protocol (Q1, Q3, Q4, Q5, Q6, Q7, Q9, Q10, Q11, Q12, Q14, Q19)
- [x] Ran benchmark to confirm results are valid

Closes #4458

🤖 Generated with [Claude Code](https://claude.com/claude-code)