### PR TITLE
fix(set-ops): propagate column count mismatch errors for INTERSECT/EXCEPT

### DIFF
--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -683,12 +683,14 @@ impl SelectExecutor<'_> {
             );
             // Issue #4602: Compute left column count from AST for schema-level validation
             // This is needed when the left result set is empty (table has no rows)
+            // Issue #4922: Must propagate errors (not use .ok()) to catch column count mismatches
+            // in set operations like UNION/INTERSECT/EXCEPT
             let left_col_count = super::nonagg::compute_select_list_column_count(
                 stmt,
                 self.database,
                 Some(cte_results),
-            )
-            .ok();
+            )?;
+            let left_col_count = Some(left_col_count);
             results = self.execute_set_operations(
                 results,
                 set_op,


### PR DESCRIPTION
## Summary

Fixes INTERSECT/EXCEPT column count validation so that queries with mismatched column counts properly error instead of silently executing.

## Root Cause

In `execute_with_ctes()`, the call to `compute_select_list_column_count()` used `.ok()` which converted validation errors to `None`, silently ignoring `SetOperationColumnMismatch` errors.

## Changes

- Changed `.ok()` to `?` to propagate the validation error
- Added comment explaining the issue (#4922)

## Test Plan

- All 2271 executor tests pass
- Manually verified the reproduction case from the issue now fails correctly:
  ```sql
  SELECT x FROM t2
  UNION
  SELECT x FROM t2
  UNION ALL
  SELECT x FROM t2
  EXCEPT
  SELECT x FROM t2
  INTERSECT
  SELECT x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x FROM t2;
  -- Now returns: "SELECTs to the left and right of INTERSECT do not have the same number of result columns"
  ```

Closes #4922