### PR TITLE
feat(executor): Add SQLite-compatible type coercion for functions

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/coercion.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/coercion.rs
@@ -1,0 +1,220 @@
+//! Type coercion helpers for SQLite compatibility
+//!
+//! SQLite automatically coerces arguments to expected types in function calls.
+//! These helpers provide consistent coercion behavior across all functions.
+
+use vibesql_types::SqlValue;
+
+/// Coerce a SqlValue to a string for string functions.
+///
+/// SQLite coercion rules for string functions:
+/// - NULL → None (propagates NULL)
+/// - String types → return as-is
+/// - Integer → decimal string representation (e.g., 123 → "123")
+/// - Float → decimal string representation (e.g., 7.5 → "7.5")
+/// - Boolean → "0" or "1"
+/// - Blob → UTF-8 lossy conversion
+/// - Date/Time → ISO format string
+pub fn coerce_to_string(value: &SqlValue) -> Option<String> {
+    match value {
+        SqlValue::Null => None,
+        SqlValue::Varchar(s) | SqlValue::Character(s) => Some(s.to_string()),
+        SqlValue::Integer(n) | SqlValue::Bigint(n) => Some(n.to_string()),
+        SqlValue::Smallint(n) => Some(n.to_string()),
+        SqlValue::Unsigned(n) => Some(n.to_string()),
+        SqlValue::Double(n) | SqlValue::Numeric(n) => Some(format_sqlite_float(*n)),
+        SqlValue::Float(n) | SqlValue::Real(n) => Some(format_sqlite_float(*n as f64)),
+        SqlValue::Boolean(b) => Some(if *b { "1" } else { "0" }.to_string()),
+        SqlValue::Vector(v) => {
+            // Format vector as comma-separated values in brackets
+            let inner: Vec<String> = v.iter().map(|f| f.to_string()).collect();
+            Some(format!("[{}]", inner.join(",")))
+        }
+        SqlValue::Date(d) => Some(d.to_string()),
+        SqlValue::Time(t) => Some(t.to_string()),
+        SqlValue::Timestamp(ts) => Some(ts.to_string()),
+        SqlValue::Interval(i) => Some(i.to_string()),
+    }
+}
+
+/// Coerce a SqlValue to a number for numeric functions.
+///
+/// SQLite coercion rules for numeric functions:
+/// - NULL → None (propagates NULL)
+/// - Numeric types → return as f64
+/// - String → parse as number, default to 0.0 on failure
+/// - Boolean → 0.0 or 1.0
+pub fn coerce_to_number(value: &SqlValue) -> Option<f64> {
+    match value {
+        SqlValue::Null => None,
+        SqlValue::Integer(n) | SqlValue::Bigint(n) => Some(*n as f64),
+        SqlValue::Smallint(n) => Some(*n as f64),
+        SqlValue::Unsigned(n) => Some(*n as f64),
+        SqlValue::Double(n) | SqlValue::Numeric(n) => Some(*n),
+        SqlValue::Float(n) | SqlValue::Real(n) => Some(*n as f64),
+        SqlValue::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
+        SqlValue::Varchar(s) | SqlValue::Character(s) => {
+            // SQLite: parse string to number, default to 0.0
+            Some(parse_sqlite_number(s))
+        }
+        // Other types coerce to 0.0
+        _ => Some(0.0),
+    }
+}
+
+/// Coerce a SqlValue to an integer for functions requiring integer arguments.
+///
+/// SQLite coercion rules:
+/// - NULL → None
+/// - Integer types → return as-is
+/// - Float → truncate to integer
+/// - String → parse as integer, default to 0
+pub fn coerce_to_integer(value: &SqlValue) -> Option<i64> {
+    match value {
+        SqlValue::Null => None,
+        SqlValue::Integer(n) | SqlValue::Bigint(n) => Some(*n),
+        SqlValue::Smallint(n) => Some(*n as i64),
+        SqlValue::Unsigned(n) => Some(*n as i64),
+        SqlValue::Double(n) | SqlValue::Numeric(n) => Some(*n as i64),
+        SqlValue::Float(n) | SqlValue::Real(n) => Some(*n as i64),
+        SqlValue::Boolean(b) => Some(if *b { 1 } else { 0 }),
+        SqlValue::Varchar(s) | SqlValue::Character(s) => {
+            // SQLite: parse string to integer, default to 0
+            Some(s.trim().parse::<i64>().unwrap_or_else(|_| {
+                // Try parsing as float then truncating
+                s.trim().parse::<f64>().map(|f| f as i64).unwrap_or(0)
+            }))
+        }
+        _ => Some(0),
+    }
+}
+
+/// Format a float value like SQLite does.
+///
+/// SQLite uses specific formatting for floats:
+/// - Integers are displayed without decimal point (e.g., 5.0 → "5.0" but may vary)
+/// - Scientific notation for very large/small numbers
+fn format_sqlite_float(n: f64) -> String {
+    if n.is_nan() {
+        return "NaN".to_string();
+    }
+    if n.is_infinite() {
+        return if n.is_sign_positive() {
+            "Inf"
+        } else {
+            "-Inf"
+        }
+        .to_string();
+    }
+
+    // SQLite typically uses standard decimal notation
+    // For whole numbers, it still includes the decimal (e.g., 5.0)
+    if n.fract() == 0.0 && n.abs() < 1e15 {
+        format!("{:.1}", n)
+    } else {
+        // Use default Display which handles precision appropriately
+        n.to_string()
+    }
+}
+
+/// Parse a string to a number like SQLite does.
+///
+/// SQLite parsing rules:
+/// - Leading/trailing whitespace is trimmed
+/// - Leading numeric portion is parsed (e.g., "123abc" → 123)
+/// - Non-numeric strings return 0.0
+fn parse_sqlite_number(s: &str) -> f64 {
+    let s = s.trim();
+    if s.is_empty() {
+        return 0.0;
+    }
+
+    // Try direct parse first
+    if let Ok(n) = s.parse::<f64>() {
+        return n;
+    }
+
+    // SQLite extracts leading numeric portion
+    // Find the longest valid numeric prefix
+    let mut end = 0;
+    let mut has_dot = false;
+    let mut has_e = false;
+    let chars: Vec<char> = s.chars().collect();
+
+    // Handle optional leading sign
+    if !chars.is_empty() && (chars[0] == '-' || chars[0] == '+') {
+        end = 1;
+    }
+
+    while end < chars.len() {
+        let c = chars[end];
+        if c.is_ascii_digit() {
+            end += 1;
+        } else if c == '.' && !has_dot && !has_e {
+            has_dot = true;
+            end += 1;
+        } else if (c == 'e' || c == 'E') && !has_e && end > 0 {
+            has_e = true;
+            end += 1;
+            // Handle exponent sign
+            if end < chars.len() && (chars[end] == '-' || chars[end] == '+') {
+                end += 1;
+            }
+        } else {
+            break;
+        }
+    }
+
+    if end == 0 || (end == 1 && (chars[0] == '-' || chars[0] == '+')) {
+        return 0.0;
+    }
+
+    let numeric_part: String = chars[..end].iter().collect();
+    numeric_part.parse::<f64>().unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_coerce_to_string() {
+        assert_eq!(coerce_to_string(&SqlValue::Null), None);
+        assert_eq!(
+            coerce_to_string(&SqlValue::Integer(123)),
+            Some("123".to_string())
+        );
+        assert_eq!(
+            coerce_to_string(&SqlValue::Varchar(arcstr::ArcStr::from("hello"))),
+            Some("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn test_coerce_to_number() {
+        assert_eq!(coerce_to_number(&SqlValue::Null), None);
+        assert_eq!(coerce_to_number(&SqlValue::Integer(123)), Some(123.0));
+        assert_eq!(
+            coerce_to_number(&SqlValue::Varchar(arcstr::ArcStr::from("456"))),
+            Some(456.0)
+        );
+        assert_eq!(
+            coerce_to_number(&SqlValue::Varchar(arcstr::ArcStr::from("free"))),
+            Some(0.0)
+        );
+        assert_eq!(
+            coerce_to_number(&SqlValue::Varchar(arcstr::ArcStr::from("-5"))),
+            Some(-5.0)
+        );
+    }
+
+    #[test]
+    fn test_parse_sqlite_number() {
+        assert_eq!(parse_sqlite_number("123"), 123.0);
+        assert_eq!(parse_sqlite_number("  456  "), 456.0);
+        assert_eq!(parse_sqlite_number("-5"), -5.0);
+        assert_eq!(parse_sqlite_number("free"), 0.0);
+        assert_eq!(parse_sqlite_number("123abc"), 123.0);
+        assert_eq!(parse_sqlite_number(""), 0.0);
+    }
+}

--- a/crates/vibesql-executor/src/evaluator/functions/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/mod.rs
@@ -18,6 +18,7 @@
 use crate::errors::ExecutorError;
 
 // Module declarations
+pub(crate) mod coercion;
 mod control;
 mod conversion;
 pub(crate) mod datetime;

--- a/crates/vibesql-executor/src/evaluator/functions/numeric/basic.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/numeric/basic.rs
@@ -5,9 +5,14 @@
 use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;
+use crate::evaluator::functions::coercion::coerce_to_number;
 
 /// ABS(x) - Absolute value
 /// SQL:1999 Section 6.27: Numeric value functions
+///
+/// SQLite compatibility: Automatically coerces string types to numbers.
+/// - ABS('-5') returns 5.0
+/// - ABS('free') returns 0.0
 pub fn abs(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
         return Err(ExecutorError::UnsupportedFeature(format!(
@@ -16,25 +21,31 @@ pub fn abs(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         )));
     }
 
+    // Fast path for numeric types to preserve their original type
     match &args[0] {
-        SqlValue::Null => Ok(SqlValue::Null),
-        SqlValue::Integer(n) => Ok(SqlValue::Integer(n.abs())),
-        SqlValue::Bigint(n) => Ok(SqlValue::Bigint(n.abs())),
-        SqlValue::Smallint(n) => Ok(SqlValue::Smallint(n.abs())),
-        SqlValue::Float(n) => Ok(SqlValue::Float(n.abs())),
-        SqlValue::Double(n) => Ok(SqlValue::Double(n.abs())),
-        SqlValue::Real(n) => Ok(SqlValue::Real(n.abs())),
-        SqlValue::Numeric(n) => Ok(SqlValue::Numeric(n.abs())),
-        SqlValue::Unsigned(n) => Ok(SqlValue::Unsigned(*n)), // Unsigned is always positive
-        val => Err(ExecutorError::UnsupportedFeature(format!(
-            "ABS requires numeric argument, got {:?}",
-            val
-        ))),
+        SqlValue::Null => return Ok(SqlValue::Null),
+        SqlValue::Integer(n) => return Ok(SqlValue::Integer(n.abs())),
+        SqlValue::Bigint(n) => return Ok(SqlValue::Bigint(n.abs())),
+        SqlValue::Smallint(n) => return Ok(SqlValue::Smallint(n.abs())),
+        SqlValue::Float(n) => return Ok(SqlValue::Float(n.abs())),
+        SqlValue::Double(n) => return Ok(SqlValue::Double(n.abs())),
+        SqlValue::Real(n) => return Ok(SqlValue::Real(n.abs())),
+        SqlValue::Numeric(n) => return Ok(SqlValue::Numeric(n.abs())),
+        SqlValue::Unsigned(n) => return Ok(SqlValue::Unsigned(*n)), // Unsigned is always positive
+        _ => {}
+    }
+
+    // Slow path: coerce other types (like strings) to numbers
+    match coerce_to_number(&args[0]) {
+        None => Ok(SqlValue::Null),
+        Some(n) => Ok(SqlValue::Double(n.abs())),
     }
 }
 
 /// SIGN(x) - Sign of number (-1, 0, or 1)
 /// SQL:1999 Section 6.27: Numeric value functions
+///
+/// SQLite compatibility: Automatically coerces string types to numbers.
 pub fn sign(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
         return Err(ExecutorError::UnsupportedFeature(format!(
@@ -43,15 +54,16 @@ pub fn sign(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         )));
     }
 
+    // Fast path for numeric types to preserve their original type
     match &args[0] {
-        SqlValue::Null => Ok(SqlValue::Null),
+        SqlValue::Null => return Ok(SqlValue::Null),
         SqlValue::Integer(n) => {
             let sign = match n.cmp(&0) {
                 std::cmp::Ordering::Less => -1,
                 std::cmp::Ordering::Greater => 1,
                 std::cmp::Ordering::Equal => 0,
             };
-            Ok(SqlValue::Integer(sign))
+            return Ok(SqlValue::Integer(sign));
         }
         SqlValue::Bigint(n) => {
             let sign = match n.cmp(&0) {
@@ -59,7 +71,7 @@ pub fn sign(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                 std::cmp::Ordering::Greater => 1,
                 std::cmp::Ordering::Equal => 0,
             };
-            Ok(SqlValue::Bigint(sign))
+            return Ok(SqlValue::Bigint(sign));
         }
         SqlValue::Smallint(n) => {
             let sign: i16 = match n.cmp(&0) {
@@ -67,7 +79,7 @@ pub fn sign(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                 std::cmp::Ordering::Greater => 1,
                 std::cmp::Ordering::Equal => 0,
             };
-            Ok(SqlValue::Smallint(sign))
+            return Ok(SqlValue::Smallint(sign));
         }
         SqlValue::Float(n) => {
             let sign = if *n < 0.0 {
@@ -77,7 +89,7 @@ pub fn sign(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             } else {
                 0.0
             };
-            Ok(SqlValue::Float(sign))
+            return Ok(SqlValue::Float(sign));
         }
         SqlValue::Double(n) => {
             let sign = if *n < 0.0 {
@@ -87,7 +99,7 @@ pub fn sign(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             } else {
                 0.0
             };
-            Ok(SqlValue::Double(sign))
+            return Ok(SqlValue::Double(sign));
         }
         SqlValue::Real(n) => {
             let sign = if *n < 0.0 {
@@ -97,7 +109,7 @@ pub fn sign(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             } else {
                 0.0
             };
-            Ok(SqlValue::Real(sign))
+            return Ok(SqlValue::Real(sign));
         }
         SqlValue::Numeric(n) => {
             let sign = if *n < 0.0 {
@@ -107,22 +119,36 @@ pub fn sign(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             } else {
                 0.0
             };
-            Ok(SqlValue::Numeric(sign))
+            return Ok(SqlValue::Numeric(sign));
         }
         SqlValue::Unsigned(n) => {
             // Unsigned is always non-negative
             let sign: u64 = if *n > 0 { 1 } else { 0 };
-            Ok(SqlValue::Unsigned(sign))
+            return Ok(SqlValue::Unsigned(sign));
         }
-        val => Err(ExecutorError::UnsupportedFeature(format!(
-            "SIGN requires numeric argument, got {:?}",
-            val
-        ))),
+        _ => {}
+    }
+
+    // Slow path: coerce other types (like strings) to numbers
+    match coerce_to_number(&args[0]) {
+        None => Ok(SqlValue::Null),
+        Some(n) => {
+            let sign = if n < 0.0 {
+                -1.0
+            } else if n > 0.0 {
+                1.0
+            } else {
+                0.0
+            };
+            Ok(SqlValue::Double(sign))
+        }
     }
 }
 
 /// MOD(x, y) - Modulo (remainder)
 /// SQL:1999 Section 6.27: Numeric value functions
+///
+/// SQLite compatibility: Automatically coerces string types to numbers.
 pub fn mod_fn(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 2 {
         return Err(ExecutorError::UnsupportedFeature(format!(
@@ -131,27 +157,42 @@ pub fn mod_fn(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         )));
     }
 
+    // Fast path: both arguments are the same numeric type
     match (&args[0], &args[1]) {
-        (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
+        (SqlValue::Null, _) | (_, SqlValue::Null) => return Ok(SqlValue::Null),
 
         (SqlValue::Integer(x), SqlValue::Integer(y)) => {
             if *y == 0 {
                 return Ok(SqlValue::Null);
             }
-            Ok(SqlValue::Integer(x % y))
+            return Ok(SqlValue::Integer(x % y));
         }
 
         (SqlValue::Float(x), SqlValue::Float(y)) | (SqlValue::Real(x), SqlValue::Real(y)) => {
             if *y == 0.0 {
                 return Ok(SqlValue::Null);
             }
-            Ok(SqlValue::Float(x % y))
+            return Ok(SqlValue::Float(x % y));
         }
 
-        _ => Err(ExecutorError::UnsupportedFeature(
-            "MOD requires numeric arguments of the same type".to_string(),
-        )),
+        _ => {}
     }
+
+    // Slow path: coerce both arguments to f64
+    let x = match coerce_to_number(&args[0]) {
+        Some(n) => n,
+        None => return Ok(SqlValue::Null),
+    };
+    let y = match coerce_to_number(&args[1]) {
+        Some(n) => n,
+        None => return Ok(SqlValue::Null),
+    };
+
+    if y == 0.0 {
+        return Ok(SqlValue::Null);
+    }
+
+    Ok(SqlValue::Double(x % y))
 }
 
 /// PI() - Mathematical constant π

--- a/crates/vibesql-executor/src/evaluator/functions/numeric/rounding.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/numeric/rounding.rs
@@ -5,9 +5,12 @@
 use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;
+use crate::evaluator::functions::coercion::{coerce_to_integer, coerce_to_number};
 
 /// ROUND(x [, precision]) - Round to nearest integer or decimal places
 /// SQL:1999 Section 6.27: Numeric value functions
+///
+/// SQLite compatibility: Automatically coerces string types to numbers.
 pub fn round(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.is_empty() || args.len() > 2 {
         return Err(ExecutorError::UnsupportedFeature(format!(
@@ -18,48 +21,51 @@ pub fn round(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
 
     let value = &args[0];
     let precision = if args.len() == 2 {
-        match &args[1] {
-            SqlValue::Integer(p) => *p as i32,
-            SqlValue::Null => return Ok(SqlValue::Null),
-            val => {
-                return Err(ExecutorError::UnsupportedFeature(format!(
-                    "ROUND precision must be integer, got {:?}",
-                    val
-                )))
-            }
+        match coerce_to_integer(&args[1]) {
+            Some(p) => p as i32,
+            None => return Ok(SqlValue::Null),
         }
     } else {
         0
     };
 
+    // Fast path for numeric types to preserve their original type
     match value {
-        SqlValue::Null => Ok(SqlValue::Null),
-        SqlValue::Integer(n) => Ok(SqlValue::Integer(*n)),
+        SqlValue::Null => return Ok(SqlValue::Null),
+        SqlValue::Integer(n) => return Ok(SqlValue::Integer(*n)),
         SqlValue::Float(f) => {
             let multiplier = 10_f32.powi(precision);
-            Ok(SqlValue::Float((f * multiplier).round() / multiplier))
+            return Ok(SqlValue::Float((f * multiplier).round() / multiplier));
         }
         SqlValue::Double(f) => {
             let multiplier = 10_f64.powi(precision);
-            Ok(SqlValue::Double((f * multiplier).round() / multiplier))
+            return Ok(SqlValue::Double((f * multiplier).round() / multiplier));
         }
         SqlValue::Real(f) => {
             let multiplier = 10_f32.powi(precision);
-            Ok(SqlValue::Real((f * multiplier).round() / multiplier))
+            return Ok(SqlValue::Real((f * multiplier).round() / multiplier));
         }
         SqlValue::Numeric(n) => {
             let multiplier = 10_f64.powi(precision);
-            Ok(SqlValue::Numeric((n * multiplier).round() / multiplier))
+            return Ok(SqlValue::Numeric((n * multiplier).round() / multiplier));
         }
-        val => Err(ExecutorError::UnsupportedFeature(format!(
-            "ROUND requires numeric argument, got {:?}",
-            val
-        ))),
+        _ => {}
+    }
+
+    // Slow path: coerce other types (like strings) to numbers
+    match coerce_to_number(value) {
+        None => Ok(SqlValue::Null),
+        Some(n) => {
+            let multiplier = 10_f64.powi(precision);
+            Ok(SqlValue::Double((n * multiplier).round() / multiplier))
+        }
     }
 }
 
 /// FLOOR(x) - Round down to nearest integer
 /// SQL:1999 Section 6.27: Numeric value functions
+///
+/// SQLite compatibility: Automatically coerces string types to numbers.
 pub fn floor(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
         return Err(ExecutorError::UnsupportedFeature(format!(
@@ -68,23 +74,29 @@ pub fn floor(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         )));
     }
 
+    // Fast path for numeric types
     match &args[0] {
-        SqlValue::Null => Ok(SqlValue::Null),
-        SqlValue::Integer(n) => Ok(SqlValue::Integer(*n)),
-        SqlValue::Float(f) => Ok(SqlValue::Float(f.floor())),
-        SqlValue::Double(f) => Ok(SqlValue::Double(f.floor())),
-        SqlValue::Real(f) => Ok(SqlValue::Real(f.floor())),
-        SqlValue::Numeric(n) => Ok(SqlValue::Numeric(n.floor())),
-        val => Err(ExecutorError::UnsupportedFeature(format!(
-            "FLOOR requires numeric argument, got {:?}",
-            val
-        ))),
+        SqlValue::Null => return Ok(SqlValue::Null),
+        SqlValue::Integer(n) => return Ok(SqlValue::Integer(*n)),
+        SqlValue::Float(f) => return Ok(SqlValue::Float(f.floor())),
+        SqlValue::Double(f) => return Ok(SqlValue::Double(f.floor())),
+        SqlValue::Real(f) => return Ok(SqlValue::Real(f.floor())),
+        SqlValue::Numeric(n) => return Ok(SqlValue::Numeric(n.floor())),
+        _ => {}
+    }
+
+    // Slow path: coerce other types (like strings) to numbers
+    match coerce_to_number(&args[0]) {
+        None => Ok(SqlValue::Null),
+        Some(n) => Ok(SqlValue::Double(n.floor())),
     }
 }
 
 /// CEIL/CEILING(x) - Round up to nearest integer
 /// SQL:1999 Section 6.27: Numeric value functions
 /// Note: CEILING is an alias for CEIL
+///
+/// SQLite compatibility: Automatically coerces string types to numbers.
 pub fn ceil(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
         return Err(ExecutorError::UnsupportedFeature(format!(
@@ -93,22 +105,28 @@ pub fn ceil(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         )));
     }
 
+    // Fast path for numeric types
     match &args[0] {
-        SqlValue::Null => Ok(SqlValue::Null),
-        SqlValue::Integer(n) => Ok(SqlValue::Integer(*n)),
-        SqlValue::Float(f) => Ok(SqlValue::Float(f.ceil())),
-        SqlValue::Double(f) => Ok(SqlValue::Double(f.ceil())),
-        SqlValue::Real(f) => Ok(SqlValue::Real(f.ceil())),
-        SqlValue::Numeric(n) => Ok(SqlValue::Numeric(n.ceil())),
-        val => Err(ExecutorError::UnsupportedFeature(format!(
-            "CEIL requires numeric argument, got {:?}",
-            val
-        ))),
+        SqlValue::Null => return Ok(SqlValue::Null),
+        SqlValue::Integer(n) => return Ok(SqlValue::Integer(*n)),
+        SqlValue::Float(f) => return Ok(SqlValue::Float(f.ceil())),
+        SqlValue::Double(f) => return Ok(SqlValue::Double(f.ceil())),
+        SqlValue::Real(f) => return Ok(SqlValue::Real(f.ceil())),
+        SqlValue::Numeric(n) => return Ok(SqlValue::Numeric(n.ceil())),
+        _ => {}
+    }
+
+    // Slow path: coerce other types (like strings) to numbers
+    match coerce_to_number(&args[0]) {
+        None => Ok(SqlValue::Null),
+        Some(n) => Ok(SqlValue::Double(n.ceil())),
     }
 }
 
 /// TRUNCATE(x [, precision]) - Truncate to specified decimal places (towards zero)
 /// SQL:1999 Section 6.27: Numeric value functions
+///
+/// SQLite compatibility: Automatically coerces string types to numbers.
 pub fn truncate(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.is_empty() || args.len() > 2 {
         return Err(ExecutorError::UnsupportedFeature(format!(
@@ -119,42 +137,43 @@ pub fn truncate(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
 
     let value = &args[0];
     let precision = if args.len() == 2 {
-        match &args[1] {
-            SqlValue::Integer(p) => *p as i32,
-            SqlValue::Null => return Ok(SqlValue::Null),
-            val => {
-                return Err(ExecutorError::UnsupportedFeature(format!(
-                    "TRUNCATE precision must be integer, got {:?}",
-                    val
-                )))
-            }
+        match coerce_to_integer(&args[1]) {
+            Some(p) => p as i32,
+            None => return Ok(SqlValue::Null),
         }
     } else {
         0
     };
 
+    // Fast path for numeric types
     match value {
-        SqlValue::Null => Ok(SqlValue::Null),
-        SqlValue::Integer(n) => Ok(SqlValue::Integer(*n)),
+        SqlValue::Null => return Ok(SqlValue::Null),
+        SqlValue::Integer(n) => return Ok(SqlValue::Integer(*n)),
         SqlValue::Float(f) => {
             let multiplier = 10_f32.powi(precision);
-            Ok(SqlValue::Float((f * multiplier).trunc() / multiplier))
+            return Ok(SqlValue::Float((f * multiplier).trunc() / multiplier));
         }
         SqlValue::Double(f) => {
             let multiplier = 10_f64.powi(precision);
-            Ok(SqlValue::Double((f * multiplier).trunc() / multiplier))
+            return Ok(SqlValue::Double((f * multiplier).trunc() / multiplier));
         }
         SqlValue::Real(f) => {
             let multiplier = 10_f32.powi(precision);
-            Ok(SqlValue::Real((f * multiplier).trunc() / multiplier))
+            return Ok(SqlValue::Real((f * multiplier).trunc() / multiplier));
         }
         SqlValue::Numeric(n) => {
             let multiplier = 10_f64.powi(precision);
-            Ok(SqlValue::Numeric((n * multiplier).trunc() / multiplier))
+            return Ok(SqlValue::Numeric((n * multiplier).trunc() / multiplier));
         }
-        val => Err(ExecutorError::UnsupportedFeature(format!(
-            "TRUNCATE requires numeric argument, got {:?}",
-            val
-        ))),
+        _ => {}
+    }
+
+    // Slow path: coerce other types (like strings) to numbers
+    match coerce_to_number(value) {
+        None => Ok(SqlValue::Null),
+        Some(n) => {
+            let multiplier = 10_f64.powi(precision);
+            Ok(SqlValue::Double((n * multiplier).trunc() / multiplier))
+        }
     }
 }

--- a/crates/vibesql-executor/src/evaluator/functions/string/case.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/string/case.rs
@@ -3,9 +3,14 @@
 //! SQL:1999 Section 6.29: String value functions
 
 use crate::errors::ExecutorError;
+use crate::evaluator::functions::coercion::coerce_to_string;
 
 /// UPPER(string) - Convert string to uppercase
 /// SQL:1999 Section 6.29: String value functions
+///
+/// SQLite compatibility: Automatically coerces numeric types to strings.
+/// - UPPER(123) returns "123"
+/// - UPPER(7.5) returns "7.5"
 pub(in crate::evaluator::functions) fn upper(
     args: &[vibesql_types::SqlValue],
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
@@ -16,23 +21,20 @@ pub(in crate::evaluator::functions) fn upper(
         )));
     }
 
-    match &args[0] {
-        vibesql_types::SqlValue::Null => Ok(vibesql_types::SqlValue::Null),
-        vibesql_types::SqlValue::Varchar(s) => {
-            Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(s.to_uppercase())))
-        }
-        vibesql_types::SqlValue::Character(s) => {
-            Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(s.to_uppercase())))
-        }
-        val => Err(ExecutorError::UnsupportedFeature(format!(
-            "UPPER requires string argument, got {:?}",
-            val
+    match coerce_to_string(&args[0]) {
+        None => Ok(vibesql_types::SqlValue::Null),
+        Some(s) => Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+            s.to_uppercase(),
         ))),
     }
 }
 
 /// LOWER(string) - Convert string to lowercase
 /// SQL:1999 Section 6.29: String value functions
+///
+/// SQLite compatibility: Automatically coerces numeric types to strings.
+/// - LOWER(123) returns "123"
+/// - LOWER(7.5) returns "7.5"
 pub(in crate::evaluator::functions) fn lower(
     args: &[vibesql_types::SqlValue],
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
@@ -43,17 +45,10 @@ pub(in crate::evaluator::functions) fn lower(
         )));
     }
 
-    match &args[0] {
-        vibesql_types::SqlValue::Null => Ok(vibesql_types::SqlValue::Null),
-        vibesql_types::SqlValue::Varchar(s) => {
-            Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(s.to_lowercase())))
-        }
-        vibesql_types::SqlValue::Character(s) => {
-            Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(s.to_lowercase())))
-        }
-        val => Err(ExecutorError::UnsupportedFeature(format!(
-            "LOWER requires string argument, got {:?}",
-            val
+    match coerce_to_string(&args[0]) {
+        None => Ok(vibesql_types::SqlValue::Null),
+        Some(s) => Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+            s.to_lowercase(),
         ))),
     }
 }

--- a/crates/vibesql-executor/src/evaluator/functions/string/length.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/string/length.rs
@@ -3,10 +3,13 @@
 //! SQL:1999 Section 6.29: String value functions
 
 use crate::errors::ExecutorError;
+use crate::evaluator::functions::coercion::coerce_to_string;
 
 /// CHAR_LENGTH(string [USING unit]) / CHARACTER_LENGTH(string [USING unit])
 /// Return string length in characters or octets
 /// SQL:1999 Section 6.29: String value functions
+///
+/// SQLite compatibility: Automatically coerces numeric types to strings.
 pub(in crate::evaluator::functions) fn char_length(
     args: &[vibesql_types::SqlValue],
     name: &str,
@@ -20,9 +23,9 @@ pub(in crate::evaluator::functions) fn char_length(
         )));
     }
 
-    match &args[0] {
-        vibesql_types::SqlValue::Null => Ok(vibesql_types::SqlValue::Null),
-        vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
+    match coerce_to_string(&args[0]) {
+        None => Ok(vibesql_types::SqlValue::Null),
+        Some(s) => {
             // Determine unit: CHARACTERS (default) or OCTETS
             let length = match character_unit {
                 Some(vibesql_ast::CharacterUnit::Octets) => {
@@ -36,10 +39,6 @@ pub(in crate::evaluator::functions) fn char_length(
             };
             Ok(vibesql_types::SqlValue::Integer(length))
         }
-        val => Err(ExecutorError::UnsupportedFeature(format!(
-            "{} requires string argument, got {:?}",
-            name, val
-        ))),
     }
 }
 
@@ -48,6 +47,9 @@ pub(in crate::evaluator::functions) fn char_length(
 /// Returns byte length, not character count. For UTF-8:
 /// - ASCII characters: 1 byte each
 /// - Multi-byte characters: 2-4 bytes each
+///
+/// SQLite compatibility: Automatically coerces numeric types to strings.
+/// - OCTET_LENGTH(7.5) returns 3 (length of "7.5")
 pub(in crate::evaluator::functions) fn octet_length(
     args: &[vibesql_types::SqlValue],
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
@@ -58,16 +60,9 @@ pub(in crate::evaluator::functions) fn octet_length(
         )));
     }
 
-    match &args[0] {
-        vibesql_types::SqlValue::Null => Ok(vibesql_types::SqlValue::Null),
-        vibesql_types::SqlValue::Varchar(s) => Ok(vibesql_types::SqlValue::Integer(s.len() as i64)),
-        vibesql_types::SqlValue::Character(s) => {
-            Ok(vibesql_types::SqlValue::Integer(s.len() as i64))
-        }
-        val => Err(ExecutorError::UnsupportedFeature(format!(
-            "OCTET_LENGTH requires string argument, got {:?}",
-            val
-        ))),
+    match coerce_to_string(&args[0]) {
+        None => Ok(vibesql_types::SqlValue::Null),
+        Some(s) => Ok(vibesql_types::SqlValue::Integer(s.len() as i64)),
     }
 }
 

--- a/crates/vibesql-executor/src/evaluator/functions/string/search.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/string/search.rs
@@ -4,10 +4,13 @@
 //! Includes POSITION (SQL standard), INSTR and LOCATE (MySQL/Oracle)
 
 use crate::errors::ExecutorError;
+use crate::evaluator::functions::coercion::{coerce_to_integer, coerce_to_string};
 
 /// POSITION(substring IN string) - Find position (1-indexed)
 /// SQL:1999 Section 6.29: String value functions
 /// Note: This is called as POSITION('sub', 'string') in our implementation
+///
+/// SQLite compatibility: Automatically coerces numeric types to strings.
 pub(in crate::evaluator::functions) fn position(
     args: &[vibesql_types::SqlValue],
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
@@ -18,50 +21,19 @@ pub(in crate::evaluator::functions) fn position(
         )));
     }
 
-    match (&args[0], &args[1]) {
-        (vibesql_types::SqlValue::Null, _) | (_, vibesql_types::SqlValue::Null) => {
-            Ok(vibesql_types::SqlValue::Null)
-        }
-        (
-            vibesql_types::SqlValue::Varchar(needle) | vibesql_types::SqlValue::Character(needle),
-            vibesql_types::SqlValue::Varchar(haystack)
-            | vibesql_types::SqlValue::Character(haystack),
-        ) => {
-            // Find returns 0-indexed position, SQL needs 1-indexed
-            match haystack.find(&**needle) {
-                Some(pos) => Ok(vibesql_types::SqlValue::Integer((pos + 1) as i64)),
-                None => Ok(vibesql_types::SqlValue::Integer(0)),
-            }
-        }
-        (a, b) => Err(ExecutorError::UnsupportedFeature(format!(
-            "POSITION requires string arguments, got {:?} and {:?}",
-            a, b
-        ))),
-    }
-}
+    // Coerce both arguments to strings
+    let needle = match coerce_to_string(&args[0]) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
+    };
+    let haystack = match coerce_to_string(&args[1]) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
+    };
 
-/// Convert SqlValue to string for INSTR/POSITION/LOCATE functions
-/// SQLite converts numeric values to strings for these functions
-fn sql_value_to_string(val: &vibesql_types::SqlValue) -> Option<String> {
-    match val {
-        vibesql_types::SqlValue::Null => None,
-        vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
-            Some(s.to_string())
-        }
-        vibesql_types::SqlValue::Integer(n) | vibesql_types::SqlValue::Bigint(n) => {
-            Some(n.to_string())
-        }
-        vibesql_types::SqlValue::Smallint(n) => Some(n.to_string()),
-        vibesql_types::SqlValue::Unsigned(n) => Some(n.to_string()),
-        vibesql_types::SqlValue::Double(n) | vibesql_types::SqlValue::Numeric(n) => {
-            Some(n.to_string())
-        }
-        vibesql_types::SqlValue::Float(n) | vibesql_types::SqlValue::Real(n) => {
-            Some(n.to_string())
-        }
-        vibesql_types::SqlValue::Boolean(b) => Some(if *b { "1" } else { "0" }.to_string()),
-        _ => None,
-    }
+    // Find character position (not byte position)
+    let position = find_char_position(&haystack, &needle);
+    Ok(vibesql_types::SqlValue::Integer(position))
 }
 
 /// Find character position (1-indexed) of needle in haystack
@@ -83,7 +55,8 @@ fn find_char_position(haystack: &str, needle: &str) -> i64 {
 
 /// INSTR(string, substring) - Find position of substring (1-indexed, 0 if not found)
 /// MySQL/Oracle function - returns first occurrence position
-/// SQLite converts numeric arguments to strings automatically
+///
+/// SQLite compatibility: Automatically coerces numeric types to strings.
 pub(in crate::evaluator::functions) fn instr(
     args: &[vibesql_types::SqlValue],
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
@@ -94,27 +67,15 @@ pub(in crate::evaluator::functions) fn instr(
         )));
     }
 
-    // Handle NULL arguments
-    if matches!(&args[0], vibesql_types::SqlValue::Null)
-        || matches!(&args[1], vibesql_types::SqlValue::Null)
-    {
-        return Ok(vibesql_types::SqlValue::Null);
-    }
-
-    // Convert both arguments to strings (SQLite does this for numbers)
-    let haystack = sql_value_to_string(&args[0]).ok_or_else(|| {
-        ExecutorError::UnsupportedFeature(format!(
-            "INSTR cannot convert first argument to string: {:?}",
-            args[0]
-        ))
-    })?;
-
-    let needle = sql_value_to_string(&args[1]).ok_or_else(|| {
-        ExecutorError::UnsupportedFeature(format!(
-            "INSTR cannot convert second argument to string: {:?}",
-            args[1]
-        ))
-    })?;
+    // Coerce both arguments to strings
+    let haystack = match coerce_to_string(&args[0]) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
+    };
+    let needle = match coerce_to_string(&args[1]) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
+    };
 
     // Find character position (not byte position)
     let position = find_char_position(&haystack, &needle);
