### PR TITLE
feat(functions): implement trim(), ltrim(), rtrim() string functions

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/mod.rs
@@ -52,7 +52,9 @@ pub(super) fn eval_scalar_function(
         "LOWER" => string::lower(args),
         "SUBSTRING" => string::substring(args),
         "SUBSTR" => string::substring(args), // Alias for SUBSTRING
-        // Note: TRIM is handled as a special expression in the parser (like POSITION)
+        "TRIM" => string::trim(args),
+        "LTRIM" => string::ltrim(args),
+        "RTRIM" => string::rtrim(args),
         "CHAR_LENGTH" | "CHARACTER_LENGTH" => string::char_length(args, name, character_unit),
         "OCTET_LENGTH" => string::octet_length(args),
         "CONCAT" => string::concat(args),

--- a/crates/vibesql-executor/src/evaluator/functions/string/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/string/mod.rs
@@ -27,7 +27,6 @@ pub(super) use length::{char_length, length, octet_length};
 pub(super) use search::{instr, locate, position};
 pub(super) use substring::{left, right, substring};
 pub(super) use transform::{replace, reverse};
+pub(super) use trim::{ltrim, rtrim, trim};
 
-// Note: trim and trim_advanced are not exported here because:
-// - trim is currently unused (reserved for future use)
-// - trim_advanced is exported directly from the trim module with pub(crate) visibility
+// Note: trim_advanced is exported directly from the trim module with pub(crate) visibility

--- a/crates/vibesql-executor/src/evaluator/functions/string/trim.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/string/trim.rs
@@ -1,28 +1,146 @@
 //! String trimming functions for SQL
 //!
 //! SQL:1999 Section 6.29: String value functions
+//! SQLite compatibility: trim(X), trim(X,Y), ltrim(X), ltrim(X,Y), rtrim(X), rtrim(X,Y)
 
 use crate::errors::ExecutorError;
 use crate::evaluator::functions::coercion::coerce_to_string;
 
-/// TRIM(string) - Remove leading and trailing spaces
-/// SQL:1999 Section 6.29: String value functions
+/// TRIM(X) or TRIM(X, Y) - Remove characters from both ends of a string
 ///
-/// SQLite compatibility: Automatically coerces numeric types to strings.
-#[allow(dead_code)] // Reserved for future use when basic TRIM needs to be exposed
+/// SQLite compatibility:
+/// - TRIM(X) removes whitespace from both ends
+/// - TRIM(X, Y) removes any character in Y from both ends
+/// - Automatically coerces numeric types to strings
+///
+/// Examples:
+/// - trim('  hello  ') returns 'hello'
+/// - trim('xxxhelloxxx', 'x') returns 'hello'
+/// - trim('abchelloabc', 'abc') returns 'hello' (removes any of a, b, or c)
 pub(in crate::evaluator::functions) fn trim(
     args: &[vibesql_types::SqlValue],
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
-    if args.len() != 1 {
+    if args.is_empty() || args.len() > 2 {
         return Err(ExecutorError::UnsupportedFeature(format!(
-            "TRIM requires exactly 1 argument, got {}",
+            "TRIM requires 1 or 2 arguments, got {}",
             args.len()
         )));
     }
 
-    match coerce_to_string(&args[0]) {
-        None => Ok(vibesql_types::SqlValue::Null),
-        Some(s) => Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(s.trim().to_string()))),
+    let s = match coerce_to_string(&args[0]) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
+    };
+
+    if args.len() == 1 {
+        // Single argument: trim whitespace
+        Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+            s.trim().to_string(),
+        )))
+    } else {
+        // Two arguments: trim specified characters
+        let chars_to_remove = match coerce_to_string(&args[1]) {
+            Some(c) => c,
+            None => return Ok(vibesql_types::SqlValue::Null),
+        };
+
+        let char_set: std::collections::HashSet<char> = chars_to_remove.chars().collect();
+        let result = s.trim_matches(|c| char_set.contains(&c)).to_string();
+        Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+            result,
+        )))
+    }
+}
+
+/// LTRIM(X) or LTRIM(X, Y) - Remove characters from the left (leading) side of a string
+///
+/// SQLite compatibility:
+/// - LTRIM(X) removes whitespace from the left
+/// - LTRIM(X, Y) removes any character in Y from the left
+/// - Automatically coerces numeric types to strings
+///
+/// Examples:
+/// - ltrim('  hello') returns 'hello'
+/// - ltrim('xxxhello', 'x') returns 'hello'
+/// - ltrim('abchello', 'abc') returns 'hello' (removes any of a, b, or c)
+pub(in crate::evaluator::functions) fn ltrim(
+    args: &[vibesql_types::SqlValue],
+) -> Result<vibesql_types::SqlValue, ExecutorError> {
+    if args.is_empty() || args.len() > 2 {
+        return Err(ExecutorError::UnsupportedFeature(format!(
+            "LTRIM requires 1 or 2 arguments, got {}",
+            args.len()
+        )));
+    }
+
+    let s = match coerce_to_string(&args[0]) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
+    };
+
+    if args.len() == 1 {
+        // Single argument: trim leading whitespace
+        Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+            s.trim_start().to_string(),
+        )))
+    } else {
+        // Two arguments: trim specified characters from left
+        let chars_to_remove = match coerce_to_string(&args[1]) {
+            Some(c) => c,
+            None => return Ok(vibesql_types::SqlValue::Null),
+        };
+
+        let char_set: std::collections::HashSet<char> = chars_to_remove.chars().collect();
+        let result = s.trim_start_matches(|c| char_set.contains(&c)).to_string();
+        Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+            result,
+        )))
+    }
+}
+
+/// RTRIM(X) or RTRIM(X, Y) - Remove characters from the right (trailing) side of a string
+///
+/// SQLite compatibility:
+/// - RTRIM(X) removes whitespace from the right
+/// - RTRIM(X, Y) removes any character in Y from the right
+/// - Automatically coerces numeric types to strings
+///
+/// Examples:
+/// - rtrim('hello  ') returns 'hello'
+/// - rtrim('helloxxx', 'x') returns 'hello'
+/// - rtrim('helloabc', 'abc') returns 'hello' (removes any of a, b, or c)
+pub(in crate::evaluator::functions) fn rtrim(
+    args: &[vibesql_types::SqlValue],
+) -> Result<vibesql_types::SqlValue, ExecutorError> {
+    if args.is_empty() || args.len() > 2 {
+        return Err(ExecutorError::UnsupportedFeature(format!(
+            "RTRIM requires 1 or 2 arguments, got {}",
+            args.len()
+        )));
+    }
+
+    let s = match coerce_to_string(&args[0]) {
+        Some(s) => s,
+        None => return Ok(vibesql_types::SqlValue::Null),
+    };
+
+    if args.len() == 1 {
+        // Single argument: trim trailing whitespace
+        Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+            s.trim_end().to_string(),
+        )))
+    } else {
+        // Two arguments: trim specified characters from right
+        let chars_to_remove = match coerce_to_string(&args[1]) {
+            Some(c) => c,
+            None => return Ok(vibesql_types::SqlValue::Null),
+        };
+
+        let char_set: std::collections::HashSet<char> = chars_to_remove.chars().collect();
+        let result = s.trim_end_matches(|c| char_set.contains(&c)).to_string();
+        Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+            result,
+        )))
     }
 }
 
