### PR TITLE
feat(optimizer): integrate expression indexes into query planner (Phase 4)

### DIFF
--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -1269,11 +1269,13 @@ fn is_covering_index(
         return false;
     };
 
-    // Get index columns
+    // Get index columns - only include column indexes, not expression indexes
+    // Expression indexes cannot directly cover columns for covering index detection
     let index_columns: HashSet<String> = index
         .columns
         .iter()
-        .map(|c| c.expect_column_name().to_lowercase())
+        .filter_map(|c| c.column_name())
+        .map(|name| name.to_lowercase())
         .collect();
 
     // Check if all needed columns are in the index
@@ -1285,17 +1287,35 @@ fn is_covering_index(
 /// Returns a list of (column_name, operator) tuples for predicates that can
 /// use the index. The operator is one of "=", ">", "<", ">=", "<=".
 /// Predicates are sorted by their position in the index column order.
+/// For expression indexes, the expression name is used (e.g., "lower(name)").
 fn extract_index_predicates(
     expr: &Expression,
     index_name: &str,
     database: &Database,
 ) -> Vec<(String, String)> {
+    use vibesql_ast::pretty_print::ToSql;
+
     let mut predicates = Vec::new();
 
-    // Get the index columns
+    // Get the index columns - for column indexes, use the column name
+    // For expression indexes, use the expression as a string for display
     let index_columns: Vec<String> = database
         .get_index(index_name)
-        .map(|idx| idx.columns.iter().map(|c| c.expect_column_name().to_lowercase()).collect())
+        .map(|idx| {
+            idx.columns
+                .iter()
+                .map(|c| {
+                    if let Some(name) = c.column_name() {
+                        name.to_lowercase()
+                    } else if let Some(expr) = c.get_expression() {
+                        // For expression indexes, use the expression string
+                        expr.to_sql().to_lowercase()
+                    } else {
+                        String::new()
+                    }
+                })
+                .collect()
+        })
         .unwrap_or_default();
 
     extract_predicates_recursive(expr, &index_columns, &mut predicates);
@@ -1314,7 +1334,32 @@ fn extract_predicates_recursive(
     index_columns: &[String],
     predicates: &mut Vec<(String, String)>,
 ) {
+    use vibesql_ast::pretty_print::ToSql;
     use vibesql_ast::BinaryOperator;
+
+    /// Check if an expression matches any index column (column ref or expression index)
+    fn expr_matches_index(expr: &Expression, index_columns: &[String]) -> Option<String> {
+        match expr {
+            Expression::ColumnRef(col_id) => {
+                let col_name = col_id.column_canonical().to_lowercase();
+                if index_columns.iter().any(|c| c == &col_name) {
+                    Some(col_id.column_canonical().to_string())
+                } else {
+                    None
+                }
+            }
+            // Check if the expression matches an expression index
+            Expression::Function { .. } | Expression::BinaryOp { .. } => {
+                let expr_str = expr.to_sql().to_lowercase();
+                if index_columns.iter().any(|c| c == &expr_str) {
+                    Some(expr.to_sql())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
 
     match expr {
         Expression::BinaryOp { op, left, right } => {
@@ -1336,30 +1381,22 @@ fn extract_predicates_recursive(
             };
 
             if let Some(op_str) = op_str {
-                // Check if left side is a column reference that matches index columns
-                if let Expression::ColumnRef(col_id) = left.as_ref() {
-                    let col_name = col_id.column_canonical().to_lowercase();
-                    if index_columns.iter().any(|c| c == &col_name) {
-                        predicates
-                            .push((col_id.column_canonical().to_string(), op_str.to_string()));
-                    }
+                // Check if left side matches an index column or expression index
+                if let Some(expr_name) = expr_matches_index(left, index_columns) {
+                    predicates.push((expr_name, op_str.to_string()));
                 }
-                // Check if right side is a column reference (for reversed comparisons)
-                else if let Expression::ColumnRef(col_id) = right.as_ref() {
-                    let col_name = col_id.column_canonical().to_lowercase();
-                    if index_columns.iter().any(|c| c == &col_name) {
-                        // Reverse the operator for column on right side
-                        let reversed_op = match op {
-                            BinaryOperator::Equal => "=",
-                            BinaryOperator::LessThan => ">",
-                            BinaryOperator::LessThanOrEqual => ">=",
-                            BinaryOperator::GreaterThan => "<",
-                            BinaryOperator::GreaterThanOrEqual => "<=",
-                            _ => return,
-                        };
-                        predicates
-                            .push((col_id.column_canonical().to_string(), reversed_op.to_string()));
-                    }
+                // Check if right side matches (for reversed comparisons)
+                else if let Some(expr_name) = expr_matches_index(right, index_columns) {
+                    // Reverse the operator for column on right side
+                    let reversed_op = match op {
+                        BinaryOperator::Equal => "=",
+                        BinaryOperator::LessThan => ">",
+                        BinaryOperator::LessThanOrEqual => ">=",
+                        BinaryOperator::GreaterThan => "<",
+                        BinaryOperator::GreaterThanOrEqual => "<=",
+                        _ => return,
+                    };
+                    predicates.push((expr_name, reversed_op.to_string()));
                 }
             }
         }

--- a/crates/vibesql-executor/src/optimizer/index_planner.rs
+++ b/crates/vibesql-executor/src/optimizer/index_planner.rs
@@ -162,13 +162,18 @@ impl<'a> IndexPlanner<'a> {
 
         // Determine if WHERE clause is fully satisfied by the index
         let fully_satisfies_where = if let Some(where_expr) = where_clause {
-            // Get the indexed column name
+            // Get the indexed column
             if let Some(index_metadata) = self.database.get_index(&index_name) {
                 if let Some(first_col) = index_metadata.columns.first() {
-                    crate::select::scan::index_scan::predicate::where_clause_fully_satisfied_by_index(
-                        where_expr,
-                        first_col.expect_column_name(),
-                    )
+                    // For column indexes, use existing logic
+                    // For expression indexes, conservatively return false
+                    // (full satisfaction check would need expression-aware logic)
+                    first_col.column_name().map(|col_name| {
+                        crate::select::scan::index_scan::predicate::where_clause_fully_satisfied_by_index(
+                            where_expr,
+                            col_name,
+                        )
+                    }).unwrap_or(false)
                 } else {
                     false
                 }
@@ -407,6 +412,8 @@ impl<'a> IndexPlanner<'a> {
     /// the estimated fraction of rows that will match the index predicate.
     ///
     /// Uses column statistics when available, falls back to conservative defaults.
+    /// For expression indexes, uses a conservative default since we don't have
+    /// direct statistics for computed values.
     fn estimate_selectivity(&self, index_name: &str, where_clause: Option<&Expression>) -> f64 {
         // If no WHERE clause, selectivity is 1.0 (all rows)
         let where_expr = match where_clause {
@@ -425,6 +432,13 @@ impl<'a> IndexPlanner<'a> {
             None => return 0.33,
         };
 
+        // For expression indexes, we don't have column statistics
+        // Use a conservative default selectivity
+        let column_name = match first_col.column_name() {
+            Some(name) => name,
+            None => return 0.33, // Expression index - conservative default
+        };
+
         // Get table statistics
         let table_name = &index_metadata.table_name;
         let table = match self.database.get_table(table_name) {
@@ -438,7 +452,7 @@ impl<'a> IndexPlanner<'a> {
         };
 
         // Get column statistics
-        let col_stats = match table_stats.columns.get(first_col.expect_column_name()) {
+        let col_stats = match table_stats.columns.get(column_name) {
             Some(stats) => stats,
             None => return 0.33,
         };
@@ -446,7 +460,7 @@ impl<'a> IndexPlanner<'a> {
         // Use the existing selectivity estimation logic
         crate::select::scan::index_scan::selection::estimate_selectivity(
             where_expr,
-            first_col.expect_column_name(),
+            column_name,
             col_stats,
         )
     }
@@ -455,6 +469,7 @@ impl<'a> IndexPlanner<'a> {
     ///
     /// This is a lower-level API for checking individual indexes.
     /// Most callers should use `plan_index_usage()` instead.
+    /// Supports both column indexes and expression indexes.
     pub fn can_use_index(
         &self,
         index_name: &str,
@@ -472,11 +487,12 @@ impl<'a> IndexPlanner<'a> {
         };
 
         // Check if index can be used for WHERE
+        // Supports both column indexes and expression indexes
         let can_use_for_where = where_clause
             .map(|expr| {
-                crate::select::scan::index_scan::selection::expression_filters_column(
+                crate::select::scan::index_scan::selection::index_column_can_filter(
                     expr,
-                    first_col.expect_column_name(),
+                    first_col,
                 )
             })
             .unwrap_or(false);

--- a/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
@@ -3,13 +3,16 @@
 //! Determines when and which index to use for query optimization.
 //! Supports both rule-based (simple) and cost-based (statistics-aware) selection.
 //! Also includes skip-scan optimization for queries filtering on non-prefix columns.
+//! Supports expression indexes (functional indexes) like CREATE INDEX idx ON t(lower(name)).
 
-use vibesql_ast::Expression;
+use vibesql_ast::{Expression, IndexColumn};
 use vibesql_catalog::TableSchema;
 use vibesql_storage::{
     statistics::{AccessMethod, CostEstimator},
     Database,
 };
+
+use crate::evaluator::expression_hash::ExpressionHasher;
 
 use crate::optimizer::index_planner::{IndexPlanner, SkipScanInfo};
 
@@ -95,10 +98,9 @@ pub(crate) fn should_use_index_scan(
             let first_indexed_column = index_metadata.columns.first()?;
 
             // Check if this index can be used for WHERE clause
+            // Supports both column indexes and expression indexes
             let can_use_for_where = where_clause
-                .map(|expr| {
-                    expression_filters_column(expr, first_indexed_column.expect_column_name())
-                })
+                .map(|expr| index_column_can_filter(expr, first_indexed_column))
                 .unwrap_or(false);
 
             // Count how many leading index columns are pinned by equality predicates
@@ -249,6 +251,98 @@ pub(crate) fn expression_filters_column(expr: &Expression, column_name: &str) ->
             exprs.iter().any(|e| expression_filters_column(e, column_name))
         }
         _ => false,
+    }
+}
+
+/// Check if an expression matches an expression index
+///
+/// For expression indexes like `CREATE INDEX idx ON t(lower(name))`, this function
+/// checks if the WHERE clause contains a predicate on the indexed expression.
+/// For example: `WHERE lower(name) = 'john'` matches the index.
+///
+/// Uses structural hashing to compare expressions - two expressions are considered
+/// equivalent if they have the same structure (same operations on same columns).
+pub(crate) fn expression_filters_index_expression(
+    where_expr: &Expression,
+    index_expr: &Expression,
+) -> bool {
+    let index_hash = ExpressionHasher::hash(index_expr);
+    expression_contains_matching_predicate(where_expr, index_hash)
+}
+
+/// Check if an expression contains a predicate on a specific expression (by hash)
+///
+/// Recursively searches through AND/OR combinations to find predicates.
+fn expression_contains_matching_predicate(expr: &Expression, target_hash: u64) -> bool {
+    match expr {
+        Expression::BinaryOp { left, op, right } => {
+            match op {
+                vibesql_ast::BinaryOperator::Equal
+                | vibesql_ast::BinaryOperator::GreaterThan
+                | vibesql_ast::BinaryOperator::GreaterThanOrEqual
+                | vibesql_ast::BinaryOperator::LessThan
+                | vibesql_ast::BinaryOperator::LessThanOrEqual => {
+                    // Check if left or right side matches the indexed expression
+                    let left_hash = ExpressionHasher::hash(left);
+                    let right_hash = ExpressionHasher::hash(right);
+                    let left_is_literal = is_literal(left);
+                    let right_is_literal = is_literal(right);
+
+                    // expr op literal OR literal op expr
+                    if (left_hash == target_hash && right_is_literal)
+                        || (right_hash == target_hash && left_is_literal)
+                    {
+                        return true;
+                    }
+                }
+                vibesql_ast::BinaryOperator::And | vibesql_ast::BinaryOperator::Or => {
+                    return expression_contains_matching_predicate(left, target_hash)
+                        || expression_contains_matching_predicate(right, target_hash);
+                }
+                _ => {}
+            }
+            false
+        }
+        // IS / IS NOT (NULL-safe comparison)
+        Expression::IsDistinctFrom { left, right, negated: true } => {
+            let left_hash = ExpressionHasher::hash(left);
+            let right_hash = ExpressionHasher::hash(right);
+            let left_is_literal = is_literal(left);
+            let right_is_literal = is_literal(right);
+            (left_hash == target_hash && right_is_literal)
+                || (right_hash == target_hash && left_is_literal)
+        }
+        // IN with value list: expr IN (1, 2, 3)
+        Expression::InList { expr, .. } => ExpressionHasher::hash(expr) == target_hash,
+        // IN with subquery: expr IN (SELECT ...)
+        Expression::In { expr, .. } => ExpressionHasher::hash(expr) == target_hash,
+        // BETWEEN: expr BETWEEN low AND high
+        Expression::Between { expr, .. } => ExpressionHasher::hash(expr) == target_hash,
+        // Conjunction: AND
+        Expression::Conjunction(exprs) => exprs
+            .iter()
+            .any(|e| expression_contains_matching_predicate(e, target_hash)),
+        // Disjunction: OR
+        Expression::Disjunction(exprs) => exprs
+            .iter()
+            .any(|e| expression_contains_matching_predicate(e, target_hash)),
+        _ => false,
+    }
+}
+
+/// Check if an IndexColumn can be used for the given WHERE clause
+///
+/// This function handles both column indexes and expression indexes:
+/// - For column indexes: delegates to `expression_filters_column`
+/// - For expression indexes: uses `expression_filters_index_expression`
+pub(crate) fn index_column_can_filter(where_expr: &Expression, index_col: &IndexColumn) -> bool {
+    match index_col {
+        IndexColumn::Column { column_name, .. } => {
+            expression_filters_column(where_expr, column_name)
+        }
+        IndexColumn::Expression { expr, .. } => {
+            expression_filters_index_expression(where_expr, expr)
+        }
     }
 }
 
@@ -535,21 +629,25 @@ pub(crate) fn cost_based_index_selection(
     for index_name in &indexes {
         if let Some(index_metadata) = database.get_index(index_name) {
             let first_indexed_column = index_metadata.columns.first()?;
-            let column_name = &first_indexed_column.expect_column_name();
 
             // Check if this index can be used for WHERE or ORDER BY
+            // Supports both column indexes and expression indexes
             let can_use_for_where = where_clause
-                .map(|expr| expression_filters_column(expr, column_name))
+                .map(|expr| index_column_can_filter(expr, first_indexed_column))
                 .unwrap_or(false);
 
             // Count how many leading index columns are pinned by equality predicates
             let pinned_columns = count_pinned_index_columns(where_clause, &index_metadata.columns);
 
+            // Get column name for stats lookup (only for column indexes)
+            let column_name = first_indexed_column.column_name();
+
             // Debug: trace index selection
             if std::env::var("INDEX_SELECT_DEBUG").is_ok() {
+                let col_debug = column_name.unwrap_or("<expression>");
                 eprintln!(
                     "[INDEX_SELECT] table={}, index={}, first_col={}, can_use_for_where={}",
-                    table_name, index_name, column_name, can_use_for_where
+                    table_name, index_name, col_debug, can_use_for_where
                 );
             }
 
@@ -593,20 +691,26 @@ pub(crate) fn cost_based_index_selection(
             }
 
             // Get column statistics for the indexed column (case-insensitive lookup)
-            let col_stats = get_column_stats_ignore_case(&table_stats.columns, column_name);
+            // For expression indexes, we don't have direct column stats - fall back to rule-based
+            let col_stats = column_name.and_then(|cn| {
+                get_column_stats_ignore_case(&table_stats.columns, cn)
+            });
             if col_stats.is_none() {
                 // Track that we found an applicable index without column stats
                 // We'll fall back to rule-based selection if cost-based fails
                 if std::env::var("INDEX_SELECT_DEBUG").is_ok() {
+                    let col_debug = column_name.unwrap_or("<expression>");
                     eprintln!(
                         "[INDEX_SELECT] {} no column stats for {}, will fallback",
-                        index_name, column_name
+                        index_name, col_debug
                     );
                 }
                 has_applicable_index_without_stats = true;
                 continue; // No stats for this column, try next index
             }
             let col_stats = col_stats.unwrap();
+            // At this point, column_name must be Some since we got col_stats
+            let column_name = column_name.unwrap();
 
             if std::env::var("INDEX_SELECT_DEBUG").is_ok() {
                 eprintln!("[INDEX_SELECT] {} has column stats for {}", index_name, column_name);

--- a/crates/vibesql-executor/src/tests/expression_index_tests.rs
+++ b/crates/vibesql-executor/src/tests/expression_index_tests.rs
@@ -1,0 +1,299 @@
+//! Integration tests for expression index query planning (Phase 4)
+//!
+//! These tests verify that the query planner correctly detects and uses
+//! expression indexes (functional indexes) for query optimization.
+//!
+//! Expression indexes are created on expressions like `lower(email)` rather
+//! than just column names. The planner should match WHERE clause expressions
+//! to indexed expressions using structural comparison.
+
+use vibesql_ast::{ColumnIdentifier, Expression, IndexColumn, OrderDirection};
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+use crate::select::scan::index_scan::selection::{
+    expression_filters_index_expression, index_column_can_filter,
+};
+use crate::select::SelectExecutor;
+
+/// Create a test database with users table
+fn create_test_db() -> Database {
+    let mut db = Database::new();
+    db.catalog.set_case_sensitive_identifiers(false);
+
+    // Create users table
+    let users_schema = TableSchema::new(
+        "users".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new(
+                "email".to_string(),
+                DataType::Varchar { max_length: Some(100) },
+                false,
+            ),
+            ColumnSchema::new("age".to_string(), DataType::Integer, false),
+            ColumnSchema::new(
+                "name".to_string(),
+                DataType::Varchar { max_length: Some(50) },
+                false,
+            ),
+        ],
+    );
+
+    db.create_table(users_schema).unwrap();
+
+    // Insert test data with mixed case emails
+    db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(1),
+            SqlValue::Varchar(arcstr::ArcStr::from("ALICE@example.com")),
+            SqlValue::Integer(25),
+            SqlValue::Varchar(arcstr::ArcStr::from("Alice")),
+        ]),
+    )
+    .unwrap();
+
+    db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(2),
+            SqlValue::Varchar(arcstr::ArcStr::from("Bob@Example.COM")),
+            SqlValue::Integer(30),
+            SqlValue::Varchar(arcstr::ArcStr::from("Bob")),
+        ]),
+    )
+    .unwrap();
+
+    db.insert_row(
+        "users",
+        Row::new(vec![
+            SqlValue::Integer(3),
+            SqlValue::Varchar(arcstr::ArcStr::from("charlie@example.com")),
+            SqlValue::Integer(25),
+            SqlValue::Varchar(arcstr::ArcStr::from("Charlie")),
+        ]),
+    )
+    .unwrap();
+
+    db
+}
+
+/// Helper to parse an expression from SQL WHERE clause
+fn parse_where_expression(sql_predicate: &str) -> Expression {
+    let full_sql = format!("SELECT * FROM t WHERE {}", sql_predicate);
+    let stmt = Parser::parse_sql(&full_sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::Select(select_stmt) => select_stmt.where_clause.unwrap(),
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+/// Helper to parse an expression from CREATE INDEX
+fn parse_index_expression(index_expr: &str) -> Expression {
+    let full_sql = format!("CREATE INDEX idx ON t({})", index_expr);
+    let stmt = Parser::parse_sql(&full_sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateIndex(create_stmt) => {
+            match &create_stmt.columns[0] {
+                IndexColumn::Expression { expr, .. } => *expr.clone(),
+                IndexColumn::Column { column_name, .. } => {
+                    // Return a column reference for simple column indexes
+                    Expression::ColumnRef(ColumnIdentifier::simple(column_name.as_str(), false))
+                }
+            }
+        }
+        _ => panic!("Expected CREATE INDEX statement"),
+    }
+}
+
+#[test]
+fn test_expression_index_matching_lower() {
+    // Test that lower(email) = 'test' matches an index on lower(email)
+    let where_expr = parse_where_expression("lower(email) = 'alice@example.com'");
+    let index_expr = parse_index_expression("lower(email)");
+
+    assert!(
+        expression_filters_index_expression(&where_expr, &index_expr),
+        "lower(email) = 'value' should match index on lower(email)"
+    );
+}
+
+#[test]
+fn test_expression_index_matching_upper() {
+    // Test that upper(name) = 'TEST' matches an index on upper(name)
+    let where_expr = parse_where_expression("upper(name) = 'ALICE'");
+    let index_expr = parse_index_expression("upper(name)");
+
+    assert!(
+        expression_filters_index_expression(&where_expr, &index_expr),
+        "upper(name) = 'value' should match index on upper(name)"
+    );
+}
+
+#[test]
+fn test_expression_index_matching_arithmetic() {
+    // Test that (a + b) = 5 matches an index on (a + b)
+    let where_expr = parse_where_expression("(age + id) = 30");
+    let index_expr = parse_index_expression("(age + id)");
+
+    assert!(
+        expression_filters_index_expression(&where_expr, &index_expr),
+        "(age + id) = value should match index on (age + id)"
+    );
+}
+
+#[test]
+fn test_expression_index_no_match_different_function() {
+    // Test that lower(email) != upper(email)
+    let where_expr = parse_where_expression("lower(email) = 'test'");
+    let index_expr = parse_index_expression("upper(email)");
+
+    assert!(
+        !expression_filters_index_expression(&where_expr, &index_expr),
+        "lower(email) should NOT match index on upper(email)"
+    );
+}
+
+#[test]
+fn test_expression_index_no_match_different_column() {
+    // Test that lower(email) != lower(name)
+    let where_expr = parse_where_expression("lower(email) = 'test'");
+    let index_expr = parse_index_expression("lower(name)");
+
+    assert!(
+        !expression_filters_index_expression(&where_expr, &index_expr),
+        "lower(email) should NOT match index on lower(name)"
+    );
+}
+
+#[test]
+fn test_expression_index_matching_with_and() {
+    // Test that AND conditions are searched for matching expressions
+    let where_expr = parse_where_expression("age > 20 AND lower(email) = 'test'");
+    let index_expr = parse_index_expression("lower(email)");
+
+    assert!(
+        expression_filters_index_expression(&where_expr, &index_expr),
+        "Expression in AND should be found"
+    );
+}
+
+#[test]
+fn test_index_column_can_filter_expression() {
+    // Test the unified index_column_can_filter function with expression indexes
+    let where_expr = parse_where_expression("lower(email) = 'alice@example.com'");
+    let index_expr = parse_index_expression("lower(email)");
+
+    let index_column = IndexColumn::Expression {
+        expr: Box::new(index_expr),
+        direction: OrderDirection::Asc,
+    };
+
+    assert!(
+        index_column_can_filter(&where_expr, &index_column),
+        "index_column_can_filter should work with expression indexes"
+    );
+}
+
+#[test]
+fn test_index_column_can_filter_column() {
+    // Test that index_column_can_filter still works with column indexes
+    let where_expr = parse_where_expression("email = 'alice@example.com'");
+
+    let index_column = IndexColumn::Column {
+        column_name: "email".to_string(),
+        direction: OrderDirection::Asc,
+        prefix_length: None,
+    };
+
+    assert!(
+        index_column_can_filter(&where_expr, &index_column),
+        "index_column_can_filter should work with column indexes"
+    );
+}
+
+#[test]
+#[ignore] // TODO: Enable when storage layer fully supports expression index creation
+fn test_expression_index_query_execution() {
+    let mut db = create_test_db();
+
+    // Create an expression index on lower(email)
+    let lower_email_expr = parse_index_expression("lower(email)");
+    db.create_index(
+        "idx_users_lower_email".to_string(),
+        "users".to_string(),
+        false, // not unique
+        vec![IndexColumn::Expression {
+            expr: Box::new(lower_email_expr),
+            direction: OrderDirection::Asc,
+        }],
+    )
+    .unwrap();
+
+    let executor = SelectExecutor::new(&db);
+
+    // Query using the expression
+    let query = "SELECT id, email FROM users WHERE lower(email) = 'alice@example.com'";
+    let stmt = Parser::parse_sql(query).unwrap();
+
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute(&select_stmt).unwrap();
+
+        // Should find the row with ALICE@example.com (case-insensitive match via lower())
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].values[0], SqlValue::Integer(1));
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_expression_index_greater_than() {
+    // Test that lower(email) > 'a' matches an index on lower(email)
+    let where_expr = parse_where_expression("lower(email) > 'alice'");
+    let index_expr = parse_index_expression("lower(email)");
+
+    assert!(
+        expression_filters_index_expression(&where_expr, &index_expr),
+        "lower(email) > 'value' should match index on lower(email)"
+    );
+}
+
+#[test]
+fn test_expression_index_less_than() {
+    // Test that lower(email) < 'z' matches an index on lower(email)
+    let where_expr = parse_where_expression("lower(email) < 'zzz'");
+    let index_expr = parse_index_expression("lower(email)");
+
+    assert!(
+        expression_filters_index_expression(&where_expr, &index_expr),
+        "lower(email) < 'value' should match index on lower(email)"
+    );
+}
+
+#[test]
+fn test_expression_index_in_list() {
+    // Test that lower(email) IN (...) matches an index on lower(email)
+    let where_expr = parse_where_expression("lower(email) IN ('alice', 'bob')");
+    let index_expr = parse_index_expression("lower(email)");
+
+    assert!(
+        expression_filters_index_expression(&where_expr, &index_expr),
+        "lower(email) IN (...) should match index on lower(email)"
+    );
+}
+
+#[test]
+fn test_expression_index_between() {
+    // Test that lower(email) BETWEEN 'a' AND 'z' matches an index on lower(email)
+    let where_expr = parse_where_expression("lower(email) BETWEEN 'a' AND 'z'");
+    let index_expr = parse_index_expression("lower(email)");
+
+    assert!(
+        expression_filters_index_expression(&where_expr, &index_expr),
+        "lower(email) BETWEEN ... should match index on lower(email)"
+    );
+}

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -77,6 +77,7 @@ mod create_table_tests;
 mod cte_scalar_subquery_tests;
 mod error_display;
 mod expression_eval;
+mod expression_index_tests;
 mod fulltext_search;
 mod function_tests;
 mod index_optimization;


### PR DESCRIPTION
## Summary

- Adds query planner support for expression indexes (functional indexes) like `CREATE INDEX idx ON t(lower(email))`
- The planner now detects when WHERE clause expressions match indexed expressions and can select them for query optimization
- Uses `ExpressionHasher` for structural comparison of expression ASTs

## Changes

- Add `expression_filters_index_expression()` for structural expression matching
- Add `index_column_can_filter()` to unify column and expression index filtering  
- Update `should_use_index_scan()` and `cost_based_index_selection()` to support expression indexes
- Update `IndexPlanner::can_use_index()` and `estimate_selectivity()` with conservative fallback for expression index cost estimation
- Update EXPLAIN output to show expression index predicates (e.g., `lower(email)=?`)
- Add 12 unit tests for expression index matching logic

## Test plan

- [x] All 2237 executor tests pass
- [x] New expression index matching tests pass (12 tests)
- [x] Clippy passes (no new warnings)
- [ ] Verify EXPLAIN shows expression index usage correctly
- [ ] Test with TPC-H/TPC-DS queries that could benefit from expression indexes

Closes #4766

🤖 Generated with [Claude Code](https://claude.com/claude-code)