### PR TITLE
fix(optimizer): qualify unqualified column refs in IN→EXISTS rewrite

### DIFF
--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
@@ -56,7 +56,7 @@ pub(super) fn rewrite_expression_with_context(
             if is_correlated(subquery) && is_simple_column {
                 // Correlated subquery with simple column: Rewrite IN → EXISTS
                 // This allows database to stop after first match and better leverage indexes
-                rewrite_in_to_exists(in_expr, subquery, *negated)
+                rewrite_in_to_exists(in_expr, subquery, *negated, outer_tables)
             } else if is_correlated(subquery) && !is_simple_column {
                 // Correlated subquery with complex expression: skip IN → EXISTS
                 // Complex expressions can't be safely used in correlation predicates

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/transformations.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/transformations.rs
@@ -4,7 +4,7 @@
 //! - Correlated IN → EXISTS with LIMIT 1 for early termination
 //! - Uncorrelated IN → IN with DISTINCT to reduce duplicates
 
-use vibesql_ast::{BinaryOperator, Expression, SelectItem, SelectStmt};
+use vibesql_ast::{BinaryOperator, ColumnIdentifier, Expression, SelectItem, SelectStmt};
 
 /// Rewrite correlated IN subquery to EXISTS with correlation predicate
 ///
@@ -22,10 +22,15 @@ use vibesql_ast::{BinaryOperator, Expression, SelectItem, SelectStmt};
 /// - Stop after finding first match (LIMIT 1 enables early termination)
 /// - Better leverage indexes on the correlation column
 /// - Potentially use better query plans
+///
+/// **Important**: When the left expression contains unqualified column references,
+/// they must be qualified with the outer table name to prevent incorrect resolution
+/// in the EXISTS subquery context (issue #4880).
 pub(super) fn rewrite_in_to_exists(
     in_expr: &Expression,
     subquery: &SelectStmt,
     negated: bool,
+    outer_tables: &[String],
 ) -> Expression {
     // Create rewritten subquery
     let mut exists_subquery = subquery.clone();
@@ -49,11 +54,17 @@ pub(super) fn rewrite_in_to_exists(
     // Extract the correlation column expression from original SELECT list
     // This assumes single-column subquery (already validated by executor)
     if let Some(SelectItem::Expression { expr: subquery_col, .. }) = subquery.select_list.first() {
+        // Fix for issue #4880: Qualify unqualified column references in the left expression
+        // When IN is rewritten to EXISTS, the left expression becomes part of the EXISTS
+        // subquery's WHERE clause. Without qualification, unqualified column refs would
+        // resolve to the subquery's tables instead of the outer query's tables.
+        let qualified_in_expr = qualify_outer_column_refs(in_expr, outer_tables);
+
         // Create correlation predicate: subquery_col = in_expr
         let correlation_predicate = Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(subquery_col.clone()),
-            right: Box::new(in_expr.clone()),
+            right: Box::new(qualified_in_expr),
         };
 
         // Combine with existing WHERE clause using AND
@@ -70,6 +81,82 @@ pub(super) fn rewrite_in_to_exists(
 
     // Create EXISTS expression
     Expression::Exists { subquery: Box::new(exists_subquery), negated }
+}
+
+/// Qualify unqualified column references in an expression with an outer table name.
+///
+/// This is needed when moving an expression from an outer query context into a subquery.
+/// Without qualification, unqualified column refs would resolve to the subquery's tables
+/// instead of the outer query's tables (issue #4880).
+///
+/// # Arguments
+/// * `expr` - The expression to qualify
+/// * `outer_tables` - List of outer table names/aliases to use for qualification
+///
+/// # Returns
+/// A new expression with unqualified column refs qualified using the first outer table
+fn qualify_outer_column_refs(expr: &Expression, outer_tables: &[String]) -> Expression {
+    // If no outer tables available, return expression unchanged
+    // This shouldn't happen in practice for correlated IN subqueries
+    let outer_table = match outer_tables.first() {
+        Some(t) => t,
+        None => return expr.clone(),
+    };
+
+    match expr {
+        Expression::ColumnRef(col_id) => {
+            // Only qualify if the column reference is unqualified (no table name)
+            if col_id.table_canonical().is_none() {
+                // Create a new qualified column identifier using the outer table
+                // Use display form for column name to preserve user's casing
+                let qualified_col = ColumnIdentifier::qualified(
+                    outer_table,                  // table
+                    false,                        // table_quoted (outer tables from FROM are unquoted)
+                    col_id.column_display(),      // column
+                    false,                        // column_quoted (assume unquoted for simplicity)
+                );
+                Expression::ColumnRef(qualified_col)
+            } else {
+                // Already qualified, return unchanged
+                expr.clone()
+            }
+        }
+
+        // Recursively qualify nested expressions
+        Expression::BinaryOp { op, left, right } => Expression::BinaryOp {
+            op: *op,
+            left: Box::new(qualify_outer_column_refs(left, outer_tables)),
+            right: Box::new(qualify_outer_column_refs(right, outer_tables)),
+        },
+
+        Expression::UnaryOp { op, expr: inner } => Expression::UnaryOp {
+            op: *op,
+            expr: Box::new(qualify_outer_column_refs(inner, outer_tables)),
+        },
+
+        Expression::IsNull { expr: inner, negated } => Expression::IsNull {
+            expr: Box::new(qualify_outer_column_refs(inner, outer_tables)),
+            negated: *negated,
+        },
+
+        Expression::Between { expr: inner, low, high, negated, symmetric } => Expression::Between {
+            expr: Box::new(qualify_outer_column_refs(inner, outer_tables)),
+            low: Box::new(qualify_outer_column_refs(low, outer_tables)),
+            high: Box::new(qualify_outer_column_refs(high, outer_tables)),
+            negated: *negated,
+            symmetric: *symmetric,
+        },
+
+        Expression::Cast { expr: inner, data_type } => Expression::Cast {
+            expr: Box::new(qualify_outer_column_refs(inner, outer_tables)),
+            data_type: data_type.clone(),
+        },
+
+        // For other expression types (including complex ones like CASE, Function, etc.),
+        // return unchanged. These are less common in IN left-side expressions.
+        // If needed, we can add more cases later.
+        _ => expr.clone(),
+    }
 }
 
 /// Attempt to rewrite correlated EXISTS to uncorrelated IN

--- a/tests/sqllogictest-files/select/in_subquery_correlated_unqualified.slt
+++ b/tests/sqllogictest-files/select/in_subquery_correlated_unqualified.slt
@@ -1,0 +1,62 @@
+# Issue #4880: Column resolution bug in correlated IN subqueries
+# When the left side of IN uses an unqualified column reference (e.g., `b`)
+# instead of a qualified one (e.g., `outside.b`), the IN→EXISTS rewrite
+# incorrectly resolved the column in the subquery context, causing wrong results.
+#
+# Bug: `b IN (SELECT ...)` returned TRUE when `outside.b IN (SELECT ...)` returned FALSE
+
+statement ok
+CREATE TABLE t7(a, b, c NOT NULL)
+
+statement ok
+INSERT INTO t7 VALUES(1, 1, 1)
+
+statement ok
+INSERT INTO t7 VALUES(2, 2, 2)
+
+statement ok
+INSERT INTO t7 VALUES(3, 3, 3)
+
+statement ok
+INSERT INTO t7 VALUES(NULL, 4, 4)
+
+statement ok
+INSERT INTO t7 VALUES(NULL, 5, 5)
+
+# Test 1: Non-correlated subquery - baseline test
+query II rowsort
+SELECT b, b IN (SELECT a FROM t7 WHERE b = 3) FROM t7 WHERE b = 1
+----
+1	0
+
+# Test 2: Correlated subquery with qualified column ref on left side
+# outside.b = 1, subquery returns [2, 3], so 1 NOT IN (2, 3) = FALSE (0)
+query II rowsort
+SELECT outside.b, outside.b IN (SELECT inside.a FROM t7 AS inside WHERE inside.b BETWEEN outside.b+1 AND outside.b+2) FROM t7 AS outside WHERE outside.b = 1
+----
+1	0
+
+# Test 3: Correlated subquery with UNqualified column ref on left side
+# This is the key test for issue #4880 - unqualified `b` must resolve to outer table
+# Previously returned 1 (TRUE), should return 0 (FALSE) - same as Test 2
+query II rowsort
+SELECT b, b IN (SELECT inside.a FROM t7 AS inside WHERE inside.b BETWEEN outside.b+1 AND outside.b+2) FROM t7 AS outside WHERE b = 1
+----
+1	0
+
+# Test 4: Verify qualified and unqualified return same result for all rows
+# Both columns should have identical values - if they differ, there's a column resolution bug
+query III rowsort
+SELECT b,
+       b IN (SELECT inside.a FROM t7 AS inside WHERE inside.b BETWEEN outside.b+1 AND outside.b+2) AS unqualified_in,
+       outside.b IN (SELECT inside.a FROM t7 AS inside WHERE inside.b BETWEEN outside.b+1 AND outside.b+2) AS qualified_in
+FROM t7 AS outside
+----
+1	0	0
+2	0	0
+3	0	0
+4	0	0
+5	0	0
+
+statement ok
+DROP TABLE t7


### PR DESCRIPTION
## Summary
- Fixes column resolution bug in IN→EXISTS subquery optimization
- Unqualified column refs on left side of IN were resolving to wrong table when moved into EXISTS correlation predicate
- Added `qualify_outer_column_refs()` helper to qualify unqualified columns with outer table name
- Includes regression test covering the fix

## Problem
When the left side of a correlated IN expression uses an unqualified column reference:
```sql
SELECT b, b IN (SELECT inside.a FROM t7 AS inside WHERE inside.b BETWEEN outside.b+1 AND outside.b+2)
FROM t7 AS outside WHERE b = 1
```

The IN→EXISTS optimization would rewrite this to:
```sql
EXISTS (SELECT 1 FROM t7 AS inside WHERE ... AND inside.a = b LIMIT 1)
```

The unqualified `b` in the correlation predicate `inside.a = b` would incorrectly resolve to `inside.b` (subquery table) instead of `outside.b` (outer table), causing wrong results.

## Solution
Qualify unqualified column references with the outer table name before inserting them into the EXISTS correlation predicate:
```sql
EXISTS (SELECT 1 FROM t7 AS inside WHERE ... AND inside.a = outside.b LIMIT 1)
```

## Test plan
- [x] Verified manually that qualified and unqualified column refs now return identical results
- [x] Added regression test `tests/sqllogictest-files/select/in_subquery_correlated_unqualified.slt`
- [ ] Full CI test suite will verify no regressions

Closes #4880

🤖 Generated with [Claude Code](https://claude.com/claude-code)