### PR TITLE
feat(parser): Support UPDATE OR conflict resolution clauses

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -598,6 +598,7 @@ impl<'a, 'arena> Converter<'a, 'arena> {
             quoted: stmt.quoted,
             assignments: stmt.assignments.iter().map(|a| self.convert_assignment(a)).collect(),
             where_clause: stmt.where_clause.as_ref().map(|wc| self.convert_where_clause(wc)),
+            conflict_clause: stmt.conflict_clause.map(ConflictClause::from),
         }
     }
 
@@ -757,8 +758,11 @@ impl From<arena_select::SetOperator> for SetOperator {
 impl From<arena_dml::ConflictClause> for ConflictClause {
     fn from(cc: arena_dml::ConflictClause) -> Self {
         match cc {
-            arena_dml::ConflictClause::Replace => ConflictClause::Replace,
+            arena_dml::ConflictClause::Abort => ConflictClause::Abort,
+            arena_dml::ConflictClause::Fail => ConflictClause::Fail,
             arena_dml::ConflictClause::Ignore => ConflictClause::Ignore,
+            arena_dml::ConflictClause::Replace => ConflictClause::Replace,
+            arena_dml::ConflictClause::Rollback => ConflictClause::Rollback,
         }
     }
 }

--- a/crates/vibesql-ast/src/arena/dml.rs
+++ b/crates/vibesql-ast/src/arena/dml.rs
@@ -19,13 +19,25 @@ pub enum InsertSource<'arena> {
     Select(&'arena SelectStmt<'arena>),
 }
 
-/// Conflict resolution strategy for INSERT statements
-#[derive(Debug, Clone, Copy, PartialEq)]
+/// Conflict resolution strategy for INSERT and UPDATE statements (SQLite extension)
+///
+/// SQLite supports conflict resolution clauses in both INSERT and UPDATE statements:
+/// - `INSERT OR REPLACE INTO ...`
+/// - `UPDATE OR REPLACE ... SET ...`
+///
+/// See: <https://www.sqlite.org/lang_conflict.html>
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConflictClause {
-    /// INSERT OR REPLACE / REPLACE INTO - delete conflicting row and insert new one
-    Replace,
-    /// INSERT OR IGNORE - silently ignore constraint violations
+    /// ABORT - Abort current statement, rollback changes from this statement (default)
+    Abort,
+    /// FAIL - Abort statement but keep prior changes within the statement
+    Fail,
+    /// IGNORE - Skip the row causing violation, continue with next row
     Ignore,
+    /// REPLACE - Delete conflicting rows, then insert/update the new row
+    Replace,
+    /// ROLLBACK - Abort and rollback entire transaction
+    Rollback,
 }
 
 /// INSERT statement
@@ -70,6 +82,9 @@ pub struct UpdateStmt<'arena> {
     pub quoted: bool,
     pub assignments: BumpVec<'arena, Assignment<'arena>>,
     pub where_clause: Option<WhereClause<'arena>>,
+    /// Optional conflict resolution clause (SQLite extension)
+    /// Syntax: UPDATE OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL table SET ...
+    pub conflict_clause: Option<ConflictClause>,
 }
 
 /// Column assignment (column = value)

--- a/crates/vibesql-ast/src/dml.rs
+++ b/crates/vibesql-ast/src/dml.rs
@@ -17,13 +17,36 @@ pub enum InsertSource {
     Select(Box<SelectStmt>),
 }
 
