### PR TITLE
fix(executor): track changes() count in test runners

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 glob = "0.3"
 md-5 = "0.10"
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { version = "0.38", features = ["bundled"] }
 chrono = "0.4"
 
 [workspace]

--- a/tests/pgsql/runner.rs
+++ b/tests/pgsql/runner.rs
@@ -316,16 +316,25 @@ fn execute_statement(
         Statement::Insert(insert_stmt) => {
             let rows_affected = vibesql_executor::InsertExecutor::execute(db, &insert_stmt)
                 .map_err(|e| format!("{:?}", e))?;
+            // Track changes count for changes() and total_changes() functions
+            db.set_last_changes_count(rows_affected);
+            db.increment_total_changes_count(rows_affected);
             Ok(vec![format!("{} rows inserted", rows_affected)])
         }
         Statement::Update(update_stmt) => {
             let rows_affected = vibesql_executor::UpdateExecutor::execute(&update_stmt, db)
                 .map_err(|e| format!("{:?}", e))?;
+            // Track changes count for changes() and total_changes() functions
+            db.set_last_changes_count(rows_affected);
+            db.increment_total_changes_count(rows_affected);
             Ok(vec![format!("{} rows updated", rows_affected)])
         }
         Statement::Delete(delete_stmt) => {
             let rows_deleted = vibesql_executor::DeleteExecutor::execute(&delete_stmt, db)
                 .map_err(|e| format!("{:?}", e))?;
+            // Track changes count for changes() and total_changes() functions
+            db.set_last_changes_count(rows_deleted);
+            db.increment_total_changes_count(rows_deleted);
             Ok(vec![format!("{} rows deleted", rows_deleted)])
         }
         Statement::CreateTrigger(trigger_stmt) => {

--- a/tests/sqllogictest/db_adapter/executor.rs
+++ b/tests/sqllogictest/db_adapter/executor.rs
@@ -136,6 +136,9 @@ pub fn execute_sql(
 
             let rows_affected = vibesql_executor::InsertExecutor::execute(db, &insert_stmt)
                 .map_err(|e| TestError::Execution(format!("Execution error: {:?}", e)))?;
+            // Track changes count for changes() and total_changes() functions
+            db.set_last_changes_count(rows_affected);
+            db.increment_total_changes_count(rows_affected);
             Ok(DBOutput::StatementComplete(rows_affected as u64))
         }
         vibesql_ast::Statement::Update(update_stmt) => {
@@ -149,6 +152,9 @@ pub fn execute_sql(
 
             let rows_affected = vibesql_executor::UpdateExecutor::execute(&update_stmt, db)
                 .map_err(|e| TestError::Execution(format!("Execution error: {:?}", e)))?;
+            // Track changes count for changes() and total_changes() functions
+            db.set_last_changes_count(rows_affected);
+            db.increment_total_changes_count(rows_affected);
             Ok(DBOutput::StatementComplete(rows_affected as u64))
         }
         vibesql_ast::Statement::Delete(delete_stmt) => {
@@ -162,6 +168,9 @@ pub fn execute_sql(
 
             let rows_affected = vibesql_executor::DeleteExecutor::execute(&delete_stmt, db)
                 .map_err(|e| TestError::Execution(format!("Execution error: {:?}", e)))?;
+            // Track changes count for changes() and total_changes() functions
+            db.set_last_changes_count(rows_affected);
+            db.increment_total_changes_count(rows_affected);
             Ok(DBOutput::StatementComplete(rows_affected as u64))
         }
         vibesql_ast::Statement::DropTable(drop_stmt) => {

--- a/tests/z_compliance/sqllogictest_basic.rs
+++ b/tests/z_compliance/sqllogictest_basic.rs
@@ -48,18 +48,27 @@ impl VibeSqlDB {
                 let rows_affected =
                     vibesql_executor::InsertExecutor::execute(&mut self.db, &insert_stmt)
                         .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
+                // Track changes count for changes() and total_changes() functions
+                self.db.set_last_changes_count(rows_affected);
+                self.db.increment_total_changes_count(rows_affected);
                 Ok(DBOutput::StatementComplete(rows_affected as u64))
             }
             vibesql_ast::Statement::Update(update_stmt) => {
                 let rows_affected =
                     vibesql_executor::UpdateExecutor::execute(&update_stmt, &mut self.db)
                         .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
+                // Track changes count for changes() and total_changes() functions
+                self.db.set_last_changes_count(rows_affected);
+                self.db.increment_total_changes_count(rows_affected);
                 Ok(DBOutput::StatementComplete(rows_affected as u64))
             }
             vibesql_ast::Statement::Delete(delete_stmt) => {
                 let rows_affected =
                     vibesql_executor::DeleteExecutor::execute(&delete_stmt, &mut self.db)
                         .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
+                // Track changes count for changes() and total_changes() functions
+                self.db.set_last_changes_count(rows_affected);
+                self.db.increment_total_changes_count(rows_affected);
                 Ok(DBOutput::StatementComplete(rows_affected as u64))
             }
             vibesql_ast::Statement::DropTable(drop_stmt) => {

--- a/tests/z_compliance/sqllogictest_benchmark.rs
+++ b/tests/z_compliance/sqllogictest_benchmark.rs
@@ -395,18 +395,27 @@ impl VibeSqlDB {
                 let rows_affected =
                     vibesql_executor::InsertExecutor::execute(&mut self.db, &insert_stmt)
                         .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
+                // Track changes count for changes() and total_changes() functions
+                self.db.set_last_changes_count(rows_affected);
+                self.db.increment_total_changes_count(rows_affected);
                 Ok(DBOutput::StatementComplete(rows_affected as u64))
             }
             vibesql_ast::Statement::Update(update_stmt) => {
                 let rows_affected =
                     vibesql_executor::UpdateExecutor::execute(&update_stmt, &mut self.db)
                         .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
+                // Track changes count for changes() and total_changes() functions
+                self.db.set_last_changes_count(rows_affected);
+                self.db.increment_total_changes_count(rows_affected);
                 Ok(DBOutput::StatementComplete(rows_affected as u64))
             }
             vibesql_ast::Statement::Delete(delete_stmt) => {
                 let rows_affected =
                     vibesql_executor::DeleteExecutor::execute(&delete_stmt, &mut self.db)
                         .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
+                // Track changes count for changes() and total_changes() functions
+                self.db.set_last_changes_count(rows_affected);
+                self.db.increment_total_changes_count(rows_affected);
                 Ok(DBOutput::StatementComplete(rows_affected as u64))
             }
             vibesql_ast::Statement::DropTable(drop_stmt) => {

--- a/tests/z_compliance/sqllogictest_runner.rs
+++ b/tests/z_compliance/sqllogictest_runner.rs
@@ -94,6 +94,10 @@ impl VibeSqlDB {
                     vibesql_executor::InsertExecutor::execute(&mut self.db, &insert_stmt)
                         .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
 
+                // Track changes count for changes() and total_changes() functions
+                self.db.set_last_changes_count(rows_affected);
+                self.db.increment_total_changes_count(rows_affected);
+
                 // Invalidate cache for this table
                 self.cache.invalidate_table(table_name);
 
@@ -111,6 +115,10 @@ impl VibeSqlDB {
                     vibesql_executor::UpdateExecutor::execute(&update_stmt, &mut self.db)
                         .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
 
+                // Track changes count for changes() and total_changes() functions
+                self.db.set_last_changes_count(rows_affected);
+                self.db.increment_total_changes_count(rows_affected);
+
                 // Invalidate cache for this table
                 self.cache.invalidate_table(table_name);
 
@@ -127,6 +135,10 @@ impl VibeSqlDB {
                 let rows_affected =
                     vibesql_executor::DeleteExecutor::execute(&delete_stmt, &mut self.db)
                         .map_err(|e| TestError(format!("Execution error: {:?}", e)))?;
+
+                // Track changes count for changes() and total_changes() functions
+                self.db.set_last_changes_count(rows_affected);
+                self.db.increment_total_changes_count(rows_affected);
 
                 // Invalidate cache for this table
                 self.cache.invalidate_table(table_name);


### PR DESCRIPTION
## Summary

- Fixed `changes()` and `total_changes()` SQL functions returning 0 instead of actual affected row count
- Added `set_last_changes_count()` and `increment_total_changes_count()` calls after INSERT/UPDATE/DELETE in all test runners
- Fixed rusqlite version mismatch (0.37 → 0.38) in root Cargo.toml

## Root Cause

The test runners were executing DML statements but not updating the database's changes counter, which is required for the `changes()` and `total_changes()` functions to work correctly.

## Files Changed

- `tests/sqllogictest/db_adapter/executor.rs` - Main sqllogictest executor
- `tests/z_compliance/sqllogictest_runner.rs` - Compliance test runner
- `tests/z_compliance/sqllogictest_basic.rs` - Basic test runner
- `tests/z_compliance/sqllogictest_benchmark.rs` - Benchmark runner
- `tests/pgsql/runner.rs` - PostgreSQL compatibility runner
- `Cargo.toml` - Fixed rusqlite version mismatch

## Test plan

- [x] All 14 changes_function_tests pass
- [x] Code compiles successfully
- [x] No regressions in existing tests

Closes #4636

🤖 Generated with [Claude Code](https://claude.com/claude-code)