### PR TITLE
fix(evaluator): CASE WHEN should treat non-zero numbers as truthy

### DIFF
--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -614,7 +614,20 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             for when_clause in when_clauses.iter() {
                 for condition in when_clause.conditions.iter() {
                     let cond_val = self.eval_with_depth(condition, row)?;
-                    if matches!(cond_val, SqlValue::Boolean(true)) {
+                    // In SQL, truthiness is:
+                    // - Boolean(true) => true
+                    // - Integer/Bigint non-zero => true
+                    // - Double/Float non-zero => true
+                    // - Everything else (Null, zero, strings) => false
+                    let is_truthy = match cond_val {
+                        SqlValue::Boolean(b) => b,
+                        SqlValue::Integer(n) => n != 0,
+                        SqlValue::Bigint(n) => n != 0,
+                        SqlValue::Double(n) => n != 0.0,
+                        SqlValue::Float(n) => n != 0.0,
+                        _ => false,
+                    };
+                    if is_truthy {
                         return self.eval_with_depth(&when_clause.result, row);
                     }
                 }

--- a/crates/vibesql-executor/src/evaluator/combined/special.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/special.rs
@@ -43,8 +43,20 @@ impl CombinedExpressionEvaluator<'_> {
                     for condition_expr in &when_clause.conditions {
                         let condition_result = self.eval(condition_expr, row)?;
 
-                        // Check if condition is TRUE (not just truthy)
-                        if matches!(condition_result, vibesql_types::SqlValue::Boolean(true)) {
+                        // In SQL, truthiness is:
+                        // - Boolean(true) => true
+                        // - Integer/Bigint non-zero => true
+                        // - Double/Float non-zero => true
+                        // - Everything else (Null, zero, strings) => false
+                        let is_truthy = match condition_result {
+                            vibesql_types::SqlValue::Boolean(b) => b,
+                            vibesql_types::SqlValue::Integer(n) => n != 0,
+                            vibesql_types::SqlValue::Bigint(n) => n != 0,
+                            vibesql_types::SqlValue::Double(n) => n != 0.0,
+                            vibesql_types::SqlValue::Float(n) => n != 0.0,
+                            _ => false,
+                        };
+                        if is_truthy {
                             return self.eval(&when_clause.result, row);
                         }
                     }

--- a/crates/vibesql-executor/src/evaluator/expressions/special.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/special.rs
@@ -39,7 +39,20 @@ impl ExpressionEvaluator<'_> {
                     for condition_expr in &when_clause.conditions {
                         let condition_result = self.eval(condition_expr, row)?;
 
-                        if matches!(condition_result, vibesql_types::SqlValue::Boolean(true)) {
+                        // In SQL, truthiness is:
+                        // - Boolean(true) => true
+                        // - Integer/Bigint non-zero => true
+                        // - Double/Float non-zero => true
+                        // - Everything else (Null, zero, strings) => false
+                        let is_truthy = match condition_result {
+                            vibesql_types::SqlValue::Boolean(b) => b,
+                            vibesql_types::SqlValue::Integer(n) => n != 0,
+                            vibesql_types::SqlValue::Bigint(n) => n != 0,
+                            vibesql_types::SqlValue::Double(n) => n != 0.0,
+                            vibesql_types::SqlValue::Float(n) => n != 0.0,
+                            _ => false,
+                        };
+                        if is_truthy {
                             return self.eval(&when_clause.result, row);
                         }
                     }


### PR DESCRIPTION
## Summary

In SQL, `CASE WHEN` conditions should evaluate numeric values as truthy based on whether they are non-zero. Previously, only `SqlValue::Boolean(true)` was treated as truthy, causing numeric conditions like `CASE WHEN 11 THEN ...` to incorrectly fall through to the ELSE branch.

## Changes

- Updated truthiness evaluation in all three evaluator implementations:
  - `expressions/special.rs` (ExpressionEvaluator)
  - `combined/special.rs` (CombinedExpressionEvaluator)
  - `arena.rs` (ArenaEvaluator)

## SQL Truthiness Rules

| Value Type | Truthy |
|------------|--------|
| `Boolean(true)` | ✅ |
| `Boolean(false)` | ❌ |
| `Integer(0)` | ❌ |
| `Integer(non-zero)` | ✅ |
| `Double(0.0)` | ❌ |
| `Double(non-zero)` | ✅ |
| `NULL` | ❌ (falls through) |
| Strings | ❌ |

## Test Results

TCL cse.test: **123/124 passing** (was 120/124 - 3 more tests now pass)

Fixed tests:
- ✅ cse-1.6.3: `SELECT CASE WHEN b THEN d ... END` (b=11 is truthy)
- ✅ cse-1.6.4: Same test, different column order
- ✅ cse-1.6.5: `SELECT CASE WHEN 0 THEN d ...` (0 is falsy)

No regressions:
- select1.test: 188/188 passing ✅
- null.test: 39/39 passing ✅

## Test Plan

- [x] cse.test shows 3 additional passing tests
- [x] No regressions on select1.test and null.test
- [x] Release build succeeds

Closes #4828

🤖 Generated with [Claude Code](https://claude.com/claude-code)