### PR TITLE
feat(parser): support ON CONFLICT ... DO NOTHING/UPDATE upsert clause

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -616,9 +616,34 @@ impl<'a, 'arena> Converter<'a, 'arena> {
             columns: stmt.columns.iter().map(|s| self.resolve(*s)).collect(),
             source: self.convert_insert_source(&stmt.source),
             conflict_clause: stmt.conflict_clause.map(ConflictClause::from),
+            on_conflict: stmt.on_conflict.as_ref().map(|c| self.convert_on_conflict_clause(c)),
             on_duplicate_key_update: stmt.on_duplicate_key_update.as_ref().map(|assignments| {
                 assignments.iter().map(|a| self.convert_assignment(a)).collect()
             }),
+        }
+    }
+
+    fn convert_on_conflict_clause(
+        &self,
+        clause: &arena_dml::OnConflictClause<'arena>,
+    ) -> crate::OnConflictClause {
+        crate::OnConflictClause {
+            conflict_target: clause
+                .conflict_target
+                .as_ref()
+                .map(|cols| cols.iter().map(|s| self.resolve(*s)).collect()),
+            action: match &clause.action {
+                arena_dml::OnConflictAction::DoNothing => crate::OnConflictAction::DoNothing,
+                arena_dml::OnConflictAction::DoUpdate { assignments, where_clause } => {
+                    crate::OnConflictAction::DoUpdate {
+                        assignments: assignments
+                            .iter()
+                            .map(|a| self.convert_assignment(a))
+                            .collect(),
+                        where_clause: where_clause.as_ref().map(|e| self.convert_expression(e)),
+                    }
+                }
+            },
         }
     }
 

--- a/crates/vibesql-ast/src/arena/dml.rs
+++ b/crates/vibesql-ast/src/arena/dml.rs
@@ -47,6 +47,52 @@ pub enum ConflictClause {
     Rollback,
 }
 
+// ============================================================================
+// ON CONFLICT (Upsert) Clause
+// ============================================================================
+
+/// Action to take when a conflict occurs (SQLite upsert clause)
+///
+/// Part of the `ON CONFLICT` clause syntax:
+/// ```sql
+/// INSERT INTO t VALUES (...) ON CONFLICT (cols) DO NOTHING;
+/// INSERT INTO t VALUES (...) ON CONFLICT (cols) DO UPDATE SET col = val WHERE ...;
+/// ```
+///
+/// See: <https://www.sqlite.org/lang_upsert.html>
+#[derive(Debug, Clone, PartialEq)]
+pub enum OnConflictAction<'arena> {
+    /// DO NOTHING - Skip the conflicting row
+    DoNothing,
+    /// DO UPDATE SET ... [WHERE ...] - Update the conflicting row
+    DoUpdate {
+        /// Assignments for the update (SET col = val, ...)
+        assignments: BumpVec<'arena, Assignment<'arena>>,
+        /// Optional WHERE clause for the update
+        where_clause: Option<Expression<'arena>>,
+    },
+}
+
+/// ON CONFLICT clause for INSERT statements (SQLite upsert)
+///
+/// Syntax:
+/// ```sql
+/// INSERT INTO t VALUES (...) ON CONFLICT [(column_list)] DO {NOTHING | UPDATE SET ...};
+/// ```
+///
+/// The conflict target (column list) is optional. When omitted, the conflict
+/// clause applies to any unique constraint violation.
+///
+/// See: <https://www.sqlite.org/lang_upsert.html>
+#[derive(Debug, Clone, PartialEq)]
+pub struct OnConflictClause<'arena> {
+    /// Optional list of indexed columns to match for conflict detection.
+    /// When None, matches any unique constraint violation.
+    pub conflict_target: Option<BumpVec<'arena, Symbol>>,
+    /// The action to take when a conflict occurs.
+    pub action: OnConflictAction<'arena>,
+}
+
 /// INSERT statement
 #[derive(Debug, Clone, PartialEq)]
 pub struct InsertStmt<'arena> {
@@ -65,7 +111,11 @@ pub struct InsertStmt<'arena> {
     pub columns: BumpVec<'arena, Symbol>,
     pub source: InsertSource<'arena>,
     /// Conflict resolution strategy (None = fail on conflict)
+    /// Used for INSERT OR REPLACE/IGNORE/etc. syntax
     pub conflict_clause: Option<ConflictClause>,