@@ -74,5 +192,99 @@ pub(crate) fn trim_advanced(
         vibesql_ast::TrimPosition::Trailing => s.trim_end_matches(char_to_remove).to_string(),
     };
 
-    Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(result)))
+    Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+        result,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibesql_types::SqlValue;
+
+    #[test]
+    fn test_trim_whitespace() {
+        let args = vec![SqlValue::Varchar(arcstr::ArcStr::from("  hello  "))];
+        let result = trim(&args).unwrap();
+        assert_eq!(result, SqlValue::Varchar(arcstr::ArcStr::from("hello")));
+    }
+
+    #[test]
+    fn test_trim_with_chars() {
+        let args = vec![
+            SqlValue::Varchar(arcstr::ArcStr::from("xxxhelloxxx")),
+            SqlValue::Varchar(arcstr::ArcStr::from("x")),
+        ];
+        let result = trim(&args).unwrap();
+        assert_eq!(result, SqlValue::Varchar(arcstr::ArcStr::from("hello")));
+    }
+
+    #[test]
+    fn test_trim_with_multiple_chars() {
+        let args = vec![
+            SqlValue::Varchar(arcstr::ArcStr::from("abchelloabc")),
+            SqlValue::Varchar(arcstr::ArcStr::from("abc")),
+        ];
+        let result = trim(&args).unwrap();
+        assert_eq!(result, SqlValue::Varchar(arcstr::ArcStr::from("hello")));
+    }
+
+    #[test]
+    fn test_ltrim_whitespace() {
+        let args = vec![SqlValue::Varchar(arcstr::ArcStr::from("  hello"))];
+        let result = ltrim(&args).unwrap();
+        assert_eq!(result, SqlValue::Varchar(arcstr::ArcStr::from("hello")));
+    }
+
+    #[test]
+    fn test_ltrim_with_chars() {
+        let args = vec![
+            SqlValue::Varchar(arcstr::ArcStr::from("xxxhello")),
+            SqlValue::Varchar(arcstr::ArcStr::from("x")),
+        ];
+        let result = ltrim(&args).unwrap();
+        assert_eq!(result, SqlValue::Varchar(arcstr::ArcStr::from("hello")));
+    }
+
+    #[test]
+    fn test_rtrim_whitespace() {
+        let args = vec![SqlValue::Varchar(arcstr::ArcStr::from("hello  "))];
+        let result = rtrim(&args).unwrap();
+        assert_eq!(result, SqlValue::Varchar(arcstr::ArcStr::from("hello")));
+    }
+
+    #[test]
+    fn test_rtrim_with_chars() {
+        let args = vec![
+            SqlValue::Varchar(arcstr::ArcStr::from("helloxxx")),
+            SqlValue::Varchar(arcstr::ArcStr::from("x")),
+        ];
+        let result = rtrim(&args).unwrap();
+        assert_eq!(result, SqlValue::Varchar(arcstr::ArcStr::from("hello")));
+    }
+
+    #[test]
+    fn test_trim_null_input() {
+        let args = vec![SqlValue::Null];
+        let result = trim(&args).unwrap();
+        assert_eq!(result, SqlValue::Null);
+    }
+
+    #[test]
+    fn test_trim_null_chars() {
+        let args = vec![
+            SqlValue::Varchar(arcstr::ArcStr::from("hello")),
+            SqlValue::Null,
+        ];
+        let result = trim(&args).unwrap();
+        assert_eq!(result, SqlValue::Null);
+    }
+
+    #[test]
+    fn test_trim_numeric_coercion() {
+        // SQLite coerces numbers to strings
+        let args = vec![SqlValue::Integer(123)];
+        let result = trim(&args).unwrap();
+        assert_eq!(result, SqlValue::Varchar(arcstr::ArcStr::from("123")));
+    }
 }


