### PR TITLE
fix(executor): apply type affinity coercion in UPDATE statements

### DIFF
--- a/crates/vibesql-executor/src/insert/mod.rs
+++ b/crates/vibesql-executor/src/insert/mod.rs
@@ -6,7 +6,7 @@ mod execution;
 mod foreign_keys;
 mod replace;
 mod row_validator;
-mod validation;
+pub mod validation;
 
 use crate::errors::ExecutorError;
 

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -34,8 +34,8 @@ use vibesql_storage::{statistics::CostEstimator, Database};
 
 use crate::{
     dml_cost::DmlOptimizer, errors::ExecutorError, evaluator::ExpressionEvaluator,
-    expression_index_maintenance, privilege_checker::PrivilegeChecker,
-    sqlite_schema::is_sqlite_schema_table,
+    expression_index_maintenance, insert::validation::coerce_value,
+    privilege_checker::PrivilegeChecker, sqlite_schema::is_sqlite_schema_table,
 };
 
 /// Executor for UPDATE statements
@@ -793,8 +793,12 @@ impl UpdateExecutor {
                 _ => evaluator.eval(&assignment.value, &old_row)?,
             };
 
+            // Apply type affinity coercion (SQLite compatibility)
+            let column = &schema.columns[col_index];
+            let coerced_value = coerce_value(new_value, &column.data_type)?;
+
             new_row
-                .set(col_index, new_value)
+                .set(col_index, coerced_value)
                 .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
             changed_columns.insert(col_index);
         }
@@ -918,9 +922,12 @@ impl UpdateExecutor {
                 return Ok(None); // Unique constraint needs validation
             }
 
-            // Check NOT NULL constraint
+            // Apply type affinity coercion (SQLite compatibility)
             let column = &schema.columns[col_index];
-            if !column.nullable && new_value == vibesql_types::SqlValue::Null {
+            let coerced_value = coerce_value(new_value, &column.data_type)?;
+
+            // Check NOT NULL constraint (after coercion)
+            if !column.nullable && coerced_value == vibesql_types::SqlValue::Null {
                 return Err(ExecutorError::ConstraintViolation(format!(
                     "NOT NULL constraint violation: column '{}' cannot be NULL",
                     column.name
@@ -932,7 +939,7 @@ impl UpdateExecutor {
                 return Ok(None); // Index update needs normal path
             }
 
-            inplace_updates.push((col_index, new_value));
+            inplace_updates.push((col_index, coerced_value));
         }
 
         // All checks passed - apply updates in-place

--- a/crates/vibesql-executor/src/update/value_updater.rs
+++ b/crates/vibesql-executor/src/update/value_updater.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use vibesql_ast::Assignment;
 
-use crate::{errors::ExecutorError, evaluator::ExpressionEvaluator};
+use crate::{errors::ExecutorError, evaluator::ExpressionEvaluator, insert::validation::coerce_value};
 
 /// Applies assignment expressions to rows
 pub struct ValueUpdater<'a> {
@@ -107,9 +107,15 @@ impl<'a> ValueUpdater<'a> {
                 }
             };
 
+            // Apply type affinity coercion (SQLite compatibility)
+            // This ensures UPDATE applies the same type conversion as INSERT
+            // e.g., UPDATE t SET r='5' on a REAL column stores 5.0, not '5'
+            let column = &self.schema.columns[col_index];
+            let coerced_value = coerce_value(new_value, &column.data_type)?;
+
             // Update column in new row
             new_row
-                .set(col_index, new_value)
+                .set(col_index, coerced_value)
                 .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
 
             // Track that this column changed


### PR DESCRIPTION
## Summary

- Apply SQLite type affinity coercion in UPDATE statements, matching INSERT behavior
- Fix issue where `UPDATE t SET r='5'` on a REAL column stored '5' as text instead of 5.0
- Add `coerce_value()` call to all three UPDATE code paths (normal, fast, super-fast)

## Test plan

- [x] Verified `UPDATE t SET r='5'` now stores 5.0 with typeof='real'
- [x] Verified expr-4.15, expr-4.16, expr-4.17 TCL tests now pass (86% pass rate, up from before)
- [x] Verified INSERT type affinity still works correctly
- [x] Release build compiles successfully

Closes #4816

🤖 Generated with [Claude Code](https://claude.com/claude-code)