### PR TITLE
fix(executor): return first row for scalar subqueries returning multiple rows

### DIFF
--- a/crates/vibesql-executor/src/evaluator/subqueries_shared.rs
+++ b/crates/vibesql-executor/src/evaluator/subqueries_shared.rs
@@ -22,47 +22,57 @@ use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;
 
-/// Evaluate scalar subquery result - must return exactly one row and one column
+/// Evaluate scalar subquery result - returns first row's single column value
 ///
-/// ## SQL Semantics (SQL:1999 Section 7.9)
-/// - Must return exactly 1 row (error if multiple rows)
-/// - Must return exactly 1 column (error if multiple columns)
-/// - Returns NULL if subquery returns zero rows
+/// ## SQL Semantics
+///
+/// Standard SQL (SQL:1999 Section 7.9) requires scalar subqueries to return exactly
+/// one row and one column, erroring if multiple rows are returned.
+///
+/// However, SQLite takes a different approach: when a scalar subquery returns multiple
+/// rows, SQLite uses the first row's value (officially "undefined" behavior per SQLite
+/// docs, but consistently implemented). This is documented at:
+/// https://www.sqlite.org/lang_expr.html#scalar_subqueries
+///
+/// VibeSQL follows SQLite's behavior for compatibility with SQLite test suites and
+/// applications that rely on this behavior.
+///
+/// ## Behavior
+/// - Zero rows: Returns NULL
+/// - One row: Returns that row's single column value
+/// - Multiple rows: Returns the first row's single column value (SQLite compatibility)
+/// - Multiple columns: Returns error (both SQL standard and SQLite agree here)
 ///
 /// ## Parameters
 /// - `rows`: The result set from executing the subquery
 ///
 /// ## Returns
 /// - `Ok(SqlValue::Null)` if no rows returned
-/// - `Ok(value)` the single value if exactly one row returned
-/// - `Err(SubqueryReturnedMultipleRows)` if more than one row
+/// - `Ok(value)` the first row's single column value
 /// - `Err(SubqueryColumnCountMismatch)` if not exactly one column
 /// - `Err(ColumnIndexOutOfBounds)` if row doesn't have a value at index 0
 pub fn eval_scalar_subquery_core(rows: &[Row]) -> Result<SqlValue, ExecutorError> {
-    // SQL:1999 Section 7.9: Scalar subquery must return exactly 1 row
-    if rows.len() > 1 {
-        return Err(ExecutorError::SubqueryReturnedMultipleRows {
-            expected: 1,
-            actual: rows.len(),
-        });
+    // Return NULL if no rows (both SQL standard and SQLite agree)
+    if rows.is_empty() {
+        return Ok(SqlValue::Null);
     }
 
-    // SQL:1999 Section 7.9: Scalar subquery must return exactly 1 column
+    // SQL:1999 Section 7.9 and SQLite both require exactly 1 column
     // SQL standard (R-35033-20570): We must validate the actual column count AFTER
     // execution because wildcards like SELECT * expand to multiple columns at runtime.
-    if !rows.is_empty() && rows[0].values.len() != 1 {
+    if rows[0].values.len() != 1 {
         return Err(ExecutorError::SubqueryColumnCountMismatch {
             expected: 1,
             actual: rows[0].values.len(),
         });
     }
 
-    // Return the single value, or NULL if no rows
-    if rows.is_empty() {
-        Ok(SqlValue::Null)
-    } else {
-        rows[0].get(0).cloned().ok_or(ExecutorError::ColumnIndexOutOfBounds { index: 0 })
-    }
+    // SQLite compatibility: Take the first row's value when multiple rows are returned.
+    // This differs from SQL standard which would error, but matches SQLite's behavior.
+    // See: https://www.sqlite.org/lang_expr.html#scalar_subqueries
+    // "If the subquery returns more than one result row, the value is undefined."
+    // In practice, SQLite consistently returns the first row.
+    rows[0].get(0).cloned().ok_or(ExecutorError::ColumnIndexOutOfBounds { index: 0 })
 }
 
 /// Evaluate EXISTS predicate result

--- a/crates/vibesql-executor/src/tests/scalar_subquery_error_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_error_tests.rs
@@ -1,14 +1,16 @@
 //! Scalar subquery error handling tests
 //!
-//! Tests for scalar subquery error cases and validation:
-//! - Multiple rows returned (cardinality violation)
-//! - Multiple columns returned (column count violation)
+//! Tests for scalar subquery behavior and validation:
+//! - Multiple rows returned: SQLite compatibility - returns first row (not an error)
+//! - Multiple columns returned: column count violation (still an error)
 
 use super::super::*;
 
 #[test]
-fn test_scalar_subquery_error_multiple_rows() {
-    // Test: Scalar subquery returns multiple rows - should error
+fn test_scalar_subquery_multiple_rows_returns_first() {
+    // Test: Scalar subquery returns multiple rows - SQLite-compatible behavior
+    // returns the first row's value instead of erroring
+    // See: https://www.sqlite.org/lang_expr.html#scalar_subqueries
     let mut db = vibesql_storage::Database::new();
 
     // Create employees table
@@ -63,7 +65,8 @@ fn test_scalar_subquery_error_multiple_rows() {
         offset: None,
     });
 
-    // Build main query: SELECT (subquery) FROM employees
+    // Build main query: SELECT (subquery) FROM employees LIMIT 1
+    // (LIMIT 1 because we only need to check one result)
     let stmt = vibesql_ast::SelectStmt {
         into_table: None,
         into_variables: None,
@@ -86,22 +89,18 @@ fn test_scalar_subquery_error_multiple_rows() {
         group_by: None,
         having: None,
         order_by: None,
-        limit: None,
+        limit: Some(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1))),
         offset: None,
     };
 
     let executor = SelectExecutor::new(&db);
     let result = executor.execute(&stmt);
 
-    // Should error with SubqueryReturnedMultipleRows
-    assert!(result.is_err());
-    match result.unwrap_err() {
-        ExecutorError::SubqueryReturnedMultipleRows { expected, actual } => {
-            assert_eq!(expected, 1);
-            assert_eq!(actual, 2);
-        }
-        _ => panic!("Expected SubqueryReturnedMultipleRows error"),
-    }
+    // SQLite-compatible: Should succeed and return the first row's value (1)
+    assert!(result.is_ok(), "Should succeed with SQLite-compatible behavior");
+    let rows = result.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(1));
 }
 
 #[test]

