### PR TITLE
feat(json): implement json() function for JSON validation and minification

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/mod.rs
@@ -149,6 +149,9 @@ pub(super) fn eval_scalar_function(
         "GLOB" => sqlite_compat::glob(args),
         "LIKE" => sqlite_compat::like(args),
 
+        // JSON functions (SQLite JSON1 extension)
+        "JSON" => sqlite_compat::json(args),
+
         // Type conversion functions
         "TO_NUMBER" => conversion::to_number(args),
         "TO_DATE" => conversion::to_date(args),

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
@@ -1,0 +1,142 @@
+//! JSON functions (SQLite JSON1 extension compatibility)
+//!
+//! This module contains SQLite-compatible JSON functions:
+//! - json(X) - Validate and minify JSON
+//!
+//! Reference: https://www.sqlite.org/json1.html
+
+use vibesql_types::SqlValue;
+
+use crate::errors::ExecutorError;
+
+/// json(X) - Validate and minify JSON
+///
+/// The json(X) function verifies that its argument X is a valid JSON string
+/// and returns a minified version of that JSON string (with all unnecessary
+/// whitespace removed). If X is not a well-formed JSON string, then this
+/// function throws an error.
+///
+/// If the argument is NULL, returns NULL.
+///
+/// Reference: https://www.sqlite.org/json1.html#the_json_function
+pub(crate) fn json(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    if args.len() != 1 {
+        return Err(ExecutorError::WrongNumberOfArguments {
+            function_name: "json".to_string(),
+        });
+    }
+
+    match &args[0] {
+        SqlValue::Null => Ok(SqlValue::Null),
+        SqlValue::Varchar(s) | SqlValue::Character(s) => {
+            // Parse the JSON to validate it
+            let parsed: Result<serde_json::Value, _> = serde_json::from_str(s.as_str());
+            match parsed {
+                Ok(value) => {
+                    // Re-serialize to minified JSON (compact format)
+                    let minified = serde_json::to_string(&value).map_err(|e| {
+                        ExecutorError::SqliteCompatError(format!("malformed JSON: {}", e))
+                    })?;
+                    Ok(SqlValue::Varchar(minified.into()))
+                }
+                Err(_) => {
+                    // SQLite returns "malformed JSON" for invalid JSON
+                    Err(ExecutorError::SqliteCompatError("malformed JSON".to_string()))
+                }
+            }
+        }
+        // For non-string types, SQLite throws an error
+        _ => Err(ExecutorError::SqliteCompatError(
+            "JSON functions require string arguments".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_json_valid_array() {
+        let result = json(&[SqlValue::Varchar("[1,2,3]".into())]).unwrap();
+        assert_eq!(result, SqlValue::Varchar("[1,2,3]".into()));
+    }
+
+    #[test]
+    fn test_json_minifies_whitespace() {
+        let result = json(&[SqlValue::Varchar("  { \"a\" : 1 }  ".into())]).unwrap();
+        assert_eq!(result, SqlValue::Varchar("{\"a\":1}".into()));
+    }
+
+    #[test]
+    fn test_json_null_input() {
+        let result = json(&[SqlValue::Null]).unwrap();
+        assert_eq!(result, SqlValue::Null);
+    }
+
+    #[test]
+    fn test_json_invalid_json() {
+        let result = json(&[SqlValue::Varchar("{invalid}".into())]);
+        assert!(result.is_err());
+        if let Err(ExecutorError::SqliteCompatError(msg)) = result {
+            assert_eq!(msg, "malformed JSON");
+        } else {
+            panic!("Expected SqliteCompatError");
+        }
+    }
+
+    #[test]
+    fn test_json_string_value() {
+        let result = json(&[SqlValue::Varchar("\"hello\"".into())]).unwrap();
+        assert_eq!(result, SqlValue::Varchar("\"hello\"".into()));
+    }
+
+    #[test]
+    fn test_json_number_value() {
+        let result = json(&[SqlValue::Varchar("42".into())]).unwrap();
+        assert_eq!(result, SqlValue::Varchar("42".into()));
+    }
+
+    #[test]
+    fn test_json_boolean_value() {
+        let result = json(&[SqlValue::Varchar("true".into())]).unwrap();
+        assert_eq!(result, SqlValue::Varchar("true".into()));
+    }
+
+    #[test]
+    fn test_json_null_json_value() {
+        let result = json(&[SqlValue::Varchar("null".into())]).unwrap();
+        assert_eq!(result, SqlValue::Varchar("null".into()));
+    }
+
+    #[test]
+    fn test_json_nested_object() {
+        let input = r#"{"a": {"b": [1, 2, 3]}, "c": "test"}"#;
+        let result = json(&[SqlValue::Varchar(input.into())]).unwrap();
+        // serde_json preserves key order in minified output
+        assert_eq!(
+            result,
+            SqlValue::Varchar(r#"{"a":{"b":[1,2,3]},"c":"test"}"#.into())
+        );
+    }
+
+    #[test]
+    fn test_json_wrong_arg_count() {
+        // No arguments
+        let result = json(&[]);
+        assert!(result.is_err());
+
+        // Too many arguments
+        let result = json(&[
+            SqlValue::Varchar("[]".into()),
+            SqlValue::Varchar("[]".into()),
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_json_non_string_input() {
+        let result = json(&[SqlValue::Integer(42)]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/mod.rs
@@ -14,9 +14,11 @@
 //! - [`conditional_funcs`]: Conditional logic (IIF, IFNULL)
 //! - [`math_funcs`]: Math and query hints (RANDOM, LIKELY, UNLIKELY, LIKELIHOOD)
 //! - [`pattern_funcs`]: Pattern matching (LIKE, GLOB)
+//! - [`json_funcs`]: JSON functions (json, json_array, json_object, etc.)
 
 mod blob_funcs;
 mod conditional_funcs;
+mod json_funcs;
 mod math_funcs;
 mod pattern_funcs;
 mod string_funcs;
@@ -28,6 +30,8 @@ pub(super) use blob_funcs::{hex, quote, randomblob, unhex, zeroblob};
 pub(super) use conditional_funcs::ifnull;
 // Re-export conditional functions
 pub(super) use conditional_funcs::iif;
+// Re-export JSON functions
+pub(super) use json_funcs::json;
 // Re-export math/hint functions
 pub(super) use math_funcs::likelihood;
 pub(super) use math_funcs::{likely, random, unlikely};


### PR DESCRIPTION
## Summary

Implements the SQLite JSON1 extension `json()` function which:
- Validates that input is well-formed JSON
- Returns minified JSON (with unnecessary whitespace removed)  
- Returns NULL for NULL input
- Throws "malformed JSON" error for invalid JSON input

## Changes

- Added `json_funcs.rs` module in `sqlite_compat/` with the `json()` function implementation
- Added function dispatch entry in `mod.rs` for the `JSON` function
- Included 11 comprehensive unit tests covering valid JSON, minification, null handling, error cases

## Test Plan

- [x] All 11 unit tests pass for the json() function
- [x] All 2,282 executor library tests pass
- [x] cargo check passes

## Examples

```sql
SELECT json('[1,2,3]');
-- Returns: [1,2,3]

SELECT json('  { "a" : 1 }  ');
-- Returns: {"a":1}

SELECT json(NULL);
-- Returns: NULL

SELECT json('{invalid}');
-- Error: malformed JSON
```

Closes #4923