### PR TITLE
fix(evaluator): coerce numeric types to strings for LIKE/GLOB pattern matching

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat.rs
@@ -4,6 +4,8 @@
 //! These functions follow SQLite's exact semantics as documented at:
 //! https://www.sqlite.org/lang_corefunc.html
 
+use std::borrow::Cow;
+
 use rand::Rng;
 use vibesql_types::SqlValue;
 
@@ -940,14 +942,19 @@ pub(super) fn like(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         }
     };
 
-    let text = match &args[1] {
-        SqlValue::Varchar(s) | SqlValue::Character(s) => s.as_str(),
-        other => {
-            return Err(ExecutorError::UnsupportedFeature(format!(
-                "LIKE text must be a string, got {:?}",
-                other
-            )));
-        }
+    // SQLite coerces non-string types to strings for LIKE comparison
+    let text: Cow<str> = match &args[1] {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => Cow::Borrowed(s.as_str()),
+        SqlValue::Integer(i) => Cow::Owned(i.to_string()),
+        SqlValue::Bigint(i) => Cow::Owned(i.to_string()),
+        SqlValue::Smallint(i) => Cow::Owned(i.to_string()),
+        SqlValue::Unsigned(u) => Cow::Owned(u.to_string()),
+        SqlValue::Real(r) => Cow::Owned(r.to_string()),
+        SqlValue::Double(d) => Cow::Owned(d.to_string()),
+        SqlValue::Numeric(n) => Cow::Owned(n.to_string()),
+        SqlValue::Float(f) => Cow::Owned(f.to_string()),
+        SqlValue::Boolean(b) => Cow::Owned(if *b { "1".to_string() } else { "0".to_string() }),
+        other => Cow::Owned(other.to_string()),
     };
 
     // Optional escape character (3rd argument)
@@ -964,7 +971,7 @@ pub(super) fn like(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         None
     };
     // SQLite's like() function uses case-insensitive matching by default
-    let matched = crate::evaluator::pattern::like_match(text, pattern, false, escape_char);
+    let matched = crate::evaluator::pattern::like_match(&text, pattern, false, escape_char);
     Ok(SqlValue::Integer(if matched { 1 } else { 0 }))
 }
 
@@ -1001,18 +1008,23 @@ pub(super) fn glob(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         }
     };
 
-    let text = match &args[1] {
-        SqlValue::Varchar(s) | SqlValue::Character(s) => s.as_str(),
-        other => {
-            return Err(ExecutorError::UnsupportedFeature(format!(
-                "GLOB text must be a string, got {:?}",
-                other
-            )));
-        }
+    // SQLite coerces non-string types to strings for GLOB comparison
+    let text: Cow<str> = match &args[1] {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => Cow::Borrowed(s.as_str()),
+        SqlValue::Integer(i) => Cow::Owned(i.to_string()),
+        SqlValue::Bigint(i) => Cow::Owned(i.to_string()),
+        SqlValue::Smallint(i) => Cow::Owned(i.to_string()),
+        SqlValue::Unsigned(u) => Cow::Owned(u.to_string()),
+        SqlValue::Real(r) => Cow::Owned(r.to_string()),
+        SqlValue::Double(d) => Cow::Owned(d.to_string()),
+        SqlValue::Numeric(n) => Cow::Owned(n.to_string()),
+        SqlValue::Float(f) => Cow::Owned(f.to_string()),
+        SqlValue::Boolean(b) => Cow::Owned(if *b { "1".to_string() } else { "0".to_string() }),
+        other => Cow::Owned(other.to_string()),
     };
 
     // Use the pattern matching function from pattern.rs
-    let matched = crate::evaluator::pattern::glob_match(text, pattern);
+    let matched = crate::evaluator::pattern::glob_match(&text, pattern);
     Ok(SqlValue::Integer(if matched { 1 } else { 0 }))
 }
 


### PR DESCRIPTION
## Summary

SQLite coerces all types to their string representation when performing LIKE and GLOB pattern matching. This fix updates the LIKE and GLOB functions in `sqlite_compat.rs` to handle non-string arguments by converting them to strings using `Cow<str>` for efficiency.

## Changes

- Added `use std::borrow::Cow` import
- Updated `like()` function to coerce non-string types (integers, floats, booleans, etc.) to their string representation
- Updated `glob()` function with the same coercion logic
- Uses `Cow::Borrowed` for string values (zero-copy) and `Cow::Owned` for coerced values

## Test Plan

TCL test suite tests that now pass:
- expr-7.59: `LIKE('10%', b)` with integer b
- expr-7.60: `LIKE('_4', b)` with integer b  
- expr-7.61: `GLOB('1?', a)` with integer a
- expr-7.62: `GLOB('1*4', b)` with integer b
- expr-7.63: `GLOB('*1[456]', b)` with integer b

Verification:
```bash
./scripts/tcltest test expr.test --verbose 2>&1 | grep -E "expr-7\.(59|60|61|62|63)"
# All 5 tests pass
```

Closes #4802