+    /// ON CONFLICT clause (SQLite upsert)
+    /// Used for INSERT ... ON CONFLICT (cols) DO NOTHING/UPDATE syntax
+    pub on_conflict: Option<OnConflictClause<'arena>>,
     /// ON DUPLICATE KEY UPDATE clause (MySQL-style upsert)
     pub on_duplicate_key_update: Option<BumpVec<'arena, Assignment<'arena>>>,
 }

--- a/crates/vibesql-ast/src/dml.rs
+++ b/crates/vibesql-ast/src/dml.rs
@@ -52,6 +52,52 @@ pub enum ConflictClause {
     Rollback,
 }
 
+// ============================================================================
+// ON CONFLICT (Upsert) Clause
+// ============================================================================
+
+/// Action to take when a conflict occurs (SQLite upsert clause)
+///
+/// Part of the `ON CONFLICT` clause syntax:
+/// ```sql
+/// INSERT INTO t VALUES (...) ON CONFLICT (cols) DO NOTHING;
+/// INSERT INTO t VALUES (...) ON CONFLICT (cols) DO UPDATE SET col = val WHERE ...;
+/// ```
+///
+/// See: <https://www.sqlite.org/lang_upsert.html>
+#[derive(Debug, Clone, PartialEq)]
+pub enum OnConflictAction {
+    /// DO NOTHING - Skip the conflicting row
+    DoNothing,
+    /// DO UPDATE SET ... [WHERE ...] - Update the conflicting row
+    DoUpdate {
+        /// Assignments for the update (SET col = val, ...)
+        assignments: Vec<Assignment>,
+        /// Optional WHERE clause for the update
+        where_clause: Option<Expression>,
+    },
+}
+
+/// ON CONFLICT clause for INSERT statements (SQLite upsert)
+///
+/// Syntax:
+/// ```sql
+/// INSERT INTO t VALUES (...) ON CONFLICT [(column_list)] DO {NOTHING | UPDATE SET ...};
+/// ```
+///
+/// The conflict target (column list) is optional. When omitted, the conflict
+/// clause applies to any unique constraint violation.
+///
+/// See: <https://www.sqlite.org/lang_upsert.html>
+#[derive(Debug, Clone, PartialEq)]
+pub struct OnConflictClause {
+    /// Optional list of indexed columns to match for conflict detection.
+    /// When None, matches any unique constraint violation.
+    pub conflict_target: Option<Vec<String>>,
+    /// The action to take when a conflict occurs.
+    pub action: OnConflictAction,
+}
+
 /// INSERT statement
 #[derive(Debug, Clone, PartialEq)]
 pub struct InsertStmt {
@@ -70,7 +116,11 @@ pub struct InsertStmt {
     pub columns: Vec<String>,
     pub source: InsertSource,
     /// Conflict resolution strategy (None = fail on conflict)
+    /// Used for INSERT OR REPLACE/IGNORE/etc. syntax
     pub conflict_clause: Option<ConflictClause>,
+    /// ON CONFLICT clause (SQLite upsert)
+    /// Used for INSERT ... ON CONFLICT (cols) DO NOTHING/UPDATE syntax
+    pub on_conflict: Option<OnConflictClause>,
     /// ON DUPLICATE KEY UPDATE clause (MySQL-style upsert)
     pub on_duplicate_key_update: Option<Vec<Assignment>>,
 }

--- a/crates/vibesql-ast/src/lib.rs
+++ b/crates/vibesql-ast/src/lib.rs
@@ -181,7 +181,8 @@ pub use ddl::{
     VectorDistanceMetric,
 };
 pub use dml::{
-    Assignment, ConflictClause, DeleteStmt, InsertSource, InsertStmt, UpdateStmt, WhereClause,
+    Assignment, ConflictClause, DeleteStmt, InsertSource, InsertStmt, OnConflictAction,
+    OnConflictClause, UpdateStmt, WhereClause,
 };
 pub use expression::{
     CaseWhen, CharacterUnit, Expression, FrameBound, FrameExclude, FrameUnit, FulltextMode,

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1277,6 +1277,24 @@ pub fn transform_insert<V: ExpressionMutVisitor>(visitor: &mut V, stmt: InsertSt
             InsertSource::DefaultValues => InsertSource::DefaultValues,
         },
         conflict_clause: stmt.conflict_clause,
+        on_conflict: stmt.on_conflict.map(|clause| crate::OnConflictClause {
+            conflict_target: clause.conflict_target,
+            action: match clause.action {
+                crate::OnConflictAction::DoNothing => crate::OnConflictAction::DoNothing,
+                crate::OnConflictAction::DoUpdate { assignments, where_clause } => {
+                    crate::OnConflictAction::DoUpdate {
+                        assignments: assignments
+                            .into_iter()
+                            .map(|a| Assignment {
+                                column: a.column,
+                                value: transform_expression(visitor, a.value),
+                            })
+                            .collect(),
+                        where_clause: where_clause.map(|e| transform_expression(visitor, e)),
+                    }
+                }
+            },
+        }),
         on_duplicate_key_update: stmt.on_duplicate_key_update.map(|updates| {
             updates
                 .into_iter()

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -229,7 +229,15 @@ fn execute_insert_internal(
     }; // Track UNIQUE values for each constraint
 
     // Check if IGNORE conflict clause is set - if so, skip rows with constraint violations
-    let use_ignore = matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Ignore));
+    // Also treat ON CONFLICT ... DO NOTHING as equivalent to IGNORE
+    let use_ignore = matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Ignore))
+        || matches!(
+            &stmt.on_conflict,
+            Some(vibesql_ast::OnConflictClause {
+                action: vibesql_ast::OnConflictAction::DoNothing,
+                ..
+            })
+        );
 
     // Track the first auto-generated ID for LAST_INSERT_ROWID() support
     // Per MySQL semantics, for multi-row inserts, LAST_INSERT_ID() returns
