### PR TITLE
fix(parser): enforce maximum ORDER BY term limit

### DIFF
--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -225,6 +225,13 @@ impl Parser {
                 }
             }
 
+            // Check for too many ORDER BY terms (SQLite compatibility)
+            if order_items.len() > super::super::MAX_ORDER_BY_TERMS {
+                return Err(ParseError {
+                    message: "too many terms in ORDER BY clause".to_string(),
+                });
+            }
+
             order_by = Some(order_items);
             self.expect_token(Token::RParen)?;
         } else {
@@ -299,6 +306,13 @@ impl Parser {
                     } else {
                         break;
                     }
+                }
+
+                // Check for too many ORDER BY terms (SQLite compatibility)
+                if order_items.len() > super::super::MAX_ORDER_BY_TERMS {
+                    return Err(ParseError {
+                        message: "too many terms in ORDER BY clause".to_string(),
+                    });
                 }
 
                 order_by = Some(order_items);

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -2,6 +2,11 @@ use std::fmt;
 
 use crate::{keywords::Keyword, lexer::Lexer, token::Token};
 
+/// Maximum number of terms allowed in an ORDER BY clause.
+/// This matches SQLite's SQLITE_MAX_COLUMN default of 2000.
+/// See: https://www.sqlite.org/limits.html
+pub const MAX_ORDER_BY_TERMS: usize = 2000;
+
 mod advanced_objects;
 mod alter;
 mod create;
@@ -930,6 +935,13 @@ impl Parser {
 
                 Ok(vibesql_ast::OrderByItem { expr, direction, nulls_order })
             })?;
+
+            // Check for too many ORDER BY terms (SQLite compatibility)
+            if order_items.len() > MAX_ORDER_BY_TERMS {
+                return Err(ParseError {
+                    message: "too many terms in ORDER BY clause".to_string(),
+                });
+            }
 
             Some(order_items)
         } else {

--- a/crates/vibesql-parser/src/parser/select/statement.rs
+++ b/crates/vibesql-parser/src/parser/select/statement.rs
@@ -244,6 +244,13 @@ impl Parser {
                 Ok(vibesql_ast::OrderByItem { expr, direction, nulls_order })
             })?;
 
+            // Check for too many ORDER BY terms (SQLite compatibility)
+            if order_items.len() > super::super::MAX_ORDER_BY_TERMS {
+                return Err(ParseError {
+                    message: "too many terms in ORDER BY clause".to_string(),
+                });
+            }
+
             Some(order_items)
         } else {
             None
@@ -613,6 +620,13 @@ impl Parser {
 
                 Ok(vibesql_ast::OrderByItem { expr, direction, nulls_order: None })
             })?;
+
+            // Check for too many ORDER BY terms (SQLite compatibility)
+            if order_items.len() > super::super::MAX_ORDER_BY_TERMS {
+                return Err(ParseError {
+                    message: "too many terms in ORDER BY clause".to_string(),
+                });
+            }
 
             Some(order_items)
         } else {

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -388,6 +388,10 @@ proc translate_error_to_sqlite {vibesql_error} {
     if {[regexp -nocase {^Parse error: (LIMIT clause should come after (?:UNION ALL|UNION|INTERSECT|EXCEPT) not before)$} $error_msg -> parse_msg]} {
         return $parse_msg
     }
+    # Too many ORDER BY terms (SQLite-compatible error message)
+    if {[regexp -nocase {^Parse error: (too many terms in ORDER BY clause)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
     # Fallback for other parse errors (e.g., descriptive messages like "Expected identifier")
     if {[regexp -nocase {^Parse error: (.+)$} $error_msg -> parse_msg]} {
         return "near \"$parse_msg\": syntax error"


### PR DESCRIPTION
## Summary

Enforces a maximum limit of 2000 terms in ORDER BY clauses, matching SQLite's `SQLITE_MAX_COLUMN` default. This prevents excessive resource usage from queries with extremely long ORDER BY clauses.

## Changes

- Added `MAX_ORDER_BY_TERMS` constant (2000) in `parser/mod.rs`
- Validates ORDER BY term count in aggregate function ORDER BY (e.g., `GROUP_CONCAT(x ORDER BY a,b,c,...)`)
- Validates ORDER BY term count in SELECT/VALUES statement ORDER BY
- Added TCL shim translation for the new error message

## Test Plan

- [x] All parser tests pass (`cargo test --package vibesql-parser`)
- [x] TCL test `aggorderby-10.1` now passes (tests ORDER BY with 70,000 terms)
- [x] Release build completes successfully

## TCL Test Results

Before fix: 21/29 passed (72.4%)
After fix: 22/29 passed (75.9%)

The new passing test: `aggorderby-10.1` - validates that "too many terms in ORDER BY clause" error is returned for excessive ORDER BY terms.

Closes #4924