### PR TITLE
fix(joins): Apply natural join condition for NATURAL CROSS JOIN

### DIFF
--- a/crates/vibesql-executor/src/select/join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/mod.rs
@@ -1182,7 +1182,13 @@ pub(super) fn nested_loop_join(
             nested_loop_full_outer_join(left, right, &combined_condition, database, timeout_ctx)
         }
         vibesql_ast::JoinType::Cross => {
-            nested_loop_cross_join(left, right, &combined_condition, database, timeout_ctx)
+            // NATURAL CROSS JOIN should apply the natural join condition
+            // (semantically equivalent to NATURAL INNER JOIN)
+            if natural && combined_condition.is_some() {
+                nested_loop_inner_join(left, right, &combined_condition, database, timeout_ctx)
+            } else {
+                nested_loop_cross_join(left, right, &combined_condition, database, timeout_ctx)
+            }
         }
         vibesql_ast::JoinType::Semi => {
             nested_loop_semi_join(left, right, &combined_condition, database, timeout_ctx)

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -107,11 +107,13 @@ pub(crate) fn count_tables_in_from(from: &FromClause) -> usize {
 pub(crate) fn all_joins_are_cross(from: &FromClause) -> bool {
     match from {
         FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => true,
-        FromClause::Join { left, right, join_type, condition, .. } => {
-            // Must be CROSS join type AND have no ON condition
+        FromClause::Join { left, right, join_type, condition, natural, .. } => {
+            // Must be CROSS join type AND have no ON condition AND not NATURAL
             // CROSS JOIN with ON clause is invalid and should not be reordered
+            // NATURAL CROSS JOIN has implicit condition and should not be reordered
             matches!(join_type, vibesql_ast::JoinType::Cross)
                 && condition.is_none()
+                && !*natural
                 && all_joins_are_cross(left)
                 && all_joins_are_cross(right)
         }

--- a/crates/vibesql-executor/src/tests/natural_join.rs
+++ b/crates/vibesql-executor/src/tests/natural_join.rs
@@ -167,8 +167,8 @@ fn test_natural_join_single_common_column() {
 
 #[test]
 fn test_natural_cross_join_accepted() {
-    // SQLite allows NATURAL CROSS JOIN, treating it as a regular CROSS JOIN
-    // (the NATURAL modifier is effectively ignored for CROSS JOINs)
+    // NATURAL CROSS JOIN is valid SQL - SQLite applies the natural join condition
+    // (matching on common column names), not a cartesian product
     let result = vibesql_parser::Parser::parse_sql("SELECT * FROM t1 NATURAL CROSS JOIN t2");
 
     assert!(result.is_ok(), "NATURAL CROSS JOIN should parse successfully");
@@ -177,8 +177,8 @@ fn test_natural_cross_join_accepted() {
         vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
             vibesql_ast::FromClause::Join { join_type, natural, .. } => {
                 assert_eq!(*join_type, vibesql_ast::JoinType::Cross);
-                // NATURAL is effectively ignored for CROSS JOIN
-                assert!(!*natural);
+                // NATURAL flag should be preserved
+                assert!(*natural);
             }
             _ => panic!("Expected JOIN"),
         },

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -468,11 +468,9 @@ impl Parser {
             _ => return Err(ParseError { message: "Expected JOIN keyword".to_string() }),
         };
 
-        // SQLite allows NATURAL CROSS JOIN, treating it as a regular CROSS JOIN
-        // (the NATURAL modifier is effectively ignored for CROSS JOINs).
-        // We parse it successfully but set is_natural to false for CROSS JOINs.
-        let is_natural = if join_type == vibesql_ast::JoinType::Cross { false } else { is_natural };
-
+        // NATURAL CROSS JOIN is valid SQL and should apply the natural join condition
+        // (matching on common column names). The executor handles this by treating
+        // NATURAL CROSS JOIN as an inner join with the natural join condition.
         Ok((join_type, is_natural))
     }
 }

--- a/crates/vibesql-parser/src/tests/joins.rs
+++ b/crates/vibesql-parser/src/tests/joins.rs
@@ -366,8 +366,8 @@ fn test_parse_natural_left_join() {
 
 #[test]
 fn test_parse_natural_cross_join() {
-    // SQLite allows NATURAL CROSS JOIN, treating it as a regular CROSS JOIN
-    // (the NATURAL modifier is effectively ignored)
+    // NATURAL CROSS JOIN is valid SQL - the NATURAL modifier applies the
+    // natural join condition (matching on common column names)
     let result = Parser::parse_sql("SELECT * FROM t1 NATURAL CROSS JOIN t2;");
     assert!(result.is_ok(), "Parse failed: {:?}", result.err());
     let stmt = result.unwrap();
@@ -376,9 +376,9 @@ fn test_parse_natural_cross_join() {
         vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
             vibesql_ast::FromClause::Join { join_type, natural, condition, using_columns, .. } => {
                 assert_eq!(*join_type, vibesql_ast::JoinType::Cross);
-                // NATURAL is effectively ignored for CROSS JOIN
-                assert!(!*natural);
-                // CROSS JOIN should have no condition
+                // NATURAL flag should be preserved
+                assert!(*natural);
+                // No explicit ON condition (natural join derives condition from common columns)
                 assert!(condition.is_none());
                 assert!(using_columns.is_none());
             }


### PR DESCRIPTION
## Summary

- Fix NATURAL CROSS JOIN to apply natural join condition instead of cartesian product
- Parser now correctly preserves `natural=true` for CROSS joins
- Executor routes NATURAL CROSS JOIN through inner join logic

## Test plan

- [x] Verify `SELECT * FROM t1 NATURAL CROSS JOIN t2` returns 2 rows (matching SQLite)
- [x] All 2147 executor tests pass
- [x] Parser tests updated and passing

Closes #4513

🤖 Generated with [Claude Code](https://claude.com/claude-code)