### PR TITLE
fix(executor): Support rowid pseudo-column in ORDER BY fast path

### DIFF
--- a/crates/vibesql-executor/src/select/executor/fast_path/helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path/helpers.rs
@@ -187,23 +187,72 @@ impl SelectExecutor<'_> {
 
         use crate::select::grouping::compare_sql_values;
 
-        // Pre-compute column indices for ORDER BY columns
-        // (col_idx, direction, nulls_first)
-        let mut sort_indices: Vec<(usize, OrderDirection, bool)> = Vec::with_capacity(order_by.len());
+        // Sort key can be either a column index or rowid pseudo-column
+        // None = sort by rowid, Some(idx) = sort by column at index
+        #[derive(Clone)]
+        enum SortKey {
+            Column(usize),
+            Rowid(Option<String>), // table qualifier for JOINs
+        }
+
+        // Pre-compute sort keys for ORDER BY columns
+        // (sort_key, direction, nulls_first)
+        let mut sort_keys: Vec<(SortKey, OrderDirection, bool)> = Vec::with_capacity(order_by.len());
 
         for item in order_by {
-            let col_idx = match &item.expr {
+            let sort_key = match &item.expr {
                 Expression::ColumnRef(col_id) => {
                     let table = col_id.table_canonical();
                     let column = col_id.column_canonical();
-                    schema
-                        .get_column_index(table, column)
-                        .ok_or_else(|| ExecutorError::ColumnNotFound {
-                            column_name: column.to_string(),
-                            table_name: table.map(|t| t.to_string()).unwrap_or_default(),
-                            searched_tables: schema.table_names(),
-                            available_columns: vec![],
-                        })?
+
+                    // First try to get column index from schema
+                    if let Some(col_idx) = schema.get_column_index(table, column) {
+                        SortKey::Column(col_idx)
+                    } else {
+                        // Check if this is a rowid pseudo-column
+                        let column_lower = column.to_lowercase();
+                        let is_rowid = column_lower == "rowid"
+                            || column_lower == "_rowid_"
+                            || column_lower == "oid";
+
+                        if is_rowid {
+                            // Verify table qualifier if present
+                            if let Some(qualifier) = table {
+                                let qualifier_lower = qualifier.to_lowercase();
+                                let table_exists = schema
+                                    .table_schemas
+                                    .keys()
+                                    .any(|k| k.canonical() == qualifier_lower);
+                                if !table_exists {
+                                    return Err(ExecutorError::ColumnNotFound {
+                                        column_name: column.to_string(),
+                                        table_name: qualifier.to_string(),
+                                        searched_tables: schema.table_names(),
+                                        available_columns: vec![],
+                                    });
+                                }
+                                SortKey::Rowid(Some(qualifier.to_string()))
+                            } else {
+                                // Unqualified rowid - valid if there's at least one table
+                                if schema.table_schemas.is_empty() {
+                                    return Err(ExecutorError::ColumnNotFound {
+                                        column_name: column.to_string(),
+                                        table_name: String::new(),
+                                        searched_tables: schema.table_names(),
+                                        available_columns: vec![],
+                                    });
+                                }
+                                SortKey::Rowid(None)
+                            }
+                        } else {
+                            return Err(ExecutorError::ColumnNotFound {
+                                column_name: column.to_string(),
+                                table_name: table.map(|t| t.to_string()).unwrap_or_default(),
+                                searched_tables: schema.table_names(),
+                                available_columns: vec![],
+                            });
+                        }
+                    }
                 }
                 _ => {
                     return Err(ExecutorError::Other(
@@ -217,14 +266,44 @@ impl SelectExecutor<'_> {
             let nulls_first = item
                 .nulls_order
                 .is_some_and(|no| matches!(no, vibesql_ast::NullsOrder::First));
-            sort_indices.push((col_idx, item.direction.clone(), nulls_first));
+            sort_keys.push((sort_key, item.direction.clone(), nulls_first));
         }
 
-        // Sort rows by the specified columns
+        // Sort rows by the specified columns/rowid
         rows.sort_by(|a, b| {
-            for (col_idx, dir, nulls_first) in &sort_indices {
-                let val_a = &a.values[*col_idx];
-                let val_b = &b.values[*col_idx];
+            for (sort_key, dir, nulls_first) in &sort_keys {
+                let (val_a, val_b) = match sort_key {
+                    SortKey::Column(col_idx) => {
+                        (&a.values[*col_idx], &b.values[*col_idx])
+                    }
+                    SortKey::Rowid(table_qualifier) => {
+                        // Get rowid from row metadata
+                        let rowid_a = a.get_row_id_for_table(table_qualifier.as_deref());
+                        let rowid_b = b.get_row_id_for_table(table_qualifier.as_deref());
+
+                        // Compare rowid values with proper NULL handling
+                        let cmp = match (rowid_a, rowid_b) {
+                            (None, None) => Ordering::Equal,
+                            (None, Some(_)) => {
+                                if *nulls_first { Ordering::Less } else { Ordering::Greater }
+                            }
+                            (Some(_), None) => {
+                                if *nulls_first { Ordering::Greater } else { Ordering::Less }
+                            }
+                            (Some(id_a), Some(id_b)) => {
+                                let raw_cmp = id_a.cmp(&id_b);
+                                match dir {
+                                    OrderDirection::Asc => raw_cmp,
+                                    OrderDirection::Desc => raw_cmp.reverse(),
+                                }
+                            }
+                        };
+                        if cmp != Ordering::Equal {
+                            return cmp;
+                        }
+                        continue; // Move to next sort key
+                    }
+                };
 
                 // Handle NULLs according to nulls_first setting
                 let cmp = match (val_a.is_null(), val_b.is_null()) {

--- a/crates/vibesql-executor/src/tests/rowid_tests.rs
+++ b/crates/vibesql-executor/src/tests/rowid_tests.rs
@@ -535,3 +535,155 @@ fn test_mixed_explicit_and_auto_rowid() {
     assert_eq!(result[2].values[0], vibesql_types::SqlValue::Bigint(20));
     assert_eq!(result[2].values[1], vibesql_types::SqlValue::Integer(300));
 }
+
+/// Test ORDER BY rowid (issue #4573)
+#[test]
+fn test_order_by_rowid() {
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "t1".to_string(),
+        vec![vibesql_catalog::ColumnSchema::new(
+            "x".to_string(),
+            vibesql_types::DataType::Integer,
+            false,
+        )],
+    );
+    db.create_table(schema).unwrap();
+
+    // Insert rows with explicit rowids in non-sequential order
+    db.insert_row(
+        "t1",
+        vibesql_storage::Row::with_row_id(vec![vibesql_types::SqlValue::Integer(30)], 3),
+    )
+    .unwrap();
+    db.insert_row(
+        "t1",
+        vibesql_storage::Row::with_row_id(vec![vibesql_types::SqlValue::Integer(10)], 1),
+    )
+    .unwrap();
+    db.insert_row(
+        "t1",
+        vibesql_storage::Row::with_row_id(vec![vibesql_types::SqlValue::Integer(20)], 2),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // SELECT x FROM t1 ORDER BY rowid ASC
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        values: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Expression {
+            expr: vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "x", false,
+            )),
+            alias: None,
+            source_text: None,
+        }],
+        from: Some(vibesql_ast::FromClause::Table {
+            quoted: false,
+            name: "t1".to_string(),
+            alias: None,
+            column_aliases: None,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: Some(vec![vibesql_ast::OrderByItem {
+            expr: vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "rowid", false,
+            )),
+            direction: vibesql_ast::OrderDirection::Asc,
+            nulls_order: None,
+        }]),
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 3);
+    // Should be sorted by rowid: 1, 2, 3 -> x values: 10, 20, 30
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Integer(10));
+    assert_eq!(result[1].values[0], vibesql_types::SqlValue::Integer(20));
+    assert_eq!(result[2].values[0], vibesql_types::SqlValue::Integer(30));
+}
+
+/// Test ORDER BY rowid DESC (issue #4573)
+#[test]
+fn test_order_by_rowid_desc() {
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "t1".to_string(),
+        vec![vibesql_catalog::ColumnSchema::new(
+            "x".to_string(),
+            vibesql_types::DataType::Integer,
+            false,
+        )],
+    );
+    db.create_table(schema).unwrap();
+
+    // Insert rows
+    db.insert_row(
+        "t1",
+        vibesql_storage::Row::new(vec![vibesql_types::SqlValue::Integer(10)]),
+    )
+    .unwrap();
+    db.insert_row(
+        "t1",
+        vibesql_storage::Row::new(vec![vibesql_types::SqlValue::Integer(20)]),
+    )
+    .unwrap();
+    db.insert_row(
+        "t1",
+        vibesql_storage::Row::new(vec![vibesql_types::SqlValue::Integer(30)]),
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // SELECT x FROM t1 ORDER BY _rowid_ DESC
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        values: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Expression {
+            expr: vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "x", false,
+            )),
+            alias: None,
+            source_text: None,
+        }],
+        from: Some(vibesql_ast::FromClause::Table {
+            quoted: false,
+            name: "t1".to_string(),
+            alias: None,
+            column_aliases: None,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: Some(vec![vibesql_ast::OrderByItem {
+            expr: vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "_rowid_", false,
+            )),
+            direction: vibesql_ast::OrderDirection::Desc,
+            nulls_order: None,
+        }]),
+        limit: None,
+        offset: None,
+    };
+
+    let result = executor.execute(&stmt).unwrap();
+    assert_eq!(result.len(), 3);
+    // Should be sorted by rowid DESC: 3, 2, 1 -> x values: 30, 20, 10
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Integer(30));
+    assert_eq!(result[1].values[0], vibesql_types::SqlValue::Integer(20));
+    assert_eq!(result[2].values[0], vibesql_types::SqlValue::Integer(10));
+}


### PR DESCRIPTION
## Summary

- Fixes the fast path ORDER BY code to handle rowid, _rowid_, and oid pseudo-columns
- When ORDER BY rowid was used, the code tried to look up rowid as a schema column and failed with "Column 'rowid' not found"
- The fix detects rowid pseudo-column references and uses Row::get_row_id_for_table() to get the rowid for comparison

## Test plan

- [x] Added `test_order_by_rowid` test case
- [x] Added `test_order_by_rowid_desc` test case
- [x] All existing tests pass
- [x] Manual testing of `SELECT y FROM t1 ORDER BY rowid` works correctly

Closes #4573

🤖 Generated with [Claude Code](https://claude.com/claude-code)