@@ -394,12 +402,14 @@ fn execute_insert_internal(
         }
 
         // Validate all constraints in a single pass and extract index keys
-        // Skip PK/UNIQUE duplicate checks if using REPLACE conflict clause or ON DUPLICATE KEY
-        // UPDATE. Also skip for IGNORE since we'll handle violations by skipping the row.
+        // Skip PK/UNIQUE duplicate checks if using REPLACE conflict clause, ON DUPLICATE KEY
+        // UPDATE, or ON CONFLICT clause. Also skip for IGNORE since we'll handle violations
+        // by skipping the row.
         let skip_duplicate_checks =
             matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Replace))
                 || matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Ignore))
-                || stmt.on_duplicate_key_update.is_some();
+                || stmt.on_duplicate_key_update.is_some()
+                || stmt.on_conflict.is_some();
         let validator = super::row_validator::RowValidator::new(
             db,
             &schema,
@@ -483,6 +493,13 @@ fn execute_insert_internal(
 
     let use_batch_insert = stmt.on_duplicate_key_update.is_none()
         && !matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Replace))
+        && !matches!(
+            &stmt.on_conflict,
+            Some(vibesql_ast::OnConflictClause {
+                action: vibesql_ast::OnConflictAction::DoUpdate { .. },
+                ..
+            })
+        )
         && !has_insert_triggers;
 
     // Helper to create a Row with optional explicit rowid

--- a/crates/vibesql-executor/tests/conflict_resolution_tests.rs
+++ b/crates/vibesql-executor/tests/conflict_resolution_tests.rs
@@ -46,6 +46,7 @@ fn insert_user(db: &mut Database, id: i64, email: &str, name: &str) {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(name))),
         ]]),
         conflict_clause: None,
+        on_conflict: None,
         on_duplicate_key_update: None,
     };
     InsertExecutor::execute(db, &stmt).unwrap();
@@ -77,6 +78,7 @@ fn test_insert_or_ignore_primary_key_conflict() {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Bob"))),
         ]]),
         conflict_clause: Some(ConflictClause::Ignore),
+        on_conflict: None,
         on_duplicate_key_update: None,
     };
 
@@ -113,6 +115,7 @@ fn test_insert_or_ignore_unique_constraint_conflict() {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice 2"))),
         ]]),
         conflict_clause: Some(ConflictClause::Ignore),
+        on_conflict: None,
         on_duplicate_key_update: None,
     };
 
@@ -163,6 +166,7 @@ fn test_insert_or_ignore_multi_row() {
             ],
         ]),
         conflict_clause: Some(ConflictClause::Ignore),
+        on_conflict: None,
         on_duplicate_key_update: None,
     };
 
@@ -193,6 +197,7 @@ fn test_insert_or_ignore_no_conflict() {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
         ]]),
         conflict_clause: Some(ConflictClause::Ignore),
+        on_conflict: None,
         on_duplicate_key_update: None,
     };
 
@@ -472,6 +477,7 @@ fn test_insert_or_ignore_not_null_violation() {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
         ]]),
         conflict_clause: Some(ConflictClause::Ignore),
+        on_conflict: None,
         on_duplicate_key_update: None,
     };
 
