### PR TITLE
feat(window): Add NTH_VALUE, PERCENT_RANK, CUME_DIST, and GROUP_CONCAT window functions

### DIFF
--- a/crates/vibesql-executor/src/evaluator/window/aggregates.rs
+++ b/crates/vibesql-executor/src/evaluator/window/aggregates.rs
@@ -51,7 +51,7 @@ where
         }
     }
 
-    SqlValue::Numeric(count as f64)
+    SqlValue::Integer(count)
 }
 
 /// Evaluate SUM aggregate window function over a frame
@@ -116,7 +116,12 @@ where
     }
 
     if has_value {
-        SqlValue::Numeric(sum)
+        // Return Integer if sum is a whole number, otherwise Numeric
+        if sum.fract() == 0.0 && sum >= i64::MIN as f64 && sum <= i64::MAX as f64 {
+            SqlValue::Integer(sum as i64)
+        } else {
+            SqlValue::Numeric(sum)
+        }
     } else {
         SqlValue::Null
     }
@@ -273,4 +278,88 @@ where
     }
 
     max_val.unwrap_or(SqlValue::Null)
+}
+
+/// Evaluate GROUP_CONCAT aggregate window function over a frame
+///
+/// Concatenates string values in the frame using the specified separator.
+/// Returns NULL if all values are NULL or frame is empty.
+///
+/// Example: GROUP_CONCAT(name, ',') OVER (ORDER BY date)
+pub fn evaluate_group_concat_window<F>(
+    partition: &Partition,
+    frame: &Range<usize>,
+    arg_expr: &Expression,
+    separator: &str,
+    eval_fn: F,
+) -> SqlValue
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
+    let mut values: Vec<String> = Vec::new();
+
+    for idx in frame.clone() {
+        if idx >= partition.len() {
+            break;
+        }
+
+        let row = &partition.rows[idx];
+
+        if let Ok(val) = eval_fn(arg_expr, row) {
+            match val {
+                SqlValue::Null => {} // Ignore NULL
+                SqlValue::Varchar(s) | SqlValue::Character(s) => {
+                    values.push(s.to_string());
+                }
+                SqlValue::Integer(n) => {
+                    values.push(n.to_string());
+                }
+                SqlValue::Bigint(n) => {
+                    values.push(n.to_string());
+                }
+                SqlValue::Smallint(n) => {
+                    values.push(n.to_string());
+                }
+                SqlValue::Numeric(n) => {
+                    // Format as integer if whole number
+                    if n.fract() == 0.0 {
+                        values.push((n as i64).to_string());
+                    } else {
+                        values.push(n.to_string());
+                    }
+                }
+                SqlValue::Float(n) => {
+                    if n.fract() == 0.0 {
+                        values.push((n as i64).to_string());
+                    } else {
+                        values.push(n.to_string());
+                    }
+                }
+                SqlValue::Real(n) => {
+                    if n.fract() == 0.0 {
+                        values.push((n as i64).to_string());
+                    } else {
+                        values.push(n.to_string());
+                    }
+                }
+                SqlValue::Double(n) => {
+                    if n.fract() == 0.0 {
+                        values.push((n as i64).to_string());
+                    } else {
+                        values.push(n.to_string());
+                    }
+                }
+                other => {
+                    // Convert other types to string
+                    values.push(format!("{}", other));
+                }
+            }
+        }
+    }
+
+    if values.is_empty() {
+        SqlValue::Null
+    } else {
+        SqlValue::Varchar(values.join(separator).into())
+    }
 }

--- a/crates/vibesql-executor/src/evaluator/window/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/window/mod.rs
@@ -27,14 +27,14 @@ mod value;
 
 // Re-export public API
 pub use aggregates::{
-    evaluate_avg_window, evaluate_count_window, evaluate_max_window, evaluate_min_window,
+    evaluate_avg_window, evaluate_count_window, evaluate_group_concat_window, evaluate_max_window, evaluate_min_window,
     evaluate_sum_window,
 };
 pub use frames::calculate_frame;
 pub use partitioning::{partition_rows, Partition};
