### PR TITLE
fix(parser): support chained NOTNULL operators

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -354,14 +354,19 @@ impl<'arena> ArenaParser<'arena> {
 
         // SQLite compatibility: ISNULL and NOTNULL as postfix operators
         // These are equivalent to IS NULL and IS NOT NULL respectively
-        if self.peek_keyword(Keyword::Isnull) {
-            self.consume_keyword(Keyword::Isnull)?;
-            let left_ref = self.arena.alloc(left);
-            left = Expression::IsNull { expr: left_ref, negated: false };
-        } else if self.peek_keyword(Keyword::Notnull) {
-            self.consume_keyword(Keyword::Notnull)?;
-            let left_ref = self.arena.alloc(left);
-            left = Expression::IsNull { expr: left_ref, negated: true };
+        // Loop to support chaining: `x NOTNULL NOTNULL` → `(x IS NOT NULL) IS NOT NULL`
+        loop {
+            if self.peek_keyword(Keyword::Isnull) {
+                self.consume_keyword(Keyword::Isnull)?;
+                let left_ref = self.arena.alloc(left);
+                left = Expression::IsNull { expr: left_ref, negated: false };
+            } else if self.peek_keyword(Keyword::Notnull) {
+                self.consume_keyword(Keyword::Notnull)?;
+                let left_ref = self.arena.alloc(left);
+                left = Expression::IsNull { expr: left_ref, negated: true };
+            } else {
+                break;
+            }
         }
 
         Ok(left)

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -570,12 +570,17 @@ impl Parser {
 
         // SQLite compatibility: ISNULL and NOTNULL as postfix operators
         // These are equivalent to IS NULL and IS NOT NULL respectively
-        if self.peek_keyword(Keyword::Isnull) {
-            self.consume_keyword(Keyword::Isnull)?;
-            left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: false };
-        } else if self.peek_keyword(Keyword::Notnull) {
-            self.consume_keyword(Keyword::Notnull)?;
-            left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: true };
+        // Loop to support chaining: `x NOTNULL NOTNULL` → `(x IS NOT NULL) IS NOT NULL`
+        loop {
+            if self.peek_keyword(Keyword::Isnull) {
+                self.consume_keyword(Keyword::Isnull)?;
+                left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: false };
+            } else if self.peek_keyword(Keyword::Notnull) {
+                self.consume_keyword(Keyword::Notnull)?;
+                left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: true };
+            } else {
+                break;
+            }
         }
 
         Ok(left)

--- a/crates/vibesql-parser/src/tests/not_is_null_precedence.rs
+++ b/crates/vibesql-parser/src/tests/not_is_null_precedence.rs
@@ -303,6 +303,132 @@ fn test_not_null_without_is() {
     }
 }
 
