### PR TITLE
fix(tcl): Fix timeouts in TCL tests with heavy INSERT loops

### DIFF
--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -850,7 +850,7 @@ def main():
     parser.add_argument("--output", "-o", help="Output JSON file")
     parser.add_argument("--parallel", action="store_true", help="Run tests in parallel")
     parser.add_argument("--verbose", "-v", action="store_true")
-    parser.add_argument("--timeout", type=float, default=5.0, help="Per-test timeout in seconds")
+    parser.add_argument("--timeout", type=float, default=None, help="Per-test timeout in seconds (default: 5 for static mode, 300 for native TCL)")
     parser.add_argument("--native-tcl", action="store_true",
                         help="Run tests using native tclsh instead of parsing (for files with TCL loops)")
     parser.add_argument("--tcl-shim", default=None,
@@ -861,6 +861,13 @@ def main():
     if not os.path.exists(args.vibesql):
         print(f"Error: VibeSQL binary not found: {args.vibesql}", file=sys.stderr)
         sys.exit(1)
+
+    # Set appropriate timeout defaults based on mode
+    if args.timeout is None:
+        if args.native_tcl:
+            args.timeout = 300.0  # 5 minutes for native TCL (handles heavy INSERT tests)
+        else:
+            args.timeout = 5.0   # 5 seconds for static parsing mode
 
     # Determine files to run
     if args.file:

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -327,18 +327,28 @@ proc track_pragma_setting {sql} {
 
 proc flush_batch {} {
     # Execute accumulated SQL statements
+    # Uses a temp file to avoid "argument list too long" errors for large batches
     if {[llength $::sql_batch] == 0} return
 
     set combined [join $::sql_batch ";\n"]
     set ::sql_batch {}
 
+    # Write SQL to temp file to avoid command line length limits
+    set tmpfile "/tmp/vibesql_batch_[pid].sql"
+    set f [open $tmpfile w]
+    puts $f $combined
+    close $f
+
     if {$::db_file eq ""} {
-        set cmd [list echo $combined | $::vibesql_path]
+        set exec_code [catch {exec $::vibesql_path < $tmpfile 2>@1} result]
     } else {
-        set cmd [list echo $combined | $::vibesql_path $::db_file]
+        set exec_code [catch {exec $::vibesql_path $::db_file < $tmpfile 2>@1} result]
     }
 
-    if {[catch {exec {*}$cmd 2>@1} result]} {
+    # Clean up temp file
+    file delete -force $tmpfile
+
+    if {$exec_code != 0} {
         error $result
     }
     return $result
@@ -372,11 +382,23 @@ proc execsql {sql {db ""}} {
     }
 
     # Handle transaction batching
-    if {$sql_upper eq "BEGIN" || [string match "BEGIN*" $sql_upper]} {
+    # Since vibesql doesn't persist transaction state across process invocations,
+    # we must batch all SQL from BEGIN to COMMIT and execute it in one process.
+    # Count BEGIN, COMMIT, ROLLBACK to track transaction state changes in this SQL
+    # Note: TCL uses \m and \M for word boundaries (not \b like PCRE)
+    set begin_count [regexp -all -nocase {\mBEGIN\M} $sql]
+    set end_count [expr {[regexp -all -nocase {\mCOMMIT\M} $sql] + [regexp -all -nocase {\mROLLBACK\M} $sql]}]
+    set net_begin [expr {$begin_count - $end_count}]
+
+    if {$net_begin > 0} {
+        # SQL opens a transaction (e.g., "BEGIN" or "CREATE TABLE...; BEGIN;")
+        # Add to batch and defer execution until COMMIT
         set ::in_transaction 1
         lappend ::sql_batch $sql
         return {}
-    } elseif {$sql_upper eq "COMMIT" || $sql_upper eq "ROLLBACK"} {
+    } elseif {$net_begin < 0 || ($::in_transaction && $end_count > 0)} {
+        # SQL closes a transaction (e.g., "COMMIT" or has more COMMITs than BEGINs)
+        # Flush the entire batch including this statement
         lappend ::sql_batch $sql
         set ::in_transaction 0
         if {[catch {flush_batch} result]} {
@@ -384,7 +406,12 @@ proc execsql {sql {db ""}} {
             error [translate_error_to_sqlite $result]
         }
         return [parse_result $result]
+    } elseif {$begin_count > 0 && $end_count > 0 && $begin_count == $end_count} {
+        # Balanced BEGIN/COMMIT in one statement - execute directly
+        # (e.g., "BEGIN; INSERT...; COMMIT;")
+        # Fall through to direct execution below
     } elseif {$::in_transaction} {
+        # Inside a transaction - add to batch
         lappend ::sql_batch $sql
         return {}
     }


### PR DESCRIPTION
## Summary
- Fixed TCL word boundary regex (`\m`/`\M` instead of `\b`) for detecting transactions
- Fixed batch SQL execution to use temp files instead of echo (avoids "argument list too long")
- Increased native TCL mode default timeout from 5s to 300s for heavy INSERT tests

## Investigation Findings

| Test File | Status | Root Cause |
|-----------|--------|------------|
| select2.test | ✅ Fixed | TCL regex bug + timeout too short - now completes in ~84s |
| select9.test | ⚠️ Still slow | Generates 1000s of tests via nested loops - needs 10+ min |
| delete3.test | ✅ Not timeout | Completes with 2 tests |
| func.test | ❌ Not timeout | Requires C extension `sqlite_register_test_function` |
| in2.test | ✅ Not timeout | Completes with 1999 tests |

## Test plan
- [x] Verified select2.test completes in ~84 seconds (was timing out at 60s)
- [x] Verified delete3.test and in2.test are not timeout issues
- [x] Identified func.test requires C extensions
- [x] Identified select9.test needs longer timeout due to test generation

Closes #4464

🤖 Generated with [Claude Code](https://claude.com/claude-code)