### PR TITLE
fix(explain): correct covering index detection for wildcard queries

### DIFF
--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -1031,11 +1031,20 @@ impl ExplainExecutor {
             // A covering index requires:
             // 1. All SELECT columns are in the index
             // 2. All WHERE clause columns are also in the index (or evaluable from index)
-            let mut all_needed_columns = needed_columns.clone();
-            if let Some(where_expr) = where_clause {
-                collect_column_refs(where_expr, &mut all_needed_columns);
-            }
-            let is_covering = is_covering_index(&index_name, &all_needed_columns, database);
+            //
+            // NOTE: If needed_columns is empty, it means SELECT * was used (wildcard),
+            // which requires ALL table columns - this can never be a covering index
+            // unless the index literally contains all columns.
+            let is_covering = if needed_columns.is_empty() {
+                // Wildcard case: need all table columns, cannot be a covering index
+                false
+            } else {
+                let mut all_needed_columns = needed_columns.clone();
+                if let Some(where_expr) = where_clause {
+                    collect_column_refs(where_expr, &mut all_needed_columns);
+                }
+                is_covering_index(&index_name, &all_needed_columns, database)
+            };
 
             // Check if we have any predicates on the index (determines SCAN vs SEARCH)
             let has_index_predicates = if let Some(where_expr) = where_clause {


### PR DESCRIPTION
## Summary

Fixes EXPLAIN QUERY PLAN output format to match SQLite for wildcard queries (`SELECT *`).

### Problem

When using `SELECT *`, VibeSQL was incorrectly labeling indexes as "COVERING INDEX" because the covering index detection only checked WHERE clause columns, ignoring that all table columns are needed for the output.

**Example:**
```sql
CREATE TABLE t1(w, x, y, z);
CREATE INDEX i1w ON t1(w);
EXPLAIN QUERY PLAN SELECT * FROM t1 WHERE w = 5;
```

- **Before (wrong):** `SEARCH t1 USING COVERING INDEX i1w (w=?)`
- **After (correct):** `SEARCH t1 USING INDEX i1w (w=?)`

The index `i1w` only contains column `w`, but `SELECT *` needs all columns (`w, x, y, z`), so it cannot be a covering index.

## Changes

- Modified `explain.rs` to check if `needed_columns` is empty (indicating wildcard) before determining covering index status
- When `needed_columns` is empty, conservatively assume the index is not covering

## Test Plan

- [x] Verified `SELECT *` queries now output `USING INDEX` instead of `USING COVERING INDEX`
- [x] Verified true covering index queries (e.g., `SELECT w FROM t1 WHERE w = 5`) still correctly output `USING COVERING INDEX`
- [x] All 2247 executor tests pass

Closes #4785

🤖 Generated with [Claude Code](https://claude.com/claude-code)