### PR TITLE
feat(parser): add CTE materialization hint support

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -463,6 +463,7 @@ impl<'a, 'arena> Converter<'a, 'arena> {
             columns: cte.columns.as_ref().map(|v| v.iter().map(|s| self.resolve(*s)).collect()),
             query: Box::new(self.convert_select(cte.query)),
             recursive: cte.recursive,
+            materialization: cte.materialization,
         }
     }
 

--- a/crates/vibesql-ast/src/arena/select.rs
+++ b/crates/vibesql-ast/src/arena/select.rs
@@ -6,6 +6,7 @@ use super::{
     expression::{Expression, OrderByItem},
     interner::Symbol,
 };
+use crate::CteMaterialization;
 
 /// Common Table Expression (CTE) definition
 #[derive(Debug, Clone, PartialEq)]
@@ -15,6 +16,8 @@ pub struct CommonTableExpr<'arena> {
     pub query: &'arena SelectStmt<'arena>,
     /// Whether this is a RECURSIVE CTE
     pub recursive: bool,
+    /// Materialization hint for optimizer control
+    pub materialization: CteMaterialization,
 }
 
 /// Arena-allocated SELECT statement structure

--- a/crates/vibesql-ast/src/lib.rs
+++ b/crates/vibesql-ast/src/lib.rs
@@ -196,8 +196,8 @@ pub use introspection::{
 pub use operators::{BinaryOperator, UnaryOperator};
 pub use revoke::{CascadeOption, RevokeStmt};
 pub use select::{
-    CommonTableExpr, FromClause, GroupByClause, GroupingElement, GroupingSet, JoinType,
-    MixedGroupingItem, NullsOrder, OrderByItem, OrderDirection, SelectItem, SelectStmt,
+    CommonTableExpr, CteMaterialization, FromClause, GroupByClause, GroupingElement, GroupingSet,
+    JoinType, MixedGroupingItem, NullsOrder, OrderByItem, OrderDirection, SelectItem, SelectStmt,
     SetOperation, SetOperator,
 };
 pub use statement::Statement;

--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -28,9 +28,9 @@ use crate::{
     },
     operators::{BinaryOperator, UnaryOperator},
     select::{
-        CommonTableExpr, FromClause, GroupByClause, GroupingElement, GroupingSet, JoinType,
-        MixedGroupingItem, OrderByItem, OrderDirection, SelectItem, SelectStmt, SetOperation,
-        SetOperator,
+        CommonTableExpr, CteMaterialization, FromClause, GroupByClause, GroupingElement,
+        GroupingSet, JoinType, MixedGroupingItem, OrderByItem, OrderDirection, SelectItem,
+        SelectStmt, SetOperation, SetOperator,
     },
 };
 
@@ -919,7 +919,13 @@ impl ToSql for CommonTableExpr {
         if let Some(cols) = &self.columns {
             result.push_str(&format!(" ({})", cols.join(", ")));
         }
-        result.push_str(&format!(" AS ({})", self.query.to_sql()));
+        // Include materialization hint if specified
+        let materialization_hint = match self.materialization {
+            CteMaterialization::Default => "",
+            CteMaterialization::Materialized => " MATERIALIZED",
+            CteMaterialization::NotMaterialized => " NOT MATERIALIZED",
+        };
+        result.push_str(&format!(" AS{}({})", materialization_hint, self.query.to_sql()));
         result
     }
 }

--- a/crates/vibesql-ast/src/select.rs
+++ b/crates/vibesql-ast/src/select.rs
@@ -9,6 +9,21 @@ use crate::Expression;
 // Common Table Expressions (CTEs)
 // ============================================================================
 
+/// CTE materialization hint for optimizer control
+///
+/// Controls whether the CTE should be materialized (computed once and stored)
+/// or inlined (substituted into each reference like a view).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CteMaterialization {
+    /// No hint provided - optimizer decides (default)
+    #[default]
+    Default,
+    /// Force materialization - compute once and store result
+    Materialized,
+    /// Force inlining - substitute CTE into each reference
+    NotMaterialized,
+}
+
 /// Common Table Expression (CTE) definition
 ///
 /// CTEs are temporary named result sets defined with the WITH clause that exist
