### PR TITLE
feat(parser): Add ON CONFLICT clause support for constraint definitions

### DIFF
--- a/crates/vibesql-ast/src/ddl/table.rs
+++ b/crates/vibesql-ast/src/ddl/table.rs
@@ -171,8 +171,24 @@ pub struct ColumnConstraint {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ColumnConstraintKind {
     NotNull,
-    PrimaryKey,
-    Unique,
+    /// PRIMARY KEY constraint with optional conflict resolution
+    PrimaryKey {
+        /// Optional conflict resolution clause (SQLite extension)
+        /// Syntax: PRIMARY KEY ON CONFLICT ROLLBACK|ABORT|FAIL|IGNORE|REPLACE
+        on_conflict: Option<crate::ConflictClause>,
+    },
+    /// UNIQUE constraint with optional conflict resolution
+    Unique {
+        /// Optional conflict resolution clause (SQLite extension)
+        /// Syntax: UNIQUE ON CONFLICT ROLLBACK|ABORT|FAIL|IGNORE|REPLACE
+        on_conflict: Option<crate::ConflictClause>,
+    },
+    /// NOT NULL constraint with optional conflict resolution
+    NotNullWithConflict {
+        /// Optional conflict resolution clause (SQLite extension)
+        /// Syntax: NOT NULL ON CONFLICT ROLLBACK|ABORT|FAIL|IGNORE|REPLACE
+        on_conflict: Option<crate::ConflictClause>,
+    },
     Check(Box<Expression>),
     References {
         table: String,
@@ -204,6 +220,9 @@ pub struct TableConstraint {
 pub enum TableConstraintKind {
     PrimaryKey {
         columns: Vec<crate::IndexColumn>,
+        /// Optional conflict resolution clause (SQLite extension)
+        /// Syntax: PRIMARY KEY (columns) ON CONFLICT ROLLBACK|ABORT|FAIL|IGNORE|REPLACE
+        on_conflict: Option<crate::ConflictClause>,
     },
     ForeignKey {
         columns: Vec<String>,
@@ -214,6 +233,9 @@ pub enum TableConstraintKind {
     },
     Unique {
         columns: Vec<crate::IndexColumn>,
+        /// Optional conflict resolution clause (SQLite extension)
+        /// Syntax: UNIQUE (columns) ON CONFLICT ROLLBACK|ABORT|FAIL|IGNORE|REPLACE
+        on_conflict: Option<crate::ConflictClause>,
     },
     Check {
         expr: Box<Expression>,

--- a/crates/vibesql-executor/src/alter/constraints.rs
+++ b/crates/vibesql-executor/src/alter/constraints.rs
@@ -16,7 +16,7 @@ pub(super) fn execute_add_constraint(
         .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
 
     match &stmt.constraint.kind {
-        TableConstraintKind::PrimaryKey { columns } => {
+        TableConstraintKind::PrimaryKey { columns, .. } => {
             // Extract column names from IndexColumn structs
             let column_names: Vec<String> = columns.iter().map(|c| c.expect_column_name().to_string()).collect();
 
@@ -57,7 +57,7 @@ pub(super) fn execute_add_constraint(
 
             Ok(format!("PRIMARY KEY constraint added to table '{}'", stmt.table_name))
         }
-        TableConstraintKind::Unique { columns } => {
+        TableConstraintKind::Unique { columns, .. } => {
             // Extract column names from IndexColumn structs
             let column_names: Vec<String> = columns.iter().map(|c| c.expect_column_name().to_string()).collect();
             table.schema_mut().add_unique_constraint(column_names)?;

--- a/crates/vibesql-executor/src/constraint_validator.rs
+++ b/crates/vibesql-executor/src/constraint_validator.rs
@@ -69,7 +69,7 @@ impl ConstraintValidator {
         for col_def in columns {
             for constraint in &col_def.constraints {
                 match &constraint.kind {
-                    ColumnConstraintKind::PrimaryKey => {
+                    ColumnConstraintKind::PrimaryKey { .. } => {
                         if has_column_level_pk {
                             return Err(ExecutorError::MultiplePrimaryKeys);
                         }
@@ -84,7 +84,7 @@ impl ConstraintValidator {
                         }
                         has_column_level_pk = true;
                     }
-                    ColumnConstraintKind::Unique => {
+                    ColumnConstraintKind::Unique { .. } => {
                         result.unique_constraints.push(vec![col_def.name.clone()]);
                     }
                     ColumnConstraintKind::Check(expr) => {
@@ -92,7 +92,7 @@ impl ConstraintValidator {
                         constraint_counter += 1;
                         result.check_constraints.push((constraint_name, (**expr).clone()));
                     }
-                    ColumnConstraintKind::NotNull => {
+                    ColumnConstraintKind::NotNull | ColumnConstraintKind::NotNullWithConflict { .. } => {
                         result.not_null_columns.push(col_def.name.clone());
                     }
                     ColumnConstraintKind::References { .. } => {
@@ -121,7 +121,7 @@ impl ConstraintValidator {
         // Process table-level constraints
         for table_constraint in table_constraints {
             match &table_constraint.kind {
-                TableConstraintKind::PrimaryKey { columns: pk_cols } => {
+                TableConstraintKind::PrimaryKey { columns: pk_cols, .. } => {
                     // Only allow one PRIMARY KEY constraint total (column-level OR table-level)
                     if result.primary_key.is_some() {
                         return Err(ExecutorError::MultiplePrimaryKeys);
@@ -142,7 +142,7 @@ impl ConstraintValidator {
                         }
                     }
                 }
-                TableConstraintKind::Unique { columns } => {
+                TableConstraintKind::Unique { columns, .. } => {
                     // Extract column names from IndexColumn structs
                     let column_names: Vec<String> =
                         columns.iter().map(|c| c.expect_column_name().to_string()).collect();
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn test_column_level_primary_key() {
-        let columns = vec![make_column_def("id", vec![ColumnConstraintKind::PrimaryKey])];
+        let columns = vec![make_column_def("id", vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }])];
         let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
 
         assert_eq!(result.primary_key, Some(vec!["id".to_string()]));
@@ -264,6 +264,7 @@ mod tests {
                         prefix_length: None,
                     },
                 ],
+                on_conflict: None,
             },
         }];
 
@@ -276,7 +277,7 @@ mod tests {
 
     #[test]
     fn test_multiple_primary_keys_fails() {
-        let columns = vec![make_column_def("id", vec![ColumnConstraintKind::PrimaryKey])];
+        let columns = vec![make_column_def("id", vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }])];
         let constraints = vec![TableConstraint {
             name: None,
             kind: TableConstraintKind::PrimaryKey {
@@ -285,6 +286,7 @@ mod tests {
                     direction: vibesql_ast::OrderDirection::Asc,
                     prefix_length: None,
                 }],
+                on_conflict: None,
             },
         }];
 
@@ -295,7 +297,7 @@ mod tests {
     #[test]
     fn test_unique_constraints() {
         let columns = vec![
-            make_column_def("email", vec![ColumnConstraintKind::Unique]),
+            make_column_def("email", vec![ColumnConstraintKind::Unique { on_conflict: None }]),
             make_column_def("username", vec![]),
         ];
         let constraints = vec![TableConstraint {
@@ -306,6 +308,7 @@ mod tests {
                     direction: vibesql_ast::OrderDirection::Asc,
                     prefix_length: None,
                 }],
+                on_conflict: None,
             },
         }];
 
@@ -365,7 +368,7 @@ mod tests {
         let columns = vec![make_column_def_with_type(
             "name",
             DataType::Varchar { max_length: None },
-            vec![ColumnConstraintKind::PrimaryKey],
+            vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }],
         )];
         let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
 
@@ -380,7 +383,7 @@ mod tests {
         let columns = vec![make_column_def_with_type(
             "c",
             DataType::Varchar { max_length: None },
-            vec![ColumnConstraintKind::PrimaryKey],
+            vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }],
         )];
         let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
 
@@ -394,7 +397,7 @@ mod tests {
         let columns = vec![make_column_def_with_type(
             "id",
             DataType::Integer,
-            vec![ColumnConstraintKind::PrimaryKey],
+            vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }],
         )];
         let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
 
@@ -424,6 +427,7 @@ mod tests {
                         prefix_length: None,
                     },
                 ],
+                on_conflict: None,
             },
         }];
 
@@ -441,7 +445,7 @@ mod tests {
         let columns = vec![make_column_def_with_type(
             "value",
             DataType::Real,
-            vec![ColumnConstraintKind::PrimaryKey],
+            vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }],
         )];
         let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
 
@@ -455,7 +459,7 @@ mod tests {
         let columns = vec![make_column_def_with_type(
             "big_id",
             DataType::Bigint,
-            vec![ColumnConstraintKind::PrimaryKey],
+            vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }],
         )];
         let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
 

--- a/crates/vibesql-executor/src/tests/auto_increment_tests.rs
+++ b/crates/vibesql-executor/src/tests/auto_increment_tests.rs
@@ -23,7 +23,7 @@ fn test_auto_increment_basic_inserts() {
                 nullable: false,
                 constraints: vec![
                     ColumnConstraint { name: None, kind: ColumnConstraintKind::AutoIncrement },
-                    ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey },
+                    ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey { on_conflict: None } },
                 ],
                 default_value: None,
                 comment: None,
@@ -146,7 +146,7 @@ fn test_last_insert_rowid_basic() {
                 nullable: false,
                 constraints: vec![
                     ColumnConstraint { name: None, kind: ColumnConstraintKind::AutoIncrement },
-                    ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey },
+                    ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey { on_conflict: None } },
                 ],
                 default_value: None,
                 comment: None,
@@ -222,7 +222,7 @@ fn test_last_insert_rowid_multi_row_insert() {
                 nullable: false,
                 constraints: vec![
                     ColumnConstraint { name: None, kind: ColumnConstraintKind::AutoIncrement },
-                    ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey },
+                    ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey { on_conflict: None } },
                 ],
                 default_value: None,
                 comment: None,
@@ -295,7 +295,7 @@ fn test_last_insert_rowid_no_auto_increment() {
                 nullable: false,
                 constraints: vec![ColumnConstraint {
                     name: None,
-                    kind: ColumnConstraintKind::PrimaryKey,
+                    kind: ColumnConstraintKind::PrimaryKey { on_conflict: None },
                 }],
                 default_value: None,
                 comment: None,
@@ -355,7 +355,7 @@ fn test_last_insert_rowid_via_select() {
                 nullable: false,
                 constraints: vec![
                     ColumnConstraint { name: None, kind: ColumnConstraintKind::AutoIncrement },
-                    ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey },
+                    ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey { on_conflict: None } },
                 ],
                 default_value: None,
                 comment: None,

--- a/crates/vibesql-executor/src/tests/create_table_constraints.rs
+++ b/crates/vibesql-executor/src/tests/create_table_constraints.rs
@@ -20,7 +20,7 @@ fn test_create_table_with_column_primary_key() {
                 nullable: true, // This should be overridden by the PK constraint
                 constraints: vec![ColumnConstraint {
                     name: None,
-                    kind: ColumnConstraintKind::PrimaryKey,
+                    kind: ColumnConstraintKind::PrimaryKey { on_conflict: None },
                 }],
                 default_value: None,
                 comment: None,
@@ -91,6 +91,7 @@ fn test_create_table_with_table_primary_key() {
                         prefix_length: None,
                     },
                 ],
+                on_conflict: None,
             },
         }],
         table_options: vec![],
@@ -119,7 +120,7 @@ fn test_create_table_with_multiple_primary_keys_fails() {
             nullable: false,
             constraints: vec![ColumnConstraint {
                 name: None,
-                kind: ColumnConstraintKind::PrimaryKey,
+                kind: ColumnConstraintKind::PrimaryKey { on_conflict: None },
             }],
             default_value: None,
             comment: None,
@@ -133,6 +134,7 @@ fn test_create_table_with_multiple_primary_keys_fails() {
                     direction: vibesql_ast::OrderDirection::Asc,
                     prefix_length: None,
                 }],
+                on_conflict: None,
             },
         }],
         table_options: vec![],
@@ -166,7 +168,7 @@ fn test_create_table_with_column_unique_constraint() {
                 nullable: false,
                 constraints: vec![ColumnConstraint {
                     name: None,
-                    kind: ColumnConstraintKind::Unique,
+                    kind: ColumnConstraintKind::Unique { on_conflict: None },
                 }],
                 default_value: None,
                 comment: None,
@@ -228,6 +230,7 @@ fn test_create_table_with_table_unique_constraint() {
                         prefix_length: None,
                     },
                 ],
+                on_conflict: None,
             },
         }],
         table_options: vec![],
@@ -301,7 +304,7 @@ fn test_auto_index_for_single_column_primary_key() {
             nullable: false,
             constraints: vec![ColumnConstraint {
                 name: None,
-                kind: ColumnConstraintKind::PrimaryKey,
+                kind: ColumnConstraintKind::PrimaryKey { on_conflict: None },
             }],
             default_value: None,
             comment: None,
@@ -370,6 +373,7 @@ fn test_auto_index_for_composite_primary_key() {
                         prefix_length: None,
                     },
                 ],
+                on_conflict: None,
             },
         }],
         table_options: vec![],
