### PR TITLE
feat(executor): increase recursive CTE iteration limit to 1M

### DIFF
--- a/crates/vibesql-executor/src/limits.rs
+++ b/crates/vibesql-executor/src/limits.rs
@@ -70,6 +70,18 @@ pub const MAX_QUERY_EXECUTION_SECONDS: u64 = 300;
 /// Should be higher than MAX_ROWS_PROCESSED to avoid false positives
 pub const MAX_LOOP_ITERATIONS: usize = 50_000_000;
 
+/// Maximum number of iterations for recursive CTEs
+///
+/// SQLite's default is 1000, but it can be increased via sqlite3_limit().
+/// We use a much higher default (1 million) because:
+/// 1. Our recursive CTE implementation is iterative, not stack-recursive
+/// 2. Many legitimate use cases need more than 1000 iterations (e.g., date ranges)
+/// 3. Memory limits already protect against truly runaway queries
+/// 4. This matches SQLite's practical behavior where the limit is configurable
+///
+/// The limit still catches truly infinite loops while allowing legitimate deep recursion.
+pub const MAX_RECURSIVE_CTE_ITERATIONS: usize = 1_000_000;
+
 /// Maximum memory usage per query execution
 ///
 /// This prevents:

--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -198,8 +198,7 @@ where
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError>,
     M: Fn(usize) -> Result<(), ExecutorError>,
 {
-    // Maximum recursion depth (SQLite default is 1000)
-    const MAX_RECURSION_DEPTH: usize = 1000;
+    use crate::limits::MAX_RECURSIVE_CTE_ITERATIONS;
 
     // Validate that recursive CTE uses UNION ALL
     let set_op = cte.query.set_operation.as_ref().ok_or_else(|| {
@@ -276,7 +275,7 @@ where
 
     // Step 2: Iterative evaluation
     let mut depth = 0;
-    while !working_table.is_empty() && depth < MAX_RECURSION_DEPTH {
+    while !working_table.is_empty() && depth < MAX_RECURSIVE_CTE_ITERATIONS {
         depth += 1;
 
         // Make working table available as this CTE for recursive reference
@@ -330,10 +329,10 @@ where
     }
 
     // Check if we hit max recursion depth
-    if depth >= MAX_RECURSION_DEPTH {
+    if depth >= MAX_RECURSIVE_CTE_ITERATIONS {
         return Err(ExecutorError::UnsupportedFeature(format!(
-            "Recursive CTE '{}' exceeded maximum recursion depth of {}",
-            cte.name, MAX_RECURSION_DEPTH
+            "Recursive CTE '{}' exceeded maximum iteration limit of {}",
+            cte.name, MAX_RECURSIVE_CTE_ITERATIONS
         )));
     }
 


### PR DESCRIPTION
## Summary

Increases the recursive CTE iteration limit from 1,000 to 1,000,000 to support legitimate deep recursion use cases like:
- Date range generation (365+ days)
- Deep hierarchical traversals
- Series generation for large ranges

## Changes

- Add `MAX_RECURSIVE_CTE_ITERATIONS` constant to `limits.rs` with comprehensive documentation
- Update `cte.rs` to use the centralized limit constant
- Update error message wording from "recursion depth" to "iteration limit" (more accurate for our iterative implementation)

## Why This is Safe

1. **Iterative, not stack-recursive**: Our CTE implementation uses a while loop, not function recursion, so there's no stack overflow risk
2. **Memory limits**: Existing memory limits (`MAX_MEMORY_BYTES`) protect against runaway queries that produce too many rows
3. **SQLite compatibility**: SQLite allows configuring its limit via `sqlite3_limit()`; we're following that philosophy with a permissive default

## Test Plan

- [x] All recursive CTE tests pass
- [x] All resource limits tests pass  
- [x] Verified `WITH RECURSIVE c(x) AS (VALUES(0) UNION ALL SELECT x+1 FROM c WHERE x<2000) SELECT max(x) FROM c;` now returns `2000` (was failing before)
- [x] Verified 1040-iteration query from func-9.14 works

Closes #4692