### PR TITLE
fix(tcl-shim): recognize END as transaction terminator

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -882,7 +882,8 @@ proc execsql {sql {db ""}} {
     # - "BEGIN TRANSACTION", "BEGIN DEFERRED", "BEGIN IMMEDIATE", "BEGIN EXCLUSIVE"
     # Match these patterns preceded by statement boundary (start of string, ;, or newline)
     set begin_count [regexp -all -nocase {(?:^|;|\n)\s*BEGIN\s*(?:TRANSACTION|DEFERRED|IMMEDIATE|EXCLUSIVE|;|\s*$)} $sql]
-    set end_count [expr {[regexp -all -nocase {(?:^|;|\n)\s*COMMIT\s*(?:;|\s*$)} $sql] + \
+    # END and END TRANSACTION are SQLite synonyms for COMMIT
+    set end_count [expr {[regexp -all -nocase {(?:^|;|\n)\s*(?:COMMIT|END)(?:\s+TRANSACTION)?\s*(?:;|\s*$)} $sql] + \
                          [regexp -all -nocase {(?:^|;|\n)\s*ROLLBACK\s*(?:;|\s*$)} $sql]}]
     set net_begin [expr {$begin_count - $end_count}]
 


### PR DESCRIPTION
## Summary

SQLite allows `END` and `END TRANSACTION` as synonyms for `COMMIT` to terminate a transaction. The TCL shim's transaction batching logic was only matching `COMMIT` and `ROLLBACK`, causing tests using the `END` syntax to fail because the batch was never flushed.

## Changes

Updated the regex pattern in `scripts/tester_vibesql.tcl` to match:
- `COMMIT` (existing)
- `COMMIT TRANSACTION` (existing)
- `END` (new)
- `END TRANSACTION` (new)

## Before/After

**Before:** Tests using `BEGIN; ...; END;` syntax failed because the transaction batch was never flushed.

**After:** Tests using `END` as a transaction terminator work correctly.

## Example

```sql
-- This now works correctly
BEGIN;
CREATE TABLE t(x);
INSERT INTO t VALUES(1);
END;  -- Now recognized as transaction terminator

SELECT * FROM t;  -- Returns: 1
```

## Test Plan

- [x] Verified regex correctly matches END, END TRANSACTION, COMMIT, COMMIT TRANSACTION
- [x] Full cargo test suite passes
- [x] join.test shows improved pass rate

Closes #4712