### PR TITLE
feat(executor): Implement INTEGER PRIMARY KEY NULL auto-generation

### DIFF
--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -321,6 +321,37 @@ impl TableSchema {
         self.primary_key.as_ref().is_some_and(|pk| pk.contains(&column_name.to_string()))
     }
 
+    /// Get the column index of the INTEGER PRIMARY KEY column (SQLite semantics)
+    ///
+    /// In SQLite, when a column is declared as `INTEGER PRIMARY KEY`:
+    /// 1. It becomes an alias for the internal `rowid`
+    /// 2. Inserting NULL auto-generates the next rowid value
+    /// 3. The auto-generated value is `max(rowid) + 1` (or 1 if table is empty)
+    ///
+    /// This method returns the column index if:
+    /// - There is exactly one primary key column
+    /// - That column's type is exactly `DataType::Integer` (not INT, not BIGINT)
+    ///
+    /// Returns `None` if the table doesn't have an INTEGER PRIMARY KEY.
+    pub fn get_integer_primary_key_index(&self) -> Option<usize> {
+        // Must have a single-column primary key
+        let pk_cols = self.primary_key.as_ref()?;
+        if pk_cols.len() != 1 {
+            return None;
+        }
+
+        // Get the column index
+        let col_idx = self.get_column_index(&pk_cols[0])?;
+        let col = &self.columns[col_idx];
+
+        // Must be exactly INTEGER type (not Bigint, not Smallint)
+        if matches!(col.data_type, vibesql_types::DataType::Integer) {
+            Some(col_idx)
+        } else {
+            None
+        }
+    }
+
     /// Set nullable property for a column by index
     pub fn set_column_nullable(
         &mut self,

--- a/crates/vibesql-executor/src/insert/defaults.rs
+++ b/crates/vibesql-executor/src/insert/defaults.rs
@@ -186,12 +186,67 @@ pub fn evaluate_default_expression(
 ///
 /// Returns the first auto-generated sequence value (for LAST_INSERT_ROWID support),
 /// or None if no sequence values were generated.
+#[allow(dead_code)]
 pub fn apply_default_values(
     schema: &vibesql_catalog::TableSchema,
     row_values: &mut [vibesql_types::SqlValue],
     database: &mut vibesql_storage::Database,
 ) -> Result<Option<i64>, ExecutorError> {
+    apply_default_values_with_table_name(schema, row_values, database, &schema.name)
+}
+
+/// Apply DEFAULT values for unspecified columns, with explicit table name for storage lookup
+///
+/// This variant is used when the storage table name differs from the schema name
+/// (e.g., for schema-qualified tables).
+///
+/// Returns the first auto-generated sequence value (for LAST_INSERT_ROWID support),
+/// or None if no sequence values were generated.
+pub fn apply_default_values_with_table_name(
+    schema: &vibesql_catalog::TableSchema,
+    row_values: &mut [vibesql_types::SqlValue],
+    database: &mut vibesql_storage::Database,
+    storage_table_name: &str,
+) -> Result<Option<i64>, ExecutorError> {
+    apply_default_values_with_batch_context(schema, row_values, database, storage_table_name, None)
+}
+
+/// Apply DEFAULT values for unspecified columns, with batch context for multi-row inserts
+///
+/// The `batch_max_ipk` parameter is used to track the maximum INTEGER PRIMARY KEY value
+/// already assigned within the current batch of inserts. This prevents duplicate values
+/// when multiple rows in the same INSERT have NULL for the INTEGER PRIMARY KEY column.
+///
+/// Returns the first auto-generated sequence value (for LAST_INSERT_ROWID support),
+/// or None if no sequence values were generated.
+pub fn apply_default_values_with_batch_context(
+    schema: &vibesql_catalog::TableSchema,
+    row_values: &mut [vibesql_types::SqlValue],
+    database: &mut vibesql_storage::Database,
+    storage_table_name: &str,
+    batch_max_ipk: Option<i64>,
+) -> Result<Option<i64>, ExecutorError> {
     let mut first_generated_id: Option<i64> = None;
+
+    // Handle INTEGER PRIMARY KEY NULL auto-generation (SQLite semantics)
+    // This must happen before regular default value processing
+    if let Some(ipk_idx) = schema.get_integer_primary_key_index() {
+        if row_values[ipk_idx] == vibesql_types::SqlValue::Null {
+            // Auto-generate: max(existing_pk, batch_max) + 1, or 1 if table is empty
+            let table_max = compute_next_integer_pk_value(database, storage_table_name, ipk_idx)?;
+            // The next value should be max of (table_max, batch_max_ipk + 1)
+            let next_val = match batch_max_ipk {
+                Some(batch_max) => table_max.max(batch_max + 1),
+                None => table_max,
+            };
+            row_values[ipk_idx] = vibesql_types::SqlValue::Integer(next_val);
+
+            // Track for LAST_INSERT_ROWID
+            if first_generated_id.is_none() {
+                first_generated_id = Some(next_val);
+            }
+        }
+    }
 
     for (col_idx, col) in schema.columns.iter().enumerate() {
         // If column is NULL and has a default value, apply it
@@ -227,6 +282,45 @@ pub fn apply_default_values(
         }
     }
     Ok(first_generated_id)
+}
+
+/// Compute the next INTEGER PRIMARY KEY value for auto-generation
+///
+/// Returns max(existing_pk_values) + 1, or 1 if the table is empty.
+/// This implements SQLite's behavior where inserting NULL into an INTEGER PRIMARY KEY
+/// column auto-generates the next available value.
+fn compute_next_integer_pk_value(
+    database: &vibesql_storage::Database,
+    table_name: &str,
+    pk_col_idx: usize,
+) -> Result<i64, ExecutorError> {
+    let table = match database.get_table(table_name) {
+        Some(t) => t,
+        None => {
+            // Table doesn't exist in storage yet, start at 1
+            return Ok(1);
+        }
+    };
+
+    // Find the maximum value in the PRIMARY KEY column
+    let mut max_val: i64 = 0;
+
+    for row in table.scan() {
+        if let Some(value) = row.get(pk_col_idx) {
+            let int_val = match value {
+                vibesql_types::SqlValue::Integer(i) => *i,
+                vibesql_types::SqlValue::Bigint(i) => *i,
+                vibesql_types::SqlValue::Null => continue, // Skip NULL values
+                _ => continue, // Skip non-integer values (shouldn't happen)
+            };
+            if int_val > max_val {
+                max_val = int_val;
+            }
+        }
+    }
+
+    // Return max + 1 (or 1 if table was empty, since max_val starts at 0)
+    Ok(max_val + 1)
 }
 
 /// Apply generated/computed column values

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -181,6 +181,13 @@ fn execute_insert_internal(
     // the first auto-generated value, not the last
     let mut first_generated_id: Option<i64> = None;
 
+    // Track the maximum INTEGER PRIMARY KEY value assigned within this batch
+    // to handle multi-row INSERTs with NULL values correctly (SQLite semantics)
+    let mut batch_max_ipk: Option<i64> = None;
+
+    // Get INTEGER PRIMARY KEY column index if present
+    let ipk_col_idx = schema.get_integer_primary_key_index();
+
     for value_exprs in &rows_to_insert {
         // Build a complete row with values for all columns
         // Start with NULL for all columns, then fill in provided values
@@ -247,8 +254,15 @@ fn execute_insert_internal(
 
         // Apply DEFAULT values for unspecified columns
         // This returns the first generated sequence value (if any)
-        let generated_id =
-            super::defaults::apply_default_values(&schema, &mut full_row_values, db)?;
+        // Use storage_table_name for correct table lookup (handles schema-qualified tables)
+        // Pass batch_max_ipk to handle multi-row INSERTs with NULL INTEGER PRIMARY KEY
+        let generated_id = super::defaults::apply_default_values_with_batch_context(
+            &schema,
+            &mut full_row_values,
+            db,
+            &storage_table_name,
+            batch_max_ipk,
+        )?;
 
         // Apply generated/computed column values (AS(expression) syntax)
         super::defaults::apply_generated_columns(&schema, &mut full_row_values, db)?;
@@ -256,6 +270,13 @@ fn execute_insert_internal(
         // Track the first generated ID across all rows
         if first_generated_id.is_none() {
             first_generated_id = generated_id;
+        }
+
+        // Update batch_max_ipk if this row has an INTEGER PRIMARY KEY value
+        if let Some(idx) = ipk_col_idx {
+            if let Some(vibesql_types::SqlValue::Integer(val)) = full_row_values.get(idx) {
+                batch_max_ipk = Some(batch_max_ipk.map_or(*val, |prev| prev.max(*val)));
+            }
         }
 
         // Validate all constraints in a single pass and extract index keys

--- a/crates/vibesql-executor/tests/insert_default_tests.rs
+++ b/crates/vibesql-executor/tests/insert_default_tests.rs
@@ -185,3 +185,371 @@ fn test_insert_default_no_default_value_defined() {
     assert_eq!(row.get(0), Some(&vibesql_types::SqlValue::Null));
     assert_eq!(row.get(1), Some(&vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Alice"))));
 }
+
+// ============================================================================
+// INTEGER PRIMARY KEY NULL Auto-Generation Tests (SQLite Semantics)
+// ============================================================================
+
+/// Test that inserting NULL into an INTEGER PRIMARY KEY column auto-generates
+/// the next value (max + 1, or 1 if table is empty).
+#[test]
+fn test_integer_primary_key_null_autogen_empty_table() {
+    let mut db = vibesql_storage::Database::new();
+
+    // CREATE TABLE track (tid INTEGER PRIMARY KEY, name TEXT)
+    let schema = vibesql_catalog::TableSchema::with_primary_key(
+        "track".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "tid".to_string(),
+                vibesql_types::DataType::Integer,
+                false, // NOT NULL (implicit for INTEGER PRIMARY KEY)
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "name".to_string(),
+                vibesql_types::DataType::Varchar { max_length: None },
+                true,
+            ),
+        ],
+        vec!["tid".to_string()],
+    );
+    db.create_table(schema).unwrap();
+
+    // INSERT INTO track VALUES (NULL, 'song1')
+    let stmt = vibesql_ast::InsertStmt {
+        schema_name: None,
+        schema_quoted: false,
+        table_quoted: false,
+        table_name: "track".to_string(),
+        columns: vec![],
+        source: vibesql_ast::InsertSource::Values(vec![vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("song1"),
+            )),
+        ]]),
+        conflict_clause: None,
+        on_duplicate_key_update: None,
+    };
+
+    let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
+    assert_eq!(rows, 1);
+
+    // Verify auto-generated value is 1 (first row in empty table)
+    let table = db.get_table("track").unwrap();
+    let row = &table.scan()[0];
+    assert_eq!(row.get(0), Some(&vibesql_types::SqlValue::Integer(1)));
+    assert_eq!(row.get(1), Some(&vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("song1"))));
+}
+
+/// Test sequential auto-generation when inserting multiple NULLs
+#[test]
+fn test_integer_primary_key_null_autogen_sequential() {
+    let mut db = vibesql_storage::Database::new();
+
+    // CREATE TABLE items (id INTEGER PRIMARY KEY, val TEXT)
+    let schema = vibesql_catalog::TableSchema::with_primary_key(
+        "items".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "id".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "val".to_string(),
+                vibesql_types::DataType::Varchar { max_length: None },
+                true,
+            ),
+        ],
+        vec!["id".to_string()],
+    );
+    db.create_table(schema).unwrap();
+
+    // INSERT first row with NULL → should get id=1
+    let stmt1 = vibesql_ast::InsertStmt {
+        schema_name: None,
+        schema_quoted: false,
+        table_quoted: false,
+        table_name: "items".to_string(),
+        columns: vec![],
+        source: vibesql_ast::InsertSource::Values(vec![vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("a"),
+            )),
+        ]]),
+        conflict_clause: None,
+        on_duplicate_key_update: None,
+    };
+    InsertExecutor::execute(&mut db, &stmt1).unwrap();
+
+    // INSERT second row with NULL → should get id=2
+    let stmt2 = vibesql_ast::InsertStmt {
+        schema_name: None,
+        schema_quoted: false,
+        table_quoted: false,
+        table_name: "items".to_string(),
+        columns: vec![],
+        source: vibesql_ast::InsertSource::Values(vec![vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("b"),
+            )),
+        ]]),
+        conflict_clause: None,
+        on_duplicate_key_update: None,
+    };
+    InsertExecutor::execute(&mut db, &stmt2).unwrap();
+
+    // Verify sequential ids
+    let table = db.get_table("items").unwrap();
+    assert_eq!(table.row_count(), 2);
+    assert_eq!(table.scan()[0].get(0), Some(&vibesql_types::SqlValue::Integer(1)));
+    assert_eq!(table.scan()[1].get(0), Some(&vibesql_types::SqlValue::Integer(2)));
+}
+
+/// Test that explicit values still work, and next NULL uses max + 1
+#[test]
+fn test_integer_primary_key_null_autogen_after_explicit() {
+    let mut db = vibesql_storage::Database::new();
+
+    // CREATE TABLE t (id INTEGER PRIMARY KEY, data TEXT)
+    let schema = vibesql_catalog::TableSchema::with_primary_key(
+        "t".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "id".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "data".to_string(),
+                vibesql_types::DataType::Varchar { max_length: None },
+                true,
+            ),
+        ],
+        vec!["id".to_string()],
+    );
+    db.create_table(schema).unwrap();
+
+    // INSERT explicit value 100
+    let stmt1 = vibesql_ast::InsertStmt {
+        schema_name: None,
+        schema_quoted: false,
+        table_quoted: false,
+        table_name: "t".to_string(),
+        columns: vec![],
+        source: vibesql_ast::InsertSource::Values(vec![vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(100)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("explicit"),
+            )),
+        ]]),
+        conflict_clause: None,
+        on_duplicate_key_update: None,
+    };
+    InsertExecutor::execute(&mut db, &stmt1).unwrap();
+
+    // INSERT NULL → should get id=101 (max + 1)
+    let stmt2 = vibesql_ast::InsertStmt {
+        schema_name: None,
+        schema_quoted: false,
+        table_quoted: false,
+        table_name: "t".to_string(),
+        columns: vec![],
+        source: vibesql_ast::InsertSource::Values(vec![vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("auto"),
+            )),
+        ]]),
+        conflict_clause: None,
+        on_duplicate_key_update: None,
+    };
+    InsertExecutor::execute(&mut db, &stmt2).unwrap();
+
+    // Verify ids
+    let table = db.get_table("t").unwrap();
+    assert_eq!(table.row_count(), 2);
+
+    // Find the auto-generated row
+    let auto_row = table.scan().iter().find(|r| {
+        r.get(1) == Some(&vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("auto")))
+    });
+    assert!(auto_row.is_some());
+    assert_eq!(auto_row.unwrap().get(0), Some(&vibesql_types::SqlValue::Integer(101)));
+}
+
+/// Test that BIGINT PRIMARY KEY does NOT auto-generate (only INTEGER does)
+#[test]
+fn test_bigint_primary_key_no_autogen() {
+    let mut db = vibesql_storage::Database::new();
+
+    // CREATE TABLE t (id BIGINT PRIMARY KEY, data TEXT)
+    let schema = vibesql_catalog::TableSchema::with_primary_key(
+        "bigint_pk".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "id".to_string(),
+                vibesql_types::DataType::Bigint, // NOT Integer!
+                true, // Must be nullable since we're inserting NULL
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "data".to_string(),
+                vibesql_types::DataType::Varchar { max_length: None },
+                true,
+            ),
+        ],
+        vec!["id".to_string()],
+    );
+    db.create_table(schema).unwrap();
+
+    // INSERT NULL should stay as NULL (no auto-generation for BIGINT)
+    let stmt = vibesql_ast::InsertStmt {
+        schema_name: None,
+        schema_quoted: false,
+        table_quoted: false,
+        table_name: "bigint_pk".to_string(),
+        columns: vec![],
+        source: vibesql_ast::InsertSource::Values(vec![vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("test"),
+            )),
+        ]]),
+        conflict_clause: None,
+        on_duplicate_key_update: None,
+    };
+    InsertExecutor::execute(&mut db, &stmt).unwrap();
+
+    // Verify NULL is preserved
+    let table = db.get_table("bigint_pk").unwrap();
+    assert_eq!(table.scan()[0].get(0), Some(&vibesql_types::SqlValue::Null));
+}
+
+/// Test multi-row INSERT with all NULLs in INTEGER PRIMARY KEY
+#[test]
+fn test_integer_primary_key_null_autogen_multirow() {
+    let mut db = vibesql_storage::Database::new();
+
+    // CREATE TABLE track (tid INTEGER PRIMARY KEY, name TEXT)
+    let schema = vibesql_catalog::TableSchema::with_primary_key(
+        "track".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "tid".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "name".to_string(),
+                vibesql_types::DataType::Varchar { max_length: None },
+                true,
+            ),
+        ],
+        vec!["tid".to_string()],
+    );
+    db.create_table(schema).unwrap();
+
+    // Multi-row INSERT with all NULLs (like SQLite's orderby1.test)
+    // INSERT INTO track VALUES (NULL, 'one'), (NULL, 'two'), (NULL, 'three');
+    let stmt = vibesql_ast::InsertStmt {
+        schema_name: None,
+        schema_quoted: false,
+        table_quoted: false,
+        table_name: "track".to_string(),
+        columns: vec![],
+        source: vibesql_ast::InsertSource::Values(vec![
+            vec![
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                    arcstr::ArcStr::from("one"),
+                )),
+            ],
+            vec![
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                    arcstr::ArcStr::from("two"),
+                )),
+            ],
+            vec![
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                    arcstr::ArcStr::from("three"),
+                )),
+            ],
+        ]),
+        conflict_clause: None,
+        on_duplicate_key_update: None,
+    };
+
+    let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
+    assert_eq!(rows, 3);
+
+    // Verify all three rows have unique auto-generated ids
+    let table = db.get_table("track").unwrap();
+    assert_eq!(table.row_count(), 3);
+
+    let ids: Vec<i64> = table
+        .scan()
+        .iter()
+        .filter_map(|r| {
+            if let Some(vibesql_types::SqlValue::Integer(id)) = r.get(0) {
+                Some(*id)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // All ids should be unique
+    let mut sorted_ids = ids.clone();
+    sorted_ids.sort();
+    assert_eq!(sorted_ids, vec![1, 2, 3], "Expected sequential ids 1, 2, 3");
+}
+
+/// Test composite primary key does NOT auto-generate
+#[test]
+fn test_composite_primary_key_no_autogen() {
+    let mut db = vibesql_storage::Database::new();
+
+    // CREATE TABLE t (a INTEGER, b INTEGER, PRIMARY KEY(a, b))
+    let schema = vibesql_catalog::TableSchema::with_primary_key(
+        "composite_pk".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "a".to_string(),
+                vibesql_types::DataType::Integer,
+                true, // Must be nullable
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "b".to_string(),
+                vibesql_types::DataType::Integer,
+                true,
+            ),
+        ],
+        vec!["a".to_string(), "b".to_string()], // Composite PK
+    );
+    db.create_table(schema).unwrap();
+
+    // INSERT NULL should stay as NULL (no auto-generation for composite PK)
+    let stmt = vibesql_ast::InsertStmt {
+        schema_name: None,
+        schema_quoted: false,
+        table_quoted: false,
+        table_name: "composite_pk".to_string(),
+        columns: vec![],
+        source: vibesql_ast::InsertSource::Values(vec![vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+        ]]),
+        conflict_clause: None,
+        on_duplicate_key_update: None,
+    };
+    InsertExecutor::execute(&mut db, &stmt).unwrap();
+
+    // Verify NULL is preserved
+    let table = db.get_table("composite_pk").unwrap();
+    assert_eq!(table.scan()[0].get(0), Some(&vibesql_types::SqlValue::Null));
+}


### PR DESCRIPTION
## Summary

- Implements SQLite's behavior where inserting NULL into an INTEGER PRIMARY KEY column auto-generates the next available value (`max(existing) + 1`, or 1 if empty)
- Adds `get_integer_primary_key_index()` to TableSchema for detecting single-column INTEGER PRIMARY KEY
- Adds batch context tracking to prevent duplicate values in multi-row INSERTs
- Improves orderby1.test pass rate from 39.1% to 54.7% (10 additional tests pass)

## Test plan

- [x] New unit tests for INTEGER PRIMARY KEY NULL auto-generation
- [x] Tests for sequential auto-generation, explicit values, multi-row inserts
- [x] Negative tests for BIGINT PRIMARY KEY and composite PRIMARY KEY (no auto-gen)
- [x] TCL test orderby1.test passes test 1.0 and related data tests

Closes #4548

🤖 Generated with [Claude Code](https://claude.com/claude-code)