### PR TITLE
feat(catalog): Use 'main' schema instead of 'public' for SQLite compatibility

### DIFF
--- a/crates/vibesql-catalog/src/lib.rs
+++ b/crates/vibesql-catalog/src/lib.rs
@@ -3,6 +3,10 @@
 //! Provides metadata structures for tables and columns along with the catalog
 //! registry that tracks table schemas.
 
+/// Default schema name for SQLite compatibility.
+/// SQLite uses "main" as the default database/schema name.
+pub const DEFAULT_SCHEMA: &str = "main";
+
 mod advanced_objects;
 mod column;
 mod domain;

--- a/crates/vibesql-catalog/src/store/mod.rs
+++ b/crates/vibesql-catalog/src/store/mod.rs
@@ -72,7 +72,7 @@ impl Catalog {
     pub fn new() -> Self {
         let mut catalog = Catalog {
             schemas: HashMap::new(),
-            current_schema: "public".to_string(),
+            current_schema: crate::DEFAULT_SCHEMA.to_string(),
             privilege_grants: Vec::new(),
             roles: HashSet::new(),
             domains: HashMap::new(),
@@ -98,8 +98,11 @@ impl Catalog {
             case_sensitive_identifiers: false,
         };
 
-        // Create the default "public" schema
-        catalog.schemas.insert("public".to_string(), Schema::new("public".to_string()));
+        // Create the default schema (SQLite uses "main")
+        catalog.schemas.insert(
+            crate::DEFAULT_SCHEMA.to_string(),
+            Schema::new(crate::DEFAULT_SCHEMA.to_string()),
+        );
 
         catalog
     }

--- a/crates/vibesql-catalog/src/store/schemas.rs
+++ b/crates/vibesql-catalog/src/store/schemas.rs
@@ -16,9 +16,9 @@ impl super::Catalog {
 
     /// Drop a schema.
     pub fn drop_schema(&mut self, name: &str, cascade: bool) -> Result<(), CatalogError> {
-        // Don't allow dropping the public schema
-        if name == "public" {
-            return Err(CatalogError::SchemaNotEmpty("public".to_string()));
+        // Don't allow dropping the default schema
+        if name == crate::DEFAULT_SCHEMA {
+            return Err(CatalogError::SchemaNotEmpty(crate::DEFAULT_SCHEMA.to_string()));
         }
 
         let schema =

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -3,7 +3,7 @@ use super::{validation, SqlExecutor};
 #[test]
 fn test_list_schemas() {
     let executor = SqlExecutor::new(None).unwrap();
-    // Default database should have "public" schema
+    // Default database should have default schema
     assert!(executor.list_schemas().is_ok());
 }
 
@@ -250,7 +250,7 @@ fn test_show_databases() {
     let mut executor = SqlExecutor::new(None).unwrap();
     let result = executor.execute("SHOW DATABASES").unwrap();
     assert_eq!(result.columns, vec!["Database"]);
-    // Should have at least the default public schema
+    // Should have at least the default schema
     assert!(result.row_count >= 1);
 }
 

--- a/crates/vibesql-executor/src/information_schema.rs
+++ b/crates/vibesql-executor/src/information_schema.rs
@@ -33,7 +33,7 @@ pub fn parse_qualified_name(qualified_name: &str) -> (&str, &str) {
         let (schema, table) = qualified_name.split_at(dot_pos);
         (schema, &table[1..]) // Skip the dot
     } else {
-        ("public", qualified_name)
+        (vibesql_catalog::DEFAULT_SCHEMA, qualified_name)
     }
 }
 
@@ -496,7 +496,7 @@ fn execute_tables_query(catalog: &vibesql_catalog::Catalog) -> Result<SelectResu
     for schema_name in catalog.list_schemas() {
         // Get tables in this schema
         for table_name in catalog.list_tables() {
-            // Check if table belongs to this schema (for now all tables are in public)
+            // Check if table belongs to this schema (for now all tables are in default schema)
             let table_schema_name = &schema_name;
 
             rows.push(Row::new(vec![
@@ -520,7 +520,7 @@ fn execute_tables_query(catalog: &vibesql_catalog::Catalog) -> Result<SelectResu
     for view_name in catalog.list_views() {
         rows.push(Row::new(vec![
             SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // table_catalog
-            SqlValue::Varchar(arcstr::ArcStr::from("public")),  // table_schema
+            SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // table_schema
             SqlValue::Varchar(arcstr::ArcStr::from(view_name.clone())), // table_name
             SqlValue::Varchar(arcstr::ArcStr::from("VIEW")),    // table_type
             SqlValue::Null,                                     // self_referencing_column_name
@@ -557,7 +557,7 @@ fn execute_columns_query(
 
                 rows.push(Row::new(vec![
                     SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // table_catalog
-                    SqlValue::Varchar(arcstr::ArcStr::from("public")),  // table_schema
+                    SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // table_schema
                     SqlValue::Varchar(arcstr::ArcStr::from(table_name.clone())), // table_name
                     SqlValue::Varchar(arcstr::ArcStr::from(column.name.clone())), // column_name
                     SqlValue::Integer((ordinal + 1) as i64),            // ordinal_position
@@ -627,10 +627,10 @@ fn execute_table_constraints_query(
                 let constraint_name = format!("{}_pkey", table_name);
                 rows.push(Row::new(vec![
                     SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // constraint_catalog
-                    SqlValue::Varchar(arcstr::ArcStr::from("public")),  // constraint_schema
+                    SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // constraint_schema
                     SqlValue::Varchar(arcstr::ArcStr::from(constraint_name)), // constraint_name
                     SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // table_catalog
-                    SqlValue::Varchar(arcstr::ArcStr::from("public")),  // table_schema
+                    SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // table_schema
                     SqlValue::Varchar(arcstr::ArcStr::from(table_name.clone())), // table_name
                     SqlValue::Varchar(arcstr::ArcStr::from("PRIMARY KEY")), // constraint_type
                     SqlValue::Varchar(arcstr::ArcStr::from("NO")),      // is_deferrable
@@ -644,10 +644,10 @@ fn execute_table_constraints_query(
                 let constraint_name = format!("{}_{}_key", table_name, idx);
                 rows.push(Row::new(vec![
                     SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // constraint_catalog
-                    SqlValue::Varchar(arcstr::ArcStr::from("public")),  // constraint_schema
+                    SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // constraint_schema
                     SqlValue::Varchar(arcstr::ArcStr::from(constraint_name)), // constraint_name
                     SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // table_catalog
-                    SqlValue::Varchar(arcstr::ArcStr::from("public")),  // table_schema
+                    SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // table_schema
                     SqlValue::Varchar(arcstr::ArcStr::from(table_name.clone())), // table_name
                     SqlValue::Varchar(arcstr::ArcStr::from("UNIQUE")),  // constraint_type
                     SqlValue::Varchar(arcstr::ArcStr::from("NO")),      // is_deferrable
@@ -664,10 +664,10 @@ fn execute_table_constraints_query(
                     .unwrap_or_else(|| format!("{}_{}_fkey", table_name, fk.parent_table));
                 rows.push(Row::new(vec![
                     SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // constraint_catalog
-                    SqlValue::Varchar(arcstr::ArcStr::from("public")),  // constraint_schema
+                    SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // constraint_schema
                     SqlValue::Varchar(arcstr::ArcStr::from(constraint_name)), // constraint_name
                     SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // table_catalog
-                    SqlValue::Varchar(arcstr::ArcStr::from("public")),  // table_schema
+                    SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // table_schema
                     SqlValue::Varchar(arcstr::ArcStr::from(table_name.clone())), // table_name
                     SqlValue::Varchar(arcstr::ArcStr::from("FOREIGN KEY")), // constraint_type
                     SqlValue::Varchar(arcstr::ArcStr::from("NO")),      // is_deferrable
@@ -680,10 +680,10 @@ fn execute_table_constraints_query(
             for (check_name, _check_expr) in &table_schema.check_constraints {
                 rows.push(Row::new(vec![
                     SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // constraint_catalog
-                    SqlValue::Varchar(arcstr::ArcStr::from("public")),  // constraint_schema
+                    SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // constraint_schema
                     SqlValue::Varchar(arcstr::ArcStr::from(check_name.clone())), // constraint_name
                     SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // table_catalog
-                    SqlValue::Varchar(arcstr::ArcStr::from("public")),  // table_schema
+                    SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // table_schema
                     SqlValue::Varchar(arcstr::ArcStr::from(table_name.clone())), // table_name
                     SqlValue::Varchar(arcstr::ArcStr::from("CHECK")),   // constraint_type
                     SqlValue::Varchar(arcstr::ArcStr::from("NO")),      // is_deferrable
@@ -713,10 +713,10 @@ fn execute_key_column_usage_query(
                 for (ordinal, col_name) in pk_cols.iter().enumerate() {
                     rows.push(Row::new(vec![
                         SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // constraint_catalog
-                        SqlValue::Varchar(arcstr::ArcStr::from("public")),  // constraint_schema
+                        SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // constraint_schema
                         SqlValue::Varchar(arcstr::ArcStr::from(constraint_name.clone())), // constraint_name
                         SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // table_catalog
-                        SqlValue::Varchar(arcstr::ArcStr::from("public")),  // table_schema
+                        SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // table_schema
                         SqlValue::Varchar(arcstr::ArcStr::from(table_name.clone())), // table_name
                         SqlValue::Varchar(arcstr::ArcStr::from(col_name.to_string())), // column_name
                         SqlValue::Integer((ordinal + 1) as i64), // ordinal_position
@@ -734,10 +734,10 @@ fn execute_key_column_usage_query(
                 for (ordinal, col_name) in unique_cols.iter().enumerate() {
                     rows.push(Row::new(vec![
                         SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // constraint_catalog
-                        SqlValue::Varchar(arcstr::ArcStr::from("public")),  // constraint_schema
+                        SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // constraint_schema
                         SqlValue::Varchar(arcstr::ArcStr::from(constraint_name.clone())), // constraint_name
                         SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // table_catalog
-                        SqlValue::Varchar(arcstr::ArcStr::from("public")),  // table_schema
+                        SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // table_schema
                         SqlValue::Varchar(arcstr::ArcStr::from(table_name.clone())), // table_name
                         SqlValue::Varchar(arcstr::ArcStr::from(col_name.to_string())), // column_name
                         SqlValue::Integer((ordinal + 1) as i64), // ordinal_position
@@ -760,15 +760,15 @@ fn execute_key_column_usage_query(
                 {
                     rows.push(Row::new(vec![
                         SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // constraint_catalog
-                        SqlValue::Varchar(arcstr::ArcStr::from("public")),  // constraint_schema
+                        SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // constraint_schema
                         SqlValue::Varchar(arcstr::ArcStr::from(constraint_name.clone())), // constraint_name
                         SqlValue::Varchar(arcstr::ArcStr::from("vibesql")), // table_catalog
-                        SqlValue::Varchar(arcstr::ArcStr::from("public")),  // table_schema
+                        SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)),  // table_schema
                         SqlValue::Varchar(arcstr::ArcStr::from(table_name.clone())), // table_name
                         SqlValue::Varchar(arcstr::ArcStr::from(col_name.to_string())), // column_name
                         SqlValue::Integer((ordinal + 1) as i64), // ordinal_position
                         SqlValue::Integer((ordinal + 1) as i64), // position_in_unique_constraint
-                        SqlValue::Varchar(arcstr::ArcStr::from("public")), // referenced_table_schema
+                        SqlValue::Varchar(arcstr::ArcStr::from(vibesql_catalog::DEFAULT_SCHEMA)), // referenced_table_schema
                         SqlValue::Varchar(arcstr::ArcStr::from(fk.parent_table.clone())), // referenced_table_name
                         SqlValue::Varchar(arcstr::ArcStr::from(ref_col_name.to_string())), // referenced_column_name
                     ]));
@@ -979,7 +979,7 @@ mod tests {
             ("information_schema", "tables")
         );
         assert_eq!(parse_qualified_name("public.users"), ("public", "users"));
-        assert_eq!(parse_qualified_name("users"), ("public", "users"));
+        assert_eq!(parse_qualified_name("users"), (vibesql_catalog::DEFAULT_SCHEMA, "users"));
     }
 
     #[test]
@@ -1004,7 +1004,7 @@ mod tests {
 
         assert_eq!(result.columns[0], "catalog_name");
         assert_eq!(result.columns[1], "schema_name");
-        assert!(!result.rows.is_empty()); // Should have at least "public" schema
+        assert!(!result.rows.is_empty()); // Should have at least default schema
     }
 
     #[test]

--- a/crates/vibesql-executor/src/introspection.rs
+++ b/crates/vibesql-executor/src/introspection.rs
@@ -620,7 +620,7 @@ mod tests {
         let result = executor.execute_show_databases(&stmt).unwrap();
         assert_eq!(result.columns, vec!["Database"]);
 
-        // Should have at least the 'public' schema
+        // Should have at least the default schema
         assert!(!result.rows.is_empty());
 
         let schema_names: Vec<&str> = result
@@ -632,7 +632,7 @@ mod tests {
             })
             .collect();
 
-        assert!(schema_names.contains(&"public"));
+        assert!(schema_names.contains(&vibesql_catalog::DEFAULT_SCHEMA));
     }
 
     #[test]

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -269,15 +269,15 @@ pub(super) fn build_column_to_table_map(
                 // Regular table: get columns from database
                 // Try multiple case variations and schema prefixes since database keys may vary
                 let actual_table_name = &tr.name;
-                let public_prefixed = format!("public.{}", actual_table_name);
+                let schema_prefixed = format!("{}.{}", vibesql_catalog::DEFAULT_SCHEMA, actual_table_name);
                 let table = database
                     .tables
                     .get(actual_table_name)
                     .or_else(|| database.tables.get(&actual_table_name.to_lowercase()))
                     .or_else(|| database.tables.get(&actual_table_name.to_uppercase()))
-                    .or_else(|| database.tables.get(&public_prefixed))
-                    .or_else(|| database.tables.get(&public_prefixed.to_lowercase()))
-                    .or_else(|| database.tables.get(&public_prefixed.to_uppercase()))
+                    .or_else(|| database.tables.get(&schema_prefixed))
+                    .or_else(|| database.tables.get(&schema_prefixed.to_lowercase()))
+                    .or_else(|| database.tables.get(&schema_prefixed.to_uppercase()))
                     .or_else(|| {
                         // Case-insensitive search through all tables (handles schema.table format)
                         let target = actual_table_name.to_lowercase();
@@ -300,15 +300,15 @@ pub(super) fn build_column_to_table_map(
             }
         } else {
             // Direct table lookup without TableRef
-            let public_prefixed = format!("public.{}", table_name);
+            let schema_prefixed = format!("{}.{}", vibesql_catalog::DEFAULT_SCHEMA, table_name);
             let table = database
                 .tables
                 .get(table_name)
                 .or_else(|| database.tables.get(&table_lower))
                 .or_else(|| database.tables.get(&table_name.to_uppercase()))
-                .or_else(|| database.tables.get(&public_prefixed))
-                .or_else(|| database.tables.get(&public_prefixed.to_lowercase()))
-                .or_else(|| database.tables.get(&public_prefixed.to_uppercase()))
+                .or_else(|| database.tables.get(&schema_prefixed))
+                .or_else(|| database.tables.get(&schema_prefixed.to_lowercase()))
+                .or_else(|| database.tables.get(&schema_prefixed.to_uppercase()))
                 .or_else(|| {
                     // Case-insensitive search through all tables (handles schema.table format)
                     database

--- a/crates/vibesql-executor/src/tests/create_table_tests.rs
+++ b/crates/vibesql-executor/src/tests/create_table_tests.rs
@@ -52,7 +52,7 @@ fn test_create_simple_table() {
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), "Table 'users' created successfully in schema 'public'");
+    assert_eq!(result.unwrap(), format!("Table 'users' created successfully in schema '{}'", vibesql_catalog::DEFAULT_SCHEMA));
 
     // Verify table exists in catalog
     assert!(db.catalog.table_exists("users"));

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -13,7 +13,7 @@ pub fn write_catalog<W: Write>(writer: &mut W, db: &Database) -> Result<(), Stor
     // Write schemas
     let schemas: Vec<String> = db.catalog.list_schemas()
         .into_iter()
-        .filter(|s| s != "public") // Skip default public schema
+        .filter(|s| s != vibesql_catalog::DEFAULT_SCHEMA) // Skip default schema
         .collect();
 
     write_u32(writer, schemas.len() as u32)?;

--- a/crates/vibesql-storage/src/persistence/json.rs
+++ b/crates/vibesql-storage/src/persistence/json.rs
@@ -30,7 +30,7 @@ use crate::{Database, Row, StorageError, Table};
 pub struct JsonDatabase {
     /// Metadata about the format
     pub vibesql: JsonMetadata,
-    /// Database schemas (excluding 'public' which is implicit)
+    /// Database schemas (excluding default schema which is implicit)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub schemas: Vec<JsonSchema>,
     /// Database roles
@@ -82,7 +82,7 @@ pub struct JsonTable {
 }
 
 fn default_schema_name() -> String {
-    "public".to_string()
+    vibesql_catalog::DEFAULT_SCHEMA.to_string()
 }
 
 /// Column schema
@@ -242,12 +242,12 @@ impl Database {
             }
         };
 
-        // Schemas (excluding default 'public')
+        // Schemas (excluding default schema)
         let schemas = self
             .catalog
             .list_schemas()
             .into_iter()
-            .filter(|name| name != "public")
+            .filter(|name| name != vibesql_catalog::DEFAULT_SCHEMA)
             .map(|name| JsonSchema { name })
             .collect();
 
@@ -356,7 +356,7 @@ fn table_to_json(table_name: &str, table: &Table) -> Result<JsonTable, StorageEr
     let schema_name = if let Some(idx) = table_name.find('.') {
         table_name[..idx].to_string()
     } else {
-        "public".to_string()
+        vibesql_catalog::DEFAULT_SCHEMA.to_string()
     };
 
     let unqualified_name = if let Some(idx) = table_name.find('.') {

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -49,11 +49,11 @@ impl Database {
         writeln!(writer)
             .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
 
-        // Export schemas (except default 'public' which always exists)
+        // Export schemas (except default schema which always exists)
         writeln!(writer, "-- Schemas")
             .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
         for schema_name in &self.catalog.list_schemas() {
-            if schema_name != "public" {
+            if schema_name != vibesql_catalog::DEFAULT_SCHEMA {
                 writeln!(writer, "CREATE SCHEMA {};", schema_name)
                     .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
             }


### PR DESCRIPTION
## Summary

SQLite uses `main` as the default schema name, but VibeSQL was using `public`. This affected error messages and table lookups.

**Before**: `no such table: public.test1`
**After**: `no such table: main.test1`

## Changes

- Added `DEFAULT_SCHEMA` constant (`"main"`) in vibesql-catalog crate
- Updated `Catalog::new()` to use `DEFAULT_SCHEMA` for initialization
- Updated all persistence modules (json, binary, save) to filter/use constant
- Updated `information_schema::parse_qualified_name()` to return correct default
- Updated table lookup code in `select/scan/reorder/utils.rs` to use correct schema prefix
- Updated tests to use constant instead of hardcoded `"public"`

## Files Changed

- `crates/vibesql-catalog/src/lib.rs` - Added `DEFAULT_SCHEMA` constant
- `crates/vibesql-catalog/src/store/mod.rs` - Use constant for initialization
- `crates/vibesql-catalog/src/store/schemas.rs` - Use constant for drop protection
- `crates/vibesql-executor/src/information_schema.rs` - Use constant for default schema
- `crates/vibesql-storage/src/persistence/{json,binary/catalog,save}.rs` - Use constant
- `crates/vibesql-executor/src/select/scan/reorder/utils.rs` - Use constant for table lookups
- Various test files - Updated expectations

## Test Plan

- [x] `cargo build --release` passes
- [x] `cargo test -p vibesql-catalog --lib` passes
- [x] `cargo test -p vibesql-executor information_schema --lib` passes
- [x] `cargo test -p vibesql-executor create_table_tests --lib` passes

Closes #4613

🤖 Generated with [Claude Code](https://claude.com/claude-code)