### PR TITLE
fix(executor): respect column COLLATE in NATURAL JOIN and USING clause

### DIFF
--- a/crates/vibesql-executor/src/select/scan/join_scan.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan.rs
@@ -374,32 +374,40 @@ fn generate_natural_join_condition(
 
     // Get all column names from left schema (normalized to lowercase for case-insensitive
     // comparison)
-    let mut left_columns: HashMap<String, Vec<(String, String)>> = HashMap::new(); // lowercase_name -> [(table, actual_name)]
+    // Store: lowercase_name -> [(table, actual_name, collation)]
+    let mut left_columns: HashMap<String, Vec<(String, String, Option<String>)>> = HashMap::new();
     for (table_name, (_table_idx, table_schema)) in &left_schema.table_schemas {
         for col in &table_schema.columns {
             let lowercase_name = col.name.to_lowercase();
-            left_columns
-                .entry(lowercase_name)
-                .or_default()
-                .push((table_name.to_string(), col.name.clone()));
+            left_columns.entry(lowercase_name).or_default().push((
+                table_name.to_string(),
+                col.name.clone(),
+                col.collation.clone(),
+            ));
         }
     }
 
     // Find common column names from right schema
-    // Store: (left_table, left_col, right_table, right_col, right_table_start_idx)
-    let mut common_columns: Vec<(String, String, String, String, usize)> = Vec::new();
+    // Store: (left_table, left_col, right_table, right_col, right_table_start_idx, collation)
+    // Collation is taken from the left column (left takes precedence per SQLite semantics),
+    // falling back to the right column's collation if the left has none.
+    let mut common_columns: Vec<(String, String, String, String, usize, Option<String>)> =
+        Vec::new();
     for (table_name, (table_idx, table_schema)) in &right_schema.table_schemas {
         for col in &table_schema.columns {
             let lowercase_name = col.name.to_lowercase();
             if let Some(left_occurrences) = left_columns.get(&lowercase_name) {
                 // Found a common column
-                for (left_table, left_col) in left_occurrences {
+                for (left_table, left_col, left_collation) in left_occurrences {
+                    // Use left column's collation if present, otherwise use right column's
+                    let collation = left_collation.clone().or_else(|| col.collation.clone());
                     common_columns.push((
                         left_table.clone(),
                         left_col.clone(),
                         table_name.to_string(),
                         col.name.clone(),
                         *table_idx,
+                        collation,
                     ));
                 }
             }
@@ -413,7 +421,9 @@ fn generate_natural_join_condition(
 
     // Build the join condition as an AND chain of equalities
     let mut condition: Option<vibesql_ast::Expression> = None;
-    for (left_table, left_col, right_table, right_col, right_table_start) in common_columns {
+    for (left_table, left_col, right_table, right_col, right_table_start, collation) in
+        common_columns
+    {
         // For self-joins, use synthetic table name for right side that matches
         // what CombinedSchema::merge will create
         let right_table_ref = if is_self_join {
@@ -427,14 +437,26 @@ fn generate_natural_join_condition(
             right_table
         };
 
+        // Build right column expression, applying COLLATE if the column has a collation
+        // defined. This ensures NATURAL JOIN respects column-level COLLATE declarations.
+        let right_col_expr = vibesql_ast::Expression::ColumnRef(
+            vibesql_ast::ColumnIdentifier::qualified(&right_table_ref, false, &right_col, false),
+        );
+        let right_col_with_collate = if let Some(ref coll) = collation {
+            vibesql_ast::Expression::Collate {
+                expr: Box::new(right_col_expr),
+                collation: coll.clone(),
+            }
+        } else {
+            right_col_expr
+        };
+
         let equality = vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef(
                 vibesql_ast::ColumnIdentifier::qualified(&left_table, false, &left_col, false),
             )),
             op: vibesql_ast::BinaryOperator::Equal,
-            right: Box::new(vibesql_ast::Expression::ColumnRef(
-                vibesql_ast::ColumnIdentifier::qualified(&right_table_ref, false, &right_col, false),
-            )),
+            right: Box::new(right_col_with_collate),
         };
 
         condition = Some(match condition {
@@ -1395,7 +1417,7 @@ fn generate_using_join_condition(
     for col_name in columns {
         let col_lower = col_name.to_lowercase();
 
-        // Find column in left schema (case-insensitive) - also get absolute index
+        // Find column in left schema (case-insensitive) - also get absolute index and collation
         let left_col = left_schema
             .table_schemas
             .iter()
@@ -1406,7 +1428,12 @@ fn generate_using_join_condition(
                     .enumerate()
                     .find_map(|(col_offset, col)| {
                         if col.name.to_lowercase() == col_lower {
-                            Some((table_name.clone(), col.name.clone(), start_idx + col_offset))
+                            Some((
+                                table_name.clone(),
+                                col.name.clone(),
+                                start_idx + col_offset,
+                                col.collation.clone(),
+                            ))
                         } else {
                             None
                         }
@@ -1416,7 +1443,7 @@ fn generate_using_join_condition(
                 column_name: col_name.to_string(),
             })?;
 
-        // Find column in right schema (case-insensitive) - get absolute index and table start
+        // Find column in right schema (case-insensitive) - get absolute index, table start, collation
         let right_col = right_schema
             .table_schemas
             .iter()
@@ -1427,12 +1454,13 @@ fn generate_using_join_condition(
                     .enumerate()
                     .find_map(|(col_offset, col)| {
                         if col.name.to_lowercase() == col_lower {
-                            // Return: (table_name, col_name, absolute_col_idx, table_start_idx)
+                            // Return: (table_name, col_name, absolute_col_idx, table_start_idx, collation)
                             Some((
                                 table_name.clone(),
                                 col.name.clone(),
                                 start_idx + col_offset,
                                 *start_idx,
+                                col.collation.clone(),
                             ))
                         } else {
                             None
@@ -1442,6 +1470,9 @@ fn generate_using_join_condition(
             .ok_or_else(|| ExecutorError::JoinUsingColumnNotPresent {
                 column_name: col_name.to_string(),
             })?;
+
+        // Use left column's collation if present, otherwise use right column's
+        let collation = left_col.3.clone().or(right_col.4.clone());
 
         // Create equality condition with table-qualified column references
         // For self-joins, we need to use a synthetic table name for the right side
@@ -1460,6 +1491,20 @@ fn generate_using_join_condition(
             right_col.0.to_string()
         };
 
+        // Build right column expression, applying COLLATE if the column has a collation
+        // defined. This ensures USING clause joins respect column-level COLLATE declarations.
+        let right_col_expr = vibesql_ast::Expression::ColumnRef(
+            vibesql_ast::ColumnIdentifier::qualified(&right_table_name, false, &right_col.1, false),
+        );
+        let right_col_with_collate = if let Some(ref coll) = collation {
+            vibesql_ast::Expression::Collate {
+                expr: Box::new(right_col_expr),
+                collation: coll.clone(),
+            }
+        } else {
+            right_col_expr
+        };
+
         let equality = vibesql_ast::Expression::BinaryOp {
             left: Box::new(vibesql_ast::Expression::ColumnRef(
                 vibesql_ast::ColumnIdentifier::qualified(
@@ -1470,14 +1515,7 @@ fn generate_using_join_condition(
                 ),
             )),
             op: vibesql_ast::BinaryOperator::Equal,
-            right: Box::new(vibesql_ast::Expression::ColumnRef(
-                vibesql_ast::ColumnIdentifier::qualified(
-                    &right_table_name,
-                    false,
-                    &right_col.1,
-                    false,
-                ),
-            )),
+            right: Box::new(right_col_with_collate),
         };
 
         condition = Some(match condition {

--- a/crates/vibesql-executor/src/tests/natural_join.rs
+++ b/crates/vibesql-executor/src/tests/natural_join.rs
@@ -202,6 +202,224 @@ fn test_natural_join_with_on_clause_error() {
     assert!(err.to_string().contains("NATURAL") || err.to_string().contains("ON"));
 }
 
+// Issue #4708: NATURAL JOIN should respect column COLLATE declarations
+#[test]
+fn test_natural_join_respects_collation() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Create people table with case-insensitive NAME column
+    let mut name_col = vibesql_catalog::ColumnSchema::new(
+        "NAME".to_string(),
+        vibesql_types::DataType::Varchar { max_length: Some(50) },
+        false,
+    );
+    name_col.collation = Some("NOCASE".to_string());
+    let people_schema = vibesql_catalog::TableSchema::new(
+        "PEOPLE".to_string(),
+        vec![name_col],
+    );
+    db.create_table(people_schema).unwrap();
+
+    // Create greetings table with case-insensitive NAME column
+    let mut greeting_name_col = vibesql_catalog::ColumnSchema::new(
+        "NAME".to_string(),
+        vibesql_types::DataType::Varchar { max_length: Some(50) },
+        false,
+    );
+    greeting_name_col.collation = Some("NOCASE".to_string());
+    let greeting_col = vibesql_catalog::ColumnSchema::new(
+        "GREETING".to_string(),
+        vibesql_types::DataType::Varchar { max_length: Some(100) },
+        false,
+    );
+    let greetings_schema = vibesql_catalog::TableSchema::new(
+        "GREETINGS".to_string(),
+        vec![greeting_name_col, greeting_col],
+    );
+    db.create_table(greetings_schema).unwrap();
+
+    // Insert data - 'Alice' in people, 'ALICE' in greetings
+    db.insert_row(
+        "people",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Alice")),
+        ]),
+    )
+    .unwrap();
+
+    db.insert_row(
+        "greetings",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("ALICE")),
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Hello, ALICE!")),
+        ]),
+    )
+    .unwrap();
+
+    // Execute NATURAL JOIN query - should match 'Alice' with 'ALICE' due to NOCASE collation
+    let executor = SelectExecutor::new(&db);
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        values: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+        from: Some(vibesql_ast::FromClause::Join {
+            left: Box::new(vibesql_ast::FromClause::Table {
+                quoted: false,
+                name: "people".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            right: Box::new(vibesql_ast::FromClause::Table {
+                quoted: false,
+                name: "greetings".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            join_type: vibesql_ast::JoinType::Inner,
+            condition: None,
+            using_columns: None,
+            natural: true, // NATURAL JOIN
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+    let result = executor.execute(&stmt).unwrap();
+
+    // Should return 1 row - 'Alice' matches 'ALICE' with NOCASE collation
+    assert_eq!(
+        result.len(),
+        1,
+        "NATURAL JOIN should match 'Alice' with 'ALICE' using NOCASE collation"
+    );
+
+    // Verify the row contains the expected values
+    assert_eq!(
+        result[0].values[0],
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Alice"))
+    );
+    assert_eq!(
+        result[0].values[1],
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Hello, ALICE!"))
+    );
+}
+
+// Issue #4708: USING clause should also respect column COLLATE declarations
+#[test]
+fn test_using_join_respects_collation() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Create people table with case-insensitive NAME column
+    let mut name_col = vibesql_catalog::ColumnSchema::new(
+        "NAME".to_string(),
+        vibesql_types::DataType::Varchar { max_length: Some(50) },
+        false,
+    );
+    name_col.collation = Some("NOCASE".to_string());
+    let people_schema = vibesql_catalog::TableSchema::new(
+        "PEOPLE".to_string(),
+        vec![name_col],
+    );
+    db.create_table(people_schema).unwrap();
+
+    // Create greetings table with case-insensitive NAME column
+    let mut greeting_name_col = vibesql_catalog::ColumnSchema::new(
+        "NAME".to_string(),
+        vibesql_types::DataType::Varchar { max_length: Some(50) },
+        false,
+    );
+    greeting_name_col.collation = Some("NOCASE".to_string());
+    let greeting_col = vibesql_catalog::ColumnSchema::new(
+        "GREETING".to_string(),
+        vibesql_types::DataType::Varchar { max_length: Some(100) },
+        false,
+    );
+    let greetings_schema = vibesql_catalog::TableSchema::new(
+        "GREETINGS".to_string(),
+        vec![greeting_name_col, greeting_col],
+    );
+    db.create_table(greetings_schema).unwrap();
+
+    // Insert data - 'bob' in people, 'BOB' in greetings
+    db.insert_row(
+        "people",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("bob")),
+        ]),
+    )
+    .unwrap();
+
+    db.insert_row(
+        "greetings",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("BOB")),
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Hello, BOB!")),
+        ]),
+    )
+    .unwrap();
+
+    // Execute JOIN USING query - should match 'bob' with 'BOB' due to NOCASE collation
+    let executor = SelectExecutor::new(&db);
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        values: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+        from: Some(vibesql_ast::FromClause::Join {
+            left: Box::new(vibesql_ast::FromClause::Table {
+                quoted: false,
+                name: "people".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            right: Box::new(vibesql_ast::FromClause::Table {
+                quoted: false,
+                name: "greetings".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            join_type: vibesql_ast::JoinType::Inner,
+            condition: None,
+            using_columns: Some(vec!["NAME".to_string()]), // USING (NAME)
+            natural: false,
+        }),
+        where_clause: None,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+    let result = executor.execute(&stmt).unwrap();
+
+    // Should return 1 row - 'bob' matches 'BOB' with NOCASE collation
+    assert_eq!(
+        result.len(),
+        1,
+        "JOIN USING should match 'bob' with 'BOB' using NOCASE collation"
+    );
+
+    // Verify the row contains the expected values
+    assert_eq!(
+        result[0].values[0],
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("bob"))
+    );
+    assert_eq!(
+        result[0].values[1],
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Hello, BOB!"))
+    );
+}
+
 // TODO: Add more comprehensive tests for:
 // - NATURAL JOIN with no common columns (should behave like CROSS JOIN)
 // - NATURAL LEFT JOIN


### PR DESCRIPTION
## Summary

- Fixed NATURAL JOIN to respect column-level COLLATE declarations when generating implicit join conditions
- Applied same fix to JOIN USING clause
- Left column's collation takes precedence, falling back to right column's collation if none (SQLite semantics)

## Changes

- Modified `generate_natural_join_condition()` to track and apply column collation
- Modified `generate_using_join_condition()` with the same fix
- Added comprehensive tests for both NATURAL JOIN and USING clause with COLLATE NOCASE

## Test plan

- [x] Added unit tests: `test_natural_join_respects_collation` and `test_using_join_respects_collation`
- [x] All executor tests pass
- [x] Clippy passes (only pre-existing warnings)

Closes #4708

🤖 Generated with [Claude Code](https://claude.com/claude-code)