### PR TITLE
fix(executor): Validate column count in recursive CTE base/recursive terms

### DIFF
--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -264,6 +264,18 @@ where
             break;
         }
 
+        // Validate that recursive term returns same number of columns as base term
+        // This check is done on first iteration to catch schema mismatches early
+        if depth == 1 && !new_rows.is_empty() && !all_rows.is_empty() {
+            let base_col_count = all_rows[0].values.len();
+            let recursive_col_count = new_rows[0].values.len();
+            if base_col_count != recursive_col_count {
+                return Err(ExecutorError::UnsupportedFeature(
+                    "SELECTs to the left and right of UNION ALL do not have the same number of result columns".to_string()
+                ));
+            }
+        }
+
         // Check memory before adding new rows
         let estimated_size = super::helpers::estimate_result_size(&new_rows);
         memory_check(estimated_size)?;

--- a/crates/vibesql-executor/src/tests/cte_scalar_subquery_tests.rs
+++ b/crates/vibesql-executor/src/tests/cte_scalar_subquery_tests.rs
@@ -533,3 +533,58 @@ fn test_cte_in_not_exists_subquery() {
         vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Gizmo"))
     );
 }
+
+/// Test that recursive CTE validates column count between base and recursive terms (issue #4482)
+///
+/// SQLite rejects recursive CTEs where the base term and recursive term return different
+/// numbers of columns. VibeSQL should match this behavior.
+#[test]
+fn test_recursive_cte_column_count_validation() {
+    let mut db = vibesql_storage::Database::new();
+
+    // This should fail: base term returns 1 column, recursive term returns 2 columns
+    let query = "
+        WITH RECURSIVE bad AS (
+            SELECT 1 AS x
+            UNION ALL
+            SELECT x+1, x+2 FROM bad WHERE x<3
+        )
+        SELECT * FROM bad
+    ";
+
+    let result = execute_sql(&mut db, query);
+
+    // Should get error about column count mismatch
+    assert!(result.is_err(), "Expected error for mismatched column counts");
+    let err = result.unwrap_err();
+    let err_msg = format!("{:?}", err);
+    assert!(
+        err_msg.contains("SELECTs to the left and right of UNION ALL do not have the same number of result columns"),
+        "Expected specific SQLite error message, got: {}",
+        err_msg
+    );
+}
+
+/// Test that recursive CTE with matching column counts works correctly (issue #4482)
+#[test]
+fn test_recursive_cte_matching_columns() {
+    let mut db = vibesql_storage::Database::new();
+
+    // This should work: both base and recursive term return 1 column
+    let query = "
+        WITH RECURSIVE good AS (
+            SELECT 1 AS x
+            UNION ALL
+            SELECT x+1 FROM good WHERE x<3
+        )
+        SELECT * FROM good
+    ";
+
+    let result = execute_sql(&mut db, query).unwrap();
+
+    // Should return rows: 1, 2, 3
+    assert_eq!(result.len(), 3);
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Integer(1));
+    assert_eq!(result[1].values[0], vibesql_types::SqlValue::Integer(2));
+    assert_eq!(result[2].values[0], vibesql_types::SqlValue::Integer(3));
+}


### PR DESCRIPTION
## Summary

Adds validation to ensure recursive CTEs have matching column counts between base and recursive terms, matching SQLite's behavior.

## Changes

- Modified `execute_recursive_cte()` in `crates/vibesql-executor/src/select/cte.rs`
- Added validation check after executing first recursive iteration
- Returns error: "SELECTs to the left and right of UNION ALL do not have the same number of result columns"

## Before

```sql
WITH RECURSIVE bad AS (
  SELECT 1 AS x 
  UNION ALL 
  SELECT x+1, x+2 FROM bad WHERE x<3
) 
SELECT * FROM bad;
```

Returns rows with NULL padding:
```
+---+---+
| x |   |
+---+---+
| 1 |   |
+---+---+
| 2 | 3 |
+---+---+
| 3 | 4 |
+---+---+
```

## After

```sql
-- Same query now returns error:
-- Error: SELECTs to the left and right of UNION ALL do not have the same number of result columns
```

## Tests

Added two new tests in `crates/vibesql-executor/src/tests/cte_scalar_subquery_tests.rs`:
- `test_recursive_cte_column_count_validation`: Verifies error for column count mismatch
- `test_recursive_cte_matching_columns`: Verifies correct behavior when counts match

## Related

- Closes #4482
- Follow-up to #4480 (recursive CTE implementation)
- Part of #4218 (TCL test suite compatibility)