### PR TITLE
fix(optimizer): only eliminate DISTINCT when unique index columns are NOT NULL

### DIFF
--- a/crates/vibesql-executor/src/optimizer/distinct_elimination.rs
+++ b/crates/vibesql-executor/src/optimizer/distinct_elimination.rs
@@ -1,0 +1,393 @@
+//! DISTINCT elimination optimization
+//!
+//! This module implements the optimization that eliminates redundant DISTINCT
+//! when the SELECT columns are guaranteed to be unique due to:
+//! 1. A UNIQUE index covering all SELECT columns
+//! 2. All columns in that unique index being NOT NULL
+//!
+//! Without the NOT NULL guarantee, multiple NULL values could exist in the result
+//! set (since NULL != NULL in SQL), making DISTINCT necessary.
+//!
+//! References:
+//! - SQLite's distinct.test (tests 1.1 vs 1.2, etc.)
+//! - SQL standard semantics for UNIQUE constraints with NULLs
+
+use std::collections::HashSet;
+
+use vibesql_ast::{Expression, SelectItem, SelectStmt};
+use vibesql_storage::Database;
+
+/// Check if DISTINCT can be eliminated for a SELECT statement.
+///
+/// DISTINCT can be eliminated when:
+/// 1. The query is a simple single-table query (no joins, subqueries)
+/// 2. There exists a UNIQUE index (or PRIMARY KEY, or rowid) that covers the SELECT columns
+/// 3. All columns in that unique index are NOT NULL
+///
+/// This follows SQLite's behavior as documented in distinct.test.
+///
+/// # Arguments
+/// * `stmt` - The SELECT statement to analyze
+/// * `database` - Database for looking up table schemas and indexes
+///
+/// # Returns
+/// * `true` if DISTINCT is provably redundant and can be eliminated
+/// * `false` if DISTINCT must be preserved
+pub fn can_eliminate_distinct(stmt: &SelectStmt, database: &Database) -> bool {
+    // Only handle simple single-table queries
+    let table_name = match &stmt.from {
+        Some(vibesql_ast::FromClause::Table { name, .. }) => name.as_str(),
+        // Joins, subqueries, etc. - don't eliminate DISTINCT
+        _ => return false,
+    };
+
+    // Get the table schema
+    let Some(table) = database.get_table(table_name) else {
+        return false;
+    };
+    let schema = &table.schema;
+
+    // Extract columns from SELECT list
+    let select_columns = match extract_select_columns(&stmt.select_list, schema) {
+        Some(cols) => cols,
+        None => return false, // Wildcard or expression - can't determine columns
+    };
+
+    if select_columns.is_empty() {
+        return false;
+    }
+
+    // Check if rowid is in the select list - rowid is always unique
+    if select_columns.iter().any(|c| c.eq_ignore_ascii_case("rowid")) {
+        return true;
+    }
+
+    // Check PRIMARY KEY (rowid alias)
+    // If we're selecting the INTEGER PRIMARY KEY column, it's always unique
+    if let Some(rowid_idx) = schema.rowid_alias_column {
+        let rowid_col = &schema.columns[rowid_idx].name;
+        if select_columns.iter().any(|c| c.eq_ignore_ascii_case(rowid_col)) {
+            return true;
+        }
+    }
+
+    // Check if PRIMARY KEY covers select columns AND all PK columns are NOT NULL
+    if let Some(ref pk_cols) = schema.primary_key {
+        if covers_columns(pk_cols, &select_columns, &stmt.where_clause, schema) {
+            // Check if all PK columns are NOT NULL
+            if all_columns_not_null(pk_cols, schema) {
+                return true;
+            }
+        }
+    }
+
+    // Check UNIQUE constraints from CREATE TABLE
+    for unique_cols in &schema.unique_constraints {
+        if covers_columns(unique_cols, &select_columns, &stmt.where_clause, schema)
+            && all_columns_not_null(unique_cols, schema) {
+                return true;
+            }
+    }
+
+    // Check user-defined UNIQUE indexes
+    for index_name in database.list_indexes() {
+        let Some(index) = database.get_index(&index_name) else {
+            continue;
+        };
+
+        // Skip if not for this table or not unique
+        if !index.table_name.eq_ignore_ascii_case(table_name) || !index.unique {
+            continue;
+        }
+
+        // Get column names from index (skip expression indexes)
+        let index_cols: Vec<String> =
+            index.columns.iter().filter_map(|c| c.column_name().map(|s| s.to_string())).collect();
+
+        if index_cols.len() != index.columns.len() {
+            // Has expression columns - skip for now
+            continue;
+        }
+
+        if covers_columns(&index_cols, &select_columns, &stmt.where_clause, schema)
+            && all_columns_not_null(&index_cols, schema) {
+                return true;
+            }
+    }
+
+    false
+}
+
+/// Extract column names from SELECT list.
+/// Returns None if the select list contains wildcards or complex expressions.
+fn extract_select_columns(
+    select_list: &[SelectItem],
+    schema: &vibesql_catalog::TableSchema,
+) -> Option<Vec<String>> {
+    let mut columns = Vec::new();
+
+    for item in select_list {
+        match item {
+            SelectItem::Wildcard { .. } => {
+                // SELECT * - return all columns
+                for col in &schema.columns {
+                    columns.push(col.name.clone());
+                }
+            }
+            SelectItem::QualifiedWildcard { .. } => {
+                // table.* - for single table, same as *
+                for col in &schema.columns {
+                    columns.push(col.name.clone());
+                }
+            }
+            SelectItem::Expression { expr, .. } => {
+                // Try to extract column reference
+                if let Some(col_name) = extract_column_from_expr(expr) {
+                    columns.push(col_name);
+                } else {
+                    // Complex expression - we can still continue
+                    // The column might still be covered by an index
+                    // But for safety, skip expressions that aren't simple column refs
+                    return None;
+                }
+            }
+        }
+    }
+
+    Some(columns)
+}
+
+/// Extract a column name from a simple column reference expression.
+fn extract_column_from_expr(expr: &Expression) -> Option<String> {
+    match expr {
+        Expression::ColumnRef(col_id) => Some(col_id.column_canonical().to_string()),
+        _ => None,
+    }
+}
+
+/// Check if a set of unique columns covers the select columns.
+///
+/// A unique index "covers" the select columns if:
+/// 1. All unique index columns are in the select columns, OR
+/// 2. Some unique index columns are fixed by WHERE clause equality conditions
+///
+/// For example, with UNIQUE INDEX ON (a, b):
+/// - SELECT a, b FROM t - covered (both columns in select)
+/// - SELECT b FROM t WHERE a = 5 - covered (a is fixed, b in select)
+fn covers_columns(
+    unique_cols: &[String],
+    select_cols: &[String],
+    where_clause: &Option<Expression>,
+    schema: &vibesql_catalog::TableSchema,
+) -> bool {
+    let select_set: HashSet<String> = select_cols.iter().map(|c| c.to_lowercase()).collect();
+
+    // Get columns fixed by WHERE clause (col = const)
+    let fixed_cols = get_fixed_columns(where_clause, schema);
+
+    // Check if every unique column is either in select list or fixed by WHERE
+    for unique_col in unique_cols {
+        let unique_col_lower = unique_col.to_lowercase();
+        if !select_set.contains(&unique_col_lower) && !fixed_cols.contains(&unique_col_lower) {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Get columns that are fixed to constant values by WHERE clause.
+/// Only considers simple equality conditions (col = const).
+fn get_fixed_columns(
+    where_clause: &Option<Expression>,
+    _schema: &vibesql_catalog::TableSchema,
+) -> HashSet<String> {
+    let mut fixed = HashSet::new();
+
+    if let Some(expr) = where_clause {
+        collect_fixed_columns(expr, &mut fixed);
+    }
+
+    fixed
+}
+
+/// Recursively collect columns that are fixed to constants.
+fn collect_fixed_columns(expr: &Expression, fixed: &mut HashSet<String>) {
+    use vibesql_ast::BinaryOperator;
+
+    match expr {
+        Expression::BinaryOp { op: BinaryOperator::Equal, left, right } => {
+            // Check if one side is a column and the other is a constant
+            if let Expression::ColumnRef(col_id) = left.as_ref() {
+                if is_constant(right) {
+                    fixed.insert(col_id.column_canonical().to_lowercase());
+                }
+            }
+            if let Expression::ColumnRef(col_id) = right.as_ref() {
+                if is_constant(left) {
+                    fixed.insert(col_id.column_canonical().to_lowercase());
+                }
+            }
+        }
+        Expression::Conjunction(exprs) => {
+            for e in exprs {
+                collect_fixed_columns(e, fixed);
+            }
+        }
+        Expression::BinaryOp { op: BinaryOperator::And, left, right } => {
+            collect_fixed_columns(left, fixed);
+            collect_fixed_columns(right, fixed);
+        }
+        _ => {}
+    }
+}
+
+/// Check if an expression is a constant (literal, placeholder, etc.).
+fn is_constant(expr: &Expression) -> bool {
+    matches!(
+        expr,
+        Expression::Literal(_)
+            | Expression::Placeholder(_)
+            | Expression::NumberedPlaceholder(_)
+            | Expression::NamedPlaceholder(_)
+    )
+}
+
+/// Check if all columns in a list are NOT NULL.
+fn all_columns_not_null(columns: &[String], schema: &vibesql_catalog::TableSchema) -> bool {
+    for col_name in columns {
+        let col_lower = col_name.to_lowercase();
+        let col = schema.columns.iter().find(|c| c.name.to_lowercase() == col_lower);
+        match col {
+            Some(c) => {
+                if c.nullable {
+                    return false;
+                }
+            }
+            None => {
+                // Column not found - shouldn't happen, but be conservative
+                return false;
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use vibesql_ast::{ColumnIdentifier, OrderDirection, SelectStmt};
+    use vibesql_catalog::{ColumnSchema, TableSchema};
+    use vibesql_storage::Database;
+    use vibesql_types::DataType;
+
+    use super::*;
+
+    fn create_test_database() -> Database {
+        let mut db = Database::new();
+
+        // Create t1: nullable columns with unique index
+        let t1_cols = vec![
+            ColumnSchema::new("a".to_string(), DataType::Integer, true),
+            ColumnSchema::new("b".to_string(), DataType::Integer, true),
+            ColumnSchema::new("c".to_string(), DataType::Integer, true),
+            ColumnSchema::new("d".to_string(), DataType::Integer, true),
+        ];
+        let t1_schema = TableSchema::new("t1".to_string(), t1_cols);
+        db.create_table(t1_schema).unwrap();
+
+        // Create t4: NOT NULL columns with unique index
+        let t4_cols = vec![
+            ColumnSchema::new("a".to_string(), DataType::Integer, true), // nullable
+            ColumnSchema::new("b".to_string(), DataType::Integer, false), // NOT NULL
+            ColumnSchema::new("c".to_string(), DataType::Integer, false), // NOT NULL
+            ColumnSchema::new("d".to_string(), DataType::Integer, false), // NOT NULL
+        ];
+        let t4_schema = TableSchema::new("t4".to_string(), t4_cols);
+        db.create_table(t4_schema).unwrap();
+
+        // Create unique index on (b, c) for both tables
+        db.create_index(
+            "i1".to_string(),
+            "t1".to_string(),
+            true, // unique
+            vec![
+                vibesql_ast::IndexColumn::new_column("b".to_string(), OrderDirection::Asc),
+                vibesql_ast::IndexColumn::new_column("c".to_string(), OrderDirection::Asc),
+            ],
+        )
+        .unwrap();
+
+        db.create_index(
+            "t4i1".to_string(),
+            "t4".to_string(),
+            true, // unique
+            vec![
+                vibesql_ast::IndexColumn::new_column("b".to_string(), OrderDirection::Asc),
+                vibesql_ast::IndexColumn::new_column("c".to_string(), OrderDirection::Asc),
+            ],
+        )
+        .unwrap();
+
+        db
+    }
+
+    fn make_select_stmt(table: &str, columns: &[&str]) -> SelectStmt {
+        let select_list: Vec<SelectItem> = columns
+            .iter()
+            .map(|c| SelectItem::Expression {
+                expr: Expression::ColumnRef(ColumnIdentifier::simple(c, false)),
+                alias: None,
+                source_text: None,
+            })
+            .collect();
+
+        SelectStmt {
+            with_clause: None,
+            distinct: true,
+            select_list,
+            into_table: None,
+            into_variables: None,
+            from: Some(vibesql_ast::FromClause::Table {
+                name: table.to_string(),
+                alias: None,
+                column_aliases: None,
+                quoted: false,
+            }),
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        }
+    }
+
+    #[test]
+    fn test_distinct_not_eliminated_nullable_columns() {
+        let db = create_test_database();
+
+        // SELECT DISTINCT b, c FROM t1 - should NOT be eliminated (nullable columns)
+        let stmt = make_select_stmt("t1", &["b", "c"]);
+        assert!(!can_eliminate_distinct(&stmt, &db));
+    }
+
+    #[test]
+    fn test_distinct_eliminated_not_null_columns() {
+        let db = create_test_database();
+
+        // SELECT DISTINCT b, c FROM t4 - SHOULD be eliminated (NOT NULL columns)
+        let stmt = make_select_stmt("t4", &["b", "c"]);
+        assert!(can_eliminate_distinct(&stmt, &db));
+    }
+
+    #[test]
+    fn test_distinct_not_eliminated_partial_unique() {
+        let db = create_test_database();
+
+        // SELECT DISTINCT a, b FROM t4 - should NOT be eliminated (a not in unique index)
+        let stmt = make_select_stmt("t4", &["a", "b"]);
+        assert!(!can_eliminate_distinct(&stmt, &db));
+    }
+}

--- a/crates/vibesql-executor/src/optimizer/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/mod.rs
@@ -11,10 +11,12 @@
 //! - Aggregate-aware query optimization for GROUP BY/HAVING performance
 //! - Unused table elimination for cross join optimization
 //! - Column pruning for post-join processing optimization (#4355)
+//! - DISTINCT elimination when unique index + NOT NULL guarantee uniqueness (#4852)
 
 pub mod adaptive;
 pub mod aggregate_analysis;
 pub mod column_pruning;
+pub mod distinct_elimination;
 mod expressions;
 pub mod index_planner;
 mod predicate_plan;
@@ -30,6 +32,7 @@ pub use column_pruning::{
     collect_columns_from_expr, collect_required_columns, compute_projection_indices, project_rows,
     remap_schema,
 };
+pub use distinct_elimination::can_eliminate_distinct;
 pub use expressions::*;
 pub use predicate_plan::PredicatePlan;
 pub use subquery_rewrite::rewrite_subquery_optimizations;

--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -13,8 +13,8 @@ use crate::{
     errors::ExecutorError,
     evaluator::compiled_pivot::PivotAggregateGroup,
     optimizer::{
-        collect_columns_from_expr, collect_required_columns, compute_projection_indices,
-        optimize_where_clause, project_rows, remap_schema,
+        can_eliminate_distinct, collect_columns_from_expr, collect_required_columns,
+        compute_projection_indices, optimize_where_clause, project_rows, remap_schema,
     },
     pipeline::ExecutionContext,
     select::{
@@ -621,8 +621,9 @@ impl SelectExecutor<'_> {
             result_rows
         };
 
-        // Apply DISTINCT if specified
-        let result_rows = if stmt.distinct { apply_distinct(result_rows) } else { result_rows };
+        // Apply DISTINCT if specified (skip if unique index guarantees uniqueness - issue #4852)
+        let needs_distinct = stmt.distinct && !can_eliminate_distinct(stmt, self.database);
+        let result_rows = if needs_distinct { apply_distinct(result_rows) } else { result_rows };
 
         // SQL Standard: Aggregates without GROUP BY must return exactly ONE row,
         // even if the input is empty. If we have no GROUP BY and result_rows is empty,

--- a/crates/vibesql-executor/src/select/executor/nonagg/materialized.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/materialized.rs
@@ -20,7 +20,7 @@ use super::{
 use crate::{
     errors::ExecutorError,
     evaluator::CombinedExpressionEvaluator,
-    optimizer::optimize_where_clause,
+    optimizer::{can_eliminate_distinct, optimize_where_clause},
     pipeline::ExecutionContext,
     select::{
         filter::apply_where_filter_combined_auto,
@@ -452,9 +452,10 @@ impl SelectExecutor<'_> {
             result
         };
 
-        // Apply DISTINCT if specified
+        // Apply DISTINCT if specified (skip if unique index guarantees uniqueness - issue #4852)
+        let needs_distinct = stmt.distinct && !can_eliminate_distinct(stmt, self.database);
         let projected_rows =
-            if stmt.distinct { apply_distinct(projected_rows) } else { projected_rows };
+            if needs_distinct { apply_distinct(projected_rows) } else { projected_rows };
 
         // Don't apply LIMIT/OFFSET if we have a set operation - it will be applied later
         if stmt.set_operation.is_some() {

--- a/tests/sqllogictest-files/select/distinct_unique_optimization.slt
+++ b/tests/sqllogictest-files/select/distinct_unique_optimization.slt
@@ -1,0 +1,80 @@
+# Test DISTINCT elimination optimization (issue #4852)
+#
+# DISTINCT should only be eliminated when:
+# 1. SELECT columns are covered by a UNIQUE index
+# 2. All columns in that unique index are NOT NULL
+#
+# Without the NOT NULL guarantee, multiple NULL values could exist
+# in the result set (since NULL != NULL in SQL).
+
+# Create table with nullable columns and unique index
+statement ok
+CREATE TABLE t1(a, b, c, d)
+
+statement ok
+CREATE UNIQUE INDEX i1 ON t1(b, c)
+
+# Create table with NOT NULL columns and unique index
+statement ok
+CREATE TABLE t4(a, b NOT NULL, c NOT NULL, d NOT NULL)
+
+statement ok
+CREATE UNIQUE INDEX t4i1 ON t4(b, c)
+
+# Insert test data with NULLs in t1
+statement ok
+INSERT INTO t1 VALUES (1, NULL, NULL, 1)
+
+statement ok
+INSERT INTO t1 VALUES (2, NULL, NULL, 2)
+
+statement ok
+INSERT INTO t1 VALUES (3, 1, 2, 3)
+
+# Insert test data in t4 (no NULLs allowed)
+statement ok
+INSERT INTO t4 VALUES (1, 1, 2, 1)
+
+statement ok
+INSERT INTO t4 VALUES (2, 3, 4, 2)
+
+# Test: SELECT DISTINCT b, c FROM t1 should return multiple NULL rows
+# because DISTINCT is NOT eliminated (columns are nullable)
+query II rowsort
+SELECT DISTINCT b, c FROM t1
+----
+1	2
+NULL	NULL
+
+# Test: SELECT DISTINCT b, c FROM t4 returns all rows
+# DISTINCT can be eliminated because unique index columns are NOT NULL
+query II rowsort
+SELECT DISTINCT b, c FROM t4
+----
+1	2
+3	4
+
+# Test: Multiple NULL values in t1 are preserved when DISTINCT not eliminated
+statement ok
+INSERT INTO t1 VALUES (4, NULL, 3, 4)
+
+query II rowsort
+SELECT DISTINCT b, c FROM t1
+----
+1	2
+NULL	3
+NULL	NULL
+
+# Test: DISTINCT on columns NOT covered by unique index is NOT eliminated
+query II rowsort
+SELECT DISTINCT a, b FROM t4
+----
+1	1
+2	3
+
+# Clean up
+statement ok
+DROP TABLE t1
+
+statement ok
+DROP TABLE t4


### PR DESCRIPTION
## Summary

- Fixed DISTINCT elimination optimization to check that all unique index columns are NOT NULL before eliminating
- Added `can_eliminate_distinct` function to optimizer that validates uniqueness guarantees
- Without NOT NULL check, multiple NULL values could appear in result (since NULL != NULL in SQL)

## Changes

- **New file**: `crates/vibesql-executor/src/optimizer/distinct_elimination.rs` - Core implementation
- **Modified**: `optimizer/mod.rs` - Module export
- **Modified**: `materialized.rs` and `aggregation/mod.rs` - Apply the check before DISTINCT elimination

## Test plan

- [x] Unit tests in `distinct_elimination.rs` verify correct behavior for nullable vs NOT NULL columns
- [x] Integration test in `distinct_unique_optimization.slt` covers real query scenarios
- [x] Existing tests pass (2255 passed, 3 pre-existing failures unrelated to this change)

Closes #4852

🤖 Generated with [Claude Code](https://claude.com/claude-code)