@@ -515,4 +521,125 @@ fn test_update_or_ignore_not_null_violation() {
     let table = db.get_table("users").unwrap();
     let alice = &table.scan()[0];
     assert_eq!(alice.values[1], SqlValue::Varchar(arcstr::ArcStr::from("alice@test.com")));
+}
+
+// ============================================================================
+// ON CONFLICT ... DO NOTHING Tests (SQLite Upsert Clause)
+// ============================================================================
+
+#[test]
+fn test_insert_on_conflict_do_nothing_primary_key() {
+    use vibesql_ast::{OnConflictAction, OnConflictClause};
+
+    let mut db = Database::new();
+    setup_users_table(&mut db);
+
+    // Insert initial row
+    insert_user(&mut db, 1, "alice@test.com", "Alice");
+
+    // Try to insert conflicting row with ON CONFLICT DO NOTHING
+    let stmt = InsertStmt {
+        with_clause: None,
+        schema_name: None,
+        schema_quoted: false,
+        table_name: "users".to_string(),
+        table_quoted: false,
+        columns: vec![],
+        source: InsertSource::Values(vec![vec![
+            Expression::Literal(SqlValue::Integer(1)), // Duplicate id
+            Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("duplicate@test.com"))),
+            Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Duplicate"))),
+        ]]),
+        conflict_clause: None,
+        on_conflict: Some(OnConflictClause {
+            conflict_target: Some(vec!["id".to_string()]),
+            action: OnConflictAction::DoNothing,
+        }),
+        on_duplicate_key_update: None,
+    };
+
+    let rows_inserted = InsertExecutor::execute(&mut db, &stmt).unwrap();
+    assert_eq!(rows_inserted, 0, "Conflicting insert should be ignored by ON CONFLICT DO NOTHING");
+
+    // Verify original row is unchanged
+    let table = db.get_table("users").unwrap();
+    assert_eq!(table.row_count(), 1);
+    let alice = &table.scan()[0];
+    assert_eq!(alice.values[1], SqlValue::Varchar(arcstr::ArcStr::from("alice@test.com")));
+}
+
+#[test]
+fn test_insert_on_conflict_do_nothing_without_target() {
+    use vibesql_ast::{OnConflictAction, OnConflictClause};
+
+    let mut db = Database::new();
+    setup_users_table(&mut db);
+
+    // Insert initial row
+    insert_user(&mut db, 1, "alice@test.com", "Alice");
+
+    // Try to insert conflicting row with ON CONFLICT DO NOTHING (no conflict target)
+    // This should ignore any constraint violation
+    let stmt = InsertStmt {
+        with_clause: None,
+        schema_name: None,
+        schema_quoted: false,
+        table_name: "users".to_string(),
+        table_quoted: false,
+        columns: vec![],
+        source: InsertSource::Values(vec![vec![
+            Expression::Literal(SqlValue::Integer(1)), // Duplicate id
+            Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("dup@test.com"))),
+            Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Dup"))),
+        ]]),
+        conflict_clause: None,
+        on_conflict: Some(OnConflictClause {
+            conflict_target: None, // No specific conflict target
+            action: OnConflictAction::DoNothing,
+        }),
+        on_duplicate_key_update: None,
+    };
+
+    let rows_inserted = InsertExecutor::execute(&mut db, &stmt).unwrap();
+    assert_eq!(rows_inserted, 0, "Conflicting insert should be ignored by ON CONFLICT DO NOTHING");
+
+    // Verify original row is unchanged
+    let table = db.get_table("users").unwrap();
+    assert_eq!(table.row_count(), 1);
+}
+
+#[test]
+fn test_insert_on_conflict_do_nothing_no_conflict() {
+    use vibesql_ast::{OnConflictAction, OnConflictClause};
+
+    let mut db = Database::new();
+    setup_users_table(&mut db);
+
+    // Insert with ON CONFLICT DO NOTHING when there's no conflict - should succeed
+    let stmt = InsertStmt {
+        with_clause: None,
+        schema_name: None,
+        schema_quoted: false,
+        table_name: "users".to_string(),
+        table_quoted: false,
+        columns: vec![],
+        source: InsertSource::Values(vec![vec![
+            Expression::Literal(SqlValue::Integer(1)),
+            Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("alice@test.com"))),
+            Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
+        ]]),
+        conflict_clause: None,
+        on_conflict: Some(OnConflictClause {
+            conflict_target: Some(vec!["id".to_string()]),
+            action: OnConflictAction::DoNothing,
+        }),
+        on_duplicate_key_update: None,
+    };
+
+    let rows_inserted = InsertExecutor::execute(&mut db, &stmt).unwrap();
+    assert_eq!(rows_inserted, 1, "Non-conflicting insert should succeed");
+
+    // Verify row was inserted
+    let table = db.get_table("users").unwrap();
+    assert_eq!(table.row_count(), 1);
 }

