### PR TITLE
fix(executor): detect aggregate misuse in scalar subquery arguments (#4853)

### DIFF
--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -59,13 +59,13 @@ impl SelectExecutor<'_> {
         // This catches queries like SELECT * FROM t, t, t, ... (65+ times)
         super::validation::validate_join_table_limit(stmt)?;
 
-        // NOTE: Validation for aggregates referencing outer columns was removed.
-        // The previous validation (issue #4730) was too strict - it rejected valid SQLite queries
-        // like `SELECT (SELECT string_agg(a1,'x') FROM t2) FROM t1;` where a scalar subquery's
-        // aggregate references an outer column. SQLite allows this when the subquery result
-        // is not used as an argument to an outer aggregate function. The specific case that
-        // should error (like `SELECT max((SELECT count(x) FROM t35b)) FROM t35a;`) requires
-        // more targeted detection of when a subquery is used as an outer aggregate argument.
+        // Validate aggregates with outer column references in subqueries (issue #4853)
+        // This catches the specific case where a scalar subquery appears as an argument
+        // to an outer aggregate function, and the subquery's aggregate references an
+        // outer column. Example: SELECT max((SELECT count(x) FROM t35b)) FROM t35a;
+        // Note: Standalone correlated subqueries are valid and allowed, e.g.,
+        // SELECT (SELECT count(x) FROM t35b) FROM t35a; is valid in SQLite.
+        super::validation::validate_aggregate_subquery_outer_refs(stmt, self.database)?;
 
         #[cfg(feature = "profile-q6")]
         let execute_start = std::time::Instant::now();
@@ -1177,11 +1177,13 @@ impl SelectExecutor<'_> {
             // LIMIT enables early termination when ORDER BY is satisfied by index (#3253)
             // Pass select_list for table elimination optimization (#3556)
             //
-            // Don't pass ORDER BY if there's a set operation - it will be handled at the set operation level
+            // Don't pass ORDER BY if there's a set operation - it will be handled at the set
+            // operation level
             let order_by_hint =
                 if stmt.set_operation.is_some() { None } else { stmt.order_by.as_deref() };
-            // Don't pass LIMIT hint for set operations - limit must be applied after combining results
-            // This prevents early termination from incorrectly limiting the left side of UNION queries
+            // Don't pass LIMIT hint for set operations - limit must be applied after combining
+            // results This prevents early termination from incorrectly limiting the
+            // left side of UNION queries
             let limit_val = if stmt.set_operation.is_some() {
                 None
             } else {
@@ -1262,7 +1264,9 @@ impl SelectExecutor<'_> {
                             } else {
                                 // If table wasn't qualified, search all tables in FROM
                                 if let Some(collation) = Self::find_column_collation_in_from(
-                                    db, from_clause.unwrap(), column_name
+                                    db,
+                                    from_clause.unwrap(),
+                                    column_name,
                                 ) {
                                     return Some(collation);
                                 }
@@ -1616,11 +1620,13 @@ impl SelectExecutor<'_> {
         mut rows: Vec<vibesql_storage::Row>,
         order_by: &[vibesql_ast::OrderByItem],
         select_list: &[vibesql_ast::SelectItem],
-        all_union_aliases: &[Vec<Option<String>>], // Aliases from all UNION branches (wildcards expanded)
-        column_collations: &[Option<String>],      // Inherited collations from first SELECT columns
+        all_union_aliases: &[Vec<Option<String>>], /* Aliases from all UNION branches (wildcards
+                                                    * expanded) */
+        column_collations: &[Option<String>], // Inherited collations from first SELECT columns
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
-        use crate::select::grouping::compare_sql_values_with_collation;
         use std::cmp::Ordering;
+
+        use crate::select::grouping::compare_sql_values_with_collation;
 
         // Build column name map from the first branch's aliases (with wildcards already expanded)
         // The all_union_aliases already contains expanded column names from collect_union_aliases
@@ -1682,9 +1688,10 @@ impl SelectExecutor<'_> {
                     };
                     (col_idx, Some(collation.clone()))
                 }
