### PR TITLE
fix(types): display BLOBs as text when valid UTF-8 (SQLite compatibility)

### DIFF
--- a/crates/vibesql-types/src/sql_value/display.rs
+++ b/crates/vibesql-types/src/sql_value/display.rs
@@ -125,11 +125,17 @@ impl fmt::Display for SqlValue {
                 write!(f, "[{}]", formatted.join(", "))
             }
             SqlValue::Blob(b) => {
-                // Format blob as hex string (without x'' prefix for raw display)
-                for byte in b {
-                    write!(f, "{:02X}", byte)?;
+                // SQLite compatibility: Display BLOB as text if it contains valid UTF-8,
+                // otherwise display as hex string (without x'' prefix)
+                if let Ok(s) = std::str::from_utf8(b) {
+                    write!(f, "{}", s)
+                } else {
+                    // Not valid UTF-8, display as hex
+                    for byte in b {
+                        write!(f, "{:02X}", byte)?;
+                    }
+                    Ok(())
                 }
-                Ok(())
             }
             SqlValue::Null => write!(f, "NULL"),
         }
@@ -261,5 +267,45 @@ mod tests {
         assert_eq!(format_f32(-0.0f32), "0.0");
         // Result of 0.0 * -1.0 should be "0.0", not "-0.0"
         assert_eq!(format_f64(0.0 * -1.0), "0.0");
+    }
+
+    #[test]
+    fn test_blob_display_utf8() {
+        // SQLite compatibility: BLOBs containing valid UTF-8 display as text
+        // x'616263' = "abc"
+        assert_eq!(
+            format!("{}", SqlValue::Blob(vec![0x61, 0x62, 0x63])),
+            "abc"
+        );
+        // x'68617265' = "hare"
+        assert_eq!(
+            format!("{}", SqlValue::Blob(vec![0x68, 0x61, 0x72, 0x65])),
+            "hare"
+        );
+        // x'68656c6c6f' = "hello"
+        assert_eq!(
+            format!("{}", SqlValue::Blob(vec![0x68, 0x65, 0x6c, 0x6c, 0x6f])),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn test_blob_display_invalid_utf8() {
+        // Non-UTF8 bytes display as hex
+        assert_eq!(
+            format!("{}", SqlValue::Blob(vec![0xFF, 0xFE])),
+            "FFFE"
+        );
+        // Invalid UTF-8 sequence
+        assert_eq!(
+            format!("{}", SqlValue::Blob(vec![0x80, 0x81, 0x82])),
+            "808182"
+        );
+    }
+
+    #[test]
+    fn test_blob_display_empty() {
+        // Empty blob displays as empty string
+        assert_eq!(format!("{}", SqlValue::Blob(vec![])), "");
     }
 }


### PR DESCRIPTION
## Summary

- SQLite displays BLOB values containing valid UTF-8 as text (e.g., `x'616263'` → `abc`)
- Changed `SqlValue::Blob` display to try UTF-8 decode first, fall back to hex for invalid UTF-8
- Added unit tests for BLOB display behavior with valid UTF-8, invalid UTF-8, and empty BLOBs

## Test plan

- [x] Unit tests added for BLOB display (`cargo test --package vibesql-types sql_value::display`)
- [x] Verified BLOB `x'616263'` now displays as `abc` in CLI
- [x] Verified BLOB `x'68617265'` now displays as `hare` in CLI
- [x] select4.test now passes 91.9% of tests (up from previous run)
- [x] Invalid UTF-8 sequences still display as hex

Closes #4669

🤖 Generated with [Claude Code](https://claude.com/claude-code)