@@ -123,6 +84,8 @@ pub(in crate::evaluator::functions) fn instr(
 
 /// LOCATE(substring, string, [start]) - Find position of substring with optional start
 /// Note: Arguments reversed compared to INSTR (needle, haystack vs haystack, needle)
+///
+/// SQLite compatibility: Automatically coerces numeric types to strings.
 pub(in crate::evaluator::functions) fn locate(
     args: &[vibesql_types::SqlValue],
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
@@ -133,48 +96,38 @@ pub(in crate::evaluator::functions) fn locate(
         )));
     }
 
-    match (&args[0], &args[1]) {
-        (vibesql_types::SqlValue::Null, _) | (_, vibesql_types::SqlValue::Null) => {
-            Ok(vibesql_types::SqlValue::Null)
-        }
-        (
-            vibesql_types::SqlValue::Varchar(needle) | vibesql_types::SqlValue::Character(needle),
-            vibesql_types::SqlValue::Varchar(haystack)
-            | vibesql_types::SqlValue::Character(haystack),
-        ) => {
-            // Optional start position (1-indexed, default to 1)
-            let start_pos = if args.len() == 3 {
-                match &args[2] {
-                    vibesql_types::SqlValue::Integer(s) => {
-                        // Convert from 1-indexed to 0-indexed, clamp to 0
-                        ((*s - 1).max(0) as usize).min(haystack.len())
-                    }
-                    vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
-                    val => {
-                        return Err(ExecutorError::UnsupportedFeature(format!(
-                            "LOCATE start position must be integer, got {:?}",
-                            val
-                        )))
-                    }
-                }
-            } else {
-                0
-            };
+    // Coerce first two arguments to strings
+    let needle = match coerce_to_string(&args[0]) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
+    };
+    let haystack = match coerce_to_string(&args[1]) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
+    };
 
