### PR TITLE
fix(optimizer): qualify outer expression in self-join subquery transformation (#4709)

### DIFF
--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/helpers.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/helpers.rs
@@ -75,6 +75,24 @@ pub(super) fn is_simple_single_table_self_join(
     }
 }
 
+/// Get the effective table name from a simple single-table FROM clause.
+///
+/// Returns the alias if present, otherwise the table name.
+/// Returns None if the FROM clause is not a simple single table.
+///
+/// This is used to qualify outer expressions in self-joins to avoid ambiguity
+/// when the same table appears on both sides of the join.
+pub(super) fn get_outer_table_name(from: &FromClause) -> Option<String> {
+    match from {
+        FromClause::Table { name, alias, .. } => {
+            // Return alias if present, otherwise table name
+            Some(alias.clone().unwrap_or_else(|| name.clone()))
+        }
+        // For non-simple FROM clauses, we can't determine a single table name
+        _ => None,
+    }
+}
+
 /// Rewrite column references in an expression to use a new table qualifier
 pub(super) fn rewrite_column_refs_with_alias(
     expr: &Expression,

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
@@ -39,7 +39,8 @@
 use vibesql_ast::{BinaryOperator, Expression, FromClause, JoinType, SelectItem, SelectStmt};
 
 use super::helpers::{
-    is_self_join, is_simple_single_table_self_join, rewrite_column_refs_with_alias,
+    get_outer_table_name, is_self_join, is_simple_single_table_self_join,
+    rewrite_column_refs_with_alias,
 };
 
 /// Result of converting an IN subquery to a join
@@ -142,24 +143,32 @@ pub(super) fn try_convert_in_to_join(
             );
         }
 
-        // FIX for issue #4493: Don't qualify the outer expression!
+        // FIX for issue #4709: For simple self-joins, qualify the outer expression
+        // with the outer table name to avoid ambiguity.
         //
-        // The original code tried to qualify the outer expression (left side of IN)
-        // with the subquery's table name to handle self-joins. But this breaks when:
-        // 1. The outer query has multiple tables (FROM t2, t1)
-        // 2. The column belongs to a different table than the subquery references
+        // When we have:
+        //   SELECT * FROM t1 WHERE w IN (SELECT rowid FROM t1)
         //
-        // Example that FAILS with qualification:
+        // After transformation:
+        //   SELECT * FROM t1 SEMI JOIN t1 AS __subquery_t1 ON w = __subquery_t1.rowid
+        //
+        // The unqualified 'w' is ambiguous because both t1 and __subquery_t1 have column 'w'.
+        // We need to qualify it as 't1.w'.
+        //
+        // However, for multi-table outer queries (FIX for issue #4493), we still leave
+        // the expression unqualified:
         //   SELECT x FROM t2, t1 WHERE x IN (SELECT c FROM t1 WHERE ...)
-        //   - Outer 'x' is from t2, not t1
-        //   - Qualifying as 't1.x' causes "column not found" error
         //
-        // Let SQL's normal resolution handle it. The join condition will be:
-        //   t2.x = __subquery_t1.c  (resolved at runtime based on available columns)
-        //
-        // For true self-joins like `SELECT * FROM t1 WHERE id IN (SELECT id FROM t1)`,
-        // the runtime resolution will correctly pick up t1.id for the outer reference.
-        let qualified_expr = expr.clone();
+        // Here 'x' might be from t2, and qualifying as 't1.x' would be wrong.
+        // The is_simple_single_table_self_join check above already filters out these cases.
+        let qualified_expr =
+            if let Some(outer_table) = get_outer_table_name(from) {
+                // Simple self-join: qualify outer expression with outer table name
+                rewrite_column_refs_with_alias(expr, &outer_table, &outer_table)
+            } else {
+                // Complex FROM clause: let SQL resolution handle it
+                expr.clone()
+            };
 
         // Use the table alias (if present) for matching column references, not just the table name
         // This is critical for Q21 where the subquery uses an alias like "l2" or "l3"


### PR DESCRIPTION
## Summary
- Fixed ambiguous column error when IN subquery uses rowid from the same table
- When transforming `SELECT * FROM t1 WHERE w IN (SELECT rowid FROM t1)` to a SEMI JOIN, the outer expression `w` is now qualified as `t1.w` to avoid ambiguity with `__subquery_t1.w`
- Added helper function `get_outer_table_name()` to extract outer table name for qualification

## Test plan
- [x] Verified the original error case: `SELECT * FROM t1 WHERE w IN (SELECT rowid FROM t1)` no longer returns "ambiguous column name: w"
- [x] All 2201 executor lib tests pass
- [x] Multi-table outer queries still work correctly (fix for #4493 preserved)

Closes #4709

🤖 Generated with [Claude Code](https://claude.com/claude-code)