### PR TITLE
fix(executor): resolve ORDER BY aggregate expressions in compound SELECT

### DIFF
--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -1432,7 +1432,7 @@ impl SelectExecutor<'_> {
         &self,
         mut rows: Vec<vibesql_storage::Row>,
         order_by: &[vibesql_ast::OrderByItem],
-        _select_list: &[vibesql_ast::SelectItem],
+        select_list: &[vibesql_ast::SelectItem],
         all_union_aliases: &[Vec<Option<String>>], // Aliases from all UNION branches (wildcards expanded)
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
         use crate::select::grouping::compare_sql_values_with_collation;
@@ -1469,7 +1469,7 @@ impl SelectExecutor<'_> {
                     (Self::resolve_order_by_column(column, &column_info, all_union_aliases), None)
                 }
                 // COLLATE expression: ORDER BY x COLLATE nocase
-                // Extract the column reference and resolve it
+                // Extract the expression and resolve it
                 vibesql_ast::Expression::Collate { expr, collation } => {
                     let col_idx = match expr.as_ref() {
                         vibesql_ast::Expression::ColumnRef(col_id) => {
@@ -1479,12 +1479,34 @@ impl SelectExecutor<'_> {
                         vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(n)) => {
                             Some((*n as usize).saturating_sub(1))
                         }
-                        _ => None,
+                        // For complex expressions inside COLLATE, match against select_list
+                        other_expr => select_list.iter().enumerate().find_map(|(idx, item)| {
+                            if let vibesql_ast::SelectItem::Expression { expr: select_expr, .. } =
+                                item
+                            {
+                                if select_expr == other_expr {
+                                    return Some(idx);
+                                }
+                            }
+                            None
+                        }),
                     };
                     (col_idx, Some(collation.clone()))
                 }
-                // Complex expressions not supported in compound query ORDER BY
-                _ => (None, None),
+                // Complex expressions (aggregates, arithmetic, etc.): match against first SELECT's select_list
+                // SQLite allows ORDER BY to reference expressions from the first SELECT
+                // e.g., SELECT count(*) FROM t UNION SELECT n FROM t2 ORDER BY count(*)
+                other_expr => {
+                    let col_idx = select_list.iter().enumerate().find_map(|(idx, item)| {
+                        if let vibesql_ast::SelectItem::Expression { expr, .. } = item {
+                            if expr == other_expr {
+                                return Some(idx);
+                            }
+                        }
+                        None
+                    });
+                    (col_idx, None)
+                }
             };
 
             if let Some(col_idx) = col_idx_opt {


### PR DESCRIPTION
## Summary

Allow ORDER BY clauses in UNION/INTERSECT/EXCEPT statements to reference aggregate expressions from the first SELECT's select_list.

## Problem

Queries like this would fail:

```sql
SELECT log, count(*) FROM t1 GROUP BY log
UNION
SELECT log, n FROM t1 WHERE n=7
ORDER BY count(*), log;
```

Error: `1st ORDER BY term does not match any column in the result set`

The `sort_set_operation_results` function only handled:
1. Numeric literals: `ORDER BY 1`
2. Column references: `ORDER BY log`
3. COLLATE expressions with column refs: `ORDER BY x COLLATE nocase`

Any other expression (including aggregates like `count(*)`) fell through to return `None`, causing the error.

## Solution

- Use the `select_list` parameter (previously unused as `_select_list`)
- For unknown expressions in ORDER BY, match against expressions in the first SELECT's select_list
- Uses PartialEq comparison which handles case-insensitive function names via `FunctionIdentifier`
- Also handles complex expressions inside COLLATE clauses

## Test Results

- `select4.test` pass rate: 91.1% → 91.9% (+1 test: `select4-6.2`)
- `select1.test`: 100% pass rate (no regressions)
- All executor unit tests pass

## Changes

- `crates/vibesql-executor/src/select/executor/execute.rs`: Extended ORDER BY resolution in `sort_set_operation_results`

Closes #4604