### PR TITLE
fix(join): support parenthesized JOIN expression aliases in ON clauses

### DIFF
--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -593,6 +593,7 @@ mod tests {
             using_coalesce_indices: std::collections::HashMap::new(),
             column_replacement_map: std::collections::HashMap::new(),
             alias_tables: std::collections::HashSet::new(),
+            shadowed_tables: std::collections::HashMap::new(),
         };
 
         let subquery = SelectStmt {

--- a/crates/vibesql-executor/src/optimizer/column_pruning.rs
+++ b/crates/vibesql-executor/src/optimizer/column_pruning.rs
@@ -534,6 +534,7 @@ pub fn remap_schema(
         using_coalesce_indices: std::collections::HashMap::new(),
         column_replacement_map: std::collections::HashMap::new(),
         alias_tables: std::collections::HashSet::new(),
+        shadowed_tables: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -145,11 +145,16 @@ pub struct CombinedSchema {
     /// by t4.id to maintain the output order (id, y, x) instead of (y, id, x).
     pub column_replacement_map: HashMap<usize, usize>,
     /// Alias tables that are added for parenthesized join expressions (issue #4905).
-    /// These are virtual tables that point to the same columns as existing tables
-    /// but should NOT be expanded in SELECT *. They only exist for column resolution
-    /// purposes (e.g., `j1.id` in `FROM t1 JOIN (t2 JOIN t3) AS j1 ON j1.id = t1.id`).
+    /// These are virtual tables that point to the same columns as existing tables.
+    /// They exist for column resolution (e.g., `j1.id` in `FROM t1 JOIN (...) AS j1 ON j1.id = t1.id`).
     /// Stores the table identifiers of alias tables.
     pub alias_tables: HashSet<TableIdentifier>,
+    /// Tables that are shadowed by an alias table (issue #4786).
+    /// When a parenthesized join has an alias, the underlying tables are shadowed
+    /// and should be skipped in SELECT * expansion. Instead, the alias table's columns
+    /// should be used.
+    /// Maps: aliased table name -> tables shadowed by that alias
+    pub shadowed_tables: HashMap<TableIdentifier, HashSet<TableIdentifier>>,
 }
 
 impl CombinedSchema {
@@ -168,6 +173,7 @@ impl CombinedSchema {
             using_coalesce_indices: HashMap::new(),
             column_replacement_map: HashMap::new(),
             alias_tables: HashSet::new(),
+            shadowed_tables: HashMap::new(),
         }
     }
 
@@ -190,6 +196,7 @@ impl CombinedSchema {
             using_coalesce_indices: HashMap::new(),
             column_replacement_map: HashMap::new(),
             alias_tables: HashSet::new(),
+            shadowed_tables: HashMap::new(),
         }
     }
 
@@ -232,6 +239,7 @@ impl CombinedSchema {
             using_coalesce_indices: HashMap::new(),
             column_replacement_map: HashMap::new(),
             alias_tables: HashSet::new(),
+            shadowed_tables: HashMap::new(),
         }
     }
 
@@ -316,7 +324,19 @@ impl CombinedSchema {
         // Use start_idx = 0 so column resolution returns indices 0, 1, 2, ...
         // The order matches the all_columns order, so j1.id maps to index 0 if id is first
         self.table_schemas.insert(table_id.clone(), (0, schema));
-        self.alias_tables.insert(table_id);
+        self.alias_tables.insert(table_id.clone());
+
+        // Issue #4786: Mark all existing non-alias tables as shadowed by this alias.
+        // This ensures that in SELECT *, the alias table's columns are used instead of
+        // the individual base tables' columns. This is especially important for outer
+        // joins with ON clause, where the aliased join needs to appear as a single table.
+        let shadowed: HashSet<TableIdentifier> = self
+            .table_schemas
+            .keys()
+            .filter(|t| !self.alias_tables.contains(*t) && *t != &table_id)
+            .cloned()
+            .collect();
+        self.shadowed_tables.insert(table_id, shadowed);
 
         self
     }
