### PR TITLE
fix(types): implement SQLite type affinity for flexible type coercion

### DIFF
--- a/crates/vibesql-executor/src/insert/validation.rs
+++ b/crates/vibesql-executor/src/insert/validation.rs
@@ -171,6 +171,96 @@ pub fn coerce_value(
             }
         }
 
+        // VARCHAR/CHARACTER → Integer types (SQLite type affinity)
+        // Try to convert text to integer, otherwise keep as text
+        (SqlValue::Varchar(s) | SqlValue::Character(s), DataType::Integer) => {
+            let trimmed = s.trim();
+            if let Ok(i) = trimmed.parse::<i64>() {
+                Ok(SqlValue::Integer(i))
+            } else if let Ok(f) = trimmed.parse::<f64>() {
+                if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+                    Ok(SqlValue::Integer(f as i64))
+                } else {
+                    // Non-integer float stored as REAL
+                    Ok(SqlValue::Double(f))
+                }
+            } else {
+                // Can't convert - keep as text (SQLite behavior)
+                Ok(value)
+            }
+        }
+        (SqlValue::Varchar(s) | SqlValue::Character(s), DataType::Smallint) => {
+            let trimmed = s.trim();
+            if let Ok(i) = trimmed.parse::<i16>() {
+                Ok(SqlValue::Smallint(i))
+            } else if let Ok(f) = trimmed.parse::<f64>() {
+                if f.fract() == 0.0 && f >= i16::MIN as f64 && f <= i16::MAX as f64 {
+                    Ok(SqlValue::Smallint(f as i16))
+                } else {
+                    Ok(SqlValue::Double(f))
+                }
+            } else {
+                Ok(value)
+            }
+        }
+        (SqlValue::Varchar(s) | SqlValue::Character(s), DataType::Bigint) => {
+            let trimmed = s.trim();
+            if let Ok(i) = trimmed.parse::<i64>() {
+                Ok(SqlValue::Bigint(i))
+            } else if let Ok(f) = trimmed.parse::<f64>() {
+                if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+                    Ok(SqlValue::Bigint(f as i64))
+                } else {
+                    Ok(SqlValue::Double(f))
+                }
+            } else {
+                Ok(value)
+            }
+        }
+
+        // VARCHAR/CHARACTER → Float types (SQLite type affinity)
+        // Try to convert text to float, otherwise keep as text
+        (SqlValue::Varchar(s) | SqlValue::Character(s), DataType::Float { .. }) => {
+            let trimmed = s.trim();
+            if let Ok(f) = trimmed.parse::<f32>() {
+                Ok(SqlValue::Float(f))
+            } else {
+                Ok(value)
+            }
+        }
+        (SqlValue::Varchar(s) | SqlValue::Character(s), DataType::Real) => {
+            let trimmed = s.trim();
+            if let Ok(f) = trimmed.parse::<f32>() {
+                Ok(SqlValue::Real(f))
+            } else {
+                Ok(value)
+            }
+        }
+        (SqlValue::Varchar(s) | SqlValue::Character(s), DataType::DoublePrecision) => {
+            let trimmed = s.trim();
+            if let Ok(f) = trimmed.parse::<f64>() {
+                Ok(SqlValue::Double(f))
+            } else {
+                Ok(value)
+            }
+        }
+
+        // VARCHAR/CHARACTER → Numeric types (SQLite type affinity)
+        (SqlValue::Varchar(s) | SqlValue::Character(s), DataType::Numeric { .. }) => {
+            let trimmed = s.trim();
+            if let Ok(i) = trimmed.parse::<i64>() {
+                Ok(SqlValue::Integer(i))
+            } else if let Ok(f) = trimmed.parse::<f64>() {
+                if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+                    Ok(SqlValue::Integer(f as i64))
+                } else {
+                    Ok(SqlValue::Double(f))
+                }
+            } else {
+                Ok(value)
+            }
+        }
+
         // Integer → Float types (safe widening conversion)
         (SqlValue::Integer(i), DataType::Float { .. }) => Ok(SqlValue::Float(*i as f32)),
         (SqlValue::Integer(i), DataType::Real) => Ok(SqlValue::Real(*i as f32)),
