### PR TITLE
fix(executor): match SQLite error message wording for INSERT

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -89,9 +89,14 @@ pub enum ExecutorError {
         provided: usize,
     },
     InsertColumnCountMismatch {
-        table_name: String,
         expected: usize,
         provided: usize,
+    },
+    /// Column not found in INSERT statement (SQLite-compatible error)
+    /// Format: "table T has no column named C"
+    InsertNoSuchColumn {
+        table_name: String,
+        column_name: String,
     },
     CastError {
         from_type: String,
@@ -598,13 +603,13 @@ impl std::fmt::Display for ExecutorError {
                     )
                 )
             }
-            ExecutorError::InsertColumnCountMismatch { table_name, expected, provided } => {
-                // SQLite format: "table T has N columns but M values were supplied"
-                write!(
-                    f,
-                    "table {} has {} columns but {} values were supplied",
-                    table_name, expected, provided
-                )
+            ExecutorError::InsertColumnCountMismatch { expected, provided } => {
+                // SQLite format: "N values for M columns"
+                write!(f, "{} values for {} columns", provided, expected)
+            }
+            ExecutorError::InsertNoSuchColumn { table_name, column_name } => {
+                // SQLite format: "table T has no column named C"
+                write!(f, "table {} has no column named {}", table_name, column_name)
             }
             ExecutorError::CastError { from_type, to_type } => {
                 write!(

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -133,7 +133,6 @@ fn execute_insert_internal(
             if select_result.columns.len() != target_column_info.len() {
                 // Match SQLite's error message format exactly
                 return Err(ExecutorError::InsertColumnCountMismatch {
-                    table_name: table_name.to_string(),
                     expected: target_column_info.len(),
                     provided: select_result.columns.len(),
                 });
@@ -817,7 +816,6 @@ fn execute_insert_on_view(
             // Validate column count
             if value_exprs.len() != target_columns.len() {
                 return Err(ExecutorError::InsertColumnCountMismatch {
-                    table_name: view_def.name.clone(),
                     expected: target_columns.len(),
                     provided: value_exprs.len(),
                 });

--- a/crates/vibesql-executor/src/insert/validation.rs
+++ b/crates/vibesql-executor/src/insert/validation.rs
@@ -56,11 +56,10 @@ pub fn resolve_target_columns_with_rowid(
                 rowid_position = Some(input_idx);
             } else {
                 // Column not found and not a pseudo-column
-                return Err(ExecutorError::ColumnNotFound {
-                    column_name: col_name.to_string(),
+                // Use SQLite-compatible error: "table T has no column named C"
+                return Err(ExecutorError::InsertNoSuchColumn {
                     table_name: table_name.to_string(),
-                    searched_tables: vec![table_name.to_string()],
-                    available_columns: schema.columns.iter().map(|c| c.name.clone()).collect(),
+                    column_name: col_name.to_string(),
                 });
             }
         }
@@ -73,13 +72,12 @@ pub fn resolve_target_columns_with_rowid(
 pub fn validate_row_column_counts(
     rows: &[Vec<vibesql_ast::Expression>],
     expected_count: usize,
-    table_name: &str,
+    _table_name: &str,
 ) -> Result<(), ExecutorError> {
     for value_exprs in rows.iter() {
         if value_exprs.len() != expected_count {
-            // Match SQLite's error message format exactly
+            // Match SQLite's error message format exactly: "N values for M columns"
             return Err(ExecutorError::InsertColumnCountMismatch {
-                table_name: table_name.to_string(),
                 expected: expected_count,
                 provided: value_exprs.len(),
             });

--- a/crates/vibesql-executor/tests/insert_basic_tests.rs
+++ b/crates/vibesql-executor/tests/insert_basic_tests.rs
@@ -251,7 +251,8 @@ fn test_insert_column_not_found() {
 
     let result = InsertExecutor::execute(&mut db, &stmt);
     assert!(result.is_err());
-    assert!(matches!(result.unwrap_err(), ExecutorError::ColumnNotFound { .. }));
+    // SQLite-compatible error: "table T has no column named C"
+    assert!(matches!(result.unwrap_err(), ExecutorError::InsertNoSuchColumn { .. }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Update error messages to exactly match SQLite's format for INSERT statements:

- **InsertColumnCountMismatch**: Changed from `"table T has M columns but N values were supplied"` to `"N values for M columns"` to match SQLite's `insert.c:1257`
- **InsertNoSuchColumn**: Added new error type that outputs `"table T has no column named C"` to match SQLite's `insert.c:1101`

### Before
```
Expected: 1 {4 values for 2 columns}
Got: 1 {table test1 has 2 columns but 4 values were supplied}

Expected: 1 {table test1 has no column named four}
Got: 1 {no such column: four}
```

### After
```
Expected: 1 {4 values for 2 columns}
Got: 1 {4 values for 2 columns} ✓

Expected: 1 {table test1 has no column named four}
Got: 1 {table test1 has no column named four} ✓
```

## Changes

- Modified `InsertColumnCountMismatch` error format in `errors.rs`
- Added new `InsertNoSuchColumn` error type for INSERT-specific column errors
- Updated `validation.rs` to use `InsertNoSuchColumn` for column not found errors
- Updated test expectation in `insert_basic_tests.rs`

## Test Plan

- [x] All executor unit tests pass (`cargo test -p vibesql-executor --test insert_basic_tests`)
- [x] Manual verification of error messages matches SQLite format
- [x] TCL insert tests show correct error message format

Closes #4614

🤖 Generated with [Claude Code](https://claude.com/claude-code)