### PR TITLE
fix(tcl-shim): clean test.db between test file runs to prevent state corruption

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2446,6 +2446,16 @@ proc run_test_file {filename} {
         file delete -force $::db_file
     }
 
+    # Clean test.db which is used by many test files
+    # This prevents state leakage between test file runs
+    if {[file exists "test.db"]} {
+        file delete -force "test.db"
+    }
+
+    # Clear the opened_dbs tracking so all databases are treated as "first time" opens
+    # This ensures sqlite3 proc will delete stale database files from previous test runs
+    set ::opened_dbs {}
+
     puts "Running: $filename"
     puts ""
 


### PR DESCRIPTION
## Summary

Fix the TCL test shim to clean `test.db` between test file runs to prevent state corruption.

## Problem

The TCL test shim accumulated database state in `test.db` across test file runs because:
1. The `::opened_dbs` list was not cleared between runs
2. This caused the `sqlite3` proc to skip deleting stale database files
3. The result was corrupted dumps with accumulated SQL statements

**Evidence** (from issue):
```
# Fresh run
where.test: Passed 247/305 (81.0%)

# After state accumulation  
where.test: Passed 66/305 (21.6%)
```

## Solution

1. Clear `::opened_dbs` at the start of each test file run so all databases are treated as "first time" opens
2. Explicitly delete `test.db` if it exists (common database name used by tests)

## Test Plan

- [x] Run `where.test` multiple times - should consistently pass ~81%
- [x] Run `select1.test` followed by `where.test` - should maintain consistent pass rates
- [x] Verify no state leakage between test files

**Verified results:**
```
# Multiple consecutive runs - all consistent
select1.test: Passed 188/188 (100.0%)
where.test: Passed 247/305 (81.0%)
where.test: Passed 247/305 (81.0%)
where.test: Passed 247/305 (81.0%)
```

Closes #4727