### PR TITLE
fix(executor): resolve outer SELECT aliases in correlated subquery HAVING

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -23,7 +23,7 @@ use crate::{
         grouping::{
             expand_group_by_clause, get_base_expressions, group_rows,
             resolve_base_expressions_aliases, resolve_grouping_set_aliases,
-            resolve_having_aliases_with_schema, GroupingContext,
+            resolve_having_aliases_with_values, GroupingContext,
         },
         helpers::{apply_distinct, apply_limit_offset},
     },
@@ -363,15 +363,22 @@ impl SelectExecutor<'_> {
 
                     // Apply HAVING filter
                     let include_group = if let Some(having_expr) = &stmt.having {
+                        // Build alias values map from computed aggregate results (issue #4676)
+                        // This enables correlated subqueries in HAVING to access outer aliases
+                        let alias_values =
+                            build_alias_values_map(&expanded_select_list, &aggregate_results);
+
                         // Resolve SELECT list aliases in HAVING (e.g., HAVING y >= 4 where y is count(*))
                         // Pass ORIGINAL GROUP BY expressions so aliases that shadow GROUP BY columns
                         // aren't resolved (HAVING should use GROUP BY columns, not SELECT aliases)
                         // Also pass schema_columns so table columns take precedence over aliases (#4531)
-                        let resolved_having = resolve_having_aliases_with_schema(
+                        // Use resolve_having_aliases_with_values to also resolve outer aliases in subqueries
+                        let resolved_having = resolve_having_aliases_with_values(
                             having_expr,
                             &expanded_select_list,
                             &original_group_by_exprs,
                             &schema_columns,
+                            &alias_values,
                         );
                         let having_result = self.evaluate_with_aggregates_and_grouping(
                             &resolved_having,
@@ -483,14 +490,21 @@ impl SelectExecutor<'_> {
 
                 // Apply HAVING filter
                 let include_group = if let Some(having_expr) = &stmt.having {
+                    // Build alias values map from computed aggregate results (issue #4676)
+                    // This enables correlated subqueries in HAVING to access outer aliases
+                    let alias_values =
+                        build_alias_values_map(&expanded_select_list, &aggregate_results);
+
                     // Resolve SELECT list aliases in HAVING (e.g., HAVING y >= 4 where y is count(*))
                     // No GROUP BY, so no GROUP BY expressions to exclude from alias resolution
                     // Still pass schema_columns so table columns take precedence over aliases (#4531)
-                    let resolved_having = resolve_having_aliases_with_schema(
+                    // Use resolve_having_aliases_with_values to also resolve outer aliases in subqueries
+                    let resolved_having = resolve_having_aliases_with_values(
                         having_expr,
                         &expanded_select_list,
                         &[],
                         &schema_columns,
+                        &alias_values,
                     );
                     let having_result = self.evaluate_with_aggregates_and_grouping(
                         &resolved_having,
@@ -741,4 +755,32 @@ pub(crate) fn build_early_schema(
         // Subqueries, VALUES, etc. - can't easily determine schema without execution
         vibesql_ast::FromClause::Subquery { .. } | vibesql_ast::FromClause::Values { .. } => None,
     }
+}
+
+/// Build a map of SELECT alias names to their computed values.
+///
+/// This is used to resolve outer alias references in correlated subqueries within HAVING.
+/// When a subquery references an alias from the outer SELECT list (e.g., `avg1` from
+/// `avg(a.y) AS avg1`), we need to replace that reference with the computed value.
+///
+/// # Arguments
+/// * `select_list` - The expanded SELECT list with aliases
+/// * `computed_values` - The computed values corresponding to each SELECT item
+///
+/// # Returns
+/// A HashMap mapping lowercase alias names to their computed SqlValue
+fn build_alias_values_map(
+    select_list: &[vibesql_ast::SelectItem],
+    computed_values: &[vibesql_types::SqlValue],
+) -> HashMap<String, vibesql_types::SqlValue> {
+    let mut alias_values = HashMap::new();
+
+    for (item, value) in select_list.iter().zip(computed_values.iter()) {
+        if let vibesql_ast::SelectItem::Expression { alias: Some(alias_name), .. } = item {
+            // Store with lowercase key for case-insensitive lookup
+            alias_values.insert(alias_name.to_lowercase(), value.clone());
+        }
+    }
+
+    alias_values
 }

--- a/crates/vibesql-executor/src/select/grouping/grouping_sets/alias_resolution.rs
+++ b/crates/vibesql-executor/src/select/grouping/grouping_sets/alias_resolution.rs
@@ -146,13 +146,49 @@ pub fn resolve_having_aliases(
 /// because table columns take precedence over aliases in SQL.
 ///
 /// The `schema_columns` parameter should contain lowercase column names from the table schema.
-pub fn resolve_having_aliases_with_schema(
+///
+/// Note: For HAVING clauses with correlated subqueries, use `resolve_having_aliases_with_values`
+/// instead, as it also resolves outer alias references within subqueries.
+#[allow(dead_code)]
+fn resolve_having_aliases_with_schema(
     having_expr: &Expression,
     select_list: &[vibesql_ast::SelectItem],
     group_by_exprs: &[Expression],
     schema_columns: &std::collections::HashSet<String>,
 ) -> Expression {
     resolve_having_aliases_inner(having_expr, select_list, group_by_exprs, Some(schema_columns))
+}
+
+/// Resolve aliases in HAVING expression with schema awareness and computed alias values.
+///
+/// This variant also traverses into subqueries (EXISTS, IN, etc.) and replaces
+/// references to outer SELECT aliases with their computed literal values.
+/// This is necessary for correlated subqueries that reference outer aliases
+/// in their HAVING clauses (issue #4676).
+///
+/// Example:
+/// ```sql
+/// SELECT a.x, avg(a.y) AS avg1 FROM t AS a GROUP BY a.x
+/// HAVING NOT EXISTS(
+///   SELECT b.x, avg(b.y) AS avg2 FROM t AS b GROUP BY b.x
+///   HAVING avg1 > avg2  -- avg1 from outer query
+/// )
+/// ```
+/// Here `avg1` in the inner HAVING is resolved to its computed value (e.g., 2.5).
+pub fn resolve_having_aliases_with_values(
+    having_expr: &Expression,
+    select_list: &[vibesql_ast::SelectItem],
+    group_by_exprs: &[Expression],
+    schema_columns: &std::collections::HashSet<String>,
+    alias_values: &std::collections::HashMap<String, vibesql_types::SqlValue>,
+) -> Expression {
+    resolve_having_aliases_with_values_inner(
+        having_expr,
+        select_list,
+        group_by_exprs,
+        Some(schema_columns),
+        alias_values,
+    )
 }
 
 /// Check if a column name matches any GROUP BY column expression
@@ -377,6 +413,492 @@ fn resolve_having_aliases_inner(
 
         // For other expression types, return as-is
         _ => having_expr.clone(),
+    }
+}
+
+/// Inner implementation for resolving HAVING aliases with computed values.
+/// Traverses into subqueries and replaces outer alias references with literal values.
+fn resolve_having_aliases_with_values_inner(
+    having_expr: &Expression,
+    select_list: &[vibesql_ast::SelectItem],
+    group_by_exprs: &[Expression],
+    schema_columns: Option<&std::collections::HashSet<String>>,
+    alias_values: &std::collections::HashMap<String, vibesql_types::SqlValue>,
+) -> Expression {
+    match having_expr {
+        // Check if this column reference matches a SELECT list alias
+        Expression::ColumnRef(col_id)
+            if col_id.schema_canonical().is_none() && col_id.table_canonical().is_none() =>
+        {
+            let column = col_id.column_canonical();
+
+            // Skip alias resolution if this column is in GROUP BY
+            if is_group_by_column(column, group_by_exprs) {
+                return having_expr.clone();
+            }
+
+            // Skip alias resolution if this column exists in the table schema
+            if let Some(schema_cols) = schema_columns {
+                if schema_cols.contains(&column.to_lowercase()) {
+                    return having_expr.clone();
+                }
+            }
+
+            // Search for matching alias in SELECT list and replace with expression
+            for item in select_list {
+                if let vibesql_ast::SelectItem::Expression {
+                    expr, alias: Some(alias_name), ..
+                } = item
+                {
+                    if alias_name.eq_ignore_ascii_case(column) {
+                        return expr.clone();
+                    }
+                }
+            }
+            having_expr.clone()
+        }
+
+        // Recursively resolve in binary operations
+        Expression::BinaryOp { left, op, right } => Expression::BinaryOp {
+            left: Box::new(resolve_having_aliases_with_values_inner(
+                left,
+                select_list,
+                group_by_exprs,
+                schema_columns,
+                alias_values,
+            )),
+            op: *op,
+            right: Box::new(resolve_having_aliases_with_values_inner(
+                right,
+                select_list,
+                group_by_exprs,
+                schema_columns,
+                alias_values,
+            )),
+        },
+
+        // Recursively resolve in unary operations
+        Expression::UnaryOp { op, expr } => Expression::UnaryOp {
+            op: *op,
+            expr: Box::new(resolve_having_aliases_with_values_inner(
+                expr,
+                select_list,
+                group_by_exprs,
+                schema_columns,
+                alias_values,
+            )),
+        },
+
+        // Recursively resolve in function arguments
+        Expression::Function { name, args, character_unit } => Expression::Function {
+            name: name.clone(),
+            args: args
+                .iter()
+                .map(|a| {
+                    resolve_having_aliases_with_values_inner(
+                        a,
+                        select_list,
+                        group_by_exprs,
+                        schema_columns,
+                        alias_values,
+                    )
+                })
+                .collect(),
+            character_unit: character_unit.clone(),
+        },
+
+        // Recursively resolve in aggregate function arguments
+        Expression::AggregateFunction { name, distinct, args, order_by, filter } => {
+            Expression::AggregateFunction {
+                name: name.clone(),
+                distinct: *distinct,
+                args: args
+                    .iter()
+                    .map(|a| {
+                        resolve_having_aliases_with_values_inner(
+                            a,
+                            select_list,
+                            group_by_exprs,
+                            schema_columns,
+                            alias_values,
+                        )
+                    })
+                    .collect(),
+                order_by: order_by.clone(),
+                filter: filter.as_ref().map(|f| {
+                    Box::new(resolve_having_aliases_with_values_inner(
+                        f,
+                        select_list,
+                        group_by_exprs,
+                        schema_columns,
+                        alias_values,
+                    ))
+                }),
+            }
+        }
+
+        // Recursively resolve in CASE expressions
+        Expression::Case { operand, when_clauses, else_result } => {
+            let resolved_operand = operand.as_ref().map(|o| {
+                Box::new(resolve_having_aliases_with_values_inner(
+                    o,
+                    select_list,
+                    group_by_exprs,
+                    schema_columns,
+                    alias_values,
+                ))
+            });
+            let resolved_when_clauses = when_clauses
+                .iter()
+                .map(|wc| vibesql_ast::CaseWhen {
+                    conditions: wc
+                        .conditions
+                        .iter()
+                        .map(|c| {
+                            resolve_having_aliases_with_values_inner(
+                                c,
+                                select_list,
+                                group_by_exprs,
+                                schema_columns,
+                                alias_values,
+                            )
+                        })
+                        .collect(),
+                    result: resolve_having_aliases_with_values_inner(
+                        &wc.result,
+                        select_list,
+                        group_by_exprs,
+                        schema_columns,
+                        alias_values,
+                    ),
+                })
+                .collect();
+            let resolved_else = else_result.as_ref().map(|e| {
+                Box::new(resolve_having_aliases_with_values_inner(
+                    e,
+                    select_list,
+                    group_by_exprs,
+                    schema_columns,
+                    alias_values,
+                ))
+            });
+            Expression::Case {
+                operand: resolved_operand,
+                when_clauses: resolved_when_clauses,
+                else_result: resolved_else,
+            }
+        }
+
+        // Recursively resolve in boolean expressions
+        Expression::Conjunction(terms) => Expression::Conjunction(
+            terms
+                .iter()
+                .map(|t| {
+                    resolve_having_aliases_with_values_inner(
+                        t,
+                        select_list,
+                        group_by_exprs,
+                        schema_columns,
+                        alias_values,
+                    )
+                })
+                .collect(),
+        ),
+        Expression::Disjunction(terms) => Expression::Disjunction(
+            terms
+                .iter()
+                .map(|t| {
+                    resolve_having_aliases_with_values_inner(
+                        t,
+                        select_list,
+                        group_by_exprs,
+                        schema_columns,
+                        alias_values,
+                    )
+                })
+                .collect(),
+        ),
+
+        // Recursively resolve in comparison expressions
+        Expression::Between { expr, low, high, negated, symmetric } => Expression::Between {
+            expr: Box::new(resolve_having_aliases_with_values_inner(
+                expr,
+                select_list,
+                group_by_exprs,
+                schema_columns,
+                alias_values,
+            )),
+            low: Box::new(resolve_having_aliases_with_values_inner(
+                low,
+                select_list,
+                group_by_exprs,
+                schema_columns,
+                alias_values,
+            )),
+            high: Box::new(resolve_having_aliases_with_values_inner(
+                high,
+                select_list,
+                group_by_exprs,
+                schema_columns,
+                alias_values,
+            )),
+            negated: *negated,
+            symmetric: *symmetric,
+        },
+
+        Expression::IsNull { expr, negated } => Expression::IsNull {
+            expr: Box::new(resolve_having_aliases_with_values_inner(
+                expr,
+                select_list,
+                group_by_exprs,
+                schema_columns,
+                alias_values,
+            )),
+            negated: *negated,
+        },
+
+        // Handle EXISTS subquery - traverse into the subquery and resolve outer aliases
+        Expression::Exists { subquery, negated } => {
+            let resolved_subquery = resolve_outer_aliases_in_subquery(subquery, alias_values);
+            Expression::Exists { subquery: Box::new(resolved_subquery), negated: *negated }
+        }
+
+        // Handle IN with subquery - resolve outer aliases in subquery
+        Expression::In { expr, subquery, negated } => {
+            let resolved_expr = resolve_having_aliases_with_values_inner(
+                expr,
+                select_list,
+                group_by_exprs,
+                schema_columns,
+                alias_values,
+            );
+            let resolved_subquery = resolve_outer_aliases_in_subquery(subquery, alias_values);
+            Expression::In {
+                expr: Box::new(resolved_expr),
+                subquery: Box::new(resolved_subquery),
+                negated: *negated,
+            }
+        }
+
+        // Handle scalar subquery - resolve outer aliases in subquery
+        Expression::ScalarSubquery(subquery) => {
+            let resolved_subquery = resolve_outer_aliases_in_subquery(subquery, alias_values);
+            Expression::ScalarSubquery(Box::new(resolved_subquery))
+        }
+
+        // Handle quantified comparison (ALL/ANY/SOME) - resolve outer aliases in subquery
+        Expression::QuantifiedComparison { expr, op, quantifier, subquery } => {
+            let resolved_expr = resolve_having_aliases_with_values_inner(
+                expr,
+                select_list,
+                group_by_exprs,
+                schema_columns,
+                alias_values,
+            );
+            let resolved_subquery = resolve_outer_aliases_in_subquery(subquery, alias_values);
+            Expression::QuantifiedComparison {
+                expr: Box::new(resolved_expr),
+                op: *op,
+                quantifier: quantifier.clone(),
+                subquery: Box::new(resolved_subquery),
+            }
+        }
+
+        // For other expression types, return as-is
+        _ => having_expr.clone(),
+    }
+}
+
+/// Resolve outer alias references in a subquery by replacing them with literal values.
+/// This enables correlated subqueries to access outer SELECT aliases.
+fn resolve_outer_aliases_in_subquery(
+    subquery: &vibesql_ast::SelectStmt,
+    alias_values: &std::collections::HashMap<String, vibesql_types::SqlValue>,
+) -> vibesql_ast::SelectStmt {
+    // Create a clone and resolve aliases in the HAVING clause
+    let resolved_having = subquery
+        .having
+        .as_ref()
+        .map(|having_expr| resolve_outer_alias_refs_to_literals(having_expr, alias_values));
+
+    // Also resolve in WHERE clause (for correlated subqueries that reference outer aliases there)
+    let resolved_where = subquery
+        .where_clause
+        .as_ref()
+        .map(|where_expr| resolve_outer_alias_refs_to_literals(where_expr, alias_values));
+
+    // Build the resolved subquery
+    vibesql_ast::SelectStmt {
+        with_clause: subquery.with_clause.clone(),
+        distinct: subquery.distinct,
+        select_list: subquery.select_list.clone(),
+        into_table: subquery.into_table.clone(),
+        into_variables: subquery.into_variables.clone(),
+        from: subquery.from.clone(),
+        where_clause: resolved_where,
+        group_by: subquery.group_by.clone(),
+        having: resolved_having,
+        order_by: subquery.order_by.clone(),
+        limit: subquery.limit.clone(),
+        offset: subquery.offset.clone(),
+        set_operation: subquery.set_operation.clone(),
+        values: subquery.values.clone(),
+    }
+}
+
+/// Replace unqualified column references that match outer aliases with literal values.
+/// This is the core transformation that makes outer SELECT aliases accessible in subqueries.
+fn resolve_outer_alias_refs_to_literals(
+    expr: &Expression,
+    alias_values: &std::collections::HashMap<String, vibesql_types::SqlValue>,
+) -> Expression {
+    match expr {
+        // Check if this unqualified column reference matches an outer alias
+        Expression::ColumnRef(col_id)
+            if col_id.schema_canonical().is_none() && col_id.table_canonical().is_none() =>
+        {
+            let column = col_id.column_canonical();
+            // Look up the column name in alias_values (case-insensitive)
+            for (alias_name, value) in alias_values {
+                if alias_name.eq_ignore_ascii_case(column) {
+                    // Found a match - replace with literal value
+                    return Expression::Literal(value.clone());
+                }
+            }
+            // Not an outer alias, keep as-is
+            expr.clone()
+        }
+
+        // Recursively process compound expressions
+        Expression::BinaryOp { left, op, right } => Expression::BinaryOp {
+            left: Box::new(resolve_outer_alias_refs_to_literals(left, alias_values)),
+            op: *op,
+            right: Box::new(resolve_outer_alias_refs_to_literals(right, alias_values)),
+        },
+
+        Expression::UnaryOp { op, expr: inner } => Expression::UnaryOp {
+            op: *op,
+            expr: Box::new(resolve_outer_alias_refs_to_literals(inner, alias_values)),
+        },
+
+        Expression::Function { name, args, character_unit } => Expression::Function {
+            name: name.clone(),
+            args: args
+                .iter()
+                .map(|a| resolve_outer_alias_refs_to_literals(a, alias_values))
+                .collect(),
+            character_unit: character_unit.clone(),
+        },
+
+        Expression::AggregateFunction { name, distinct, args, order_by, filter } => {
+            Expression::AggregateFunction {
+                name: name.clone(),
+                distinct: *distinct,
+                args: args
+                    .iter()
+                    .map(|a| resolve_outer_alias_refs_to_literals(a, alias_values))
+                    .collect(),
+                order_by: order_by.clone(),
+                filter: filter
+                    .as_ref()
+                    .map(|f| Box::new(resolve_outer_alias_refs_to_literals(f, alias_values))),
+            }
+        }
+
+        Expression::Case { operand, when_clauses, else_result } => Expression::Case {
+            operand: operand
+                .as_ref()
+                .map(|o| Box::new(resolve_outer_alias_refs_to_literals(o, alias_values))),
+            when_clauses: when_clauses
+                .iter()
+                .map(|wc| vibesql_ast::CaseWhen {
+                    conditions: wc
+                        .conditions
+                        .iter()
+                        .map(|c| resolve_outer_alias_refs_to_literals(c, alias_values))
+                        .collect(),
+                    result: resolve_outer_alias_refs_to_literals(&wc.result, alias_values),
+                })
+                .collect(),
+            else_result: else_result
+                .as_ref()
+                .map(|e| Box::new(resolve_outer_alias_refs_to_literals(e, alias_values))),
+        },
+
+        Expression::Conjunction(terms) => Expression::Conjunction(
+            terms.iter().map(|t| resolve_outer_alias_refs_to_literals(t, alias_values)).collect(),
+        ),
+
+        Expression::Disjunction(terms) => Expression::Disjunction(
+            terms.iter().map(|t| resolve_outer_alias_refs_to_literals(t, alias_values)).collect(),
+        ),
+
+        Expression::Between { expr, low, high, negated, symmetric } => Expression::Between {
+            expr: Box::new(resolve_outer_alias_refs_to_literals(expr, alias_values)),
+            low: Box::new(resolve_outer_alias_refs_to_literals(low, alias_values)),
+            high: Box::new(resolve_outer_alias_refs_to_literals(high, alias_values)),
+            negated: *negated,
+            symmetric: *symmetric,
+        },
+
+        Expression::IsNull { expr, negated } => Expression::IsNull {
+            expr: Box::new(resolve_outer_alias_refs_to_literals(expr, alias_values)),
+            negated: *negated,
+        },
+
+        Expression::InList { expr, values, negated } => Expression::InList {
+            expr: Box::new(resolve_outer_alias_refs_to_literals(expr, alias_values)),
+            values: values
+                .iter()
+                .map(|v| resolve_outer_alias_refs_to_literals(v, alias_values))
+                .collect(),
+            negated: *negated,
+        },
+
+        Expression::Like { expr, pattern, negated } => Expression::Like {
+            expr: Box::new(resolve_outer_alias_refs_to_literals(expr, alias_values)),
+            pattern: Box::new(resolve_outer_alias_refs_to_literals(pattern, alias_values)),
+            negated: *negated,
+        },
+
+        Expression::Glob { expr, pattern, negated } => Expression::Glob {
+            expr: Box::new(resolve_outer_alias_refs_to_literals(expr, alias_values)),
+            pattern: Box::new(resolve_outer_alias_refs_to_literals(pattern, alias_values)),
+            negated: *negated,
+        },
+
+        Expression::Cast { expr, data_type } => Expression::Cast {
+            expr: Box::new(resolve_outer_alias_refs_to_literals(expr, alias_values)),
+            data_type: data_type.clone(),
+        },
+
+        // Nested subqueries - recursively resolve in their clauses
+        Expression::Exists { subquery, negated } => {
+            let resolved_subquery = resolve_outer_aliases_in_subquery(subquery, alias_values);
+            Expression::Exists { subquery: Box::new(resolved_subquery), negated: *negated }
+        }
+
+        Expression::In { expr, subquery, negated } => Expression::In {
+            expr: Box::new(resolve_outer_alias_refs_to_literals(expr, alias_values)),
+            subquery: Box::new(resolve_outer_aliases_in_subquery(subquery, alias_values)),
+            negated: *negated,
+        },
+
+        Expression::ScalarSubquery(subquery) => Expression::ScalarSubquery(Box::new(
+            resolve_outer_aliases_in_subquery(subquery, alias_values),
+        )),
+
+        Expression::QuantifiedComparison { expr, op, quantifier, subquery } => {
+            Expression::QuantifiedComparison {
+                expr: Box::new(resolve_outer_alias_refs_to_literals(expr, alias_values)),
+                op: *op,
+                quantifier: quantifier.clone(),
+                subquery: Box::new(resolve_outer_aliases_in_subquery(subquery, alias_values)),
+            }
+        }
+
+        // For other expressions, return as-is
+        _ => expr.clone(),
     }
 }
 

--- a/crates/vibesql-executor/src/select/grouping/grouping_sets/mod.rs
+++ b/crates/vibesql-executor/src/select/grouping/grouping_sets/mod.rs
@@ -10,7 +10,7 @@ mod expression_utils;
 // Re-export public API
 pub use alias_resolution::{
     resolve_base_expressions_aliases, resolve_grouping_set_aliases,
-    resolve_having_aliases_with_schema,
+    resolve_having_aliases_with_values,
 };
 pub use expansion::{expand_group_by_clause, get_base_expressions};
 pub use expression_utils::expressions_equal;

--- a/crates/vibesql-executor/src/select/grouping/mod.rs
+++ b/crates/vibesql-executor/src/select/grouping/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use aggregates::{
 pub(crate) use grouping_sets::expressions_equal;
 pub(super) use grouping_sets::{
     expand_group_by_clause, get_base_expressions, resolve_base_expressions_aliases,
-    resolve_grouping_set_aliases, resolve_having_aliases_with_schema, GroupingContext,
+    resolve_grouping_set_aliases, resolve_having_aliases_with_values, GroupingContext,
 };
 pub(super) use hash::group_rows;
 pub(crate) use keys::{GroupKey, GroupKeySpec};

--- a/crates/vibesql-executor/src/tests/aggregate_having_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_having_tests.rs
@@ -365,3 +365,70 @@ fn test_having_valid_aggregate_alias_in_order_by() {
         _ => panic!("Expected SELECT"),
     }
 }
+
+/// Test for issue #4676: Outer query SELECT alias accessible in correlated subquery HAVING
+///
+/// When a HAVING clause contains a correlated subquery (EXISTS, IN, etc.), the subquery
+/// should be able to reference SELECT aliases from the outer query.
+/// Example:
+///   SELECT a.x, avg(a.y) AS avg1 FROM t AS a GROUP BY a.x
+///   HAVING NOT EXISTS(SELECT b.x FROM t AS b GROUP BY b.x HAVING avg1 > avg(b.y))
+///
+/// The `avg1` alias in the inner HAVING should resolve to the outer query's computed value.
+#[test]
+fn test_having_outer_alias_in_correlated_subquery() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Create test table
+    let create_sql = "CREATE TABLE t34(x INTEGER, y INTEGER)";
+    let stmt = Parser::parse_sql(create_sql).unwrap();
+    match stmt {
+        Statement::CreateTable(create_stmt) => {
+            CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
+        }
+        _ => panic!("Expected CREATE TABLE"),
+    }
+
+    // Insert data: x=1 has avg(y)=2.0, x=2 has avg(y)=5.0, x=3 has avg(y)=7.0
+    for (x, y) in [(1, 1), (1, 2), (1, 3), (2, 4), (2, 5), (2, 6), (3, 7)] {
+        let insert_sql = format!("INSERT INTO t34 VALUES ({}, {})", x, y);
+        let stmt = Parser::parse_sql(&insert_sql).unwrap();
+        match stmt {
+            Statement::Insert(insert_stmt) => {
+                InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
+            }
+            _ => panic!("Expected INSERT"),
+        }
+    }
+
+    // Query: Find groups where NO other group has a lower average
+    // Expected: Only x=1 (avg1=2.0) qualifies because no group has avg2 < 2.0
+    let query = r#"
+        SELECT a.x, avg(a.y) AS avg1 FROM t34 AS a GROUP BY a.x
+        HAVING NOT EXISTS(
+            SELECT b.x, avg(b.y) AS avg2 FROM t34 AS b GROUP BY b.x
+            HAVING avg1 > avg2
+        )
+    "#;
+
+    let stmt = Parser::parse_sql(query).unwrap();
+    match stmt {
+        Statement::Select(select_stmt) => {
+            let executor = SelectExecutor::new(&db);
+            let result = executor.execute(&select_stmt);
+
+            assert!(result.is_ok(), "Query should succeed: {:?}", result.err());
+            let rows = result.unwrap();
+
+            // Only x=1 should be returned
+            assert_eq!(rows.len(), 1, "Only the group with the minimum average should be returned");
+
+            let x_value = match &rows[0].values[0] {
+                vibesql_types::SqlValue::Integer(v) => *v,
+                _ => panic!("Expected integer for x"),
+            };
+            assert_eq!(x_value, 1, "x=1 has the minimum average (2.0)");
+        }
+        _ => panic!("Expected SELECT"),
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes issue where outer SELECT aliases (like `avg1` from `avg(a.y) AS avg1`) couldn't be referenced in correlated subqueries within HAVING clauses
- Adds `resolve_having_aliases_with_values()` function that traverses into subqueries and replaces outer alias references with their computed literal values
- Handles all subquery types: EXISTS, IN, ScalarSubquery, and QuantifiedComparison (ALL/ANY/SOME)

## Test plan
- [x] Added unit test `test_having_outer_alias_in_correlated_subquery` covering the exact scenario from the issue
- [x] All 2198 executor tests pass
- [x] Manual verification with the reproducer query returns correct result

Closes #4676

🤖 Generated with [Claude Code](https://claude.com/claude-code)