### PR TITLE
fix(cli): stop script execution on first error for SQLite compatibility

### DIFF
--- a/crates/vibesql-cli/src/script.rs
+++ b/crates/vibesql-cli/src/script.rs
@@ -136,7 +136,12 @@ impl ScriptExecutor {
                         vibe_msg!("script-error", index = (idx + 1) as i64, error = e.to_string())
                     );
                     error_count += 1;
-                    // Continue executing remaining statements
+                    // SQLite compatibility: Stop on first error (issue #4731)
+                    // SQLite's TCL interface and CLI stop execution when a statement fails.
+                    // Previously, we continued executing remaining statements which caused
+                    // bugs like catchsql { CREATE TABLE t1; INSERT... } where CREATE fails
+                    // but INSERT succeeds, adding duplicate rows.
+                    break;
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Fix script executor to stop on first error** for SQLite compatibility
- Previously, multi-statement execution continued past errors, causing duplicate rows
- This fixes TCL test failures where `catchsql { CREATE TABLE t1; INSERT... }` would execute INSERT even when CREATE failed

## Root Cause Analysis

In the TCL test `subquery-3.2`:
1. `catchsql { CREATE TABLE t1(a,b); INSERT INTO t1 VALUES(1,2); }` runs
2. If t1 already exists from previous test, CREATE TABLE fails
3. **Bug**: VibeSQL continued executing INSERT, adding duplicate rows
4. Result: `SELECT (SELECT t1.a) FROM t1` returned "1 1" instead of "1"

SQLite's behavior is to stop execution on the first error within a statement block.

## Changes

- Modified `crates/vibesql-cli/src/script.rs` to `break` on error instead of continuing
- Added detailed comment explaining the SQLite compatibility requirement

## Test Results

**Before fix:**
- subquery-3.2: FAILED (Expected: 1, Got: 1 1)
- subquery-3.3.5: FAILED (Expected: 1 1 2 1, Got: 1 1 1 1 2 1)

**After fix:**
- subquery-3.2: ✅ PASSED
- subquery-3.3.5: ✅ PASSED
- All CLI tests: ✅ PASSED (112 tests)
- All persistence tests: ✅ PASSED (5 tests)

## Test plan

- [x] Verified multi-statement scripts stop on first error
- [x] Confirmed subquery-3.2 and subquery-3.3.5 now pass
- [x] All `cargo test -p vibesql-cli` tests pass
- [ ] CI pipeline validation

Closes #4731

🤖 Generated with [Claude Code](https://claude.com/claude-code)