@@ -205,6 +295,186 @@ pub fn coerce_value(
         // (which default to BLOB affinity) can store values of any type.
         // The value is stored as-is without conversion.
         (_, DataType::BinaryLargeObject) => Ok(value),
+
+        // UserDefined types: Apply SQLite's type affinity rules based on the type name
+        // See https://www.sqlite.org/datatype3.html#determination_of_column_affinity
+        //
+        // Type affinity is determined by checking substrings in the type name:
+        // 1. Contains "INT" → INTEGER affinity
+        // 2. Contains "CHAR", "CLOB", "TEXT" → TEXT affinity
+        // 3. Contains "BLOB" or no type specified → BLOB affinity (accept any)
+        // 4. Contains "REAL", "FLOA", "DOUB" → REAL affinity
+        // 5. Otherwise → NUMERIC affinity (try to convert text to number)
+        (_, DataType::UserDefined { type_name }) => {
+            let type_upper = type_name.to_uppercase();
+            let affinity = if type_upper.contains("INT") {
+                "INTEGER"
+            } else if type_upper.contains("CHAR")
+                || type_upper.contains("CLOB")
+                || type_upper.contains("TEXT")
+            {
+                "TEXT"
+            } else if type_upper.contains("BLOB") || type_upper.is_empty() {
+                "BLOB"
+            } else if type_upper.contains("REAL")
+                || type_upper.contains("FLOA")
+                || type_upper.contains("DOUB")
+            {
+                "REAL"
+            } else {
+                // Default: NUMERIC affinity (including NUM, NUMBER, etc.)
+                "NUMERIC"
+            };
+
+            match affinity {
+                "BLOB" => {
+                    // BLOB affinity: accept any value as-is
+                    Ok(value)
+                }
+                "TEXT" => {
+                    // TEXT affinity: convert to text representation
+                    match &value {
+                        SqlValue::Varchar(_) | SqlValue::Character(_) => Ok(value),
+                        SqlValue::Integer(i) => {
+                            Ok(SqlValue::Varchar(arcstr::ArcStr::from(i.to_string())))
+                        }
+                        SqlValue::Bigint(i) => {
+                            Ok(SqlValue::Varchar(arcstr::ArcStr::from(i.to_string())))
+                        }
+                        SqlValue::Smallint(i) => {
+                            Ok(SqlValue::Varchar(arcstr::ArcStr::from(i.to_string())))
+                        }
+                        SqlValue::Numeric(f) => {
+                            Ok(SqlValue::Varchar(arcstr::ArcStr::from(f.to_string())))
+                        }
+                        SqlValue::Double(f) => {
+                            Ok(SqlValue::Varchar(arcstr::ArcStr::from(f.to_string())))
+                        }
+                        SqlValue::Real(f) => {
+                            Ok(SqlValue::Varchar(arcstr::ArcStr::from(f.to_string())))
+                        }
+                        SqlValue::Float(f) => {
+                            Ok(SqlValue::Varchar(arcstr::ArcStr::from(f.to_string())))
+                        }
+                        _ => Ok(value), // Other types pass through
+                    }
+                }
+                "INTEGER" => {
+                    // INTEGER affinity: try to convert to integer
+                    match &value {
+                        SqlValue::Integer(_)
+                        | SqlValue::Bigint(_)
+                        | SqlValue::Smallint(_)
+                        | SqlValue::Unsigned(_) => Ok(value),
+                        SqlValue::Numeric(f) => {
+                            if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
+                                Ok(SqlValue::Integer(*f as i64))
+                            } else {
+                                // Non-integer stays as-is (SQLite stores actual type)
+                                Ok(value)
+                            }
+                        }
+                        SqlValue::Double(f) => {
+                            if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
+                                Ok(SqlValue::Integer(*f as i64))
+                            } else {
+                                Ok(value)
+                            }
+                        }
+                        SqlValue::Real(f) => {
+                            let f64_val = *f as f64;
+                            if f64_val.fract() == 0.0
+                                && f64_val >= i64::MIN as f64
+                                && f64_val <= i64::MAX as f64
+                            {
+                                Ok(SqlValue::Integer(f64_val as i64))
+                            } else {
+                                Ok(value)
+                            }
+                        }
+                        SqlValue::Varchar(s) | SqlValue::Character(s) => {
+                            // Try to parse as integer
+                            if let Ok(i) = s.trim().parse::<i64>() {
+                                Ok(SqlValue::Integer(i))
+                            } else if let Ok(f) = s.trim().parse::<f64>() {
+                                // Try as float, convert to int if whole number
+                                if f.fract() == 0.0
+                                    && f >= i64::MIN as f64
+                                    && f <= i64::MAX as f64
+                                {
+                                    Ok(SqlValue::Integer(f as i64))
+                                } else {
+                                    // Store as text if can't convert to integer
+                                    Ok(value)
+                                }
+                            } else {
+                                // Non-numeric text stays as text
+                                Ok(value)
+                            }
+                        }
+                        _ => Ok(value), // Other types pass through
+                    }
+                }
+                "REAL" => {
+                    // REAL affinity: convert to floating point
+                    match &value {
+                        SqlValue::Real(_) | SqlValue::Double(_) | SqlValue::Float(_) => Ok(value),
+                        SqlValue::Integer(i) => Ok(SqlValue::Double(*i as f64)),
+                        SqlValue::Bigint(i) => Ok(SqlValue::Double(*i as f64)),
+                        SqlValue::Smallint(i) => Ok(SqlValue::Double(*i as f64)),
+                        SqlValue::Numeric(f) => Ok(SqlValue::Double(*f)),
+                        SqlValue::Varchar(s) | SqlValue::Character(s) => {
+                            // Try to parse as float
+                            if let Ok(f) = s.trim().parse::<f64>() {
+                                Ok(SqlValue::Double(f))
+                            } else {
+                                // Non-numeric text stays as text
+                                Ok(value)
+                            }
+                        }
+                        _ => Ok(value),
+                    }
+                }
+                "NUMERIC" | _ => {
+                    // NUMERIC affinity: try integer first, then real, else keep as text
+                    // This is SQLite's behavior for types like NUM, NUMBER, etc.
+                    match &value {
+                        // Numeric types pass through
+                        SqlValue::Integer(_)
+                        | SqlValue::Bigint(_)
+                        | SqlValue::Smallint(_)
+                        | SqlValue::Numeric(_)
+                        | SqlValue::Double(_)
+                        | SqlValue::Real(_)
+                        | SqlValue::Float(_)
+                        | SqlValue::Unsigned(_) => Ok(value),
+                        // Text: try to convert to number
+                        SqlValue::Varchar(s) | SqlValue::Character(s) => {
+                            let trimmed = s.trim();
+                            // Try integer first
+                            if let Ok(i) = trimmed.parse::<i64>() {
+                                return Ok(SqlValue::Integer(i));
+                            }
+                            // Try float next
+                            if let Ok(f) = trimmed.parse::<f64>() {
+                                // SQLite converts to integer if it's a whole number
+                                if f.fract() == 0.0
+                                    && f >= i64::MIN as f64
+                                    && f <= i64::MAX as f64
+                                {
+                                    return Ok(SqlValue::Integer(f as i64));
+                                }
+                                return Ok(SqlValue::Double(f));
+                            }
+                            // Can't convert - keep as text (SQLite behavior)
+                            Ok(value)
+                        }
+                        // Other types pass through
+                        _ => Ok(value),
+                    }
+                }
+            }
+        }
 
         // SQLite type affinity: any value can be stored in TEXT columns by converting to string
         // This implements SQLite's behavior where TEXT affinity columns accept any value type

