### PR TITLE
feat(executor): Add static column count validation for recursive CTEs

### DIFF
--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -237,6 +237,21 @@ where
     };
     let recursive_query = &set_op.right;
 
+    // Try static validation first (works for explicit column lists)
+    // This provides better SQLite compatibility by catching errors at prepare time
+    // rather than waiting until runtime
+    if let (Some(base_count), Some(recursive_count)) = (
+        count_explicit_columns(&cte.query.select_list),
+        count_explicit_columns(&recursive_query.select_list),
+    ) {
+        if base_count != recursive_count {
+            return Err(ExecutorError::UnsupportedFeature(
+                "SELECTs to the left and right of UNION ALL do not have the same number of result columns".to_string()
+            ));
+        }
+    }
+    // Fall back to runtime validation for wildcards (existing code below at line 279-289)
+
     // Step 1: Execute base term to get initial rows
     let mut all_rows = executor(&base_query, cte_results)?;
     let mut working_table = all_rows.clone();
@@ -322,6 +337,25 @@ where
     }
 
     Ok(all_rows)
+}
+
+/// Count columns if select list has only explicit expressions (no wildcards)
+///
+/// Returns Some(count) if all select items are explicit expressions.
+/// Returns None if any wildcards are present (requires schema info to count).
+fn count_explicit_columns(select_list: &[vibesql_ast::SelectItem]) -> Option<usize> {
+    let mut count = 0;
+    for item in select_list {
+        match item {
+            vibesql_ast::SelectItem::Expression { .. } => count += 1,
+            // Can't count wildcards statically - need schema info
+            vibesql_ast::SelectItem::Wildcard { .. }
+            | vibesql_ast::SelectItem::QualifiedWildcard { .. } => {
+                return None;
+            }
+        }
+    }
+    Some(count)
 }
 
 /// Infer data type from a SQL value

--- a/crates/vibesql-executor/src/tests/cte_scalar_subquery_tests.rs
+++ b/crates/vibesql-executor/src/tests/cte_scalar_subquery_tests.rs
@@ -588,3 +588,60 @@ fn test_recursive_cte_matching_columns() {
     assert_eq!(result[1].values[0], vibesql_types::SqlValue::Integer(2));
     assert_eq!(result[2].values[0], vibesql_types::SqlValue::Integer(3));
 }
+
+/// Test static column count validation for recursive CTEs (issue #4486)
+///
+/// This tests the edge case where the recursive term returns 0 rows (never executes),
+/// so runtime validation would be bypassed. Static validation should catch the error
+/// at prepare time, matching SQLite behavior.
+#[test]
+fn test_recursive_cte_static_column_validation_edge_case() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Edge case: recursive term never executes (x=1 is not > 1000)
+    // SQLite fails at prepare time with column count error
+    // VibeSQL should also fail before execution (static validation)
+    let query = "
+        WITH RECURSIVE edge AS (
+            SELECT 1 AS x
+            UNION ALL
+            SELECT x+1, x+2 FROM edge WHERE x > 1000
+        )
+        SELECT * FROM edge
+    ";
+
+    let result = execute_sql(&mut db, query);
+
+    // Should get error even though recursive term never executes
+    assert!(result.is_err(), "Expected error for mismatched column counts (static validation)");
+    let err = result.unwrap_err();
+    let err_msg = format!("{:?}", err);
+    assert!(
+        err_msg.contains("SELECTs to the left and right of UNION ALL do not have the same number of result columns"),
+        "Expected specific SQLite error message, got: {}",
+        err_msg
+    );
+}
+
+/// Test that static validation doesn't trigger for matching column counts (issue #4486)
+#[test]
+fn test_recursive_cte_static_validation_success() {
+    let mut db = vibesql_storage::Database::new();
+
+    // This should work: both base and recursive term return 1 column (explicit)
+    // Even though recursive term never executes
+    let query = "
+        WITH RECURSIVE edge AS (
+            SELECT 1 AS x
+            UNION ALL
+            SELECT x+1 FROM edge WHERE x > 1000
+        )
+        SELECT * FROM edge
+    ";
+
+    let result = execute_sql(&mut db, query).unwrap();
+
+    // Should return just the base row since x=1 is not > 1000
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Integer(1));
+}


### PR DESCRIPTION
## Summary

Add static validation for recursive CTE column counts when select lists contain only explicit columns (no wildcards). This matches SQLite's prepare-time validation behavior and addresses the edge case identified in issue #4486.

## Changes

- **Added `count_explicit_columns()` helper** (crate::vibesql-executor::src::select::cte.rs:327-344)
  - Counts columns in explicit select lists
  - Returns `None` for wildcards (requires schema info)
  
- **Added static validation in `execute_recursive_cte()`** (crate::vibesql-executor::src::select::cte.rs:240-253)
  - Validates column counts before execution
  - Falls back to existing runtime validation for wildcards
  
- **Added comprehensive tests** (crate::vibesql-executor::src::tests::cte_scalar_subquery_tests.rs:592-647)
  - `test_recursive_cte_static_column_validation_edge_case`: Edge case where recursive term never executes
  - `test_recursive_cte_static_validation_success`: Success case with matching columns

## Problem Solved

Previously, VibeSQL validated recursive CTE column counts at **runtime** (when the recursive term returned rows). This caused a SQLite compatibility issue in edge cases:

```sql
-- SQLite: Fails at prepare time with column count error
-- VibeSQL (before): Succeeds, returns (1)
WITH RECURSIVE edge AS (
  SELECT 1 AS x 
  UNION ALL  
  SELECT x+1, x+2 FROM edge WHERE x > 1000  -- Never executes
)
SELECT * FROM edge;
```

**SQLite behavior**: Error at prepare time
**VibeSQL behavior (before)**: Query succeeds because recursive term never executes
**VibeSQL behavior (after)**: Error before execution (matches SQLite)

## Benefits

✅ Better SQLite compatibility (matches prepare-time validation)
✅ Catches errors earlier (before execution)  
✅ Handles edge cases completely for explicit column lists
✅ Low complexity - simple column counting
✅ Graceful degradation (falls back to runtime for wildcards)

## Test Results

All tests pass:
```
running 4 tests
test tests::cte_scalar_subquery_tests::test_recursive_cte_column_count_validation ... ok
test tests::cte_scalar_subquery_tests::test_recursive_cte_static_column_validation_edge_case ... ok
test tests::cte_scalar_subquery_tests::test_recursive_cte_static_validation_success ... ok
test tests::cte_scalar_subquery_tests::test_recursive_cte_matching_columns ... ok
```

Closes #4486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>