### PR TITLE
fix(executor): use representative row for correlated subqueries in aggregate context

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/subquery.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/subquery.rs
@@ -7,15 +7,30 @@ use crate::{
 };
 
 /// Evaluate scalar subqueries and EXISTS expressions in aggregate context
+///
+/// This function handles SQLite's behavior where correlated subqueries in aggregate
+/// SELECT lists use the row that corresponds to the aggregate result. For example,
+/// in `SELECT max(a), (SELECT d FROM t2 WHERE a=c) FROM t1`, the subquery uses
+/// `a` from the row where `a` has its maximum value, not just the first row.
+///
+/// See issue #4683 for details.
 pub(super) fn evaluate_scalar(
-    _executor: &SelectExecutor,
+    executor: &SelectExecutor,
     expr: &vibesql_ast::Expression,
     group_rows: &[vibesql_storage::Row],
     evaluator: &CombinedExpressionEvaluator,
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
-    // Use first row from group as context for subquery evaluation
-    if let Some(first_row) = group_rows.first() {
-        evaluator.eval(expr, first_row)
+    // Use the representative row for aggregate-context subquery evaluation (issue #4683)
+    // The representative row is the row that corresponds to MAX/MIN aggregate result.
+    // If no representative row was set (no MAX/MIN aggregate), fall back to first row.
+    let representative_row = if let Some(idx) = executor.get_aggregate_representative_row() {
+        group_rows.get(idx)
+    } else {
+        group_rows.first()
+    };
+
+    if let Some(row) = representative_row {
+        evaluator.eval(expr, row)
     } else {
         Ok(vibesql_types::SqlValue::Null)
     }

--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -337,6 +337,12 @@ impl SelectExecutor<'_> {
                     // Check timeout during aggregation
                     self.check_timeout()?;
 
+                    // Find the representative row for aggregate-context subquery evaluation (issue #4683)
+                    // SQLite uses the row corresponding to MAX/MIN aggregate for correlated subqueries
+                    let representative_row_idx =
+                        self.find_representative_row_index(&expanded_select_list, &group_rows, &evaluator);
+                    self.set_aggregate_representative_row(representative_row_idx);
+
                     // Compute aggregates for this group
                     let mut aggregate_results = Vec::new();
                     for item in &expanded_select_list {
@@ -463,6 +469,12 @@ impl SelectExecutor<'_> {
 
                 // Check timeout during aggregation
                 self.check_timeout()?;
+
+                // Find the representative row for aggregate-context subquery evaluation (issue #4683)
+                // SQLite uses the row corresponding to MAX/MIN aggregate for correlated subqueries
+                let representative_row_idx =
+                    self.find_representative_row_index(&expanded_select_list, &group_rows, &evaluator);
+                self.set_aggregate_representative_row(representative_row_idx);
 
                 // Compute aggregates for this group
                 let mut aggregate_results = Vec::new();

--- a/crates/vibesql-executor/src/select/executor/builder.rs
+++ b/crates/vibesql-executor/src/select/executor/builder.rs
@@ -49,6 +49,12 @@ pub struct SelectExecutor<'a> {
     /// Detected once per query, executed once per group
     /// Stores results directly in aggregate_cache
     pub(super) pivot_group: RefCell<Option<PivotAggregateGroup>>,
+    /// Index of the "representative row" for aggregate context subqueries.
+    /// When evaluating correlated subqueries in aggregate SELECT lists, SQLite uses
+    /// the row that corresponds to the aggregate result (e.g., the row where the column
+    /// has its MAX value for MAX(col)). This field stores that row's index.
+    /// See issue #4683 for details.
+    pub(super) aggregate_representative_row_idx: RefCell<Option<usize>>,
 }
 
 impl<'a> SelectExecutor<'a> {
@@ -75,6 +81,7 @@ impl<'a> SelectExecutor<'a> {
             aggregate_cache: OnceCell::new(),
             arena: OnceCell::new(),
             pivot_group: RefCell::new(None),
+            aggregate_representative_row_idx: RefCell::new(None),
         }
     }
 
@@ -107,6 +114,7 @@ impl<'a> SelectExecutor<'a> {
             aggregate_cache: OnceCell::new(),
             arena: OnceCell::new(),
             pivot_group: RefCell::new(None),
+            aggregate_representative_row_idx: RefCell::new(None),
         }
     }
 
@@ -127,6 +135,7 @@ impl<'a> SelectExecutor<'a> {
             aggregate_cache: OnceCell::new(),
             arena: OnceCell::new(),
             pivot_group: RefCell::new(None),
+            aggregate_representative_row_idx: RefCell::new(None),
         }
     }
 
@@ -166,6 +175,7 @@ impl<'a> SelectExecutor<'a> {
             aggregate_cache: OnceCell::new(),
             arena: OnceCell::new(),
             pivot_group: RefCell::new(None),
+            aggregate_representative_row_idx: RefCell::new(None),
         }
     }
 
@@ -188,6 +198,7 @@ impl<'a> SelectExecutor<'a> {
             aggregate_cache: OnceCell::new(),
             arena: OnceCell::new(),
             pivot_group: RefCell::new(None),
+            aggregate_representative_row_idx: RefCell::new(None),
         }
     }
 
@@ -212,6 +223,7 @@ impl<'a> SelectExecutor<'a> {
             aggregate_cache: OnceCell::new(),
             arena: OnceCell::new(),
             pivot_group: RefCell::new(None),
+            aggregate_representative_row_idx: RefCell::new(None),
         }
     }
 
@@ -238,6 +250,7 @@ impl<'a> SelectExecutor<'a> {
             aggregate_cache: OnceCell::new(),
             arena: OnceCell::new(),
             pivot_group: RefCell::new(None),
+            aggregate_representative_row_idx: RefCell::new(None),
         }
     }
 
