### PR TITLE
feat(trigger): Add INSTEAD OF trigger support for views

### DIFF
--- a/crates/vibesql-cli/src/script.rs
+++ b/crates/vibesql-cli/src/script.rs
@@ -269,6 +269,7 @@ fn parse_statements(script: &str) -> Vec<String> {
     let mut current_statement = String::new();
     let mut in_string = false;
     let mut in_multiline_comment = false;
+    let mut begin_depth = 0; // Track BEGIN...END nesting for trigger bodies
     let mut chars = script.chars().peekable();
 
     while let Some(ch) = chars.next() {
@@ -312,18 +313,51 @@ fn parse_statements(script: &str) -> Vec<String> {
             continue;
         }
 
+        // Track BEGIN/END keywords for trigger body nesting (case-insensitive)
+        if !in_string && ch.is_ascii_alphabetic() {
+            current_statement.push(ch);
+            // Peek ahead to check for BEGIN or END keyword
+            let rest: String = chars
+                .clone()
+                .take_while(|c| c.is_ascii_alphabetic())
+                .collect();
+            let word = format!("{}{}", ch, rest).to_uppercase();
+            if word == "BEGIN" {
+                // Consume the rest of the word
+                for _ in 0..(rest.len()) {
+                    if let Some(c) = chars.next() {
+                        current_statement.push(c);
+                    }
+                }
+                begin_depth += 1;
+                continue;
+            } else if word == "END" && begin_depth > 0 {
+                // Consume the rest of the word
+                for _ in 0..(rest.len()) {
+                    if let Some(c) = chars.next() {
+                        current_statement.push(c);
+                    }
+                }
+                begin_depth -= 1;
+                continue;
+            }
+            // Not BEGIN/END, let normal processing continue
+            continue;
+        }
+
         // Handle statement delimiter (semicolon)
         // Include the semicolon in the statement so the parser can see it.
-        // This allows the parser to distinguish between:
-        // - "SELECT f1 FROM test1 ORDER BY"   → incomplete input (no semicolon)
-        // - "SELECT f1 FROM test1 ORDER BY;"  → syntax error (has semicolon, but invalid)
+        // But don't split if we're inside a BEGIN...END block (trigger body)
         if !in_string && ch == ';' {
             current_statement.push(ch); // Include the semicolon
-            let trimmed = current_statement.trim();
-            if !trimmed.is_empty() {
-                statements.push(trimmed.to_string());
+            if begin_depth == 0 {
+                // Only split if we're not inside a BEGIN...END block
+                let trimmed = current_statement.trim();
+                if !trimmed.is_empty() {
+                    statements.push(trimmed.to_string());
+                }
+                current_statement.clear();
             }
-            current_statement.clear();
             continue;
         }
 

--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -121,6 +121,11 @@ impl DeleteExecutor {
         // Check DELETE privilege on the table
         PrivilegeChecker::check_delete(database, &stmt.table_name)?;
 
+        // Check if target is a VIEW with INSTEAD OF triggers
+        if let Some(view_def) = database.catalog.get_view(&stmt.table_name).cloned() {
+            return execute_delete_on_view(database, stmt, &view_def, procedural_context, trigger_context);
+        }
+
         // Use TableIdentifier for SQL:1999 case-sensitive lookups when quoted
         let table_id = TableIdentifier::new(&stmt.table_name, stmt.quoted);
 
@@ -608,4 +613,116 @@ pub fn execute_delete_with_trigger_context(
     trigger_context: &crate::trigger_execution::TriggerContext,
 ) -> Result<usize, ExecutorError> {
     DeleteExecutor::execute_with_trigger_context(stmt, database, trigger_context)
+}
+
+/// Execute DELETE on a VIEW using INSTEAD OF triggers
+///
+/// When deleting from a view, we need to fire INSTEAD OF DELETE triggers
+/// instead of actually deleting data. The triggers typically delete from
+/// the underlying tables.
+fn execute_delete_on_view(
+    database: &mut Database,
+    stmt: &DeleteStmt,
+    view_def: &vibesql_catalog::ViewDefinition,
+    procedural_context: Option<&crate::procedural::ExecutionContext>,
+    trigger_context: Option<&crate::trigger_execution::TriggerContext>,
+) -> Result<usize, ExecutorError> {
+    use vibesql_ast::TriggerTiming;
+
+    // Find INSTEAD OF DELETE triggers for this view
+    let triggers = crate::TriggerFirer::find_triggers(
+        database,
+        &view_def.name,
+        TriggerTiming::InsteadOf,
+        vibesql_ast::TriggerEvent::Delete,
+    );
+
+    if triggers.is_empty() {
+        return Err(ExecutorError::UnsupportedExpression(format!(
+            "Cannot DELETE from view '{}' without INSTEAD OF trigger",
+            view_def.name
+        )));
+    }
+
+    // Build a pseudo-schema for the view
+    let view_schema = build_view_schema(database, view_def)?;
+
+    // Execute the view query to get the rows to potentially delete
+    let select_executor = crate::SelectExecutor::new(database);
+    let all_rows = select_executor.execute_with_columns(&view_def.query)?;
+
+    // Collect rows to delete first, before firing triggers
+    // This avoids borrow conflicts with the evaluator
+    let rows_to_delete: Vec<vibesql_storage::Row> = {
+        // Create evaluator for WHERE clause (if any)
+        let evaluator = if let Some(ctx) = trigger_context {
+            ExpressionEvaluator::with_trigger_context(&view_schema, database, ctx)
+        } else if let Some(ctx) = procedural_context {
+            ExpressionEvaluator::with_procedural_context(&view_schema, database, ctx)
+        } else {
+            ExpressionEvaluator::with_database(&view_schema, database)
+        };
+
+        // Select rows matching WHERE clause
+        let mut collected_rows = Vec::new();
+        for row in &all_rows.rows {
+            let matches = match &stmt.where_clause {
+                Some(vibesql_ast::WhereClause::Condition(expr)) => {
+                    match evaluator.eval(expr, row)? {
+                        vibesql_types::SqlValue::Boolean(b) => b,
+                        vibesql_types::SqlValue::Null => false,
+                        _ => false,
+                    }
+                }
+                None => true, // No WHERE clause - delete all rows
+                Some(vibesql_ast::WhereClause::CurrentOf(_)) => {
+                    return Err(ExecutorError::UnsupportedExpression(
+                        "CURRENT OF not supported for view deletes".to_string(),
+                    ));
+                }
+            };
+
+            if matches {
+                collected_rows.push(row.clone());
+            }
+        }
+        collected_rows
+    }; // evaluator dropped here
+
+    // Now fire triggers (database can be mutably borrowed)
+    let rows_processed = rows_to_delete.len();
+    for old_row in rows_to_delete {
+        for trigger in &triggers {
+            crate::TriggerFirer::execute_trigger(database, trigger, Some(&old_row), None)?;
+        }
+    }
+
+    Ok(rows_processed)
+}
+
+/// Build a pseudo TableSchema from a view definition
+fn build_view_schema(
+    database: &Database,
+    view_def: &vibesql_catalog::ViewDefinition,
+) -> Result<vibesql_catalog::TableSchema, ExecutorError> {
+    // Execute the view's SELECT query to get column names
+    let select_executor = crate::SelectExecutor::new(database);
+    let result = select_executor.execute_with_columns(&view_def.query)?;
+
+    // Use explicit column names if provided, otherwise derive from SELECT
+    let column_names: Vec<String> = if let Some(ref cols) = view_def.columns {
+        cols.clone()
+    } else {
+        result.columns.clone()
+    };
+
+    // Build columns with a generic data type (we just need names for trigger binding)
+    let columns: Vec<vibesql_catalog::ColumnSchema> = column_names
+        .into_iter()
+        .map(|name| {
+            vibesql_catalog::ColumnSchema::new(name, vibesql_types::DataType::Varchar { max_length: None }, true)
+        })
+        .collect();
+
+    Ok(vibesql_catalog::TableSchema::new(view_def.name.clone(), columns))
 }

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -49,6 +49,11 @@ fn execute_insert_internal(
     // Check INSERT privilege on the table
     PrivilegeChecker::check_insert(db, &full_table_name)?;
 
+    // Check if target is a VIEW with INSTEAD OF triggers
+    if let Some(view_def) = db.catalog.get_view(&stmt.table_name).cloned() {
+        return execute_insert_on_view(db, stmt, &view_def, procedural_context, trigger_context);
+    }
+
     // Get table schema from catalog (clone to avoid borrow issues)
     // Use TableIdentifier for SQL:1999 case-sensitive lookups when quoted
     // For schema-qualified names, use TableIdentifier::qualified to preserve
@@ -700,4 +705,150 @@ fn check_would_violate_constraints(
     }
 
     false
+}
+
+/// Execute INSERT on a VIEW using INSTEAD OF triggers
+///
+/// When inserting into a view, we need to fire INSTEAD OF INSERT triggers
+/// instead of actually inserting data. The triggers typically insert into
+/// the underlying tables.
+fn execute_insert_on_view(
+    db: &mut vibesql_storage::Database,
+    stmt: &vibesql_ast::InsertStmt,
+    view_def: &vibesql_catalog::ViewDefinition,
+    procedural_context: Option<&crate::procedural::ExecutionContext>,
+    trigger_context: Option<&crate::trigger_execution::TriggerContext>,
+) -> Result<usize, ExecutorError> {
+    use vibesql_ast::TriggerTiming;
+
+    // Find INSTEAD OF INSERT triggers for this view
+    let triggers = crate::TriggerFirer::find_triggers(
+        db,
+        &view_def.name,
+        TriggerTiming::InsteadOf,
+        vibesql_ast::TriggerEvent::Insert,
+    );
+
+    if triggers.is_empty() {
+        return Err(ExecutorError::UnsupportedExpression(format!(
+            "Cannot INSERT into view '{}' without INSTEAD OF trigger",
+            view_def.name
+        )));
+    }
+
+    // Build a pseudo-schema for the view to evaluate values and resolve column names
+    // We derive column info from the view's SELECT query
+    let view_schema = build_view_schema(db, view_def)?;
+
+    // Get the rows to insert based on the source
+    let rows_to_insert = match &stmt.source {
+        vibesql_ast::InsertSource::Values(values) => values.clone(),
+        vibesql_ast::InsertSource::Select(select_stmt) => {
+            // Execute SELECT and convert to expressions
+            let select_executor = crate::SelectExecutor::new(db);
+            let select_result = select_executor.execute_with_columns(select_stmt)?;
+            select_result
+                .rows
+                .into_iter()
+                .map(|row| row.values.into_iter().map(vibesql_ast::Expression::Literal).collect())
+                .collect()
+        }
+    };
+
+    // Determine target column indices from the statement's column list
+    // If no columns specified, use all view columns in order
+    let target_columns: Vec<(usize, &vibesql_catalog::ColumnSchema)> = if stmt.columns.is_empty() {
+        view_schema.columns.iter().enumerate().collect()
+    } else {
+        stmt.columns
+            .iter()
+            .map(|col_name| {
+                view_schema
+                    .columns
+                    .iter()
+                    .enumerate()
+                    .find(|(_, c)| c.name.to_uppercase() == col_name.to_uppercase())
+                    .ok_or_else(|| ExecutorError::ColumnNotFound {
+                        column_name: col_name.clone(),
+                        table_name: view_def.name.clone(),
+                        searched_tables: vec![view_def.name.clone()],
+                        available_columns: view_schema.columns.iter().map(|c| c.name.clone()).collect(),
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?
+    };
+
+    // Collect all new rows first, before firing triggers
+    // This avoids borrow conflicts with the evaluator
+    let new_rows: Vec<vibesql_storage::Row> = {
+        let dummy_row = vibesql_storage::Row::new(vec![]);
+        let evaluator = if let Some(ctx) = trigger_context {
+            crate::evaluator::ExpressionEvaluator::with_trigger_context(&view_schema, db, ctx)
+        } else if let Some(ctx) = procedural_context {
+            crate::evaluator::ExpressionEvaluator::with_procedural_context(&view_schema, db, ctx)
+        } else {
+            crate::evaluator::ExpressionEvaluator::with_database(&view_schema, db)
+        };
+
+        let mut collected_rows = Vec::new();
+        for value_exprs in &rows_to_insert {
+            // Validate column count
+            if value_exprs.len() != target_columns.len() {
+                return Err(ExecutorError::InsertColumnCountMismatch {
+                    table_name: view_def.name.clone(),
+                    expected: target_columns.len(),
+                    provided: value_exprs.len(),
+                });
+            }
+
+            // Build a row with values for all view columns
+            let mut row_values = vec![vibesql_types::SqlValue::Null; view_schema.columns.len()];
+
+            for (expr, (col_idx, _col)) in value_exprs.iter().zip(target_columns.iter()) {
+                // Evaluate expression - for INSERT, these are typically literals
+                let value = evaluator.eval(expr, &dummy_row)?;
+                row_values[*col_idx] = value;
+            }
+
+            collected_rows.push(vibesql_storage::Row::new(row_values));
+        }
+        collected_rows
+    }; // evaluator dropped here
+
+    // Now fire triggers (database can be mutably borrowed)
+    let rows_processed = new_rows.len();
+    for row in new_rows {
+        for trigger in &triggers {
+            crate::TriggerFirer::execute_trigger(db, trigger, None, Some(&row))?;
+        }
+    }
+
+    Ok(rows_processed)
+}
+
+/// Build a pseudo TableSchema from a view definition
+fn build_view_schema(
+    db: &vibesql_storage::Database,
+    view_def: &vibesql_catalog::ViewDefinition,
+) -> Result<vibesql_catalog::TableSchema, ExecutorError> {
+    // Execute the view's SELECT query to get column names
+    let select_executor = crate::SelectExecutor::new(db);
+    let result = select_executor.execute_with_columns(&view_def.query)?;
+
+    // Use explicit column names if provided, otherwise derive from SELECT
+    let column_names: Vec<String> = if let Some(ref cols) = view_def.columns {
+        cols.clone()
+    } else {
+        result.columns.clone()
+    };
+
+    // Build columns with a generic data type (we just need names for trigger binding)
+    let columns: Vec<vibesql_catalog::ColumnSchema> = column_names
+        .into_iter()
+        .map(|name| {
+            vibesql_catalog::ColumnSchema::new(name, vibesql_types::DataType::Varchar { max_length: None }, true)
+        })
+        .collect();
+
+    Ok(vibesql_catalog::TableSchema::new(view_def.name.clone(), columns))
 }

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -296,11 +296,15 @@ impl TriggerFirer {
         let statements = Self::parse_trigger_sql(&sql)?;
 
         // Get table schema for trigger context (clone to avoid borrow checker issues)
-        let schema = db
-            .catalog
-            .get_table(&trigger.table_name)
-            .ok_or_else(|| ExecutorError::TableNotFound(trigger.table_name.clone()))?
-            .clone();
+        // For INSTEAD OF triggers on views, build schema from the view definition
+        let schema = if let Some(table_schema) = db.catalog.get_table(&trigger.table_name) {
+            table_schema.clone()
+        } else if let Some(view_def) = db.catalog.get_view(&trigger.table_name) {
+            // Build a pseudo-schema from the view for OLD/NEW column resolution
+            Self::build_view_schema(db, view_def)?
+        } else {
+            return Err(ExecutorError::TableNotFound(trigger.table_name.clone()));
+        };
 
         // Create trigger context for OLD/NEW pseudo-variable resolution
         let trigger_context = TriggerContext { old_row, new_row, table_schema: &schema };
@@ -311,6 +315,37 @@ impl TriggerFirer {
         }
 
         Ok(())
+    }
+
+    /// Build a pseudo TableSchema from a view definition for trigger OLD/NEW column resolution
+    fn build_view_schema(
+        db: &Database,
+        view_def: &vibesql_catalog::ViewDefinition,
+    ) -> Result<TableSchema, ExecutorError> {
+        // Execute the view's SELECT query to get column names
+        let select_executor = crate::SelectExecutor::new(db);
+        let result = select_executor.execute_with_columns(&view_def.query)?;
+
+        // Use explicit column names if provided, otherwise derive from SELECT
+        let column_names: Vec<String> = if let Some(ref cols) = view_def.columns {
+            cols.clone()
+        } else {
+            result.columns.clone()
+        };
+
+        // Build columns with a generic data type
+        let columns: Vec<vibesql_catalog::ColumnSchema> = column_names
+            .into_iter()
+            .map(|name| {
+                vibesql_catalog::ColumnSchema::new(
+                    name,
+                    vibesql_types::DataType::Varchar { max_length: None },
+                    true,
+                )
+            })
+            .collect();
+
+        Ok(TableSchema::new(view_def.name.clone(), columns))
     }
 
     /// Parse trigger SQL into statements

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -153,6 +153,11 @@ impl UpdateExecutor {
         // Check UPDATE privilege on the table
         PrivilegeChecker::check_update(database, &stmt.table_name)?;
 
+        // Check if target is a VIEW with INSTEAD OF triggers
+        if let Some(view_def) = database.catalog.get_view(&stmt.table_name).cloned() {
+            return execute_update_on_view(database, stmt, &view_def, procedural_context, trigger_context);
+        }
+
         // Step 1: Get table schema - clone it to avoid borrow issues
         // We need owned schema because we take mutable references to database later
         // Use TableIdentifier for SQL:1999 case-sensitive lookups when quoted
@@ -965,6 +970,142 @@ pub fn execute_update_with_trigger_context(
     trigger_context: &crate::trigger_execution::TriggerContext,
 ) -> Result<usize, ExecutorError> {
     UpdateExecutor::execute_with_trigger_context(stmt, database, trigger_context)
+}
+
+/// Execute UPDATE on a VIEW using INSTEAD OF triggers
+///
+/// When updating a view, we need to fire INSTEAD OF UPDATE triggers
+/// instead of actually updating data. The triggers typically update
+/// the underlying tables.
+fn execute_update_on_view(
+    database: &mut Database,
+    stmt: &UpdateStmt,
+    view_def: &vibesql_catalog::ViewDefinition,
+    procedural_context: Option<&crate::procedural::ExecutionContext>,
+    trigger_context: Option<&crate::trigger_execution::TriggerContext>,
+) -> Result<usize, ExecutorError> {
+    use vibesql_ast::TriggerTiming;
+
+    // Find INSTEAD OF UPDATE triggers for this view
+    let triggers = crate::TriggerFirer::find_triggers(
+        database,
+        &view_def.name,
+        TriggerTiming::InsteadOf,
+        vibesql_ast::TriggerEvent::Update(None),
+    );
+
+    if triggers.is_empty() {
+        return Err(ExecutorError::UnsupportedExpression(format!(
+            "Cannot UPDATE view '{}' without INSTEAD OF trigger",
+            view_def.name
+        )));
+    }
+
+    // Build a pseudo-schema for the view
+    let view_schema = build_view_schema(database, view_def)?;
+
+    // Execute the view query to get the rows to potentially update
+    let select_executor = crate::SelectExecutor::new(database);
+    let all_rows = select_executor.execute_with_columns(&view_def.query)?;
+
+    // Collect all (old_row, new_row) pairs first, before firing triggers
+    // This avoids borrow conflicts with the evaluator
+    let updates: Vec<(vibesql_storage::Row, vibesql_storage::Row)> = {
+        // Create evaluator for WHERE clause (if any)
+        let evaluator = if let Some(ctx) = trigger_context {
+            ExpressionEvaluator::with_trigger_context(&view_schema, database, ctx)
+        } else if let Some(ctx) = procedural_context {
+            ExpressionEvaluator::with_procedural_context(&view_schema, database, ctx)
+        } else {
+            ExpressionEvaluator::with_database(&view_schema, database)
+        };
+
+        // Select rows matching WHERE clause and build updates
+        let mut collected_updates = Vec::new();
+        for row in &all_rows.rows {
+            let matches = match &stmt.where_clause {
+                Some(vibesql_ast::WhereClause::Condition(expr)) => {
+                    match evaluator.eval(expr, row)? {
+                        vibesql_types::SqlValue::Boolean(b) => b,
+                        vibesql_types::SqlValue::Null => false,
+                        _ => false,
+                    }
+                }
+                None => true, // No WHERE clause - update all rows
+                Some(vibesql_ast::WhereClause::CurrentOf(_)) => {
+                    return Err(ExecutorError::UnsupportedExpression(
+                        "CURRENT OF not supported for view updates".to_string(),
+                    ));
+                }
+            };
+
+            if matches {
+                let old_row = row.clone();
+
+                // Build NEW row by applying assignments
+                let mut new_row_values = old_row.values.clone();
+
+                for assignment in &stmt.assignments {
+                    // Find column index in view
+                    let col_idx = view_schema
+                        .columns
+                        .iter()
+                        .position(|c| c.name.to_uppercase() == assignment.column.to_uppercase())
+                        .ok_or_else(|| ExecutorError::ColumnNotFound {
+                            column_name: assignment.column.clone(),
+                            table_name: view_def.name.clone(),
+                            searched_tables: vec![view_def.name.clone()],
+                            available_columns: view_schema.columns.iter().map(|c| c.name.clone()).collect(),
+                        })?;
+
+                    // Evaluate the new value
+                    let new_value = evaluator.eval(&assignment.value, &old_row)?;
+                    new_row_values[col_idx] = new_value;
+                }
+
+                let new_row = vibesql_storage::Row::new(new_row_values);
+                collected_updates.push((old_row, new_row));
+            }
+        }
+        collected_updates
+    }; // evaluator dropped here
+
+    // Now fire triggers (database can be mutably borrowed)
+    let rows_processed = updates.len();
+    for (old_row, new_row) in updates {
+        for trigger in &triggers {
+            crate::TriggerFirer::execute_trigger(database, trigger, Some(&old_row), Some(&new_row))?;
+        }
+    }
+
+    Ok(rows_processed)
+}
+
+/// Build a pseudo TableSchema from a view definition
+fn build_view_schema(
+    database: &Database,
+    view_def: &vibesql_catalog::ViewDefinition,
+) -> Result<vibesql_catalog::TableSchema, ExecutorError> {
+    // Execute the view's SELECT query to get column names
+    let select_executor = crate::SelectExecutor::new(database);
+    let result = select_executor.execute_with_columns(&view_def.query)?;
+
+    // Use explicit column names if provided, otherwise derive from SELECT
+    let column_names: Vec<String> = if let Some(ref cols) = view_def.columns {
+        cols.clone()
+    } else {
+        result.columns.clone()
+    };
+
+    // Build columns with a generic data type (we just need names for trigger binding)
+    let columns: Vec<vibesql_catalog::ColumnSchema> = column_names
+        .into_iter()
+        .map(|name| {
+            vibesql_catalog::ColumnSchema::new(name, vibesql_types::DataType::Varchar { max_length: None }, true)
+        })
+        .collect();
+
+    Ok(vibesql_catalog::TableSchema::new(view_def.name.clone(), columns))
 }
 
 /// Find row indices that would conflict with an updated row (for REPLACE conflict resolution)


### PR DESCRIPTION
## Summary
- Add INSTEAD OF INSERT/UPDATE/DELETE trigger handling for views
- Update CLI script parser to handle BEGIN...END blocks for trigger bodies
- Views with INSTEAD OF triggers can now receive DML operations

## Changes
- **insert/execution.rs**: Add `execute_insert_on_view()` to fire INSTEAD OF INSERT triggers
- **update/mod.rs**: Add `execute_update_on_view()` to fire INSTEAD OF UPDATE triggers  
- **delete/executor.rs**: Add `execute_delete_on_view()` to fire INSTEAD OF DELETE triggers
- **trigger_execution.rs**: Add `build_view_schema()` to handle views in trigger context
- **script.rs**: Track BEGIN/END nesting to prevent splitting trigger bodies on semicolons

## Test plan
- [x] All 26 trigger unit tests pass
- [x] All 112 CLI tests pass
- [x] Manual testing of INSTEAD OF INSERT/UPDATE/DELETE triggers works

## Known limitations
- TCL test pass rate for trigger4.test remains at 13% due to view/trigger persistence issues (separate concern)
- Views and triggers are not persisted to database files across sessions

Closes #4581

🤖 Generated with [Claude Code](https://claude.com/claude-code)