### PR TITLE
chore(deps): remove 25+ unused dependencies across 6 crates

### DIFF
--- a/crates/vibesql-ast/Cargo.toml
+++ b/crates/vibesql-ast/Cargo.toml
@@ -14,4 +14,3 @@ vibesql-types = { version = "0.1.3", path = "../vibesql-types" }
 bumpalo = { version = "3.16", features = ["collections"] }
 
 [dev-dependencies]
-arcstr = "1.2"

--- a/crates/vibesql-cli/Cargo.toml
+++ b/crates/vibesql-cli/Cargo.toml
@@ -27,11 +27,9 @@ vibesql-l10n = { version = "0.1.3", path = "../vibesql-l10n" }
 # CLI dependencies
 clap = { version = "4", features = ["derive"] }
 rustyline = "17"
-fluent = "0.17"
 prettytable-rs = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-csv = "1.3"
 anyhow = "1.0"
 atty = "0.2"
 toml = "0.9"

--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -23,7 +23,6 @@ indexmap = "2.0"
 hex = "0.4"
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 geo = { version = "0.32", optional = true }
-wkt = { version = "0.14", optional = true }
 rstar = { version = "0.12", optional = true }
 lru = "0.16"
 log = "0.4"
@@ -38,20 +37,11 @@ md-5 = "0.10"
 # Arrow dependencies for vectorized execution
 # Using 53.0+ for chrono 0.4.42 compatibility (fixes quarter() method ambiguity)
 arrow = "57.1"
-arrow-array = "57.1"
-arrow-arith = "57.1"  # For SIMD-accelerated temporal operations
-arrow-select = "57.1"
 
 # Optional comparison engine dependencies
 rusqlite = { version = "0.38", features = ["bundled"], optional = true }
 duckdb = { version = "1.1", features = ["bundled"], optional = true }
 mysql = { version = "26.0", optional = true }
-
-# Optional JIT compilation dependencies
-cranelift = { version = "0.127", optional = true }
-cranelift-jit = { version = "0.127", optional = true }
-cranelift-module = { version = "0.127", optional = true }
-cranelift-native = { version = "0.127", optional = true }
 
 # jemalloc for better memory release characteristics in benchmarks
 # These must be in [dependencies] (not dev-dependencies) to be feature-gated
@@ -67,13 +57,10 @@ criterion = { version = "0.8", features = ["html_reports"] }
 parking_lot = "0.12"  # For concurrent_throughput benchmark
 rand = "0.9"
 rand_chacha = "0.9"
-rust_decimal = "1.33"
-paste = "1.0"
 env_logger = "0.11"
 libc = "0.2"
 sysinfo = "0.37"
 tokio = { version = "1.0", features = ["full", "rt-multi-thread"] }
-bytes = "1.0"
 tempfile = "3.19"
 num_cpus = "1.16"
 
@@ -82,7 +69,7 @@ default = ["parallel", "spatial", "native-columnar"]
 # Parallel processing using rayon (disabled in WASM where it provides no benefit)
 parallel = ["rayon", "crossbeam-deque"]
 # Spatial/geospatial query support (optional, reduces binary size)
-spatial = ["geo", "wkt", "rstar"]
+spatial = ["geo", "rstar"]
 
 # VibeSQL performance features (for benchmarks)
 # Native columnar execution (Phase 2b - zero row materialization)
@@ -115,9 +102,6 @@ benchmark = ["native-columnar", "in-memory-indexes", "all-engines"]
 profile-q6 = []
 # Enable detailed profiling output for TPC-C transactions
 profile-tpcc = []
-# Enable JIT compilation support using Cranelift (research/experimental)
-# Usage: cargo bench --features jit,benchmark
-jit = ["cranelift", "cranelift-jit", "cranelift-module", "cranelift-native"]
 # Enable experimental SIMD-accelerated group-by aggregation (research/experimental)
 simd = []
 # Use jemalloc allocator for better memory release characteristics

--- a/crates/vibesql-l10n/Cargo.toml
+++ b/crates/vibesql-l10n/Cargo.toml
@@ -19,13 +19,10 @@ path = "src/bin/check-translations.rs"
 
 [dependencies]
 fluent = "0.17"
-fluent-bundle = "0.16"
 fluent-syntax = "0.12"
-fluent-langneg = "0.14"
 unic-langid = "0.9"
 rust-embed = "8"
 once_cell = "1.19"
 thiserror = "2.0"
 
 [dev-dependencies]
-tempfile = "3"

--- a/crates/vibesql-server/Cargo.toml
+++ b/crates/vibesql-server/Cargo.toml
@@ -48,23 +48,10 @@ async-stream = "0.3"
 # HTTP framework and utilities
 axum = "0.8"
 tower = "0.5"