-            // Search from start position
-            let position = if start_pos >= haystack.len() {
-                0 // Start beyond string length -> not found
-            } else {
-                haystack[start_pos..].find(&**needle)
-                    .map(|pos| (pos + start_pos + 1) as i64) // Convert to 1-indexed
-                    .unwrap_or(0)
-            };
-
-            Ok(vibesql_types::SqlValue::Integer(position))
+    // Optional start position (1-indexed, default to 1) with coercion
+    let start_pos = if args.len() == 3 {
+        match coerce_to_integer(&args[2]) {
+            Some(s) => {
+                // Convert from 1-indexed to 0-indexed, clamp to 0
+                ((s - 1).max(0) as usize).min(haystack.len())
+            }
+            None => return Ok(vibesql_types::SqlValue::Null),
         }
-        (needle, haystack) => Err(ExecutorError::UnsupportedFeature(format!(
-            "LOCATE requires string arguments, got {:?} and {:?}",
-            needle, haystack
-        ))),
-    }
+    } else {
+        0
+    };
+
+    // Search from start position
+    let position = if start_pos >= haystack.len() {
+        0 // Start beyond string length -> not found
+    } else {
+        haystack[start_pos..]
+            .find(&needle)
+            .map(|pos| (pos + start_pos + 1) as i64) // Convert to 1-indexed
+            .unwrap_or(0)
+    };
+
+    Ok(vibesql_types::SqlValue::Integer(position))
 }