@@ -29,6 +44,8 @@ pub struct CommonTableExpr {
     /// Whether this is a RECURSIVE CTE (SQLite/SQL:1999)
     /// Recursive CTEs must use UNION ALL and may reference themselves in the recursive term
     pub recursive: bool,
+    /// Materialization hint for optimizer control (AS MATERIALIZED / AS NOT MATERIALIZED)
+    pub materialization: CteMaterialization,
 }
 
 // ============================================================================

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1083,6 +1083,7 @@ pub fn transform_select<V: ExpressionMutVisitor>(visitor: &mut V, stmt: SelectSt
                     columns: cte.columns,
                     query: Box::new(transform_select(visitor, *cte.query)),
                     recursive: cte.recursive,
+                    materialization: cte.materialization,
                 })
                 .collect()
         }),
@@ -1249,6 +1250,7 @@ pub fn transform_insert<V: ExpressionMutVisitor>(visitor: &mut V, stmt: InsertSt
                     columns: cte.columns,
                     query: Box::new(transform_select(visitor, *cte.query)),
                     recursive: cte.recursive,
+                    materialization: cte.materialization,
                 })
                 .collect()
         }),

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -263,11 +263,22 @@ impl<'arena> ArenaParser<'arena> {
         };
 
         self.consume_keyword(Keyword::As)?;
+
+        // Parse optional materialization hint: MATERIALIZED or NOT MATERIALIZED
+        let materialization = if self.try_consume_keyword(Keyword::Not) {
+            self.consume_keyword(Keyword::Materialized)?;
+            vibesql_ast::CteMaterialization::NotMaterialized
+        } else if self.try_consume_keyword(Keyword::Materialized) {
+            vibesql_ast::CteMaterialization::Materialized
+        } else {
+            vibesql_ast::CteMaterialization::Default
+        };
+
         self.expect_token(Token::LParen)?;
         let query = self.parse_select_statement()?;
         self.expect_token(Token::RParen)?;
 
