### PR TITLE
feat(catalog): Add session-scoped temp tables for isolation

### DIFF
--- a/crates/vibesql-catalog/src/store/mod.rs
+++ b/crates/vibesql-catalog/src/store/mod.rs
@@ -10,6 +10,7 @@
 //! - `advanced` - Advanced SQL objects (types, domains, sequences, views, triggers, etc.)
 
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
 use indexmap::IndexMap;
 
 use crate::{
@@ -36,9 +37,22 @@ mod tables;
 // Re-export types from submodules
 pub use advanced::ViewDropBehavior;
 
+/// Global counter for generating unique session IDs.
+/// This ensures each Catalog instance gets a unique session ID,
+/// even if created in the same process.
+static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
+
 /// Database catalog - manages all schemas and their objects.
 #[derive(Debug, Clone)]
 pub struct Catalog {
+    /// Session ID for temp table isolation.
+    /// Each Catalog instance gets a unique session ID, and temp tables
+    /// are stored in a session-specific schema (e.g., "temp_12345").
+    /// This ensures temp tables are isolated between database connections.
+    pub(crate) session_id: u64,
+    /// The name of this session's temp schema (e.g., "temp_12345").
+    /// Computed once on Catalog creation from the session_id.
+    pub(crate) temp_schema_name: String,
     pub(crate) schemas: HashMap<String, Schema>,
     pub(crate) current_schema: String,
     pub(crate) privilege_grants: Vec<PrivilegeGrant>,
@@ -70,9 +84,20 @@ pub struct Catalog {
 }
 
 impl Catalog {
-    /// Create a new empty catalog.
+    /// Create a new empty catalog with a unique session ID.
+    ///
+    /// Each catalog instance gets a unique session ID, which is used to create
+    /// a session-specific temp schema for temporary table isolation.
+    /// This ensures temporary tables are isolated between database connections,
+    /// matching SQLite's behavior where temp tables are connection-local.
     pub fn new() -> Self {
+        // Generate unique session ID
+        let session_id = NEXT_SESSION_ID.fetch_add(1, Ordering::Relaxed);
+        let temp_schema_name = format!("{}_{}", crate::TEMP_SCHEMA, session_id);
+
         let mut catalog = Catalog {
+            session_id,
+            temp_schema_name: temp_schema_name.clone(),
             schemas: HashMap::new(),
             current_schema: crate::DEFAULT_SCHEMA.to_string(),
             privilege_grants: Vec::new(),
@@ -106,14 +131,41 @@ impl Catalog {
             Schema::new(crate::DEFAULT_SCHEMA.to_string()),
         );
 
-        // Create the temp schema for temporary tables (SQLite compatibility)
-        // Temp tables are stored here and are not persisted
+        // Create the session-specific temp schema for temporary tables
+        // Each session gets its own temp schema (e.g., "temp_1", "temp_2", etc.)
+        // This provides session isolation for temp tables, matching SQLite semantics
         catalog.schemas.insert(
-            crate::TEMP_SCHEMA.to_string(),
-            Schema::new(crate::TEMP_SCHEMA.to_string()),
+            temp_schema_name.clone(),
+            Schema::new(temp_schema_name),
         );
 
         catalog
+    }
+
+    /// Get this session's temp schema name.
+    ///
+    /// Returns the session-specific temp schema name (e.g., "temp_12345").
+    /// Temporary tables created in this session will be stored in this schema.
+    #[inline]
+    pub fn temp_schema_name(&self) -> &str {
+        &self.temp_schema_name
+    }
+
+    /// Get this session's ID.
+    ///
+    /// Each Catalog instance has a unique session ID used for temp table isolation.
+    #[inline]
+    pub fn session_id(&self) -> u64 {
+        self.session_id
+    }
+
+    /// Check if a schema name is a temp schema (matches "temp_*" pattern).
+    ///
+    /// This is used to identify temp schemas for special handling (e.g., not persisting them).
+    #[inline]
+    pub fn is_temp_schema(schema_name: &str) -> bool {
+        schema_name.starts_with(crate::TEMP_SCHEMA) && schema_name.len() > crate::TEMP_SCHEMA.len()
+            && schema_name.as_bytes().get(crate::TEMP_SCHEMA.len()) == Some(&b'_')
     }
 
     /// Set whether identifier lookups should be case-sensitive

--- a/crates/vibesql-catalog/src/store/tables.rs
+++ b/crates/vibesql-catalog/src/store/tables.rs
@@ -208,9 +208,9 @@ impl super::Catalog {
                 schema.get_table_by_identifier(&table_id)
             })
         } else {
-            // For unqualified identifiers, check temp schema first (SQLite semantics)
+            // For unqualified identifiers, check session-specific temp schema first (SQLite semantics)
             // Temp tables shadow tables in the main schema
-            if let Some(temp_schema) = self.schemas.get(crate::TEMP_SCHEMA) {
+            if let Some(temp_schema) = self.schemas.get(&self.temp_schema_name) {
                 if let Some(table) = temp_schema.get_table_by_identifier(identifier) {
                     return Some(table);
                 }
@@ -238,12 +238,12 @@ impl super::Catalog {
                 schema.get_table(&normalized_table, self.case_sensitive_identifiers)
             })
         } else {
-            // Unqualified name: check temp schema first (SQLite semantics)
+            // Unqualified name: check session-specific temp schema first (SQLite semantics)
             // Temp tables shadow tables in the main schema
             let normalized_table = self.normalize_identifier(name);
 
-            // First check temp schema
-            if let Some(temp_schema) = self.schemas.get(crate::TEMP_SCHEMA) {
+            // First check session's temp schema
+            if let Some(temp_schema) = self.schemas.get(&self.temp_schema_name) {
                 if let Some(table) =
                     temp_schema.get_table(&normalized_table, self.case_sensitive_identifiers)
                 {
@@ -358,10 +358,10 @@ impl super::Catalog {
     /// - Quoted identifiers are case-sensitive (match exact canonical form)
     /// - Unquoted identifiers are case-insensitive (lowercase canonical form)
     ///
-    /// For unqualified identifiers, checks temp schema first (SQLite semantics).
+    /// For unqualified identifiers, checks session-specific temp schema first (SQLite semantics).
     pub fn table_exists_by_identifier(&self, identifier: &TableIdentifier) -> bool {
-        // Check temp schema first
-        if let Some(temp_schema) = self.schemas.get(crate::TEMP_SCHEMA) {
+        // Check session's temp schema first
+        if let Some(temp_schema) = self.schemas.get(&self.temp_schema_name) {
             if temp_schema.table_exists_by_identifier(identifier) {
                 return true;
             }

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -71,16 +71,19 @@ impl CreateTableExecutor {
         database: &mut Database,
     ) -> Result<String, ExecutorError> {
         // Parse qualified table name (schema.table or just table)
-        // For TEMP tables, force the schema to "temp" (SQLite compatibility)
+        // For TEMP tables, use the session-specific temp schema (SQLite compatibility)
         let (schema_name, table_name, identifier) = if stmt.temporary {
-            // Temporary table - always use temp schema
+            // Temporary table - use session-specific temp schema
+            // Each session gets its own temp schema (e.g., "temp_1", "temp_2")
+            // for isolation between database connections
+            let temp_schema = database.catalog.temp_schema_name();
             let id = TableIdentifier::qualified(
-                vibesql_catalog::TEMP_SCHEMA,
+                temp_schema,
                 false,
                 &stmt.table_name,
                 stmt.quoted,
             );
-            (vibesql_catalog::TEMP_SCHEMA.to_string(), stmt.table_name.clone(), id)
+            (temp_schema.to_string(), stmt.table_name.clone(), id)
         } else if let Some((schema_part, table_part)) = stmt.table_name.split_once('.') {
             // Schema-qualified table name - use qualified identifier
             // Note: We use stmt.quoted for both parts since the parser combined them

--- a/crates/vibesql-executor/src/persistence.rs
+++ b/crates/vibesql-executor/src/persistence.rs
@@ -94,11 +94,11 @@ fn execute_statement_for_load(
 ) -> Result<(), ExecutorError> {
     match statement {
         vibesql_ast::Statement::CreateSchema(schema_stmt) => {
-            // Skip built-in schemas (main and temp) - they already exist
+            // Skip built-in schemas (main and all temp schemas) - they already exist
             // This handles backward compatibility with old SQL dumps
             let schema_name = schema_stmt.schema_name.to_lowercase();
             if schema_name != vibesql_catalog::DEFAULT_SCHEMA
-                && schema_name != vibesql_catalog::TEMP_SCHEMA
+                && !vibesql_catalog::Catalog::is_temp_schema(&schema_name)
             {
                 SchemaExecutor::execute_create_schema(&schema_stmt, db)?;
             }

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -109,8 +109,8 @@ impl Operations {
 
         // Try with schema prefix if not already qualified
         if !table_name.contains('.') {
-            // Try 3: Temp schema first (SQLite semantics - temp tables shadow main tables)
-            let temp_qualified = format!("{}.{}", vibesql_catalog::TEMP_SCHEMA, normalized_name);
+            // Try 3: Session's temp schema first (SQLite semantics - temp tables shadow main tables)
+            let temp_qualified = format!("{}.{}", catalog.temp_schema_name(), normalized_name);
             if tables.contains_key(&temp_qualified) {
                 return Ok(tables.get_mut(&temp_qualified).unwrap());
             }

--- a/crates/vibesql-storage/src/database/table_api.rs
+++ b/crates/vibesql-storage/src/database/table_api.rs
@@ -17,20 +17,22 @@ impl Database {
     // Table Operations
     // ============================================================================
 
-    /// Check if a table name refers to a temporary table (in the "temp" schema)
+    /// Check if a table name refers to a temporary table (in any temp schema)
     ///
     /// Temporary tables are not persisted to WAL.
+    /// This checks if the table is in ANY temp schema (temp_1, temp_2, etc.)
     fn is_temp_table(&self, table_name: &str) -> bool {
-        // Check if the table name is qualified with "temp." schema
+        // Check if the table name is qualified with a temp schema prefix (e.g., "temp_1.foo")
         if let Some((schema, _)) = table_name.split_once('.') {
-            schema.eq_ignore_ascii_case(vibesql_catalog::TEMP_SCHEMA)
+            vibesql_catalog::Catalog::is_temp_schema(schema)
         } else {
-            // Unqualified name - check if it exists in temp schema
-            self.tables.contains_key(&format!(
+            // Unqualified name - check if it exists in this session's temp schema
+            let temp_qualified = format!(
                 "{}.{}",
-                vibesql_catalog::TEMP_SCHEMA,
+                self.catalog.temp_schema_name(),
                 table_name.to_lowercase()
-            ))
+            );
+            self.tables.contains_key(&temp_qualified)
         }
     }
 
@@ -61,11 +63,11 @@ impl Database {
             format!("{}.{}", current_schema, identifier.canonical())
         };
 
-        // Check if this is a temporary table (in the "temp" schema)
+        // Check if this is a temporary table (in any temp schema)
         // Temp tables are not persisted to WAL
         let is_temp = identifier
             .schema_canonical()
-            .is_some_and(|s| s.eq_ignore_ascii_case(vibesql_catalog::TEMP_SCHEMA));
+            .is_some_and(|s| vibesql_catalog::Catalog::is_temp_schema(s));
 
         if !is_temp {
             // Assign table ID and emit WAL entry for persistence
@@ -180,11 +182,11 @@ impl Database {
             }
         }
 
-        // For unqualified names, check temp schema first (SQLite semantics)
+        // For unqualified names, check session's temp schema first (SQLite semantics)
         // Temp tables shadow tables in the main schema
         if !name.contains('.') {
-            // Check temp schema first
-            let temp_qualified = format!("{}.{}", vibesql_catalog::TEMP_SCHEMA, lowercase_name);
+            // Check session's temp schema first
+            let temp_qualified = format!("{}.{}", self.catalog.temp_schema_name(), lowercase_name);
             if let Some(table) = self.tables.get(&temp_qualified) {
                 return Some(table);
             }
@@ -241,11 +243,11 @@ impl Database {
             return self.tables.get_mut(&uppercase_name);
         }
 
-        // For unqualified names, check temp schema first (SQLite semantics)
+        // For unqualified names, check session's temp schema first (SQLite semantics)
         // Temp tables shadow tables in the main schema
         if !name.contains('.') {
-            // Check temp schema first
-            let temp_qualified = format!("{}.{}", vibesql_catalog::TEMP_SCHEMA, lowercase_name);
+            // Check session's temp schema first
+            let temp_qualified = format!("{}.{}", self.catalog.temp_schema_name(), lowercase_name);
             if self.tables.contains_key(&temp_qualified) {
                 return self.tables.get_mut(&temp_qualified);
             }

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -11,10 +11,10 @@ use crate::{persistence::save, Database, StorageError};
 
 pub fn write_catalog<W: Write>(writer: &mut W, db: &Database) -> Result<(), StorageError> {
     // Write schemas
-    // Skip built-in schemas (main and temp) - they are recreated on load
+    // Skip built-in schemas (main and all temp schemas) - they are recreated on load
     let schemas: Vec<String> = db.catalog.list_schemas()
         .into_iter()
-        .filter(|s| s != vibesql_catalog::DEFAULT_SCHEMA && s != vibesql_catalog::TEMP_SCHEMA)
+        .filter(|s| s != vibesql_catalog::DEFAULT_SCHEMA && !vibesql_catalog::Catalog::is_temp_schema(s))
         .collect();
 
     write_u32(writer, schemas.len() as u32)?;
@@ -237,10 +237,10 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
     let schema_count = read_u32(reader)?;
     for _ in 0..schema_count {
         let schema_name = read_string(reader)?;
-        // Skip built-in schemas (main and temp) - they are already created by Database::new()
+        // Skip built-in schemas (main and all temp schemas) - they are already created by Database::new()
         // This handles backward compatibility with databases saved before the write-side fix
         if schema_name == vibesql_catalog::DEFAULT_SCHEMA
-            || schema_name == vibesql_catalog::TEMP_SCHEMA
+            || vibesql_catalog::Catalog::is_temp_schema(&schema_name)
         {
             continue;
         }

--- a/crates/vibesql-storage/src/persistence/json.rs
+++ b/crates/vibesql-storage/src/persistence/json.rs
@@ -243,12 +243,14 @@ impl Database {
         };
 
         // Schemas (excluding default and temp schemas which are auto-created)
+        // Skip all temp schemas (temp_1, temp_2, etc.) - they are session-scoped
         let schemas = self
             .catalog
             .list_schemas()
             .into_iter()
             .filter(|name| {
-                name != vibesql_catalog::DEFAULT_SCHEMA && name != vibesql_catalog::TEMP_SCHEMA
+                name != vibesql_catalog::DEFAULT_SCHEMA
+                    && !vibesql_catalog::Catalog::is_temp_schema(name)
             })
             .map(|name| JsonSchema { name })
             .collect();
@@ -486,11 +488,12 @@ fn sql_value_to_json(value: &SqlValue) -> serde_json::Value {
 fn json_database_to_db(json_db: JsonDatabase) -> Result<Database, StorageError> {
     let mut db = Database::new();
 
-    // Create schemas (skip auto-created ones like public/temp)
+    // Create schemas (skip auto-created ones like public/temp schemas)
     for schema in json_db.schemas {
-        // Skip schemas that already exist (e.g., temp schema is auto-created)
+        // Skip schemas that already exist (e.g., default and temp schemas are auto-created)
+        // Also skip any temp schemas (temp_1, temp_2, etc.) from old data files
         if schema.name == vibesql_catalog::DEFAULT_SCHEMA
-            || schema.name == vibesql_catalog::TEMP_SCHEMA
+            || vibesql_catalog::Catalog::is_temp_schema(&schema.name)
         {
             continue;
         }

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -107,8 +107,9 @@ impl Database {
             .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
         for schema_name in &self.catalog.list_schemas() {
             // Skip built-in schemas - they are recreated automatically on load
+            // Skip default schema and all temp schemas (temp_1, temp_2, etc.)
             if schema_name != vibesql_catalog::DEFAULT_SCHEMA
-                && schema_name != vibesql_catalog::TEMP_SCHEMA
+                && !vibesql_catalog::Catalog::is_temp_schema(schema_name)
             {
                 writeln!(writer, "CREATE SCHEMA {};", schema_name)
                     .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
@@ -131,12 +132,12 @@ impl Database {
         writeln!(writer, "-- Tables and Data")
             .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
 
-        // Iterate through all schemas except temp schema
+        // Iterate through all schemas except temp schemas
         // We must NOT use get_table() which follows shadowing rules - temp tables would
         // incorrectly override main schema tables in the dump.
         for schema_name in &self.catalog.list_schemas() {
-            // Skip temp schema - temp tables are session-scoped and should not be persisted
-            if schema_name == vibesql_catalog::TEMP_SCHEMA {
+            // Skip all temp schemas (temp_1, temp_2, etc.) - they are session-scoped
+            if vibesql_catalog::Catalog::is_temp_schema(schema_name) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary

- Add session ID to Catalog for temp table isolation
- Create session-specific temp schemas (e.g., "temp_1", "temp_2")  
- Update all table lookups and persistence to use session-scoped temp schemas
- Temp tables are now properly isolated between database connections

## Changes

- **vibesql-catalog**: Add `session_id` field, `temp_schema_name()` method, and `is_temp_schema()` static helper
- **vibesql-executor**: Route temp tables to session-specific schema in CreateTableExecutor
- **vibesql-storage**: Update table lookups and persistence to handle session-scoped temp schemas

## Test plan

- [x] Build passes (`cargo check`)
- [x] Catalog unit tests pass (`cargo test -p vibesql-catalog`)
- [x] Storage tests pass (`cargo test -p vibesql-storage`)
- [x] Manual test: CREATE TEMP TABLE works correctly

Closes #4789

🤖 Generated with [Claude Code](https://claude.com/claude-code)