### PR TITLE
fix(tcl-shim): skip tests using db function command

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1416,6 +1416,12 @@ proc uses_sqlite_internals {script} {
         return [list 1 "uses db cache (statement cache metrics)"]
     }
 
+    # db function command - registers TCL functions as SQL functions
+    # This is SQLite/TCL integration, not standard SQL functionality
+    if {[regexp {db\s+function\s+} $script]} {
+        return [list 1 "uses db function (TCL function registration)"]
+    }
+
     # sqlite3_test_control - test harness control function
     if {[regexp {sqlite3_test_control} $script]} {
         return [list 1 "uses sqlite3_test_control (test harness function)"]


### PR DESCRIPTION
## Summary
Skip TCL tests that use the `db function` command, which is SQLite's TCL integration for registering custom functions as SQL functions. VibeSQL doesn't implement TCL bindings, so these tests are not applicable.

## Changes
- Added detection for `db function` in `uses_sqlite_internals()` function in `scripts/tester_vibesql.tcl`
- Tests using this command are now skipped with message: "uses db function (TCL function registration)"

## Test Plan
- Verified `where-10.2` is now skipped (previously failed with "Unknown db command: function")
- Verified `subquery-5.1` is now skipped
- 33 test files contain `db function` usage and will benefit from this fix

Closes #4733