@@ -412,7 +416,7 @@ fn test_auto_index_for_single_unique_constraint() {
                 nullable: false,
                 constraints: vec![ColumnConstraint {
                     name: None,
-                    kind: ColumnConstraintKind::Unique,
+                    kind: ColumnConstraintKind::Unique { on_conflict: None },
                 }],
                 default_value: None,
                 comment: None,
@@ -461,7 +465,7 @@ fn test_auto_index_for_multiple_unique_constraints() {
                 nullable: false,
                 constraints: vec![ColumnConstraint {
                     name: None,
-                    kind: ColumnConstraintKind::Unique,
+                    kind: ColumnConstraintKind::Unique { on_conflict: None },
                 }],
                 default_value: None,
                 comment: None,
@@ -473,7 +477,7 @@ fn test_auto_index_for_multiple_unique_constraints() {
                 nullable: false,
                 constraints: vec![ColumnConstraint {
                     name: None,
-                    kind: ColumnConstraintKind::Unique,
+                    kind: ColumnConstraintKind::Unique { on_conflict: None },
                 }],
                 default_value: None,
                 comment: None,
@@ -535,6 +539,7 @@ fn test_auto_index_for_composite_unique_constraint() {
                         prefix_length: None,
                     },
                 ],
+                on_conflict: None,
             },
         }],
         table_options: vec![],
