### PR TITLE
feat(executor): Implement SQLite type affinity rules for comparisons

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -1,9 +1,120 @@
 //! Main evaluation entry point for combined expressions
 
+use vibesql_types::{SqlValue, TypeAffinity};
+
 use super::super::core::{CombinedExpressionEvaluator, ExpressionEvaluator};
 use crate::{errors::ExecutorError, select::WindowFunctionKey};
 
 impl CombinedExpressionEvaluator<'_> {
+    /// Get the SQLite type affinity of an expression if it's a column reference.
+    ///
+    /// Returns Some(affinity) if the expression is a column reference and we can
+    /// determine its declared type from the schema. Returns None for literals,
+    /// function calls, and other non-column expressions.
+    fn get_expression_affinity(&self, expr: &vibesql_ast::Expression) -> Option<TypeAffinity> {
+        match expr {
+            vibesql_ast::Expression::ColumnRef(col_id) => {
+                let table = col_id.table_canonical();
+                let column = col_id.column_canonical();
+
+                // Look up the column in the combined schema to get its declared type
+                for (_table_id, (_start_idx, table_schema)) in &self.schema.table_schemas {
+                    // If table qualifier is specified, check if this is the right table
+                    if let Some(t) = table {
+                        let table_name_lower = table_schema.name.to_lowercase();
+                        if t.to_lowercase() != table_name_lower {
+                            continue;
+                        }
+                    }
+
+                    // Look up the column in this table
+                    if let Some(col_offset) = table_schema.get_column_index(column) {
+                        let col_schema = &table_schema.columns[col_offset];
+                        return Some(col_schema.data_type.sqlite_affinity());
+                    }
+                }
+
+                // Column not found - treat as NONE affinity
+                Some(TypeAffinity::None)
+            }
+            // For COLLATE expressions, get affinity of the inner expression
+            vibesql_ast::Expression::Collate { expr, .. } => self.get_expression_affinity(expr),
+            // Literals, functions, and other expressions don't have column affinity
+            _ => None,
+        }
+    }
+
+    /// Check if an expression is a numeric literal (INTEGER or REAL).
+    fn is_numeric_literal(&self, expr: &vibesql_ast::Expression) -> bool {
+        match expr {
+            vibesql_ast::Expression::Literal(val) => {
+                matches!(
+                    val,
+                    SqlValue::Integer(_)
+                        | SqlValue::Smallint(_)
+                        | SqlValue::Bigint(_)
+                        | SqlValue::Unsigned(_)
+                        | SqlValue::Float(_)
+                        | SqlValue::Real(_)
+                        | SqlValue::Double(_)
+                        | SqlValue::Numeric(_)
+                )
+            }
+            _ => false,
+        }
+    }
+
+    /// Apply SQLite affinity rules for comparisons.
+    ///
+    /// When comparing a TEXT-affinity column to an INTEGER literal, SQLite:
+    /// 1. Converts the INTEGER to TEXT
+    /// 2. Performs string comparison
+    pub(super) fn apply_affinity_for_comparison(
+        &self,
+        left_expr: &vibesql_ast::Expression,
+        left_val: SqlValue,
+        right_expr: &vibesql_ast::Expression,
+        right_val: SqlValue,
+    ) -> (SqlValue, SqlValue) {
+        let left_affinity = self.get_expression_affinity(left_expr);
+        let right_affinity = self.get_expression_affinity(right_expr);
+
+        // Case 1: Left is TEXT column, right is numeric literal
+        if left_affinity == Some(TypeAffinity::Text) && self.is_numeric_literal(right_expr) {
+            let right_as_text = match &right_val {
+                SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Bigint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Unsigned(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Float(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Real(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Double(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Numeric(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                _ => right_val,
+            };
+            return (left_val, right_as_text);
+        }
+
+        // Case 2: Right is TEXT column, left is numeric literal
+        if right_affinity == Some(TypeAffinity::Text) && self.is_numeric_literal(left_expr) {
+            let left_as_text = match &left_val {
+                SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Bigint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Unsigned(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Float(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Real(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Double(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Numeric(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                _ => left_val,
+            };
+            return (left_as_text, right_val);
+        }
+
+        // No affinity conversion needed
+        (left_val, right_val)
+    }
+
     /// Evaluate an expression in the context of a combined row
     /// This is the main entry point for expression evaluation
     pub(crate) fn eval(
@@ -293,8 +404,28 @@ impl CombinedExpressionEvaluator<'_> {
                     }
                     // For all other operators, evaluate both sides as before
                     _ => {
+                        // Check if this is a comparison operator
+                        let is_comparison = matches!(
+                            op,
+                            vibesql_ast::BinaryOperator::Equal
+                                | vibesql_ast::BinaryOperator::NotEqual
+                                | vibesql_ast::BinaryOperator::LessThan
+                                | vibesql_ast::BinaryOperator::LessThanOrEqual
+                                | vibesql_ast::BinaryOperator::GreaterThan
+                                | vibesql_ast::BinaryOperator::GreaterThanOrEqual
+                        );
+
                         let left_val = self.eval(left, row)?;
                         let right_val = self.eval(right, row)?;
+
+                        // Apply SQLite type affinity rules for comparisons
+                        // TEXT column vs INTEGER literal → convert INTEGER to TEXT, string compare
+                        let (left_val, right_val) = if is_comparison {
+                            self.apply_affinity_for_comparison(left, left_val, right, right_val)
+                        } else {
+                            (left_val, right_val)
+                        };
+
                         let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
                         ExpressionEvaluator::eval_binary_op_static(
                             &left_val, op, &right_val, sql_mode,

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -58,7 +58,7 @@ impl CombinedExpressionEvaluator<'_> {
             }
         };
 
-        let (expr_val, mut low_val, mut high_val) = if let Some(ref collation_name) = collation {
+        let (expr_val, low_val, high_val) = if let Some(ref collation_name) = collation {
             (
                 transform_for_collation(expr_val, collation_name),
                 transform_for_collation(low_val, collation_name),
@@ -67,6 +67,11 @@ impl CombinedExpressionEvaluator<'_> {
         } else {
             (expr_val, low_val, high_val)
         };
+
+        // Apply SQLite type affinity rules for BETWEEN comparisons
+        // TEXT column vs INTEGER literal → convert INTEGER to TEXT, string compare
+        let (expr_val, mut low_val) = self.apply_affinity_for_comparison(expr, expr_val, low, low_val);
+        let (expr_val, mut high_val) = self.apply_affinity_for_comparison(expr, expr_val, high, high_val);
 
         // Check if bounds are reversed (low > high)
         let gt_result = ExpressionEvaluator::eval_binary_op_static(

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -1,11 +1,119 @@
 //! Main evaluation entry point and basic expression types
 
-use vibesql_types::SqlValue;
+use vibesql_types::{SqlValue, TypeAffinity};
 
 use super::super::core::ExpressionEvaluator;
 use crate::errors::ExecutorError;
 
 impl ExpressionEvaluator<'_> {
+    /// Get the SQLite type affinity of an expression if it's a column reference.
+    ///
+    /// Returns Some(affinity) if the expression is a column reference and we can
+    /// determine its declared type from the schema. Returns None for literals,
+    /// function calls, and other non-column expressions.
+    ///
+    /// This is used to implement SQLite's type affinity rules for comparisons:
+    /// - TEXT column vs INTEGER literal → convert INTEGER to TEXT, string compare
+    /// - Bare column (NONE affinity) vs INTEGER → type ordering (TEXT > INTEGER)
+    pub(super) fn get_expression_affinity(&self, expr: &vibesql_ast::Expression) -> Option<TypeAffinity> {
+        match expr {
+            vibesql_ast::Expression::ColumnRef(col_id) => {
+                // Look up the column in the schema to get its declared type
+                let column_name = col_id.column_canonical();
+                if let Some(col_idx) = self.schema.get_column_index(column_name) {
+                    let col_schema = &self.schema.columns[col_idx];
+                    Some(col_schema.data_type.sqlite_affinity())
+                } else {
+                    // Column not found in schema - treat as NONE affinity
+                    Some(TypeAffinity::None)
+                }
+            }
+            // For COLLATE expressions, get affinity of the inner expression
+            vibesql_ast::Expression::Collate { expr, .. } => self.get_expression_affinity(expr),
+            // Literals, functions, and other expressions don't have column affinity
+            _ => None,
+        }
+    }
+
+    /// Check if an expression is a numeric literal (INTEGER or REAL).
+    pub(super) fn is_numeric_literal(&self, expr: &vibesql_ast::Expression) -> bool {
+        match expr {
+            vibesql_ast::Expression::Literal(val) => {
+                matches!(
+                    val,
+                    SqlValue::Integer(_)
+                        | SqlValue::Smallint(_)
+                        | SqlValue::Bigint(_)
+                        | SqlValue::Unsigned(_)
+                        | SqlValue::Float(_)
+                        | SqlValue::Real(_)
+                        | SqlValue::Double(_)
+                        | SqlValue::Numeric(_)
+                )
+            }
+            _ => false,
+        }
+    }
+
+    /// Apply SQLite affinity rules for comparisons.
+    ///
+    /// When comparing a TEXT-affinity column to an INTEGER literal, SQLite:
+    /// 1. Converts the INTEGER to TEXT
+    /// 2. Performs string comparison
+    ///
+    /// This function returns modified values based on affinity rules.
+    pub(super) fn apply_affinity_for_comparison(
+        &self,
+        left_expr: &vibesql_ast::Expression,
+        left_val: SqlValue,
+        right_expr: &vibesql_ast::Expression,
+        right_val: SqlValue,
+    ) -> (SqlValue, SqlValue) {
+        let left_affinity = self.get_expression_affinity(left_expr);
+        let right_affinity = self.get_expression_affinity(right_expr);
+
+        // Case 1: Left is TEXT column, right is numeric literal
+        // Convert the numeric literal to text for string comparison
+        if left_affinity == Some(TypeAffinity::Text) && self.is_numeric_literal(right_expr) {
+            let right_as_text = match &right_val {
+                SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Bigint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Unsigned(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Float(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Real(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Double(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Numeric(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                _ => right_val,
+            };
+            return (left_val, right_as_text);
+        }
+
+        // Case 2: Right is TEXT column, left is numeric literal
+        // Convert the numeric literal to text for string comparison
+        if right_affinity == Some(TypeAffinity::Text) && self.is_numeric_literal(left_expr) {
+            let left_as_text = match &left_val {
+                SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Bigint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Unsigned(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Float(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Real(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Double(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Numeric(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                _ => left_val,
+            };
+            return (left_as_text, right_val);
+        }
+
+        // No affinity conversion needed - use original values
+        // This includes:
+        // - Bare columns (NONE affinity) vs numeric → type ordering (handled in compare)
+        // - Literal vs literal → type ordering (handled in compare)
+        // - Same-type comparisons → direct comparison
+        (left_val, right_val)
+    }
+
     /// Evaluate an expression in the context of a row
     #[inline]
     pub fn eval(
@@ -170,6 +278,14 @@ impl ExpressionEvaluator<'_> {
                                 // For BINARY or other collations, use values as-is
                                 (left_val, right_val)
                             }
+                        } else {
+                            (left_val, right_val)
+                        };
+
+                        // Apply SQLite type affinity rules for comparisons
+                        // TEXT column vs INTEGER literal → convert INTEGER to TEXT, string compare
+                        let (left_val, right_val) = if is_comparison {
+                            self.apply_affinity_for_comparison(left, left_val, right, right_val)
                         } else {
                             (left_val, right_val)
                         };

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -56,7 +56,7 @@ impl ExpressionEvaluator<'_> {
             }
         };
 
-        let (expr_val, mut low_val, mut high_val) = if let Some(ref collation_name) = collation {
+        let (expr_val, low_val, high_val) = if let Some(ref collation_name) = collation {
             (
                 transform_for_collation(expr_val, collation_name),
                 transform_for_collation(low_val, collation_name),
@@ -65,6 +65,11 @@ impl ExpressionEvaluator<'_> {
         } else {
             (expr_val, low_val, high_val)
         };
+
+        // Apply SQLite type affinity rules for BETWEEN comparisons
+        // TEXT column vs INTEGER literal → convert INTEGER to TEXT, string compare
+        let (expr_val, mut low_val) = self.apply_affinity_for_comparison(expr, expr_val, low, low_val);
+        let (expr_val, mut high_val) = self.apply_affinity_for_comparison(expr, expr_val, high, high_val);
 
         // Check if bounds are reversed (low > high)
         let gt_result = Self::eval_binary_op_static(

--- a/crates/vibesql-types/src/data_type.rs
+++ b/crates/vibesql-types/src/data_type.rs
@@ -2,6 +2,33 @@
 
 use crate::temporal::IntervalField;
 
+/// SQLite Type Affinity
+///
+/// SQLite uses type affinity to determine how values are compared and stored.
+/// This enum represents the five affinity types defined by SQLite:
+/// - TEXT: String comparison semantics
+/// - NUMERIC: Numeric comparison, converts strings to numbers when possible
+/// - INTEGER: Prefers integer storage
+/// - REAL: Floating-point storage
+/// - BLOB/NONE: No affinity, uses type ordering for cross-type comparisons
+///
+/// See: https://www.sqlite.org/datatype3.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeAffinity {
+    /// TEXT affinity - string comparison semantics
+    /// When comparing TEXT vs INTEGER, converts INTEGER to TEXT
+    Text,
+    /// NUMERIC affinity - tries to convert to number first
+    Numeric,
+    /// INTEGER affinity - prefers integer storage
+    Integer,
+    /// REAL affinity - floating-point storage
+    Real,
+    /// BLOB/NONE affinity - no type preference, uses type ordering
+    /// This is used for bare columns with no declared type
+    None,
+}
+
 /// SQL:1999 Data Types
 ///
 /// Represents the type of a column or expression in SQL.
@@ -385,5 +412,58 @@ impl DataType {
         };
 
         ENUM_OVERHEAD + value_size
+    }
+
+    /// Returns the SQLite type affinity for this data type.
+    ///
+    /// SQLite determines affinity based on the declared type name:
+    /// 1. If the type contains "INT" → INTEGER affinity
+    /// 2. If the type contains "CHAR", "CLOB", or "TEXT" → TEXT affinity
+    /// 3. If the type contains "BLOB" or has no type → BLOB/NONE affinity
+    /// 4. If the type contains "REAL", "FLOA", or "DOUB" → REAL affinity
+    /// 5. Otherwise → NUMERIC affinity
+    ///
+    /// See: https://www.sqlite.org/datatype3.html#type_affinity
+    pub fn sqlite_affinity(&self) -> TypeAffinity {
+        match self {
+            // Integer types → INTEGER affinity
+            DataType::Integer | DataType::Smallint | DataType::Bigint | DataType::Unsigned => {
+                TypeAffinity::Integer
+            }
+
+            // Character/Text types → TEXT affinity
+            DataType::Character { .. }
+            | DataType::Varchar { .. }
+            | DataType::CharacterLargeObject
+            | DataType::Name => TypeAffinity::Text,
+
+            // Floating-point types → REAL affinity
+            DataType::Real | DataType::Float { .. } | DataType::DoublePrecision => {
+                TypeAffinity::Real
+            }
+
+            // Decimal/Numeric → NUMERIC affinity
+            DataType::Decimal { .. } | DataType::Numeric { .. } => TypeAffinity::Numeric,
+
+            // Binary types → NONE/BLOB affinity
+            DataType::BinaryLargeObject | DataType::Bit { .. } => TypeAffinity::None,
+
+            // Boolean → NUMERIC affinity (SQLite stores as 0/1)
+            DataType::Boolean => TypeAffinity::Numeric,
+
+            // Temporal types → NUMERIC affinity (SQLite stores as numbers or text)
+            DataType::Date | DataType::Time { .. } | DataType::Timestamp { .. } => {
+                TypeAffinity::Numeric
+            }
+
+            // Interval → NUMERIC affinity
+            DataType::Interval { .. } => TypeAffinity::Numeric,
+
+            // Vector → NONE affinity (custom type)
+            DataType::Vector { .. } => TypeAffinity::None,
+
+            // User-defined and NULL → NONE affinity
+            DataType::UserDefined { .. } | DataType::Null => TypeAffinity::None,
+        }
     }
 }

--- a/crates/vibesql-types/src/lib.rs
+++ b/crates/vibesql-types/src/lib.rs
@@ -12,7 +12,7 @@ mod sql_value;
 mod temporal;
 
 // Re-export all public types to maintain the same public API
-pub use data_type::DataType;
+pub use data_type::{DataType, TypeAffinity};
 pub use sql_mode::{
     types::{TypeBehavior, ValueType},
     ConcatOperator, DivisionBehavior, MySqlModeFlags, OperatorBehavior, SqlMode,


### PR DESCRIPTION
## Summary
- Add `TypeAffinity` enum (Text, Numeric, Integer, Real, None) to vibesql-types
- Implement `DataType::sqlite_affinity()` to determine SQLite affinity from SQL types
- Add affinity-aware comparison logic to both evaluators:
  - `ExpressionEvaluator` (single-table queries)
  - `CombinedExpressionEvaluator` (JOIN queries)
- Apply affinity rules for binary comparisons and BETWEEN predicates

## SQLite Behavior Fixed
When comparing a TEXT-affinity column to an INTEGER literal, SQLite converts the integer to text and performs string comparison:

| Query | Before | After (Correct) |
|-------|--------|-----------------|
| `SELECT a > 2 FROM t1` where a TEXT = '10' | 1 | 0 |
| `SELECT a < 2 FROM t1` where a TEXT = '10' | 0 | 1 |
| `SELECT x BETWEEN 1 AND '5' FROM t1` where x TEXT = '0' | 1 | 0 |

## Test plan
- [x] TEXT column `a='10'` vs INTEGER 2: `a > 2` returns 0 (FALSE), `a < 2` returns 1 (TRUE)
- [x] BETWEEN with TEXT column correctly applies string comparison to numeric bounds
- [x] All 2158 executor tests pass (no regressions)
- [x] All parser tests pass
- [x] between.test improved from 36.4% to 50.0% (3 tests fixed: 2.1.1, 2.1.2, 2.1.3)

Closes #4549

🤖 Generated with [Claude Code](https://claude.com/claude-code)