### PR TITLE
fix(tcl): initialize default database connection in TCL test shim

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2138,6 +2138,9 @@ proc run_test_file {filename} {
         set TEMP_STORE $::TEMP_STORE
         set SQLITE_DEFAULT_AUTOVACUUM $::SQLITE_DEFAULT_AUTOVACUUM
         array set sqlite_options [array get ::sqlite_options]
+        # Initialize the default database connection (as SQLite's tester.tcl does)
+        # This ensures tests that use execsql without explicit sqlite3 db calls work correctly
+        sqlite3 db test.db
     }
     regsub {source \$testdir/tester\.tcl} $content $tester_vars content
 


### PR DESCRIPTION
## Summary
- Adds `sqlite3 db test.db` initialization in TCL test shim's `$tester_vars` block
- Ensures tests use consistent database file throughout close/reopen cycles
- Fixes sqlite_master queries returning empty results after `db close; sqlite3 db test.db`

## Root Cause
The TCL test shim was not initializing a default database connection when test files are loaded. This caused:
1. Initial `execsql` calls used `/tmp/vibesql_test_[pid].vbsql` (default temp file)
2. When tests called `sqlite3 db test.db`, it switched to a different file
3. Subsequent queries saw an empty database - no tables, no indexes

## Test Plan
- [x] Verified index-1.1c, index-1.1d, and index-1.2 now pass (previously failed due to this issue)
- [x] Ran `cargo test --release` - all tests pass
- [x] index.test pass rate improved from 49/98 to 53/98 (4 tests fixed)

Closes #4659

🤖 Generated with [Claude Code](https://claude.com/claude-code)