### PR TITLE
fix(parser): handle numeric literals in CREATE INDEX column list

### DIFF
--- a/crates/vibesql-executor/src/index_ddl/create_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/create_index.rs
@@ -86,6 +86,17 @@ impl CreateIndexExecutor {
             .get_table(&qualified_table_name)
             .ok_or_else(|| ExecutorError::TableNotFound(qualified_table_name.clone()))?;
 
+        // Check for expression indexes (not yet fully supported)
+        for index_col in &stmt.columns {
+            if index_col.is_expression() {
+                // Expression indexes are parsed but not yet fully executed
+                // Return an unsupported error instead of panicking
+                return Err(ExecutorError::UnsupportedFeature(
+                    "Expression indexes are not yet supported".to_string(),
+                ));
+            }
+        }
+
         // Validate that all indexed columns exist in the table
         for index_col in &stmt.columns {
             if table_schema.get_column(index_col.expect_column_name()).is_none() {

--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -370,9 +370,11 @@ impl Parser {
     ///
     /// Supports both simple column references and expression indexes:
     /// - Column: `col1`, `col1 ASC`, `col1(10)` (with prefix length)
-    /// - Expression: `(lower(name))`, `(a + b) DESC`
+    /// - Expression: `(lower(name))`, `(a + b) DESC`, `0`, `0 LIKE col`
     ///
-    /// SQLite/PostgreSQL syntax: expressions must be wrapped in parentheses
+    /// SQLite allows expressions without parentheses, so we must detect when
+    /// the token cannot be a column name (e.g., numeric literals) and parse
+    /// as an expression instead.
     fn parse_index_column_list(&mut self) -> Result<Vec<vibesql_ast::IndexColumn>, ParseError> {
         let mut columns = Vec::new();
         loop {
@@ -389,6 +391,23 @@ impl Parser {
                 let expr = self.parse_expression()?;
 
                 self.expect_token(Token::RParen)?;
+
+                // Check for optional ASC/DESC
+                let direction = if self.peek_keyword(crate::keywords::Keyword::Asc) {
+                    self.advance();
+                    vibesql_ast::OrderDirection::Asc
+                } else if self.peek_keyword(crate::keywords::Keyword::Desc) {
+                    self.advance();
+                    vibesql_ast::OrderDirection::Desc
+                } else {
+                    vibesql_ast::OrderDirection::Asc
+                };
+
+                columns.push(vibesql_ast::IndexColumn::new_expression(expr, direction));
+            } else if matches!(self.peek(), Token::Number(_)) {
+                // Numeric literal - cannot be a column name, must be an expression
+                // SQLite allows: CREATE INDEX i ON t(0), CREATE INDEX i ON t(0 LIKE col)
+                let expr = self.parse_expression()?;
 
                 // Check for optional ASC/DESC
                 let direction = if self.peek_keyword(crate::keywords::Keyword::Asc) {


### PR DESCRIPTION
## Summary

Fixes the parser error "near '0': syntax error" when encountering numeric literals in CREATE INDEX column list.

SQLite allows expressions like `CREATE INDEX i ON t(0)` or `CREATE INDEX i ON t(0 LIKE col)` without requiring parentheses around the expression.

## Changes

1. **Parser** (`crates/vibesql-parser/src/parser/index.rs`):
   - Added branch to detect numeric literal tokens at the start of an indexed column spec
   - Parses numeric literals as expressions instead of expecting column names
   - Supports compound expressions like `0 LIKE COALESCE(c0, 0)`

2. **Executor** (`crates/vibesql-executor/src/index_ddl/create_index.rs`):
   - Added graceful error for expression indexes instead of panicking
   - Returns "Unsupported feature: Expression indexes are not yet supported"

## Test Plan

- [x] Parser tests pass (1178 tests)
- [x] Executor tests pass (31 tests)
- [x] SQL that previously failed now parses correctly:
  - `CREATE INDEX t1x ON t1(0) WHERE NULL IN (c1);`
  - `CREATE INDEX i0 ON t0(0 LIKE COALESCE(c0, 0));`

Note: Full expression index execution is a separate enhancement. This PR fixes the parser error and adds graceful handling in the executor.

Closes #4643