-                // Complex expressions (aggregates, arithmetic, etc.): match against first SELECT's select_list
-                // SQLite allows ORDER BY to reference expressions from the first SELECT
-                // e.g., SELECT count(*) FROM t UNION SELECT n FROM t2 ORDER BY count(*)
+                // Complex expressions (aggregates, arithmetic, etc.): match against first SELECT's
+                // select_list SQLite allows ORDER BY to reference expressions from
+                // the first SELECT e.g., SELECT count(*) FROM t UNION SELECT n FROM
+                // t2 ORDER BY count(*)
                 other_expr => {
                     let col_idx = select_list.iter().enumerate().find_map(|(idx, item)| {
                         if let vibesql_ast::SelectItem::Expression { expr, .. } = item {
@@ -1719,9 +1726,8 @@ impl SelectExecutor<'_> {
                     None => !is_desc, // SQLite default: NULL is smallest
                 };
                 // Use explicit collation if specified, otherwise inherit from column schema
-                let collation = explicit_collation.or_else(|| {
-                    inherited_collations.get(col_idx).cloned().flatten()
-                });
+                let collation = explicit_collation
+                    .or_else(|| inherited_collations.get(col_idx).cloned().flatten());
                 sort_columns.push((col_idx, is_desc, nulls_first, collation));
             } else {
                 // ORDER BY term doesn't match any column in the result set

--- a/crates/vibesql-executor/src/select/executor/validation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/mod.rs
@@ -29,8 +29,7 @@ pub use aggregates::{
 pub use column_refs::ColumnReference;
 pub use column_refs::{extract_column_refs, validate_column_ref};
 pub use join_limits::validate_join_table_limit;
-#[allow(unused_imports)]
-pub use schema::validate_no_aggregate_with_outer_column;
+pub use schema::validate_aggregate_subquery_outer_refs;
 use vibesql_ast::{Expression, SelectItem};
 
 use crate::{errors::ExecutorError, schema::CombinedSchema};

--- a/crates/vibesql-executor/src/select/executor/validation/schema.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/schema.rs
@@ -1,6 +1,23 @@
 //! Schema-level validation for subqueries
 //!
 //! Validates that aggregates in subqueries don't reference outer columns.
+//!
+//! ## Key Validation: Aggregates with Outer Column References
+//!
+//! SQLite rejects queries where a scalar subquery is used as an argument to
+//! an outer aggregate function, and the subquery's aggregate references an
+//! outer column. For example:
+//!
+//! ```sql
+//! -- REJECT: count(x) references outer t35a.x, and subquery is argument to max()
+//! SELECT max((SELECT count(x) FROM t35b)) FROM t35a;
+//!
+//! -- ALLOW: count(x) references outer column, but subquery is NOT inside an aggregate
+//! SELECT (SELECT count(x) FROM t35b) FROM t35a;
+//! ```
+//!
+//! This distinction is critical: correlated subqueries with aggregates are valid
+//! when they stand alone, but invalid when used as arguments to outer aggregates.
 
 use std::collections::{HashMap, HashSet};
 
@@ -14,7 +31,6 @@ use crate::{errors::ExecutorError, schema::CombinedSchema};
 /// (not the subquery's own tables)
 ///
 /// Returns Some(column_name) if an outer column is found, None otherwise.
-#[allow(dead_code)]
 fn find_outer_column_in_expression(
     expr: &Expression,
     subquery_tables: &[String],
@@ -197,7 +213,6 @@ fn find_outer_column_in_expression(
 /// Check if an aggregate function's arguments reference columns from the outer schema
 ///
 /// Returns Some(aggregate_name) if misuse is found, None otherwise.
-#[allow(dead_code)]
 fn find_aggregate_with_outer_column(
     expr: &Expression,
     subquery_tables: &[String],
@@ -395,7 +410,6 @@ fn find_aggregate_with_outer_column(
 }
 
 /// Extract table names from a FROM clause
-#[allow(dead_code)]
 fn extract_table_names(from: Option<&vibesql_ast::FromClause>) -> Vec<String> {
     let mut tables = Vec::new();
     if let Some(from_clause) = from {
@@ -405,7 +419,6 @@ fn extract_table_names(from: Option<&vibesql_ast::FromClause>) -> Vec<String> {
 }
 
 /// Recursively extract table names from a FROM clause
-#[allow(dead_code)]
 fn extract_table_names_recursive(from: &vibesql_ast::FromClause, tables: &mut Vec<String>) {
     match from {
         vibesql_ast::FromClause::Table { name, alias, .. } => {
@@ -427,7 +440,6 @@ fn extract_table_names_recursive(from: &vibesql_ast::FromClause, tables: &mut Ve
 /// Build a CombinedSchema from table names in a FROM clause
 ///
 /// Looks up each table in the database and builds a schema containing all columns.
-#[allow(dead_code)]
 fn build_schema_from_tables(
     tables: &[String],
     database: &vibesql_storage::Database,
@@ -483,7 +495,6 @@ fn build_schema_from_tables(
 /// Note: This validation is skipped if the subquery's FROM clause contains CTEs or
 /// subquery aliases, since we can't reliably determine the inner schema without
 /// executing the CTE/subquery first.
-#[allow(dead_code)]
 pub fn validate_no_aggregate_with_outer_column(
     stmt: &SelectStmt,
     outer_schema: &CombinedSchema,
@@ -529,4 +540,219 @@ pub fn validate_no_aggregate_with_outer_column(
     }
 
     Ok(())
+}
+
+/// Validate that scalar subqueries inside outer aggregate arguments don't have
+/// aggregates referencing outer columns.
+///
+/// This is the targeted validation for issue #4853. It specifically checks for:
+///
+/// ```sql
+/// SELECT max((SELECT count(x) FROM t35b)) FROM t35a;
+/// --     ^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/// --     |    Scalar subquery with aggregate referencing outer column 'x'
+/// --     Outer aggregate function
+/// ```
+///
+/// The key distinction from the general `validate_no_aggregate_with_outer_column`:
+/// - This ONLY validates when a scalar subquery appears as an argument to an outer aggregate
+/// - Standalone correlated subqueries like `SELECT (SELECT count(x) FROM t35b) FROM t35a` are valid
+///   and should not be rejected
+///
+/// Returns an error if a scalar subquery inside an outer aggregate contains an aggregate
+/// that references an outer column.
+pub fn validate_aggregate_subquery_outer_refs(
+    stmt: &SelectStmt,
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    // Build outer schema from FROM clause
+    let outer_tables = extract_table_names(stmt.from.as_ref());
+    let outer_schema = match build_schema_from_tables(&outer_tables, database) {
+        Some(schema) => schema,
+        None => return Ok(()), // No outer schema, nothing to validate
+    };
+
+    // Check each SELECT item for outer aggregates containing scalar subqueries
+    for item in &stmt.select_list {
+        if let SelectItem::Expression { expr, .. } = item {
+            validate_aggregates_with_subquery_args(expr, &outer_schema, database)?;
+        }
+    }
+
+    // Also check HAVING clause
+    if let Some(having) = &stmt.having {
+        validate_aggregates_with_subquery_args(having, &outer_schema, database)?;
+    }
+
+    Ok(())
+}
+
+/// Recursively find outer aggregate functions and validate their scalar subquery arguments
+fn validate_aggregates_with_subquery_args(
+    expr: &Expression,
+    outer_schema: &CombinedSchema,
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    match expr {
+        Expression::AggregateFunction { args, .. } => {
+            // This is an outer aggregate - check its arguments for scalar subqueries
+            for arg in args {
+                validate_subqueries_in_aggregate_arg(arg, outer_schema, database)?;
+            }
+            Ok(())
+        }
+        Expression::Function { name, args, .. } => {
+            // Check if this is a built-in aggregate function
+            if is_aggregate_function(name.as_str()) {
+                let upper = name.to_uppercase();
+                // Multi-arg MIN/MAX are scalar functions, not aggregates
+                let is_scalar_minmax = matches!(upper.as_str(), "MIN" | "MAX") && args.len() > 1;
+                if !is_scalar_minmax {
+                    // This is an outer aggregate - check its arguments for scalar subqueries
+                    for arg in args {
+                        validate_subqueries_in_aggregate_arg(arg, outer_schema, database)?;
+                    }
+                    return Ok(());
+                }
+            }
+            // Non-aggregate function or scalar MIN/MAX - recurse into arguments
+            for arg in args {
+                validate_aggregates_with_subquery_args(arg, outer_schema, database)?;
+            }
+            Ok(())
+        }
+        Expression::BinaryOp { left, right, .. } => {
+            validate_aggregates_with_subquery_args(left, outer_schema, database)?;
+            validate_aggregates_with_subquery_args(right, outer_schema, database)
+        }
+        Expression::UnaryOp { expr, .. } => {
+            validate_aggregates_with_subquery_args(expr, outer_schema, database)
+        }
+        Expression::Cast { expr, .. } => {
+            validate_aggregates_with_subquery_args(expr, outer_schema, database)
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                validate_aggregates_with_subquery_args(op, outer_schema, database)?;
+            }
+            for when_clause in when_clauses {
+                for cond in &when_clause.conditions {
+                    validate_aggregates_with_subquery_args(cond, outer_schema, database)?;
+                }
+                validate_aggregates_with_subquery_args(
+                    &when_clause.result,
+                    outer_schema,
+                    database,
+                )?;
+            }
+            if let Some(else_expr) = else_result {
+                validate_aggregates_with_subquery_args(else_expr, outer_schema, database)?;
+            }
+            Ok(())
+        }
+        Expression::IsNull { expr, .. } => {
+            validate_aggregates_with_subquery_args(expr, outer_schema, database)
+        }
+        Expression::Between { expr, low, high, .. } => {
+            validate_aggregates_with_subquery_args(expr, outer_schema, database)?;
+            validate_aggregates_with_subquery_args(low, outer_schema, database)?;
+            validate_aggregates_with_subquery_args(high, outer_schema, database)
+        }
+        Expression::InList { expr, values, .. } => {
+            validate_aggregates_with_subquery_args(expr, outer_schema, database)?;
+            for val in values {
+                validate_aggregates_with_subquery_args(val, outer_schema, database)?;
+            }
+            Ok(())
+        }
+        Expression::Like { expr, pattern, .. } => {
+            validate_aggregates_with_subquery_args(expr, outer_schema, database)?;
+            validate_aggregates_with_subquery_args(pattern, outer_schema, database)
+        }
+        Expression::Conjunction(children) | Expression::Disjunction(children) => {
+            for child in children {
+                validate_aggregates_with_subquery_args(child, outer_schema, database)?;
+            }
+            Ok(())
+        }
+        // Scalar subqueries NOT inside an aggregate are fine - don't recurse into them
+        Expression::ScalarSubquery(_) | Expression::Exists { .. } | Expression::In { .. } => Ok(()),
+        _ => Ok(()),
+    }
+}
+
+/// Validate scalar subqueries that appear as arguments to outer aggregates
+///
+/// This function is called when we're inside an outer aggregate's arguments.
+/// Any scalar subquery found here must be validated for aggregates referencing outer columns.
+fn validate_subqueries_in_aggregate_arg(
+    expr: &Expression,
+    outer_schema: &CombinedSchema,
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    match expr {
+        Expression::ScalarSubquery(subquery) => {
+            // Found a scalar subquery inside an outer aggregate - validate it
+            validate_no_aggregate_with_outer_column(subquery, outer_schema, database)
+        }
+        // Recurse into composite expressions to find nested scalar subqueries
+        Expression::BinaryOp { left, right, .. } => {
+            validate_subqueries_in_aggregate_arg(left, outer_schema, database)?;
+            validate_subqueries_in_aggregate_arg(right, outer_schema, database)
+        }
+        Expression::UnaryOp { expr, .. } => {
+            validate_subqueries_in_aggregate_arg(expr, outer_schema, database)
+        }
+        Expression::Function { args, .. } => {
+            for arg in args {
+                validate_subqueries_in_aggregate_arg(arg, outer_schema, database)?;
+            }
+            Ok(())
+        }
+        Expression::Cast { expr, .. } => {
+            validate_subqueries_in_aggregate_arg(expr, outer_schema, database)
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                validate_subqueries_in_aggregate_arg(op, outer_schema, database)?;
+            }
+            for when_clause in when_clauses {
+                for cond in &when_clause.conditions {
+                    validate_subqueries_in_aggregate_arg(cond, outer_schema, database)?;
+                }
+                validate_subqueries_in_aggregate_arg(&when_clause.result, outer_schema, database)?;
+            }
+            if let Some(else_expr) = else_result {
+                validate_subqueries_in_aggregate_arg(else_expr, outer_schema, database)?;
+            }
+            Ok(())
+        }
+        Expression::IsNull { expr, .. } => {
+            validate_subqueries_in_aggregate_arg(expr, outer_schema, database)
+        }
+        Expression::Between { expr, low, high, .. } => {
+            validate_subqueries_in_aggregate_arg(expr, outer_schema, database)?;
+            validate_subqueries_in_aggregate_arg(low, outer_schema, database)?;
+            validate_subqueries_in_aggregate_arg(high, outer_schema, database)
+        }
+        Expression::InList { expr, values, .. } => {
+            validate_subqueries_in_aggregate_arg(expr, outer_schema, database)?;
+            for val in values {
+                validate_subqueries_in_aggregate_arg(val, outer_schema, database)?;
+            }
+            Ok(())
+        }
+        Expression::Like { expr, pattern, .. } => {
+            validate_subqueries_in_aggregate_arg(expr, outer_schema, database)?;
+            validate_subqueries_in_aggregate_arg(pattern, outer_schema, database)
+        }
+        Expression::Conjunction(children) | Expression::Disjunction(children) => {
+            for child in children {
+                validate_subqueries_in_aggregate_arg(child, outer_schema, database)?;
+            }
+            Ok(())
+        }
+        // Note: We don't recurse into nested aggregates because the outer check handles those
+        _ => Ok(()),
+    }
 }

--- a/tests/sqllogictest-files/select/aggregate_subquery_outer_refs.slt
+++ b/tests/sqllogictest-files/select/aggregate_subquery_outer_refs.slt
@@ -1,0 +1,63 @@
+# Issue #4853: Detect and reject aggregate functions with outer column references in subqueries
+#
+# SQLite rejects queries where a scalar subquery is used as an argument to an outer
+# aggregate function, and the subquery's aggregate references an outer column.
+
+# Setup tables
+statement ok
+CREATE TABLE t35a(x INTEGER)
+
+statement ok
+CREATE TABLE t35b(y INTEGER)
+
+statement ok
+INSERT INTO t35a VALUES(1), (2)
+
+statement ok
+INSERT INTO t35b VALUES(10), (20)
+
+# This should fail: count(x) references outer table t35a.x
+# and the subquery is used as argument to outer aggregate max()
+statement error misuse of aggregate: count()
+SELECT max((SELECT count(x) FROM t35b)) FROM t35a
+
+# This variation IS valid - references inner column y
+query I
+SELECT max((SELECT count(y) FROM t35b)) FROM t35a
+----
+2
+
+# Standalone correlated subquery with aggregate referencing outer column is valid
+# (not inside an outer aggregate)
+query I rowsort
+SELECT (SELECT count(x) FROM t35b) FROM t35a
+----
+2
+2
+
+# Multiple outer aggregates with subqueries - first one should trigger error
+statement error misuse of aggregate: count()
+SELECT max((SELECT count(x) FROM t35b)), min(y) FROM t35a, t35b
+
+# Nested expression with subquery inside outer aggregate
+statement error misuse of aggregate: count()
+SELECT sum(1 + (SELECT count(x) FROM t35b)) FROM t35a
+
+# Valid: aggregate on inner column even with outer table in subquery correlation
+query I
+SELECT max((SELECT count(*) FROM t35b WHERE y > 0)) FROM t35a
+----
+2
+
+# Valid: scalar subquery NOT inside outer aggregate
+query I
+SELECT x + (SELECT count(x) FROM t35b) FROM t35a WHERE x = 1
+----
+3
+
+# Cleanup
+statement ok
+DROP TABLE t35a
+
+statement ok
+DROP TABLE t35b


### PR DESCRIPTION
## Summary

- Add targeted validation to detect when a scalar subquery used as an argument to an outer aggregate function contains an aggregate that references outer columns
- This matches SQLite's behavior and produces the error "misuse of aggregate: count()"

## Key Changes

The key distinction from the previous (too strict) validation:

- **REJECT**: `SELECT max((SELECT count(x) FROM t35b)) FROM t35a;`
  - Subquery is argument to outer aggregate `max()`
  - Inner aggregate `count(x)` references outer column `x` from `t35a`
  
- **ALLOW**: `SELECT (SELECT count(x) FROM t35b) FROM t35a;`
  - Standalone correlated subquery is valid in SQLite
  - Not used as argument to an outer aggregate

## Implementation

- Added `validate_aggregate_subquery_outer_refs()` function in `validation/schema.rs`
- The function walks through outer aggregate arguments, finds scalar subqueries, and validates that their aggregates don't reference outer columns
- Called from `execute()` early in the validation phase

## Test plan

- [x] Manual testing with SQLite-compatible queries
- [x] Added SQLLogicTest file: `tests/sqllogictest-files/select/aggregate_subquery_outer_refs.slt`
- [x] Verified REJECT case produces correct error
- [x] Verified ALLOW cases work correctly

Closes #4853

🤖 Generated with [Claude Code](https://claude.com/claude-code)