### PR TITLE
refactor(executor): decompose create_index.rs into focused modules

### DIFF
--- a/crates/vibesql-executor/src/index_ddl/btree_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/btree_index.rs
@@ -1,0 +1,116 @@
+//! B-tree index creation
+//!
+//! This module handles creation of B-tree indexes, including:
+//! - Standard column-based indexes
+//! - Unique indexes
+//! - Multi-column composite indexes
+//! - Expression indexes (delegated to expression_index module)
+
+use vibesql_ast::{CreateIndexStmt, IndexColumn};
+use vibesql_catalog::TableSchema;
+use vibesql_storage::Database;
+
+use super::expression_index::create_expression_index;
+use crate::errors::ExecutorError;
+
+/// Create a B-tree index on a table.
+///
+/// Handles both column-based and expression indexes.
+/// Returns success message on completion.
+pub fn create_btree_index(
+    database: &mut Database,
+    stmt: &CreateIndexStmt,
+    table_name: &str,
+    qualified_table_name: &str,
+    table_schema: &TableSchema,
+    unique: bool,
+) -> Result<String, ExecutorError> {
+    let index_name = &stmt.index_name;
+
+    // Check if this is an expression index
+    let has_expression = stmt.columns.iter().any(|col| col.is_expression());
+
+    // Compute column indices early (before mutable borrows)
+    // For expression indexes, we use 0xFFFFFFFF to indicate computed columns
+    let column_indices: Vec<u32> = stmt
+        .columns
+        .iter()
+        .map(|col| {
+            if let Some(name) = col.column_name() {
+                table_schema.get_column_index(name).map(|idx| idx as u32).unwrap_or(0xFFFFFFFF)
+            } else {
+                0xFFFFFFFF // Expression column marker
+            }
+        })
+        .collect();
+
+    // Convert AST IndexColumn to catalog IndexedColumn
+    let catalog_columns = convert_to_catalog_columns(&stmt.columns);
+
+    // Add to catalog first (use unqualified table name as stored in catalog)
+    let index_metadata = vibesql_catalog::IndexMetadata::new(
+        index_name.clone(),
+        table_name.to_string(),
+        vibesql_catalog::IndexType::BTree,
+        catalog_columns,
+        unique,
+    );
+    database.catalog.add_index(index_metadata)?;
+
+    // Create the B-tree index
+    if has_expression {
+        // Expression index: pre-compute keys using ExpressionEvaluator
+        create_expression_index(database, table_name, index_name, table_schema, &stmt.columns, unique)?;
+    } else {
+        // Column-only index: use existing storage API
+        database.create_index(index_name.clone(), table_name.to_string(), unique, stmt.columns.clone())?;
+    }
+
+    // Emit WAL entry for persistence
+    database.emit_wal_create_index(
+        index_name_to_id(index_name),
+        index_name,
+        qualified_table_name,
+        column_indices,
+        unique,
+    );
+
+    Ok(format!("Index '{}' created successfully on table '{}'", index_name, qualified_table_name))
+}
+
+/// Convert AST IndexColumn to catalog IndexedColumn.
+fn convert_to_catalog_columns(columns: &[IndexColumn]) -> Vec<vibesql_catalog::IndexedColumn> {
+    columns
+        .iter()
+        .map(|col| {
+            let order = match col.direction() {
+                vibesql_ast::OrderDirection::Asc => vibesql_catalog::SortOrder::Ascending,
+                vibesql_ast::OrderDirection::Desc => vibesql_catalog::SortOrder::Descending,
+            };
+
+            if let Some(expr) = col.get_expression() {
+                // Expression index: store the expression for later use
+                vibesql_catalog::IndexedColumn::new_expression(expr.clone(), order)
+            } else if let Some(prefix_len) = col.prefix_length() {
+                vibesql_catalog::IndexedColumn::new_column_with_prefix(
+                    col.column_name().unwrap().to_string(),
+                    order,
+                    prefix_len,
+                )
+            } else {
+                vibesql_catalog::IndexedColumn::new_column(
+                    col.column_name().unwrap().to_string(),
+                    order,
+                )
+            }
+        })
+        .collect()
+}
+
+/// Compute an index ID from index name using hash (for consistent mapping).
+pub fn index_name_to_id(name: &str) -> u32 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    name.hash(&mut hasher);
+    hasher.finish() as u32
+}

--- a/crates/vibesql-executor/src/index_ddl/create_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/create_index.rs
@@ -1,17 +1,24 @@
 //! CREATE INDEX statement execution
+//!
+//! This module provides the main executor for CREATE INDEX statements,
+//! dispatching to specialized modules based on index type:
+//!
+//! - [`btree_index`] - B-tree indexes (standard and unique)
+//! - [`spatial_index`] - R-tree spatial indexes
+//! - [`vector_index`] - IVFFlat and HNSW vector indexes
+//! - [`expression_index`] - Expression-based functional indexes
+//! - [`validation`] - Pre-creation validation
 
 use vibesql_ast::CreateIndexStmt;
-use vibesql_storage::{
-    index::{extract_mbr_from_sql_value, SpatialIndex, SpatialIndexEntry},
-    Database, SpatialIndexMetadata,
-};
+use vibesql_storage::Database;
 
