### PR TITLE
fix(join): Make table.* return all columns in NATURAL JOIN context

### DIFF
--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -525,7 +525,7 @@ mod tests {
     #[test]
     fn test_empty_outer_schema() {
         let outer_schema =
-            CombinedSchema { table_schemas: std::collections::HashMap::new(), total_columns: 0 };
+            CombinedSchema { table_schemas: std::collections::HashMap::new(), total_columns: 0, hidden_columns: std::collections::HashSet::new() };
 
         let subquery = SelectStmt {
             with_clause: None,

--- a/crates/vibesql-executor/src/optimizer/column_pruning.rs
+++ b/crates/vibesql-executor/src/optimizer/column_pruning.rs
@@ -484,6 +484,7 @@ pub fn remap_schema(
     crate::schema::CombinedSchema {
         table_schemas: new_table_schemas,
         total_columns: projection_indices.len(),
+        hidden_columns: std::collections::HashSet::new(),
     }
 }
 

--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Borrow,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt,
     hash::{Hash, Hasher},
     ops::Deref,
@@ -108,6 +108,11 @@ pub struct CombinedSchema {
     pub table_schemas: HashMap<TableKey, (usize, vibesql_catalog::TableSchema)>,
     /// Total number of columns across all tables
     pub total_columns: usize,
+    /// Columns that are hidden from `SELECT *` expansion due to NATURAL JOIN deduplication.
+    /// These columns are still accessible via qualified references like `table.*`.
+    /// This allows `SELECT t1.*` to return all columns from t1, while `SELECT *`
+    /// correctly deduplicates columns for NATURAL JOIN.
+    pub hidden_columns: HashSet<usize>,
 }
 
 impl CombinedSchema {
@@ -119,7 +124,7 @@ impl CombinedSchema {
         let mut table_schemas = HashMap::new();
         // TableKey automatically normalizes to lowercase
         table_schemas.insert(TableKey::new(table_name), (0, schema));
-        CombinedSchema { table_schemas, total_columns }
+        CombinedSchema { table_schemas, total_columns, hidden_columns: HashSet::new() }
     }
 
     /// Create a new combined schema from a derived table (subquery result)
@@ -148,7 +153,7 @@ impl CombinedSchema {
         let mut table_schemas = HashMap::new();
         // TableKey automatically normalizes to lowercase
         table_schemas.insert(TableKey::new(alias), (0, schema));
-        CombinedSchema { table_schemas, total_columns }
+        CombinedSchema { table_schemas, total_columns, hidden_columns: HashSet::new() }
     }
 
     /// Combine two schemas (for JOIN operations)
@@ -164,7 +169,11 @@ impl CombinedSchema {
         let right_columns = right_schema.columns.len();
         // TableKey automatically normalizes to lowercase
         table_schemas.insert(right_table.into(), (left_total, right_schema));
-        CombinedSchema { table_schemas, total_columns: left_total + right_columns }
+        CombinedSchema {
+            table_schemas,
+            total_columns: left_total + right_columns,
+            hidden_columns: left.hidden_columns,
+        }
     }
 
     /// Merge two CombinedSchemas (for JOIN operations with nested joins)
@@ -186,7 +195,13 @@ impl CombinedSchema {
             table_schemas.insert(table_key, (adjusted_start, schema));
         }
 
-        CombinedSchema { table_schemas, total_columns: left_total + right.total_columns }
+        // Merge hidden columns, adjusting right side indices
+        let mut hidden_columns = left.hidden_columns;
+        for idx in right.hidden_columns {
+            hidden_columns.insert(left_total + idx);
+        }
+
+        CombinedSchema { table_schemas, total_columns: left_total + right.total_columns, hidden_columns }
     }
 
     /// Look up a column by name (optionally qualified with table name)
@@ -361,6 +376,27 @@ impl CombinedSchema {
         // Fallback: return the input column name if not found in schema
         column.to_string()
     }
+
+    /// Check if a column index is hidden from `SELECT *` expansion.
+    ///
+    /// Columns are hidden when they are duplicates in a NATURAL JOIN.
+    /// For example, in `SELECT * FROM t1 NATURAL JOIN t2` where both tables
+    /// have column `a`, the `t2.a` column is hidden so `SELECT *` only shows
+    /// one copy of `a` (from t1).
+    ///
+    /// However, `SELECT t2.*` should still include `t2.a` because qualified
+    /// wildcards expand all columns from that specific table.
+    #[inline]
+    pub fn is_column_hidden(&self, idx: usize) -> bool {
+        self.hidden_columns.contains(&idx)
+    }
+
+    /// Mark a column as hidden from `SELECT *` expansion.
+    ///
+    /// This is used by NATURAL JOIN to hide duplicate columns from the right side.
+    pub fn hide_column(&mut self, idx: usize) {
+        self.hidden_columns.insert(idx);
+    }
 }
 
 /// Builder for incrementally constructing a CombinedSchema
@@ -371,12 +407,13 @@ impl CombinedSchema {
 pub struct SchemaBuilder {
     table_schemas: HashMap<TableKey, (usize, vibesql_catalog::TableSchema)>,
     column_offset: usize,
+    hidden_columns: HashSet<usize>,
 }
 
 impl SchemaBuilder {
     /// Create a new empty schema builder
     pub fn new() -> Self {
-        SchemaBuilder { table_schemas: HashMap::new(), column_offset: 0 }
+        SchemaBuilder { table_schemas: HashMap::new(), column_offset: 0, hidden_columns: HashSet::new() }
     }
 
     /// Create a schema builder initialized with an existing CombinedSchema
@@ -385,7 +422,7 @@ impl SchemaBuilder {
     pub fn from_schema(schema: CombinedSchema) -> Self {
         let column_offset = schema.total_columns;
         // TableKeys are already normalized, just pass them through
-        SchemaBuilder { table_schemas: schema.table_schemas, column_offset }
+        SchemaBuilder { table_schemas: schema.table_schemas, column_offset, hidden_columns: schema.hidden_columns }
     }
 
     /// Add a table to the schema
@@ -408,7 +445,7 @@ impl SchemaBuilder {
     ///
     /// This consumes the builder and produces the schema in O(1) time
     pub fn build(self) -> CombinedSchema {
-        CombinedSchema { table_schemas: self.table_schemas, total_columns: self.column_offset }
+        CombinedSchema { table_schemas: self.table_schemas, total_columns: self.column_offset, hidden_columns: self.hidden_columns }
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -210,7 +210,7 @@ fn build_aggregate_result_schema(select_list: &[SelectItem]) -> CombinedSchema {
     let mut table_schemas = std::collections::HashMap::new();
     table_schemas.insert(TableKey::new("result"), (0, table_schema.clone()));
 
-    CombinedSchema { table_schemas, total_columns: table_schema.columns.len() }
+    CombinedSchema { table_schemas, total_columns: table_schema.columns.len(), hidden_columns: std::collections::HashSet::new() }
 }
 
 /// Map an expression to a column reference in the result schema

--- a/crates/vibesql-executor/src/select/executor/arena_execution.rs
+++ b/crates/vibesql-executor/src/select/executor/arena_execution.rs
@@ -25,7 +25,7 @@
 //!
 //! This is particularly beneficial for OLTP workloads with high query rates.
 
-use std::{cmp::Ordering, collections::HashMap};
+use std::{cmp::Ordering, collections::{HashMap, HashSet}};
 
 use vibesql_ast::arena::{
     ArenaInterner, Expression as ArenaExpression, ExtendedExpr as ArenaExtendedExpr,
@@ -119,7 +119,7 @@ impl SelectExecutor<'_> {
         interner: &'arena ArenaInterner<'arena>,
     ) -> Result<Vec<Row>, ExecutorError> {
         // Create an empty schema and row for expression evaluation
-        let schema = CombinedSchema { table_schemas: HashMap::new(), total_columns: 0 };
+        let schema = CombinedSchema { table_schemas: HashMap::new(), total_columns: 0, hidden_columns: HashSet::new() };
         let empty_row = Row::new(vec![]);
         let evaluator = ArenaExpressionEvaluator::new(&schema, params, interner);
 

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -3,7 +3,7 @@
 //! This module contains free functions that support the JOIN execution path,
 //! including join tree flattening, condition extraction, and schema building.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use vibesql_ast::{BinaryOperator, Expression, FromClause, JoinType};
 
@@ -176,7 +176,7 @@ fn extract_non_join_predicates_recursive(
 pub(super) fn build_combined_schema(
     batches: &[(String, Option<String>, columnar::ColumnarBatch, vibesql_catalog::TableSchema)],
 ) -> CombinedSchema {
-    let mut combined = CombinedSchema { table_schemas: HashMap::new(), total_columns: 0 };
+    let mut combined = CombinedSchema { table_schemas: HashMap::new(), total_columns: 0, hidden_columns: HashSet::new() };
 
     for (table_name, alias, _batch, schema) in batches {
         let name = alias.as_ref().unwrap_or(table_name);

--- a/crates/vibesql-executor/src/select/executor/columns.rs
+++ b/crates/vibesql-executor/src/select/executor/columns.rs
@@ -76,6 +76,7 @@ impl SelectExecutor<'_> {
             match item {
                 vibesql_ast::SelectItem::Wildcard { alias } => {
                     // SELECT * [AS (col1, col2, ...)] - expand to all column names from schema
+                    // Skip hidden columns (from NATURAL JOIN deduplication)
                     if let Some(from_res) = from_result {
                         // Get all column names in order from the combined schema
                         let mut table_columns: Vec<(usize, String)> = Vec::new();
@@ -84,6 +85,11 @@ impl SelectExecutor<'_> {
                             &from_res.schema.table_schemas
                         {
                             for (col_idx, col_schema) in table_schema.columns.iter().enumerate() {
+                                let abs_idx = start_index + col_idx;
+                                // Skip hidden columns (from NATURAL JOIN deduplication)
+                                if from_res.schema.is_column_hidden(abs_idx) {
+                                    continue;
+                                }
                                 let col_name = match mode {
                                     ColumnNamingMode::Full => {
                                         // Use the table key (alias or table name) as the prefix
@@ -94,7 +100,7 @@ impl SelectExecutor<'_> {
                                         col_schema.name.clone()
                                     }
                                 };
-                                table_columns.push((start_index + col_idx, col_name));
+                                table_columns.push((abs_idx, col_name));
                             }
                         }
 

--- a/crates/vibesql-executor/src/select/iterator/join.rs
+++ b/crates/vibesql-executor/src/select/iterator/join.rs
@@ -119,8 +119,14 @@ impl<'schema, I: RowIterator> LazyNestedLoopJoin<'schema, I> {
             right_total += schema.columns.len();
         }
 
+        // Merge hidden columns, adjusting right side indices
+        let mut hidden_columns = left_schema.hidden_columns.clone();
+        for idx in right_schema.hidden_columns.iter() {
+            hidden_columns.insert(left_total + idx);
+        }
+
         let combined_schema =
-            CombinedSchema { table_schemas, total_columns: left_total + right_total };
+            CombinedSchema { table_schemas, total_columns: left_total + right_total, hidden_columns };
 
         let right_count = right_rows.len();
 

--- a/crates/vibesql-executor/src/select/iterator/tests/phase_c.rs
+++ b/crates/vibesql-executor/src/select/iterator/tests/phase_c.rs
@@ -207,6 +207,7 @@ fn test_phase_c_proof_of_concept_join_pipeline() {
     let combined_schema = CombinedSchema {
         table_schemas: combined_tables,
         total_columns: orders_combined.total_columns + customers_combined.total_columns,
+        hidden_columns: std::collections::HashSet::new(),
     };
 
     let where_expr = vibesql_ast::Expression::BinaryOp {

--- a/crates/vibesql-executor/src/select/join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/mod.rs
@@ -1212,16 +1212,23 @@ pub(super) fn nested_loop_join(
     Ok(result)
 }
 
-/// Remove duplicate columns for NATURAL JOIN
+/// Mark duplicate columns as hidden for NATURAL JOIN
 ///
-/// NATURAL JOIN should only include common columns once (from the left side).
-/// This function identifies common columns and removes duplicates from the right side.
+/// NATURAL JOIN should only include common columns once (from the left side) in `SELECT *`.
+/// However, qualified wildcards like `SELECT t1.*` should still return all columns from t1.
+///
+/// This function marks duplicate columns from the right side as hidden in the schema,
+/// rather than removing them. This allows:
+/// - `SELECT *` to correctly deduplicate columns (skips hidden columns)
+/// - `SELECT t1.*` to return all columns from t1 (includes hidden columns)
+///
+/// Issue #4466: table.* should return all columns in NATURAL JOIN context
 fn remove_duplicate_columns_for_natural_join(
     mut result: FromResult,
     left_schema: &CombinedSchema,
     right_schema: &CombinedSchema,
 ) -> Result<FromResult, ExecutorError> {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
 
     // Find common column names (case-insensitive)
     // Use table_start_idx to compute correct absolute positions
@@ -1241,75 +1248,32 @@ fn remove_duplicate_columns_for_natural_join(
     // Identify which columns from the right side are duplicates
     // Use table_start_idx from right_schema to compute correct absolute positions
     let left_col_count = left_schema.total_columns;
-    let mut right_duplicate_indices: HashSet<usize> = HashSet::new();
     for (_table_name, (table_start_idx, table_schema)) in &right_schema.table_schemas {
         for (col_idx, col) in table_schema.columns.iter().enumerate() {
             let lowercase = col.name.to_lowercase();
             if left_column_map.contains_key(&lowercase) {
-                // This is a common column, mark it as a duplicate to remove
+                // This is a common column, mark it as hidden for SELECT * expansion
                 // Position in result = left_col_count + position_in_right_schema
-                right_duplicate_indices.insert(left_col_count + table_start_idx + col_idx);
+                let hidden_idx = left_col_count + table_start_idx + col_idx;
+                result.schema.hide_column(hidden_idx);
             }
         }
     }
 
-    // If no duplicates, return as-is
-    if right_duplicate_indices.is_empty() {
-        return Ok(result);
-    }
-
-    // Project out the duplicate columns from the result
-    let total_cols = left_col_count + right_schema.total_columns;
-    let keep_indices: Vec<usize> =
-        (0..total_cols).filter(|i| !right_duplicate_indices.contains(i)).collect();
-
-    // Build new schema without duplicate columns
-    // Sort tables by their start index to ensure consistent ordering
-    // (HashMap iteration order is non-deterministic)
-    let mut sorted_tables: Vec<_> = result.schema.table_schemas.iter().collect();
-    sorted_tables.sort_by_key(|(_, (start_idx, _))| *start_idx);
-
-    let mut new_schema = CombinedSchema { table_schemas: HashMap::new(), total_columns: 0 };
-    for (table_name, (table_start_idx, table_schema)) in sorted_tables {
-        let mut new_cols = Vec::new();
-
-        for (idx, col) in table_schema.columns.iter().enumerate() {
-            // Calculate absolute column index manually
-            let abs_col_idx = table_start_idx + idx;
-
-            if keep_indices.contains(&abs_col_idx) {
-                new_cols.push(col.clone());
-            }
-        }
-
-        if !new_cols.is_empty() {
-            let new_table_schema =
-                vibesql_catalog::TableSchema::new(table_schema.name.clone(), new_cols);
-            new_schema
-                .table_schemas
-                .insert(table_name.clone(), (new_schema.total_columns, new_table_schema.clone()));
-            new_schema.total_columns += new_table_schema.columns.len();
-        }
-    }
-
-    // Project the rows - get mutable reference to rows to work with FromResult API
-    let rows = result.rows();
-    let new_rows: Vec<vibesql_storage::Row> = rows
-        .iter()
-        .map(|row| {
-            let new_values: Vec<vibesql_types::SqlValue> =
-                keep_indices.iter().filter_map(|&i| row.values.get(i).cloned()).collect();
-            vibesql_storage::Row::new(new_values)
-        })
-        .collect();
-
-    Ok(FromResult::from_rows(new_schema, new_rows))
+    Ok(result)
 }
 
-/// Remove duplicate columns for USING clause JOIN
+/// Mark USING columns as hidden for USING clause JOIN
 ///
-/// USING clause should only include the specified columns once (from the left side).
-/// This function removes the USING columns from the right side of the join result.
+/// USING clause should only include the specified columns once (from the left side) in `SELECT *`.
+/// However, qualified wildcards like `SELECT t1.*` should still return all columns from t1.
+///
+/// This function marks USING columns from the right side as hidden in the schema,
+/// rather than removing them. This allows:
+/// - `SELECT *` to correctly deduplicate columns (skips hidden columns)
+/// - `SELECT t1.*` to return all columns from t1 (includes hidden columns)
+///
+/// Issue #4466: table.* should return all columns in NATURAL JOIN context
 fn remove_duplicate_columns_for_using_join(
     mut result: FromResult,
     left_schema: &CombinedSchema,
@@ -1325,72 +1289,19 @@ fn remove_duplicate_columns_for_using_join(
     // Count columns in left schema
     let left_col_count = left_schema.total_columns;
 
-    // Identify which columns from the right side are USING columns to remove
+    // Identify which columns from the right side are USING columns to hide
     // Use table_start_idx from right_schema to compute correct absolute positions
-    // (HashMap iteration order is non-deterministic, so we can't use a sequential counter)
-    let mut right_duplicate_indices: HashSet<usize> = HashSet::new();
     for (_table_name, (table_start_idx, table_schema)) in &right_schema.table_schemas {
         for (col_idx, col) in table_schema.columns.iter().enumerate() {
             let lowercase = col.name.to_lowercase();
             if using_cols_lower.contains(&lowercase) {
-                // This is a USING column, mark it as a duplicate to remove
+                // This is a USING column, mark it as hidden for SELECT * expansion
                 // Position in result = left_col_count + position_in_right_schema
-                // Position in right schema = table_start_idx + col_idx
-                right_duplicate_indices.insert(left_col_count + table_start_idx + col_idx);
+                let hidden_idx = left_col_count + table_start_idx + col_idx;
+                result.schema.hide_column(hidden_idx);
             }
         }
     }
 
-    // If no duplicates, return as-is
-    if right_duplicate_indices.is_empty() {
-        return Ok(result);
-    }
-
-    // Project out the duplicate columns from the result
-    let total_cols = left_col_count + right_schema.total_columns;
-    let keep_indices: Vec<usize> =
-        (0..total_cols).filter(|i| !right_duplicate_indices.contains(i)).collect();
-
-    // Build new schema without duplicate columns
-    // Sort tables by their start index to ensure consistent ordering
-    // (HashMap iteration order is non-deterministic)
-    use std::collections::HashMap;
-    let mut sorted_tables: Vec<_> = result.schema.table_schemas.iter().collect();
-    sorted_tables.sort_by_key(|(_, (start_idx, _))| *start_idx);
-
-    let mut new_schema = CombinedSchema { table_schemas: HashMap::new(), total_columns: 0 };
-    for (table_name, (table_start_idx, table_schema)) in sorted_tables {
-        let mut new_cols = Vec::new();
-
-        for (idx, col) in table_schema.columns.iter().enumerate() {
-            // Calculate absolute column index manually
-            let abs_col_idx = table_start_idx + idx;
-
-            if keep_indices.contains(&abs_col_idx) {
-                new_cols.push(col.clone());
-            }
-        }
-
-        if !new_cols.is_empty() {
-            let new_table_schema =
-                vibesql_catalog::TableSchema::new(table_schema.name.clone(), new_cols);
-            new_schema
-                .table_schemas
-                .insert(table_name.clone(), (new_schema.total_columns, new_table_schema.clone()));
-            new_schema.total_columns += new_table_schema.columns.len();
-        }
-    }
-
-    // Project the rows
-    let rows = result.rows();
-    let new_rows: Vec<vibesql_storage::Row> = rows
-        .iter()
-        .map(|row| {
-            let new_values: Vec<vibesql_types::SqlValue> =
-                keep_indices.iter().filter_map(|&i| row.values.get(i).cloned()).collect();
-            vibesql_storage::Row::new(new_values)
-        })
-        .collect();
-
-    Ok(FromResult::from_rows(new_schema, new_rows))
+    Ok(result)
 }

--- a/crates/vibesql-executor/src/select/projection.rs
+++ b/crates/vibesql-executor/src/select/projection.rs
@@ -17,20 +17,29 @@ pub(crate) fn project_row_combined(
     for item in columns {
         match item {
             vibesql_ast::SelectItem::Wildcard { .. } => {
-                // SELECT * - include all columns
+                // SELECT * - include all columns except hidden ones (from NATURAL JOIN deduplication)
                 // When window functions are present, only include base columns (not appended window
                 // values)
-                if let Some(mapping) = window_mapping {
+                let max_col = if let Some(mapping) = window_mapping {
                     if !mapping.is_empty() {
                         // Find the minimum window column index to know where base columns end
-                        let min_window_col =
-                            mapping.values().min().copied().unwrap_or(row.values.len());
-                        values.extend(row.values[..min_window_col].iter().cloned());
+                        mapping.values().min().copied().unwrap_or(row.values.len())
                     } else {
-                        values.extend(row.values.iter().cloned());
+                        row.values.len()
                     }
                 } else {
-                    values.extend(row.values.iter().cloned());
+                    row.values.len()
+                };
+
+                // Iterate through columns, skipping hidden ones
+                for (idx, value) in row.values.iter().enumerate() {
+                    if idx >= max_col {
+                        break;
+                    }
+                    // Skip hidden columns (from NATURAL JOIN deduplication)
+                    if !schema.is_column_hidden(idx) {
+                        values.push(value.clone());
+                    }
                 }
             }
             vibesql_ast::SelectItem::QualifiedWildcard { qualifier, .. } => {

--- a/crates/vibesql-executor/src/select/scan/join_scan.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan.rs
@@ -296,12 +296,19 @@ where
     Ok(result)
 }
 
-/// Remove duplicate columns from a USING clause join result
+/// Mark USING columns as hidden for USING clause join result
 ///
-/// USING clause should only include join columns once (from the left side).
-/// This function identifies USING columns in the right side and removes them.
+/// USING clause should only include join columns once (from the left side) in `SELECT *`.
+/// However, qualified wildcards like `SELECT t1.*` should still return all columns from t1.
+///
+/// This function marks USING columns from the right side as hidden in the schema,
+/// rather than removing them. This allows:
+/// - `SELECT *` to correctly deduplicate columns (skips hidden columns)
+/// - `SELECT t1.*` to return all columns from t1 (includes hidden columns)
+///
+/// Issue #4466: table.* should return all columns in NATURAL JOIN context
 fn remove_duplicate_columns_for_using_join(
-    result: super::FromResult,
+    mut result: super::FromResult,
     left_schema: &CombinedSchema,
     right_schema: &CombinedSchema,
     using_columns: &[String],
@@ -313,73 +320,21 @@ fn remove_duplicate_columns_for_using_join(
     // Count columns in left schema
     let left_col_count = left_schema.total_columns;
 
-    // Identify which columns from the right side are USING columns to remove
+    // Identify which columns from the right side are USING columns to hide
     // Use table_start_idx from right_schema to compute correct absolute positions
-    // (HashMap iteration order is non-deterministic, so we can't use a sequential counter)
-    let mut right_duplicate_indices: HashSet<usize> = HashSet::new();
     for (_table_name, (table_start_idx, table_schema)) in &right_schema.table_schemas {
         for (col_idx, col) in table_schema.columns.iter().enumerate() {
             let lowercase = col.name.to_lowercase();
             if using_cols_lower.contains(&lowercase) {
-                // This is a USING column, mark it as a duplicate to remove
+                // This is a USING column, mark it as hidden for SELECT * expansion
                 // Position in result = left_col_count + position_in_right_schema
-                right_duplicate_indices.insert(left_col_count + table_start_idx + col_idx);
+                let hidden_idx = left_col_count + table_start_idx + col_idx;
+                result.schema.hide_column(hidden_idx);
             }
         }
     }
 
-    // If no duplicates, return as-is
-    if right_duplicate_indices.is_empty() {
-        return Ok(result);
-    }
-
-    // Project out the duplicate columns from the result
-    let total_cols = left_col_count + right_schema.total_columns;
-    let keep_indices: Vec<usize> =
-        (0..total_cols).filter(|i| !right_duplicate_indices.contains(i)).collect();
-
-    // Build new schema without duplicate columns
-    // Sort tables by their start index to ensure consistent ordering
-    // (HashMap iteration order is non-deterministic)
-    let mut sorted_tables: Vec<_> = result.schema.table_schemas.iter().collect();
-    sorted_tables.sort_by_key(|(_, (start_idx, _))| *start_idx);
-
-    let mut new_schema = CombinedSchema { table_schemas: HashMap::new(), total_columns: 0 };
-    for (table_name, (table_start_idx, table_schema)) in sorted_tables {
-        let mut new_cols = Vec::new();
-
-        for (idx, col) in table_schema.columns.iter().enumerate() {
-            // Calculate absolute column index
-            let abs_col_idx = table_start_idx + idx;
-
-            if keep_indices.contains(&abs_col_idx) {
-                new_cols.push(col.clone());
-            }
-        }
-
-        if !new_cols.is_empty() {
-            let new_table_schema =
-                vibesql_catalog::TableSchema::new(table_schema.name.clone(), new_cols);
-            new_schema
-                .table_schemas
-                .insert(table_name.clone(), (new_schema.total_columns, new_table_schema.clone()));
-            new_schema.total_columns += new_table_schema.columns.len();
-        }
-    }
-
-    // Project the rows
-    let new_rows: Vec<vibesql_storage::Row> = result
-        .data
-        .as_slice()
-        .iter()
-        .map(|row| {
-            let new_values: Vec<vibesql_types::SqlValue> =
-                keep_indices.iter().filter_map(|&i| row.values.get(i).cloned()).collect();
-            vibesql_storage::Row::new(new_values)
-        })
-        .collect();
-
-    Ok(super::FromResult::from_rows(new_schema, new_rows))
+    Ok(result)
 }
 
 /// Generate the implicit join condition for a NATURAL JOIN

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -145,7 +145,10 @@ pub(super) fn build_reordered_schema(
         }
     }
 
-    CombinedSchema { table_schemas: new_table_schemas, total_columns: current_position }
+    // For reordered schemas, hidden_columns would need to be remapped to new positions
+    // However, reordering happens before NATURAL JOIN deduplication, so hidden_columns
+    // should be empty at this point
+    CombinedSchema { table_schemas: new_table_schemas, total_columns: current_position, hidden_columns: std::collections::HashSet::new() }
 }
 
 /// Build a column permutation to restore original table ordering

--- a/tests/sqllogictest-files/select/joins.slt
+++ b/tests/sqllogictest-files/select/joins.slt
@@ -42,3 +42,58 @@ DROP TABLE orders
 
 statement ok
 DROP TABLE customers
+
+# Issue #4466: table.* should return all columns in NATURAL JOIN context
+statement ok
+CREATE TABLE t1(a, b, c)
+
+statement ok
+CREATE TABLE t2(b, c, d)
+
+statement ok
+INSERT INTO t1 VALUES(1, 2, 3)
+
+statement ok
+INSERT INTO t2 VALUES(2, 3, 4)
+
+# SELECT t1.* from NATURAL JOIN should return all columns from t1
+query III rowsort
+SELECT t1.* FROM t2 NATURAL JOIN t1
+----
+1 2 3
+
+# SELECT t2.* from NATURAL JOIN should return all columns from t2
+query III rowsort
+SELECT t2.* FROM t2 NATURAL JOIN t1
+----
+2 3 4
+
+# SELECT * from NATURAL JOIN should deduplicate columns
+query IIII rowsort
+SELECT * FROM t2 NATURAL JOIN t1
+----
+2 3 4 1
+
+# Mixed wildcards should return all columns from each table
+query IIIIII rowsort
+SELECT t1.*, t2.* FROM t2 NATURAL JOIN t1
+----
+1 2 3 2 3 4
+
+# USING clause: table.* should return all columns
+query III rowsort
+SELECT t1.* FROM t1 JOIN t2 USING(b, c)
+----
+1 2 3
+
+# USING clause: SELECT * should deduplicate columns
+query IIII rowsort
+SELECT * FROM t1 JOIN t2 USING(b, c)
+----
+1 2 3 4
+
+statement ok
+DROP TABLE t1
+
+statement ok
+DROP TABLE t2


### PR DESCRIPTION
## Summary

- Fix `SELECT t1.*` in NATURAL JOIN to return all columns from t1, not just non-duplicate columns
- Add `hidden_columns` field to `CombinedSchema` to track columns hidden from `SELECT *`
- Rewrite NATURAL JOIN and USING JOIN deduplication to mark columns as hidden instead of removing them
- Update wildcard expansion to skip hidden columns for `SELECT *` but include all for `table.*`

## Test plan

- [x] Test `SELECT t1.*` from NATURAL JOIN returns all columns
- [x] Test `SELECT *` from NATURAL JOIN correctly deduplicates columns  
- [x] Test `SELECT t1.*, t2.*` returns all columns from both tables
- [x] Test USING clause with `table.*` returns all columns
- [x] Run existing executor tests - all pass
- [x] Run join-related SQLLogicTests - all pass

Closes #4466

🤖 Generated with [Claude Code](https://claude.com/claude-code)