-/// Conflict resolution strategy for INSERT statements
-#[derive(Debug, Clone, PartialEq)]
+/// Conflict resolution strategy for INSERT and UPDATE statements (SQLite extension)
+///
+/// SQLite supports conflict resolution clauses in both INSERT and UPDATE statements:
+/// - `INSERT OR REPLACE INTO ...`
+/// - `UPDATE OR REPLACE ... SET ...`
+///
+/// See: <https://www.sqlite.org/lang_conflict.html>
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConflictClause {
-    /// INSERT OR REPLACE / REPLACE INTO - delete conflicting row and insert new one
-    Replace,
-    /// INSERT OR IGNORE - silently ignore constraint violations (future)
+    /// ABORT - Abort current statement, rollback changes from this statement (default)
+    /// When a constraint violation occurs, the statement is aborted and all changes
+    /// made by the statement are rolled back, but changes from prior statements
+    /// in the same transaction are preserved.
+    Abort,
+    /// FAIL - Abort statement but keep prior changes within the statement
+    /// When a constraint violation occurs, the statement is aborted but changes
+    /// made by the statement prior to the violation are preserved.
+    Fail,
+    /// IGNORE - Skip the row causing violation, continue with next row
+    /// When a constraint violation occurs, the row is simply skipped and processing
+    /// continues with the next row.
     Ignore,
+    /// REPLACE - Delete conflicting rows, then insert/update the new row
+    /// When a UNIQUE or PRIMARY KEY constraint violation occurs, the conflicting
+    /// row is deleted before inserting/updating the new row.
+    Replace,
+    /// ROLLBACK - Abort and rollback entire transaction
+    /// When a constraint violation occurs, the entire transaction is rolled back
+    /// and the statement returns an error.
+    Rollback,
 }
 
 /// INSERT statement
@@ -68,6 +91,9 @@ pub struct UpdateStmt {
     pub quoted: bool,
     pub assignments: Vec<Assignment>,
     pub where_clause: Option<WhereClause>,
+    /// Optional conflict resolution clause (SQLite extension)
+    /// Syntax: UPDATE OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL table SET ...
+    pub conflict_clause: Option<ConflictClause>,
 }
 
 /// Column assignment (column = value)

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1265,6 +1265,7 @@ pub fn transform_update<V: ExpressionMutVisitor>(visitor: &mut V, stmt: UpdateSt
             }
             other => other,
         }),
+        conflict_clause: stmt.conflict_clause,
     }
 }
 

--- a/crates/vibesql-ast/tests/statements.rs
+++ b/crates/vibesql-ast/tests/statements.rs
@@ -61,6 +61,7 @@ fn test_create_update_statement() {
             value: Expression::Literal(SqlValue::Varchar(StringValue::from("Bob"))),
         }],
         where_clause: None,
+        conflict_clause: None,
     });
 
     match stmt {

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -66,6 +66,7 @@ fn test_after_update_trigger_fires() {
                 )),
             },
         )),
+        conflict_clause: None,
     };
     UpdateExecutor::execute(&update, &mut db).expect("Failed to update");
 
@@ -131,6 +132,7 @@ fn test_before_update_trigger_fires() {
                 )),
             },
         )),
+        conflict_clause: None,
     };
     UpdateExecutor::execute(&update, &mut db).expect("Failed to update");
 

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -89,6 +89,7 @@ impl UpdateExecutor {
     ///         value: Expression::Literal(SqlValue::Integer(60000)),
     ///     }],
     ///     where_clause: None,
+    ///     conflict_clause: None,
     /// };
     ///
     /// let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/update_basic_tests.rs
+++ b/crates/vibesql-executor/tests/update_basic_tests.rs
@@ -19,6 +19,7 @@ fn test_update_all_rows() {
             value: Expression::Literal(SqlValue::Integer(50000)),
         }],
         where_clause: None,
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -50,6 +51,7 @@ fn test_update_with_where_clause() {
                 "Engineering",
             )))),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -90,6 +92,7 @@ fn test_update_multiple_columns() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -127,6 +130,7 @@ fn test_update_with_expression() {
             },
         }],
         where_clause: None,
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -150,6 +154,7 @@ fn test_update_table_not_found() {
         table_name: "nonexistent".to_string(),
         assignments: vec![],
         where_clause: None,
+        conflict_clause: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);
@@ -170,6 +175,7 @@ fn test_update_column_not_found() {
             value: Expression::Literal(SqlValue::Integer(123)),
         }],
         where_clause: None,