--- a/crates/vibesql-executor/tests/insert_basic_tests.rs
+++ b/crates/vibesql-executor/tests/insert_basic_tests.rs
@@ -146,11 +146,16 @@ fn test_insert_null_value() {
 }
 
 #[test]
-fn test_insert_type_mismatch() {
+fn test_insert_sqlite_type_affinity() {
+    // SQLite type affinity: any value can be stored in any column
+    // This implements SQLite's flexible typing where column types are
+    // preferences, not constraints. A Varchar value can be stored
+    // in an Integer column (it stays as Varchar, not converted).
     let mut db = vibesql_storage::Database::new();
     setup_test_table(&mut db);
 
     // INSERT INTO users VALUES ('not_a_number', 'Alice')
+    // This should succeed - SQLite allows storing any type in any column
     let stmt = vibesql_ast::InsertStmt {
         with_clause: None,
         schema_name: None,
@@ -170,9 +175,10 @@ fn test_insert_type_mismatch() {
         on_duplicate_key_update: None,
     };
 
+    // SQLite affinity: this should succeed
     let result = InsertExecutor::execute(&mut db, &stmt);
-    assert!(result.is_err());
-    assert!(matches!(result.unwrap_err(), ExecutorError::UnsupportedExpression(_)));
+    assert!(result.is_ok(), "SQLite type affinity should accept any value type");
+    assert_eq!(result.unwrap(), 1);
 }
 
 #[test]

--- a/crates/vibesql-executor/tests/insert_multi_row_tests.rs
+++ b/crates/vibesql-executor/tests/insert_multi_row_tests.rs
@@ -134,12 +134,15 @@ fn test_multi_row_insert_with_column_list() {
 }
 
 #[test]
-fn test_multi_row_insert_type_mismatch() {
+fn test_multi_row_insert_sqlite_type_affinity() {
+    // SQLite type affinity: any value can be stored in any column
+    // This implements SQLite's flexible typing where column types are
+    // preferences, not constraints.
     let mut db = vibesql_storage::Database::new();
     setup_test_table(&mut db);
 
     // INSERT INTO users VALUES (1, 'Alice'), ('not_a_number', 'Bob')
-    // Second row has type mismatch, should fail atomically
+    // Both rows should succeed - SQLite allows storing any type in any column
     let stmt = vibesql_ast::InsertStmt {
         with_clause: None,
         schema_name: None,
@@ -157,7 +160,7 @@ fn test_multi_row_insert_type_mismatch() {
             vec![
                 vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                     arcstr::ArcStr::from("not_a_number"),
-                )), /* Wrong type for id */
+                )), // Varchar in Integer column - allowed by SQLite affinity
                 vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                     arcstr::ArcStr::from("Bob"),
                 )),
@@ -167,12 +170,14 @@ fn test_multi_row_insert_type_mismatch() {
         on_duplicate_key_update: None,
     };
 
+    // SQLite affinity: both rows should be inserted successfully
     let result = InsertExecutor::execute(&mut db, &stmt);
-    assert!(result.is_err());
+    assert!(result.is_ok(), "SQLite type affinity should accept any value type");
+    assert_eq!(result.unwrap(), 2);
 
-    // No rows should be inserted due to atomicity
+    // Both rows should be inserted
     let table = db.get_table("users").unwrap();
-    assert_eq!(table.row_count(), 0);
+    assert_eq!(table.row_count(), 2);
 }
 
 #[test]

