### PR TITLE
fix(executor): match SQLite error messages for UNION column count mismatches

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
@@ -88,19 +88,78 @@ pub(super) fn build_merged_outer_row<'a>(
 /// Handles wildcards by expanding them using table schemas from the database
 ///
 /// Issue #3562: Added CTE context so wildcards can be expanded for CTE references
+/// Issue #4881: Validates set operation column count mismatches (UNION, INTERSECT, EXCEPT)
 pub fn compute_select_list_column_count(
     stmt: &vibesql_ast::SelectStmt,
     database: &vibesql_storage::Database,
     cte_results: Option<&HashMap<String, CteResult>>,
 ) -> Result<usize, ExecutorError> {
+    let left_count = compute_single_select_column_count(&stmt.select_list, &stmt.from, database, cte_results)?;
+
+    // Issue #4881: Validate set operation column counts
+    // If this SELECT has a set operation (UNION, INTERSECT, EXCEPT),
+    // validate that left and right sides have the same number of columns.
+    // This produces SQLite-compatible error messages for column count mismatches.
+    if let Some(set_op) = &stmt.set_operation {
+        validate_set_operation_column_counts(left_count, set_op, database, cte_results)?;
+    }
+
+    Ok(left_count)
+}
+
+/// Validate column counts for a chain of set operations
+/// Returns SetOperationColumnMismatch error if any operation has mismatched column counts
+fn validate_set_operation_column_counts(
+    left_count: usize,
+    set_op: &vibesql_ast::SetOperation,
+    database: &vibesql_storage::Database,
+    cte_results: Option<&HashMap<String, CteResult>>,
+) -> Result<(), ExecutorError> {
+    let right_stmt = &set_op.right;
+    let right_count = compute_single_select_column_count(
+        &right_stmt.select_list,
+        &right_stmt.from,
+        database,
+        cte_results,
+    )?;
+
+    if left_count != right_count {
+        let operator = match (&set_op.op, set_op.all) {
+            (vibesql_ast::SetOperator::Union, true) => "UNION ALL",
+            (vibesql_ast::SetOperator::Union, false) => "UNION",
+            (vibesql_ast::SetOperator::Intersect, true) => "INTERSECT ALL",
+            (vibesql_ast::SetOperator::Intersect, false) => "INTERSECT",
+            (vibesql_ast::SetOperator::Except, true) => "EXCEPT ALL",
+            (vibesql_ast::SetOperator::Except, false) => "EXCEPT",
+        };
+        return Err(ExecutorError::SetOperationColumnMismatch {
+            operator: operator.to_string(),
+        });
+    }
+
+    // Recursively validate nested set operations
+    if let Some(next_set_op) = &right_stmt.set_operation {
+        validate_set_operation_column_counts(right_count, next_set_op, database, cte_results)?;
+    }
+
+    Ok(())
+}
+
+/// Compute column count for a single SELECT statement (without considering set operations)
+fn compute_single_select_column_count(
+    select_list: &[vibesql_ast::SelectItem],
+    from: &Option<vibesql_ast::FromClause>,
+    database: &vibesql_storage::Database,
+    cte_results: Option<&HashMap<String, CteResult>>,
+) -> Result<usize, ExecutorError> {
     let mut count = 0;
 
-    for item in &stmt.select_list {
+    for item in select_list {
         match item {
             vibesql_ast::SelectItem::Wildcard { .. } => {
                 // Expand * to count all columns from all tables in FROM clause
-                if let Some(from) = &stmt.from {
-                    count += count_columns_in_from_clause(from, database, cte_results)?;
+                if let Some(from_clause) = from {
+                    count += count_columns_in_from_clause(from_clause, database, cte_results)?;
                 } else {
                     // SELECT * without FROM is an error (should be caught earlier)
                     return Err(ExecutorError::UnsupportedFeature(

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -99,7 +99,60 @@ pub(super) fn validate_where_clause_subqueries(
 ///
 /// Issue #3562: Added CTE context so wildcards can be expanded for CTE references
 /// Issue #4602: Made public for set operation column count validation
+/// Issue #4881: Validates set operation column count mismatches (UNION, INTERSECT, EXCEPT)
 pub(crate) fn compute_select_list_column_count(
+    stmt: &vibesql_ast::SelectStmt,
+    database: &vibesql_storage::Database,
+    cte_results: Option<&HashMap<String, CteResult>>,
+) -> Result<usize, ExecutorError> {
+    let left_count = compute_single_select_column_count(stmt, database, cte_results)?;
+
+    // Issue #4881: Validate set operation column counts
+    // If this SELECT has a set operation (UNION, INTERSECT, EXCEPT),
+    // validate that left and right sides have the same number of columns.
+    // This produces SQLite-compatible error messages for column count mismatches.
+    if let Some(set_op) = &stmt.set_operation {
+        validate_set_operation_column_counts(left_count, set_op, database, cte_results)?;
+    }
+
+    Ok(left_count)
+}
+
+/// Validate column counts for a chain of set operations
+/// Returns SetOperationColumnMismatch error if any operation has mismatched column counts
+fn validate_set_operation_column_counts(
+    left_count: usize,
+    set_op: &vibesql_ast::SetOperation,
+    database: &vibesql_storage::Database,
+    cte_results: Option<&HashMap<String, CteResult>>,
+) -> Result<(), ExecutorError> {
+    let right_stmt = &set_op.right;
+    let right_count = compute_single_select_column_count(right_stmt, database, cte_results)?;
+
+    if left_count != right_count {
+        let operator = match (&set_op.op, set_op.all) {
+            (vibesql_ast::SetOperator::Union, true) => "UNION ALL",
+            (vibesql_ast::SetOperator::Union, false) => "UNION",
+            (vibesql_ast::SetOperator::Intersect, true) => "INTERSECT ALL",
+            (vibesql_ast::SetOperator::Intersect, false) => "INTERSECT",
+            (vibesql_ast::SetOperator::Except, true) => "EXCEPT ALL",
+            (vibesql_ast::SetOperator::Except, false) => "EXCEPT",
+        };
+        return Err(ExecutorError::SetOperationColumnMismatch {
+            operator: operator.to_string(),
+        });
+    }
+
+    // Recursively validate nested set operations
+    if let Some(next_set_op) = &right_stmt.set_operation {
+        validate_set_operation_column_counts(right_count, next_set_op, database, cte_results)?;
+    }
+
+    Ok(())
+}
+
+/// Compute column count for a single SELECT statement (without considering set operations)
+fn compute_single_select_column_count(
     stmt: &vibesql_ast::SelectStmt,
     database: &vibesql_storage::Database,
     cte_results: Option<&HashMap<String, CteResult>>,


### PR DESCRIPTION
## Summary

- Fix error message for UNION/INTERSECT/EXCEPT column count mismatches in IN subqueries
- Now matches SQLite's exact error message format

## Changes

Added set operation column count validation to `compute_select_list_column_count` in:
- `crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs`
- `crates/vibesql-executor/src/select/executor/nonagg/validation.rs`

When left and right sides of a set operation have different column counts, returns:
```
SELECTs to the left and right of {op} do not have the same number of result columns
```

Instead of the previous message:
```
sub-select returns X columns - expected 1
```

## Test Plan

Manual testing verified all TCL test cases from `in.test` now return correct error messages:
- in-12.6: UNION ALL with 2 cols left, 1 col right → ✅
- in-12.7: UNION with 2 cols left, 1 col right → ✅  
- in-12.8: EXCEPT with 2 cols left, 1 col right → ✅
- in-12.9: INTERSECT with 2 cols left, 1 col right → ✅
- in-12.10: UNION ALL with 1 col left, 2 cols right → ✅
- in-12.2: Both sides 2 cols (no mismatch), IN expects 1 → ✅ (correctly shows "sub-select returns 2 columns - expected 1")

Closes #4881