### PR TITLE
fix(parser): Reject DISTINCT aggregates with multiple arguments

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -939,6 +939,12 @@ impl<'arena> ArenaParser<'arena> {
             };
 
             if is_aggregate {
+                // DISTINCT aggregates must have exactly one argument (SQLite compatibility)
+                if distinct && args.len() != 1 {
+                    return Err(ParseError {
+                        message: "DISTINCT aggregates must have exactly one argument".to_string(),
+                    });
+                }
                 return Ok(Expression::Extended(
                     self.arena.alloc(ExtendedExpr::AggregateFunction {
                         name: name_sym,

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -244,6 +244,12 @@ impl Parser {
         // (canonical lowercase for comparison, display preserves original case)
         let func_id = vibesql_ast::FunctionIdentifier::new(&first);
         if is_aggregate {
+            // DISTINCT aggregates must have exactly one argument (SQLite compatibility)
+            if distinct && args.len() != 1 {
+                return Err(ParseError {
+                    message: "DISTINCT aggregates must have exactly one argument".to_string(),
+                });
+            }
             Ok(Some(vibesql_ast::Expression::AggregateFunction {
                 name: func_id,
                 distinct,

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -334,6 +334,9 @@ proc translate_error_to_sqlite {vibesql_error} {
     if {[regexp -nocase {^Parse error: (unknown join type: .+)$} $error_msg -> parse_msg]} {
         return $parse_msg
     }
+    if {[regexp -nocase {^Parse error: (DISTINCT aggregates must have exactly one argument)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
     # Fallback for other parse errors (e.g., descriptive messages like "Expected identifier")
     if {[regexp -nocase {^Parse error: (.+)$} $error_msg -> parse_msg]} {
         return "near \"$parse_msg\": syntax error"


### PR DESCRIPTION
## Summary
- Add validation to reject DISTINCT aggregate functions with anything other than exactly one argument
- Matches SQLite's behavior: `COUNT(DISTINCT a, b)` and `COUNT(DISTINCT)` now error
- Updated both main parser and arena parser for consistency
- Added TCL shim translation for error message compatibility

## Test plan
- [x] Verified `COUNT(DISTINCT a, b)` produces error "DISTINCT aggregates must have exactly one argument"
- [x] Verified `COUNT(DISTINCT)` (no args) produces the same error
- [x] Verified `SUM(DISTINCT a, b)` and `AVG(DISTINCT)` error correctly
- [x] Verified valid `COUNT(DISTINCT a)` still works correctly
- [x] Parser test suite passes (1134 tests)
- [x] TCL distinctagg tests for error validation (2.1 and 2.2) now pass

Closes #4542

🤖 Generated with [Claude Code](https://claude.com/claude-code)