### PR TITLE
fix(parser): add SQLite compatibility for END transaction and TEXT(n) types

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/ddl.rs
+++ b/crates/vibesql-parser/src/arena_parser/ddl.rs
@@ -74,9 +74,16 @@ impl<'arena> ArenaParser<'arena> {
         }
     }
 
-    /// Parse COMMIT statement.
+    /// Parse COMMIT or END statement (END is SQLite alias for COMMIT).
     pub(crate) fn parse_commit_statement(&mut self) -> Result<CommitStmt, ParseError> {
-        self.consume_keyword(Keyword::Commit)?;
+        // Consume COMMIT or END (SQLite uses END as alias for COMMIT)
+        if self.peek_keyword(Keyword::Commit) {
+            self.consume_keyword(Keyword::Commit)?;
+        } else if self.peek_keyword(Keyword::End) {
+            self.consume_keyword(Keyword::End)?;
+        } else {
+            return Err(ParseError { message: "Expected COMMIT or END".to_string() });
+        }
         Ok(CommitStmt)
     }
 

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -1167,7 +1167,17 @@ impl<'arena> ArenaParser<'arena> {
                 }
                 Ok(vibesql_types::DataType::Varchar { max_length: None })
             }
-            "TEXT" => Ok(vibesql_types::DataType::Varchar { max_length: None }),
+            "TEXT" => {
+                // SQLite allows TEXT(n) for compatibility but ignores the size
+                if self.try_consume(&Token::LParen) {
+                    // Parse and ignore the size parameter
+                    if let Token::Number(_) = self.peek() {
+                        self.advance();
+                    }
+                    self.expect_token(Token::RParen)?;
+                }
+                Ok(vibesql_types::DataType::Varchar { max_length: None })
+            }
             "DATE" => Ok(vibesql_types::DataType::Date),
             "TIME" => Ok(vibesql_types::DataType::Time { with_timezone: false }),
             "TIMESTAMP" => Ok(vibesql_types::DataType::Timestamp { with_timezone: false }),

--- a/crates/vibesql-parser/src/arena_parser/mod.rs
+++ b/crates/vibesql-parser/src/arena_parser/mod.rs
@@ -211,7 +211,9 @@ impl<'arena> ArenaParser<'arena> {
                 let stmt = self.parse_begin_statement()?;
                 Ok(Statement::BeginTransaction(stmt))
             }
-            Token::Keyword { keyword: Keyword::Commit, .. } => {
+            Token::Keyword { keyword: Keyword::Commit, .. }
+            | Token::Keyword { keyword: Keyword::End, .. } => {
+                // END is a SQLite alias for COMMIT in transaction context
                 let stmt = self.parse_commit_statement()?;
                 Ok(Statement::Commit(stmt))
             }

--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -443,7 +443,26 @@ impl Parser {
             }
             "TEXT" => {
                 // TEXT is SQLite-style unlimited VARCHAR
+                // SQLite allows TEXT(n) for compatibility but ignores the size
                 // Maps to VARCHAR without length constraint (unlimited)
+                if matches!(self.peek(), Token::LParen) {
+                    self.advance(); // consume (
+                    // Parse and ignore the size parameter (SQLite compatibility)
+                    match self.peek() {
+                        Token::Number(n) => {
+                            let _ = n.parse::<usize>().map_err(|_| ParseError {
+                                message: "Invalid TEXT size".to_string(),
+                            })?;
+                            self.advance();
+                        }
+                        _ => {
+                            return Err(ParseError {
+                                message: "Expected size after TEXT(".to_string(),
+                            })
+                        }
+                    }
+                    self.expect_token(Token::RParen)?;
+                }
                 Ok(vibesql_types::DataType::Varchar { max_length: None })
             }
             "BINARY" | "VARBINARY" => {

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -318,7 +318,9 @@ impl Parser {
                 let begin_stmt = self.parse_begin_statement()?;
                 Ok(vibesql_ast::Statement::BeginTransaction(begin_stmt))
             }
-            Token::Keyword { keyword: Keyword::Commit, .. } => {
+            Token::Keyword { keyword: Keyword::Commit, .. }
+            | Token::Keyword { keyword: Keyword::End, .. } => {
+                // END is a SQLite alias for COMMIT in transaction context
                 let commit_stmt = self.parse_commit_statement()?;
                 Ok(vibesql_ast::Statement::Commit(commit_stmt))
             }

--- a/crates/vibesql-parser/src/parser/transaction.rs
+++ b/crates/vibesql-parser/src/parser/transaction.rs
@@ -90,12 +90,18 @@ fn parse_durability_hint(
     }
 }
 
-/// Parse COMMIT statement
+/// Parse COMMIT or END statement (END is SQLite alias for COMMIT)
 pub(super) fn parse_commit_statement(
     parser: &mut super::Parser,
 ) -> Result<vibesql_ast::CommitStmt, ParseError> {
-    // Consume COMMIT
-    parser.consume_keyword(Keyword::Commit)?;
+    // Consume COMMIT or END (SQLite uses END as alias for COMMIT)
+    if parser.peek_keyword(Keyword::Commit) {
+        parser.consume_keyword(Keyword::Commit)?;
+    } else if parser.peek_keyword(Keyword::End) {
+        parser.consume_keyword(Keyword::End)?;
+    } else {
+        return Err(ParseError { message: "Expected COMMIT or END".to_string() });
+    }
 
     Ok(vibesql_ast::CommitStmt)
 }


### PR DESCRIPTION
## Summary

- Add `END` as an alias for `COMMIT` in transaction context (SQLite compatibility)
- Support `TEXT(n)` type syntax, ignoring the size parameter (SQLite compatibility)

These changes fix 6 tests in `join.test` (from 32 failures to 26) by resolving:
1. Syntax errors when TCL tests use `END` to commit transactions
2. Parse errors with `TEXT(10000)` type declarations

## Test plan

- [x] Verified `BEGIN; SELECT 1; END;` works correctly
- [x] Verified `CREATE TABLE t(c TEXT(10000))` parses without errors
- [x] All vibesql-parser tests pass (1182 tests)
- [x] join.test improvements: 32 failures → 26 failures

Closes #4697

🤖 Generated with [Claude Code](https://claude.com/claude-code)