### PR TITLE
feat(parser): support VALUES clause as view source in CREATE VIEW

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/ddl.rs
+++ b/crates/vibesql-parser/src/arena_parser/ddl.rs
@@ -207,7 +207,13 @@ impl<'arena> ArenaParser<'arena> {
 
         self.consume_keyword(Keyword::As)?;
 
-        let query = self.parse_select_statement()?;
+        // Parse the query: can be SELECT or VALUES
+        // Example: CREATE VIEW dual AS VALUES('x')
+        let query = if self.peek_keyword(Keyword::Values) {
+            self.parse_values_statement()?
+        } else {
+            self.parse_select_statement()?
+        };
 
         // Check for WITH CHECK OPTION
         let with_check_option = if self.try_consume_keyword(Keyword::With) {

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -201,6 +201,85 @@ impl<'arena> ArenaParser<'arena> {
         Ok(self.arena.alloc(stmt))
     }
 
+    /// Parse a VALUES statement (standalone or as part of a view definition).
+    ///
+    /// Syntax: VALUES(expr, ...) [, (expr, ...), ...] [ORDER BY] [LIMIT] [OFFSET]
+    ///
+    /// Used for:
+    /// - Standalone VALUES statements: VALUES(1);
+    /// - View definitions: CREATE VIEW dual AS VALUES('x');
+    /// - CTEs: WITH t AS (VALUES(1)) SELECT * FROM t;
+    pub(crate) fn parse_values_statement(
+        &mut self,
+    ) -> Result<&'arena SelectStmt<'arena>, ParseError> {
+        self.consume_keyword(Keyword::Values)?;
+
+        // Parse VALUES rows: (row1), (row2), ...
+        let mut rows = BumpVec::new_in(self.arena);
+        loop {
+            self.expect_token(Token::LParen)?;
+            let row = self.parse_expression_list()?;
+            self.expect_token(Token::RParen)?;
+            rows.push(row);
+
+            if !self.try_consume(&Token::Comma) {
+                break;
+            }
+        }
+
+        // Parse set operations (UNION, INTERSECT, EXCEPT)
+        let set_operation = self.parse_set_operation_internal()?;
+
+        // Parse ORDER BY
+        let order_by = if self.try_consume_keyword(Keyword::Order) {
+            self.consume_keyword(Keyword::By)?;
+            Some(self.parse_order_by_clause()?)
+        } else {
+            None
+        };
+
+        // Parse LIMIT (supports comma syntax: LIMIT offset,count)
+        let (limit, offset_from_limit) = if self.try_consume_keyword(Keyword::Limit) {
+            let first_expr = self.parse_expression()?;
+            if self.try_consume(&Token::Comma) {
+                let second_expr = self.parse_expression()?;
+                (Some(second_expr), Some(first_expr))
+            } else {
+                (Some(first_expr), None)
+            }
+        } else {
+            (None, None)
+        };
+
+        // Parse OFFSET (only if not already set via comma syntax)
+        let offset = if offset_from_limit.is_some() {
+            offset_from_limit
+        } else if self.try_consume_keyword(Keyword::Offset) {
+            Some(self.parse_expression()?)
+        } else {
+            None
+        };
+
+        let stmt = SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: BumpVec::new_in(self.arena),
+            into_table: None,
+            into_variables: None,
+            from: None,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by,
+            limit,
+            offset,
+            set_operation,
+            values: Some(rows),
+        };
+
+        Ok(self.arena.alloc(stmt))
+    }
+
     /// Parse WITH clause (CTEs).
     ///
     /// If `recursive` is true, all CTEs in this list are marked as recursive.
@@ -307,7 +386,8 @@ impl<'arena> ArenaParser<'arena> {
 
         // Check for qualified wildcard (table.* or alias.*)
         // Must check BEFORE parsing as expression to avoid losing the qualifier.
-        // The expression parser would parse "table.*" as Expression::Wildcard, losing the table name.
+        // The expression parser would parse "table.*" as Expression::Wildcard, losing the table
+        // name.
         let saved_position = self.position;
         if let Token::Identifier(qualifier) | Token::DelimitedIdentifier(qualifier) = self.peek() {
             let qualifier = qualifier.clone();

--- a/crates/vibesql-parser/src/parser/select/statement.rs
+++ b/crates/vibesql-parser/src/parser/select/statement.rs
@@ -6,12 +6,21 @@ impl Parser {
         self.parse_select_statement_internal(true, true)
     }
 
-    /// Parse SELECT statement when embedded in another statement (cursor, view, etc.)
-    /// This allows tokens after SELECT that belong to the outer statement.
+    /// Parse SELECT or VALUES statement when embedded in another statement (cursor, view, etc.)
+    /// This allows tokens after SELECT/VALUES that belong to the outer statement.
+    ///
+    /// Supports:
+    /// - SELECT ... (standard select statement)
+    /// - VALUES(expr, ...) [, ...] (table value constructor, e.g., CREATE VIEW dual AS VALUES('x'))
     pub(crate) fn parse_embedded_select_statement(
         &mut self,
     ) -> Result<vibesql_ast::SelectStmt, ParseError> {
-        self.parse_select_statement_internal(true, false)
+        if self.peek_keyword(Keyword::Values) {
+            // Handle VALUES clause as view source (e.g., CREATE VIEW dual(dummy) AS VALUES('x'))
+            self.parse_values_statement_internal(true, false)
+        } else {
+            self.parse_select_statement_internal(true, false)
+        }
     }
 
     /// Internal SELECT parser with control over ORDER BY/LIMIT parsing
@@ -271,7 +280,8 @@ impl Parser {
 
         // Parse LIMIT clause
         // SQLite allows expressions in LIMIT (e.g., LIMIT 5+3)
-        // SQLite also allows comma syntax: LIMIT offset,count (equivalent to LIMIT count OFFSET offset)
+        // SQLite also allows comma syntax: LIMIT offset,count (equivalent to LIMIT count OFFSET
+        // offset)
         let (limit, offset_from_limit) = if allow_order_limit && self.peek_keyword(Keyword::Limit) {
             self.consume_keyword(Keyword::Limit)?;
             let first_expr = self.parse_expression()?;

--- a/crates/vibesql-parser/src/tests/view.rs
+++ b/crates/vibesql-parser/src/tests/view.rs
@@ -283,3 +283,114 @@ fn test_create_temp_view_if_not_exists() {
         panic!("Expected CreateView statement");
     }
 }
+
+// ============================================================================
+// VALUES clause as view source (Issue #4799)
+// ============================================================================
+
+#[test]
+fn test_create_view_with_values_single_row() {
+    // Classic Oracle-style dual view
+    let sql = "CREATE VIEW dual(dummy) AS VALUES('x')";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    if let Ok(vibesql_ast::Statement::CreateView(stmt)) = result {
+        assert_eq!(stmt.view_name, "dual");
+        assert!(stmt.columns.is_some());
+        let cols = stmt.columns.unwrap();
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0], "dummy");
+        // Query should have values
+        assert!(stmt.query.values.is_some());
+        let values = stmt.query.values.as_ref().unwrap();
+        assert_eq!(values.len(), 1); // Single row
+        assert_eq!(values[0].len(), 1); // Single column
+    } else {
+        panic!("Expected CreateView statement");
+    }
+}
+
+#[test]
+fn test_create_view_with_values_multiple_rows() {
+    // View with multiple rows
+    let sql = "CREATE VIEW numbers(n) AS VALUES(1),(2),(3)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    if let Ok(vibesql_ast::Statement::CreateView(stmt)) = result {
+        assert_eq!(stmt.view_name, "numbers");
+        assert!(stmt.query.values.is_some());
+        let values = stmt.query.values.as_ref().unwrap();
+        assert_eq!(values.len(), 3); // Three rows
+    } else {
+        panic!("Expected CreateView statement");
+    }
+}
+
+#[test]
+fn test_create_view_with_values_multiple_columns() {
+    // View with multiple columns
+    let sql = "CREATE VIEW pairs(a, b) AS VALUES(1, 'one'),(2, 'two')";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    if let Ok(vibesql_ast::Statement::CreateView(stmt)) = result {
+        assert_eq!(stmt.view_name, "pairs");
+        assert!(stmt.columns.is_some());
+        let cols = stmt.columns.unwrap();
+        assert_eq!(cols.len(), 2);
+        assert!(stmt.query.values.is_some());
+        let values = stmt.query.values.as_ref().unwrap();
+        assert_eq!(values.len(), 2); // Two rows
+        assert_eq!(values[0].len(), 2); // Two columns per row
+    } else {
+        panic!("Expected CreateView statement");
+    }
+}
+
+#[test]
+fn test_create_temp_view_with_values() {
+    let sql = "CREATE TEMP VIEW constants(name, value) AS VALUES('PI', 3.14159),('E', 2.71828)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    if let Ok(vibesql_ast::Statement::CreateView(stmt)) = result {
+        assert_eq!(stmt.view_name, "constants");
+        assert!(stmt.temporary);
+        assert!(stmt.query.values.is_some());
+    } else {
+        panic!("Expected CreateView statement");
+    }
+}
+
+#[test]
+fn test_create_view_if_not_exists_with_values() {
+    let sql = "CREATE VIEW IF NOT EXISTS singleton(x) AS VALUES(42)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    if let Ok(vibesql_ast::Statement::CreateView(stmt)) = result {
+        assert_eq!(stmt.view_name, "singleton");
+        assert!(stmt.if_not_exists);
+        assert!(stmt.query.values.is_some());
+    } else {
+        panic!("Expected CreateView statement");
+    }
+}
+
+#[test]
+fn test_create_view_values_without_column_list() {
+    // Column names should be derived from VALUES expression positions
+    let sql = "CREATE VIEW data AS VALUES(1, 2, 3)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    if let Ok(vibesql_ast::Statement::CreateView(stmt)) = result {
+        assert_eq!(stmt.view_name, "data");
+        assert!(stmt.columns.is_none()); // No explicit column list
+        assert!(stmt.query.values.is_some());
+    } else {
+        panic!("Expected CreateView statement");
+    }
+}


### PR DESCRIPTION
## Summary

Add support for the `CREATE VIEW name(columns) AS VALUES(...)` syntax which is valid SQL used to create single-row views like Oracle's `dual` table.

- Enable `parse_embedded_select_statement` to handle VALUES in addition to SELECT
- Add `parse_values_statement` method to arena parser for VALUES statement parsing
- Update `parse_create_view_statement` to check for VALUES keyword as view source

## Example

```sql
-- Now works: Classic Oracle-style dual view
CREATE VIEW dual(dummy) AS VALUES('x');

-- Now works: Multi-row constant views
CREATE VIEW numbers(n) AS VALUES(1),(2),(3);

-- Now works: Multi-column constant views
CREATE VIEW pairs(a, b) AS VALUES(1, 'one'),(2, 'two');
```

## Test Plan

- [x] Added 6 new unit tests for VALUES in CREATE VIEW
- [x] All 24 view tests pass
- [x] All 1204 parser tests pass
- [x] Release build succeeds

This unblocks ~146 TCL tests in `join9.test` that depend on views created with VALUES.

Closes #4799