### PR TITLE
fix(tcl): Enable expression index tests by fixing persistence

### DIFF
--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -144,7 +144,7 @@ impl ToSql for SqlValue {
                 }
             }
             SqlValue::Real(r) => {
-                let f64_val = *r as f64;
+                let f64_val = *r;
                 if f64_val.is_nan() || f64_val.is_infinite() {
                     "NULL".to_string()
                 } else if f64_val.fract() == 0.0 {

--- a/crates/vibesql-storage/Cargo.toml
+++ b/crates/vibesql-storage/Cargo.toml
@@ -31,6 +31,7 @@ storage-all = ["storage-fs", "storage-s3", "storage-gcs", "storage-azure", "stor
 vibesql-types = { version = "0.1.3", path = "../vibesql-types" }
 vibesql-catalog = { version = "0.1.3", path = "../vibesql-catalog" }
 vibesql-ast = { version = "0.1.3", path = "../vibesql-ast" }
+vibesql-parser = { version = "0.1.3", path = "../vibesql-parser" }
 vibesql-l10n = { version = "0.1.3", path = "../vibesql-l10n" }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -74,7 +75,6 @@ web-sys = { version = "0.3", features = [
 ] }
 
 [dev-dependencies]
-vibesql-parser = { version = "0.1.3", path = "../vibesql-parser" }
 tempfile = "3.8"
 criterion = { version = "0.8", features = ["html_reports"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -113,9 +113,26 @@ pub fn write_catalog<W: Write>(writer: &mut W, db: &Database) -> Result<(), Stor
             write_bool(writer, metadata.unique)?;
 
             // Write indexed columns
+            // Format (v6+): type_byte, content_string, direction_byte
+            // type_byte: 0 = column reference, 1 = expression
             write_u32(writer, metadata.columns.len() as u32)?;
             for col in &metadata.columns {
-                write_string(writer, col.expect_column_name())?;
+                use vibesql_ast::IndexColumn;
+                match col {
+                    IndexColumn::Column { column_name, .. } => {
+                        // Type 0 = column reference
+                        writer.write_all(&[0u8])
+                            .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+                        write_string(writer, column_name)?;
+                    }
+                    IndexColumn::Expression { expr, .. } => {
+                        // Type 1 = expression (stored as SQL text)
+                        writer.write_all(&[1u8])
+                            .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+                        use vibesql_ast::pretty_print::ToSql;
+                        write_string(writer, &expr.to_sql())?;
+                    }
+                }
                 // Write direction as u8 (0 = Asc, 1 = Desc)
                 let direction = match col.direction() {
                     vibesql_ast::OrderDirection::Asc => 0u8,
@@ -379,24 +396,73 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
         let mut columns = Vec::new();
 
         for _ in 0..column_count {
-            let column_name = read_string(reader)?;
-            let direction_byte = read_u8(reader)?;
-            let direction = match direction_byte {
-                0 => vibesql_ast::OrderDirection::Asc,
-                1 => vibesql_ast::OrderDirection::Desc,
-                _ => {
-                    return Err(StorageError::NotImplemented(format!(
-                        "Invalid sort direction: {}",
-                        direction_byte
-                    )))
+            // Version 6+ stores index column type (0 = column, 1 = expression)
+            // Version 1-5 stored only column names (no type byte)
+            let index_column = if version >= 6 {
+                let type_byte = read_u8(reader)?;
+                let content = read_string(reader)?;
+                let direction_byte = read_u8(reader)?;
+                let direction = match direction_byte {
+                    0 => vibesql_ast::OrderDirection::Asc,
+                    1 => vibesql_ast::OrderDirection::Desc,
+                    _ => {
+                        return Err(StorageError::NotImplemented(format!(
+                            "Invalid sort direction: {}",
+                            direction_byte
+                        )))
+                    }
+                };
+
+                match type_byte {
+                    0 => {
+                        // Column reference
+                        vibesql_ast::IndexColumn::Column {
+                            column_name: content,
+                            direction,
+                            prefix_length: None,
+                        }
+                    }
+                    1 => {
+                        // Expression index - parse the SQL expression
+                        let expr = vibesql_parser::arena_parser::parse_expression_to_owned(&content)
+                            .map_err(|e| StorageError::NotImplemented(format!(
+                                "Failed to parse expression index '{}': {}",
+                                content, e
+                            )))?;
+                        vibesql_ast::IndexColumn::Expression {
+                            expr: Box::new(expr),
+                            direction,
+                        }
+                    }
+                    _ => {
+                        return Err(StorageError::NotImplemented(format!(
+                            "Invalid index column type: {}",
+                            type_byte
+                        )))
+                    }
+                }
+            } else {
+                // Legacy format (v1-5): just column name + direction
+                let column_name = read_string(reader)?;
+                let direction_byte = read_u8(reader)?;
+                let direction = match direction_byte {
+                    0 => vibesql_ast::OrderDirection::Asc,
+                    1 => vibesql_ast::OrderDirection::Desc,
+                    _ => {
+                        return Err(StorageError::NotImplemented(format!(
+                            "Invalid sort direction: {}",
+                            direction_byte
+                        )))
+                    }
+                };
+                vibesql_ast::IndexColumn::Column {
+                    column_name,
+                    direction,
+                    prefix_length: None,
                 }
             };
 
-            columns.push(vibesql_ast::IndexColumn::Column {
-                column_name,
-                direction,
-                prefix_length: None,
-            });
+            columns.push(index_column);
         }
 
         index_specs.push((index_name, table_name, unique, columns));

--- a/crates/vibesql-storage/src/persistence/binary/format.rs
+++ b/crates/vibesql-storage/src/persistence/binary/format.rs
@@ -18,7 +18,8 @@ pub const MAGIC: &[u8; 5] = b"VBSQL";
 /// - v3: Added primary key and unique constraints persistence
 /// - v4: Added quoted flag for TableIdentifier (SQL:1999 case-sensitivity)
 /// - v5: Added column-level collation persistence
-pub const VERSION: u8 = 5;
+/// - v6: Added expression index support (type_byte before each index column)
+pub const VERSION: u8 = 6;
 
 /// Type tags for binary serialization
 #[repr(u8)]

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -304,8 +304,19 @@ impl Database {
                     write!(writer, ", ")
                         .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
                 }
-                write!(writer, "{}", col.expect_column_name())
-                    .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+                // Handle both column references and expression indexes
+                use vibesql_ast::IndexColumn;
+                match col {
+                    IndexColumn::Column { column_name, .. } => {
+                        write!(writer, "{}", column_name)
+                            .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+                    }
+                    IndexColumn::Expression { expr, .. } => {
+                        use vibesql_ast::pretty_print::ToSql;
+                        write!(writer, "{}", expr.to_sql())
+                            .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+                    }
+                }
                 write!(writer, " {:?}", col.direction())
                     .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
             }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1936,16 +1936,6 @@ proc uses_sqlite_internals {script} {
         return [list 1 "uses EXPLAIN on DDL (not supported)"]
     }
 
-    # Expression indexes (CREATE INDEX ... ON table(expression)) - not supported
-    # Detect expressions in index definitions: operators or function calls inside
-    if {[regexp -nocase {CREATE\s+(?:UNIQUE\s+)?INDEX\s+\w+\s+ON\s+\w+\s*\([^)]*[-+*/=<>]} $script]} {
-        return [list 1 "uses expression index (not supported)"]
-    }
-    # Also detect function calls in index definitions like abs(b), lower(x)
-    if {[regexp -nocase {CREATE\s+(?:UNIQUE\s+)?INDEX\s+\w+\s+ON\s+\w+\s*\([^)]*\w+\s*\(} $script]} {
-        return [list 1 "uses expression index with function (not supported)"]
-    }
-
     # CREATE/DROP TRIGGER - triggers not fully supported
     if {[regexp -nocase {CREATE\s+TRIGGER\s} $script]} {
         return [list 1 "uses CREATE TRIGGER (not supported)"]


### PR DESCRIPTION
## Summary

Fixes the expression index tests (indexexpr1.test) that were silently failing. The setup test `indexexpr1-100` wasn't appearing in test output because:

1. The TCL test harness was skipping tests with expression indexes
2. The persistence layer panicked when serializing expression indexes

## Changes

- **scripts/tester_vibesql.tcl**: Remove expression index skip logic from `uses_sqlite_internals()`
- **crates/vibesql-storage/src/persistence/save.rs**: Fix SQL dump to properly serialize expression indexes using `to_sql()`
- **crates/vibesql-storage/src/persistence/binary/catalog.rs**: 
  - Add v6 format with type byte for index columns (0=column, 1=expression)
  - Update read_catalog_v to handle both old (v1-5) and new (v6+) formats
- **crates/vibesql-storage/src/persistence/binary/format.rs**: Bump VERSION to 6
- **crates/vibesql-storage/Cargo.toml**: Add vibesql-parser dependency for parsing expression SQL
- **crates/vibesql-ast/src/pretty_print.rs**: Fix unrelated clippy warning (unnecessary f64 cast)

## Test Plan

- [x] `cargo test` - All tests pass
- [x] Manual verification: Expression indexes can be created and used in queries
- [x] TCL tests: indexexpr1.test now has 20 passing tests (up from 0 appearing in output)
- [x] The remaining 86 failures are due to incomplete expression index support in query execution (separate issues)

Closes #4782