@@ -568,7 +573,7 @@ fn test_auto_index_for_primary_key_plus_unique() {
                 nullable: false,
                 constraints: vec![ColumnConstraint {
                     name: None,
-                    kind: ColumnConstraintKind::PrimaryKey,
+                    kind: ColumnConstraintKind::PrimaryKey { on_conflict: None },
                 }],
                 default_value: None,
                 comment: None,
@@ -580,7 +585,7 @@ fn test_auto_index_for_primary_key_plus_unique() {
                 nullable: false,
                 constraints: vec![ColumnConstraint {
                     name: None,
-                    kind: ColumnConstraintKind::Unique,
+                    kind: ColumnConstraintKind::Unique { on_conflict: None },
                 }],
                 default_value: None,
                 comment: None,
@@ -614,7 +619,7 @@ fn test_auto_index_visible_in_catalog() {
                 nullable: false,
                 constraints: vec![ColumnConstraint {
                     name: None,
-                    kind: ColumnConstraintKind::PrimaryKey,
+                    kind: ColumnConstraintKind::PrimaryKey { on_conflict: None },
                 }],
                 default_value: None,
                 comment: None,
@@ -626,7 +631,7 @@ fn test_auto_index_visible_in_catalog() {
                 nullable: false,
                 constraints: vec![ColumnConstraint {
                     name: None,
-                    kind: ColumnConstraintKind::Unique,
+                    kind: ColumnConstraintKind::Unique { on_conflict: None },
                 }],
                 default_value: None,
                 comment: None,

--- a/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
@@ -40,6 +40,7 @@ fn create_table_with_pk(db: &mut Database, table_name: &str, pk_column: &str) {
                     direction: vibesql_ast::OrderDirection::Asc,
                     prefix_length: None,
                 }],
+                on_conflict: None,
             },
         }],
         table_options: vec![],
