### PR TITLE
fix(executor): deduplicate joined columns in SELECT * for chained NATURAL JOINs

### DIFF
--- a/crates/vibesql-executor/src/select/executor/columns.rs
+++ b/crates/vibesql-executor/src/select/executor/columns.rs
@@ -160,6 +160,24 @@ impl SelectExecutor<'_> {
                         // This ensures USING columns appear first in SELECT * output
                         table_columns.sort_by_key(|(idx, _, _, is_joined)| (!*is_joined, *idx));
 
+                        // Deduplicate joined columns: for chained NATURAL JOINs like
+                        // t4 NATURAL RIGHT JOIN t5 NATURAL RIGHT JOIN t6, multiple columns
+                        // might be marked as "joined" with the same name (e.g., both t4.id
+                        // and t5.id). We should only output ONE column per joined column name.
+                        // Keep the first occurrence (which has the lowest index after sorting).
+                        let mut seen_joined_columns: std::collections::HashSet<String> =
+                            std::collections::HashSet::new();
+                        table_columns.retain(|(_, col_name, _, is_joined)| {
+                            if *is_joined {
+                                let col_lower = col_name.to_lowercase();
+                                if seen_joined_columns.contains(&col_lower) {
+                                    return false; // Skip duplicate joined column
+                                }
+                                seen_joined_columns.insert(col_lower);
+                            }
+                            true
+                        });
+
                         // Apply derived column list if present
                         if let Some(derived_cols) = alias {
                             if derived_cols.len() != table_columns.len() {

--- a/crates/vibesql-executor/src/select/projection.rs
+++ b/crates/vibesql-executor/src/select/projection.rs
@@ -43,8 +43,9 @@ pub(crate) fn project_row_combined(
                     // No USING/NATURAL JOIN - use natural order
                     (0..max_col).collect()
                 } else {
-                    // Collect visible column indices with their join status
-                    let mut joined_cols: Vec<usize> = Vec::new();
+                    // Collect visible column indices with their join status and column name
+                    // Store (abs_idx, col_name_lower, is_joined)
+                    let mut joined_cols: Vec<(usize, String)> = Vec::new();
                     let mut other_cols: Vec<usize> = Vec::new();
 
                     // Sort table_schemas by start_index for deterministic iteration order
@@ -84,10 +85,10 @@ pub(crate) fn project_row_combined(
                             };
 
                             if should_include {
-                                let is_joined =
-                                    schema.joined_columns.contains(&col_schema.name.to_lowercase());
+                                let col_name_lower = col_schema.name.to_lowercase();
+                                let is_joined = schema.joined_columns.contains(&col_name_lower);
                                 if is_joined {
-                                    joined_cols.push(abs_idx);
+                                    joined_cols.push((abs_idx, col_name_lower));
                                 } else {
                                     other_cols.push(abs_idx);
                                 }
@@ -96,11 +97,30 @@ pub(crate) fn project_row_combined(
                     }
 
                     // Sort each group by index to maintain relative order
-                    joined_cols.sort();
+                    joined_cols.sort_by_key(|(idx, _)| *idx);
                     other_cols.sort();
 
+                    // Deduplicate joined columns: for chained NATURAL JOINs like
+                    // t4 NATURAL RIGHT JOIN t5 NATURAL RIGHT JOIN t6, multiple columns
+                    // might be marked as "joined" with the same name (e.g., both t4.id
+                    // and t5.id). We should only output ONE column per joined column name.
+                    // Keep the first occurrence (which has the lowest index after sorting).
+                    let mut seen_joined_columns: std::collections::HashSet<String> =
+                        std::collections::HashSet::new();
+                    let deduped_joined: Vec<usize> = joined_cols
+                        .into_iter()
+                        .filter_map(|(idx, col_name)| {
+                            if seen_joined_columns.contains(&col_name) {
+                                None // Skip duplicate joined column
+                            } else {
+                                seen_joined_columns.insert(col_name);
+                                Some(idx)
+                            }
+                        })
+                        .collect();
+
                     // Concatenate: joined columns first, then others
-                    joined_cols.into_iter().chain(other_cols).collect()
+                    deduped_joined.into_iter().chain(other_cols).collect()
                 };
 
                 // Iterate through reordered columns, handling hidden columns with replacements


### PR DESCRIPTION
## Summary

Fixes duplicate join columns appearing in `SELECT *` output for chained NATURAL RIGHT/FULL JOINs.

For queries like `t4 NATURAL RIGHT JOIN t5 NATURAL RIGHT JOIN t6`, the `SELECT *` was outputting 8 columns instead of 7 because intermediate join columns (e.g., both `t4.id` and `t5.id`) were both being included when only one coalesced `id` column should appear.

## Changes

- Added deduplication of joined columns by name in column name derivation (`columns.rs`)
- Added matching deduplication in row projection (`projection.rs`)
- After sorting joined columns by index, only the first occurrence of each column name is kept

## Test Results

- **join9.test**: Improved from 37.3% (56/150) to 40.0% (60/150) - 4 more tests pass
- All Rust unit tests pass

## Example

```sql
SELECT *, t4.id, t5.id, t6.id 
FROM t4 NATURAL RIGHT JOIN t5 NATURAL RIGHT JOIN t6;
```

**Before (8 columns):**
```
id|id|x|y|z|id|id|id
```

**After (7 columns):**
```
id|x|y|z|id|id|id
```

## Note

Some join9.test failures remain due to a separate pre-existing coalescing issue in chained NATURAL JOINs where the coalesced column value doesn't properly chain through multiple joins. This should be tracked in a separate issue.

Closes #4901