@@ -363,6 +383,7 @@ impl CombinedSchema {
             using_coalesce_indices: left.using_coalesce_indices,
             column_replacement_map: left.column_replacement_map,
             alias_tables: left.alias_tables,
+            shadowed_tables: left.shadowed_tables,
         }
     }
 
@@ -443,6 +464,10 @@ impl CombinedSchema {
         let mut alias_tables = left.alias_tables;
         alias_tables.extend(right.alias_tables);
 
+        // Merge shadowed_tables from both sides
+        let mut shadowed_tables = left.shadowed_tables;
+        shadowed_tables.extend(right.shadowed_tables);
+
         CombinedSchema {
             table_schemas,
             total_columns: left_total + right.total_columns,
@@ -453,6 +478,7 @@ impl CombinedSchema {
             using_coalesce_indices,
             column_replacement_map,
             alias_tables,
+            shadowed_tables,
         }
     }
 
@@ -939,6 +965,7 @@ pub struct SchemaBuilder {
     using_coalesce_indices: HashMap<String, Vec<usize>>,
     column_replacement_map: HashMap<usize, usize>,
     alias_tables: HashSet<TableIdentifier>,
+    shadowed_tables: HashMap<TableIdentifier, HashSet<TableIdentifier>>,
 }
 
 impl SchemaBuilder {
@@ -953,6 +980,7 @@ impl SchemaBuilder {
             using_coalesce_indices: HashMap::new(),
             column_replacement_map: HashMap::new(),
             alias_tables: HashSet::new(),
+            shadowed_tables: HashMap::new(),
         }
     }
 
@@ -970,6 +998,7 @@ impl SchemaBuilder {
             using_coalesce_indices: schema.using_coalesce_indices,
             column_replacement_map: schema.column_replacement_map,
             alias_tables: schema.alias_tables,
+            shadowed_tables: schema.shadowed_tables,
         }
     }
 
@@ -1010,6 +1039,7 @@ impl SchemaBuilder {
             using_coalesce_indices: self.using_coalesce_indices,
             column_replacement_map: self.column_replacement_map,
             alias_tables: self.alias_tables,
+            shadowed_tables: self.shadowed_tables,
         }
     }
 

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -232,6 +232,7 @@ fn build_aggregate_result_schema(select_list: &[SelectItem]) -> CombinedSchema {
         using_coalesce_indices: std::collections::HashMap::new(),
         column_replacement_map: std::collections::HashMap::new(),
         alias_tables: std::collections::HashSet::new(),
+        shadowed_tables: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/arena_execution.rs
+++ b/crates/vibesql-executor/src/select/executor/arena_execution.rs
@@ -132,6 +132,7 @@ impl SelectExecutor<'_> {
             using_coalesce_indices: HashMap::new(),
             column_replacement_map: HashMap::new(),
             alias_tables: HashSet::new(),
+            shadowed_tables: HashMap::new(),
         };
         let empty_row = Row::new(vec![]);
         let evaluator = ArenaExpressionEvaluator::new(&schema, params, interner);

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -194,6 +194,7 @@ pub(super) fn build_combined_schema(
         using_coalesce_indices: HashMap::new(),
         column_replacement_map: HashMap::new(),
         alias_tables: HashSet::new(),
+            shadowed_tables: HashMap::new(),
     };
 
     for (table_name, alias, _batch, schema) in batches {

--- a/crates/vibesql-executor/src/select/executor/validation/schema.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/schema.rs
@@ -475,6 +475,7 @@ fn build_schema_from_tables(
             using_coalesce_indices: HashMap::new(),
             column_replacement_map: HashMap::new(),
             alias_tables: HashSet::new(),
+            shadowed_tables: HashMap::new(),
         })
     }
 }