-        Ok(CommonTableExpr { name, columns, query, recursive })
+        Ok(CommonTableExpr { name, columns, query, recursive, materialization })
     }
 
     /// Parse select list.

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -69,6 +69,8 @@ pub enum Keyword {
     Except,
     With,
     Recursive,
+    // CTE materialization hints (SQL:1999)
+    Materialized,
     Date,
     Time,
     Timestamp,
@@ -448,6 +450,7 @@ impl fmt::Display for Keyword {
             Keyword::Except => "EXCEPT",
             Keyword::With => "WITH",
             Keyword::Recursive => "RECURSIVE",
+            Keyword::Materialized => "MATERIALIZED",
             Keyword::Date => "DATE",
             Keyword::Time => "TIME",
             Keyword::Timestamp => "TIMESTAMP",

--- a/crates/vibesql-parser/src/lexer/keywords.rs
+++ b/crates/vibesql-parser/src/lexer/keywords.rs
@@ -76,6 +76,7 @@ static KEYWORDS: phf::Map<&'static str, Keyword> = phf_map! {
     "EXCEPT" => Keyword::Except,
     "WITH" => Keyword::With,
     "RECURSIVE" => Keyword::Recursive,
+    "MATERIALIZED" => Keyword::Materialized,
     "DATE" => Keyword::Date,
     "DEFAULT" => Keyword::Default,
     "TIME" => Keyword::Time,

--- a/crates/vibesql-parser/src/parser/select/statement.rs
+++ b/crates/vibesql-parser/src/parser/select/statement.rs
@@ -465,6 +465,18 @@ impl Parser {
         // Expect AS keyword
         self.expect_keyword(Keyword::As)?;
 
+        // Parse optional materialization hint: MATERIALIZED or NOT MATERIALIZED
+        let materialization = if self.peek_keyword(Keyword::Not) {
+            self.advance(); // consume NOT
+            self.expect_keyword(Keyword::Materialized)?;
+            vibesql_ast::CteMaterialization::NotMaterialized
+        } else if self.peek_keyword(Keyword::Materialized) {
+            self.advance(); // consume MATERIALIZED
+            vibesql_ast::CteMaterialization::Materialized
+        } else {
+            vibesql_ast::CteMaterialization::Default
+        };
+
         // Expect opening paren for subquery
         if !matches!(self.peek(), Token::LParen) {
             return Err(ParseError {
@@ -487,7 +499,7 @@ impl Parser {
         }
         self.advance(); // consume ')'
 
-        Ok(vibesql_ast::CommonTableExpr { name, columns, query, recursive })
+        Ok(vibesql_ast::CommonTableExpr { name, columns, query, recursive, materialization })
     }
 
     /// Parse a VALUES statement (standalone or in set operations)

--- a/crates/vibesql-parser/src/tests/cte.rs
+++ b/crates/vibesql-parser/src/tests/cte.rs
@@ -229,3 +229,73 @@ fn test_parse_cte_with_values_sum() {
     let result = Parser::parse_sql("WITH t(x) AS (VALUES(1), (2), (3)) SELECT SUM(x) FROM t;");
     assert!(result.is_ok(), "CTE with VALUES and aggregate should parse: {:?}", result);
 }
+
+// ========================================================================
+// CTE Materialization Hint Tests
+// ========================================================================
+
+#[test]
+fn test_parse_cte_materialized() {
+    let result = Parser::parse_sql(
+        "WITH t(b) AS MATERIALIZED (SELECT b FROM t1 LEFT JOIN t2 ON c IN (SELECT x FROM t3)) SELECT * FROM t;",
+    );
+    assert!(result.is_ok(), "CTE with MATERIALIZED hint should parse: {:?}", result);
+}
+
+#[test]
+fn test_parse_cte_not_materialized() {
+    let result = Parser::parse_sql(
+        "WITH t(b) AS NOT MATERIALIZED (SELECT b FROM t1 LEFT JOIN t2 ON c IN (SELECT x FROM t3)) SELECT * FROM t;",
+    );
+    assert!(result.is_ok(), "CTE with NOT MATERIALIZED hint should parse: {:?}", result);
+}
+
+#[test]
+fn test_parse_cte_materialized_verify_ast() {
+    use vibesql_ast::{CteMaterialization, Statement};
+
+    let stmt = Parser::parse_sql("WITH t AS MATERIALIZED (SELECT 1) SELECT * FROM t;").unwrap();
+    match stmt {
+        Statement::Select(select) => {
+            let cte = &select.with_clause.as_ref().unwrap()[0];
+            assert_eq!(cte.materialization, CteMaterialization::Materialized);
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_parse_cte_not_materialized_verify_ast() {
+    use vibesql_ast::{CteMaterialization, Statement};
+
+    let stmt = Parser::parse_sql("WITH t AS NOT MATERIALIZED (SELECT 1) SELECT * FROM t;").unwrap();
+    match stmt {
+        Statement::Select(select) => {
+            let cte = &select.with_clause.as_ref().unwrap()[0];
+            assert_eq!(cte.materialization, CteMaterialization::NotMaterialized);
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_parse_cte_default_materialization() {
+    use vibesql_ast::{CteMaterialization, Statement};
+
+    let stmt = Parser::parse_sql("WITH t AS (SELECT 1) SELECT * FROM t;").unwrap();
+    match stmt {
+        Statement::Select(select) => {
+            let cte = &select.with_clause.as_ref().unwrap()[0];
+            assert_eq!(cte.materialization, CteMaterialization::Default);
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_parse_cte_materialized_with_column_list() {
+    let result = Parser::parse_sql(
+        "WITH t(a, b) AS MATERIALIZED (SELECT 1, 2) SELECT * FROM t;",
+    );
+    assert!(result.is_ok(), "CTE with column list and MATERIALIZED should parse: {:?}", result);
+}


### PR DESCRIPTION
## Summary
Add support for SQLite's CTE materialization hints, allowing CTEs to be declared with `AS MATERIALIZED` or `AS NOT MATERIALIZED` syntax.

## Changes
- Add `Materialized` keyword to lexer and parser
- Add `CteMaterialization` enum (Default, Materialized, NotMaterialized) to AST
- Update both regular and arena parsers to handle materialization hints
- Add `materialization` field to `CommonTableExpr` in all AST variants
- Update pretty printer to output materialization hints
- Add comprehensive parser tests for materialization syntax

## Test Plan
- All 32 CTE parser tests pass including 6 new materialization tests
- TCL tests for join-27.2 and join-27.3 (which use MATERIALIZED syntax) now pass
- Clippy clean with no warnings

Closes #4640