### PR TITLE
fix(executor): Support column references in generated column expressions

### DIFF
--- a/crates/vibesql-executor/src/insert/defaults.rs
+++ b/crates/vibesql-executor/src/insert/defaults.rs
@@ -226,11 +226,16 @@ pub fn apply_default_values(
 pub fn apply_generated_columns(
     schema: &vibesql_catalog::TableSchema,
     row_values: &mut [vibesql_types::SqlValue],
+    _database: &vibesql_storage::Database,
 ) -> Result<(), ExecutorError> {
+    // Create a temporary row to evaluate generated expressions
+    let temp_row = vibesql_storage::Row::new(row_values.to_vec());
+    let evaluator = crate::ExpressionEvaluator::new(schema);
+
     for (col_idx, col) in schema.columns.iter().enumerate() {
         // If column has a generated expression, compute and apply it
         if let Some(generated_expr) = &col.generated_expr {
-            let generated_value = evaluate_default_expression(generated_expr)?;
+            let generated_value = evaluator.eval(generated_expr, &temp_row)?;
             let coerced_value = super::validation::coerce_value(generated_value, &col.data_type)?;
             row_values[col_idx] = coerced_value;
         }

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -179,7 +179,7 @@ fn execute_insert_internal(
             super::defaults::apply_default_values(&schema, &mut full_row_values, db)?;
 
         // Apply generated/computed column values (AS(expression) syntax)
-        super::defaults::apply_generated_columns(&schema, &mut full_row_values)?;
+        super::defaults::apply_generated_columns(&schema, &mut full_row_values, db)?;
 
         // Track the first generated ID across all rows
         if first_generated_id.is_none() {


### PR DESCRIPTION
## Summary

Fixes core functionality for #4492 by enabling generated columns to reference other columns in the same row.

## Changes

- **Fixed column reference support**: Modified `apply_generated_columns()` to use `ExpressionEvaluator` instead of `evaluate_default_expression()`
- **Improved expression evaluation**: Generated columns can now use any expression including column references like `AS(a*2)`

## Examples

```sql
-- Now works correctly
CREATE TABLE t1 (a INT, b AS(a*2));
INSERT INTO t1(a) VALUES (5), (10);
SELECT * FROM t1;
-- Returns: 5|10, 10|20

-- Original failing example now works
CREATE TABLE t1 (
  a INTEGER PRIMARY KEY,
  b AS('Y') UNIQUE
);
INSERT INTO t1(a) VALUES (10);
SELECT * FROM t1;  -- Returns: 10|Y
```

## Testing

- ✅ Tested generated columns with literal expressions: `AS('Y')`
- ✅ Tested generated columns with column references: `AS(a*2)`
- ✅ Tested generated columns in WHERE clauses
- ✅ Basic SELECT queries work correctly
- ⚠️  JOIN USING display issues remain (pre-existing, not introduced by this PR)

## Remaining Work

This PR resolves the core issue. The following enhancements remain for future work:

1. **VIRTUAL/STORED keywords**: Parser doesn't yet support optional VIRTUAL/STORED keywords (SQLite compatibility)
2. **UPDATE validation**: Should prevent direct UPDATE of generated columns
3. **JOIN USING display**: Investigate formatting issues with generated columns in JOIN USING queries

Closes #4492

🤖 Generated with [Claude Code](https://claude.com/claude-code)