### PR TITLE
fix(storage): implement atomic writes to prevent database corruption

### DIFF
--- a/crates/vibesql-storage/src/persistence/load.rs
+++ b/crates/vibesql-storage/src/persistence/load.rs
@@ -10,10 +10,15 @@ use std::{fs, path::Path};
 
 use crate::StorageError;
 
+/// Marker that indicates a complete SQL dump file
+pub const SQL_DUMP_END_MARKER: &str = "-- End of dump";
+
 /// Read SQL dump content from file
 ///
 /// # Errors
-/// Returns `StorageError::NotImplemented` if the file cannot be read or is not a text file
+/// Returns `StorageError::NotImplemented` if:
+/// - The file cannot be read or is not a text file
+/// - The file appears to be truncated (missing end marker)
 pub fn read_sql_dump<P: AsRef<Path>>(path: P) -> Result<String, StorageError> {
     let path_ref = path.as_ref();
     if !path_ref.exists() {
@@ -22,7 +27,27 @@ pub fn read_sql_dump<P: AsRef<Path>>(path: P) -> Result<String, StorageError> {
 
     // Try to read the file as text
     match fs::read_to_string(path_ref) {
-        Ok(content) => Ok(content),
+        Ok(content) => {
+            // Verify the dump is complete by checking for the end marker
+            // This detects truncated/corrupted files from interrupted writes
+            if content.contains(SQL_DUMP_END_MARKER) {
+                Ok(content)
+            } else if content.trim().is_empty() {
+                // Empty file is valid for a new database
+                Ok(content)
+            } else if content.starts_with("-- VibeSQL Database Dump") {
+                // File has our header but is missing the end marker - truncated
+                Err(StorageError::NotImplemented(format!(
+                    "Database file {:?} appears to be truncated (missing end marker). \
+                     This may be caused by an interrupted write. \
+                     If you have a backup, please restore it.",
+                    path_ref
+                )))
+            } else {
+                // Not a VibeSQL dump file - might be plain SQL, allow it
+                Ok(content)
+            }
+        }
         Err(e) => {
             // Check if this might be a binary database file (like SQLite)
             if let Ok(bytes) = fs::read(path_ref).map(|b| b.get(0..16).unwrap_or(&[]).to_vec()) {
@@ -233,5 +258,40 @@ mod tests {
         assert_eq!(statements.len(), 1);
         assert!(statements[0].contains("'Alice'"));
         assert!(!statements[0].contains("Add first user"));
+    }
+
+    #[test]
+    fn test_truncation_detection() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        // Test 1: Complete dump file should succeed
+        let mut complete_file = NamedTempFile::new().unwrap();
+        writeln!(
+            complete_file,
+            "-- VibeSQL Database Dump\nCREATE TABLE t(x INT);\n-- End of dump"
+        )
+        .unwrap();
+        assert!(read_sql_dump(complete_file.path()).is_ok());
+
+        // Test 2: Truncated dump file should fail
+        let mut truncated_file = NamedTempFile::new().unwrap();
+        writeln!(
+            truncated_file,
+            "-- VibeSQL Database Dump\nCREATE TABLE t(x INT);\nINSERT INTO t VALUES ("
+        )
+        .unwrap();
+        let result = read_sql_dump(truncated_file.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("truncated"));
+
+        // Test 3: Empty file should succeed (valid for new database)
+        let empty_file = NamedTempFile::new().unwrap();
+        assert!(read_sql_dump(empty_file.path()).is_ok());
+
+        // Test 4: Plain SQL (not a VibeSQL dump) should succeed
+        let mut plain_sql = NamedTempFile::new().unwrap();
+        writeln!(plain_sql, "CREATE TABLE t(x INT);").unwrap();
+        assert!(read_sql_dump(plain_sql.path()).is_ok());
     }
 }

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -8,9 +8,14 @@
 // - Indexes
 // - Data (INSERT statements)
 // - Roles and privileges
+//
+// IMPORTANT: This module uses atomic writes to prevent database corruption.
+// All writes go to a temporary file first, then are atomically renamed to the
+// target path. This ensures that even if the process crashes mid-write, the
+// original database file remains intact.
 
 use std::{
-    fs::File,
+    fs::{self, File},
     io::{BufWriter, Write},
     path::Path,
 };
@@ -27,6 +32,16 @@ impl Database {
     /// - Data (INSERT statements)
     /// - Roles and privileges
     ///
+    /// # Atomicity
+    ///
+    /// This function uses atomic writes to prevent corruption:
+    /// 1. Writes to a temporary file in the same directory
+    /// 2. Flushes and syncs the buffer to ensure all data is on disk
+    /// 3. Atomically renames the temp file to the target path
+    ///
+    /// This ensures the database file is never in a partial/corrupt state,
+    /// even if the process crashes or is interrupted mid-write.
+    ///
     /// # Example
     /// ```no_run
     /// # use vibesql_storage::Database;
@@ -34,8 +49,46 @@ impl Database {
     /// db.save_sql_dump("database.sql").unwrap();
     /// ```
     pub fn save_sql_dump<P: AsRef<Path>>(&self, path: P) -> Result<(), StorageError> {
-        let file = File::create(path)
-            .map_err(|e| StorageError::NotImplemented(format!("Failed to create file: {}", e)))?;
+        let path_ref = path.as_ref();
+
+        // Create temp file in the same directory to ensure atomic rename works
+        // (rename across filesystems would fail)
+        let temp_path = {
+            let parent = path_ref.parent().unwrap_or(Path::new("."));
+            let file_name = path_ref
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string());
+            let temp_name = format!(
+                ".{}.tmp.{}",
+                file_name.unwrap_or_else(|| "database".to_string()),
+                std::process::id()
+            );
+            parent.join(temp_name)
+        };
+
+        // Write to temp file - clean up on error
+        let result = self.write_sql_dump_to_file(&temp_path);
+        if let Err(e) = &result {
+            // Clean up temp file on error
+            let _ = fs::remove_file(&temp_path);
+            return Err(e.clone());
+        }
+
+        // Atomically rename temp file to target path
+        fs::rename(&temp_path, path_ref).map_err(|e| {
+            // Clean up temp file on rename failure
+            let _ = fs::remove_file(&temp_path);
+            StorageError::NotImplemented(format!("Failed to rename temp file to target: {}", e))
+        })?;
+
+        Ok(())
+    }
+
+    /// Internal helper to write the SQL dump to a file
+    fn write_sql_dump_to_file(&self, path: &Path) -> Result<(), StorageError> {
+        let file = File::create(path).map_err(|e| {
+            StorageError::NotImplemented(format!("Failed to create temp file: {}", e))
+        })?;
 
         let mut writer = BufWriter::new(file);
 
@@ -216,6 +269,19 @@ impl Database {
 
         writeln!(writer, "-- End of dump")
             .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+
+        // Flush the buffer and sync to disk to ensure data durability
+        // This is critical for atomic writes - we need all data on disk before rename
+        writer
+            .flush()
+            .map_err(|e| StorageError::NotImplemented(format!("Failed to flush buffer: {}", e)))?;
+
+        // Get the underlying file to sync it to disk
+        let file = writer
+            .into_inner()
+            .map_err(|e| StorageError::NotImplemented(format!("Failed to get file: {}", e)))?;
+        file.sync_all()
+            .map_err(|e| StorageError::NotImplemented(format!("Failed to sync file: {}", e)))?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

This PR fixes database dump file corruption during TCL test runs by implementing atomic writes and truncation detection.

## Changes

### Atomic Writes (`save.rs`)
- Write to a temporary file first (`.filename.tmp.PID`)
- Flush buffer and sync to disk to ensure durability
- Atomically rename temp file to target path
- Clean up temp file on any error

### Truncation Detection (`load.rs`)
- Check for `-- End of dump` marker to detect complete files
- Return clear error if VibeSQL dump file is truncated
- Allow plain SQL files and empty files (backwards compatible)
- Add comprehensive tests for truncation detection

## Root Cause

Previously, `save_sql_dump()` would:
1. Open target file directly with `File::create()`
2. Write incrementally with `BufWriter`
3. If process crashed/was interrupted, file would be incomplete

Now the write is atomic - either the old complete file exists, or the new complete file exists. Never an incomplete file.

## Test Plan

- [x] All existing persistence tests pass
- [x] New truncation detection tests pass
- [x] TCL test file (select1.test) passes
- [x] Manual verification that temp files are cleaned up
- [x] Manual verification that dump files have correct end marker

Closes #4745