-pub use ranking::{evaluate_dense_rank, evaluate_ntile, evaluate_rank, evaluate_row_number};
+pub use ranking::{evaluate_cume_dist, evaluate_dense_rank, evaluate_ntile, evaluate_percent_rank, evaluate_rank, evaluate_row_number};
 pub use sorting::{compare_values, sort_partition};
-pub use value::{evaluate_first_value, evaluate_lag, evaluate_last_value, evaluate_lead};
+pub use value::{evaluate_first_value, evaluate_lag, evaluate_last_value, evaluate_lead, evaluate_nth_value};
 
 #[cfg(test)]
 mod tests;

--- a/crates/vibesql-executor/src/evaluator/window/ranking.rs
+++ b/crates/vibesql-executor/src/evaluator/window/ranking.rs
@@ -125,6 +125,129 @@ pub fn evaluate_dense_rank(
     ranks
 }
 
+/// Evaluate PERCENT_RANK() window function
+///
+/// Returns the relative rank of the current row: (rank - 1) / (partition_size - 1).
+/// The first row always has percent_rank of 0.0.
+/// The last row (or last tie group) has percent_rank of 1.0.
+/// Returns 0.0 for single-row partitions.
+///
+/// Example for scores [95, 90, 90, 85]:
+///   - ranks: [1, 2, 2, 4]
+///   - percent_rank: [0.0, 0.333..., 0.333..., 1.0]
+///
+/// Requires ORDER BY clause - partitions must be pre-sorted.
+pub fn evaluate_percent_rank(
+    partition: &Partition,
+    order_by: &Option<Vec<OrderByItem>>,
+) -> Vec<SqlValue> {
+    let n = partition.len();
+
+    // Single row partition - return 0.0
+    if n <= 1 {
+        return vec![SqlValue::Numeric(0.0); n];
+    }
+
+    // Get ranks first (reuse RANK logic)
+    let ranks = evaluate_rank(partition, order_by);
+
+    // Convert ranks to percent_rank: (rank - 1) / (n - 1)
+    let denominator = (n - 1) as f64;
+
+    ranks
+        .into_iter()
+        .map(|rank| {
+            if let SqlValue::Integer(r) = rank {
+                SqlValue::Numeric((r - 1) as f64 / denominator)
+            } else {
+                SqlValue::Numeric(0.0)
+            }
+        })
+        .collect()
+}
+
+/// Evaluate CUME_DIST() window function
+///
+/// Returns the cumulative distribution: the fraction of partition rows
+/// that are less than or equal to the current row.
+///
+/// Formula: (number of rows <= current row) / (total rows in partition)
+/// Value range: (0, 1] - always > 0, maximum is 1.0
+///
+/// Example for scores [95, 90, 90, 85] (sorted DESC):
+///   - row 1 (95): 1/4 = 0.25
+///   - rows 2-3 (90): 3/4 = 0.75 (3 rows are <= 90)
+///   - row 4 (85): 4/4 = 1.0
+///   - cume_dist: [0.25, 0.75, 0.75, 1.0]
+///
+/// Requires ORDER BY clause - partitions must be pre-sorted.
+pub fn evaluate_cume_dist(
+    partition: &Partition,
+    order_by: &Option<Vec<OrderByItem>>,
+) -> Vec<SqlValue> {
+    let n = partition.len();
+
+    // Empty partition - shouldn't happen but handle gracefully
+    if n == 0 {
+        return vec![];
+    }
+
+    // Without ORDER BY, all rows are considered equal - cume_dist = 1.0 for all
+    if order_by.is_none() || order_by.as_ref().unwrap().is_empty() {
+        return vec![SqlValue::Numeric(1.0); n];
+    }
+
+    let order_items = order_by.as_ref().unwrap();
+    let mut results = Vec::with_capacity(n);
+
+    // For each row, count how many rows are <= current row
+    // Due to sorting, we can track where the "group" ends
+    let mut group_end_indices = Vec::new();
+    let mut current_group_start = 0;
+
+    for idx in 0..n {
+        let is_last_row = idx == n - 1;
+        let is_new_group = if is_last_row {
+            true // Last row always ends a group
+        } else {
+            // Check if next row differs from current
+            let curr_row = &partition.rows[idx];
+            let next_row = &partition.rows[idx + 1];
+
+            let mut differs = false;
+            for order_item in order_items {
+                let val_curr = evaluate_expression(&order_item.expr, curr_row).unwrap_or(SqlValue::Null);
+                let val_next = evaluate_expression(&order_item.expr, next_row).unwrap_or(SqlValue::Null);
+
+                if compare_values(&val_curr, &val_next) != Ordering::Equal {
+                    differs = true;
+                    break;
+                }
+            }
+            differs
+        };
+
+        if is_new_group {
+            // End of a tie group at index idx
+            let group_end = idx + 1; // 1-based count of rows <= current
+
+            // All rows from current_group_start to idx get the same cume_dist
+            for _ in current_group_start..=idx {
+                group_end_indices.push(group_end);
+            }
+            current_group_start = idx + 1;
+        }
+    }
+
+    // Convert to cumulative distribution values
+    let denominator = n as f64;
+    for group_end in group_end_indices {
+        results.push(SqlValue::Numeric(group_end as f64 / denominator));
+    }
+
+    results
+}
+
 /// Evaluate NTILE(n) window function
 ///
 /// Divides partition into n approximately equal groups (buckets/tiles).

