### PR TITLE
feat(ast): Add FunctionIdentifier for case-preserving function names

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -25,8 +25,8 @@ use super::{
 };
 use crate::{
     Assignment, BinaryOperator, CaseWhen, CharacterUnit, CommonTableExpr, ConflictClause,
-    DeleteStmt, Expression, FrameBound, FrameUnit, FromClause, FulltextMode, GroupByClause,
-    GroupingElement, GroupingSet, InsertSource, InsertStmt, IntervalUnit, JoinType,
+    DeleteStmt, Expression, FrameBound, FrameUnit, FromClause, FulltextMode, FunctionIdentifier,
+    GroupByClause, GroupingElement, GroupingSet, InsertSource, InsertStmt, IntervalUnit, JoinType,
     MixedGroupingItem, NullsOrder, OrderByItem, OrderDirection, PseudoTable, Quantifier,
     SelectItem, SelectStmt, SetOperation, SetOperator, TrimPosition, TruthValue, UpdateStmt,
     WhereClause, WindowFrame, WindowFunctionSpec, WindowSpec,
@@ -186,14 +186,14 @@ impl<'a, 'arena> Converter<'a, 'arena> {
         match ext {
             arena_expr::ExtendedExpr::Function { name, args, character_unit } => {
                 Expression::Function {
-                    name: self.resolve(*name),
+                    name: FunctionIdentifier::new(&self.resolve(*name)),
                     args: args.iter().map(|e| self.convert_expression(e)).collect(),
                     character_unit: character_unit.map(|u| u.into()),
                 }
             }
             arena_expr::ExtendedExpr::AggregateFunction { name, distinct, args } => {
                 Expression::AggregateFunction {
-                    name: self.resolve(*name),
+                    name: FunctionIdentifier::new(&self.resolve(*name)),
                     distinct: *distinct,
                     args: args.iter().map(|e| self.convert_expression(e)).collect(),
                     order_by: None, // Arena parser doesn't support ORDER BY in aggregates yet
@@ -329,16 +329,16 @@ impl<'a, 'arena> Converter<'a, 'arena> {
         match spec {
             arena_expr::WindowFunctionSpec::Aggregate { name, args } => {
                 WindowFunctionSpec::Aggregate {
-                    name: self.resolve(*name),
+                    name: FunctionIdentifier::new(&self.resolve(*name)),
                     args: args.iter().map(|e| self.convert_expression(e)).collect(),
                 }
             }
             arena_expr::WindowFunctionSpec::Ranking { name, args } => WindowFunctionSpec::Ranking {
-                name: self.resolve(*name),
+                name: FunctionIdentifier::new(&self.resolve(*name)),
                 args: args.iter().map(|e| self.convert_expression(e)).collect(),
             },
             arena_expr::WindowFunctionSpec::Value { name, args } => WindowFunctionSpec::Value {
-                name: self.resolve(*name),
+                name: FunctionIdentifier::new(&self.resolve(*name)),
                 args: args.iter().map(|e| self.convert_expression(e)).collect(),
             },
         }

--- a/crates/vibesql-ast/src/expression.rs
+++ b/crates/vibesql-ast/src/expression.rs
@@ -2,7 +2,7 @@
 
 use vibesql_types::SqlValue;
 
-use crate::identifier::ColumnIdentifier;
+use crate::identifier::{ColumnIdentifier, FunctionIdentifier};
 use crate::{BinaryOperator, OrderByItem, SelectStmt, UnaryOperator};
 
 /// SQL Expression (can appear in SELECT, WHERE, etc.)
@@ -59,8 +59,12 @@ pub enum Expression {
     },
 
     /// Function call (UPPER(x), SUBSTRING(x, 1, 3))
+    ///
+    /// Uses `FunctionIdentifier` for proper case handling:
+    /// - Canonical (lowercase) for case-insensitive comparison
+    /// - Display (original case) for error messages
     Function {
-        name: String,
+        name: FunctionIdentifier,
         args: Vec<Expression>,
         character_unit: Option<CharacterUnit>,
     },
@@ -70,8 +74,12 @@ pub enum Expression {
     /// SQL:2003 ordered set functions with ORDER BY clause
     /// Example: COUNT(DISTINCT customer_id), SUM(ALL amount)
     /// Example: GROUP_CONCAT(name ORDER BY name ASC)
+    ///
+    /// Uses `FunctionIdentifier` for proper case handling:
+    /// - Canonical (lowercase) for case-insensitive comparison
+    /// - Display (original case) for error messages
     AggregateFunction {
-        name: String,
+        name: FunctionIdentifier,
         distinct: bool, // true = DISTINCT, false = ALL (implicit)
         args: Vec<Expression>,
         /// Optional ORDER BY clause within the aggregate function
@@ -398,19 +406,21 @@ pub enum TruthValue {
 }
 
 /// Window function specification
+///
+/// Uses `FunctionIdentifier` for proper case handling in all variants.
 #[derive(Debug, Clone, PartialEq)]
 pub enum WindowFunctionSpec {
     /// Aggregate function used as window function
     /// Example: SUM(salary), AVG(price), COUNT(*)
-    Aggregate { name: String, args: Vec<Expression> },
+    Aggregate { name: FunctionIdentifier, args: Vec<Expression> },
 
     /// Ranking function
     /// Example: ROW_NUMBER(), RANK(), DENSE_RANK(), NTILE(4)
-    Ranking { name: String, args: Vec<Expression> },
+    Ranking { name: FunctionIdentifier, args: Vec<Expression> },
 
     /// Value function
     /// Example: LAG(salary, 1), LEAD(price, 2), FIRST_VALUE(name), LAST_VALUE(amount)
-    Value { name: String, args: Vec<Expression> },
+    Value { name: FunctionIdentifier, args: Vec<Expression> },
 }
 
 /// Window specification (OVER clause)

--- a/crates/vibesql-ast/src/identifier.rs
+++ b/crates/vibesql-ast/src/identifier.rs
@@ -941,11 +941,46 @@ impl FunctionIdentifier {
     pub fn matches(&self, name: &str) -> bool {
         self.canonical == name.to_lowercase()
     }
+
+    /// Get the canonical form as str (alias for canonical()).
+    pub fn as_str(&self) -> &str {
+        &self.canonical
+    }
+
+    /// Return the canonical (lowercase) form as a new String.
+    /// Provides compatibility with code expecting String methods.
+    pub fn to_lowercase(&self) -> String {
+        self.canonical.clone()
+    }
+
+    /// Return the canonical form uppercased.
+    /// Provides compatibility with code expecting String methods.
+    pub fn to_uppercase(&self) -> String {
+        self.canonical.to_uppercase()
+    }
+
+    /// Case-insensitive comparison with a string slice.
+    /// Provides compatibility with code expecting String methods.
+    pub fn eq_ignore_ascii_case(&self, other: &str) -> bool {
+        self.canonical == other.to_ascii_lowercase()
+    }
 }
 
 impl PartialEq for FunctionIdentifier {
     fn eq(&self, other: &Self) -> bool {
         self.canonical == other.canonical
+    }
+}
+
+impl PartialEq<str> for FunctionIdentifier {
+    fn eq(&self, other: &str) -> bool {
+        self.canonical == other.to_lowercase()
+    }
+}
+
+impl PartialEq<&str> for FunctionIdentifier {
+    fn eq(&self, other: &&str) -> bool {
+        self.canonical == other.to_lowercase()
     }
 }
 

--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -330,7 +330,8 @@ impl ToSql for Expression {
 
             Expression::Function { name, args, character_unit } => {
                 let args_sql: Vec<String> = args.iter().map(|a| a.to_sql()).collect();
-                let mut result = format!("{}({})", name.to_uppercase(), args_sql.join(", "));
+                let mut result =
+                    format!("{}({})", name.canonical().to_uppercase(), args_sql.join(", "));
                 if let Some(unit) = character_unit {
                     result.push_str(&format!(" USING {}", unit.to_sql()));
                 }
@@ -355,14 +356,14 @@ impl ToSql for Expression {
                 if *distinct {
                     format!(
                         "{}(DISTINCT {}{})",
-                        name.to_uppercase(),
+                        name.canonical().to_uppercase(),
                         args_sql.join(", "),
                         order_by_sql.unwrap_or_default()
                     )
                 } else {
                     format!(
                         "{}({}{})",
-                        name.to_uppercase(),
+                        name.canonical().to_uppercase(),
                         args_sql.join(", "),
                         order_by_sql.unwrap_or_default()
                     )
@@ -694,19 +695,19 @@ impl ToSql for WindowFunctionSpec {
         match self {
             WindowFunctionSpec::Aggregate { name, args } => {
                 let args_sql: Vec<String> = args.iter().map(|a| a.to_sql()).collect();
-                format!("{}({})", name.to_uppercase(), args_sql.join(", "))
+                format!("{}({})", name.canonical().to_uppercase(), args_sql.join(", "))
             }
             WindowFunctionSpec::Ranking { name, args } => {
                 let args_sql: Vec<String> = args.iter().map(|a| a.to_sql()).collect();
                 if args_sql.is_empty() {
-                    format!("{}()", name.to_uppercase())
+                    format!("{}()", name.canonical().to_uppercase())
                 } else {
-                    format!("{}({})", name.to_uppercase(), args_sql.join(", "))
+                    format!("{}({})", name.canonical().to_uppercase(), args_sql.join(", "))
                 }
             }
             WindowFunctionSpec::Value { name, args } => {
                 let args_sql: Vec<String> = args.iter().map(|a| a.to_sql()).collect();
-                format!("{}({})", name.to_uppercase(), args_sql.join(", "))
+                format!("{}({})", name.canonical().to_uppercase(), args_sql.join(", "))
             }
         }
     }
@@ -1084,7 +1085,7 @@ impl ToSql for MixedGroupingItem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ColumnIdentifier;
+    use crate::{ColumnIdentifier, FunctionIdentifier};
 
     #[test]
     fn test_binary_operators() {
@@ -1275,7 +1276,7 @@ mod tests {
     #[test]
     fn test_aggregate_function() {
         let expr = Expression::AggregateFunction {
-            name: "count".to_string(),
+            name: FunctionIdentifier::new("count"),
             distinct: true,
             args: vec![Expression::ColumnRef(ColumnIdentifier::simple("id", false))],
             order_by: None,
@@ -1340,9 +1341,14 @@ mod tests {
     #[test]
     fn test_window_function() {
         let expr = Expression::WindowFunction {
-            function: WindowFunctionSpec::Ranking { name: "row_number".to_string(), args: vec![] },
+            function: WindowFunctionSpec::Ranking {
+                name: FunctionIdentifier::new("row_number"),
+                args: vec![],
+            },
             over: WindowSpec {
-                partition_by: Some(vec![Expression::ColumnRef(ColumnIdentifier::simple("dept", false))]),
+                partition_by: Some(vec![Expression::ColumnRef(ColumnIdentifier::simple(
+                    "dept", false,
+                ))]),
                 order_by: Some(vec![OrderByItem {
                     expr: Expression::ColumnRef(ColumnIdentifier::simple("salary", false)),
                     direction: OrderDirection::Desc,

--- a/crates/vibesql-ast/tests/complex_expressions.rs
+++ b/crates/vibesql-ast/tests/complex_expressions.rs
@@ -60,7 +60,7 @@ fn test_scalar_subquery() {
         distinct: false,
         select_list: vec![SelectItem::Expression {
             expr: Expression::Function {
-                name: "AVG".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("salary", false))],
                 character_unit: None,
             },

--- a/crates/vibesql-ast/tests/expressions.rs
+++ b/crates/vibesql-ast/tests/expressions.rs
@@ -84,7 +84,7 @@ fn test_binary_operation_equality() {
 #[test]
 fn test_function_call_count_star() {
     let expr = Expression::Function {
-        name: "COUNT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("COUNT"),
         args: vec![Expression::Wildcard],
         character_unit: None,
     };

--- a/crates/vibesql-ast/tests/select_stmt.rs
+++ b/crates/vibesql-ast/tests/select_stmt.rs
@@ -225,7 +225,7 @@ fn test_select_with_group_by() {
         distinct: false,
         select_list: vec![SelectItem::Expression {
             expr: Expression::Function {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 args: vec![Expression::Wildcard],
                 character_unit: None,
             },
@@ -269,7 +269,7 @@ fn test_select_with_having() {
         having: Some(Expression::BinaryOp {
             op: BinaryOperator::GreaterThan,
             left: Box::new(Expression::Function {
-                name: "SUM".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("SUM"),
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                 character_unit: None,
             }),

--- a/crates/vibesql-executor/src/cache/query_signature.rs
+++ b/crates/vibesql-executor/src/cache/query_signature.rs
@@ -342,7 +342,7 @@ impl QuerySignature {
 
             Expression::Function { name, args, character_unit } => {
                 "FUNCTION".hash(hasher);
-                name.to_lowercase().hash(hasher);
+                name.canonical().hash(hasher);
                 for arg in args {
                     Self::hash_expression(arg, hasher);
                 }
@@ -353,7 +353,7 @@ impl QuerySignature {
 
             Expression::AggregateFunction { name, distinct, args, order_by } => {
                 "AGGREGATE".hash(hasher);
-                name.to_lowercase().hash(hasher);
+                name.canonical().hash(hasher);
                 distinct.hash(hasher);
                 for arg in args {
                     Self::hash_expression(arg, hasher);
@@ -523,21 +523,21 @@ impl QuerySignature {
                 match function {
                     vibesql_ast::WindowFunctionSpec::Aggregate { name, args } => {
                         "AGGREGATE".hash(hasher);
-                        name.to_lowercase().hash(hasher);
+                        name.canonical().hash(hasher);
                         for arg in args {
                             Self::hash_expression(arg, hasher);
                         }
                     }
                     vibesql_ast::WindowFunctionSpec::Ranking { name, args } => {
                         "RANKING".hash(hasher);
-                        name.to_lowercase().hash(hasher);
+                        name.canonical().hash(hasher);
                         for arg in args {
                             Self::hash_expression(arg, hasher);
                         }
                     }
                     vibesql_ast::WindowFunctionSpec::Value { name, args } => {
                         "VALUE".hash(hasher);
-                        name.to_lowercase().hash(hasher);
+                        name.canonical().hash(hasher);
                         for arg in args {
                             Self::hash_expression(arg, hasher);
                         }

--- a/crates/vibesql-executor/src/delete/tests/subqueries.rs
+++ b/crates/vibesql-executor/src/delete/tests/subqueries.rs
@@ -314,7 +314,7 @@ mod scalar_subquery {
             distinct: false,
             select_list: vec![vibesql_ast::SelectItem::Expression {
                 expr: Expression::Function {
-                    name: "AVG".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("AVG"),
                     args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("salary", false))],
                     character_unit: None,
                 },
@@ -385,7 +385,7 @@ mod scalar_subquery {
             distinct: false,
             select_list: vec![vibesql_ast::SelectItem::Expression {
                 expr: Expression::Function {
-                    name: "MAX".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("MAX"),
                     args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))],
                     character_unit: None,
                 },

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -407,7 +407,7 @@ impl CombinedExpressionEvaluator<'_> {
 
             // Function expressions - handle scalar functions (not aggregates)
             vibesql_ast::Expression::Function { name, args, character_unit } => {
-                self.eval_function(name, args, character_unit, row)
+                self.eval_function(name.display(), args, character_unit, row)
             }
 
             // Current date/time functions
@@ -466,7 +466,7 @@ impl CombinedExpressionEvaluator<'_> {
                 // This error occurs when an aggregate is evaluated outside of aggregation,
                 // such as in ORDER BY clauses of non-aggregate queries.
                 // Uses "misuse of aggregate: X()" format (with colon) to match SQLite's expr.c
-                Err(ExecutorError::MisuseOfAggregateContext { function_name: name.clone() })
+                Err(ExecutorError::MisuseOfAggregateContext { function_name: name.to_string() })
             }
 
             // Full-text search

--- a/crates/vibesql-executor/src/evaluator/compiled_pivot.rs
+++ b/crates/vibesql-executor/src/evaluator/compiled_pivot.rs
@@ -317,7 +317,7 @@ mod tests {
     fn create_sum_case_expression(match_value: &str) -> Expression {
         // SUM(CASE WHEN d_day_name = match_value THEN sales_price ELSE NULL END)
         Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             distinct: false,
             args: vec![Expression::Case {
                 operand: None,
@@ -401,7 +401,7 @@ mod tests {
         // Second aggregate: SUM(CASE WHEN d_week_seq = 1 THEN sales_price ...)
         // Different condition column
         let expr2 = Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             distinct: false,
             args: vec![Expression::Case {
                 operand: None,

--- a/crates/vibesql-executor/src/evaluator/expression_hash.rs
+++ b/crates/vibesql-executor/src/evaluator/expression_hash.rs
@@ -567,7 +567,7 @@ mod tests {
     #[test]
     fn test_rand_function_is_not_deterministic() {
         let expr = vibesql_ast::Expression::Function {
-            name: "RAND".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("RAND"),
             args: vec![],
             character_unit: None,
         };
@@ -578,7 +578,7 @@ mod tests {
     fn test_deterministic_function_is_deterministic() {
         let arg = vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(42));
         let expr = vibesql_ast::Expression::Function {
-            name: "ABS".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ABS"),
             args: vec![arg],
             character_unit: None,
         };

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -187,7 +187,7 @@ impl ExpressionEvaluator<'_> {
 
             // Function call
             vibesql_ast::Expression::Function { name, args, character_unit } => {
-                self.eval_function(name, args, character_unit, row)
+                self.eval_function(name.display(), args, character_unit, row)
             }
 
             // Current date/time functions
@@ -297,7 +297,7 @@ impl ExpressionEvaluator<'_> {
                 // This error occurs when an aggregate is evaluated outside of aggregation,
                 // such as in ORDER BY clauses of non-aggregate queries.
                 // Uses "misuse of aggregate: X()" format (with colon) to match SQLite's expr.c
-                Err(ExecutorError::MisuseOfAggregateContext { function_name: name.clone() })
+                Err(ExecutorError::MisuseOfAggregateContext { function_name: name.to_string() })
             }
 
             // NEXT VALUE FOR sequence expression

--- a/crates/vibesql-executor/src/optimizer/adaptive/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/adaptive/mod.rs
@@ -173,7 +173,7 @@ mod tests {
                     alias: None, source_text: None },
                 SelectItem::Expression {
                     expr: Expression::AggregateFunction {
-                        name: "SUM".to_string(),
+                        name: vibesql_ast::FunctionIdentifier::new("SUM"),
                         distinct: false,
                         args: vec![Expression::BinaryOp {
                             left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))),
@@ -215,7 +215,7 @@ mod tests {
             distinct: false,
             select_list: vec![SelectItem::Expression {
                 expr: Expression::AggregateFunction {
-                    name: "SUM".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("SUM"),
                     distinct: false,
                     args: vec![Expression::BinaryOp {
                         left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))),
@@ -319,7 +319,7 @@ mod tests {
             distinct: false,
             select_list: vec![SelectItem::Expression {
                 expr: Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: false,
                     args: vec![Expression::Wildcard],
                     order_by: None,

--- a/crates/vibesql-executor/src/optimizer/adaptive/strategy.rs
+++ b/crates/vibesql-executor/src/optimizer/adaptive/strategy.rs
@@ -361,7 +361,7 @@ mod tests {
             distinct: false,
             select_list: vec![SelectItem::Expression {
                 expr: Expression::AggregateFunction {
-                    name: "SUM".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("SUM"),
                     distinct: false,
                     args: vec![Expression::BinaryOp {
                         left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))),

--- a/crates/vibesql-executor/src/optimizer/aggregate_analysis.rs
+++ b/crates/vibesql-executor/src/optimizer/aggregate_analysis.rs
@@ -495,7 +495,7 @@ mod tests {
     }
 
     fn make_aggregate(name: &str, arg: Expression) -> Expression {
-        Expression::AggregateFunction { name: name.to_string(), distinct: false, args: vec![arg], order_by: None }
+        Expression::AggregateFunction { name: vibesql_ast::FunctionIdentifier::new(name), distinct: false, args: vec![arg], order_by: None }
     }
 
     #[test]

--- a/crates/vibesql-executor/src/optimizer/column_pruning.rs
+++ b/crates/vibesql-executor/src/optimizer/column_pruning.rs
@@ -556,7 +556,7 @@ mod tests {
     #[test]
     fn test_collect_from_aggregate() {
         let expr = Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             args: vec![Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))),
                 op: BinaryOperator::Multiply,

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
@@ -350,7 +350,7 @@ mod tests {
         // Replace SELECT with complex expression
         subquery.select_list = vec![SelectItem::Expression {
             expr: Expression::Function {
-                name: "UPPER".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("UPPER"),
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("customer_id", false))],
                 character_unit: None,
             },

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/tests.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/tests.rs
@@ -115,7 +115,7 @@ fn test_aggregate_subquery_transforms_to_derived_table() {
     subquery.having = Some(Expression::BinaryOp {
         op: BinaryOperator::GreaterThan,
         left: Box::new(Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             distinct: false,
             args: vec![column_ref("l_quantity")],
             order_by: None,

--- a/crates/vibesql-executor/src/pipeline/columnar.rs
+++ b/crates/vibesql-executor/src/pipeline/columnar.rs
@@ -529,7 +529,7 @@ mod tests {
 
         // COUNT(*) should return 0 for empty set
         let count_expr = Expression::AggregateFunction {
-            name: "COUNT".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("COUNT"),
             args: vec![Expression::Wildcard],
             distinct: false, order_by: None,
         };
@@ -538,7 +538,7 @@ mod tests {
 
         // count (lowercase) should also return 0
         let count_lower = Expression::AggregateFunction {
-            name: "count".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("count"),
             args: vec![Expression::Wildcard],
             distinct: false, order_by: None,
         };
@@ -553,7 +553,7 @@ mod tests {
         let evaluator = ctx.create_evaluator();
 
         let sum_expr = Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("x", false))],
             distinct: false, order_by: None,
         };
@@ -569,7 +569,7 @@ mod tests {
 
         for agg_name in &["AVG", "MIN", "MAX"] {
             let expr = Expression::AggregateFunction {
-                name: agg_name.to_string(),
+                name: vibesql_ast::FunctionIdentifier::new(agg_name),
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("x", false))],
                 distinct: false, order_by: None,
             };
@@ -598,7 +598,7 @@ mod tests {
         // COUNT(*) + 10 should return 0 + 10 = 10
         let expr = Expression::BinaryOp {
             left: Box::new(Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 args: vec![Expression::Wildcard],
                 distinct: false, order_by: None,
             }),
@@ -619,7 +619,7 @@ mod tests {
         let expr = Expression::UnaryOp {
             op: vibesql_ast::UnaryOperator::Minus,
             expr: Box::new(Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 args: vec![Expression::Wildcard],
                 distinct: false, order_by: None,
             }),
@@ -637,7 +637,7 @@ mod tests {
         // CAST(COUNT(*) AS VARCHAR) should return "0"
         let expr = Expression::Cast {
             expr: Box::new(Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 args: vec![Expression::Wildcard],
                 distinct: false, order_by: None,
             }),
@@ -655,7 +655,7 @@ mod tests {
 
         // Some parsers may represent COUNT as Expression::Function instead of AggregateFunction
         let expr = Expression::Function {
-            name: "COUNT".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("COUNT"),
             args: vec![Expression::Wildcard],
             character_unit: None,
         };
@@ -689,7 +689,7 @@ mod tests {
         let complex_agg = Expression::UnaryOp {
             op: vibesql_ast::UnaryOperator::Minus,
             expr: Box::new(Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 args: vec![Expression::Wildcard],
                 distinct: false, order_by: None,
             }),
@@ -721,7 +721,7 @@ mod tests {
         let complex_agg = Expression::UnaryOp {
             op: vibesql_ast::UnaryOperator::Minus,
             expr: Box::new(Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 args: vec![Expression::Wildcard],
                 distinct: false, order_by: None,
             }),

--- a/crates/vibesql-executor/src/select/columnar/aggregate/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/mod.rs
@@ -299,7 +299,7 @@ mod tests {
 
         // Test SUM(col1)
         let exprs = vec![Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             distinct: false,
             args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("col1", false))],
             order_by: None,
@@ -314,7 +314,7 @@ mod tests {
 
         // Test COUNT(*)
         let exprs = vec![Expression::AggregateFunction {
-            name: "COUNT".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("COUNT"),
             distinct: false,
             args: vec![Expression::Wildcard],
             order_by: None,
@@ -330,13 +330,13 @@ mod tests {
         // Test multiple aggregates: SUM(col1), AVG(col2)
         let exprs = vec![
             Expression::AggregateFunction {
-                name: "SUM".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("SUM"),
                 distinct: false,
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("col1", false))],
                 order_by: None,
             },
             Expression::AggregateFunction {
-                name: "AVG".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
                 distinct: false,
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("col2", false))],
                 order_by: None,
@@ -369,7 +369,7 @@ mod tests {
 
         // Test DISTINCT aggregate (should return None)
         let exprs = vec![Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             distinct: true,
             args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("col1", false))],
             order_by: None,
@@ -386,7 +386,7 @@ mod tests {
 
         // Test subquery in aggregate (should return None - not supported)
         let exprs = vec![Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             distinct: false,
             args: vec![Expression::ScalarSubquery(Box::new(vibesql_ast::SelectStmt {
                 with_clause: None,
@@ -431,7 +431,7 @@ mod tests {
 
         // Test SUM(price * discount) - simple binary operation
         let exprs = vec![Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             distinct: false,
             args: vec![Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))),

--- a/crates/vibesql-executor/src/select/columnar/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/mod.rs
@@ -786,7 +786,7 @@ mod tests {
 
         // SELECT SUM(price) FROM test
         let aggregates = vec![Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             distinct: false,
             args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))],
             order_by: None,
@@ -823,7 +823,7 @@ mod tests {
         };
 
         let aggregates = vec![Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             distinct: false,
             args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))],
             order_by: None,
@@ -855,19 +855,19 @@ mod tests {
         // SELECT SUM(price), COUNT(*), AVG(quantity) FROM test
         let aggregates = vec![
             Expression::AggregateFunction {
-                name: "SUM".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("SUM"),
                 distinct: false,
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))],
                 order_by: None,
             },
             Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 distinct: false,
                 args: vec![Expression::Wildcard],
                 order_by: None,
             },
             Expression::AggregateFunction {
-                name: "AVG".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
                 distinct: false,
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("quantity", false))],
                 order_by: None,
@@ -909,7 +909,7 @@ mod tests {
 
         // SELECT SUM(DISTINCT price) FROM test - should return None
         let aggregates = vec![Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             distinct: true,
             args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))],
             order_by: None,
@@ -943,7 +943,7 @@ mod tests {
         }));
 
         let aggregates = vec![Expression::AggregateFunction {
-            name: "SUM".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUM"),
             distinct: false,
             args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))],
             order_by: None,

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
@@ -90,7 +90,7 @@ pub(super) fn evaluate(
     };
 
     // Validate argument count first
-    validate_aggregate_args(name, args)?;
+    validate_aggregate_args(name.canonical(), args)?;
 
     // Generate cache key for this aggregate expression
     // Format: "{name}:{distinct}:{arg_debug}"
@@ -101,7 +101,7 @@ pub(super) fn evaluate(
         return Ok(cached_result.clone());
     }
 
-    let mut acc = AggregateAccumulator::new(name, distinct)?;
+    let mut acc = AggregateAccumulator::new(name.canonical(), distinct)?;
 
     // Special handling for COUNT(*)
     if name.to_uppercase() == "COUNT" && args.len() == 1 {
@@ -132,7 +132,7 @@ pub(super) fn evaluate(
         if !distinct {
             // SQLite-compatible error message
             return Err(ExecutorError::WrongNumberOfArguments {
-                function_name: name.clone(),
+                function_name: name.to_string(),
             });
         }
 
@@ -225,7 +225,7 @@ pub(super) fn evaluate(
             });
 
             // Now accumulate in sorted order
-            let mut acc = AggregateAccumulator::new_with_separator(name, distinct, &separator)?;
+            let mut acc = AggregateAccumulator::new_with_separator(name.canonical(), distinct, &separator)?;
             for (value, _) in value_sort_pairs {
                 acc.accumulate(&value);
             }
@@ -236,7 +236,7 @@ pub(super) fn evaluate(
         }
 
         // No ORDER BY - use the original path
-        let mut acc = AggregateAccumulator::new_with_separator(name, distinct, &separator)?;
+        let mut acc = AggregateAccumulator::new_with_separator(name.canonical(), distinct, &separator)?;
 
         for row in group_rows {
             evaluator.clear_cse_cache();

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -66,7 +66,7 @@ fn collect_aggregate_window_functions(select_list: &[SelectItem]) -> Vec<Aggrega
         {
             result.push(AggregateWindowFunction {
                 select_index: idx,
-                outer_func_name: name.clone(),
+                outer_func_name: name.to_string(),
                 window_spec: over.clone(),
             });
         }

--- a/crates/vibesql-executor/src/select/executor/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/validation.rs
@@ -216,28 +216,28 @@ fn check_aggregate_arg_count(expr: &Expression) -> Option<String> {
                     // Multi-arg COUNT without DISTINCT is an error
                     // SQLite: "wrong number of arguments to function count()"
                     if arg_count > 1 && !*distinct {
-                        Some(name.clone())
+                        Some(name.to_string())
                     } else {
                         None
                     }
                 }
                 "MIN" | "MAX" => {
                     if has_wildcard || arg_count == 0 {
-                        Some(name.clone()) // Preserve original case for SQLite-compatible error
+                        Some(name.to_string()) // Preserve original case for SQLite-compatible error
                     } else {
                         None
                     }
                 }
                 "SUM" | "AVG" | "TOTAL" => {
                     if has_wildcard || arg_count == 0 || arg_count > 1 {
-                        Some(name.clone()) // Preserve original case for SQLite-compatible error
+                        Some(name.to_string()) // Preserve original case for SQLite-compatible error
                     } else {
                         None
                     }
                 }
                 "GROUP_CONCAT" => {
                     if arg_count == 0 || arg_count > 2 {
-                        Some(name.clone()) // Preserve original case for SQLite-compatible error
+                        Some(name.to_string()) // Preserve original case for SQLite-compatible error
                     } else {
                         None
                     }
@@ -247,7 +247,7 @@ fn check_aggregate_arg_count(expr: &Expression) -> Option<String> {
         }
         Expression::Function { name, args, .. } => {
             // Check if this is an aggregate function with wrong args
-            if is_aggregate_function(name) {
+            if is_aggregate_function(name.as_str()) {
                 let upper = name.to_uppercase();
                 let arg_count = args.len();
 
@@ -265,7 +265,7 @@ fn check_aggregate_arg_count(expr: &Expression) -> Option<String> {
                         // count(a, b) without DISTINCT is wrong
                         // Regular count without DISTINCT can only have 0-1 args
                         if arg_count > 1 {
-                            Some(name.clone()) // Preserve original case
+                            Some(name.to_string()) // Preserve original case
                         } else {
                             None
                         }
@@ -273,21 +273,21 @@ fn check_aggregate_arg_count(expr: &Expression) -> Option<String> {
                     "MIN" | "MAX" => {
                         // Multi-arg min/max are scalar, so only check single arg case
                         if arg_count <= 1 && (has_wildcard || arg_count == 0) {
-                            Some(name.clone()) // Preserve original case
+                            Some(name.to_string()) // Preserve original case
                         } else {
                             None
                         }
                     }
                     "SUM" | "AVG" | "TOTAL" => {
                         if has_wildcard || arg_count == 0 || arg_count > 1 {
-                            Some(name.clone()) // Preserve original case
+                            Some(name.to_string()) // Preserve original case
                         } else {
                             None
                         }
                     }
                     "GROUP_CONCAT" => {
                         if arg_count == 0 || arg_count > 2 {
-                            Some(name.clone()) // Preserve original case
+                            Some(name.to_string()) // Preserve original case
                         } else {
                             None
                         }
@@ -347,17 +347,17 @@ fn check_aggregate_arg_count(expr: &Expression) -> Option<String> {
 /// Returns the function name (original case preserved) if found, None otherwise
 fn find_aggregate_in_expression(expr: &Expression) -> Option<String> {
     match expr {
-        Expression::AggregateFunction { name, .. } => Some(name.clone()), // Preserve original case
+        Expression::AggregateFunction { name, .. } => Some(name.to_string()), // Preserve original case
         Expression::Function { name, args, .. } => {
             // Check if this function is a built-in aggregate
             // Note: MIN/MAX with multiple args are scalar functions in SQLite
-            if is_aggregate_function(name) {
+            if is_aggregate_function(name.as_str()) {
                 let upper = name.to_uppercase();
                 if matches!(upper.as_str(), "MIN" | "MAX") && args.len() > 1 {
                     // Multi-arg min/max are scalar, not aggregate
                     None
                 } else {
-                    Some(name.clone()) // Preserve original case
+                    Some(name.to_string()) // Preserve original case
                 }
             } else {
                 // Check function arguments recursively
@@ -466,7 +466,7 @@ fn find_nested_aggregate(expr: &Expression) -> Option<String> {
         }
         Expression::Function { name, args, .. } => {
             // Check if this function is a built-in aggregate with nested aggregate args
-            if is_aggregate_function(name) {
+            if is_aggregate_function(name.as_str()) {
                 let upper = name.to_uppercase();
                 // Multi-arg MIN/MAX are scalar functions, not aggregates
                 let is_scalar_minmax = matches!(upper.as_str(), "MIN" | "MAX") && args.len() > 1;
@@ -834,7 +834,7 @@ fn expression_contains_aggregate(expr: &Expression) -> bool {
         Expression::AggregateFunction { .. } => true,
         Expression::Function { name, args, .. } => {
             // Check if this function is a built-in aggregate
-            if is_aggregate_function(name) {
+            if is_aggregate_function(name.as_str()) {
                 let upper = name.to_uppercase();
                 // Multi-arg MIN/MAX are scalar functions
                 if matches!(upper.as_str(), "MIN" | "MAX") && args.len() > 1 {
@@ -930,7 +930,7 @@ fn find_aliased_aggregate_misuse_in_expression(
         }
         Expression::Function { name, args, .. } => {
             // Check if this function is a built-in aggregate
-            let is_agg = is_aggregate_function(name);
+            let is_agg = is_aggregate_function(name.as_str());
             let upper = name.to_uppercase();
             // Multi-arg MIN/MAX are scalar functions
             let effectively_aggregate =
@@ -1366,7 +1366,7 @@ mod tests {
     fn test_min_star_invalid() {
         // MIN(*) should be invalid - returns error with function name (preserving original case)
         let expr = Expression::AggregateFunction {
-            name: "MIN".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("MIN"),
             distinct: false,
             args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("*", false))],
             order_by: None,
@@ -1380,7 +1380,7 @@ mod tests {
     fn test_max_star_invalid() {
         // MAX(*) should be invalid
         let expr = Expression::AggregateFunction {
-            name: "MAX".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("MAX"),
             distinct: false,
             args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("*", false))],
             order_by: None,
@@ -1394,7 +1394,7 @@ mod tests {
     fn test_min_no_args_invalid() {
         // MIN() with no arguments should be invalid
         let expr = Expression::AggregateFunction {
-            name: "MIN".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("MIN"),
             distinct: false,
             args: vec![],
             order_by: None,
@@ -1409,7 +1409,7 @@ mod tests {
         // Test the public function
         let select_list = vec![SelectItem::Expression {
             expr: Expression::AggregateFunction {
-                name: "MIN".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("MIN"),
                 distinct: false,
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("*", false))],
                 order_by: None,
@@ -1452,7 +1452,7 @@ mod tests {
         // Note: 'm' is NOT a column in the table, so it's treated as an alias reference
         let select_list = vec![SelectItem::Expression {
             expr: Expression::AggregateFunction {
-                name: "min".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("min"),
                 distinct: false,
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("f1", false))],
                 order_by: None,
@@ -1465,7 +1465,7 @@ mod tests {
         let having_expr = Expression::BinaryOp {
             op: vibesql_ast::BinaryOperator::LessThan,
             left: Box::new(Expression::AggregateFunction {
-                name: "max".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("max"),
                 distinct: false,
                 args: vec![Expression::BinaryOp {
                     op: vibesql_ast::BinaryOperator::Plus,
@@ -1498,7 +1498,7 @@ mod tests {
         // For now, we only detect the case where it's inside an aggregate.
         let select_list = vec![SelectItem::Expression {
             expr: Expression::AggregateFunction {
-                name: "min".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("min"),
                 distinct: false,
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("f1", false))],
                 order_by: None,
@@ -1527,7 +1527,7 @@ mod tests {
         // No aliased aggregate, should pass
         let select_list = vec![SelectItem::Expression {
             expr: Expression::AggregateFunction {
-                name: "count".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("count"),
                 distinct: false,
                 args: vec![Expression::Wildcard],
                 order_by: None,
@@ -1559,7 +1559,7 @@ mod tests {
             },
             SelectItem::Expression {
                 expr: Expression::AggregateFunction {
-                    name: "count".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("count"),
                     distinct: false,
                     args: vec![Expression::Wildcard],
                     order_by: None,
@@ -1573,7 +1573,7 @@ mod tests {
         let having_expr = Expression::BinaryOp {
             op: vibesql_ast::BinaryOperator::LessThan,
             left: Box::new(Expression::AggregateFunction {
-                name: "max".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("max"),
                 distinct: false,
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("x", false))],
                 order_by: None,
@@ -1602,7 +1602,7 @@ mod tests {
                 right: Box::new(Expression::UnaryOp {
                     op: vibesql_ast::UnaryOperator::Minus,
                     expr: Box::new(Expression::AggregateFunction {
-                        name: "AVG".to_string(),
+                        name: vibesql_ast::FunctionIdentifier::new("AVG"),
                         distinct: false,
                         args: vec![Expression::UnaryOp {
                             op: vibesql_ast::UnaryOperator::Minus,
@@ -1619,7 +1619,7 @@ mod tests {
         // HAVING AVG(col0) IS NULL - col0 is a real column, not the alias
         let having_expr = Expression::IsNull {
             expr: Box::new(Expression::AggregateFunction {
-                name: "AVG".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
                 distinct: false,
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("col0", false))],
                 order_by: None,
@@ -1665,7 +1665,7 @@ mod tests {
         let select_list = vec![
             SelectItem::Expression {
                 expr: Expression::AggregateFunction {
-                    name: "min".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("min"),
                     distinct: false,
                     args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("f1", false))],
                     order_by: None,
@@ -1681,12 +1681,12 @@ mod tests {
             SelectItem::Expression {
                 // coalesce(min(f1)+5, 11) AS m2
                 expr: Expression::Function {
-                    name: "coalesce".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("coalesce"),
                     args: vec![
                         Expression::BinaryOp {
                             op: vibesql_ast::BinaryOperator::Plus,
                             left: Box::new(Expression::AggregateFunction {
-                                name: "min".to_string(),
+                                name: vibesql_ast::FunctionIdentifier::new("min"),
                                 distinct: false,
                                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("f1", false))],
                                 order_by: None,

--- a/crates/vibesql-executor/src/select/grouping/grouping_sets/alias_resolution.rs
+++ b/crates/vibesql-executor/src/select/grouping/grouping_sets/alias_resolution.rs
@@ -290,7 +290,7 @@ mod tests {
             select_item(col("n_name"), Some("nation")),
             select_item(
                 Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: false,
                     args: vec![Expression::Wildcard],
                     order_by: None,
@@ -394,7 +394,7 @@ mod tests {
     fn test_resolve_group_by_alias_expression_alias() {
         // SELECT SUBSTR(o_orderdate, 1, 4) AS o_year ... GROUP BY o_year
         let substr_expr = Expression::Function {
-            name: "SUBSTR".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("SUBSTR"),
             args: vec![
                 col("o_orderdate"),
                 Expression::Literal(vibesql_types::SqlValue::Integer(1)),

--- a/crates/vibesql-executor/src/select/grouping/grouping_sets/expression_utils.rs
+++ b/crates/vibesql-executor/src/select/grouping/grouping_sets/expression_utils.rs
@@ -40,24 +40,24 @@ pub fn expressions_equal(a: &Expression, b: &Expression) -> bool {
             op1 == op2 && expressions_equal(e1, e2)
         }
 
-        // Function: case-insensitive name, recurse into args
+        // Function: case-insensitive name (via FunctionIdentifier), recurse into args
         (
             Expression::Function { name: n1, args: a1, character_unit: cu1 },
             Expression::Function { name: n2, args: a2, character_unit: cu2 },
         ) => {
-            n1.eq_ignore_ascii_case(n2)
+            n1 == n2 // FunctionIdentifier comparison is case-insensitive via canonical
                 && cu1 == cu2
                 && a1.len() == a2.len()
                 && a1.iter().zip(a2).all(|(x, y)| expressions_equal(x, y))
         }
 
-        // AggregateFunction: case-insensitive name, check distinct, recurse into args
+        // AggregateFunction: case-insensitive name (via FunctionIdentifier), check distinct, recurse into args
         // Note: order_by is ignored in equality check for grouping purposes
         (
             Expression::AggregateFunction { name: n1, distinct: d1, args: a1, .. },
             Expression::AggregateFunction { name: n2, distinct: d2, args: a2, .. },
         ) => {
-            n1.eq_ignore_ascii_case(n2)
+            n1 == n2 // FunctionIdentifier comparison is case-insensitive via canonical
                 && d1 == d2
                 && a1.len() == a2.len()
                 && a1.iter().zip(a2).all(|(x, y)| expressions_equal(x, y))
@@ -255,7 +255,7 @@ fn window_function_equal(a: &WindowFunctionSpec, b: &WindowFunctionSpec) -> bool
             WindowFunctionSpec::Value { name: n1, args: a1 },
             WindowFunctionSpec::Value { name: n2, args: a2 },
         ) => {
-            n1.eq_ignore_ascii_case(n2)
+            n1 == n2 // FunctionIdentifier comparison is case-insensitive via canonical
                 && a1.len() == a2.len()
                 && a1.iter().zip(a2).all(|(x, y)| expressions_equal(x, y))
         }
@@ -313,11 +313,11 @@ mod tests {
     }
 
     fn func(name: &str, args: Vec<Expression>) -> Expression {
-        Expression::Function { name: name.to_string(), args, character_unit: None }
+        Expression::Function { name: vibesql_ast::FunctionIdentifier::new(name), args, character_unit: None }
     }
 
     fn agg(name: &str, args: Vec<Expression>, distinct: bool) -> Expression {
-        Expression::AggregateFunction { name: name.to_string(), distinct, args, order_by: None }
+        Expression::AggregateFunction { name: vibesql_ast::FunctionIdentifier::new(name), distinct, args, order_by: None }
     }
 
     // --- ColumnRef tests ---

--- a/crates/vibesql-executor/src/select/order.rs
+++ b/crates/vibesql-executor/src/select/order.rs
@@ -616,7 +616,7 @@ fn expressions_equal(a: &vibesql_ast::Expression, b: &vibesql_ast::Expression) -
             vibesql_ast::Expression::Function { name: n1, args: a1, .. },
             vibesql_ast::Expression::Function { name: n2, args: a2, .. },
         ) => {
-            n1.eq_ignore_ascii_case(n2)
+            n1 == n2 // FunctionIdentifier comparison is case-insensitive via canonical
                 && a1.len() == a2.len()
                 && a1.iter().zip(a2.iter()).all(|(x, y)| expressions_equal(x, y))
         }

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -44,9 +44,9 @@ fn extract_column_name_from_expr(expr: &Expression) -> String {
                     return col_id.column_canonical().to_string();
                 }
             }
-            name.clone()
+            name.to_string()
         }
-        Expression::Function { name, .. } => name.clone(),
+        Expression::Function { name, .. } => name.to_string(),
         Expression::BinaryOp { left, .. } => extract_column_name_from_expr(left),
         _ => "?column?".to_string(),
     }

--- a/crates/vibesql-executor/src/tests/aggregate_caching.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_caching.rs
@@ -33,7 +33,7 @@ fn test_repeated_count_star_cached() {
     // Build: COUNT(*) * 37 + NULLIF(45, COUNT(*) * 13) + COUNT(*) + 22
     // Expected: 5 * 37 + NULLIF(45, 5 * 13) + 5 + 22 = 185 + 45 + 5 + 22 = 257
     let count_star = vibesql_ast::Expression::AggregateFunction {
-        name: "COUNT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("COUNT"),
         distinct: false,
         args: vec![vibesql_ast::Expression::Wildcard],
         order_by: None,
@@ -55,7 +55,7 @@ fn test_repeated_count_star_cached() {
 
     // NULLIF(45, COUNT(*) * 13)
     let nullif_expr = vibesql_ast::Expression::Function {
-        name: "NULLIF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("NULLIF"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(45)),
             count_times_13,
@@ -136,7 +136,7 @@ fn test_repeated_sum_cached() {
     let executor = SelectExecutor::new(&db);
 
     let sum_amount = vibesql_ast::Expression::AggregateFunction {
-        name: "SUM".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUM"),
         distinct: false,
         args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
         order_by: None,
@@ -254,7 +254,7 @@ fn test_cache_cleared_between_groups() {
     let executor = SelectExecutor::new(&db);
 
     let count_star = vibesql_ast::Expression::AggregateFunction {
-        name: "COUNT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("COUNT"),
         distinct: false,
         args: vec![vibesql_ast::Expression::Wildcard],
         order_by: None,
@@ -341,14 +341,14 @@ fn test_distinct_aggregates_not_confused() {
     let executor = SelectExecutor::new(&db);
 
     let count_val = vibesql_ast::Expression::AggregateFunction {
-        name: "COUNT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("COUNT"),
         distinct: false,
         args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("val", false))],
         order_by: None,
     };
 
     let count_distinct_val = vibesql_ast::Expression::AggregateFunction {
-        name: "COUNT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("COUNT"),
         distinct: true,
         args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("val", false))],
         order_by: None,

--- a/crates/vibesql-executor/src/tests/aggregate_count_sum_avg_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_count_sum_avg_tests.rs
@@ -58,7 +58,7 @@ fn test_count_star_no_group_by() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 args: vec![vibesql_ast::Expression::Wildcard],
                 character_unit: None,
             },
@@ -137,7 +137,7 @@ fn test_sum_no_group_by() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "SUM".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("SUM"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                 character_unit: None,
             },
@@ -218,7 +218,7 @@ fn test_count_with_nulls() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 args: vec![vibesql_ast::Expression::Wildcard],
                 character_unit: None,
             },
@@ -297,7 +297,7 @@ fn test_sum_with_nulls() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "SUM".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("SUM"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("value", false))],
                 character_unit: None,
             },
@@ -378,7 +378,7 @@ fn test_avg_function() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "AVG".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("score", false))],
                 character_unit: None,
             },
@@ -458,7 +458,7 @@ fn test_avg_with_nulls() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "AVG".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("rating", false))],
                 character_unit: None,
             },
@@ -541,7 +541,7 @@ fn test_count_column_all_nulls() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("value", false))],
                 character_unit: None,
             },
@@ -575,7 +575,7 @@ fn test_count_column_all_nulls() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 args: vec![vibesql_ast::Expression::Wildcard],
                 character_unit: None,
             },
@@ -635,7 +635,7 @@ fn test_count_star_in_simple_case_expression() {
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Case {
                 operand: Some(Box::new(vibesql_ast::Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Wildcard],
                     order_by: None,
@@ -710,7 +710,7 @@ fn test_count_star_in_searched_case_expression() {
                 when_clauses: vec![vibesql_ast::CaseWhen {
                     conditions: vec![vibesql_ast::Expression::BinaryOp {
                         left: Box::new(vibesql_ast::Expression::AggregateFunction {
-                            name: "COUNT".to_string(),
+                            name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                             distinct: false,
                             args: vec![vibesql_ast::Expression::Wildcard],
                             order_by: None,
@@ -784,7 +784,7 @@ fn test_count_star_in_arithmetic_expression() {
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Wildcard],
                     order_by: None,
@@ -855,7 +855,7 @@ fn test_count_star_in_case_then_clause() {
                         )),
                     }],
                     result: vibesql_ast::Expression::AggregateFunction {
-                        name: "COUNT".to_string(),
+                        name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                         distinct: false,
                         args: vec![vibesql_ast::Expression::Wildcard],
                         order_by: None,
@@ -915,7 +915,7 @@ fn test_count_star_in_nested_case_expression() {
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Case {
                 operand: Some(Box::new(vibesql_ast::Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Wildcard],
                     order_by: None,

--- a/crates/vibesql-executor/src/tests/aggregate_distinct.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_distinct.rs
@@ -94,7 +94,7 @@ fn test_count_distinct_basic() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                 order_by: None,
@@ -137,7 +137,7 @@ fn test_count_distinct_vs_count_all() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                     order_by: None,
@@ -145,7 +145,7 @@ fn test_count_distinct_vs_count_all() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: true,
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                     order_by: None,
@@ -188,7 +188,7 @@ fn test_sum_distinct() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "SUM".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("SUM"),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                 order_by: None,
@@ -232,7 +232,7 @@ fn test_sum_distinct_vs_sum_all() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "SUM".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("SUM"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                     order_by: None,
@@ -240,7 +240,7 @@ fn test_sum_distinct_vs_sum_all() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "SUM".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("SUM"),
                     distinct: true,
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                     order_by: None,
@@ -285,7 +285,7 @@ fn test_avg_distinct() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "AVG".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                 order_by: None,
@@ -327,7 +327,7 @@ fn test_min_distinct() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "MIN".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("MIN"),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                 order_by: None,
@@ -369,7 +369,7 @@ fn test_max_distinct() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "MAX".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("MAX"),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                 order_by: None,
@@ -431,7 +431,7 @@ fn test_count_distinct_with_nulls() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("val", false))],
                 order_by: None,
@@ -492,7 +492,7 @@ fn test_distinct_all_same_value() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: true,
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("val", false))],
                     order_by: None,
@@ -500,7 +500,7 @@ fn test_distinct_all_same_value() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "SUM".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("SUM"),
                     distinct: true,
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("val", false))],
                     order_by: None,
@@ -555,7 +555,7 @@ fn test_distinct_empty_table() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: true,
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("val", false))],
                     order_by: None,
@@ -563,7 +563,7 @@ fn test_distinct_empty_table() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "SUM".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("SUM"),
                     distinct: true,
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("val", false))],
                     order_by: None,

--- a/crates/vibesql-executor/src/tests/aggregate_edge_case_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_edge_case_tests.rs
@@ -59,7 +59,7 @@ fn test_avg_precision_decimal() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "AVG".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))],
                 character_unit: None,
             },
@@ -146,7 +146,7 @@ fn test_sum_mixed_numeric_types() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "SUM".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("SUM"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                 character_unit: None,
             },
@@ -237,7 +237,7 @@ fn test_aggregate_with_case_expression() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "SUM".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("SUM"),
                 args: vec![vibesql_ast::Expression::Case {
                     operand: None,
                     when_clauses: vec![vibesql_ast::CaseWhen {
@@ -309,7 +309,7 @@ fn test_max_with_unary_plus() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "MAX".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("MAX"),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::UnaryOp {
                     op: vibesql_ast::UnaryOperator::Plus,
@@ -368,7 +368,7 @@ fn test_max_with_unary_minus() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "MAX".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("MAX"),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::UnaryOp {
                     op: vibesql_ast::UnaryOperator::Minus,
@@ -428,7 +428,7 @@ fn test_count_with_not() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::UnaryOp {
                     op: vibesql_ast::UnaryOperator::Not,

--- a/crates/vibesql-executor/src/tests/aggregate_group_by_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_group_by_tests.rs
@@ -77,7 +77,7 @@ fn test_group_by_select_alias() {
                 alias: Some("department".to_string()), source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Wildcard],
                     order_by: None,
@@ -192,7 +192,7 @@ fn test_group_by_numeric_position() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Wildcard],
                     order_by: None,
@@ -302,7 +302,7 @@ fn test_group_by_with_count() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::Function {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     args: vec![vibesql_ast::Expression::Wildcard],
                     character_unit: None,
                 },

--- a/crates/vibesql-executor/src/tests/aggregate_having_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_having_tests.rs
@@ -142,7 +142,7 @@ fn test_having_clause() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::Function {
-                    name: "SUM".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("SUM"),
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                     character_unit: None,
                 },
@@ -159,7 +159,7 @@ fn test_having_clause() {
         ])),
         having: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::Function {
-                name: "SUM".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("SUM"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                 character_unit: None,
             }),

--- a/crates/vibesql-executor/src/tests/aggregate_min_max_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_min_max_tests.rs
@@ -58,7 +58,7 @@ fn test_min_function() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "MIN".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("MIN"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("temp", false))],
                 character_unit: None,
             },
@@ -137,7 +137,7 @@ fn test_max_function() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "MAX".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("MAX"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("temp", false))],
                 character_unit: None,
             },
@@ -219,7 +219,7 @@ fn test_min_max_on_strings() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "MIN".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("MIN"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("name", false))],
                 character_unit: None,
             },
@@ -256,7 +256,7 @@ fn test_min_max_on_strings() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "MAX".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("MAX"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("name", false))],
                 character_unit: None,
             },

--- a/crates/vibesql-executor/src/tests/aggregate_without_from.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_without_from.rs
@@ -20,7 +20,7 @@ fn test_max_constant_without_from() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "MAX".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("MAX"),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(100))],
                 order_by: None,
@@ -55,7 +55,7 @@ fn test_count_star_without_from() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::Wildcard],
                 order_by: None,
@@ -91,7 +91,7 @@ fn test_aggregate_in_expression_without_from() {
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::BinaryOp {
                 left: Box::new(vibesql_ast::Expression::AggregateFunction {
-                    name: "MAX".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("MAX"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(
                         5,
@@ -133,7 +133,7 @@ fn test_count_distinct_without_from() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 distinct: true,
                 args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(65))],
                 order_by: None,
@@ -169,7 +169,7 @@ fn test_multiple_aggregates_without_from() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "MAX".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("MAX"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(
                         5,
@@ -179,7 +179,7 @@ fn test_multiple_aggregates_without_from() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "MIN".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("MIN"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(
                         10,
@@ -189,7 +189,7 @@ fn test_multiple_aggregates_without_from() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Wildcard],
                     order_by: None,
@@ -228,7 +228,7 @@ fn test_sum_avg_without_from() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "SUM".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("SUM"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(
                         100,
@@ -238,7 +238,7 @@ fn test_sum_avg_without_from() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "AVG".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("AVG"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(
                         50,

--- a/crates/vibesql-executor/src/tests/count_star_fast_path.rs
+++ b/crates/vibesql-executor/src/tests/count_star_fast_path.rs
@@ -49,7 +49,7 @@ fn test_count_star_fast_path_simple() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::Wildcard],
                 order_by: None,
@@ -99,7 +99,7 @@ fn test_count_star_fast_path_empty_table() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::Wildcard],
                 order_by: None,
@@ -167,7 +167,7 @@ fn test_count_star_with_where_no_fast_path() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::Wildcard],
                 order_by: None,
@@ -275,7 +275,7 @@ fn test_count_star_with_group_by_no_fast_path() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Wildcard],
                     order_by: None,
@@ -334,7 +334,7 @@ fn test_count_star_distinct_no_fast_path() {
         distinct: true, // DISTINCT specified
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::Wildcard],
                 order_by: None,
@@ -392,7 +392,7 @@ fn test_count_column_no_fast_path() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("id", false))],
                 order_by: None,
@@ -450,7 +450,7 @@ fn test_count_star_with_alias() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::Wildcard],
                 order_by: None,
@@ -519,7 +519,7 @@ fn test_count_star_multiple_select_items_no_fast_path() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::Wildcard],
                     order_by: None,
@@ -527,7 +527,7 @@ fn test_count_star_multiple_select_items_no_fast_path() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::AggregateFunction {
-                    name: "SUM".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("SUM"),
                     distinct: false,
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("value", false))],
                     order_by: None,

--- a/crates/vibesql-executor/src/tests/function_tests.rs
+++ b/crates/vibesql-executor/src/tests/function_tests.rs
@@ -286,7 +286,7 @@ fn test_function_varchar_return_type() {
             ProceduralStatement::Set {
                 name: "greeting".to_string(),
                 value: Box::new(Expression::Function {
-                    name: "CONCAT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("CONCAT"),
                     args: vec![
                         Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Hello, "))),
                         Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("name", false)),

--- a/crates/vibesql-executor/src/tests/join_aggregation.rs
+++ b/crates/vibesql-executor/src/tests/join_aggregation.rs
@@ -148,7 +148,7 @@ fn test_inner_join_with_group_by_count() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::Function {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::qualified("e", false, "emp_id", false))],
                     character_unit: None,
                 },
@@ -243,7 +243,7 @@ fn test_left_join_with_group_by_avg_salary() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::Function {
-                    name: "AVG".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("AVG"),
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::qualified("e", false, "salary", false))],
                     character_unit: None,
                 },
@@ -336,7 +336,7 @@ fn test_join_group_by_with_having() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::Function {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::qualified("e", false, "emp_id", false))],
                     character_unit: None,
                 },
@@ -368,7 +368,7 @@ fn test_join_group_by_with_having() {
         ])),
         having: Some(vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::Function {
-                name: "COUNT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::qualified("e", false, "emp_id", false))],
                 character_unit: None,
             }),
@@ -419,21 +419,21 @@ fn test_join_group_by_multiple_aggregates() {
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::Function {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     args: vec![vibesql_ast::Expression::Wildcard],
                     character_unit: None,
                 },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::Function {
-                    name: "MIN".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("MIN"),
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::qualified("e", false, "salary", false))],
                     character_unit: None,
                 },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::Function {
-                    name: "MAX".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("MAX"),
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::qualified("e", false, "salary", false))],
                     character_unit: None,
                 },

--- a/crates/vibesql-executor/src/tests/lazy_evaluation_tests.rs
+++ b/crates/vibesql-executor/src/tests/lazy_evaluation_tests.rs
@@ -20,7 +20,7 @@ fn test_coalesce_lazy_evaluation_short_circuits() {
 
     // Create expression: COALESCE(10, NULL/0) - should return 10 and not evaluate division
     let expr = vibesql_ast::Expression::Function {
-        name: "COALESCE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("COALESCE"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(10)),
             // This expression would cause a division by zero if evaluated
@@ -48,7 +48,7 @@ fn test_coalesce_evaluates_all_when_all_null() {
     let row = Row::new(vec![]);
 
     let expr = vibesql_ast::Expression::Function {
-        name: "COALESCE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("COALESCE"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Null),
             vibesql_ast::Expression::Literal(SqlValue::Null),
@@ -73,7 +73,7 @@ fn test_nullif_lazy_evaluation_short_circuits() {
     // Create expression: NULLIF(NULL, expensive_expr) - should return NULL without evaluating
     // division
     let expr = vibesql_ast::Expression::Function {
-        name: "NULLIF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("NULLIF"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Null),
             // This expression would cause a division by zero if evaluated
@@ -101,7 +101,7 @@ fn test_nullif_evaluates_second_when_first_not_null() {
     let row = Row::new(vec![]);
 
     let expr = vibesql_ast::Expression::Function {
-        name: "NULLIF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("NULLIF"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(42)),
             vibesql_ast::Expression::Literal(SqlValue::Integer(42)),
@@ -123,7 +123,7 @@ fn test_nullif_returns_first_when_not_equal() {
     let row = Row::new(vec![]);
 
     let expr = vibesql_ast::Expression::Function {
-        name: "NULLIF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("NULLIF"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Integer(42)),
             vibesql_ast::Expression::Literal(SqlValue::Integer(43)),
@@ -145,7 +145,7 @@ fn test_coalesce_with_strings() {
     let row = Row::new(vec![]);
 
     let expr = vibesql_ast::Expression::Function {
-        name: "COALESCE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("COALESCE"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Null),
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("hello"))),
@@ -168,11 +168,11 @@ fn test_nested_coalesce() {
     let row = Row::new(vec![]);
 
     let expr = vibesql_ast::Expression::Function {
-        name: "COALESCE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("COALESCE"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Null),
             vibesql_ast::Expression::Function {
-                name: "COALESCE".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("COALESCE"),
                 args: vec![
                     vibesql_ast::Expression::Literal(SqlValue::Null),
                     vibesql_ast::Expression::Literal(SqlValue::Integer(42)),

--- a/crates/vibesql-executor/src/tests/procedures/parameters.rs
+++ b/crates/vibesql-executor/src/tests/procedures/parameters.rs
@@ -221,7 +221,7 @@ fn test_concat_function_in_procedure() {
             ProceduralStatement::Set {
                 name: "full_name".to_string(),
                 value: Box::new(Expression::Function {
-                    name: "CONCAT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("CONCAT"),
                     args: vec![
                         Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("first", false)),
                         Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(" "))),

--- a/crates/vibesql-executor/src/tests/scalar_subquery_basic_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_basic_tests.rs
@@ -74,7 +74,7 @@ fn test_scalar_subquery_in_where_clause() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "AVG".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("salary", false))],
                 character_unit: None,
             },
@@ -191,7 +191,7 @@ fn test_scalar_subquery_in_select_list() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "MAX".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("MAX"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("salary", false))],
                 character_unit: None,
             },

--- a/crates/vibesql-executor/src/tests/scalar_subquery_correlated_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_correlated_tests.rs
@@ -85,7 +85,7 @@ fn test_correlated_subquery_uppercase_identifiers_issue_4111() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::AggregateFunction {
-                name: "AVG".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
                 distinct: false,
                 args: vec![vibesql_ast::Expression::ColumnRef(
                     vibesql_ast::ColumnIdentifier::qualified("J", false, "I_CURRENT_PRICE", false)
@@ -257,7 +257,7 @@ fn test_correlated_subquery_basic() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "AVG".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
                 args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("salary", false))],
                 character_unit: None,
             },

--- a/crates/vibesql-executor/src/tests/select_without_from.rs
+++ b/crates/vibesql-executor/src/tests/select_without_from.rs
@@ -154,7 +154,7 @@ fn test_select_function_call() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: vibesql_ast::Expression::Function {
-                name: "UPPER".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("UPPER"),
                 args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                     arcstr::ArcStr::from("hello"),
                 ))],

--- a/crates/vibesql-executor/tests/advanced_function_tests/conditional_functions.rs
+++ b/crates/vibesql-executor/tests/advanced_function_tests/conditional_functions.rs
@@ -7,7 +7,7 @@ fn test_greatest_integers() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "GREATEST".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("GREATEST"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(5)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(10)),
@@ -25,7 +25,7 @@ fn test_greatest_with_null() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "GREATEST".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("GREATEST"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(5)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
@@ -42,7 +42,7 @@ fn test_least_integers() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "LEAST".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LEAST"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(5)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(10)),
@@ -60,7 +60,7 @@ fn test_least_with_null() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "LEAST".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LEAST"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(5)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
@@ -77,7 +77,7 @@ fn test_if_true_condition() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "IF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("IF"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(true)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -98,7 +98,7 @@ fn test_if_false_condition() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "IF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("IF"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(false)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -119,7 +119,7 @@ fn test_if_null_condition() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "IF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("IF"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(

--- a/crates/vibesql-executor/tests/advanced_function_tests/fixtures.rs
+++ b/crates/vibesql-executor/tests/advanced_function_tests/fixtures.rs
@@ -13,7 +13,7 @@ pub fn create_function_expr(
     name: &str,
     args: Vec<vibesql_ast::Expression>,
 ) -> vibesql_ast::Expression {
-    vibesql_ast::Expression::Function { name: name.to_string(), args, character_unit: None }
+    vibesql_ast::Expression::Function { name: vibesql_ast::FunctionIdentifier::new(name), args, character_unit: None }
 }
 
 /// Helper to create a literal expression from a SQL value

--- a/crates/vibesql-executor/tests/advanced_function_tests/math_functions.rs
+++ b/crates/vibesql-executor/tests/advanced_function_tests/math_functions.rs
@@ -7,7 +7,7 @@ fn test_exp_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "EXP".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("EXP"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1))],
         character_unit: None,
     };
@@ -26,7 +26,7 @@ fn test_ln_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "LN".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LN"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(2.718281828))],
         character_unit: None,
     };
@@ -45,7 +45,7 @@ fn test_log_alias() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "LOG".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOG"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(2.718281828))],
         character_unit: None,
     };
@@ -64,7 +64,7 @@ fn test_log10_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "LOG10".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOG10"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(100))],
         character_unit: None,
     };
@@ -77,7 +77,7 @@ fn test_sign_positive() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "SIGN".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SIGN"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(42))],
         character_unit: None,
     };
@@ -90,7 +90,7 @@ fn test_sign_negative() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "SIGN".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SIGN"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(-42))],
         character_unit: None,
     };
@@ -103,7 +103,7 @@ fn test_sign_zero() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "SIGN".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SIGN"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(0))],
         character_unit: None,
     };
@@ -116,7 +116,7 @@ fn test_pi_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "PI".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("PI"),
         args: vec![],
         character_unit: None,
     };

--- a/crates/vibesql-executor/tests/advanced_function_tests/nested_expressions.rs
+++ b/crates/vibesql-executor/tests/advanced_function_tests/nested_expressions.rs
@@ -8,9 +8,9 @@ fn test_trig_with_pi() {
 
     // SIN(PI()) should be approximately 0
     let expr = vibesql_ast::Expression::Function {
-        name: "SIN".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SIN"),
         args: vec![vibesql_ast::Expression::Function {
-            name: "PI".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("PI"),
             args: vec![],
             character_unit: None,
         }],
@@ -31,9 +31,9 @@ fn test_radians_degrees_roundtrip() {
 
     // DEGREES(RADIANS(90)) should equal 90
     let expr = vibesql_ast::Expression::Function {
-        name: "DEGREES".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DEGREES"),
         args: vec![vibesql_ast::Expression::Function {
-            name: "RADIANS".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("RADIANS"),
             args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(90))],
             character_unit: None,
         }],
@@ -54,9 +54,9 @@ fn test_exp_ln_roundtrip() {
 
     // LN(EXP(2)) should equal 2
     let expr = vibesql_ast::Expression::Function {
-        name: "LN".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LN"),
         args: vec![vibesql_ast::Expression::Function {
-            name: "EXP".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("EXP"),
             args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2))],
             character_unit: None,
         }],
@@ -77,15 +77,15 @@ fn test_greatest_with_abs() {
 
     // GREATEST(ABS(-5), ABS(3)) should be 5
     let expr = vibesql_ast::Expression::Function {
-        name: "GREATEST".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("GREATEST"),
         args: vec![
             vibesql_ast::Expression::Function {
-                name: "ABS".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("ABS"),
                 args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(-5))],
                 character_unit: None,
             },
             vibesql_ast::Expression::Function {
-                name: "ABS".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("ABS"),
                 args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(3))],
                 character_unit: None,
             },

--- a/crates/vibesql-executor/tests/advanced_function_tests/trig_functions.rs
+++ b/crates/vibesql-executor/tests/advanced_function_tests/trig_functions.rs
@@ -8,7 +8,7 @@ fn test_sin_function() {
 
     // sin(0) = 0
     let expr = vibesql_ast::Expression::Function {
-        name: "SIN".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SIN"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(0))],
         character_unit: None,
     };
@@ -22,7 +22,7 @@ fn test_cos_function() {
 
     // cos(0) = 1
     let expr = vibesql_ast::Expression::Function {
-        name: "COS".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("COS"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(0))],
         character_unit: None,
     };
@@ -36,7 +36,7 @@ fn test_tan_function() {
 
     // tan(0) = 0
     let expr = vibesql_ast::Expression::Function {
-        name: "TAN".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("TAN"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(0))],
         character_unit: None,
     };
@@ -50,7 +50,7 @@ fn test_asin_function() {
 
     // asin(0.5) ≈ 0.5236 (30 degrees in radians)
     let expr = vibesql_ast::Expression::Function {
-        name: "ASIN".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ASIN"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(0.5))],
         character_unit: None,
     };
@@ -69,7 +69,7 @@ fn test_acos_function() {
 
     // acos(0.5) ≈ 1.0472 (60 degrees in radians)
     let expr = vibesql_ast::Expression::Function {
-        name: "ACOS".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ACOS"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(0.5))],
         character_unit: None,
     };
@@ -88,7 +88,7 @@ fn test_atan_function() {
 
     // atan(1) ≈ 0.7854 (45 degrees in radians)
     let expr = vibesql_ast::Expression::Function {
-        name: "ATAN".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ATAN"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1))],
         character_unit: None,
     };
@@ -107,7 +107,7 @@ fn test_atan2_function() {
 
     // atan2(1, 1) ≈ 0.7854 (45 degrees)
     let expr = vibesql_ast::Expression::Function {
-        name: "ATAN2".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ATAN2"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -129,7 +129,7 @@ fn test_radians_function() {
 
     // 180 degrees = π radians
     let expr = vibesql_ast::Expression::Function {
-        name: "RADIANS".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("RADIANS"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(180))],
         character_unit: None,
     };
@@ -148,7 +148,7 @@ fn test_degrees_function() {
 
     // π radians = 180 degrees
     let expr = vibesql_ast::Expression::Function {
-        name: "DEGREES".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DEGREES"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(
             std::f64::consts::PI,
         ))],

--- a/crates/vibesql-executor/tests/advanced_function_tests/truncate_functions.rs
+++ b/crates/vibesql-executor/tests/advanced_function_tests/truncate_functions.rs
@@ -7,7 +7,7 @@ fn test_truncate_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "TRUNCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("TRUNCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(3.14159)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
@@ -29,7 +29,7 @@ fn test_truncate_no_precision() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "TRUNCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("TRUNCATE"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(3.999))],
         character_unit: None,
     };
@@ -48,7 +48,7 @@ fn test_truncate_negative() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "TRUNCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("TRUNCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(-1.999)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -70,7 +70,7 @@ fn test_truncate_null() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "TRUNCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("TRUNCATE"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)],
         character_unit: None,
     };
@@ -83,7 +83,7 @@ fn test_truncate_negative_precision() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "TRUNCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("TRUNCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(123.456)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(-1)),

--- a/crates/vibesql-executor/tests/conversion_function_tests.rs
+++ b/crates/vibesql-executor/tests/conversion_function_tests.rs
@@ -16,7 +16,7 @@ use common::create_test_evaluator;
 
 /// Helper to create a function expression
 fn create_function_expr(name: &str, args: Vec<vibesql_ast::Expression>) -> vibesql_ast::Expression {
-    vibesql_ast::Expression::Function { name: name.to_string(), args, character_unit: None }
+    vibesql_ast::Expression::Function { name: vibesql_ast::FunctionIdentifier::new(name), args, character_unit: None }
 }
 
 /// Helper to evaluate a function and return the result

--- a/crates/vibesql-executor/tests/date_arithmetic_tests/date_operations.rs
+++ b/crates/vibesql-executor/tests/date_arithmetic_tests/date_operations.rs
@@ -9,7 +9,7 @@ fn test_datediff_basic() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATEDIFF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATEDIFF"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-01-10".parse().unwrap(),
@@ -29,7 +29,7 @@ fn test_datediff_negative() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATEDIFF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATEDIFF"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-01-05".parse().unwrap(),
@@ -49,7 +49,7 @@ fn test_datediff_same_date() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATEDIFF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATEDIFF"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-01-15".parse().unwrap(),
@@ -71,7 +71,7 @@ fn test_date_add_days() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_ADD".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_ADD"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-01-15".parse().unwrap(),
@@ -92,7 +92,7 @@ fn test_date_add_months() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_ADD".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_ADD"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-01-15".parse().unwrap(),
@@ -113,7 +113,7 @@ fn test_date_add_years() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_ADD".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_ADD"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-01-15".parse().unwrap(),
@@ -134,7 +134,7 @@ fn test_date_add_negative() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_ADD".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_ADD"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-01-15".parse().unwrap(),
@@ -155,7 +155,7 @@ fn test_adddate_alias() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "ADDDATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ADDDATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-01-15".parse().unwrap(),
@@ -178,7 +178,7 @@ fn test_date_sub_days() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_SUB".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_SUB"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-01-15".parse().unwrap(),
@@ -199,7 +199,7 @@ fn test_date_sub_months() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_SUB".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_SUB"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-04-15".parse().unwrap(),
@@ -220,7 +220,7 @@ fn test_subdate_alias() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBDATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBDATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-01-15".parse().unwrap(),

--- a/crates/vibesql-executor/tests/date_arithmetic_tests/edge_cases.rs
+++ b/crates/vibesql-executor/tests/date_arithmetic_tests/edge_cases.rs
@@ -6,7 +6,7 @@ use crate::common::create_test_evaluator;
 
 /// Helper to create a function expression
 fn create_function_expr(name: &str, args: Vec<vibesql_ast::Expression>) -> vibesql_ast::Expression {
-    vibesql_ast::Expression::Function { name: name.to_string(), args, character_unit: None }
+    vibesql_ast::Expression::Function { name: vibesql_ast::FunctionIdentifier::new(name), args, character_unit: None }
 }
 
 /// Helper to evaluate a function and return the result

--- a/crates/vibesql-executor/tests/date_arithmetic_tests/interval_operations.rs
+++ b/crates/vibesql-executor/tests/date_arithmetic_tests/interval_operations.rs
@@ -9,7 +9,7 @@ fn test_extract_year() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "EXTRACT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("EXTRACT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("YEAR"),
@@ -29,7 +29,7 @@ fn test_extract_month() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "EXTRACT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("EXTRACT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("MONTH"),
@@ -49,7 +49,7 @@ fn test_extract_day() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "EXTRACT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("EXTRACT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("DAY"),
@@ -71,7 +71,7 @@ fn test_age_two_dates_years_only() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "AGE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("AGE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-01-15".parse().unwrap(),
@@ -95,7 +95,7 @@ fn test_age_two_dates_complex() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "AGE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("AGE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-05-20".parse().unwrap(),
@@ -121,7 +121,7 @@ fn test_age_negative() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "AGE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("AGE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2020-01-15".parse().unwrap(),
@@ -146,7 +146,7 @@ fn test_age_same_date() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "AGE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("AGE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "2024-01-15".parse().unwrap(),

--- a/crates/vibesql-executor/tests/date_arithmetic_tests/time_operations.rs
+++ b/crates/vibesql-executor/tests/date_arithmetic_tests/time_operations.rs
@@ -10,7 +10,7 @@ fn test_date_add_hours_across_midnight() {
 
     // 11 PM + 2 hours → 1 AM next day
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_ADD".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_ADD"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Timestamp(
                 "2024-01-15 23:00:00".parse().unwrap(),
@@ -32,7 +32,7 @@ fn test_date_add_minutes_overflow() {
 
     // 90 minutes from 11:30 → 1:00 PM
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_ADD".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_ADD"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Timestamp(
                 "2024-01-15 11:30:00".parse().unwrap(),
@@ -54,7 +54,7 @@ fn test_date_add_seconds_overflow() {
 
     // 3661 seconds (1 hour, 1 minute, 1 second)
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_ADD".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_ADD"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Timestamp(
                 "2024-01-15 10:30:30".parse().unwrap(),
@@ -76,7 +76,7 @@ fn test_date_sub_hours_across_midnight() {
 
     // 1 AM - 2 hours → 11 PM previous day
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_SUB".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_SUB"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Timestamp(
                 "2024-01-16 01:00:00".parse().unwrap(),

--- a/crates/vibesql-executor/tests/date_arithmetic_tests/timestamp_operations.rs
+++ b/crates/vibesql-executor/tests/date_arithmetic_tests/timestamp_operations.rs
@@ -7,7 +7,7 @@ fn test_datediff_with_timestamps() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATEDIFF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATEDIFF"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Timestamp(
                 "2024-01-10 15:30:00".parse().unwrap(),
@@ -27,7 +27,7 @@ fn test_date_add_timestamp_with_time() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_ADD".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_ADD"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Timestamp(
                 "2024-01-15 14:30:00".parse().unwrap(),
@@ -48,7 +48,7 @@ fn test_extract_hour_from_timestamp() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "EXTRACT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("EXTRACT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("HOUR"),

--- a/crates/vibesql-executor/tests/date_arithmetic_tests/type_coercion.rs
+++ b/crates/vibesql-executor/tests/date_arithmetic_tests/type_coercion.rs
@@ -17,7 +17,7 @@ fn test_datediff_varchar_dates() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATEDIFF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATEDIFF"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("2024-01-10"))),
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("2024-01-01"))),
@@ -34,7 +34,7 @@ fn test_datediff_mixed_varchar_date() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATEDIFF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATEDIFF"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("2024-01-10"))),
             vibesql_ast::Expression::Literal(SqlValue::Date("2024-01-01".parse().unwrap())),
@@ -51,7 +51,7 @@ fn test_datediff_invalid_varchar() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATEDIFF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATEDIFF"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("not-a-date"))),
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("2024-01-01"))),
@@ -68,7 +68,7 @@ fn test_datediff_varchar_null() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "DATEDIFF".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATEDIFF"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Null),
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("2024-01-01"))),
@@ -238,7 +238,7 @@ fn test_date_add_varchar_with_interval() {
 
     // DATE_ADD('2024-01-01', INTERVAL '5' DAY)
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_ADD".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_ADD"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("2024-01-01"))),
             vibesql_ast::Expression::Literal(SqlValue::Interval(Interval::new(
@@ -266,7 +266,7 @@ fn test_date_add_varchar_legacy_syntax() {
 
     // DATE_ADD('2024-01-01', 5, 'DAY') - legacy 3-arg syntax
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_ADD".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_ADD"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("2024-01-01"))),
             vibesql_ast::Expression::Literal(SqlValue::Integer(5)),
@@ -293,7 +293,7 @@ fn test_date_sub_varchar_with_interval() {
 
     // DATE_SUB('2024-01-10', INTERVAL '5' DAY)
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_SUB".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_SUB"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("2024-01-10"))),
             vibesql_ast::Expression::Literal(SqlValue::Interval(Interval::new(
@@ -321,7 +321,7 @@ fn test_date_sub_varchar_legacy_syntax() {
 
     // DATE_SUB('2024-01-10', 5, 'DAY') - legacy 3-arg syntax
     let expr = vibesql_ast::Expression::Function {
-        name: "DATE_SUB".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATE_SUB"),
         args: vec![
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("2024-01-10"))),
             vibesql_ast::Expression::Literal(SqlValue::Integer(5)),

--- a/crates/vibesql-executor/tests/date_time_function_tests/fixtures.rs
+++ b/crates/vibesql-executor/tests/date_time_function_tests/fixtures.rs
@@ -7,7 +7,7 @@ pub fn create_datetime_function(
     name: &str,
     args: Vec<vibesql_ast::Expression>,
 ) -> vibesql_ast::Expression {
-    vibesql_ast::Expression::Function { name: name.to_string(), args, character_unit: None }
+    vibesql_ast::Expression::Function { name: vibesql_ast::FunctionIdentifier::new(name), args, character_unit: None }
 }
 
 /// Helper to create a literal expression from a SQL value

--- a/crates/vibesql-executor/tests/insert_select_tests.rs
+++ b/crates/vibesql-executor/tests/insert_select_tests.rs
@@ -315,14 +315,14 @@ fn test_insert_from_select_with_aggregates() {
         select_list: vec![
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::Function {
-                    name: "SUM".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("SUM"),
                     args: vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("amount", false))],
                     character_unit: None,
                 },
                 alias: None, source_text: None },
             vibesql_ast::SelectItem::Expression {
                 expr: vibesql_ast::Expression::Function {
-                    name: "COUNT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("COUNT"),
                     args: vec![vibesql_ast::Expression::Wildcard],
                     character_unit: None,
                 },

--- a/crates/vibesql-executor/tests/scalar_function_tests.rs
+++ b/crates/vibesql-executor/tests/scalar_function_tests.rs
@@ -14,7 +14,7 @@ fn test_abs_positive() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "ABS".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ABS"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(-5.2))],
         character_unit: None,
     };
@@ -27,7 +27,7 @@ fn test_abs_integer() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "ABS".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ABS"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(-42))],
         character_unit: None,
     };
@@ -40,7 +40,7 @@ fn test_round_basic() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "ROUND".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ROUND"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(3.7))],
         character_unit: None,
     };
@@ -53,7 +53,7 @@ fn test_round_with_precision() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "ROUND".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ROUND"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(3.14159)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
@@ -69,7 +69,7 @@ fn test_floor_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "FLOOR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("FLOOR"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(3.9))],
         character_unit: None,
     };
@@ -82,7 +82,7 @@ fn test_ceil_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "CEIL".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CEIL"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(3.1))],
         character_unit: None,
     };
@@ -95,7 +95,7 @@ fn test_ceiling_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "CEILING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CEILING"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(3.1))],
         character_unit: None,
     };
@@ -108,7 +108,7 @@ fn test_mod_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "MOD".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("MOD"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(17)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(5)),
@@ -124,7 +124,7 @@ fn test_power_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "POWER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("POWER"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(3)),
@@ -140,7 +140,7 @@ fn test_pow_alias() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "POW".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("POW"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(5)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
@@ -156,7 +156,7 @@ fn test_sqrt_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "SQRT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SQRT"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(16))],
         character_unit: None,
     };
@@ -171,7 +171,7 @@ fn test_concat_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "CONCAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CONCAT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("Hello"),
@@ -194,7 +194,7 @@ fn test_concat_with_integer() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "CONCAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CONCAT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("ID:"),
@@ -212,7 +212,7 @@ fn test_length_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("Hello"),
         ))],
@@ -227,7 +227,7 @@ fn test_position_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "POSITION".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("POSITION"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("lo"),
@@ -248,7 +248,7 @@ fn test_position_not_found() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "POSITION".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("POSITION"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("xyz"),
@@ -268,7 +268,7 @@ fn test_replace_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "REPLACE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REPLACE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("Hello World"),
@@ -291,7 +291,7 @@ fn test_reverse_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "REVERSE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REVERSE"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("Hello"),
         ))],
@@ -306,7 +306,7 @@ fn test_left_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "LEFT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LEFT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("Hello"),
@@ -324,7 +324,7 @@ fn test_right_function() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "RIGHT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("RIGHT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("Hello"),
@@ -344,7 +344,7 @@ fn test_abs_with_null() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "ABS".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ABS"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)],
         character_unit: None,
     };
@@ -357,7 +357,7 @@ fn test_concat_with_null() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "CONCAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CONCAT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("Hello"),
@@ -375,7 +375,7 @@ fn test_length_with_null() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)],
         character_unit: None,
     };
@@ -388,7 +388,7 @@ fn test_octet_length_ascii() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "OCTET_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("OCTET_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("foo"),
         ))],
@@ -403,7 +403,7 @@ fn test_octet_length_empty_string() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "OCTET_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("OCTET_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from(""),
         ))],
@@ -419,7 +419,7 @@ fn test_octet_length_multibyte() {
 
     // Emoji is 4 bytes in UTF-8
     let expr = vibesql_ast::Expression::Function {
-        name: "OCTET_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("OCTET_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("🦀"),
         ))],
@@ -434,7 +434,7 @@ fn test_octet_length_with_null() {
     let (evaluator, row) = create_test_evaluator();
 
     let expr = vibesql_ast::Expression::Function {
-        name: "OCTET_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("OCTET_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)],
         character_unit: None,
     };
@@ -450,9 +450,9 @@ fn test_nested_functions() {
 
     // ABS(ROUND(-3.7)) should equal 4.0
     let expr = vibesql_ast::Expression::Function {
-        name: "ABS".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ABS"),
         args: vec![vibesql_ast::Expression::Function {
-            name: "ROUND".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ROUND"),
             args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(-3.7))],
             character_unit: None,
         }],
@@ -468,9 +468,9 @@ fn test_upper_left_nested() {
 
     // UPPER(LEFT('hello', 3)) should equal 'HEL'
     let expr = vibesql_ast::Expression::Function {
-        name: "UPPER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("UPPER"),
         args: vec![vibesql_ast::Expression::Function {
-            name: "LEFT".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("LEFT"),
             args: vec![
                 vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                     arcstr::ArcStr::from("hello"),

--- a/crates/vibesql-executor/tests/spatial_measurements_tests.rs
+++ b/crates/vibesql-executor/tests/spatial_measurements_tests.rs
@@ -27,17 +27,17 @@ fn eval_expr(expr: Expression) -> Result<SqlValue, String> {
 fn test_st_distance_point_to_point() {
     // ST_Distance(ST_GeomFromText('POINT(0 0)'), ST_GeomFromText('POINT(3 4)'))
     let expr = Expression::Function {
-        name: "ST_DISTANCE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_DISTANCE"),
         args: vec![
             Expression::Function {
-                name: "ST_GEOMFROMTEXT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                 args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "POINT(0 0)",
                 )))],
                 character_unit: None,
             },
             Expression::Function {
-                name: "ST_GEOMFROMTEXT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                 args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "POINT(3 4)",
                 )))],
@@ -59,17 +59,17 @@ fn test_st_distance_point_to_point() {
 #[test]
 fn test_st_distance_same_point() {
     let expr = Expression::Function {
-        name: "ST_DISTANCE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_DISTANCE"),
         args: vec![
             Expression::Function {
-                name: "ST_GEOMFROMTEXT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                 args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "POINT(1 1)",
                 )))],
                 character_unit: None,
             },
             Expression::Function {
-                name: "ST_GEOMFROMTEXT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                 args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "POINT(1 1)",
                 )))],
@@ -91,9 +91,9 @@ fn test_st_distance_same_point() {
 #[test]
 fn test_st_length_linestring() {
     let expr = Expression::Function {
-        name: "ST_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_LENGTH"),
         args: vec![Expression::Function {
-            name: "ST_GEOMFROMTEXT".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
             args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                 "LINESTRING(0 0, 3 0, 3 4)",
             )))],
@@ -114,9 +114,9 @@ fn test_st_length_linestring() {
 #[test]
 fn test_st_area_polygon() {
     let expr = Expression::Function {
-        name: "ST_AREA".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_AREA"),
         args: vec![Expression::Function {
-            name: "ST_GEOMFROMTEXT".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
             args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                 "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
             )))],
@@ -137,11 +137,11 @@ fn test_st_area_polygon() {
 #[test]
 fn test_st_centroid_polygon() {
     let expr = Expression::Function {
-        name: "ST_ASTEXT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_ASTEXT"),
         args: vec![Expression::Function {
-            name: "ST_CENTROID".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_CENTROID"),
             args: vec![Expression::Function {
-                name: "ST_GEOMFROMTEXT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                 args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
                 )))],
@@ -164,11 +164,11 @@ fn test_st_centroid_polygon() {
 #[test]
 fn test_st_envelope() {
     let expr = Expression::Function {
-        name: "ST_ASTEXT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_ASTEXT"),
         args: vec![Expression::Function {
-            name: "ST_ENVELOPE".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_ENVELOPE"),
             args: vec![Expression::Function {
-                name: "ST_GEOMFROMTEXT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                 args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "POINT(5 5)",
                 )))],
@@ -191,11 +191,11 @@ fn test_st_envelope() {
 #[test]
 fn test_st_null_handling_distance() {
     let expr = Expression::Function {
-        name: "ST_DISTANCE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_DISTANCE"),
         args: vec![
             Expression::Literal(SqlValue::Null),
             Expression::Function {
-                name: "ST_GEOMFROMTEXT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                 args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "POINT(0 0)",
                 )))],
@@ -212,7 +212,7 @@ fn test_st_null_handling_distance() {
 #[test]
 fn test_st_null_handling_area() {
     let expr = Expression::Function {
-        name: "ST_AREA".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_AREA"),
         args: vec![Expression::Literal(SqlValue::Null)],
         character_unit: None,
     };
@@ -224,9 +224,9 @@ fn test_st_null_handling_area() {
 #[test]
 fn test_st_perimeter_polygon() {
     let expr = Expression::Function {
-        name: "ST_PERIMETER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_PERIMETER"),
         args: vec![Expression::Function {
-            name: "ST_GEOMFROMTEXT".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
             args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                 "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
             )))],
@@ -247,11 +247,11 @@ fn test_st_perimeter_polygon() {
 #[test]
 fn test_st_convex_hull() {
     let expr = Expression::Function {
-        name: "ST_ASTEXT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_ASTEXT"),
         args: vec![Expression::Function {
-            name: "ST_CONVEXHULL".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_CONVEXHULL"),
             args: vec![Expression::Function {
-                name: "ST_GEOMFROMTEXT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                 args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "LINESTRING(0 0, 1 1, 0 1)",
                 )))],
@@ -274,11 +274,11 @@ fn test_st_convex_hull() {
 #[test]
 fn test_st_point_on_surface_point() {
     let expr = Expression::Function {
-        name: "ST_ASTEXT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_ASTEXT"),
         args: vec![Expression::Function {
-            name: "ST_POINTONSURFACE".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_POINTONSURFACE"),
             args: vec![Expression::Function {
-                name: "ST_GEOMFROMTEXT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                 args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "POINT(5 5)",
                 )))],
@@ -301,9 +301,9 @@ fn test_st_point_on_surface_point() {
 #[test]
 fn test_st_wrong_arity_distance() {
     let expr = Expression::Function {
-        name: "ST_DISTANCE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_DISTANCE"),
         args: vec![Expression::Function {
-            name: "ST_GEOMFROMTEXT".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
             args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("POINT(0 0)")))],
             character_unit: None,
         }],
@@ -318,9 +318,9 @@ fn test_st_wrong_arity_distance() {
 fn test_st_wrong_type_area() {
     // ST_Area on a Point should error
     let expr = Expression::Function {
-        name: "ST_AREA".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_AREA"),
         args: vec![Expression::Function {
-            name: "ST_GEOMFROMTEXT".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
             args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("POINT(5 5)")))],
             character_unit: None,
         }],

--- a/crates/vibesql-executor/tests/spatial_operations_tests.rs
+++ b/crates/vibesql-executor/tests/spatial_operations_tests.rs
@@ -29,12 +29,12 @@ fn test_st_simplify_linestring() {
     // The original line goes: (0,0) -> (1,0.1) -> (2,0) -> (3,0)
     // With a high tolerance, it should simplify to: (0,0) -> (3,0)
     let expr = Expression::Function {
-        name: "ST_ASTEXT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_ASTEXT"),
         args: vec![Expression::Function {
-            name: "ST_SIMPLIFY".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_SIMPLIFY"),
             args: vec![
                 Expression::Function {
-                    name: "ST_GEOMFROMTEXT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                     args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                         "LINESTRING(0 0, 1 0.1, 2 0, 3 0)",
                     )))],
@@ -60,12 +60,12 @@ fn test_st_simplify_linestring() {
 fn test_st_simplify_polygon() {
     // ST_Simplify on a polygon with small deviations
     let expr = Expression::Function {
-        name: "ST_ASTEXT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_ASTEXT"),
         args: vec![Expression::Function {
-            name: "ST_SIMPLIFY".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_SIMPLIFY"),
             args: vec![
                 Expression::Function {
-                    name: "ST_GEOMFROMTEXT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                     args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                         "POLYGON((0 0, 10 0, 10.1 5, 10 10, 0 10, 0 0))",
                     )))],
@@ -90,7 +90,7 @@ fn test_st_simplify_polygon() {
 #[test]
 fn test_st_simplify_null_handling() {
     let expr = Expression::Function {
-        name: "ST_SIMPLIFY".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_SIMPLIFY"),
         args: vec![Expression::Literal(SqlValue::Null), Expression::Literal(SqlValue::Double(0.1))],
         character_unit: None,
     };
@@ -103,12 +103,12 @@ fn test_st_simplify_null_handling() {
 fn test_st_simplify_zero_tolerance() {
     // Zero tolerance should still work (no simplification)
     let expr = Expression::Function {
-        name: "ST_ASTEXT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_ASTEXT"),
         args: vec![Expression::Function {
-            name: "ST_SIMPLIFY".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_SIMPLIFY"),
             args: vec![
                 Expression::Function {
-                    name: "ST_GEOMFROMTEXT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                     args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                         "LINESTRING(0 0, 1 1, 2 2)",
                     )))],
@@ -133,9 +133,9 @@ fn test_st_simplify_zero_tolerance() {
 #[test]
 fn test_st_simplify_wrong_arity() {
     let expr = Expression::Function {
-        name: "ST_SIMPLIFY".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_SIMPLIFY"),
         args: vec![Expression::Function {
-            name: "ST_GEOMFROMTEXT".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
             args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                 "LINESTRING(0 0, 1 1)",
             )))],
@@ -151,10 +151,10 @@ fn test_st_simplify_wrong_arity() {
 #[test]
 fn test_st_simplify_negative_tolerance() {
     let expr = Expression::Function {
-        name: "ST_SIMPLIFY".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_SIMPLIFY"),
         args: vec![
             Expression::Function {
-                name: "ST_GEOMFROMTEXT".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                 args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                     "LINESTRING(0 0, 1 1)",
                 )))],
@@ -173,12 +173,12 @@ fn test_st_simplify_negative_tolerance() {
 fn test_st_simplify_with_integer_tolerance() {
     // ST_Simplify should handle integer tolerance values too
     let expr = Expression::Function {
-        name: "ST_ASTEXT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("ST_ASTEXT"),
         args: vec![Expression::Function {
-            name: "ST_SIMPLIFY".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("ST_SIMPLIFY"),
             args: vec![
                 Expression::Function {
-                    name: "ST_GEOMFROMTEXT".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new("ST_GEOMFROMTEXT"),
                     args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(
                         "LINESTRING(0 0, 1 1, 2 2)",
                     )))],

--- a/crates/vibesql-executor/tests/spatial_set_operations_tests.rs
+++ b/crates/vibesql-executor/tests/spatial_set_operations_tests.rs
@@ -25,7 +25,7 @@ fn eval_expr(expr: Expression) -> Result<SqlValue, String> {
 
 /// Helper to create a function call expression
 fn function_call(name: &str, args: Vec<Expression>) -> Expression {
-    Expression::Function { name: name.to_string(), args, character_unit: None }
+    Expression::Function { name: vibesql_ast::FunctionIdentifier::new(name), args, character_unit: None }
 }
 
 /// Helper to create a literal expression

--- a/crates/vibesql-executor/tests/string_function_tests.rs
+++ b/crates/vibesql-executor/tests/string_function_tests.rs
@@ -12,7 +12,7 @@ use common::create_test_evaluator;
 fn test_substring_from_for() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -30,7 +30,7 @@ fn test_substring_from_for() {
 fn test_substring_from_only() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -49,7 +49,7 @@ fn test_substring_both_syntaxes_equivalent() {
 
     // Test comma syntax
     let comma_expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -63,7 +63,7 @@ fn test_substring_both_syntaxes_equivalent() {
 
     // Test FROM/FOR syntax (same AST)
     let from_for_expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -208,7 +208,7 @@ fn test_substring_with_date_extract_year() {
     let (evaluator, row) = create_test_evaluator();
     let date = vibesql_types::Date::new(1996, 7, 15).unwrap();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(date)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -226,7 +226,7 @@ fn test_substring_with_date_extract_month() {
     let (evaluator, row) = create_test_evaluator();
     let date = vibesql_types::Date::new(1996, 7, 15).unwrap();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTR".to_string(), // Test alias
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTR"), // Test alias
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(date)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(6)),
@@ -244,7 +244,7 @@ fn test_substring_with_date_extract_day() {
     let (evaluator, row) = create_test_evaluator();
     let date = vibesql_types::Date::new(1996, 7, 15).unwrap();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(date)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(9)),
@@ -264,7 +264,7 @@ fn test_substring_with_timestamp() {
     let time = vibesql_types::Time::new(8, 30, 0, 0).unwrap();
     let timestamp = vibesql_types::Timestamp::new(date, time);
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Timestamp(timestamp)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),

--- a/crates/vibesql-executor/tests/string_tests/case_conversion.rs
+++ b/crates/vibesql-executor/tests/string_tests/case_conversion.rs
@@ -14,7 +14,7 @@ use crate::common::create_test_evaluator;
 fn test_upper_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "UPPER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("UPPER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)],
         character_unit: None,
     };
@@ -26,7 +26,7 @@ fn test_upper_null() {
 fn test_upper_empty() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "UPPER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("UPPER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from(""),
         ))],
@@ -41,7 +41,7 @@ fn test_upper_unicode() {
     let (evaluator, row) = create_test_evaluator();
     // Test Greek, accented characters, emojis
     let expr = vibesql_ast::Expression::Function {
-        name: "UPPER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("UPPER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("café"),
         ))],
@@ -55,7 +55,7 @@ fn test_upper_unicode() {
 fn test_upper_mixed_case() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "UPPER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("UPPER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("HeLLo WoRLd"),
         ))],
@@ -69,7 +69,7 @@ fn test_upper_mixed_case() {
 fn test_upper_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "UPPER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("UPPER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
             arcstr::ArcStr::from("test"),
         ))],
@@ -83,7 +83,7 @@ fn test_upper_character_type() {
 fn test_upper_wrong_arg_count() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "UPPER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("UPPER"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("test"),
@@ -102,7 +102,7 @@ fn test_upper_wrong_arg_count() {
 fn test_upper_wrong_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "UPPER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("UPPER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123))],
         character_unit: None,
     };
@@ -114,7 +114,7 @@ fn test_upper_wrong_type() {
 fn test_lower_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOWER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOWER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)],
         character_unit: None,
     };
@@ -126,7 +126,7 @@ fn test_lower_null() {
 fn test_lower_empty() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOWER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOWER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from(""),
         ))],
@@ -140,7 +140,7 @@ fn test_lower_empty() {
 fn test_lower_unicode() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOWER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOWER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("CAFÉ"),
         ))],
@@ -154,7 +154,7 @@ fn test_lower_unicode() {
 fn test_lower_wrong_arg_count() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOWER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOWER"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("TEST"),
@@ -173,7 +173,7 @@ fn test_lower_wrong_arg_count() {
 fn test_lower_wrong_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOWER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOWER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123))],
         character_unit: None,
     };
@@ -185,7 +185,7 @@ fn test_lower_wrong_type() {
 fn test_lower_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOWER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOWER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
             arcstr::ArcStr::from("TEST"),
         ))],

--- a/crates/vibesql-executor/tests/string_tests/length_functions.rs
+++ b/crates/vibesql-executor/tests/string_tests/length_functions.rs
@@ -15,7 +15,7 @@ use crate::common::create_test_evaluator;
 fn test_char_length_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CHAR_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CHAR_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)],
         character_unit: None,
     };
@@ -27,7 +27,7 @@ fn test_char_length_null() {
 fn test_char_length_empty() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CHAR_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CHAR_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from(""),
         ))],
@@ -42,7 +42,7 @@ fn test_char_length_multibyte() {
     let (evaluator, row) = create_test_evaluator();
     // "café" is 4 characters but 5 bytes
     let expr = vibesql_ast::Expression::Function {
-        name: "CHAR_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CHAR_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("café"),
         ))],
@@ -56,7 +56,7 @@ fn test_char_length_multibyte() {
 fn test_char_length_using_characters() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CHAR_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CHAR_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("café"),
         ))],
@@ -71,7 +71,7 @@ fn test_char_length_using_octets() {
     let (evaluator, row) = create_test_evaluator();
     // "café" is 5 bytes in UTF-8 (c=1, a=1, f=1, é=2)
     let expr = vibesql_ast::Expression::Function {
-        name: "CHAR_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CHAR_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("café"),
         ))],
@@ -85,7 +85,7 @@ fn test_char_length_using_octets() {
 fn test_octet_length_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "OCTET_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("OCTET_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)],
         character_unit: None,
     };
@@ -97,7 +97,7 @@ fn test_octet_length_null() {
 fn test_octet_length_empty() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "OCTET_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("OCTET_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from(""),
         ))],
@@ -112,7 +112,7 @@ fn test_octet_length_multibyte() {
     let (evaluator, row) = create_test_evaluator();
     // "café" is 5 bytes in UTF-8
     let expr = vibesql_ast::Expression::Function {
-        name: "OCTET_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("OCTET_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("café"),
         ))],
@@ -128,7 +128,7 @@ fn test_octet_length_vs_char_length() {
 
     // ASCII: same count
     let ascii_expr = vibesql_ast::Expression::Function {
-        name: "CHAR_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CHAR_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("hello"),
         ))],
@@ -137,7 +137,7 @@ fn test_octet_length_vs_char_length() {
     let char_result = evaluator.eval(&ascii_expr, &row).unwrap();
 
     let octet_expr = vibesql_ast::Expression::Function {
-        name: "OCTET_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("OCTET_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("hello"),
         ))],
@@ -153,7 +153,7 @@ fn test_octet_length_vs_char_length() {
 fn test_length_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)],
         character_unit: None,
     };
@@ -165,7 +165,7 @@ fn test_length_null() {
 fn test_length_empty() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from(""),
         ))],
@@ -179,7 +179,7 @@ fn test_length_empty() {
 fn test_length_basic() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("hello"),
         ))],
@@ -194,7 +194,7 @@ fn test_length_multibyte() {
     let (evaluator, row) = create_test_evaluator();
     // LENGTH returns byte count (unlike CHAR_LENGTH)
     let expr = vibesql_ast::Expression::Function {
-        name: "LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("café"),
         ))],
@@ -209,7 +209,7 @@ fn test_length_multibyte() {
 fn test_length_wrong_arg_count() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LENGTH"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -229,7 +229,7 @@ fn test_length_integer() {
     // SQLite compatibility: LENGTH() accepts any type, converting to string first
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123))],
         character_unit: None,
     };
@@ -243,7 +243,7 @@ fn test_length_float() {
     // SQLite compatibility: LENGTH() accepts any type, converting to string first
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Numeric(1.5))],
         character_unit: None,
     };
@@ -256,7 +256,7 @@ fn test_length_float() {
 fn test_char_length_wrong_arg_count() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CHAR_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CHAR_LENGTH"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -275,7 +275,7 @@ fn test_char_length_wrong_arg_count() {
 fn test_char_length_wrong_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CHAR_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CHAR_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123))],
         character_unit: None,
     };
@@ -287,7 +287,7 @@ fn test_char_length_wrong_type() {
 fn test_octet_length_wrong_arg_count() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "OCTET_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("OCTET_LENGTH"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -306,7 +306,7 @@ fn test_octet_length_wrong_arg_count() {
 fn test_octet_length_wrong_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "OCTET_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("OCTET_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123))],
         character_unit: None,
     };
@@ -318,7 +318,7 @@ fn test_octet_length_wrong_type() {
 fn test_char_length_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CHAR_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CHAR_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
             arcstr::ArcStr::from("test"),
         ))],
@@ -332,7 +332,7 @@ fn test_char_length_character_type() {
 fn test_octet_length_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "OCTET_LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("OCTET_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
             arcstr::ArcStr::from("café"),
         ))],
@@ -346,7 +346,7 @@ fn test_octet_length_character_type() {
 fn test_length_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LENGTH".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
             arcstr::ArcStr::from("test"),
         ))],

--- a/crates/vibesql-executor/tests/string_tests/search_functions.rs
+++ b/crates/vibesql-executor/tests/string_tests/search_functions.rs
@@ -19,7 +19,7 @@ use crate::common::create_test_evaluator;
 fn test_position_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "POSITION".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("POSITION"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -36,7 +36,7 @@ fn test_position_null() {
 fn test_position_not_found() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "POSITION".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("POSITION"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("xyz"),
@@ -55,7 +55,7 @@ fn test_position_not_found() {
 fn test_position_found() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "POSITION".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("POSITION"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("lo"),
@@ -74,7 +74,7 @@ fn test_position_found() {
 fn test_position_empty_needle() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "POSITION".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("POSITION"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from(""),
@@ -94,7 +94,7 @@ fn test_position_empty_needle() {
 fn test_position_multiple_occurrences() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "POSITION".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("POSITION"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("l"),
@@ -114,7 +114,7 @@ fn test_position_multiple_occurrences() {
 fn test_position_wrong_arg_count() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "POSITION".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("POSITION"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("hello"),
         ))],
@@ -128,7 +128,7 @@ fn test_position_wrong_arg_count() {
 fn test_position_wrong_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "POSITION".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("POSITION"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -145,7 +145,7 @@ fn test_position_wrong_type() {
 fn test_position_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "POSITION".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("POSITION"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
                 arcstr::ArcStr::from("lo"),
@@ -168,7 +168,7 @@ fn test_position_character_type() {
 fn test_instr_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "INSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("INSTR"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -185,7 +185,7 @@ fn test_instr_null() {
 fn test_instr_not_found() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "INSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("INSTR"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -204,7 +204,7 @@ fn test_instr_not_found() {
 fn test_instr_found() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "INSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("INSTR"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -223,7 +223,7 @@ fn test_instr_found() {
 fn test_instr_wrong_arg_count() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "INSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("INSTR"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("hello"),
         ))],
@@ -239,7 +239,7 @@ fn test_instr_integer_coercion() {
     // INSTR(123, 'l') -> INSTR('123', 'l') -> 0 (not found)
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "INSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("INSTR"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -256,7 +256,7 @@ fn test_instr_integer_coercion() {
 fn test_instr_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "INSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("INSTR"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
                 arcstr::ArcStr::from("hello"),
@@ -279,7 +279,7 @@ fn test_instr_character_type() {
 fn test_locate_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -296,7 +296,7 @@ fn test_locate_null() {
 fn test_locate_not_found() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("xyz"),
@@ -316,7 +316,7 @@ fn test_locate_with_start_position() {
     let (evaluator, row) = create_test_evaluator();
     // Find second occurrence of 'l' in 'hello'
     let expr = vibesql_ast::Expression::Function {
-        name: "LOCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("l"),
@@ -336,7 +336,7 @@ fn test_locate_with_start_position() {
 fn test_locate_start_beyond_length() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("l"),
@@ -356,7 +356,7 @@ fn test_locate_start_beyond_length() {
 fn test_locate_wrong_arg_count() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("l"),
         ))],
@@ -370,7 +370,7 @@ fn test_locate_wrong_arg_count() {
 fn test_locate_wrong_type_needle() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -387,7 +387,7 @@ fn test_locate_wrong_type_needle() {
 fn test_locate_wrong_type_start() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("l"),
@@ -409,7 +409,7 @@ fn test_locate_wrong_type_start() {
 fn test_locate_null_start() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("l"),
@@ -429,7 +429,7 @@ fn test_locate_null_start() {
 fn test_locate_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
                 arcstr::ArcStr::from("ll"),

--- a/crates/vibesql-executor/tests/string_tests/substring_operations.rs
+++ b/crates/vibesql-executor/tests/string_tests/substring_operations.rs
@@ -18,7 +18,7 @@ use crate::common::create_test_evaluator;
 fn test_substring_null_string() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -33,7 +33,7 @@ fn test_substring_null_string() {
 fn test_substring_null_start() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -50,7 +50,7 @@ fn test_substring_null_start() {
 fn test_substring_null_length() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -68,7 +68,7 @@ fn test_substring_null_length() {
 fn test_substring_negative_start() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -86,7 +86,7 @@ fn test_substring_negative_start() {
 fn test_substring_zero_start() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -103,7 +103,7 @@ fn test_substring_zero_start() {
 fn test_substring_start_beyond_length() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -120,7 +120,7 @@ fn test_substring_start_beyond_length() {
 fn test_substring_zero_length() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -142,7 +142,7 @@ fn test_substring_negative_length() {
     // Position 2 is 'e', extracting leftward gets chars before it: "h"
     // (only 1 char available since we can't go before position 1)
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -162,7 +162,7 @@ fn test_substring_multibyte_characters() {
     let (evaluator, row) = create_test_evaluator();
     // "café" is 4 characters but 5 bytes in UTF-8
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("café"),
@@ -180,7 +180,7 @@ fn test_substring_multibyte_characters() {
 fn test_substring_empty_string() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from(""),
@@ -197,7 +197,7 @@ fn test_substring_empty_string() {
 fn test_substring_wrong_arg_count_too_few() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("hello"),
         ))],
@@ -211,7 +211,7 @@ fn test_substring_wrong_arg_count_too_few() {
 fn test_substring_wrong_arg_count_too_many() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -230,7 +230,7 @@ fn test_substring_wrong_arg_count_too_many() {
 fn test_substring_wrong_type_string() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -245,7 +245,7 @@ fn test_substring_wrong_type_string() {
 fn test_substring_wrong_type_start() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -264,7 +264,7 @@ fn test_substring_wrong_type_start() {
 fn test_substring_wrong_type_length() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -288,7 +288,7 @@ fn test_substring_wrong_type_length() {
 fn test_left_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LEFT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LEFT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(3)),
@@ -303,7 +303,7 @@ fn test_left_null() {
 fn test_left_negative_length() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LEFT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LEFT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -320,7 +320,7 @@ fn test_left_negative_length() {
 fn test_left_zero_length() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LEFT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LEFT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -337,7 +337,7 @@ fn test_left_zero_length() {
 fn test_left_length_exceeds_string() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LEFT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LEFT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -354,7 +354,7 @@ fn test_left_length_exceeds_string() {
 fn test_left_multibyte() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LEFT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LEFT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("café"),
@@ -371,7 +371,7 @@ fn test_left_multibyte() {
 fn test_left_wrong_arg_count() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LEFT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LEFT"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("hello"),
         ))],
@@ -385,7 +385,7 @@ fn test_left_wrong_arg_count() {
 fn test_left_wrong_type_string() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LEFT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LEFT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(3)),
@@ -400,7 +400,7 @@ fn test_left_wrong_type_string() {
 fn test_left_wrong_type_length() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LEFT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LEFT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -419,7 +419,7 @@ fn test_left_wrong_type_length() {
 fn test_left_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LEFT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LEFT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
                 arcstr::ArcStr::from("hello"),
@@ -440,7 +440,7 @@ fn test_left_character_type() {
 fn test_right_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "RIGHT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("RIGHT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(3)),
@@ -455,7 +455,7 @@ fn test_right_null() {
 fn test_right_negative_length() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "RIGHT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("RIGHT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -472,7 +472,7 @@ fn test_right_negative_length() {
 fn test_right_zero_length() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "RIGHT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("RIGHT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -489,7 +489,7 @@ fn test_right_zero_length() {
 fn test_right_length_exceeds_string() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "RIGHT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("RIGHT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -506,7 +506,7 @@ fn test_right_length_exceeds_string() {
 fn test_right_multibyte() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "RIGHT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("RIGHT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("café"),
@@ -523,7 +523,7 @@ fn test_right_multibyte() {
 fn test_right_wrong_arg_count() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "RIGHT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("RIGHT"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("hello"),
         ))],
@@ -537,7 +537,7 @@ fn test_right_wrong_arg_count() {
 fn test_right_wrong_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "RIGHT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("RIGHT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(3)),
@@ -552,7 +552,7 @@ fn test_right_wrong_type() {
 fn test_right_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "RIGHT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("RIGHT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
                 arcstr::ArcStr::from("hello"),
@@ -574,7 +574,7 @@ fn test_substring_date_extract_year() {
     // TPC-H Q7/Q9 pattern: SUBSTR(l_shipdate, 1, 4) to extract year from date
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "1995-06-15".parse().unwrap(),
@@ -593,7 +593,7 @@ fn test_substring_date_extract_month() {
     // Extract month from date using SUBSTRING
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "1995-06-15".parse().unwrap(),
@@ -612,7 +612,7 @@ fn test_substring_date_extract_day() {
     // Extract day from date using SUBSTRING
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "1995-06-15".parse().unwrap(),
@@ -631,7 +631,7 @@ fn test_substring_timestamp_extract_year() {
     // Extract year from timestamp using SUBSTRING
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Timestamp(
                 "1996-12-25 14:30:45".parse().unwrap(),
@@ -650,7 +650,7 @@ fn test_substring_timestamp_extract_time() {
     // Extract time portion from timestamp using SUBSTRING
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Timestamp(
                 "1996-12-25 14:30:45".parse().unwrap(),
@@ -669,7 +669,7 @@ fn test_substr_alias_with_date() {
     // Test SUBSTR alias (commonly used in TPC-H queries)
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTR"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "1995-01-01".parse().unwrap(),
@@ -688,7 +688,7 @@ fn test_substring_date_without_length() {
     // SUBSTRING on date without explicit length - returns rest of string
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTRING".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(
                 "1995-06-15".parse().unwrap(),

--- a/crates/vibesql-executor/tests/string_tests/transformations.rs
+++ b/crates/vibesql-executor/tests/string_tests/transformations.rs
@@ -20,7 +20,7 @@ use crate::common::create_test_evaluator;
 fn test_concat_null_propagation() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CONCAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CONCAT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -40,7 +40,7 @@ fn test_concat_null_propagation() {
 fn test_concat_empty_strings() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CONCAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CONCAT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from(""),
@@ -62,7 +62,7 @@ fn test_concat_empty_strings() {
 fn test_concat_single_arg() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CONCAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CONCAT"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("hello"),
         ))],
@@ -76,7 +76,7 @@ fn test_concat_single_arg() {
 fn test_concat_many_args() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CONCAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CONCAT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("a"),
@@ -104,7 +104,7 @@ fn test_concat_many_args() {
 fn test_concat_integer_conversion() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CONCAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CONCAT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("ID:"),
@@ -121,7 +121,7 @@ fn test_concat_integer_conversion() {
 fn test_concat_no_args() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CONCAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CONCAT"),
         args: vec![],
         character_unit: None,
     };
@@ -133,7 +133,7 @@ fn test_concat_no_args() {
 fn test_concat_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CONCAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CONCAT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
                 arcstr::ArcStr::from("hello"),
@@ -159,7 +159,7 @@ fn test_concat_character_type() {
 fn test_replace_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REPLACE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REPLACE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -179,7 +179,7 @@ fn test_replace_null() {
 fn test_replace_multiple_occurrences() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REPLACE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REPLACE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello hello"),
@@ -201,7 +201,7 @@ fn test_replace_multiple_occurrences() {
 fn test_replace_empty_search() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REPLACE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REPLACE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -224,7 +224,7 @@ fn test_replace_empty_search() {
 fn test_replace_empty_replacement() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REPLACE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REPLACE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -246,7 +246,7 @@ fn test_replace_empty_replacement() {
 fn test_replace_not_found() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REPLACE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REPLACE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -268,7 +268,7 @@ fn test_replace_not_found() {
 fn test_replace_wrong_arg_count() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REPLACE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REPLACE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -287,7 +287,7 @@ fn test_replace_wrong_arg_count() {
 fn test_replace_wrong_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REPLACE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REPLACE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -307,7 +307,7 @@ fn test_replace_wrong_type() {
 fn test_replace_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REPLACE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REPLACE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
                 arcstr::ArcStr::from("hello"),
@@ -333,7 +333,7 @@ fn test_replace_character_type() {
 fn test_reverse_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REVERSE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REVERSE"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)],
         character_unit: None,
     };
@@ -345,7 +345,7 @@ fn test_reverse_null() {
 fn test_reverse_empty() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REVERSE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REVERSE"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from(""),
         ))],
@@ -359,7 +359,7 @@ fn test_reverse_empty() {
 fn test_reverse_single_char() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REVERSE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REVERSE"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("a"),
         ))],
@@ -373,7 +373,7 @@ fn test_reverse_single_char() {
 fn test_reverse_basic() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REVERSE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REVERSE"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("hello"),
         ))],
@@ -387,7 +387,7 @@ fn test_reverse_basic() {
 fn test_reverse_multibyte() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REVERSE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REVERSE"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
             arcstr::ArcStr::from("café"),
         ))],
@@ -401,7 +401,7 @@ fn test_reverse_multibyte() {
 fn test_reverse_wrong_arg_count() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REVERSE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REVERSE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("hello"),
@@ -420,7 +420,7 @@ fn test_reverse_wrong_arg_count() {
 fn test_reverse_wrong_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REVERSE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REVERSE"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123))],
         character_unit: None,
     };
@@ -432,7 +432,7 @@ fn test_reverse_wrong_type() {
 fn test_reverse_character_type() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "REVERSE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("REVERSE"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Character(
             arcstr::ArcStr::from("test"),
         ))],

--- a/crates/vibesql-executor/tests/test_numeric_edge_cases/basic.rs
+++ b/crates/vibesql-executor/tests/test_numeric_edge_cases/basic.rs
@@ -7,7 +7,7 @@ use super::common::create_test_evaluator;
 // Helper functions for this module
 pub fn create_function_expr(name: &str, args: Vec<SqlValue>) -> vibesql_ast::Expression {
     vibesql_ast::Expression::Function {
-        name: name.to_string(),
+        name: vibesql_ast::FunctionIdentifier::new(name),
         args: args.into_iter().map(vibesql_ast::Expression::Literal).collect(),
         character_unit: None,
     }

--- a/crates/vibesql-executor/tests/test_numeric_edge_cases/helpers.rs
+++ b/crates/vibesql-executor/tests/test_numeric_edge_cases/helpers.rs
@@ -9,7 +9,7 @@ use vibesql_types::SqlValue;
 /// Helper to create a function expression with literal arguments
 pub fn create_function_expr(name: &str, args: Vec<SqlValue>) -> vibesql_ast::Expression {
     vibesql_ast::Expression::Function {
-        name: name.to_string(),
+        name: vibesql_ast::FunctionIdentifier::new(name),
         args: args.into_iter().map(vibesql_ast::Expression::Literal).collect(),
         character_unit: None,
     }

--- a/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
@@ -84,7 +84,7 @@ fn create_aggregate_subquery(
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: Expression::Function {
-                name: func_name.to_string(),
+                name: vibesql_ast::FunctionIdentifier::new(func_name),
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(&column_name.to_string(), false))],
                 character_unit: None,
             },

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
@@ -113,7 +113,7 @@ fn test_update_where_scalar_subquery_less_than() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: Expression::Function {
-                name: "AVG".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("salary", false))],
                 character_unit: None,
             },
@@ -271,7 +271,7 @@ fn test_update_where_subquery_with_aggregate() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Expression {
             expr: Expression::Function {
-                name: "MAX".to_string(),
+                name: vibesql_ast::FunctionIdentifier::new("MAX"),
                 args: vec![Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("price", false))],
                 character_unit: None,
             },

--- a/crates/vibesql-executor/tests/utility_function_tests.rs
+++ b/crates/vibesql-executor/tests/utility_function_tests.rs
@@ -16,7 +16,7 @@ use common::create_test_evaluator;
 fn test_substr_basic() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTR"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("Hello World"),
@@ -34,7 +34,7 @@ fn test_substr_basic() {
 fn test_substr_to_end() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTR"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("Hello World"),
@@ -51,7 +51,7 @@ fn test_substr_to_end() {
 fn test_substr_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SUBSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SUBSTR"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
@@ -69,7 +69,7 @@ fn test_substr_null() {
 fn test_instr_found() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "INSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("INSTR"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("Hello World"),
@@ -88,7 +88,7 @@ fn test_instr_found() {
 fn test_instr_not_found() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "INSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("INSTR"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("Hello World"),
@@ -107,7 +107,7 @@ fn test_instr_not_found() {
 fn test_instr_null() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "INSTR".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("INSTR"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
@@ -127,7 +127,7 @@ fn test_instr_null() {
 fn test_locate_basic() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("World"),
@@ -146,7 +146,7 @@ fn test_locate_basic() {
 fn test_locate_with_start() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "LOCATE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("o"),
@@ -170,7 +170,7 @@ fn test_locate_with_start() {
 fn test_format_basic() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "FORMAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("FORMAT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(1234567.89)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
@@ -185,7 +185,7 @@ fn test_format_basic() {
 fn test_format_zero_decimals() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "FORMAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("FORMAT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(1234567.89)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(0)),
@@ -201,7 +201,7 @@ fn test_format_zero_decimals() {
 fn test_format_adds_zeros() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "FORMAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("FORMAT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(42)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
@@ -216,7 +216,7 @@ fn test_format_adds_zeros() {
 fn test_format_negative() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "FORMAT".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("FORMAT"),
         args: vec![
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Double(-1234567.89)),
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
@@ -235,7 +235,7 @@ fn test_format_negative() {
 fn test_version() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "VERSION".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("VERSION"),
         args: vec![],
         character_unit: None,
     };
@@ -260,7 +260,7 @@ fn test_version() {
 fn test_database() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "DATABASE".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("DATABASE"),
         args: vec![],
         character_unit: None,
     };
@@ -280,7 +280,7 @@ fn test_database() {
 fn test_schema_alias() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "SCHEMA".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("SCHEMA"),
         args: vec![],
         character_unit: None,
     };
@@ -297,7 +297,7 @@ fn test_schema_alias() {
 fn test_user() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "USER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("USER"),
         args: vec![],
         character_unit: None,
     };
@@ -314,7 +314,7 @@ fn test_user() {
 fn test_current_user_alias() {
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
-        name: "CURRENT_USER".to_string(),
+        name: vibesql_ast::FunctionIdentifier::new("CURRENT_USER"),
         args: vec![],
         character_unit: None,
     };

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -240,11 +240,12 @@ impl Parser {
         };
 
         // Return appropriate expression type
-        // SQL:1999 normalizes unquoted identifiers to lowercase
-        let normalized_name = first.to_lowercase();
+        // FunctionIdentifier handles SQL:1999 case normalization internally
+        // (canonical lowercase for comparison, display preserves original case)
+        let func_id = vibesql_ast::FunctionIdentifier::new(&first);
         if is_aggregate {
             Ok(Some(vibesql_ast::Expression::AggregateFunction {
-                name: normalized_name,
+                name: func_id,
                 distinct,
                 args,
                 order_by,
@@ -255,11 +256,11 @@ impl Parser {
                 return Err(ParseError {
                     message: format!(
                         "ORDER BY may not be used with non-aggregate {}()",
-                        normalized_name.to_uppercase()
+                        first.to_uppercase()
                     ),
                 });
             }
-            Ok(Some(vibesql_ast::Expression::Function { name: normalized_name, args, character_unit }))
+            Ok(Some(vibesql_ast::Expression::Function { name: func_id, args, character_unit }))
         }
     }
 }

--- a/crates/vibesql-parser/src/parser/expressions/functions/string_special.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/string_special.rs
@@ -192,7 +192,11 @@ impl Parser {
             args.push(length);
         }
 
-        Ok(vibesql_ast::Expression::Function { name: function_name, args, character_unit })
+        Ok(vibesql_ast::Expression::Function {
+            name: vibesql_ast::FunctionIdentifier::new(&function_name),
+            args,
+            character_unit,
+        })
     }
 
     /// Parse CHARACTERS or OCTETS keyword for USING clause

--- a/crates/vibesql-parser/src/parser/expressions/functions/window.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/window.rs
@@ -15,24 +15,23 @@ impl Parser {
         name: &str,
         args: Vec<vibesql_ast::Expression>,
     ) -> vibesql_ast::WindowFunctionSpec {
-        // Use uppercase for matching, but store the original name (which is already
-        // normalized to lowercase by the lexer for unquoted identifiers)
+        // Use uppercase for matching, FunctionIdentifier preserves original case for display
         let name_upper = name.to_uppercase();
-        let name_owned = name.to_string();
+        let func_id = vibesql_ast::FunctionIdentifier::new(name);
 
         match name_upper.as_str() {
             // Ranking functions
             "ROW_NUMBER" | "RANK" | "DENSE_RANK" | "NTILE" => {
-                vibesql_ast::WindowFunctionSpec::Ranking { name: name_owned, args }
+                vibesql_ast::WindowFunctionSpec::Ranking { name: func_id, args }
             }
 
             // Value functions
             "LAG" | "LEAD" | "FIRST_VALUE" | "LAST_VALUE" => {
-                vibesql_ast::WindowFunctionSpec::Value { name: name_owned, args }
+                vibesql_ast::WindowFunctionSpec::Value { name: func_id, args }
             }
 
             // Aggregate functions (SUM, AVG, COUNT, MIN, MAX, etc.)
-            _ => vibesql_ast::WindowFunctionSpec::Aggregate { name: name_owned, args },
+            _ => vibesql_ast::WindowFunctionSpec::Aggregate { name: func_id, args },
         }
     }
 

--- a/crates/vibesql-parser/src/parser/expressions/special_forms.rs
+++ b/crates/vibesql-parser/src/parser/expressions/special_forms.rs
@@ -8,25 +8,28 @@ impl Parser {
         match self.peek() {
             // CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP (as identifiers)
             Token::Identifier(ref id) if id.to_uppercase() == "CURRENT_DATE" => {
+                let orig_name = id.clone();
                 self.advance();
                 Ok(Some(vibesql_ast::Expression::Function {
-                    name: "CURRENT_DATE".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new(&orig_name),
                     args: vec![],
                     character_unit: None,
                 }))
             }
             Token::Identifier(ref id) if id.to_uppercase() == "CURRENT_TIME" => {
+                let orig_name = id.clone();
                 self.advance();
                 Ok(Some(vibesql_ast::Expression::Function {
-                    name: "CURRENT_TIME".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new(&orig_name),
                     args: vec![],
                     character_unit: None,
                 }))
             }
             Token::Identifier(ref id) if id.to_uppercase() == "CURRENT_TIMESTAMP" => {
+                let orig_name = id.clone();
                 self.advance();
                 Ok(Some(vibesql_ast::Expression::Function {
-                    name: "CURRENT_TIMESTAMP".to_string(),
+                    name: vibesql_ast::FunctionIdentifier::new(&orig_name),
                     args: vec![],
                     character_unit: None,
                 }))
@@ -40,18 +43,20 @@ impl Parser {
 
                 // Check for underscore followed by DATE/TIME/TIMESTAMP
                 if let Token::Identifier(ref id) = self.peek() {
+                    // Build the original name by combining CURRENT with the suffix
+                    let suffix = id.clone();
                     let function_name = match id.to_uppercase().as_str() {
                         "_DATE" => {
                             self.advance(); // consume _DATE
-                            "CURRENT_DATE"
+                            format!("CURRENT{}", suffix)
                         }
                         "_TIME" => {
                             self.advance(); // consume _TIME
-                            "CURRENT_TIME"
+                            format!("CURRENT{}", suffix)
                         }
                         "_TIMESTAMP" => {
                             self.advance(); // consume _TIMESTAMP
-                            "CURRENT_TIMESTAMP"
+                            format!("CURRENT{}", suffix)
                         }
                         _ => {
                             return Err(ParseError {
@@ -64,7 +69,7 @@ impl Parser {
                     };
 
                     Ok(Some(vibesql_ast::Expression::Function {
-                        name: function_name.to_string(),
+                        name: vibesql_ast::FunctionIdentifier::new(&function_name),
                         args: vec![],
                         character_unit: None,
                     }))

--- a/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
+++ b/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
@@ -173,7 +173,7 @@ pub fn write_expression<W: Write>(writer: &mut W, expr: &Expression) -> Result<(
         }
         Expression::Function { name, args, character_unit } => {
             write_tag!(writer, ExprTag::Function);
-            write_string(writer, name)?;
+            write_string(writer, name.canonical())?;
             write_u32(writer, args.len() as u32)?;
             for arg in args {
                 write_expression(writer, arg)?;
@@ -185,7 +185,7 @@ pub fn write_expression<W: Write>(writer: &mut W, expr: &Expression) -> Result<(
         }
         Expression::AggregateFunction { name, distinct, args, order_by } => {
             write_tag!(writer, ExprTag::AggregateFunction);
-            write_string(writer, name)?;
+            write_string(writer, name.canonical())?;
             write_bool(writer, *distinct)?;
             write_u32(writer, args.len() as u32)?;
             for arg in args {
@@ -473,7 +473,8 @@ pub fn read_expression<R: Read>(reader: &mut R) -> Result<Expression, StorageErr
             Ok(Expression::UnaryOp { op, expr })
         }
         ExprTag::Function => {
-            let name = read_string(reader)?;
+            let name_str = read_string(reader)?;
+            let name = vibesql_ast::FunctionIdentifier::new(&name_str);
             let arg_count = read_u32(reader)?;
             let mut args = Vec::new();
             for _ in 0..arg_count {
@@ -484,7 +485,8 @@ pub fn read_expression<R: Read>(reader: &mut R) -> Result<Expression, StorageErr
             Ok(Expression::Function { name, args, character_unit })
         }
         ExprTag::AggregateFunction => {
-            let name = read_string(reader)?;
+            let name_str = read_string(reader)?;
+            let name = vibesql_ast::FunctionIdentifier::new(&name_str);
             let distinct = read_bool(reader)?;
             let arg_count = read_u32(reader)?;
             let mut args = Vec::new();
@@ -740,7 +742,7 @@ mod tests {
     #[test]
     fn test_function_roundtrip() {
         let expr = Expression::Function {
-            name: "UPPER".to_string(),
+            name: vibesql_ast::FunctionIdentifier::new("UPPER"),
             args: vec![Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("test")))],
             character_unit: None,
         };

--- a/crates/vibesql-storage/src/persistence/binary/expression/window.rs
+++ b/crates/vibesql-storage/src/persistence/binary/expression/window.rs
@@ -6,7 +6,9 @@
 
 use std::io::{Read, Write};
 
-use vibesql_ast::{FrameBound, FrameUnit, WindowFrame, WindowFunctionSpec, WindowSpec};
+use vibesql_ast::{
+    FrameBound, FrameUnit, WindowFrame, WindowFunctionSpec, WindowSpec,
+};
 
 use super::super::io::*;
 use crate::StorageError;
@@ -20,7 +22,7 @@ pub(super) fn write_window_function_spec<W: Write>(
             writer
                 .write_all(&[0u8])
                 .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
-            write_string(writer, name)?;
+            write_string(writer, name.canonical())?;
             write_u32(writer, args.len() as u32)?;
             for arg in args {
                 super::write_expression(writer, arg)?;
@@ -30,7 +32,7 @@ pub(super) fn write_window_function_spec<W: Write>(
             writer
                 .write_all(&[1u8])
                 .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
-            write_string(writer, name)?;
+            write_string(writer, name.canonical())?;
             write_u32(writer, args.len() as u32)?;
             for arg in args {
                 super::write_expression(writer, arg)?;
@@ -40,7 +42,7 @@ pub(super) fn write_window_function_spec<W: Write>(
             writer
                 .write_all(&[2u8])
                 .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
-            write_string(writer, name)?;
+            write_string(writer, name.canonical())?;
             write_u32(writer, args.len() as u32)?;
             for arg in args {
                 super::write_expression(writer, arg)?;
@@ -56,7 +58,8 @@ pub(super) fn read_window_function_spec<R: Read>(
     let tag = read_u8(reader)?;
     match tag {
         0 => {
-            let name = read_string(reader)?;
+            let name_str = read_string(reader)?;
+            let name = vibesql_ast::FunctionIdentifier::new(&name_str);
             let arg_count = read_u32(reader)?;
             let mut args = Vec::new();
             for _ in 0..arg_count {
@@ -65,7 +68,8 @@ pub(super) fn read_window_function_spec<R: Read>(
             Ok(WindowFunctionSpec::Aggregate { name, args })
         }
         1 => {
-            let name = read_string(reader)?;
+            let name_str = read_string(reader)?;
+            let name = vibesql_ast::FunctionIdentifier::new(&name_str);
             let arg_count = read_u32(reader)?;
             let mut args = Vec::new();
             for _ in 0..arg_count {
@@ -74,7 +78,8 @@ pub(super) fn read_window_function_spec<R: Read>(
             Ok(WindowFunctionSpec::Ranking { name, args })
         }
         2 => {
-            let name = read_string(reader)?;
+            let name_str = read_string(reader)?;
+            let name = vibesql_ast::FunctionIdentifier::new(&name_str);
             let arg_count = read_u32(reader)?;
             let mut args = Vec::new();
             for _ in 0..arg_count {

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -100,10 +100,23 @@ proc translate_error_to_sqlite {vibesql_error} {
         return "no such table: [string tolower $table_name]"
     }
 
+    # Column not found in INSERT: "Column 'X' not found (searched tables: T)" -> "table t has no column named x"
+    # This format is used by SQLite for INSERT INTO table(columns) when a column doesn't exist
+    if {[regexp -nocase {^Column '([^']+)' not found \(searched tables: ([^)]+)\)} $error_msg -> col_name table_name]} {
+        # If it's a single table (no commas), use the INSERT-specific format
+        if {![string match "*,*" $table_name]} {
+            return "table [string tolower $table_name] has no column named [string tolower $col_name]"
+        }
+        # Otherwise, fall through to the generic "no such column" format
+    }
+
     # Column not found: "Column 'X' not found..." -> "no such column: x"
     if {[regexp -nocase {^Column '([^']+)' not found} $error_msg -> col_name]} {
         return "no such column: [string tolower $col_name]"
     }
+
+    # Note: Column/value count mismatch errors like "table X has N columns but M values were supplied"
+    # are already in SQLite format from VibeSQL - no translation needed.
 
     # Index not found: "Index 'X' not found" -> "no such index: x"
     if {[regexp -nocase {^Index '([^']+)' not found} $error_msg -> idx_name]} {


### PR DESCRIPTION
## Summary

- Introduces `FunctionIdentifier` type that preserves original function name casing for error messages while using canonical (lowercase) form for comparisons
- Enables SQLite-compatible error messages like `no such function: sUM` instead of `no such function: SUM`
- Updates `Expression::Function`, `Expression::AggregateFunction`, and `WindowFunctionSpec` variants to use `FunctionIdentifier`

## Changes

- **vibesql-ast**: Add `FunctionIdentifier` struct with `canonical()` and `display()` methods
- **vibesql-parser**: Construct `FunctionIdentifier` from parsed tokens
- **vibesql-executor**: Use `display()` for error messages, `canonical()` for internal logic
- **vibesql-storage**: Update serialization to handle `FunctionIdentifier`
- **Tests**: Update 70+ test files to use new `FunctionIdentifier` API

## Test plan

- [x] All 4,611 library tests pass
- [x] Verified error message case preservation: `SELECT nonExistentFunc(1)` → `Unknown function: nonExistentFunc`
- [x] AST, parser, executor, and storage tests green

Closes #4531

🤖 Generated with [Claude Code](https://claude.com/claude-code)