### PR TITLE
feat(evaluator): Add GLOB operator support to combined evaluator

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -604,6 +604,11 @@ impl CombinedExpressionEvaluator<'_> {
                 self.eval_like(expr, pattern, *negated, row)
             }
 
+            // GLOB pattern matching: expr GLOB pattern (SQLite)
+            vibesql_ast::Expression::Glob { expr, pattern, negated } => {
+                self.eval_glob(expr, pattern, *negated, row)
+            }
+
             // IN operator with value list: expr IN (val1, val2, ...)
             vibesql_ast::Expression::InList { expr, values, negated } => {
                 self.eval_in_list(expr, values, *negated, row)

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -4,7 +4,7 @@ use chrono::{Datelike, Timelike};
 
 use super::super::{
     core::{CombinedExpressionEvaluator, ExpressionEvaluator},
-    pattern::like_match,
+    pattern::{glob_match, like_match},
 };
 use crate::errors::ExecutorError;
 
@@ -197,6 +197,57 @@ impl CombinedExpressionEvaluator<'_> {
 
         // Perform pattern matching
         let matches = like_match(&text, &pattern_str, case_sensitive);
+
+        // Apply negation if needed
+        let result = if negated { !matches } else { matches };
+
+        Ok(vibesql_types::SqlValue::Boolean(result))
+    }
+
+    /// Evaluate GLOB pattern matching: expr GLOB pattern (SQLite)
+    /// Supports Unix-style wildcards: * (any chars), ? (single char), [...] (character class)
+    /// GLOB is always case-sensitive (unlike LIKE which is case-insensitive by default)
+    pub(super) fn eval_glob(
+        &self,
+        expr: &vibesql_ast::Expression,
+        pattern: &vibesql_ast::Expression,
+        negated: bool,
+        row: &vibesql_storage::Row,
+    ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        let expr_val = self.eval(expr, row)?;
+        let pattern_val = self.eval(pattern, row)?;
+
+        // Extract string values
+        let text = match expr_val {
+            vibesql_types::SqlValue::Varchar(ref s) | vibesql_types::SqlValue::Character(ref s) => {
+                s.clone()
+            }
+            vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
+            _ => {
+                return Err(ExecutorError::TypeMismatch {
+                    left: expr_val,
+                    op: "GLOB".to_string(),
+                    right: pattern_val,
+                })
+            }
+        };
+
+        let pattern_str = match pattern_val {
+            vibesql_types::SqlValue::Varchar(ref s) | vibesql_types::SqlValue::Character(ref s) => {
+                s.clone()
+            }
+            vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
+            _ => {
+                return Err(ExecutorError::TypeMismatch {
+                    left: expr_val,
+                    op: "GLOB".to_string(),
+                    right: pattern_val,
+                })
+            }
+        };
+
+        // Perform GLOB pattern matching (always case-sensitive)
+        let matches = glob_match(&text, &pattern_str);
 
         // Apply negation if needed
         let result = if negated { !matches } else { matches };


### PR DESCRIPTION
## Summary

Add GLOB operator support to the combined expression evaluator, fixing "Unsupported expression: Glob" errors in TCL tests.

## Changes

- Add `eval_glob` function to `CombinedExpressionEvaluator` in `combined/predicates.rs`
- Add match arm for `Expression::Glob` in `combined/eval.rs`
- Import `glob_match` function from the existing pattern module

## Details

The GLOB operator is SQLite's Unix-style pattern matching:
- `*` matches any sequence of characters (like `%` in LIKE)
- `?` matches exactly one character (like `_` in LIKE)  
- `[...]` matches any character in the brackets
- `[^...]` or `[!...]` matches any character NOT in the brackets
- GLOB is always case-sensitive (unlike LIKE which is case-insensitive by default)

## Test Plan

- [x] GLOB operator works in SELECT expressions: `SELECT 'hello' GLOB 'h*'` → 1
- [x] Case-sensitivity verified: `SELECT 'hello' GLOB 'H*'` → 0
- [x] Character class support: `SELECT 'hello' GLOB '[hH]ello'` → 1
- [x] NOT GLOB works: `SELECT 'hello' NOT GLOB 'H*'` → 1
- [x] All 2181 executor unit tests pass
- [x] TCL tests no longer show "Unsupported expression: Glob" error

Closes #4602