### PR TITLE
fix(executor): remove space before column list in CREATE INDEX formatting

### DIFF
--- a/crates/vibesql-executor/src/index_ddl/create_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/create_index.rs
@@ -566,7 +566,7 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(
             result.unwrap(),
-            "Index 'idx_users_email' created successfully on table 'public.users'"
+            "Index 'idx_users_email' created successfully on table 'main.users'"
         );
 
         // Verify index exists
@@ -714,7 +714,7 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(
             result.unwrap(),
-            "Index 'idx_users_email' created successfully on table 'public.users'"
+            "Index 'idx_users_email' created successfully on table 'main.users'"
         );
         assert!(db.index_exists("idx_users_email"));
     }
@@ -760,11 +760,11 @@ mod tests {
         let mut db = Database::new();
         create_test_table(&mut db);
 
-        // Create index using schema-qualified table name (with default public schema)
+        // Create index using schema-qualified table name (with default main schema)
         let index_stmt = CreateIndexStmt {
             index_name: "idx_users_email_qualified".to_string(),
             if_not_exists: false,
-            table_name: "public.users".to_string(), // Explicitly qualify with public schema
+            table_name: "main.users".to_string(), // Explicitly qualify with main schema
             index_type: vibesql_ast::IndexType::BTree { unique: false },
             columns: vec![IndexColumn::Column {
                 column_name: "email".to_string(),
@@ -777,7 +777,7 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(
             result.unwrap(),
-            "Index 'idx_users_email_qualified' created successfully on table 'public.users'"
+            "Index 'idx_users_email_qualified' created successfully on table 'main.users'"
         );
 
         // Verify index exists

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -192,7 +192,7 @@ fn generate_create_index_sql(index: &vibesql_catalog::IndexMetadata) -> String {
         .collect();
 
     format!(
-        "CREATE {}INDEX {} ON {} ({})",
+        "CREATE {}INDEX {} ON {}({})",
         unique_str,
         index.name,
         index.table_name,
@@ -513,7 +513,7 @@ mod tests {
         );
 
         let sql = generate_create_index_sql(&index);
-        assert_eq!(sql, "CREATE INDEX idx_name ON users (last_name, first_name DESC)");
+        assert_eq!(sql, "CREATE INDEX idx_name ON users(last_name, first_name DESC)");
     }
 
     #[test]
@@ -531,7 +531,7 @@ mod tests {
         );
 
         let sql = generate_create_index_sql(&index);
-        assert_eq!(sql, "CREATE UNIQUE INDEX idx_email ON users (email(50))");
+        assert_eq!(sql, "CREATE UNIQUE INDEX idx_email ON users(email(50))");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the CREATE INDEX SQL reconstruction to match SQLite's expected format by removing the space before the column list parenthesis.

**Before:** `CREATE INDEX index1 ON test1 (f1)`
**After:** `CREATE INDEX index1 ON test1(f1)`

## Changes

- Remove space before `({})` in `generate_create_index_sql()` format string
- Update unit tests to match the corrected format
- Update create_index.rs tests to use 'main' schema (per #4623)

## Test Plan

- [x] All sqlite_schema unit tests pass
- [x] All create_index unit tests pass  
- [x] Full executor test suite passes (2182 tests)
- [x] Cargo check passes

Closes #4617