--- a/crates/vibesql-executor/tests/tpcds_schema_tests.rs
+++ b/crates/vibesql-executor/tests/tpcds_schema_tests.rs
@@ -143,10 +143,10 @@ fn test_web_site_date_columns() {
     assert_eq!(table.row_count(), 1);
 }
 
-/// Test that inserting INTEGER into DATE column fails with TypeMismatch.
-/// This documents the expected behavior that was broken before the fix.
+/// Test that inserting INTEGER into DATE column succeeds with SQLite type affinity.
+/// SQLite allows any value to be stored in any column - types are preferences, not constraints.
 #[test]
-fn test_integer_into_date_column_fails() {
+fn test_integer_into_date_column_sqlite_affinity() {
     use vibesql_catalog::{ColumnSchema, TableSchema};
     use vibesql_storage::{Database, Row};
     use vibesql_types::{DataType, SqlValue};
@@ -177,21 +177,17 @@ fn test_integer_into_date_column_fails() {
     ))
     .unwrap();
 
-    // Try to insert INTEGER into DATE column - this should fail
+    // Insert INTEGER into DATE column - SQLite affinity allows this
     let row = Row::new(vec![
         SqlValue::Integer(1),
-        SqlValue::Integer(19980101), // Wrong type - should be SqlValue::Date
+        SqlValue::Integer(19980101), // SQLite affinity: stored as-is
     ]);
 
+    // SQLite type affinity: this should succeed
     let result = db.insert_row("test_table", row);
-    assert!(result.is_err(), "Inserting INTEGER into DATE column should fail");
+    assert!(result.is_ok(), "SQLite type affinity should accept INTEGER in DATE column");
 
-    // Verify the error is TypeMismatch
-    let err = result.unwrap_err();
-    let err_string = format!("{:?}", err);
-    assert!(
-        err_string.contains("TypeMismatch") || err_string.contains("type mismatch"),
-        "Error should be TypeMismatch, got: {}",
-        err_string
-    );
+    // Verify the row was inserted
+    let table = db.get_table("test_table").unwrap();
+    assert_eq!(table.row_count(), 1);
 }