--- a/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
@@ -5,7 +5,10 @@ use vibesql_storage::{Database, Row};
 use vibesql_types::{DataType, SqlValue};
 
 #[test]
-fn test_update_with_subquery_multiple_rows_error() {
+fn test_update_with_subquery_multiple_rows_uses_first() {
+    // SQLite-compatible behavior: When a scalar subquery returns multiple rows,
+    // use the first row's value instead of erroring.
+    // See: https://www.sqlite.org/lang_expr.html#scalar_subqueries
     let mut db = Database::new();
 
     // CREATE TABLE employees (id INT, salary INT)
@@ -31,7 +34,8 @@ fn test_update_with_subquery_multiple_rows_error() {
     db.insert_row("salaries", Row::new(vec![SqlValue::Integer(60000)])).unwrap();
     db.insert_row("salaries", Row::new(vec![SqlValue::Integer(70000)])).unwrap();
 
-    // UPDATE employees SET salary = (SELECT amount FROM salaries) -- ERROR: multiple rows
+    // UPDATE employees SET salary = (SELECT amount FROM salaries)
+    // SQLite uses the first row (60000)
     let subquery = Box::new(vibesql_ast::SelectStmt {
         with_clause: None,
 
@@ -71,13 +75,14 @@ fn test_update_with_subquery_multiple_rows_error() {
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);
-    assert!(result.is_err());
-    match result.unwrap_err() {
-        ExecutorError::SubqueryReturnedMultipleRows { .. } => {
-            // Expected error
-        }
-        other => panic!("Expected SubqueryReturnedMultipleRows, got {:?}", other),
-    }
+    // SQLite-compatible: Should succeed and use the first value (60000)
+    assert!(result.is_ok(), "Should succeed with SQLite-compatible behavior");
+
+    // Verify the update was applied with the first value
+    let table = db.get_table("employees").unwrap();
+    let rows: Vec<&Row> = table.scan().iter().collect();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get(1).unwrap(), &SqlValue::Integer(60000));
 }
 
 #[test]

--- a/tests/test_error_handling/executor_errors.rs
+++ b/tests/test_error_handling/executor_errors.rs
@@ -54,7 +54,10 @@ fn test_division_by_zero_error() {
 }
 
 #[test]
-fn test_subquery_returned_multiple_rows_error() {
+fn test_subquery_multiple_rows_returns_first() {
+    // SQLite-compatible behavior: When a scalar subquery returns multiple rows,
+    // return the first row's value instead of erroring.
+    // See: https://www.sqlite.org/lang_expr.html#scalar_subqueries
     let mut db = Database::new();
 
     // Create and populate table
@@ -71,23 +74,17 @@ fn test_subquery_returned_multiple_rows_error() {
         InsertExecutor::execute(&mut db, &insert_stmt).expect("Insert should succeed");
     }
 
-    // Scalar subquery returning multiple rows
+    // Scalar subquery returning multiple rows - should return the first value (1)
     let sql = "SELECT (SELECT id FROM items) AS single_value";
     let stmt = Parser::parse_sql(sql).expect("Failed to parse");
     if let Statement::Select(select_stmt) = stmt {
         let result = SelectExecutor::new(&db).execute(&select_stmt);
-        assert!(result.is_err(), "Should fail with SubqueryReturnedMultipleRows");
+        assert!(result.is_ok(), "Should succeed with SQLite-compatible behavior");
 
-        match result {
-            Err(ExecutorError::SubqueryReturnedMultipleRows { expected, actual }) => {
-                assert_eq!(expected, 1);
-                assert_eq!(actual, 2);
-                let error_msg =
-                    format!("{}", ExecutorError::SubqueryReturnedMultipleRows { expected, actual });
-                assert!(error_msg.contains("returned") && error_msg.contains("rows"));
-            }
-            other => panic!("Expected SubqueryReturnedMultipleRows error, got: {:?}", other),
-        }
+        let rows = result.unwrap();
+        assert_eq!(rows.len(), 1);
+        // First row's value should be 1 (the first id inserted)
+        assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(1));
     }
 }
 


### PR DESCRIPTION
## Summary

Make VibeSQL's scalar subquery behavior match SQLite's when multiple rows are returned:
- Instead of erroring with "Scalar subquery returned N rows, expected 1", return the first row's value
- This is officially "undefined" behavior per SQLite docs but is consistently implemented

## Changes

- Modified `eval_scalar_subquery_core()` to return first row instead of erroring
- Updated tests to expect success with first row value instead of error
- Added comprehensive documentation explaining the SQLite compatibility

## Test Plan

- [x] TCL tests subquery2-1.11 and subquery2-1.12 now pass (were failing with "Scalar subquery returned 4 rows")
- [x] All executor unit tests pass
- [x] All update_subquery_tests pass
- [x] Manual verification with the specific failing query from the issue

Closes #4658