### PR TITLE
fix(executor): resolve outer-scope columns in compound SELECT subqueries

### DIFF
--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -64,6 +64,18 @@ fn extract_table_names_recursive(from: &FromClause, tables: &mut Vec<String>) {
     }
 }
 
+/// Helper to extract table names from a SelectStmt's FROM clause
+/// Used for set operation traversal (issue #4749)
+fn extract_table_names_recursive_from_select(stmt: &SelectStmt, tables: &mut Vec<String>) {
+    if let Some(from_clause) = &stmt.from {
+        extract_table_names_recursive(from_clause, tables);
+    }
+    // Recursively handle chained set operations
+    if let Some(set_op) = &stmt.set_operation {
+        extract_table_names_recursive_from_select(&set_op.right, tables);
+    }
+}
+
 /// Check if a SELECT statement references columns from outer schema
 fn is_select_stmt_correlated_impl(
     stmt: &SelectStmt,
@@ -128,9 +140,14 @@ fn is_select_stmt_correlated_impl(
     }
 
     // Check set operations (UNION, INTERSECT, EXCEPT)
+    // FIX for issue #4749: Collect tables from all branches of the set operation
+    // Each branch has its own FROM clause, so we need to include those tables
+    // when checking for correlation to distinguish inner vs outer columns.
     if let Some(set_op) = &stmt.set_operation {
-        // Set operations combine results, but both sides should use same subquery tables
-        if is_select_stmt_correlated_impl(&set_op.right, outer_schema, subquery_tables) {
+        // Collect tables from the set operation's right side
+        let mut all_subquery_tables = subquery_tables.to_vec();
+        extract_table_names_recursive_from_select(&set_op.right, &mut all_subquery_tables);
+        if is_select_stmt_correlated_impl(&set_op.right, outer_schema, &all_subquery_tables) {
             return true;
         }
     }

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
@@ -125,6 +125,31 @@ fn collect_correlation_refs(
             collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
         }
     }
+
+    // FIX for issue #4749: Also check set operations (INTERSECT, UNION, EXCEPT)
+    // When a subquery contains a set operation, the right side may reference
+    // outer columns that need to be included in correlation detection.
+    // For example: SELECT 123 INTERSECT SELECT c2 FROM t4
+    // where c2 references an outer table t2, not t4.
+    if let Some(set_op) = &subquery.set_operation {
+        // Collect tables from the set operation's right side to know what's "inner"
+        let mut all_subquery_tables = subquery_tables.to_vec();
+        extract_table_names_recursive_from_select(&set_op.right, &mut all_subquery_tables);
+
+        // Recursively collect correlation refs from the right side of the set operation
+        collect_correlation_refs(&set_op.right, outer_schema, &all_subquery_tables, refs);
+    }
+}
+
+/// Helper to extract table names from a SelectStmt's FROM clause
+fn extract_table_names_recursive_from_select(stmt: &vibesql_ast::SelectStmt, tables: &mut Vec<String>) {
+    if let Some(from_clause) = &stmt.from {
+        extract_table_names_recursive(from_clause, tables);
+    }
+    // Recursively handle chained set operations
+    if let Some(set_op) = &stmt.set_operation {
+        extract_table_names_recursive_from_select(&set_op.right, tables);
+    }
 }
 
 /// Collect correlation column references from an expression


### PR DESCRIPTION
## Summary

Fix correlated subquery column resolution inside set operations (INTERSECT, UNION, EXCEPT).

- Add set_operation traversal in correlation detection to properly identify outer-scope column references
- Enables correct caching for correlated subqueries containing compound SELECTs
- Fixes selectA-7.2 and selectA-7.3 from SQLite's TCL test suite

## Root Cause

When a scalar subquery contained a set operation like `SELECT 123 INTERSECT SELECT c2 FROM t4`, and `c2` referenced an outer table (not t4), the correlation detection did not traverse into the set operation's right side. This caused:

1. The correlation column `c2` was not detected
2. The cache key didn't include `c2`'s value
3. The first result was incorrectly reused for all outer rows

## Changes

- `crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs`:
  - Add set_operation traversal in `collect_correlation_refs()`
  - Add helper `extract_table_names_recursive_from_select()`

- `crates/vibesql-executor/src/correlation.rs`:
  - Update `is_select_stmt_correlated_impl()` to include set operation tables
  - Add helper `extract_table_names_recursive_from_select()`

## Test Plan

- [x] selectA-7.2 passes (was failing with 0 rows, now returns `123 123`)
- [x] selectA-7.3 passes
- [x] All 227 selectA.test cases pass
- [x] All cargo tests pass
- [x] UNION, INTERSECT, EXCEPT with outer references work correctly

Closes #4749

🤖 Generated with [Claude Code](https://claude.com/claude-code)