### PR TITLE
fix(executor): support expressions in VALUES clause

### DIFF
--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -608,9 +608,12 @@ impl SelectExecutor<'_> {
             let collations = Self::extract_collations_from_select_list(&stmt.select_list);
             // Issue #4602: Compute left column count from AST for schema-level validation
             // This is needed when the left result set is empty (table has no rows)
-            let left_col_count =
-                super::nonagg::compute_select_list_column_count(stmt, self.database, Some(cte_results))
-                    .ok();
+            let left_col_count = super::nonagg::compute_select_list_column_count(
+                stmt,
+                self.database,
+                Some(cte_results),
+            )
+            .ok();
             results = self.execute_set_operations(
                 results,
                 set_op,
@@ -665,8 +668,12 @@ impl SelectExecutor<'_> {
         // Handle standalone VALUES statements (Issue #4546)
         // VALUES(1,2), (3,4) returns rows directly without a SELECT list
         if let Some(values_rows) = &stmt.values {
-            let from_result =
-                crate::select::scan::values::execute_values(values_rows, "_values_", None)?;
+            let from_result = crate::select::scan::values::execute_values(
+                values_rows,
+                "_values_",
+                None,
+                Some(self.database),
+            )?;
             let mut results = from_result.into_rows();
 
             // Apply ORDER BY if specified
@@ -1218,8 +1225,12 @@ impl SelectExecutor<'_> {
             self.execute_without_aggregation(right_stmt, from_result, cte_results)?
         } else if let Some(values_rows) = &right_stmt.values {
             // Handle standalone VALUES in set operation right side (Issue #4546)
-            let from_result =
-                crate::select::scan::values::execute_values(values_rows, "_values_", None)?;
+            let from_result = crate::select::scan::values::execute_values(
+                values_rows,
+                "_values_",
+                None,
+                Some(self.database),
+            )?;
             from_result.into_rows()
         } else {
             self.execute_select_without_from(right_stmt)?
@@ -1483,8 +1494,9 @@ impl SelectExecutor<'_> {
                         }
                         // For complex expressions inside COLLATE, match against select_list
                         other_expr => select_list.iter().enumerate().find_map(|(idx, item)| {
-                            if let vibesql_ast::SelectItem::Expression { expr: select_expr, .. } =
-                                item
+                            if let vibesql_ast::SelectItem::Expression {
+                                expr: select_expr, ..
+                            } = item
                             {
                                 if select_expr == other_expr {
                                     return Some(idx);

--- a/crates/vibesql-executor/src/select/scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/mod.rs
@@ -171,7 +171,7 @@ where
             derived::execute_derived_table(query, alias, column_aliases.as_ref(), execute_subquery)
         }
         vibesql_ast::FromClause::Values { rows, alias, column_aliases } => {
-            values::execute_values(rows, alias, column_aliases.as_ref())
+            values::execute_values(rows, alias, column_aliases.as_ref(), Some(database))
         }
     }
 }

--- a/crates/vibesql-executor/src/select/scan/values.rs
+++ b/crates/vibesql-executor/src/select/scan/values.rs
@@ -5,80 +5,9 @@
 //!
 //! Example: `SELECT * FROM (VALUES(1,'a'), (2,'b')) AS t(x, y)`
 
-use crate::{errors::ExecutorError, schema::CombinedSchema};
-
-/// Evaluate a simple expression to SqlValue
-/// Supports literals and basic expressions. For VALUES clauses,
-/// expressions are typically constants.
-fn evaluate_values_expression(
-    expr: &vibesql_ast::Expression,
-) -> Result<vibesql_types::SqlValue, ExecutorError> {
-    match expr {
-        vibesql_ast::Expression::Literal(val) => Ok(val.clone()),
-        vibesql_ast::Expression::UnaryOp { op, expr } => {
-            let inner_val = evaluate_values_expression(expr)?;
-            match op {
-                vibesql_ast::UnaryOperator::Minus => match inner_val {
-                    vibesql_types::SqlValue::Integer(n) => {
-                        Ok(vibesql_types::SqlValue::Integer(-n))
-                    }
-                    vibesql_types::SqlValue::Bigint(n) => Ok(vibesql_types::SqlValue::Bigint(-n)),
-                    vibesql_types::SqlValue::Smallint(n) => {
-                        Ok(vibesql_types::SqlValue::Smallint(-n))
-                    }
-                    vibesql_types::SqlValue::Numeric(n) => {
-                        Ok(vibesql_types::SqlValue::Numeric(-n))
-                    }
-                    vibesql_types::SqlValue::Double(n) => Ok(vibesql_types::SqlValue::Double(-n)),
-                    vibesql_types::SqlValue::Float(n) => Ok(vibesql_types::SqlValue::Float(-n)),
-                    vibesql_types::SqlValue::Real(n) => Ok(vibesql_types::SqlValue::Real(-n)),
-                    vibesql_types::SqlValue::Null => Ok(vibesql_types::SqlValue::Null),
-                    _ => Err(ExecutorError::TypeError(format!(
-                        "Cannot negate value of type {:?}",
-                        inner_val.get_type()
-                    ))),
-                },
-                vibesql_ast::UnaryOperator::Plus => Ok(inner_val),
-                vibesql_ast::UnaryOperator::Not => match inner_val {
-                    vibesql_types::SqlValue::Boolean(b) => {
-                        Ok(vibesql_types::SqlValue::Boolean(!b))
-                    }
-                    vibesql_types::SqlValue::Null => Ok(vibesql_types::SqlValue::Null),
-                    _ => Err(ExecutorError::TypeError(format!(
-                        "Cannot apply NOT to value of type {:?}",
-                        inner_val.get_type()
-                    ))),
-                },
-                vibesql_ast::UnaryOperator::IsNull => {
-                    Ok(vibesql_types::SqlValue::Boolean(inner_val.is_null()))
-                }
-                vibesql_ast::UnaryOperator::IsNotNull => {
-                    Ok(vibesql_types::SqlValue::Boolean(!inner_val.is_null()))
-                }
-                vibesql_ast::UnaryOperator::BitwiseNot => match inner_val {
-                    vibesql_types::SqlValue::Integer(n) => {
-                        Ok(vibesql_types::SqlValue::Integer(!n))
-                    }
-                    vibesql_types::SqlValue::Bigint(n) => {
-                        Ok(vibesql_types::SqlValue::Integer(!n))
-                    }
-                    vibesql_types::SqlValue::Smallint(n) => {
-                        Ok(vibesql_types::SqlValue::Integer(!(n as i64)))
-                    }
-                    vibesql_types::SqlValue::Null => Ok(vibesql_types::SqlValue::Null),
-                    _ => Err(ExecutorError::TypeError(format!(
-                        "Cannot apply bitwise NOT to value of type {:?}",
-                        inner_val.get_type()
-                    ))),
-                },
-            }
-        }
-        _ => Err(ExecutorError::UnsupportedExpression(format!(
-            "Expression type {:?} not supported in VALUES clause. Only literals are currently supported.",
-            std::any::type_name_of_val(expr)
-        ))),
-    }
-}
+use crate::{
+    errors::ExecutorError, evaluator::CombinedExpressionEvaluator, schema::CombinedSchema,
+};
 
 /// Execute a VALUES table constructor
 ///
@@ -90,10 +19,13 @@ fn evaluate_values_expression(
 /// * `rows` - The VALUE rows, each containing expressions for columns
 /// * `alias` - The table alias (required)
 /// * `column_aliases` - Optional column name overrides
+/// * `database` - Optional database reference for expression evaluation (enables
+///   function calls, subqueries, etc.)
 pub(crate) fn execute_values(
     rows: &[Vec<vibesql_ast::Expression>],
     alias: &str,
     column_aliases: Option<&Vec<String>>,
+    database: Option<&vibesql_storage::Database>,
 ) -> Result<super::FromResult, ExecutorError> {
     // Handle empty VALUES - return empty result with appropriate schema
     if rows.is_empty() {
@@ -110,6 +42,18 @@ pub(crate) fn execute_values(
     // Determine expected column count from first row
     let expected_columns = rows[0].len();
 
+    // Create an empty schema and row for expression evaluation
+    // VALUES expressions should not reference columns, so this is safe
+    let empty_schema = CombinedSchema::empty();
+    let empty_row = vibesql_storage::Row::new(vec![]);
+
+    // Create evaluator - use database if available for function calls, subqueries, etc.
+    let evaluator = if let Some(db) = database {
+        CombinedExpressionEvaluator::with_database(&empty_schema, db)
+    } else {
+        CombinedExpressionEvaluator::new(&empty_schema)
+    };
+
     // Evaluate all rows and collect results
     let mut result_rows = Vec::with_capacity(rows.len());
     for (row_idx, row_exprs) in rows.iter().enumerate() {
@@ -124,7 +68,7 @@ pub(crate) fn execute_values(
         // Evaluate each expression in the row
         let mut values = Vec::with_capacity(row_exprs.len());
         for expr in row_exprs {
-            let value = evaluate_values_expression(expr).map_err(|e| {
+            let value = evaluator.eval(expr, &empty_row).map_err(|e| {
                 ExecutorError::TypeError(format!(
                     "Error evaluating VALUES row {}: {}",
                     row_idx + 1,


### PR DESCRIPTION
## Summary

The VALUES clause now supports arbitrary expressions, not just literals.
Previously, expressions like `VALUES(1+2)` or `VALUES(upper('abc'))`
would fail with "Only literals are currently supported."

## Changes

- Modified `execute_values` to accept optional database reference
- Replaced limited literal-only evaluator with `CombinedExpressionEvaluator`
- Updated call sites in `scan/mod.rs` and `executor/execute.rs` to pass database

## Test Plan

- [x] Binary expressions work: `SELECT * FROM (VALUES(1+2)) AS t(x)` → returns 3
- [x] Function calls work: `SELECT * FROM (VALUES(upper('abc'))) AS t(x)` → returns 'ABC'
- [x] INSERT with expressions works: `INSERT INTO t1 VALUES (1+2)` → inserts 3
- [x] CTE with expressions works: `WITH c(x) AS (VALUES(char(350))) SELECT * FROM c`
- [x] All 2182 executor tests pass

Closes #4639