### PR TITLE
fix(tcl-shim): skip affinity() function tests

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1419,6 +1419,12 @@ proc uses_sqlite_internals {script} {
         return [list 1 "uses sqlite_source_id() (SQLite internal function)"]
     }
 
+    # affinity() - SQLite internal/test function that returns type affinity of a value
+    # Not part of SQL standard, used for SQLite's internal testing
+    if {[regexp {affinity\s*\(} $script]} {
+        return [list 1 "uses affinity() (SQLite internal function)"]
+    }
+
     # SQLite C API functions - not available in VibeSQL
     # These are low-level SQLite library functions, not SQL
     if {[regexp {sqlite3_prepare} $script]} {


### PR DESCRIPTION
## Summary

Add detection for SQLite's internal `affinity()` function to skip tests that use it, since this is a SQLite-internal testing function not part of the SQL standard.

## Changes

- Add `affinity()` pattern matching in `uses_sqlite_internals` function in `scripts/tester_vibesql.tcl`
- Tests using `affinity()` are now skipped with message: "uses affinity() (SQLite internal function)"

## Test Plan

- Ran `make test-tcl-file FILE=subquery.test --verbose`
- Verified 13 tests (subquery-11.1 through subquery-11.14) are now properly skipped instead of failing with "no such function: affinity"

Closes #4728