@@ -92,6 +93,7 @@ fn create_table_with_fk(
                         direction: vibesql_ast::OrderDirection::Asc,
                         prefix_length: None,
                     }],
+                    on_conflict: None,
                 },
             },
             // Add FK as table-level constraint (ensures catalog.foreign_keys is populated)

--- a/crates/vibesql-executor/src/tests/truncate_table_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_table_tests.rs
@@ -345,7 +345,7 @@ fn test_truncate_resets_auto_increment() {
                 nullable: false,
                 constraints: vec![
                     ColumnConstraint { name: None, kind: ColumnConstraintKind::AutoIncrement },
-                    ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey },
+                    ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey { on_conflict: None } },
                 ],
                 default_value: None,
                 comment: None,
@@ -440,7 +440,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
                 nullable: false,
                 constraints: vec![
                     ColumnConstraint { name: None, kind: ColumnConstraintKind::AutoIncrement },
-                    ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey },
+                    ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey { on_conflict: None } },
                 ],
                 default_value: None,
                 comment: None,

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -334,6 +334,7 @@ pub enum Keyword {
     // SQLite conflict resolution keywords
     Abort,
     Fail,
+    Conflict,
 }
 
 impl Keyword {
@@ -671,6 +672,7 @@ impl fmt::Display for Keyword {
             // SQLite conflict resolution keywords
             Keyword::Abort => "ABORT",
             Keyword::Fail => "FAIL",
+            Keyword::Conflict => "CONFLICT",
         };
         write!(f, "{}", keyword_str)
     }

--- a/crates/vibesql-parser/src/lexer/keywords.rs
+++ b/crates/vibesql-parser/src/lexer/keywords.rs
@@ -331,6 +331,7 @@ static KEYWORDS: phf::Map<&'static str, Keyword> = phf_map! {
     // SQLite conflict resolution keywords
     "ABORT" => Keyword::Abort,
     "FAIL" => Keyword::Fail,
+    "CONFLICT" => Keyword::Conflict,
 };
 
 /// Map an uppercase string to its corresponding Keyword using perfect hash lookup.

