### PR TITLE
feat(parser): Support schema-qualified table names in INSERT statements

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -554,8 +554,10 @@ impl<'a, 'arena> Converter<'a, 'arena> {
     /// Convert an arena InsertStmt to an owned InsertStmt.
     pub fn convert_insert(&self, stmt: &arena_dml::InsertStmt<'arena>) -> InsertStmt {
         InsertStmt {
+            schema_name: stmt.schema_name.map(|s| self.resolve(s)),
+            schema_quoted: stmt.schema_quoted,
             table_name: self.resolve(stmt.table_name),
-            quoted: stmt.quoted,
+            table_quoted: stmt.table_quoted,
             columns: stmt.columns.iter().map(|s| self.resolve(*s)).collect(),
             source: self.convert_insert_source(&stmt.source),
             conflict_clause: stmt.conflict_clause.map(ConflictClause::from),

--- a/crates/vibesql-ast/src/arena/dml.rs
+++ b/crates/vibesql-ast/src/arena/dml.rs
@@ -31,10 +31,15 @@ pub enum ConflictClause {
 /// INSERT statement
 #[derive(Debug, Clone, PartialEq)]
 pub struct InsertStmt<'arena> {
+    /// Optional schema name for schema-qualified table references (e.g., schema.table)
+    pub schema_name: Option<Symbol>,
+    /// Whether the schema name was quoted (delimited) in the original SQL.
+    /// Per SQL:1999, quoted identifiers are case-sensitive.
+    pub schema_quoted: bool,
     pub table_name: Symbol,
     /// Whether the table name was quoted (delimited) in the original SQL.
     /// Per SQL:1999, quoted identifiers are case-sensitive.
-    pub quoted: bool,
+    pub table_quoted: bool,
     pub columns: BumpVec<'arena, Symbol>,
     pub source: InsertSource<'arena>,
     /// Conflict resolution strategy (None = fail on conflict)

--- a/crates/vibesql-ast/src/dml.rs
+++ b/crates/vibesql-ast/src/dml.rs
@@ -29,10 +29,15 @@ pub enum ConflictClause {
 /// INSERT statement
 #[derive(Debug, Clone, PartialEq)]
 pub struct InsertStmt {
+    /// Optional schema name for schema-qualified table references (e.g., schema.table)
+    pub schema_name: Option<String>,
+    /// Whether the schema name was quoted (delimited) in the original SQL.
+    /// Per SQL:1999, quoted identifiers are case-sensitive.
+    pub schema_quoted: bool,
     pub table_name: String,
     /// Whether the table name was quoted (delimited) in the original SQL.
     /// Per SQL:1999, quoted identifiers are case-sensitive.
-    pub quoted: bool,
+    pub table_quoted: bool,
     pub columns: Vec<String>,
     pub source: InsertSource,
     /// Conflict resolution strategy (None = fail on conflict)

--- a/crates/vibesql-ast/src/lib.rs
+++ b/crates/vibesql-ast/src/lib.rs
@@ -63,6 +63,10 @@ pub mod visitor;
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct TableRef {
+    /// Optional schema name for qualified references (e.g., schema.table)
+    pub schema_name: Option<String>,
+    /// Whether the schema name was quoted (delimited) in the original SQL.
+    pub schema_quoted: bool,
     /// The table name as written in the SQL
     pub name: String,
     /// Whether the identifier was quoted (delimited) in the original SQL.
@@ -74,17 +78,50 @@ pub struct TableRef {
 impl TableRef {
     /// Create a new table reference.
     pub fn new(name: String, quoted: bool) -> Self {
-        Self { name, quoted }
+        Self {
+            schema_name: None,
+            schema_quoted: false,
+            name,
+            quoted,
+        }
+    }
+
+    /// Create a qualified table reference with schema.
+    pub fn qualified(
+        schema_name: String,
+        schema_quoted: bool,
+        table_name: String,
+        table_quoted: bool,
+    ) -> Self {
+        Self {
+            schema_name: Some(schema_name),
+            schema_quoted,
+            name: table_name,
+            quoted: table_quoted,
+        }
     }
 
     /// Create an unquoted (case-insensitive) table reference.
     pub fn unquoted(name: String) -> Self {
-        Self { name, quoted: false }
+        Self::new(name, false)
     }
 
     /// Create a quoted (case-sensitive) table reference.
-    pub fn quoted(name: String) -> Self {
-        Self { name, quoted: true }
+    pub fn quoted_ref(name: String) -> Self {
+        Self::new(name, true)
+    }
+
+    /// Get the full name (schema.table or just table)
+    pub fn full_name(&self) -> String {
+        match &self.schema_name {
+            Some(schema) => format!("{}.{}", schema, self.name),
+            None => self.name.clone(),
+        }
+    }
+
+    /// Check if any part is quoted
+    pub fn is_any_quoted(&self) -> bool {
+        self.quoted || self.schema_quoted
     }
 }
 

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1218,8 +1218,10 @@ fn transform_mixed_grouping_item<V: ExpressionMutVisitor>(
 /// Transform an INSERT statement
 pub fn transform_insert<V: ExpressionMutVisitor>(visitor: &mut V, stmt: InsertStmt) -> InsertStmt {
     InsertStmt {
+        schema_name: stmt.schema_name,
+        schema_quoted: stmt.schema_quoted,
         table_name: stmt.table_name,
-        quoted: stmt.quoted,
+        table_quoted: stmt.table_quoted,
         columns: stmt.columns,
         source: match stmt.source {
             InsertSource::Values(rows) => InsertSource::Values(

--- a/crates/vibesql-ast/tests/statements.rs
+++ b/crates/vibesql-ast/tests/statements.rs
@@ -33,8 +33,10 @@ fn test_create_select_statement() {
 #[test]
 fn test_create_insert_statement() {
     let stmt = Statement::Insert(InsertStmt {
+        schema_name: None,
+        schema_quoted: false,
         table_name: "users".to_string(),
-        quoted: false,
+        table_quoted: false,
         columns: vec!["name".to_string()],
         source: InsertSource::Values(vec![vec![Expression::Literal(SqlValue::Varchar(
             StringValue::from("Alice"),

--- a/crates/vibesql-catalog/src/store/tables.rs
+++ b/crates/vibesql-catalog/src/store/tables.rs
@@ -192,10 +192,24 @@ impl super::Catalog {
     ///
     /// The `identifier` parameter determines case-sensitivity based on whether
     /// the identifier was quoted in the original SQL.
+    ///
+    /// For qualified identifiers (schema.table), looks up in the specified schema.
+    /// For unqualified identifiers, looks up in the current schema.
     pub fn get_table_by_identifier(&self, identifier: &TableIdentifier) -> Option<&TableSchema> {
-        self.schemas.get(&self.current_schema).and_then(|schema| {
-            schema.get_table_by_identifier(identifier)
-        })
+        if identifier.is_qualified() {
+            // For qualified identifiers, look up in the specified schema
+            let schema_canonical = identifier.schema_canonical().unwrap_or(&self.current_schema);
+            self.schemas.get(schema_canonical).and_then(|schema| {
+                // Create a simple identifier with just the table part for lookup
+                let table_id = TableIdentifier::new(identifier.table_canonical(), identifier.is_table_quoted());
+                schema.get_table_by_identifier(&table_id)
+            })
+        } else {
+            // For unqualified identifiers, use current schema
+            self.schemas.get(&self.current_schema).and_then(|schema| {
+                schema.get_table_by_identifier(identifier)
+            })
+        }
     }
 
     /// Get a table schema by name (supports qualified names like "schema.table").

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -69,19 +69,21 @@ impl CreateTableExecutor {
         database: &mut Database,
     ) -> Result<String, ExecutorError> {
         // Parse qualified table name (schema.table or just table)
-        let (schema_name, table_name) =
+        let (schema_name, table_name, identifier) =
             if let Some((schema_part, table_part)) = stmt.table_name.split_once('.') {
-                (schema_part.to_string(), table_part.to_string())
+                // Schema-qualified table name - use qualified identifier
+                // Note: We use stmt.quoted for both parts since the parser combined them
+                // In a future iteration, CREATE TABLE could also store schema/table quoted status separately
+                let id = TableIdentifier::qualified(schema_part, stmt.quoted, table_part, stmt.quoted);
+                (schema_part.to_string(), table_part.to_string(), id)
             } else {
-                (database.catalog.get_current_schema().to_string(), stmt.table_name.clone())
+                // Simple table name - use current schema
+                let id = TableIdentifier::new(&stmt.table_name, stmt.quoted);
+                (database.catalog.get_current_schema().to_string(), stmt.table_name.clone(), id)
             };
 
         // Check CREATE privilege on the schema
         PrivilegeChecker::check_create(database, &schema_name)?;
-
-        // Create TableIdentifier with proper case semantics based on quoted flag
-        // This identifier is used for both existence check and table creation
-        let identifier = TableIdentifier::new(&table_name, stmt.quoted);
 
         // Check if table already exists using identifier (respects quoted semantics)
         if database.catalog.table_exists_by_identifier(&identifier) {

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -40,20 +40,43 @@ fn execute_insert_internal(
     procedural_context: Option<&crate::procedural::ExecutionContext>,
     trigger_context: Option<&crate::trigger_execution::TriggerContext>,
 ) -> Result<usize, ExecutorError> {
+    // Build full table name for error messages and privilege checks
+    let full_table_name = match &stmt.schema_name {
+        Some(schema) => format!("{}.{}", schema, stmt.table_name),
+        None => stmt.table_name.clone(),
+    };
+
     // Check INSERT privilege on the table
-    PrivilegeChecker::check_insert(db, &stmt.table_name)?;
+    PrivilegeChecker::check_insert(db, &full_table_name)?;
 
     // Get table schema from catalog (clone to avoid borrow issues)
     // Use TableIdentifier for SQL:1999 case-sensitive lookups when quoted
-    let table_id = TableIdentifier::new(&stmt.table_name, stmt.quoted);
+    // For schema-qualified names, use TableIdentifier::qualified to preserve
+    // the individual quoted status of schema and table parts
+    let table_id = match &stmt.schema_name {
+        Some(schema_name) => TableIdentifier::qualified(
+            schema_name,
+            stmt.schema_quoted,
+            &stmt.table_name,
+            stmt.table_quoted,
+        ),
+        None => TableIdentifier::new(&stmt.table_name, stmt.table_quoted),
+    };
     let schema = db
         .catalog
         .get_table_by_identifier(&table_id)
-        .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?
+        .ok_or_else(|| ExecutorError::TableNotFound(full_table_name.clone()))?
         .clone();
 
-    // Use canonical table name from schema for all storage operations
-    // This ensures case-sensitive tables (quoted identifiers) are accessed correctly
+    // Use canonical table name from identifier for storage layer operations
+    // For schema-qualified inserts (e.g., INSERT INTO "mySchema"."users"), this produces
+    // the full qualified name so storage looks up in the correct schema.
+    // For unqualified inserts (e.g., INSERT INTO tab1), this produces just the table name -
+    // the storage layer's fallback logic will find it and this matches how indexes
+    // are registered (with unqualified table names).
+    let storage_table_name = table_id.canonical().to_string();
+
+    // Use the schema's table name for catalog operations (matches how table was created)
     let table_name = &schema.name;
 
     // Determine target column indices and types
@@ -113,10 +136,10 @@ fn execute_insert_internal(
     // Estimate DML cost for query analysis and optimization decisions
     // This helps with profiling and can inform future batch size decisions
     if std::env::var("DML_COST_DEBUG").is_ok() {
-        if let Some(index_info) = db.get_table_index_info(table_name) {
+        if let Some(index_info) = db.get_table_index_info(&storage_table_name) {
             // Get table statistics for cost estimation (use cached if available, or fallback to
             // estimate)
-            if let Some(table) = db.get_table(table_name) {
+            if let Some(table) = db.get_table(&storage_table_name) {
                 let table_stats = table.get_statistics().cloned().unwrap_or_else(|| {
                     vibesql_storage::TableStatistics::estimate_from_row_count(table.row_count())
                 });
@@ -195,7 +218,7 @@ fn execute_insert_internal(
         let validator = super::row_validator::RowValidator::new(
             db,
             &schema,
-            table_name,
+            &storage_table_name,
             &primary_key_values,
             &unique_constraint_values,
             skip_duplicate_checks,
@@ -246,7 +269,7 @@ fn execute_insert_internal(
     // Track row count before inserts for assertion rollback
     let row_count_before_all = if has_assertions {
         Some(
-            db.get_table(table_name)
+            db.get_table(&storage_table_name)
                 .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?
                 .row_count(),
         )
@@ -271,7 +294,7 @@ fn execute_insert_internal(
                 let rows: Vec<vibesql_storage::Row> =
                     chunk.iter().map(|v| vibesql_storage::Row::new(v.clone())).collect();
 
-                rows_inserted += db.insert_rows_batch(table_name, rows).map_err(|e| {
+                rows_inserted += db.insert_rows_batch(&storage_table_name, rows).map_err(|e| {
                     ExecutorError::UnsupportedExpression(format!("Storage error: {}", e))
                 })?;
             }
@@ -280,7 +303,7 @@ fn execute_insert_internal(
             let rows: Vec<vibesql_storage::Row> =
                 validated_rows.into_iter().map(vibesql_storage::Row::new).collect();
 
-            rows_inserted = db.insert_rows_batch(table_name, rows).map_err(|e| {
+            rows_inserted = db.insert_rows_batch(&storage_table_name, rows).map_err(|e| {
                 ExecutorError::UnsupportedExpression(format!("Storage error: {}", e))
             })?;
         }
@@ -328,13 +351,13 @@ fn execute_insert_internal(
 
             // Get row count before insert to enable rollback
             let row_count_before = db
-                .get_table(table_name)
-                .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?
+                .get_table(&storage_table_name)
+                .ok_or_else(|| ExecutorError::TableNotFound(full_table_name.clone()))?
                 .row_count();
 
             // Insert the row
             let row = vibesql_storage::Row::new(full_row_values);
-            db.insert_row(table_name, row.clone()).map_err(|e| {
+            db.insert_row(&storage_table_name, row.clone()).map_err(|e| {
                 ExecutorError::UnsupportedExpression(format!("Storage error: {}", e))
             })?;
 
@@ -354,8 +377,8 @@ fn execute_insert_internal(
                     // Note: This is a simple rollback mechanism for Phase 3
                     // Full transaction support will come in a later phase
                     let table = db
-                        .get_table_mut(table_name)
-                        .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+                        .get_table_mut(&storage_table_name)
+                        .ok_or_else(|| ExecutorError::TableNotFound(full_table_name.clone()))?;
 
                     // Delete the last row (the one we just inserted)
                     // Row was inserted at index row_count_before
@@ -370,7 +393,7 @@ fn execute_insert_internal(
                     });
 
                     // Rebuild indexes since we modified the table (handles compaction)
-                    db.rebuild_indexes(table_name);
+                    db.rebuild_indexes(&storage_table_name);
 
                     // Re-throw the trigger error
                     return Err(trigger_error);
@@ -402,7 +425,7 @@ fn execute_insert_internal(
     // - Table-level cache: used by Table::scan_columnar() for SIMD filtering
     // - Database-level cache: used by Database::get_columnar() for cached access
     if rows_inserted > 0 {
-        db.invalidate_columnar_cache(table_name);
+        db.invalidate_columnar_cache(&storage_table_name);
     }
 
     // Check all assertions after INSERT completes (SQL:1999 Feature F671/F672)
@@ -414,7 +437,7 @@ fn execute_insert_internal(
         if let Some(start_index) = row_count_before_all {
             if rows_inserted > 0 {
                 // Delete rows starting from start_index (the rows we inserted)
-                if let Some(table_mut) = db.get_table_mut(table_name) {
+                if let Some(table_mut) = db.get_table_mut(&storage_table_name) {
                     use std::cell::Cell;
                     let current_index = Cell::new(0);
                     // Delete all rows from start_index onwards (the newly inserted rows)
@@ -426,8 +449,8 @@ fn execute_insert_internal(
                 }
 
                 // Rebuild indexes since we modified the table (handles compaction)
-                db.rebuild_indexes(table_name);
-                db.invalidate_columnar_cache(table_name);
+                db.rebuild_indexes(&storage_table_name);
+                db.invalidate_columnar_cache(&storage_table_name);
             }
         }
         return Err(assertion_error);

--- a/crates/vibesql-executor/src/tests/auto_increment_tests.rs
+++ b/crates/vibesql-executor/src/tests/auto_increment_tests.rs
@@ -48,7 +48,7 @@ fn test_auto_increment_basic_inserts() {
     assert!(result.is_ok(), "Failed to create table: {:?}", result.err());
 
     // Insert without specifying id - should auto-generate 1
-    let insert1 = InsertStmt { quoted: false,
+    let insert1 = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec!["username".to_string()],
         source: InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
@@ -61,7 +61,7 @@ fn test_auto_increment_basic_inserts() {
     assert!(result.is_ok(), "Failed to insert alice: {:?}", result.err());
 
     // Insert without specifying id - should auto-generate 2
-    let insert2 = InsertStmt { quoted: false,
+    let insert2 = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec!["username".to_string()],
         source: InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
@@ -172,7 +172,7 @@ fn test_last_insert_rowid_basic() {
     assert_eq!(db.last_insert_rowid(), 0);
 
     // Insert first row - should auto-generate id=1
-    let insert1 = InsertStmt { quoted: false,
+    let insert1 = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec!["username".to_string()],
         source: InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
@@ -188,7 +188,7 @@ fn test_last_insert_rowid_basic() {
     assert_eq!(db.last_insert_rowid(), 1);
 
     // Insert second row - should auto-generate id=2
-    let insert2 = InsertStmt { quoted: false,
+    let insert2 = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec!["username".to_string()],
         source: InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
@@ -244,7 +244,7 @@ fn test_last_insert_rowid_multi_row_insert() {
     assert!(result.is_ok(), "Failed to create table: {:?}", result.err());
 
     // Multi-row insert - per MySQL semantics, LAST_INSERT_ID returns the FIRST generated ID
-    let multi_insert = InsertStmt { quoted: false,
+    let multi_insert = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "items".to_string(),
         columns: vec!["name".to_string()],
         source: InsertSource::Values(vec![
@@ -316,7 +316,7 @@ fn test_last_insert_rowid_no_auto_increment() {
     assert!(result.is_ok(), "Failed to create table: {:?}", result.err());
 
     // Insert with explicit ID - no auto-generation
-    let insert1 = InsertStmt { quoted: false,
+    let insert1 = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "manual".to_string(),
         columns: vec!["id".to_string(), "name".to_string()],
         source: InsertSource::Values(vec![vec![
@@ -375,7 +375,7 @@ fn test_last_insert_rowid_via_select() {
     assert!(result.is_ok(), "Failed to create table: {:?}", result.err());
 
     // Insert a row
-    let insert1 = InsertStmt { quoted: false,
+    let insert1 = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec!["name".to_string()],
         source: InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(

--- a/crates/vibesql-executor/src/tests/transaction_tests.rs
+++ b/crates/vibesql-executor/src/tests/transaction_tests.rs
@@ -118,7 +118,7 @@ fn test_transaction_insert_commit() {
         .unwrap();
 
     // Insert a row
-    let insert_stmt = InsertStmt { quoted: false,
+    let insert_stmt = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -153,7 +153,7 @@ fn test_transaction_insert_rollback() {
         .unwrap();
 
     // Insert a row
-    let insert_stmt = InsertStmt { quoted: false,
+    let insert_stmt = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -184,7 +184,7 @@ fn test_transaction_multiple_operations_commit() {
     setup_test_table(&mut db);
 
     // Insert initial data outside transaction
-    let insert_stmt1 = InsertStmt { quoted: false,
+    let insert_stmt1 = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -201,7 +201,7 @@ fn test_transaction_multiple_operations_commit() {
         .unwrap();
 
     // Insert another row
-    let insert_stmt2 = InsertStmt { quoted: false,
+    let insert_stmt2 = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -231,7 +231,7 @@ fn test_transaction_multiple_operations_rollback() {
     setup_test_table(&mut db);
 
     // Insert initial data outside transaction
-    let insert_stmt1 = InsertStmt { quoted: false,
+    let insert_stmt1 = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -248,7 +248,7 @@ fn test_transaction_multiple_operations_rollback() {
         .unwrap();
 
     // Insert another row
-    let insert_stmt2 = InsertStmt { quoted: false,
+    let insert_stmt2 = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -286,7 +286,7 @@ fn test_transaction_isolation() {
     // db1 begins transaction and inserts
     BeginTransactionExecutor::execute(&BeginStmt { durability: DurabilityHint::Default }, &mut db1)
         .unwrap();
-    let insert_stmt = InsertStmt { quoted: false,
+    let insert_stmt = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -324,7 +324,7 @@ fn test_transaction_nested_operations() {
 
     // Insert multiple rows
     for i in 1..=5 {
-        let insert_stmt = InsertStmt { quoted: false,
+        let insert_stmt = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
             table_name: "users".to_string(),
             columns: vec![],
             source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -358,7 +358,7 @@ fn test_transaction_empty_rollback() {
     setup_test_table(&mut db);
 
     // Insert data outside transaction
-    let insert_stmt = InsertStmt { quoted: false,
+    let insert_stmt = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -390,7 +390,7 @@ fn test_multiple_transactions() {
     // First transaction
     BeginTransactionExecutor::execute(&BeginStmt { durability: DurabilityHint::Default }, &mut db)
         .unwrap();
-    let insert_stmt1 = InsertStmt { quoted: false,
+    let insert_stmt1 = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -406,7 +406,7 @@ fn test_multiple_transactions() {
     // Second transaction
     BeginTransactionExecutor::execute(&BeginStmt { durability: DurabilityHint::Default }, &mut db)
         .unwrap();
-    let insert_stmt2 = InsertStmt { quoted: false,
+    let insert_stmt2 = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/src/tests/triggers/conditions.rs
+++ b/crates/vibesql-executor/src/tests/triggers/conditions.rs
@@ -69,7 +69,7 @@ fn test_when_clause_filters_firing() {
         .expect("Failed to create trigger");
 
     // Insert row with amount=50 (should NOT fire)
-    let insert1 = vibesql_ast::InsertStmt { quoted: false,
+    let insert1 = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "TRANSACTIONS".to_string(),
         columns: vec!["id".to_string(), "amount".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -85,7 +85,7 @@ fn test_when_clause_filters_firing() {
     assert_eq!(count_audit_rows(&db), 0);
 
     // Insert row with amount=150 (should fire)
-    let insert2 = vibesql_ast::InsertStmt { quoted: false,
+    let insert2 = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "TRANSACTIONS".to_string(),
         columns: vec!["id".to_string(), "amount".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/src/tests/triggers/coordination.rs
+++ b/crates/vibesql-executor/src/tests/triggers/coordination.rs
@@ -45,7 +45,7 @@ fn test_multiple_triggers_fire_in_order() {
         .expect("Failed to create trigger 2");
 
     // Insert a row - should fire both triggers
-    let insert = vibesql_ast::InsertStmt { quoted: false,
+    let insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "USERS".to_string(),
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -86,7 +86,7 @@ fn test_trigger_with_multiple_statements() {
         .expect("Failed to create trigger");
 
     // Insert a row - should fire trigger with both statements
-    let insert = vibesql_ast::InsertStmt { quoted: false,
+    let insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "USERS".to_string(),
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -129,7 +129,7 @@ fn test_before_trigger_executes_first() {
     CreateTableExecutor::execute(&counter_stmt, &mut db).expect("Failed to create counter table");
 
     // Initialize counter to 0
-    let init_insert = vibesql_ast::InsertStmt { quoted: false,
+    let init_insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "COUNTER".to_string(),
         columns: vec!["value".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
@@ -154,7 +154,7 @@ fn test_before_trigger_executes_first() {
         .expect("Failed to create before trigger");
 
     // Insert a row
-    let insert = vibesql_ast::InsertStmt { quoted: false,
+    let insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "USERS".to_string(),
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/src/tests/triggers/delete.rs
+++ b/crates/vibesql-executor/src/tests/triggers/delete.rs
@@ -15,7 +15,7 @@ fn test_after_delete_trigger_fires() {
     create_audit_table(&mut db);
 
     // Insert a user first
-    let insert = vibesql_ast::InsertStmt { quoted: false,
+    let insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "USERS".to_string(),
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -75,7 +75,7 @@ fn test_before_delete_trigger_fires() {
     create_audit_table(&mut db);
 
     // Insert a user first
-    let insert = vibesql_ast::InsertStmt { quoted: false,
+    let insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "USERS".to_string(),
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/src/tests/triggers/error_handling.rs
+++ b/crates/vibesql-executor/src/tests/triggers/error_handling.rs
@@ -29,7 +29,7 @@ fn test_trigger_failure_causes_rollback() {
         .expect("Failed to create trigger");
 
     // Try to insert - should fail due to trigger error
-    let insert = vibesql_ast::InsertStmt { quoted: false,
+    let insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -95,7 +95,7 @@ fn test_recursion_prevention() {
         .expect("Failed to create trigger");
 
     // Try to insert - should fail with recursion depth error
-    let insert = vibesql_ast::InsertStmt { quoted: false,
+    let insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/src/tests/triggers/insert.rs
+++ b/crates/vibesql-executor/src/tests/triggers/insert.rs
@@ -30,7 +30,7 @@ fn test_after_insert_trigger_fires() {
         .expect("Failed to create trigger");
 
     // Insert a row - should fire trigger
-    let insert = vibesql_ast::InsertStmt { quoted: false,
+    let insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "USERS".to_string(),
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -70,7 +70,7 @@ fn test_after_insert_trigger_fires_for_each_row() {
         .expect("Failed to create trigger");
 
     // Insert 3 rows - should fire trigger 3 times
-    let insert = vibesql_ast::InsertStmt { quoted: false,
+    let insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "USERS".to_string(),
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![
@@ -124,7 +124,7 @@ fn test_before_insert_trigger_fires() {
         .expect("Failed to create trigger");
 
     // Insert a row - should fire trigger
-    let insert = vibesql_ast::InsertStmt { quoted: false,
+    let insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "USERS".to_string(),
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -15,7 +15,7 @@ fn test_after_update_trigger_fires() {
     create_audit_table(&mut db);
 
     // Insert a user first
-    let insert = vibesql_ast::InsertStmt { quoted: false,
+    let insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "USERS".to_string(),
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -80,7 +80,7 @@ fn test_before_update_trigger_fires() {
     create_audit_table(&mut db);
 
     // Insert a user first
-    let insert = vibesql_ast::InsertStmt { quoted: false,
+    let insert = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "USERS".to_string(),
         columns: vec!["id".to_string(), "username".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
@@ -114,8 +114,10 @@ fn create_table_with_fk(
 /// Helper to insert a row into a table
 fn insert_row(db: &mut Database, table_name: &str, values: Vec<SqlValue>) {
     let stmt = InsertStmt {
-        quoted: false,
+        schema_name: None,
+        schema_quoted: false,
         table_name: table_name.to_string(),
+        table_quoted: false,
         columns: vec![],
         source: InsertSource::Values(vec![values.into_iter().map(Expression::Literal).collect()]),
         conflict_clause: None,

--- a/crates/vibesql-executor/src/tests/truncate_table_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_table_tests.rs
@@ -362,7 +362,7 @@ fn test_truncate_resets_auto_increment() {
 
     // Insert 3 rows (ids should be 1, 2, 3)
     for val in ["a", "b", "c"] {
-        let insert = InsertStmt { quoted: false,
+        let insert = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
             table_name: "auto_inc_test".to_string(),
             columns: vec!["data".to_string()],
             source: InsertSource::Values(vec![vec![Expression::Literal(SqlValue::Varchar(
@@ -390,7 +390,7 @@ fn test_truncate_resets_auto_increment() {
     TruncateTableExecutor::execute(&truncate, &mut db).unwrap();
 
     // Insert new row - should get id = 1, not 4
-    let insert = InsertStmt { quoted: false,
+    let insert = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "auto_inc_test".to_string(),
         columns: vec!["data".to_string()],
         source: InsertSource::Values(vec![vec![Expression::Literal(SqlValue::Varchar(
@@ -456,7 +456,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
 
     // Insert 10 rows to get counter up to 10
     for i in 1..=10 {
-        let insert = InsertStmt { quoted: false,
+        let insert = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
             table_name: "multi_test".to_string(),
             columns: vec!["value".to_string()],
             source: InsertSource::Values(vec![vec![Expression::Literal(SqlValue::Integer(
@@ -482,7 +482,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
     TruncateTableExecutor::execute(&truncate, &mut db).unwrap();
 
     // Insert new row - should get id = 1, not 11
-    let insert = InsertStmt { quoted: false,
+    let insert = InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "multi_test".to_string(),
         columns: vec!["value".to_string()],
         source: InsertSource::Values(vec![vec![Expression::Literal(SqlValue::Integer(9999))]]),

--- a/crates/vibesql-executor/tests/alter_table_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/alter_table_columnar_cache_tests.rs
@@ -31,7 +31,7 @@ fn setup_test_table(db: &mut Database) {
 
 /// Helper to insert a row into test_table
 fn insert_row(db: &mut Database, id: i64, name: &str, value: i64) {
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "test_table".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -341,7 +341,7 @@ fn test_alter_column_drop_not_null_invalidates_cache() {
     db.create_table(schema).unwrap();
 
     // Insert data
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "test_table".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -429,7 +429,7 @@ fn test_alter_column_drop_default_invalidates_cache() {
     db.create_table(schema).unwrap();
 
     // Insert data
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "test_table".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/tests/common/insert_constraint_fixtures.rs
+++ b/crates/vibesql-executor/tests/common/insert_constraint_fixtures.rs
@@ -303,8 +303,10 @@ pub fn build_insert_values(
     values: Vec<vibesql_types::SqlValue>,
 ) -> vibesql_ast::InsertStmt {
     vibesql_ast::InsertStmt {
-        quoted: false,
+        schema_name: None,
+        schema_quoted: false,
         table_name: table_name.to_string(),
+        table_quoted: false,
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![values
             .into_iter()
@@ -323,8 +325,10 @@ pub fn build_insert_columns(
     values: Vec<vibesql_types::SqlValue>,
 ) -> vibesql_ast::InsertStmt {
     vibesql_ast::InsertStmt {
-        quoted: false,
+        schema_name: None,
+        schema_quoted: false,
         table_name: table_name.to_string(),
+        table_quoted: false,
         columns: columns.iter().map(|s| s.to_string()).collect(),
         source: vibesql_ast::InsertSource::Values(vec![values
             .into_iter()

--- a/crates/vibesql-executor/tests/duplicate_key_update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/duplicate_key_update_columnar_cache_tests.rs
@@ -27,7 +27,7 @@ fn setup_products_table(db: &mut Database) {
 
 /// Helper to insert a row into products table
 fn insert_product(db: &mut Database, id: i64, name: &str, stock: i64) {
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -43,7 +43,7 @@ fn insert_product(db: &mut Database, id: i64, name: &str, stock: i64) {
 
 /// Helper to execute an INSERT ... ON DUPLICATE KEY UPDATE statement
 fn upsert_product(db: &mut Database, id: i64, name: &str, stock: i64) {
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -202,7 +202,7 @@ fn test_on_duplicate_key_update_unique_constraint_invalidates_cache() {
 
     // Insert users
     let insert = |db: &mut Database, id: i64, name: &str, score: i64| {
-        let stmt = vibesql_ast::InsertStmt { quoted: false,
+        let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
             table_name: "users".to_string(),
             columns: vec![],
             source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -223,7 +223,7 @@ fn test_on_duplicate_key_update_unique_constraint_invalidates_cache() {
     let _ = db.get_columnar("users").unwrap();
 
     // ON DUPLICATE KEY UPDATE with same name (unique key conflict) - should update existing row
-    let upsert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let upsert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -304,7 +304,7 @@ fn test_on_duplicate_key_update_arithmetic_invalidates_cache() {
     assert_eq!(initial_stock_col.get(0), SqlValue::Integer(10));
 
     // ON DUPLICATE KEY UPDATE with arithmetic: stock = stock + VALUES(stock)
-    let upsert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let upsert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/tests/index_ordering_tests.rs
+++ b/crates/vibesql-executor/tests/index_ordering_tests.rs
@@ -39,7 +39,7 @@ fn test_index_ordering() {
     vibesql_executor::CreateTableExecutor::execute(&create_table_stmt, &mut db).unwrap();
 
     // Insert data
-    let insert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let insert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![

--- a/crates/vibesql-executor/tests/insert_basic_tests.rs
+++ b/crates/vibesql-executor/tests/insert_basic_tests.rs
@@ -9,7 +9,7 @@ fn test_basic_insert() {
     setup_test_table(&mut db);
 
     // INSERT INTO users VALUES (1, 'Alice')
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![], // No columns specified
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -36,7 +36,7 @@ fn test_multi_row_insert() {
     setup_test_table(&mut db);
 
     // INSERT INTO users VALUES (1, 'Alice'), (2, 'Bob')
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
@@ -70,7 +70,7 @@ fn test_insert_with_column_list() {
     setup_test_table(&mut db);
 
     // INSERT INTO users (name, id) VALUES ('Alice', 1)
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec!["name".to_string(), "id".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -114,7 +114,7 @@ fn test_insert_null_value() {
     db.create_table(schema).unwrap();
 
     // INSERT INTO users VALUES (1, NULL)
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -135,7 +135,7 @@ fn test_insert_type_mismatch() {
     setup_test_table(&mut db);
 
     // INSERT INTO users VALUES ('not_a_number', 'Alice')
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -161,7 +161,7 @@ fn test_insert_column_count_mismatch() {
     setup_test_table(&mut db);
 
     // INSERT INTO users VALUES (1)  -- Missing name column
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![vibesql_ast::Expression::Literal(
@@ -180,7 +180,7 @@ fn test_insert_table_not_found() {
     let mut db = vibesql_storage::Database::new();
 
     // INSERT INTO nonexistent VALUES (1, 'Alice')
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "nonexistent".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -204,7 +204,7 @@ fn test_insert_column_not_found() {
     setup_test_table(&mut db);
 
     // INSERT INTO users (id, invalid_col) VALUES (1, 'Alice')
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec!["id".to_string(), "invalid_col".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -229,7 +229,7 @@ fn test_insert_not_null_constraint_violation() {
 
     // INSERT INTO users VALUES (NULL, 'Alice')
     // id column is NOT NULL, so this should fail
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/tests/insert_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/insert_columnar_cache_tests.rs
@@ -27,7 +27,7 @@ fn setup_products_table(db: &mut Database) {
 
 /// Helper to insert a row into products table
 fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -153,7 +153,7 @@ fn test_multi_row_insert_invalidates_cache() {
     let stats_before = db.columnar_cache_stats();
 
     // Multi-row INSERT
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
@@ -231,7 +231,7 @@ fn test_insert_select_invalidates_cache() {
 
     // Populate source table
     let insert_source = |db: &mut Database, id: i64, name: &str, price: i64| {
-        let stmt = vibesql_ast::InsertStmt { quoted: false,
+        let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
             table_name: "source_products".to_string(),
             columns: vec![],
             source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -275,7 +275,7 @@ fn test_insert_select_invalidates_cache() {
             values: None,
     };
 
-    let insert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let insert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),

--- a/crates/vibesql-executor/tests/insert_default_tests.rs
+++ b/crates/vibesql-executor/tests/insert_default_tests.rs
@@ -25,7 +25,7 @@ fn test_character_varying_column_with_length() {
     db.create_table(schema).unwrap();
 
     // INSERT INTO test_cv VALUES (1, 'Test description')
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "test_cv".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -69,7 +69,7 @@ fn test_character_varying_column_without_length() {
     db.create_table(schema).unwrap();
 
     // INSERT INTO test_cv_nolen VALUES (1, 'Unlimited length text')
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "test_cv_nolen".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -117,7 +117,7 @@ fn test_insert_with_default_value() {
     db.create_table(schema).unwrap();
 
     // INSERT INTO users (id, name) VALUES (DEFAULT, 'Alice')
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec!["id".to_string(), "name".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -163,7 +163,7 @@ fn test_insert_default_no_default_value_defined() {
     db.create_table(schema).unwrap();
 
     // INSERT INTO users (id, name) VALUES (DEFAULT, 'Alice')
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec!["id".to_string(), "name".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/tests/insert_duplicate_key_update_tests.rs
+++ b/crates/vibesql-executor/tests/insert_duplicate_key_update_tests.rs
@@ -33,7 +33,7 @@ fn test_on_duplicate_key_update_basic() {
     setup_products_table(&mut db);
 
     // Initial INSERT: INSERT INTO products VALUES (1, 'Widget', 10)
-    let initial_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let initial_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -52,7 +52,7 @@ fn test_on_duplicate_key_update_basic() {
 
     // Upsert: INSERT INTO products VALUES (1, 'Widget', 20) ON DUPLICATE KEY UPDATE stock =
     // VALUES(stock)
-    let upsert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let upsert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -89,7 +89,7 @@ fn test_on_duplicate_key_update_with_arithmetic() {
     setup_products_table(&mut db);
 
     // Initial INSERT
-    let initial_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let initial_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -106,7 +106,7 @@ fn test_on_duplicate_key_update_with_arithmetic() {
     InsertExecutor::execute(&mut db, &initial_stmt).unwrap();
 
     // Upsert with arithmetic: stock = stock + VALUES(stock)
-    let upsert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let upsert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -149,7 +149,7 @@ fn test_on_duplicate_key_update_no_conflict() {
     setup_products_table(&mut db);
 
     // INSERT with ON DUPLICATE KEY UPDATE - no conflict, should insert normally
-    let upsert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let upsert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/tests/insert_multi_row_tests.rs
+++ b/crates/vibesql-executor/tests/insert_multi_row_tests.rs
@@ -10,7 +10,7 @@ fn test_multi_row_insert_atomic_success() {
 
     // INSERT INTO users VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie')
     // All should succeed
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
@@ -51,7 +51,7 @@ fn test_multi_row_insert_atomic_failure() {
 
     // INSERT INTO users VALUES (1, 'Alice'), (NULL, 'Bob'), (3, 'Charlie')
     // Second row violates NOT NULL constraint on id, should fail atomically
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
@@ -93,7 +93,7 @@ fn test_multi_row_insert_with_column_list() {
     setup_test_table(&mut db);
 
     // INSERT INTO users (name, id) VALUES ('Alice', 1), ('Bob', 2)
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec!["name".to_string(), "id".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![
@@ -128,7 +128,7 @@ fn test_multi_row_insert_type_mismatch() {
 
     // INSERT INTO users VALUES (1, 'Alice'), ('not_a_number', 'Bob')
     // Second row has type mismatch, should fail atomically
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
@@ -195,7 +195,7 @@ fn test_multi_row_insert_various_data_types() {
     //   (1, 'Alice', TRUE, 95.5),
     //   (2, 'Bob', FALSE, 87.2),
     //   (3, NULL, NULL, NULL)
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "test_types".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
@@ -258,7 +258,7 @@ fn test_multi_row_insert_primary_key_violation() {
 
     // INSERT INTO users VALUES (1, 'Alice'), (1, 'Bob')
     // Second row violates PRIMARY KEY, should fail atomically
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
@@ -294,7 +294,7 @@ fn test_single_row_insert_no_transaction() {
     setup_test_table(&mut db);
 
     // Single row INSERT should work without implicit transaction
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/tests/insert_select_tests.rs
+++ b/crates/vibesql-executor/tests/insert_select_tests.rs
@@ -9,7 +9,7 @@ fn test_insert_from_select_basic() {
     setup_test_table(&mut db);
 
     // First insert some data to select from
-    let insert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let insert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -64,7 +64,7 @@ fn test_insert_from_select_basic() {
             values: None,
     };
 
-    let insert_select_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let insert_select_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users_backup".to_string(),
         columns: vec![], // No explicit columns, use all
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
@@ -85,7 +85,7 @@ fn test_insert_from_select_with_where() {
     setup_test_table(&mut db);
 
     // Insert multiple users
-    let insert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let insert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
@@ -155,7 +155,7 @@ fn test_insert_from_select_with_where() {
             values: None,
     };
 
-    let insert_select_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let insert_select_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "active_users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
@@ -176,7 +176,7 @@ fn test_insert_from_select_column_mismatch() {
     setup_test_table(&mut db);
 
     // Insert some data
-    let insert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let insert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -236,7 +236,7 @@ fn test_insert_from_select_column_mismatch() {
             values: None,
     };
 
-    let insert_select_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let insert_select_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "wrong_table".to_string(),
         columns: vec![], // Should match all columns
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
@@ -275,7 +275,7 @@ fn test_insert_from_select_with_aggregates() {
     db.create_table(schema).unwrap();
 
     // Insert sales data
-    let insert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let insert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "sales".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![
@@ -352,7 +352,7 @@ fn test_insert_from_select_with_aggregates() {
             values: None,
     };
 
-    let insert_select_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let insert_select_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "summary".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),

--- a/crates/vibesql-executor/tests/replace_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/replace_columnar_cache_tests.rs
@@ -27,7 +27,7 @@ fn setup_products_table(db: &mut Database) {
 
 /// Helper to insert a row into products table
 fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -43,7 +43,7 @@ fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
 
 /// Helper to execute a REPLACE statement
 fn replace_product(db: &mut Database, id: i64, name: &str, price: i64) {
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -191,7 +191,7 @@ fn test_replace_unique_constraint_invalidates_cache() {
 
     // Insert users
     let insert = |db: &mut Database, id: i64, name: &str, score: i64| {
-        let stmt = vibesql_ast::InsertStmt { quoted: false,
+        let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
             table_name: "users".to_string(),
             columns: vec![],
             source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -212,7 +212,7 @@ fn test_replace_unique_constraint_invalidates_cache() {
     let _ = db.get_columnar("users").unwrap();
 
     // REPLACE with same name (unique key conflict) - should delete old row and insert new
-    let replace_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let replace_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "users".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/tests/transaction_tests.rs
+++ b/crates/vibesql-executor/tests/transaction_tests.rs
@@ -26,7 +26,7 @@ fn test_basic_savepoint() {
     BeginTransactionExecutor::execute(&begin_stmt, &mut db).unwrap();
 
     // Insert initial row
-    let insert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let insert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "accounts".to_string(),
         columns: vec!["id".to_string(), "balance".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -43,7 +43,7 @@ fn test_basic_savepoint() {
     SavepointExecutor::execute(&savepoint_stmt, &mut db).unwrap();
 
     // Insert another row
-    let insert_stmt2 = vibesql_ast::InsertStmt { quoted: false,
+    let insert_stmt2 = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "accounts".to_string(),
         columns: vec!["id".to_string(), "balance".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -91,7 +91,7 @@ fn test_nested_savepoints() {
     BeginTransactionExecutor::execute(&begin_stmt, &mut db).unwrap();
 
     // Insert initial row
-    let insert_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let insert_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "accounts".to_string(),
         columns: vec!["id".to_string(), "balance".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -108,7 +108,7 @@ fn test_nested_savepoints() {
     SavepointExecutor::execute(&savepoint_stmt1, &mut db).unwrap();
 
     // Insert second row
-    let insert_stmt2 = vibesql_ast::InsertStmt { quoted: false,
+    let insert_stmt2 = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "accounts".to_string(),
         columns: vec!["id".to_string(), "balance".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -125,7 +125,7 @@ fn test_nested_savepoints() {
     SavepointExecutor::execute(&savepoint_stmt2, &mut db).unwrap();
 
     // Insert third row
-    let insert_stmt3 = vibesql_ast::InsertStmt { quoted: false,
+    let insert_stmt3 = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "accounts".to_string(),
         columns: vec!["id".to_string(), "balance".to_string()],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-executor/tests/truncate_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/truncate_columnar_cache_tests.rs
@@ -28,7 +28,7 @@ fn setup_products_table(db: &mut Database) {
 
 /// Helper to insert a row into products table
 fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
-    let stmt = vibesql_ast::InsertStmt { quoted: false,
+    let stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "products".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -248,7 +248,7 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
     db.create_table(child_schema).unwrap();
 
     // Insert data into parent using InsertExecutor
-    let parent_stmt = vibesql_ast::InsertStmt { quoted: false,
+    let parent_stmt = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "categories".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -263,7 +263,7 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
     InsertExecutor::execute(&mut db, &parent_stmt).unwrap();
 
     // Insert data into child using InsertExecutor
-    let child_stmt1 = vibesql_ast::InsertStmt { quoted: false,
+    let child_stmt1 = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "items".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![
@@ -276,7 +276,7 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
     };
     InsertExecutor::execute(&mut db, &child_stmt1).unwrap();
 
-    let child_stmt2 = vibesql_ast::InsertStmt { quoted: false,
+    let child_stmt2 = vibesql_ast::InsertStmt { schema_name: None, schema_quoted: false, table_quoted: false,
         table_name: "items".to_string(),
         columns: vec![],
         source: vibesql_ast::InsertSource::Values(vec![vec![

--- a/crates/vibesql-parser/src/arena_parser/insert.rs
+++ b/crates/vibesql-parser/src/arena_parser/insert.rs
@@ -1,12 +1,77 @@
 //! Arena-allocated INSERT statement parsing.
 
 use bumpalo::collections::Vec as BumpVec;
-use vibesql_ast::arena::{ConflictClause, InsertSource, InsertStmt};
+use vibesql_ast::arena::{ConflictClause, InsertSource, InsertStmt, Symbol};
 
 use super::ArenaParser;
 use crate::{keywords::Keyword, token::Token, ParseError};
 
+/// Result of parsing a table reference (schema.table or just table)
+struct TableRefParts {
+    schema_name: Option<Symbol>,
+    schema_quoted: bool,
+    table_name: Symbol,
+    table_quoted: bool,
+}
+
 impl<'arena> ArenaParser<'arena> {
+    /// Parse a table reference with optional schema qualifier.
+    /// Supports: tablename, "TableName", schema.table, "schema"."table"
+    fn parse_insert_table_ref(&mut self) -> Result<TableRefParts, ParseError> {
+        // Parse first identifier and track if it was quoted
+        let (first_part, first_quoted) = match self.peek() {
+            Token::Identifier(name) => {
+                let name = name.clone();
+                self.advance();
+                (self.intern(&name), false)
+            }
+            Token::DelimitedIdentifier(name) => {
+                let name = name.clone();
+                self.advance();
+                (self.intern(&name), true)
+            }
+            _ => {
+                return Err(ParseError {
+                    message: "Expected table name".to_string(),
+                });
+            }
+        };
+
+        // Check if there's a dot followed by another identifier
+        if self.try_consume(&Token::Symbol('.')) {
+            let (second_part, second_quoted) = match self.peek() {
+                Token::Identifier(name) => {
+                    let name = name.clone();
+                    self.advance();
+                    (self.intern(&name), false)
+                }
+                Token::DelimitedIdentifier(name) => {
+                    let name = name.clone();
+                    self.advance();
+                    (self.intern(&name), true)
+                }
+                _ => {
+                    return Err(ParseError {
+                        message: "Expected identifier after '.'".to_string(),
+                    });
+                }
+            };
+            Ok(TableRefParts {
+                schema_name: Some(first_part),
+                schema_quoted: first_quoted,
+                table_name: second_part,
+                table_quoted: second_quoted,
+            })
+        } else {
+            Ok(TableRefParts {
+                schema_name: None,
+                schema_quoted: false,
+                table_name: first_part,
+                table_quoted: first_quoted,
+            })
+        }
+    }
+
     /// Parse an INSERT statement (including INSERT OR REPLACE).
     pub(crate) fn parse_insert_statement(
         &mut self,
@@ -30,24 +95,8 @@ impl<'arena> ArenaParser<'arena> {
 
         self.consume_keyword(Keyword::Into)?;
 
-        // Parse table name and track if quoted (for SQL:1999 case-sensitive lookups)
-        let (table_name, quoted) = match self.peek() {
-            Token::Identifier(name) => {
-                let name = name.clone();
-                self.advance();
-                (self.intern(&name), false)
-            }
-            Token::DelimitedIdentifier(name) => {
-                let name = name.clone();
-                self.advance();
-                (self.intern(&name), true)
-            }
-            _ => {
-                return Err(ParseError {
-                    message: "Expected table name after INSERT INTO".to_string(),
-                });
-            }
-        };
+        // Parse table name with optional schema qualifier
+        let table_ref = self.parse_insert_table_ref()?;
 
         // Parse column list (optional)
         let columns = if self.try_consume(&Token::LParen) {
@@ -86,8 +135,16 @@ impl<'arena> ArenaParser<'arena> {
         // Consume optional semicolon
         self.try_consume(&Token::Semicolon);
 
-        let stmt =
-            InsertStmt { table_name, quoted, columns, source, conflict_clause, on_duplicate_key_update };
+        let stmt = InsertStmt {
+            schema_name: table_ref.schema_name,
+            schema_quoted: table_ref.schema_quoted,
+            table_name: table_ref.table_name,
+            table_quoted: table_ref.table_quoted,
+            columns,
+            source,
+            conflict_clause,
+            on_duplicate_key_update,
+        };
 
         Ok(self.arena.alloc(stmt))
     }
@@ -99,24 +156,8 @@ impl<'arena> ArenaParser<'arena> {
         self.consume_keyword(Keyword::Replace)?;
         self.consume_keyword(Keyword::Into)?;
 
-        // Parse table name and track if quoted (for SQL:1999 case-sensitive lookups)
-        let (table_name, quoted) = match self.peek() {
-            Token::Identifier(name) => {
-                let name = name.clone();
-                self.advance();
-                (self.intern(&name), false)
-            }
-            Token::DelimitedIdentifier(name) => {
-                let name = name.clone();
-                self.advance();
-                (self.intern(&name), true)
-            }
-            _ => {
-                return Err(ParseError {
-                    message: "Expected table name after REPLACE INTO".to_string(),
-                });
-            }
-        };
+        // Parse table name with optional schema qualifier
+        let table_ref = self.parse_insert_table_ref()?;
 
         // Parse column list (optional)
         let columns = if self.try_consume(&Token::LParen) {
@@ -154,8 +195,10 @@ impl<'arena> ArenaParser<'arena> {
         self.try_consume(&Token::Semicolon);
 
         let stmt = InsertStmt {
-            table_name,
-            quoted,
+            schema_name: table_ref.schema_name,
+            schema_quoted: table_ref.schema_quoted,
+            table_name: table_ref.table_name,
+            table_quoted: table_ref.table_quoted,
             columns,
             source,
             conflict_clause: Some(ConflictClause::Replace),

--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -160,11 +160,11 @@ impl Parser {
 
         Ok(vibesql_ast::CreateTableStmt {
             if_not_exists,
-            table_name: table.name,
+            table_name: table.full_name(),
             columns,
             table_constraints,
             table_options,
-            quoted: table.quoted,
+            quoted: table.is_any_quoted(),
         })
     }
 

--- a/crates/vibesql-parser/src/parser/delete.rs
+++ b/crates/vibesql-parser/src/parser/delete.rs
@@ -18,8 +18,9 @@ impl Parser {
         // Parse table name with optional schema qualifier and quoted flag
         // Supports: tablename, "TableName", schema.table, "schema"."table"
         let table_ref = self.parse_table_ref()?;
-        let table_name = table_ref.name;
-        let quoted = table_ref.quoted;
+        // Use full_name() to get combined schema.table format for backward compatibility
+        let table_name = table_ref.full_name();
+        let quoted = table_ref.is_any_quoted();
 
         // If we had opening paren, expect closing paren
         if has_paren {

--- a/crates/vibesql-parser/src/parser/drop.rs
+++ b/crates/vibesql-parser/src/parser/drop.rs
@@ -34,6 +34,6 @@ impl Parser {
             self.advance();
         }
 
-        Ok(vibesql_ast::DropTableStmt { table_name: table.name, if_exists, quoted: table.quoted })
+        Ok(vibesql_ast::DropTableStmt { table_name: table.full_name(), if_exists, quoted: table.is_any_quoted() })
     }
 }

--- a/crates/vibesql-parser/src/parser/helpers.rs
+++ b/crates/vibesql-parser/src/parser/helpers.rs
@@ -163,7 +163,7 @@ impl Parser {
     /// Parse a qualified identifier (schema.table or just table)
     pub(super) fn parse_qualified_identifier(&mut self) -> Result<String, ParseError> {
         let table_ref = self.parse_table_ref()?;
-        Ok(table_ref.name)
+        Ok(table_ref.full_name())
     }
 
     /// Parse a table reference with quoted flag (schema.table or just table)
@@ -172,6 +172,9 @@ impl Parser {
     /// This is important for SQL:1999 case-sensitivity semantics:
     /// - Unquoted identifiers are case-insensitive
     /// - Quoted identifiers are case-sensitive
+    ///
+    /// For schema-qualified names, the schema and table parts are stored separately
+    /// with their individual quoted flags preserved.
     pub(super) fn parse_table_ref(&mut self) -> Result<vibesql_ast::TableRef, ParseError> {
         // Parse first identifier and track if it was quoted
         let (first_part, first_quoted) = match self.peek() {
@@ -216,11 +219,13 @@ impl Parser {
                     return Err(ParseError { message: "Expected identifier after '.'".to_string() })
                 }
             };
-            // For qualified names, the table part's quoted status matters most
-            // If either part is quoted, we consider the whole reference quoted
-            Ok(vibesql_ast::TableRef::new(
-                format!("{}.{}", first_part, second_part),
-                first_quoted || second_quoted,
+            // For qualified names, store schema and table parts separately
+            // This preserves the individual quoted status for proper case handling
+            Ok(vibesql_ast::TableRef::qualified(
+                first_part,
+                first_quoted,
+                second_part,
+                second_quoted,
             ))
         } else {
             Ok(vibesql_ast::TableRef::new(first_part, first_quoted))

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -28,8 +28,10 @@ impl Parser {
         // Parse table name with optional schema qualifier and quoted flag
         // Supports: tablename, "TableName", schema.table, "schema"."table"
         let table_ref = self.parse_table_ref()?;
+        let schema_name = table_ref.schema_name;
+        let schema_quoted = table_ref.schema_quoted;
         let table_name = table_ref.name;
-        let quoted = table_ref.quoted;
+        let table_quoted = table_ref.quoted;
 
         // Parse column list (optional in SQL, but we'll require it for now)
         let columns = if matches!(self.peek(), Token::LParen) {
@@ -123,8 +125,10 @@ impl Parser {
         }
 
         Ok(vibesql_ast::InsertStmt {
+            schema_name,
+            schema_quoted,
             table_name,
-            quoted,
+            table_quoted,
             columns,
             source,
             conflict_clause,
@@ -142,8 +146,10 @@ impl Parser {
         // Parse table name with optional schema qualifier and quoted flag
         // Supports: tablename, "TableName", schema.table, "schema"."table"
         let table_ref = self.parse_table_ref()?;
+        let schema_name = table_ref.schema_name;
+        let schema_quoted = table_ref.schema_quoted;
         let table_name = table_ref.name;
-        let quoted = table_ref.quoted;
+        let table_quoted = table_ref.quoted;
 
         // Parse column list (optional)
         let columns = if matches!(self.peek(), Token::LParen) {
@@ -243,8 +249,10 @@ impl Parser {
         }
 
         Ok(vibesql_ast::InsertStmt {
+            schema_name,
+            schema_quoted,
             table_name,
-            quoted,
+            table_quoted,
             columns,
             source,
             conflict_clause: Some(vibesql_ast::ConflictClause::Replace),

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -302,10 +302,10 @@ impl Parser {
                     if alias.is_some() { self.parse_column_alias_list()? } else { None };
 
                 Ok(vibesql_ast::FromClause::Table {
-                    name: table.name,
+                    name: table.full_name(),
                     alias,
                     column_aliases,
-                    quoted: table.quoted,
+                    quoted: table.is_any_quoted(),
                 })
             }
             _ => Err(ParseError {

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -8,8 +8,9 @@ impl Parser {
         // Parse table name with optional schema qualifier and quoted flag
         // Supports: tablename, "TableName", schema.table, "schema"."table"
         let table_ref = self.parse_table_ref()?;
-        let table_name = table_ref.name;
-        let quoted = table_ref.quoted;
+        // Use full_name() to get combined schema.table format for backward compatibility
+        let table_name = table_ref.full_name();
+        let quoted = table_ref.is_any_quoted();
 
         // Parse SET keyword
         self.expect_keyword(Keyword::Set)?;

--- a/crates/vibesql-parser/src/tests/dml_schema_qualified.rs
+++ b/crates/vibesql-parser/src/tests/dml_schema_qualified.rs
@@ -9,8 +9,10 @@ fn test_insert_schema_qualified_quoted() {
     let stmt = Parser::parse_sql(sql).unwrap();
     match stmt {
         Statement::Insert(insert) => {
-            assert_eq!(insert.table_name, "mySchema.users");
-            assert!(insert.quoted);
+            assert_eq!(insert.schema_name, Some("mySchema".to_string()));
+            assert!(insert.schema_quoted);
+            assert_eq!(insert.table_name, "users");
+            assert!(insert.table_quoted);
         }
         _ => panic!("Expected INSERT statement"),
     }
@@ -22,8 +24,10 @@ fn test_insert_schema_qualified_unquoted() {
     let stmt = Parser::parse_sql(sql).unwrap();
     match stmt {
         Statement::Insert(insert) => {
-            assert_eq!(insert.table_name, "myschema.users");
-            assert!(!insert.quoted);
+            assert_eq!(insert.schema_name, Some("myschema".to_string()));
+            assert!(!insert.schema_quoted);
+            assert_eq!(insert.table_name, "users");
+            assert!(!insert.table_quoted);
         }
         _ => panic!("Expected INSERT statement"),
     }
@@ -62,8 +66,10 @@ fn test_insert_mixed_quoted_unquoted() {
     let stmt = Parser::parse_sql(sql).unwrap();
     match stmt {
         Statement::Insert(insert) => {
-            assert_eq!(insert.table_name, "mySchema.users");
-            assert!(insert.quoted); // quoted if any part is quoted
+            assert_eq!(insert.schema_name, Some("mySchema".to_string()));
+            assert!(insert.schema_quoted);
+            assert_eq!(insert.table_name, "users");
+            assert!(!insert.table_quoted);
         }
         _ => panic!("Expected INSERT statement"),
     }
@@ -75,8 +81,10 @@ fn test_replace_schema_qualified() {
     let stmt = Parser::parse_sql(sql).unwrap();
     match stmt {
         Statement::Insert(insert) => {
-            assert_eq!(insert.table_name, "mySchema.users");
-            assert!(insert.quoted);
+            assert_eq!(insert.schema_name, Some("mySchema".to_string()));
+            assert!(insert.schema_quoted);
+            assert_eq!(insert.table_name, "users");
+            assert!(insert.table_quoted);
         }
         _ => panic!("Expected INSERT statement"),
     }

--- a/tests/parser/delimited_identifiers.rs
+++ b/tests/parser/delimited_identifiers.rs
@@ -360,7 +360,6 @@ fn test_error_on_case_mismatch_quoted_table() {
 // ========================================================================
 
 #[test]
-#[ignore] // TODO: Schema-qualified quoted identifiers need parser support for INSERT
 fn test_quoted_schema_and_table_names() {
     let mut db = Database::new();
 
@@ -379,9 +378,9 @@ fn test_quoted_schema_and_table_names() {
     execute_create_table(&mut db, r#"CREATE TABLE "mySchema"."users" (id INT)"#).unwrap();
     execute_create_table(&mut db, r#"CREATE TABLE "MYSCHEMA"."users" (id INT)"#).unwrap();
 
-    // Insert different data using direct storage API (parser doesn't support schema-qualified INSERT)
-    db.insert_row("mySchema.users", Row::new(vec![SqlValue::Integer(1)])).unwrap();
-    db.insert_row("MYSCHEMA.users", Row::new(vec![SqlValue::Integer(2)])).unwrap();
+    // Insert different data using SQL INSERT with schema-qualified names
+    execute_insert_sql(&mut db, r#"INSERT INTO "mySchema"."users" VALUES (1)"#).unwrap();
+    execute_insert_sql(&mut db, r#"INSERT INTO "MYSCHEMA"."users" VALUES (2)"#).unwrap();
 
     // Query each separately
     let result1 = execute_select(&db, r#"SELECT * FROM "mySchema"."users""#).unwrap();
@@ -401,11 +400,11 @@ fn test_mixed_quoted_unquoted_schema_table() {
         vibesql_executor::SchemaExecutor::execute_create_schema(&create_schema, &mut db).unwrap();
     }
 
-    // Create table: quoted schema, unquoted table (normalized to USERS)
+    // Create table: quoted schema, unquoted table (normalized to users)
     execute_create_table(&mut db, r#"CREATE TABLE "myApp".users (id INT)"#).unwrap();
 
-    // Insert using direct storage API (parser doesn't support schema-qualified INSERT)
-    db.insert_row("myApp.users", Row::new(vec![SqlValue::Integer(42)])).unwrap();
+    // Insert using SQL INSERT with schema-qualified name
+    execute_insert_sql(&mut db, r#"INSERT INTO "myApp".users VALUES (42)"#).unwrap();
 
     // Query with quoted schema, unquoted table
     let result = execute_select(&db, r#"SELECT * FROM "myApp".users"#).unwrap();

--- a/tests/storage/insert_constraint_performance.rs
+++ b/tests/storage/insert_constraint_performance.rs
@@ -41,7 +41,10 @@ fn test_insert_with_merged_constraint_validation() {
     // Batch insert multiple rows
     for i in 0..num_rows {
         let stmt = InsertStmt {
+            schema_name: None,
+            schema_quoted: false,
             table_name: "test_table".to_string(),
+            table_quoted: false,
             columns: vec![],
             source: InsertSource::Values(vec![vec![
                 Expression::Literal(SqlValue::Integer(i)),
@@ -50,7 +53,6 @@ fn test_insert_with_merged_constraint_validation() {
             ]]),
             conflict_clause: None,
             on_duplicate_key_update: None,
-            quoted: false,
         };
 
         InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -108,12 +110,14 @@ fn test_insert_multi_row_with_constraints() {
     let start = std::time::Instant::now();
 
     let stmt = InsertStmt {
+        schema_name: None,
+        schema_quoted: false,
         table_name: "test_table".to_string(),
+        table_quoted: false,
         columns: vec![],
         source: InsertSource::Values(rows),
         conflict_clause: None,
         on_duplicate_key_update: None,
-        quoted: false,
     };
 
     InsertExecutor::execute(&mut db, &stmt).unwrap();


### PR DESCRIPTION
## Summary
- Add parser support for schema-qualified table names in INSERT statements
- Enable SQL like `INSERT INTO "mySchema"."users" VALUES (1)` to work properly
- Extended InsertStmt AST with schema_name and schema_quoted fields
- Fixed storage layer table name resolution to maintain index compatibility

## Test plan
- [x] `test_quoted_schema_and_table_names` passes - validates schema-qualified INSERT works
- [x] `test_reset_clears_index_state` passes - confirms no regression with indexes
- [x] Full test suite passes with no regressions

Closes #4498

🤖 Generated with [Claude Code](https://claude.com/claude-code)