### PR TITLE
fix(parser): recognize expression indexes without outer parentheses

### DIFF
--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -82,43 +82,71 @@ impl Parser {
             return Ok(vibesql_ast::IndexColumn::new_expression(expr, direction));
         }
 
+        // Save position before parsing identifier - we may need to backtrack
+        // if this turns out to be an expression like abs(b) rather than a column name
+        let saved_position = self.position;
+
         let column_name = self.parse_identifier()?;
 
         // Check for optional prefix length: column_name(length)
+        // BUT: if the token after ( is not a number, this is likely a function call
+        // like abs(b), not a prefix length like name(10). In that case, backtrack
+        // and parse as an expression.
         let prefix_length = if self.peek() == &Token::LParen {
-            self.advance(); // consume LParen
+            // Peek ahead to check if this is a prefix length (number) or function args
+            if matches!(self.peek_at_offset(1), Token::Number(_)) {
+                self.advance(); // consume LParen
 
-            // Parse the integer length
-            let length = match self.peek() {
-                Token::Number(n) => {
-                    let value = n.parse::<i64>().map_err(|_| ParseError {
-                        message: "Invalid integer for column prefix length".to_string(),
-                    })?;
+                // Parse the integer length
+                let length = match self.peek() {
+                    Token::Number(n) => {
+                        let value = n.parse::<i64>().map_err(|_| ParseError {
+                            message: "Invalid integer for column prefix length".to_string(),
+                        })?;
+                        self.advance();
+
+                        // Validate prefix length range
+                        if value < 1 {
+                            return Err(ParseError {
+                                message: "Prefix length must be at least 1".to_string(),
+                            });
+                        }
+                        if value > 10000 {
+                            return Err(ParseError {
+                                message: "Prefix length must not exceed 10000".to_string(),
+                            });
+                        }
+
+                        value
+                    }
+                    _ => {
+                        return Err(ParseError {
+                            message: "Expected integer for column prefix length".to_string(),
+                        })
+                    }
+                };
+
+                self.expect_token(Token::RParen)?;
+                Some(length as u64)
+            } else {
+                // Not a prefix length - this is a function call like abs(b)
+                // Backtrack and parse as an expression
+                self.position = saved_position;
+                let expr = self.parse_expression()?;
+
+                // Check for optional ASC/DESC
+                let direction = if self.peek_keyword(crate::keywords::Keyword::Asc) {
                     self.advance();
+                    vibesql_ast::OrderDirection::Asc
+                } else if self.peek_keyword(crate::keywords::Keyword::Desc) {
+                    self.advance();
+                    vibesql_ast::OrderDirection::Desc
+                } else {
+                    vibesql_ast::OrderDirection::Asc
+                };
 
-                    // Validate prefix length range
-                    if value < 1 {
-                        return Err(ParseError {
-                            message: "Prefix length must be at least 1".to_string(),
-                        });
-                    }
-                    if value > 10000 {
-                        return Err(ParseError {
-                            message: "Prefix length must not exceed 10000".to_string(),
-                        });
-                    }
-
-                    value
-                }
-                _ => {
-                    return Err(ParseError {
-                        message: "Expected integer for column prefix length".to_string(),
-                    })
-                }
-            };
-
-            self.expect_token(Token::RParen)?;
-            Some(length as u64)
+                return Ok(vibesql_ast::IndexColumn::new_expression(expr, direction));
+            }
         } else {
             None
         };