### PR DESCRIPTION
## Summary

Implement SQLite-compatible string trimming functions:

- `trim(X)` / `trim(X, Y)` - Remove characters from both ends
- `ltrim(X)` / `ltrim(X, Y)` - Remove characters from left  
- `rtrim(X)` / `rtrim(X, Y)` - Remove characters from right

**Single-argument form** trims whitespace:
```sql
SELECT trim('  hello  ');  -- Returns: 'hello'
SELECT ltrim('  hello');   -- Returns: 'hello'
SELECT rtrim('hello  ');   -- Returns: 'hello'
```

**Two-argument form** trims any character in the specified set:
```sql
SELECT trim('xxxhelloxxx', 'x');  -- Returns: 'hello'
SELECT ltrim('xxxhello', 'x');    -- Returns: 'hello'
SELECT rtrim('helloxxx', 'x');    -- Returns: 'hello'
SELECT trim('abchelloabc', 'abc'); -- Returns: 'hello' (removes a, b, or c)
```

## Changes

- Updated `trim.rs` with implementations for `trim()`, `ltrim()`, and `rtrim()` functions supporting 1-2 arguments
- Exported new functions from string module
- Registered functions in the scalar function dispatcher
- Added comprehensive unit tests (10 tests covering all variants)

## Test Plan

- [x] Unit tests pass: `cargo test --package vibesql-executor evaluator::functions::string::trim`
- [x] End-to-end verification with CLI
- [x] Build succeeds: `cargo build --package vibesql-executor`
- [x] All packages check: `cargo check --all`

Closes #4654