### PR TITLE
fix(executor): use SQLite error format for UNIQUE INDEX violations

### DIFF
--- a/crates/vibesql-executor/src/insert/constraints.rs
+++ b/crates/vibesql-executor/src/insert/constraints.rs
@@ -249,17 +249,10 @@ pub fn enforce_unique_indexes(
             // Check if this key already exists in the index
             if let Some(index_data) = db.get_index_data(&index_name) {
                 if index_data.contains_key(&key_values) {
-                    // Format column names for error message
-                    let column_names: Vec<String> = index_metadata
-                        .columns
-                        .iter()
-                        .map(|c| c.expect_column_name().to_string())
-                        .collect();
-
+                    // SQLite format for explicit UNIQUE INDEX violations
                     return Err(ExecutorError::ConstraintViolation(format!(
-                        "UNIQUE constraint '{}' violated: duplicate key value for ({})",
-                        index_metadata.index_name,
-                        column_names.join(", ")
+                        "UNIQUE constraint failed: index '{}'",
+                        index_metadata.index_name
                     )));
                 }
             }

--- a/crates/vibesql-executor/src/update/constraints.rs
+++ b/crates/vibesql-executor/src/update/constraints.rs
@@ -101,17 +101,10 @@ impl<'a> ConstraintValidator<'a> {
                 // Check if this key already exists in the index
                 if let Some(index_data) = db.get_index_data(&index_name) {
                     if index_data.contains_key(&new_key_values) {
-                        // Format column names for error message
-                        let column_names: Vec<String> = index_metadata
-                            .columns
-                            .iter()
-                            .map(|c| c.expect_column_name().to_string())
-                            .collect();
-
+                        // SQLite format for explicit UNIQUE INDEX violations
                         return Err(ExecutorError::ConstraintViolation(format!(
-                            "UNIQUE constraint '{}' violated: duplicate key value for ({})",
-                            index_metadata.index_name,
-                            column_names.join(", ")
+                            "UNIQUE constraint failed: index '{}'",
+                            index_metadata.index_name
                         )));
                     }
                 }

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -217,15 +217,10 @@ impl IndexManager {
                         match index_data {
                             IndexData::InMemory { data, .. } => {
                                 if data.contains_key(&key_values) {
-                                    let column_names: Vec<String> = metadata
-                                        .columns
-                                        .iter()
-                                        .map(|c| c.expect_column_name().to_string())
-                                        .collect();
+                                    // SQLite format for explicit UNIQUE INDEX violations
                                     return Err(StorageError::UniqueConstraintViolation(format!(
-                                        "UNIQUE constraint '{}' violated: duplicate key value for ({})",
-                                        index_name,
-                                        column_names.join(", ")
+                                        "UNIQUE constraint failed: index '{}'",
+                                        index_name
                                     )));
                                 }
                             }
@@ -234,15 +229,10 @@ impl IndexManager {
                                 let guard = acquire_btree_lock(btree)?;
                                 if let Ok(row_ids) = guard.lookup(&key_values) {
                                     if !row_ids.is_empty() {
-                                        let column_names: Vec<String> = metadata
-                                            .columns
-                                            .iter()
-                                            .map(|c| c.expect_column_name().to_string())
-                                            .collect();
+                                        // SQLite format for explicit UNIQUE INDEX violations
                                         return Err(StorageError::UniqueConstraintViolation(format!(
-                                            "UNIQUE constraint '{}' violated: duplicate key value for ({})",
-                                            index_name,
-                                            column_names.join(", ")
+                                            "UNIQUE constraint failed: index '{}'",
+                                            index_name
                                         )));
                                     }
                                 }


### PR DESCRIPTION
## Summary

Update the error message format for CREATE UNIQUE INDEX constraint violations to match SQLite's format for better compatibility.

## Changes

- Updated error message format in `crates/vibesql-executor/src/insert/constraints.rs`
- Updated error message format in `crates/vibesql-executor/src/update/constraints.rs`
- Updated error message format in `crates/vibesql-storage/src/database/indexes/index_manager.rs`

## Error Format Changes

**Before:**
```
UNIQUE constraint 'idx1' violated: duplicate key value for (x)
```

**After:**
```
UNIQUE constraint failed: index 'idx1'
```

This matches SQLite's exact format when a CREATE UNIQUE INDEX constraint is violated.

Note: Column-level UNIQUE constraints (e.g., `CREATE TABLE t(x UNIQUE)`) already used the correct format:
```
UNIQUE constraint failed: t.x
```

## Test Plan

- [x] Verified both constraint types produce correct error messages
- [x] All insert constraint tests pass (13/13)
- [x] All executor lib tests pass (2201/2201)
- [x] All storage lib tests pass (569/569)

Closes #4694