--- a/crates/vibesql-storage/src/table/normalization.rs
+++ b/crates/vibesql-storage/src/table/normalization.rs
@@ -66,76 +66,33 @@ impl<'a> RowNormalizer<'a> {
     ) -> Result<(), StorageError> {
         match expected_type {
             // Exact numeric types
-            // SQLite type affinity: INTEGER columns can store REAL/NUMERIC values
-            // (value keeps its actual type, column type is just a preference)
+            // SQLite type affinity: INTEGER columns can store any value type.
+            // The column type is a preference, not a constraint. Values that couldn't
+            // be converted to the column type are stored in their original form.
             DataType::Integer => {
-                if !matches!(
-                    value,
-                    SqlValue::Integer(_) | SqlValue::Numeric(_) | SqlValue::Double(_) | SqlValue::Real(_) | SqlValue::Float(_)
-                ) {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "INTEGER".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
-                }
+                // Accept any value type (SQLite type affinity)
+                // INTEGER, NUMERIC, DOUBLE, REAL, FLOAT are numeric compatibles
+                // VARCHAR, CHARACTER are accepted as-is (couldn't convert in executor)
             }
             DataType::Smallint => {
-                if !matches!(
-                    value,
-                    SqlValue::Smallint(_) | SqlValue::Numeric(_) | SqlValue::Double(_) | SqlValue::Real(_) | SqlValue::Float(_)
-                ) {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "SMALLINT".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
-                }
+                // Accept any value type (SQLite type affinity)
             }
             DataType::Bigint => {
-                if !matches!(
-                    value,
-                    SqlValue::Bigint(_) | SqlValue::Numeric(_) | SqlValue::Double(_) | SqlValue::Real(_) | SqlValue::Float(_)
-                ) {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "BIGINT".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
-                }
+                // Accept any value type (SQLite type affinity)
             }
             DataType::Unsigned => {
-                if !matches!(value, SqlValue::Unsigned(_)) {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "UNSIGNED".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
-                }
+                // Accept any value type (SQLite type affinity)
             }
             DataType::Numeric { .. } | DataType::Decimal { .. } => {
-                if !matches!(value, SqlValue::Numeric(_)) {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "NUMERIC".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
-                }
+                // Accept any value type (SQLite type affinity)
+                // Values that couldn't be converted stay as text
             }
-            // Approximate numeric types
+            // Approximate numeric types - all accept any value (SQLite type affinity)
             DataType::Float { .. } => {
-                if !matches!(value, SqlValue::Float(_)) {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "FLOAT".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
-                }
+                // FLOAT affinity: accept any value type
             }
             DataType::Real => {
-                // REAL affinity: Accept and convert any numeric type to Real (f32)
-                // This implements SQLite's flexible type affinity where REAL columns
-                // accept INTEGER, REAL, DOUBLE, NUMERIC, etc. and convert to floating point
+                // REAL affinity: Accept any value type, convert numeric types to Real
                 match value {
                     SqlValue::Real(_) => {
                         // Already correct type
@@ -162,34 +119,19 @@ impl<'a> RowNormalizer<'a> {
                         *value = SqlValue::Real(*u as f32);
                     }
                     _ => {
-                        return Err(StorageError::TypeMismatch {
-                            column: column_name.to_string(),
-                            expected: "REAL".to_string(),
-                            actual: value.type_name().to_string(),
-                        });
+                        // SQLite affinity: keep non-numeric values as-is
                     }
                 }
             }
             DataType::DoublePrecision => {
-                if !matches!(value, SqlValue::Double(_)) {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "DOUBLE PRECISION".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
-                }
+                // DOUBLE PRECISION affinity: accept any value type
             }
-            // Character types
+            // Character types - SQLite type affinity allows any value
             DataType::Character { length } => {
                 if let SqlValue::Character(s) = value {
                     *s = Self::normalize_char_value(s, *length).into();
-                } else {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: format!("CHAR({})", length),
-                        actual: value.type_name().to_string(),
-                    });
                 }
+                // SQLite affinity: accept any value type
             }
             DataType::Varchar { max_length } => {
                 if let SqlValue::Varchar(s) = value {
@@ -199,16 +141,8 @@ impl<'a> RowNormalizer<'a> {
                             *s = s[..*max_len].into();
                         }
                     }
-                } else {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: format!(
-                            "VARCHAR({})",
-                            max_length.map(|l| l.to_string()).unwrap_or_else(|| "MAX".to_string())
-                        ),
-                        actual: value.type_name().to_string(),
-                    });
                 }