@@ -361,6 +374,9 @@ impl<'a> SelectExecutor<'a> {
 
         // Clear pivot group
         *self.pivot_group.borrow_mut() = None;
+
+        // Clear representative row index
+        *self.aggregate_representative_row_idx.borrow_mut() = None;
     }
 
     /// Set the pivot aggregate group for this query
@@ -397,5 +413,101 @@ impl<'a> SelectExecutor<'a> {
     /// Check if a pivot group is set for this query
     pub(super) fn has_pivot_group(&self) -> bool {
         self.pivot_group.borrow().is_some()
+    }
+
+    /// Set the representative row index for aggregate context subquery evaluation.
+    ///
+    /// This is used to implement SQLite's behavior where correlated subqueries in
+    /// aggregate SELECT lists use the row that corresponds to the aggregate result.
+    /// For example, in `SELECT max(a), (SELECT d FROM t2 WHERE a=c) FROM t1`,
+    /// the subquery uses `a` from the row where `a` has its maximum value.
+    ///
+    /// # Arguments
+    /// * `idx` - The index of the representative row in the current group's rows
+    pub(super) fn set_aggregate_representative_row(&self, idx: Option<usize>) {
+        *self.aggregate_representative_row_idx.borrow_mut() = idx;
+    }
+
+    /// Get the representative row index for aggregate context subquery evaluation.
+    /// Returns None if no representative row has been set.
+    pub(super) fn get_aggregate_representative_row(&self) -> Option<usize> {
+        *self.aggregate_representative_row_idx.borrow()
+    }
+
+    /// Find the representative row based on aggregates in the SELECT list.
+    ///
+    /// For MAX(col) aggregates, returns the index of the row where col has its maximum value.
+    /// For MIN(col) aggregates, returns the index of the row where col has its minimum value.
+    /// For other aggregates or no aggregates, returns None (fallback to first row behavior).
+    ///
+    /// This implements SQLite's behavior where bare column references in aggregate queries
+    /// use values from the row that contributed to the aggregate result.
+    ///
+    /// # Arguments
+    /// * `select_list` - The expanded SELECT list to scan for aggregates
+    /// * `group_rows` - The rows in the current group
+    /// * `evaluator` - Expression evaluator for computing column values
+    pub(super) fn find_representative_row_index(
+        &self,
+        select_list: &[vibesql_ast::SelectItem],
+        group_rows: &[vibesql_storage::Row],
+        evaluator: &crate::evaluator::CombinedExpressionEvaluator,
+    ) -> Option<usize> {
+        use crate::select::grouping::compare_sql_values;
+        use vibesql_types::SqlValue;
+
+        if group_rows.is_empty() {
+            return None;
+        }
+
+        // Scan SELECT list for MAX or MIN aggregates on a column
+        for item in select_list {
+            if let vibesql_ast::SelectItem::Expression { expr, .. } = item {
+                if let vibesql_ast::Expression::AggregateFunction { name, args, .. } = expr {
+                    let name_upper = name.to_uppercase();
+
+                    // We only care about MAX/MIN aggregates on columns
+                    if (name_upper == "MAX" || name_upper == "MIN") && args.len() == 1 {
+                        // Find the row where the column has its max/min value
+                        let mut best_idx = 0;
+                        let mut best_val: Option<SqlValue> = None;
+
+                        for (idx, row) in group_rows.iter().enumerate() {
+                            if let Ok(val) = evaluator.eval(&args[0], row) {
+                                // Skip NULL values
+                                if matches!(val, SqlValue::Null) {
+                                    continue;
+                                }
+
+                                let is_better = match &best_val {
+                                    None => true,
+                                    Some(best) => {
+                                        let cmp = compare_sql_values(&val, best);
+                                        if name_upper == "MAX" {
+                                            cmp == std::cmp::Ordering::Greater
+                                        } else {
+                                            cmp == std::cmp::Ordering::Less
+                                        }
+                                    }
+                                };
+
+                                if is_better {
+                                    best_idx = idx;
+                                    best_val = Some(val);
+                                }
+                            }
+                        }
+
+                        // If we found a non-NULL value, use that row
+                        if best_val.is_some() {
+                            return Some(best_idx);
+                        }
+                    }
+                }
+            }
+        }
+
+        // No suitable aggregate found, return None (will fall back to first row)
+        None
     }
 }


### PR DESCRIPTION
## Summary

Fixes #4683 - Correlated subquery evaluation in aggregate context differs from SQLite

When evaluating correlated subqueries in aggregate SELECT lists, SQLite uses the row that corresponds to the aggregate result. For example, in:
```sql
SELECT max(a), (SELECT d FROM t2 WHERE a=c) FROM t1;
```

The subquery should use `a` from the row where `a` has its maximum value, not just the first row.

**Before:** VibeSQL returned `2|one` (using first row's `a=1`)
**After:** VibeSQL returns `2|two` (using `a=2`, the max value) ✓

### Changes

- Adds `aggregate_representative_row_idx` field to `SelectExecutor` to track the representative row
- Adds `find_representative_row_index()` method to find the row where MAX/MIN aggregate column has its extreme value
- Sets the representative row before evaluating SELECT list items in aggregate context
- Updates `evaluate_scalar()` in subquery.rs to use the representative row when available

### Test Results

This fix improves TCL test suite results:
- `subquery-3.3.3`: FAILING → PASSING ✓
- `subquery-3.3.4`: FAILING → PASSING ✓

## Test plan

- [x] Manual verification with example SQL from issue
- [x] `cargo test --release --lib` passes
- [x] TCL subquery tests show improvement (2 new passing tests)
- [x] Verified MIN aggregate also works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)