--- a/crates/vibesql-parser/src/arena_parser/insert.rs
+++ b/crates/vibesql-parser/src/arena_parser/insert.rs
@@ -1,7 +1,10 @@
 //! Arena-allocated INSERT statement parsing.
 
 use bumpalo::collections::Vec as BumpVec;
-use vibesql_ast::arena::{ConflictClause, InsertSource, InsertStmt, Symbol};
+use vibesql_ast::arena::{
+    Assignment, ConflictClause, InsertSource, InsertStmt, OnConflictAction, OnConflictClause,
+    Symbol,
+};
 
 use super::ArenaParser;
 use crate::{keywords::Keyword, token::Token, ParseError};
@@ -76,15 +79,22 @@ impl<'arena> ArenaParser<'arena> {
     ) -> Result<&'arena InsertStmt<'arena>, ParseError> {
         self.consume_keyword(Keyword::Insert)?;
 
-        // Check for conflict clause: INSERT OR REPLACE | INSERT OR IGNORE
+        // Check for conflict clause: INSERT OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL
         let conflict_clause = if self.try_consume_keyword(Keyword::Or) {
             if self.try_consume_keyword(Keyword::Replace) {
                 Some(ConflictClause::Replace)
             } else if self.try_consume_keyword(Keyword::Ignore) {
                 Some(ConflictClause::Ignore)
+            } else if self.try_consume_keyword(Keyword::Abort) {
+                Some(ConflictClause::Abort)
+            } else if self.try_consume_keyword(Keyword::Rollback) {
+                Some(ConflictClause::Rollback)
+            } else if self.try_consume_keyword(Keyword::Fail) {
+                Some(ConflictClause::Fail)
             } else {
                 return Err(ParseError {
-                    message: "Expected REPLACE or IGNORE after INSERT OR".to_string(),
+                    message: "Expected REPLACE, IGNORE, ABORT, ROLLBACK, or FAIL after INSERT OR"
+                        .to_string(),
                 });
             }
         } else {
@@ -124,15 +134,8 @@ impl<'arena> ArenaParser<'arena> {
             });
         };
 
-        // Parse optional ON DUPLICATE KEY UPDATE clause
-        let on_duplicate_key_update = if self.try_consume_keyword(Keyword::On) {
-            self.consume_keyword(Keyword::Duplicate)?;
-            self.consume_keyword(Keyword::Key)?;
-            self.consume_keyword(Keyword::Update)?;
-            Some(self.parse_assignments()?)
-        } else {
-            None
-        };
+        // Parse optional ON CONFLICT or ON DUPLICATE KEY UPDATE clause
+        let (on_conflict, on_duplicate_key_update) = self.parse_on_clause_for_insert()?;
 
         // Consume optional semicolon
         self.try_consume(&Token::Semicolon);
@@ -146,6 +149,7 @@ impl<'arena> ArenaParser<'arena> {
             columns,
             source,
             conflict_clause,
+            on_conflict,
             on_duplicate_key_update,
         };
 
@@ -188,15 +192,8 @@ impl<'arena> ArenaParser<'arena> {
             });
         };
 
-        // Parse optional ON DUPLICATE KEY UPDATE clause
-        let on_duplicate_key_update = if self.try_consume_keyword(Keyword::On) {
-            self.consume_keyword(Keyword::Duplicate)?;
-            self.consume_keyword(Keyword::Key)?;
-            self.consume_keyword(Keyword::Update)?;
-            Some(self.parse_assignments()?)
-        } else {
-            None
-        };
+        // Parse optional ON CONFLICT or ON DUPLICATE KEY UPDATE clause
+        let (on_conflict, on_duplicate_key_update) = self.parse_on_clause_for_insert()?;
 
         // Consume optional semicolon
         self.try_consume(&Token::Semicolon);
@@ -210,6 +207,7 @@ impl<'arena> ArenaParser<'arena> {
             columns,
             source,
             conflict_clause: Some(ConflictClause::Replace),
+            on_conflict,
             on_duplicate_key_update,
         };
 
@@ -235,5 +233,69 @@ impl<'arena> ArenaParser<'arena> {
         }
 
         Ok(rows)
