### PR TITLE
fix(parser): support compound operators in INSERT VALUES clause

### DIFF
--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -362,7 +362,19 @@ impl SelectExecutor<'_> {
         };
 
         // Derive column names from the SELECT list (with table prefix for display)
-        let columns = self.derive_column_names(&stmt.select_list, from_result.as_ref())?;
+        // Issue #4696: For VALUES statements, select_list is empty - derive from VALUES rows
+        let columns = if stmt.select_list.is_empty() {
+            if let Some(values_rows) = &stmt.values {
+                // Generate column names: column1, column2, etc.
+                let num_cols = values_rows.first().map(|r| r.len()).unwrap_or(0);
+                (1..=num_cols).map(|i| format!("column{}", i)).collect()
+            } else {
+                // Empty select_list and no VALUES - return empty columns
+                Vec::new()
+            }
+        } else {
+            self.derive_column_names(&stmt.select_list, from_result.as_ref())?
+        };
 
         // Execute the query to get rows
         let rows = self.execute(stmt)?;
@@ -432,7 +444,19 @@ impl SelectExecutor<'_> {
         };
 
         // Derive column names from the SELECT list (without table prefix)
-        let columns = self.derive_simple_column_names(&stmt.select_list, from_result.as_ref())?;
+        // Issue #4696: For VALUES statements, select_list is empty - derive from VALUES rows
+        let columns = if stmt.select_list.is_empty() {
+            if let Some(values_rows) = &stmt.values {
+                // Generate column names: column1, column2, etc.
+                let num_cols = values_rows.first().map(|r| r.len()).unwrap_or(0);
+                (1..=num_cols).map(|i| format!("column{}", i)).collect()
+            } else {
+                // Empty select_list and no VALUES - return empty columns
+                Vec::new()
+            }
+        } else {
+            self.derive_simple_column_names(&stmt.select_list, from_result.as_ref())?
+        };
 
         // Execute the query to get rows
         let rows = self.execute(stmt)?;
@@ -675,6 +699,12 @@ impl SelectExecutor<'_> {
                 Some(self.database),
             )?;
             let mut results = from_result.into_rows();
