### PR TITLE
feat(parser): add ISNULL and NOTNULL postfix operators

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -347,6 +347,18 @@ impl<'arena> ArenaParser<'arena> {
             }
         }
 
+        // SQLite compatibility: ISNULL and NOTNULL as postfix operators
+        // These are equivalent to IS NULL and IS NOT NULL respectively
+        if self.peek_keyword(Keyword::Isnull) {
+            self.consume_keyword(Keyword::Isnull)?;
+            let left_ref = self.arena.alloc(left);
+            left = Expression::IsNull { expr: left_ref, negated: false };
+        } else if self.peek_keyword(Keyword::Notnull) {
+            self.consume_keyword(Keyword::Notnull)?;
+            let left_ref = self.arena.alloc(left);
+            left = Expression::IsNull { expr: left_ref, negated: true };
+        }
+
         Ok(left)
     }
 

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -103,6 +103,9 @@ pub enum Keyword {
     References,
     // IS NULL keywords
     Is,
+    // SQLite ISNULL/NOTNULL postfix operators
+    Isnull,
+    Notnull,
     // Transaction keywords
     Begin,
     Commit,
@@ -474,6 +477,8 @@ impl fmt::Display for Keyword {
             Keyword::Check => "CHECK",
             Keyword::References => "REFERENCES",
             Keyword::Is => "IS",
+            Keyword::Isnull => "ISNULL",
+            Keyword::Notnull => "NOTNULL",
             Keyword::Begin => "BEGIN",
             Keyword::Commit => "COMMIT",
             Keyword::Rollback => "ROLLBACK",

--- a/crates/vibesql-parser/src/lexer/keywords.rs
+++ b/crates/vibesql-parser/src/lexer/keywords.rs
@@ -65,6 +65,9 @@ static KEYWORDS: phf::Map<&'static str, Keyword> = phf_map! {
     "EXISTS" => Keyword::Exists,
     "IF" => Keyword::If,
     "IS" => Keyword::Is,
+    // SQLite ISNULL/NOTNULL postfix operators
+    "ISNULL" => Keyword::Isnull,
+    "NOTNULL" => Keyword::Notnull,
     "ALL" => Keyword::All,
     "ANY" => Keyword::Any,
     "SOME" => Keyword::Some,

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -530,6 +530,16 @@ impl Parser {
             }
         }
 
+        // SQLite compatibility: ISNULL and NOTNULL as postfix operators
+        // These are equivalent to IS NULL and IS NOT NULL respectively
+        if self.peek_keyword(Keyword::Isnull) {
+            self.consume_keyword(Keyword::Isnull)?;
+            left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: false };
+        } else if self.peek_keyword(Keyword::Notnull) {
+            self.consume_keyword(Keyword::Notnull)?;
+            left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: true };
+        }
+
         Ok(left)
     }
 

--- a/crates/vibesql-parser/src/tests/not_is_null_precedence.rs
+++ b/crates/vibesql-parser/src/tests/not_is_null_precedence.rs
@@ -130,3 +130,141 @@ fn test_not_null_is_null_parsing() {
         _ => panic!("Expected UnaryOp(NOT), got {:?}", where_clause),
     }
 }
