### PR TITLE
fix(executor): enforce 64-table limit on joins (#4711)

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -151,6 +151,12 @@ pub enum ExecutorError {
         used_bytes: usize,
         max_bytes: usize,
     },
+    /// Join exceeded maximum number of tables (SQLite-compatible error)
+    /// Format: "at most 64 tables in a join"
+    JoinTableLimitExceeded {
+        table_count: usize,
+        max_tables: usize,
+    },
     /// Variable not found in procedural context (with available variables)
     VariableNotFound {
         variable_name: String,
@@ -737,6 +743,10 @@ impl std::fmt::Display for ExecutorError {
                         max_gb = max_gb.as_str()
                     )
                 )
+            }
+            ExecutorError::JoinTableLimitExceeded { max_tables, .. } => {
+                // SQLite-compatible error message: "at most 64 tables in a join"
+                write!(f, "at most {} tables in a join", max_tables)
             }
             ExecutorError::VariableNotFound { variable_name, available_variables } => {
                 if available_variables.is_empty() {

--- a/crates/vibesql-executor/src/limits.rs
+++ b/crates/vibesql-executor/src/limits.rs
@@ -82,6 +82,15 @@ pub const MAX_LOOP_ITERATIONS: usize = 50_000_000;
 /// The limit still catches truly infinite loops while allowing legitimate deep recursion.
 pub const MAX_RECURSIVE_CTE_ITERATIONS: usize = 1_000_000;
 
+/// Maximum number of tables in a single join operation
+///
+/// SQLite uses 64 for SQLITE_LIMIT_COMPOUND_SELECT-like join limits
+/// This prevents exponential cost from very large multi-table joins
+/// and catches queries that would likely be impractical anyway.
+///
+/// Error message: "at most 64 tables in a join"
+pub const MAX_TABLES_IN_JOIN: usize = 64;
+
 /// Maximum memory usage per query execution
 ///
 /// This prevents:

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -54,6 +54,11 @@ impl SelectExecutor<'_> {
         // Uses "misuse of aggregate function X()" format to match SQLite's resolve.c
         super::validation::validate_no_nested_aggregates(&stmt.select_list)?;
 
+        // Validate join table limit (issue #4711)
+        // SQLite enforces a limit of 64 tables in a single join
+        // This catches queries like SELECT * FROM t, t, t, ... (65+ times)
+        super::validation::validate_join_table_limit(stmt)?;
+
         #[cfg(feature = "profile-q6")]
         let execute_start = std::time::Instant::now();
 

--- a/crates/vibesql-executor/src/select/executor/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/validation.rs
@@ -6,9 +6,46 @@
 
 #![allow(clippy::collapsible_if)]
 
-use vibesql_ast::{Expression, SelectItem};
+use vibesql_ast::{Expression, FromClause, SelectItem, SelectStmt};
 
-use crate::{errors::ExecutorError, schema::CombinedSchema};
+use crate::{errors::ExecutorError, limits::MAX_TABLES_IN_JOIN, schema::CombinedSchema};
+
+/// Count the number of tables in a FROM clause
+///
+/// This recursively counts all table references in the FROM clause,
+/// including tables in JOIN operations and subqueries.
+///
+/// SQLite enforces a limit of 64 tables in a single join.
+fn count_tables_in_from_clause(from: &FromClause) -> usize {
+    match from {
+        FromClause::Table { .. } => 1,
+        FromClause::Join { left, right, .. } => {
+            count_tables_in_from_clause(left) + count_tables_in_from_clause(right)
+        }
+        FromClause::Subquery { .. } => 1, // Subquery counts as 1 table
+        FromClause::Values { .. } => 1,   // VALUES clause counts as 1 table
+    }
+}
+
+/// Validate that the number of tables in a join doesn't exceed SQLite's limit
+///
+/// SQLite enforces a limit of 64 tables in a single join operation.
+/// This validation catches queries like `SELECT * FROM t, t, t, ... (65+ times)`
+/// before execution begins.
+///
+/// Returns an error if the table count exceeds MAX_TABLES_IN_JOIN (64).
+pub fn validate_join_table_limit(stmt: &SelectStmt) -> Result<(), ExecutorError> {
+    if let Some(from_clause) = &stmt.from {
+        let table_count = count_tables_in_from_clause(from_clause);
+        if table_count > MAX_TABLES_IN_JOIN {
+            return Err(ExecutorError::JoinTableLimitExceeded {
+                table_count,
+                max_tables: MAX_TABLES_IN_JOIN,
+            });
+        }
+    }
+    Ok(())
+}
 
 /// Represents a column reference extracted from an expression
 #[derive(Debug)]
@@ -1779,5 +1816,130 @@ mod tests {
         assert!(aliases.contains("m")); // min(f1) AS m is an aggregate alias
         assert!(!aliases.contains("col2")); // f2 AS col2 is NOT an aggregate alias
         assert!(aliases.contains("m2")); // coalesce(min(f1)+5, 11) contains an aggregate
+    }
+
+    // Tests for join table limit validation (#4711)
+
+    #[test]
+    fn test_join_table_limit_under_limit() {
+        // Create a SELECT with 64 tables (exactly at limit) - should pass
+        // SELECT * FROM t1, t2, t3, ... (64 times)
+        let mut from: FromClause = FromClause::Table {
+            name: "t1".to_string(),
+            alias: None,
+            column_aliases: None,
+            quoted: false,
+        };
+        for i in 2..=64 {
+            from = FromClause::Join {
+                left: Box::new(from),
+                right: Box::new(FromClause::Table {
+                    name: format!("t{}", i),
+                    alias: None,
+                    column_aliases: None,
+                    quoted: false,
+                }),
+                join_type: vibesql_ast::JoinType::Cross,
+                condition: None,
+                using_columns: None,
+                natural: false,
+            };
+        }
+        let stmt = SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Wildcard { alias: None }],
+            into_table: None,
+            into_variables: None,
+            from: Some(from),
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        };
+        // Should pass - exactly 64 tables
+        assert!(validate_join_table_limit(&stmt).is_ok());
+    }
+
+    #[test]
+    fn test_join_table_limit_exceeds_limit() {
+        // Create a SELECT with 65 tables (exceeds limit) - should fail
+        let mut from: FromClause = FromClause::Table {
+            name: "t1".to_string(),
+            alias: None,
+            column_aliases: None,
+            quoted: false,
+        };
+        for i in 2..=65 {
+            from = FromClause::Join {
+                left: Box::new(from),
+                right: Box::new(FromClause::Table {
+                    name: format!("t{}", i),
+                    alias: None,
+                    column_aliases: None,
+                    quoted: false,
+                }),
+                join_type: vibesql_ast::JoinType::Cross,
+                condition: None,
+                using_columns: None,
+                natural: false,
+            };
+        }
+        let stmt = SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Wildcard { alias: None }],
+            into_table: None,
+            into_variables: None,
+            from: Some(from),
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        };
+        // Should fail - 65 tables exceeds limit
+        let result = validate_join_table_limit(&stmt);
+        assert!(result.is_err());
+        match result {
+            Err(ExecutorError::JoinTableLimitExceeded { table_count, max_tables }) => {
+                assert_eq!(table_count, 65);
+                assert_eq!(max_tables, 64);
+            }
+            _ => panic!("Expected JoinTableLimitExceeded error"),
+        }
+    }
+
+    #[test]
+    fn test_join_table_limit_no_from_clause() {
+        // SELECT 1 (no FROM clause) - should pass
+        let stmt = SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Expression {
+                expr: Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+                alias: None,
+                source_text: None,
+            }],
+            into_table: None,
+            into_variables: None,
+            from: None,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        };
+        assert!(validate_join_table_limit(&stmt).is_ok());
     }
 }


### PR DESCRIPTION
## Summary
- Implement SQLite-compatible 64-table join limit validation
- Add `MAX_TABLES_IN_JOIN` constant to enforce the limit
- Return clear error message: "at most 64 tables in a join"

Closes #4711

## Test plan
- [x] Unit tests for validation function pass
- [x] Tests verify limit at exactly 64 tables (passes)
- [x] Tests verify limit exceeded at 65 tables (fails with correct error)
- [x] Tests verify queries without FROM clause pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)