### PR TITLE
fix(executor): return proper errors for sqlite_master/sqlite_schema modifications

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -7,7 +7,8 @@ use vibesql_storage::Database;
 use super::integrity::check_no_child_references;
 use crate::{
     dml_cost::DmlOptimizer, errors::ExecutorError, evaluator::ExpressionEvaluator,
-    privilege_checker::PrivilegeChecker, truncate_validation::can_use_truncate,
+    privilege_checker::PrivilegeChecker, sqlite_schema::is_sqlite_schema_table,
+    truncate_validation::can_use_truncate,
 };
 
 /// Executor for DELETE statements
@@ -117,6 +118,14 @@ impl DeleteExecutor {
         // Note: stmt.only is currently ignored (treated as false)
         // ONLY keyword is used in table inheritance to exclude derived tables.
         // Since table inheritance is not yet implemented, we treat all deletes the same.
+
+        // Check if target is sqlite_master/sqlite_schema (read-only system table)
+        if is_sqlite_schema_table(&stmt.table_name) {
+            return Err(ExecutorError::SqliteSystemTableReadOnly {
+                table_name: stmt.table_name.clone(),
+                operation: "modified".to_string(),
+            });
+        }
 
         // Check DELETE privilege on the table
         PrivilegeChecker::check_delete(database, &stmt.table_name)?;

--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -2,6 +2,8 @@
 pub enum ExecutorError {
     TableNotFound(String),
     TableAlreadyExists(String),
+    /// SQLite system table may not be modified (sqlite_master, sqlite_schema)
+    SqliteSystemTableReadOnly { table_name: String, operation: String },
     ColumnNotFound {
         column_name: String,
         table_name: String,
@@ -379,6 +381,10 @@ impl std::fmt::Display for ExecutorError {
             }
             ExecutorError::TableAlreadyExists(name) => {
                 write!(f, "{}", vibe_msg!("executor-table-already-exists", name = name.as_str()))
+            }
+            ExecutorError::SqliteSystemTableReadOnly { table_name, operation } => {
+                // SQLite-compatible error message format
+                write!(f, "table {} may not be {}", table_name, operation)
             }
             ExecutorError::ColumnNotFound {
                 column_name,

--- a/crates/vibesql-executor/src/index_ddl/create_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/create_index.rs
@@ -6,7 +6,7 @@ use vibesql_storage::{
     Database, SpatialIndexMetadata,
 };
 
-use crate::{errors::ExecutorError, privilege_checker::PrivilegeChecker};
+use crate::{errors::ExecutorError, privilege_checker::PrivilegeChecker, sqlite_schema::is_sqlite_schema_table};
 
 /// Executor for CREATE INDEX statements
 pub struct CreateIndexExecutor;
@@ -60,6 +60,14 @@ impl CreateIndexExecutor {
             } else {
                 (database.catalog.get_current_schema().to_string(), stmt.table_name.clone())
             };
+
+        // Check if target is sqlite_master/sqlite_schema (read-only system table)
+        if is_sqlite_schema_table(&table_name) {
+            return Err(ExecutorError::SqliteSystemTableReadOnly {
+                table_name: table_name.clone(),
+                operation: "indexed".to_string(),
+            });
+        }
 
         // Check CREATE privilege on the schema
         PrivilegeChecker::check_create(database, &schema_name)?;

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -1,7 +1,10 @@
 use vibesql_catalog::TableIdentifier;
 use vibesql_storage::statistics::CostEstimator;
 
-use crate::{dml_cost::DmlOptimizer, errors::ExecutorError, privilege_checker::PrivilegeChecker};
+use crate::{
+    dml_cost::DmlOptimizer, errors::ExecutorError, privilege_checker::PrivilegeChecker,
+    sqlite_schema::is_sqlite_schema_table,
+};
 
 /// Execute an INSERT statement
 /// Returns number of rows inserted
@@ -45,6 +48,14 @@ fn execute_insert_internal(
         Some(schema) => format!("{}.{}", schema, stmt.table_name),
         None => stmt.table_name.clone(),
     };
+
+    // Check if target is sqlite_master/sqlite_schema (read-only system table)
+    if is_sqlite_schema_table(&stmt.table_name) {
+        return Err(ExecutorError::SqliteSystemTableReadOnly {
+            table_name: stmt.table_name.clone(),
+            operation: "modified".to_string(),
+        });
+    }
 
     // Check INSERT privilege on the table
     PrivilegeChecker::check_insert(db, &full_table_name)?;

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -34,7 +34,7 @@ use vibesql_storage::{statistics::CostEstimator, Database};
 
 use crate::{
     dml_cost::DmlOptimizer, errors::ExecutorError, evaluator::ExpressionEvaluator,
-    privilege_checker::PrivilegeChecker,
+    privilege_checker::PrivilegeChecker, sqlite_schema::is_sqlite_schema_table,
 };
 
 /// Executor for UPDATE statements
@@ -150,6 +150,14 @@ impl UpdateExecutor {
         procedural_context: Option<&crate::procedural::ExecutionContext>,
         trigger_context: Option<&crate::trigger_execution::TriggerContext>,
     ) -> Result<usize, ExecutorError> {
+        // Check if target is sqlite_master/sqlite_schema (read-only system table)
+        if is_sqlite_schema_table(&stmt.table_name) {
+            return Err(ExecutorError::SqliteSystemTableReadOnly {
+                table_name: stmt.table_name.clone(),
+                operation: "modified".to_string(),
+            });
+        }
+
         // Check UPDATE privilege on the table
         PrivilegeChecker::check_update(database, &stmt.table_name)?;
 


### PR DESCRIPTION
## Summary

SQLite's `sqlite_master` and `sqlite_schema` are read-only system tables. Previously, attempts to INSERT, UPDATE, DELETE, or CREATE INDEX on these tables returned "no such table" errors. Now they return proper SQLite-compatible error messages:

- INSERT/UPDATE/DELETE: `table sqlite_master may not be modified`  
- CREATE INDEX: `table sqlite_master may not be indexed`

## Changes

- Added `SqliteSystemTableReadOnly` error variant to `ExecutorError` with SQLite-compatible formatting
- Added `is_sqlite_schema_table()` check at the start of:
  - INSERT execution (`insert/execution.rs`)
  - UPDATE execution (`update/mod.rs`)
  - DELETE execution (`delete/executor.rs`)  
  - CREATE INDEX execution (`index_ddl/create_index.rs`)
- Errors are returned before privilege checks or table lookups

## Test Plan

Verified manually with vibesql CLI:
- ✅ `SELECT * FROM sqlite_master` - Works (returns empty result)
- ✅ `INSERT INTO sqlite_master VALUES(...)` - Returns "table sqlite_master may not be modified"
- ✅ `UPDATE sqlite_master SET ...` - Returns "table sqlite_master may not be modified"
- ✅ `DELETE FROM sqlite_master WHERE ...` - Returns "table sqlite_master may not be modified"
- ✅ `CREATE INDEX idx ON sqlite_master(name)` - Returns "table sqlite_master may not be indexed"
- ✅ Same behavior for `sqlite_schema` alias
- ✅ All 13 sqlite_schema module tests pass

This improves TCL test compatibility for:
- `insert-1.2`: Expected: `table sqlite_master may not be modified`
- `index-5.1`: Expected: `table sqlite_master may not be indexed`

Closes #4615