### PR TITLE
fix(join): Fix RIGHT JOIN schema and data order mismatch

### DIFF
--- a/crates/vibesql-executor/src/select/join/nested_loop.rs
+++ b/crates/vibesql-executor/src/select/join/nested_loop.rs
@@ -748,8 +748,12 @@ pub(super) fn nested_loop_right_outer_join(
     // RIGHT OUTER JOIN = LEFT OUTER JOIN with sides swapped
     // Then we need to reorder columns to put left first, right second
 
+    // Save original schemas before swapping - we need these to build the correct output schema
+    let left_schema = left.schema.clone();
+    let right_schema = right.schema.clone();
+
     // Get the right column count (handles nested joins with multiple tables)
-    let right_col_count = right.schema.total_columns;
+    let right_col_count = right_schema.total_columns;
 
     // Do LEFT OUTER JOIN with swapped sides
     let swapped_result =
@@ -774,7 +778,11 @@ pub(super) fn nested_loop_right_outer_join(
         })
         .collect();
 
-    Ok(FromResult::from_rows(swapped_result.schema, reordered_rows))
+    // Build the correct schema: left columns first, then right columns
+    // The swapped_result.schema has [right, left] order, so we need to merge correctly
+    let correct_schema = CombinedSchema::merge(left_schema, right_schema);
+
+    Ok(FromResult::from_rows(correct_schema, reordered_rows))
 }
 
 /// Nested loop FULL OUTER JOIN implementation


### PR DESCRIPTION
## Summary

Fix RIGHT JOIN queries that return incorrect results due to a schema/data order mismatch.

## Problem

The RIGHT JOIN implementation had a bug where it correctly reordered data values after swapping tables, but returned the wrong schema. This caused:
- Column name/value mismatches (left values in right columns and vice versa)
- NULLs appearing on the wrong side for non-matching rows

**Before fix:**
```sql
SELECT L.la, L.lb, R.ra, R.rb FROM L RIGHT JOIN R ON L.la = R.ra;
-- Returns: la=2, lb='R2', ra=2, rb='L2'  (values swapped!)
-- Returns: la=3, lb='R3', ra=NULL, rb=NULL  (NULLs on wrong side!)
```

**After fix:**
```sql
SELECT L.la, L.lb, R.ra, R.rb FROM L RIGHT JOIN R ON L.la = R.ra;
-- Returns: la=2, lb='L2', ra=2, rb='R2'  ✓
-- Returns: la=NULL, lb=NULL, ra=3, rb='R3'  ✓
```

## Root Cause

When implementing RIGHT JOIN by swapping tables and calling LEFT JOIN:
1. ✅ Data values were correctly reordered to (left, right) order
2. ❌ But `swapped_result.schema` was returned, which had (right, left) order

## Fix

Save the original schemas before swapping, then construct the correct schema using `CombinedSchema::merge(left_schema, right_schema)` to match the reordered data.

## Testing

- All 2171 executor lib tests pass
- Manual verification with multiple test cases confirms correct behavior
- RIGHT JOIN now produces results equivalent to swapped LEFT JOIN

Closes #4575