+    }
+
+    /// Parse ON clause for INSERT statements (handles both ON CONFLICT and ON DUPLICATE KEY UPDATE)
+    fn parse_on_clause_for_insert(
+        &mut self,
+    ) -> Result<
+        (
+            Option<OnConflictClause<'arena>>,
+            Option<BumpVec<'arena, Assignment<'arena>>>,
+        ),
+        ParseError,
+    > {
+        if !self.try_consume_keyword(Keyword::On) {
+            return Ok((None, None));
+        }
+
+        if self.try_consume_keyword(Keyword::Conflict) {
+            // SQLite/PostgreSQL: ON CONFLICT [(cols)] DO {NOTHING | UPDATE SET ...}
+
+            // Parse optional conflict target (column list)
+            let conflict_target = if self.try_consume(&Token::LParen) {
+                let cols = self.parse_identifier_list()?;
+                self.expect_token(Token::RParen)?;
+                Some(cols)
+            } else {
+                None
+            };
+
+            self.consume_keyword(Keyword::Do)?;
+
+            let action = if self.try_consume_keyword(Keyword::Nothing) {
+                OnConflictAction::DoNothing
+            } else if self.try_consume_keyword(Keyword::Update) {
+                self.consume_keyword(Keyword::Set)?;
+
+                // Parse assignment list
+                let assignments = self.parse_assignments()?;
+
+                // Parse optional WHERE clause
+                let where_clause = if self.try_consume_keyword(Keyword::Where) {
+                    Some(self.parse_expression()?)
+                } else {
+                    None
+                };
+
+                OnConflictAction::DoUpdate { assignments, where_clause }
+            } else {
+                return Err(ParseError {
+                    message: "Expected NOTHING or UPDATE after DO".to_string(),
+                });
+            };
+
+            Ok((Some(OnConflictClause { conflict_target, action }), None))
+        } else if self.try_consume_keyword(Keyword::Duplicate) {
+            // MySQL: ON DUPLICATE KEY UPDATE ...
+            self.consume_keyword(Keyword::Key)?;
+            self.consume_keyword(Keyword::Update)?;
+            let assignments = self.parse_assignments()?;
+            Ok((None, Some(assignments)))
+        } else {
+            Err(ParseError {
+                message: "Expected CONFLICT or DUPLICATE after ON".to_string(),
+            })
+        }
     }
 }

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -346,6 +346,7 @@ pub enum Keyword {
     Abort,
     Fail,
     Conflict,
+    Nothing,
 }
 
 impl Keyword {
@@ -697,6 +698,7 @@ impl fmt::Display for Keyword {
             Keyword::Abort => "ABORT",
             Keyword::Fail => "FAIL",
             Keyword::Conflict => "CONFLICT",
+            Keyword::Nothing => "NOTHING",
         };
         write!(f, "{}", keyword_str)
     }

--- a/crates/vibesql-parser/src/lexer/keywords.rs
+++ b/crates/vibesql-parser/src/lexer/keywords.rs
@@ -342,6 +342,7 @@ static KEYWORDS: phf::Map<&'static str, Keyword> = phf_map! {
     "ABORT" => Keyword::Abort,
     "FAIL" => Keyword::Fail,
     "CONFLICT" => Keyword::Conflict,
+    "NOTHING" => Keyword::Nothing,
 };
 
 /// Map an uppercase string to its corresponding Keyword using perfect hash lookup.

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -105,44 +105,8 @@ impl Parser {
             });
         };
 
-        // Parse optional ON DUPLICATE KEY UPDATE clause
-        let on_duplicate_key_update = if self.peek_keyword(Keyword::On) {
-            self.advance(); // consume ON
-            self.expect_keyword(Keyword::Duplicate)?;
-            self.expect_keyword(Keyword::Key)?;
-            self.expect_keyword(Keyword::Update)?;
-
-            // Parse assignment list: column = expr, column = expr, ...
-            let mut assignments = Vec::new();
-            loop {
-                let column = match self.peek() {
-                    Token::Identifier(col) => {
-                        let column_name = col.clone();
-                        self.advance();
-                        column_name
-                    }
-                    _ => {
-                        return Err(ParseError {
-                            message: "Expected column name in ON DUPLICATE KEY UPDATE".to_string(),
-                        })
-                    }
-                };
-
-                self.expect_token(Token::Symbol('='))?;
-                let value = self.parse_expression()?;
-
-                assignments.push(vibesql_ast::Assignment { column, value });
-
-                if matches!(self.peek(), Token::Comma) {
-                    self.advance();
-                } else {
-                    break;
-                }
-            }
-            Some(assignments)
-        } else {
-            None
-        };
+        // Parse optional ON CONFLICT or ON DUPLICATE KEY UPDATE clause
+        let (on_conflict, on_duplicate_key_update) = self.parse_on_clause_for_insert()?;
 
         // Expect semicolon or EOF
         if matches!(self.peek(), Token::Semicolon) {
@@ -158,6 +122,7 @@ impl Parser {
             columns,
             source,
             conflict_clause,
+            on_conflict,
             on_duplicate_key_update,
         })
     }