+                // SQLite affinity: accept any value type
             }
             DataType::Name => {
                 // NAME is VARCHAR(128) in SQL:1999
@@ -217,134 +151,74 @@ impl<'a> RowNormalizer<'a> {
                     if s.len() > 128 {
                         *s = s[..128].into();
                     }
-                } else {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "NAME".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
                 }
+                // SQLite affinity: accept any value type
             }
             DataType::CharacterLargeObject => {
-                // CLOB stored as Varchar
-                if !matches!(value, SqlValue::Varchar(_)) {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "CLOB".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
-                }
+                // CLOB: accept any value type (SQLite affinity)
             }
-            // Boolean
+            // Boolean - accept any value (SQLite affinity)
             DataType::Boolean => {
-                if !matches!(value, SqlValue::Boolean(_)) {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "BOOLEAN".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
-                }
+                // SQLite affinity: accept any value type
             }
-            // Date/Time types
+            // Date/Time types - SQLite affinity: accept any value
             DataType::Date => {
-                // Allow implicit conversion from VARCHAR to DATE
+                // Try implicit conversion from VARCHAR to DATE
                 match value {
                     SqlValue::Date(_) => {
                         // Already correct type
                     }
                     SqlValue::Varchar(s) | SqlValue::Character(s) => {
-                        // Try to parse VARCHAR as DATE
-                        match s.parse::<vibesql_types::Date>() {
-                            Ok(date) => {
-                                *value = SqlValue::Date(date);
-                            }
-                            Err(_) => {
-                                return Err(StorageError::TypeMismatch {
-                                    column: column_name.to_string(),
-                                    expected: format!("DATE (cannot parse '{}')", s),
-                                    actual: value.type_name().to_string(),
-                                });
-                            }
+                        // Try to parse VARCHAR as DATE, keep as-is if fails
+                        if let Ok(date) = s.parse::<vibesql_types::Date>() {
+                            *value = SqlValue::Date(date);
                         }
+                        // SQLite affinity: keep non-parseable values as text
                     }
                     _ => {
-                        return Err(StorageError::TypeMismatch {
-                            column: column_name.to_string(),
-                            expected: "DATE".to_string(),
-                            actual: value.type_name().to_string(),
-                        });
+                        // SQLite affinity: accept any value type
                     }
                 }
             }
             DataType::Time { .. } => {
-                // Allow implicit conversion from VARCHAR to TIME
+                // Try implicit conversion from VARCHAR to TIME
                 match value {
                     SqlValue::Time(_) => {
                         // Already correct type
                     }
                     SqlValue::Varchar(s) | SqlValue::Character(s) => {
-                        // Try to parse VARCHAR as TIME
-                        match s.parse::<vibesql_types::Time>() {
-                            Ok(time) => {
-                                *value = SqlValue::Time(time);
-                            }
-                            Err(_) => {
-                                return Err(StorageError::TypeMismatch {
-                                    column: column_name.to_string(),
-                                    expected: format!("TIME (cannot parse '{}')", s),
-                                    actual: value.type_name().to_string(),
-                                });
-                            }
+                        // Try to parse VARCHAR as TIME, keep as-is if fails
+                        if let Ok(time) = s.parse::<vibesql_types::Time>() {
+                            *value = SqlValue::Time(time);
                         }
+                        // SQLite affinity: keep non-parseable values as text
                     }
                     _ => {
-                        return Err(StorageError::TypeMismatch {
-                            column: column_name.to_string(),
-                            expected: "TIME".to_string(),
-                            actual: value.type_name().to_string(),
-                        });
+                        // SQLite affinity: accept any value type
                     }
                 }
             }
             DataType::Timestamp { .. } => {
-                // Allow implicit conversion from VARCHAR to TIMESTAMP
+                // Try implicit conversion from VARCHAR to TIMESTAMP
                 match value {
                     SqlValue::Timestamp(_) => {
                         // Already correct type
                     }
                     SqlValue::Varchar(s) | SqlValue::Character(s) => {
-                        // Try to parse VARCHAR as TIMESTAMP
-                        match s.parse::<vibesql_types::Timestamp>() {
-                            Ok(ts) => {
-                                *value = SqlValue::Timestamp(ts);
-                            }
-                            Err(_) => {
-                                return Err(StorageError::TypeMismatch {
-                                    column: column_name.to_string(),
-                                    expected: format!("TIMESTAMP (cannot parse '{}')", s),
-                                    actual: value.type_name().to_string(),
-                                });
-                            }
+                        // Try to parse VARCHAR as TIMESTAMP, keep as-is if fails
+                        if let Ok(ts) = s.parse::<vibesql_types::Timestamp>() {
+                            *value = SqlValue::Timestamp(ts);
                         }
+                        // SQLite affinity: keep non-parseable values as text
                     }
                     _ => {
-                        return Err(StorageError::TypeMismatch {
-                            column: column_name.to_string(),
-                            expected: "TIMESTAMP".to_string(),
-                            actual: value.type_name().to_string(),
-                        });
+                        // SQLite affinity: accept any value type
                     }
                 }
             }
-            // Interval type
+            // Interval type - SQLite affinity: accept any value
             DataType::Interval { .. } => {
-                if !matches!(value, SqlValue::Interval(_)) {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "INTERVAL".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
-                }
+                // SQLite affinity: accept any value type
             }
             // Binary types - implements SQLite's BLOB affinity
             DataType::BinaryLargeObject => {
@@ -354,22 +228,7 @@ impl<'a> RowNormalizer<'a> {
                 // The value is stored as-is without conversion.
             }
             DataType::Bit { .. } => {
-                // BIT type: For now, accept Varchar or Integer as placeholder until proper BIT type
-                // is fully implemented VARCHAR can hold binary literals like
-                // b'1010', INTEGER can hold numeric values
-                if !matches!(
-                    value,
-                    SqlValue::Varchar(_)
-                        | SqlValue::Integer(_)
-                        | SqlValue::Bigint(_)
-                        | SqlValue::Unsigned(_)
-                ) {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: "BIT".to_string(),
-                        actual: value.type_name().to_string(),
-                    });
-                }
+                // BIT type: accept any value (SQLite affinity)
             }
             // User-defined types
             #[cfg_attr(not(debug_assertions), allow(unused_variables))]
@@ -404,7 +263,7 @@ impl<'a> RowNormalizer<'a> {
                     );
                 }
             }
