### PR TITLE
fix(executor): improve window function misuse error message

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -75,6 +75,12 @@ pub enum ExecutorError {
     MisuseOfAliasedAggregate {
         alias_name: String,
     },
+    /// Misuse of window function (SQLite-compatible error)
+    /// e.g., window function in WHERE, GROUP BY, or HAVING clause
+    /// Format: "misuse of window function X()"
+    MisuseOfWindowFunction {
+        function_name: String,
+    },
     UnsupportedExpression(String),
     UnsupportedFeature(String),
     StorageError(String),
@@ -573,6 +579,10 @@ impl std::fmt::Display for ExecutorError {
             ExecutorError::MisuseOfAliasedAggregate { alias_name } => {
                 // SQLite-compatible error message format
                 write!(f, "misuse of aliased aggregate {}", alias_name)
+            }
+            ExecutorError::MisuseOfWindowFunction { function_name } => {
+                // SQLite-compatible error message format
+                write!(f, "misuse of window function {}()", function_name)
             }
             ExecutorError::UnsupportedExpression(msg) => {
                 write!(

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -774,9 +774,14 @@ impl CombinedExpressionEvaluator<'_> {
                         )))
                     }
                 } else {
-                    Err(ExecutorError::UnsupportedExpression(
-                        "Window functions require window mapping context".to_string(),
-                    ))
+                    // Extract function name for SQLite-compatible error message
+                    // Window functions in WHERE, GROUP BY, or HAVING clauses are misuse
+                    let function_name = match function {
+                        vibesql_ast::WindowFunctionSpec::Aggregate { name, .. }
+                        | vibesql_ast::WindowFunctionSpec::Ranking { name, .. }
+                        | vibesql_ast::WindowFunctionSpec::Value { name, .. } => name.to_string(),
+                    };
+                    Err(ExecutorError::MisuseOfWindowFunction { function_name })
                 }
             }
 

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -546,9 +546,16 @@ impl ExpressionEvaluator<'_> {
                 Ok(SqlValue::Boolean(final_result))
             }
 
-            vibesql_ast::Expression::WindowFunction { .. } => Err(ExecutorError::UnsupportedExpression(
-                "Window functions should be evaluated separately".to_string(),
-            )),
+            vibesql_ast::Expression::WindowFunction { function, .. } => {
+                // Extract function name for SQLite-compatible error message
+                // Window functions in WHERE, GROUP BY, or HAVING clauses are misuse
+                let function_name = match function {
+                    vibesql_ast::WindowFunctionSpec::Aggregate { name, .. }
+                    | vibesql_ast::WindowFunctionSpec::Ranking { name, .. }
+                    | vibesql_ast::WindowFunctionSpec::Value { name, .. } => name.to_string(),
+                };
+                Err(ExecutorError::MisuseOfWindowFunction { function_name })
+            }
 
             vibesql_ast::Expression::AggregateFunction { name, .. } => {
                 // SQLite-compatible error message for aggregate misuse in execution context


### PR DESCRIPTION
## Summary

- Improve error message for window function misuse to match SQLite format
- Changes "Window functions require window mapping context" to "misuse of window function X()"
- Add `MisuseOfWindowFunction` error variant matching the pattern used for aggregates

## Investigation Finding

During investigation, discovered that window functions in compound SELECT statements (UNION, INTERSECT, EXCEPT) actually work correctly. The error message in the issue was appearing in different contexts - specifically when window functions are used in invalid locations like WHERE, GROUP BY, or HAVING clauses.

## Test plan

- [x] TCL test window1.test passes 3.1 and 3.2 (previously failing)
- [x] TCL test pass rate improved from 30.7% to 31.9%
- [x] Regression test issue_3809 still passes
- [x] Compound SELECT with window functions verified working

Closes #4695

🤖 Generated with [Claude Code](https://claude.com/claude-code)