### PR TITLE
feat(executor): Support INSERT with explicit rowid pseudo-column

### DIFF
--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -79,9 +79,11 @@ fn execute_insert_internal(
     // Use the schema's table name for catalog operations (matches how table was created)
     let table_name = &schema.name;
 
-    // Determine target column indices and types
-    let target_column_info =
-        super::validation::resolve_target_columns(&schema, table_name, &stmt.columns)?;
+    // Determine target column indices and types, including rowid pseudo-column support
+    let resolved_columns =
+        super::validation::resolve_target_columns_with_rowid(&schema, table_name, &stmt.columns)?;
+    let target_column_info = &resolved_columns.columns;
+    let rowid_position = resolved_columns.rowid_position;
 
     // Get the rows to insert based on the source
     let rows_to_insert = match &stmt.source {
@@ -127,11 +129,13 @@ fn execute_insert_internal(
     };
 
     // Validate each row has correct number of values
-    super::validation::validate_row_column_counts(
-        &rows_to_insert,
-        target_column_info.len(),
-        table_name,
-    )?;
+    // If rowid is specified, the expected count includes the rowid column
+    let expected_value_count = if rowid_position.is_some() {
+        target_column_info.len() + 1
+    } else {
+        target_column_info.len()
+    };
+    super::validation::validate_row_column_counts(&rows_to_insert, expected_value_count, table_name)?;
 
     // Estimate DML cost for query analysis and optimization decisions
     // This helps with profiling and can inform future batch size decisions
@@ -161,7 +165,7 @@ fn execute_insert_internal(
 
     // For multi-row INSERT, validate all rows first, then insert all
     // This ensures atomicity: all rows succeed or all fail
-    let mut validated_rows = Vec::new();
+    let mut validated_rows: Vec<(Vec<vibesql_types::SqlValue>, Option<u64>)> = Vec::new();
     let mut primary_key_values: Vec<Vec<vibesql_types::SqlValue>> = Vec::new(); // Track PK values for duplicate checking within batch
     let mut unique_constraint_values = if schema.get_unique_constraint_indices().is_empty() {
         Vec::new()
@@ -179,7 +183,49 @@ fn execute_insert_internal(
         // Start with NULL for all columns, then fill in provided values
         let mut full_row_values = vec![vibesql_types::SqlValue::Null; schema.columns.len()];
 
-        for (expr, (col_idx, data_type)) in value_exprs.iter().zip(target_column_info.iter()) {
+        // Extract rowid value if present (SQLite compatibility)
+        let explicit_rowid = if let Some(rowid_pos) = rowid_position {
+            // Get the rowid expression
+            let rowid_expr = &value_exprs[rowid_pos];
+
+            // Extract literal value from expression
+            match rowid_expr {
+                vibesql_ast::Expression::Literal(val) => {
+                    // Convert to u64 for row_id
+                    match val {
+                        vibesql_types::SqlValue::Integer(i) if *i > 0 => Some(*i as u64),
+                        vibesql_types::SqlValue::Bigint(i) if *i > 0 => Some(*i as u64),
+                        vibesql_types::SqlValue::Null => None, // NULL rowid means auto-assign
+                        _ => {
+                            return Err(ExecutorError::UnsupportedExpression(
+                                "ROWID must be a positive integer".to_string(),
+                            ));
+                        }
+                    }
+                }
+                _ => {
+                    return Err(ExecutorError::UnsupportedExpression(
+                        "ROWID value must be a literal integer".to_string(),
+                    ));
+                }
+            }
+        } else {
+            None
+        };
+
+        // Filter out the rowid value when iterating over column values
+        let column_values: Vec<_> = if let Some(rowid_pos) = rowid_position {
+            value_exprs
+                .iter()
+                .enumerate()
+                .filter(|(idx, _)| *idx != rowid_pos)
+                .map(|(_, expr)| expr)
+                .collect()
+        } else {
+            value_exprs.iter().collect()
+        };
+
+        for (expr, (col_idx, data_type)) in column_values.iter().zip(target_column_info.iter()) {
             // Evaluate expression (literals, DEFAULT, procedural variables, and trigger
             // pseudo-variables)
             let value = super::defaults::evaluate_insert_expression_with_trigger_context(
@@ -238,8 +284,8 @@ fn execute_insert_internal(
             }
         }
 
-        // Store validated row for insertion
-        validated_rows.push(full_row_values);
+        // Store validated row for insertion (with optional explicit rowid)
+        validated_rows.push((full_row_values, explicit_rowid));
     }
 
     // All rows validated successfully, now insert them
@@ -281,6 +327,14 @@ fn execute_insert_internal(
         && !matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Replace))
         && !has_insert_triggers;
 
+    // Helper to create a Row with optional explicit rowid
+    let make_row = |(values, rowid): (Vec<vibesql_types::SqlValue>, Option<u64>)| {
+        match rowid {
+            Some(id) => vibesql_storage::Row::with_row_id(values, id),
+            None => vibesql_storage::Row::new(values),
+        }
+    };
+
     if use_batch_insert && validated_rows.len() > 1 {
         // Fast path: Use batch insert for multiple rows without triggers
         // Use cost-based batch sizing to optimize for tables with many indexes
@@ -292,7 +346,7 @@ fn execute_insert_internal(
             // Chunked batch insert for high-cost tables
             for chunk in validated_rows.chunks(optimal_batch_size) {
                 let rows: Vec<vibesql_storage::Row> =
-                    chunk.iter().map(|v| vibesql_storage::Row::new(v.clone())).collect();
+                    chunk.iter().map(|(v, rowid)| make_row((v.clone(), *rowid))).collect();
 
                 rows_inserted += db.insert_rows_batch(&storage_table_name, rows).map_err(|e| {
                     ExecutorError::UnsupportedExpression(format!("Storage error: {}", e))
@@ -301,7 +355,7 @@ fn execute_insert_internal(
         } else {
             // Single batch insert for low-cost tables
             let rows: Vec<vibesql_storage::Row> =
-                validated_rows.into_iter().map(vibesql_storage::Row::new).collect();
+                validated_rows.into_iter().map(make_row).collect();
 
             rows_inserted = db.insert_rows_batch(&storage_table_name, rows).map_err(|e| {
                 ExecutorError::UnsupportedExpression(format!("Storage error: {}", e))
@@ -309,7 +363,7 @@ fn execute_insert_internal(
         }
     } else {
         // Slow path: Insert rows one by one (needed for triggers, special clauses)
-        for full_row_values in validated_rows {
+        for (full_row_values, explicit_rowid) in validated_rows {
             // Check if ON DUPLICATE KEY UPDATE is specified
             if let Some(ref assignments) = stmt.on_duplicate_key_update {
                 // Try to update an existing row if there's a conflict
@@ -338,7 +392,7 @@ fn execute_insert_internal(
             }
 
             // Fire BEFORE INSERT triggers only if triggers exist
-            let row_to_insert = vibesql_storage::Row::new(full_row_values.clone());
+            let row_to_insert = make_row((full_row_values.clone(), explicit_rowid));
             if has_insert_triggers {
                 crate::TriggerFirer::execute_before_triggers(
                     db,
@@ -356,7 +410,7 @@ fn execute_insert_internal(
                 .row_count();
 
             // Insert the row
-            let row = vibesql_storage::Row::new(full_row_values);
+            let row = make_row((full_row_values, explicit_rowid));
             db.insert_row(&storage_table_name, row.clone()).map_err(|e| {
                 ExecutorError::UnsupportedExpression(format!("Storage error: {}", e))
             })?;

--- a/crates/vibesql-executor/src/insert/validation.rs
+++ b/crates/vibesql-executor/src/insert/validation.rs
@@ -1,40 +1,74 @@
 use crate::errors::ExecutorError;
 
-/// Determine target column indices and types for an INSERT statement
-pub fn resolve_target_columns(
+/// Result of resolving INSERT column targets
+pub struct ResolvedInsertColumns {
+    /// Column indices and types for regular columns (schema columns)
+    pub columns: Vec<(usize, vibesql_types::DataType)>,
+    /// Position of rowid pseudo-column in the input column list, if specified
+    /// This allows extracting the rowid value from VALUES for explicit rowid inserts
+    pub rowid_position: Option<usize>,
+}
+
+/// Check if a column name is a ROWID pseudo-column (SQLite compatibility)
+/// Returns true for "rowid", "_rowid_", "oid" (case-insensitive)
+fn is_rowid_pseudo_column(col_name: &str) -> bool {
+    let lower = col_name.to_lowercase();
+    lower == "rowid" || lower == "_rowid_" || lower == "oid"
+}
+
+/// Determine target column indices and types for an INSERT statement,
+/// including support for the ROWID pseudo-column (SQLite compatibility)
+pub fn resolve_target_columns_with_rowid(
     schema: &vibesql_catalog::TableSchema,
     table_name: &str,
     specified_columns: &[String],
-) -> Result<Vec<(usize, vibesql_types::DataType)>, ExecutorError> {
+) -> Result<ResolvedInsertColumns, ExecutorError> {
     if specified_columns.is_empty() {
         // No columns specified: INSERT INTO t VALUES (...)
         // Use all columns in schema order
-        Ok(schema
-            .columns
-            .iter()
-            .enumerate()
-            .map(|(idx, col)| (idx, col.data_type.clone()))
-            .collect())
+        Ok(ResolvedInsertColumns {
+            columns: schema
+                .columns
+                .iter()
+                .enumerate()
+                .map(|(idx, col)| (idx, col.data_type.clone()))
+                .collect(),
+            rowid_position: None,
+        })
     } else {
         // Columns specified: INSERT INTO t (col1, col2) VALUES (...)
-        // Validate and resolve columns
-        specified_columns
-            .iter()
-            .map(|col_name| {
-                schema
-                    .get_column_index(col_name)
-                    .map(|idx| {
-                        let col = &schema.columns[idx];
-                        (idx, col.data_type.clone())
-                    })
-                    .ok_or_else(|| ExecutorError::ColumnNotFound {
-                        column_name: col_name.clone(),
-                        table_name: table_name.to_string(),
-                        searched_tables: vec![table_name.to_string()],
-                        available_columns: schema.columns.iter().map(|c| c.name.clone()).collect(),
-                    })
-            })
-            .collect::<Result<Vec<_>, _>>()
+        // Validate and resolve columns, handling rowid pseudo-column specially
+        let mut columns = Vec::new();
+        let mut rowid_position = None;
+
+        for (input_idx, col_name) in specified_columns.iter().enumerate() {
+            // First check if there's a real column with this name
+            if let Some(schema_idx) = schema.get_column_index(col_name) {
+                let col = &schema.columns[schema_idx];
+                columns.push((schema_idx, col.data_type.clone()));
+            } else if is_rowid_pseudo_column(col_name) {
+                // It's a rowid pseudo-column - record its position but don't add to columns
+                if rowid_position.is_some() {
+                    return Err(ExecutorError::UnsupportedExpression(
+                        "Multiple rowid columns specified in INSERT".to_string(),
+                    ));
+                }
+                rowid_position = Some(input_idx);
+            } else {
+                // Column not found and not a pseudo-column
+                return Err(ExecutorError::ColumnNotFound {
+                    column_name: col_name.clone(),
+                    table_name: table_name.to_string(),
+                    searched_tables: vec![table_name.to_string()],
+                    available_columns: schema.columns.iter().map(|c| c.name.clone()).collect(),
+                });
+            }
+        }
+
+        Ok(ResolvedInsertColumns {
+            columns,
+            rowid_position,
+        })
     }
 }
 

--- a/crates/vibesql-executor/src/tests/rowid_tests.rs
+++ b/crates/vibesql-executor/src/tests/rowid_tests.rs
@@ -402,3 +402,172 @@ fn test_rowid_with_table_alias() {
     assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(1));
     assert_eq!(result[1].values[0], vibesql_types::SqlValue::Bigint(2));
 }
+
+/// Test that explicit row_id is preserved when using Row::with_row_id()
+#[test]
+fn test_explicit_rowid_preserved() {
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "t1".to_string(),
+        vec![vibesql_catalog::ColumnSchema::new(
+            "x".to_string(),
+            vibesql_types::DataType::Integer,
+            false,
+        )],
+    );
+    db.create_table(schema).unwrap();
+
+    // Insert with explicit rowid = 5
+    db.insert_row(
+        "t1",
+        vibesql_storage::Row::with_row_id(
+            vec![vibesql_types::SqlValue::Integer(100)],
+            5,
+        ),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // SELECT rowid, x FROM t1
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        values: None,
+        distinct: false,
+        select_list: vec![
+            vibesql_ast::SelectItem::Expression {
+                expr: vibesql_ast::Expression::ColumnRef {
+                    table: None,
+                    column: "rowid".to_string(),
+                },
+                alias: None,
+                source_text: None,
+            },
+            vibesql_ast::SelectItem::Expression {
+                expr: vibesql_ast::Expression::ColumnRef {
+                    table: None,
+                    column: "x".to_string(),
+                },
+                alias: None,
+                source_text: None,
+            },
+        ],
+        from: Some(vibesql_ast::FromClause::Table {
+            quoted: false,
+            name: "t1".to_string(),
+            alias: None,
+            column_aliases: None,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 1);
+    // Rowid should be 5 (the explicit value), not 1 (physical index)
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(5));
+    assert_eq!(result[0].values[1], vibesql_types::SqlValue::Integer(100));
+}
+
+/// Test that mixed explicit and auto-assigned rowids work correctly
+#[test]
+fn test_mixed_explicit_and_auto_rowid() {
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "t1".to_string(),
+        vec![vibesql_catalog::ColumnSchema::new(
+            "x".to_string(),
+            vibesql_types::DataType::Integer,
+            false,
+        )],
+    );
+    db.create_table(schema).unwrap();
+
+    // Insert with explicit rowid = 10
+    db.insert_row(
+        "t1",
+        vibesql_storage::Row::with_row_id(
+            vec![vibesql_types::SqlValue::Integer(100)],
+            10,
+        ),
+    )
+    .unwrap();
+
+    // Insert without explicit rowid (should get auto-assigned based on physical index)
+    db.insert_row(
+        "t1",
+        vibesql_storage::Row::new(vec![vibesql_types::SqlValue::Integer(200)]),
+    )
+    .unwrap();
+
+    // Insert with explicit rowid = 20
+    db.insert_row(
+        "t1",
+        vibesql_storage::Row::with_row_id(
+            vec![vibesql_types::SqlValue::Integer(300)],
+            20,
+        ),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // SELECT rowid, x FROM t1
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        values: None,
+        distinct: false,
+        select_list: vec![
+            vibesql_ast::SelectItem::Expression {
+                expr: vibesql_ast::Expression::ColumnRef {
+                    table: None,
+                    column: "rowid".to_string(),
+                },
+                alias: None,
+                source_text: None,
+            },
+            vibesql_ast::SelectItem::Expression {
+                expr: vibesql_ast::Expression::ColumnRef {
+                    table: None,
+                    column: "x".to_string(),
+                },
+                alias: None,
+                source_text: None,
+            },
+        ],
+        from: Some(vibesql_ast::FromClause::Table {
+            quoted: false,
+            name: "t1".to_string(),
+            alias: None,
+            column_aliases: None,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 3);
+    // First row: explicit rowid 10
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Bigint(10));
+    assert_eq!(result[0].values[1], vibesql_types::SqlValue::Integer(100));
+    // Second row: auto-assigned rowid 2 (physical index 1 + 1)
+    assert_eq!(result[1].values[0], vibesql_types::SqlValue::Bigint(2));
+    assert_eq!(result[1].values[1], vibesql_types::SqlValue::Integer(200));
+    // Third row: explicit rowid 20
+    assert_eq!(result[2].values[0], vibesql_types::SqlValue::Bigint(20));
+    assert_eq!(result[2].values[1], vibesql_types::SqlValue::Integer(300));
+}

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -532,8 +532,11 @@ impl Table {
             if !self.deleted[idx] {
                 let mut cloned = row.clone();
                 // Set row_id for ROWID pseudo-column support (SQLite compatibility)
-                // SQLite ROWIDs are 1-indexed, so we add 1 to the physical index
-                cloned.row_id = Some((idx + 1) as u64);
+                // If the row already has an explicit row_id (from INSERT INTO t(rowid,...)),
+                // preserve it. Otherwise, use 1-indexed physical index.
+                if cloned.row_id.is_none() {
+                    cloned.row_id = Some((idx + 1) as u64);
+                }
                 result.push(cloned);
             }
         }


### PR DESCRIPTION
## Summary
- Add SQLite compatibility for explicit rowid column references in INSERT statements
- Enable syntax: `INSERT INTO t(rowid, x) VALUES(5, 'hello')`
- Recognize `rowid`, `_rowid_`, `oid` as pseudo-columns (case-insensitive)
- Preserve explicit rowid values during table scan
- Improves TCL test compatibility (select5.test: 16→22 passing)

## Test plan
- [x] All existing rowid tests pass (10 tests)
- [x] New tests for explicit rowid preservation (2 tests)
- [x] Full executor test suite passes (2149 tests)
- [x] TCL select5.test improved from 16 to 22 passing tests

Closes #4514

🤖 Generated with [Claude Code](https://claude.com/claude-code)