--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -422,52 +422,88 @@ impl Parser {
 
                 columns.push(vibesql_ast::IndexColumn::new_expression(expr, direction));
             } else {
+                // Save position before parsing identifier - we may need to backtrack
+                // if this turns out to be an expression like abs(b) rather than a column name
+                let saved_position = self.position;
+
                 // Parse column name (use parse_alias_name to allow SQLite-style single-quoted
                 // identifiers)
                 // SQLite allows: CREATE INDEX i1xy ON t1(`x`,'y' ASC); -- 'y' is a column name
                 let column_name = self.parse_alias_name()?;
 
                 // Check for optional prefix length: column_name(length)
+                // BUT: if the token after ( is not a number, this is likely a function call
+                // like abs(b), not a prefix length like name(10). In that case, backtrack
+                // and parse as an expression.
                 let prefix_length = if self.peek() == &Token::LParen {
-                    self.advance(); // consume LParen
+                    // Peek ahead to check if this is a prefix length (number) or function args
+                    if matches!(self.peek_at_offset(1), Token::Number(_)) {
+                        self.advance(); // consume LParen
 
-                    // Parse the integer length
-                    let length = match self.peek() {
-                        Token::Number(n) => {
-                            let value = n.parse::<i64>().map_err(|_| ParseError {
-                                message: "Invalid integer for column prefix length".to_string(),
-                            })?;
+                        // Parse the integer length
+                        let length = match self.peek() {
+                            Token::Number(n) => {
+                                let value = n.parse::<i64>().map_err(|_| ParseError {
+                                    message: "Invalid integer for column prefix length".to_string(),
+                                })?;
+                                self.advance();
+
+                                // Validate prefix length range (MySQL compatibility)
+                                if value < 1 {
+                                    return Err(ParseError {
+                                        message: format!(
+                                            "Key part '{}' length cannot be 0",
+                                            column_name
+                                        ),
+                                    });
+                                }
+                                // MySQL InnoDB limit: 3072 bytes for index prefix length
+                                if value > 3072 {
+                                    return Err(ParseError {
+                                        message:
+                                            "Specified key was too long; max key length is 3072 bytes"
+                                                .to_string(),
+                                    });
+                                }
+
+                                value
+                            }
+                            _ => {
+                                return Err(ParseError {
+                                    message: "Expected integer for column prefix length"
+                                        .to_string(),
+                                })
+                            }
+                        };
+
+                        self.expect_token(Token::RParen)?;
+                        Some(length as u64)
+                    } else {
+                        // Not a prefix length - this is a function call like abs(b)
+                        // Backtrack and parse as an expression
+                        self.position = saved_position;
+                        let expr = self.parse_expression()?;
+
+                        // Check for optional ASC/DESC
+                        let direction = if self.peek_keyword(crate::keywords::Keyword::Asc) {
                             self.advance();
+                            vibesql_ast::OrderDirection::Asc
+                        } else if self.peek_keyword(crate::keywords::Keyword::Desc) {
+                            self.advance();
+                            vibesql_ast::OrderDirection::Desc
+                        } else {
+                            vibesql_ast::OrderDirection::Asc
+                        };
 
-                            // Validate prefix length range (MySQL compatibility)
-                            if value < 1 {
-                                return Err(ParseError {
-                                    message: format!(
-                                        "Key part '{}' length cannot be 0",
-                                        column_name
-                                    ),
-                                });
-                            }
-                            // MySQL InnoDB limit: 3072 bytes for index prefix length
-                            if value > 3072 {
-                                return Err(ParseError {
-                                    message:
-                                        "Specified key was too long; max key length is 3072 bytes"
-                                            .to_string(),
-                                });
-                            }
+                        columns.push(vibesql_ast::IndexColumn::new_expression(expr, direction));
 
-                            value
+                        if self.peek() == &Token::Comma {
+                            self.advance(); // consume comma
+                        } else {
+                            break;
                         }
-                        _ => {
-                            return Err(ParseError {
-                                message: "Expected integer for column prefix length".to_string(),
-                            })
-                        }
-                    };
-
-                    self.expect_token(Token::RParen)?;
-                    Some(length as u64)
+                        continue;
+                    }
                 } else {
                     None
                 };
@@ -476,7 +512,7 @@ impl Parser {
                 // Syntax: column_name COLLATE collation_name
                 if self.peek_keyword(crate::keywords::Keyword::Collate) {
                     self.advance(); // consume COLLATE
-                    // Parse collation name (e.g., NOCASE, BINARY, RTRIM)
+                                    // Parse collation name (e.g., NOCASE, BINARY, RTRIM)
                     let _collation = self.parse_identifier()?;
                     // Note: We parse and ignore the collation for now
                     // Full collation support would require storing it in IndexColumn

--- a/crates/vibesql-parser/src/tests/index.rs
+++ b/crates/vibesql-parser/src/tests/index.rs
@@ -394,3 +394,161 @@ fn test_create_index_expression_complex() {
         other => panic!("Expected CreateIndex, got: {:?}", other),
     }
 }
+
+// ============================================================================
+// Expression Indexes Without Outer Parentheses (Issue #4715)
+// ============================================================================
+// SQLite allows expression indexes without the outer parentheses, e.g.:
+// CREATE INDEX idx ON t(abs(b)) -- instead of ((abs(b)))
+// This should NOT be confused with prefix length syntax: name(10)
+
+#[test]
+fn test_create_index_expression_function_no_parens() {
+    // SQLite-style: abs(b) without extra outer parens
+    // This was previously misinterpreted as column "abs" with prefix length "b"
+    let sql = "CREATE INDEX t1b ON t1(abs(b))";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.index_name, "t1b");
+            assert_eq!(stmt.table_name, "t1");
+            assert_eq!(stmt.columns.len(), 1);
+            assert!(stmt.columns[0].is_expression(), "Expected expression index, got column");
+            assert_eq!(stmt.columns[0].direction(), vibesql_ast::OrderDirection::Asc);
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_unique_index_expression_no_parens() {
+    // Test case from issue #4715
+    let sql = "CREATE UNIQUE INDEX t1b ON t1(abs(b))";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            match &stmt.index_type {
+                vibesql_ast::IndexType::BTree { unique } => {
+                    assert!(*unique, "Expected unique=true");
+                }
+                other => panic!("Expected BTree index, got: {:?}", other),
+            }
+            assert!(stmt.columns[0].is_expression());
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_index_expression_lower_no_parens() {
+    // Common case: lower() function for case-insensitive index
+    let sql = "CREATE INDEX idx_lower ON users(lower(email))";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.columns.len(), 1);
+            assert!(stmt.columns[0].is_expression());
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_index_expression_with_desc_no_parens() {
+    // Expression index with DESC, no outer parens
+    let sql = "CREATE INDEX idx ON t(abs(x) DESC)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.columns.len(), 1);
+            assert!(stmt.columns[0].is_expression());
+            assert_eq!(stmt.columns[0].direction(), vibesql_ast::OrderDirection::Desc);
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_index_mixed_expression_no_parens_and_columns() {
+    // Mix of expression (no outer parens) and regular columns
+    let sql = "CREATE INDEX idx ON t(a, lower(b), c DESC)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.columns.len(), 3);
+
+            // First: column 'a'
+            assert!(!stmt.columns[0].is_expression());
+            assert_eq!(stmt.columns[0].expect_column_name(), "a");
+
+            // Second: expression lower(b)
+            assert!(stmt.columns[1].is_expression());
+
+            // Third: column 'c' DESC
+            assert!(!stmt.columns[2].is_expression());
+            assert_eq!(stmt.columns[2].expect_column_name(), "c");
+            assert_eq!(stmt.columns[2].direction(), vibesql_ast::OrderDirection::Desc);
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_index_prefix_length_still_works() {
+    // Ensure prefix length syntax still works: column_name(integer)
+    let sql = "CREATE INDEX idx ON users(name(10))";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.columns.len(), 1);
+            assert!(!stmt.columns[0].is_expression());
+            assert_eq!(stmt.columns[0].expect_column_name(), "name");
+            assert_eq!(stmt.columns[0].prefix_length(), Some(10));
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_index_multi_arg_function_no_parens() {
+    // Multi-argument function
+    let sql = "CREATE INDEX idx ON t(substr(name, 1, 3))";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.columns.len(), 1);
+            assert!(stmt.columns[0].is_expression());
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_index_nested_function_no_parens() {
+    // Nested function calls
+    let sql = "CREATE INDEX idx ON t(lower(trim(name)))";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.columns.len(), 1);
+            assert!(stmt.columns[0].is_expression());
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary

When creating an index on an expression like `abs(b)`, the parser previously misinterpreted the parentheses as a column prefix length specification rather than an expression. This led to a confusing error message "Expected integer for column prefix length".

### The Problem

SQLite supports expression indexes:
```sql
CREATE INDEX idx ON t1(abs(b));  -- Index on expression abs(b)
```

And prefix indexes:
```sql
CREATE INDEX idx ON t1(name(10));  -- Index on first 10 chars of 'name'
```

The parser was treating `abs(b)` as `column_name(prefix_length)`, expecting an integer inside the parentheses.

### The Solution

Use lookahead to distinguish between:
- Prefix length: `identifier(integer)` → parse as column with prefix
- Expression: `identifier(non-integer)` → backtrack and parse as expression

This allows both forms of expression indexes:
```sql
CREATE INDEX idx ON t(abs(b));     -- Now works (SQLite-style)
CREATE INDEX idx ON t((abs(b)));   -- Still works (PostgreSQL-style)
```

## Changes

- `crates/vibesql-parser/src/parser/index.rs`: Added lookahead check before assuming prefix length
- `crates/vibesql-parser/src/parser/create/constraints.rs`: Same fix for table constraint parsing
- `crates/vibesql-parser/src/tests/index.rs`: Added 8 new tests for expression indexes without outer parens

## Test Plan

- [x] All existing parser tests pass (1194 tests)
- [x] New tests cover:
  - Basic function call: `abs(b)`
  - Multi-argument functions: `substr(name, 1, 3)`
  - Nested functions: `lower(trim(name))`
  - Mixed columns and expressions: `a, lower(b), c DESC`
  - Prefix length still works: `name(10)`
  - With UNIQUE constraint
  - With DESC direction

Closes #4715