-use crate::{
-    errors::ExecutorError,
-    evaluator::ExpressionEvaluator,
-    privilege_checker::PrivilegeChecker,
-    sqlite_schema::is_sqlite_schema_table,
+use super::{
+    btree_index::create_btree_index,
+    spatial_index::create_spatial_index,
+    validation::{index_already_exists, validate_create_index},
+    vector_index::{create_hnsw_index, create_ivfflat_index},
 };
+use crate::errors::ExecutorError;
 
 /// Executor for CREATE INDEX statements
 pub struct CreateIndexExecutor;
@@ -58,711 +65,59 @@ impl CreateIndexExecutor {
         stmt: &CreateIndexStmt,
         database: &mut Database,
     ) -> Result<String, ExecutorError> {
-        // Parse qualified table name (schema.table or just table)
-        let (schema_name, table_name) =
-            if let Some((schema_part, table_part)) = stmt.table_name.split_once('.') {
-                (schema_part.to_string(), table_part.to_string())
-            } else {
-                (database.catalog.get_current_schema().to_string(), stmt.table_name.clone())
-            };
-
-        // Check if target is sqlite_master/sqlite_schema (read-only system table)
-        if is_sqlite_schema_table(&table_name) {
-            return Err(ExecutorError::SqliteSystemTableReadOnly {
-                table_name: table_name.clone(),
-                operation: "indexed".to_string(),
-            });
+        // Handle IF NOT EXISTS early (before validation which also checks this)
+        if stmt.if_not_exists && index_already_exists(stmt, database) {
+            return Ok(format!("Index '{}' already exists (skipped)", stmt.index_name));
         }
 
-        // Check CREATE privilege on the schema
-        PrivilegeChecker::check_create(database, &schema_name)?;
+        // Validate the CREATE INDEX statement
+        let validation = validate_create_index(stmt, database)?;
 
-        // Build fully qualified table name for catalog lookups
-        let qualified_table_name = format!("{}.{}", schema_name, table_name);
-
-        // Check if table exists
-        if !database.catalog.table_exists(&qualified_table_name) {
-            return Err(ExecutorError::TableNotFound(qualified_table_name.clone()));
-        }
-
-        // Get table schema to validate columns (clone to avoid borrow issues)
-        let table_schema = database
-            .catalog
-            .get_table(&qualified_table_name)
-            .ok_or_else(|| ExecutorError::TableNotFound(qualified_table_name.clone()))?
-            .clone();
-
-        // Expression index validation: check for non-deterministic expressions
-        // Expression indexes must use deterministic expressions (no RANDOM(), NOW(), etc.)
-        for index_col in &stmt.columns {
-            if let Some(expr) = index_col.get_expression() {
-                if !crate::evaluator::expression_hash::ExpressionHasher::is_deterministic_for_index(expr) {
-                    return Err(ExecutorError::UnsupportedFeature(
-                        "Expression indexes must use deterministic expressions. \
-                         Non-deterministic functions like RANDOM(), CURRENT_TIMESTAMP, etc. \
-                         are not allowed."
-                            .to_string(),
-                    ));
-                }
-            }
-        }
-
-        // Validate that all indexed columns exist in the table (for column-based indexes)
-        for index_col in &stmt.columns {
-            if let Some(col_name) = index_col.column_name() {
-                if table_schema.get_column(col_name).is_none() {
-                    let available_columns =
-                        table_schema.columns.iter().map(|c| c.name.clone()).collect();
-                    return Err(ExecutorError::ColumnNotFound {
-                        column_name: col_name.to_string(),
-                        table_name: qualified_table_name.clone(),
-                        searched_tables: vec![qualified_table_name.clone()],
-                        available_columns,
-                    });
-                }
-            }
-            // For expression indexes, validate that all column references in the expression exist
-            if let Some(expr) = index_col.get_expression() {
-                validate_expression_columns(expr, &table_schema, &qualified_table_name)?;
-            }
-        }
-
-        // Validate prefix length specifications (only for column-based indexes)
-        for index_col in &stmt.columns {
-            if let Some(prefix_len) = index_col.prefix_length() {
-                // Expression indexes don't support prefix lengths
-                if index_col.is_expression() {
-                    return Err(ExecutorError::InvalidIndexDefinition(
-                        "Prefix length cannot be specified for expression indexes".to_string(),
-                    ));
-                }
-
-                let col_name = index_col.column_name().unwrap(); // Safe: not an expression
-
-                // Prefix length must be positive
-                if prefix_len == 0 {
-                    return Err(ExecutorError::InvalidIndexDefinition(format!(
-                        "Prefix length must be greater than 0 for column '{}'",
-                        col_name
-                    )));
-                }
-
-                // Prefix length should only be used with string columns
-                let column = table_schema.get_column(col_name).unwrap(); // Safe: already validated above
-                match column.data_type {
-                    vibesql_types::DataType::Varchar { .. }
-                    | vibesql_types::DataType::Character { .. } => {
-                        // Valid string types for prefix indexing
-                    }
-                    _ => {
-                        return Err(ExecutorError::InvalidIndexDefinition(
-                            format!(
-                                "Prefix length can only be specified for string columns, but column '{}' has type {:?}",
-                                col_name, column.data_type
-                            ),
-                        ));
-                    }
-                }
-
-                // Reasonable upper limit check (64KB = 65536 characters)
-                // This prevents accidental extremely large prefix specifications
-                const MAX_PREFIX_LENGTH: u64 = 65536;
-                if prefix_len > MAX_PREFIX_LENGTH {
-                    return Err(ExecutorError::InvalidIndexDefinition(format!(
-                        "Prefix length {} is too large for column '{}' (maximum: {})",
-                        prefix_len,
-                        col_name,
-                        MAX_PREFIX_LENGTH
-                    )));
-                }
-            }
-        }
-
-        // Check if index already exists (either B-tree or spatial)
-        let index_name = &stmt.index_name;
-        let index_exists =
-            database.index_exists(index_name) || database.spatial_index_exists(index_name);
-
-        if index_exists {
-            if stmt.if_not_exists {
-                // IF NOT EXISTS: silently succeed if index already exists
-                return Ok(format!("Index '{}' already exists (skipped)", index_name));
-            } else {
-                return Err(ExecutorError::IndexAlreadyExists(index_name.clone()));
-            }
-        }
-
-        // SQLite namespace check: tables and indexes share a namespace
-        // Cannot create an index with the same name as an existing table
-        let normalized_index_name = index_name.to_lowercase();
-        for schema in database.catalog.list_schemas() {
-            let qualified_name = format!("{}.{}", schema, normalized_index_name);
-            if database.catalog.table_exists(&qualified_name) {
-                // Use SQLite-compatible error message (exact format required for TCL tests)
-                return Err(ExecutorError::SqliteCompatError(format!(
-                    "there is already a table named {}",
-                    index_name
-                )));
-            }
-        }
-
-        // Create the index based on type
+        // Dispatch to appropriate index creation based on type
         match &stmt.index_type {
-            vibesql_ast::IndexType::BTree { unique } => {
-                // Check if this is an expression index
-                let has_expression = stmt.columns.iter().any(|col| col.is_expression());
+            vibesql_ast::IndexType::BTree { unique } => create_btree_index(
+                database,
+                stmt,
+                &validation.table_name,
+                &validation.qualified_table_name,
+                &validation.table_schema,
+                *unique,
+            ),
 
-                // Compute column indices early (before mutable borrows)
-                // For expression indexes, we use 0xFFFFFFFF to indicate computed columns
-                let column_indices: Vec<u32> = stmt
-                    .columns
-                    .iter()
-                    .map(|col| {
-                        if let Some(name) = col.column_name() {
-                            table_schema
-                                .get_column_index(name)
-                                .map(|idx| idx as u32)
-                                .unwrap_or(0xFFFFFFFF)
-                        } else {
-                            0xFFFFFFFF // Expression column marker
-                        }
-                    })
-                    .collect();
-
-                // Convert AST IndexColumn to catalog IndexedColumn
-                let catalog_columns: Vec<vibesql_catalog::IndexedColumn> = stmt
-                    .columns
-                    .iter()
-                    .map(|col| {
-                        let order = match col.direction() {
-                            vibesql_ast::OrderDirection::Asc => {
-                                vibesql_catalog::SortOrder::Ascending
-                            }
-                            vibesql_ast::OrderDirection::Desc => {
-                                vibesql_catalog::SortOrder::Descending
-                            }
-                        };
-
-                        if let Some(expr) = col.get_expression() {
-                            // Expression index: store the expression for later use
-                            vibesql_catalog::IndexedColumn::new_expression(
-                                expr.clone(),
-                                order,
-                            )
-                        } else if let Some(prefix_len) = col.prefix_length() {
-                            vibesql_catalog::IndexedColumn::new_column_with_prefix(
-                                col.column_name().unwrap().to_string(),
-                                order,
-                                prefix_len,
-                            )
-                        } else {
-                            vibesql_catalog::IndexedColumn::new_column(
-                                col.column_name().unwrap().to_string(),
-                                order,
-                            )
-                        }
-                    })
-                    .collect();
-
-                // Add to catalog first (use unqualified table name as stored in catalog)
-                let index_metadata = vibesql_catalog::IndexMetadata::new(
-                    index_name.clone(),
-                    table_name.clone(),
-                    vibesql_catalog::IndexType::BTree,
-                    catalog_columns,
-                    *unique,
-                );
-                database.catalog.add_index(index_metadata)?;
-
-                // Create the B-tree index
-                if has_expression {
-                    // Expression index: pre-compute keys using ExpressionEvaluator
-                    create_expression_index(
-                        database,
-                        &table_name,
-                        index_name,
-                        &table_schema,
-                        &stmt.columns,
-                        *unique,
-                    )?;
-                } else {
-                    // Column-only index: use existing storage API
-                    database.create_index(
-                        index_name.clone(),
-                        table_name.clone(),
-                        *unique,
-                        stmt.columns.clone(),
-                    )?;
-                }
-
-                // Emit WAL entry for persistence
-                database.emit_wal_create_index(
-                    index_name_to_id(index_name),
-                    index_name,
-                    &qualified_table_name,
-                    column_indices,
-                    *unique,
-                );
-
-                Ok(format!(
-                    "Index '{}' created successfully on table '{}'",
-                    index_name, qualified_table_name
-                ))
-            }
             vibesql_ast::IndexType::Fulltext => Err(ExecutorError::UnsupportedFeature(
                 "FULLTEXT indexes are not yet implemented".to_string(),
             )),
-            vibesql_ast::IndexType::Spatial => {
-                // Spatial index validation: must be exactly 1 column
-                if stmt.columns.len() != 1 {
-                    return Err(ExecutorError::InvalidIndexDefinition(
-                        "SPATIAL indexes must be defined on exactly one column".to_string(),
-                    ));
-                }
 
-                let column_name = stmt.columns[0].expect_column_name();
+            vibesql_ast::IndexType::Spatial => create_spatial_index(
+                database,
+                stmt,
+                &validation.table_name,
+                &validation.qualified_table_name,
+                &validation.table_schema,
+            ),
 
-                // Get the column index
-                let col_idx = table_schema.get_column_index(column_name).ok_or_else(|| {
-                    ExecutorError::ColumnNotFound {
-                        column_name: column_name.to_string(),
-                        table_name: qualified_table_name.clone(),
-                        searched_tables: vec![qualified_table_name.clone()],
-                        available_columns: table_schema
-                            .columns
-                            .iter()
-                            .map(|c| c.name.clone())
-                            .collect(),
-                    }
-                })?;
+            vibesql_ast::IndexType::IVFFlat { metric, lists } => create_ivfflat_index(
+                database,
+                stmt,
+                &validation.table_name,
+                &validation.qualified_table_name,
+                &validation.table_schema,
+                *metric,
+                *lists,
+            ),
 
-                // Extract MBRs from all existing rows (use unqualified name, database handles
-                // qualification)
-                let table = database
-                    .get_table(&table_name)
-                    .ok_or_else(|| ExecutorError::TableNotFound(qualified_table_name.clone()))?;
-
-                let mut entries = Vec::new();
-                // Use scan_live() to skip deleted rows and get correct physical indices
-                for (row_idx, row) in table.scan_live() {
-                    let geom_value = &row.values[col_idx];
-
-                    // Extract MBR from geometry value (skip NULLs and invalid geometries)
-                    if let Some(mbr) = extract_mbr_from_sql_value(geom_value) {
-                        entries.push(SpatialIndexEntry { row_id: row_idx, mbr });
-                    }
-                }
-
-                // Build spatial index via bulk_load (more efficient than incremental inserts)
-                let spatial_index = SpatialIndex::bulk_load(column_name.to_string(), entries);
-
-                // Add to catalog first (use unqualified table name as stored in catalog)
-                let index_metadata = vibesql_catalog::IndexMetadata::new(
-                    index_name.clone(),
-                    table_name.clone(),
-                    vibesql_catalog::IndexType::RTree,
-                    vec![vibesql_catalog::IndexedColumn::new_column(
-                        column_name.to_string(),
-                        vibesql_catalog::SortOrder::Ascending,
-                    )],
-                    false,
-                );
-                database.catalog.add_index(index_metadata)?;
-
-                // Store in database (use unqualified table name for storage metadata)
-                let metadata = SpatialIndexMetadata {
-                    index_name: index_name.clone(),
-                    table_name: table_name.clone(),
-                    column_name: column_name.to_string(),
-                    created_at: Some(chrono::Utc::now()),
-                };
-
-                database.create_spatial_index(metadata, spatial_index)?;
-
-                // Emit WAL entry for persistence (spatial indexes are never unique)
-                database.emit_wal_create_index(
-                    index_name_to_id(index_name),
-                    index_name,
-                    &qualified_table_name,
-                    vec![col_idx as u32],
-                    false,
-                );
-
-                Ok(format!(
-                    "Spatial index '{}' created successfully on table '{}'",
-                    index_name, qualified_table_name
-                ))
-            }
-            vibesql_ast::IndexType::IVFFlat { metric, lists } => {
-                // IVFFlat index validation: must be exactly 1 column (vector column)
-                if stmt.columns.len() != 1 {
-                    return Err(ExecutorError::InvalidIndexDefinition(
-                        "IVFFlat indexes must be defined on exactly one vector column".to_string(),
-                    ));
-                }
-
-                let column_name = stmt.columns[0].expect_column_name();
-
-                // Get the column index and validate it's a vector type
-                let col_idx = table_schema.get_column_index(column_name).ok_or_else(|| {
-                    ExecutorError::ColumnNotFound {
-                        column_name: column_name.to_string(),
-                        table_name: qualified_table_name.clone(),
-                        searched_tables: vec![qualified_table_name.clone()],
-                        available_columns: table_schema
-                            .columns
-                            .iter()
-                            .map(|c| c.name.clone())
-                            .collect(),
-                    }
-                })?;
-
-                // Validate column type is VECTOR
-                let col_type = &table_schema.columns[col_idx].data_type;
-                let dimensions = match col_type {
-                    vibesql_types::DataType::Vector { dimensions } => *dimensions as usize,
-                    _ => {
-                        return Err(ExecutorError::InvalidIndexDefinition(format!(
-                            "IVFFlat indexes can only be created on VECTOR columns, but '{}' has type {:?}",
-                            column_name, col_type
-                        )));
-                    }
-                };
-
-                // Convert AST metric to catalog metric
-                let catalog_metric = match metric {
-                    vibesql_ast::VectorDistanceMetric::L2 => {
-                        vibesql_catalog::VectorDistanceMetric::L2
-                    }
-                    vibesql_ast::VectorDistanceMetric::Cosine => {
-                        vibesql_catalog::VectorDistanceMetric::Cosine
-                    }
-                    vibesql_ast::VectorDistanceMetric::InnerProduct => {
-                        vibesql_catalog::VectorDistanceMetric::InnerProduct
-                    }
-                };
-
-                // Add to catalog first
-                let index_metadata = vibesql_catalog::IndexMetadata::new(
-                    index_name.clone(),
-                    table_name.clone(),
-                    vibesql_catalog::IndexType::IVFFlat { metric: catalog_metric, lists: *lists },
-                    vec![vibesql_catalog::IndexedColumn::new_column(
-                        column_name.to_string(),
-                        vibesql_catalog::SortOrder::Ascending, // Not meaningful for vector indexes
-                    )],
-                    false, // IVFFlat indexes are never unique
-                );
-                database.catalog.add_index(index_metadata)?;
-
-                // Create the IVFFlat index in storage
-                database.create_ivfflat_index(
-                    index_name.clone(),
-                    table_name.clone(),
-                    column_name.to_string(),
-                    col_idx,
-                    dimensions,
-                    *lists as usize,
-                    *metric,
-                )?;
-
-                // Emit WAL entry for persistence (IVFFlat indexes are never unique)
-                database.emit_wal_create_index(
-                    index_name_to_id(index_name),
-                    index_name,
-                    &qualified_table_name,
-                    vec![col_idx as u32],
-                    false,
-                );
-
-                Ok(format!(
-                    "IVFFlat index '{}' created successfully on table '{}' column '{}'",
-                    index_name, qualified_table_name, column_name
-                ))
-            }
-            vibesql_ast::IndexType::Hnsw { metric, m, ef_construction } => {
-                // HNSW index validation: must be exactly 1 column (vector column)
-                if stmt.columns.len() != 1 {
-                    return Err(ExecutorError::InvalidIndexDefinition(
-                        "HNSW indexes must be defined on exactly one vector column".to_string(),
-                    ));
-                }
-
-                let column_name = stmt.columns[0].expect_column_name();
-
-                // Get the column index and validate it's a vector type
-                let col_idx = table_schema.get_column_index(column_name).ok_or_else(|| {
-                    ExecutorError::ColumnNotFound {
-                        column_name: column_name.to_string(),
-                        table_name: qualified_table_name.clone(),
-                        searched_tables: vec![qualified_table_name.clone()],
-                        available_columns: table_schema
-                            .columns
-                            .iter()
-                            .map(|c| c.name.clone())
-                            .collect(),
-                    }
-                })?;
-
-                // Validate column type is VECTOR
-                let col_type = &table_schema.columns[col_idx].data_type;
-                let dimensions = match col_type {
-                    vibesql_types::DataType::Vector { dimensions } => *dimensions as usize,
-                    _ => {
-                        return Err(ExecutorError::InvalidIndexDefinition(format!(
-                            "HNSW indexes can only be created on VECTOR columns, but '{}' has type {:?}",
-                            column_name, col_type
-                        )));
-                    }
-                };
-
-                // Convert AST metric to catalog metric
-                let catalog_metric = match metric {
-                    vibesql_ast::VectorDistanceMetric::L2 => {
-                        vibesql_catalog::VectorDistanceMetric::L2
-                    }
-                    vibesql_ast::VectorDistanceMetric::Cosine => {
-                        vibesql_catalog::VectorDistanceMetric::Cosine
-                    }
-                    vibesql_ast::VectorDistanceMetric::InnerProduct => {
-                        vibesql_catalog::VectorDistanceMetric::InnerProduct
-                    }
-                };
-
-                // Add to catalog first
-                let index_metadata = vibesql_catalog::IndexMetadata::new(
-                    index_name.clone(),
-                    table_name.clone(),
-                    vibesql_catalog::IndexType::Hnsw {
-                        metric: catalog_metric,
-                        m: *m,
-                        ef_construction: *ef_construction,
-                    },
-                    vec![vibesql_catalog::IndexedColumn::new_column(
-                        column_name.to_string(),
-                        vibesql_catalog::SortOrder::Ascending, // Not meaningful for vector indexes
-                    )],
-                    false, // HNSW indexes are never unique
-                );
-                database.catalog.add_index(index_metadata)?;
-
-                // Create the HNSW index in storage
-                database.create_hnsw_index(
-                    index_name.clone(),
-                    table_name.clone(),
-                    column_name.to_string(),
-                    col_idx,
-                    dimensions,
-                    *m,
-                    *ef_construction,
-                    *metric,
-                )?;
-
-                // Emit WAL entry for persistence (HNSW indexes are never unique)
-                database.emit_wal_create_index(
-                    index_name_to_id(index_name),
-                    index_name,
-                    &qualified_table_name,
-                    vec![col_idx as u32],
-                    false,
-                );
-
-                Ok(format!(
-                    "HNSW index '{}' created successfully on table '{}' column '{}'",
-                    index_name, qualified_table_name, column_name
-                ))
-            }
+            vibesql_ast::IndexType::Hnsw { metric, m, ef_construction } => create_hnsw_index(
+                database,
+                stmt,
+                &validation.table_name,
+                &validation.qualified_table_name,
+                &validation.table_schema,
+                *metric,
+                *m,
+                *ef_construction,
+            ),
         }
     }
-}
-
-/// Compute an index ID from index name using hash (for consistent mapping)
-fn index_name_to_id(name: &str) -> u32 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    name.hash(&mut hasher);
-    hasher.finish() as u32
-}
-
-/// Validate that all column references in an expression exist in the table schema.
-fn validate_expression_columns(
-    expr: &vibesql_ast::Expression,
-    table_schema: &vibesql_catalog::TableSchema,
-    qualified_table_name: &str,
-) -> Result<(), ExecutorError> {
-    use vibesql_ast::Expression;
-
-    match expr {
-        Expression::ColumnRef(col_id) => {
-            let col_name = col_id.column_canonical();
-            if table_schema.get_column(col_name).is_none() {
-                let available_columns =
-                    table_schema.columns.iter().map(|c| c.name.clone()).collect();
-                return Err(ExecutorError::ColumnNotFound {
-                    column_name: col_name.to_string(),
-                    table_name: qualified_table_name.to_string(),
-                    searched_tables: vec![qualified_table_name.to_string()],
-                    available_columns,
-                });
-            }
-            Ok(())
-        }
-        Expression::BinaryOp { left, right, .. } => {
-            validate_expression_columns(left, table_schema, qualified_table_name)?;
-            validate_expression_columns(right, table_schema, qualified_table_name)
-        }
-        Expression::UnaryOp { expr, .. } => {
-            validate_expression_columns(expr, table_schema, qualified_table_name)
-        }
-        Expression::Function { args, .. } => {
-            for arg in args {
-                validate_expression_columns(arg, table_schema, qualified_table_name)?;
-            }
-            Ok(())
-        }
-        Expression::Case { operand, when_clauses, else_result } => {
-            if let Some(op) = operand {
-                validate_expression_columns(op, table_schema, qualified_table_name)?;
-            }
-            for clause in when_clauses {
-                for cond in &clause.conditions {
-                    validate_expression_columns(cond, table_schema, qualified_table_name)?;
-                }
-                validate_expression_columns(&clause.result, table_schema, qualified_table_name)?;
-            }
-            if let Some(else_expr) = else_result {
-                validate_expression_columns(else_expr, table_schema, qualified_table_name)?;
-            }
-            Ok(())
-        }
-        Expression::Cast { expr, .. } => {
-            validate_expression_columns(expr, table_schema, qualified_table_name)
-        }
-        Expression::Collate { expr, .. } => {
-            validate_expression_columns(expr, table_schema, qualified_table_name)
-        }
-        Expression::IsNull { expr, .. } => {
-            validate_expression_columns(expr, table_schema, qualified_table_name)
-        }
-        Expression::Between { expr, low, high, .. } => {
-            validate_expression_columns(expr, table_schema, qualified_table_name)?;
-            validate_expression_columns(low, table_schema, qualified_table_name)?;
-            validate_expression_columns(high, table_schema, qualified_table_name)
-        }
-        Expression::InList { expr, values, .. } => {
-            validate_expression_columns(expr, table_schema, qualified_table_name)?;
-            for item in values {
-                validate_expression_columns(item, table_schema, qualified_table_name)?;
-            }
-            Ok(())
-        }
-        Expression::Like { expr, pattern, .. } => {
-            validate_expression_columns(expr, table_schema, qualified_table_name)?;
-            validate_expression_columns(pattern, table_schema, qualified_table_name)
-        }
-        // Literals and other self-contained expressions don't reference columns
-        Expression::Literal(_)
-        | Expression::Wildcard
-        | Expression::Placeholder(_)
-        | Expression::NumberedPlaceholder(_)
-        | Expression::NamedPlaceholder(_) => Ok(()),
-        // For other expression types, conservatively allow them
-        // (they may be validated during evaluation)
-        _ => Ok(()),
-    }
-}
-
-/// Create an expression index by evaluating expressions for each row.
-///
-/// This function:
-/// 1. Scans all rows in the table
-/// 2. Evaluates the expression(s) for each row to compute index key values
-/// 3. Builds the B-tree index with the computed keys
-/// 4. Enforces UNIQUE constraint if specified
-fn create_expression_index(
-    database: &mut Database,
-    table_name: &str,
-    index_name: &str,
-    table_schema: &vibesql_catalog::TableSchema,
-    columns: &[vibesql_ast::IndexColumn],
-    unique: bool,
-) -> Result<(), ExecutorError> {
-    use std::collections::HashSet;
-
-    // Get table for scanning
-    let table = database
-        .get_table(table_name)
-        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
-
-    // Create expression evaluator for this table's schema
-    let evaluator = ExpressionEvaluator::new(table_schema);
-
-    // Collect all key-value pairs (key, row_id)
-    let mut keys: Vec<(Vec<vibesql_types::SqlValue>, usize)> = Vec::new();
-    let mut unique_keys: HashSet<Vec<vibesql_types::SqlValue>> = HashSet::new();
-
-    // Scan all live rows
-    for (row_idx, row) in table.scan_live() {
-        // Evaluate each expression/column to build the key
-        let mut key_values: Vec<vibesql_types::SqlValue> = Vec::new();
-
-        for col in columns {
-            let value = if let Some(expr) = col.get_expression() {
-                // Expression: evaluate it
-                evaluator.eval(expr, row)?
-            } else if let Some(col_name) = col.column_name() {
-                // Column reference: extract value directly
-                let col_idx = table_schema
-                    .get_column_index(col_name)
-                    .ok_or_else(|| ExecutorError::ColumnNotFound {
-                        column_name: col_name.to_string(),
-                        table_name: table_name.to_string(),
-                        searched_tables: vec![table_name.to_string()],
-                        available_columns: table_schema
-                            .columns
-                            .iter()
-                            .map(|c| c.name.clone())
-                            .collect(),
-                    })?;
-                row.values[col_idx].clone()
-            } else {
-                // Should not happen: validated earlier
-                return Err(ExecutorError::InvalidIndexDefinition(
-                    "Index column must be either a column name or an expression".to_string(),
-                ));
-            };
-
-            key_values.push(value);
-        }
-
-        // UNIQUE constraint validation
-        // NULL values are excluded from uniqueness checks (SQL standard)
-        if unique {
-            let has_null = key_values.iter().any(|v| matches!(v, vibesql_types::SqlValue::Null));
-            if !has_null {
-                if unique_keys.contains(&key_values) {
-                    return Err(ExecutorError::ConstraintViolation(format!(
-                        "UNIQUE constraint failed: duplicate key in expression index '{}'",
-                        index_name
-                    )));
-                }
-                unique_keys.insert(key_values.clone());
-            }
-        }
-
-        keys.push((key_values, row_idx));
-    }
-
-    // Create the index in storage using the pre-computed keys
-    database.create_index_with_keys(
-        index_name.to_string(),
-        table_name.to_string(),
-        unique,
-        columns.to_vec(),
-        keys,
-    )?;
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -775,7 +130,8 @@ mod tests {
     use crate::CreateTableExecutor;
 
     fn create_test_table(db: &mut Database) {
-        let stmt = CreateTableStmt { temporary: false,
+        let stmt = CreateTableStmt {
+            temporary: false,
             if_not_exists: false,
             table_name: "users".to_string(),
             columns: vec![
@@ -786,7 +142,8 @@ mod tests {
                     constraints: vec![],
                     default_value: None,
                     comment: None,
-                    generated_expr: None, is_exact_integer_type: false,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
                 },
                 ColumnDef {
                     name: "email".to_string(),
@@ -795,7 +152,8 @@ mod tests {
                     constraints: vec![],
                     default_value: None,
                     comment: None,
-                    generated_expr: None, is_exact_integer_type: false,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
                 },
                 ColumnDef {
                     name: "name".to_string(),
@@ -804,13 +162,15 @@ mod tests {
                     constraints: vec![],
                     default_value: None,
                     comment: None,
-                    generated_expr: None, is_exact_integer_type: false,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
                 },
             ],
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
-            as_query: None, without_rowid: false,
+            as_query: None,
+            without_rowid: false,
         };
 
         CreateTableExecutor::execute(&stmt, db).unwrap();
@@ -1085,7 +445,8 @@ mod tests {
     // ========================================================================
 
     fn create_vector_table(db: &mut Database) {
-        let stmt = CreateTableStmt { temporary: false,
+        let stmt = CreateTableStmt {
+            temporary: false,
             if_not_exists: false,
             table_name: "documents".to_string(),
             columns: vec![
@@ -1096,7 +457,8 @@ mod tests {
                     constraints: vec![],
                     default_value: None,
                     comment: None,
-                    generated_expr: None, is_exact_integer_type: false,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
                 },
                 ColumnDef {
                     name: "embedding".to_string(),
@@ -1105,7 +467,8 @@ mod tests {
                     constraints: vec![],
                     default_value: None,
                     comment: None,
-                    generated_expr: None, is_exact_integer_type: false,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
                 },
                 ColumnDef {
                     name: "content".to_string(),
@@ -1114,13 +477,15 @@ mod tests {
                     constraints: vec![],
                     default_value: None,
                     comment: None,
-                    generated_expr: None, is_exact_integer_type: false,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
                 },
             ],
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
-            as_query: None, without_rowid: false,
+            as_query: None,
+            without_rowid: false,
         };
 
         CreateTableExecutor::execute(&stmt, db).unwrap();
@@ -1506,7 +871,8 @@ mod tests {
                     constraints: vec![],
                     default_value: None,
                     comment: None,
-                    generated_expr: None, is_exact_integer_type: false,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
                 },
                 vibesql_ast::ColumnDef {
                     name: "price".to_string(),
@@ -1515,7 +881,8 @@ mod tests {
                     constraints: vec![],
                     default_value: None,
                     comment: None,
-                    generated_expr: None, is_exact_integer_type: false,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
                 },
                 vibesql_ast::ColumnDef {
                     name: "discount".to_string(),
@@ -1524,13 +891,15 @@ mod tests {
                     constraints: vec![],
                     default_value: None,
                     comment: None,
-                    generated_expr: None, is_exact_integer_type: false,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
                 },
             ],
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
-            as_query: None, without_rowid: false,
+            as_query: None,
+            without_rowid: false,
         };
         crate::CreateTableExecutor::execute(&table_stmt, &mut db).unwrap();
 

--- a/crates/vibesql-executor/src/index_ddl/expression_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/expression_index.rs
@@ -1,0 +1,106 @@
+//! Expression index creation
+//!
+//! This module handles creation of expression-based indexes (functional indexes).
+//! Expression indexes compute index keys by evaluating expressions on each row,
+//! rather than using column values directly.
+
+use std::collections::HashSet;
+
+use vibesql_ast::IndexColumn;
+use vibesql_catalog::TableSchema;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+use crate::{errors::ExecutorError, evaluator::ExpressionEvaluator};
+
+/// Create an expression index by evaluating expressions for each row.
+///
+/// This function:
+/// 1. Scans all rows in the table
+/// 2. Evaluates the expression(s) for each row to compute index key values
+/// 3. Builds the B-tree index with the computed keys
+/// 4. Enforces UNIQUE constraint if specified
+pub fn create_expression_index(
+    database: &mut Database,
+    table_name: &str,
+    index_name: &str,
+    table_schema: &TableSchema,
+    columns: &[IndexColumn],
+    unique: bool,
+) -> Result<(), ExecutorError> {
+    // Get table for scanning
+    let table = database
+        .get_table(table_name)
+        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+
+    // Create expression evaluator for this table's schema
+    let evaluator = ExpressionEvaluator::new(table_schema);
+
+    // Collect all key-value pairs (key, row_id)
+    let mut keys: Vec<(Vec<SqlValue>, usize)> = Vec::new();
+    let mut unique_keys: HashSet<Vec<SqlValue>> = HashSet::new();
+
+    // Scan all live rows
+    for (row_idx, row) in table.scan_live() {
+        // Evaluate each expression/column to build the key
+        let mut key_values: Vec<SqlValue> = Vec::new();
+
+        for col in columns {
+            let value = if let Some(expr) = col.get_expression() {
+                // Expression: evaluate it
+                evaluator.eval(expr, row)?
+            } else if let Some(col_name) = col.column_name() {
+                // Column reference: extract value directly
+                let col_idx =
+                    table_schema.get_column_index(col_name).ok_or_else(|| {
+                        ExecutorError::ColumnNotFound {
+                            column_name: col_name.to_string(),
+                            table_name: table_name.to_string(),
+                            searched_tables: vec![table_name.to_string()],
+                            available_columns: table_schema
+                                .columns
+                                .iter()
+                                .map(|c| c.name.clone())
+                                .collect(),
+                        }
+                    })?;
+                row.values[col_idx].clone()
+            } else {
+                // Should not happen: validated earlier
+                return Err(ExecutorError::InvalidIndexDefinition(
+                    "Index column must be either a column name or an expression".to_string(),
+                ));
+            };
+
+            key_values.push(value);
+        }
+
+        // UNIQUE constraint validation
+        // NULL values are excluded from uniqueness checks (SQL standard)
+        if unique {
+            let has_null = key_values.iter().any(|v| matches!(v, SqlValue::Null));
+            if !has_null {
+                if unique_keys.contains(&key_values) {
+                    return Err(ExecutorError::ConstraintViolation(format!(
+                        "UNIQUE constraint failed: duplicate key in expression index '{}'",
+                        index_name
+                    )));
+                }
+                unique_keys.insert(key_values.clone());
+            }
+        }
+
+        keys.push((key_values, row_idx));
+    }
+
+    // Create the index in storage using the pre-computed keys
+    database.create_index_with_keys(
+        index_name.to_string(),
+        table_name.to_string(),
+        unique,
+        columns.to_vec(),
+        keys,
+    )?;
+
+    Ok(())
+}

--- a/crates/vibesql-executor/src/index_ddl/mod.rs
+++ b/crates/vibesql-executor/src/index_ddl/mod.rs
@@ -4,15 +4,28 @@
 //!
 //! # Structure
 //!
-//! - `create_index.rs` - CREATE INDEX executor
+//! ## CREATE INDEX submodules
+//! - `create_index.rs` - Main CREATE INDEX executor and dispatch logic
+//! - `validation.rs` - Pre-creation validation (column checks, privileges, etc.)
+//! - `btree_index.rs` - B-tree index creation (standard and unique)
+//! - `spatial_index.rs` - Spatial/R-tree index creation
+//! - `vector_index.rs` - IVFFlat and HNSW vector index creation
+//! - `expression_index.rs` - Expression-based functional index creation
+//!
+//! ## Other DDL operations
 //! - `drop_index.rs` - DROP INDEX executor
 //! - `reindex.rs` - REINDEX executor
 //! - `analyze.rs` - ANALYZE executor
 
 pub mod analyze;
+mod btree_index;
 pub mod create_index;
 pub mod drop_index;
+mod expression_index;
 pub mod reindex;
+mod spatial_index;
+mod validation;
+mod vector_index;
 
 pub use analyze::AnalyzeExecutor;
 pub use create_index::CreateIndexExecutor;

--- a/crates/vibesql-executor/src/index_ddl/spatial_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/spatial_index.rs
@@ -1,0 +1,104 @@
+//! Spatial index creation
+//!
+//! This module handles creation of spatial/R-tree indexes for geometry data.
+//! Spatial indexes use minimum bounding rectangles (MBRs) for efficient
+//! spatial queries.
+
+use vibesql_ast::CreateIndexStmt;
+use vibesql_catalog::TableSchema;
+use vibesql_storage::{
+    index::{extract_mbr_from_sql_value, SpatialIndex, SpatialIndexEntry},
+    Database, SpatialIndexMetadata,
+};
+
+use super::btree_index::index_name_to_id;
+use crate::errors::ExecutorError;
+
+/// Create a spatial index on a table.
+///
+/// Spatial indexes must be on exactly one geometry column.
+/// Returns success message on completion.
+pub fn create_spatial_index(
+    database: &mut Database,
+    stmt: &CreateIndexStmt,
+    table_name: &str,
+    qualified_table_name: &str,
+    table_schema: &TableSchema,
+) -> Result<String, ExecutorError> {
+    let index_name = &stmt.index_name;
+
+    // Spatial index validation: must be exactly 1 column
+    if stmt.columns.len() != 1 {
+        return Err(ExecutorError::InvalidIndexDefinition(
+            "SPATIAL indexes must be defined on exactly one column".to_string(),
+        ));
+    }
+
+    let column_name = stmt.columns[0].expect_column_name();
+
+    // Get the column index
+    let col_idx = table_schema.get_column_index(column_name).ok_or_else(|| {
+        ExecutorError::ColumnNotFound {
+            column_name: column_name.to_string(),
+            table_name: qualified_table_name.to_string(),
+            searched_tables: vec![qualified_table_name.to_string()],
+            available_columns: table_schema.columns.iter().map(|c| c.name.clone()).collect(),
+        }
+    })?;
+
+    // Extract MBRs from all existing rows (use unqualified name, database handles qualification)
+    let table = database
+        .get_table(table_name)
+        .ok_or_else(|| ExecutorError::TableNotFound(qualified_table_name.to_string()))?;
+
+    let mut entries = Vec::new();
+    // Use scan_live() to skip deleted rows and get correct physical indices
+    for (row_idx, row) in table.scan_live() {
+        let geom_value = &row.values[col_idx];
+
+        // Extract MBR from geometry value (skip NULLs and invalid geometries)
+        if let Some(mbr) = extract_mbr_from_sql_value(geom_value) {
+            entries.push(SpatialIndexEntry { row_id: row_idx, mbr });
+        }
+    }
+
+    // Build spatial index via bulk_load (more efficient than incremental inserts)
+    let spatial_index = SpatialIndex::bulk_load(column_name.to_string(), entries);
+
+    // Add to catalog first (use unqualified table name as stored in catalog)
+    let index_metadata = vibesql_catalog::IndexMetadata::new(
+        index_name.clone(),
+        table_name.to_string(),
+        vibesql_catalog::IndexType::RTree,
+        vec![vibesql_catalog::IndexedColumn::new_column(
+            column_name.to_string(),
+            vibesql_catalog::SortOrder::Ascending,
+        )],
+        false,
+    );
+    database.catalog.add_index(index_metadata)?;
+
+    // Store in database (use unqualified table name for storage metadata)
+    let metadata = SpatialIndexMetadata {
+        index_name: index_name.clone(),
+        table_name: table_name.to_string(),
+        column_name: column_name.to_string(),
+        created_at: Some(chrono::Utc::now()),
+    };
+
+    database.create_spatial_index(metadata, spatial_index)?;
+
+    // Emit WAL entry for persistence (spatial indexes are never unique)
+    database.emit_wal_create_index(
+        index_name_to_id(index_name),
+        index_name,
+        qualified_table_name,
+        vec![col_idx as u32],
+        false,
+    );
+
+    Ok(format!(
+        "Spatial index '{}' created successfully on table '{}'",
+        index_name, qualified_table_name
+    ))
+}

--- a/crates/vibesql-executor/src/index_ddl/validation.rs
+++ b/crates/vibesql-executor/src/index_ddl/validation.rs
@@ -1,0 +1,321 @@
+//! Validation logic for CREATE INDEX statements
+//!
+//! This module handles pre-creation validation including:
+//! - Table and schema existence checks
+//! - Column validation for indexed columns
+//! - Expression validation (determinism checks, column references)
+//! - Prefix length validation
+//! - Index name collision checks
+
+use vibesql_ast::{CreateIndexStmt, Expression, IndexColumn};
+use vibesql_catalog::TableSchema;
+use vibesql_storage::Database;
+
+use crate::{
+    errors::ExecutorError,
+    privilege_checker::PrivilegeChecker,
+    sqlite_schema::is_sqlite_schema_table,
+};
+
+/// Result of validating a CREATE INDEX statement
+pub struct ValidationResult {
+    /// The table name (without schema prefix)
+    pub table_name: String,
+    /// Fully qualified table name (schema.table)
+    pub qualified_table_name: String,
+    /// Cloned table schema for use in index creation
+    pub table_schema: TableSchema,
+}
+
+/// Validate a CREATE INDEX statement before execution.
+///
+/// Performs all pre-creation checks:
+/// - Parses qualified table name
+/// - Checks for sqlite_schema table
+/// - Verifies CREATE privilege
+/// - Verifies table exists
+/// - Validates indexed columns exist
+/// - Validates expression determinism
+/// - Validates prefix length specifications
+/// - Checks for index name collisions
+pub fn validate_create_index(
+    stmt: &CreateIndexStmt,
+    database: &Database,
+) -> Result<ValidationResult, ExecutorError> {
+    // Parse qualified table name (schema.table or just table)
+    let (schema_name, table_name) =
+        if let Some((schema_part, table_part)) = stmt.table_name.split_once('.') {
+            (schema_part.to_string(), table_part.to_string())
+        } else {
+            (database.catalog.get_current_schema().to_string(), stmt.table_name.clone())
+        };
+
+    // Check if target is sqlite_master/sqlite_schema (read-only system table)
+    if is_sqlite_schema_table(&table_name) {
+        return Err(ExecutorError::SqliteSystemTableReadOnly {
+            table_name: table_name.clone(),
+            operation: "indexed".to_string(),
+        });
+    }
+
+    // Check CREATE privilege on the schema
+    PrivilegeChecker::check_create(database, &schema_name)?;
+
+    // Build fully qualified table name for catalog lookups
+    let qualified_table_name = format!("{}.{}", schema_name, table_name);
+
+    // Check if table exists
+    if !database.catalog.table_exists(&qualified_table_name) {
+        return Err(ExecutorError::TableNotFound(qualified_table_name.clone()));
+    }
+
+    // Get table schema to validate columns (clone to avoid borrow issues)
+    let table_schema = database
+        .catalog
+        .get_table(&qualified_table_name)
+        .ok_or_else(|| ExecutorError::TableNotFound(qualified_table_name.clone()))?
+        .clone();
+
+    // Validate expression determinism
+    validate_expression_determinism(&stmt.columns)?;
+
+    // Validate that all indexed columns exist in the table
+    validate_indexed_columns(&stmt.columns, &table_schema, &qualified_table_name)?;
+
+    // Validate prefix length specifications
+    validate_prefix_lengths(&stmt.columns, &table_schema)?;
+
+    // Check if index already exists
+    check_index_exists(stmt, database)?;
+
+    // Check SQLite namespace (tables and indexes share namespace)
+    check_namespace_collision(&stmt.index_name, database)?;
+
+    Ok(ValidationResult { table_name, qualified_table_name, table_schema })
+}
+
+/// Validate that expression indexes use deterministic expressions.
+fn validate_expression_determinism(columns: &[IndexColumn]) -> Result<(), ExecutorError> {
+    for index_col in columns {
+        if let Some(expr) = index_col.get_expression() {
+            if !crate::evaluator::expression_hash::ExpressionHasher::is_deterministic_for_index(
+                expr,
+            ) {
+                return Err(ExecutorError::UnsupportedFeature(
+                    "Expression indexes must use deterministic expressions. \
+                     Non-deterministic functions like RANDOM(), CURRENT_TIMESTAMP, etc. \
+                     are not allowed."
+                        .to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate that all indexed columns exist in the table schema.
+fn validate_indexed_columns(
+    columns: &[IndexColumn],
+    table_schema: &TableSchema,
+    qualified_table_name: &str,
+) -> Result<(), ExecutorError> {
+    for index_col in columns {
+        // Validate column-based index columns
+        if let Some(col_name) = index_col.column_name() {
+            if table_schema.get_column(col_name).is_none() {
+                let available_columns =
+                    table_schema.columns.iter().map(|c| c.name.clone()).collect();
+                return Err(ExecutorError::ColumnNotFound {
+                    column_name: col_name.to_string(),
+                    table_name: qualified_table_name.to_string(),
+                    searched_tables: vec![qualified_table_name.to_string()],
+                    available_columns,
+                });
+            }
+        }
+
+        // Validate column references in expressions
+        if let Some(expr) = index_col.get_expression() {
+            validate_expression_columns(expr, table_schema, qualified_table_name)?;
+        }
+    }
+    Ok(())
+}
+
+/// Validate prefix length specifications for indexed columns.
+fn validate_prefix_lengths(
+    columns: &[IndexColumn],
+    table_schema: &TableSchema,
+) -> Result<(), ExecutorError> {
+    for index_col in columns {
+        if let Some(prefix_len) = index_col.prefix_length() {
+            // Expression indexes don't support prefix lengths
+            if index_col.is_expression() {
+                return Err(ExecutorError::InvalidIndexDefinition(
+                    "Prefix length cannot be specified for expression indexes".to_string(),
+                ));
+            }
+
+            let col_name = index_col.column_name().unwrap(); // Safe: not an expression
+
+            // Prefix length must be positive
+            if prefix_len == 0 {
+                return Err(ExecutorError::InvalidIndexDefinition(format!(
+                    "Prefix length must be greater than 0 for column '{}'",
+                    col_name
+                )));
+            }
+
+            // Prefix length should only be used with string columns
+            let column = table_schema.get_column(col_name).unwrap(); // Safe: validated above
+            match column.data_type {
+                vibesql_types::DataType::Varchar { .. }
+                | vibesql_types::DataType::Character { .. } => {
+                    // Valid string types for prefix indexing
+                }
+                _ => {
+                    return Err(ExecutorError::InvalidIndexDefinition(format!(
+                        "Prefix length can only be specified for string columns, but column '{}' has type {:?}",
+                        col_name, column.data_type
+                    )));
+                }
+            }
+
+            // Reasonable upper limit check (64KB = 65536 characters)
+            const MAX_PREFIX_LENGTH: u64 = 65536;
+            if prefix_len > MAX_PREFIX_LENGTH {
+                return Err(ExecutorError::InvalidIndexDefinition(format!(
+                    "Prefix length {} is too large for column '{}' (maximum: {})",
+                    prefix_len, col_name, MAX_PREFIX_LENGTH
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Check if an index with the same name already exists.
+fn check_index_exists(stmt: &CreateIndexStmt, database: &Database) -> Result<(), ExecutorError> {
+    let index_name = &stmt.index_name;
+    let index_exists =
+        database.index_exists(index_name) || database.spatial_index_exists(index_name);
+
+    if index_exists {
+        if stmt.if_not_exists {
+            // IF NOT EXISTS is handled by returning early with success message
+            // The caller should check this case
+            return Ok(());
+        } else {
+            return Err(ExecutorError::IndexAlreadyExists(index_name.clone()));
+        }
+    }
+    Ok(())
+}
+
+/// Check that the index name doesn't collide with existing table names.
+fn check_namespace_collision(index_name: &str, database: &Database) -> Result<(), ExecutorError> {
+    let normalized_index_name = index_name.to_lowercase();
+    for schema in database.catalog.list_schemas() {
+        let qualified_name = format!("{}.{}", schema, normalized_index_name);
+        if database.catalog.table_exists(&qualified_name) {
+            // Use SQLite-compatible error message (exact format required for TCL tests)
+            return Err(ExecutorError::SqliteCompatError(format!(
+                "there is already a table named {}",
+                index_name
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Check if an index already exists (for IF NOT EXISTS handling).
+pub fn index_already_exists(stmt: &CreateIndexStmt, database: &Database) -> bool {
+    let index_name = &stmt.index_name;
+    database.index_exists(index_name) || database.spatial_index_exists(index_name)
+}
+
+/// Validate that all column references in an expression exist in the table schema.
+pub fn validate_expression_columns(
+    expr: &Expression,
+    table_schema: &TableSchema,
+    qualified_table_name: &str,
+) -> Result<(), ExecutorError> {
+    match expr {
+        Expression::ColumnRef(col_id) => {
+            let col_name = col_id.column_canonical();
+            if table_schema.get_column(col_name).is_none() {
+                let available_columns =
+                    table_schema.columns.iter().map(|c| c.name.clone()).collect();
+                return Err(ExecutorError::ColumnNotFound {
+                    column_name: col_name.to_string(),
+                    table_name: qualified_table_name.to_string(),
+                    searched_tables: vec![qualified_table_name.to_string()],
+                    available_columns,
+                });
+            }
+            Ok(())
+        }
+        Expression::BinaryOp { left, right, .. } => {
+            validate_expression_columns(left, table_schema, qualified_table_name)?;
+            validate_expression_columns(right, table_schema, qualified_table_name)
+        }
+        Expression::UnaryOp { expr, .. } => {
+            validate_expression_columns(expr, table_schema, qualified_table_name)
+        }
+        Expression::Function { args, .. } => {
+            for arg in args {
+                validate_expression_columns(arg, table_schema, qualified_table_name)?;
+            }
+            Ok(())
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                validate_expression_columns(op, table_schema, qualified_table_name)?;
+            }
+            for clause in when_clauses {
+                for cond in &clause.conditions {
+                    validate_expression_columns(cond, table_schema, qualified_table_name)?;
+                }
+                validate_expression_columns(&clause.result, table_schema, qualified_table_name)?;
+            }
+            if let Some(else_expr) = else_result {
+                validate_expression_columns(else_expr, table_schema, qualified_table_name)?;
+            }
+            Ok(())
+        }
+        Expression::Cast { expr, .. } => {
+            validate_expression_columns(expr, table_schema, qualified_table_name)
+        }
+        Expression::Collate { expr, .. } => {
+            validate_expression_columns(expr, table_schema, qualified_table_name)
+        }
+        Expression::IsNull { expr, .. } => {
+            validate_expression_columns(expr, table_schema, qualified_table_name)
+        }
+        Expression::Between { expr, low, high, .. } => {
+            validate_expression_columns(expr, table_schema, qualified_table_name)?;
+            validate_expression_columns(low, table_schema, qualified_table_name)?;
+            validate_expression_columns(high, table_schema, qualified_table_name)
+        }
+        Expression::InList { expr, values, .. } => {
+            validate_expression_columns(expr, table_schema, qualified_table_name)?;
+            for item in values {
+                validate_expression_columns(item, table_schema, qualified_table_name)?;
+            }
+            Ok(())
+        }
+        Expression::Like { expr, pattern, .. } => {
+            validate_expression_columns(expr, table_schema, qualified_table_name)?;
+            validate_expression_columns(pattern, table_schema, qualified_table_name)
+        }
+        // Literals and other self-contained expressions don't reference columns
+        Expression::Literal(_)
+        | Expression::Wildcard
+        | Expression::Placeholder(_)
+        | Expression::NumberedPlaceholder(_)
+        | Expression::NamedPlaceholder(_) => Ok(()),
+        // For other expression types, conservatively allow them
+        // (they may be validated during evaluation)
+        _ => Ok(()),
+    }
+}

--- a/crates/vibesql-executor/src/index_ddl/vector_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/vector_index.rs
@@ -1,0 +1,200 @@
+//! Vector index creation
+//!
+//! This module handles creation of vector indexes for approximate nearest neighbor search:
+//! - IVFFlat (Inverted File with Flat quantization)
+//! - HNSW (Hierarchical Navigable Small World)
+
+use vibesql_ast::{CreateIndexStmt, VectorDistanceMetric};
+use vibesql_catalog::TableSchema;
+use vibesql_storage::Database;
+use vibesql_types::DataType;
+
+use super::btree_index::index_name_to_id;
+use crate::errors::ExecutorError;
+
+/// Create an IVFFlat index on a vector column.
+///
+/// IVFFlat indexes partition vectors into clusters (lists) for efficient
+/// approximate nearest neighbor search.
+pub fn create_ivfflat_index(
+    database: &mut Database,
+    stmt: &CreateIndexStmt,
+    table_name: &str,
+    qualified_table_name: &str,
+    table_schema: &TableSchema,
+    metric: VectorDistanceMetric,
+    lists: u32,
+) -> Result<String, ExecutorError> {
+    let index_name = &stmt.index_name;
+
+    // IVFFlat index validation: must be exactly 1 column (vector column)
+    if stmt.columns.len() != 1 {
+        return Err(ExecutorError::InvalidIndexDefinition(
+            "IVFFlat indexes must be defined on exactly one vector column".to_string(),
+        ));
+    }
+
+    let column_name = stmt.columns[0].expect_column_name();
+
+    // Get the column index and validate it's a vector type
+    let col_idx = table_schema.get_column_index(column_name).ok_or_else(|| {
+        ExecutorError::ColumnNotFound {
+            column_name: column_name.to_string(),
+            table_name: qualified_table_name.to_string(),
+            searched_tables: vec![qualified_table_name.to_string()],
+            available_columns: table_schema.columns.iter().map(|c| c.name.clone()).collect(),
+        }
+    })?;
+
+    // Validate column type is VECTOR
+    let col_type = &table_schema.columns[col_idx].data_type;
+    let dimensions = match col_type {
+        DataType::Vector { dimensions } => *dimensions as usize,
+        _ => {
+            return Err(ExecutorError::InvalidIndexDefinition(format!(
+                "IVFFlat indexes can only be created on VECTOR columns, but '{}' has type {:?}",
+                column_name, col_type
+            )));
+        }
+    };
+
+    // Convert AST metric to catalog metric
+    let catalog_metric = convert_metric_to_catalog(metric);
+
+    // Add to catalog first
+    let index_metadata = vibesql_catalog::IndexMetadata::new(
+        index_name.clone(),
+        table_name.to_string(),
+        vibesql_catalog::IndexType::IVFFlat { metric: catalog_metric, lists },
+        vec![vibesql_catalog::IndexedColumn::new_column(
+            column_name.to_string(),
+            vibesql_catalog::SortOrder::Ascending, // Not meaningful for vector indexes
+        )],
+        false, // IVFFlat indexes are never unique
+    );
+    database.catalog.add_index(index_metadata)?;
+
+    // Create the IVFFlat index in storage
+    database.create_ivfflat_index(
+        index_name.clone(),
+        table_name.to_string(),
+        column_name.to_string(),
+        col_idx,
+        dimensions,
+        lists as usize,
+        metric,
+    )?;
+
+    // Emit WAL entry for persistence (IVFFlat indexes are never unique)
+    database.emit_wal_create_index(
+        index_name_to_id(index_name),
+        index_name,
+        qualified_table_name,
+        vec![col_idx as u32],
+        false,
+    );
+
+    Ok(format!(
+        "IVFFlat index '{}' created successfully on table '{}' column '{}'",
+        index_name, qualified_table_name, column_name
+    ))
+}
+
+/// Create an HNSW index on a vector column.
+///
+/// HNSW (Hierarchical Navigable Small World) indexes build a multi-layer graph
+/// for efficient approximate nearest neighbor search with high recall.
+pub fn create_hnsw_index(
+    database: &mut Database,
+    stmt: &CreateIndexStmt,
+    table_name: &str,
+    qualified_table_name: &str,
+    table_schema: &TableSchema,
+    metric: VectorDistanceMetric,
+    m: u32,
+    ef_construction: u32,
+) -> Result<String, ExecutorError> {
+    let index_name = &stmt.index_name;
+
+    // HNSW index validation: must be exactly 1 column (vector column)
+    if stmt.columns.len() != 1 {
+        return Err(ExecutorError::InvalidIndexDefinition(
+            "HNSW indexes must be defined on exactly one vector column".to_string(),
+        ));
+    }
+
+    let column_name = stmt.columns[0].expect_column_name();
+
+    // Get the column index and validate it's a vector type
+    let col_idx = table_schema.get_column_index(column_name).ok_or_else(|| {
+        ExecutorError::ColumnNotFound {
+            column_name: column_name.to_string(),
+            table_name: qualified_table_name.to_string(),
+            searched_tables: vec![qualified_table_name.to_string()],
+            available_columns: table_schema.columns.iter().map(|c| c.name.clone()).collect(),
+        }
+    })?;
+
+    // Validate column type is VECTOR
+    let col_type = &table_schema.columns[col_idx].data_type;
+    let dimensions = match col_type {
+        DataType::Vector { dimensions } => *dimensions as usize,
+        _ => {
+            return Err(ExecutorError::InvalidIndexDefinition(format!(
+                "HNSW indexes can only be created on VECTOR columns, but '{}' has type {:?}",
+                column_name, col_type
+            )));
+        }
+    };
+
+    // Convert AST metric to catalog metric
+    let catalog_metric = convert_metric_to_catalog(metric);
+
+    // Add to catalog first
+    let index_metadata = vibesql_catalog::IndexMetadata::new(
+        index_name.clone(),
+        table_name.to_string(),
+        vibesql_catalog::IndexType::Hnsw { metric: catalog_metric, m, ef_construction },
+        vec![vibesql_catalog::IndexedColumn::new_column(
+            column_name.to_string(),
+            vibesql_catalog::SortOrder::Ascending, // Not meaningful for vector indexes
+        )],
+        false, // HNSW indexes are never unique
+    );
+    database.catalog.add_index(index_metadata)?;
+
+    // Create the HNSW index in storage
+    database.create_hnsw_index(
+        index_name.clone(),
+        table_name.to_string(),
+        column_name.to_string(),
+        col_idx,
+        dimensions,
+        m,
+        ef_construction,
+        metric,
+    )?;
+
+    // Emit WAL entry for persistence (HNSW indexes are never unique)
+    database.emit_wal_create_index(
+        index_name_to_id(index_name),
+        index_name,
+        qualified_table_name,
+        vec![col_idx as u32],
+        false,
+    );
+
+    Ok(format!(
+        "HNSW index '{}' created successfully on table '{}' column '{}'",
+        index_name, qualified_table_name, column_name
+    ))
+}
+
+/// Convert AST VectorDistanceMetric to catalog VectorDistanceMetric.
+fn convert_metric_to_catalog(metric: VectorDistanceMetric) -> vibesql_catalog::VectorDistanceMetric {
+    match metric {
+        VectorDistanceMetric::L2 => vibesql_catalog::VectorDistanceMetric::L2,
+        VectorDistanceMetric::Cosine => vibesql_catalog::VectorDistanceMetric::Cosine,
+        VectorDistanceMetric::InnerProduct => vibesql_catalog::VectorDistanceMetric::InnerProduct,
+    }
+}


### PR DESCRIPTION
## Summary

- Breaks down the 1704-line `create_index.rs` file into smaller, focused modules for better maintainability and testability
- Main `create_index.rs` implementation reduced to ~122 lines (tests remain in place)
- Each index type now has a dedicated creation module

## New Modules

| Module | Lines | Responsibility |
|--------|-------|----------------|
| `validation.rs` | ~320 | Pre-creation validation (table/column checks, privileges, determinism) |
| `btree_index.rs` | ~116 | B-tree index creation (standard and unique) |
| `spatial_index.rs` | ~104 | R-tree/spatial index creation for geometry data |
| `vector_index.rs` | ~200 | IVFFlat and HNSW vector index creation |
| `expression_index.rs` | ~106 | Expression-based functional index creation |

## Test plan

- [x] All 28 CREATE INDEX tests pass
- [x] Build succeeds without warnings
- [x] No changes to public API

Closes #4868

🤖 Generated with [Claude Code](https://claude.com/claude-code)