+        conflict_clause: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);
@@ -194,6 +200,7 @@ fn test_update_no_matching_rows() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(999))),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
@@ -63,6 +63,7 @@ fn test_update_invalidates_columnar_cache() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        conflict_clause: None,
     };
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(count, 1, "Should update 1 row");
@@ -128,6 +129,7 @@ fn test_update_invalidates_prewarmed_cache() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Bob")))),
         })),
+        conflict_clause: None,
     };
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(count, 1, "Should update 1 row");
@@ -163,6 +165,7 @@ fn test_update_all_rows_invalidates_cache() {
             value: Expression::Literal(SqlValue::Integer(60000)),
         }],
         where_clause: None,
+        conflict_clause: None,
     };
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(count, 3, "Should update 3 rows");
@@ -200,6 +203,7 @@ fn test_update_no_match_does_not_invalidate_cache() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(999))), // No such id
         })),
+        conflict_clause: None,
     };
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(count, 0, "Should update 0 rows");
@@ -238,6 +242,7 @@ fn test_multiple_updates_invalidate_cache() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        conflict_clause: None,
     };
     UpdateExecutor::execute(&stmt1, &mut db).unwrap();
 
@@ -262,6 +267,7 @@ fn test_multiple_updates_invalidate_cache() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
+        conflict_clause: None,
     };
     UpdateExecutor::execute(&stmt2, &mut db).unwrap();
 
@@ -308,6 +314,7 @@ fn test_update_multiple_columns_invalidates_cache() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        conflict_clause: None,
     };
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(count, 1, "Should update 1 row");

--- a/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
@@ -25,6 +25,7 @@ fn test_update_check_constraint_passes() {
             value: Expression::Literal(SqlValue::Integer(100)),
         }],
         where_clause: None,
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -48,6 +49,7 @@ fn test_update_check_constraint_violation() {
             value: Expression::Literal(SqlValue::Integer(-10)),
         }],
         where_clause: None,
+        conflict_clause: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);
@@ -78,6 +80,7 @@ fn test_update_check_constraint_with_null() {
             value: Expression::Literal(SqlValue::Null),
         }],
         where_clause: None,
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -105,6 +108,7 @@ fn test_update_check_constraint_with_expression() {
             value: Expression::Literal(SqlValue::Integer(15000)),
         }],
         where_clause: None,
+        conflict_clause: None,
     };
     let count = UpdateExecutor::execute(&stmt1, &mut db).unwrap();
     assert_eq!(count, 1);
@@ -118,6 +122,7 @@ fn test_update_check_constraint_with_expression() {
             value: Expression::Literal(SqlValue::Integer(60000)),
         }],
         where_clause: None,
+        conflict_clause: None,
     };
 
     let result = UpdateExecutor::execute(&stmt2, &mut db);

--- a/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
@@ -181,5 +181,6 @@ pub fn create_update_with_id_clause(
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(id))),
         })),
+        conflict_clause: None,
     }
 }

--- a/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
@@ -177,6 +177,7 @@ fn test_update_unique_constraint_composite() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
+        conflict_clause: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);

--- a/crates/vibesql-executor/tests/update_default_tests.rs
+++ b/crates/vibesql-executor/tests/update_default_tests.rs
@@ -37,6 +37,7 @@ fn test_update_with_default_value() {
             left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -83,6 +84,7 @@ fn test_update_default_no_default_value_defined() {
             left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/update_onepass_tests.rs
+++ b/crates/vibesql-executor/tests/update_onepass_tests.rs
@@ -122,6 +122,7 @@ fn test_onepass_multiple_literal_assignments() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -158,6 +159,7 @@ fn test_onepass_single_literal_assignment() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -186,6 +188,7 @@ fn test_onepass_pk_not_found_returns_zero() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(999))),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -223,6 +226,7 @@ fn test_onepass_not_null_constraint_enforced() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        conflict_clause: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);
@@ -266,6 +270,7 @@ fn test_composite_pk_update_both_columns_specified() {
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -315,6 +320,7 @@ fn test_composite_pk_update_reversed_order() {
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -345,6 +351,7 @@ fn test_composite_pk_partial_match_uses_scan() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -390,6 +397,7 @@ fn test_composite_pk_not_found_returns_zero() {
                 right: Box::new(Expression::Literal(SqlValue::Integer(99))),
             }),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -434,6 +442,7 @@ fn test_composite_pk_multiple_columns_updated() {
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
@@ -48,7 +48,7 @@ fn test_update_with_subquery_multiple_rows_error() {
         quoted: false,
         }),
         where_clause: None,
-        group_by: None,
+                group_by: None,
         having: None,
         order_by: None,
         limit: None,
@@ -65,6 +65,7 @@ fn test_update_with_subquery_multiple_rows_error() {
             value: Expression::ScalarSubquery(subquery),
         }],
         where_clause: None,