--- a/crates/vibesql-executor/src/select/iterator/join.rs
+++ b/crates/vibesql-executor/src/select/iterator/join.rs
@@ -154,6 +154,10 @@ impl<'schema, I: RowIterator> LazyNestedLoopJoin<'schema, I> {
         let mut alias_tables = left_schema.alias_tables.clone();
         alias_tables.extend(right_schema.alias_tables.iter().cloned());
 
+        // Merge shadowed_tables from both sides
+        let mut shadowed_tables = left_schema.shadowed_tables.clone();
+        shadowed_tables.extend(right_schema.shadowed_tables.iter().map(|(k, v)| (k.clone(), v.clone())));
+
         let combined_schema = CombinedSchema {
             table_schemas,
             total_columns: left_total + right_total,
@@ -164,6 +168,7 @@ impl<'schema, I: RowIterator> LazyNestedLoopJoin<'schema, I> {
             using_coalesce_indices,
             column_replacement_map,
             alias_tables,
+            shadowed_tables,
         };
 
         let right_count = right_rows.len();

--- a/crates/vibesql-executor/src/select/iterator/tests/phase_c.rs
+++ b/crates/vibesql-executor/src/select/iterator/tests/phase_c.rs
@@ -211,6 +211,7 @@ fn test_phase_c_proof_of_concept_join_pipeline() {
         using_coalesce_indices: std::collections::HashMap::new(),
         column_replacement_map: std::collections::HashMap::new(),
         alias_tables: std::collections::HashSet::new(),
+        shadowed_tables: std::collections::HashMap::new(),
     };
 
     let where_expr = vibesql_ast::Expression::BinaryOp {

--- a/crates/vibesql-executor/src/select/join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/mod.rs
@@ -1532,30 +1532,34 @@ fn remove_duplicate_columns_for_using_join(
     // - RIGHT OUTER: left can be NULL for unmatched rows from right
     // - FULL OUTER: either side can be NULL for unmatched rows
     // Issue #4783: USING column semantics differ from SQLite in OUTER JOINs
-    let needs_coalesce = matches!(
+    let _needs_coalesce = matches!(
         join_type,
         vibesql_ast::JoinType::RightOuter | vibesql_ast::JoinType::FullOuter
     );
 
     // Build a map of column name -> leftmost left column index
     // This is the index that unqualified references will resolve to
+    //
+    // Issue #4786: We ALWAYS need to build this map, not just for FULL/RIGHT joins.
+    // When a LEFT/INNER join has USING on a right side with nested USING joins,
+    // we need to add the left column to the coalesce chain so that the inner
+    // join's visible column becomes a non-first position and gets properly
+    // filtered by is_using_coalesce_right_side() in projection.
     let mut leftmost_left_indices: std::collections::HashMap<String, usize> =
         std::collections::HashMap::new();
-    if needs_coalesce {
-        for (table_start_idx, table_schema) in left_schema.table_schemas.values() {
-            for (col_idx, col) in table_schema.columns.iter().enumerate() {
-                let lowercase = col.name.to_lowercase();
-                if using_cols_lower.contains(&lowercase) {
-                    let absolute_idx = table_start_idx + col_idx;
-                    leftmost_left_indices
-                        .entry(lowercase)
-                        .and_modify(|e| {
-                            if absolute_idx < *e {
-                                *e = absolute_idx
-                            }
-                        })
-                        .or_insert(absolute_idx);
-                }
+    for (table_start_idx, table_schema) in left_schema.table_schemas.values() {
+        for (col_idx, col) in table_schema.columns.iter().enumerate() {
+            let lowercase = col.name.to_lowercase();
+            if using_cols_lower.contains(&lowercase) {
+                let absolute_idx = table_start_idx + col_idx;
+                leftmost_left_indices
+                    .entry(lowercase)
+                    .and_modify(|e| {
+                        if absolute_idx < *e {
+                            *e = absolute_idx
+                        }
+                    })
+                    .or_insert(absolute_idx);
             }
         }
     }
@@ -1571,15 +1575,19 @@ fn remove_duplicate_columns_for_using_join(
                 let right_idx = left_col_count + table_start_idx + col_idx;
                 result.schema.hide_column(right_idx);
 
-                // If coalescing is needed, register the coalesce pair in the schema
-                // This maps the column name to (left_idx, right_idx) so the evaluator
-                // can apply COALESCE semantics for unqualified column references
-                if needs_coalesce {
-                    if let Some(&left_idx) = leftmost_left_indices.get(&lowercase) {
-                        result
-                            .schema
-                            .add_using_coalesce_pair(&col.name, left_idx, right_idx);
-                    }
+                // Issue #4786: ALWAYS register the coalesce pair in the schema, not just
+                // for FULL/RIGHT joins. This ensures that when a nested USING join's
+                // visible column is hidden by an outer LEFT/INNER USING join, the
+                // is_using_coalesce_right_side() check in projection will correctly
+                // filter it out (because it's no longer first in the chain).
+                //
+                // For LEFT/INNER joins, the COALESCE semantics won't be applied in
+                // output (the left column value is used directly), but the chain
+                // structure is needed for correct column filtering.
+                if let Some(&left_idx) = leftmost_left_indices.get(&lowercase) {
+                    result
+                        .schema
+                        .add_using_coalesce_pair(&col.name, left_idx, right_idx);
                 }
             }
         }

--- a/crates/vibesql-executor/src/select/projection.rs
+++ b/crates/vibesql-executor/src/select/projection.rs
@@ -55,7 +55,16 @@ pub(crate) fn project_row_combined(
 
                     // Build a reverse lookup: for each column index, find its name
                     // to check if it's a joined column
-                    for (_, (start_index, table_schema)) in sorted_tables {
+                    for (table_id, (start_index, table_schema)) in sorted_tables {
+                        // Issue #4786: Skip alias tables in SELECT * expansion.
+                        // Alias tables are virtual tables created for parenthesized join expressions
+                        // (e.g., `(...) AS j1`). They have start_index=0 which doesn't match the
+                        // actual row positions, so including them would produce wrong column values.
+                        // They exist only for qualified column resolution (`j1.column`), not for
+                        // SELECT * expansion. The base tables' visible columns are used instead.
+                        if schema.alias_tables.contains(table_id) {
+                            continue;
+                        }
                         for (col_idx, col_schema) in table_schema.columns.iter().enumerate() {
                             let abs_idx = start_index + col_idx;
                             if abs_idx >= max_col {
@@ -86,7 +95,24 @@ pub(crate) fn project_row_combined(
 
                             if should_include {
                                 let col_name_lower = col_schema.name.to_lowercase();
-                                let is_joined = schema.joined_columns.contains(&col_name_lower);
+                                // A column should be reordered to the front only if ALL of:
+                                // 1. Its name is in joined_columns (from USING/NATURAL JOIN)
+                                // 2. It's the FIRST index in a using_coalesce_indices chain
+                                // 3. That first index is 0 (meaning the USING is at top level)
+                                //
+                                // Condition 3 prevents reordering when the USING join is nested
+                                // inside a parenthesized expression with an ON join at the outer
+                                // level. E.g., for `t3 FULL JOIN (...) AS j1 ON j1.id=t3.id`,
+                                // the inner join's coalesced id starts at idx > 0, so it should
+                                // NOT be moved to the front of t3's columns.
+                                let is_joined = schema.joined_columns.contains(&col_name_lower)
+                                    && schema
+                                        .using_coalesce_indices
+                                        .get(&col_name_lower)
+                                        .map_or(false, |indices| {
+                                            // Must be first in chain AND chain starts at idx 0
+                                            indices.first() == Some(&abs_idx) && abs_idx == 0
+                                        });
                                 if is_joined {
                                     joined_cols.push((abs_idx, col_name_lower));
                                 } else {

--- a/crates/vibesql-executor/src/select/scan/join_scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan/mod.rs
@@ -54,6 +54,10 @@ const INL_MAX_THRESHOLD: usize = 100_000;
 const INL_SIZE_RATIO_THRESHOLD: usize = 10;
 
 /// Execute a JOIN operation
+///
+/// The `join_alias` parameter is the alias for a parenthesized join expression (e.g., `(A JOIN B) AS X`).
+/// This alias must be passed so that ON clause validation can recognize references like `X.column`.
+/// Issue #4786: ON clause validation was failing because the alias wasn't available.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn execute_join<F>(
     left: &vibesql_ast::FromClause,
@@ -67,6 +71,7 @@ pub(crate) fn execute_join<F>(
     where_clause: Option<&vibesql_ast::Expression>,
     outer_row: Option<&vibesql_storage::Row>,
     outer_schema: Option<&crate::schema::CombinedSchema>,
+    join_alias: Option<&str>,
     execute_subquery: F,
 ) -> Result<super::FromResult, ExecutorError>
 where
@@ -177,7 +182,7 @@ where
         }
         _ => where_clause.cloned(),
     };
-    let right_result = super::execute_from_clause(
+    let mut right_result = super::execute_from_clause(
         right,
         cte_results,
         database,
@@ -188,6 +193,15 @@ where
         outer_schema,
         execute_subquery,
     )?;
+
+    // Issue #4786: If the join has an alias (parenthesized join expression), add it to the
+    // right side's schema BEFORE combining with the left side. This ensures:
+    // 1. ON clause validation recognizes `j1.column` references
+    // 2. Only the right side's tables are shadowed by the alias, not the left side's tables
+    // 3. SELECT * outputs both left side columns AND alias columns correctly
+    if let Some(alias) = join_alias {
+        right_result.schema = right_result.schema.add_join_alias(alias);
+    }
 
     // Validate ON clause doesn't reference tables not yet introduced (to the right)
     // This is a SQLite-specific semantic check: ON clause can only reference tables
@@ -204,11 +218,14 @@ where
     );
     if is_outer_join {
         if let Some(on_condition) = condition {
+            // Pass join_alias so validation recognizes references like `j1.column` as valid.
+            // Issue #4786: ON clause validation was failing for parenthesized join aliases.
             validate_on_clause_table_references(
                 on_condition,
                 &left_result.schema,
                 &right_result.schema,
                 database,
+                join_alias,
             )?;
         }
     }
@@ -472,6 +489,31 @@ fn remove_duplicate_columns_for_using_join(
         }
     } else {
         // For LEFT/INNER JOIN: hide right-side USING columns (original behavior)
+        //
+        // Issue #4786: Build map of leftmost left indices for coalesce pairs.
+        // Even though LEFT/INNER joins don't need COALESCE semantics for output,
+        // we need to add the left column to any existing coalesce chain from
+        // nested USING joins. This ensures is_using_coalesce_right_side() correctly
+        // filters out the nested join's visible column.
+        let mut leftmost_left_indices: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        for (table_start_idx, table_schema) in left_schema.table_schemas.values() {
+            for (col_idx, col) in table_schema.columns.iter().enumerate() {
+                let lowercase = col.name.to_lowercase();
+                if using_cols_lower.contains(&lowercase) {
+                    let absolute_idx = table_start_idx + col_idx;
+                    leftmost_left_indices
+                        .entry(lowercase)
+                        .and_modify(|e| {
+                            if absolute_idx < *e {
+                                *e = absolute_idx
+                            }
+                        })
+                        .or_insert(absolute_idx);
+                }
+            }
+        }
+
         for (table_start_idx, table_schema) in right_schema.table_schemas.values() {
             for (col_idx, col) in table_schema.columns.iter().enumerate() {
                 let lowercase = col.name.to_lowercase();
@@ -480,6 +522,17 @@ fn remove_duplicate_columns_for_using_join(
                     // Position in result = left_col_count + position_in_right_schema
                     let right_idx = left_col_count + table_start_idx + col_idx;
                     result.schema.hide_column(right_idx);
+
+                    // Issue #4786: Add coalesce pair so is_using_coalesce_right_side()
+                    // correctly filters the nested join's visible column.
+                    if let Some(&left_idx) = leftmost_left_indices.get(&lowercase) {
+                        let original_name = using_columns
+                            .iter()
+                            .find(|c| c.to_lowercase() == lowercase)
+                            .map(|s| s.as_str())
+                            .unwrap_or(&col.name);
+                        result.schema.add_using_coalesce_pair(original_name, left_idx, right_idx);
+                    }
                 }
             }
         }
@@ -1171,11 +1224,16 @@ fn generate_using_join_condition(
 /// SELECT * FROM t1 INNER JOIN t2 ON t2.a = t3.x INNER JOIN t3
 /// ```
 /// The ON clause for the t1/t2 join references t3, which hasn't been introduced yet.
+///
+/// The `join_alias` parameter is the alias for the parenthesized join expression on the right
+/// side (e.g., for `t1 JOIN (...) AS j1 ON j1.id = t1.id`, the alias is "j1").
+/// Issue #4786: This alias must be recognized as a valid table reference.
 fn validate_on_clause_table_references(
     on_condition: &vibesql_ast::Expression,
     left_schema: &CombinedSchema,
     right_schema: &CombinedSchema,
     database: &vibesql_storage::Database,
+    join_alias: Option<&str>,
 ) -> Result<(), ExecutorError> {
     // Collect all table names from both schemas (lowercase for case-insensitive comparison)
     let mut valid_tables: HashSet<String> = HashSet::new();
@@ -1184,6 +1242,11 @@ fn validate_on_clause_table_references(
     }
     for table_id in right_schema.table_schemas.keys() {
         valid_tables.insert(table_id.canonical().to_lowercase());
+    }
+    // Issue #4786: Add the join alias (if any) to valid tables so that references like
+    // `j1.column` are recognized when the right side is a parenthesized join with alias.
+    if let Some(alias) = join_alias {
+        valid_tables.insert(alias.to_lowercase());
     }
 
     // Collect all column names from both schemas (lowercase for case-insensitive comparison)

--- a/crates/vibesql-executor/src/select/scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/mod.rs
@@ -156,7 +156,12 @@ where
             alias,
             ..
         } => {
-            let mut result = join_scan::execute_join(
+            // Pass the join alias to execute_join so it can:
+            // 1. Recognize `j1.column` references in ON clause validation
+            // 2. Add the alias to the right side's schema so only right-side tables are shadowed
+            // Issue #4786: The alias must be added to the right side BEFORE combining with left side,
+            // otherwise the left side's tables would also be shadowed, causing missing columns.
+            let result = join_scan::execute_join(
                 left,
                 right,
                 join_type,
@@ -168,14 +173,9 @@ where
                 where_clause,
                 outer_row,
                 outer_schema,
+                alias.as_deref(),
                 execute_subquery,
             )?;
-            // If the join has an alias (parenthesized join expression),
-            // add it to the schema so column references like `j1.column` can be resolved.
-            // Issue #4905: Parenthesized JOIN expression aliases were being ignored.
-            if let Some(join_alias) = alias {
-                result.schema = result.schema.add_join_alias(join_alias);
-            }
             Ok(result)
         }
         vibesql_ast::FromClause::Subquery { query, alias, column_aliases } => {

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -163,6 +163,7 @@ pub(super) fn build_reordered_schema(
         using_coalesce_indices: std::collections::HashMap::new(),
         column_replacement_map: std::collections::HashMap::new(),
         alias_tables: std::collections::HashSet::new(),
+        shadowed_tables: std::collections::HashMap::new(),
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixes #4786
- Improves join9.test from 88.0% (132/150) to 98.0% (147/150)

## Changes
1. **ON clause validation** - Pass join alias to `validate_on_clause_table_references` so references like `j1.column` are recognized
2. **Column ordering** - Only reorder joined columns to front if the USING chain starts at idx 0 (top-level USING, not nested)
3. **USING coalesce chains** - Register coalesce pairs for LEFT/INNER joins too, ensuring `is_using_coalesce_right_side()` correctly filters nested join columns
4. **Schema updates** - Add `shadowed_tables` field to `CombinedSchema`

## Test plan
- [x] join9.test passes 147/150 (was 132/150)
- [x] All cargo tests pass
- [x] join2.test, join4.test show no regressions

## Remaining failures
The 3 remaining join9 failures (join9-3.700, join9-4.700, join9-5.700) involve VIEWs and complex multi-table joins - a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)