### PR TITLE
feat(update): support UPDATE SET rowid = expr (SQLite compatibility)

### DIFF
--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -327,8 +327,19 @@ impl UpdateExecutor {
             // Check if primary key is being updated
             let updates_pk = if let Some(ref pk_idx) = pk_indices {
                 stmt.assignments.iter().any(|a| {
-                    let col_index = schema.get_column_index(&a.column).unwrap();
-                    pk_idx.contains(&col_index)
+                    // Check if this is a rowid assignment
+                    let col_name_lower = a.column.to_lowercase();
+                    let is_rowid = col_name_lower == "rowid" || col_name_lower == "_rowid_" || col_name_lower == "oid";
+
+                    if is_rowid {
+                        // For INTEGER PRIMARY KEY tables, rowid IS the PK
+                        // For other tables, rowid is virtual and not in PK
+                        schema.rowid_alias_column.is_some()
+                    } else if let Some(col_index) = schema.get_column_index(&a.column) {
+                        pk_idx.contains(&col_index)
+                    } else {
+                        false
+                    }
                 })
             } else {
                 false
@@ -707,6 +718,13 @@ impl UpdateExecutor {
         let mut changed_columns = std::collections::HashSet::new();
 
         for assignment in &stmt.assignments {
+            // Check if this is a rowid assignment - fall back to normal path
+            let col_name_lower = assignment.column.to_lowercase();
+            let is_rowid = col_name_lower == "rowid" || col_name_lower == "_rowid_" || col_name_lower == "oid";
+            if is_rowid {
+                return Ok(None); // rowid update needs normal path for proper handling
+            }
+
             let col_index = schema.get_column_index(&assignment.column).ok_or_else(|| {
                 ExecutorError::ColumnNotFound {
                     column_name: assignment.column.clone(),
@@ -813,6 +831,13 @@ impl UpdateExecutor {
         let pk_indices = schema.get_primary_key_indices();
 
         for assignment in &stmt.assignments {
+            // Check if this is a rowid assignment - fall back to normal path
+            let col_name_lower = assignment.column.to_lowercase();
+            let is_rowid = col_name_lower == "rowid" || col_name_lower == "_rowid_" || col_name_lower == "oid";
+            if is_rowid {
+                return Ok(None); // rowid update needs normal path for proper handling
+            }
+
             // Check if value is a literal (no expression evaluation needed)
             let new_value = match &assignment.value {
                 vibesql_ast::Expression::Literal(val) => val.clone(),
@@ -1417,7 +1442,10 @@ fn validate_set_expressions(
 ) -> Result<(), ExecutorError> {
     for assignment in assignments {
         // Validate target column exists (LHS of assignment)
-        if schema.get_column_index(&assignment.column).is_none() {
+        // Special case: rowid is a virtual column that always exists (SQLite compatibility)
+        let col_name_lower = assignment.column.to_lowercase();
+        let is_rowid = col_name_lower == "rowid" || col_name_lower == "_rowid_" || col_name_lower == "oid";
+        if !is_rowid && schema.get_column_index(&assignment.column).is_none() {
             return Err(ExecutorError::NoSuchColumn { column_ref: assignment.column.clone() });
         }
 

--- a/crates/vibesql-executor/src/update/row_selector.rs
+++ b/crates/vibesql-executor/src/update/row_selector.rs
@@ -36,7 +36,12 @@ impl<'a> RowSelector<'a> {
                 if let Some(pk_index) = table.primary_key_index() {
                     if let Some(&row_index) = pk_index.get(&pk_values) {
                         // Found the row via index - single row to update
-                        return Ok(vec![(row_index, table.scan()[row_index].clone())]);
+                        // Clone and set row_id for ROWID pseudo-column support
+                        let mut cloned_row = table.scan()[row_index].clone();
+                        if cloned_row.row_id.is_none() {
+                            cloned_row.row_id = Some((row_index + 1) as u64);
+                        }
+                        return Ok(vec![(row_index, cloned_row)]);
                     } else {
                         // Primary key not found - no rows to update
                         return Ok(vec![]);
@@ -226,7 +231,12 @@ impl<'a> RowSelector<'a> {
             };
 
             if should_update {
-                candidate_rows.push((row_index, row.clone()));
+                // Clone the row and set row_id for ROWID pseudo-column support
+                let mut cloned_row = row.clone();
+                if cloned_row.row_id.is_none() {
+                    cloned_row.row_id = Some((row_index + 1) as u64);
+                }
+                candidate_rows.push((row_index, cloned_row));
             }
         }
 

--- a/crates/vibesql-executor/src/update/value_updater.rs
+++ b/crates/vibesql-executor/src/update/value_updater.rs
@@ -36,6 +36,43 @@ impl<'a> ValueUpdater<'a> {
 
         // Apply each assignment
         for assignment in assignments {
+            // Check if this is a rowid assignment (SQLite compatibility)
+            let col_name_lower = assignment.column.to_lowercase();
+            let is_rowid = col_name_lower == "rowid" || col_name_lower == "_rowid_" || col_name_lower == "oid";
+
+            if is_rowid {
+                // Handle rowid update
+                // If the table has an INTEGER PRIMARY KEY (rowid alias), update that column
+                // Otherwise, update the row's internal row_id field
+                if let Some(ipk_col_idx) = self.schema.rowid_alias_column {
+                    // The INTEGER PRIMARY KEY column IS the rowid - update it
+                    let new_value = self.evaluator.eval(&assignment.value, original_row)?;
+                    new_row
+                        .set(ipk_col_idx, new_value)
+                        .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+                    changed_columns.insert(ipk_col_idx);
+                } else {
+                    // No INTEGER PRIMARY KEY - update the virtual rowid
+                    // Evaluate the new rowid value
+                    let new_value = self.evaluator.eval(&assignment.value, original_row)?;
+                    // Convert to u64 for row_id
+                    let new_rowid = match new_value {
+                        vibesql_types::SqlValue::Integer(i) => i as u64,
+                        vibesql_types::SqlValue::Bigint(i) => i as u64,
+                        other => {
+                            return Err(ExecutorError::UnsupportedExpression(format!(
+                                "ROWID must be an integer, got {:?}",
+                                other
+                            )));
+                        }
+                    };
+                    new_row.row_id = Some(new_rowid);
+                    // Note: We don't add anything to changed_columns since row_id
+                    // is not a real column. The storage layer will use the updated row_id.
+                }
+                continue;
+            }
+
             // Find column index
             // Use SQLite-compatible "no such column: X" error format
             let col_index = self.schema.get_column_index(&assignment.column).ok_or_else(|| {

--- a/crates/vibesql-parser/src/arena_parser/update.rs
+++ b/crates/vibesql-parser/src/arena_parser/update.rs
@@ -96,15 +96,23 @@ impl<'arena> ArenaParser<'arena> {
         let mut assignments = BumpVec::new_in(self.arena);
 
         loop {
-            // Parse column name
-            let column = if let Token::Identifier(col) = self.peek() {
-                let col = col.clone();
-                self.advance();
-                self.intern(&col)
-            } else {
-                return Err(ParseError {
-                    message: "Expected column name in SET clause".to_string(),
-                });
+            // Parse column name (including rowid keyword for SQLite compatibility)
+            let column = match self.peek() {
+                Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
+                    let col = col.clone();
+                    self.advance();
+                    self.intern(&col)
+                }
+                // SQLite allows updating the virtual rowid column
+                Token::Keyword { keyword: Keyword::Rowid, .. } => {
+                    self.advance();
+                    self.intern("rowid")
+                }
+                _ => {
+                    return Err(ParseError {
+                        message: "Expected column name in SET clause".to_string(),
+                    });
+                }
             };
 
             // Expect =

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -46,12 +46,17 @@ impl Parser {
         // Parse assignments
         let mut assignments = Vec::new();
         loop {
-            // Parse column name (support both regular and delimited identifiers)
+            // Parse column name (support regular, delimited identifiers, and rowid keyword)
             let column = match self.peek() {
                 Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
                     let c = col.clone();
                     self.advance();
                     c
+                }
+                // SQLite allows updating the virtual rowid column
+                Token::Keyword { keyword: Keyword::Rowid, .. } => {
+                    self.advance();
+                    "rowid".to_string()
                 }
                 _ => {
                     return Err(ParseError {


### PR DESCRIPTION
## Summary

- Add support for `UPDATE t SET rowid = expr` syntax where the virtual rowid column can be updated
- Handle both INTEGER PRIMARY KEY tables (where rowid is an alias for the PK column) and regular tables (where rowid is a hidden virtual column)
- Set row_id on rows selected for update so expressions like `rowid + 10` evaluate correctly

## Changes

**Parser:**
- Accept `Keyword::Rowid` as a valid column name in SET clause
- Implemented in both main parser and arena parser

**Executor:**
- Allow rowid as assignment target in validation
- For INTEGER PRIMARY KEY tables: update the PK column directly
- For other tables: update the row's internal `row_id` field
- Fast paths fall back to normal path when rowid is updated
- Fix row_id not being set on rows fetched for update

## Test plan

- [x] `UPDATE t SET rowid = rowid + 10` works for regular tables
- [x] `UPDATE t SET rowid = rowid + 100` works for INTEGER PRIMARY KEY tables
- [x] Multiple rows can have their rowids updated
- [x] WHERE clause works with rowid updates
- [x] All existing UPDATE tests pass

Closes #4674

🤖 Generated with [Claude Code](https://claude.com/claude-code)