### PR TITLE
fix(executor): ORDER BY with join now sorts correctly

### DIFF
--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
@@ -86,6 +86,13 @@ impl SelectExecutor<'_> {
             return Ok(None);
         }
 
+        // ORDER BY requires sorting after projection - fall back to row-oriented (#4552)
+        // The row-oriented path handles ORDER BY correctly via apply_sorting()
+        if stmt.order_by.is_some() {
+            log::debug!("Columnar join: skipping - ORDER BY not supported");
+            return Ok(None);
+        }
+
         // ROWID pseudo-column references require row-oriented execution (#4370)
         // Columnar batches don't track per-row ROWIDs, so we fall back when ROWID is referenced
         if select_list_has_rowid(&stmt.select_list) {

--- a/crates/vibesql-executor/src/tests/select_order_by.rs
+++ b/crates/vibesql-executor/src/tests/select_order_by.rs
@@ -188,3 +188,136 @@ fn test_order_by_multiple_columns() {
     assert_eq!(result[3].values[1], vibesql_types::SqlValue::Integer(2));
     assert_eq!(result[3].values[2], vibesql_types::SqlValue::Integer(20));
 }
+
+/// Test ORDER BY with join (issue #4552)
+/// ORDER BY should work correctly when there's an equi-join condition in WHERE clause
+#[test]
+fn test_order_by_with_join_issue_4552() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Create t1 table
+    let schema1 = vibesql_catalog::TableSchema::new(
+        "t1".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "a".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+        ],
+    );
+    db.create_table(schema1).unwrap();
+    db.insert_row(
+        "t1",
+        vibesql_storage::Row::new(vec![vibesql_types::SqlValue::Integer(1)]),
+    )
+    .unwrap();
+
+    // Create t2 table
+    let schema2 = vibesql_catalog::TableSchema::new(
+        "t2".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "d".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "e".to_string(),
+                vibesql_types::DataType::Varchar { max_length: None },
+                false,
+            ),
+        ],
+    );
+    db.create_table(schema2).unwrap();
+    db.insert_row(
+        "t2",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(1),
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("c")),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "t2",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(1),
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("a")),
+        ]),
+    )
+    .unwrap();
+    db.insert_row(
+        "t2",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(1),
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("b")),
+        ]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+    // SELECT * FROM t1, t2 WHERE d=a ORDER BY e
+    let stmt = vibesql_ast::SelectStmt {
+        into_variables: None,
+        into_table: None,
+        with_clause: None,
+        set_operation: None,
+        values: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+        from: Some(vibesql_ast::FromClause::Join {
+            left: Box::new(vibesql_ast::FromClause::Table {
+                quoted: false,
+                name: "t1".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            right: Box::new(vibesql_ast::FromClause::Table {
+                quoted: false,
+                name: "t2".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            join_type: vibesql_ast::JoinType::Cross,
+            condition: None,
+            using_columns: None,
+            natural: false,
+        }),
+        where_clause: Some(vibesql_ast::Expression::BinaryOp {
+            left: Box::new(vibesql_ast::Expression::ColumnRef(
+                vibesql_ast::ColumnIdentifier::simple("d", false),
+            )),
+            op: vibesql_ast::BinaryOperator::Equal,
+            right: Box::new(vibesql_ast::Expression::ColumnRef(
+                vibesql_ast::ColumnIdentifier::simple("a", false),
+            )),
+        }),
+        group_by: None,
+        having: None,
+        order_by: Some(vec![vibesql_ast::OrderByItem {
+            expr: vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "e", false,
+            )),
+            direction: vibesql_ast::OrderDirection::Asc,
+            nulls_order: None,
+        }]),
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 3);
+    // Should be sorted alphabetically by 'e': a, b, c
+    assert_eq!(
+        result[0].values[2],
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("a"))
+    );
+    assert_eq!(
+        result[1].values[2],
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("b"))
+    );
+    assert_eq!(
+        result[2].values[2],
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("c"))
+    );
+}


### PR DESCRIPTION
## Summary
- Fixed ORDER BY not sorting correctly when combined with equi-joins
- The columnar join execution path was not applying ORDER BY to results
- When ORDER BY is present, now falls back to row-oriented execution which handles sorting correctly

## Root Cause
The `try_columnar_join_execution` path in `execute_with_ctes` returned results without applying ORDER BY. This fast-path for equi-join queries bypassed the normal materialized execution which handles ORDER BY correctly via `apply_order_by()`.

## Test plan
- [x] Added test case `test_order_by_with_join_issue_4552` to verify fix
- [x] Verified original issue reproduction case now returns correct order
- [x] All existing ORDER BY tests pass
- [x] All executor tests pass

Closes #4552

🤖 Generated with [Claude Code](https://claude.com/claude-code)