### PR TITLE
feat(parser): Support NATURAL in all JOIN syntax positions

### DIFF
--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -421,9 +421,14 @@ impl Parser {
 
     /// Parse JOIN type (INNER JOIN, LEFT JOIN, NATURAL JOIN, etc.)
     /// Returns (JoinType, is_natural)
+    ///
+    /// SQLite supports NATURAL in various positions:
+    /// - NATURAL JOIN, NATURAL LEFT JOIN, NATURAL LEFT OUTER JOIN
+    /// - LEFT NATURAL JOIN, LEFT OUTER NATURAL JOIN
+    /// - OUTER LEFT NATURAL JOIN
     pub(crate) fn parse_join_type(&mut self) -> Result<(vibesql_ast::JoinType, bool), ParseError> {
         // Check for optional NATURAL keyword first
-        let is_natural = if self.peek_keyword(Keyword::Natural) {
+        let mut is_natural = if self.peek_keyword(Keyword::Natural) {
             self.consume_keyword(Keyword::Natural)?;
             true
         } else {
@@ -437,6 +442,11 @@ impl Parser {
             }
             Token::Keyword { keyword: Keyword::Inner, .. } => {
                 self.advance();
+                // Check for NATURAL after INNER (INNER NATURAL JOIN)
+                if self.peek_keyword(Keyword::Natural) {
+                    self.consume_keyword(Keyword::Natural)?;
+                    is_natural = true;
+                }
                 self.expect_keyword(Keyword::Join)?;
                 vibesql_ast::JoinType::Inner
             }
@@ -445,6 +455,11 @@ impl Parser {
                 // Optional OUTER keyword
                 if self.peek_keyword(Keyword::Outer) {
                     self.consume_keyword(Keyword::Outer)?;
+                }
+                // Check for NATURAL after LEFT [OUTER] (LEFT NATURAL JOIN, LEFT OUTER NATURAL JOIN)
+                if self.peek_keyword(Keyword::Natural) {
+                    self.consume_keyword(Keyword::Natural)?;
+                    is_natural = true;
                 }
                 self.expect_keyword(Keyword::Join)?;
                 vibesql_ast::JoinType::LeftOuter
@@ -455,11 +470,21 @@ impl Parser {
                 if self.peek_keyword(Keyword::Outer) {
                     self.consume_keyword(Keyword::Outer)?;
                 }
+                // Check for NATURAL after RIGHT [OUTER]
+                if self.peek_keyword(Keyword::Natural) {
+                    self.consume_keyword(Keyword::Natural)?;
+                    is_natural = true;
+                }
                 self.expect_keyword(Keyword::Join)?;
                 vibesql_ast::JoinType::RightOuter
             }
             Token::Keyword { keyword: Keyword::Cross, .. } => {
                 self.advance();
+                // Check for NATURAL after CROSS
+                if self.peek_keyword(Keyword::Natural) {
+                    self.consume_keyword(Keyword::Natural)?;
+                    is_natural = true;
+                }
                 self.expect_keyword(Keyword::Join)?;
                 vibesql_ast::JoinType::Cross
             }
@@ -468,6 +493,11 @@ impl Parser {
                 // Optional OUTER keyword
                 if self.peek_keyword(Keyword::Outer) {
                     self.consume_keyword(Keyword::Outer)?;
+                }
+                // Check for NATURAL after FULL [OUTER]
+                if self.peek_keyword(Keyword::Natural) {
+                    self.consume_keyword(Keyword::Natural)?;
+                    is_natural = true;
                 }
                 self.expect_keyword(Keyword::Join)?;
                 vibesql_ast::JoinType::FullOuter
@@ -478,16 +508,31 @@ impl Parser {
                 match self.peek() {
                     Token::Keyword { keyword: Keyword::Left, .. } => {
                         self.advance();
+                        // Check for NATURAL after OUTER LEFT
+                        if self.peek_keyword(Keyword::Natural) {
+                            self.consume_keyword(Keyword::Natural)?;
+                            is_natural = true;
+                        }
                         self.expect_keyword(Keyword::Join)?;
                         vibesql_ast::JoinType::LeftOuter
                     }
                     Token::Keyword { keyword: Keyword::Right, .. } => {
                         self.advance();
+                        // Check for NATURAL after OUTER RIGHT
+                        if self.peek_keyword(Keyword::Natural) {
+                            self.consume_keyword(Keyword::Natural)?;
+                            is_natural = true;
+                        }
                         self.expect_keyword(Keyword::Join)?;
                         vibesql_ast::JoinType::RightOuter
                     }
                     Token::Keyword { keyword: Keyword::Full, .. } => {
                         self.advance();
+                        // Check for NATURAL after OUTER FULL
+                        if self.peek_keyword(Keyword::Natural) {
+                            self.consume_keyword(Keyword::Natural)?;
+                            is_natural = true;
+                        }
                         self.expect_keyword(Keyword::Join)?;
                         vibesql_ast::JoinType::FullOuter
                     }

--- a/crates/vibesql-parser/src/tests/joins.rs
+++ b/crates/vibesql-parser/src/tests/joins.rs
@@ -397,6 +397,82 @@ fn test_parse_natural_cross_join_complex() {
     assert!(result.is_ok(), "Parse failed: {:?}", result.err());
 }
 
+#[test]
+fn test_parse_outer_left_natural_join() {
+    // SQLite allows OUTER before LEFT in "OUTER LEFT NATURAL JOIN" (#4574)
+    let result = Parser::parse_sql("SELECT * FROM t1 OUTER LEFT NATURAL JOIN t2;");
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
+            vibesql_ast::FromClause::Join { join_type, natural, .. } => {
+                assert_eq!(*join_type, vibesql_ast::JoinType::LeftOuter);
+                assert!(*natural);
+            }
+            _ => panic!("Expected JOIN"),
+        },
+        _ => panic!("Expected SELECT"),
+    }
+}
+
+#[test]
+fn test_parse_left_natural_join() {
+    // NATURAL can appear after LEFT: "LEFT NATURAL JOIN" (#4574)
+    let result = Parser::parse_sql("SELECT * FROM t1 LEFT NATURAL JOIN t2;");
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
+            vibesql_ast::FromClause::Join { join_type, natural, .. } => {
+                assert_eq!(*join_type, vibesql_ast::JoinType::LeftOuter);
+                assert!(*natural);
+            }
+            _ => panic!("Expected JOIN"),
+        },
+        _ => panic!("Expected SELECT"),
+    }
+}
+
+#[test]
+fn test_parse_left_outer_natural_join() {
+    // NATURAL can appear after LEFT OUTER: "LEFT OUTER NATURAL JOIN" (#4574)
+    let result = Parser::parse_sql("SELECT * FROM t1 LEFT OUTER NATURAL JOIN t2;");
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
+            vibesql_ast::FromClause::Join { join_type, natural, .. } => {
+                assert_eq!(*join_type, vibesql_ast::JoinType::LeftOuter);
+                assert!(*natural);
+            }
+            _ => panic!("Expected JOIN"),
+        },
+        _ => panic!("Expected SELECT"),
+    }
+}
+
+#[test]
+fn test_parse_natural_left_outer_join() {
+    // Standard form: "NATURAL LEFT OUTER JOIN"
+    let result = Parser::parse_sql("SELECT * FROM t1 NATURAL LEFT OUTER JOIN t2;");
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
+            vibesql_ast::FromClause::Join { join_type, natural, .. } => {
+                assert_eq!(*join_type, vibesql_ast::JoinType::LeftOuter);
+                assert!(*natural);
+            }
+            _ => panic!("Expected JOIN"),
+        },
+        _ => panic!("Expected SELECT"),
+    }
+}
+
 // ========================================================================
 // Legacy Comma-Join ON Syntax Tests (#4369)
 // ========================================================================


### PR DESCRIPTION
## Summary

- Support SQLite's flexible NATURAL JOIN syntax where NATURAL can appear in various positions
- Add support for: `OUTER LEFT NATURAL JOIN`, `LEFT NATURAL JOIN`, `LEFT OUTER NATURAL JOIN`, etc.
- Add parser tests for all new syntax variants

## Test plan

- [x] All existing parser tests pass
- [x] All existing executor NATURAL JOIN tests pass  
- [x] New parser tests for syntax variants added and passing
- [x] Manual testing of `OUTER LEFT NATURAL JOIN` syntax

Closes #4574

🤖 Generated with [Claude Code](https://claude.com/claude-code)