### PR TITLE
fix(storage): use scan_live() in persistence to skip deleted rows

### DIFF
--- a/crates/vibesql-storage/src/persistence/binary/data.rs
+++ b/crates/vibesql-storage/src/persistence/binary/data.rs
@@ -23,8 +23,10 @@ pub fn write_data<W: Write>(writer: &mut W, db: &Database) -> Result<(), Storage
             // Write row count
             write_u64(writer, table.row_count() as u64)?;
 
-            // Write each row
-            for row in table.scan() {
+            // Write each row (only live/non-deleted rows)
+            // Using scan_live() to skip rows marked as deleted in the deletion bitmap.
+            // This fixes a bug where deleted rows were being persisted to disk.
+            for (_idx, row) in table.scan_live() {
                 for value in &row.values {
                     write_sql_value(writer, value)?;
                 }

--- a/crates/vibesql-storage/src/persistence/json.rs
+++ b/crates/vibesql-storage/src/persistence/json.rs
@@ -375,10 +375,11 @@ fn table_to_json(table_name: &str, table: &Table) -> Result<JsonTable, StorageEr
 
     let columns = table.schema.columns.iter().map(column_to_json).collect();
 
+    // Only persist live (non-deleted) rows.
+    // Using scan_live() to skip rows marked as deleted in the deletion bitmap.
     let rows = table
-        .scan()
-        .iter()
-        .map(|row| {
+        .scan_live()
+        .map(|(_idx, row)| {
             let mut row_map = HashMap::new();
             for (i, value) in row.values.iter().enumerate() {
                 let col_name = &table.schema.columns[i].name;

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -122,11 +122,12 @@ impl Database {
                 writeln!(writer, ");")
                     .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
 
-                // INSERT statements for data
+                // INSERT statements for data (only live/non-deleted rows)
+                // Using scan_live() to skip rows marked as deleted in the deletion bitmap.
                 if table.row_count() > 0 {
                     writeln!(writer)
                         .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
-                    for row in table.scan() {
+                    for (_idx, row) in table.scan_live() {
                         write!(writer, "INSERT INTO {} VALUES (", &table_name).map_err(|e| {
                             StorageError::NotImplemented(format!("Write error: {}", e))
                         })?;


### PR DESCRIPTION
## Summary

- Fixed persistence layer to use `scan_live()` instead of `scan()` when writing table data
- Applied fix to all three persistence formats: binary, SQL dump, and JSON
- Deleted rows are now correctly excluded from persistence, fixing DELETE operations not being saved

## Root Cause

The `table.scan()` method returns **all rows including deleted ones** (as documented in the method's comments). The persistence layer was using `scan()` instead of `scan_live()`, causing:

1. DELETE marks rows as deleted in a bitmap
2. When saving, `scan()` returns all rows including deleted ones
3. The deleted rows get written to disk
4. On reload, deleted rows reappear

## Test Results

This fix improves TCL test pass rate:
- **update.test**: 58 → 30 failures (28 tests fixed, 77% pass rate)
- **delete.test**: 27 → 20 failures (7 tests fixed, 64% pass rate)

## Test Plan

- [x] Manual verification: DELETE followed by reload now correctly excludes deleted rows
- [x] All 62 persistence unit tests pass
- [x] TCL tests show significant improvement

Closes #4656

🤖 Generated with [Claude Code](https://claude.com/claude-code)