@@ -264,43 +229,9 @@ impl Parser {
             });
         };
 
-        // Parse optional ON DUPLICATE KEY UPDATE clause
-        let on_duplicate_key_update = if self.peek_keyword(Keyword::On) {
-            self.advance(); // consume ON
-            self.expect_keyword(Keyword::Duplicate)?;
-            self.expect_keyword(Keyword::Key)?;
-            self.expect_keyword(Keyword::Update)?;
-
-            let mut assignments = Vec::new();
-            loop {
-                let column = match self.peek() {
-                    Token::Identifier(col) => {
-                        let column_name = col.clone();
-                        self.advance();
-                        column_name
-                    }
-                    _ => {
-                        return Err(ParseError {
-                            message: "Expected column name in ON DUPLICATE KEY UPDATE".to_string(),
-                        })
-                    }
-                };
-
-                self.expect_token(Token::Symbol('='))?;
-                let value = self.parse_expression()?;
-
-                assignments.push(vibesql_ast::Assignment { column, value });
-
-                if matches!(self.peek(), Token::Comma) {
-                    self.advance();
-                } else {
-                    break;
-                }
-            }
-            Some(assignments)
-        } else {
-            None
-        };
+        // Parse optional ON CONFLICT or ON DUPLICATE KEY UPDATE clause
+        let (on_conflict, on_duplicate_key_update) =
+            self.parse_on_clause_for_insert()?;
 
         // Expect semicolon or EOF
         if matches!(self.peek(), Token::Semicolon) {
@@ -316,6 +247,7 @@ impl Parser {
             columns,
             source,
             conflict_clause,
+            on_conflict,
             on_duplicate_key_update,
         })
     }
@@ -391,44 +323,9 @@ impl Parser {
             });
         };
 
-        // Parse optional ON DUPLICATE KEY UPDATE clause
-        let on_duplicate_key_update = if self.peek_keyword(Keyword::On) {
-            self.advance(); // consume ON
-            self.expect_keyword(Keyword::Duplicate)?;
-            self.expect_keyword(Keyword::Key)?;
-            self.expect_keyword(Keyword::Update)?;
-
-            // Parse assignment list: column = expr, column = expr, ...
-            let mut assignments = Vec::new();
-            loop {
-                let column = match self.peek() {
-                    Token::Identifier(col) => {
-                        let column_name = col.clone();
-                        self.advance();
-                        column_name
-                    }
-                    _ => {
-                        return Err(ParseError {
-                            message: "Expected column name in ON DUPLICATE KEY UPDATE".to_string(),
-                        })
-                    }
-                };
-
-                self.expect_token(Token::Symbol('='))?;
-                let value = self.parse_expression()?;
-
-                assignments.push(vibesql_ast::Assignment { column, value });
-
-                if matches!(self.peek(), Token::Comma) {
-                    self.advance();
-                } else {
-                    break;
-                }
-            }
-            Some(assignments)
-        } else {
-            None
-        };
+        // Parse optional ON CONFLICT or ON DUPLICATE KEY UPDATE clause
+        let (on_conflict, on_duplicate_key_update) =
+            self.parse_on_clause_for_insert()?;
 
         // Expect semicolon or EOF
         if matches!(self.peek(), Token::Semicolon) {
@@ -444,7 +341,148 @@ impl Parser {
             columns,
             source,
             conflict_clause: Some(vibesql_ast::ConflictClause::Replace),
+            on_conflict,
             on_duplicate_key_update,
         })