--- a/crates/vibesql-executor/src/evaluator/functions/string/substring.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/string/substring.rs
@@ -2,9 +2,8 @@
 //!
 //! SQL:1999 Section 6.29: String value functions
 
-use std::borrow::Cow;
-
 use crate::errors::ExecutorError;
+use crate::evaluator::functions::coercion::{coerce_to_integer, coerce_to_string};
 
 /// SUBSTRING(string, start [, length]) - Extract substring (SQLite compatible)
 ///
@@ -14,6 +13,9 @@ use crate::errors::ExecutorError;
 /// - Zero start: treated as position before first character
 /// - Negative length: extract leftward from start position
 /// - Zero length: return empty string
+///
+/// SQLite compatibility: Automatically coerces numeric types to strings.
+/// - SUBSTR(12345, 2, 3) returns "234"
 pub(in crate::evaluator::functions) fn substring(
     args: &[vibesql_types::SqlValue],
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
@@ -35,43 +37,21 @@ pub(in crate::evaluator::functions) fn substring(
         return Ok(vibesql_types::SqlValue::Null);
     }
 
-    // Extract string - supports implicit coercion from Date/Timestamp to string
-    // This enables TPC-H Q9 pattern: SUBSTR(o_orderdate, 1, 4) to extract year
-    let s: Cow<str> = match string_val {
-        vibesql_types::SqlValue::Varchar(s) => Cow::Borrowed(&**s),
-        vibesql_types::SqlValue::Character(s) => Cow::Borrowed(&**s),
-        vibesql_types::SqlValue::Date(d) => Cow::Owned(d.to_string()),
-        vibesql_types::SqlValue::Timestamp(ts) => Cow::Owned(ts.to_string()),
-        _ => {
-            return Err(ExecutorError::UnsupportedFeature(format!(
-                "SUBSTRING requires string or date/timestamp argument, got {:?}",
-                string_val
-            )))
-        }
+    // Extract string with coercion (supports numeric types)
+    let s = match coerce_to_string(string_val) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
     };
 
-    // Extract start position (1-based in SQL)
-    let start = match start_val {
-        vibesql_types::SqlValue::Integer(n) => *n,
-        _ => {
-            return Err(ExecutorError::UnsupportedFeature(format!(
-                "SUBSTRING start position must be integer, got {:?}",
-                start_val
-            )))
-        }
+    // Extract start position (1-based in SQL) with coercion
+    let start = match coerce_to_integer(start_val) {
+        Some(n) => n,
+        None => return Ok(vibesql_types::SqlValue::Null),
     };
 
-    // Extract optional length
+    // Extract optional length with coercion
     let length = if let Some(len_val) = length_val {
-        match len_val {
-            vibesql_types::SqlValue::Integer(n) => Some(*n),
-            _ => {
-                return Err(ExecutorError::UnsupportedFeature(format!(
-                    "SUBSTRING length must be integer, got {:?}",
-                    len_val
-                )))
-            }
-        }
+        coerce_to_integer(len_val)
     } else {
         None
     };

--- a/crates/vibesql-executor/src/evaluator/functions/string/transform.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/string/transform.rs
@@ -3,9 +3,12 @@
 //! SQL:1999 Section 6.29: String value functions
 
 use crate::errors::ExecutorError;
+use crate::evaluator::functions::coercion::coerce_to_string;
 
 /// REPLACE(string, from, to) - Replace occurrences
 /// SQL:1999 Section 6.29: String value functions
+///
+/// SQLite compatibility: Automatically coerces numeric types to strings.
 pub(in crate::evaluator::functions) fn replace(
     args: &[vibesql_types::SqlValue],
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
@@ -16,23 +19,28 @@ pub(in crate::evaluator::functions) fn replace(
         )));
     }
 
