### PR TITLE
fix(executor): implement SQLite-compatible type affinity for IN expressions

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -307,6 +307,88 @@ impl CombinedExpressionEvaluator<'_> {
         (left_val, right_val)
     }
 
+    /// Apply SQLite type affinity rules for IN expression comparisons.
+    ///
+    /// IN expressions have different affinity rules than regular comparisons:
+    /// - For INTEGER columns, string literals are NOT coerced to integers
+    /// - For REAL columns, string literals ARE coerced to REAL
+    /// - For TEXT columns, numeric literals are converted to text
+    pub fn apply_affinity_for_in_comparison(
+        &self,
+        left_expr: &vibesql_ast::Expression,
+        left_val: SqlValue,
+        right_expr: &vibesql_ast::Expression,
+        right_val: SqlValue,
+    ) -> (SqlValue, SqlValue) {
+        let left_affinity = self.get_expression_affinity(left_expr);
+        let right_affinity = self.get_expression_affinity(right_expr);
+
+        // Case 1: Left is TEXT column, right is numeric literal
+        if left_affinity == Some(TypeAffinity::Text) && self.is_numeric_literal(right_expr) {
+            let right_as_text = match &right_val {
+                SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Bigint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Unsigned(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Float(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n as f64),
+                )),
+                SqlValue::Real(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n),
+                )),
+                SqlValue::Double(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n),
+                )),
+                SqlValue::Numeric(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n),
+                )),
+                _ => right_val,
+            };
+            return (left_val, right_as_text);
+        }
+
+        // Case 2: Right is TEXT column, left is numeric literal
+        if right_affinity == Some(TypeAffinity::Text) && self.is_numeric_literal(left_expr) {
+            let left_as_text = match &left_val {
+                SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Bigint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Unsigned(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Float(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n as f64),
+                )),
+                SqlValue::Real(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n),
+                )),
+                SqlValue::Double(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n),
+                )),
+                SqlValue::Numeric(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n),
+                )),
+                _ => left_val,
+            };
+            return (left_as_text, right_val);
+        }
+
+        // Case 3: Left is REAL column, right is string literal
+        // REAL affinity DOES coerce strings to numbers in IN expressions
+        if left_affinity == Some(TypeAffinity::Real) && self.is_string_literal(right_expr) {
+            let right_coerced = Self::try_coerce_string_to_numeric(&right_val);
+            return (left_val, right_coerced);
+        }
+
+        // Case 4: Right is REAL column, left is string literal
+        if right_affinity == Some(TypeAffinity::Real) && self.is_string_literal(left_expr) {
+            let left_coerced = Self::try_coerce_string_to_numeric(&left_val);
+            return (left_coerced, right_val);
+        }
+
+        // For IN expressions, INTEGER affinity does NOT coerce strings
+        // (unlike regular comparison). No affinity conversion needed.
+        (left_val, right_val)
+    }
+
     /// Evaluate an expression in the context of a combined row
     /// This is the main entry point for expression evaluation
     pub(crate) fn eval(

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -476,9 +476,9 @@ impl CombinedExpressionEvaluator<'_> {
                 }
 
                 // Apply SQLite type affinity rules for IN comparisons
-                // e.g., NUMERIC column compared to '2' should coerce '2' to 2
+                // Note: IN expressions have different affinity rules than regular comparisons
                 let (expr_coerced, value_coerced) =
-                    self.apply_affinity_for_comparison(expr, expr_val.clone(), value_expr, value);
+                    self.apply_affinity_for_in_comparison(expr, expr_val.clone(), value_expr, value);
 
                 // Compare using equality
                 let eq_result = ExpressionEvaluator::eval_binary_op_static(
@@ -517,7 +517,7 @@ impl CombinedExpressionEvaluator<'_> {
                     found_null = true;
                 } else {
                     // Apply SQLite type affinity rules for IN comparisons
-                    let (_, value_coerced) = self.apply_affinity_for_comparison(
+                    let (_, value_coerced) = self.apply_affinity_for_in_comparison(
                         expr,
                         expr_val.clone(),
                         value_expr,

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -283,6 +283,88 @@ impl ExpressionEvaluator<'_> {
         (left_val, right_val)
     }
 
+    /// Apply SQLite type affinity rules for IN expression comparisons.
+    ///
+    /// IN expressions have different affinity rules than regular comparisons:
+    /// - For INTEGER columns, string literals are NOT coerced to integers
+    /// - For REAL columns, string literals ARE coerced to REAL
+    /// - For TEXT columns, numeric literals are converted to text
+    pub(super) fn apply_affinity_for_in_comparison(
+        &self,
+        left_expr: &vibesql_ast::Expression,
+        left_val: SqlValue,
+        right_expr: &vibesql_ast::Expression,
+        right_val: SqlValue,
+    ) -> (SqlValue, SqlValue) {
+        let left_affinity = self.get_expression_affinity(left_expr);
+        let right_affinity = self.get_expression_affinity(right_expr);
+
+        // Case 1: Left is TEXT column, right is numeric literal
+        if left_affinity == Some(TypeAffinity::Text) && self.is_numeric_literal(right_expr) {
+            let right_as_text = match &right_val {
+                SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Bigint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Unsigned(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Float(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n as f64),
+                )),
+                SqlValue::Real(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n),
+                )),
+                SqlValue::Double(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n),
+                )),
+                SqlValue::Numeric(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n),
+                )),
+                _ => right_val,
+            };
+            return (left_val, right_as_text);
+        }
+
+        // Case 2: Right is TEXT column, left is numeric literal
+        if right_affinity == Some(TypeAffinity::Text) && self.is_numeric_literal(left_expr) {
+            let left_as_text = match &left_val {
+                SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Bigint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Unsigned(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+                SqlValue::Float(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n as f64),
+                )),
+                SqlValue::Real(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n),
+                )),
+                SqlValue::Double(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n),
+                )),
+                SqlValue::Numeric(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                    format_float_for_text_comparison(*n),
+                )),
+                _ => left_val,
+            };
+            return (left_as_text, right_val);
+        }
+
+        // Case 3: Left is REAL column, right is string literal
+        // REAL affinity DOES coerce strings to numbers in IN expressions
+        if left_affinity == Some(TypeAffinity::Real) && self.is_string_literal(right_expr) {
+            let right_coerced = Self::try_coerce_string_to_numeric(&right_val);
+            return (left_val, right_coerced);
+        }
+
+        // Case 4: Right is REAL column, left is string literal
+        if right_affinity == Some(TypeAffinity::Real) && self.is_string_literal(left_expr) {
+            let left_coerced = Self::try_coerce_string_to_numeric(&left_val);
+            return (left_coerced, right_val);
+        }
+
+        // For IN expressions, INTEGER affinity does NOT coerce strings
+        // (unlike regular comparison). No affinity conversion needed.
+        (left_val, right_val)
+    }
+
     /// Evaluate an expression in the context of a row
     #[inline]
     pub fn eval(

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -617,9 +617,9 @@ impl ExpressionEvaluator<'_> {
                 }
 
                 // Apply SQLite type affinity rules for IN comparisons