--- a/crates/vibesql-executor/src/evaluator/window/tests/aggregates.rs
+++ b/crates/vibesql-executor/src/evaluator/window/tests/aggregates.rs
@@ -18,7 +18,7 @@ fn test_count_star_window() {
 
     let result = evaluate_count_window(&partition, &frame, None, evaluate_expression);
 
-    assert_eq!(result, SqlValue::Numeric(5.0));
+    assert_eq!(result, SqlValue::Integer(5));
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn test_count_window_with_frame() {
     let frame = 1..4;
     let result = evaluate_count_window(&partition, &frame, None, evaluate_expression);
 
-    assert_eq!(result, SqlValue::Numeric(3.0));
+    assert_eq!(result, SqlValue::Integer(3));
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn test_count_expr_window() {
     let result = evaluate_count_window(&partition, &frame, Some(&expr), evaluate_expression);
 
     // All 3 values are non-NULL
-    assert_eq!(result, SqlValue::Numeric(3.0));
+    assert_eq!(result, SqlValue::Integer(3));
 }
 
 // ===== SUM Tests =====
@@ -60,7 +60,7 @@ fn test_sum_window_running_total() {
     let frame = 0..3; // 10 + 20 + 30 = 60
     let result = evaluate_sum_window(&partition, &frame, &expr, evaluate_expression);
 
-    assert_eq!(result, SqlValue::Numeric(60.0));
+    assert_eq!(result, SqlValue::Integer(60));
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn test_sum_window_moving() {
     let frame = 2..5;
     let result = evaluate_sum_window(&partition, &frame, &expr, evaluate_expression);
 
-    assert_eq!(result, SqlValue::Numeric(60.0)); // 15 + 20 + 25
+    assert_eq!(result, SqlValue::Integer(60)); // 15 + 20 + 25
 }
 
 #[test]
@@ -232,5 +232,5 @@ fn test_frame_at_partition_boundaries() {
     let result = evaluate_sum_window(&partition, &frame, &expr, evaluate_expression);
 
     // Should only sum rows 3, 4 (values 40, 50)
-    assert_eq!(result, SqlValue::Numeric(90.0));
+    assert_eq!(result, SqlValue::Integer(90));
 }

--- a/crates/vibesql-executor/src/evaluator/window/value.rs
+++ b/crates/vibesql-executor/src/evaluator/window/value.rs
@@ -168,3 +168,48 @@ where
         Ok(SqlValue::Null)
     }
 }
+
+/// Evaluate NTH_VALUE() value window function
+///
+/// Returns the value of the expression from the Nth row in the window frame.
+/// N is 1-based (NTH_VALUE(expr, 1) returns the first row's value).
+///
+/// Signature: NTH_VALUE(expr, n)
+/// - expr: Expression to evaluate on the Nth row
+/// - n: 1-based row position (must be positive integer)
+///
+/// Example: NTH_VALUE(price, 2) OVER (ORDER BY date) -- returns 2nd row's price
+/// Example: NTH_VALUE(name, 1) OVER (PARTITION BY dept ORDER BY salary DESC)
+///
+/// Returns NULL if N is out of bounds or if the partition has fewer than N rows.
+pub fn evaluate_nth_value<F>(
+    partition: &Partition,
+    n: i64,
+    value_expr: &Expression,
+    eval_fn: F,
+) -> Result<SqlValue, String>
+where
+    F: Fn(&Expression, &vibesql_storage::Row) -> Result<SqlValue, String>,
+{
+    // N must be positive (1-based indexing)
+    if n < 1 {
+        return Err(format!("NTH_VALUE n must be a positive integer, got {}", n));
+    }
+
+    // Convert to 0-based index
+    let idx = (n - 1) as usize;
+
+    // Check if index is within partition bounds
+    if idx >= partition.len() {
+        // Out of bounds - return NULL
+        return Ok(SqlValue::Null);
+    }
+
+    // Get value from the Nth row
+    if let Some(row) = partition.rows.get(idx) {
+        eval_fn(value_expr, row)
+    } else {
+        // Should not happen if bounds check is correct
+        Ok(SqlValue::Null)
+    }
+}

--- a/crates/vibesql-executor/src/select/window/evaluation.rs
+++ b/crates/vibesql-executor/src/select/window/evaluation.rs
@@ -15,7 +15,7 @@ use crate::{
     errors::ExecutorError,
     evaluator::{
         window::{
-            calculate_frame, evaluate_avg_window, evaluate_count_window, evaluate_max_window,
+            calculate_frame, evaluate_avg_window, evaluate_count_window, evaluate_group_concat_window, evaluate_max_window,
             evaluate_min_window, evaluate_sum_window, partition_rows, sort_partition, Partition,
         },
         CombinedExpressionEvaluator,
@@ -192,6 +192,8 @@ fn evaluate_window_function_for_partition(
         "ROW_NUMBER" => crate::evaluator::window::evaluate_row_number(partition),
         "RANK" => crate::evaluator::window::evaluate_rank(partition, order_by),
         "DENSE_RANK" => crate::evaluator::window::evaluate_dense_rank(partition, order_by),
+        "PERCENT_RANK" => crate::evaluator::window::evaluate_percent_rank(partition, order_by),
+        "CUME_DIST" => crate::evaluator::window::evaluate_cume_dist(partition, order_by),
         "NTILE" => {
             if args.is_empty() {
                 return Err(ExecutorError::UnsupportedExpression(
@@ -357,6 +359,41 @@ fn evaluate_window_function_for_partition(
             // Return the same value for all rows
             vec![value; partition.len()]
         }
+        "NTH_VALUE" => {
+            // NTH_VALUE(expr, n)
+            if args.len() < 2 {
+                return Err(ExecutorError::UnsupportedExpression(
+                    "NTH_VALUE requires two arguments (expression and n)".to_string(),
+                ));
+            }
+
+            let value_expr = &args[0];
+
+            // Evaluate n argument (should be constant integer)
+            let n_value = evaluator.eval(&args[1], &partition.rows[0])?;
+            let n = match n_value {
+                SqlValue::Integer(n) => n,
+                _ => {
+                    return Err(ExecutorError::UnsupportedExpression(
+                        "NTH_VALUE second argument must be an integer".to_string(),
+                    ))
+                }
+            };
+
+            // Create closure that evaluates expressions using the evaluator
+            let eval_fn = |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
+                evaluator.clear_cse_cache();
+                evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
+            };
+
+            // NTH_VALUE returns the value from the Nth row for all rows in the partition
+            let value =
+                crate::evaluator::window::evaluate_nth_value(partition, n, value_expr, eval_fn)
+                    .map_err(ExecutorError::UnsupportedExpression)?;
+
+            // Return the same value for all rows
+            vec![value; partition.len()]
+        }
         _ => {
             // Handle aggregate functions that use frames
             let mut results: Vec<SqlValue> = Vec::with_capacity(partition.len());
@@ -378,8 +415,9 @@ fn evaluate_window_function_for_partition(
                 let value = match func_name.to_uppercase().as_str() {
                     "COUNT" => {
                         // COUNT(*) or COUNT(expr)
-                        // Check if arg is the special "*" column reference
+                        // Check if arg is the special "*" (Wildcard) or empty args
                         let arg_expr = if args.is_empty()
+                            || matches!(&args[0], Expression::Wildcard)
                             || matches!(&args[0], Expression::ColumnRef(col_id) if col_id.column_canonical() == "*")
                         {
                             None // COUNT(*) should count all rows
@@ -419,6 +457,28 @@ fn evaluate_window_function_for_partition(
                             ));
                         }
                         evaluate_max_window(partition, &frame, &args[0], eval_fn)
+                    }
+                    "GROUP_CONCAT" | "STRING_AGG" => {
+                        if args.is_empty() {
+                            return Err(ExecutorError::UnsupportedExpression(
+                                "GROUP_CONCAT/STRING_AGG requires an argument".to_string(),
+                            ));
+                        }
+                        // Get separator (default is comma for group_concat, required for string_agg)
+                        let separator = if args.len() > 1 {
+                            // Evaluate separator expression
+                            if let Ok(sep_val) = evaluator.eval(&args[1], &partition.rows[0]) {
+                                match sep_val {
+                                    SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+                                    _ => ",".to_string(),
+                                }
+                            } else {
+                                ",".to_string()
+                            }
+                        } else {
+                            ",".to_string()
+                        };
+                        evaluate_group_concat_window(partition, &frame, &args[0], &separator, eval_fn)
                     }
                     _ => {
                         return Err(ExecutorError::UnsupportedExpression(format!(

--- a/crates/vibesql-executor/src/tests/select_window_aggregate.rs
+++ b/crates/vibesql-executor/src/tests/select_window_aggregate.rs
@@ -58,9 +58,9 @@ fn test_count_star_window_function() {
         assert_eq!(result[0].values.len(), 2);
 
         // All rows should have count = 3 (total rows)
-        assert_eq!(result[0].values[1], SqlValue::Numeric(3.0));
-        assert_eq!(result[1].values[1], SqlValue::Numeric(3.0));
-        assert_eq!(result[2].values[1], SqlValue::Numeric(3.0));
+        assert_eq!(result[0].values[1], SqlValue::Integer(3));
+        assert_eq!(result[1].values[1], SqlValue::Integer(3));
+        assert_eq!(result[2].values[1], SqlValue::Integer(3));
     } else {
         panic!("Expected SELECT statement");
     }
@@ -85,9 +85,9 @@ fn test_sum_window_running_total() {
         assert_eq!(result[0].values.len(), 2);
 
         // Verify running totals: 100, 300, 600
-        assert_eq!(result[0].values[1], SqlValue::Numeric(100.0));
-        assert_eq!(result[1].values[1], SqlValue::Numeric(300.0));
-        assert_eq!(result[2].values[1], SqlValue::Numeric(600.0));
+        assert_eq!(result[0].values[1], SqlValue::Integer(100));
+        assert_eq!(result[1].values[1], SqlValue::Integer(300));
+        assert_eq!(result[2].values[1], SqlValue::Integer(600));
     } else {
         panic!("Expected SELECT statement");
     }
@@ -212,8 +212,8 @@ fn test_multiple_window_functions_same_query() {
 
         // All rows should have cnt=3 and total=600
         for row in &result {
-            assert_eq!(row.values[1], SqlValue::Numeric(3.0));
-            assert_eq!(row.values[2], SqlValue::Numeric(600.0));
+            assert_eq!(row.values[1], SqlValue::Integer(3));
+            assert_eq!(row.values[2], SqlValue::Integer(600));
         }
     } else {
         panic!("Expected SELECT statement");


### PR DESCRIPTION
## Summary
- Add NTH_VALUE(expr, n) window function for accessing the Nth row's value
- Add PERCENT_RANK() for relative rank calculation: (rank-1)/(n-1)
- Add CUME_DIST() for cumulative distribution calculation
- Add GROUP_CONCAT/STRING_AGG as window functions with frame support
- Fix COUNT(*) to properly detect Expression::Wildcard variant
- Fix COUNT/SUM to return Integer instead of Numeric for whole numbers

## Test plan
- [x] All 60 window unit tests pass
- [x] All executor tests pass
- [x] Window TCL test pass rate improved from ~16.6% to 24.3% (690/2841 tests)

## Performance impact
None - these are new window function implementations following the existing patterns.

Closes #4578

🤖 Generated with [Claude Code](https://claude.com/claude-code)