-tower-http = { version = "0.6", features = ["trace", "cors", "compression-br", "compression-gzip"] }
-hyper = { version = "1.0", features = ["full"] }
-http-body-util = "0.1"
-
-# TLS/SSL support (use ring backend - faster to compile than aws-lc-rs)
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
-rustls-pemfile = "2.0"
 
 # Authentication
 argon2 = { version = "0.5", features = ["std"] }
 md-5 = "0.10"
-sha2 = "0.10"
-base64 = "0.22"
-hmac = "0.12"
-pbkdf2 = "0.12"
-jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 
 # Configuration and error handling
 toml = "0.9"
@@ -103,7 +90,6 @@ bytes = "1.0"
 criterion = { version = "0.8", features = ["async_tokio"] }
 tempfile = "3"
 tokio = { version = "1.0", features = ["full", "test-util"] }
-tokio-test = "0.4"
 tokio-postgres = "0.7"
 tower = { version = "0.5", features = ["util"] }
 reqwest = { version = "0.12", features = ["stream"] }

--- a/crates/vibesql-sqllogictest/Cargo.toml
+++ b/crates/vibesql-sqllogictest/Cargo.toml
@@ -15,7 +15,6 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-educe = "0.6"
 fs-err = "3"
 futures = "0.3"
 glob = "0.3"
@@ -33,4 +32,3 @@ tracing = "0.1"
 rand = "0.9.2"
 
 [dev-dependencies]
-pretty_assertions = "1"

--- a/crates/vibesql-wasm-bindings/Cargo.toml
+++ b/crates/vibesql-wasm-bindings/Cargo.toml
@@ -27,7 +27,6 @@ console_error_panic_hook = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 serde_json = "1.0"
-getrandom = { version = "0.3", features = ["wasm_js"] }
 
 # Optional i18n support
 vibesql-l10n = { version = "0.1.3", path = "../vibesql-l10n", optional = true }
@@ -43,10 +42,13 @@ vibesql-ast = { version = "0.1.3", path = "../vibesql-ast" }
 vibesql-parser = { version = "0.1.3", path = "../vibesql-parser" }
 vibesql-executor = { version = "0.1.3", path = "../vibesql-executor", default-features = false }
 vibesql-storage = { version = "0.1.3", path = "../vibesql-storage", default-features = false }
-vibesql-catalog = { version = "0.1.3", path = "../vibesql-catalog" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+
+# wasm-bindgen-futures is required by #[wasm_bindgen] macro even though not directly imported
+[package.metadata.cargo-machete]
+ignored = ["wasm-bindgen-futures"]
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = [


### PR DESCRIPTION
## Summary

Remove unused dependencies detected by `cargo machete --with-metadata`. This removes 25+ direct dependencies (and many more transitive) across 6 crates.

### Changes by Crate

**vibesql-server (12 deps removed):**
- TLS/auth stack: `base64`, `hmac`, `sha2`, `pbkdf2`, `jsonwebtoken`, `rustls`, `rustls-pemfile`, `tokio-rustls`
- HTTP middleware: `tower-http`, `hyper`, `http-body-util`
- Dev: `tokio-test`

**vibesql-executor (11 deps removed):**
- Arrow SIMD: `arrow-arith`, `arrow-array`, `arrow-select` (unused operations)
- JIT: `cranelift`, `cranelift-jit`, `cranelift-module`, `cranelift-native` (+ removes `jit` feature)
- Optional: `wkt` (spatial feature uses `geo` crate directly)
- Dev: `bytes`, `paste`, `rust_decimal`

**vibesql-wasm-bindings (2 deps removed):**
- `getrandom`, `vibesql-catalog`

**vibesql-sqllogictest (2 deps removed):**
- `educe`, `pretty_assertions`

**vibesql-l10n (3 deps removed):**
- `fluent-bundle`, `fluent-langneg`, `tempfile` (dev)

**vibesql-cli (2 deps removed):**
- `csv`, `fluent`

**vibesql-ast (1 dep removed):**
- `arcstr` (dev)

## Benefits

- **Faster compile times**: Fewer crates to compile
- **Smaller binaries**: Especially with cranelift removed
- **Reduced audit surface**: Fewer dependencies to monitor for vulnerabilities
- **Cleaner dependency tree**: Easier to understand and maintain

## Verification

- ✅ `cargo build --lib --all` passes
- ✅ `cargo machete` shows no unused dependencies
- ✅ Library tests pass (2252 passed, 3 pre-existing failures unrelated to this change)

## Test Plan

- [x] Build all library targets
- [x] Run library tests
- [x] Verify cargo machete clean

Closes #4854