-                // e.g., NUMERIC column compared to '2' should coerce '2' to 2
+                // Note: IN expressions have different affinity rules than regular comparisons
                 let (expr_coerced, value_coerced) =
-                    self.apply_affinity_for_comparison(expr, expr_val.clone(), value_expr, value);
+                    self.apply_affinity_for_in_comparison(expr, expr_val.clone(), value_expr, value);
 
                 let eq_result = self.eval_binary_op(
                     &expr_coerced,
@@ -652,7 +652,7 @@ impl ExpressionEvaluator<'_> {
                     found_null = true;
                 } else {
                     // Apply SQLite type affinity rules for IN comparisons
-                    let (_, value_coerced) = self.apply_affinity_for_comparison(
+                    let (_, value_coerced) = self.apply_affinity_for_in_comparison(
                         expr,
                         expr_val.clone(),
                         value_expr,

--- a/tests/sqllogictest-files/select/in_type_affinity.slt
+++ b/tests/sqllogictest-files/select/in_type_affinity.slt
@@ -1,0 +1,72 @@
+# Test for issue #4879: Type affinity mismatch in IN expressions
+# SQLite has specific type affinity rules for IN expressions
+# String '1' should NOT equal integer 1 in IN expressions
+
+statement ok
+DROP TABLE IF EXISTS t0
+
+statement ok
+CREATE TABLE t0(c0 INT UNIQUE)
+
+statement ok
+INSERT INTO t0(c0) VALUES (1)
+
+# in-18.1: String literal '1' should NOT match integer column value 1
+# SQLite returns empty result (no rows)
+query I nosort
+SELECT * FROM t0 WHERE '1' IN (t0.c0)
+----
+
+# in-17.1: Integer 1 should NOT match string '1' in IN expression
+query I nosort
+SELECT 1 IN ('1')
+----
+0
+
+# in-17.2: Integer 1 should NOT match string '1' even with NOCASE collation
+query I nosort
+SELECT 1 IN ('1' COLLATE nocase)
+----
+0
+
+# in-17.3: Integer 1 should NOT match CAST('1' AS text)
+query I nosort
+SELECT 1 IN (CAST('1' AS text))
+----
+0
+
+# Additional test: verify the issue with different integer values
+statement ok
+INSERT INTO t0(c0) VALUES (42)
+
+query I nosort
+SELECT * FROM t0 WHERE '42' IN (t0.c0)
+----
+
+# Test that actual integer matches still work
+query I rowsort
+SELECT * FROM t0 WHERE 1 IN (t0.c0)
+----
+1
+
+# Test REAL affinity - strings SHOULD be coerced for REAL columns
+statement ok
+DROP TABLE IF EXISTS t1
+
+statement ok
+CREATE TABLE t1(c0 REAL UNIQUE)
+
+statement ok
+INSERT INTO t1(c0) VALUES (2.0625)
+
+# in-19.10: For REAL columns, string should be coerced and match
+query I nosort
+SELECT 1 FROM t1 WHERE c0 IN ('2.0625')
+----
+1
+
+# in-19.20: Test scalar context as well
+query I nosort
+SELECT c0 IN ('2.0625') FROM t1
+----
+1


### PR DESCRIPTION
## Summary

Fixes #4879 - Type affinity mismatch in IN expressions (string vs integer comparison)

SQLite has different type affinity rules for IN expressions vs regular comparisons:
- For INTEGER columns, string literals are NOT coerced to integers (so `'1' IN (int_col)` does NOT match when int_col = 1)
- For REAL columns, string literals ARE coerced to REAL (so `real_col IN ('2.0625')` DOES match when real_col = 2.0625)
- For TEXT columns, numeric literals are converted to text (same as regular comparison)

This PR:
- Adds new `apply_affinity_for_in_comparison` function in both expressions and combined evaluators
- Updates `eval_in_list` to use the new IN-specific affinity function
- Adds test case `in_type_affinity.slt` with test cases from the SQLite in.test TCL suite

## Test plan

- [x] Manual verification: `SELECT * FROM t0 WHERE '1' IN (t0.c0)` returns empty when c0 is INT with value 1
- [x] Manual verification: `SELECT 1 FROM t1 WHERE c0 IN ('2.0625')` returns 1 when c0 is REAL with value 2.0625
- [x] Added SQLLogicTest test file covering the issue scenarios
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)