### PR TITLE
fix(types): preserve integer type in SUM when NULLs or text integers present

### DIFF
--- a/crates/vibesql-executor/src/memory/external_aggregate.rs
+++ b/crates/vibesql-executor/src/memory/external_aggregate.rs
@@ -771,7 +771,8 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0][1], SqlValue::Integer(2)); // COUNT = 2 (NULLs not counted)
-        assert_eq!(results[0][2], SqlValue::Double(30.0)); // SUM = 30.0 (NULL encountered → REAL)
+        // SUM = 30 as Integer (NULLs are skipped, don't affect type - SQLite behavior)
+        assert_eq!(results[0][2], SqlValue::Integer(30));
     }
 
     #[test]

--- a/crates/vibesql-executor/src/select/grouping/aggregates.rs
+++ b/crates/vibesql-executor/src/select/grouping/aggregates.rs
@@ -146,34 +146,40 @@ impl AggregateAccumulator {
                 distinct,
                 seen,
             } => {
-                // Track non-integer values for type determination
-                // SQLite: If ANY non-integer value is encountered (NULL, TEXT, REAL, etc.),
-                // the result should be REAL, even if that value is skipped
-                if !matches!(
-                    value,
-                    vibesql_types::SqlValue::Integer(_)
-                        | vibesql_types::SqlValue::Bigint(_)
-                        | vibesql_types::SqlValue::Smallint(_)
-                ) {
-                    *has_non_integer = true;
+                // Skip NULL values - they don't affect sum or type
+                if value.is_null() {
+                    return;
                 }
 
-                // Fast path: Skip non-numeric values early
-                if value.is_null() || !is_numeric_value(value) {
-                    return;
+                // Try to coerce the value to a numeric type
+                // This handles TEXT values that contain integers/reals
+                let (coerced_value, is_integer) = match try_coerce_to_numeric(value) {
+                    Some((coerced, is_int)) => (coerced, is_int),
+                    None => {
+                        // Cannot coerce to numeric - skip this value
+                        // (non-numeric text like "abc" is treated as 0 and skipped)
+                        return;
+                    }
+                };
+
+                // Track non-integer values for type determination
+                // SQLite: If ANY REAL/FLOAT value is encountered, result should be REAL
+                // TEXT values that parse as integers are treated as integers
+                if !is_integer {
+                    *has_non_integer = true;
                 }
 
                 if *distinct {
                     // Only sum if we haven't seen this value before
-                    // Optimization: Check membership before cloning
+                    // For DISTINCT, use original value for deduplication
                     let seen_set = seen.as_mut().unwrap();
                     if !seen_set.contains(value) {
                         seen_set.insert(value.clone());
-                        *sum = add_sql_values(sum, value);
+                        *sum = add_sql_values(sum, &coerced_value);
                         *count += 1;
                     }
                 } else {
-                    *sum = add_sql_values(sum, value);
+                    *sum = add_sql_values(sum, &coerced_value);
                     *count += 1;
                 }
             }
@@ -716,6 +722,58 @@ fn is_numeric_value(value: &vibesql_types::SqlValue) -> bool {
             | vibesql_types::SqlValue::Real(_)
             | vibesql_types::SqlValue::Double(_)
     )
+}
+
+/// Try to coerce a SqlValue to a numeric value for SUM
+/// Returns Some((coerced_value, is_integer_type)) if coercion is possible
+/// Returns None if the value cannot be coerced to a number
+fn try_coerce_to_numeric(
+    value: &vibesql_types::SqlValue,
+) -> Option<(vibesql_types::SqlValue, bool)> {
+    match value {
+        // Already numeric types - return as-is (preserve original type)
+        vibesql_types::SqlValue::Integer(v) => {
+            Some((vibesql_types::SqlValue::Integer(*v), true))
+        }
+        vibesql_types::SqlValue::Bigint(v) => Some((vibesql_types::SqlValue::Bigint(*v), true)),
+        vibesql_types::SqlValue::Smallint(v) => {
+            Some((vibesql_types::SqlValue::Smallint(*v), true))
+        }
+        vibesql_types::SqlValue::Unsigned(v) => {
+            Some((vibesql_types::SqlValue::Integer(*v as i64), true))
+        }
+        vibesql_types::SqlValue::Float(v) => Some((vibesql_types::SqlValue::Float(*v), false)),
+        vibesql_types::SqlValue::Double(v) => Some((vibesql_types::SqlValue::Double(*v), false)),
+        vibesql_types::SqlValue::Numeric(v) => {
+            Some((vibesql_types::SqlValue::Numeric(*v), false))
+        }
+        vibesql_types::SqlValue::Real(v) => Some((vibesql_types::SqlValue::Real(*v), false)),
+
+        // Text types - try to parse as integer first, then as real
+        vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
+            let trimmed = s.trim();
+            // Try to parse as integer first
+            if let Ok(i) = trimmed.parse::<i64>() {
+                Some((vibesql_types::SqlValue::Integer(i), true))
+            } else if let Ok(f) = trimmed.parse::<f64>() {
+                // Parsed as real - this is a non-integer type
+                Some((vibesql_types::SqlValue::Double(f), false))
+            } else {
+                // Cannot parse as number - SQLite treats this as 0 for SUM
+                // but it doesn't count as a value and doesn't affect type
+                None
+            }
+        }
+
+        // Boolean - treat as 0 or 1 (integer)
+        vibesql_types::SqlValue::Boolean(b) => {
+            Some((vibesql_types::SqlValue::Integer(if *b { 1 } else { 0 }), true))
+        }
+
+        // NULL and other types - cannot coerce
+        vibesql_types::SqlValue::Null => None,
+        _ => None,
+    }
 }
 
 /// Fast check if a value is comparable for MIN/MAX (optimization to avoid full match)

--- a/crates/vibesql-executor/src/tests/aggregate_count_sum_avg_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_count_sum_avg_tests.rs
@@ -328,8 +328,8 @@ fn test_sum_with_nulls() {
     let result = executor.execute(&stmt).unwrap();
     assert_eq!(result.len(), 1);
     // SUM ignores NULL values, so 100 + 200 = 300
-    // SQLite's SUM() returns REAL when NULL encountered, even if NULLs are skipped
-    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Double(300.0));
+    // SQLite's SUM() preserves INTEGER type for integer inputs (NULLs don't affect type)
+    assert_eq!(result[0].values[0], vibesql_types::SqlValue::Integer(300));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fixes SUM() function to preserve INTEGER type when NULL values are present (they're skipped, don't affect type)
- Properly handles TEXT values that can be coerced to integers (treat as integer for type determination)
- Adds `try_coerce_to_numeric` helper function for proper type handling
- Updates tests to reflect correct SQLite type affinity behavior

## Test Cases Fixed

| Test | Query | Expected | Before | After |
|------|-------|----------|--------|-------|
| func-8.1 | `SELECT sum(a) FROM t2` (with NULLs) | `68236` (integer) | `68236.0` (real) | ✓ |
| func-8.6 | `SELECT typeof(sum(x))` (text "9223..." + integer) | `integer` | `real` | ✓ |
| func-18.6 | `SELECT sum(x), total(x)` | `123, 123.0` | `123.0, 123.0` | ✓ |

## Test plan

- [x] All 3 issue test cases pass manually
- [x] Unit tests pass (2192 tests)
- [x] func.test TCL tests improved (5 more tests passing)

Closes #4661

🤖 Generated with [Claude Code](https://claude.com/claude-code)