+
+/// Tests for SQLite ISNULL postfix operator
+/// ISNULL is equivalent to IS NULL
+#[test]
+fn test_isnull_operator() {
+    // Parse: SELECT * FROM t WHERE col0 ISNULL
+    let sql = "SELECT * FROM t WHERE col0 ISNULL";
+    let stmt = Parser::parse_sql(sql).expect("Should parse");
+
+    let select = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        _ => panic!("Expected SELECT statement"),
+    };
+
+    let where_clause = select.where_clause.expect("Should have WHERE clause");
+
+    // This should parse as: IsNull(col0, negated: false)
+    match &where_clause {
+        Expression::IsNull { expr, negated } => {
+            assert!(!*negated, "ISNULL should have negated=false (equivalent to IS NULL)");
+
+            match &**expr {
+                Expression::ColumnRef(col_id) => {
+                    let table = col_id.table_canonical();
+                    let column = col_id.column_canonical();
+                    assert!(table.is_none());
+                    assert_eq!(column, "col0");
+                }
+                _ => panic!("Expected column reference, got {:?}", expr),
+            }
+        }
+        _ => panic!("Expected IsNull, got {:?}", where_clause),
+    }
+}
+
+/// Tests for SQLite NOTNULL postfix operator
+/// NOTNULL is equivalent to IS NOT NULL
+#[test]
+fn test_notnull_operator() {
+    // Parse: SELECT * FROM t WHERE col0 NOTNULL
+    let sql = "SELECT * FROM t WHERE col0 NOTNULL";
+    let stmt = Parser::parse_sql(sql).expect("Should parse");
+
+    let select = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        _ => panic!("Expected SELECT statement"),
+    };
+
+    let where_clause = select.where_clause.expect("Should have WHERE clause");
+
+    // This should parse as: IsNull(col0, negated: true)
+    match &where_clause {
+        Expression::IsNull { expr, negated } => {
+            assert!(*negated, "NOTNULL should have negated=true (equivalent to IS NOT NULL)");
+
+            match &**expr {
+                Expression::ColumnRef(col_id) => {
+                    let table = col_id.table_canonical();
+                    let column = col_id.column_canonical();
+                    assert!(table.is_none());
+                    assert_eq!(column, "col0");
+                }
+                _ => panic!("Expected column reference, got {:?}", expr),
+            }
+        }
+        _ => panic!("Expected IsNull, got {:?}", where_clause),
+    }
+}
+
+/// Test ISNULL with complex expressions
+#[test]
+fn test_isnull_complex_expression() {
+    // Parse: SELECT * FROM t WHERE (a + b) ISNULL
+    let sql = "SELECT * FROM t WHERE (a + b) ISNULL";
+    let stmt = Parser::parse_sql(sql).expect("Should parse");
+
+    let select = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        _ => panic!("Expected SELECT statement"),
+    };
+
+    let where_clause = select.where_clause.expect("Should have WHERE clause");
+
+    // This should parse as: IsNull((a + b), negated: false)
+    match &where_clause {
+        Expression::IsNull { expr, negated } => {
+            assert!(!*negated, "ISNULL should have negated=false");
+
+            // Inner should be a binary op (a + b)
+            match &**expr {
+                Expression::BinaryOp { op, .. } => {
+                    assert_eq!(*op, vibesql_ast::BinaryOperator::Plus);
+                }
+                _ => panic!("Expected BinaryOp, got {:?}", expr),
+            }
+        }
+        _ => panic!("Expected IsNull, got {:?}", where_clause),
+    }
+}
+
+/// Test NOT col ISNULL precedence
+#[test]
+fn test_not_isnull_precedence() {
+    // Parse: SELECT * FROM t WHERE NOT col0 ISNULL
+    // This should parse as: NOT (col0 ISNULL) = NOT (col0 IS NULL)
+    let sql = "SELECT * FROM t WHERE NOT col0 ISNULL";
+    let stmt = Parser::parse_sql(sql).expect("Should parse");
+
+    let select = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        _ => panic!("Expected SELECT statement"),
+    };
+
+    let where_clause = select.where_clause.expect("Should have WHERE clause");
+
+    // Should be: UnaryOp(Not, IsNull(col0, negated: false))
+    match &where_clause {
+        Expression::UnaryOp { op, expr } => {
+            assert_eq!(*op, UnaryOperator::Not, "Outer operator should be NOT");
+
+            match &**expr {
+                Expression::IsNull { expr: inner_expr, negated } => {
+                    assert!(!*negated, "ISNULL should not be negated");
+
+                    match &**inner_expr {
+                        Expression::ColumnRef(col_id) => {
+                            let column = col_id.column_canonical();
+                            assert_eq!(column, "col0");
+                        }
+                        _ => panic!("Expected column reference, got {:?}", inner_expr),
+                    }
+                }
+                _ => panic!("Expected IS NULL expression, got {:?}", expr),
+            }
+        }
+        _ => panic!("Expected UnaryOp(NOT), got {:?}", where_clause),
+    }
+}


### PR DESCRIPTION
## Summary

Add support for SQLite's `ISNULL` and `NOTNULL` postfix operators, which are equivalent to `IS NULL` and `IS NOT NULL` respectively.

## Changes

- Add `Isnull` and `Notnull` keywords to the keyword enum
- Add keyword mappings in the lexer's phf_map
- Handle ISNULL and NOTNULL in `parse_comparison_expression` (both standard and arena parsers)
- Add comprehensive tests for the new operators

## SQL Behavior

```sql
-- These are now equivalent:
SELECT * FROM t1 WHERE x ISNULL;      -- Now works!
SELECT * FROM t1 WHERE x IS NULL;     -- Already works

SELECT * FROM t1 WHERE x NOTNULL;     -- Now works!
SELECT * FROM t1 WHERE x IS NOT NULL; -- Already works
```

## Test Plan

- [x] Unit tests for ISNULL operator
- [x] Unit tests for NOTNULL operator
- [x] Tests for complex expressions with ISNULL
- [x] Tests for NOT precedence with ISNULL
- [x] All 1170 parser tests pass
- [x] Manual verification with vibesql CLI

Closes #4637