### PR TITLE
fix(evaluator): Add type coercion for LIKE/GLOB pattern matching

### DIFF
--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -676,20 +676,45 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
         // Get case_sensitive_like setting from database (default: false = case-insensitive)
         let case_sensitive = self.database.map(|db| db.case_sensitive_like()).unwrap_or(false);
 
-        match (value, pattern) {
-            (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
-            (SqlValue::Varchar(s), SqlValue::Varchar(p))
-            | (SqlValue::Character(s), SqlValue::Varchar(p))
-            | (SqlValue::Varchar(s), SqlValue::Character(p))
-            | (SqlValue::Character(s), SqlValue::Character(p)) => {
-                let matches = super::pattern::like_match(s, p, case_sensitive, escape_char);
-                Ok(SqlValue::Boolean(if negated { !matches } else { matches }))
+        // Issue #4913: SQLite coerces numeric types to strings for LIKE comparison
+        let text = match value {
+            SqlValue::Null => return Ok(SqlValue::Null),
+            SqlValue::Varchar(s) | SqlValue::Character(s) => s.clone(),
+            SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Blob(b) => {
+                let hex: String = b.iter().map(|byte| format!("{:02X}", byte)).collect();
+                arcstr::ArcStr::from(hex)
             }
-            _ => Err(ExecutorError::TypeError(format!(
-                "LIKE requires string operands, got {:?} and {:?}",
-                value, pattern
-            ))),
-        }
+            _ => {
+                return Err(ExecutorError::TypeError(format!(
+                    "LIKE requires string operands, got {:?} and {:?}",
+                    value, pattern
+                )))
+            }
+        };
+
+        let pattern_str = match pattern {
+            SqlValue::Null => return Ok(SqlValue::Null),
+            SqlValue::Varchar(s) | SqlValue::Character(s) => s.clone(),
+            SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            _ => {
+                return Err(ExecutorError::TypeError(format!(
+                    "LIKE requires string operands, got {:?} and {:?}",
+                    value, pattern
+                )))
+            }
+        };
+
+        let matches = super::pattern::like_match(&text, &pattern_str, case_sensitive, escape_char);
+        Ok(SqlValue::Boolean(if negated { !matches } else { matches }))
     }
 
     /// Evaluate GLOB pattern matching (SQLite).
@@ -699,20 +724,45 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
         pattern: &SqlValue,
         negated: bool,
     ) -> Result<SqlValue, ExecutorError> {
-        match (value, pattern) {
-            (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlValue::Null),
-            (SqlValue::Varchar(s), SqlValue::Varchar(p))
-            | (SqlValue::Character(s), SqlValue::Varchar(p))
-            | (SqlValue::Varchar(s), SqlValue::Character(p))
-            | (SqlValue::Character(s), SqlValue::Character(p)) => {
-                let matches = super::pattern::glob_match(s, p);
-                Ok(SqlValue::Boolean(if negated { !matches } else { matches }))
+        // Issue #4913: SQLite coerces numeric types to strings for GLOB comparison
+        let text = match value {
+            SqlValue::Null => return Ok(SqlValue::Null),
+            SqlValue::Varchar(s) | SqlValue::Character(s) => s.clone(),
+            SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Blob(b) => {
+                let hex: String = b.iter().map(|byte| format!("{:02X}", byte)).collect();
+                arcstr::ArcStr::from(hex)
             }
-            _ => Err(ExecutorError::TypeError(format!(
-                "GLOB requires string operands, got {:?} and {:?}",
-                value, pattern
-            ))),
-        }
+            _ => {
+                return Err(ExecutorError::TypeError(format!(
+                    "GLOB requires string operands, got {:?} and {:?}",
+                    value, pattern
+                )))
+            }
+        };
+
+        let pattern_str = match pattern {
+            SqlValue::Null => return Ok(SqlValue::Null),
+            SqlValue::Varchar(s) | SqlValue::Character(s) => s.clone(),
+            SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            _ => {
+                return Err(ExecutorError::TypeError(format!(
+                    "GLOB requires string operands, got {:?} and {:?}",
+                    value, pattern
+                )))
+            }
+        };
+
+        let matches = super::pattern::glob_match(&text, &pattern_str);
+        Ok(SqlValue::Boolean(if negated { !matches } else { matches }))
     }
 
     /// Evaluate POSITION function.

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -451,11 +451,23 @@ impl ExpressionEvaluator<'_> {
         let expr_val = self.eval(expr, row)?;
         let pattern_val = self.eval(pattern, row)?;
 
-        let text = match expr_val {
-            vibesql_types::SqlValue::Varchar(ref s) | vibesql_types::SqlValue::Character(ref s) => {
+        // Issue #4913: SQLite coerces numeric types to strings for LIKE comparison
+        let text = match &expr_val {
+            vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
                 s.clone()
             }
             vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
+            // SQLite coerces numeric types to strings for LIKE comparison
+            vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
+            vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
+            vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Blob values are coerced to hex representation in SQLite
+            vibesql_types::SqlValue::Blob(b) => {
+                let hex: String = b.iter().map(|byte| format!("{:02X}", byte)).collect();
+                arcstr::ArcStr::from(hex)
+            }
             _ => {
                 return Err(ExecutorError::TypeMismatch {
                     left: expr_val,
@@ -465,11 +477,17 @@ impl ExpressionEvaluator<'_> {
             }
         };
 
-        let pattern_str = match pattern_val {
-            vibesql_types::SqlValue::Varchar(ref s) | vibesql_types::SqlValue::Character(ref s) => {
+        let pattern_str = match &pattern_val {
+            vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
                 s.clone()
             }
             vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
+            // SQLite coerces numeric types to strings for LIKE comparison
+            vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
+            vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
+            vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
             _ => {
                 return Err(ExecutorError::TypeMismatch {
                     left: expr_val,
@@ -542,11 +560,23 @@ impl ExpressionEvaluator<'_> {
         let expr_val = self.eval(expr, row)?;
         let pattern_val = self.eval(pattern, row)?;
 
-        let text = match expr_val {
-            vibesql_types::SqlValue::Varchar(ref s) | vibesql_types::SqlValue::Character(ref s) => {
+        // Issue #4913: SQLite coerces numeric types to strings for GLOB comparison
+        let text = match &expr_val {
+            vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
                 s.clone()
             }
             vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
+            // SQLite coerces numeric types to strings for GLOB comparison
+            vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
+            vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
+            vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Blob values are coerced to hex representation in SQLite
+            vibesql_types::SqlValue::Blob(b) => {
+                let hex: String = b.iter().map(|byte| format!("{:02X}", byte)).collect();
+                arcstr::ArcStr::from(hex)
+            }
             _ => {
                 return Err(ExecutorError::TypeMismatch {
                     left: expr_val,
@@ -556,11 +586,17 @@ impl ExpressionEvaluator<'_> {
             }
         };
 
-        let pattern_str = match pattern_val {
-            vibesql_types::SqlValue::Varchar(ref s) | vibesql_types::SqlValue::Character(ref s) => {
+        let pattern_str = match &pattern_val {
+            vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
                 s.clone()
             }
             vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
+            // SQLite coerces numeric types to strings for GLOB comparison
+            vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
+            vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
+            vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
             _ => {
                 return Err(ExecutorError::TypeMismatch {
                     left: expr_val,

--- a/crates/vibesql-executor/src/select/columnar/filter/evaluation.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/evaluation.rs
@@ -155,11 +155,37 @@ pub fn evaluate_predicate(predicate: &ColumnPredicate, value: &SqlValue) -> bool
             passes_low && passes_high
         }
         ColumnPredicate::Like { pattern, negated, .. } => {
-            // Extract string value
-            let text = match value {
-                SqlValue::Character(s) | SqlValue::Varchar(s) => &**s,
+            // Issue #4913: SQLite coerces numeric types to strings for LIKE comparison
+            let text_owned: String;
+            let text: &str = match value {
+                SqlValue::Character(s) | SqlValue::Varchar(s) => s,
                 SqlValue::Null => return false,
-                _ => return false, // Non-string types don't match LIKE patterns
+                // SQLite coerces numeric types to strings for LIKE comparison
+                SqlValue::Integer(i) => {
+                    text_owned = i.to_string();
+                    &text_owned
+                }
+                SqlValue::Bigint(i) => {
+                    text_owned = i.to_string();
+                    &text_owned
+                }
+                SqlValue::Float(f) => {
+                    text_owned = f.to_string();
+                    &text_owned
+                }
+                SqlValue::Double(f) => {
+                    text_owned = f.to_string();
+                    &text_owned
+                }
+                SqlValue::Real(f) => {
+                    text_owned = f.to_string();
+                    &text_owned
+                }
+                SqlValue::Blob(b) => {
+                    text_owned = b.iter().map(|byte| format!("{:02X}", byte)).collect();
+                    &text_owned
+                }
+                _ => return false,
             };
 
             let matches = like_match(text, pattern);


### PR DESCRIPTION
## Summary

- Add numeric type coercion (Integer, Bigint, Float, Double, Real) to string for LIKE/GLOB pattern matching
- Fix applied consistently across all three evaluator implementations:
  - `expressions/predicates.rs` (direct expression evaluation)
  - `arena.rs` (arena-based evaluation)
  - `columnar/filter/evaluation.rs` (columnar scan evaluation)

Fixes #4913

## Test plan

- [x] `SELECT 1024 LIKE '10%'` returns 1 (previously errored with "Type mismatch")
- [x] `SELECT a FROM test1 WHERE b LIKE '10%'` now returns matching rows (previously returned 0 rows)
- [x] expr.test passes expr-7.9 and expr-7.10 (increased from 612 to 614 passed tests)
- [x] All cargo tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)