+        conflict_clause: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);
@@ -129,7 +130,7 @@ fn test_update_with_subquery_multiple_columns_error() {
         quoted: false,
         }),
         where_clause: None,
-        group_by: None,
+                group_by: None,
         having: None,
         order_by: None,
         limit: None,
@@ -146,6 +147,7 @@ fn test_update_with_subquery_multiple_columns_error() {
             value: Expression::ScalarSubquery(subquery),
         }],
         where_clause: None,
+        conflict_clause: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);

--- a/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
@@ -119,6 +119,7 @@ fn create_update_stmt(
         table_name: table_name.to_string(),
         assignments: vec![Assignment { column: column.to_string(), value }],
         where_clause,
+        conflict_clause: None,
     }
 }
 
@@ -134,6 +135,7 @@ fn create_multi_column_update_stmt(
             .map(|(col, val)| Assignment { column: col.to_string(), value: val })
             .collect(),
         where_clause: None,
+        conflict_clause: None,
     }
 }
 

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
@@ -47,7 +47,7 @@ fn test_update_where_scalar_subquery_equal() {
         quoted: false,
         }),
         where_clause: None,
-        group_by: None,
+                group_by: None,
         having: None,
         order_by: None,
         limit: None,
@@ -69,6 +69,7 @@ fn test_update_where_scalar_subquery_equal() {
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -126,7 +127,7 @@ fn test_update_where_scalar_subquery_less_than() {
         quoted: false,
         }),
         where_clause: None,
-        group_by: None,
+                group_by: None,
         having: None,
         order_by: None,
         limit: None,
@@ -148,6 +149,7 @@ fn test_update_where_scalar_subquery_less_than() {
             op: vibesql_ast::BinaryOperator::LessThan,
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -199,7 +201,7 @@ fn test_update_where_subquery_returns_null() {
         quoted: false,
         }),
         where_clause: None,
-        group_by: None,
+                group_by: None,
         having: None,
         order_by: None,
         limit: None,
@@ -221,6 +223,7 @@ fn test_update_where_subquery_returns_null() {
             op: vibesql_ast::BinaryOperator::LessThan,
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -282,7 +285,7 @@ fn test_update_where_subquery_with_aggregate() {
         quoted: false,
         }),
         where_clause: None,
-        group_by: None,
+                group_by: None,
         having: None,
         order_by: None,
         limit: None,
@@ -304,6 +307,7 @@ fn test_update_where_subquery_with_aggregate() {
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -374,7 +378,7 @@ fn test_update_where_and_set_both_use_subqueries() {
         quoted: false,
         }),
         where_clause: None,
-        group_by: None,
+                group_by: None,
         having: None,
         order_by: None,
         limit: None,
@@ -399,7 +403,7 @@ fn test_update_where_and_set_both_use_subqueries() {
         quoted: false,
         }),
         where_clause: None,
-        group_by: None,
+                group_by: None,
         having: None,
         order_by: None,
         limit: None,
@@ -422,6 +426,7 @@ fn test_update_where_and_set_both_use_subqueries() {
             subquery: where_subquery,
             negated: false,
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
@@ -62,7 +62,7 @@ fn test_update_where_in_subquery() {
         quoted: false,
         }),
         where_clause: None,