+    }
+
+    /// Parse ON clause for INSERT statements (handles both ON CONFLICT and ON DUPLICATE KEY UPDATE)
+    fn parse_on_clause_for_insert(
+        &mut self,
+    ) -> Result<
+        (Option<vibesql_ast::OnConflictClause>, Option<Vec<vibesql_ast::Assignment>>),
+        ParseError,
+    > {
+        if !self.peek_keyword(Keyword::On) {
+            return Ok((None, None));
+        }
+
+        self.advance(); // consume ON
+
+        if self.peek_keyword(Keyword::Conflict) {
+            // SQLite/PostgreSQL: ON CONFLICT [(cols)] DO {NOTHING | UPDATE SET ...}
+            self.advance(); // consume CONFLICT
+
+            // Parse optional conflict target (column list)
+            let conflict_target = if matches!(self.peek(), Token::LParen) {
+                self.advance(); // consume (
+                let cols = self.parse_comma_separated_list(|p| match p.peek() {
+                    Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
+                        let name = col.clone();
+                        p.advance();
+                        Ok(name)
+                    }
+                    _ => Err(ParseError {
+                        message: "Expected column name in ON CONFLICT".to_string(),
+                    }),
+                })?;
+                self.expect_token(Token::RParen)?;
+                Some(cols)
+            } else {
+                None
+            };
+
+            self.expect_keyword(Keyword::Do)?;
+
+            let action = if self.peek_keyword(Keyword::Nothing) {
+                self.advance(); // consume NOTHING
+                vibesql_ast::OnConflictAction::DoNothing
+            } else if self.peek_keyword(Keyword::Update) {
+                self.advance(); // consume UPDATE
+                self.expect_keyword(Keyword::Set)?;
+
+                // Parse assignment list
+                let assignments = self.parse_on_conflict_assignments()?;
+
+                // Parse optional WHERE clause
+                let where_clause = if self.peek_keyword(Keyword::Where) {
+                    self.advance();
+                    Some(self.parse_expression()?)
+                } else {
+                    None
+                };
+
+                vibesql_ast::OnConflictAction::DoUpdate { assignments, where_clause }
+            } else {
+                return Err(ParseError {
+                    message: "Expected NOTHING or UPDATE after DO".to_string(),
+                });
+            };
+
+            Ok((
+                Some(vibesql_ast::OnConflictClause { conflict_target, action }),
+                None,
+            ))
+        } else if self.peek_keyword(Keyword::Duplicate) {
+            // MySQL: ON DUPLICATE KEY UPDATE ...
+            self.advance(); // consume DUPLICATE
+            self.expect_keyword(Keyword::Key)?;
+            self.expect_keyword(Keyword::Update)?;
+
+            // Parse assignment list: column = expr, column = expr, ...
+            let mut assignments = Vec::new();
+            loop {
+                let column = match self.peek() {
+                    Token::Identifier(col) => {
+                        let column_name = col.clone();
+                        self.advance();
+                        column_name
+                    }
+                    _ => {
+                        return Err(ParseError {
+                            message: "Expected column name in ON DUPLICATE KEY UPDATE"
+                                .to_string(),
+                        })
+                    }
+                };
+
+                self.expect_token(Token::Symbol('='))?;
+                let value = self.parse_expression()?;
+
+                assignments.push(vibesql_ast::Assignment { column, value });
+
+                if matches!(self.peek(), Token::Comma) {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+            Ok((None, Some(assignments)))
+        } else {
+            Err(ParseError {
+                message: "Expected CONFLICT or DUPLICATE after ON".to_string(),
+            })
+        }
+    }
+
+    /// Parse assignments for ON CONFLICT ... DO UPDATE SET
+    fn parse_on_conflict_assignments(&mut self) -> Result<Vec<vibesql_ast::Assignment>, ParseError> {
+        let mut assignments = Vec::new();
+        loop {
+            let column = match self.peek() {
+                Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
+                    let column_name = col.clone();
+                    self.advance();
+                    column_name
+                }
+                _ => {
+                    return Err(ParseError {
+                        message: "Expected column name in ON CONFLICT UPDATE".to_string(),
+                    })
+                }
+            };
+
+            self.expect_token(Token::Symbol('='))?;
+            let value = self.parse_expression()?;
+
+            assignments.push(vibesql_ast::Assignment { column, value });
+
+            if matches!(self.peek(), Token::Comma) {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        Ok(assignments)
     }
 }


### PR DESCRIPTION
## Summary
- Implements SQLite's upsert clause syntax: `INSERT ... ON CONFLICT (cols) DO NOTHING/UPDATE`
- Adds `OnConflictAction` and `OnConflictClause` AST types
- Updates both regular and arena parsers with shared helper methods
- Adds executor support treating `ON CONFLICT DO NOTHING` as equivalent to `INSERT OR IGNORE`
- Adds `NOTHING` keyword to lexer

## Test plan
- [x] All existing conflict resolution tests pass (12 tests)
- [x] New ON CONFLICT DO NOTHING tests pass (3 tests)
  - `test_insert_on_conflict_do_nothing_primary_key`
  - `test_insert_on_conflict_do_nothing_without_target`
  - `test_insert_on_conflict_do_nothing_no_conflict`

Closes #4883

🤖 Generated with [Claude Code](https://claude.com/claude-code)