### PR TITLE
fix(joins): partial fix for FULL JOIN USING COALESCE in SELECT *

### DIFF
--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -702,6 +702,20 @@ impl CombinedSchema {
     pub fn get_column_replacement(&self, hidden_idx: usize) -> Option<usize> {
         self.column_replacement_map.get(&hidden_idx).copied()
     }
+
+    /// Get the right-side column index for a left-side USING column (for COALESCE in SELECT *).
+    ///
+    /// In FULL OUTER JOIN with USING clause, when expanding SELECT *, we need to apply
+    /// COALESCE(left_val, right_val) for USING columns. This method returns the right-side
+    /// index for a given left-side USING column index.
+    ///
+    /// Returns Some(right_idx) if the given index is a left-side USING column, None otherwise.
+    pub fn get_using_coalesce_right_for_left(&self, left_idx: usize) -> Option<usize> {
+        self.using_coalesce_pairs
+            .values()
+            .find(|(l, _)| *l == left_idx)
+            .map(|(_, r)| *r)
+    }
 }
 
 /// Builder for incrementally constructing a CombinedSchema

--- a/crates/vibesql-executor/src/select/projection.rs
+++ b/crates/vibesql-executor/src/select/projection.rs
@@ -43,7 +43,21 @@ pub(crate) fn project_row_combined(
                         }
                         // If no replacement, skip this hidden column
                     } else {
-                        values.push(row.values[idx].clone());
+                        // Check if this is a left-side USING column that needs COALESCE
+                        // In FULL OUTER JOIN with USING, the visible left column should show
+                        // COALESCE(left_val, right_val) to handle unmatched rows from either side
+                        if let Some(right_idx) = schema.get_using_coalesce_right_for_left(idx) {
+                            let left_val = &row.values[idx];
+                            if *left_val == vibesql_types::SqlValue::Null
+                                && right_idx < row.values.len()
+                            {
+                                values.push(row.values[right_idx].clone());
+                            } else {
+                                values.push(left_val.clone());
+                            }
+                        } else {
+                            values.push(row.values[idx].clone());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Add COALESCE semantics for USING columns in SELECT * expansion for FULL OUTER JOIN
- When the left-side USING column value is NULL, use the right-side value instead
- Added `get_using_coalesce_right_for_left()` method to `CombinedSchema` for index-based lookup

## Test Results
- joinB.test improved from 342/512 (66.8%) to 344/512 (67.2%) passing - +2 tests fixed

## Known Limitation
This is a **partial fix**. Most failing tests remain due to a secondary issue: column ordering in SELECT * is non-deterministic because `columns.rs` iterates over a HashMap. The USING column should appear first per SQL standard, but currently appears in random order. This causes the COALESCE to be applied to the wrong column position in many cases.

A follow-up PR is needed to fix the column ordering issue.

## Test plan
- [x] Build succeeds in worktree
- [x] joinB.test shows improvement (+2 tests)
- [ ] Full TCL test suite regression check (pending)

Closes #4806

🤖 Generated with [Claude Code](https://claude.com/claude-code)