### PR TITLE
fix(trigger): default to ROW granularity for SQLite compatibility

### DIFF
--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -101,8 +101,9 @@ impl Parser {
                 });
             }
         } else {
-            // Default per SQL:1999
-            vibesql_ast::TriggerGranularity::Statement
+            // Default to ROW for SQLite compatibility
+            // SQLite doesn't support STATEMENT-level triggers - all triggers are FOR EACH ROW
+            vibesql_ast::TriggerGranularity::Row
         };
 
         // Parse optional WHEN condition

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -17,7 +17,7 @@ fn test_create_trigger_before_insert() {
             assert_eq!(trigger.timing, TriggerTiming::Before);
             assert_eq!(trigger.event, TriggerEvent::Insert);
             assert_eq!(trigger.table_name, "my_table");
-            assert_eq!(trigger.granularity, TriggerGranularity::Statement); // Default
+            assert_eq!(trigger.granularity, TriggerGranularity::Row); // Default (SQLite compatible)
         }
         _ => panic!("Expected CreateTrigger statement"),
     }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2143,13 +2143,6 @@ proc uses_sqlite_internals {script} {
         return [list 1 "uses EXPLAIN on DDL (not supported)"]
     }
 
-    # CREATE/DROP TRIGGER - triggers not fully supported
-    if {[regexp -nocase {CREATE\s+TRIGGER\s} $script]} {
-        return [list 1 "uses CREATE TRIGGER (not supported)"]
-    }
-    if {[regexp -nocase {DROP\s+TRIGGER\s} $script]} {
-        return [list 1 "uses DROP TRIGGER (not supported)"]
-    }
 
     # UPDATE/INSERT OR REPLACE/IGNORE/ABORT conflict resolution - not fully supported
     if {[regexp -nocase {(?:UPDATE|INSERT)\s+OR\s+(?:REPLACE|IGNORE|ABORT|ROLLBACK|FAIL)\s} $script]} {


### PR DESCRIPTION
## Summary

- Fix default trigger granularity to match SQLite behavior (ROW, not STATEMENT)
- SQLite doesn't support STATEMENT-level triggers - all triggers are FOR EACH ROW
- Enable self-referential DELETE triggers to work correctly
- Remove trigger skip logic from TCL tester since triggers now work

## Changes

- `crates/vibesql-parser/src/parser/trigger.rs`: Change default granularity from STATEMENT to ROW
- `crates/vibesql-parser/src/tests/trigger.rs`: Update test to expect Row as default
- `scripts/tester_vibesql.tcl`: Remove CREATE/DROP TRIGGER skip logic

## Test Plan

- [x] Parser trigger tests pass (17/17)
- [x] End-to-end trigger test works:
  ```sql
  CREATE TRIGGER t3t BEFORE DELETE ON t3 BEGIN
      DELETE FROM t3 WHERE id=old.id+3;
  END;
  ```
- [x] delete4.test improved: 21 -> 24 passing (tests 7.3.0, 7.3.1, 7.3.3 now pass)

## Known Limitations

Trigger persistence is not addressed in this PR - triggers are not saved to the database file. This is a separate issue.

Closes #4788