-    match (&args[0], &args[1], &args[2]) {
-        (vibesql_types::SqlValue::Null, _, _)
-        | (_, vibesql_types::SqlValue::Null, _)
-        | (_, _, vibesql_types::SqlValue::Null) => Ok(vibesql_types::SqlValue::Null),
-        (
-            vibesql_types::SqlValue::Varchar(text) | vibesql_types::SqlValue::Character(text),
-            vibesql_types::SqlValue::Varchar(from) | vibesql_types::SqlValue::Character(from),
-            vibesql_types::SqlValue::Varchar(to) | vibesql_types::SqlValue::Character(to),
-        ) => Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(text.replace(&**from, to)))),
-        (a, b, c) => Err(ExecutorError::UnsupportedFeature(format!(
-            "REPLACE requires string arguments, got {:?}, {:?}, {:?}",
-            a, b, c
-        ))),
-    }
+    // Coerce all arguments to strings
+    let text = match coerce_to_string(&args[0]) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
+    };
+    let from = match coerce_to_string(&args[1]) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
+    };
+    let to = match coerce_to_string(&args[2]) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
+    };
+
+    Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+        text.replace(&from, &to),
+    )))
 }
 
 /// REVERSE(string) - Reverse a string
+///
+/// SQLite compatibility: Automatically coerces numeric types to strings.
 pub(in crate::evaluator::functions) fn reverse(
     args: &[vibesql_types::SqlValue],
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
@@ -43,15 +51,13 @@ pub(in crate::evaluator::functions) fn reverse(
         )));
     }
 