-        group_by: None,
+                group_by: None,
         having: None,
         order_by: None,
         limit: None,
@@ -84,6 +84,7 @@ fn test_update_where_in_subquery() {
             subquery,
             negated: false,
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -147,7 +148,7 @@ fn test_update_where_not_in_subquery() {
         quoted: false,
         }),
         where_clause: None,
-        group_by: None,
+                group_by: None,
         having: None,
         order_by: None,
         limit: None,
@@ -169,6 +170,7 @@ fn test_update_where_not_in_subquery() {
             subquery,
             negated: true,
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -225,7 +227,7 @@ fn test_update_where_subquery_empty_result() {
         quoted: false,
         }),
         where_clause: None,
-        group_by: None,
+                group_by: None,
         having: None,
         order_by: None,
         limit: None,
@@ -247,6 +249,7 @@ fn test_update_where_subquery_empty_result() {
             subquery,
             negated: false,
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -340,6 +343,7 @@ fn test_update_where_complex_subquery_condition() {
             subquery,
             negated: false,
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -407,7 +411,7 @@ fn test_update_where_multiple_rows_in_subquery() {
         quoted: false,
         }),
         where_clause: None,
-        group_by: None,
+                group_by: None,
         having: None,
         order_by: None,
         limit: None,
@@ -429,6 +433,7 @@ fn test_update_where_multiple_rows_in_subquery() {
             subquery,
             negated: false,
         })),
+        conflict_clause: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-parser/src/arena_parser/dml.rs
+++ b/crates/vibesql-parser/src/arena_parser/dml.rs
@@ -18,7 +18,7 @@ impl<'arena> ArenaParser<'arena> {
     ) -> Result<InsertStmt<'arena>, ParseError> {
         self.expect_keyword(Keyword::Insert)?;
 
