### PR TITLE
fix(tcl): allow PRAGMA integrity_check and other supported PRAGMAs through TCL shim

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1039,9 +1039,9 @@ proc execsql {sql {db ""}} {
     while {1} {
         set sql_upper [string toupper [string trim $sql]]
 
-        # Check for unsupported PRAGMAs (allow full_column_names and short_column_names through)
+        # Check for unsupported PRAGMAs (allow supported PRAGMAs through)
         if {[string match "PRAGMA*" $sql_upper]} {
-            if {[regexp -nocase {^PRAGMA\s+(?:database\.)?(full_column_names|short_column_names)} $sql]} {
+            if {[regexp -nocase {^PRAGMA\s+(?:database\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check)} [string trim $sql]]} {
                 # This PRAGMA is supported - stop stripping
                 break
             } else {


### PR DESCRIPTION
## Summary

The TCL test shim was stripping `PRAGMA integrity_check` statements instead of executing them, causing tests like `delete4-3.4` to fail with empty results.

## Changes

- Fixed regex to use trimmed SQL when checking for supported PRAGMAs (SQL in test files often has leading whitespace)
- Added missing supported PRAGMAs to the allowlist:
  - `integrity_check`
  - `case_sensitive_like`
  - `reverse_unordered_selects`

## Root Cause

Two issues were causing the failure:

1. The `string match "PRAGMA*"` check used trimmed `$sql_upper`, but the regex used untrimmed `$sql`. With leading whitespace (common in TCL test files), the regex failed to match `^PRAGMA`.

2. Only `full_column_names` and `short_column_names` were in the allowlist, even though the CLI executor supports additional PRAGMAs.

## Test Plan

- [x] `delete4-3.4` now passes (was failing with empty result)
- [x] `delete.test` passes (44/44)
- [x] `select1.test` passes (188/188)

Closes #4787

🤖 Generated with [Claude Code](https://claude.com/claude-code)