-    match &args[0] {
-        vibesql_types::SqlValue::Null => Ok(vibesql_types::SqlValue::Null),
-        vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
+    match coerce_to_string(&args[0]) {
+        None => Ok(vibesql_types::SqlValue::Null),
+        Some(s) => {
             let reversed: String = s.chars().rev().collect();
-            Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(reversed)))
+            Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+                reversed,
+            )))
         }
-        val => Err(ExecutorError::UnsupportedFeature(format!(
-            "REVERSE requires string argument, got {:?}",
-            val
-        ))),
     }
 }

--- a/crates/vibesql-executor/src/evaluator/functions/string/trim.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/string/trim.rs
@@ -3,9 +3,12 @@
 //! SQL:1999 Section 6.29: String value functions
 
 use crate::errors::ExecutorError;
+use crate::evaluator::functions::coercion::coerce_to_string;
 
 /// TRIM(string) - Remove leading and trailing spaces
 /// SQL:1999 Section 6.29: String value functions
+///
+/// SQLite compatibility: Automatically coerces numeric types to strings.
 #[allow(dead_code)] // Reserved for future use when basic TRIM needs to be exposed
 pub(in crate::evaluator::functions) fn trim(
     args: &[vibesql_types::SqlValue],
@@ -17,17 +20,10 @@ pub(in crate::evaluator::functions) fn trim(
         )));
     }
 