-        // Check for conflict clause: INSERT OR REPLACE | INSERT OR IGNORE
+        // Check for conflict clause: INSERT OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL
         let conflict_clause = if self.peek_keyword(Keyword::Or) {
             self.advance();
             if self.peek_keyword(Keyword::Replace) {
@@ -27,9 +27,19 @@ impl<'arena> ArenaParser<'arena> {
             } else if self.peek_keyword(Keyword::Ignore) {
                 self.advance();
                 Some(ConflictClause::Ignore)
+            } else if self.peek_keyword(Keyword::Abort) {
+                self.advance();
+                Some(ConflictClause::Abort)
+            } else if self.peek_keyword(Keyword::Rollback) {
+                self.advance();
+                Some(ConflictClause::Rollback)
+            } else if self.peek_keyword(Keyword::Fail) {
+                self.advance();
+                Some(ConflictClause::Fail)
             } else {
                 return Err(ParseError {
-                    message: "Expected REPLACE or IGNORE after INSERT OR".to_string(),
+                    message: "Expected REPLACE, IGNORE, ABORT, ROLLBACK, or FAIL after INSERT OR"
+                        .to_string(),
                 });
             }
         } else {
@@ -147,6 +157,34 @@ impl<'arena> ArenaParser<'arena> {
     ) -> Result<UpdateStmt<'arena>, ParseError> {
         self.expect_keyword(Keyword::Update)?;
 
+        // Check for conflict clause: UPDATE OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL
+        let conflict_clause = if self.peek_keyword(Keyword::Or) {
+            self.advance();
+            if self.peek_keyword(Keyword::Replace) {
+                self.advance();
+                Some(ConflictClause::Replace)
+            } else if self.peek_keyword(Keyword::Ignore) {
+                self.advance();
+                Some(ConflictClause::Ignore)
+            } else if self.peek_keyword(Keyword::Abort) {
+                self.advance();
+                Some(ConflictClause::Abort)
+            } else if self.peek_keyword(Keyword::Rollback) {
+                self.advance();
+                Some(ConflictClause::Rollback)
+            } else if self.peek_keyword(Keyword::Fail) {
+                self.advance();
+                Some(ConflictClause::Fail)
+            } else {
+                return Err(ParseError {
+                    message: "Expected REPLACE, IGNORE, ABORT, ROLLBACK, or FAIL after UPDATE OR"
+                        .to_string(),
+                });
+            }
+        } else {
+            None
+        };
+
         let table_name = self.parse_arena_identifier()?;
 
         self.expect_keyword(Keyword::Set)?;
@@ -170,8 +208,10 @@ impl<'arena> ArenaParser<'arena> {
 
         Ok(UpdateStmt {
             table_name,
+            quoted: false, // Arena parser doesn't track quoted status
             assignments,
             where_clause,
+            conflict_clause,
         })
     }
 

--- a/crates/vibesql-parser/src/arena_parser/update.rs
+++ b/crates/vibesql-parser/src/arena_parser/update.rs
@@ -1,7 +1,7 @@
 //! Arena-allocated UPDATE statement parsing.
 
 use bumpalo::collections::Vec as BumpVec;
-use vibesql_ast::arena::{Assignment, UpdateStmt, WhereClause};
+use vibesql_ast::arena::{Assignment, ConflictClause, UpdateStmt, WhereClause};
 
 use super::ArenaParser;
 use crate::{keywords::Keyword, token::Token, ParseError};
@@ -12,6 +12,28 @@ impl<'arena> ArenaParser<'arena> {
         &mut self,
     ) -> Result<&'arena UpdateStmt<'arena>, ParseError> {
         self.consume_keyword(Keyword::Update)?;
+
+        // Check for conflict clause: UPDATE OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL
+        let conflict_clause = if self.try_consume_keyword(Keyword::Or) {
+            if self.try_consume_keyword(Keyword::Replace) {
+                Some(ConflictClause::Replace)
+            } else if self.try_consume_keyword(Keyword::Ignore) {
+                Some(ConflictClause::Ignore)
+            } else if self.try_consume_keyword(Keyword::Abort) {
+                Some(ConflictClause::Abort)
+            } else if self.try_consume_keyword(Keyword::Rollback) {
+                Some(ConflictClause::Rollback)
+            } else if self.try_consume_keyword(Keyword::Fail) {
+                Some(ConflictClause::Fail)
+            } else {
+                return Err(ParseError {
+                    message: "Expected REPLACE, IGNORE, ABORT, ROLLBACK, or FAIL after UPDATE OR"
+                        .to_string(),
+                });
+            }
+        } else {
+            None
+        };
 
         // Parse table name and track if quoted (for SQL:1999 case-sensitive lookups)
         let (table_name, quoted) = match self.peek() {
@@ -62,7 +84,7 @@ impl<'arena> ArenaParser<'arena> {
         // Consume optional semicolon
         self.try_consume(&Token::Semicolon);
 
-        let stmt = UpdateStmt { table_name, quoted, assignments, where_clause };
+        let stmt = UpdateStmt { table_name, quoted, assignments, where_clause, conflict_clause };
 
         Ok(self.arena.alloc(stmt))
     }

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -325,6 +325,9 @@ pub enum Keyword {
     Volatile,
     // SQLite compatibility keywords
     Pragma,
+    // SQLite conflict resolution keywords
+    Abort,
+    Fail,
 }
 
 impl Keyword {
@@ -654,6 +657,9 @@ impl fmt::Display for Keyword {
             Keyword::Volatile => "VOLATILE",
             // SQLite compatibility keywords
             Keyword::Pragma => "PRAGMA",
+            // SQLite conflict resolution keywords
+            Keyword::Abort => "ABORT",
+            Keyword::Fail => "FAIL",
         };
         write!(f, "{}", keyword_str)
     }

--- a/crates/vibesql-parser/src/lexer/keywords.rs
+++ b/crates/vibesql-parser/src/lexer/keywords.rs
@@ -322,6 +322,9 @@ static KEYWORDS: phf::Map<&'static str, Keyword> = phf_map! {
     "VOLATILE" => Keyword::Volatile,
     // SQLite compatibility keywords
     "PRAGMA" => Keyword::Pragma,
+    // SQLite conflict resolution keywords
+    "ABORT" => Keyword::Abort,
+    "FAIL" => Keyword::Fail,
 };
 
 /// Map an uppercase string to its corresponding Keyword using perfect hash lookup.

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -5,18 +5,28 @@ impl Parser {
     pub(super) fn parse_insert_statement(&mut self) -> Result<vibesql_ast::InsertStmt, ParseError> {
         self.expect_keyword(Keyword::Insert)?;
 
-        // Check for conflict clause: INSERT OR REPLACE | INSERT OR IGNORE
+        // Check for conflict clause: INSERT OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL
         let conflict_clause = if self.peek_keyword(Keyword::Or) {
             self.advance(); // consume OR
             if self.peek_keyword(Keyword::Replace) {
-                self.advance(); // consume REPLACE
+                self.advance();
                 Some(vibesql_ast::ConflictClause::Replace)
             } else if self.peek_keyword(Keyword::Ignore) {
-                self.advance(); // consume IGNORE
+                self.advance();
                 Some(vibesql_ast::ConflictClause::Ignore)
+            } else if self.peek_keyword(Keyword::Abort) {
+                self.advance();
+                Some(vibesql_ast::ConflictClause::Abort)
+            } else if self.peek_keyword(Keyword::Rollback) {
+                self.advance();
+                Some(vibesql_ast::ConflictClause::Rollback)
+            } else if self.peek_keyword(Keyword::Fail) {
+                self.advance();
+                Some(vibesql_ast::ConflictClause::Fail)
             } else {
                 return Err(ParseError {
-                    message: "Expected REPLACE or IGNORE after INSERT OR".to_string(),
+                    message: "Expected REPLACE, IGNORE, ABORT, ROLLBACK, or FAIL after INSERT OR"
+                        .to_string(),
                 });
             }
         } else {

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -5,6 +5,34 @@ impl Parser {
     pub(super) fn parse_update_statement(&mut self) -> Result<vibesql_ast::UpdateStmt, ParseError> {
         self.expect_keyword(Keyword::Update)?;
 
+        // Check for conflict clause: UPDATE OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL
+        let conflict_clause = if self.peek_keyword(Keyword::Or) {
+            self.advance(); // consume OR
+            if self.peek_keyword(Keyword::Replace) {
+                self.advance();
+                Some(vibesql_ast::ConflictClause::Replace)
+            } else if self.peek_keyword(Keyword::Ignore) {
+                self.advance();
+                Some(vibesql_ast::ConflictClause::Ignore)
+            } else if self.peek_keyword(Keyword::Abort) {
+                self.advance();
+                Some(vibesql_ast::ConflictClause::Abort)
+            } else if self.peek_keyword(Keyword::Rollback) {
+                self.advance();
+                Some(vibesql_ast::ConflictClause::Rollback)
+            } else if self.peek_keyword(Keyword::Fail) {
+                self.advance();
+                Some(vibesql_ast::ConflictClause::Fail)
+            } else {
+                return Err(ParseError {
+                    message: "Expected REPLACE, IGNORE, ABORT, ROLLBACK, or FAIL after UPDATE OR"
+                        .to_string(),
+                });
+            }
+        } else {
+            None
+        };
+
         // Parse table name with optional schema qualifier and quoted flag
         // Supports: tablename, "TableName", schema.table, "schema"."table"
         let table_ref = self.parse_table_ref()?;
@@ -67,6 +95,12 @@ impl Parser {
             self.advance();
         }
 
-        Ok(vibesql_ast::UpdateStmt { table_name, quoted, assignments, where_clause })
+        Ok(vibesql_ast::UpdateStmt {
+            table_name,
+            quoted,
+            assignments,
+            where_clause,
+            conflict_clause,
+        })
     }
 }

--- a/crates/vibesql-parser/src/tests/update.rs
+++ b/crates/vibesql-parser/src/tests/update.rs
@@ -73,3 +73,112 @@ fn test_parse_update_multiple_defaults() {
         _ => panic!("Expected UPDATE statement"),
     }
 }
+
+// ========================================================================
+// UPDATE OR Conflict Resolution Tests (SQLite Extension)
+// ========================================================================
+
+#[test]
+fn test_parse_update_or_replace() {
+    let result = Parser::parse_sql("UPDATE OR REPLACE users SET name = 'Bob' WHERE id = 1;");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Update(update) => {
+            assert_eq!(update.table_name, "users");
+            assert_eq!(
+                update.conflict_clause,
+                Some(vibesql_ast::ConflictClause::Replace)
+            );
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_or_ignore() {
+    let result = Parser::parse_sql("UPDATE OR IGNORE users SET name = 'Bob' WHERE id = 1;");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Update(update) => {
+            assert_eq!(update.table_name, "users");
+            assert_eq!(
+                update.conflict_clause,
+                Some(vibesql_ast::ConflictClause::Ignore)
+            );
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_or_abort() {
+    let result = Parser::parse_sql("UPDATE OR ABORT users SET name = 'Bob' WHERE id = 1;");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Update(update) => {
+            assert_eq!(update.table_name, "users");
+            assert_eq!(
+                update.conflict_clause,
+                Some(vibesql_ast::ConflictClause::Abort)
+            );
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_or_rollback() {
+    let result = Parser::parse_sql("UPDATE OR ROLLBACK users SET name = 'Bob' WHERE id = 1;");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Update(update) => {
+            assert_eq!(update.table_name, "users");
+            assert_eq!(
+                update.conflict_clause,
+                Some(vibesql_ast::ConflictClause::Rollback)
+            );
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_or_fail() {
+    let result = Parser::parse_sql("UPDATE OR FAIL users SET name = 'Bob' WHERE id = 1;");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Update(update) => {
+            assert_eq!(update.table_name, "users");
+            assert_eq!(
+                update.conflict_clause,
+                Some(vibesql_ast::ConflictClause::Fail)
+            );
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_without_conflict_clause() {
+    let result = Parser::parse_sql("UPDATE users SET name = 'Bob' WHERE id = 1;");
+    assert!(result.is_ok());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Update(update) => {
+            assert_eq!(update.table_name, "users");
+            assert!(update.conflict_clause.is_none());
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}


### PR DESCRIPTION
## Summary

- Add support for SQLite conflict resolution clauses in UPDATE statements
- Expand `ConflictClause` enum to support all 5 SQLite variants (Abort, Fail, Ignore, Replace, Rollback)
- Add `conflict_clause` field to `UpdateStmt` AST node
- Update parser and arena parser to handle UPDATE OR syntax
- Add parser tests for all conflict clause variants

## Changes

**Parser Changes:**
- Added `Abort` and `Fail` keywords to the lexer
- Updated UPDATE parser to check for `UPDATE OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL`
- Updated INSERT parser to support all 5 conflict clause variants (was only Replace and Ignore)

**AST Changes:**
- Expanded `ConflictClause` enum with Abort, Fail, Rollback variants
- Added `conflict_clause: Option<ConflictClause>` field to `UpdateStmt`
- Updated arena AST and conversion code

**Test Changes:**
- Added 6 parser tests for UPDATE OR conflict clause variants
- Updated all existing tests to include `conflict_clause: None`

## Test plan

- [x] All parser tests pass including new UPDATE OR tests
- [x] All unit tests pass
- [x] All doc tests pass
- [x] `UPDATE OR REPLACE` syntax is now accepted without parse errors

## Notes

This PR implements parsing support only. The actual conflict resolution behavior in the executor (e.g., REPLACE deleting conflicting rows before update) can be implemented in a follow-up PR.

Closes #4512

🤖 Generated with [Claude Code](https://claude.com/claude-code)