### PR TITLE
feat(parser): make trigger timing optional (SQLite compatibility)

### DIFF
--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -8,11 +8,13 @@ impl Parser {
     ///
     /// Syntax:
     ///   CREATE TRIGGER trigger_name
-    ///   {BEFORE | AFTER | INSTEAD OF} {INSERT | UPDATE | DELETE}
+    ///   [{BEFORE | AFTER | INSTEAD OF}] {INSERT | UPDATE | DELETE}
     ///   ON table_name
     ///   [FOR EACH {ROW | STATEMENT}]
     ///   [WHEN (condition)]
     ///   triggered_action
+    ///
+    /// Note: BEFORE/AFTER/INSTEAD OF is optional; defaults to BEFORE (SQLite compatibility)
     pub(super) fn parse_create_trigger_statement(
         &mut self,
     ) -> Result<vibesql_ast::CreateTriggerStmt, ParseError> {
@@ -25,7 +27,7 @@ impl Parser {
         // Parse trigger name
         let trigger_name = self.parse_identifier()?;
 
-        // Parse timing: BEFORE | AFTER | INSTEAD OF
+        // Parse timing: BEFORE | AFTER | INSTEAD OF (optional, defaults to BEFORE per SQLite)
         let timing = if self.try_consume_keyword(Keyword::Before) {
             vibesql_ast::TriggerTiming::Before
         } else if self.try_consume_keyword(Keyword::After) {
@@ -34,9 +36,18 @@ impl Parser {
             self.expect_keyword(Keyword::Of)?;
             vibesql_ast::TriggerTiming::InsteadOf
         } else {
-            return Err(ParseError {
-                message: "Expected BEFORE, AFTER, or INSTEAD OF after trigger name".to_string(),
-            });
+            // SQLite allows omitting the timing, defaulting to BEFORE
+            // Check if next token is an event keyword (INSERT, UPDATE, DELETE)
+            if self.peek_keyword(Keyword::Insert)
+                || self.peek_keyword(Keyword::Update)
+                || self.peek_keyword(Keyword::Delete)
+            {
+                vibesql_ast::TriggerTiming::Before
+            } else {
+                return Err(ParseError {
+                    message: "Expected BEFORE, AFTER, INSTEAD OF, or event (INSERT/UPDATE/DELETE) after trigger name".to_string(),
+                });
+            }
         };
 
         // Parse event: INSERT | UPDATE [OF columns] | DELETE

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -178,11 +178,57 @@ fn test_drop_trigger_restrict() {
     }
 }
 
+/// Test that omitting timing defaults to BEFORE (SQLite compatibility)
 #[test]
-fn test_create_trigger_missing_timing() {
+fn test_create_trigger_optional_timing_defaults_to_before() {
     let sql = "CREATE TRIGGER my_trigger INSERT ON my_table BEGIN END;";
     let result = Parser::parse_sql(sql);
-    assert!(result.is_err(), "Should fail without timing");
+    assert!(result.is_ok(), "Should parse without timing: {:?}", result.err());
+
+    let stmt = result.unwrap();
+    match stmt {
+        Statement::CreateTrigger(trigger) => {
+            assert_eq!(trigger.trigger_name, "my_trigger");
+            assert_eq!(trigger.timing, TriggerTiming::Before, "Default timing should be BEFORE");
+            assert_eq!(trigger.event, TriggerEvent::Insert);
+            assert_eq!(trigger.table_name, "my_table");
+        }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+/// Test omitting timing with UPDATE event
+#[test]
+fn test_create_trigger_optional_timing_update() {
+    let sql = "CREATE TRIGGER my_trigger UPDATE ON my_table BEGIN END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Should parse without timing: {:?}", result.err());
+
+    let stmt = result.unwrap();
+    match stmt {
+        Statement::CreateTrigger(trigger) => {
+            assert_eq!(trigger.timing, TriggerTiming::Before, "Default timing should be BEFORE");
+            assert!(matches!(trigger.event, TriggerEvent::Update(None)));
+        }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+/// Test omitting timing with DELETE event
+#[test]
+fn test_create_trigger_optional_timing_delete() {
+    let sql = "CREATE TRIGGER my_trigger DELETE ON my_table BEGIN END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Should parse without timing: {:?}", result.err());
+
+    let stmt = result.unwrap();
+    match stmt {
+        Statement::CreateTrigger(trigger) => {
+            assert_eq!(trigger.timing, TriggerTiming::Before, "Default timing should be BEFORE");
+            assert_eq!(trigger.event, TriggerEvent::Delete);
+        }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Make BEFORE/AFTER/INSTEAD OF optional in CREATE TRIGGER syntax, defaulting to BEFORE as SQLite does.

## Problem

The trigger parser expected BEFORE, AFTER, or INSTEAD OF immediately after the trigger name, but SQLite's syntax allows omitting these keywords:

```sql
-- SQLite allows this (timing omitted, defaults to BEFORE):
CREATE TRIGGER tr1 UPDATE ON t1 BEGIN ... END;

-- VibeSQL was incorrectly rejecting this with:
-- "near 'Expected BEFORE, AFTER, or INSTEAD OF after trigger name': syntax error"
```

## Solution

Modified `parse_create_trigger_statement` to make the timing clause optional:
- If BEFORE, AFTER, or INSTEAD OF is present, use it
- If the next token is an event keyword (INSERT, UPDATE, DELETE), default to BEFORE
- Otherwise, return an error with updated message

## Changes

- `parser/trigger.rs`: Make timing optional, default to BEFORE
- `tests/trigger.rs`: Add 3 tests for optional timing (INSERT, UPDATE, DELETE)

## Test Plan

- [x] `test_create_trigger_optional_timing_defaults_to_before` - INSERT without timing
- [x] `test_create_trigger_optional_timing_update` - UPDATE without timing  
- [x] `test_create_trigger_optional_timing_delete` - DELETE without timing
- [x] All 17 trigger tests pass
- [x] All 1172 parser tests pass

Closes #4641