### PR TITLE
fix(executor): round() now returns REAL for SQLite compatibility

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/numeric/rounding.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/numeric/rounding.rs
@@ -29,25 +29,31 @@ pub fn round(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         0
     };
 
-    // Fast path for numeric types to preserve their original type
+    // SQLite always returns REAL from round(), regardless of input type
+    // This ensures whole numbers display with ".0" suffix (e.g., "2.0" not "2")
     match value {
         SqlValue::Null => return Ok(SqlValue::Null),
-        SqlValue::Integer(n) => return Ok(SqlValue::Integer(*n)),
+        SqlValue::Integer(n) => {
+            // Convert integer to double for SQLite-compatible output
+            let n = *n as f64;
+            let multiplier = 10_f64.powi(precision);
+            return Ok(SqlValue::Double((n * multiplier).round() / multiplier));
+        }
         SqlValue::Float(f) => {
-            let multiplier = 10_f32.powi(precision);
-            return Ok(SqlValue::Float((f * multiplier).round() / multiplier));
+            let multiplier = 10_f64.powi(precision);
+            return Ok(SqlValue::Double(((*f as f64) * multiplier).round() / multiplier));
         }
         SqlValue::Double(f) => {
             let multiplier = 10_f64.powi(precision);
             return Ok(SqlValue::Double((f * multiplier).round() / multiplier));
         }
         SqlValue::Real(f) => {
-            let multiplier = 10_f32.powi(precision);
-            return Ok(SqlValue::Real((f * multiplier).round() / multiplier));
+            let multiplier = 10_f64.powi(precision);
+            return Ok(SqlValue::Double(((*f as f64) * multiplier).round() / multiplier));
         }
         SqlValue::Numeric(n) => {
             let multiplier = 10_f64.powi(precision);
-            return Ok(SqlValue::Numeric((n * multiplier).round() / multiplier));
+            return Ok(SqlValue::Double((n * multiplier).round() / multiplier));
         }
         _ => {}
     }

--- a/crates/vibesql-executor/tests/test_numeric_edge_cases/rounding.rs
+++ b/crates/vibesql-executor/tests/test_numeric_edge_cases/rounding.rs
@@ -93,16 +93,17 @@ fn test_ceil_negative() {
 
 // Tests for Numeric type support (issue #1708)
 
+// SQLite round() always returns REAL (Double) for compatibility
 #[test]
 fn test_round_numeric() {
     let (evaluator, row) = create_test_evaluator();
     let expr = create_function_expr("ROUND", vec![SqlValue::Numeric(3.14159)]);
     let result = evaluator.eval(&expr, &row).unwrap();
     match result {
-        SqlValue::Numeric(n) => {
+        SqlValue::Double(n) => {
             assert!((n - 3.0).abs() < 0.001, "Expected 3.0, got {}", n);
         }
-        _ => panic!("Expected Numeric result, got {:?}", result),
+        _ => panic!("Expected Double result (SQLite REAL), got {:?}", result),
     }
 }
 
@@ -113,10 +114,10 @@ fn test_round_numeric_with_precision() {
         create_function_expr("ROUND", vec![SqlValue::Numeric(3.14159), SqlValue::Integer(2)]);
     let result = evaluator.eval(&expr, &row).unwrap();
     match result {
-        SqlValue::Numeric(n) => {
+        SqlValue::Double(n) => {
             assert!((n - 3.14).abs() < 0.001, "Expected 3.14, got {}", n);
         }
-        _ => panic!("Expected Numeric result, got {:?}", result),
+        _ => panic!("Expected Double result (SQLite REAL), got {:?}", result),
     }
 }
 
@@ -127,10 +128,10 @@ fn test_round_numeric_negative_precision() {
         create_function_expr("ROUND", vec![SqlValue::Numeric(123.456), SqlValue::Integer(-1)]);
     let result = evaluator.eval(&expr, &row).unwrap();
     match result {
-        SqlValue::Numeric(n) => {
+        SqlValue::Double(n) => {
             assert!((n - 120.0).abs() < 0.001, "Expected 120.0, got {}", n);
         }
-        _ => panic!("Expected Numeric result, got {:?}", result),
+        _ => panic!("Expected Double result (SQLite REAL), got {:?}", result),
     }
 }
 


### PR DESCRIPTION
## Summary

- round() now always returns REAL (SqlValue::Double) regardless of input type
- This matches SQLite behavior where round() always returns REAL
- Fixes float formatting issue where whole numbers displayed as "3" instead of "3.0"

## Changes

- Modified `round()` in `rounding.rs` to return Double for all numeric inputs
- Updated tests to expect Double result instead of Numeric

## Test Results

Before fix:
```
func-4.7: Expected: 0 {2.0 1.0 -2.0}  Got: 0 {2 1.0 -2}
func-4.8: Expected: 0 {3.0 -12346.0 -5.0}  Got: 0 {3 -12346.0 -5}
```

After fix:
```
func-4.7... ok
func-4.8... ok
func-4.9... ok
func-4.10... ok
```

## Related Issues

- Closes #4608
- Related: #4621 (ORDER BY mixed types bug discovered during investigation)
- Parent tracking: #4607

## Test plan

- [x] `cargo test` passes (all 46 rounding tests pass)
- [x] func-4.7 through func-4.12 now pass in TCL tests
- [ ] Review by Judge

🤖 Generated with [Claude Code](https://claude.com/claude-code)