+
+            // Issue #4696: If there's a set_operation, don't apply ORDER BY or LIMIT/OFFSET here
+            // Let the caller handle them after set operations are processed
+            if stmt.set_operation.is_some() {
+                return Ok(results);
+            }
 
             // Apply ORDER BY if specified
             if let Some(order_by) = &stmt.order_by {

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -66,25 +66,30 @@ impl Parser {
         };
 
         // Parse source: VALUES or SELECT
+        // Use parse_values_statement_internal to handle compound VALUES like:
+        // INSERT INTO t VALUES(1) UNION VALUES(2)
         let source = if self.peek_keyword(Keyword::Values) {
-            // Parse VALUES
-            self.expect_keyword(Keyword::Values)?;
+            // Parse VALUES using the full statement parser to handle compound operators
+            // allow_order_limit=false: INSERT VALUES doesn't support ORDER BY/LIMIT
+            // validate_end_tokens=false: INSERT has additional tokens after VALUES
+            let values_stmt = self.parse_values_statement_internal(false, false)?;
 
-            // Parse value lists
-            let mut values = Vec::new();
-            loop {
-                self.expect_token(Token::LParen)?;
-                let row = self.parse_comma_separated_list(|p| p.parse_expression())?;
-                self.expect_token(Token::RParen)?;
-                values.push(row);
-
-                if matches!(self.peek(), Token::Comma) {
-                    self.advance();
-                } else {
-                    break;
+            // If there's a set operation (UNION/INTERSECT/EXCEPT), use Select source
+            // Otherwise, extract the values directly for the Values source
+            if values_stmt.set_operation.is_some() {
+                vibesql_ast::InsertSource::Select(Box::new(values_stmt))
+            } else {
+                // Extract values from the SelectStmt
+                // values_stmt.values should be Some for a pure VALUES statement
+                match values_stmt.values {
+                    Some(values) => vibesql_ast::InsertSource::Values(values),
+                    None => {
+                        return Err(ParseError {
+                            message: "Internal error: VALUES statement missing values".to_string(),
+                        })
+                    }
                 }
             }
-            vibesql_ast::InsertSource::Values(values)
         } else if self.peek_keyword(Keyword::Select) || self.peek_keyword(Keyword::With) {
             // Parse SELECT
             let select_stmt = self.parse_select_statement()?;
@@ -220,23 +225,25 @@ impl Parser {
 
         // Parse source: VALUES or SELECT
         // Note: The CTE is already parsed, so the SELECT here should NOT start with WITH
+        // Use parse_values_statement_internal to handle compound VALUES like:
+        // WITH cte AS (...) INSERT INTO t VALUES(1) UNION VALUES(2)
         let source = if self.peek_keyword(Keyword::Values) {
-            self.expect_keyword(Keyword::Values)?;
+            // Parse VALUES using the full statement parser to handle compound operators
+            let values_stmt = self.parse_values_statement_internal(false, false)?;
 
-            let mut values = Vec::new();
-            loop {
-                self.expect_token(Token::LParen)?;
-                let row = self.parse_comma_separated_list(|p| p.parse_expression())?;
-                self.expect_token(Token::RParen)?;
-                values.push(row);
-
-                if matches!(self.peek(), Token::Comma) {
-                    self.advance();
-                } else {
-                    break;
+            // If there's a set operation (UNION/INTERSECT/EXCEPT), use Select source
+            if values_stmt.set_operation.is_some() {
+                vibesql_ast::InsertSource::Select(Box::new(values_stmt))
+            } else {
+                match values_stmt.values {
+                    Some(values) => vibesql_ast::InsertSource::Values(values),
+                    None => {
+                        return Err(ParseError {
+                            message: "Internal error: VALUES statement missing values".to_string(),
+                        })
+                    }
                 }
             }
-            vibesql_ast::InsertSource::Values(values)
         } else if self.peek_keyword(Keyword::Select) {
             // Parse SELECT without consuming WITH (already parsed)
             let select_stmt = self.parse_select_statement()?;
@@ -341,24 +348,25 @@ impl Parser {
         };
 
         // Parse source: VALUES or SELECT
+        // Use parse_values_statement_internal to handle compound VALUES like:
+        // REPLACE INTO t VALUES(1) UNION VALUES(2)
         let source = if self.peek_keyword(Keyword::Values) {
-            self.expect_keyword(Keyword::Values)?;
+            // Parse VALUES using the full statement parser to handle compound operators
+            let values_stmt = self.parse_values_statement_internal(false, false)?;
 
-            // Parse value lists
-            let mut values = Vec::new();
-            loop {
-                self.expect_token(Token::LParen)?;
-                let row = self.parse_comma_separated_list(|p| p.parse_expression())?;
-                self.expect_token(Token::RParen)?;
-                values.push(row);
-
-                if matches!(self.peek(), Token::Comma) {
-                    self.advance();
-                } else {
-                    break;
+            // If there's a set operation (UNION/INTERSECT/EXCEPT), use Select source
+            if values_stmt.set_operation.is_some() {
+                vibesql_ast::InsertSource::Select(Box::new(values_stmt))
+            } else {
+                match values_stmt.values {
+                    Some(values) => vibesql_ast::InsertSource::Values(values),
+                    None => {
+                        return Err(ParseError {
+                            message: "Internal error: VALUES statement missing values".to_string(),
+                        })
+                    }
                 }
             }
-            vibesql_ast::InsertSource::Values(values)
         } else if self.peek_keyword(Keyword::Select) || self.peek_keyword(Keyword::With) {
             let select_stmt = self.parse_select_statement()?;
             vibesql_ast::InsertSource::Select(Box::new(select_stmt))

--- a/crates/vibesql-parser/src/parser/select/statement.rs
+++ b/crates/vibesql-parser/src/parser/select/statement.rs
@@ -519,7 +519,10 @@ impl Parser {
     ///
     /// The `validate_end_tokens` parameter controls whether to validate that no
     /// unexpected tokens follow the statement.
-    fn parse_values_statement_internal(
+    ///
+    /// This is used by INSERT parser to handle compound VALUES statements like:
+    /// `INSERT INTO t VALUES(1) UNION VALUES(2)`
+    pub(crate) fn parse_values_statement_internal(
         &mut self,
         allow_order_limit: bool,
         validate_end_tokens: bool,


### PR DESCRIPTION
## Summary
- Fixed INSERT INTO t VALUES(...) UNION VALUES(...) syntax which was previously failing silently
- Parser now properly handles compound operators (UNION/EXCEPT/INTERSECT) after VALUES in INSERT statements
- Executor now correctly processes VALUES with set_operation and derives column names for VALUES statements

## Details

The issue was three-fold:

1. **Parser**: The INSERT parser manually parsed VALUES rows but didn't check for compound operators (UNION/EXCEPT/INTERSECT) after the VALUES. Now uses `parse_values_statement_internal()` to properly handle compound operators.

2. **Executor**: `execute_expression_only()` returned early for VALUES statements without checking for `set_operation`, bypassing the compound operator handling code. Now returns raw VALUES results when `set_operation` is present, letting the caller handle it.

3. **Column Names**: `execute_with_columns()` derived column names from `select_list`, which is empty for VALUES statements. Now generates `column1`, `column2`, etc. from VALUES rows when `select_list` is empty.

## Test plan
- [x] Verified `INSERT INTO t VALUES(1),(2) UNION VALUES(3)` inserts 3 rows
- [x] Verified `INSERT INTO t VALUES(1),(2) UNION ALL VALUES(1)` inserts 3 rows (with duplicate)
- [x] Verified `INSERT INTO t VALUES(1),(2),(3) EXCEPT VALUES(2)` inserts 2 rows (1, 3)
- [x] Verified `INSERT INTO t VALUES(1),(2),(3) INTERSECT VALUES(2),(3),(4)` inserts 2 rows (2, 3)
- [x] All parser tests pass (1182 tests)
- [x] All executor VALUES tests pass (29 tests)

Closes #4696

🤖 Generated with [Claude Code](https://claude.com/claude-code)