### PR TITLE
fix(executor): use combine_for_join for proper ROWID tracking in SEMI/ANTI joins

### DIFF
--- a/crates/vibesql-executor/src/select/join/nested_loop.rs
+++ b/crates/vibesql-executor/src/select/join/nested_loop.rs
@@ -50,9 +50,7 @@ fn check_cross_join_size_limit(left_count: usize, right_count: usize) -> Result<
 /// - Integer(0) -> false
 /// - Integer(non-zero) -> true
 /// - Other types -> error
-fn eval_join_condition_to_bool(
-    value: vibesql_types::SqlValue,
-) -> Result<bool, ExecutorError> {
+fn eval_join_condition_to_bool(value: vibesql_types::SqlValue) -> Result<bool, ExecutorError> {
     match value {
         vibesql_types::SqlValue::Boolean(b) => Ok(b),
         vibesql_types::SqlValue::Null => Ok(false),
@@ -989,6 +987,10 @@ pub(super) fn nested_loop_semi_join(
     let left_slice = left.as_slice();
     let right_slice = right.as_slice();
 
+    // Get table names for ROWID tracking (issue #4716)
+    let left_table_names = left.schema.table_names();
+    let right_table_names = right.schema.table_names();
+
     let mut result_rows = Vec::new();
     let mut iterations = 0;
 
@@ -1003,7 +1005,13 @@ pub(super) fn nested_loop_semi_join(
                 timeout_ctx.check()?;
             }
 
-            let combined_row = combine_rows(left_row, right_row);
+            // Use combine_for_join for proper ROWID tracking (issue #4716)
+            let combined_row = vibesql_storage::Row::combine_for_join(
+                left_row,
+                right_row,
+                &left_table_names,
+                &right_table_names,
+            );
 
             // Check join condition
             let matches = match condition {
@@ -1085,6 +1093,10 @@ pub(super) fn nested_loop_anti_join(
     let left_slice = left.as_slice();
     let right_slice = right.as_slice();
 
+    // Get table names for ROWID tracking (issue #4716)
+    let left_table_names = left.schema.table_names();
+    let right_table_names = right.schema.table_names();
+
     let mut result_rows = Vec::new();
     let mut iterations = 0;
 
@@ -1099,7 +1111,13 @@ pub(super) fn nested_loop_anti_join(
                 timeout_ctx.check()?;
             }
 
-            let combined_row = combine_rows(left_row, right_row);
+            // Use combine_for_join for proper ROWID tracking (issue #4716)
+            let combined_row = vibesql_storage::Row::combine_for_join(
+                left_row,
+                right_row,
+                &left_table_names,
+                &right_table_names,
+            );
 
             // Check join condition
             let matches = match condition {


### PR DESCRIPTION
## Summary

- Fixes ROWID resolution in SEMI and ANTI join condition evaluation
- Changes `nested_loop_semi_join` and `nested_loop_anti_join` to use `Row::combine_for_join()` with proper table names instead of `combine_rows()`
- Enables proper table-qualified ROWID lookups when subqueries with `rowid` are transformed into SEMI JOINs

## Problem

When a query like this was executed:
```sql
SELECT * FROM t1 WHERE w IN (SELECT rowid FROM t1 WHERE rowid IN (1,2))
```

The subquery gets transformed into a SEMI JOIN:
```sql
SELECT * FROM t1 SEMI JOIN t1 AS __subquery_t1 ON t1.w = __subquery_t1.rowid AND __subquery_t1.rowid IN (1, 2)
```

The `nested_loop_semi_join` function was using `combine_rows()` which only merges existing `row_ids` HashMaps from input rows. Single-table scan rows have `row_id` (singular) set but `row_ids` (HashMap) is None. This caused `__subquery_t1.rowid` lookups to fail, returning NULL, and the join condition to never match.

## Solution

Changed both `nested_loop_semi_join` and `nested_loop_anti_join` to use `Row::combine_for_join()` with table names from the schema. This function properly populates the `row_ids` HashMap from each row's `row_id` value and the schema's table names.

## Test plan

- [x] Verified fix with the original failing query - now returns 2 rows as expected
- [x] TCL tests where-5.7 and where-5.8 now pass
- [x] All lib tests pass

Closes #4716

🤖 Generated with [Claude Code](https://claude.com/claude-code)