### PR TITLE
fix(star): correct SELECT * column ordering for aliased parenthesized joins

### DIFF
--- a/crates/vibesql-executor/src/select/executor/columns.rs
+++ b/crates/vibesql-executor/src/select/executor/columns.rs
@@ -81,108 +81,105 @@ impl SelectExecutor<'_> {
                     // Respects full_column_names PRAGMA when there are multiple tables with
                     // duplicate columns
                     //
-                    // SQL Standard Column Ordering for USING/NATURAL JOINs:
-                    // According to SQL:2011, SELECT * from JOIN USING should output:
-                    // 1. The common/USING columns (merged) - appear FIRST
-                    // 2. Remaining columns from the left table
-                    // 3. Remaining columns from the right table
+                    // Issue #4916: SQLite's behavior for USING column reordering:
+                    // - Simple USING joins (no alias): columns stay in table order (a, b, c)
+                    // - Aliased USING joins ((t1 JOIN t2 USING(b)) AS j1): USING columns first (b, a, c)
+                    //
+                    // We detect aliased joins by checking if there's an alias table that shadows
+                    // all non-alias tables. In that case, we use the alias table's column order.
                     if let Some(from_res) = from_result {
-                        // Get all column names in order from the combined schema
-                        // Store (index, column_name, table_name_for_display, is_joined_column)
-                        let mut table_columns: Vec<(usize, String, String, bool)> = Vec::new();
+                        // Store (index, column_name, table_name_for_display)
+                        let mut table_columns: Vec<(usize, String, String)> = Vec::new();
 
-                        // Build a set of replacement target indices (columns that are replacement
-                        // sources) These should be skipped since they're
-                        // output via the hidden column's position
-                        let replacement_targets: std::collections::HashSet<usize> =
-                            from_res.schema.column_replacement_map.values().copied().collect();
-
-                        // Sort table_schemas by start_index for deterministic iteration order
-                        // HashMap iteration is non-deterministic; sorting ensures consistent
-                        // results
-                        let mut sorted_tables: Vec<_> =
-                            from_res.schema.table_schemas.iter().collect();
-                        sorted_tables.sort_by_key(|(_, (start_index, _))| *start_index);
-
-                        for (table_id, (start_index, table_schema)) in sorted_tables {
-                            // Skip alias tables (from parenthesized join expressions like `(...) AS j1`)
-                            // These are virtual tables for column resolution only, not for SELECT *
-                            if from_res.schema.alias_tables.contains(table_id) {
-                                continue;
-                            }
-
-                            // Get the effective table name using TableIdentifier's display form
-                            let effective_table_name = table_id.display().to_string();
-
-                            for (col_idx, col_schema) in table_schema.columns.iter().enumerate() {
-                                let abs_idx = start_index + col_idx;
-
-                                // Skip columns that are replacement targets (they're output via
-                                // replacement)
-                                if replacement_targets.contains(&abs_idx) {
-                                    continue;
-                                }
-
-                                // Skip right-side USING columns (they're output via the left-side
-                                // column with COALESCE applied)
-                                if from_res.schema.is_using_coalesce_right_side(abs_idx) {
-                                    continue;
-                                }
-
-                                // For hidden columns, check if they have a replacement or coalesce
-                                // pair If so, include the name
-                                // (value comes from replacement/coalesce)
-                                // If not, skip them
-                                if from_res.schema.is_column_hidden(abs_idx) {
-                                    let has_replacement =
-                                        from_res.schema.get_column_replacement(abs_idx).is_some();
-                                    let has_coalesce = from_res
+                        // Check if there's an alias table covering all non-alias tables
+                        let alias_covering_all =
+                            from_res.schema.alias_tables.iter().find(|alias_id| {
+                                if let Some(shadowed) =
+                                    from_res.schema.shadowed_tables.get(*alias_id)
+                                {
+                                    let non_alias_tables: Vec<_> = from_res
                                         .schema
-                                        .get_using_coalesce_right_for_left(abs_idx)
-                                        .is_some();
-                                    if !has_replacement && !has_coalesce {
-                                        continue;
+                                        .table_schemas
+                                        .keys()
+                                        .filter(|t| !from_res.schema.alias_tables.contains(*t))
+                                        .collect();
+                                    non_alias_tables.iter().all(|t| shadowed.contains(*t))
+                                } else {
+                                    false
+                                }
+                            });
+
+                        if let Some(alias_id) = alias_covering_all {
+                            // Aliased join: use alias table's column order
+                            if let Some((_, alias_schema)) =
+                                from_res.schema.table_schemas.get(alias_id)
+                            {
+                                let alias_name = alias_id.display().to_string();
+                                for col_schema in &alias_schema.columns {
+                                    if let Some(actual_idx) = from_res
+                                        .schema
+                                        .get_column_index(Some(&alias_name), &col_schema.name)
+                                    {
+                                        table_columns.push((
+                                            actual_idx,
+                                            col_schema.name.clone(),
+                                            alias_name.clone(),
+                                        ));
                                     }
                                 }
+                            }
+                        } else {
+                            // No covering alias: use table column order (no USING reordering)
+                            let replacement_targets: std::collections::HashSet<usize> =
+                                from_res.schema.column_replacement_map.values().copied().collect();
 
-                                let col_name = col_schema.name.clone();
-                                // Check if this is a USING/NATURAL JOIN column
-                                let is_joined = from_res
-                                    .schema
-                                    .joined_columns
-                                    .contains(&col_name.to_lowercase());
-                                table_columns.push((
-                                    abs_idx,
-                                    col_name,
-                                    effective_table_name.clone(),
-                                    is_joined,
-                                ));
+                            let mut sorted_tables: Vec<_> =
+                                from_res.schema.table_schemas.iter().collect();
+                            sorted_tables.sort_by_key(|(_, (start_index, _))| *start_index);
+
+                            for (table_id, (start_index, table_schema)) in sorted_tables {
+                                // Skip alias tables - they have incorrect row indices
+                                if from_res.schema.alias_tables.contains(table_id) {
+                                    continue;
+                                }
+
+                                let effective_table_name = table_id.display().to_string();
+
+                                for (col_idx, col_schema) in table_schema.columns.iter().enumerate()
+                                {
+                                    let abs_idx = start_index + col_idx;
+
+                                    // Skip replacement targets
+                                    if replacement_targets.contains(&abs_idx) {
+                                        continue;
+                                    }
+
+                                    // Skip right-side USING columns
+                                    if from_res.schema.is_using_coalesce_right_side(abs_idx) {
+                                        continue;
+                                    }
+
+                                    // For hidden columns, check if they have a replacement or coalesce
+                                    if from_res.schema.is_column_hidden(abs_idx) {
+                                        let has_replacement =
+                                            from_res.schema.get_column_replacement(abs_idx).is_some();
+                                        let has_coalesce = from_res
+                                            .schema
+                                            .get_using_coalesce_right_for_left(abs_idx)
+                                            .is_some();
+                                        if !has_replacement && !has_coalesce {
+                                            continue;
+                                        }
+                                    }
+
+                                    table_columns.push((
+                                        abs_idx,
+                                        col_schema.name.clone(),
+                                        effective_table_name.clone(),
+                                    ));
+                                }
                             }
                         }
-
-                        // Sort columns per SQL standard for USING/NATURAL JOINs:
-                        // 1. Joined columns first (in order of their original position)
-                        // 2. Then remaining columns (in order of their original position)
-                        // This ensures USING columns appear first in SELECT * output
-                        table_columns.sort_by_key(|(idx, _, _, is_joined)| (!*is_joined, *idx));
-
-                        // Deduplicate joined columns: for chained NATURAL JOINs like
-                        // t4 NATURAL RIGHT JOIN t5 NATURAL RIGHT JOIN t6, multiple columns
-                        // might be marked as "joined" with the same name (e.g., both t4.id
-                        // and t5.id). We should only output ONE column per joined column name.
-                        // Keep the first occurrence (which has the lowest index after sorting).
-                        let mut seen_joined_columns: std::collections::HashSet<String> =
-                            std::collections::HashSet::new();
-                        table_columns.retain(|(_, col_name, _, is_joined)| {
-                            if *is_joined {
-                                let col_lower = col_name.to_lowercase();
-                                if seen_joined_columns.contains(&col_lower) {
-                                    return false; // Skip duplicate joined column
-                                }
-                                seen_joined_columns.insert(col_lower);
-                            }
-                            true
-                        });
 
                         // Apply derived column list if present
                         if let Some(derived_cols) = alias {
@@ -198,7 +195,7 @@ impl SelectExecutor<'_> {
                             // BUT only when there's ambiguity (multiple tables or explicit alias)
                             let has_multiple_tables = from_res.schema.table_schemas.len() > 1;
 
-                            for (_, col_name, effective_table_name, _) in table_columns {
+                            for (_, col_name, effective_table_name) in table_columns {
                                 let display_name = match mode {
                                     ColumnNamingMode::Full if has_multiple_tables => {
                                         format!("{}.{}", effective_table_name, col_name)

--- a/crates/vibesql-executor/src/select/projection.rs
+++ b/crates/vibesql-executor/src/select/projection.rs
@@ -37,116 +37,97 @@ pub(crate) fn project_row_combined(
                     row.values.len()
                 };
 
-                // Build column indices, reordering for SQL standard USING/NATURAL JOIN output
-                // If there are joined columns, put them first
-                let column_indices: Vec<usize> = if schema.joined_columns.is_empty() {
-                    // No USING/NATURAL JOIN - use natural order
-                    (0..max_col).collect()
-                } else {
-                    // Collect visible column indices with their join status and column name
-                    // Store (abs_idx, col_name_lower, is_joined)
-                    let mut joined_cols: Vec<(usize, String)> = Vec::new();
-                    let mut other_cols: Vec<usize> = Vec::new();
-
-                    // Sort table_schemas by start_index for deterministic iteration order
-                    // HashMap iteration is non-deterministic; sorting ensures consistent results
-                    let mut sorted_tables: Vec<_> = schema.table_schemas.iter().collect();
-                    sorted_tables.sort_by_key(|(_, (start_index, _))| *start_index);
-
-                    // Build a reverse lookup: for each column index, find its name
-                    // to check if it's a joined column
-                    for (table_id, (start_index, table_schema)) in sorted_tables {
-                        // Issue #4786: Skip alias tables in SELECT * expansion.
-                        // Alias tables are virtual tables created for parenthesized join expressions
-                        // (e.g., `(...) AS j1`). They have start_index=0 which doesn't match the
-                        // actual row positions, so including them would produce wrong column values.
-                        // They exist only for qualified column resolution (`j1.column`), not for
-                        // SELECT * expansion. The base tables' visible columns are used instead.
-                        if schema.alias_tables.contains(table_id) {
-                            continue;
+                // Build column indices for SELECT * expansion
+                //
+                // Issue #4916: SQLite's behavior for USING column reordering:
+                // - Simple USING joins (no alias): columns stay in table order (a, b, c)
+                // - Aliased USING joins ((t1 JOIN t2 USING(b)) AS j1): USING columns first (b, a, c)
+                //
+                // We detect aliased joins by checking if there's an alias table that shadows
+                // all non-alias tables. In that case, we use the alias table's column order
+                // (which already has USING columns first) and resolve actual row indices.
+                let column_indices: Vec<usize> = {
+                    // Check if there's an alias table covering all non-alias tables
+                    // This indicates an aliased parenthesized join expression
+                    let alias_covering_all = schema.alias_tables.iter().find(|alias_id| {
+                        if let Some(shadowed) = schema.shadowed_tables.get(*alias_id) {
+                            // Count non-alias tables
+                            let non_alias_tables: Vec<_> = schema
+                                .table_schemas
+                                .keys()
+                                .filter(|t| !schema.alias_tables.contains(*t))
+                                .collect();
+                            // Check if all non-alias tables are shadowed by this alias
+                            non_alias_tables
+                                .iter()
+                                .all(|t| shadowed.contains(*t))
+                        } else {
+                            false
                         }
-                        for (col_idx, col_schema) in table_schema.columns.iter().enumerate() {
-                            let abs_idx = start_index + col_idx;
-                            if abs_idx >= max_col {
+                    });
+
+                    if let Some(alias_id) = alias_covering_all {
+                        // Aliased join: use alias table's column order and resolve actual indices
+                        let mut indices = Vec::new();
+                        if let Some((_, alias_schema)) = schema.table_schemas.get(alias_id) {
+                            for col_schema in &alias_schema.columns {
+                                // Resolve the actual row index for this column
+                                let alias_name = alias_id.display().to_string();
+                                if let Some(actual_idx) = schema.get_column_index(
+                                    Some(&alias_name),
+                                    &col_schema.name,
+                                ) {
+                                    if actual_idx < max_col {
+                                        indices.push(actual_idx);
+                                    }
+                                }
+                            }
+                        }
+                        indices
+                    } else {
+                        // No covering alias: use table column order (no USING reordering)
+                        let mut other_cols: Vec<usize> = Vec::new();
+
+                        // Sort table_schemas by start_index for deterministic iteration order
+                        let mut sorted_tables: Vec<_> = schema.table_schemas.iter().collect();
+                        sorted_tables.sort_by_key(|(_, (start_index, _))| *start_index);
+
+                        for (table_id, (start_index, table_schema)) in sorted_tables {
+                            // Skip alias tables - they have incorrect row indices
+                            if schema.alias_tables.contains(table_id) {
                                 continue;
                             }
+                            for (col_idx, _col_schema) in table_schema.columns.iter().enumerate() {
+                                let abs_idx = start_index + col_idx;
+                                if abs_idx >= max_col {
+                                    continue;
+                                }
 
-                            // Skip replacement targets (they're output via hidden column's
-                            // position)
-                            if schema.column_replacement_map.values().any(|&v| v == abs_idx) {
-                                continue;
-                            }
+                                // Skip replacement targets (output via hidden column's position)
+                                if schema.column_replacement_map.values().any(|&v| v == abs_idx) {
+                                    continue;
+                                }
 
-                            // Skip right-side USING columns (they're output via the left-side
-                            // column with COALESCE applied)
-                            if schema.is_using_coalesce_right_side(abs_idx) {
-                                continue;
-                            }
+                                // Skip right-side USING columns (output via left-side with COALESCE)
+                                if schema.is_using_coalesce_right_side(abs_idx) {
+                                    continue;
+                                }
 
-                            // Check if column should be included
-                            // Hidden columns are included if they have a replacement OR
-                            // if they are USING columns with coalesce pairs (for COALESCE output)
-                            let should_include = if schema.is_column_hidden(abs_idx) {
-                                schema.get_column_replacement(abs_idx).is_some()
-                                    || schema.get_using_coalesce_right_for_left(abs_idx).is_some()
-                            } else {
-                                true
-                            };
-
-                            if should_include {
-                                let col_name_lower = col_schema.name.to_lowercase();
-                                // A column should be reordered to the front only if ALL of:
-                                // 1. Its name is in joined_columns (from USING/NATURAL JOIN)
-                                // 2. It's the FIRST index in a using_coalesce_indices chain
-                                // 3. That first index is 0 (meaning the USING is at top level)
-                                //
-                                // Condition 3 prevents reordering when the USING join is nested
-                                // inside a parenthesized expression with an ON join at the outer
-                                // level. E.g., for `t3 FULL JOIN (...) AS j1 ON j1.id=t3.id`,
-                                // the inner join's coalesced id starts at idx > 0, so it should
-                                // NOT be moved to the front of t3's columns.
-                                let is_joined = schema.joined_columns.contains(&col_name_lower)
-                                    && schema
-                                        .using_coalesce_indices
-                                        .get(&col_name_lower)
-                                        .map_or(false, |indices| {
-                                            // Must be first in chain AND chain starts at idx 0
-                                            indices.first() == Some(&abs_idx) && abs_idx == 0
-                                        });
-                                if is_joined {
-                                    joined_cols.push((abs_idx, col_name_lower));
+                                // Check if column should be included
+                                let should_include = if schema.is_column_hidden(abs_idx) {
+                                    schema.get_column_replacement(abs_idx).is_some()
+                                        || schema.get_using_coalesce_right_for_left(abs_idx).is_some()
                                 } else {
+                                    true
+                                };
+
+                                if should_include {
                                     other_cols.push(abs_idx);
                                 }
                             }
                         }
+                        other_cols
                     }
-
-                    // Sort each group by index to maintain relative order
-                    joined_cols.sort_by_key(|(idx, _)| *idx);
-                    other_cols.sort();
-
-                    // Deduplicate joined columns: for chained NATURAL JOINs like
-                    // t4 NATURAL RIGHT JOIN t5 NATURAL RIGHT JOIN t6, multiple columns
-                    // might be marked as "joined" with the same name (e.g., both t4.id
-                    // and t5.id). We should only output ONE column per joined column name.
-                    // Keep the first occurrence (which has the lowest index after sorting).
-                    let mut seen_joined_columns: std::collections::HashSet<String> =
-                        std::collections::HashSet::new();
-                    let deduped_joined: Vec<usize> = joined_cols
-                        .into_iter()
-                        .filter_map(|(idx, col_name)| {
-                            if seen_joined_columns.contains(&col_name) {
-                                None // Skip duplicate joined column
-                            } else {
-                                seen_joined_columns.insert(col_name);
-                                Some(idx)
-                            }
-                        })
-                        .collect();
-
-                    // Concatenate: joined columns first, then others
-                    deduped_joined.into_iter().chain(other_cols).collect()
                 };
 
                 // Iterate through reordered columns, handling hidden columns with replacements
@@ -208,32 +189,71 @@ pub(crate) fn project_row_combined(
             vibesql_ast::SelectItem::QualifiedWildcard { qualifier, .. } => {
                 // SELECT table.* or SELECT alias.* - include columns from specific table/alias
                 // TableKey lookup is case-insensitive
+                let table_id = vibesql_ast::TableIdentifier::unquoted(qualifier);
                 let result = schema.get_table(qualifier).cloned();
 
                 if let Some((start_index, table_schema)) = result {
-                    let num_columns = table_schema.columns.len();
-                    let end_index = start_index + num_columns;
-
-                    // When window functions are present, only include base columns
-                    let effective_end = if let Some(mapping) = window_mapping {
-                        if !mapping.is_empty() {
-                            // Find the minimum window column index to know where base columns end
-                            let min_window_col =
-                                mapping.values().min().copied().unwrap_or(row.values.len());
-                            end_index.min(min_window_col)
-                        } else {
-                            end_index
+                    // Issue #4916: For alias tables (e.g., j1 for `(t1 JOIN t2) AS j1`),
+                    // the start_index is 0 which doesn't correspond to actual row positions.
+                    // We need to resolve each column individually using get_column_index.
+                    if schema.alias_tables.contains(&table_id) {
+                        // Alias table: resolve each column to its actual row index
+                        for col_schema in &table_schema.columns {
+                            if let Some(actual_idx) =
+                                schema.get_column_index(Some(qualifier), &col_schema.name)
+                            {
+                                if actual_idx < row.values.len() {
+                                    // Handle USING column coalescing
+                                    if let Some(all_indices) =
+                                        schema.get_all_coalesce_indices_for_column(actual_idx)
+                                    {
+                                        // Apply N-way COALESCE: return first non-NULL from chain
+                                        let mut found = false;
+                                        for &chain_idx in all_indices {
+                                            if chain_idx < row.values.len() {
+                                                let val = &row.values[chain_idx];
+                                                if *val != vibesql_types::SqlValue::Null {
+                                                    values.push(val.clone());
+                                                    found = true;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        if !found {
+                                            values.push(vibesql_types::SqlValue::Null);
+                                        }
+                                    } else {
+                                        values.push(row.values[actual_idx].clone());
+                                    }
+                                }
+                            }
                         }
                     } else {
-                        end_index
-                    };
+                        // Regular table: use start_index directly
+                        let num_columns = table_schema.columns.len();
+                        let end_index = start_index + num_columns;
 
-                    // Extract the columns for this table
-                    if start_index < effective_end && effective_end <= row.values.len() {
-                        values.extend(row.values[start_index..effective_end].iter().cloned());
+                        // When window functions are present, only include base columns
+                        let effective_end = if let Some(mapping) = window_mapping {
+                            if !mapping.is_empty() {
+                                // Find the minimum window column index to know where base columns end
+                                let min_window_col =
+                                    mapping.values().min().copied().unwrap_or(row.values.len());
+                                end_index.min(min_window_col)
+                            } else {
+                                end_index
+                            }
+                        } else {
+                            end_index
+                        };
+
+                        // Extract the columns for this table
+                        if start_index < effective_end && effective_end <= row.values.len() {
+                            values.extend(row.values[start_index..effective_end].iter().cloned());
+                        }
+                        // If indices are out of bounds, this might be an error, but we'll be silent
+                        // for now
                     }
-                    // If indices are out of bounds, this might be an error, but we'll be silent for
-                    // now
                 }
                 // If table not found, skip silently (this should be caught during column name
                 // derivation)

--- a/crates/vibesql-executor/src/select/scan/join_scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan/mod.rs
@@ -182,7 +182,7 @@ where
         }
         _ => where_clause.cloned(),
     };
-    let mut right_result = super::execute_from_clause(
+    let right_result = super::execute_from_clause(
         right,
         cte_results,
         database,
@@ -194,14 +194,9 @@ where
         execute_subquery,
     )?;
 
-    // Issue #4786: If the join has an alias (parenthesized join expression), add it to the
-    // right side's schema BEFORE combining with the left side. This ensures:
-    // 1. ON clause validation recognizes `j1.column` references
-    // 2. Only the right side's tables are shadowed by the alias, not the left side's tables
-    // 3. SELECT * outputs both left side columns AND alias columns correctly
-    if let Some(alias) = join_alias {
-        right_result.schema = right_result.schema.add_join_alias(alias);
-    }
+    // Note: Join alias (if any) is added AFTER the join completes, not here.
+    // This ensures the alias covers all tables in the combined result, not just the right side.
+    // ON clause validation receives the alias separately and doesn't need it in the schema.
 
     // Validate ON clause doesn't reference tables not yet introduced (to the right)
     // This is a SQLite-specific semantic check: ON clause can only reference tables
@@ -337,6 +332,13 @@ where
             using_cols,
             join_type,
         )?;
+    }
+
+    // Issue #4916: Add the join alias AFTER the join is complete.
+    // This ensures the alias covers ALL tables in the combined result (both left and right sides).
+    // For `(t1 JOIN t2 USING(b)) AS j1`, the alias j1 should include columns from both t1 and t2.
+    if let Some(alias) = join_alias {
+        result.schema = result.schema.add_join_alias(alias);
     }
 
     Ok(result)

--- a/crates/vibesql-executor/src/select/scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/mod.rs
@@ -158,9 +158,9 @@ where
         } => {
             // Pass the join alias to execute_join so it can:
             // 1. Recognize `j1.column` references in ON clause validation
-            // 2. Add the alias to the right side's schema so only right-side tables are shadowed
-            // Issue #4786: The alias must be added to the right side BEFORE combining with left side,
-            // otherwise the left side's tables would also be shadowed, causing missing columns.
+            // 2. Add the alias to the combined schema after the join, covering all joined tables
+            // Issue #4916: The alias is added AFTER combining left and right sides, so for
+            // `(t1 JOIN t2) AS j1`, the alias j1 covers both t1 and t2 columns.
             let result = join_scan::execute_join(
                 left,
                 right,


### PR DESCRIPTION
## Summary
- Fixes incorrect column ordering and duplicate columns in `SELECT *` expansion for aliased parenthesized JOIN expressions
- Moves `add_join_alias()` to AFTER the join completes, ensuring the alias covers all tables in the combined result
- For aliased joins like `(t1 JOIN t2 USING(b)) AS j1`, correctly puts USING columns first (b, a, c)
- For simple joins without alias, keeps table column order (a, b, c) matching SQLite behavior
- Fixes regression from PR #4915 where `abs_idx == 0` check was too strict

Closes #4916

## Test plan
- [x] join9.test passes at 98.0% (147/150 - same as before)
- [x] Simple USING `t1 JOIN t2 USING(b)` produces correct column order: a|b|c = 1|2|3
- [x] Aliased USING `(t1 JOIN t2 USING(b)) AS j1` produces correct order: b|a|c = 2|1|3
- [x] Nested USING produces correct column count (5 instead of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)