### PR TITLE
fix(evaluator): handle trailing escape character in LIKE pattern

### DIFF
--- a/crates/vibesql-executor/src/evaluator/pattern.rs
+++ b/crates/vibesql-executor/src/evaluator/pattern.rs
@@ -24,11 +24,19 @@ pub(crate) fn like_match(text: &str, pattern: &str, case_sensitive: bool, escape
             let mut processed_pattern: Vec<PatternElement> = Vec::with_capacity(pattern_bytes.len());
 
             while i < pattern_bytes.len() {
-                if pattern_bytes[i] == esc_byte && i + 1 < pattern_bytes.len() {
-                    // Next character is escaped - treat as literal
-                    let next_char = pattern_bytes[i + 1];
-                    processed_pattern.push(PatternElement::Literal(next_char));
-                    i += 2;
+                if pattern_bytes[i] == esc_byte {
+                    if i + 1 < pattern_bytes.len() {
+                        // Next character is escaped - treat as literal
+                        let next_char = pattern_bytes[i + 1];
+                        processed_pattern.push(PatternElement::Literal(next_char));
+                        i += 2;
+                    } else {
+                        // Escape character at end of pattern with nothing to escape.
+                        // Per SQLite documentation: "If there is no character following
+                        // the escape character in the LIKE pattern, then the pattern is
+                        // invalid and the LIKE expression evaluates to false."
+                        return false;
+                    }
                 } else if pattern_bytes[i] == b'%' {
                     processed_pattern.push(PatternElement::AnySequence);
                     i += 1;


### PR DESCRIPTION
## Summary

- Fixed handling of trailing escape character in LIKE patterns with ESCAPE clause
- A trailing escape character with nothing to escape now correctly returns false
- Previously treated as literal, causing incorrect matches

## Reproduction

```sql
SELECT 'AB' LIKE 'A%b' ESCAPE 'b';
```

**Before:** 1 (incorrect)
**After:** 0 (correct, matches SQLite)

## Test Results

- expr.test: 85.8% → 86.5% (+4 tests fixed)
- Verified edge cases:
  - `'A%' LIKE 'Ab%' ESCAPE 'b'` → 1 (proper escape of %)
  - `'Ab' LIKE 'Abb' ESCAPE 'b'` → 1 (escape the escape char)
  - `'AB' LIKE 'A%b' ESCAPE 'b'` → 0 (trailing escape = unmatchable)

## Test Plan

- [x] Build succeeds
- [x] Manual verification matches SQLite behavior
- [x] expr.test improvement confirmed

Closes #4826

🤖 Generated with [Claude Code](https://claude.com/claude-code)