+/// Test chained NOTNULL operators (issue #4713)
+/// SQLite allows: `x NOTNULL NOTNULL` → `(x IS NOT NULL) IS NOT NULL`
+#[test]
+fn test_chained_notnull_operators() {
+    // Parse: SELECT 1 NOTNULL NOTNULL
+    let sql = "SELECT 1 NOTNULL NOTNULL";
+    let stmt = Parser::parse_sql(sql).expect("Should parse");
+
+    let select = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        _ => panic!("Expected SELECT statement"),
+    };
+
+    let expr = &select.select_list[0];
+    match expr {
+        vibesql_ast::SelectItem::Expression { expr, .. } => {
+            // Should be: IsNull(IsNull(1, negated: true), negated: true)
+            // i.e., (1 IS NOT NULL) IS NOT NULL
+            match expr {
+                Expression::IsNull { expr: inner, negated: outer_negated } => {
+                    assert!(*outer_negated, "Outer NOTNULL should have negated=true");
+
+                    match inner.as_ref() {
+                        Expression::IsNull { expr: innermost, negated: inner_negated } => {
+                            assert!(*inner_negated, "Inner NOTNULL should have negated=true");
+
+                            match innermost.as_ref() {
+                                Expression::Literal(vibesql_types::SqlValue::Integer(1)) => {
+                                    // Correct!
+                                }
+                                _ => panic!("Expected literal 1, got {:?}", innermost),
+                            }
+                        }
+                        _ => panic!("Expected inner IsNull, got {:?}", inner),
+                    }
+                }
+                _ => panic!("Expected IsNull, got {:?}", expr),
+            }
+        }
+        _ => panic!("Expected Expression column"),
+    }
+}
+
+/// Test chained ISNULL operators
+#[test]
+fn test_chained_isnull_operators() {
+    // Parse: SELECT 1 ISNULL ISNULL
+    let sql = "SELECT 1 ISNULL ISNULL";
+    let stmt = Parser::parse_sql(sql).expect("Should parse");
+
+    let select = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        _ => panic!("Expected SELECT statement"),
+    };
+
+    let expr = &select.select_list[0];
+    match expr {
+        vibesql_ast::SelectItem::Expression { expr, .. } => {
+            // Should be: IsNull(IsNull(1, negated: false), negated: false)
+            match expr {
+                Expression::IsNull { expr: inner, negated: outer_negated } => {
+                    assert!(!*outer_negated, "Outer ISNULL should have negated=false");
+
+                    match inner.as_ref() {
+                        Expression::IsNull { expr: innermost, negated: inner_negated } => {
+                            assert!(!*inner_negated, "Inner ISNULL should have negated=false");
+
+                            match innermost.as_ref() {
+                                Expression::Literal(vibesql_types::SqlValue::Integer(1)) => {
+                                    // Correct!
+                                }
+                                _ => panic!("Expected literal 1, got {:?}", innermost),
+                            }
+                        }
+                        _ => panic!("Expected inner IsNull, got {:?}", inner),
+                    }
+                }
+                _ => panic!("Expected IsNull, got {:?}", expr),
+            }
+        }
+        _ => panic!("Expected Expression column"),
+    }
+}
+
+/// Test mixed NOTNULL and ISNULL chaining
+#[test]
+fn test_mixed_notnull_isnull_chaining() {
+    // Parse: SELECT 1 NOTNULL ISNULL
+    let sql = "SELECT 1 NOTNULL ISNULL";
+    let stmt = Parser::parse_sql(sql).expect("Should parse");
+
+    let select = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        _ => panic!("Expected SELECT statement"),
+    };
+
+    let expr = &select.select_list[0];
+    match expr {
+        vibesql_ast::SelectItem::Expression { expr, .. } => {
+            // Should be: IsNull(IsNull(1, negated: true), negated: false)
+            // i.e., (1 IS NOT NULL) IS NULL
+            match expr {
+                Expression::IsNull { expr: inner, negated: outer_negated } => {
+                    assert!(!*outer_negated, "Outer ISNULL should have negated=false");
+
+                    match inner.as_ref() {
+                        Expression::IsNull { expr: innermost, negated: inner_negated } => {
+                            assert!(*inner_negated, "Inner NOTNULL should have negated=true");
+
+                            match innermost.as_ref() {
+                                Expression::Literal(vibesql_types::SqlValue::Integer(1)) => {
+                                    // Correct!
+                                }
+                                _ => panic!("Expected literal 1, got {:?}", innermost),
+                            }
+                        }
+                        _ => panic!("Expected inner IsNull, got {:?}", inner),
+                    }
+                }
+                _ => panic!("Expected IsNull, got {:?}", expr),
+            }
+        }
+        _ => panic!("Expected Expression column"),
+    }
+}
+
 /// Test NOT NULL in complex WHERE clause
 #[test]
 fn test_not_null_in_complex_where() {


### PR DESCRIPTION
## Summary

SQLite allows chained NOTNULL operators like `x NOTNULL NOTNULL` which should parse as `(x IS NOT NULL) IS NOT NULL`. This was failing with a syntax error on the second NOTNULL.

## Changes

- Modified both the arena parser and regular parser to use a loop instead of a single `if` check for ISNULL/NOTNULL operators
- Added 3 new tests for chained operators:
  - `test_chained_notnull_operators`: Tests `SELECT 1 NOTNULL NOTNULL`
  - `test_chained_isnull_operators`: Tests `SELECT 1 ISNULL ISNULL`
  - `test_mixed_notnull_isnull_chaining`: Tests `SELECT 1 NOTNULL ISNULL`

## Test Plan

- [x] Parser tests pass (1189 tests)
- [x] New chained operator tests verify correct AST structure
- [x] Manual verification: `SELECT 1 NOTNULL NOTNULL` returns 1
- [x] Manual verification: `SELECT * FROM v0 WHERE v0.c NOTNULL NOTNULL` works correctly

Closes #4713

🤖 Generated with [Claude Code](https://claude.com/claude-code)