### PR TITLE
fix(parser): allow match() as function name without AGAINST keyword

### DIFF
--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -29,8 +29,8 @@ impl Parser {
                 }
                 name
             }
-            // Allow LEFT, RIGHT, REPLACE, SCHEMA, GROUPING, GROUPING_ID, GLOB, and LIKE keywords as function
-            // names. These are reserved keywords but can also be functions.
+            // Allow LEFT, RIGHT, REPLACE, SCHEMA, GROUPING, GROUPING_ID, GLOB, LIKE, and MATCH keywords
+            // as function names. These are reserved keywords but can also be functions.
             Token::Keyword { keyword: Keyword::Left, .. }
             | Token::Keyword { keyword: Keyword::Right, .. }
             | Token::Keyword { keyword: Keyword::Replace, .. }
@@ -38,7 +38,8 @@ impl Parser {
             | Token::Keyword { keyword: Keyword::Grouping, .. }
             | Token::Keyword { keyword: Keyword::GroupingId, .. }
             | Token::Keyword { keyword: Keyword::Glob, .. }
-            | Token::Keyword { keyword: Keyword::Like, .. } => {
+            | Token::Keyword { keyword: Keyword::Like, .. }
+            | Token::Keyword { keyword: Keyword::Match, .. } => {
                 // Peek ahead to see if this is followed by '('
                 // Don't consume the keyword unless we're sure it's a function
                 // SQL:1999 normalizes unquoted identifiers (including function names) to lowercase
@@ -51,6 +52,7 @@ impl Parser {
                     Token::Keyword { keyword: Keyword::GroupingId, .. } => "grouping_id",
                     Token::Keyword { keyword: Keyword::Glob, .. } => "glob",
                     Token::Keyword { keyword: Keyword::Like, .. } => "like",
+                    Token::Keyword { keyword: Keyword::Match, .. } => "match",
                     _ => unreachable!(),
                 };
 

--- a/crates/vibesql-parser/src/parser/expressions/special_forms.rs
+++ b/crates/vibesql-parser/src/parser/expressions/special_forms.rs
@@ -327,6 +327,11 @@ impl Parser {
             Ok(Some(vibesql_ast::Expression::NextValue { sequence_name }))
         } else if self.peek_keyword(Keyword::Match) {
             // MATCH...AGAINST full-text search
+            // We need to look ahead to check if AGAINST follows the parenthesized expression.
+            // If not, this is a regular function call like match(a, b), not FTS syntax.
+            if !self.is_match_against_expression() {
+                return Ok(None);
+            }
             self.advance(); // consume MATCH
             self.expect_token(Token::LParen)?;
 
@@ -502,5 +507,38 @@ impl Parser {
         } else {
             Ok(first_unit)
         }
+    }
+
+    /// Check if the current MATCH keyword is part of a MATCH...AGAINST expression.
+    /// Returns true if AGAINST keyword follows after the parenthesized column list.
+    /// This allows `match(a, b)` to be parsed as a regular function call.
+    fn is_match_against_expression(&self) -> bool {
+        // We're at MATCH keyword. Look ahead to find the closing paren
+        // and check if AGAINST follows.
+        let mut pos = self.position + 1; // skip MATCH
+
+        // Expect LParen
+        if pos >= self.tokens.len() || !matches!(self.tokens[pos], Token::LParen) {
+            return false;
+        }
+        pos += 1;
+
+        // Skip past the parenthesized content (handling nested parens)
+        let mut depth = 1;
+        while pos < self.tokens.len() && depth > 0 {
+            match &self.tokens[pos] {
+                Token::LParen => depth += 1,
+                Token::RParen => depth -= 1,
+                _ => {}
+            }
+            pos += 1;
+        }
+
+        // Check if AGAINST follows
+        pos < self.tokens.len()
+            && matches!(
+                &self.tokens[pos],
+                Token::Keyword { keyword: Keyword::Against, .. }
+            )
     }
 }

--- a/crates/vibesql-parser/src/tests/fulltext.rs
+++ b/crates/vibesql-parser/src/tests/fulltext.rs
@@ -216,3 +216,66 @@ fn test_parse_create_fulltext_index_in_create_table() {
         panic!("Expected CreateTable statement");
     }
 }
+
+// ========================================================================
+// match() as a Regular Function Tests (Issue #4693)
+// ========================================================================
+
+/// Issue #4693: `match(a, b)` should be parsed as a regular function call,
+/// not as a MATCH...AGAINST full-text search expression.
+#[test]
+fn test_match_as_function_call() {
+    // This was failing with: "near 'FROM': syntax error"
+    // because the parser treated MATCH as the start of MATCH...AGAINST
+    let result = Parser::parse_sql("SELECT match(a, b) FROM t1 WHERE 0;");
+    assert!(result.is_ok(), "match() as function should parse: {:?}", result);
+
+    let stmt = result.unwrap();
+    if let vibesql_ast::Statement::Select(select) = stmt {
+        assert_eq!(select.select_list.len(), 1);
+        if let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] {
+            if let vibesql_ast::Expression::Function { name, args, .. } = expr {
+                assert_eq!(name.canonical(), "match");
+                assert_eq!(args.len(), 2);
+            } else {
+                panic!("Expected Function expression, got {:?}", expr);
+            }
+        } else {
+            panic!("Expected Expression SelectItem");
+        }
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_match_as_function_with_single_arg() {
+    let result = Parser::parse_sql("SELECT match(x) FROM t;");
+    assert!(result.is_ok(), "match(x) should parse: {:?}", result);
+}
+
+#[test]
+fn test_match_as_function_in_where() {
+    let result = Parser::parse_sql("SELECT * FROM t WHERE match(a, b) = 1;");
+    assert!(result.is_ok(), "match() in WHERE should parse: {:?}", result);
+}
+
+#[test]
+fn test_match_against_still_works() {
+    // Ensure we haven't broken MATCH...AGAINST syntax
+    let result =
+        Parser::parse_sql("SELECT * FROM articles WHERE MATCH(title) AGAINST ('search');");
+    assert!(result.is_ok(), "MATCH...AGAINST should still work: {:?}", result);
+
+    let stmt = result.unwrap();
+    if let vibesql_ast::Statement::Select(select) = stmt {
+        if let Some(vibesql_ast::Expression::MatchAgainst { columns, .. }) = &select.where_clause {
+            assert_eq!(columns.len(), 1);
+            assert_eq!(columns[0], "title");
+        } else {
+            panic!("Expected MatchAgainst in WHERE clause");
+        }
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}


### PR DESCRIPTION
## Summary
- Add lookahead in parser to check if AGAINST follows MATCH before treating it as FTS syntax
- Add MATCH to the list of keywords that can be function names
- Add tests for match() as a regular function call

Closes #4693

## Test plan
- [x] New tests pass: `cargo test --package vibesql-parser -- fulltext`
- [x] All parser tests pass: `cargo test --package vibesql-parser` (1186 tests)
- [x] Full project builds: `cargo build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)