-    match &args[0] {
-        vibesql_types::SqlValue::Null => Ok(vibesql_types::SqlValue::Null),
-        vibesql_types::SqlValue::Varchar(s) => {
-            Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(s.trim().to_string())))
-        }
-        vibesql_types::SqlValue::Character(s) => {
-            Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(s.trim().to_string())))
-        }
-        val => Err(ExecutorError::UnsupportedFeature(format!(
-            "TRIM requires string argument, got {:?}",
-            val
+    match coerce_to_string(&args[0]) {
+        None => Ok(vibesql_types::SqlValue::Null),
+        Some(s) => Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+            s.trim().to_string(),
         ))),
     }
 }
@@ -35,27 +31,18 @@ pub(in crate::evaluator::functions) fn trim(
 /// TRIM with position and custom character support
 /// Supports TRIM(BOTH/LEADING/TRAILING 'x' FROM 'string')
 /// SQL:1999 Section 6.29: String value functions
+///
+/// SQLite compatibility: Automatically coerces numeric types to strings.
 #[allow(dead_code)] // Currently called via eval_trim method, may be used directly in future
 pub(crate) fn trim_advanced(
     string_val: vibesql_types::SqlValue,
     position: Option<vibesql_ast::TrimPosition>,
     removal_char: Option<vibesql_types::SqlValue>,
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
-    // Handle NULL string
-    if matches!(string_val, vibesql_types::SqlValue::Null) {
-        return Ok(vibesql_types::SqlValue::Null);
-    }
-
-    // Extract string
-    let s = match &string_val {
-        vibesql_types::SqlValue::Varchar(s) => &**s,
-        vibesql_types::SqlValue::Character(s) => &**s,
-        _ => {
-            return Err(ExecutorError::UnsupportedFeature(format!(
-                "TRIM requires string argument, got {:?}",
-                string_val
-            )))
-        }
+    // Extract string with coercion
+    let s = match coerce_to_string(&string_val) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
     };
 
     // Determine character to remove (default: space)

--- a/crates/vibesql-executor/tests/string_tests/case_conversion.rs
+++ b/crates/vibesql-executor/tests/string_tests/case_conversion.rs
@@ -100,14 +100,18 @@ fn test_upper_wrong_arg_count() {
 
 #[test]
 fn test_upper_wrong_type() {
+    // SQLite compatibility: numeric types are coerced to strings
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
         name: vibesql_ast::FunctionIdentifier::new("UPPER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123))],
         character_unit: None,
     };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(
+        result,
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("123"))
+    );
 }
 
 #[test]
@@ -171,14 +175,18 @@ fn test_lower_wrong_arg_count() {
 
 #[test]
 fn test_lower_wrong_type() {
+    // SQLite compatibility: numeric types are coerced to strings
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
         name: vibesql_ast::FunctionIdentifier::new("LOWER"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123))],
         character_unit: None,
     };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(
+        result,
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("123"))
+    );
 }
 
 #[test]

