### PR TITLE
feat(parser): Support three-part column names (schema.table.column)

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -107,7 +107,8 @@ impl<'a, 'arena> Converter<'a, 'arena> {
             arena_expr::Expression::NamedPlaceholder(name) => {
                 Expression::NamedPlaceholder(self.resolve(*name))
             }
-            arena_expr::Expression::ColumnRef { table, column } => Expression::ColumnRef {
+            arena_expr::Expression::ColumnRef { schema, table, column } => Expression::ColumnRef {
+                schema: self.resolve_opt(*schema),
                 table: self.resolve_opt(*table),
                 column: self.resolve(*column),
             },

--- a/crates/vibesql-ast/src/arena/expression.rs
+++ b/crates/vibesql-ast/src/arena/expression.rs
@@ -44,9 +44,10 @@ pub enum Expression<'arena> {
     /// Named parameter placeholder (:name)
     NamedPlaceholder(Symbol),
 
-    /// Column reference (id, users.id)
+    /// Column reference (id, users.id, schema.table.column)
     /// Second most common expression type.
     ColumnRef {
+        schema: Option<Symbol>,
         table: Option<Symbol>,
         column: Symbol,
     },

--- a/crates/vibesql-ast/src/expression.rs
+++ b/crates/vibesql-ast/src/expression.rs
@@ -26,8 +26,9 @@ pub enum Expression {
     /// Example: WHERE id = :user_id AND name = :name
     NamedPlaceholder(String),
 
-    /// Column reference (id, users.id)
+    /// Column reference (id, users.id, schema.table.column)
     ColumnRef {
+        schema: Option<String>,
         table: Option<String>,
         column: String,
     },

--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -275,9 +275,15 @@ impl ToSql for Expression {
 
             Expression::NamedPlaceholder(name) => format!(":{}", name),
 
-            Expression::ColumnRef { table, column } => match table {
-                Some(t) => format!("{}.{}", format_identifier(t), format_identifier(column)),
-                None => format_identifier(column),
+            Expression::ColumnRef { schema, table, column } => match (schema, table) {
+                (Some(s), Some(t)) => format!(
+                    "{}.{}.{}",
+                    format_identifier(s),
+                    format_identifier(t),
+                    format_identifier(column)
+                ),
+                (None, Some(t)) => format!("{}.{}", format_identifier(t), format_identifier(column)),
+                _ => format_identifier(column),
             },
 
             Expression::BinaryOp { op, left, right } => {
@@ -1120,11 +1126,11 @@ mod tests {
 
     #[test]
     fn test_column_ref() {
-        let expr = Expression::ColumnRef { table: None, column: "id".to_string() };
+        let expr = Expression::ColumnRef { schema: None, table: None, column: "id".to_string() };
         assert_eq!(expr.to_sql(), "id");
 
         let expr =
-            Expression::ColumnRef { table: Some("users".to_string()), column: "name".to_string() };
+            Expression::ColumnRef { schema: None, table: Some("users".to_string()), column: "name".to_string() };
         assert_eq!(expr.to_sql(), "users.name");
     }
 
@@ -1132,7 +1138,7 @@ mod tests {
     fn test_binary_op() {
         let expr = Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         };
         assert_eq!(expr.to_sql(), "id = 1");
@@ -1144,7 +1150,7 @@ mod tests {
             with_clause: None,
             distinct: false,
             select_list: vec![SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "id".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
                 alias: None,
                 source_text: None,
             }],
@@ -1175,12 +1181,12 @@ mod tests {
             distinct: false,
             select_list: vec![
                 SelectItem::Expression {
-                    expr: Expression::ColumnRef { table: None, column: "id".to_string() },
+                    expr: Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
                     alias: None,
                     source_text: None,
                 },
                 SelectItem::Expression {
-                    expr: Expression::ColumnRef { table: None, column: "name".to_string() },
+                    expr: Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
                     alias: None,
                     source_text: None,
                 },
@@ -1195,7 +1201,7 @@ mod tests {
             }),
             where_clause: Some(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "active".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "active".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
             group_by: None,
@@ -1215,7 +1221,7 @@ mod tests {
             with_clause: None,
             distinct: true,
             select_list: vec![SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "name".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
                 alias: None,
                 source_text: None,
             }],
@@ -1231,7 +1237,7 @@ mod tests {
             group_by: None,
             having: None,
             order_by: Some(vec![OrderByItem {
-                expr: Expression::ColumnRef { table: None, column: "name".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
                 direction: OrderDirection::Asc,
                 nulls_order: None,
             }]),
@@ -1262,10 +1268,12 @@ mod tests {
             condition: Some(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: Some("o".to_string()),
                     column: "customer_id".to_string(),
                 }),
                 right: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: Some("c".to_string()),
                     column: "id".to_string(),
                 }),
@@ -1282,7 +1290,7 @@ mod tests {
         let expr = Expression::AggregateFunction {
             name: "count".to_string(),
             distinct: true,
-            args: vec![Expression::ColumnRef { table: None, column: "id".to_string() }],
+            args: vec![Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }],
             order_by: None,
         };
         assert_eq!(expr.to_sql(), "COUNT(DISTINCT id)");
@@ -1295,7 +1303,7 @@ mod tests {
             when_clauses: vec![CaseWhen {
                 conditions: vec![Expression::BinaryOp {
                     op: BinaryOperator::GreaterThan,
-                    left: Box::new(Expression::ColumnRef { table: None, column: "x".to_string() }),
+                    left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
                     right: Box::new(Expression::Literal(SqlValue::Integer(0))),
                 }],
                 result: Expression::Literal(SqlValue::Varchar("positive".into())),
@@ -1310,7 +1318,7 @@ mod tests {
     #[test]
     fn test_in_list() {
         let expr = Expression::InList {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             values: vec![
                 Expression::Literal(SqlValue::Integer(1)),
                 Expression::Literal(SqlValue::Integer(2)),
@@ -1324,7 +1332,7 @@ mod tests {
     #[test]
     fn test_between() {
         let expr = Expression::Between {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "age".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "age".to_string() }),
             low: Box::new(Expression::Literal(SqlValue::Integer(18))),
             high: Box::new(Expression::Literal(SqlValue::Integer(65))),
             negated: false,
@@ -1337,10 +1345,12 @@ mod tests {
     fn test_group_by_rollup() {
         let group_by = GroupByClause::Rollup(vec![
             GroupingElement::Single(Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "year".to_string(),
             }),
             GroupingElement::Single(Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "month".to_string(),
             }),
@@ -1354,11 +1364,12 @@ mod tests {
             function: WindowFunctionSpec::Ranking { name: "row_number".to_string(), args: vec![] },
             over: WindowSpec {
                 partition_by: Some(vec![Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "dept".to_string(),
                 }]),
                 order_by: Some(vec![OrderByItem {
-                    expr: Expression::ColumnRef { table: None, column: "salary".to_string() },
+                    expr: Expression::ColumnRef { schema: None, table: None, column: "salary".to_string() },
                     direction: OrderDirection::Desc,
                     nulls_order: None,
                 }]),

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -32,7 +32,7 @@
 //! }
 //!
 //! impl ExpressionVisitor for ColumnCollector {
-//!     fn visit_column_ref(&mut self, table: Option<&str>, column: &str) -> VisitResult {
+//!     fn visit_column_ref(&mut self, _schema: Option<&str>, table: Option<&str>, column: &str) -> VisitResult {
 //!         self.columns.push((table.map(String::from), column.to_string()));
 //!         VisitResult::Continue
 //!     }
@@ -144,7 +144,12 @@ pub trait ExpressionVisitor {
     }
 
     /// Visit a column reference
-    fn visit_column_ref(&mut self, _table: Option<&str>, _column: &str) -> VisitResult {
+    fn visit_column_ref(
+        &mut self,
+        _schema: Option<&str>,
+        _table: Option<&str>,
+        _column: &str,
+    ) -> VisitResult {
         VisitResult::Continue
     }
 
@@ -219,8 +224,8 @@ pub fn walk_expression<V: ExpressionVisitor>(visitor: &mut V, expr: &Expression)
 
         Expression::NamedPlaceholder(name) => visitor.visit_named_placeholder(name),
 
-        Expression::ColumnRef { table, column } => {
-            visitor.visit_column_ref(table.as_deref(), column)
+        Expression::ColumnRef { schema, table, column } => {
+            visitor.visit_column_ref(schema.as_deref(), table.as_deref(), column)
         }
 
         Expression::BinaryOp { left, right, .. } => {
@@ -1424,7 +1429,12 @@ mod tests {
             columns: Vec<(Option<String>, String)>,
         }
         impl ExpressionVisitor for ColumnCollector {
-            fn visit_column_ref(&mut self, table: Option<&str>, column: &str) -> VisitResult {
+            fn visit_column_ref(
+                &mut self,
+                _schema: Option<&str>,
+                table: Option<&str>,
+                column: &str,
+            ) -> VisitResult {
                 self.columns.push((table.map(String::from), column.to_string()));
                 VisitResult::Continue
             }
@@ -1433,10 +1443,15 @@ mod tests {
         let expr = Expression::BinaryOp {
             op: crate::BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("users".to_string()),
                 column: "id".to_string(),
             }),
-            right: Box::new(Expression::ColumnRef { table: None, column: "value".to_string() }),
+            right: Box::new(Expression::ColumnRef {
+                schema: None,
+                table: None,
+                column: "value".to_string(),
+            }),
         };
 
         let mut visitor = ColumnCollector { columns: vec![] };
@@ -1573,7 +1588,7 @@ mod tests {
             from: None,
             where_clause: Some(Expression::BinaryOp {
                 op: crate::BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
                 right: Box::new(Expression::Placeholder(0)),
             }),
             group_by: None,

--- a/crates/vibesql-ast/tests/complex_expressions.rs
+++ b/crates/vibesql-ast/tests/complex_expressions.rs
@@ -9,6 +9,7 @@ use vibesql_types::{SqlValue, StringValue};
 fn test_case_expression_simple() {
     let expr = Expression::Case {
         operand: Some(Box::new(Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "status".to_string(),
         })),
@@ -39,7 +40,7 @@ fn test_case_expression_searched() {
         when_clauses: vec![CaseWhen {
             conditions: vec![Expression::BinaryOp {
                 op: BinaryOperator::GreaterThan,
-                left: Box::new(Expression::ColumnRef { table: None, column: "age".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "age".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(18))),
             }],
             result: Expression::Literal(SqlValue::Varchar(StringValue::from("adult"))),
@@ -64,7 +65,7 @@ fn test_scalar_subquery() {
         select_list: vec![SelectItem::Expression {
             expr: Expression::Function {
                 name: "AVG".to_string(),
-                args: vec![Expression::ColumnRef { table: None, column: "salary".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "salary".to_string() }],
                 character_unit: None,
             },
             alias: None,
@@ -100,7 +101,7 @@ fn test_in_expression() {
             values: None,
         distinct: false,
         select_list: vec![SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "department_id".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "department_id".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -120,7 +121,7 @@ fn test_in_expression() {
     };
 
     let expr = Expression::In {
-        expr: Box::new(Expression::ColumnRef { table: None, column: "dept_id".to_string() }),
+        expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() }),
         subquery: Box::new(subquery),
         negated: false,
     };
@@ -154,7 +155,7 @@ fn test_not_in_expression() {
     };
 
     let expr = Expression::In {
-        expr: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+        expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
         subquery: Box::new(subquery),
         negated: true,
     };

--- a/crates/vibesql-ast/tests/ddl.rs
+++ b/crates/vibesql-ast/tests/ddl.rs
@@ -65,7 +65,7 @@ fn test_create_assertion_statement() {
         assertion_name: "valid_balance".to_string(),
         check_condition: Box::new(Expression::BinaryOp {
             op: BinaryOperator::GreaterThanOrEqual,
-            left: Box::new(Expression::ColumnRef { table: None, column: "balance".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "balance".to_string() }),
             right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(0))),
         }),
     });

--- a/crates/vibesql-ast/tests/expressions.rs
+++ b/crates/vibesql-ast/tests/expressions.rs
@@ -25,20 +25,20 @@ fn test_literal_string_expression() {
 
 #[test]
 fn test_column_reference_expression() {
-    let expr = Expression::ColumnRef { table: None, column: "id".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "id".to_string() };
 
     match expr {
-        Expression::ColumnRef { table: None, column } if column == "id" => {} // Success
+        Expression::ColumnRef { schema: None, table: None, column } if column == "id" => {} // Success
         _ => panic!("Expected column reference"),
     }
 }
 
 #[test]
 fn test_qualified_column_reference() {
-    let expr = Expression::ColumnRef { table: Some("users".to_string()), column: "id".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: Some("users".to_string()), column: "id".to_string() };
 
     match expr {
-        Expression::ColumnRef { table: Some(t), column: c } if t == "users" && c == "id" => {} /* Success */
+        Expression::ColumnRef { schema: None, table: Some(t), column: c } if t == "users" && c == "id" => {} /* Success */
         _ => panic!("Expected qualified column reference"),
     }
 }
@@ -61,7 +61,7 @@ fn test_binary_operation_addition() {
 fn test_binary_operation_equality() {
     let expr = Expression::BinaryOp {
         op: BinaryOperator::Equal,
-        left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
         right: Box::new(Expression::Literal(SqlValue::Integer(1))),
     };
 
@@ -88,7 +88,7 @@ fn test_function_call_count_star() {
 #[test]
 fn test_is_null_predicate() {
     let expr = Expression::IsNull {
-        expr: Box::new(Expression::ColumnRef { table: None, column: "name".to_string() }),
+        expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "name".to_string() }),
         negated: false,
     };
 
@@ -101,7 +101,7 @@ fn test_is_null_predicate() {
 #[test]
 fn test_is_not_null_predicate() {
     let expr = Expression::IsNull {
-        expr: Box::new(Expression::ColumnRef { table: None, column: "name".to_string() }),
+        expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "name".to_string() }),
         negated: true,
     };
 

--- a/crates/vibesql-ast/tests/operators.rs
+++ b/crates/vibesql-ast/tests/operators.rs
@@ -62,7 +62,7 @@ fn test_concat_operator() {
 fn test_not_equal_operator() {
     let expr = Expression::BinaryOp {
         op: BinaryOperator::NotEqual,
-        left: Box::new(Expression::ColumnRef { table: None, column: "status".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "status".to_string() }),
         right: Box::new(Expression::Literal(SqlValue::Varchar(StringValue::from("active")))),
     };
     match expr {
@@ -75,7 +75,7 @@ fn test_not_equal_operator() {
 fn test_less_than_operator() {
     let expr = Expression::BinaryOp {
         op: BinaryOperator::LessThan,
-        left: Box::new(Expression::ColumnRef { table: None, column: "age".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "age".to_string() }),
         right: Box::new(Expression::Literal(SqlValue::Integer(18))),
     };
     match expr {
@@ -88,7 +88,7 @@ fn test_less_than_operator() {
 fn test_greater_than_operator() {
     let expr = Expression::BinaryOp {
         op: BinaryOperator::GreaterThan,
-        left: Box::new(Expression::ColumnRef { table: None, column: "salary".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "salary".to_string() }),
         right: Box::new(Expression::Literal(SqlValue::Integer(50000))),
     };
     match expr {

--- a/crates/vibesql-ast/tests/select_stmt.rs
+++ b/crates/vibesql-ast/tests/select_stmt.rs
@@ -40,12 +40,12 @@ fn test_select_with_columns() {
         distinct: false,
         select_list: vec![
             SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "id".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
                 alias: None,
                 source_text: None,
             },
             SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "name".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
                 alias: None,
                 source_text: None,
             },
@@ -72,7 +72,7 @@ fn test_select_with_alias() {
             values: None,
         distinct: false,
         select_list: vec![SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "id".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
             alias: Some("user_id".to_string()),
             source_text: None,
         }],
@@ -139,7 +139,7 @@ fn test_select_with_where() {
         }),
         where_clause: Some(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         }),
         group_by: None,
@@ -171,7 +171,7 @@ fn test_select_with_order_by() {
         group_by: None,
         having: None,
         order_by: Some(vec![OrderByItem {
-            expr: Expression::ColumnRef { table: None, column: "name".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
             direction: OrderDirection::Asc,
             nulls_order: None,
         }]),
@@ -195,7 +195,7 @@ fn test_select_distinct() {
             values: None,
         distinct: true,
         select_list: vec![SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "country".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "country".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -241,6 +241,7 @@ fn test_select_with_group_by() {
         }),
         where_clause: None,
         group_by: Some(GroupByClause::Simple(vec![Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "customer_id".to_string(),
         }])),
@@ -269,6 +270,7 @@ fn test_select_with_having() {
         }),
         where_clause: None,
         group_by: Some(GroupByClause::Simple(vec![Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "region".to_string(),
         }])),
@@ -276,7 +278,7 @@ fn test_select_with_having() {
             op: BinaryOperator::GreaterThan,
             left: Box::new(Expression::Function {
                 name: "SUM".to_string(),
-                args: vec![Expression::ColumnRef { table: None, column: "amount".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "amount".to_string() }],
                 character_unit: None,
             }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1000))),
@@ -357,7 +359,7 @@ fn test_order_by_desc() {
         group_by: None,
         having: None,
         order_by: Some(vec![OrderByItem {
-            expr: Expression::ColumnRef { table: None, column: "created_at".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "created_at".to_string() },
             direction: OrderDirection::Desc,
             nulls_order: None,
         }]),
@@ -389,10 +391,12 @@ fn test_inner_join() {
         condition: Some(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("users".to_string()),
                 column: "id".to_string(),
             }),
             right: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("orders".to_string()),
                 column: "user_id".to_string(),
             }),
@@ -523,7 +527,7 @@ fn test_from_subquery() {
         }),
         where_clause: Some(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "active".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "active".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Boolean(true))),
         }),
         group_by: None,

--- a/crates/vibesql-catalog/src/tests.rs
+++ b/crates/vibesql-catalog/src/tests.rs
@@ -314,7 +314,7 @@ mod catalog_tests {
         // Create a check constraint: age >= 18
         let check_expr = Expression::BinaryOp {
             op: BinaryOperator::GreaterThanOrEqual,
-            left: Box::new(Expression::ColumnRef { table: None, column: "age".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "age".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(18))),
         };
 
@@ -358,7 +358,7 @@ mod catalog_tests {
         // Create a check constraint: age >= 18
         let check_expr = Expression::BinaryOp {
             op: BinaryOperator::GreaterThanOrEqual,
-            left: Box::new(Expression::ColumnRef { table: None, column: "age".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "age".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(18))),
         };
 
@@ -397,8 +397,8 @@ mod catalog_tests {
         // Create a check constraint: min_value < max_value
         let check_expr = Expression::BinaryOp {
             op: BinaryOperator::LessThan,
-            left: Box::new(Expression::ColumnRef { table: None, column: "min_value".to_string() }),
-            right: Box::new(Expression::ColumnRef { table: None, column: "max_value".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "min_value".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "max_value".to_string() }),
         };
 
         let check_constraints = vec![("range_check".to_string(), check_expr)];
@@ -456,7 +456,7 @@ mod catalog_tests {
         // Create a check constraint: age >= 18
         let check_expr = Expression::BinaryOp {
             op: BinaryOperator::GreaterThanOrEqual,
-            left: Box::new(Expression::ColumnRef { table: None, column: "age".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "age".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(18))),
         };
 

--- a/crates/vibesql-executor/src/advanced_objects/procedures.rs
+++ b/crates/vibesql-executor/src/advanced_objects/procedures.rs
@@ -136,7 +136,7 @@ pub fn execute_drop_procedure(
 /// reference.
 fn extract_variable_name(expr: &Expression) -> Result<String, ExecutorError> {
     match expr {
-        Expression::ColumnRef { table: None, column } => {
+        Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // Column reference without table - treat as session variable
             // If it starts with @, strip it; otherwise use as-is
             let var_name = if let Some(stripped) = column.strip_prefix('@') {
@@ -146,7 +146,7 @@ fn extract_variable_name(expr: &Expression) -> Result<String, ExecutorError> {
             };
             Ok(var_name)
         }
-        Expression::ColumnRef { table: Some(_), column: _ } => {
+        Expression::ColumnRef { schema: None, table: Some(_), column: _, .. } => {
             Err(ExecutorError::Other(
                 "OUT/INOUT parameter target must be a session variable (e.g., @var_name), not a table.column reference".to_string()
             ))

--- a/crates/vibesql-executor/src/cache/parameterized.rs
+++ b/crates/vibesql-executor/src/cache/parameterized.rs
@@ -543,7 +543,7 @@ mod tests {
             with_clause: None,
             distinct: false,
             select_list: vec![SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "col0".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() },
                 alias: None, source_text: None }],
             into_table: None,
             into_variables: None,
@@ -558,6 +558,7 @@ mod tests {
                 left: Box::new(Expression::BinaryOp {
                     op: BinaryOperator::GreaterThan,
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "col1".to_string(),
                     }),
@@ -566,6 +567,7 @@ mod tests {
                 right: Box::new(Expression::BinaryOp {
                     op: BinaryOperator::Equal,
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "col2".to_string(),
                     }),
@@ -608,7 +610,7 @@ mod tests {
             quoted: false,
             }),
             where_clause: Some(Expression::InList {
-                expr: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+                expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
                 values: vec![
                     Expression::Literal(SqlValue::Integer(1)),
                     Expression::Literal(SqlValue::Integer(2)),

--- a/crates/vibesql-executor/src/cache/prepared_statement/bind/mutation.rs
+++ b/crates/vibesql-executor/src/cache/prepared_statement/bind/mutation.rs
@@ -858,7 +858,7 @@ mod tests {
         use vibesql_ast::BinaryOperator;
         let mut expr = Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             right: Box::new(Expression::Placeholder(0)),
         };
         bind_expression_mut(&mut expr, &[SqlValue::Integer(42)]);

--- a/crates/vibesql-executor/src/cache/prepared_statement/plan.rs
+++ b/crates/vibesql-executor/src/cache/prepared_statement/plan.rs
@@ -407,8 +407,8 @@ fn analyze_select_list(select_list: &[SelectItem]) -> Option<ProjectionPlan> {
             }
             SelectItem::Expression { expr, alias, .. } => {
                 let column_name = match expr {
-                    Expression::ColumnRef { column, table: None } => column.clone(),
-                    Expression::ColumnRef { column, table: Some(_) } => {
+                    Expression::ColumnRef { column, table: None, .. } => column.clone(),
+                    Expression::ColumnRef { column, table: Some(_), .. } => {
                         // Qualified column ref - support it
                         column.clone()
                     }

--- a/crates/vibesql-executor/src/cache/query_signature.rs
+++ b/crates/vibesql-executor/src/cache/query_signature.rs
@@ -315,7 +315,7 @@ impl QuerySignature {
             | Expression::NumberedPlaceholder(_)
             | Expression::NamedPlaceholder(_) => "LITERAL_PLACEHOLDER".hash(hasher),
 
-            Expression::ColumnRef { table, column } => {
+            Expression::ColumnRef { table, column, .. } => {
                 "COLUMN".hash(hasher);
                 table.hash(hasher);
                 column.hash(hasher);
@@ -772,7 +772,7 @@ impl QuerySignature {
             | ArenaExpression::NumberedPlaceholder(_)
             | ArenaExpression::NamedPlaceholder(_) => "LITERAL_PLACEHOLDER".hash(hasher),
 
-            ArenaExpression::ColumnRef { table, column } => {
+            ArenaExpression::ColumnRef { table, column, .. } => {
                 "COLUMN".hash(hasher);
                 table.hash(hasher);
                 column.hash(hasher);
@@ -1113,7 +1113,7 @@ mod tests {
             with_clause: None,
             distinct: false,
             select_list: vec![SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "col0".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() },
                 alias: None, source_text: None }],
             into_table: None,
             into_variables: None,
@@ -1125,7 +1125,7 @@ mod tests {
             }),
             where_clause: Some(Expression::BinaryOp {
                 op: BinaryOperator::GreaterThan,
-                left: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(5))),
             }),
             group_by: None,
@@ -1142,7 +1142,7 @@ mod tests {
             with_clause: None,
             distinct: false,
             select_list: vec![SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "col0".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() },
                 alias: None, source_text: None }],
             into_table: None,
             into_variables: None,
@@ -1154,7 +1154,7 @@ mod tests {
             }),
             where_clause: Some(Expression::BinaryOp {
                 op: BinaryOperator::GreaterThan,
-                left: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(10))),
             }),
             group_by: None,
@@ -1185,7 +1185,7 @@ mod tests {
             with_clause: None,
             distinct: false,
             select_list: vec![SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "col0".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() },
                 alias: None, source_text: None }],
             into_table: None,
             into_variables: None,
@@ -1197,7 +1197,7 @@ mod tests {
             }),
             where_clause: Some(Expression::BinaryOp {
                 op: BinaryOperator::GreaterThan,
-                left: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(5))),
             }),
             group_by: None,
@@ -1214,7 +1214,7 @@ mod tests {
             with_clause: None,
             distinct: false,
             select_list: vec![SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "col0".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() },
                 alias: None, source_text: None }],
             into_table: None,
             into_variables: None,
@@ -1226,7 +1226,7 @@ mod tests {
             }),
             where_clause: Some(Expression::BinaryOp {
                 op: BinaryOperator::LessThan, // Different operator!
-                left: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(5))),
             }),
             group_by: None,

--- a/crates/vibesql-executor/src/constraint_validator.rs
+++ b/crates/vibesql-executor/src/constraint_validator.rs
@@ -316,7 +316,7 @@ mod tests {
         use vibesql_types::SqlValue;
 
         let check_expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "age".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "age".to_string() }),
             op: vibesql_ast::BinaryOperator::GreaterThan,
             right: Box::new(Expression::Literal(SqlValue::Integer(0))),
         };

--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -207,7 +207,7 @@ fn is_expression_correlated(
         | Expression::NamedPlaceholder(_)
         | Expression::Wildcard => false,
 
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             // Check if this column reference belongs to the outer schema
             // But exclude references to the subquery's own tables
 
@@ -489,7 +489,7 @@ mod tests {
             with_clause: None,
             distinct: false,
             select_list: vec![SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "col0".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() },
                 alias: None, source_text: None }],
             into_table: None,
             into_variables: None,
@@ -501,7 +501,7 @@ mod tests {
             }),
             where_clause: Some(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "col4".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col4".to_string() }),
                 right: Box::new(Expression::Literal(vibesql_types::SqlValue::Float(97.5))),
             }),
             group_by: None,
@@ -536,6 +536,7 @@ mod tests {
             where_clause: Some(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: Some("tab0".to_string()),
                     column: "col3".to_string(),
                 }),

--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -74,7 +74,7 @@ impl DeleteExecutor {
     ///     table_name: "users".to_string(),
     ///     quoted: false,
     ///     where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-    ///         left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+    ///         left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
     ///         op: BinaryOperator::Equal,
     ///         right: Box::new(Expression::Literal(SqlValue::Integer(1))),
     ///     })),

--- a/crates/vibesql-executor/src/delete/tests/basic.rs
+++ b/crates/vibesql-executor/src/delete/tests/basic.rs
@@ -33,7 +33,7 @@ fn test_delete_with_simple_where() {
         only: false,
         table_name: "users".to_string(),
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
@@ -68,7 +68,7 @@ fn test_delete_with_boolean_where() {
         only: false,
         table_name: "users".to_string(),
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "active".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "active".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Boolean(true))),
         })),
@@ -101,7 +101,7 @@ fn test_delete_multiple_rows() {
         only: false,
         table_name: "users".to_string(),
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::GreaterThan,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),

--- a/crates/vibesql-executor/src/delete/tests/edge_cases.rs
+++ b/crates/vibesql-executor/src/delete/tests/edge_cases.rs
@@ -31,7 +31,7 @@ fn test_delete_no_matching_rows() {
         only: false,
         table_name: "users".to_string(),
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(999))),
         })),
@@ -76,6 +76,7 @@ fn test_delete_column_not_found() {
         table_name: "users".to_string(),
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "nonexistent_column".to_string(),
             }),

--- a/crates/vibesql-executor/src/delete/tests/subqueries.rs
+++ b/crates/vibesql-executor/src/delete/tests/subqueries.rs
@@ -190,7 +190,7 @@ mod in_subquery {
             with_clause: None,
             distinct: false,
             select_list: vec![vibesql_ast::SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "dept_id".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() },
                 alias: None, source_text: None }],
             from: Some(vibesql_ast::FromClause::Table {
                 name: "inactive_depts".to_string(),
@@ -214,6 +214,7 @@ mod in_subquery {
             table_name: "employees".to_string(),
             where_clause: Some(WhereClause::Condition(Expression::In {
                 expr: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "dept_id".to_string(),
                 }),
@@ -251,7 +252,7 @@ mod in_subquery {
             with_clause: None,
             distinct: false,
             select_list: vec![vibesql_ast::SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "dept_id".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() },
                 alias: None, source_text: None }],
             from: Some(vibesql_ast::FromClause::Table {
                 name: "active_depts".to_string(),
@@ -275,6 +276,7 @@ mod in_subquery {
             table_name: "employees".to_string(),
             where_clause: Some(WhereClause::Condition(Expression::In {
                 expr: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "dept_id".to_string(),
                 }),
@@ -321,7 +323,7 @@ mod scalar_subquery {
             select_list: vec![vibesql_ast::SelectItem::Expression {
                 expr: Expression::Function {
                     name: "AVG".to_string(),
-                    args: vec![Expression::ColumnRef { table: None, column: "salary".to_string() }],
+                    args: vec![Expression::ColumnRef { schema: None, table: None, column: "salary".to_string() }],
                     character_unit: None,
                 },
                 alias: None, source_text: None }],
@@ -346,7 +348,7 @@ mod scalar_subquery {
             quoted: false, only: false,
             table_name: "employees".to_string(),
             where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "salary".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "salary".to_string() }),
                 op: vibesql_ast::BinaryOperator::LessThan,
                 right: Box::new(Expression::ScalarSubquery(subquery)),
             })),
@@ -392,7 +394,7 @@ mod scalar_subquery {
             select_list: vec![vibesql_ast::SelectItem::Expression {
                 expr: Expression::Function {
                     name: "MAX".to_string(),
-                    args: vec![Expression::ColumnRef { table: None, column: "price".to_string() }],
+                    args: vec![Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }],
                     character_unit: None,
                 },
                 alias: None, source_text: None }],
@@ -417,7 +419,7 @@ mod scalar_subquery {
             quoted: false, only: false,
             table_name: "items".to_string(),
             where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(Expression::ScalarSubquery(subquery)),
             })),
@@ -455,7 +457,7 @@ mod scalar_subquery {
             with_clause: None,
             distinct: false,
             select_list: vec![vibesql_ast::SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "threshold".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "threshold".to_string() },
                 alias: None, source_text: None }],
             from: Some(vibesql_ast::FromClause::Table {
                 name: "config".to_string(),
@@ -478,7 +480,7 @@ mod scalar_subquery {
             quoted: false, only: false,
             table_name: "employees".to_string(),
             where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "salary".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "salary".to_string() }),
                 op: vibesql_ast::BinaryOperator::GreaterThan,
                 right: Box::new(Expression::ScalarSubquery(subquery)),
             })),
@@ -516,7 +518,7 @@ mod empty_subquery {
             with_clause: None,
             distinct: false,
             select_list: vec![vibesql_ast::SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "dept_id".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() },
                 alias: None, source_text: None }],
             from: Some(vibesql_ast::FromClause::Table {
                 name: "old_depts".to_string(),
@@ -540,6 +542,7 @@ mod empty_subquery {
             table_name: "employees".to_string(),
             where_clause: Some(WhereClause::Condition(Expression::In {
                 expr: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "dept_id".to_string(),
                 }),
@@ -586,7 +589,7 @@ mod complex_subquery {
             with_clause: None,
             distinct: false,
             select_list: vec![vibesql_ast::SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "customer_id".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "customer_id".to_string() },
                 alias: None, source_text: None }],
             from: Some(vibesql_ast::FromClause::Table {
                 name: "inactive_customers".to_string(),
@@ -595,7 +598,7 @@ mod complex_subquery {
             quoted: false,
             }),
             where_clause: Some(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "status".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "status".to_string() }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "inactive",
@@ -617,6 +620,7 @@ mod complex_subquery {
             table_name: "orders".to_string(),
             where_clause: Some(WhereClause::Condition(Expression::In {
                 expr: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "customer_id".to_string(),
                 }),

--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -179,9 +179,30 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             }
 
             // Column reference
-            ArenaExpression::ColumnRef { table, column } => {
+            ArenaExpression::ColumnRef { schema, table, column } => {
                 let column_str = self.resolve(*column);
                 let table_str = table.map(|t| self.resolve(t));
+
+                // Handle schema qualifier (three-part names like schema.table.column)
+                if let Some(schema_sym) = schema {
+                    let schema_str = self.resolve(*schema_sym);
+                    if !schema_str.eq_ignore_ascii_case("main") {
+                        // SQLite returns "no such column: schema.table.column" for unknown schemas
+                        return Err(ExecutorError::ColumnNotFound {
+                            column_name: format!(
+                                "{}.{}.{}",
+                                schema_str,
+                                table_str.unwrap_or(""),
+                                column_str
+                            ),
+                            table_name: table_str
+                                .map(|t| t.to_string())
+                                .unwrap_or_else(|| "unknown".to_string()),
+                            searched_tables: self.schema.table_names(),
+                            available_columns: self.get_available_columns(),
+                        });
+                    }
+                }
 
                 // Special case: "*" is a wildcard used in COUNT(*)
                 if column_str == "*" {
@@ -840,11 +861,11 @@ mod tests {
         let row =
             Row::new(vec![SqlValue::Integer(42), SqlValue::Varchar(arcstr::ArcStr::from("Bob"))]);
 
-        let expr = ArenaExpression::ColumnRef { table: None, column: id_sym };
+        let expr = ArenaExpression::ColumnRef { schema: None, table: None, column: id_sym };
         let result = evaluator.eval(&expr, &row).unwrap();
         assert_eq!(result, SqlValue::Integer(42));
 
-        let expr = ArenaExpression::ColumnRef { table: None, column: name_sym };
+        let expr = ArenaExpression::ColumnRef { schema: None, table: None, column: name_sym };
         let result = evaluator.eval(&expr, &row).unwrap();
         assert_eq!(result, SqlValue::Varchar(arcstr::ArcStr::from("Bob")));
     }
@@ -864,14 +885,14 @@ mod tests {
         let row = Row::new(vec![SqlValue::Integer(1), SqlValue::Null]);
 
         let expr = ArenaExpression::IsNull {
-            expr: arena.alloc(ArenaExpression::ColumnRef { table: None, column: name_sym }),
+            expr: arena.alloc(ArenaExpression::ColumnRef { schema: None, table: None, column: name_sym }),
             negated: false,
         };
         let result = evaluator.eval(&expr, &row).unwrap();
         assert_eq!(result, SqlValue::Boolean(true));
 
         let expr = ArenaExpression::IsNull {
-            expr: arena.alloc(ArenaExpression::ColumnRef { table: None, column: id_sym }),
+            expr: arena.alloc(ArenaExpression::ColumnRef { schema: None, table: None, column: id_sym }),
             negated: false,
         };
         let result = evaluator.eval(&expr, &row).unwrap();

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -58,7 +58,34 @@ impl CombinedExpressionEvaluator<'_> {
             )),
 
             // Column reference - look up column index (with optional table qualifier)
-            vibesql_ast::Expression::ColumnRef { table, column } => {
+            vibesql_ast::Expression::ColumnRef { schema, table, column } => {
+                // Handle schema qualifier (three-part names like schema.table.column)
+                // SQLite schemas: "main" (default), "temp" (temporary tables), or attached database names
+                // For our single-database implementation:
+                // - "main" is silently accepted (treated as default)
+                // - Other schemas return "no such column" error to match SQLite behavior
+                if let Some(schema_name) = schema {
+                    let schema_lower = schema_name.to_lowercase();
+                    if schema_lower != "main" {
+                        // SQLite returns "no such column: schema.table.column" for unknown schemas
+                        let mut available_columns = Vec::new();
+                        for (_start, schema) in self.schema.table_schemas.values() {
+                            available_columns.extend(schema.columns.iter().map(|c| c.name.clone()));
+                        }
+                        return Err(ExecutorError::ColumnNotFound {
+                            column_name: format!(
+                                "{}.{}.{}",
+                                schema_name,
+                                table.as_deref().unwrap_or(""),
+                                column
+                            ),
+                            table_name: table.clone().unwrap_or_else(|| "unknown".to_string()),
+                            searched_tables: self.schema.table_names(),
+                            available_columns,
+                        });
+                    }
+                }
+
                 // Special case: "*" is a wildcard used in COUNT(*) and is not a real column
                 // Return NULL here - the actual COUNT(*) logic handles this specially
                 if column == "*" {

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
@@ -135,7 +135,7 @@ fn collect_correlation_refs_from_expr(
     refs: &mut std::collections::BTreeSet<(Option<String>, String)>,
 ) {
     match expr {
-        vibesql_ast::Expression::ColumnRef { table, column } => {
+        vibesql_ast::Expression::ColumnRef { table, column, .. } => {
             // Check if this column reference belongs to the outer schema
             if let Some(table_name) = table {
                 let table_lower = table_name.to_lowercase();

--- a/crates/vibesql-executor/src/evaluator/compiled.rs
+++ b/crates/vibesql-executor/src/evaluator/compiled.rs
@@ -119,7 +119,7 @@ impl CompiledPredicate {
 
             // IS NULL / IS NOT NULL
             Expression::IsNull { expr, negated } => {
-                if let Expression::ColumnRef { table, column } = expr.as_ref() {
+                if let Expression::ColumnRef { table, column, .. } = expr.as_ref() {
                     let col_idx = schema.get_column_index(table.as_deref(), column)?;
                     if *negated {
                         Some(CompiledPredicate::IsNotNull { col_idx })
@@ -197,14 +197,14 @@ impl CompiledPredicate {
         schema: &CombinedSchema,
     ) -> Option<Self> {
         // Try col <op> literal
-        if let (Expression::ColumnRef { table, column }, Expression::Literal(value)) = (left, right)
+        if let (Expression::ColumnRef { table, column, .. }, Expression::Literal(value)) = (left, right)
         {
             let col_idx = schema.get_column_index(table.as_deref(), column)?;
             return Self::compile_comparison_with_idx(col_idx, op, value.clone(), false);
         }
 
         // Try literal <op> col (reverse the operator)
-        if let (Expression::Literal(value), Expression::ColumnRef { table, column }) = (left, right)
+        if let (Expression::Literal(value), Expression::ColumnRef { table, column, .. }) = (left, right)
         {
             let col_idx = schema.get_column_index(table.as_deref(), column)?;
             return Self::compile_comparison_with_idx(col_idx, op, value.clone(), true);
@@ -680,7 +680,7 @@ mod tests {
     fn test_compile_simple_equals() {
         let schema = create_test_schema();
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(42))),
         };
@@ -700,7 +700,7 @@ mod tests {
     fn test_evaluate_equals() {
         let schema = create_test_schema();
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(42))),
         };
@@ -727,13 +727,13 @@ mod tests {
         let schema = create_test_schema();
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
                 op: BinaryOperator::GreaterThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(10))),
             }),
             op: BinaryOperator::And,
             right: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
                 op: BinaryOperator::LessThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(100))),
             }),

--- a/crates/vibesql-executor/src/evaluator/compiled_case.rs
+++ b/crates/vibesql-executor/src/evaluator/compiled_case.rs
@@ -102,7 +102,7 @@ impl CompiledCaseExpression {
         schema: &CombinedSchema,
     ) -> Option<(usize, SqlValue)> {
         let col_idx = match col_expr {
-            Expression::ColumnRef { table, column } => {
+            Expression::ColumnRef { table, column, .. } => {
                 schema.get_column_index(table.as_deref(), column)?
             }
             _ => return None,
@@ -125,7 +125,7 @@ impl CompiledCaseExpression {
         schema: &CombinedSchema,
     ) -> Option<Self> {
         match result {
-            Expression::ColumnRef { table, column } => {
+            Expression::ColumnRef { table, column, .. } => {
                 let result_col_idx = schema.get_column_index(table.as_deref(), column)?;
                 Some(CompiledCaseExpression::WhenEqualsThenColumn {
                     condition_col_idx,

--- a/crates/vibesql-executor/src/evaluator/compiled_pivot.rs
+++ b/crates/vibesql-executor/src/evaluator/compiled_pivot.rs
@@ -194,7 +194,7 @@ impl PivotAggregateGroup {
 
         // Result must be a column reference (value column)
         let value_col_idx = match result {
-            Expression::ColumnRef { table, column } => {
+            Expression::ColumnRef { table, column, .. } => {
                 schema.get_column_index(table.as_deref(), column)?
             }
             _ => return None,
@@ -220,7 +220,7 @@ impl PivotAggregateGroup {
         schema: &CombinedSchema,
     ) -> Option<(usize, SqlValue)> {
         let col_idx = match col_expr {
-            Expression::ColumnRef { table, column } => {
+            Expression::ColumnRef { table, column, .. } => {
                 schema.get_column_index(table.as_deref(), column)?
             }
             _ => return None,
@@ -324,6 +324,7 @@ mod tests {
                 when_clauses: vec![CaseWhen {
                     conditions: vec![Expression::BinaryOp {
                         left: Box::new(Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "d_day_name".to_string(),
                         }),
@@ -333,6 +334,7 @@ mod tests {
                         ))),
                     }],
                     result: Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "sales_price".to_string(),
                     },
@@ -414,6 +416,7 @@ mod tests {
                 when_clauses: vec![CaseWhen {
                     conditions: vec![Expression::BinaryOp {
                         left: Box::new(Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "d_week_seq".to_string(),
                         }),
@@ -421,6 +424,7 @@ mod tests {
                         right: Box::new(Expression::Literal(SqlValue::Integer(1))),
                     }],
                     result: Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "sales_price".to_string(),
                     },

--- a/crates/vibesql-executor/src/evaluator/expression_hash.rs
+++ b/crates/vibesql-executor/src/evaluator/expression_hash.rs
@@ -201,7 +201,7 @@ impl ExpressionHasher {
                 Self::hash_sql_value(val, hasher);
             }
 
-            vibesql_ast::Expression::ColumnRef { table, column } => {
+            vibesql_ast::Expression::ColumnRef { table, column, .. } => {
                 table.hash(hasher);
                 column.hash(hasher);
             }
@@ -554,7 +554,7 @@ mod tests {
         // Column references are NOT deterministic because they depend on row data
         // Caching expressions with column references would cause incorrect results
         // when evaluating across multiple rows with different column values
-        let expr = vibesql_ast::Expression::ColumnRef { table: None, column: "col1".to_string() };
+        let expr = vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() };
         assert!(!ExpressionHasher::is_deterministic(&expr));
     }
 

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -64,8 +64,8 @@ impl ExpressionEvaluator<'_> {
             )),
 
             // Column reference - look up column index and get value from row
-            vibesql_ast::Expression::ColumnRef { table, column } => {
-                self.eval_column_ref(table.as_deref(), column, row)
+            vibesql_ast::Expression::ColumnRef { schema, table, column } => {
+                self.eval_column_ref(schema.as_deref(), table.as_deref(), column, row)
             }
 
             // Binary operations
@@ -440,7 +440,7 @@ impl ExpressionEvaluator<'_> {
         // Collect text values from the specified columns
         let mut text_values: Vec<arcstr::ArcStr> = Vec::new();
         for column_name in columns {
-            match self.eval_column_ref(None, column_name, row) {
+            match self.eval_column_ref(None, None, column_name, row) {
                 Ok(SqlValue::Varchar(s)) | Ok(SqlValue::Character(s)) => text_values.push(s),
                 Ok(SqlValue::Null) => {
                     // NULL values are treated as empty strings in MATCH
@@ -463,10 +463,30 @@ impl ExpressionEvaluator<'_> {
     #[inline]
     fn eval_column_ref(
         &self,
+        schema_qualifier: Option<&str>,
         table_qualifier: Option<&str>,
         column: &str,
         row: &vibesql_storage::Row,
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        // Handle schema qualifier (three-part names like schema.table.column)
+        // SQLite schemas: "main" (default), "temp" (temporary tables), or attached database names
+        // For our single-database implementation:
+        // - "main" is silently accepted (treated as default)
+        // - Other schemas return "no such column" error to match SQLite behavior
+        if let Some(schema) = schema_qualifier {
+            let schema_lower = schema.to_lowercase();
+            if schema_lower != "main" {
+                // SQLite returns "no such column: schema.table.column" for unknown schemas
+                return Err(ExecutorError::ColumnNotFound {
+                    column_name: format!("{}.{}.{}", schema, table_qualifier.unwrap_or(""), column),
+                    table_name: self.schema.name.clone(),
+                    searched_tables: vec![self.schema.name.clone()],
+                    available_columns: self.schema.columns.iter().map(|c| c.name.clone()).collect(),
+                });
+            }
+            // "main" schema - continue with normal resolution
+        }
+
         // Special case: "*" is a wildcard used in COUNT(*) and is not a real column
         // Return NULL here - the actual COUNT(*) logic handles this specially
         if column == "*" {

--- a/crates/vibesql-executor/src/evaluator/tests/compiled_case_tests.rs
+++ b/crates/vibesql-executor/src/evaluator/tests/compiled_case_tests.rs
@@ -33,11 +33,11 @@ fn create_simple_case_expression(
         operand: None,
         when_clauses: vec![CaseWhen {
             conditions: vec![Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: col_name.to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: col_name.to_string() }),
                 op: BinaryOperator::Equal,
                 right: Box::new(Expression::Literal(match_value)),
             }],
-            result: Expression::ColumnRef { table: None, column: result_col.to_string() },
+            result: Expression::ColumnRef { schema: None, table: None, column: result_col.to_string() },
         }],
         else_result: Some(Box::new(Expression::Literal(SqlValue::Null))),
     }
@@ -81,6 +81,7 @@ fn test_compile_when_equals_then_literal() {
         when_clauses: vec![CaseWhen {
             conditions: vec![Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "day_name".to_string(),
                 }),
@@ -165,6 +166,7 @@ fn test_evaluate_literal_result() {
         when_clauses: vec![CaseWhen {
             conditions: vec![Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "day_name".to_string(),
                 }),
@@ -204,6 +206,7 @@ fn test_does_not_compile_simple_case_with_operand() {
     // Simple CASE day_name WHEN 'Sunday' THEN sales_price END (has operand)
     let expr = Expression::Case {
         operand: Some(Box::new(Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "day_name".to_string(),
         })),
@@ -211,7 +214,7 @@ fn test_does_not_compile_simple_case_with_operand() {
             conditions: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                 "Sunday",
             )))],
-            result: Expression::ColumnRef { table: None, column: "sales_price".to_string() },
+            result: Expression::ColumnRef { schema: None, table: None, column: "sales_price".to_string() },
         }],
         else_result: None,
     };
@@ -231,6 +234,7 @@ fn test_does_not_compile_multiple_when_clauses() {
             CaseWhen {
                 conditions: vec![Expression::BinaryOp {
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "day_name".to_string(),
                     }),
@@ -244,6 +248,7 @@ fn test_does_not_compile_multiple_when_clauses() {
             CaseWhen {
                 conditions: vec![Expression::BinaryOp {
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "day_name".to_string(),
                     }),
@@ -272,6 +277,7 @@ fn test_does_not_compile_non_null_else() {
         when_clauses: vec![CaseWhen {
             conditions: vec![Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "day_name".to_string(),
                 }),
@@ -280,7 +286,7 @@ fn test_does_not_compile_non_null_else() {
                     "Sunday",
                 )))),
             }],
-            result: Expression::ColumnRef { table: None, column: "sales_price".to_string() },
+            result: Expression::ColumnRef { schema: None, table: None, column: "sales_price".to_string() },
         }],
         else_result: Some(Box::new(Expression::Literal(SqlValue::Integer(0)))),
     };
@@ -299,13 +305,14 @@ fn test_does_not_compile_non_equality_condition() {
         when_clauses: vec![CaseWhen {
             conditions: vec![Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "quantity".to_string(),
                 }),
                 op: BinaryOperator::GreaterThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(5))),
             }],
-            result: Expression::ColumnRef { table: None, column: "sales_price".to_string() },
+            result: Expression::ColumnRef { schema: None, table: None, column: "sales_price".to_string() },
         }],
         else_result: Some(Box::new(Expression::Literal(SqlValue::Null))),
     };
@@ -324,6 +331,7 @@ fn test_does_not_compile_complex_result() {
         when_clauses: vec![CaseWhen {
             conditions: vec![Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "day_name".to_string(),
                 }),
@@ -334,6 +342,7 @@ fn test_does_not_compile_complex_result() {
             }],
             result: Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "sales_price".to_string(),
                 }),
@@ -358,6 +367,7 @@ fn test_compiles_with_absent_else() {
         when_clauses: vec![CaseWhen {
             conditions: vec![Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "day_name".to_string(),
                 }),
@@ -366,7 +376,7 @@ fn test_compiles_with_absent_else() {
                     "Sunday",
                 )))),
             }],
-            result: Expression::ColumnRef { table: None, column: "sales_price".to_string() },
+            result: Expression::ColumnRef { schema: None, table: None, column: "sales_price".to_string() },
         }],
         else_result: None,
     };
@@ -389,11 +399,12 @@ fn test_literal_on_left_side_of_equality() {
                 )))),
                 op: BinaryOperator::Equal,
                 right: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "day_name".to_string(),
                 }),
             }],
-            result: Expression::ColumnRef { table: None, column: "sales_price".to_string() },
+            result: Expression::ColumnRef { schema: None, table: None, column: "sales_price".to_string() },
         }],
         else_result: Some(Box::new(Expression::Literal(SqlValue::Null))),
     };
@@ -407,7 +418,7 @@ fn test_does_not_compile_non_case_expression() {
     let schema = create_test_schema();
 
     // Plain column reference - not a CASE expression
-    let expr = Expression::ColumnRef { table: None, column: "day_name".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "day_name".to_string() };
 
     let compiled = CompiledCaseExpression::try_compile(&expr, &schema);
     assert!(compiled.is_none(), "Should not compile non-CASE expressions");
@@ -423,16 +434,18 @@ fn test_does_not_compile_column_to_column_comparison() {
         when_clauses: vec![CaseWhen {
             conditions: vec![Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "day_name".to_string(),
                 }),
                 op: BinaryOperator::Equal,
                 right: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "sales_price".to_string(),
                 }),
             }],
-            result: Expression::ColumnRef { table: None, column: "quantity".to_string() },
+            result: Expression::ColumnRef { schema: None, table: None, column: "quantity".to_string() },
         }],
         else_result: Some(Box::new(Expression::Literal(SqlValue::Null))),
     };

--- a/crates/vibesql-executor/src/evaluator/tests/cse_tests.rs
+++ b/crates/vibesql-executor/src/evaluator/tests/cse_tests.rs
@@ -24,9 +24,10 @@ fn test_cse_repeated_arithmetic() -> Result<(), ExecutorError> {
 
     // Build expression: (a + b)
     let a_plus_b = vibesql_ast::Expression::BinaryOp {
-        left: Box::new(vibesql_ast::Expression::ColumnRef { table: None, column: "a".to_string() }),
+        left: Box::new(vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
         op: vibesql_ast::BinaryOperator::Plus,
         right: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "b".to_string(),
         }),
@@ -63,9 +64,10 @@ fn test_cse_nested_expressions() -> Result<(), ExecutorError> {
 
     // Build expression: (x * y)
     let x_times_y = vibesql_ast::Expression::BinaryOp {
-        left: Box::new(vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() }),
+        left: Box::new(vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
         op: vibesql_ast::BinaryOperator::Multiply,
         right: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "y".to_string(),
         }),
@@ -100,9 +102,10 @@ fn test_cse_case_expression() -> Result<(), ExecutorError> {
 
     // Build expression: (x * y)
     let x_times_y = || vibesql_ast::Expression::BinaryOp {
-        left: Box::new(vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() }),
+        left: Box::new(vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
         op: vibesql_ast::BinaryOperator::Multiply,
         right: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "y".to_string(),
         }),
@@ -149,7 +152,7 @@ fn test_cse_disabled_via_env() -> Result<(), ExecutorError> {
 
     let evaluator = ExpressionEvaluator::new(&schema);
 
-    let expr = vibesql_ast::Expression::ColumnRef { table: None, column: "a".to_string() };
+    let expr = vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "a".to_string() };
 
     let result = evaluator.eval(&expr, &row)?;
     assert_eq!(result, SqlValue::Integer(42));
@@ -208,9 +211,10 @@ fn test_cse_complex_expression() -> Result<(), ExecutorError> {
     // Build: ((a + b) * c) + ((a + b) * 2)
     // The sub-expression (a + b) should be cached
     let a_plus_b = || vibesql_ast::Expression::BinaryOp {
-        left: Box::new(vibesql_ast::Expression::ColumnRef { table: None, column: "a".to_string() }),
+        left: Box::new(vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
         op: vibesql_ast::BinaryOperator::Plus,
         right: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "b".to_string(),
         }),
@@ -221,6 +225,7 @@ fn test_cse_complex_expression() -> Result<(), ExecutorError> {
             left: Box::new(a_plus_b()),
             op: vibesql_ast::BinaryOperator::Multiply,
             right: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "c".to_string(),
             }),
@@ -258,9 +263,10 @@ fn test_cse_with_nulls() -> Result<(), ExecutorError> {
 
     // Build expression: (a + b)
     let expr = vibesql_ast::Expression::BinaryOp {
-        left: Box::new(vibesql_ast::Expression::ColumnRef { table: None, column: "a".to_string() }),
+        left: Box::new(vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
         op: vibesql_ast::BinaryOperator::Plus,
         right: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "b".to_string(),
         }),
@@ -307,6 +313,7 @@ fn test_cse_string_expressions() -> Result<(), ExecutorError> {
     let full_name = || vibesql_ast::Expression::BinaryOp {
         left: Box::new(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "first_name".to_string(),
             }),
@@ -317,6 +324,7 @@ fn test_cse_string_expressions() -> Result<(), ExecutorError> {
         }),
         op: vibesql_ast::BinaryOperator::Concat,
         right: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "last_name".to_string(),
         }),

--- a/crates/vibesql-executor/src/evaluator/tests/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/tests/mod.rs
@@ -34,7 +34,7 @@ mod evaluator_tests {
 
         // Should resolve inner_col from inner row
         let expr =
-            vibesql_ast::Expression::ColumnRef { table: None, column: "inner_col".to_string() };
+            vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "inner_col".to_string() };
 
         let result = evaluator.eval(&expr, &inner_row).unwrap();
         assert_eq!(result, SqlValue::Integer(42));
@@ -62,7 +62,7 @@ mod evaluator_tests {
 
         // Should resolve outer_col from outer row (not in inner schema)
         let expr =
-            vibesql_ast::Expression::ColumnRef { table: None, column: "outer_col".to_string() };
+            vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "outer_col".to_string() };
 
         let result = evaluator.eval(&expr, &inner_row).unwrap();
         assert_eq!(result, SqlValue::Integer(100));
@@ -87,7 +87,7 @@ mod evaluator_tests {
         let evaluator =
             ExpressionEvaluator::with_outer_context(&inner_schema, &outer_row, &outer_schema);
 
-        let expr = vibesql_ast::Expression::ColumnRef { table: None, column: "col".to_string() };
+        let expr = vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "col".to_string() };
 
         let result = evaluator.eval(&expr, &inner_row).unwrap();
         // Should get inner value (42), not outer (999)
@@ -114,7 +114,7 @@ mod evaluator_tests {
 
         // Try to resolve non-existent column
         let expr =
-            vibesql_ast::Expression::ColumnRef { table: None, column: "nonexistent".to_string() };
+            vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "nonexistent".to_string() };
 
         let result = evaluator.eval(&expr, &inner_row);
         assert!(matches!(result, Err(ExecutorError::ColumnNotFound { .. })));
@@ -131,7 +131,7 @@ mod evaluator_tests {
         let evaluator = ExpressionEvaluator::new(&schema);
         let row = vibesql_storage::Row::new(vec![SqlValue::Integer(42)]);
 
-        let expr = vibesql_ast::Expression::ColumnRef { table: None, column: "col".to_string() };
+        let expr = vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "col".to_string() };
 
         let result = evaluator.eval(&expr, &row).unwrap();
         assert_eq!(result, SqlValue::Integer(42));
@@ -171,7 +171,7 @@ mod evaluator_tests {
             ExpressionEvaluator::with_outer_context(&inner_schema, &outer_row, &outer_schema);
 
         // Try to resolve non-existent column
-        let expr = vibesql_ast::Expression::ColumnRef { table: None, column: "email".to_string() };
+        let expr = vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "email".to_string() };
 
         let result = evaluator.eval(&expr, &inner_row);
 
@@ -228,6 +228,7 @@ mod evaluator_tests {
 
         // Try to resolve with table qualifier
         let expr = vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("products".to_string()),
             column: "description".to_string(),
         };
@@ -274,6 +275,7 @@ mod evaluator_tests {
 
         // Column reference with correct table qualifier
         let expr = vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("users".to_string()),
             column: "name".to_string(),
         };
@@ -295,6 +297,7 @@ mod evaluator_tests {
 
         // Use different case for table qualifier
         let expr = vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("PRODUCTS".to_string()),
             column: "id".to_string(),
         };
@@ -316,6 +319,7 @@ mod evaluator_tests {
 
         // Column reference with wrong table qualifier
         let expr = vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("products".to_string()),
             column: "id".to_string(),
         };
@@ -354,6 +358,7 @@ mod evaluator_tests {
 
         // Column reference with invalid table qualifier
         let expr = vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("products".to_string()),
             column: "product_id".to_string(),
         };
@@ -393,6 +398,7 @@ mod evaluator_tests {
 
         // Column reference with outer table qualifier
         let expr = vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("outer_table".to_string()),
             column: "outer_col".to_string(),
         };
@@ -424,6 +430,7 @@ mod evaluator_tests {
 
         // Column reference with correct table but non-existent column
         let expr = vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("users".to_string()),
             column: "email".to_string(),
         };
@@ -468,12 +475,13 @@ mod evaluator_tests {
 
         // Without qualifier - should get inner value (shadowing)
         let expr_unqualified =
-            vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() };
+            vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "id".to_string() };
         let result = evaluator.eval(&expr_unqualified, &inner_row);
         assert_eq!(result, Ok(SqlValue::Integer(42)));
 
         // With inner qualifier - should get inner value
         let expr_inner = vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("inner_table".to_string()),
             column: "id".to_string(),
         };
@@ -482,6 +490,7 @@ mod evaluator_tests {
 
         // With outer qualifier - should get outer value
         let expr_outer = vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("outer_table".to_string()),
             column: "id".to_string(),
         };

--- a/crates/vibesql-executor/src/evaluator/window/tests/aggregates.rs
+++ b/crates/vibesql-executor/src/evaluator/window/tests/aggregates.rs
@@ -39,7 +39,7 @@ fn test_count_expr_window() {
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
     let frame = 0..3;
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     let result = evaluate_count_window(&partition, &frame, Some(&expr), evaluate_expression);
 
@@ -54,7 +54,7 @@ fn test_sum_window_running_total() {
     // SUM for running total
     let partition = Partition::new(make_test_rows(vec![10, 20, 30, 40, 50]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Running total at position 2: sum of rows 0, 1, 2
     let frame = 0..3; // 10 + 20 + 30 = 60
@@ -68,7 +68,7 @@ fn test_sum_window_moving() {
     // SUM over 3-row moving window
     let partition = Partition::new(make_test_rows(vec![5, 10, 15, 20, 25]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Frame: rows 2, 3, 4 (values 15, 20, 25)
     let frame = 2..5;
@@ -81,7 +81,7 @@ fn test_sum_window_moving() {
 fn test_sum_window_empty_frame() {
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Empty frame
     let frame = 0..0;
@@ -97,7 +97,7 @@ fn test_avg_window_simple() {
     // AVG over entire partition
     let partition = Partition::new(make_test_rows(vec![10, 20, 30, 40, 50]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     let frame = 0..5;
     let result = evaluate_avg_window(&partition, &frame, &expr, evaluate_expression);
@@ -111,7 +111,7 @@ fn test_avg_window_moving() {
     // 3-row moving average
     let partition = Partition::new(make_test_rows(vec![10, 20, 30, 40, 50]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Frame: rows 1, 2, 3 (values 20, 30, 40)
     let frame = 1..4;
@@ -125,7 +125,7 @@ fn test_avg_window_moving() {
 fn test_avg_window_empty_frame() {
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Empty frame
     let frame = 0..0;
@@ -141,7 +141,7 @@ fn test_min_window_partition() {
     // MIN over entire partition
     let partition = Partition::new(make_test_rows(vec![50, 20, 80, 10, 40]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     let frame = 0..5;
     let result = evaluate_min_window(&partition, &frame, &expr, evaluate_expression);
@@ -154,7 +154,7 @@ fn test_min_window_moving() {
     // MIN in 3-row window
     let partition = Partition::new(make_test_rows(vec![50, 20, 80, 10, 40]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Frame: rows 1, 2, 3 (values 20, 80, 10)
     let frame = 1..4;
@@ -167,7 +167,7 @@ fn test_min_window_moving() {
 fn test_min_window_empty_frame() {
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Empty frame
     let frame = 0..0;
@@ -183,7 +183,7 @@ fn test_max_window_partition() {
     // MAX over entire partition
     let partition = Partition::new(make_test_rows(vec![50, 20, 80, 10, 40]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     let frame = 0..5;
     let result = evaluate_max_window(&partition, &frame, &expr, evaluate_expression);
@@ -196,7 +196,7 @@ fn test_max_window_moving() {
     // MAX in 3-row window
     let partition = Partition::new(make_test_rows(vec![50, 20, 80, 10, 40]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Frame: rows 2, 3, 4 (values 80, 10, 40)
     let frame = 2..5;
@@ -209,7 +209,7 @@ fn test_max_window_moving() {
 fn test_max_window_empty_frame() {
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Empty frame
     let frame = 0..0;
@@ -225,7 +225,7 @@ fn test_frame_at_partition_boundaries() {
     // Test frame behavior at partition start and end
     let partition = Partition::new(make_test_rows(vec![10, 20, 30, 40, 50]));
 
-    let expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Frame extends beyond partition end
     let frame = 3..10; // Should clamp to 3..5

--- a/crates/vibesql-executor/src/evaluator/window/tests/lag_lead.rs
+++ b/crates/vibesql-executor/src/evaluator/window/tests/lag_lead.rs
@@ -30,7 +30,7 @@ fn test_lag_default_offset() {
     // LAG(value) with default offset of 1
     let partition = Partition::new(make_test_rows(vec![10, 20, 30, 40, 50]));
 
-    let value_expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let value_expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Row 0: LAG should return NULL (no previous row)
     let result = evaluate_lag(&partition, 0, &value_expr, None, None, simple_eval).unwrap();
@@ -54,7 +54,7 @@ fn test_lag_custom_offset() {
     // LAG(value, 2) - look back 2 rows
     let partition = Partition::new(make_test_rows(vec![10, 20, 30, 40, 50]));
 
-    let value_expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let value_expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Row 0: offset 2 goes before partition start -> NULL
     let result = evaluate_lag(&partition, 0, &value_expr, Some(2), None, simple_eval).unwrap();
@@ -82,7 +82,7 @@ fn test_lag_with_default_value() {
     // LAG(value, 1, 0) - default value of 0 instead of NULL
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
 
-    let value_expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let value_expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     let default_expr = Expression::Literal(SqlValue::Integer(0));
 
@@ -107,7 +107,7 @@ fn test_lag_offset_beyond_partition_start() {
     // Large offset that goes way before partition start
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
 
-    let value_expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let value_expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Row 2 with offset 100 should return NULL
     let result = evaluate_lag(&partition, 2, &value_expr, Some(100), None, simple_eval).unwrap();
@@ -128,7 +128,7 @@ fn test_lead_default_offset() {
     // LEAD(value) with default offset of 1
     let partition = Partition::new(make_test_rows(vec![10, 20, 30, 40, 50]));
 
-    let value_expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let value_expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Row 0: LEAD should return 20 (next row value)
     let result = evaluate_lead(&partition, 0, &value_expr, None, None, simple_eval).unwrap();
@@ -152,7 +152,7 @@ fn test_lead_custom_offset() {
     // LEAD(value, 2) - look forward 2 rows
     let partition = Partition::new(make_test_rows(vec![10, 20, 30, 40, 50]));
 
-    let value_expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let value_expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Row 0: LEAD(value, 2) should return 30 (row 2)
     let result = evaluate_lead(&partition, 0, &value_expr, Some(2), None, simple_eval).unwrap();
@@ -180,7 +180,7 @@ fn test_lead_with_default_value() {
     // LEAD(value, 1, 999) - default value of 999 instead of NULL
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
 
-    let value_expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let value_expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     let default_expr = Expression::Literal(SqlValue::Integer(999));
 
@@ -205,7 +205,7 @@ fn test_lead_offset_beyond_partition_end() {
     // Large offset that goes way past partition end
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
 
-    let value_expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let value_expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // Row 0 with offset 100 should return NULL
     let result = evaluate_lead(&partition, 0, &value_expr, Some(100), None, simple_eval).unwrap();
@@ -226,7 +226,7 @@ fn test_lag_lead_single_row_partition() {
     // Edge case: partition with only one row
     let partition = Partition::new(make_test_rows(vec![42]));
 
-    let value_expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let value_expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // LAG on single row should return NULL
     let result = evaluate_lag(&partition, 0, &value_expr, None, None, simple_eval).unwrap();
@@ -242,7 +242,7 @@ fn test_lag_lead_with_zero_offset() {
     // Special case: offset of 0 should return current row value
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
 
-    let value_expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let value_expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     // LAG(value, 0) should return current row value
     let result = evaluate_lag(&partition, 1, &value_expr, Some(0), None, simple_eval).unwrap();
@@ -260,7 +260,7 @@ fn test_lag_negative_offset_error() {
     // LAG with negative offset should return error
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
 
-    let value_expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let value_expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     let result = evaluate_lag(&partition, 1, &value_expr, Some(-1), None, simple_eval);
     assert!(result.is_err());
@@ -272,7 +272,7 @@ fn test_lead_negative_offset_error() {
     // LEAD with negative offset should return error
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
 
-    let value_expr = Expression::ColumnRef { table: None, column: "0".to_string() };
+    let value_expr = Expression::ColumnRef { schema: None, table: None, column: "0".to_string() };
 
     let result = evaluate_lead(&partition, 1, &value_expr, Some(-1), None, simple_eval);
     assert!(result.is_err());

--- a/crates/vibesql-executor/src/evaluator/window/tests/ranking.rs
+++ b/crates/vibesql-executor/src/evaluator/window/tests/ranking.rs
@@ -34,6 +34,7 @@ fn test_rank_with_ties() {
 
     let order_by = Some(vec![OrderByItem {
         expr: Expression::ColumnRef {
+            schema: None,
             table: None,
             column: String::new(), // Will use first column
         },
@@ -55,7 +56,7 @@ fn test_rank_no_ties() {
     let partition = Partition::new(make_test_rows(vec![4, 3, 2, 1]));
 
     let order_by = Some(vec![OrderByItem {
-        expr: Expression::ColumnRef { table: None, column: String::new() },
+        expr: Expression::ColumnRef { schema: None, table: None, column: String::new() },
         direction: OrderDirection::Desc,
         nulls_order: None,
     }]);
@@ -91,7 +92,7 @@ fn test_dense_rank_with_ties() {
     let partition = Partition::new(make_test_rows(vec![95, 90, 90, 85]));
 
     let order_by = Some(vec![OrderByItem {
-        expr: Expression::ColumnRef { table: None, column: String::new() },
+        expr: Expression::ColumnRef { schema: None, table: None, column: String::new() },
         direction: OrderDirection::Desc,
         nulls_order: None,
     }]);
@@ -112,7 +113,7 @@ fn test_dense_rank_multiple_tie_groups() {
     let partition = Partition::new(make_test_rows(vec![100, 90, 90, 80, 80, 80, 70]));
 
     let order_by = Some(vec![OrderByItem {
-        expr: Expression::ColumnRef { table: None, column: String::new() },
+        expr: Expression::ColumnRef { schema: None, table: None, column: String::new() },
         direction: OrderDirection::Desc,
         nulls_order: None,
     }]);

--- a/crates/vibesql-executor/src/evaluator/window/utils.rs
+++ b/crates/vibesql-executor/src/evaluator/window/utils.rs
@@ -41,7 +41,7 @@ use vibesql_types::SqlValue;
 pub fn evaluate_expression(expr: &Expression, row: &Row) -> Result<SqlValue, String> {
     match expr {
         Expression::Literal(val) => Ok(val.clone()),
-        Expression::ColumnRef { table: _, column } => {
+        Expression::ColumnRef { column, .. } => {
             // Try parsing column name as index (e.g., "0", "1")
             if let Ok(index) = column.parse::<usize>() {
                 row.get(index)

--- a/crates/vibesql-executor/src/insert/defaults.rs
+++ b/crates/vibesql-executor/src/insert/defaults.rs
@@ -32,7 +32,7 @@ pub fn evaluate_insert_expression_with_trigger_context(
                 Ok(vibesql_types::SqlValue::Null)
             }
         }
-        vibesql_ast::Expression::ColumnRef { table: None, column: col_name } => {
+        vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: col_name } => {
             // Check if this is a procedural variable reference
             if let Some(ctx) = procedural_context {
                 // Try to resolve as procedural variable

--- a/crates/vibesql-executor/src/insert/duplicate_key_update.rs
+++ b/crates/vibesql-executor/src/insert/duplicate_key_update.rs
@@ -165,7 +165,7 @@ fn evaluate_duplicate_key_expression(
                 })?;
             Ok(insert_values[column_idx].clone())
         }
-        vibesql_ast::Expression::ColumnRef { table: _, column } => {
+        vibesql_ast::Expression::ColumnRef { column, .. } => {
             // Column reference - get the value from existing row
             let column_idx =
                 schema.columns.iter().position(|col| col.name == *column).ok_or_else(|| {

--- a/crates/vibesql-executor/src/optimizer/adaptive/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/adaptive/mod.rs
@@ -143,7 +143,7 @@ mod tests {
             quoted: false,
             }),
             where_clause: Some(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
                 op: BinaryOperator::Equal,
                 right: Box::new(Expression::Literal(SqlValue::Integer(123))),
             }),
@@ -169,7 +169,7 @@ mod tests {
             distinct: false,
             select_list: vec![
                 SelectItem::Expression {
-                    expr: Expression::ColumnRef { table: None, column: "region".to_string() },
+                    expr: Expression::ColumnRef { schema: None, table: None, column: "region".to_string() },
                     alias: None, source_text: None },
                 SelectItem::Expression {
                     expr: Expression::AggregateFunction {
@@ -177,11 +177,13 @@ mod tests {
                         distinct: false,
                         args: vec![Expression::BinaryOp {
                             left: Box::new(Expression::ColumnRef {
+                                schema: None,
                                 table: None,
                                 column: "price".to_string(),
                             }),
                             op: BinaryOperator::Multiply,
                             right: Box::new(Expression::ColumnRef {
+                                schema: None,
                                 table: None,
                                 column: "quantity".to_string(),
                             }),
@@ -200,6 +202,7 @@ mod tests {
             }),
             where_clause: None,
             group_by: Some(GroupByClause::Simple(vec![Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "region".to_string(),
             }])),
@@ -228,11 +231,13 @@ mod tests {
                     distinct: false,
                     args: vec![Expression::BinaryOp {
                         left: Box::new(Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "price".to_string(),
                         }),
                         op: BinaryOperator::Multiply,
                         right: Box::new(Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "quantity".to_string(),
                         }),
@@ -369,11 +374,13 @@ mod tests {
             select_list: vec![SelectItem::Expression {
                 expr: Expression::BinaryOp {
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "price".to_string(),
                     }),
                     op: BinaryOperator::Multiply,
                     right: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "quantity".to_string(),
                     }),
@@ -408,10 +415,10 @@ mod tests {
             distinct: false,
             select_list: vec![
                 SelectItem::Expression {
-                    expr: Expression::ColumnRef { table: None, column: "id".to_string() },
+                    expr: Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
                     alias: None, source_text: None },
                 SelectItem::Expression {
-                    expr: Expression::ColumnRef { table: None, column: "name".to_string() },
+                    expr: Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
                     alias: None, source_text: None },
             ],
             into_table: None,

--- a/crates/vibesql-executor/src/optimizer/adaptive/strategy.rs
+++ b/crates/vibesql-executor/src/optimizer/adaptive/strategy.rs
@@ -365,11 +365,13 @@ mod tests {
                     distinct: false,
                     args: vec![Expression::BinaryOp {
                         left: Box::new(Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "price".to_string(),
                         }),
                         op: BinaryOperator::Multiply,
                         right: Box::new(Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "quantity".to_string(),
                         }),
@@ -460,6 +462,7 @@ mod tests {
     fn test_row_oriented_for_group_by_when_native_disabled() {
         let mut stmt = make_aggregate_query("orders");
         stmt.group_by = Some(GroupByClause::Simple(vec![Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "region".to_string(),
         }]));
@@ -477,6 +480,7 @@ mod tests {
     fn test_native_columnar_for_group_by_when_enabled() {
         let mut stmt = make_aggregate_query("orders");
         stmt.group_by = Some(GroupByClause::Simple(vec![Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "region".to_string(),
         }]));

--- a/crates/vibesql-executor/src/optimizer/aggregate_analysis.rs
+++ b/crates/vibesql-executor/src/optimizer/aggregate_analysis.rs
@@ -227,7 +227,7 @@ impl AggregateAnalysis {
     /// Extract table references from an expression
     fn extract_table_refs(expr: &Expression, tables: &mut HashSet<String>) {
         match expr {
-            Expression::ColumnRef { table: Some(table), .. } => {
+            Expression::ColumnRef { schema: None, table: Some(table), .. } => {
                 tables.insert(table.clone());
             }
             Expression::BinaryOp { left, right, .. } => {
@@ -491,7 +491,7 @@ mod tests {
     use super::*;
 
     fn make_column_ref(table: &str, column: &str) -> Expression {
-        Expression::ColumnRef { table: Some(table.to_string()), column: column.to_string() }
+        Expression::ColumnRef { schema: None, table: Some(table.to_string()), column: column.to_string() }
     }
 
     fn make_aggregate(name: &str, arg: Expression) -> Expression {

--- a/crates/vibesql-executor/src/optimizer/column_pruning.rs
+++ b/crates/vibesql-executor/src/optimizer/column_pruning.rs
@@ -159,7 +159,7 @@ fn collect_columns_from_grouping_elements(
 /// Recursively collect column references from an expression
 pub fn collect_columns_from_expr(expr: &Expression, columns: &mut HashSet<ColumnRef>) {
     match expr {
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             // Skip the special "*" wildcard (used in COUNT(*))
             if column != "*" {
                 columns.insert(ColumnRef::new(table.clone(), column.clone()));
@@ -516,7 +516,7 @@ mod tests {
 
     #[test]
     fn test_collect_simple_column_ref() {
-        let expr = Expression::ColumnRef { table: Some("t".to_string()), column: "c".to_string() };
+        let expr = Expression::ColumnRef { schema: None, table: Some("t".to_string()), column: "c".to_string() };
 
         let mut columns = HashSet::new();
         collect_columns_from_expr(&expr, &mut columns);
@@ -527,7 +527,7 @@ mod tests {
 
     #[test]
     fn test_collect_unqualified_column_ref() {
-        let expr = Expression::ColumnRef { table: None, column: "col".to_string() };
+        let expr = Expression::ColumnRef { schema: None, table: None, column: "col".to_string() };
 
         let mut columns = HashSet::new();
         collect_columns_from_expr(&expr, &mut columns);
@@ -540,11 +540,13 @@ mod tests {
     fn test_collect_from_binary_op() {
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "a".to_string(),
             }),
             op: BinaryOperator::Multiply,
             right: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t2".to_string()),
                 column: "b".to_string(),
             }),
@@ -564,11 +566,13 @@ mod tests {
             name: "SUM".to_string(),
             args: vec![Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "price".to_string(),
                 }),
                 op: BinaryOperator::Multiply,
                 right: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "qty".to_string(),
                 }),
@@ -590,6 +594,7 @@ mod tests {
         let expr = Expression::Extract {
             field: vibesql_ast::IntervalUnit::Year,
             expr: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("lineitem".to_string()),
                 column: "l_shipdate".to_string(),
             }),

--- a/crates/vibesql-executor/src/optimizer/expressions.rs
+++ b/crates/vibesql-executor/src/optimizer/expressions.rs
@@ -479,7 +479,7 @@ mod tests {
     fn test_cast_non_literal_not_folded() {
         // CAST(column AS INTEGER) should not be folded
         let expr = Expression::Cast {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "x".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
             data_type: DataType::Integer,
         };
 
@@ -570,7 +570,7 @@ mod tests {
     fn test_between_with_column_not_folded() {
         // x BETWEEN 1 AND 10 should not be folded
         let expr = Expression::Between {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "x".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
             low: Box::new(Expression::Literal(SqlValue::Integer(1))),
             high: Box::new(Expression::Literal(SqlValue::Integer(10))),
             negated: false,
@@ -645,7 +645,7 @@ mod tests {
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::Literal(SqlValue::Integer(9933))),
             op: vibesql_ast::BinaryOperator::GreaterThanOrEqual,
-            right: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
         };
 
         let db = vibesql_storage::Database::new();
@@ -674,7 +674,7 @@ mod tests {
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::Literal(SqlValue::Integer(8524))),
             op: vibesql_ast::BinaryOperator::LessThanOrEqual,
-            right: Box::new(Expression::ColumnRef { table: None, column: "col3".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col3".to_string() }),
         };
 
         let db = vibesql_storage::Database::new();
@@ -701,7 +701,7 @@ mod tests {
     fn test_predicate_normalization_already_normalized() {
         // col0 <= 9933 should remain unchanged (already normalized)
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             op: vibesql_ast::BinaryOperator::LessThanOrEqual,
             right: Box::new(Expression::Literal(SqlValue::Integer(9933))),
         };
@@ -732,7 +732,7 @@ mod tests {
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::Literal(SqlValue::Integer(100))),
             op: vibesql_ast::BinaryOperator::Equal,
-            right: Box::new(Expression::ColumnRef { table: None, column: "x".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
         };
 
         let db = vibesql_storage::Database::new();
@@ -761,7 +761,7 @@ mod tests {
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::Literal(SqlValue::Integer(5))),
             op: vibesql_ast::BinaryOperator::Plus,
-            right: Box::new(Expression::ColumnRef { table: None, column: "x".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
         };
 
         let db = vibesql_storage::Database::new();
@@ -790,7 +790,7 @@ mod tests {
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::Literal(SqlValue::Integer(100))),
             op: vibesql_ast::BinaryOperator::LessThan,
-            right: Box::new(Expression::ColumnRef { table: None, column: "x".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
         };
 
         let db = vibesql_storage::Database::new();
@@ -819,7 +819,7 @@ mod tests {
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::Literal(SqlValue::Integer(200))),
             op: vibesql_ast::BinaryOperator::GreaterThan,
-            right: Box::new(Expression::ColumnRef { table: None, column: "x".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
         };
 
         let db = vibesql_storage::Database::new();

--- a/crates/vibesql-executor/src/optimizer/selectivity.rs
+++ b/crates/vibesql-executor/src/optimizer/selectivity.rs
@@ -353,7 +353,7 @@ mod tests {
         // status = 'active' should be 3/4 = 75% (of non-null values)
         let pred = Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "status".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "status".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("active")))),
         };
 
@@ -370,14 +370,14 @@ mod tests {
             op: BinaryOperator::And,
             left: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "status".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "status".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "active",
                 )))),
             }),
             right: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::LessThan,
-                left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(10))),
             }),
         };
@@ -403,14 +403,14 @@ mod tests {
             op: BinaryOperator::Or,
             left: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "status".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "status".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "active",
                 )))),
             }),
             right: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::LessThan,
-                left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(10))),
             }),
         };
@@ -430,7 +430,7 @@ mod tests {
         // Should match all non-null rows: 4/5 = 80%
         // NDV for status is 2 (active, inactive), so selectivity = 2/2 = 1.0
         let pred = Expression::InList {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "status".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "status".to_string() }),
             values: vec![
                 Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("active"))),
                 Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("inactive"))),
@@ -450,7 +450,7 @@ mod tests {
         // Should match 3/5 = 60% of rows (3 out of 4 non-null have 'active')
         // NDV for status is 2, so selectivity = 1/2 = 0.5
         let pred_single = Expression::InList {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "status".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "status".to_string() }),
             values: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("active")))],
             negated: false,
         };
@@ -476,6 +476,7 @@ mod tests {
                 left: Box::new(Expression::BinaryOp {
                     op: BinaryOperator::Equal,
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "status".to_string(),
                     }),
@@ -486,6 +487,7 @@ mod tests {
                 right: Box::new(Expression::BinaryOp {
                     op: BinaryOperator::Equal,
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "status".to_string(),
                     }),
@@ -496,7 +498,7 @@ mod tests {
             }),
             right: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::LessThan,
-                left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(3))),
             }),
         };

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
@@ -88,12 +88,18 @@ pub(crate) fn is_correlated(subquery: &SelectStmt) -> bool {
 /// TODO: Implement full symbol table analysis for more accurate correlation detection
 pub(crate) fn has_external_column_refs(expr: &Expression, subquery: &SelectStmt) -> bool {
     match expr {
-        Expression::ColumnRef { table: Some(table), .. } => {
+        Expression::ColumnRef { schema: Some(_), .. } => {
+            // Schema-qualified column references are always considered external
+            // (they explicitly reference a different database schema)
+            true
+        }
+
+        Expression::ColumnRef { schema: None, table: Some(table), .. } => {
             // If column is qualified, check if table is in subquery's FROM clause
             !subquery_references_table(subquery, table)
         }
 
-        Expression::ColumnRef { table: None, column } => {
+        Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // Unqualified column refs: Conservative approach
             //
             // Per SQL semantics (section 7.6 of SQL:1999), unqualified column references

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
@@ -193,7 +193,7 @@ mod tests {
             with_clause: None,
             distinct: false,
             select_list: vec![SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: column.to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: column.to_string() },
                 alias: None, source_text: None }],
             into_table: None,
             into_variables: None,
@@ -217,7 +217,7 @@ mod tests {
     #[test]
     fn test_add_distinct_to_uncorrelated_in_subquery() {
         let subquery = simple_select("customers", "region");
-        let in_expr = Expression::ColumnRef { table: None, column: "region".to_string() };
+        let in_expr = Expression::ColumnRef { schema: None, table: None, column: "region".to_string() };
 
         let mut stmt = simple_select("orders", "order_id");
         stmt.where_clause = Some(Expression::In {
@@ -244,7 +244,7 @@ mod tests {
         let mut subquery = simple_select("customers", "region");
         subquery.distinct = true;
 
-        let in_expr = Expression::ColumnRef { table: None, column: "region".to_string() };
+        let in_expr = Expression::ColumnRef { schema: None, table: None, column: "region".to_string() };
 
         let mut stmt = simple_select("orders", "order_id");
         stmt.where_clause = Some(Expression::In {
@@ -279,10 +279,12 @@ mod tests {
         subquery.where_clause = Some(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("customers".to_string()),
                 column: "region".to_string(),
             }),
             right: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("orders".to_string()),
                 column: "region".to_string(),
             }),
@@ -295,17 +297,19 @@ mod tests {
 
     #[test]
     fn test_in_to_exists_rewrite() {
-        let in_expr = Expression::ColumnRef { table: None, column: "customer_id".to_string() };
+        let in_expr = Expression::ColumnRef { schema: None, table: None, column: "customer_id".to_string() };
 
         let mut subquery = simple_select("customers", "customer_id");
         // Make it correlated
         subquery.where_clause = Some(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("customers".to_string()),
                 column: "region".to_string(),
             }),
             right: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("orders".to_string()),
                 column: "region".to_string(),
             }),
@@ -349,17 +353,19 @@ mod tests {
     #[test]
     fn test_complex_expression_skips_in_to_exists() {
         // Test that complex expressions in SELECT list skip IN → EXISTS transformation
-        let in_expr = Expression::ColumnRef { table: None, column: "customer_id".to_string() };
+        let in_expr = Expression::ColumnRef { schema: None, table: None, column: "customer_id".to_string() };
 
         let mut subquery = simple_select("customers", "customer_id");
         // Add WHERE clause to make it correlated
         subquery.where_clause = Some(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("customers".to_string()),
                 column: "region".to_string(),
             }),
             right: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("orders".to_string()),
                 column: "region".to_string(),
             }),
@@ -370,6 +376,7 @@ mod tests {
             expr: Expression::Function {
                 name: "UPPER".to_string(),
                 args: vec![Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "customer_id".to_string(),
                 }],
@@ -404,12 +411,12 @@ mod tests {
     #[test]
     fn test_multi_column_in_skips_optimization() {
         // Test that multi-column IN subqueries are not optimized
-        let in_expr = Expression::ColumnRef { table: None, column: "customer_id".to_string() };
+        let in_expr = Expression::ColumnRef { schema: None, table: None, column: "customer_id".to_string() };
 
         let mut subquery = simple_select("customers", "customer_id");
         // Add second column to SELECT list
         subquery.select_list.push(SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "region".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "region".to_string() },
             alias: None, source_text: None });
 
         let mut stmt = simple_select("orders", "order_id");
@@ -442,17 +449,19 @@ mod tests {
     #[test]
     fn test_negated_in_preserved() {
         // Test that NOT IN negation is preserved
-        let in_expr = Expression::ColumnRef { table: None, column: "customer_id".to_string() };
+        let in_expr = Expression::ColumnRef { schema: None, table: None, column: "customer_id".to_string() };
 
         let mut subquery = simple_select("customers", "customer_id");
         // Make it correlated
         subquery.where_clause = Some(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("customers".to_string()),
                 column: "region".to_string(),
             }),
             right: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("orders".to_string()),
                 column: "region".to_string(),
             }),
@@ -483,12 +492,12 @@ mod tests {
         // Add nested IN subquery in WHERE clause
         let inner_subquery = simple_select("regions", "region_id");
         outer_subquery.where_clause = Some(Expression::In {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "region_id".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "region_id".to_string() }),
             subquery: Box::new(inner_subquery),
             negated: false,
         });
 
-        let in_expr = Expression::ColumnRef { table: None, column: "customer_id".to_string() };
+        let in_expr = Expression::ColumnRef { schema: None, table: None, column: "customer_id".to_string() };
 
         let mut stmt = simple_select("orders", "order_id");
         stmt.where_clause = Some(Expression::In {
@@ -538,6 +547,7 @@ mod tests {
         let mut stmt_with_in = simple_select("orders", "order_id");
         stmt_with_in.where_clause = Some(Expression::In {
             expr: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "customer_id".to_string(),
             }),
@@ -555,6 +565,7 @@ mod tests {
             distinct: false,
             select_list: vec![SelectItem::Expression {
                 expr: Expression::ColumnRef {
+                    schema: None,
                     table: Some(alias.to_string()),
                     column: column.to_string(),
                 },
@@ -588,10 +599,12 @@ mod tests {
         subquery.where_clause = Some(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("l2".to_string()),
                 column: "l_orderkey".to_string(),
             }),
             right: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("l1".to_string()),
                 column: "l_orderkey".to_string(),
             }),
@@ -610,7 +623,7 @@ mod tests {
                 assert!(!negated, "Should not be negated");
                 // The outer expression should be l1.l_orderkey
                 match expr.as_ref() {
-                    Expression::ColumnRef { table: Some(t), column: c } => {
+                    Expression::ColumnRef { schema: None, table: Some(t), column: c, .. } => {
                         assert_eq!(t, "l1");
                         assert_eq!(c, "l_orderkey");
                     }
@@ -634,10 +647,12 @@ mod tests {
         subquery.where_clause = Some(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("o".to_string()),
                 column: "o_custkey".to_string(),
             }),
             right: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("c".to_string()),
                 column: "c_custkey".to_string(),
             }),

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/transformations.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/transformations.rs
@@ -198,8 +198,8 @@ fn try_extract_correlation(
 /// Check if an expression references a specific table
 fn is_from_table(expr: &Expression, table: &str) -> bool {
     match expr {
-        Expression::ColumnRef { table: Some(t), .. } => t.eq_ignore_ascii_case(table),
-        Expression::ColumnRef { table: None, .. } => true, // Unqualified could be from inner
+        Expression::ColumnRef { schema: None, table: Some(t), .. } => t.eq_ignore_ascii_case(table),
+        Expression::ColumnRef { schema: None, table: None, .. } => true, // Unqualified could be from inner
         _ => false,
     }
 }
@@ -209,11 +209,11 @@ fn is_from_table(expr: &Expression, table: &str) -> bool {
 /// orders table)
 fn is_from_outer_tables(expr: &Expression, outer_tables: &[String], inner_table: &str) -> bool {
     match expr {
-        Expression::ColumnRef { table: Some(t), .. } => {
+        Expression::ColumnRef { schema: None, table: Some(t), .. } => {
             outer_tables.iter().any(|ot| ot.eq_ignore_ascii_case(t))
         }
         // Handle unqualified columns that use table prefix convention (e.g., o_orderkey for orders)
-        Expression::ColumnRef { table: None, column } => {
+        Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // Don't match if column starts with inner table's prefix
             let inner_prefix = inner_table.chars().next().unwrap_or('_').to_ascii_lowercase();
             let col_prefix = column.chars().next().unwrap_or('_').to_ascii_lowercase();

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/exists.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/exists.rs
@@ -232,6 +232,7 @@ fn try_convert_complex_exists_to_join(
             .iter()
             .map(|col| SelectItem::Expression {
                 expr: Expression::ColumnRef {
+                    schema: None,
                     table: col.table.clone(),
                     column: col.column.clone(),
                 },
@@ -413,7 +414,7 @@ fn extract_subquery_column_from_correlation(
 /// Extract column reference from an expression
 fn extract_column_ref(expr: &Expression) -> Option<ColumnRef> {
     match expr {
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             Some(ColumnRef { table: table.clone(), column: column.clone() })
         }
         _ => None,
@@ -429,12 +430,16 @@ fn rewrite_join_condition_for_derived_table(
     alias: &str,
 ) -> Expression {
     match condition {
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             // Check if this column is one of the subquery columns
             if subquery_columns.iter().any(|c| {
                 c.column == *column && (c.table.is_none() || c.table.as_ref() == table.as_ref())
             }) {
-                Expression::ColumnRef { table: Some(alias.to_string()), column: column.clone() }
+                Expression::ColumnRef {
+                    schema: None,
+                    table: Some(alias.to_string()),
+                    column: column.clone(),
+                }
             } else {
                 condition.clone()
             }

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/helpers.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/helpers.rs
@@ -82,7 +82,7 @@ pub(super) fn rewrite_column_refs_with_alias(
     new_alias: &str,
 ) -> Expression {
     match expr {
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             // Rewrite if:
             // 1. No table qualifier (unqualified column from the subquery table)
             // 2. Table qualifier matches the old table name
@@ -92,7 +92,11 @@ pub(super) fn rewrite_column_refs_with_alias(
             };
 
             if should_rewrite {
-                Expression::ColumnRef { table: Some(new_alias.to_string()), column: column.clone() }
+                Expression::ColumnRef {
+                    schema: None,
+                    table: Some(new_alias.to_string()),
+                    column: column.clone(),
+                }
             } else {
                 expr.clone()
             }

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
@@ -107,7 +107,7 @@ pub(super) fn try_convert_in_to_join(
     //   SELECT o_orderkey FROM orders WHERE o_orderkey IN (SELECT l_orderkey FROM lineitem)
     //   Different tables, no ambiguity - l_orderkey can only be from lineitem.
     if needs_alias {
-        if let Expression::ColumnRef { table: None, .. } = &subquery_column {
+        if let Expression::ColumnRef { schema: None, table: None, .. } = &subquery_column {
             // Check if outer query has exactly one table and it matches the subquery's table
             let is_simple_self_join = is_simple_single_table_self_join(from, &table_name, &table_alias);
 
@@ -313,7 +313,11 @@ fn try_convert_aggregate_in_to_join(
     let join_condition = Expression::BinaryOp {
         op: BinaryOperator::Equal,
         left: Box::new(outer_expr.clone()),
-        right: Box::new(Expression::ColumnRef { table: Some(alias.clone()), column: column_name }),
+        right: Box::new(Expression::ColumnRef {
+            schema: None,
+            table: Some(alias.clone()),
+            column: column_name,
+        }),
     };
 
     // Create SEMI or ANTI join based on negation

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/tests.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/tests.rs
@@ -11,7 +11,7 @@ fn simple_table_from(name: &str) -> FromClause {
 }
 
 fn column_ref(column: &str) -> Expression {
-    Expression::ColumnRef { table: None, column: column.to_string() }
+    Expression::ColumnRef { schema: None, table: None, column: column.to_string() }
 }
 
 fn simple_select(table: &str, column: &str) -> SelectStmt {
@@ -283,7 +283,7 @@ fn test_nested_in_subquery_self_join_column_qualification() {
                         Expression::In { expr: inner_expr, .. } => {
                             // The outer expression of the nested IN should be qualified
                             match inner_expr.as_ref() {
-                                Expression::ColumnRef { table: Some(t), column: c } => {
+                                Expression::ColumnRef { schema: None, table: Some(t), column: c, .. } => {
                                     t.starts_with("__subquery_") && c.eq_ignore_ascii_case("col0")
                                 }
                                 _ => false,
@@ -318,7 +318,7 @@ fn table_from_with_alias(name: &str, alias: &str) -> FromClause {
 }
 
 fn qualified_column_ref(table: &str, column: &str) -> Expression {
-    Expression::ColumnRef { table: Some(table.to_string()), column: column.to_string() }
+    Expression::ColumnRef { schema: None, table: Some(table.to_string()), column: column.to_string() }
 }
 
 #[test]
@@ -423,7 +423,7 @@ fn test_exists_self_join_column_qualification() {
             if let Some(cond) = condition {
                 fn contains_rewritten_alias(expr: &Expression) -> bool {
                     match expr {
-                        Expression::ColumnRef { table: Some(t), .. } => t == "__subquery_l2",
+                        Expression::ColumnRef { schema: None, table: Some(t), .. } => t == "__subquery_l2",
                         Expression::BinaryOp { left, right, .. } => {
                             contains_rewritten_alias(left) || contains_rewritten_alias(right)
                         }
@@ -545,7 +545,7 @@ fn test_not_exists_self_join_column_qualification() {
             if let Some(cond) = condition {
                 fn contains_rewritten_l3_ref(expr: &Expression) -> bool {
                     match expr {
-                        Expression::ColumnRef { table: Some(t), .. } => t == "__subquery_l3",
+                        Expression::ColumnRef { schema: None, table: Some(t), .. } => t == "__subquery_l3",
                         Expression::BinaryOp { left, right, .. } => {
                             contains_rewritten_l3_ref(left) || contains_rewritten_l3_ref(right)
                         }

--- a/crates/vibesql-executor/src/optimizer/table_elimination/prefix.rs
+++ b/crates/vibesql-executor/src/optimizer/table_elimination/prefix.rs
@@ -135,7 +135,7 @@ fn collect_qualified_columns_from_expr(
     table_columns: &mut HashMap<String, Vec<String>>,
 ) {
     match expr {
-        Expression::ColumnRef { table: Some(t), column } => {
+        Expression::ColumnRef { schema: None, table: Some(t), column, .. } => {
             table_columns.entry(t.to_lowercase()).or_default().push(column.to_lowercase());
         }
         Expression::BinaryOp { left, right, .. } => {

--- a/crates/vibesql-executor/src/optimizer/table_elimination/select_analysis.rs
+++ b/crates/vibesql-executor/src/optimizer/table_elimination/select_analysis.rs
@@ -122,7 +122,7 @@ pub(super) fn has_any_column_ref(expr: &Expression) -> bool {
 /// Check if expression contains any unqualified column references
 pub(super) fn has_unqualified_column_ref(expr: &Expression) -> bool {
     match expr {
-        Expression::ColumnRef { table: None, .. } => true,
+        Expression::ColumnRef { schema: None, table: None, .. } => true,
         Expression::BinaryOp { left, right, .. } => {
             has_unqualified_column_ref(left) || has_unqualified_column_ref(right)
         }
@@ -150,7 +150,7 @@ pub(super) fn has_unqualified_column_ref(expr: &Expression) -> bool {
 /// Extract tables referenced in an expression (only qualified column refs)
 pub(super) fn extract_tables_from_expr(expr: &Expression, tables: &mut HashSet<String>) {
     match expr {
-        Expression::ColumnRef { table: Some(t), .. } => {
+        Expression::ColumnRef { schema: None, table: Some(t), .. } => {
             tables.insert(t.to_lowercase());
         }
         Expression::BinaryOp { left, right, .. } => {
@@ -218,7 +218,7 @@ pub(super) fn collect_unqualified_columns_from_expr(
     columns: &mut HashSet<String>,
 ) {
     match expr {
-        Expression::ColumnRef { table: None, column } => {
+        Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // Skip the special "*" wildcard (used in COUNT(*))
             if column != "*" {
                 columns.insert(column.to_lowercase());

--- a/crates/vibesql-executor/src/optimizer/table_elimination/tests.rs
+++ b/crates/vibesql-executor/src/optimizer/table_elimination/tests.rs
@@ -117,7 +117,7 @@ mod eliminate_unused_tables_tests {
     use super::super::eliminate_unused_tables;
 
     fn make_column_ref(table: Option<&str>, column: &str) -> Expression {
-        Expression::ColumnRef { table: table.map(|t| t.to_string()), column: column.to_string() }
+        Expression::ColumnRef { schema: None, table: table.map(|t| t.to_string()), column: column.to_string() }
     }
 
     fn make_table(name: &str, alias: Option<&str>) -> FromClause {
@@ -515,10 +515,11 @@ mod helper_function_tests {
     fn collect_unqualified_columns_finds_refs() {
         let select_list = vec![
             SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "col1".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() },
                 alias: None, source_text: None },
             SelectItem::Expression {
                 expr: Expression::ColumnRef {
+                    schema: None,
                     table: Some("t1".to_string()),
                     column: "col2".to_string(),
                 },
@@ -532,10 +533,10 @@ mod helper_function_tests {
     #[test]
     fn has_unqualified_column_ref_detects_unqualified() {
         let qualified =
-            Expression::ColumnRef { table: Some("t1".to_string()), column: "col1".to_string() };
+            Expression::ColumnRef { schema: None, table: Some("t1".to_string()), column: "col1".to_string() };
         assert!(!has_unqualified_column_ref(&qualified));
 
-        let unqualified = Expression::ColumnRef { table: None, column: "col1".to_string() };
+        let unqualified = Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() };
         assert!(has_unqualified_column_ref(&unqualified));
     }
 }

--- a/crates/vibesql-executor/src/optimizer/where_pushdown/table_refs.rs
+++ b/crates/vibesql-executor/src/optimizer/where_pushdown/table_refs.rs
@@ -46,7 +46,7 @@ fn extract_tables_recursive_branch(
     tables: &mut HashSet<String>,
 ) -> bool {
     match expr {
-        vibesql_ast::Expression::ColumnRef { table: Some(table_name), .. } => {
+        vibesql_ast::Expression::ColumnRef { schema: None, table: Some(table_name), .. } => {
             let normalized = table_name.to_lowercase();
             if schema.contains_table(&normalized) {
                 tables.insert(normalized);
@@ -56,7 +56,7 @@ fn extract_tables_recursive_branch(
                 false
             }
         }
-        vibesql_ast::Expression::ColumnRef { table: None, column } => {
+        vibesql_ast::Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // Unqualified column reference - need to resolve it to table(s)
             // Search all tables in the schema to find which contain this column
             let column_lower = column.to_lowercase();
@@ -186,7 +186,7 @@ fn extract_column_reference_branch(
     schema: &CombinedSchema,
 ) -> Option<(String, String)> {
     match expr {
-        vibesql_ast::Expression::ColumnRef { table, column } => {
+        vibesql_ast::Expression::ColumnRef { table, column, .. } => {
             if let Some(table_name) = table {
                 let normalized_table = table_name.to_lowercase();
                 if schema.contains_table(&normalized_table) {

--- a/crates/vibesql-executor/src/optimizer/where_pushdown/tests.rs
+++ b/crates/vibesql-executor/src/optimizer/where_pushdown/tests.rs
@@ -96,6 +96,7 @@ fn test_or_filter_extraction() {
     let n1_france = Expression::BinaryOp {
         op: BinaryOperator::Equal,
         left: Box::new(Expression::ColumnRef {
+            schema: None,
             table: Some("n1".to_string()),
             column: "n_name".to_string(),
         }),
@@ -104,6 +105,7 @@ fn test_or_filter_extraction() {
     let n2_germany = Expression::BinaryOp {
         op: BinaryOperator::Equal,
         left: Box::new(Expression::ColumnRef {
+            schema: None,
             table: Some("n2".to_string()),
             column: "n_name".to_string(),
         }),
@@ -112,6 +114,7 @@ fn test_or_filter_extraction() {
     let n1_germany = Expression::BinaryOp {
         op: BinaryOperator::Equal,
         left: Box::new(Expression::ColumnRef {
+            schema: None,
             table: Some("n1".to_string()),
             column: "n_name".to_string(),
         }),
@@ -120,6 +123,7 @@ fn test_or_filter_extraction() {
     let n2_france = Expression::BinaryOp {
         op: BinaryOperator::Equal,
         left: Box::new(Expression::ColumnRef {
+            schema: None,
             table: Some("n2".to_string()),
             column: "n_name".to_string(),
         }),
@@ -200,6 +204,7 @@ fn test_or_filter_extraction_multi_branch() {
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "a".to_string(),
             }),
@@ -208,6 +213,7 @@ fn test_or_filter_extraction_multi_branch() {
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t2".to_string()),
                 column: "b".to_string(),
             }),
@@ -220,6 +226,7 @@ fn test_or_filter_extraction_multi_branch() {
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "a".to_string(),
             }),
@@ -228,6 +235,7 @@ fn test_or_filter_extraction_multi_branch() {
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t2".to_string()),
                 column: "b".to_string(),
             }),
@@ -240,6 +248,7 @@ fn test_or_filter_extraction_multi_branch() {
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "a".to_string(),
             }),
@@ -248,6 +257,7 @@ fn test_or_filter_extraction_multi_branch() {
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t2".to_string()),
                 column: "b".to_string(),
             }),
@@ -312,6 +322,7 @@ fn test_or_filter_extraction_nested_or() {
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "a".to_string(),
             }),
@@ -320,6 +331,7 @@ fn test_or_filter_extraction_nested_or() {
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "a".to_string(),
             }),
@@ -333,6 +345,7 @@ fn test_or_filter_extraction_nested_or() {
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "b".to_string(),
             }),
@@ -345,6 +358,7 @@ fn test_or_filter_extraction_nested_or() {
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "a".to_string(),
             }),
@@ -353,6 +367,7 @@ fn test_or_filter_extraction_nested_or() {
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "a".to_string(),
             }),
@@ -366,6 +381,7 @@ fn test_or_filter_extraction_nested_or() {
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "b".to_string(),
             }),
@@ -421,6 +437,7 @@ fn test_or_filter_extraction_asymmetric() {
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "a".to_string(),
             }),
@@ -429,6 +446,7 @@ fn test_or_filter_extraction_asymmetric() {
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t2".to_string()),
                 column: "b".to_string(),
             }),
@@ -440,6 +458,7 @@ fn test_or_filter_extraction_asymmetric() {
     let right_branch = Expression::BinaryOp {
         op: BinaryOperator::Equal,
         left: Box::new(Expression::ColumnRef {
+            schema: None,
             table: Some("t1".to_string()),
             column: "a".to_string(),
         }),
@@ -486,6 +505,7 @@ fn test_or_filter_extraction_single_table() {
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "a".to_string(),
             }),
@@ -494,6 +514,7 @@ fn test_or_filter_extraction_single_table() {
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "a".to_string(),
             }),
@@ -557,6 +578,7 @@ fn test_or_filter_extraction_no_common_tables() {
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "a".to_string(),
             }),
@@ -565,6 +587,7 @@ fn test_or_filter_extraction_no_common_tables() {
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t2".to_string()),
                 column: "b".to_string(),
             }),
@@ -578,6 +601,7 @@ fn test_or_filter_extraction_no_common_tables() {
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t3".to_string()),
                 column: "c".to_string(),
             }),
@@ -586,6 +610,7 @@ fn test_or_filter_extraction_no_common_tables() {
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("t4".to_string()),
                 column: "d".to_string(),
             }),

--- a/crates/vibesql-executor/src/pipeline/columnar.rs
+++ b/crates/vibesql-executor/src/pipeline/columnar.rs
@@ -554,7 +554,7 @@ mod tests {
 
         let sum_expr = Expression::AggregateFunction {
             name: "SUM".to_string(),
-            args: vec![Expression::ColumnRef { table: None, column: "x".to_string() }],
+            args: vec![Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }],
             distinct: false, order_by: None,
         };
         let result = ColumnarPipeline::evaluate_empty_aggregate(&sum_expr, &evaluator).unwrap();
@@ -570,7 +570,7 @@ mod tests {
         for agg_name in &["AVG", "MIN", "MAX"] {
             let expr = Expression::AggregateFunction {
                 name: agg_name.to_string(),
-                args: vec![Expression::ColumnRef { table: None, column: "x".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }],
                 distinct: false, order_by: None,
             };
             let result = ColumnarPipeline::evaluate_empty_aggregate(&expr, &evaluator).unwrap();
@@ -670,7 +670,7 @@ mod tests {
         let evaluator = ctx.create_evaluator();
 
         // Column reference without aggregate should return NULL
-        let expr = Expression::ColumnRef { table: None, column: "x".to_string() };
+        let expr = Expression::ColumnRef { schema: None, table: None, column: "x".to_string() };
         let result = ColumnarPipeline::evaluate_empty_aggregate(&expr, &evaluator).unwrap();
         assert_eq!(result, SqlValue::Null);
     }

--- a/crates/vibesql-executor/src/pipeline/native_columnar.rs
+++ b/crates/vibesql-executor/src/pipeline/native_columnar.rs
@@ -473,7 +473,7 @@ impl NativeColumnarPipeline {
         let group_cols: Vec<usize> = group_exprs
             .iter()
             .filter_map(|expr| match expr {
-                Expression::ColumnRef { table, column } => {
+                Expression::ColumnRef { table, column, .. } => {
                     ctx.schema.get_column_index(table.as_deref(), column.as_str())
                 }
                 _ => None,

--- a/crates/vibesql-executor/src/procedural/executor.rs
+++ b/crates/vibesql-executor/src/procedural/executor.rs
@@ -124,7 +124,7 @@ pub fn evaluate_expression(
 
     match expr {
         // Variable, parameter, or session variable reference
-        Expression::ColumnRef { table: None, column } => {
+        Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // Check if it's a session variable (starts with @)
             if let Some(var_name) = column.strip_prefix('@') {
                 // Strip @ prefix

--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/batch.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/batch.rs
@@ -84,7 +84,7 @@ fn evaluate_batch_expression(
     schema: &CombinedSchema,
 ) -> Result<ColumnArray, ExecutorError> {
     match expr {
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             // Simple column reference - return the column directly
             let col_idx = schema.get_column_index(table.as_deref(), column).ok_or_else(|| {
                 ExecutorError::UnsupportedExpression(format!("Column not found: {}", column))

--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/evaluator.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/evaluator.rs
@@ -20,7 +20,7 @@ pub fn eval_simple_expr(
     schema: &CombinedSchema,
 ) -> Result<SqlValue, ExecutorError> {
     match expr {
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             let col_idx = schema.get_column_index(table.as_deref(), column).ok_or_else(|| {
                 ExecutorError::UnsupportedExpression(format!("Column not found: {}", column))
             })?;

--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/mod.rs
@@ -107,7 +107,7 @@ pub fn extract_aggregates(
                                 .push(AggregateSpec { op, source: AggregateSource::CountStar });
                             continue;
                         }
-                        Expression::ColumnRef { table: _, column } if column == "*" => {
+                        Expression::ColumnRef { column, .. } if column == "*" => {
                             aggregates
                                 .push(AggregateSpec { op, source: AggregateSource::CountStar });
                             continue;
@@ -123,7 +123,7 @@ pub fn extract_aggregates(
 
                 let source = match &args[0] {
                     // Fast path: simple column reference
-                    Expression::ColumnRef { table, column } => {
+                    Expression::ColumnRef { table, column, .. } => {
                         let column_idx = schema.get_column_index(table.as_deref(), column)?;
                         AggregateSource::Column(column_idx)
                     }
@@ -157,7 +157,7 @@ pub fn extract_aggregates(
 /// Returns None if the expression contains unsupported operations.
 fn is_simple_arithmetic_expr(expr: &Expression, schema: &CombinedSchema) -> Option<()> {
     match expr {
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             // Verify column exists
             schema.get_column_index(table.as_deref(), column)?;
             Some(())

--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/tests.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/tests.rs
@@ -49,9 +49,9 @@ fn test_batch_expression_aggregate_multiply() {
 
     // Test SUM(price * discount)
     let expr = Expression::BinaryOp {
-        left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
         op: BinaryOperator::Multiply,
-        right: Box::new(Expression::ColumnRef { table: None, column: "discount".to_string() }),
+        right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "discount".to_string() }),
     };
 
     let result = compute_batch_expression_aggregate(&batch, &expr, AggregateOp::Sum, &schema)
@@ -79,9 +79,9 @@ fn test_batch_expression_aggregate_avg() {
 
     // Test AVG(price * discount)
     let expr = Expression::BinaryOp {
-        left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
         op: BinaryOperator::Multiply,
-        right: Box::new(Expression::ColumnRef { table: None, column: "discount".to_string() }),
+        right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "discount".to_string() }),
     };
 
     let result = compute_batch_expression_aggregate(&batch, &expr, AggregateOp::Avg, &schema)
@@ -109,9 +109,9 @@ fn test_batch_expression_aggregate_mixed_types() {
 
     // Test SUM(price * quantity) - Float64 * Int64
     let expr = Expression::BinaryOp {
-        left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
         op: BinaryOperator::Multiply,
-        right: Box::new(Expression::ColumnRef { table: None, column: "quantity".to_string() }),
+        right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "quantity".to_string() }),
     };
 
     let result = compute_batch_expression_aggregate(&batch, &expr, AggregateOp::Sum, &schema)
@@ -139,7 +139,7 @@ fn test_batch_expression_aggregate_with_literal() {
 
     // Test SUM(price * 2)
     let expr = Expression::BinaryOp {
-        left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
         op: BinaryOperator::Multiply,
         right: Box::new(Expression::Literal(SqlValue::Integer(2))),
     };
@@ -169,12 +169,12 @@ fn test_batch_expression_aggregate_nested() {
 
     // Test SUM(price * (1 - discount))
     let expr = Expression::BinaryOp {
-        left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
         op: BinaryOperator::Multiply,
         right: Box::new(Expression::BinaryOp {
             left: Box::new(Expression::Literal(SqlValue::Double(1.0))),
             op: BinaryOperator::Minus,
-            right: Box::new(Expression::ColumnRef { table: None, column: "discount".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "discount".to_string() }),
         }),
     };
 
@@ -203,9 +203,9 @@ fn test_batch_expression_aggregate_min_max() {
 
     // Test MIN(price * discount)
     let expr = Expression::BinaryOp {
-        left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
         op: BinaryOperator::Multiply,
-        right: Box::new(Expression::ColumnRef { table: None, column: "discount".to_string() }),
+        right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "discount".to_string() }),
     };
 
     let min_result = compute_batch_expression_aggregate(&batch, &expr, AggregateOp::Min, &schema)
@@ -257,9 +257,9 @@ fn test_batch_expression_aggregate_empty_batch() {
     let combined_schema = CombinedSchema::from_table("test".to_string(), schema);
 
     let expr = Expression::BinaryOp {
-        left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
         op: BinaryOperator::Multiply,
-        right: Box::new(Expression::ColumnRef { table: None, column: "discount".to_string() }),
+        right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "discount".to_string() }),
     };
 
     // SUM of empty batch should return NULL
@@ -306,9 +306,9 @@ fn test_batch_expression_aggregate_with_nulls() {
     let combined_schema = CombinedSchema::from_table("test".to_string(), schema);
 
     let expr = Expression::BinaryOp {
-        left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
         op: BinaryOperator::Multiply,
-        right: Box::new(Expression::ColumnRef { table: None, column: "discount".to_string() }),
+        right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "discount".to_string() }),
     };
 
     let result =

--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/vectorized.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/vectorized.rs
@@ -63,8 +63,8 @@ fn try_vectorized_binary_aggregate(
         // Both operands must be simple column references
         let (left_col, right_col) = match (left.as_ref(), right.as_ref()) {
             (
-                Expression::ColumnRef { table: t1, column: c1 },
-                Expression::ColumnRef { table: t2, column: c2 },
+                Expression::ColumnRef { schema: None, table: t1, column: c1, .. },
+                Expression::ColumnRef { schema: None, table: t2, column: c2, .. },
             ) => {
                 let idx1 = schema.get_column_index(t1.as_deref(), c1).ok_or_else(|| {
                     ExecutorError::UnsupportedExpression(format!("Column not found: {}", c1))

--- a/crates/vibesql-executor/src/select/columnar/aggregate/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/mod.rs
@@ -301,7 +301,7 @@ mod tests {
         let exprs = vec![Expression::AggregateFunction {
             name: "SUM".to_string(),
             distinct: false,
-            args: vec![Expression::ColumnRef { table: None, column: "col1".to_string() }],
+            args: vec![Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }],
             order_by: None,
         }];
 
@@ -332,13 +332,13 @@ mod tests {
             Expression::AggregateFunction {
                 name: "SUM".to_string(),
                 distinct: false,
-                args: vec![Expression::ColumnRef { table: None, column: "col1".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }],
                 order_by: None,
             },
             Expression::AggregateFunction {
                 name: "AVG".to_string(),
                 distinct: false,
-                args: vec![Expression::ColumnRef { table: None, column: "col2".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "col2".to_string() }],
                 order_by: None,
             },
         ];
@@ -371,7 +371,7 @@ mod tests {
         let exprs = vec![Expression::AggregateFunction {
             name: "SUM".to_string(),
             distinct: true,
-            args: vec![Expression::ColumnRef { table: None, column: "col1".to_string() }],
+            args: vec![Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }],
             order_by: None,
         }];
 
@@ -379,7 +379,7 @@ mod tests {
         assert!(result.is_none());
 
         // Test non-aggregate expression (should return None)
-        let exprs = vec![Expression::ColumnRef { table: None, column: "col1".to_string() }];
+        let exprs = vec![Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }];
 
         let result = extract_aggregates(&exprs, &combined_schema);
         assert!(result.is_none());
@@ -434,9 +434,10 @@ mod tests {
             name: "SUM".to_string(),
             distinct: false,
             args: vec![Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
                 op: vibesql_ast::BinaryOperator::Multiply,
                 right: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "discount".to_string(),
                 }),

--- a/crates/vibesql-executor/src/select/columnar/executor/expression.rs
+++ b/crates/vibesql-executor/src/select/columnar/executor/expression.rs
@@ -28,8 +28,8 @@ pub fn compute_expression_aggregate_batch(
         if *bin_op == BinaryOperator::Multiply {
             // Get column indices from left and right operands
             if let (
-                Expression::ColumnRef { column: col1, .. },
-                Expression::ColumnRef { column: col2, .. },
+                Expression::ColumnRef { schema: None, column: col1, .. },
+                Expression::ColumnRef { schema: None, column: col2, .. },
             ) = (left.as_ref(), right.as_ref())
             {
                 // Find column indices by name

--- a/crates/vibesql-executor/src/select/columnar/executor/fused.rs
+++ b/crates/vibesql-executor/src/select/columnar/executor/fused.rs
@@ -248,8 +248,8 @@ fn compute_fused_expression_aggregate(
     if let Expression::BinaryOp { left, op: bin_op, right } = expr {
         if *bin_op == BinaryOperator::Multiply {
             if let (
-                Expression::ColumnRef { column: col1, .. },
-                Expression::ColumnRef { column: col2, .. },
+                Expression::ColumnRef { schema: None, column: col1, .. },
+                Expression::ColumnRef { schema: None, column: col2, .. },
             ) = (left.as_ref(), right.as_ref())
             {
                 let left_idx = batch.column_index_by_name(col1);

--- a/crates/vibesql-executor/src/select/columnar/filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/mod.rs
@@ -472,13 +472,13 @@ mod tests {
         // Build: col0 < 10 OR col1 > 20
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
                 op: BinaryOperator::LessThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(10))),
             }),
             op: BinaryOperator::Or,
             right: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }),
                 op: BinaryOperator::GreaterThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(20))),
             }),

--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -369,7 +369,7 @@ fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<
         // Binary comparison: column op value (value can be literal or foldable expression)
         Expression::BinaryOp { left, op, right } => {
             // Try: column op value (fold right side if possible)
-            if let Expression::ColumnRef { table, column } = left.as_ref() {
+            if let Expression::ColumnRef { table, column, .. } = left.as_ref() {
                 if let Some(value) = try_fold_constant(right) {
                     let column_idx = schema.get_column_index(table.as_deref(), column)?;
                     let predicate = match op {
@@ -392,7 +392,7 @@ fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<
             }
 
             // Try: value op column (reverse the comparison, fold left side if possible)
-            if let Expression::ColumnRef { table, column } = right.as_ref() {
+            if let Expression::ColumnRef { table, column, .. } = right.as_ref() {
                 if let Some(value) = try_fold_constant(left) {
                     let column_idx = schema.get_column_index(table.as_deref(), column)?;
                     let predicate = match op {
@@ -420,8 +420,8 @@ fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<
             // Try: column op column (column-to-column comparison)
             // This handles predicates like `l_commitdate < l_receiptdate` in TPC-H Q4
             if let (
-                Expression::ColumnRef { table: t1, column: c1 },
-                Expression::ColumnRef { table: t2, column: c2 },
+                Expression::ColumnRef { schema: None, table: t1, column: c1, .. },
+                Expression::ColumnRef { schema: None, table: t2, column: c2, .. },
             ) = (left.as_ref(), right.as_ref())
             {
                 let left_idx = schema.get_column_index(t1.as_deref(), c1)?;
@@ -449,7 +449,7 @@ fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<
         // Only support ASYMMETRIC (default) BETWEEN for columnar optimization
         // SYMMETRIC BETWEEN falls through to general evaluator which handles bounds swapping
         Expression::Between { expr: inner, low, high, negated: false, symmetric: false } => {
-            if let Expression::ColumnRef { table, column } = inner.as_ref() {
+            if let Expression::ColumnRef { table, column, .. } = inner.as_ref() {
                 // Try to fold bounds to literals (handles arithmetic expressions like 1+2)
                 let low_val = try_fold_constant(low)?;
                 let high_val = try_fold_constant(high)?;
@@ -466,7 +466,7 @@ fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<
 
         // LIKE: column LIKE pattern
         Expression::Like { expr: inner, pattern, negated, .. } => {
-            if let Expression::ColumnRef { table, column } = inner.as_ref() {
+            if let Expression::ColumnRef { table, column, .. } = inner.as_ref() {
                 // Extract pattern string from literal
                 if let Expression::Literal(SqlValue::Character(pattern_str))
                 | Expression::Literal(SqlValue::Varchar(pattern_str)) = pattern.as_ref()
@@ -484,7 +484,7 @@ fn extract_tree_recursive(expr: &Expression, schema: &CombinedSchema) -> Option<
 
         // IN list: column IN (value1, value2, ...)
         Expression::InList { expr: inner, values, negated } => {
-            if let Expression::ColumnRef { table, column } = inner.as_ref() {
+            if let Expression::ColumnRef { table, column, .. } = inner.as_ref() {
                 // Extract all values from the IN list (try to fold each to a constant)
                 let mut folded_values = Vec::with_capacity(values.len());
                 for value_expr in values {
@@ -538,7 +538,7 @@ fn extract_predicates_recursive(
         // Binary comparison: column op value (value can be literal or foldable expression)
         Expression::BinaryOp { left, op, right } => {
             // Try: column op value (fold right side if possible)
-            if let Expression::ColumnRef { table, column } = left.as_ref() {
+            if let Expression::ColumnRef { table, column, .. } = left.as_ref() {
                 if let Some(value) = try_fold_constant(right) {
                     // Skip if column not in schema (cross-table predicate)
                     if let Some(column_idx) = schema.get_column_index(table.as_deref(), column) {
@@ -568,7 +568,7 @@ fn extract_predicates_recursive(
             }
 
             // Try: value op column (reverse the comparison, fold left side if possible)
-            if let Expression::ColumnRef { table, column } = right.as_ref() {
+            if let Expression::ColumnRef { table, column, .. } = right.as_ref() {
                 if let Some(value) = try_fold_constant(left) {
                     // Skip if column not in schema (cross-table predicate)
                     if let Some(column_idx) = schema.get_column_index(table.as_deref(), column) {
@@ -602,8 +602,8 @@ fn extract_predicates_recursive(
             // Try: column op column (column-to-column comparison within same table)
             // This handles predicates like `l_commitdate < l_receiptdate` in TPC-H Q4
             if let (
-                Expression::ColumnRef { table: t1, column: c1 },
-                Expression::ColumnRef { table: t2, column: c2 },
+                Expression::ColumnRef { schema: None, table: t1, column: c1, .. },
+                Expression::ColumnRef { schema: None, table: t2, column: c2, .. },
             ) = (left.as_ref(), right.as_ref())
             {
                 // Only add if BOTH columns are in schema (same-table comparison)
@@ -636,7 +636,7 @@ fn extract_predicates_recursive(
         // BETWEEN: column BETWEEN low AND high
         // Only support ASYMMETRIC (default) BETWEEN for columnar optimization
         Expression::Between { expr: inner, low, high, negated: false, symmetric: false } => {
-            if let Expression::ColumnRef { table, column } = inner.as_ref() {
+            if let Expression::ColumnRef { table, column, .. } = inner.as_ref() {
                 // Try to fold bounds to literals (handles arithmetic expressions like 1+2)
                 if let (Some(low_val), Some(high_val)) =
                     (try_fold_constant(low), try_fold_constant(high))
@@ -658,7 +658,7 @@ fn extract_predicates_recursive(
 
         // LIKE: column LIKE pattern
         Expression::Like { expr: inner, pattern, negated, .. } => {
-            if let Expression::ColumnRef { table, column } = inner.as_ref() {
+            if let Expression::ColumnRef { table, column, .. } = inner.as_ref() {
                 // Extract pattern string from literal
                 if let Expression::Literal(SqlValue::Character(pattern_str))
                 | Expression::Literal(SqlValue::Varchar(pattern_str)) = pattern.as_ref()
@@ -680,7 +680,7 @@ fn extract_predicates_recursive(
 
         // IN list: column IN (value1, value2, ...)
         Expression::InList { expr: inner, values, negated } => {
-            if let Expression::ColumnRef { table, column } = inner.as_ref() {
+            if let Expression::ColumnRef { table, column, .. } = inner.as_ref() {
                 // Extract all values from the IN list (try to fold each to a constant)
                 let mut folded_values = Vec::with_capacity(values.len());
                 for value_expr in values {
@@ -779,7 +779,7 @@ mod tests {
     #[test]
     fn test_try_fold_constant_column_ref_returns_none() {
         // Column references cannot be folded
-        let expr = Expression::ColumnRef { table: None, column: "x".to_string() };
+        let expr = Expression::ColumnRef { schema: None, table: None, column: "x".to_string() };
         assert_eq!(try_fold_constant(&expr), None);
     }
 
@@ -789,7 +789,7 @@ mod tests {
 
         // col0 BETWEEN 1 AND 1+2
         let expr = Expression::Between {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             low: Box::new(Expression::Literal(SqlValue::Integer(1))),
             high: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::Literal(SqlValue::Integer(1))),
@@ -819,7 +819,7 @@ mod tests {
 
         // col0 < 10 - 3
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             op: BinaryOperator::LessThan,
             right: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::Literal(SqlValue::Integer(10))),
@@ -852,7 +852,7 @@ mod tests {
                 right: Box::new(Expression::Literal(SqlValue::Integer(5))),
             }),
             op: BinaryOperator::GreaterThan,
-            right: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
         };
 
         let tree = extract_predicate_tree(&expr, &schema);
@@ -873,7 +873,7 @@ mod tests {
 
         // col0 IN (1, 1+1, 2+1)
         let expr = Expression::InList {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             values: vec![
                 Expression::Literal(SqlValue::Integer(1)),
                 Expression::BinaryOp {
@@ -912,9 +912,9 @@ mod tests {
 
         // col0 BETWEEN 1 AND col1 (col1 cannot be folded)
         let expr = Expression::Between {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             low: Box::new(Expression::Literal(SqlValue::Integer(1))),
-            high: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+            high: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }),
             negated: false,
             symmetric: false,
         };
@@ -929,9 +929,9 @@ mod tests {
 
         // col0 < col1 (column-to-column comparison)
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             op: BinaryOperator::LessThan,
-            right: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }),
         };
 
         let tree = extract_predicate_tree(&expr, &schema);
@@ -966,9 +966,9 @@ mod tests {
 
         for (binary_op, expected_compare_op) in operators {
             let expr = Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
                 op: binary_op,
-                right: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+                right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }),
             };
 
             let tree = extract_predicate_tree(&expr, &schema);
@@ -990,13 +990,13 @@ mod tests {
         // col0 < col1 AND col0 > 5 (mix of column-to-column and column-to-value)
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
                 op: BinaryOperator::LessThan,
-                right: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+                right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }),
             }),
             op: BinaryOperator::And,
             right: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
                 op: BinaryOperator::GreaterThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(5))),
             }),

--- a/crates/vibesql-executor/src/select/columnar/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/mod.rs
@@ -788,7 +788,7 @@ mod tests {
         let aggregates = vec![Expression::AggregateFunction {
             name: "SUM".to_string(),
             distinct: false,
-            args: vec![Expression::ColumnRef { table: None, column: "price".to_string() }],
+            args: vec![Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }],
             order_by: None,
         }];
 
@@ -817,7 +817,7 @@ mod tests {
 
         // SELECT SUM(price) FROM test WHERE quantity < 25
         let filter = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "quantity".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "quantity".to_string() }),
             op: BinaryOperator::LessThan,
             right: Box::new(Expression::Literal(SqlValue::Integer(25))),
         };
@@ -825,7 +825,7 @@ mod tests {
         let aggregates = vec![Expression::AggregateFunction {
             name: "SUM".to_string(),
             distinct: false,
-            args: vec![Expression::ColumnRef { table: None, column: "price".to_string() }],
+            args: vec![Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }],
             order_by: None,
         }];
 
@@ -857,7 +857,7 @@ mod tests {
             Expression::AggregateFunction {
                 name: "SUM".to_string(),
                 distinct: false,
-                args: vec![Expression::ColumnRef { table: None, column: "price".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }],
                 order_by: None,
             },
             Expression::AggregateFunction {
@@ -869,7 +869,7 @@ mod tests {
             Expression::AggregateFunction {
                 name: "AVG".to_string(),
                 distinct: false,
-                args: vec![Expression::ColumnRef { table: None, column: "quantity".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "quantity".to_string() }],
                 order_by: None,
             },
         ];
@@ -911,7 +911,7 @@ mod tests {
         let aggregates = vec![Expression::AggregateFunction {
             name: "SUM".to_string(),
             distinct: true,
-            args: vec![Expression::ColumnRef { table: None, column: "price".to_string() }],
+            args: vec![Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }],
             order_by: None,
         }];
 
@@ -945,7 +945,7 @@ mod tests {
         let aggregates = vec![Expression::AggregateFunction {
             name: "SUM".to_string(),
             distinct: false,
-            args: vec![Expression::ColumnRef { table: None, column: "price".to_string() }],
+            args: vec![Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }],
             order_by: None,
         }];
 

--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -146,7 +146,7 @@ pub(super) fn derive_cte_schema(
                         } else {
                             // Try to extract name from expression
                             match expr {
-                                vibesql_ast::Expression::ColumnRef { table: _, column } => {
+                                vibesql_ast::Expression::ColumnRef { column, .. } => {
                                     column.clone()
                                 }
                                 _ => format!("col{}", i),

--- a/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
@@ -134,7 +134,7 @@ impl SelectExecutor<'_> {
                         matches!(args[0], vibesql_ast::Expression::Wildcard)
                             || matches!(
                                 &args[0],
-                                vibesql_ast::Expression::ColumnRef { table: None, column } if column == "*"
+                                vibesql_ast::Expression::ColumnRef { schema: None, table: None, column, .. } if column == "*"
                             )
                     }
                     vibesql_ast::Expression::Function { name, args, .. } => {
@@ -145,7 +145,7 @@ impl SelectExecutor<'_> {
                         matches!(args[0], vibesql_ast::Expression::Wildcard)
                             || matches!(
                                 &args[0],
-                                vibesql_ast::Expression::ColumnRef { table: None, column } if column == "*"
+                                vibesql_ast::Expression::ColumnRef { schema: None, table: None, column, .. } if column == "*"
                             )
                     }
                     _ => false,

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
@@ -18,7 +18,7 @@ fn validate_aggregate_args(name: &str, args: &[vibesql_ast::Expression]) -> Resu
         matches!(arg, vibesql_ast::Expression::Wildcard)
             || matches!(
                 arg,
-                vibesql_ast::Expression::ColumnRef { table: None, column } if column == "*"
+                vibesql_ast::Expression::ColumnRef { schema: None, table: None, column, .. } if column == "*"
             )
     });
 
@@ -108,7 +108,7 @@ pub(super) fn evaluate(
         let is_count_star = matches!(args[0], vibesql_ast::Expression::Wildcard)
             || matches!(
                 &args[0],
-                vibesql_ast::Expression::ColumnRef { table: None, column } if column == "*"
+                vibesql_ast::Expression::ColumnRef { schema: None, table: None, column, .. } if column == "*"
             );
 
         if is_count_star {
@@ -262,7 +262,7 @@ pub(super) fn evaluate(
         let is_count_star_fallback = matches!(&args[0], vibesql_ast::Expression::Wildcard)
             || matches!(
                 &args[0],
-                vibesql_ast::Expression::ColumnRef { table: None, column } if column == "*"
+                vibesql_ast::Expression::ColumnRef { schema: None, table: None, column, .. } if column == "*"
             );
 
         if is_count_star_fallback {

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -338,6 +338,7 @@ fn replace_aggregates_with_columns(
             if format!("{:?}", expr) == format!("{:?}", agg) {
                 // Replace with column reference to the hidden column
                 return Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: format!("__order_by_agg_{}", i),
                 };

--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -613,6 +613,7 @@ impl SelectExecutor<'_> {
                         for column in &table_schema.columns {
                             // Create a column reference expression for each column
                             let column_expr = vibesql_ast::Expression::ColumnRef {
+                                schema: None,
                                 table: if schema.table_schemas.len() > 1 {
                                     // Multiple tables: qualify the column
                                     Some(table_name.to_string())
@@ -637,6 +638,7 @@ impl SelectExecutor<'_> {
                     if let Some((_start_idx, table_schema)) = table_result {
                         for column in &table_schema.columns {
                             let column_expr = vibesql_ast::Expression::ColumnRef {
+                                schema: None,
                                 table: Some(qualifier.clone()),
                                 column: column.name.clone(),
                             };

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -145,6 +145,7 @@ pub(super) fn apply_window_functions_to_aggregates(
 
             // Create an expression that references this column
             let arg_expr = Expression::ColumnRef {
+                schema: None,
                 table: Some("result".to_string()),
                 column: format!("col{}", arg_col_idx),
             };
@@ -227,6 +228,7 @@ fn map_expr_to_result_column(expr: &Expression, select_list: &[SelectItem]) -> E
             if expressions_match(expr, select_expr) {
                 let col_name = alias.clone().unwrap_or_else(|| format!("col{}", idx));
                 return Expression::ColumnRef {
+                    schema: None,
                     table: Some("result".to_string()),
                     column: col_name,
                 };
@@ -234,9 +236,10 @@ fn map_expr_to_result_column(expr: &Expression, select_list: &[SelectItem]) -> E
 
             // Also check if expr matches an alias
             if let Some(alias) = alias {
-                if let Expression::ColumnRef { column, table: None } = expr {
+                if let Expression::ColumnRef { column, table: None, .. } = expr {
                     if column.eq_ignore_ascii_case(alias) {
                         return Expression::ColumnRef {
+                            schema: None,
                             table: Some("result".to_string()),
                             column: alias.clone(),
                         };

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/cse.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/cse.rs
@@ -30,7 +30,7 @@ pub(super) fn hash_expression(expr: &Expression) -> u64 {
 fn hash_expression_recursive<H: std::hash::Hasher>(expr: &Expression, hasher: &mut H) {
     use std::hash::Hash;
     match expr {
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             "col".hash(hasher);
             table.hash(hasher);
             column.hash(hasher);

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/group_by.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/group_by.rs
@@ -62,7 +62,7 @@ impl SelectExecutor<'_> {
             .iter()
             .filter_map(|expr| {
                 match expr {
-                    vibesql_ast::Expression::ColumnRef { table, column } => {
+                    vibesql_ast::Expression::ColumnRef { table, column, .. } => {
                         schema.get_column_index(table.as_deref(), column.as_str())
                     }
                     _ => None, // Only simple column references supported for now
@@ -266,7 +266,7 @@ impl SelectExecutor<'_> {
         let group_cols: Vec<usize> = simple_exprs
             .iter()
             .filter_map(|expr| match expr {
-                Expression::ColumnRef { table, column } => {
+                Expression::ColumnRef { table, column, .. } => {
                     schema.get_column_index(table.as_deref(), column.as_str())
                 }
                 _ => None,

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/having.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/having.rs
@@ -123,7 +123,7 @@ fn evaluate_expr_on_result_row(
                 AggregateSource::CountStar
             } else if args.len() == 1 {
                 match &args[0] {
-                    Expression::ColumnRef { table, column } => {
+                    Expression::ColumnRef { table, column, .. } => {
                         if let Some(idx) =
                             schema.get_column_index(table.as_deref(), column.as_str())
                         {
@@ -216,7 +216,7 @@ fn evaluate_expr_on_result_row(
         // Note: The result row has group columns first, then aggregate values.
         // The group columns are stored in GROUP BY clause order, which may not match
         // schema order. We fall back to row-based for this case as a temporary fix.
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             // Column references in HAVING with GROUP BY require knowing the mapping
             // from GROUP BY expression order to result row positions. Since the columnar
             // path currently doesn't have this mapping, fall back to row-based execution.
@@ -466,8 +466,8 @@ fn sources_match(spec_source: &AggregateSource, having_source: &AggregateSource)
 fn expressions_equal(a: &Expression, b: &Expression) -> bool {
     match (a, b) {
         (
-            Expression::ColumnRef { table: t1, column: c1 },
-            Expression::ColumnRef { table: t2, column: c2 },
+            Expression::ColumnRef { schema: None, table: t1, column: c1, .. },
+            Expression::ColumnRef { schema: None, table: t2, column: c2, .. },
         ) => t1 == t2 && c1 == c2,
         (
             Expression::BinaryOp { left: l1, op: o1, right: r1 },

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -111,8 +111,8 @@ pub(super) fn extract_equijoin_conditions(
         Expression::BinaryOp { left, op: BinaryOperator::Equal, right } => {
             // Check if this is col1 = col2 (equi-join)
             if let (
-                Expression::ColumnRef { table: lt, column: lc },
-                Expression::ColumnRef { table: rt, column: rc },
+                Expression::ColumnRef { schema: None, table: lt, column: lc, .. },
+                Expression::ColumnRef { schema: None, table: rt, column: rc, .. },
             ) = (left.as_ref(), right.as_ref())
             {
                 conditions.push(EquiJoinCondition {

--- a/crates/vibesql-executor/src/select/executor/columns.rs
+++ b/crates/vibesql-executor/src/select/executor/columns.rs
@@ -197,7 +197,7 @@ fn derive_expression_name_impl(
     mode: ColumnNamingMode,
 ) -> String {
     match expr {
-        vibesql_ast::Expression::ColumnRef { table, column } => {
+        vibesql_ast::Expression::ColumnRef { table, column, .. } => {
             match mode {
                 ColumnNamingMode::Full => {
                     // Use schema to get the full column name (table.column format)

--- a/crates/vibesql-executor/src/select/executor/fast_path/analysis.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path/analysis.rs
@@ -264,7 +264,7 @@ pub(crate) fn uses_select_alias(order_by: &[OrderByItem], select_list: &[SelectI
 
     // Check if any ORDER BY column matches an alias
     for item in order_by {
-        if let Expression::ColumnRef { table: None, column } = &item.expr {
+        if let Expression::ColumnRef { schema: None, table: None, column, .. } = &item.expr {
             // Case-insensitive comparison for SQL identifiers
             if aliases.iter().any(|alias| alias.eq_ignore_ascii_case(column)) {
                 return true;
@@ -484,7 +484,7 @@ mod tests {
         // No sorted_by means we need to sort
         assert!(needs_sorting(
             &[vibesql_ast::OrderByItem {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "a".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "a".to_string() },
                 direction: vibesql_ast::OrderDirection::Asc,
                 nulls_order: None,
             }],
@@ -494,7 +494,7 @@ mod tests {
         // Matching sorted_by means no sorting needed
         assert!(!needs_sorting(
             &[vibesql_ast::OrderByItem {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "a".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "a".to_string() },
                 direction: vibesql_ast::OrderDirection::Asc,
                 nulls_order: None,
             }],
@@ -504,7 +504,7 @@ mod tests {
         // Different column means sorting needed
         assert!(needs_sorting(
             &[vibesql_ast::OrderByItem {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "b".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "b".to_string() },
                 direction: vibesql_ast::OrderDirection::Asc,
                 nulls_order: None,
             }],
@@ -514,7 +514,7 @@ mod tests {
         // Different direction means sorting needed
         assert!(needs_sorting(
             &[vibesql_ast::OrderByItem {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "a".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "a".to_string() },
                 direction: vibesql_ast::OrderDirection::Desc,
                 nulls_order: None,
             }],
@@ -524,7 +524,7 @@ mod tests {
         // ORDER BY prefix of sorted_by is OK
         assert!(!needs_sorting(
             &[vibesql_ast::OrderByItem {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "a".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "a".to_string() },
                 direction: vibesql_ast::OrderDirection::Asc,
                 nulls_order: None,
             }],
@@ -539,6 +539,7 @@ mod tests {
             &[
                 vibesql_ast::OrderByItem {
                     expr: vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "a".to_string()
                     },
@@ -547,6 +548,7 @@ mod tests {
                 },
                 vibesql_ast::OrderByItem {
                     expr: vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "b".to_string()
                     },

--- a/crates/vibesql-executor/src/select/executor/fast_path/helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path/helpers.rs
@@ -115,7 +115,7 @@ impl SelectExecutor<'_> {
         schema: &CombinedSchema,
     ) -> Result<(), ExecutorError> {
         match expr {
-            Expression::ColumnRef { table, column } => {
+            Expression::ColumnRef { table, column, .. } => {
                 if schema.get_column_index(table.as_deref(), column).is_none() {
                     // SQLite compatibility: Allow ROWID pseudo-column references
                     // Only if there's no actual column with that name (real columns take precedence)
@@ -191,7 +191,7 @@ impl SelectExecutor<'_> {
 
         for item in order_by {
             let col_idx = match &item.expr {
-                Expression::ColumnRef { table, column } => schema
+                Expression::ColumnRef { table, column, .. } => schema
                     .get_column_index(table.as_deref(), column)
                     .ok_or_else(|| ExecutorError::ColumnNotFound {
                         column_name: column.clone(),
@@ -462,7 +462,7 @@ impl SelectExecutor<'_> {
         for item in select_list {
             match item {
                 SelectItem::Expression {
-                    expr: Expression::ColumnRef { table: _, column }, ..
+                    expr: Expression::ColumnRef { column, .. }, ..
                 } => {
                     // Find column index by name (case-insensitive)
                     let idx = table_schema

--- a/crates/vibesql-executor/src/select/executor/index_optimization/spatial.rs
+++ b/crates/vibesql-executor/src/select/executor/index_optimization/spatial.rs
@@ -130,8 +130,8 @@ fn try_detect_spatial_predicate(
 ) -> Result<Option<SpatialIndexUsage>, ExecutorError> {
     // First argument should be a column reference
     let column_name = match column_expr {
-        Expression::ColumnRef { table: None, column } => column.clone(),
-        Expression::ColumnRef { table: Some(_table), column } => column.clone(),
+        Expression::ColumnRef { schema: None, table: None, column, .. } => column.clone(),
+        Expression::ColumnRef { schema: None, table: Some(_table), column, .. } => column.clone(),
         _ => return Ok(None), // Not a column reference
     };
 

--- a/crates/vibesql-executor/src/select/executor/nonagg/materialized.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/materialized.rs
@@ -344,7 +344,7 @@ impl SelectExecutor<'_> {
                     |((col_name, sort_order), order_item)| {
                         // Check if column names match and sort direction matches
                         match &order_item.expr {
-                            vibesql_ast::Expression::ColumnRef { table: None, column } => {
+                            vibesql_ast::Expression::ColumnRef { schema: None, table: None, column, .. } => {
                                 column == col_name && &order_item.direction == sort_order
                             }
                             _ => false,

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -311,7 +311,7 @@ fn validate_expression_column_refs(
     use vibesql_ast::Expression;
 
     match expr {
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             // Skip "*" - it's a wildcard used in COUNT(*) and is not a real column
             if column == "*" {
                 return Ok(());

--- a/crates/vibesql-executor/src/select/executor/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/validation.rs
@@ -22,7 +22,7 @@ struct ColumnReference {
 /// Extract all column references from an expression recursively
 fn extract_column_refs(expr: &Expression, refs: &mut Vec<ColumnReference>) {
     match expr {
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             // Skip "*" - it's a wildcard, not an actual column reference
             // This handles cases like COUNT(*) parsed as ColumnRef { column: "*" }
             if column != "*" {
@@ -205,7 +205,7 @@ fn check_aggregate_arg_count(expr: &Expression) -> Option<String> {
                 let is_wildcard = matches!(arg, Expression::Wildcard);
                 let is_star_ref = matches!(
                     arg,
-                    Expression::ColumnRef { table: None, column } if column == "*"
+                    Expression::ColumnRef { schema: None, table: None, column, .. } if column == "*"
                 );
                 is_wildcard || is_star_ref
             });
@@ -255,7 +255,7 @@ fn check_aggregate_arg_count(expr: &Expression) -> Option<String> {
                     matches!(arg, Expression::Wildcard)
                         || matches!(
                             arg,
-                            Expression::ColumnRef { table: None, column } if column == "*"
+                            Expression::ColumnRef { schema: None, table: None, column, .. } if column == "*"
                         )
                 });
 
@@ -950,7 +950,7 @@ fn find_aliased_aggregate_misuse_in_expression(
             None
         }
         // Column reference - check if it's an aggregate alias used inside an aggregate
-        Expression::ColumnRef { table: None, column } => {
+        Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // If this column exists in the actual table schema, it's a real column reference,
             // not a reference to a SELECT alias (even if an alias with the same name exists).
             // Table columns take precedence over aliases in HAVING clause.
@@ -1277,7 +1277,7 @@ mod tests {
     fn test_valid_column_ref() {
         let schema = make_test_schema();
         let select_list = vec![SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "id".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
             alias: None, source_text: None }];
 
         let result = validate_select_columns(&select_list, None, &schema);
@@ -1288,7 +1288,7 @@ mod tests {
     fn test_invalid_column_ref() {
         let schema = make_test_schema();
         let select_list = vec![SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "invalid_column".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "invalid_column".to_string() },
             alias: None, source_text: None }];
 
         let result = validate_select_columns(&select_list, None, &schema);
@@ -1308,6 +1308,7 @@ mod tests {
         let schema = make_test_schema();
         let select_list = vec![SelectItem::Expression {
             expr: Expression::ColumnRef {
+                schema: None,
                 table: Some("products".to_string()),
                 column: "id".to_string(),
             },
@@ -1322,6 +1323,7 @@ mod tests {
         let schema = make_test_schema();
         let select_list = vec![SelectItem::Expression {
             expr: Expression::ColumnRef {
+                schema: None,
                 table: Some("products".to_string()),
                 column: "invalid_column".to_string(),
             },
@@ -1344,6 +1346,7 @@ mod tests {
             expr: Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Plus,
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "invalid_col".to_string(),
                 }),
@@ -1362,6 +1365,7 @@ mod tests {
         let where_clause = Expression::BinaryOp {
             op: vibesql_ast::BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "nonexistent".to_string(),
             }),
@@ -1378,7 +1382,7 @@ mod tests {
         let expr = Expression::AggregateFunction {
             name: "MIN".to_string(),
             distinct: false,
-            args: vec![Expression::ColumnRef { table: None, column: "*".to_string() }],
+            args: vec![Expression::ColumnRef { schema: None, table: None, column: "*".to_string() }],
             order_by: None,
         };
         let result = check_aggregate_arg_count(&expr);
@@ -1392,7 +1396,7 @@ mod tests {
         let expr = Expression::AggregateFunction {
             name: "MAX".to_string(),
             distinct: false,
-            args: vec![Expression::ColumnRef { table: None, column: "*".to_string() }],
+            args: vec![Expression::ColumnRef { schema: None, table: None, column: "*".to_string() }],
             order_by: None,
         };
         let result = check_aggregate_arg_count(&expr);
@@ -1421,7 +1425,7 @@ mod tests {
             expr: Expression::AggregateFunction {
                 name: "MIN".to_string(),
                 distinct: false,
-                args: vec![Expression::ColumnRef { table: None, column: "*".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "*".to_string() }],
                 order_by: None,
             },
             alias: None,
@@ -1464,7 +1468,7 @@ mod tests {
             expr: Expression::AggregateFunction {
                 name: "min".to_string(),
                 distinct: false,
-                args: vec![Expression::ColumnRef { table: None, column: "f1".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "f1".to_string() }],
                 order_by: None,
             },
             alias: Some("m".to_string()),
@@ -1479,7 +1483,7 @@ mod tests {
                 distinct: false,
                 args: vec![Expression::BinaryOp {
                     op: vibesql_ast::BinaryOperator::Plus,
-                    left: Box::new(Expression::ColumnRef { table: None, column: "m".to_string() }),
+                    left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "m".to_string() }),
                     right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(5))),
                 }],
                 order_by: None,
@@ -1510,7 +1514,7 @@ mod tests {
             expr: Expression::AggregateFunction {
                 name: "min".to_string(),
                 distinct: false,
-                args: vec![Expression::ColumnRef { table: None, column: "f1".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "f1".to_string() }],
                 order_by: None,
             },
             alias: Some("m".to_string()),
@@ -1520,7 +1524,7 @@ mod tests {
         // HAVING m>0 - alias used directly, not inside an aggregate
         let having_expr = Expression::BinaryOp {
             op: vibesql_ast::BinaryOperator::GreaterThan,
-            left: Box::new(Expression::ColumnRef { table: None, column: "m".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "m".to_string() }),
             right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(0))),
         };
 
@@ -1548,7 +1552,7 @@ mod tests {
 
         let having_expr = Expression::BinaryOp {
             op: vibesql_ast::BinaryOperator::GreaterThan,
-            left: Box::new(Expression::ColumnRef { table: None, column: "f1".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "f1".to_string() }),
             right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(0))),
         };
 
@@ -1563,7 +1567,7 @@ mod tests {
         // 'x' is an alias for f1, not an aggregate - should pass
         let select_list = vec![
             SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "f1".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "f1".to_string() },
                 alias: Some("x".to_string()),
                 source_text: None,
             },
@@ -1585,7 +1589,7 @@ mod tests {
             left: Box::new(Expression::AggregateFunction {
                 name: "max".to_string(),
                 distinct: false,
-                args: vec![Expression::ColumnRef { table: None, column: "x".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }],
                 order_by: None,
             }),
             right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(10))),
@@ -1607,7 +1611,7 @@ mod tests {
                 op: vibesql_ast::BinaryOperator::Multiply,
                 left: Box::new(Expression::UnaryOp {
                     op: vibesql_ast::UnaryOperator::Minus,
-                    expr: Box::new(Expression::ColumnRef { table: None, column: "col2".to_string() }),
+                    expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col2".to_string() }),
                 }),
                 right: Box::new(Expression::UnaryOp {
                     op: vibesql_ast::UnaryOperator::Minus,
@@ -1616,7 +1620,7 @@ mod tests {
                         distinct: false,
                         args: vec![Expression::UnaryOp {
                             op: vibesql_ast::UnaryOperator::Minus,
-                            expr: Box::new(Expression::ColumnRef { table: None, column: "col2".to_string() }),
+                            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col2".to_string() }),
                         }],
                         order_by: None,
                     }),
@@ -1631,7 +1635,7 @@ mod tests {
             expr: Box::new(Expression::AggregateFunction {
                 name: "AVG".to_string(),
                 distinct: false,
-                args: vec![Expression::ColumnRef { table: None, column: "col0".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }],
                 order_by: None,
             }),
             negated: false,
@@ -1677,14 +1681,14 @@ mod tests {
                 expr: Expression::AggregateFunction {
                     name: "min".to_string(),
                     distinct: false,
-                    args: vec![Expression::ColumnRef { table: None, column: "f1".to_string() }],
+                    args: vec![Expression::ColumnRef { schema: None, table: None, column: "f1".to_string() }],
                     order_by: None,
                 },
                 alias: Some("m".to_string()),
                 source_text: None,
             },
             SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "f2".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "f2".to_string() },
                 alias: Some("col2".to_string()),
                 source_text: None,
             },
@@ -1698,7 +1702,7 @@ mod tests {
                             left: Box::new(Expression::AggregateFunction {
                                 name: "min".to_string(),
                                 distinct: false,
-                                args: vec![Expression::ColumnRef { table: None, column: "f1".to_string() }],
+                                args: vec![Expression::ColumnRef { schema: None, table: None, column: "f1".to_string() }],
                                 order_by: None,
                             }),
                             right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(5))),

--- a/crates/vibesql-executor/src/select/filter/pattern.rs
+++ b/crates/vibesql-executor/src/select/filter/pattern.rs
@@ -144,7 +144,7 @@ impl PredicatePattern {
             let comp_op = ComparisonOp::from_binary_op(op)?;
 
             // Pattern: column op date_literal
-            if let Expression::ColumnRef { table, column } = left.as_ref() {
+            if let Expression::ColumnRef { table, column, .. } = left.as_ref() {
                 let col_idx = schema.get_column_index(table.as_deref(), column)?;
                 if let Expression::Literal(SqlValue::Date(date)) = right.as_ref() {
                     return Some((col_idx, comp_op, *date));
@@ -153,7 +153,7 @@ impl PredicatePattern {
 
             // Pattern: date_literal op column (need to reverse operator)
             if let Expression::Literal(SqlValue::Date(date)) = left.as_ref() {
-                if let Expression::ColumnRef { table, column } = right.as_ref() {
+                if let Expression::ColumnRef { table, column, .. } = right.as_ref() {
                     let col_idx = schema.get_column_index(table.as_deref(), column)?;
                     let reversed_op = match comp_op {
                         ComparisonOp::Lt => ComparisonOp::Gt,
@@ -179,7 +179,7 @@ impl PredicatePattern {
         schema: &CombinedSchema,
     ) -> Option<PredicatePattern> {
         // Extract column reference
-        if let Expression::ColumnRef { table, column } = expr {
+        if let Expression::ColumnRef { table, column, .. } = expr {
             let col_idx = schema.get_column_index(table.as_deref(), column)?;
 
             // Extract numeric bounds
@@ -200,7 +200,7 @@ impl PredicatePattern {
         schema: &CombinedSchema,
     ) -> Option<PredicatePattern> {
         // Extract column index
-        if let Expression::ColumnRef { table, column } = left {
+        if let Expression::ColumnRef { table, column, .. } = left {
             let col_idx = schema.get_column_index(table.as_deref(), column)?;
 
             // Try to extract integer constant FIRST (before f64)
@@ -226,7 +226,7 @@ impl PredicatePattern {
         schema: &CombinedSchema,
     ) -> Option<PredicatePattern> {
         // Extract column index from right side
-        if let Expression::ColumnRef { table, column } = right {
+        if let Expression::ColumnRef { table, column, .. } = right {
             let col_idx = schema.get_column_index(table.as_deref(), column)?;
 
             // Reverse the operator since constant is on left
@@ -338,6 +338,7 @@ mod tests {
         // Test: price < 100.0
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("lineitem".to_string()),
                 column: "price".to_string(),
             }),
@@ -364,6 +365,7 @@ mod tests {
         // Test: quantity > 10
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("lineitem".to_string()),
                 column: "quantity".to_string(),
             }),
@@ -393,6 +395,7 @@ mod tests {
 
         let left_comparison = Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("lineitem".to_string()),
                 column: "shipdate".to_string(),
             }),
@@ -402,6 +405,7 @@ mod tests {
 
         let right_comparison = Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("lineitem".to_string()),
                 column: "shipdate".to_string(),
             }),

--- a/crates/vibesql-executor/src/select/grouping/grouping_sets/alias_resolution.rs
+++ b/crates/vibesql-executor/src/select/grouping/grouping_sets/alias_resolution.rs
@@ -46,7 +46,7 @@ pub fn resolve_group_by_alias(
     }
 
     // Check if GROUP BY expression is a simple column reference (no table qualifier)
-    if let Expression::ColumnRef { table: None, column } = group_expr {
+    if let Expression::ColumnRef { schema: None, table: None, column, .. } = group_expr {
         // Search for matching alias in SELECT list (case-insensitive)
         for item in select_list {
             if let vibesql_ast::SelectItem::Expression { expr, alias: Some(alias_name) , .. } = item {
@@ -129,11 +129,11 @@ pub fn resolve_having_aliases(
 /// Check if a column name matches any GROUP BY column expression
 fn is_group_by_column(column: &str, group_by_exprs: &[Expression]) -> bool {
     for expr in group_by_exprs {
-        if let Expression::ColumnRef { table: None, column: group_col } = expr {
+        if let Expression::ColumnRef { schema: None, table: None, column: group_col } = expr {
             if group_col.eq_ignore_ascii_case(column) {
                 return true;
             }
-        } else if let Expression::ColumnRef { table: Some(_), column: group_col } = expr {
+        } else if let Expression::ColumnRef { schema: None, table: Some(_), column: group_col, .. } = expr {
             // Also match qualified column references
             if group_col.eq_ignore_ascii_case(column) {
                 return true;
@@ -150,7 +150,7 @@ fn resolve_having_aliases_inner(
 ) -> Expression {
     match having_expr {
         // Check if this column reference matches a SELECT list alias
-        Expression::ColumnRef { table: None, column } => {
+        Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // Skip alias resolution if this column is in GROUP BY
             // GROUP BY columns take precedence over SELECT aliases in HAVING
             if is_group_by_column(column, group_by_exprs) {
@@ -274,7 +274,7 @@ mod tests {
     use super::*;
 
     fn col(name: &str) -> Expression {
-        Expression::ColumnRef { table: None, column: name.to_string() }
+        Expression::ColumnRef { schema: None, table: None, column: name.to_string() }
     }
 
     fn select_item(expr: Expression, alias: Option<&str>) -> SelectItem {
@@ -302,7 +302,7 @@ mod tests {
         let resolved = resolve_group_by_alias(&group_expr, &select_list, 0).unwrap();
 
         assert!(
-            matches!(resolved, Expression::ColumnRef { table: None, column } if column == "n_name")
+            matches!(resolved, Expression::ColumnRef { schema: None, table: None, column, .. } if column == "n_name")
         );
     }
 
@@ -316,7 +316,7 @@ mod tests {
         let resolved = resolve_group_by_alias(&group_expr, &select_list, 0).unwrap();
 
         assert!(
-            matches!(resolved, Expression::ColumnRef { table: None, column } if column == "n_name")
+            matches!(resolved, Expression::ColumnRef { schema: None, table: None, column, .. } if column == "n_name")
         );
     }
 
@@ -330,7 +330,7 @@ mod tests {
         let resolved = resolve_group_by_alias(&group_expr, &select_list, 0).unwrap();
 
         assert!(
-            matches!(resolved, Expression::ColumnRef { table: None, column } if column == "n_name")
+            matches!(resolved, Expression::ColumnRef { schema: None, table: None, column, .. } if column == "n_name")
         );
 
         // GROUP BY 2 should return the second SELECT item
@@ -338,7 +338,7 @@ mod tests {
         let resolved2 = resolve_group_by_alias(&group_expr2, &select_list, 1).unwrap();
 
         assert!(
-            matches!(resolved2, Expression::ColumnRef { table: None, column } if column == "amount")
+            matches!(resolved2, Expression::ColumnRef { schema: None, table: None, column, .. } if column == "amount")
         );
     }
 
@@ -368,7 +368,7 @@ mod tests {
         let resolved = resolve_group_by_alias(&group_expr, &select_list, 0).unwrap();
 
         assert!(
-            matches!(resolved, Expression::ColumnRef { table: None, column } if column == "something_else")
+            matches!(resolved, Expression::ColumnRef { schema: None, table: None, column, .. } if column == "something_else")
         );
     }
 
@@ -379,12 +379,12 @@ mod tests {
 
         // GROUP BY t.nation should NOT resolve to n_name (it's table-qualified)
         let group_expr =
-            Expression::ColumnRef { table: Some("t".to_string()), column: "nation".to_string() };
+            Expression::ColumnRef { schema: None, table: Some("t".to_string()), column: "nation".to_string() };
         let resolved = resolve_group_by_alias(&group_expr, &select_list, 0).unwrap();
 
         // Should remain unchanged
         assert!(
-            matches!(resolved, Expression::ColumnRef { table: Some(t), column } if t == "t" && column == "nation")
+            matches!(resolved, Expression::ColumnRef { schema: None, table: Some(t), column } if t == "t" && column == "nation")
         );
     }
 
@@ -428,10 +428,10 @@ mod tests {
         // Both should resolve to the actual column names
         assert_eq!(resolved_set.group_by_exprs.len(), 2);
         assert!(
-            matches!(&resolved_set.group_by_exprs[0], Expression::ColumnRef { table: None, column } if column == "n1_n_name")
+            matches!(&resolved_set.group_by_exprs[0], Expression::ColumnRef { schema: None, table: None, column, .. } if column == "n1_n_name")
         );
         assert!(
-            matches!(&resolved_set.group_by_exprs[1], Expression::ColumnRef { table: None, column } if column == "n2_n_name")
+            matches!(&resolved_set.group_by_exprs[1], Expression::ColumnRef { schema: None, table: None, column, .. } if column == "n2_n_name")
         );
         // rolled_up should be preserved
         assert_eq!(resolved_set.rolled_up, vec![false, false]);
@@ -447,10 +447,10 @@ mod tests {
 
         assert_eq!(resolved.len(), 2);
         assert!(
-            matches!(&resolved[0], Expression::ColumnRef { table: None, column } if column == "a_col")
+            matches!(&resolved[0], Expression::ColumnRef { schema: None, table: None, column, .. } if column == "a_col")
         );
         assert!(
-            matches!(&resolved[1], Expression::ColumnRef { table: None, column } if column == "b_col")
+            matches!(&resolved[1], Expression::ColumnRef { schema: None, table: None, column, .. } if column == "b_col")
         );
     }
 }

--- a/crates/vibesql-executor/src/select/grouping/grouping_sets/expansion.rs
+++ b/crates/vibesql-executor/src/select/grouping/grouping_sets/expansion.rs
@@ -272,7 +272,7 @@ mod tests {
     use super::*;
 
     fn col(name: &str) -> Expression {
-        Expression::ColumnRef { table: None, column: name.to_string() }
+        Expression::ColumnRef { schema: None, table: None, column: name.to_string() }
     }
 
     #[test]

--- a/crates/vibesql-executor/src/select/grouping/grouping_sets/expression_utils.rs
+++ b/crates/vibesql-executor/src/select/grouping/grouping_sets/expression_utils.rs
@@ -11,8 +11,8 @@ pub fn expressions_equal(a: &Expression, b: &Expression) -> bool {
     match (a, b) {
         // ColumnRef: case-insensitive comparison for identifiers
         (
-            Expression::ColumnRef { table: t1, column: c1 },
-            Expression::ColumnRef { table: t2, column: c2 },
+            Expression::ColumnRef { schema: None, table: t1, column: c1, .. },
+            Expression::ColumnRef { schema: None, table: t2, column: c2, .. },
         ) => {
             let columns_equal = c1.eq_ignore_ascii_case(c2);
             let tables_equal = match (t1, t2) {
@@ -287,11 +287,11 @@ mod tests {
     use super::*;
 
     fn col(name: &str) -> Expression {
-        Expression::ColumnRef { table: None, column: name.to_string() }
+        Expression::ColumnRef { schema: None, table: None, column: name.to_string() }
     }
 
     fn qualified_col(table: &str, column: &str) -> Expression {
-        Expression::ColumnRef { table: Some(table.to_string()), column: column.to_string() }
+        Expression::ColumnRef { schema: None, table: Some(table.to_string()), column: column.to_string() }
     }
 
     fn lit_int(n: i64) -> Expression {

--- a/crates/vibesql-executor/src/select/grouping/grouping_sets/mod.rs
+++ b/crates/vibesql-executor/src/select/grouping/grouping_sets/mod.rs
@@ -88,7 +88,7 @@ mod tests {
     use super::*;
 
     fn col(name: &str) -> Expression {
-        Expression::ColumnRef { table: None, column: name.to_string() }
+        Expression::ColumnRef { schema: None, table: None, column: name.to_string() }
     }
 
     fn lit_int(n: i64) -> Expression {

--- a/crates/vibesql-executor/src/select/grouping/parallel_sink.rs
+++ b/crates/vibesql-executor/src/select/grouping/parallel_sink.rs
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     fn test_aggregate_info_creation() {
-        let expr = vibesql_ast::Expression::ColumnRef { table: None, column: "col1".to_string() };
+        let expr = vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() };
         let info = AggregateInfo::new("SUM".to_string(), expr, false);
         assert_eq!(info.function_name, "SUM");
         assert!(!info.distinct);

--- a/crates/vibesql-executor/src/select/iterator/filter.rs
+++ b/crates/vibesql-executor/src/select/iterator/filter.rs
@@ -22,7 +22,7 @@ use crate::{
 /// ```text
 /// let scan = TableScanIterator::new(schema.clone(), rows);
 /// let predicate = Expression::Binary {
-///     left: Box::new(Expression::ColumnRef { column: "age".to_string() }),
+///     left: Box::new(Expression::ColumnRef { schema: None, column: "age".to_string() }),
 ///     op: BinaryOp::GreaterThan,
 ///     right: Box::new(Expression::Literal(SqlValue::Integer(18))),
 /// };

--- a/crates/vibesql-executor/src/select/iterator/tests/basic.rs
+++ b/crates/vibesql-executor/src/select/iterator/tests/basic.rs
@@ -146,6 +146,7 @@ fn test_evaluator_direct() {
 
     let predicate = vibesql_ast::Expression::BinaryOp {
         left: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "age".to_string(),
         }),
@@ -208,6 +209,7 @@ fn test_filter_with_column_ref() {
     // Predicate: age > 18 (using unqualified column reference)
     let predicate = vibesql_ast::Expression::BinaryOp {
         left: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: None, // Try without table qualifier
             column: "age".to_string(),
         }),

--- a/crates/vibesql-executor/src/select/iterator/tests/join.rs
+++ b/crates/vibesql-executor/src/select/iterator/tests/join.rs
@@ -72,11 +72,13 @@ fn test_lazy_nested_loop_join_inner_with_condition() {
     // Condition: t1.id = t2.id (column 0 = column 2)
     let condition = vibesql_ast::Expression::BinaryOp {
         left: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("t1".to_string()),
             column: "id".to_string(),
         }),
         op: vibesql_ast::BinaryOperator::Equal,
         right: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("t2".to_string()),
             column: "id".to_string(),
         }),
@@ -133,11 +135,13 @@ fn test_lazy_nested_loop_join_left_outer() {
     // Condition: t1.id = t2.id
     let condition = vibesql_ast::Expression::BinaryOp {
         left: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("t1".to_string()),
             column: "id".to_string(),
         }),
         op: vibesql_ast::BinaryOperator::Equal,
         right: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("t2".to_string()),
             column: "id".to_string(),
         }),

--- a/crates/vibesql-executor/src/select/iterator/tests/phase_c.rs
+++ b/crates/vibesql-executor/src/select/iterator/tests/phase_c.rs
@@ -72,6 +72,7 @@ fn test_phase_c_proof_of_concept_full_pipeline() {
     // Stage 2: WHERE age > 18
     let where_expr = vibesql_ast::Expression::BinaryOp {
         left: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("users".to_string()),
             column: "age".to_string(),
         }),
@@ -178,11 +179,13 @@ fn test_phase_c_proof_of_concept_join_pipeline() {
     // Stage 2: JOIN customers ON orders.customer_id = customers.id
     let join_condition = vibesql_ast::Expression::BinaryOp {
         left: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("orders".to_string()),
             column: "customer_id".to_string(),
         }),
         op: vibesql_ast::BinaryOperator::Equal,
         right: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("customers".to_string()),
             column: "id".to_string(),
         }),
@@ -215,6 +218,7 @@ fn test_phase_c_proof_of_concept_join_pipeline() {
 
     let where_expr = vibesql_ast::Expression::BinaryOp {
         left: Box::new(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: Some("orders".to_string()),
             column: "amount".to_string(),
         }),

--- a/crates/vibesql-executor/src/select/join/expression_mapper.rs
+++ b/crates/vibesql-executor/src/select/join/expression_mapper.rs
@@ -143,7 +143,7 @@ impl ExpressionMapper {
         resolvable: &mut bool,
     ) {
         match expr {
-            Expression::ColumnRef { table, column } => {
+            Expression::ColumnRef { table, column, .. } => {
                 let column_lower = column.to_lowercase();
                 if let Some(t) = table {
                     let table_lower = t.to_lowercase();

--- a/crates/vibesql-executor/src/select/join/join_analyzer.rs
+++ b/crates/vibesql-executor/src/select/join/join_analyzer.rs
@@ -254,7 +254,7 @@ fn flatten_and_conditions<'a>(expr: &'a Expression, out: &mut Vec<&'a Expression
 /// Extract column index from an expression if it's a simple column reference
 fn extract_column_index(expr: &Expression, schema: &CombinedSchema) -> Option<usize> {
     match expr {
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             // Resolve column to index in combined schema
             schema.get_column_index(table.as_deref(), column)
         }

--- a/crates/vibesql-executor/src/select/join/nested_loop.rs
+++ b/crates/vibesql-executor/src/select/join/nested_loop.rs
@@ -1200,11 +1200,13 @@ mod tests {
         // Condition: users.id = orders.user_id (column 0 = column 2 in combined row)
         let condition = vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("users".to_string()),
                 column: "id".to_string(),
             }),
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("orders".to_string()),
                 column: "user_id".to_string(),
             }),
@@ -1348,11 +1350,13 @@ mod tests {
             // Condition: users.id = orders.user_id
             let condition = vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("users".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("orders".to_string()),
                     column: "user_id".to_string(),
                 }),
@@ -1459,11 +1463,13 @@ mod tests {
             // Condition: left.a = right.b (no matches since ranges don't overlap)
             let condition = vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("left".to_string()),
                     column: "a".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("right".to_string()),
                     column: "b".to_string(),
                 }),
@@ -1516,11 +1522,13 @@ mod tests {
             // Condition: left.id = right.id
             let condition = vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("left".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("right".to_string()),
                     column: "id".to_string(),
                 }),
@@ -1588,11 +1596,13 @@ mod tests {
             // Condition: left.key = right.key
             let condition = vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("left".to_string()),
                     column: "key".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("right".to_string()),
                     column: "key".to_string(),
                 }),

--- a/crates/vibesql-executor/src/select/join/reorder.rs
+++ b/crates/vibesql-executor/src/select/join/reorder.rs
@@ -350,7 +350,7 @@ impl JoinOrderAnalyzer {
         tables: &HashSet<String>,
     ) -> (Option<String>, Option<String>) {
         match expr {
-            Expression::ColumnRef { table, column } => {
+            Expression::ColumnRef { table, column, .. } => {
                 // If explicit table prefix exists, use it
                 if let Some(t) = table {
                     return (Some(t.clone()), Some(column.clone()));

--- a/crates/vibesql-executor/src/select/join/tests/expression_mapper_tests.rs
+++ b/crates/vibesql-executor/src/select/join/tests/expression_mapper_tests.rs
@@ -114,7 +114,7 @@ fn test_expression_analysis_single_table() {
     mapper.add_table("users", &schema);
 
     // Single column reference
-    let expr = Expression::ColumnRef { table: Some("users".to_string()), column: "id".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: Some("users".to_string()), column: "id".to_string() };
 
     let analysis = mapper.analyze_expression(&expr);
     assert!(analysis.all_resolvable);
@@ -132,10 +132,12 @@ fn test_expression_analysis_two_tables() {
     let expr = Expression::BinaryOp {
         op: vibesql_ast::BinaryOperator::Equal,
         left: Box::new(Expression::ColumnRef {
+            schema: None,
             table: Some("users".to_string()),
             column: "id".to_string(),
         }),
         right: Box::new(Expression::ColumnRef {
+            schema: None,
             table: Some("orders".to_string()),
             column: "user_id".to_string(),
         }),
@@ -152,7 +154,7 @@ fn test_expression_analysis_unresolvable() {
     let mapper = ExpressionMapper::new();
 
     // Try to reference non-existent column
-    let expr = Expression::ColumnRef { table: Some("users".to_string()), column: "id".to_string() };
+    let expr = Expression::ColumnRef { schema: None, table: Some("users".to_string()), column: "id".to_string() };
 
     let analysis = mapper.analyze_expression(&expr);
     assert!(!analysis.all_resolvable);
@@ -168,10 +170,12 @@ fn test_expression_refs_only_tables() {
     let expr = Expression::BinaryOp {
         op: vibesql_ast::BinaryOperator::Equal,
         left: Box::new(Expression::ColumnRef {
+            schema: None,
             table: Some("users".to_string()),
             column: "id".to_string(),
         }),
         right: Box::new(Expression::ColumnRef {
+            schema: None,
             table: Some("orders".to_string()),
             column: "user_id".to_string(),
         }),

--- a/crates/vibesql-executor/src/select/order.rs
+++ b/crates/vibesql-executor/src/select/order.rs
@@ -388,7 +388,7 @@ pub(crate) fn resolve_order_by_for_aggregates(
         ColumnPositionResult::Position(pos) => {
             let idx = validate_column_position(pos, column_count, term_index)?;
             if let Some(col_name) = resolve_position_to_column_name(idx, select_list) {
-                return Ok(vibesql_ast::Expression::ColumnRef { table: None, column: col_name });
+                return Ok(vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: col_name });
             }
         }
         ColumnPositionResult::Negative(pos) => {
@@ -432,7 +432,7 @@ fn resolve_order_by_for_aggregates_inner(
                 } else {
                     format!("col{}", idx + 1)
                 };
-                return vibesql_ast::Expression::ColumnRef { table: None, column: col_name };
+                return vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: col_name };
             }
         }
         // If not a valid column position, just return the literal as-is
@@ -440,13 +440,14 @@ fn resolve_order_by_for_aggregates_inner(
     }
 
     // Check if ORDER BY expression is a simple column reference (no table qualifier)
-    if let vibesql_ast::Expression::ColumnRef { table: None, column } = order_expr {
+    if let vibesql_ast::Expression::ColumnRef { schema: None, table: None, column, .. } = order_expr {
         // First, check if column matches an alias name - return ColumnRef to that alias
         for item in select_list {
             if let vibesql_ast::SelectItem::Expression { alias: Some(alias_name), .. } = item {
                 if alias_name.eq_ignore_ascii_case(column) {
                     // ORDER BY uses alias name, return ColumnRef to that alias
                     return vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: alias_name.clone(),
                     };
@@ -457,7 +458,7 @@ fn resolve_order_by_for_aggregates_inner(
         // Second, check if column matches an original column name that has an alias
         for item in select_list {
             if let vibesql_ast::SelectItem::Expression {
-                expr: vibesql_ast::Expression::ColumnRef { column: select_col, .. },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, column: select_col, .. },
                 alias: Some(alias_name),
                 ..
             } = item
@@ -465,6 +466,7 @@ fn resolve_order_by_for_aggregates_inner(
                 if select_col.eq_ignore_ascii_case(column) {
                     // ORDER BY uses original column name, return ColumnRef to the alias
                     return vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: alias_name.clone(),
                     };
@@ -475,7 +477,7 @@ fn resolve_order_by_for_aggregates_inner(
         // Third, check if column matches a SELECT list column without alias
         for item in select_list {
             if let vibesql_ast::SelectItem::Expression {
-                expr: vibesql_ast::Expression::ColumnRef { column: select_col, .. },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, column: select_col, .. },
                 alias: None,
                 ..
             } = item
@@ -492,7 +494,7 @@ fn resolve_order_by_for_aggregates_inner(
     // This handles cases like GROUPING(a) + GROUPING(b) matching an alias like "lochierarchy"
     // before we try to recursively decompose the expression
     if let Some(alias) = find_matching_select_expression(order_expr, select_list) {
-        return vibesql_ast::Expression::ColumnRef { table: None, column: alias };
+        return vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: alias };
     }
 
     // Handle CASE expressions by recursively resolving sub-expressions
@@ -545,7 +547,7 @@ fn resolve_order_by_for_aggregates_inner(
         if name.eq_ignore_ascii_case("GROUPING") || name.eq_ignore_ascii_case("GROUPING_ID") {
             // Try to find a matching GROUPING expression in the SELECT list
             if let Some(alias) = find_matching_select_expression(order_expr, select_list) {
-                return vibesql_ast::Expression::ColumnRef { table: None, column: alias };
+                return vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: alias };
             }
         }
     }
@@ -587,8 +589,8 @@ fn find_matching_select_expression(
 fn expressions_equal(a: &vibesql_ast::Expression, b: &vibesql_ast::Expression) -> bool {
     match (a, b) {
         (
-            vibesql_ast::Expression::ColumnRef { table: t1, column: c1 },
-            vibesql_ast::Expression::ColumnRef { table: t2, column: c2 },
+            vibesql_ast::Expression::ColumnRef { schema: None, table: t1, column: c1, .. },
+            vibesql_ast::Expression::ColumnRef { schema: None, table: t2, column: c2, .. },
         ) => t1 == t2 && c1.eq_ignore_ascii_case(c2),
 
         (vibesql_ast::Expression::Literal(v1), vibesql_ast::Expression::Literal(v2)) => v1 == v2,
@@ -653,6 +655,7 @@ pub(crate) fn resolve_order_by_alias<'a>(
                 }
                 ResolvedPosition::ColumnName(col_name) => {
                     return Ok(Cow::Owned(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: col_name,
                     }));
@@ -676,7 +679,7 @@ pub(crate) fn resolve_order_by_alias<'a>(
     }
 
     // Check if ORDER BY expression is a simple column reference (no table qualifier)
-    if let vibesql_ast::Expression::ColumnRef { table: None, column } = order_expr {
+    if let vibesql_ast::Expression::ColumnRef { schema: None, table: None, column, .. } = order_expr {
         // First, search for matching alias in SELECT list (ORDER BY using alias name)
         for item in select_list {
             if let vibesql_ast::SelectItem::Expression { expr, alias: Some(alias_name) , .. } = item {
@@ -693,7 +696,7 @@ pub(crate) fn resolve_order_by_alias<'a>(
         for item in select_list {
             // Check if the SELECT expression is a column reference to the same column
             if let vibesql_ast::SelectItem::Expression {
-                expr: vibesql_ast::Expression::ColumnRef { column: select_col, .. },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, column: select_col, .. },
                 alias: Some(alias_name),
                 ..
             } = item
@@ -702,6 +705,7 @@ pub(crate) fn resolve_order_by_alias<'a>(
                     // The ORDER BY column matches the original column, but it's aliased
                     // Return a new ColumnRef using the alias name
                     return Ok(Cow::Owned(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: alias_name.clone(),
                     }));
@@ -862,7 +866,7 @@ fn resolve_alias_or_clone(
     select_list: &[vibesql_ast::SelectItem],
 ) -> Option<vibesql_ast::Expression> {
     // Check if this is a simple column reference that matches an alias
-    if let vibesql_ast::Expression::ColumnRef { table: None, column } = expr {
+    if let vibesql_ast::Expression::ColumnRef { schema: None, table: None, column, .. } = expr {
         // Search for matching alias in SELECT list
         for item in select_list {
             if let vibesql_ast::SelectItem::Expression { expr: select_expr, alias: Some(alias_name), .. } =
@@ -939,7 +943,7 @@ fn resolve_where_expression_with_schema(
 
     match expr {
         // Column reference: check if it's an alias
-        Expression::ColumnRef { table: None, column } => {
+        Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // SQLite behavior: table column names ALWAYS take precedence over aliases
             // If the column name exists in the table schema, it refers to the table column,
             // not to any SELECT alias with the same name.
@@ -957,7 +961,7 @@ fn resolve_where_expression_with_schema(
             // (this is for backward compatibility when no schema is provided)
             for item in select_list {
                 if let vibesql_ast::SelectItem::Expression {
-                    expr: Expression::ColumnRef { table: None, column: col_name },
+                    expr: Expression::ColumnRef { schema: None, table: None, column: col_name },
                     ..
                 } = item
                 {
@@ -968,7 +972,7 @@ fn resolve_where_expression_with_schema(
                 }
                 // Also check qualified column references
                 if let vibesql_ast::SelectItem::Expression {
-                    expr: Expression::ColumnRef { table: Some(_), column: col_name },
+                    expr: Expression::ColumnRef { schema: None, table: Some(_), column: col_name, .. },
                     ..
                 } = item
                 {
@@ -998,7 +1002,10 @@ fn resolve_where_expression_with_schema(
         }
 
         // Qualified column reference: not an alias, return as-is
-        Expression::ColumnRef { table: Some(_), .. } => expr.clone(),
+        Expression::ColumnRef { schema: None, table: Some(_), .. } => expr.clone(),
+
+        // Schema-qualified column reference: not an alias, return as-is
+        Expression::ColumnRef { schema: Some(_), .. } => expr.clone(),
 
         // BinaryOp: resolve both sides
         Expression::BinaryOp { left, op, right } => Expression::BinaryOp {

--- a/crates/vibesql-executor/src/select/projection_simd.rs
+++ b/crates/vibesql-executor/src/select/projection_simd.rs
@@ -64,7 +64,7 @@ fn extract_simple_column_indices(
         match item {
             // Simple column reference: expr is ColumnRef
             SelectItem::Expression { expr, alias: _ , .. } => {
-                if let Expression::ColumnRef { table, column } = expr {
+                if let Expression::ColumnRef { table, column, .. } = expr {
                     // Resolve column index from schema
                     if let Some(idx) = resolve_column_index(table.as_deref(), column, schema) {
                         indices.push(idx);
@@ -229,7 +229,7 @@ mod tests {
             .collect();
 
         let columns = vec![SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "a".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "a".to_string() },
             alias: None, source_text: None }];
 
         let evaluator = create_test_evaluator();
@@ -252,7 +252,7 @@ mod tests {
 
         // SELECT b FROM test (just column b)
         let columns = vec![SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "b".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "b".to_string() },
             alias: None, source_text: None }];
 
         let evaluator = create_test_evaluator();
@@ -285,10 +285,10 @@ mod tests {
 
         let columns = vec![
             SelectItem::Expression {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "b".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "b".to_string() },
                 alias: None, source_text: None },
             SelectItem::Expression {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "a".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "a".to_string() },
                 alias: None, source_text: None },
         ];
 

--- a/crates/vibesql-executor/src/select/scan/bloom_context.rs
+++ b/crates/vibesql-executor/src/select/scan/bloom_context.rs
@@ -151,10 +151,10 @@ fn extract_column_table_and_name(
     use vibesql_ast::Expression;
 
     match expr {
-        Expression::ColumnRef { table: Some(t), column, .. } => {
+        Expression::ColumnRef { schema: None, table: Some(t), column, .. } => {
             Some((t.to_lowercase(), column.to_lowercase()))
         }
-        Expression::ColumnRef { table: None, column, .. } => {
+        Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // Try to resolve unqualified column using schema-based mapping
             let col_lower = column.to_lowercase();
             column_to_table.get(&col_lower).map(|t| (t.to_lowercase(), col_lower))

--- a/crates/vibesql-executor/src/select/scan/derived.rs
+++ b/crates/vibesql-executor/src/select/scan/derived.rs
@@ -8,7 +8,7 @@ use crate::{errors::ExecutorError, schema::CombinedSchema, select::SelectResult}
 /// Derive a column name from an expression (simplified version from columns.rs)
 fn derive_column_name_from_expr(expr: &vibesql_ast::Expression) -> String {
     match expr {
-        vibesql_ast::Expression::ColumnRef { table: _, column } => column.clone(),
+        vibesql_ast::Expression::ColumnRef { column, .. } => column.clone(),
         vibesql_ast::Expression::Function { name, args, character_unit: _ } => {
             let args_str = if args.is_empty() {
                 "*".to_string()

--- a/crates/vibesql-executor/src/select/scan/index_scan/predicate_tests.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/predicate_tests.rs
@@ -9,7 +9,7 @@ use super::*;
 fn test_extract_range_predicate_greater_than() {
     let expr = Expression::BinaryOp {
         op: BinaryOperator::GreaterThan,
-        left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
         right: Box::new(Expression::Literal(SqlValue::Integer(60))),
     };
 
@@ -23,7 +23,7 @@ fn test_extract_range_predicate_greater_than() {
 fn test_extract_range_predicate_less_than_or_equal() {
     let expr = Expression::BinaryOp {
         op: BinaryOperator::LessThanOrEqual,
-        left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
         right: Box::new(Expression::Literal(SqlValue::Integer(43))),
     };
 
@@ -36,7 +36,7 @@ fn test_extract_range_predicate_less_than_or_equal() {
 #[test]
 fn test_extract_range_predicate_between() {
     let expr = Expression::Between {
-        expr: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+        expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
         low: Box::new(Expression::Literal(SqlValue::Integer(10))),
         high: Box::new(Expression::Literal(SqlValue::Integer(20))),
         negated: false,
@@ -57,12 +57,12 @@ fn test_extract_range_predicate_combined_and() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::GreaterThan,
-            left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(10))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::LessThan,
-            left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(20))),
         }),
     };
@@ -80,7 +80,7 @@ fn test_extract_range_predicate_flipped_comparison() {
     let expr = Expression::BinaryOp {
         op: BinaryOperator::LessThan,
         left: Box::new(Expression::Literal(SqlValue::Integer(60))),
-        right: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+        right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
     };
 
     let range = extract_range_predicate(&expr, "col0").unwrap();
@@ -94,7 +94,7 @@ fn test_where_clause_fully_satisfied_simple_equal() {
     // col0 = 5
     let expr = Expression::BinaryOp {
         op: BinaryOperator::Equal,
-        left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
         right: Box::new(Expression::Literal(SqlValue::Integer(5))),
     };
 
@@ -105,7 +105,7 @@ fn test_where_clause_fully_satisfied_simple_equal() {
 fn test_where_clause_fully_satisfied_between() {
     // col0 BETWEEN 10 AND 20
     let expr = Expression::Between {
-        expr: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+        expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
         low: Box::new(Expression::Literal(SqlValue::Integer(10))),
         high: Box::new(Expression::Literal(SqlValue::Integer(20))),
         negated: false,
@@ -119,7 +119,7 @@ fn test_where_clause_fully_satisfied_between() {
 fn test_where_clause_fully_satisfied_in_list() {
     // col0 IN (1, 2, 3)
     let expr = Expression::InList {
-        expr: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+        expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
         values: vec![
             Expression::Literal(SqlValue::Integer(1)),
             Expression::Literal(SqlValue::Integer(2)),
@@ -138,12 +138,12 @@ fn test_where_clause_fully_satisfied_combined_range() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::GreaterThan,
-            left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(10))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::LessThan,
-            left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(20))),
         }),
     };
@@ -158,12 +158,12 @@ fn test_where_clause_not_fully_satisfied_multiple_columns() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(5))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "col1".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col1".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(10))),
         }),
     };
@@ -178,12 +178,12 @@ fn test_where_clause_not_fully_satisfied_or() {
         op: BinaryOperator::Or,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(5))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "col0".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col0".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(10))),
         }),
     };
@@ -202,18 +202,18 @@ fn test_extract_composite_predicates_full_match() {
             op: BinaryOperator::And,
             left: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
             right: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(2))),
             }),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(3))),
         }),
     };
@@ -236,12 +236,12 @@ fn test_extract_composite_predicates_partial_match() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         }),
     };
@@ -260,12 +260,12 @@ fn test_extract_composite_predicates_case_insensitive() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "C_W_ID".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "C_W_ID".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "C_D_ID".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "C_D_ID".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         }),
     };
@@ -287,14 +287,14 @@ fn test_extract_composite_predicates_with_string_values() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "department".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "department".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                 "Engineering",
             )))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "name".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "name".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice")))),
         }),
     };
@@ -313,7 +313,7 @@ fn test_extract_composite_predicates_with_string_values() {
 fn test_extract_composite_predicates_empty_columns() {
     let expr = Expression::BinaryOp {
         op: BinaryOperator::Equal,
-        left: Box::new(Expression::ColumnRef { table: None, column: "col".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "col".to_string() }),
         right: Box::new(Expression::Literal(SqlValue::Integer(1))),
     };
 
@@ -339,18 +339,18 @@ fn test_extract_prefix_predicates_partial_match() {
             op: BinaryOperator::And,
             left: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
             right: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(2))),
             }),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::GreaterThan,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_balance".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_balance".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(100))),
         }),
     };
@@ -377,12 +377,12 @@ fn test_extract_prefix_predicates_single_column() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::GreaterThan,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_balance".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_balance".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(100))),
         }),
     };
@@ -406,12 +406,12 @@ fn test_extract_prefix_predicates_gap_in_columns() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(3))),
         }),
     };
@@ -432,7 +432,7 @@ fn test_extract_prefix_predicates_no_first_column() {
     // Expected: None (can't use prefix without first column)
     let expr = Expression::BinaryOp {
         op: BinaryOperator::Equal,
-        left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
         right: Box::new(Expression::Literal(SqlValue::Integer(2))),
     };
 
@@ -453,18 +453,18 @@ fn test_extract_prefix_predicates_full_match() {
             op: BinaryOperator::And,
             left: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
             right: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(2))),
             }),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(3))),
         }),
     };
@@ -492,18 +492,18 @@ fn test_build_residual_where_clause_partial_covered() {
             op: BinaryOperator::And,
             left: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
             right: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(2))),
             }),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::GreaterThan,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_balance".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_balance".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(100))),
         }),
     };
@@ -542,12 +542,12 @@ fn test_build_residual_where_clause_all_covered() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         }),
     };
@@ -570,12 +570,12 @@ fn test_build_residual_where_clause_none_covered() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::GreaterThan,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_balance".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_balance".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(100))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_credit".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_credit".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("BC")))),
         }),
     };
@@ -598,12 +598,13 @@ fn test_build_residual_where_clause_multiple_uncovered() {
             op: BinaryOperator::And,
             left: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
             right: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::GreaterThan,
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "c_balance".to_string(),
                 }),
@@ -612,7 +613,7 @@ fn test_build_residual_where_clause_multiple_uncovered() {
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_credit".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_credit".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("BC")))),
         }),
     };
@@ -637,7 +638,7 @@ fn test_extract_composite_predicates_with_in_basic() {
     let expr = Expression::BinaryOp {
         op: BinaryOperator::And,
         left: Box::new(Expression::InList {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
             values: vec![
                 Expression::Literal(SqlValue::Integer(1)),
                 Expression::Literal(SqlValue::Integer(2)),
@@ -647,7 +648,7 @@ fn test_extract_composite_predicates_with_in_basic() {
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(5))),
         }),
     };
@@ -686,11 +687,11 @@ fn test_extract_composite_predicates_with_in_reversed() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(5))),
         }),
         right: Box::new(Expression::InList {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
             values: vec![
                 Expression::Literal(SqlValue::Integer(1)),
                 Expression::Literal(SqlValue::Integer(2)),
@@ -798,12 +799,12 @@ fn test_where_clause_satisfied_by_composite_key_equality_only() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         }),
     };
@@ -818,7 +819,7 @@ fn test_where_clause_satisfied_by_composite_key_with_in() {
     let expr = Expression::BinaryOp {
         op: BinaryOperator::And,
         left: Box::new(Expression::InList {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
             values: vec![
                 Expression::Literal(SqlValue::Integer(1)),
                 Expression::Literal(SqlValue::Integer(2)),
@@ -828,7 +829,7 @@ fn test_where_clause_satisfied_by_composite_key_with_in() {
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(5))),
         }),
     };
@@ -846,18 +847,18 @@ fn test_where_clause_not_satisfied_extra_predicate() {
             op: BinaryOperator::And,
             left: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
             right: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(2))),
             }),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "extra_col".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "extra_col".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(3))),
         }),
     };
@@ -873,7 +874,7 @@ fn test_where_clause_not_satisfied_negated_in() {
     let expr = Expression::BinaryOp {
         op: BinaryOperator::And,
         left: Box::new(Expression::InList {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
             values: vec![
                 Expression::Literal(SqlValue::Integer(1)),
                 Expression::Literal(SqlValue::Integer(2)),
@@ -883,7 +884,7 @@ fn test_where_clause_not_satisfied_negated_in() {
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(5))),
         }),
     };
@@ -904,18 +905,18 @@ fn test_composite_key_satisfaction_full_match() {
             op: BinaryOperator::And,
             left: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
             right: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(2))),
             }),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(3))),
         }),
     };
@@ -932,12 +933,12 @@ fn test_composite_key_satisfaction_missing_predicate() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         }),
     };
@@ -954,12 +955,12 @@ fn test_composite_key_satisfaction_range_predicate() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::GreaterThan,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         }),
     };
@@ -976,12 +977,12 @@ fn test_composite_key_satisfaction_or_predicate() {
         op: BinaryOperator::Or,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_w_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_w_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "c_d_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_d_id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         }),
     };
@@ -995,7 +996,7 @@ fn test_composite_key_satisfaction_single_column() {
     // WHERE c_id = 42 with index [c_id]
     let expr = Expression::BinaryOp {
         op: BinaryOperator::Equal,
-        left: Box::new(Expression::ColumnRef { table: None, column: "c_id".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_id".to_string() }),
         right: Box::new(Expression::Literal(SqlValue::Integer(42))),
     };
 
@@ -1010,12 +1011,12 @@ fn test_composite_key_satisfaction_case_insensitive() {
         op: BinaryOperator::And,
         left: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "C_W_ID".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "C_W_ID".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         }),
         right: Box::new(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "C_D_ID".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "C_D_ID".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         }),
     };
@@ -1029,7 +1030,7 @@ fn test_composite_key_satisfaction_null_value() {
     // WHERE c_id = NULL should NOT be satisfied (NULL comparisons need special handling)
     let expr = Expression::BinaryOp {
         op: BinaryOperator::Equal,
-        left: Box::new(Expression::ColumnRef { table: None, column: "c_id".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c_id".to_string() }),
         right: Box::new(Expression::Literal(SqlValue::Null)),
     };
 

--- a/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
@@ -328,7 +328,7 @@ pub(crate) fn can_use_index_for_order_by_with_pinned(
     for (order_item, index_col) in order_items.iter().zip(remaining_index_columns.iter()) {
         // ORDER BY expression must be a simple column reference
         let order_col_name = match &order_item.expr {
-            Expression::ColumnRef { table: None, column } => column,
+            Expression::ColumnRef { schema: None, table: None, column, .. } => column,
             _ => return false, // Complex expressions not supported
         };
 
@@ -843,7 +843,7 @@ mod tests {
     fn test_expression_filters_column_simple() {
         let expr = Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "age".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "age".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(25))),
         };
 
@@ -857,12 +857,12 @@ mod tests {
             op: BinaryOperator::And,
             left: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::GreaterThan,
-                left: Box::new(Expression::ColumnRef { table: None, column: "age".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "age".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Integer(18))),
             }),
             right: Box::new(Expression::BinaryOp {
                 op: BinaryOperator::Equal,
-                left: Box::new(Expression::ColumnRef { table: None, column: "city".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "city".to_string() }),
                 right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "Boston",
                 )))),
@@ -876,7 +876,7 @@ mod tests {
 
     #[test]
     fn test_is_column_reference() {
-        let expr = Expression::ColumnRef { table: None, column: "age".to_string() };
+        let expr = Expression::ColumnRef { schema: None, table: None, column: "age".to_string() };
 
         assert!(is_column_reference(&expr, "age"));
         assert!(!is_column_reference(&expr, "name"));
@@ -887,6 +887,7 @@ mod tests {
         // SQL parser normalizes unquoted identifiers to uppercase
         // but index columns might be lowercase
         let expr = Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "I_ID".to_string(), // Uppercase from parser
         };
@@ -903,7 +904,7 @@ mod tests {
         // WHERE I_ID = 42 (uppercase from parser)
         let expr = Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "I_ID".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "I_ID".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(42))),
         };
 

--- a/crates/vibesql-executor/src/select/scan/join_scan.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan.rs
@@ -394,11 +394,13 @@ fn generate_natural_join_condition(
     for (left_table, left_col, right_table, right_col) in common_columns {
         let equality = vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some(left_table),
                 column: left_col,
             }),
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some(right_table),
                 column: right_col,
             }),
@@ -589,11 +591,11 @@ fn predicate_references_only_tables(
     table_set: &HashSet<String>,
 ) -> bool {
     match expr {
-        vibesql_ast::Expression::ColumnRef { table: Some(t), .. } => {
+        vibesql_ast::Expression::ColumnRef { schema: None, table: Some(t), .. } => {
             let t_lower = t.to_lowercase();
             table_set.contains(t) || table_set.contains(&t_lower)
         }
-        vibesql_ast::Expression::ColumnRef { table: None, .. } => {
+        vibesql_ast::Expression::ColumnRef { schema: None, table: None, .. } => {
             // Unqualified column - can't determine which table, assume it might be from nullable
             // side Return false to be conservative (keep the predicate)
             false
@@ -918,8 +920,8 @@ fn parse_semi_join_condition(
         } = &pred
         {
             if let (
-                vibesql_ast::Expression::ColumnRef { table: left_tbl, column: left_col },
-                vibesql_ast::Expression::ColumnRef { table: right_tbl, column: right_col },
+                vibesql_ast::Expression::ColumnRef { schema: None, table: left_tbl, column: left_col, .. },
+                vibesql_ast::Expression::ColumnRef { schema: None, table: right_tbl, column: right_col, .. },
             ) = (left.as_ref(), right.as_ref())
             {
                 // Determine which column is from left and which from right
@@ -1368,11 +1370,13 @@ fn generate_using_join_condition(
         // Create equality condition with qualified column references
         let equality = vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some(left_col.0.to_string()),
                 column: left_col.1,
             }),
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some(right_col.0.to_string()),
                 column: right_col.1,
             }),

--- a/crates/vibesql-executor/src/select/scan/reorder/graph.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/graph.rs
@@ -125,10 +125,10 @@ pub(super) fn extract_referenced_tables_with_schema(
     column_to_table: &HashMap<String, String>,
 ) {
     match expr {
-        Expression::ColumnRef { table: Some(table), .. } => {
+        Expression::ColumnRef { schema: None, table: Some(table), .. } => {
             output.insert(table.to_lowercase());
         }
-        Expression::ColumnRef { table: None, column } => {
+        Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // Use schema-based lookup
             if let Some(table) = super::utils::resolve_column_with_fallback(column, column_to_table)
             {

--- a/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/optimizer.rs
@@ -905,7 +905,7 @@ fn find_inner_table_in_condition(expr: &Expression, inner_tables: &[String]) -> 
             }
             find_inner_table_in_condition(right, inner_tables)
         }
-        Expression::ColumnRef { table: Some(t), column, .. } => {
+        Expression::ColumnRef { schema: None, table: Some(t), column, .. } => {
             let t_lower = t.to_lowercase();
             if inner_tables.contains(&t_lower) {
                 return Some(t_lower);
@@ -913,7 +913,7 @@ fn find_inner_table_in_condition(expr: &Expression, inner_tables: &[String]) -> 
             // Also try to infer from column naming convention (o_ → orders)
             infer_table_from_column(column, inner_tables)
         }
-        Expression::ColumnRef { table: None, column, .. } => {
+        Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // Try to infer from column naming convention
             infer_table_from_column(column, inner_tables)
         }

--- a/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/predicates.rs
@@ -86,14 +86,14 @@ pub(super) fn extract_in_predicates_from_or(
         table_set: &HashSet<String>,
     ) -> Option<(String, String, vibesql_types::SqlValue)> {
         if let Expression::BinaryOp { op: BinaryOperator::Equal, left, right } = pred {
-            if let (Expression::ColumnRef { table: Some(t), column: c }, Expression::Literal(v)) =
+            if let (Expression::ColumnRef { schema: None, table: Some(t), column: c, .. }, Expression::Literal(v)) =
                 (left.as_ref(), right.as_ref())
             {
                 if table_set.contains(&t.to_lowercase()) {
                     return Some((t.clone(), c.clone(), v.clone()));
                 }
             }
-            if let (Expression::Literal(v), Expression::ColumnRef { table: Some(t), column: c }) =
+            if let (Expression::Literal(v), Expression::ColumnRef { schema: None, table: Some(t), column: c, .. }) =
                 (left.as_ref(), right.as_ref())
             {
                 if table_set.contains(&t.to_lowercase()) {
@@ -134,6 +134,7 @@ pub(super) fn extract_in_predicates_from_or(
             if col_count.get(&(t.clone(), c.clone())) == Some(&branches.len()) && vals.len() >= 2 {
                 let in_pred = Expression::InList {
                     expr: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: Some(t.clone()),
                         column: c.clone(),
                     }),
@@ -431,15 +432,15 @@ pub(super) fn extract_where_equijoins_with_schema(
                 // Use schema-based lookup
 
                 let left_table = match left.as_ref() {
-                    Expression::ColumnRef { table: Some(t), .. } => Some(t.to_lowercase()),
-                    Expression::ColumnRef { table: None, column } => {
+                    Expression::ColumnRef { schema: None, table: Some(t), .. } => Some(t.to_lowercase()),
+                    Expression::ColumnRef { schema: None, table: None, column, .. } => {
                         resolve_column_with_fallback(column, column_to_table)
                     }
                     _ => None,
                 };
                 let right_table = match right.as_ref() {
-                    Expression::ColumnRef { table: Some(t), .. } => Some(t.to_lowercase()),
-                    Expression::ColumnRef { table: None, column } => {
+                    Expression::ColumnRef { schema: None, table: Some(t), .. } => Some(t.to_lowercase()),
+                    Expression::ColumnRef { schema: None, table: None, column, .. } => {
                         resolve_column_with_fallback(column, column_to_table)
                     }
                     _ => None,

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -375,13 +375,17 @@ fn qualify_columns(expr: &vibesql_ast::Expression, table_name: &str) -> vibesql_
     let table_name_lower = table_name.to_lowercase();
 
     match expr {
-        Expression::ColumnRef { table: None, column } => {
+        Expression::ColumnRef { schema: None, table: None, column, .. } => {
             // Add table qualifier to unqualified column
-            Expression::ColumnRef { table: Some(table_name_lower.clone()), column: column.clone() }
+            Expression::ColumnRef {
+                schema: None,
+                table: Some(table_name_lower.clone()),
+                column: column.clone(),
+            }
         }
-        Expression::ColumnRef { table: Some(t), column } => {
+        Expression::ColumnRef { schema: None, table: Some(t), column, .. } => {
             // Already qualified, keep as is
-            Expression::ColumnRef { table: Some(t.clone()), column: column.clone() }
+            Expression::ColumnRef { schema: None, table: Some(t.clone()), column: column.clone() }
         }
         Expression::BinaryOp { op, left, right } => Expression::BinaryOp {
             op: *op,

--- a/crates/vibesql-executor/src/select/vectorized/arithmetic.rs
+++ b/crates/vibesql-executor/src/select/vectorized/arithmetic.rs
@@ -289,9 +289,9 @@ mod tests {
         .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
             op: BinaryOperator::Multiply,
-            right: Box::new(Expression::ColumnRef { table: None, column: "quantity".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "quantity".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -312,7 +312,7 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(price_array)]).unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
             op: BinaryOperator::Multiply,
             right: Box::new(Expression::Literal(SqlValue::Float(0.9))),
         };
@@ -344,12 +344,13 @@ mod tests {
 
         // price * (1 - discount)
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
             op: BinaryOperator::Multiply,
             right: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::Literal(SqlValue::Float(1.0))),
                 op: BinaryOperator::Minus,
                 right: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "discount".to_string(),
                 }),
@@ -381,9 +382,9 @@ mod tests {
                 .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Plus,
-            right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -408,9 +409,9 @@ mod tests {
                 .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Minus,
-            right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -435,9 +436,9 @@ mod tests {
                 .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Divide,
-            right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -465,9 +466,9 @@ mod tests {
 
         // Test addition
         let add_expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Plus,
-            right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &add_expr).unwrap();
@@ -477,9 +478,9 @@ mod tests {
 
         // Test multiplication
         let mul_expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Multiply,
-            right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &mul_expr).unwrap();
@@ -503,9 +504,9 @@ mod tests {
                 .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Plus,
-            right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -525,9 +526,9 @@ mod tests {
                 .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Multiply,
-            right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -551,9 +552,9 @@ mod tests {
                 .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Plus,
-            right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -577,9 +578,9 @@ mod tests {
                 .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Multiply,
-            right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -603,9 +604,9 @@ mod tests {
                 .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Divide,
-            right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -629,9 +630,9 @@ mod tests {
                 .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Multiply,
-            right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -652,7 +653,7 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a_array)]).unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Plus,
             right: Box::new(Expression::Literal(SqlValue::Float(5.0))),
         };
@@ -672,7 +673,7 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a_array)]).unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
             op: BinaryOperator::Multiply,
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         };
@@ -708,15 +709,15 @@ mod tests {
 
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
                 op: BinaryOperator::Plus,
-                right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+                right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
             }),
             op: BinaryOperator::Multiply,
             right: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "c".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c".to_string() }),
                 op: BinaryOperator::Minus,
-                right: Box::new(Expression::ColumnRef { table: None, column: "d".to_string() }),
+                right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "d".to_string() }),
             }),
         };
 
@@ -739,7 +740,7 @@ mod tests {
         let a_array = Float64Array::from(vec![10.0, 20.0, 30.0]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a_array)]).unwrap();
 
-        let expr = Expression::ColumnRef { table: None, column: "a".to_string() };
+        let expr = Expression::ColumnRef { schema: None, table: None, column: "a".to_string() };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
         let result_arr = result.as_any().downcast_ref::<Float64Array>().unwrap();
@@ -762,7 +763,7 @@ mod tests {
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::Literal(SqlValue::Null)),
             op: BinaryOperator::Plus,
-            right: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -784,7 +785,7 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(price_array)]).unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
             op: BinaryOperator::Plus,
             right: Box::new(Expression::Literal(SqlValue::Null)),
         };
@@ -817,9 +818,9 @@ mod tests {
         .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "quantity".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "quantity".to_string() }),
             op: BinaryOperator::Multiply,
-            right: Box::new(Expression::ColumnRef { table: None, column: "discount".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "discount".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -878,12 +879,13 @@ mod tests {
 
         // price * (1 - discount)
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
             op: BinaryOperator::Multiply,
             right: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::Literal(SqlValue::Float(1.0))),
                 op: BinaryOperator::Minus,
                 right: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "discount".to_string(),
                 }),
@@ -920,9 +922,9 @@ mod tests {
         .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
             op: BinaryOperator::Divide,
-            right: Box::new(Expression::ColumnRef { table: None, column: "quantity".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "quantity".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();
@@ -955,9 +957,9 @@ mod tests {
         .unwrap();
 
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "revenue".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "revenue".to_string() }),
             op: BinaryOperator::Minus,
-            right: Box::new(Expression::ColumnRef { table: None, column: "cost".to_string() }),
+            right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "cost".to_string() }),
         };
 
         let result = evaluate_arithmetic_simd(&batch, &expr).unwrap();

--- a/crates/vibesql-executor/src/select/vectorized/compiled_predicate.rs
+++ b/crates/vibesql-executor/src/select/vectorized/compiled_predicate.rs
@@ -338,7 +338,7 @@ impl CompiledWhereClause {
     ) -> bool {
         // Extract column reference
         let column_idx = match col_expr {
-            Expression::ColumnRef { table, column } => {
+            Expression::ColumnRef { table, column, .. } => {
                 schema.get_column_index(table.as_deref(), column)
             }
             _ => return false,
@@ -385,7 +385,7 @@ impl CompiledWhereClause {
     ) -> bool {
         // Extract column reference
         let column_idx = match col_expr {
-            Expression::ColumnRef { table, column } => {
+            Expression::ColumnRef { table, column, .. } => {
                 schema.get_column_index(table.as_deref(), column)
             }
             _ => None,
@@ -485,7 +485,7 @@ impl CompiledWhereClause {
     /// Try to extract a column index from an expression
     fn try_extract_column(expr: &Expression, schema: &CombinedSchema) -> Option<usize> {
         match expr {
-            Expression::ColumnRef { table, column } => {
+            Expression::ColumnRef { table, column, .. } => {
                 schema.get_column_index(table.as_deref(), column)
             }
             _ => None,
@@ -734,7 +734,7 @@ mod tests {
 
         // l_quantity < 24
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "l_quantity".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "l_quantity".to_string() }),
             op: BinaryOperator::LessThan,
             right: Box::new(Expression::Literal(SqlValue::Integer(24))),
         };
@@ -754,6 +754,7 @@ mod tests {
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "l_quantity".to_string(),
                 }),
@@ -763,6 +764,7 @@ mod tests {
             op: BinaryOperator::And,
             right: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "l_discount".to_string(),
                 }),
@@ -784,7 +786,7 @@ mod tests {
 
         // l_quantity < 24
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "l_quantity".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "l_quantity".to_string() }),
             op: BinaryOperator::LessThan,
             right: Box::new(Expression::Literal(SqlValue::Integer(24))),
         };
@@ -817,6 +819,7 @@ mod tests {
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "l_quantity".to_string(),
                 }),
@@ -826,6 +829,7 @@ mod tests {
             op: BinaryOperator::And,
             right: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "l_discount".to_string(),
                 }),
@@ -886,6 +890,7 @@ mod tests {
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "l_discount".to_string(),
                 }),
@@ -895,6 +900,7 @@ mod tests {
             op: BinaryOperator::And,
             right: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "l_quantity".to_string(),
                 }),
@@ -922,7 +928,7 @@ mod tests {
 
         // l_quantity > 10
         let expr = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "l_quantity".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "l_quantity".to_string() }),
             op: BinaryOperator::GreaterThan,
             right: Box::new(Expression::Literal(SqlValue::Integer(10))),
         };
@@ -949,7 +955,7 @@ mod tests {
         // l_quantity NOT BETWEEN 31 AND NULL
         // This should fall back to regular evaluator for proper NULL semantics
         let expr = Expression::Between {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "l_quantity".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "l_quantity".to_string() }),
             low: Box::new(Expression::Literal(SqlValue::Integer(31))),
             high: Box::new(Expression::Literal(SqlValue::Null)),
             negated: true,
@@ -962,7 +968,7 @@ mod tests {
 
         // Also test with NULL low bound
         let expr_null_low = Expression::Between {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "l_quantity".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "l_quantity".to_string() }),
             low: Box::new(Expression::Literal(SqlValue::Null)),
             high: Box::new(Expression::Literal(SqlValue::Integer(100))),
             negated: false,
@@ -980,7 +986,7 @@ mod tests {
 
         // l_quantity BETWEEN 10 AND 100
         let expr = Expression::Between {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "l_quantity".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "l_quantity".to_string() }),
             low: Box::new(Expression::Literal(SqlValue::Integer(10))),
             high: Box::new(Expression::Literal(SqlValue::Integer(100))),
             negated: false,
@@ -1071,11 +1077,13 @@ mod tests {
             left: Box::new(Expression::BinaryOp {
                 // p_partkey = l_partkey (column-to-column, should be skipped)
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: Some("part".to_string()),
                     column: "p_partkey".to_string(),
                 }),
                 op: BinaryOperator::Equal,
                 right: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: Some("lineitem".to_string()),
                     column: "l_partkey".to_string(),
                 }),
@@ -1084,6 +1092,7 @@ mod tests {
             right: Box::new(Expression::BinaryOp {
                 // p_brand = 'Brand#12'
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: Some("part".to_string()),
                     column: "p_brand".to_string(),
                 }),
@@ -1098,11 +1107,13 @@ mod tests {
             left: Box::new(Expression::BinaryOp {
                 // p_partkey = l_partkey (column-to-column, should be skipped)
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: Some("part".to_string()),
                     column: "p_partkey".to_string(),
                 }),
                 op: BinaryOperator::Equal,
                 right: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: Some("lineitem".to_string()),
                     column: "l_partkey".to_string(),
                 }),
@@ -1111,6 +1122,7 @@ mod tests {
             right: Box::new(Expression::BinaryOp {
                 // p_brand = 'Brand#23'
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: Some("part".to_string()),
                     column: "p_brand".to_string(),
                 }),
@@ -1155,11 +1167,13 @@ mod tests {
         // l_partkey > p_partkey (inequality - should NOT be skipped, should fail compilation)
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("lineitem".to_string()),
                 column: "l_partkey".to_string(),
             }),
             op: BinaryOperator::GreaterThan,
             right: Box::new(Expression::ColumnRef {
+                schema: None,
                 table: Some("part".to_string()),
                 column: "p_partkey".to_string(),
             }),

--- a/crates/vibesql-executor/src/select/vectorized/filter.rs
+++ b/crates/vibesql-executor/src/select/vectorized/filter.rs
@@ -641,7 +641,7 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)]).unwrap();
 
         let predicate = Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "value".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() }),
             op: BinaryOperator::GreaterThan,
             right: Box::new(Expression::Literal(SqlValue::Integer(3))),
         };
@@ -660,13 +660,13 @@ mod tests {
         // value > 10 (all false) AND value < 100 (would be all true)
         let predicate = Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "value".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() }),
                 op: BinaryOperator::GreaterThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(10))),
             }),
             op: BinaryOperator::And,
             right: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "value".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() }),
                 op: BinaryOperator::LessThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(100))),
             }),
@@ -687,13 +687,13 @@ mod tests {
         // value < 100 (all true) OR value > 10 (would be all false)
         let predicate = Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "value".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() }),
                 op: BinaryOperator::LessThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(100))),
             }),
             op: BinaryOperator::Or,
             right: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "value".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() }),
                 op: BinaryOperator::GreaterThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(10))),
             }),
@@ -714,13 +714,13 @@ mod tests {
         // value > 3 AND value < 8
         let predicate = Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "value".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() }),
                 op: BinaryOperator::GreaterThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(3))),
             }),
             op: BinaryOperator::And,
             right: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "value".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() }),
                 op: BinaryOperator::LessThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(8))),
             }),
@@ -740,7 +740,7 @@ mod tests {
 
         // name LIKE 'Al%'
         let predicate = Expression::Like {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "name".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "name".to_string() }),
             pattern: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Al%")))),
             negated: false,
         };
@@ -764,7 +764,7 @@ mod tests {
 
         // name LIKE '%lie'
         let predicate = Expression::Like {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "name".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "name".to_string() }),
             pattern: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("%lie")))),
             negated: false,
         };
@@ -783,7 +783,7 @@ mod tests {
 
         // name NOT LIKE 'Al%'
         let predicate = Expression::Like {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "name".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "name".to_string() }),
             pattern: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Al%")))),
             negated: true,
         };
@@ -806,7 +806,7 @@ mod tests {
 
         // name LIKE '%li%'
         let predicate = Expression::Like {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "name".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "name".to_string() }),
             pattern: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("%li%")))),
             negated: false,
         };

--- a/crates/vibesql-executor/src/tests/aggregate_caching.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_caching.rs
@@ -139,6 +139,7 @@ fn test_repeated_sum_cached() {
         name: "SUM".to_string(),
         distinct: false,
         args: vec![vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "amount".to_string(),
         }],
@@ -280,6 +281,7 @@ fn test_cache_cleared_between_groups() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "category".to_string(),
                 },
@@ -293,11 +295,12 @@ fn test_cache_cleared_between_groups() {
         }),
         where_clause: None,
         group_by: Some(vibesql_ast::GroupByClause::Simple(vec![
-            vibesql_ast::Expression::ColumnRef { table: None, column: "category".to_string() },
+            vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "category".to_string() },
         ])),
         having: None,
         order_by: Some(vec![vibesql_ast::OrderByItem {
             expr: vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "category".to_string(),
             },
@@ -352,14 +355,14 @@ fn test_distinct_aggregates_not_confused() {
     let count_val = vibesql_ast::Expression::AggregateFunction {
         name: "COUNT".to_string(),
         distinct: false,
-        args: vec![vibesql_ast::Expression::ColumnRef { table: None, column: "val".to_string() }],
+        args: vec![vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "val".to_string() }],
         order_by: None,
     };
 
     let count_distinct_val = vibesql_ast::Expression::AggregateFunction {
         name: "COUNT".to_string(),
         distinct: true,
-        args: vec![vibesql_ast::Expression::ColumnRef { table: None, column: "val".to_string() }],
+        args: vec![vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "val".to_string() }],
         order_by: None,
     };
 

--- a/crates/vibesql-executor/src/tests/aggregate_count_sum_avg_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_count_sum_avg_tests.rs
@@ -139,6 +139,7 @@ fn test_sum_no_group_by() {
             expr: vibesql_ast::Expression::Function {
                 name: "SUM".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "amount".to_string(),
                 }],
@@ -302,6 +303,7 @@ fn test_sum_with_nulls() {
             expr: vibesql_ast::Expression::Function {
                 name: "SUM".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "value".to_string(),
                 }],
@@ -386,6 +388,7 @@ fn test_avg_function() {
             expr: vibesql_ast::Expression::Function {
                 name: "AVG".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "score".to_string(),
                 }],
@@ -469,6 +472,7 @@ fn test_avg_with_nulls() {
             expr: vibesql_ast::Expression::Function {
                 name: "AVG".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "rating".to_string(),
                 }],
@@ -555,6 +559,7 @@ fn test_count_column_all_nulls() {
             expr: vibesql_ast::Expression::Function {
                 name: "COUNT".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "value".to_string(),
                 }],

--- a/crates/vibesql-executor/src/tests/aggregate_distinct.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_distinct.rs
@@ -97,6 +97,7 @@ fn test_count_distinct_basic() {
                 name: "COUNT".to_string(),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "amount".to_string(),
                 }],
@@ -143,6 +144,7 @@ fn test_count_distinct_vs_count_all() {
                     name: "COUNT".to_string(),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "amount".to_string(),
                     }],
@@ -154,6 +156,7 @@ fn test_count_distinct_vs_count_all() {
                     name: "COUNT".to_string(),
                     distinct: true,
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "amount".to_string(),
                     }],
@@ -200,6 +203,7 @@ fn test_sum_distinct() {
                 name: "SUM".to_string(),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "amount".to_string(),
                 }],
@@ -247,6 +251,7 @@ fn test_sum_distinct_vs_sum_all() {
                     name: "SUM".to_string(),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "amount".to_string(),
                     }],
@@ -258,6 +263,7 @@ fn test_sum_distinct_vs_sum_all() {
                     name: "SUM".to_string(),
                     distinct: true,
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "amount".to_string(),
                     }],
@@ -306,6 +312,7 @@ fn test_avg_distinct() {
                 name: "AVG".to_string(),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "amount".to_string(),
                 }],
@@ -351,6 +358,7 @@ fn test_min_distinct() {
                 name: "MIN".to_string(),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "amount".to_string(),
                 }],
@@ -396,6 +404,7 @@ fn test_max_distinct() {
                 name: "MAX".to_string(),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "amount".to_string(),
                 }],
@@ -461,6 +470,7 @@ fn test_count_distinct_with_nulls() {
                 name: "COUNT".to_string(),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "val".to_string(),
                 }],
@@ -525,6 +535,7 @@ fn test_distinct_all_same_value() {
                     name: "COUNT".to_string(),
                     distinct: true,
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "val".to_string(),
                     }],
@@ -536,6 +547,7 @@ fn test_distinct_all_same_value() {
                     name: "SUM".to_string(),
                     distinct: true,
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "val".to_string(),
                     }],
@@ -594,6 +606,7 @@ fn test_distinct_empty_table() {
                     name: "COUNT".to_string(),
                     distinct: true,
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "val".to_string(),
                     }],
@@ -605,6 +618,7 @@ fn test_distinct_empty_table() {
                     name: "SUM".to_string(),
                     distinct: true,
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "val".to_string(),
                     }],

--- a/crates/vibesql-executor/src/tests/aggregate_edge_case_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_edge_case_tests.rs
@@ -61,6 +61,7 @@ fn test_avg_precision_decimal() {
             expr: vibesql_ast::Expression::Function {
                 name: "AVG".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "price".to_string(),
                 }],
@@ -151,6 +152,7 @@ fn test_sum_mixed_numeric_types() {
             expr: vibesql_ast::Expression::Function {
                 name: "SUM".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "amount".to_string(),
                 }],
@@ -249,6 +251,7 @@ fn test_aggregate_with_case_expression() {
                     when_clauses: vec![vibesql_ast::CaseWhen {
                         conditions: vec![vibesql_ast::Expression::BinaryOp {
                             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                                schema: None,
                                 table: None,
                                 column: "type".to_string(),
                             }),
@@ -258,6 +261,7 @@ fn test_aggregate_with_case_expression() {
                             )),
                         }],
                         result: vibesql_ast::Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "amount".to_string(),
                         },
@@ -326,6 +330,7 @@ fn test_max_with_unary_plus() {
                 args: vec![vibesql_ast::Expression::UnaryOp {
                     op: vibesql_ast::UnaryOperator::Plus,
                     expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "col0".to_string(),
                     }),
@@ -388,6 +393,7 @@ fn test_max_with_unary_minus() {
                 args: vec![vibesql_ast::Expression::UnaryOp {
                     op: vibesql_ast::UnaryOperator::Minus,
                     expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "col0".to_string(),
                     }),
@@ -451,6 +457,7 @@ fn test_count_with_not() {
                 args: vec![vibesql_ast::Expression::UnaryOp {
                     op: vibesql_ast::UnaryOperator::Not,
                     expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "col1".to_string(),
                     }),

--- a/crates/vibesql-executor/src/tests/aggregate_group_by_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_group_by_tests.rs
@@ -74,6 +74,7 @@ fn test_group_by_select_alias() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "dept".to_string(),
                 },
@@ -95,7 +96,7 @@ fn test_group_by_select_alias() {
         where_clause: None,
         // GROUP BY "department" - uses alias from SELECT list
         group_by: Some(vibesql_ast::GroupByClause::Simple(vec![
-            vibesql_ast::Expression::ColumnRef { table: None, column: "department".to_string() },
+            vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "department".to_string() },
         ])),
         having: None,
         order_by: None,
@@ -192,6 +193,7 @@ fn test_group_by_numeric_position() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "dept".to_string(),
                 },
@@ -305,6 +307,7 @@ fn test_group_by_with_count() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "dept".to_string(),
                 },
@@ -324,7 +327,7 @@ fn test_group_by_with_count() {
         }),
         where_clause: None,
         group_by: Some(vibesql_ast::GroupByClause::Simple(vec![
-            vibesql_ast::Expression::ColumnRef { table: None, column: "dept".to_string() },
+            vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "dept".to_string() },
         ])),
         having: None,
         order_by: None,

--- a/crates/vibesql-executor/src/tests/aggregate_having_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_having_tests.rs
@@ -139,6 +139,7 @@ fn test_having_clause() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "dept".to_string(),
                 },
@@ -147,6 +148,7 @@ fn test_having_clause() {
                 expr: vibesql_ast::Expression::Function {
                     name: "SUM".to_string(),
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "amount".to_string(),
                     }],
@@ -161,12 +163,13 @@ fn test_having_clause() {
         }),
         where_clause: None,
         group_by: Some(vibesql_ast::GroupByClause::Simple(vec![
-            vibesql_ast::Expression::ColumnRef { table: None, column: "dept".to_string() },
+            vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "dept".to_string() },
         ])),
         having: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::Function {
                 name: "SUM".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "amount".to_string(),
                 }],

--- a/crates/vibesql-executor/src/tests/aggregate_min_max_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_min_max_tests.rs
@@ -60,6 +60,7 @@ fn test_min_function() {
             expr: vibesql_ast::Expression::Function {
                 name: "MIN".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "temp".to_string(),
                 }],
@@ -142,6 +143,7 @@ fn test_max_function() {
             expr: vibesql_ast::Expression::Function {
                 name: "MAX".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "temp".to_string(),
                 }],
@@ -227,6 +229,7 @@ fn test_min_max_on_strings() {
             expr: vibesql_ast::Expression::Function {
                 name: "MIN".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "name".to_string(),
                 }],
@@ -267,6 +270,7 @@ fn test_min_max_on_strings() {
             expr: vibesql_ast::Expression::Function {
                 name: "MAX".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "name".to_string(),
                 }],

--- a/crates/vibesql-executor/src/tests/between_predicates.rs
+++ b/crates/vibesql-executor/src/tests/between_predicates.rs
@@ -79,12 +79,13 @@ fn test_between_integer() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "name".to_string(),
                 },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "age".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "age".to_string() },
                 alias: None, source_text: None },
         ],
         from: Some(vibesql_ast::FromClause::Table { quoted: false,
@@ -94,6 +95,7 @@ fn test_between_integer() {
         }),
         where_clause: Some(vibesql_ast::Expression::Between {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "age".to_string(),
             }),
@@ -188,7 +190,7 @@ fn test_not_between() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "name".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -199,6 +201,7 @@ fn test_not_between() {
         }),
         where_clause: Some(vibesql_ast::Expression::Between {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "price".to_string(),
             }),
@@ -272,6 +275,7 @@ fn test_between_boundary_inclusive() {
         }),
         where_clause: Some(vibesql_ast::Expression::Between {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "VALUE".to_string(),
             }),
@@ -362,7 +366,7 @@ fn test_between_with_column_references() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "VALUE".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "VALUE".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -373,14 +377,17 @@ fn test_between_with_column_references() {
         }),
         where_clause: Some(vibesql_ast::Expression::Between {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "VALUE".to_string(),
             }),
             low: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "min_val".to_string(),
             }),
             high: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "max_val".to_string(),
             }),

--- a/crates/vibesql-executor/src/tests/comparison_ops.rs
+++ b/crates/vibesql-executor/src/tests/comparison_ops.rs
@@ -37,6 +37,7 @@ fn test_greater_than_comparison() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -88,6 +89,7 @@ fn test_less_than_comparison() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -141,6 +143,7 @@ fn test_not_equal_comparison() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -195,6 +198,7 @@ fn test_less_than_or_equal_comparison() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),

--- a/crates/vibesql-executor/src/tests/count_star_fast_path.rs
+++ b/crates/vibesql-executor/src/tests/count_star_fast_path.rs
@@ -182,6 +182,7 @@ fn test_count_star_with_where_no_fast_path() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "value".to_string(),
             }),
@@ -275,6 +276,7 @@ fn test_count_star_with_group_by_no_fast_path() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "category".to_string(),
                 },
@@ -295,7 +297,7 @@ fn test_count_star_with_group_by_no_fast_path() {
         }),
         where_clause: None,
         group_by: Some(vibesql_ast::GroupByClause::Simple(vec![
-            vibesql_ast::Expression::ColumnRef { table: None, column: "category".to_string() },
+            vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "category".to_string() },
         ])),
         having: None,
         order_by: None,
@@ -401,6 +403,7 @@ fn test_count_column_no_fast_path() {
                 name: "COUNT".to_string(),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "id".to_string(),
                 }],
@@ -539,6 +542,7 @@ fn test_count_star_multiple_select_items_no_fast_path() {
                     name: "SUM".to_string(),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "value".to_string(),
                     }],

--- a/crates/vibesql-executor/src/tests/create_table_constraints.rs
+++ b/crates/vibesql-executor/src/tests/create_table_constraints.rs
@@ -245,7 +245,7 @@ fn test_create_table_with_table_unique_constraint() {
 fn test_create_table_with_check_constraint() {
     let mut db = Database::new();
     let check_expr = Expression::BinaryOp {
-        left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
         op: vibesql_ast::BinaryOperator::GreaterThan,
         right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(0))),
     };

--- a/crates/vibesql-executor/src/tests/expression_eval.rs
+++ b/crates/vibesql-executor/src/tests/expression_eval.rs
@@ -63,11 +63,11 @@ fn test_eval_column_ref() {
         vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Alice")),
     ]);
 
-    let expr = vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() };
+    let expr = vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "id".to_string() };
     let result = evaluator.eval(&expr, &row).unwrap();
     assert_eq!(result, vibesql_types::SqlValue::Integer(1));
 
-    let expr = vibesql_ast::Expression::ColumnRef { table: None, column: "name".to_string() };
+    let expr = vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "name".to_string() };
     let result = evaluator.eval(&expr, &row).unwrap();
     assert_eq!(result, vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Alice")));
 }
@@ -85,7 +85,7 @@ fn test_eval_column_not_found() {
     let evaluator = ExpressionEvaluator::new(&schema);
     let row = vibesql_storage::Row::new(vec![vibesql_types::SqlValue::Integer(1)]);
 
-    let expr = vibesql_ast::Expression::ColumnRef { table: None, column: "missing".to_string() };
+    let expr = vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "missing".to_string() };
     let err = evaluator.eval(&expr, &row).unwrap_err();
     match err {
         ExecutorError::ColumnNotFound { column_name, .. } => assert_eq!(column_name, "missing"),

--- a/crates/vibesql-executor/src/tests/function_tests.rs
+++ b/crates/vibesql-executor/src/tests/function_tests.rs
@@ -133,12 +133,13 @@ fn test_function_with_parameter() {
             ProceduralStatement::Set {
                 name: "result".to_string(),
                 value: Box::new(Expression::BinaryOp {
-                    left: Box::new(Expression::ColumnRef { table: None, column: "x".to_string() }),
+                    left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
                     op: BinaryOperator::Multiply,
                     right: Box::new(Expression::Literal(SqlValue::Integer(2))),
                 }),
             },
             ProceduralStatement::Return(Box::new(Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "result".to_string(),
             })),
@@ -169,6 +170,7 @@ fn test_function_parameter_shadowing() {
                 default_value: Some(Box::new(Expression::Literal(SqlValue::Integer(100)))),
             },
             ProceduralStatement::Return(Box::new(Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "x".to_string(),
             })),
@@ -245,23 +247,25 @@ fn test_function_multiple_parameters() {
             ProceduralStatement::Set {
                 name: "result".to_string(),
                 value: Box::new(Expression::BinaryOp {
-                    left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+                    left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
                     op: BinaryOperator::Plus,
-                    right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+                    right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
                 }),
             },
             ProceduralStatement::Set {
                 name: "result".to_string(),
                 value: Box::new(Expression::BinaryOp {
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "result".to_string(),
                     }),
                     op: BinaryOperator::Plus,
-                    right: Box::new(Expression::ColumnRef { table: None, column: "c".to_string() }),
+                    right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c".to_string() }),
                 }),
             },
             ProceduralStatement::Return(Box::new(Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "result".to_string(),
             })),
@@ -301,12 +305,13 @@ fn test_function_varchar_return_type() {
                     name: "CONCAT".to_string(),
                     args: vec![
                         Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Hello, "))),
-                        Expression::ColumnRef { table: None, column: "name".to_string() },
+                        Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
                     ],
                     character_unit: None,
                 }),
             },
             ProceduralStatement::Return(Box::new(Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "greeting".to_string(),
             })),
@@ -339,6 +344,7 @@ fn test_function_long_body() {
     }
 
     statements.push(ProceduralStatement::Return(Box::new(Expression::ColumnRef {
+        schema: None,
         table: None,
         column: "counter".to_string(),
     })));
@@ -367,11 +373,12 @@ fn test_function_with_control_flow() {
         DataType::Integer,
         vec![ProceduralStatement::If {
             condition: Box::new(Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "x".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
                 op: BinaryOperator::GreaterThan,
                 right: Box::new(Expression::Literal(SqlValue::Integer(0))),
             }),
             then_statements: vec![ProceduralStatement::Return(Box::new(Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "x".to_string(),
             }))],

--- a/crates/vibesql-executor/src/tests/join_aggregation.rs
+++ b/crates/vibesql-executor/src/tests/join_aggregation.rs
@@ -145,6 +145,7 @@ fn test_inner_join_with_group_by_count() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("d".to_string()),
                     column: "dept_name".to_string(),
                 },
@@ -153,6 +154,7 @@ fn test_inner_join_with_group_by_count() {
                 expr: vibesql_ast::Expression::Function {
                     name: "COUNT".to_string(),
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("e".to_string()),
                         column: "emp_id".to_string(),
                     }],
@@ -174,11 +176,13 @@ fn test_inner_join_with_group_by_count() {
             join_type: vibesql_ast::JoinType::Inner,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("d".to_string()),
                     column: "dept_id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("e".to_string()),
                     column: "dept_id".to_string(),
                 }),
@@ -189,6 +193,7 @@ fn test_inner_join_with_group_by_count() {
         where_clause: None,
         group_by: Some(vibesql_ast::GroupByClause::Simple(vec![
             vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("d".to_string()),
                 column: "dept_name".to_string(),
             },
@@ -255,6 +260,7 @@ fn test_left_join_with_group_by_avg_salary() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("d".to_string()),
                     column: "dept_name".to_string(),
                 },
@@ -263,6 +269,7 @@ fn test_left_join_with_group_by_avg_salary() {
                 expr: vibesql_ast::Expression::Function {
                     name: "AVG".to_string(),
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("e".to_string()),
                         column: "salary".to_string(),
                     }],
@@ -284,11 +291,13 @@ fn test_left_join_with_group_by_avg_salary() {
             join_type: vibesql_ast::JoinType::LeftOuter,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("d".to_string()),
                     column: "dept_id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("e".to_string()),
                     column: "dept_id".to_string(),
                 }),
@@ -299,6 +308,7 @@ fn test_left_join_with_group_by_avg_salary() {
         where_clause: None,
         group_by: Some(vibesql_ast::GroupByClause::Simple(vec![
             vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("d".to_string()),
                 column: "dept_name".to_string(),
             },
@@ -363,6 +373,7 @@ fn test_join_group_by_with_having() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("d".to_string()),
                     column: "dept_name".to_string(),
                 },
@@ -371,6 +382,7 @@ fn test_join_group_by_with_having() {
                 expr: vibesql_ast::Expression::Function {
                     name: "COUNT".to_string(),
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("e".to_string()),
                         column: "emp_id".to_string(),
                     }],
@@ -392,11 +404,13 @@ fn test_join_group_by_with_having() {
             join_type: vibesql_ast::JoinType::Inner,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("d".to_string()),
                     column: "dept_id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("e".to_string()),
                     column: "dept_id".to_string(),
                 }),
@@ -407,6 +421,7 @@ fn test_join_group_by_with_having() {
         where_clause: None,
         group_by: Some(vibesql_ast::GroupByClause::Simple(vec![
             vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("d".to_string()),
                 column: "dept_name".to_string(),
             },
@@ -415,6 +430,7 @@ fn test_join_group_by_with_having() {
             left: Box::new(vibesql_ast::Expression::Function {
                 name: "COUNT".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("e".to_string()),
                     column: "emp_id".to_string(),
                 }],
@@ -464,6 +480,7 @@ fn test_join_group_by_multiple_aggregates() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("d".to_string()),
                     column: "dept_name".to_string(),
                 },
@@ -479,6 +496,7 @@ fn test_join_group_by_multiple_aggregates() {
                 expr: vibesql_ast::Expression::Function {
                     name: "MIN".to_string(),
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("e".to_string()),
                         column: "salary".to_string(),
                     }],
@@ -489,6 +507,7 @@ fn test_join_group_by_multiple_aggregates() {
                 expr: vibesql_ast::Expression::Function {
                     name: "MAX".to_string(),
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("e".to_string()),
                         column: "salary".to_string(),
                     }],
@@ -510,11 +529,13 @@ fn test_join_group_by_multiple_aggregates() {
             join_type: vibesql_ast::JoinType::Inner,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("d".to_string()),
                     column: "dept_id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("e".to_string()),
                     column: "dept_id".to_string(),
                 }),
@@ -525,6 +546,7 @@ fn test_join_group_by_multiple_aggregates() {
         where_clause: None,
         group_by: Some(vibesql_ast::GroupByClause::Simple(vec![
             vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("d".to_string()),
                 column: "dept_name".to_string(),
             },

--- a/crates/vibesql-executor/src/tests/limit_offset.rs
+++ b/crates/vibesql-executor/src/tests/limit_offset.rs
@@ -234,11 +234,13 @@ fn test_limit_with_inner_join() {
             join_type: vibesql_ast::JoinType::Inner,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("users".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("orders".to_string()),
                     column: "user_id".to_string(),
                 }),
@@ -347,11 +349,13 @@ fn test_offset_with_inner_join() {
             join_type: vibesql_ast::JoinType::Inner,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("users".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("orders".to_string()),
                     column: "user_id".to_string(),
                 }),
@@ -460,11 +464,13 @@ fn test_limit_offset_with_inner_join() {
             join_type: vibesql_ast::JoinType::Inner,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("users".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("orders".to_string()),
                     column: "user_id".to_string(),
                 }),

--- a/crates/vibesql-executor/src/tests/not_operator_tests.rs
+++ b/crates/vibesql-executor/src/tests/not_operator_tests.rs
@@ -64,7 +64,7 @@ fn test_not_in_select_where() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "pk".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "pk".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -77,6 +77,7 @@ fn test_not_in_select_where() {
             op: vibesql_ast::UnaryOperator::Not,
             expr: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "col0".to_string(),
                 }),
@@ -147,7 +148,7 @@ fn test_not_with_equality() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "pk".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "pk".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -160,6 +161,7 @@ fn test_not_with_equality() {
             op: vibesql_ast::UnaryOperator::Not,
             expr: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "col0".to_string(),
                 }),
@@ -239,6 +241,7 @@ fn test_not_in_delete_where() {
             op: vibesql_ast::UnaryOperator::Not,
             expr: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "col0".to_string(),
                 }),
@@ -330,7 +333,7 @@ fn test_not_with_null() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "pk".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "pk".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -343,6 +346,7 @@ fn test_not_with_null() {
             op: vibesql_ast::UnaryOperator::Not,
             expr: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "col0".to_string(),
                 }),

--- a/crates/vibesql-executor/src/tests/operator_edge_cases/comparison_operators.rs
+++ b/crates/vibesql-executor/src/tests/operator_edge_cases/comparison_operators.rs
@@ -37,6 +37,7 @@ fn test_nested_comparisons() {
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "val".to_string(),
                 }),
@@ -48,6 +49,7 @@ fn test_nested_comparisons() {
             op: vibesql_ast::BinaryOperator::And,
             right: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "val".to_string(),
                 }),

--- a/crates/vibesql-executor/src/tests/phase3_join_optimization.rs
+++ b/crates/vibesql-executor/src/tests/phase3_join_optimization.rs
@@ -103,11 +103,13 @@ fn test_hash_join_from_where_equijoin_no_on_clause() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "id".to_string(),
             }),
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("t2".to_string()),
                 column: "id".to_string(),
             }),
@@ -230,11 +232,13 @@ fn test_hash_join_multiple_equijoins_in_where() {
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t1".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t2".to_string()),
                     column: "id".to_string(),
                 }),
@@ -242,11 +246,13 @@ fn test_hash_join_multiple_equijoins_in_where() {
             op: vibesql_ast::BinaryOperator::And,
             right: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t1".to_string()),
                     column: "value".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t2".to_string()),
                     column: "value".to_string(),
                 }),
@@ -372,11 +378,13 @@ fn test_cascading_joins_with_where_equijoins() {
             left: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::BinaryOp {
                     left: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("t1".to_string()),
                         column: "id".to_string(),
                     }),
                     op: vibesql_ast::BinaryOperator::Equal,
                     right: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("t2".to_string()),
                         column: "id".to_string(),
                     }),
@@ -384,11 +392,13 @@ fn test_cascading_joins_with_where_equijoins() {
                 op: vibesql_ast::BinaryOperator::And,
                 right: Box::new(vibesql_ast::Expression::BinaryOp {
                     left: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("t2".to_string()),
                         column: "id".to_string(),
                     }),
                     op: vibesql_ast::BinaryOperator::Equal,
                     right: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("t3".to_string()),
                         column: "id".to_string(),
                     }),
@@ -397,11 +407,13 @@ fn test_cascading_joins_with_where_equijoins() {
             op: vibesql_ast::BinaryOperator::And,
             right: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t3".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t4".to_string()),
                     column: "id".to_string(),
                 }),
@@ -510,11 +522,13 @@ fn test_hash_join_with_on_clause_and_where_equijoins() {
             join_type: vibesql_ast::JoinType::Inner,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t1".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t2".to_string()),
                     column: "id".to_string(),
                 }),
@@ -524,11 +538,13 @@ fn test_hash_join_with_on_clause_and_where_equijoins() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("t1".to_string()),
                 column: "key".to_string(),
             }),
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("t2".to_string()),
                 column: "key".to_string(),
             }),
@@ -657,11 +673,13 @@ fn test_multi_column_hash_join_composite_keys() {
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::BinaryOp {
                     left: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("sales".to_string()),
                         column: "region_id".to_string(),
                     }),
                     op: vibesql_ast::BinaryOperator::Equal,
                     right: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("inventory".to_string()),
                         column: "region_id".to_string(),
                     }),
@@ -669,11 +687,13 @@ fn test_multi_column_hash_join_composite_keys() {
                 op: vibesql_ast::BinaryOperator::And,
                 right: Box::new(vibesql_ast::Expression::BinaryOp {
                     left: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("sales".to_string()),
                         column: "product_id".to_string(),
                     }),
                     op: vibesql_ast::BinaryOperator::Equal,
                     right: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("inventory".to_string()),
                         column: "product_id".to_string(),
                     }),
@@ -857,11 +877,13 @@ fn test_star_join_select5_pattern() {
                     left: Box::new(vibesql_ast::Expression::BinaryOp {
                         left: Box::new(vibesql_ast::Expression::BinaryOp {
                             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                                schema: None,
                                 table: Some("t1".to_string()),
                                 column: "id".to_string(),
                             }),
                             op: vibesql_ast::BinaryOperator::Equal,
                             right: Box::new(vibesql_ast::Expression::ColumnRef {
+                                schema: None,
                                 table: Some("t2".to_string()),
                                 column: "id".to_string(),
                             }),
@@ -869,11 +891,13 @@ fn test_star_join_select5_pattern() {
                         op: vibesql_ast::BinaryOperator::And,
                         right: Box::new(vibesql_ast::Expression::BinaryOp {
                             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                                schema: None,
                                 table: Some("t1".to_string()),
                                 column: "id".to_string(),
                             }),
                             op: vibesql_ast::BinaryOperator::Equal,
                             right: Box::new(vibesql_ast::Expression::ColumnRef {
+                                schema: None,
                                 table: Some("t3".to_string()),
                                 column: "id".to_string(),
                             }),
@@ -882,11 +906,13 @@ fn test_star_join_select5_pattern() {
                     op: vibesql_ast::BinaryOperator::And,
                     right: Box::new(vibesql_ast::Expression::BinaryOp {
                         left: Box::new(vibesql_ast::Expression::ColumnRef {
+                            schema: None,
                             table: Some("t1".to_string()),
                             column: "id".to_string(),
                         }),
                         op: vibesql_ast::BinaryOperator::Equal,
                         right: Box::new(vibesql_ast::Expression::ColumnRef {
+                            schema: None,
                             table: Some("t4".to_string()),
                             column: "id".to_string(),
                         }),
@@ -895,11 +921,13 @@ fn test_star_join_select5_pattern() {
                 op: vibesql_ast::BinaryOperator::And,
                 right: Box::new(vibesql_ast::Expression::BinaryOp {
                     left: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("t1".to_string()),
                         column: "id".to_string(),
                     }),
                     op: vibesql_ast::BinaryOperator::Equal,
                     right: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("t5".to_string()),
                         column: "id".to_string(),
                     }),
@@ -908,11 +936,13 @@ fn test_star_join_select5_pattern() {
             op: vibesql_ast::BinaryOperator::And,
             right: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t1".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t6".to_string()),
                     column: "id".to_string(),
                 }),

--- a/crates/vibesql-executor/src/tests/predicate_pushdown.rs
+++ b/crates/vibesql-executor/src/tests/predicate_pushdown.rs
@@ -65,6 +65,7 @@ fn test_table_local_predicate_applied_at_scan() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "a".to_string(),
             }),
@@ -167,6 +168,7 @@ fn test_multi_table_with_local_predicates() {
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t1".to_string()),
                     column: "id".to_string(),
                 }),
@@ -178,6 +180,7 @@ fn test_multi_table_with_local_predicates() {
             op: vibesql_ast::BinaryOperator::And,
             right: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t2".to_string()),
                     column: "id".to_string(),
                 }),
@@ -300,11 +303,13 @@ fn test_table_local_predicate_with_explicit_join() {
             join_type: vibesql_ast::JoinType::Inner,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("orders".to_string()),
                     column: "customer_id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("customers".to_string()),
                     column: "customer_id".to_string(),
                 }),
@@ -314,6 +319,7 @@ fn test_table_local_predicate_with_explicit_join() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("orders".to_string()),
                 column: "amount".to_string(),
             }),
@@ -403,6 +409,7 @@ fn test_table_local_predicate_with_multiple_conditions() {
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "price".to_string(),
                 }),
@@ -414,6 +421,7 @@ fn test_table_local_predicate_with_multiple_conditions() {
             op: vibesql_ast::BinaryOperator::And,
             right: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "stock".to_string(),
                 }),

--- a/crates/vibesql-executor/src/tests/predicate_tests/between_predicate.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/between_predicate.rs
@@ -40,6 +40,7 @@ fn test_between_with_null_expr() {
         }),
         where_clause: Some(vibesql_ast::Expression::Between {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -97,6 +98,7 @@ fn test_not_between() {
         }),
         where_clause: Some(vibesql_ast::Expression::Between {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -153,6 +155,7 @@ fn test_between_boundary_values() {
         }),
         where_clause: Some(vibesql_ast::Expression::Between {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -212,6 +215,7 @@ fn test_not_between_with_null_bound() {
         }),
         where_clause: Some(vibesql_ast::Expression::Between {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -270,6 +274,7 @@ fn test_between_with_null_bound() {
         }),
         where_clause: Some(vibesql_ast::Expression::Between {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -331,6 +336,7 @@ fn test_not_between_with_null_lower_bound() {
         }),
         where_clause: Some(vibesql_ast::Expression::Between {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),

--- a/crates/vibesql-executor/src/tests/predicate_tests/in_predicate.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/in_predicate.rs
@@ -43,6 +43,7 @@ fn test_in_list_basic() {
         }),
         where_clause: Some(vibesql_ast::Expression::InList {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -101,6 +102,7 @@ fn test_not_in_list() {
         }),
         where_clause: Some(vibesql_ast::Expression::InList {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -157,6 +159,7 @@ fn test_in_list_with_null_value() {
         }),
         where_clause: Some(vibesql_ast::Expression::InList {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -213,6 +216,7 @@ fn test_in_list_with_null_in_list() {
         }),
         where_clause: Some(vibesql_ast::Expression::InList {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -270,6 +274,7 @@ fn test_empty_in_list() {
         }),
         where_clause: Some(vibesql_ast::Expression::InList {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -323,6 +328,7 @@ fn test_empty_not_in_list() {
         }),
         where_clause: Some(vibesql_ast::Expression::InList {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),

--- a/crates/vibesql-executor/src/tests/predicate_tests/in_subquery_multi_column_validation.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/in_subquery_multi_column_validation.rs
@@ -156,12 +156,14 @@ fn test_in_subquery_explicit_multi_column_rejected() {
                 select_list: vec![
                     vibesql_ast::SelectItem::Expression {
                         expr: vibesql_ast::Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "x".to_string(),
                         },
                         alias: None, source_text: None },
                     vibesql_ast::SelectItem::Expression {
                         expr: vibesql_ast::Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "y".to_string(),
                         },
@@ -260,6 +262,7 @@ fn test_in_subquery_single_column_accepted() {
                 distinct: false,
                 select_list: vec![vibesql_ast::SelectItem::Expression {
                     expr: vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "x".to_string(),
                     },

--- a/crates/vibesql-executor/src/tests/predicate_tests/like_predicate.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/like_predicate.rs
@@ -58,6 +58,7 @@ fn test_like_wildcard_percent() {
         }),
         where_clause: Some(vibesql_ast::Expression::Like {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "name".to_string(),
             }),
@@ -129,6 +130,7 @@ fn test_like_wildcard_underscore() {
         }),
         where_clause: Some(vibesql_ast::Expression::Like {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "name".to_string(),
             }),
@@ -200,6 +202,7 @@ fn test_not_like() {
         }),
         where_clause: Some(vibesql_ast::Expression::Like {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "name".to_string(),
             }),
@@ -258,6 +261,7 @@ fn test_like_null_pattern() {
         }),
         where_clause: Some(vibesql_ast::Expression::Like {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "name".to_string(),
             }),
@@ -314,6 +318,7 @@ fn test_like_null_value() {
         }),
         where_clause: Some(vibesql_ast::Expression::Like {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "name".to_string(),
             }),

--- a/crates/vibesql-executor/src/tests/procedures/control_flow.rs
+++ b/crates/vibesql-executor/src/tests/procedures/control_flow.rs
@@ -482,7 +482,7 @@ fn test_procedure_body_caching_performance() {
             ProceduralStatement::Set {
                 name: "temp".to_string(),
                 value: Box::new(Expression::BinaryOp {
-                    left: Box::new(Expression::ColumnRef { table: None, column: "x".to_string() }),
+                    left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
                     op: BinaryOperator::Multiply,
                     right: Box::new(Expression::Literal(SqlValue::Integer(2))),
                 }),
@@ -491,6 +491,7 @@ fn test_procedure_body_caching_performance() {
                 name: "result".to_string(),
                 value: Box::new(Expression::BinaryOp {
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "temp".to_string(),
                     }),
@@ -511,7 +512,7 @@ fn test_procedure_body_caching_performance() {
         procedure_name: "test_cache_proc".to_string(),
         arguments: vec![
             Expression::Literal(SqlValue::Integer(5)),
-            Expression::ColumnRef { table: None, column: "@out".to_string() },
+            Expression::ColumnRef { schema: None, table: None, column: "@out".to_string() },
         ],
     };
     advanced_objects::execute_call(&call_stmt, &mut db).unwrap();
@@ -528,7 +529,7 @@ fn test_procedure_body_caching_performance() {
             procedure_name: "test_cache_proc".to_string(),
             arguments: vec![
                 Expression::Literal(SqlValue::Integer(i)),
-                Expression::ColumnRef { table: None, column: format!("@out{}", i) },
+                Expression::ColumnRef { schema: None, table: None, column: format!("@out{}", i) },
             ],
         };
         advanced_objects::execute_call(&call_stmt, &mut db).unwrap();
@@ -580,7 +581,7 @@ fn test_cache_invalidation_on_drop() {
     // Call once to populate cache
     let call_stmt = CallStmt {
         procedure_name: "test_invalidate".to_string(),
-        arguments: vec![Expression::ColumnRef { table: None, column: "@out".to_string() }],
+        arguments: vec![Expression::ColumnRef { schema: None, table: None, column: "@out".to_string() }],
     };
     advanced_objects::execute_call(&call_stmt, &mut db).unwrap();
     assert_eq!(db.get_session_variable("out"), Some(&SqlValue::Integer(42)));
@@ -614,7 +615,7 @@ fn test_cache_invalidation_on_drop() {
     // Call again - should use new procedure body, not cached old one
     let call_stmt2 = CallStmt {
         procedure_name: "test_invalidate".to_string(),
-        arguments: vec![Expression::ColumnRef { table: None, column: "@out2".to_string() }],
+        arguments: vec![Expression::ColumnRef { schema: None, table: None, column: "@out2".to_string() }],
     };
     advanced_objects::execute_call(&call_stmt2, &mut db).unwrap();
     assert_eq!(db.get_session_variable("out2"), Some(&SqlValue::Integer(99)));

--- a/crates/vibesql-executor/src/tests/procedures/edge_cases.rs
+++ b/crates/vibesql-executor/src/tests/procedures/edge_cases.rs
@@ -45,7 +45,7 @@ fn test_null_parameter_in_procedure() {
             },
             ProceduralStatement::Set {
                 name: "result".to_string(),
-                value: Box::new(Expression::ColumnRef { table: None, column: "x".to_string() }),
+                value: Box::new(Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
             },
         ],
     );
@@ -271,6 +271,7 @@ fn test_large_number_arithmetic() {
                 name: "result".to_string(),
                 value: Box::new(Expression::BinaryOp {
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "large".to_string(),
                     }),
@@ -317,9 +318,9 @@ fn test_multiple_variable_operations() {
             ProceduralStatement::Set {
                 name: "a".to_string(),
                 value: Box::new(Expression::BinaryOp {
-                    left: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+                    left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
                     op: BinaryOperator::Plus,
-                    right: Box::new(Expression::ColumnRef { table: None, column: "c".to_string() }),
+                    right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "c".to_string() }),
                 }),
             },
         ],
@@ -368,7 +369,7 @@ fn test_procedural_select_into_single_column() {
                 with_clause: None,
                 distinct: false,
                 select_list: vec![SelectItem::Expression {
-                    expr: Expression::ColumnRef { table: None, column: "name".to_string() },
+                    expr: Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
                     alias: None, source_text: None }],
                 into_table: None,
                 into_variables: Some(vec!["user_name".to_string()]),
@@ -379,9 +380,10 @@ fn test_procedural_select_into_single_column() {
                 quoted: false,
                 }),
                 where_clause: Some(Expression::BinaryOp {
-                    left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+                    left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
                     op: BinaryOperator::Equal,
                     right: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "user_id".to_string(),
                     }),
@@ -446,10 +448,10 @@ fn test_procedural_select_into_multiple_columns() {
                 distinct: false,
                 select_list: vec![
                     SelectItem::Expression {
-                        expr: Expression::ColumnRef { table: None, column: "id".to_string() },
+                        expr: Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
                         alias: None, source_text: None },
                     SelectItem::Expression {
-                        expr: Expression::ColumnRef { table: None, column: "name".to_string() },
+                        expr: Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
                         alias: None, source_text: None },
                 ],
                 into_table: None,
@@ -461,9 +463,10 @@ fn test_procedural_select_into_multiple_columns() {
                 quoted: false,
                 }),
                 where_clause: Some(Expression::BinaryOp {
-                    left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+                    left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
                     op: BinaryOperator::Equal,
                     right: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "user_id".to_string(),
                     }),
@@ -519,7 +522,7 @@ fn test_procedural_select_into_error_no_rows() {
                 with_clause: None,
                 distinct: false,
                 select_list: vec![SelectItem::Expression {
-                    expr: Expression::ColumnRef { table: None, column: "name".to_string() },
+                    expr: Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
                     alias: None, source_text: None }],
                 into_table: None,
                 into_variables: Some(vec!["user_name".to_string()]),
@@ -530,9 +533,10 @@ fn test_procedural_select_into_error_no_rows() {
                 quoted: false,
                 }),
                 where_clause: Some(Expression::BinaryOp {
-                    left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+                    left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
                     op: BinaryOperator::Equal,
                     right: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "user_id".to_string(),
                     }),
@@ -601,7 +605,7 @@ fn test_procedural_select_into_error_multiple_rows() {
                 with_clause: None,
                 distinct: false,
                 select_list: vec![SelectItem::Expression {
-                    expr: Expression::ColumnRef { table: None, column: "name".to_string() },
+                    expr: Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
                     alias: None, source_text: None }],
                 into_table: None,
                 into_variables: Some(vec!["user_name".to_string()]),
@@ -666,10 +670,10 @@ fn test_procedural_select_into_error_column_count_mismatch() {
                 distinct: false,
                 select_list: vec![
                     SelectItem::Expression {
-                        expr: Expression::ColumnRef { table: None, column: "id".to_string() },
+                        expr: Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
                         alias: None, source_text: None },
                     SelectItem::Expression {
-                        expr: Expression::ColumnRef { table: None, column: "name".to_string() },
+                        expr: Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
                         alias: None, source_text: None },
                 ],
                 into_table: None,
@@ -681,7 +685,7 @@ fn test_procedural_select_into_error_column_count_mismatch() {
                 quoted: false,
                 }),
                 where_clause: Some(Expression::BinaryOp {
-                    left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+                    left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
                     op: BinaryOperator::Equal,
                     right: Box::new(Expression::Literal(SqlValue::Integer(1))),
                 }),

--- a/crates/vibesql-executor/src/tests/procedures/parameters.rs
+++ b/crates/vibesql-executor/src/tests/procedures/parameters.rs
@@ -26,7 +26,7 @@ fn test_call_procedure_with_in_parameter() {
             },
             ProceduralStatement::Set {
                 name: "greeting".to_string(),
-                value: Box::new(Expression::ColumnRef { table: None, column: "name".to_string() }),
+                value: Box::new(Expression::ColumnRef { schema: None, table: None, column: "name".to_string() }),
             },
         ]),
         sql_security: None,
@@ -78,9 +78,9 @@ fn test_call_procedure_with_multiple_parameters() {
             ProceduralStatement::Set {
                 name: "result".to_string(),
                 value: Box::new(Expression::BinaryOp {
-                    left: Box::new(Expression::ColumnRef { table: None, column: "a".to_string() }),
+                    left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "a".to_string() }),
                     op: BinaryOperator::Plus,
-                    right: Box::new(Expression::ColumnRef { table: None, column: "b".to_string() }),
+                    right: Box::new(Expression::ColumnRef { schema: None, table: None, column: "b".to_string() }),
                 }),
             },
         ]),
@@ -170,7 +170,7 @@ fn test_variable_in_expression() {
             ProceduralStatement::Set {
                 name: "y".to_string(),
                 value: Box::new(Expression::BinaryOp {
-                    left: Box::new(Expression::ColumnRef { table: None, column: "x".to_string() }),
+                    left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "x".to_string() }),
                     op: BinaryOperator::Multiply,
                     right: Box::new(Expression::Literal(SqlValue::Integer(2))),
                 }),
@@ -223,9 +223,9 @@ fn test_concat_function_in_procedure() {
                 value: Box::new(Expression::Function {
                     name: "CONCAT".to_string(),
                     args: vec![
-                        Expression::ColumnRef { table: None, column: "first".to_string() },
+                        Expression::ColumnRef { schema: None, table: None, column: "first".to_string() },
                         Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(" "))),
-                        Expression::ColumnRef { table: None, column: "last".to_string() },
+                        Expression::ColumnRef { schema: None, table: None, column: "last".to_string() },
                     ],
                     character_unit: None,
                 }),

--- a/crates/vibesql-executor/src/tests/quantified_comparison_tests.rs
+++ b/crates/vibesql-executor/src/tests/quantified_comparison_tests.rs
@@ -56,7 +56,7 @@ fn test_all_greater_than_basic() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "y".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -81,7 +81,7 @@ fn test_all_greater_than_basic() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "x".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -92,6 +92,7 @@ fn test_all_greater_than_basic() {
         }),
         where_clause: Some(vibesql_ast::Expression::QuantifiedComparison {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "x".to_string(),
             }),
@@ -160,7 +161,7 @@ fn test_any_less_than_basic() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "y".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -185,7 +186,7 @@ fn test_any_less_than_basic() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "x".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -196,6 +197,7 @@ fn test_any_less_than_basic() {
         }),
         where_clause: Some(vibesql_ast::Expression::QuantifiedComparison {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "x".to_string(),
             }),
@@ -265,7 +267,7 @@ fn test_some_equals_basic() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "y".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -290,7 +292,7 @@ fn test_some_equals_basic() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "x".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -301,6 +303,7 @@ fn test_some_equals_basic() {
         }),
         where_clause: Some(vibesql_ast::Expression::QuantifiedComparison {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "x".to_string(),
             }),
@@ -364,7 +367,7 @@ fn test_all_with_empty_subquery() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "y".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -389,7 +392,7 @@ fn test_all_with_empty_subquery() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "x".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -400,6 +403,7 @@ fn test_all_with_empty_subquery() {
         }),
         where_clause: Some(vibesql_ast::Expression::QuantifiedComparison {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "x".to_string(),
             }),
@@ -463,7 +467,7 @@ fn test_any_with_empty_subquery() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "y".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -488,7 +492,7 @@ fn test_any_with_empty_subquery() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "x".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -499,6 +503,7 @@ fn test_any_with_empty_subquery() {
         }),
         where_clause: Some(vibesql_ast::Expression::QuantifiedComparison {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "x".to_string(),
             }),
@@ -569,7 +574,7 @@ fn test_all_with_null_in_subquery() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "y".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -594,7 +599,7 @@ fn test_all_with_null_in_subquery() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "x".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -605,6 +610,7 @@ fn test_all_with_null_in_subquery() {
         }),
         where_clause: Some(vibesql_ast::Expression::QuantifiedComparison {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "x".to_string(),
             }),
@@ -664,7 +670,7 @@ fn test_all_with_null_left_value() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "y".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "y".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -689,7 +695,7 @@ fn test_all_with_null_left_value() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "x".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "x".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -700,6 +706,7 @@ fn test_all_with_null_left_value() {
         }),
         where_clause: Some(vibesql_ast::Expression::QuantifiedComparison {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "x".to_string(),
             }),

--- a/crates/vibesql-executor/src/tests/rowid_tests.rs
+++ b/crates/vibesql-executor/src/tests/rowid_tests.rs
@@ -59,18 +59,21 @@ fn test_select_rowid() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "rowid".to_string(),
                 },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "a".to_string(),
                 },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "b".to_string(),
                 },
@@ -135,6 +138,7 @@ fn test_select_underscore_rowid() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "_rowid_".to_string(),
             },
@@ -191,6 +195,7 @@ fn test_select_oid() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "oid".to_string(),
             },
@@ -247,6 +252,7 @@ fn test_rowid_case_insensitive() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "ROWID".to_string(),
             },
@@ -316,6 +322,7 @@ fn test_real_rowid_column_takes_precedence() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "rowid".to_string(),
             },
@@ -378,6 +385,7 @@ fn test_rowid_with_table_alias() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("t".to_string()),
                 column: "rowid".to_string(),
             },
@@ -440,6 +448,7 @@ fn test_explicit_rowid_preserved() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "rowid".to_string(),
                 },
@@ -448,6 +457,7 @@ fn test_explicit_rowid_preserved() {
             },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "x".to_string(),
                 },
@@ -530,6 +540,7 @@ fn test_mixed_explicit_and_auto_rowid() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "rowid".to_string(),
                 },
@@ -538,6 +549,7 @@ fn test_mixed_explicit_and_auto_rowid() {
             },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "x".to_string(),
                 },

--- a/crates/vibesql-executor/src/tests/scalar_subquery_basic_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_basic_tests.rs
@@ -76,6 +76,7 @@ fn test_scalar_subquery_in_where_clause() {
             expr: vibesql_ast::Expression::Function {
                 name: "AVG".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "salary".to_string(),
                 }],
@@ -113,6 +114,7 @@ fn test_scalar_subquery_in_where_clause() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "salary".to_string(),
             }),
@@ -199,6 +201,7 @@ fn test_scalar_subquery_in_select_list() {
             expr: vibesql_ast::Expression::Function {
                 name: "MAX".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "salary".to_string(),
                 }],
@@ -231,12 +234,14 @@ fn test_scalar_subquery_in_select_list() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "name".to_string(),
                 },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "salary".to_string(),
                 },
@@ -306,7 +311,7 @@ fn test_scalar_subquery_returns_null_when_empty() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -317,6 +322,7 @@ fn test_scalar_subquery_returns_null_when_empty() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "id".to_string(),
             }),

--- a/crates/vibesql-executor/src/tests/scalar_subquery_correlated_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_correlated_tests.rs
@@ -88,6 +88,7 @@ fn test_correlated_subquery_uppercase_identifiers_issue_4111() {
                 name: "AVG".to_string(),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("J".to_string()),          // UPPERCASE alias
                     column: "I_CURRENT_PRICE".to_string(), // UPPERCASE column - this was failing
                 }],
@@ -103,11 +104,13 @@ fn test_correlated_subquery_uppercase_identifiers_issue_4111() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("J".to_string()),     // UPPERCASE alias
                 column: "I_CATEGORY".to_string(), // UPPERCASE column
             }),
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("I".to_string()),     // UPPERCASE outer alias
                 column: "I_CATEGORY".to_string(), // UPPERCASE column
             }),
@@ -130,6 +133,7 @@ fn test_correlated_subquery_uppercase_identifiers_issue_4111() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("I".to_string()),
                 column: "I_ITEM_SK".to_string(),
             },
@@ -143,6 +147,7 @@ fn test_correlated_subquery_uppercase_identifiers_issue_4111() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: Some("I".to_string()),
                 column: "I_CURRENT_PRICE".to_string(),
             }),
@@ -268,6 +273,7 @@ fn test_correlated_subquery_basic() {
             expr: vibesql_ast::Expression::Function {
                 name: "AVG".to_string(),
                 args: vec![vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "salary".to_string(),
                 }],
@@ -283,11 +289,13 @@ fn test_correlated_subquery_basic() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "department".to_string(),
             }),
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "department".to_string(),
             }),
@@ -310,12 +318,14 @@ fn test_correlated_subquery_basic() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "name".to_string(),
                 },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "salary".to_string(),
                 },
@@ -328,6 +338,7 @@ fn test_correlated_subquery_basic() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "salary".to_string(),
             }),

--- a/crates/vibesql-executor/src/tests/scalar_subquery_error_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_error_tests.rs
@@ -43,7 +43,7 @@ fn test_scalar_subquery_error_multiple_rows() {
             values: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -143,10 +143,11 @@ fn test_scalar_subquery_error_multiple_columns() {
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "name".to_string(),
                 },

--- a/crates/vibesql-executor/src/tests/select_basic_projection.rs
+++ b/crates/vibesql-executor/src/tests/select_basic_projection.rs
@@ -120,12 +120,13 @@ fn test_select_specific_columns() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "name".to_string(),
                 },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "age".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "age".to_string() },
                 alias: None, source_text: None },
         ],
         from: Some(vibesql_ast::FromClause::Table { quoted: false,

--- a/crates/vibesql-executor/src/tests/select_distinct.rs
+++ b/crates/vibesql-executor/src/tests/select_distinct.rs
@@ -70,6 +70,7 @@ fn test_distinct_removes_duplicate_rows() {
         distinct: true,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "category".to_string(),
             },
@@ -184,12 +185,14 @@ fn test_distinct_with_multiple_columns() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "customer_id".to_string(),
                 },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "status".to_string(),
                 },
@@ -280,6 +283,7 @@ fn test_distinct_with_null_values() {
         distinct: true,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "description".to_string(),
             },
@@ -434,7 +438,7 @@ fn test_distinct_with_where_clause() {
             values: None,
         distinct: true,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "role".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "role".to_string() },
             alias: None,
             source_text: None,
         }],
@@ -445,6 +449,7 @@ fn test_distinct_with_where_clause() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "id".to_string(),
             }),
@@ -531,6 +536,7 @@ fn test_distinct_with_order_by() {
         distinct: true,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "category".to_string(),
             },
@@ -547,6 +553,7 @@ fn test_distinct_with_order_by() {
         having: None,
         order_by: Some(vec![vibesql_ast::OrderByItem {
             expr: vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "category".to_string(),
             },

--- a/crates/vibesql-executor/src/tests/select_into_tests.rs
+++ b/crates/vibesql-executor/src/tests/select_into_tests.rs
@@ -52,10 +52,11 @@ fn test_select_into_single_row() {
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "name".to_string(),
                 },
@@ -142,7 +143,7 @@ fn test_select_into_no_rows_error() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
             alias: None, source_text: None }],
         into_table: Some("target".to_string()),
         into_variables: None,
@@ -211,7 +212,7 @@ fn test_select_into_multiple_rows_error() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
             alias: None, source_text: None }],
         into_table: Some("target".to_string()),
         into_variables: None,
@@ -278,6 +279,7 @@ fn test_select_into_with_expressions() {
             expr: vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Plus,
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "x".to_string(),
                 }),

--- a/crates/vibesql-executor/src/tests/select_joins.rs
+++ b/crates/vibesql-executor/src/tests/select_joins.rs
@@ -104,11 +104,13 @@ fn test_inner_join_two_tables() {
             join_type: vibesql_ast::JoinType::Inner,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("users".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("orders".to_string()),
                     column: "user_id".to_string(),
                 }),
@@ -232,11 +234,13 @@ fn test_right_outer_join() {
             join_type: vibesql_ast::JoinType::RightOuter,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("users".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("orders".to_string()),
                     column: "user_id".to_string(),
                 }),
@@ -367,11 +371,13 @@ fn test_full_outer_join() {
             join_type: vibesql_ast::JoinType::FullOuter,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("users".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("orders".to_string()),
                     column: "user_id".to_string(),
                 }),
@@ -568,11 +574,13 @@ fn test_cross_join_with_condition_fails() {
             join_type: vibesql_ast::JoinType::Cross,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("users".to_string()),
                     column: "id".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("products".to_string()),
                     column: "id".to_string(),
                 }),
@@ -686,12 +694,14 @@ fn test_inner_join_null_values_dont_match() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t1".to_string()),
                     column: "name".to_string(),
                 },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t2".to_string()),
                     column: "value".to_string(),
                 },
@@ -711,11 +721,13 @@ fn test_inner_join_null_values_dont_match() {
             join_type: vibesql_ast::JoinType::Inner,
             condition: Some(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t1".to_string()),
                     column: "x".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: Some("t2".to_string()),
                     column: "y".to_string(),
                 }),

--- a/crates/vibesql-executor/src/tests/select_order_by.rs
+++ b/crates/vibesql-executor/src/tests/select_order_by.rs
@@ -67,7 +67,7 @@ fn test_order_by_single_column_asc() {
         group_by: None,
         having: None,
         order_by: Some(vec![vibesql_ast::OrderByItem {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "age".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "age".to_string() },
             direction: vibesql_ast::OrderDirection::Asc,
             nulls_order: None,
         }]),
@@ -164,6 +164,7 @@ fn test_order_by_multiple_columns() {
         order_by: Some(vec![
             vibesql_ast::OrderByItem {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "dept".to_string(),
                 },
@@ -171,7 +172,7 @@ fn test_order_by_multiple_columns() {
                 nulls_order: None,
             },
             vibesql_ast::OrderByItem {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "age".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "age".to_string() },
                 direction: vibesql_ast::OrderDirection::Desc,
                 nulls_order: None,
             },

--- a/crates/vibesql-executor/src/tests/select_where.rs
+++ b/crates/vibesql-executor/src/tests/select_where.rs
@@ -64,6 +64,7 @@ fn test_select_with_where() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "age".to_string(),
             }),
@@ -153,6 +154,7 @@ fn test_select_with_and_condition() {
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "price".to_string(),
                 }),
@@ -164,6 +166,7 @@ fn test_select_with_and_condition() {
             op: vibesql_ast::BinaryOperator::And,
             right: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "stock".to_string(),
                 }),
@@ -248,6 +251,7 @@ fn test_select_with_or_condition() {
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "category".to_string(),
                 }),
@@ -259,6 +263,7 @@ fn test_select_with_or_condition() {
             op: vibesql_ast::BinaryOperator::Or,
             right: Box::new(vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "category".to_string(),
                 }),
@@ -340,6 +345,7 @@ fn test_select_with_null_in_where() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "value".to_string(),
             }),

--- a/crates/vibesql-executor/src/tests/select_without_from.rs
+++ b/crates/vibesql-executor/src/tests/select_without_from.rs
@@ -224,6 +224,7 @@ fn test_column_reference_without_from_fails() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "some_column".to_string(),
             },
@@ -262,6 +263,7 @@ fn test_is_null_with_column_reference_fails() {
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::IsNull {
                 expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "id".to_string(),
                 }),
@@ -302,6 +304,7 @@ fn test_between_with_column_reference_fails() {
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Between {
                 expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "price".to_string(),
                 }),
@@ -349,6 +352,7 @@ fn test_cast_with_column_reference_fails() {
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Cast {
                 expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "id".to_string(),
                 }),
@@ -389,6 +393,7 @@ fn test_like_with_column_reference_fails() {
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Like {
                 expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "name".to_string(),
                 }),
@@ -432,6 +437,7 @@ fn test_in_list_with_column_reference_fails() {
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::InList {
                 expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "id".to_string(),
                 }),

--- a/crates/vibesql-executor/src/tests/subquery_mysql_compat.rs
+++ b/crates/vibesql-executor/src/tests/subquery_mysql_compat.rs
@@ -68,6 +68,7 @@ fn test_mysql_null_in_empty_subquery() {
         }),
         where_clause: Some(vibesql_ast::Expression::In {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -76,6 +77,7 @@ fn test_mysql_null_in_empty_subquery() {
                 distinct: false,
                 select_list: vec![vibesql_ast::SelectItem::Expression {
                     expr: vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "id".to_string(),
                     },
@@ -157,6 +159,7 @@ fn test_mysql_null_not_in_empty_subquery() {
         }),
         where_clause: Some(vibesql_ast::Expression::In {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -165,6 +168,7 @@ fn test_mysql_null_not_in_empty_subquery() {
                 distinct: false,
                 select_list: vec![vibesql_ast::SelectItem::Expression {
                     expr: vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "id".to_string(),
                     },
@@ -255,6 +259,7 @@ fn test_mysql_null_in_non_empty_without_null() {
         }),
         where_clause: Some(vibesql_ast::Expression::In {
             expr: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -263,6 +268,7 @@ fn test_mysql_null_in_non_empty_without_null() {
                 distinct: false,
                 select_list: vec![vibesql_ast::SelectItem::Expression {
                     expr: vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "id".to_string(),
                     },
@@ -388,6 +394,7 @@ fn test_mysql_triple_nested_subquery() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "val".to_string(),
             }),
@@ -398,6 +405,7 @@ fn test_mysql_triple_nested_subquery() {
                     distinct: false,
                     select_list: vec![vibesql_ast::SelectItem::Expression {
                         expr: vibesql_ast::Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "max_val".to_string(),
                         },
@@ -411,6 +419,7 @@ fn test_mysql_triple_nested_subquery() {
                     }),
                     where_clause: Some(vibesql_ast::Expression::BinaryOp {
                         left: Box::new(vibesql_ast::Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "max_val".to_string(),
                         }),
@@ -422,6 +431,7 @@ fn test_mysql_triple_nested_subquery() {
                                 select_list: vec![vibesql_ast::SelectItem::Expression {
                                     expr: vibesql_ast::Expression::BinaryOp {
                                         left: Box::new(vibesql_ast::Expression::ColumnRef {
+                                            schema: None,
                                             table: None,
                                             column: "multiplier".to_string(),
                                         }),
@@ -561,6 +571,7 @@ fn test_mysql_exists_short_circuit() {
                 }),
                 where_clause: Some(vibesql_ast::Expression::BinaryOp {
                     left: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "customer_id".to_string(),
                     }),
@@ -685,6 +696,7 @@ fn test_mysql_scalar_within_exists() {
                 }),
                 where_clause: Some(vibesql_ast::Expression::BinaryOp {
                     left: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: Some("p".to_string()),
                         column: "price".to_string(),
                     }),
@@ -695,6 +707,7 @@ fn test_mysql_scalar_within_exists() {
                             distinct: false,
                             select_list: vec![vibesql_ast::SelectItem::Expression {
                                 expr: vibesql_ast::Expression::ColumnRef {
+                                    schema: None,
                                     table: None,
                                     column: "avg".to_string(),
                                 },

--- a/crates/vibesql-executor/src/tests/triggers/conditions.rs
+++ b/crates/vibesql-executor/src/tests/triggers/conditions.rs
@@ -54,6 +54,7 @@ fn test_when_clause_filters_firing() {
         when_condition: Some(Box::new(vibesql_ast::Expression::BinaryOp {
             op: vibesql_ast::BinaryOperator::GreaterThan,
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 column: "amount".to_string(),
                 table: None,
             }),

--- a/crates/vibesql-executor/src/tests/triggers/coordination.rs
+++ b/crates/vibesql-executor/src/tests/triggers/coordination.rs
@@ -173,7 +173,7 @@ fn test_before_trigger_executes_first() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { column: "value".to_string(), table: None },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, column: "value".to_string(), table: None },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,

--- a/crates/vibesql-executor/src/tests/triggers/delete.rs
+++ b/crates/vibesql-executor/src/tests/triggers/delete.rs
@@ -53,6 +53,7 @@ fn test_after_delete_trigger_fires() {
             vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Equal,
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     column: "id".to_string(),
                     table: None,
                 }),
@@ -113,6 +114,7 @@ fn test_before_delete_trigger_fires() {
             vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Equal,
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     column: "id".to_string(),
                     table: None,
                 }),

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -58,6 +58,7 @@ fn test_after_update_trigger_fires() {
             vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Equal,
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     column: "id".to_string(),
                     table: None,
                 }),
@@ -124,6 +125,7 @@ fn test_before_update_trigger_fires() {
             vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Equal,
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     column: "id".to_string(),
                     table: None,
                 }),

--- a/crates/vibesql-executor/tests/case_expression_tests.rs
+++ b/crates/vibesql-executor/tests/case_expression_tests.rs
@@ -29,6 +29,7 @@ fn test_simple_case_basic_match() {
     // 'Unknown' END
     let case_expr = Expression::Case {
         operand: Some(Box::new(Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "status".to_string(),
         })),
@@ -89,6 +90,7 @@ fn test_simple_case_null_handling() {
     // CASE status WHEN NULL THEN 'Null Status' ELSE 'Not Null' END
     let case_expr = Expression::Case {
         operand: Some(Box::new(Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "status".to_string(),
         })),
@@ -122,6 +124,7 @@ fn test_searched_case_basic() {
                 conditions: vec![Expression::BinaryOp {
                     op: vibesql_ast::BinaryOperator::LessThan,
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "value".to_string(),
                     }),
@@ -133,6 +136,7 @@ fn test_searched_case_basic() {
                 conditions: vec![Expression::BinaryOp {
                     op: vibesql_ast::BinaryOperator::LessThan,
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "value".to_string(),
                     }),
@@ -210,7 +214,7 @@ fn test_case_no_else_defaults_to_null() {
     // CASE value WHEN 1 THEN 'one' WHEN 2 THEN 'two' END
     // No ELSE clause, value = 3 -> should return NULL
     let case_expr = Expression::Case {
-        operand: Some(Box::new(Expression::ColumnRef { table: None, column: "value".to_string() })),
+        operand: Some(Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() })),
         when_clauses: vec![
             vibesql_ast::CaseWhen {
                 conditions: vec![Expression::Literal(SqlValue::Integer(1))],
@@ -241,7 +245,7 @@ fn test_case_lazy_evaluation() {
     // CASE value WHEN 1 THEN 'first' WHEN 1 THEN 'second' ELSE 'other' END
     // Should return 'first' and not evaluate second WHEN
     let case_expr = Expression::Case {
-        operand: Some(Box::new(Expression::ColumnRef { table: None, column: "value".to_string() })),
+        operand: Some(Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() })),
         when_clauses: vec![
             vibesql_ast::CaseWhen {
                 conditions: vec![Expression::Literal(SqlValue::Integer(1))],
@@ -276,7 +280,7 @@ fn test_case_comma_separated_matching_first() {
 
     // CASE value WHEN 2, 3, 4 THEN 'match' ELSE 'no' END
     let case_expr = Expression::Case {
-        operand: Some(Box::new(Expression::ColumnRef { table: None, column: "value".to_string() })),
+        operand: Some(Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() })),
         when_clauses: vec![vibesql_ast::CaseWhen {
             conditions: vec![
                 Expression::Literal(SqlValue::Integer(2)),
@@ -307,7 +311,7 @@ fn test_case_comma_separated_matching_last() {
 
     // CASE value WHEN 2, 3, 4 THEN 'match' ELSE 'no' END
     let case_expr = Expression::Case {
-        operand: Some(Box::new(Expression::ColumnRef { table: None, column: "value".to_string() })),
+        operand: Some(Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() })),
         when_clauses: vec![vibesql_ast::CaseWhen {
             conditions: vec![
                 Expression::Literal(SqlValue::Integer(2)),
@@ -338,7 +342,7 @@ fn test_case_comma_separated_no_match() {
 
     // CASE value WHEN 2, 3, 4 THEN 'match' ELSE 'no' END
     let case_expr = Expression::Case {
-        operand: Some(Box::new(Expression::ColumnRef { table: None, column: "value".to_string() })),
+        operand: Some(Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() })),
         when_clauses: vec![vibesql_ast::CaseWhen {
             conditions: vec![
                 Expression::Literal(SqlValue::Integer(2)),
@@ -370,7 +374,7 @@ fn test_case_comma_separated_duplicate_values() {
 
     // CASE value WHEN 2, 2 THEN 1 ELSE 1 END (duplicate values allowed)
     let case_expr = Expression::Case {
-        operand: Some(Box::new(Expression::ColumnRef { table: None, column: "value".to_string() })),
+        operand: Some(Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() })),
         when_clauses: vec![vibesql_ast::CaseWhen {
             conditions: vec![
                 Expression::Literal(SqlValue::Integer(2)),
@@ -398,7 +402,7 @@ fn test_case_comma_separated_with_null() {
 
     // CASE value WHEN 2, 2 THEN 1 ELSE NULL END
     let case_expr = Expression::Case {
-        operand: Some(Box::new(Expression::ColumnRef { table: None, column: "value".to_string() })),
+        operand: Some(Box::new(Expression::ColumnRef { schema: None, table: None, column: "value".to_string() })),
         when_clauses: vec![vibesql_ast::CaseWhen {
             conditions: vec![
                 Expression::Literal(SqlValue::Integer(2)),
@@ -427,6 +431,7 @@ fn test_case_comma_separated_varchar() {
     // CASE status WHEN 'active', 'pending', 'new' THEN 'open' ELSE 'closed' END
     let case_expr = Expression::Case {
         operand: Some(Box::new(Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "status".to_string(),
         })),

--- a/crates/vibesql-executor/tests/case_sensitivity_tests.rs
+++ b/crates/vibesql-executor/tests/case_sensitivity_tests.rs
@@ -243,10 +243,11 @@ fn test_view_lookup_case_insensitive_when_enabled() {
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
-                expr: vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() },
+                expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "name".to_string(),
                 },
@@ -308,7 +309,7 @@ fn test_drop_view_case_insensitive_when_enabled() {
     let select_stmt = vibesql_ast::SelectStmt {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -368,7 +369,7 @@ fn test_view_case_sensitive_mode() {
     let select_stmt = vibesql_ast::SelectStmt {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "id".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,

--- a/crates/vibesql-executor/tests/common/insert_constraint_fixtures.rs
+++ b/crates/vibesql-executor/tests/common/insert_constraint_fixtures.rs
@@ -182,6 +182,7 @@ pub fn create_check_price_table(db: &mut vibesql_storage::Database, nullable_pri
             "price_positive".to_string(),
             vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "price".to_string(),
                 }),
@@ -225,6 +226,7 @@ pub fn create_multi_check_table(db: &mut vibesql_storage::Database) {
                 "price_positive".to_string(),
                 vibesql_ast::Expression::BinaryOp {
                     left: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "price".to_string(),
                     }),
@@ -238,6 +240,7 @@ pub fn create_multi_check_table(db: &mut vibesql_storage::Database) {
                 "quantity_positive".to_string(),
                 vibesql_ast::Expression::BinaryOp {
                     left: Box::new(vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "quantity".to_string(),
                     }),
@@ -281,11 +284,13 @@ pub fn create_check_comparison_table(db: &mut vibesql_storage::Database) {
             "bonus_less_than_salary".to_string(),
             vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "bonus".to_string(),
                 }),
                 op: vibesql_ast::BinaryOperator::LessThan,
                 right: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "salary".to_string(),
                 }),

--- a/crates/vibesql-executor/tests/duplicate_key_update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/duplicate_key_update_columnar_cache_tests.rs
@@ -318,6 +318,7 @@ fn test_on_duplicate_key_update_arithmetic_invalidates_cache() {
             value: vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Plus,
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "stock".to_string(),
                 }),

--- a/crates/vibesql-executor/tests/index_ordering_tests.rs
+++ b/crates/vibesql-executor/tests/index_ordering_tests.rs
@@ -88,7 +88,7 @@ fn test_index_ordering() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "name".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -102,7 +102,7 @@ fn test_index_ordering() {
         group_by: None,
         having: None,
         order_by: Some(vec![vibesql_ast::OrderByItem {
-            expr: vibesql_ast::Expression::ColumnRef { table: None, column: "name".to_string() },
+            expr: vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
             direction: OrderDirection::Asc,
             nulls_order: None,
         }]),

--- a/crates/vibesql-executor/tests/insert_duplicate_key_update_tests.rs
+++ b/crates/vibesql-executor/tests/insert_duplicate_key_update_tests.rs
@@ -122,6 +122,7 @@ fn test_on_duplicate_key_update_with_arithmetic() {
             value: vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Plus,
                 left: Box::new(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "stock".to_string(),
                 }),

--- a/crates/vibesql-executor/tests/insert_select_tests.rs
+++ b/crates/vibesql-executor/tests/insert_select_tests.rs
@@ -140,6 +140,7 @@ fn test_insert_from_select_with_where() {
         }),
         where_clause: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef {
+                schema: None,
                 table: None,
                 column: "id".to_string(),
             }),
@@ -320,6 +321,7 @@ fn test_insert_from_select_with_aggregates() {
                 expr: vibesql_ast::Expression::Function {
                     name: "SUM".to_string(),
                     args: vec![vibesql_ast::Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "amount".to_string(),
                     }],

--- a/crates/vibesql-executor/tests/update_basic_tests.rs
+++ b/crates/vibesql-executor/tests/update_basic_tests.rs
@@ -45,7 +45,7 @@ fn test_update_with_where_clause() {
             value: Expression::Literal(SqlValue::Integer(60000)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "department".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "department".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                 "Engineering",
@@ -88,7 +88,7 @@ fn test_update_multiple_columns() {
             },
         ],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
@@ -119,6 +119,7 @@ fn test_update_with_expression() {
             value: Expression::BinaryOp {
                 left: Box::new(Expression::BinaryOp {
                     left: Box::new(Expression::ColumnRef {
+                        schema: None,
                         table: None,
                         column: "salary".to_string(),
                     }),
@@ -196,7 +197,7 @@ fn test_update_no_matching_rows() {
             value: Expression::Literal(SqlValue::Integer(99999)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(999))),
         })),

--- a/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
@@ -59,7 +59,7 @@ fn test_update_invalidates_columnar_cache() {
             value: Expression::Literal(SqlValue::Integer(55000)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
@@ -125,7 +125,7 @@ fn test_update_invalidates_prewarmed_cache() {
             value: Expression::Literal(SqlValue::Integer(75000)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "name".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "name".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Bob")))),
         })),
@@ -199,7 +199,7 @@ fn test_update_no_match_does_not_invalidate_cache() {
             value: Expression::Literal(SqlValue::Integer(999999)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(999))), // No such id
         })),
@@ -238,7 +238,7 @@ fn test_multiple_updates_invalidate_cache() {
             value: Expression::Literal(SqlValue::Integer(50000)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
@@ -263,7 +263,7 @@ fn test_multiple_updates_invalidate_cache() {
             value: Expression::Literal(SqlValue::Integer(55000)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
@@ -310,7 +310,7 @@ fn test_update_multiple_columns_invalidates_cache() {
             },
         ],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),

--- a/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
@@ -70,7 +70,7 @@ pub fn create_products_table_with_check_price(db: &mut Database) {
         vec![(
             "price_positive".to_string(),
             Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
                 op: BinaryOperator::GreaterThanOrEqual,
                 right: Box::new(Expression::Literal(SqlValue::Integer(0))),
             },
@@ -93,7 +93,7 @@ pub fn create_products_table_with_nullable_price(db: &mut Database) {
         vec![(
             "price_positive".to_string(),
             Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
                 op: BinaryOperator::GreaterThanOrEqual,
                 right: Box::new(Expression::Literal(SqlValue::Integer(0))),
             },
@@ -117,9 +117,10 @@ pub fn create_employees_table_with_check_bonus(db: &mut Database) {
         vec![(
             "bonus_less_than_salary".to_string(),
             Expression::BinaryOp {
-                left: Box::new(Expression::ColumnRef { table: None, column: "bonus".to_string() }),
+                left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "bonus".to_string() }),
                 op: BinaryOperator::LessThan,
                 right: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "salary".to_string(),
                 }),
@@ -177,7 +178,7 @@ pub fn create_update_with_id_clause(
             value: Expression::Literal(value),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(id))),
         })),

--- a/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
@@ -173,7 +173,7 @@ fn test_update_unique_constraint_composite() {
             },
         ],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),

--- a/crates/vibesql-executor/tests/update_default_tests.rs
+++ b/crates/vibesql-executor/tests/update_default_tests.rs
@@ -34,7 +34,7 @@ fn test_update_with_default_value() {
         assignments: vec![Assignment { column: "name".to_string(), value: Expression::Default }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: None,
@@ -81,7 +81,7 @@ fn test_update_default_no_default_value_defined() {
         assignments: vec![Assignment { column: "name".to_string(), value: Expression::Default }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             op: BinaryOperator::Equal,
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: None,

--- a/crates/vibesql-executor/tests/update_onepass_tests.rs
+++ b/crates/vibesql-executor/tests/update_onepass_tests.rs
@@ -118,7 +118,7 @@ fn test_onepass_multiple_literal_assignments() {
             },
         ],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
@@ -155,7 +155,7 @@ fn test_onepass_single_literal_assignment() {
             value: Expression::Literal(SqlValue::Integer(777)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
@@ -184,7 +184,7 @@ fn test_onepass_pk_not_found_returns_zero() {
             value: Expression::Literal(SqlValue::Integer(999)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(999))),
         })),
@@ -222,7 +222,7 @@ fn test_onepass_not_null_constraint_enforced() {
             value: Expression::Literal(SqlValue::Null),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
@@ -254,6 +254,7 @@ fn test_composite_pk_update_both_columns_specified() {
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "order_id".to_string(),
                 }),
@@ -263,6 +264,7 @@ fn test_composite_pk_update_both_columns_specified() {
             op: BinaryOperator::And,
             right: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "item_id".to_string(),
                 }),
@@ -304,6 +306,7 @@ fn test_composite_pk_update_reversed_order() {
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "item_id".to_string(),
                 }),
@@ -313,6 +316,7 @@ fn test_composite_pk_update_reversed_order() {
             op: BinaryOperator::And,
             right: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "order_id".to_string(),
                 }),
@@ -347,7 +351,7 @@ fn test_composite_pk_partial_match_uses_scan() {
             value: Expression::Literal(SqlValue::Integer(1)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "order_id".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "order_id".to_string() }),
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
@@ -381,6 +385,7 @@ fn test_composite_pk_not_found_returns_zero() {
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "order_id".to_string(),
                 }),
@@ -390,6 +395,7 @@ fn test_composite_pk_not_found_returns_zero() {
             op: BinaryOperator::And,
             right: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "item_id".to_string(),
                 }),
@@ -426,6 +432,7 @@ fn test_composite_pk_multiple_columns_updated() {
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             left: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "order_id".to_string(),
                 }),
@@ -435,6 +442,7 @@ fn test_composite_pk_multiple_columns_updated() {
             op: BinaryOperator::And,
             right: Box::new(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef {
+                    schema: None,
                     table: None,
                     column: "item_id".to_string(),
                 }),

--- a/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
@@ -37,7 +37,7 @@ fn test_update_with_subquery_multiple_rows_error() {
 
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "amount".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "amount".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -115,10 +115,10 @@ fn test_update_with_subquery_multiple_columns_error() {
         distinct: false,
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "min_amt".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "min_amt".to_string() },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "max_amt".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "max_amt".to_string() },
                 alias: None, source_text: None },
         ],
         into_table: None,

--- a/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
@@ -53,7 +53,7 @@ fn create_scalar_subquery(table_name: &str, column_name: &str) -> Box<vibesql_as
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: column_name.to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: column_name.to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -85,7 +85,7 @@ fn create_aggregate_subquery(
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: Expression::Function {
                 name: func_name.to_string(),
-                args: vec![Expression::ColumnRef { table: None, column: column_name.to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: column_name.to_string() }],
                 character_unit: None,
             },
             alias: None, source_text: None }],
@@ -355,7 +355,7 @@ fn test_update_with_subquery_and_where_clause() {
 
     let subquery = create_scalar_subquery("config", "max_salary");
     let where_clause = vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
-        left: Box::new(Expression::ColumnRef { table: None, column: "id".to_string() }),
+        left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "id".to_string() }),
         op: vibesql_ast::BinaryOperator::Equal,
         right: Box::new(Expression::Literal(SqlValue::Integer(1))),
     });

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
@@ -36,7 +36,7 @@ fn test_update_where_scalar_subquery_equal() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "min_salary".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "min_salary".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -65,7 +65,7 @@ fn test_update_where_scalar_subquery_equal() {
             value: Expression::Literal(SqlValue::Integer(55000)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "salary".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "salary".to_string() }),
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
@@ -114,7 +114,7 @@ fn test_update_where_scalar_subquery_less_than() {
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: Expression::Function {
                 name: "AVG".to_string(),
-                args: vec![Expression::ColumnRef { table: None, column: "salary".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "salary".to_string() }],
                 character_unit: None,
             },
             alias: None, source_text: None }],
@@ -145,7 +145,7 @@ fn test_update_where_scalar_subquery_less_than() {
             value: Expression::Literal(SqlValue::Integer(5000)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "salary".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "salary".to_string() }),
             op: vibesql_ast::BinaryOperator::LessThan,
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
@@ -190,7 +190,7 @@ fn test_update_where_subquery_returns_null() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "max_salary".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "max_salary".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -219,7 +219,7 @@ fn test_update_where_subquery_returns_null() {
             value: Expression::Literal(SqlValue::Integer(60000)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "salary".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "salary".to_string() }),
             op: vibesql_ast::BinaryOperator::LessThan,
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
@@ -272,7 +272,7 @@ fn test_update_where_subquery_with_aggregate() {
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: Expression::Function {
                 name: "MAX".to_string(),
-                args: vec![Expression::ColumnRef { table: None, column: "price".to_string() }],
+                args: vec![Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }],
                 character_unit: None,
             },
             alias: None, source_text: None }],
@@ -303,7 +303,7 @@ fn test_update_where_subquery_with_aggregate() {
             value: Expression::Literal(SqlValue::Boolean(true)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "price".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "price".to_string() }),
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
@@ -367,7 +367,7 @@ fn test_update_where_and_set_both_use_subqueries() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "target".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "target".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -392,7 +392,7 @@ fn test_update_where_and_set_both_use_subqueries() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "dept_id".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -422,7 +422,7 @@ fn test_update_where_and_set_both_use_subqueries() {
             value: Expression::ScalarSubquery(set_subquery),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::In {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "dept_id".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() }),
             subquery: where_subquery,
             negated: false,
         })),

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
@@ -51,7 +51,7 @@ fn test_update_where_in_subquery() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "dept_id".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -80,7 +80,7 @@ fn test_update_where_in_subquery() {
             value: Expression::Literal(SqlValue::Integer(80000)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::In {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "dept_id".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() }),
             subquery,
             negated: false,
         })),
@@ -137,7 +137,7 @@ fn test_update_where_not_in_subquery() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "dept_id".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -166,7 +166,7 @@ fn test_update_where_not_in_subquery() {
             value: Expression::Literal(SqlValue::Boolean(false)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::In {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "dept_id".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() }),
             subquery,
             negated: true,
         })),
@@ -216,7 +216,7 @@ fn test_update_where_subquery_empty_result() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "dept_id".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -245,7 +245,7 @@ fn test_update_where_subquery_empty_result() {
             value: Expression::Literal(SqlValue::Boolean(false)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::In {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "dept_id".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() }),
             subquery,
             negated: false,
         })),
@@ -305,7 +305,7 @@ fn test_update_where_complex_subquery_condition() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "dept_id".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -316,7 +316,7 @@ fn test_update_where_complex_subquery_condition() {
         quoted: false,
         }),
         where_clause: Some(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "budget".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "budget".to_string() }),
             op: vibesql_ast::BinaryOperator::GreaterThan,
             right: Box::new(Expression::Literal(SqlValue::Integer(80000))),
         }),
@@ -339,7 +339,7 @@ fn test_update_where_complex_subquery_condition() {
             value: Expression::Literal(SqlValue::Integer(70000)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::In {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "dept_id".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() }),
             subquery,
             negated: false,
         })),
@@ -400,7 +400,7 @@ fn test_update_where_multiple_rows_in_subquery() {
         with_clause: None,
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
-            expr: Expression::ColumnRef { table: None, column: "dept_id".to_string() },
+            expr: Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() },
             alias: None, source_text: None }],
         into_table: None,
         into_variables: None,
@@ -429,7 +429,7 @@ fn test_update_where_multiple_rows_in_subquery() {
             value: Expression::Literal(SqlValue::Boolean(false)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::In {
-            expr: Box::new(Expression::ColumnRef { table: None, column: "dept_id".to_string() }),
+            expr: Box::new(Expression::ColumnRef { schema: None, table: None, column: "dept_id".to_string() }),
             subquery,
             negated: false,
         })),

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -474,20 +474,44 @@ impl<'arena> ArenaParser<'arena> {
             self.advance();
             let name_sym = self.intern(&name);
 
-            // Check for qualified name (table.column)
+            // Check for qualified name (table.column or schema.table.column)
             if self.try_consume(&Token::Symbol('.')) {
-                if let Token::Identifier(col) = self.peek() {
-                    let col = col.clone();
+                if let Token::Identifier(second) = self.peek() {
+                    let second = second.clone();
                     self.advance();
-                    let col_sym = self.intern(&col);
-                    return Ok(Expression::ColumnRef { table: Some(name_sym), column: col_sym });
+                    let second_sym = self.intern(&second);
+
+                    // Check for three-part name (schema.table.column)
+                    if self.try_consume(&Token::Symbol('.')) {
+                        if let Token::Identifier(third) = self.peek() {
+                            let third = third.clone();
+                            self.advance();
+                            let third_sym = self.intern(&third);
+                            return Ok(Expression::ColumnRef {
+                                schema: Some(name_sym),
+                                table: Some(second_sym),
+                                column: third_sym,
+                            });
+                        } else if matches!(self.peek(), Token::Symbol('*')) {
+                            // schema.table.* - not supported, treat as error
+                            self.advance();
+                            return Ok(Expression::Wildcard);
+                        }
+                    }
+
+                    // Two-part name (table.column)
+                    return Ok(Expression::ColumnRef {
+                        schema: None,
+                        table: Some(name_sym),
+                        column: second_sym,
+                    });
                 } else if matches!(self.peek(), Token::Symbol('*')) {
                     self.advance();
                     return Ok(Expression::Wildcard);
                 }
             }
 
-            return Ok(Expression::ColumnRef { table: None, column: name_sym });
+            return Ok(Expression::ColumnRef { schema: None, table: None, column: name_sym });
         }
 
         // Wildcard (*)
@@ -590,6 +614,7 @@ impl<'arena> ArenaParser<'arena> {
                     _ => {
                         // Treat DATE as column name when not followed by string literal
                         Some(Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: self.interner.intern("DATE"),
                         })
@@ -614,6 +639,7 @@ impl<'arena> ArenaParser<'arena> {
                     _ => {
                         // Treat TIME as column name when not followed by string literal
                         Some(Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: self.interner.intern("TIME"),
                         })
@@ -640,6 +666,7 @@ impl<'arena> ArenaParser<'arena> {
                     _ => {
                         // Treat TIMESTAMP as column name when not followed by string literal
                         Some(Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: self.interner.intern("TIMESTAMP"),
                         })

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -267,7 +267,7 @@ impl<'arena> ArenaParser<'arena> {
         // with "*" becomes Expression::Wildcard So this check shouldn't match anymore since
         // Expression::ColumnRef won't have "*" as column. The wildcard case is handled in
         // expression parsing.
-        if let Expression::ColumnRef { table: Some(t), column: _ } = &expr {
+        if let Expression::ColumnRef { schema: _, table: Some(t), column: _ } = &expr {
             // Check if it's a qualified wildcard - but this won't happen since
             // we parse table.* as Wildcard expression, not as ColumnRef with "*" column
             // Keep this code path but it likely won't be hit

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -152,7 +152,11 @@ impl Parser {
             self.advance(); // consume '*'
             self.expect_token(Token::RParen)?;
             // Represent * as a special wildcard expression
-            args.push(vibesql_ast::Expression::ColumnRef { table: None, column: "*".to_string() });
+            args.push(vibesql_ast::Expression::ColumnRef {
+                schema: None,
+                table: None,
+                column: "*".to_string(),
+            });
         } else {
             // Parse comma-separated argument list
             loop {

--- a/crates/vibesql-parser/src/parser/expressions/identifiers.rs
+++ b/crates/vibesql-parser/src/parser/expressions/identifiers.rs
@@ -113,26 +113,26 @@ impl Parser {
             return Ok(None);
         }
 
-        // Check for qualified column reference (table.column)
+        // Check for qualified column reference (table.column or schema.table.column)
         // Keywords are allowed as column names when qualified (e.g., ss.year)
         if matches!(self.peek(), Token::Symbol('.')) {
-            self.advance(); // consume '.'
-            let column = match self.peek() {
-                Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
-                    let column = col.clone();
+            self.advance(); // consume first '.'
+            let second = match self.peek() {
+                Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
+                    let name = id.clone();
                     self.advance();
-                    column
+                    name
                 }
                 Token::Keyword { keyword: kw, .. } => {
                     // Allow keywords as column names when qualified (e.g., table.year)
                     // SQL:1999 normalizes unquoted identifiers to lowercase
-                    let column = kw.to_string().to_lowercase();
+                    let name = kw.to_string().to_lowercase();
                     self.advance();
-                    column
+                    name
                 }
                 _ => {
                     return Err(ParseError {
-                        message: "Expected column name after '.'".to_string(),
+                        message: "Expected identifier after '.'".to_string(),
                     });
                 }
             };
@@ -145,13 +145,54 @@ impl Parser {
                 } else {
                     vibesql_ast::PseudoTable::New
                 };
-                Ok(Some(vibesql_ast::Expression::PseudoVariable { pseudo_table, column }))
+                return Ok(Some(vibesql_ast::Expression::PseudoVariable {
+                    pseudo_table,
+                    column: second,
+                }));
+            }
+
+            // Check for three-part name (schema.table.column)
+            if matches!(self.peek(), Token::Symbol('.')) {
+                self.advance(); // consume second '.'
+                let third = match self.peek() {
+                    Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
+                        let name = id.clone();
+                        self.advance();
+                        name
+                    }
+                    Token::Keyword { keyword: kw, .. } => {
+                        let name = kw.to_string().to_lowercase();
+                        self.advance();
+                        name
+                    }
+                    _ => {
+                        return Err(ParseError {
+                            message: "Expected column name after '.'".to_string(),
+                        });
+                    }
+                };
+
+                // schema.table.column
+                Ok(Some(vibesql_ast::Expression::ColumnRef {
+                    schema: Some(first),
+                    table: Some(second),
+                    column: third,
+                }))
             } else {
-                Ok(Some(vibesql_ast::Expression::ColumnRef { table: Some(first), column }))
+                // table.column (two-part name)
+                Ok(Some(vibesql_ast::Expression::ColumnRef {
+                    schema: None,
+                    table: Some(first),
+                    column: second,
+                }))
             }
         } else {
             // Simple column reference
-            Ok(Some(vibesql_ast::Expression::ColumnRef { table: None, column: first }))
+            Ok(Some(vibesql_ast::Expression::ColumnRef {
+                schema: None,
+                table: None,
+                column: first,
+            }))
         }
     }
 }

--- a/crates/vibesql-parser/src/parser/expressions/literals.rs
+++ b/crates/vibesql-parser/src/parser/expressions/literals.rs
@@ -64,6 +64,7 @@ impl Parser {
                     _ => {
                         // Treat DATE as column name when not followed by string literal
                         Ok(Some(vibesql_ast::Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "DATE".to_string(),
                         }))
@@ -90,6 +91,7 @@ impl Parser {
                     _ => {
                         // Treat TIME as column name when not followed by string literal
                         Ok(Some(vibesql_ast::Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "TIME".to_string(),
                         }))
@@ -116,6 +118,7 @@ impl Parser {
                     _ => {
                         // Treat TIMESTAMP as column name when not followed by string literal
                         Ok(Some(vibesql_ast::Expression::ColumnRef {
+                            schema: None,
                             table: None,
                             column: "TIMESTAMP".to_string(),
                         }))

--- a/crates/vibesql-parser/src/tests/group_by.rs
+++ b/crates/vibesql-parser/src/tests/group_by.rs
@@ -119,7 +119,7 @@ fn test_parse_group_by_qualified_columns() {
                 GroupByClause::Simple(exprs) => {
                     assert_eq!(exprs.len(), 1);
                     match &exprs[0] {
-                        vibesql_ast::Expression::ColumnRef { table, column } => {
+                        vibesql_ast::Expression::ColumnRef { table, column, .. } => {
                             assert_eq!(table.as_ref().unwrap(), "u");
                             assert_eq!(column, "dept");
                         }
@@ -323,19 +323,20 @@ fn test_parse_grouping_function() {
 fn test_group_by_clause_len() {
     // Test the len() helper method
     let simple = GroupByClause::Simple(vec![
-        vibesql_ast::Expression::ColumnRef { table: None, column: "a".to_string() },
-        vibesql_ast::Expression::ColumnRef { table: None, column: "b".to_string() },
+        vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "a".to_string() },
+        vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "b".to_string() },
     ]);
     assert_eq!(simple.len(), 2);
 
     let rollup = GroupByClause::Rollup(vec![
         GroupingElement::Single(vibesql_ast::Expression::ColumnRef {
+            schema: None,
             table: None,
             column: "a".to_string(),
         }),
         GroupingElement::Composite(vec![
-            vibesql_ast::Expression::ColumnRef { table: None, column: "b".to_string() },
-            vibesql_ast::Expression::ColumnRef { table: None, column: "c".to_string() },
+            vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "b".to_string() },
+            vibesql_ast::Expression::ColumnRef { schema: None, table: None, column: "c".to_string() },
         ]),
     ]);
     assert_eq!(rollup.len(), 3); // a, b, c = 3 total expressions

--- a/crates/vibesql-parser/src/tests/not_is_null_precedence.rs
+++ b/crates/vibesql-parser/src/tests/not_is_null_precedence.rs
@@ -38,7 +38,7 @@ fn test_not_is_null_precedence() {
 
                     // Innermost expression should be column reference
                     match &**inner_expr {
-                        Expression::ColumnRef { table, column } => {
+                        Expression::ColumnRef { table, column, .. } => {
                             assert_eq!(*table, None);
                             assert_eq!(column, "col0");
                         }
@@ -79,7 +79,7 @@ fn test_is_not_null_parsing() {
             assert!(*negated, "IS NOT NULL should have negated=true");
 
             match &**expr {
-                Expression::ColumnRef { table, column } => {
+                Expression::ColumnRef { table, column, .. } => {
                     assert_eq!(*table, None);
                     assert_eq!(column, "col0");
                 }

--- a/crates/vibesql-parser/src/tests/predicates.rs
+++ b/crates/vibesql-parser/src/tests/predicates.rs
@@ -76,7 +76,7 @@ fn test_between_integer() {
 
                 // Check expr is 'age'
                 match *expr {
-                    vibesql_ast::Expression::ColumnRef { table, column } => {
+                    vibesql_ast::Expression::ColumnRef { table, column, .. } => {
                         assert_eq!(table, None);
                         assert_eq!(column, "age");
                     }
@@ -122,7 +122,7 @@ fn test_not_between() {
 
                 // Check expr is 'price'
                 match *expr {
-                    vibesql_ast::Expression::ColumnRef { table, column } => {
+                    vibesql_ast::Expression::ColumnRef { table, column, .. } => {
                         assert_eq!(table, None);
                         assert_eq!(column, "price");
                     }

--- a/crates/vibesql-parser/src/tests/select/extract.rs
+++ b/crates/vibesql-parser/src/tests/select/extract.rs
@@ -196,7 +196,7 @@ fn test_parse_extract_with_qualified_column() {
                 vibesql_ast::Expression::Extract { field, expr } => {
                     assert_eq!(*field, vibesql_ast::IntervalUnit::Month);
                     match &**expr {
-                        vibesql_ast::Expression::ColumnRef { table, column } => {
+                        vibesql_ast::Expression::ColumnRef { table, column, .. } => {
                             assert_eq!(table.as_deref(), Some("orders"));
                             assert_eq!(column, "order_date");
                         }

--- a/crates/vibesql-parser/src/tests/select/position.rs
+++ b/crates/vibesql-parser/src/tests/select/position.rs
@@ -101,6 +101,7 @@ fn test_parse_position_with_column() {
                         assert_eq!(
                             **string,
                             vibesql_ast::Expression::ColumnRef {
+                                schema: None,
                                 table: None,
                                 column: "name".to_string()
                             }
@@ -132,6 +133,7 @@ fn test_parse_position_both_columns() {
                         assert_eq!(
                             **substring,
                             vibesql_ast::Expression::ColumnRef {
+                                schema: None,
                                 table: None,
                                 column: "needle".to_string()
                             }
@@ -139,6 +141,7 @@ fn test_parse_position_both_columns() {
                         assert_eq!(
                             **string,
                             vibesql_ast::Expression::ColumnRef {
+                                schema: None,
                                 table: None,
                                 column: "haystack".to_string()
                             }

--- a/crates/vibesql-parser/src/tests/subquery.rs
+++ b/crates/vibesql-parser/src/tests/subquery.rs
@@ -22,7 +22,7 @@ fn test_parse_in_subquery() {
                     assert!(!negated);
                     // Check left expression is 'id'
                     match *expr {
-                        Expression::ColumnRef { table, column } => {
+                        Expression::ColumnRef { table, column, .. } => {
                             assert_eq!(table, None);
                             assert_eq!(column, "id");
                         }
@@ -52,7 +52,7 @@ fn test_parse_not_in_subquery() {
                     assert!(negated); // Should be negated
                                       // Check left expression is 'status'
                     match *expr {
-                        Expression::ColumnRef { table, column } => {
+                        Expression::ColumnRef { table, column, .. } => {
                             assert_eq!(table, None);
                             assert_eq!(column, "status");
                         }
@@ -79,7 +79,7 @@ fn test_parse_in_subquery_simple_column() {
                 Expression::In { expr, subquery: _, negated } => {
                     assert!(!negated);
                     match *expr {
-                        Expression::ColumnRef { table, column } => {
+                        Expression::ColumnRef { table, column, .. } => {
                             assert_eq!(table, None);
                             assert_eq!(column, "user_id");
                         }

--- a/crates/vibesql-server/src/subscription/filter.rs
+++ b/crates/vibesql-server/src/subscription/filter.rs
@@ -88,7 +88,7 @@ impl SubscriptionFilter {
         match expr {
             Expression::Literal(val) => Ok(val.clone()),
 
-            Expression::ColumnRef { table: _, column } => {
+            Expression::ColumnRef { column, .. } => {
                 // Look up column by name (case-insensitive)
                 let idx = self
                     .column_indices

--- a/crates/vibesql-server/src/subscription/pk_detector.rs
+++ b/crates/vibesql-server/src/subscription/pk_detector.rs
@@ -408,7 +408,7 @@ fn map_columns_to_result_positions(
 /// Extract column name from an expression (if it's a simple column reference)
 fn extract_column_name(expr: &Expression, table_alias: Option<&str>) -> Option<String> {
     match expr {
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { table, column, .. } => {
             // For qualified references (t.col), check if table matches our alias
             if let Some(tbl) = table {
                 if let Some(alias) = table_alias {

--- a/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
+++ b/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
@@ -141,8 +141,12 @@ pub fn write_expression<W: Write>(writer: &mut W, expr: &Expression) -> Result<(
             write_tag!(writer, ExprTag::Literal);
             write_sql_value(writer, value)?;
         }
-        Expression::ColumnRef { table, column } => {
+        Expression::ColumnRef { schema, table, column } => {
             write_tag!(writer, ExprTag::ColumnRef);
+            write_bool(writer, schema.is_some())?;
+            if let Some(s) = schema {
+                write_string(writer, s)?;
+            }
             write_bool(writer, table.is_some())?;
             if let Some(t) = table {
                 write_string(writer, t)?;
@@ -430,10 +434,12 @@ pub fn read_expression<R: Read>(reader: &mut R) -> Result<Expression, StorageErr
             Ok(Expression::Literal(value))
         }
         ExprTag::ColumnRef => {
+            let has_schema = read_bool(reader)?;
+            let schema = if has_schema { Some(read_string(reader)?) } else { None };
             let has_table = read_bool(reader)?;
             let table = if has_table { Some(read_string(reader)?) } else { None };
             let column = read_string(reader)?;
-            Ok(Expression::ColumnRef { table, column })
+            Ok(Expression::ColumnRef { schema, table, column })
         }
         ExprTag::BinaryOp => {
             let op = read_binary_operator(reader)?;
@@ -687,7 +693,7 @@ mod tests {
     #[test]
     fn test_column_ref_roundtrip() {
         let expr =
-            Expression::ColumnRef { table: Some("users".to_string()), column: "id".to_string() };
+            Expression::ColumnRef { schema: None, table: Some("users".to_string()), column: "id".to_string() };
         let mut buf = Vec::new();
         write_expression(&mut buf, &expr).unwrap();
 

--- a/crates/vibesql-storage/src/persistence/tests/json_persistence.rs
+++ b/crates/vibesql-storage/src/persistence/tests/json_persistence.rs
@@ -926,12 +926,12 @@ fn test_json_view_preservation() {
         distinct: false,
         select_list: vec![
             SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "id".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "id".to_string() },
                 alias: None,
                 source_text: None,
             },
             SelectItem::Expression {
-                expr: Expression::ColumnRef { table: None, column: "name".to_string() },
+                expr: Expression::ColumnRef { schema: None, table: None, column: "name".to_string() },
                 alias: None,
                 source_text: None,
             },
@@ -945,7 +945,7 @@ fn test_json_view_preservation() {
         quoted: false,
         }),
         where_clause: Some(Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef { table: None, column: "active".to_string() }),
+            left: Box::new(Expression::ColumnRef { schema: None, table: None, column: "active".to_string() }),
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Boolean(true))),
         }),


### PR DESCRIPTION
## Summary
- Add optional `schema` field to ColumnRef AST node and arena-allocated expressions
- Update parser grammar to recognize three-part identifiers (schema.table.column)
- Update all evaluators to handle schema validation - only "main" schema is supported
- Non-"main" schema references return "Column not found" error matching SQLite behavior

## Test plan
- [x] Verified `main.table.column` syntax works correctly
- [x] Verified non-main schemas (e.g., `other.table.column`) return appropriate errors
- [x] Verified two-part column names (`table.column`) still work (regression test)
- [x] Verified JOINs with schema-qualified columns work
- [x] All existing tests pass

Closes #4515

🤖 Generated with [Claude Code](https://claude.com/claude-code)