### PR TITLE
fix(executor): Return correct error for wildcard in scalar functions

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/special.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/special.rs
@@ -196,6 +196,17 @@ impl CombinedExpressionEvaluator<'_> {
             _ => {}
         }
 
+        // Check for wildcard expressions in function arguments
+        // Scalar functions don't accept wildcards (only aggregate functions like COUNT(*) do)
+        // SQLite returns "wrong number of arguments to function X()" for this case
+        for arg in args {
+            if matches!(arg, vibesql_ast::Expression::Wildcard) {
+                return Err(ExecutorError::WrongNumberOfArguments {
+                    function_name: name.to_lowercase(),
+                });
+            }
+        }
+
         // Evaluate all arguments for standard functions
         let mut arg_values = Vec::new();
         for arg in args {

--- a/crates/vibesql-executor/src/evaluator/expressions/special.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/special.rs
@@ -221,6 +221,17 @@ impl ExpressionEvaluator<'_> {
             }
         }
 
+        // Check for wildcard expressions in function arguments
+        // Scalar functions don't accept wildcards (only aggregate functions like COUNT(*) do)
+        // SQLite returns "wrong number of arguments to function X()" for this case
+        for arg in args {
+            if matches!(arg, vibesql_ast::Expression::Wildcard) {
+                return Err(ExecutorError::WrongNumberOfArguments {
+                    function_name: name.to_lowercase(),
+                });
+            }
+        }
+
         // Standard function call: evaluate all arguments eagerly
         let mut arg_values = Vec::new();
         for arg in args {


### PR DESCRIPTION
## Summary

Scalar functions like `length(*)` now return `wrong number of arguments to function length()` instead of `Unsupported expression: Wildcard`.

This matches SQLite's error behavior for invalid wildcard usage in non-aggregate functions.

## Changes

- Add wildcard expression check in `eval_function` before evaluating arguments
- Return `WrongNumberOfArguments` error for scalar functions called with wildcards
- Apply fix to both `expressions/special.rs` and `combined/special.rs` evaluators

## Test Plan

- [x] Build passes (`cargo build`)
- [x] `SELECT length(*)` returns `wrong number of arguments to function length()`
- [x] `SELECT abs(*)` returns `wrong number of arguments to function abs()`
- [x] Existing unit tests pass (`cargo test --package vibesql-executor`)
- [x] Clippy passes

Closes #4611