### PR TITLE
fix(tests): Fix TCL test batching to avoid double semicolons

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -334,8 +334,25 @@ proc flush_batch {} {
     # Uses a temp file to avoid "argument list too long" errors for large batches
     if {[llength $::sql_batch] == 0} return
 
-    set combined [join $::sql_batch ";\n"]
+    # Strip trailing semicolons from each statement to avoid double semicolons
+    # when joining (VibeSQL rejects ";;" with "Parse error: near ";": syntax error")
+    set cleaned_statements {}
+    foreach stmt $::sql_batch {
+        set stmt [string trimright $stmt]
+        set stmt [string trimright $stmt ";"]
+        lappend cleaned_statements $stmt
+    }
+
+    set combined [join $cleaned_statements ";\n"]
     set ::sql_batch {}
+
+    # Debug: Print combined SQL to temp file for inspection
+    if {[info exists ::env(DEBUG_FLUSH_BATCH)]} {
+        puts stderr "\n=== FLUSH_BATCH DEBUG ==="
+        puts stderr "Number of statements: [llength $cleaned_statements]"
+        puts stderr "Combined SQL:\n$combined"
+        puts stderr "=== END DEBUG ==="
+    }
 
     # Write SQL to temp file to avoid command line length limits
     set tmpfile "/tmp/vibesql_batch_[pid].sql"
@@ -349,8 +366,12 @@ proc flush_batch {} {
         set exec_code [catch {exec $::vibesql_path $::db_file < $tmpfile 2>@1} result]
     }
 
-    # Clean up temp file
-    file delete -force $tmpfile
+    # Clean up temp file (unless debugging)
+    if {![info exists ::env(DEBUG_FLUSH_BATCH)]} {
+        file delete -force $tmpfile
+    } else {
+        puts stderr "DEBUG: Temp file saved at: $tmpfile"
+    }
 
     if {$exec_code != 0} {
         error $result


### PR DESCRIPTION
## Summary

Fixes #4494 - Performance: Slow execution of nested subqueries in aggregate context

The issue was not actually a performance problem, but a parse error in the TCL test infrastructure that prevented the test from running.

## Root Cause

The TCL test shim's `flush_batch` function was creating double semicolons (`;;`) when joining batched SQL statements for transaction processing. VibeSQL rejects double semicolons with "Parse error: near ';': syntax error".

## Changes

- Modified `scripts/tester_vibesql.tcl` to strip trailing semicolons before joining statements
- Added optional `DEBUG_FLUSH_BATCH` environment variable for troubleshooting

## Test Results

Before:
- select1-13.1: **FAILED** (parse error)
- select1.test: 182/188 passed (96.8%)

After:
- select1-13.1: **PASSED** ✓
- select1.test: 183/188 passed (97.3%)
- Priority 1 tests: 308/421 passed (73.2%) - no regressions

## Verification

The fix was verified by:
1. Running the problematic query manually (executes in 0.07s, returns correct result: 0)
2. Running select1.test (select1-13.1 now passes)
3. Running Priority 1 TCL tests (no regressions)

Closes #4494

🤖 Generated with [Claude Code](https://claude.com/claude-code)