--- a/crates/vibesql-executor/tests/string_tests/length_functions.rs
+++ b/crates/vibesql-executor/tests/string_tests/length_functions.rs
@@ -273,14 +273,16 @@ fn test_char_length_wrong_arg_count() {
 
 #[test]
 fn test_char_length_wrong_type() {
+    // SQLite compatibility: numeric types are coerced to strings
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
         name: vibesql_ast::FunctionIdentifier::new("CHAR_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123))],
         character_unit: None,
     };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    let result = evaluator.eval(&expr, &row).unwrap();
+    // "123" has 3 characters
+    assert_eq!(result, vibesql_types::SqlValue::Integer(3));
 }
 
 #[test]
@@ -304,14 +306,16 @@ fn test_octet_length_wrong_arg_count() {
 
 #[test]
 fn test_octet_length_wrong_type() {
+    // SQLite compatibility: numeric types are coerced to strings
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
         name: vibesql_ast::FunctionIdentifier::new("OCTET_LENGTH"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123))],
         character_unit: None,
     };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    let result = evaluator.eval(&expr, &row).unwrap();
+    // "123" has 3 bytes
+    assert_eq!(result, vibesql_types::SqlValue::Integer(3));
 }
 
 #[test]

--- a/crates/vibesql-executor/tests/string_tests/search_functions.rs
+++ b/crates/vibesql-executor/tests/string_tests/search_functions.rs
@@ -126,6 +126,7 @@ fn test_position_wrong_arg_count() {
 
 #[test]
 fn test_position_wrong_type() {
+    // SQLite compatibility: numeric types are coerced to strings
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
         name: vibesql_ast::FunctionIdentifier::new("POSITION"),
@@ -137,8 +138,9 @@ fn test_position_wrong_type() {
         ],
         character_unit: None,
     };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    let result = evaluator.eval(&expr, &row).unwrap();
+    // "123" is not found in "hello", so returns 0
+    assert_eq!(result, vibesql_types::SqlValue::Integer(0));
 }
 
 #[test]
@@ -368,6 +370,7 @@ fn test_locate_wrong_arg_count() {
 
 #[test]
 fn test_locate_wrong_type_needle() {
+    // SQLite compatibility: numeric types are coerced to strings
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
         name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
@@ -379,12 +382,14 @@ fn test_locate_wrong_type_needle() {
         ],
         character_unit: None,
     };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    let result = evaluator.eval(&expr, &row).unwrap();
+    // "123" is not found in "hello", so returns 0
+    assert_eq!(result, vibesql_types::SqlValue::Integer(0));
 }
 
 #[test]
 fn test_locate_wrong_type_start() {
+    // SQLite compatibility: string start position is coerced to integer (becomes 0)
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
         name: vibesql_ast::FunctionIdentifier::new("LOCATE"),
@@ -401,8 +406,9 @@ fn test_locate_wrong_type_start() {
         ],
         character_unit: None,
     };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    let result = evaluator.eval(&expr, &row).unwrap();
+    // "one" coerces to 0, so search starts at beginning, finds "l" at position 3
+    assert_eq!(result, vibesql_types::SqlValue::Integer(3));
 }
 
 #[test]

--- a/crates/vibesql-executor/tests/string_tests/substring_operations.rs
+++ b/crates/vibesql-executor/tests/string_tests/substring_operations.rs
@@ -228,6 +228,7 @@ fn test_substring_wrong_arg_count_too_many() {
 
 #[test]
 fn test_substring_wrong_type_string() {
+    // SQLite compatibility: numeric types are coerced to strings
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
         name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
@@ -237,12 +238,17 @@ fn test_substring_wrong_type_string() {
         ],
         character_unit: None,
     };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    let result = evaluator.eval(&expr, &row).unwrap();
+    // SUBSTR(123, 1) = SUBSTR("123", 1) = "123"
+    assert_eq!(
+        result,
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("123"))
+    );
 }
 
 #[test]
 fn test_substring_wrong_type_start() {
+    // SQLite compatibility: string start position is coerced to integer
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
         name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
@@ -256,12 +262,17 @@ fn test_substring_wrong_type_start() {
         ],
         character_unit: None,
     };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    let result = evaluator.eval(&expr, &row).unwrap();
+    // "one" coerces to 0, start=0 returns whole string
+    assert_eq!(
+        result,
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("hello"))
+    );
 }
 
 #[test]
 fn test_substring_wrong_type_length() {
+    // SQLite compatibility: string length is coerced to integer
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
         name: vibesql_ast::FunctionIdentifier::new("SUBSTRING"),
@@ -276,8 +287,12 @@ fn test_substring_wrong_type_length() {
         ],
         character_unit: None,
     };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    let result = evaluator.eval(&expr, &row).unwrap();
+    // "two" coerces to 0, length=0 returns empty string
+    assert_eq!(
+        result,
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(""))
+    );
 }
 
 // ============================================================================

--- a/crates/vibesql-executor/tests/string_tests/transformations.rs
+++ b/crates/vibesql-executor/tests/string_tests/transformations.rs
@@ -285,6 +285,7 @@ fn test_replace_wrong_arg_count() {
 
 #[test]
 fn test_replace_wrong_type() {
+    // SQLite compatibility: numeric types are coerced to strings
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
         name: vibesql_ast::FunctionIdentifier::new("REPLACE"),
@@ -299,8 +300,12 @@ fn test_replace_wrong_type() {
         ],
         character_unit: None,
     };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    let result = evaluator.eval(&expr, &row).unwrap();
+    // "123" not found in "hello", so returns "hello" unchanged
+    assert_eq!(
+        result,
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("hello"))
+    );
 }
 
 #[test]
@@ -418,14 +423,19 @@ fn test_reverse_wrong_arg_count() {
 
 #[test]
 fn test_reverse_wrong_type() {
+    // SQLite compatibility: numeric types are coerced to strings
     let (evaluator, row) = create_test_evaluator();
     let expr = vibesql_ast::Expression::Function {
         name: vibesql_ast::FunctionIdentifier::new("REVERSE"),
         args: vec![vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(123))],
         character_unit: None,
     };
-    let result = evaluator.eval(&expr, &row);
-    assert!(result.is_err());
+    let result = evaluator.eval(&expr, &row).unwrap();
+    // REVERSE(123) = REVERSE("123") = "321"
+    assert_eq!(
+        result,
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("321"))
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add automatic type coercion for string and numeric functions to match SQLite behavior
- String functions (UPPER, LOWER, SUBSTR, etc.) now accept numeric types by converting them to strings
- Numeric functions (ABS, ROUND, etc.) now accept string types by parsing them as numbers

## Changes

- **New**: `coercion.rs` module with `coerce_to_string`, `coerce_to_number`, and `coerce_to_integer` helpers
- **Updated string functions**: UPPER, LOWER, CHAR_LENGTH, OCTET_LENGTH, SUBSTRING, REPLACE, REVERSE, TRIM, POSITION, LOCATE, INSTR
- **Updated numeric functions**: ABS, SIGN, MOD, ROUND, FLOOR, CEIL, TRUNCATE
- **Updated tests**: Changed "wrong type" tests to expect coercion instead of errors

## Examples

| Query | Result |
|-------|--------|
| `SELECT UPPER(123)` | `"123"` |
| `SELECT SUBSTR(12345, 2, 3)` | `"234"` |
| `SELECT LENGTH(123.45)` | `6` |
| `SELECT ABS('-5')` | `5.0` |
| `SELECT ROUND('3.14159', 2)` | `3.14` |
| `SELECT ABS('free')` | `0.0` |

## Test plan

- [x] All acceptance criteria from issue pass
- [x] All 124 string edge case tests pass
- [x] NULL propagation works correctly
- [x] Build completes successfully

Closes #4544

🤖 Generated with [Claude Code](https://claude.com/claude-code)