### PR TITLE
fix(deps): align root rusqlite dev-dependency with subcrates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 glob = "0.3"
 md-5 = "0.10"
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { version = "0.38", features = ["bundled"] }
 chrono = "0.4"
 
 [workspace]


### PR DESCRIPTION
## Summary

- Update root `Cargo.toml` dev-dependency rusqlite from 0.37 to 0.38

## Problem

PR #4633 updated rusqlite to 0.38 in `vibesql-executor` and `vibesql-server` but missed updating the root `Cargo.toml` dev-dependency. This causes build failures due to `libsqlite3-sys` link conflicts when both versions try to link to the native sqlite3 library.

## Test plan

- [x] `cargo build --release -p vibesql-cli` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)