-            // Vector type
+            // Vector type - check dimensions if it's a vector, otherwise accept any value
             DataType::Vector { dimensions } => {
                 if let SqlValue::Vector(v) = value {
                     if v.len() != *dimensions as usize {
@@ -414,13 +273,8 @@ impl<'a> RowNormalizer<'a> {
                             actual: format!("VECTOR({})", v.len()),
                         });
                     }
-                } else {
-                    return Err(StorageError::TypeMismatch {
-                        column: column_name.to_string(),
-                        expected: format!("VECTOR({})", dimensions),
-                        actual: value.type_name().to_string(),
-                    });
                 }
+                // SQLite affinity: accept any value type
             }
             // NULL type
             DataType::Null => {
@@ -519,19 +373,27 @@ mod tests {
     }
 
     #[test]
-    fn test_type_mismatch() {
+    fn test_sqlite_type_affinity() {
+        // SQLite type affinity: any value can be stored in any column
+        // This implements SQLite's flexible typing where column types are
+        // preferences, not constraints. A Varchar value can be stored
+        // in an Integer column (it stays as Varchar, not converted).
         let schema = create_test_schema();
         let normalizer = RowNormalizer::new(&schema);
 
         let row = Row::from_vec(vec![
-            SqlValue::Varchar(arcstr::ArcStr::from("not_an_int")), // Wrong type for id
+            SqlValue::Varchar(arcstr::ArcStr::from("not_an_int")), // Varchar in Integer column
             SqlValue::Varchar(arcstr::ArcStr::from("Alice")),
             SqlValue::Character(arcstr::ArcStr::from("ABC")),
         ]);
 
+        // SQLite affinity: this should succeed, storing the value as-is
         let result = normalizer.normalize_and_validate(row);
-        assert!(result.is_err());
-        assert!(matches!(result, Err(StorageError::TypeMismatch { .. })));
+        assert!(result.is_ok(), "SQLite type affinity should accept any value type");
+
+        // Verify the value was stored as-is (Varchar, not converted)
+        let normalized = result.unwrap();
+        assert!(matches!(normalized.values[0], SqlValue::Varchar(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Implement SQLite's type affinity rules for INSERT operations, allowing any value type to be stored in any column
- Add proper type affinity detection for UserDefined types based on type name patterns (INT→INTEGER, CHAR/TEXT→TEXT, BLOB→BLOB, REAL/FLOA/DOUB→REAL, otherwise NUMERIC)
- Add VARCHAR→Integer/Float/Numeric coercion in the executor validation layer
- Relax storage layer normalization to accept any value type in all column types, matching SQLite's flexible typing

## Test plan

- [x] All cargo tests pass (5000+ tests)
- [x] No more "datatype mismatch" errors in index.test TCL tests
- [x] index.test improved from 51 passing (52%) to 58 passing (59.2%) - 7 more tests fixed

Closes #4657

🤖 Generated with [Claude Code](https://claude.com/claude-code)