--- a/crates/vibesql-parser/src/parser/alter.rs
+++ b/crates/vibesql-parser/src/parser/alter.rs
@@ -110,12 +110,12 @@ fn parse_add_column(
                 parser.advance();
                 parser.expect_keyword(Keyword::Key)?;
                 constraints
-                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey });
+                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey { on_conflict: None } });
             }
             Token::Keyword { keyword: Keyword::Unique, .. } => {
                 parser.advance();
                 constraints
-                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::Unique });
+                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::Unique { on_conflict: None } });
             }
             Token::Keyword { keyword: Keyword::References, .. } => {
                 parser.advance();
@@ -298,12 +298,12 @@ fn parse_modify_column(
                 parser.advance();
                 parser.expect_keyword(Keyword::Key)?;
                 constraints
-                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey });
+                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey { on_conflict: None } });
             }
             Token::Keyword { keyword: Keyword::Unique, .. } => {
                 parser.advance();
                 constraints
-                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::Unique });
+                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::Unique { on_conflict: None } });
             }
             Token::Keyword { keyword: Keyword::References, .. } => {
                 parser.advance();
@@ -381,12 +381,12 @@ fn parse_change_column(
                 parser.advance();
                 parser.expect_keyword(Keyword::Key)?;
                 constraints
-                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey });
+                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::PrimaryKey { on_conflict: None } });
             }
             Token::Keyword { keyword: Keyword::Unique, .. } => {
                 parser.advance();
                 constraints
-                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::Unique });
+                    .push(ColumnConstraint { name: None, kind: ColumnConstraintKind::Unique { on_conflict: None } });
             }
             Token::Keyword { keyword: Keyword::References, .. } => {
                 parser.advance();

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -3,6 +3,53 @@
 use super::super::*;
 
 impl Parser {
+    /// Parse an optional ON CONFLICT clause for constraints
+    /// Returns None if no ON CONFLICT clause is present
+    /// Syntax: ON CONFLICT ROLLBACK|ABORT|FAIL|IGNORE|REPLACE
+    pub(in crate::parser) fn parse_constraint_conflict_clause(
+        &mut self,
+    ) -> Result<Option<vibesql_ast::ConflictClause>, ParseError> {
+        // Check for ON keyword
+        if !self.peek_keyword(Keyword::On) {
+            return Ok(None);
+        }
+
+        // Peek ahead to see if next is CONFLICT (vs ON DELETE/UPDATE for foreign keys)
+        if self.position + 1 < self.tokens.len() {
+            if let Token::Keyword { keyword: Keyword::Conflict, .. } = &self.tokens[self.position + 1]
+            {
+                self.advance(); // consume ON
+                self.advance(); // consume CONFLICT
+
+                // Parse the conflict resolution algorithm
+                if self.peek_keyword(Keyword::Rollback) {
+                    self.advance();
+                    return Ok(Some(vibesql_ast::ConflictClause::Rollback));
+                } else if self.peek_keyword(Keyword::Abort) {
+                    self.advance();
+                    return Ok(Some(vibesql_ast::ConflictClause::Abort));
+                } else if self.peek_keyword(Keyword::Fail) {
+                    self.advance();
+                    return Ok(Some(vibesql_ast::ConflictClause::Fail));
+                } else if self.peek_keyword(Keyword::Ignore) {
+                    self.advance();
+                    return Ok(Some(vibesql_ast::ConflictClause::Ignore));
+                } else if self.peek_keyword(Keyword::Replace) {
+                    self.advance();
+                    return Ok(Some(vibesql_ast::ConflictClause::Replace));
+                } else {
+                    return Err(ParseError {
+                        message:
+                            "Expected ROLLBACK, ABORT, FAIL, IGNORE, or REPLACE after ON CONFLICT"
+                                .to_string(),
+                    });
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
     /// Parse an index column specification with optional prefix length or expression
     ///
     /// Supports both simple column references and expression indexes:
@@ -208,9 +255,11 @@ impl Parser {
                     if self.peek_keyword(Keyword::Asc) || self.peek_keyword(Keyword::Desc) {
                         self.advance(); // consume ASC or DESC (ignored - SQLite ignores it too)
                     }
+                    // Parse optional ON CONFLICT clause
+                    let on_conflict = self.parse_constraint_conflict_clause()?;
                     constraints.push(vibesql_ast::ColumnConstraint {
                         name,
-                        kind: vibesql_ast::ColumnConstraintKind::PrimaryKey,
+                        kind: vibesql_ast::ColumnConstraintKind::PrimaryKey { on_conflict },
                     });
                 }
                 Token::Keyword { keyword: Keyword::Unique, .. } => {
@@ -219,9 +268,11 @@ impl Parser {
                     if self.peek_keyword(Keyword::Key) {
                         self.advance(); // consume KEY
                     }
+                    // Parse optional ON CONFLICT clause
+                    let on_conflict = self.parse_constraint_conflict_clause()?;
                     constraints.push(vibesql_ast::ColumnConstraint {
                         name,
-                        kind: vibesql_ast::ColumnConstraintKind::Unique,
+                        kind: vibesql_ast::ColumnConstraintKind::Unique { on_conflict },
                     });
                 }
                 Token::Keyword { keyword: Keyword::Check, .. } => {
@@ -377,7 +428,9 @@ impl Parser {
                 }
 
                 self.expect_token(Token::RParen)?;
-                vibesql_ast::TableConstraintKind::PrimaryKey { columns }
+                // Parse optional ON CONFLICT clause
+                let on_conflict = self.parse_constraint_conflict_clause()?;
+                vibesql_ast::TableConstraintKind::PrimaryKey { columns, on_conflict }
             }
             Token::Keyword { keyword: Keyword::Foreign, .. } => {
                 self.advance(); // consume FOREIGN
@@ -472,7 +525,9 @@ impl Parser {
                 }
 
                 self.expect_token(Token::RParen)?;
-                vibesql_ast::TableConstraintKind::Unique { columns }
+                // Parse optional ON CONFLICT clause
+                let on_conflict = self.parse_constraint_conflict_clause()?;
+                vibesql_ast::TableConstraintKind::Unique { columns, on_conflict }
             }
             Token::Keyword { keyword: Keyword::Check, .. } => {
                 self.advance(); // consume CHECK

--- a/crates/vibesql-parser/src/tests/alter_table.rs
+++ b/crates/vibesql-parser/src/tests/alter_table.rs
@@ -152,7 +152,7 @@ fn test_alter_table_add_unique_no_keyword() {
                 assert_eq!(add.table_name, "t");
                 assert!(add.constraint.name.is_none(), "Expected unnamed constraint");
                 match &add.constraint.kind {
-                    vibesql_ast::TableConstraintKind::Unique { columns } => {
+                    vibesql_ast::TableConstraintKind::Unique { columns, .. } => {
                         assert_eq!(columns.len(), 1);
                         assert_eq!(columns[0].expect_column_name(), "col");
                     }
@@ -177,7 +177,7 @@ fn test_alter_table_add_primary_key_no_keyword() {
                 assert_eq!(add.table_name, "t");
                 assert!(add.constraint.name.is_none(), "Expected unnamed constraint");
                 match &add.constraint.kind {
-                    vibesql_ast::TableConstraintKind::PrimaryKey { columns } => {
+                    vibesql_ast::TableConstraintKind::PrimaryKey { columns, .. } => {
                         assert_eq!(columns.len(), 1);
                         assert_eq!(columns[0].expect_column_name(), "col");
                     }

--- a/crates/vibesql-parser/src/tests/arena_alter_table.rs
+++ b/crates/vibesql-parser/src/tests/arena_alter_table.rs
@@ -285,7 +285,7 @@ fn test_arena_alter_table_add_unique_constraint() {
         AlterTableStmt::AddConstraint(add) => {
             assert_eq!(interner.resolve(add.table_name), "t");
             match &add.constraint.kind {
-                TableConstraintKind::Unique { columns } => {
+                TableConstraintKind::Unique { columns, .. } => {
                     assert_eq!(columns.len(), 1);
                     assert_eq!(interner.resolve(columns[0].column_name().unwrap()), "col");
                 }
@@ -310,7 +310,7 @@ fn test_arena_alter_table_add_primary_key_constraint() {
         AlterTableStmt::AddConstraint(add) => {
             assert_eq!(interner.resolve(add.table_name), "t");
             match &add.constraint.kind {
-                TableConstraintKind::PrimaryKey { columns } => {
+                TableConstraintKind::PrimaryKey { columns, .. } => {
                     assert_eq!(columns.len(), 1);
                     assert_eq!(interner.resolve(columns[0].column_name().unwrap()), "col");
                 }

--- a/crates/vibesql-parser/src/tests/create_table/auto_increment.rs
+++ b/crates/vibesql-parser/src/tests/create_table/auto_increment.rs
@@ -65,7 +65,7 @@ fn test_auto_increment_with_other_constraints() {
             assert!(id_col
                 .constraints
                 .iter()
-                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::PrimaryKey)));
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::PrimaryKey { .. })));
         }
         _ => panic!("Expected CREATE TABLE statement"),
     }

--- a/crates/vibesql-parser/src/tests/create_table/constraints_column.rs
+++ b/crates/vibesql-parser/src/tests/create_table/constraints_column.rs
@@ -20,7 +20,7 @@ fn test_parse_create_table_with_primary_key() {
             assert!(matches!(
                 create.columns[0].constraints[0],
                 vibesql_ast::ColumnConstraint {
-                    kind: vibesql_ast::ColumnConstraintKind::PrimaryKey,
+                    kind: vibesql_ast::ColumnConstraintKind::PrimaryKey { on_conflict: None },
                     ..
                 }
             ));
@@ -41,7 +41,7 @@ fn test_parse_create_table_with_unique() {
             assert!(matches!(
                 create.columns[0].constraints[0],
                 vibesql_ast::ColumnConstraint {
-                    kind: vibesql_ast::ColumnConstraintKind::Unique,
+                    kind: vibesql_ast::ColumnConstraintKind::Unique { on_conflict: None },
                     ..
                 }
             ));
@@ -127,7 +127,7 @@ fn test_parse_create_table_with_multiple_constraints() {
             assert!(matches!(
                 create.columns[0].constraints[0],
                 vibesql_ast::ColumnConstraint {
-                    kind: vibesql_ast::ColumnConstraintKind::PrimaryKey,
+                    kind: vibesql_ast::ColumnConstraintKind::PrimaryKey { on_conflict: None },
                     ..
                 }
             ));
@@ -137,7 +137,7 @@ fn test_parse_create_table_with_multiple_constraints() {
             assert!(matches!(
                 create.columns[1].constraints[0],
                 vibesql_ast::ColumnConstraint {
-                    kind: vibesql_ast::ColumnConstraintKind::Unique,
+                    kind: vibesql_ast::ColumnConstraintKind::Unique { on_conflict: None },
                     ..
                 }
             ));
@@ -273,6 +273,93 @@ fn test_parse_create_table_references_without_column() {
                     assert_eq!(column, &None); // Column not specified
                 }
                 _ => panic!("Expected REFERENCES constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+/// Test ON CONFLICT clause for column-level constraints (SQLite extension)
+#[test]
+fn test_parse_on_conflict_column_constraints() {
+    // Test PRIMARY KEY with ON CONFLICT
+    let result = Parser::parse_sql("CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT IGNORE);");
+    assert!(result.is_ok(), "Should parse PRIMARY KEY with ON CONFLICT");
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].constraints.len(), 1);
+            match &create.columns[0].constraints[0].kind {
+                vibesql_ast::ColumnConstraintKind::PrimaryKey { on_conflict } => {
+                    assert_eq!(*on_conflict, Some(vibesql_ast::ConflictClause::Ignore));
+                }
+                _ => panic!("Expected PrimaryKey constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+
+    // Test UNIQUE with ON CONFLICT REPLACE
+    let result = Parser::parse_sql("CREATE TABLE t2(email TEXT UNIQUE ON CONFLICT REPLACE);");
+    assert!(result.is_ok(), "Should parse UNIQUE with ON CONFLICT");
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].constraints.len(), 1);
+            match &create.columns[0].constraints[0].kind {
+                vibesql_ast::ColumnConstraintKind::Unique { on_conflict } => {
+                    assert_eq!(*on_conflict, Some(vibesql_ast::ConflictClause::Replace));
+                }
+                _ => panic!("Expected Unique constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+
+    // Test UNIQUE with ON CONFLICT ABORT
+    let result = Parser::parse_sql("CREATE TABLE t3(code TEXT UNIQUE ON CONFLICT ABORT);");
+    assert!(result.is_ok(), "Should parse UNIQUE with ON CONFLICT ABORT");
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            match &create.columns[0].constraints[0].kind {
+                vibesql_ast::ColumnConstraintKind::Unique { on_conflict } => {
+                    assert_eq!(*on_conflict, Some(vibesql_ast::ConflictClause::Abort));
+                }
+                _ => panic!("Expected Unique constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+
+    // Test PRIMARY KEY with ON CONFLICT ROLLBACK
+    let result =
+        Parser::parse_sql("CREATE TABLE t4(id INTEGER PRIMARY KEY ON CONFLICT ROLLBACK);");
+    assert!(result.is_ok(), "Should parse PRIMARY KEY with ON CONFLICT ROLLBACK");
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            match &create.columns[0].constraints[0].kind {
+                vibesql_ast::ColumnConstraintKind::PrimaryKey { on_conflict } => {
+                    assert_eq!(*on_conflict, Some(vibesql_ast::ConflictClause::Rollback));
+                }
+                _ => panic!("Expected PrimaryKey constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+
+    // Test UNIQUE with ON CONFLICT FAIL
+    let result = Parser::parse_sql("CREATE TABLE t5(name TEXT UNIQUE ON CONFLICT FAIL);");
+    assert!(result.is_ok(), "Should parse UNIQUE with ON CONFLICT FAIL");
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            match &create.columns[0].constraints[0].kind {
+                vibesql_ast::ColumnConstraintKind::Unique { on_conflict } => {
+                    assert_eq!(*on_conflict, Some(vibesql_ast::ConflictClause::Fail));
+                }
+                _ => panic!("Expected Unique constraint"),
             }
         }
         _ => panic!("Expected CREATE TABLE statement"),

--- a/crates/vibesql-parser/src/tests/create_table/constraints_table.rs
+++ b/crates/vibesql-parser/src/tests/create_table/constraints_table.rs
@@ -22,7 +22,7 @@ fn test_parse_create_table_with_table_level_primary_key() {
             assert_eq!(create.table_constraints.len(), 1);
             match &create.table_constraints[0] {
                 vibesql_ast::TableConstraint {
-                    kind: vibesql_ast::TableConstraintKind::PrimaryKey { columns },
+                    kind: vibesql_ast::TableConstraintKind::PrimaryKey { columns, .. },
                     ..
                 } => {
                     assert_eq!(columns.len(), 2);
@@ -206,7 +206,7 @@ fn test_parse_create_table_with_table_level_unique() {
             assert_eq!(create.table_constraints.len(), 1);
             match &create.table_constraints[0] {
                 vibesql_ast::TableConstraint {
-                    kind: vibesql_ast::TableConstraintKind::Unique { columns },
+                    kind: vibesql_ast::TableConstraintKind::Unique { columns, .. },
                     ..
                 } => {
                     assert_eq!(columns.len(), 2);
@@ -260,7 +260,7 @@ fn test_parse_create_table_with_indexed_column_prefix() {
             assert_eq!(create.table_constraints.len(), 1);
             match &create.table_constraints[0] {
                 vibesql_ast::TableConstraint {
-                    kind: vibesql_ast::TableConstraintKind::Unique { columns },
+                    kind: vibesql_ast::TableConstraintKind::Unique { columns, .. },
                     ..
                 } => {
                     assert_eq!(columns.len(), 1);
@@ -285,7 +285,7 @@ fn test_parse_create_table_with_primary_key_prefix() {
             assert_eq!(create.table_constraints.len(), 1);
             match &create.table_constraints[0] {
                 vibesql_ast::TableConstraint {
-                    kind: vibesql_ast::TableConstraintKind::PrimaryKey { columns },
+                    kind: vibesql_ast::TableConstraintKind::PrimaryKey { columns, .. },
                     ..
                 } => {
                     assert_eq!(columns.len(), 1);
@@ -402,4 +402,80 @@ fn test_parse_unique_constraint_prefix_boundary_values() {
     // Test maximum valid value: 10000
     let result = Parser::parse_sql("CREATE TABLE t2(a TEXT, UNIQUE (a(10000)))");
     assert!(result.is_ok(), "Should accept prefix length of 10000: {:?}", result.err());
+}
+
+/// Test ON CONFLICT clause for table-level constraints (SQLite extension)
+#[test]
+fn test_parse_on_conflict_table_constraints() {
+    // Test table-level PRIMARY KEY with ON CONFLICT IGNORE
+    let result = Parser::parse_sql(
+        "CREATE TABLE t1(a INT, b INT, PRIMARY KEY (a, b) ON CONFLICT IGNORE);",
+    );
+    assert!(result.is_ok(), "Should parse table-level PRIMARY KEY with ON CONFLICT");
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_constraints.len(), 1);
+            match &create.table_constraints[0].kind {
+                vibesql_ast::TableConstraintKind::PrimaryKey { columns, on_conflict } => {
+                    assert_eq!(columns.len(), 2);
+                    assert_eq!(*on_conflict, Some(vibesql_ast::ConflictClause::Ignore));
+                }
+                _ => panic!("Expected PrimaryKey constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+
+    // Test table-level UNIQUE with ON CONFLICT REPLACE
+    let result =
+        Parser::parse_sql("CREATE TABLE t2(email TEXT, code TEXT, UNIQUE (email) ON CONFLICT REPLACE);");
+    assert!(result.is_ok(), "Should parse table-level UNIQUE with ON CONFLICT");
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_constraints.len(), 1);
+            match &create.table_constraints[0].kind {
+                vibesql_ast::TableConstraintKind::Unique { columns, on_conflict } => {
+                    assert_eq!(columns.len(), 1);
+                    assert_eq!(*on_conflict, Some(vibesql_ast::ConflictClause::Replace));
+                }
+                _ => panic!("Expected Unique constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+
+    // Test table-level UNIQUE with ON CONFLICT ABORT
+    let result =
+        Parser::parse_sql("CREATE TABLE t3(a INT, b INT, UNIQUE (a, b) ON CONFLICT ABORT);");
+    assert!(result.is_ok(), "Should parse table-level UNIQUE with ON CONFLICT ABORT");
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            match &create.table_constraints[0].kind {
+                vibesql_ast::TableConstraintKind::Unique { on_conflict, .. } => {
+                    assert_eq!(*on_conflict, Some(vibesql_ast::ConflictClause::Abort));
+                }
+                _ => panic!("Expected Unique constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+
+    // Test table-level PRIMARY KEY with ON CONFLICT FAIL
+    let result = Parser::parse_sql("CREATE TABLE t4(id INT, PRIMARY KEY (id) ON CONFLICT FAIL);");
+    assert!(result.is_ok(), "Should parse table-level PRIMARY KEY with ON CONFLICT FAIL");
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            match &create.table_constraints[0].kind {
+                vibesql_ast::TableConstraintKind::PrimaryKey { on_conflict, .. } => {
+                    assert_eq!(*on_conflict, Some(vibesql_ast::ConflictClause::Fail));
+                }
+                _ => panic!("Expected PrimaryKey constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
 }

--- a/crates/vibesql-parser/src/tests/create_table/northwind.rs
+++ b/crates/vibesql-parser/src/tests/create_table/northwind.rs
@@ -25,7 +25,7 @@ fn test_parse_northwind_categories_table() {
             assert!(matches!(
                 create.columns[0].constraints[0],
                 vibesql_ast::ColumnConstraint {
-                    kind: vibesql_ast::ColumnConstraintKind::PrimaryKey,
+                    kind: vibesql_ast::ColumnConstraintKind::PrimaryKey { on_conflict: None },
                     ..
                 }
             ));
@@ -59,7 +59,7 @@ fn test_parse_northwind_products_table() {
             assert!(matches!(
                 create.columns[0].constraints[0],
                 vibesql_ast::ColumnConstraint {
-                    kind: vibesql_ast::ColumnConstraintKind::PrimaryKey,
+                    kind: vibesql_ast::ColumnConstraintKind::PrimaryKey { on_conflict: None },
                     ..
                 }
             ));

--- a/crates/vibesql-parser/src/tests/create_table/string_types/varchar_types.rs
+++ b/crates/vibesql-parser/src/tests/create_table/string_types/varchar_types.rs
@@ -385,7 +385,7 @@ fn test_parse_nvarchar_with_constraint() {
             assert!(create.columns[0]
                 .constraints
                 .iter()
-                .any(|c| matches!(&c.kind, vibesql_ast::ColumnConstraintKind::Unique)));
+                .any(|c| matches!(&c.kind, vibesql_ast::ColumnConstraintKind::Unique { .. })));
 
             // Check second column (backtick-quoted, preserves case)
             assert_eq!(create.columns[1].name, "c2");
@@ -560,7 +560,7 @@ fn test_parse_national_varchar_with_constraint() {
             assert!(create.columns[0]
                 .constraints
                 .iter()
-                .any(|c| matches!(&c.kind, vibesql_ast::ColumnConstraintKind::Unique)));
+                .any(|c| matches!(&c.kind, vibesql_ast::ColumnConstraintKind::Unique { .. })));
 
             // Check second column (unquoted, normalized to uppercase)
             assert_eq!(create.columns[1].name, "c2");
@@ -572,7 +572,7 @@ fn test_parse_national_varchar_with_constraint() {
             assert!(create.columns[1]
                 .constraints
                 .iter()
-                .any(|c| matches!(&c.kind, vibesql_ast::ColumnConstraintKind::Unique)));
+                .any(|c| matches!(&c.kind, vibesql_ast::ColumnConstraintKind::Unique { .. })));
         }
         _ => panic!("Expected CREATE TABLE statement"),
     }

--- a/crates/vibesql-parser/src/tests/create_table/typeless_columns.rs
+++ b/crates/vibesql-parser/src/tests/create_table/typeless_columns.rs
@@ -68,7 +68,7 @@ fn test_parse_create_table_typeless_with_primary_key() {
             assert!(create.columns[0]
                 .constraints
                 .iter()
-                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::PrimaryKey)));
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::PrimaryKey { .. })));
         }
         _ => panic!("Expected CREATE TABLE statement"),
     }
@@ -103,7 +103,7 @@ fn test_parse_create_table_typeless_with_unique() {
             assert!(create.columns[0]
                 .constraints
                 .iter()
-                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Unique)));
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Unique { .. })));
         }
         _ => panic!("Expected CREATE TABLE statement"),
     }
@@ -166,13 +166,13 @@ fn test_parse_create_table_typeless_with_multiple_constraints() {
             let constraints = &create.columns[0].constraints;
             assert!(constraints
                 .iter()
-                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::PrimaryKey)));
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::PrimaryKey { .. })));
             assert!(constraints
                 .iter()
                 .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::NotNull)));
             assert!(constraints
                 .iter()
-                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Unique)));
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Unique { .. })));
         }
         _ => panic!("Expected CREATE TABLE statement"),
     }
@@ -235,7 +235,7 @@ fn test_parse_create_table_complex_sqlite_pattern() {
             assert!(!create.table_constraints.is_empty());
             assert!(create.table_constraints.iter().any(|c| matches!(
                 &c.kind,
-                vibesql_ast::TableConstraintKind::PrimaryKey { columns } if columns.len() == 2
+                vibesql_ast::TableConstraintKind::PrimaryKey { columns, .. } if columns.len() == 2
             )));
         }
         _ => panic!("Expected CREATE TABLE statement"),


### PR DESCRIPTION
## Summary
- Implements SQLite's ON CONFLICT clause parsing for PRIMARY KEY and UNIQUE constraints (#4538)
- Adds on_conflict field to constraint AST types to store the conflict resolution algorithm
- Adds CONFLICT keyword to lexer and parses ON CONFLICT ROLLBACK|ABORT|FAIL|IGNORE|REPLACE

## Changes
- **AST**: Extended `ColumnConstraintKind::PrimaryKey`, `ColumnConstraintKind::Unique`, `TableConstraintKind::PrimaryKey`, and `TableConstraintKind::Unique` with `on_conflict: Option<ConflictClause>` field
- **Parser**: Added `parse_constraint_conflict_clause()` helper method to parse ON CONFLICT clauses
- **Lexer**: Added CONFLICT keyword

## Test plan
- [x] Added parser tests for column-level ON CONFLICT (`test_parse_on_conflict_column_constraints`)
- [x] Added parser tests for table-level ON CONFLICT (`test_parse_on_conflict_table_constraints`)
- [x] All 1143 parser tests pass
- [x] All constraint_validator tests pass

## Note
This PR adds the AST and parser support for ON CONFLICT in constraint definitions. The executor-level implementation (storing in catalog and enforcing during INSERT/UPDATE) will be handled in a follow-up PR.

Closes #4538

🤖 Generated with [Claude Code](https://claude.com/claude-code)