### PR TITLE
fix(aggregates): return NULL for MIN/MAX when all values are NULL

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/executor/aggregate.rs
+++ b/crates/vibesql-executor/src/select/columnar/executor/aggregate.rs
@@ -184,10 +184,7 @@ pub fn compute_i64_aggregate(
                     min = Some(min.map_or(v, |m| m.min(v)));
                 }
             }
-            min.map(SqlValue::Integer).ok_or_else(|| ExecutorError::SimdOperationFailed {
-                operation: "MIN".to_string(),
-                reason: "all values NULL".to_string(),
-            })
+            Ok(min.map(SqlValue::Integer).unwrap_or(SqlValue::Null))
         }
         AggregateOp::Max => {
             let mut max: Option<i64> = None;
@@ -196,10 +193,7 @@ pub fn compute_i64_aggregate(
                     max = Some(max.map_or(v, |m| m.max(v)));
                 }
             }
-            max.map(SqlValue::Integer).ok_or_else(|| ExecutorError::SimdOperationFailed {
-                operation: "MAX".to_string(),
-                reason: "all values NULL".to_string(),
-            })
+            Ok(max.map(SqlValue::Integer).unwrap_or(SqlValue::Null))
         }
     }
 }
@@ -287,10 +281,7 @@ pub fn compute_f64_aggregate(
                     min = Some(min.map_or(v, |m| m.min(v)));
                 }
             }
-            min.map(SqlValue::Double).ok_or_else(|| ExecutorError::SimdOperationFailed {
-                operation: "MIN".to_string(),
-                reason: "all values NULL".to_string(),
-            })
+            Ok(min.map(SqlValue::Double).unwrap_or(SqlValue::Null))
         }
         AggregateOp::Max => {
             let mut max: Option<f64> = None;
@@ -299,10 +290,7 @@ pub fn compute_f64_aggregate(
                     max = Some(max.map_or(v, |m| m.max(v)));
                 }
             }
-            max.map(SqlValue::Double).ok_or_else(|| ExecutorError::SimdOperationFailed {
-                operation: "MAX".to_string(),
-                reason: "all values NULL".to_string(),
-            })
+            Ok(max.map(SqlValue::Double).unwrap_or(SqlValue::Null))
         }
     }
 }


### PR DESCRIPTION
## Summary

When calling `MIN()` or `MAX()` on a column where all values are NULL, the columnar aggregate path was throwing an error ("SIMD MIN failed: all values NULL") instead of returning NULL as required by the SQL standard.

## Changes

- Return `SqlValue::Null` instead of error when MIN/MAX finds no non-NULL values
- Applied to both i64 and f64 columnar aggregate paths

## Test Results

TCL minmax.test: **75/109 passing** (was 71/109 - 4 more tests now pass)

Fixed tests:
- ✅ minmax-10.7: `SELECT (SELECT min(x) FROM t6), (SELECT max(x) FROM t6)` with all NULL values
- ✅ minmax-10.8: `SELECT min(x), max(x) FROM t6` with all NULL values
- ✅ minmax-10.11: Same test with 1024 NULL rows
- ✅ minmax-10.12: Same test with 1024 NULL rows

No regressions:
- select1.test: 188/188 passing ✅
- null.test: 39/39 passing ✅

## Test Plan

- [x] minmax.test shows 4 additional passing tests
- [x] No regressions on select1.test and null.test
- [x] Release build succeeds

Closes #4819

🤖 Generated with [Claude Code](https://claude.com/claude-code)