### PR TITLE
fix(scan): return INTEGER PRIMARY KEY tables in rowid order

### DIFF
--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -79,6 +79,36 @@ fn apply_column_aliases(
     Ok(schema)
 }
 
+/// Sort rows by INTEGER PRIMARY KEY column value (Issue #4926)
+///
+/// SQLite guarantees that tables with INTEGER PRIMARY KEY return rows in rowid order
+/// when no ORDER BY is specified. This function sorts rows by the INTEGER PRIMARY KEY
+/// column value to match SQLite's behavior.
+///
+/// # Arguments
+/// * `rows` - Mutable vector of rows to sort in place
+/// * `ipk_col_idx` - Column index of the INTEGER PRIMARY KEY column
+fn sort_rows_by_integer_primary_key(rows: &mut Vec<vibesql_storage::Row>, ipk_col_idx: usize) {
+    rows.sort_by(|a, b| {
+        let a_val = a.get(ipk_col_idx);
+        let b_val = b.get(ipk_col_idx);
+
+        match (a_val, b_val) {
+            (Some(vibesql_types::SqlValue::Integer(a)), Some(vibesql_types::SqlValue::Integer(b))) => a.cmp(b),
+            (Some(vibesql_types::SqlValue::Bigint(a)), Some(vibesql_types::SqlValue::Bigint(b))) => a.cmp(b),
+            (Some(vibesql_types::SqlValue::Unsigned(a)), Some(vibesql_types::SqlValue::Unsigned(b))) => a.cmp(b),
+            // Cross-type comparisons (SQLite INTEGER can be any of these)
+            (Some(vibesql_types::SqlValue::Integer(a)), Some(vibesql_types::SqlValue::Bigint(b))) => (*a).cmp(b),
+            (Some(vibesql_types::SqlValue::Bigint(a)), Some(vibesql_types::SqlValue::Integer(b))) => a.cmp(&(*b)),
+            // NULL handling: NULLs sort first (SQLite behavior)
+            (None, _) | (Some(vibesql_types::SqlValue::Null), _) => std::cmp::Ordering::Less,
+            (_, None) | (_, Some(vibesql_types::SqlValue::Null)) => std::cmp::Ordering::Greater,
+            // Fallback for unexpected types
+            _ => std::cmp::Ordering::Equal,
+        }
+    });
+}
+
 /// Execute a table scan with SQL:1999 identifier semantics
 ///
 /// This is the new entry point that properly handles case-sensitivity based on
@@ -445,9 +475,15 @@ pub(crate) fn execute_table_scan(
             // Return unfiltered rows for correlated subqueries
             // Filtering will happen later with full outer row context
             // Issue #3790: Must use scan_live_vec() to filter deleted rows
-            let live_rows = table.scan_live_vec();
+            let mut live_rows = table.scan_live_vec();
             // sqlite_search_count: Track rows examined during table scan
             database.increment_search_count(live_rows.len() as u64);
+            // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
+            if order_by.is_none() {
+                if let Some(ipk_col_idx) = table.schema.rowid_alias_column {
+                    sort_rows_by_integer_primary_key(&mut live_rows, ipk_col_idx);
+                }
+            }
             use crate::select::from_iterator::FromIterator;
             return Ok(super::FromResult::from_iterator(
                 schema,
@@ -507,8 +543,14 @@ pub(crate) fn execute_table_scan(
                 // For native columnar tables, use SIMD filtering on typed columns
                 // This avoids SqlValue overhead by working directly on i64/f64/String arrays
                 if table.is_native_columnar() && all_rows.len() >= SIMD_COLUMNAR_THRESHOLD {
-                    if let Ok(filtered_rows) = filter_with_simd_columnar(table, &column_predicates)
+                    if let Ok(mut filtered_rows) = filter_with_simd_columnar(table, &column_predicates)
                     {
+                        // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
+                        if order_by.is_none() {
+                            if let Some(ipk_col_idx) = table.schema.rowid_alias_column {
+                                sort_rows_by_integer_primary_key(&mut filtered_rows, ipk_col_idx);
+                            }
+                        }
                         return Ok(super::FromResult::from_rows(schema, filtered_rows));
                     }
                     // Fall through to row-based path if SIMD fails
@@ -518,12 +560,18 @@ pub(crate) fn execute_table_scan(
                 // Issue #4136: Use database columnar cache for SIMD filtering, clone only passing
                 // rows
                 if all_rows.len() >= SIMD_COLUMNAR_THRESHOLD {
-                    if let Ok(filtered_rows) = filter_with_cached_columnar(
+                    if let Ok(mut filtered_rows) = filter_with_cached_columnar(
                         database,
                         table_name,
                         all_rows,
                         &column_predicates,
                     ) {
+                        // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
+                        if order_by.is_none() {
+                            if let Some(ipk_col_idx) = table.schema.rowid_alias_column {
+                                sort_rows_by_integer_primary_key(&mut filtered_rows, ipk_col_idx);
+                            }
+                        }
                         return Ok(super::FromResult::from_rows(schema, filtered_rows));
                     }
                     // Fall through to row-based path if cached columnar fails
@@ -537,7 +585,7 @@ pub(crate) fn execute_table_scan(
                 // This is the key optimization: we skip cloning rows that don't pass
                 // Issue #4370: Preserve row_id for ROWID pseudo-column support
                 // Issue #4536: Preserve explicit row_id from INSERT INTO t(rowid, ...) VALUES(...)
-                let filtered_rows: Vec<_> = indices
+                let mut filtered_rows: Vec<_> = indices
                     .into_iter()
                     .filter(|&idx| !table.is_row_deleted(idx))
                     .filter_map(|idx| {
@@ -551,6 +599,12 @@ pub(crate) fn execute_table_scan(
                         })
                     })
                     .collect();
+                // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
+                if order_by.is_none() {
+                    if let Some(ipk_col_idx) = table.schema.rowid_alias_column {
+                        sort_rows_by_integer_primary_key(&mut filtered_rows, ipk_col_idx);
+                    }
+                }
                 return Ok(super::FromResult::from_rows(schema, filtered_rows));
             }
 
@@ -569,7 +623,7 @@ pub(crate) fn execute_table_scan(
             let live_rows = table.scan_live_vec();
             // sqlite_search_count: Track rows examined during table scan
             database.increment_search_count(live_rows.len() as u64);
-            let filtered_rows = apply_table_local_predicates(
+            let mut filtered_rows = apply_table_local_predicates(
                 live_rows,
                 schema.clone(),
                 &predicate_plan,
@@ -579,15 +633,29 @@ pub(crate) fn execute_table_scan(
                 None,
                 Some(cte_results), // CTE context for IN subqueries referencing CTEs
             )?;
+            // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
+            if order_by.is_none() {
+                if let Some(ipk_col_idx) = table.schema.rowid_alias_column {
+                    sort_rows_by_integer_primary_key(&mut filtered_rows, ipk_col_idx);
+                }
+            }
             return Ok(super::FromResult::from_rows(schema, filtered_rows));
         }
     }
 
     // No table-local predicates or no WHERE clause: return live rows
     // Issue #3790: Must filter deleted rows via scan_live_vec()
-    let live_rows = table.scan_live_vec();
+    let mut live_rows = table.scan_live_vec();
     // sqlite_search_count: Track rows examined during table scan
     database.increment_search_count(live_rows.len() as u64);
+
+    // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
+    // when no explicit ORDER BY is specified. Apply implicit sorting here.
+    if order_by.is_none() {
+        if let Some(ipk_col_idx) = table.schema.rowid_alias_column {
+            sort_rows_by_integer_primary_key(&mut live_rows, ipk_col_idx);
+        }
+    }
 
     #[cfg(feature = "parallel")]
     let rows = parallel_scan_materialize(&live_rows);

--- a/crates/vibesql-executor/tests/integer_primary_key_order_tests.rs
+++ b/crates/vibesql-executor/tests/integer_primary_key_order_tests.rs
@@ -1,0 +1,201 @@
+//! Tests for INTEGER PRIMARY KEY implicit row ordering (Issue #4926)
+//!
+//! SQLite guarantees that tables with INTEGER PRIMARY KEY return rows in rowid order
+//! when no ORDER BY is specified. This is because INTEGER PRIMARY KEY is an alias
+//! for the rowid, and the B-tree naturally stores rows in rowid order.
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor, SelectExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn setup_db() -> Database {
+    let mut db = Database::new();
+
+    // Create table with INTEGER PRIMARY KEY
+    let create = Parser::parse_sql("CREATE TABLE t1 (a INTEGER PRIMARY KEY, b TEXT, c TEXT)").unwrap();
+    if let vibesql_ast::Statement::CreateTable(stmt) = create {
+        CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+    }
+
+    // Insert rows out of order (by primary key)
+    let inserts = [
+        "INSERT INTO t1 VALUES (5, 'hello', 'world')",
+        "INSERT INTO t1 VALUES (6, 'second', 'entry')",
+        "INSERT INTO t1 VALUES (4, 'one', 'two')",
+        "INSERT INTO t1 VALUES (10, 'ten', 'value')",
+        "INSERT INTO t1 VALUES (1, 'first', 'row')",
+    ];
+
+    for sql in inserts {
+        let stmt = Parser::parse_sql(sql).unwrap();
+        if let vibesql_ast::Statement::Insert(insert_stmt) = stmt {
+            InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
+        }
+    }
+
+    db
+}
+
+fn execute_query(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor.execute(&select_stmt).unwrap()
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_select_star_returns_rowid_order() {
+    let db = setup_db();
+
+    // SELECT * should return rows in rowid (INTEGER PRIMARY KEY) order
+    let rows = execute_query(&db, "SELECT * FROM t1");
+
+    assert_eq!(rows.len(), 5);
+
+    // Extract the 'a' (INTEGER PRIMARY KEY) values
+    let a_values: Vec<i64> = rows
+        .iter()
+        .map(|row| match row.get(0).unwrap() {
+            SqlValue::Integer(v) => *v,
+            _ => panic!("Expected Integer"),
+        })
+        .collect();
+
+    // Should be in ascending rowid order: 1, 4, 5, 6, 10
+    assert_eq!(a_values, vec![1, 4, 5, 6, 10], "Rows should be in INTEGER PRIMARY KEY order");
+}
+
+#[test]
+fn test_select_rowid_returns_rowid_order() {
+    let db = setup_db();
+
+    // SELECT rowid should also return in rowid order
+    let rows = execute_query(&db, "SELECT rowid FROM t1");
+
+    assert_eq!(rows.len(), 5);
+
+    let rowid_values: Vec<i64> = rows
+        .iter()
+        .map(|row| match row.get(0).unwrap() {
+            SqlValue::Integer(v) => *v,
+            SqlValue::Bigint(v) => *v,
+            _ => panic!("Expected Integer or Bigint"),
+        })
+        .collect();
+
+    assert_eq!(rowid_values, vec![1, 4, 5, 6, 10], "ROWID should be in ascending order");
+}
+
+#[test]
+fn test_select_with_where_returns_rowid_order() {
+    let db = setup_db();
+
+    // SELECT with WHERE should still return in rowid order
+    let rows = execute_query(&db, "SELECT a, b FROM t1 WHERE a > 3");
+
+    assert_eq!(rows.len(), 4);
+
+    let a_values: Vec<i64> = rows
+        .iter()
+        .map(|row| match row.get(0).unwrap() {
+            SqlValue::Integer(v) => *v,
+            _ => panic!("Expected Integer"),
+        })
+        .collect();
+
+    // Should be in ascending rowid order: 4, 5, 6, 10
+    assert_eq!(a_values, vec![4, 5, 6, 10], "Filtered rows should be in INTEGER PRIMARY KEY order");
+}
+
+#[test]
+fn test_explicit_order_by_overrides_implicit() {
+    let db = setup_db();
+
+    // Explicit ORDER BY DESC should override the implicit rowid order
+    let rows = execute_query(&db, "SELECT a FROM t1 ORDER BY a DESC");
+
+    assert_eq!(rows.len(), 5);
+
+    let a_values: Vec<i64> = rows
+        .iter()
+        .map(|row| match row.get(0).unwrap() {
+            SqlValue::Integer(v) => *v,
+            _ => panic!("Expected Integer"),
+        })
+        .collect();
+
+    // Should be in descending order: 10, 6, 5, 4, 1
+    assert_eq!(a_values, vec![10, 6, 5, 4, 1], "ORDER BY DESC should override implicit order");
+}
+
+#[test]
+fn test_non_integer_primary_key_no_implicit_order() {
+    // Tables without INTEGER PRIMARY KEY don't have guaranteed order
+    let mut db = Database::new();
+
+    // Create table with TEXT primary key (not INTEGER PRIMARY KEY)
+    let create = Parser::parse_sql("CREATE TABLE t2 (id TEXT PRIMARY KEY, val INTEGER)").unwrap();
+    if let vibesql_ast::Statement::CreateTable(stmt) = create {
+        CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+    }
+
+    let inserts = [
+        "INSERT INTO t2 VALUES ('c', 3)",
+        "INSERT INTO t2 VALUES ('a', 1)",
+        "INSERT INTO t2 VALUES ('b', 2)",
+    ];
+
+    for sql in inserts {
+        let stmt = Parser::parse_sql(sql).unwrap();
+        if let vibesql_ast::Statement::Insert(insert_stmt) = stmt {
+            InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
+        }
+    }
+
+    let rows = execute_query(&db, "SELECT * FROM t2");
+    assert_eq!(rows.len(), 3);
+    // For TEXT primary key, order is not guaranteed (insertion order is acceptable)
+}
+
+#[test]
+fn test_integer_primary_key_with_negative_values() {
+    let mut db = Database::new();
+
+    let create = Parser::parse_sql("CREATE TABLE t3 (id INTEGER PRIMARY KEY, name TEXT)").unwrap();
+    if let vibesql_ast::Statement::CreateTable(stmt) = create {
+        CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+    }
+
+    let inserts = [
+        "INSERT INTO t3 VALUES (5, 'five')",
+        "INSERT INTO t3 VALUES (-3, 'neg three')",
+        "INSERT INTO t3 VALUES (0, 'zero')",
+        "INSERT INTO t3 VALUES (-10, 'neg ten')",
+        "INSERT INTO t3 VALUES (2, 'two')",
+    ];
+
+    for sql in inserts {
+        let stmt = Parser::parse_sql(sql).unwrap();
+        if let vibesql_ast::Statement::Insert(insert_stmt) = stmt {
+            InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
+        }
+    }
+
+    let rows = execute_query(&db, "SELECT id FROM t3");
+    assert_eq!(rows.len(), 5);
+
+    let id_values: Vec<i64> = rows
+        .iter()
+        .map(|row| match row.get(0).unwrap() {
+            SqlValue::Integer(v) => *v,
+            _ => panic!("Expected Integer"),
+        })
+        .collect();
+
+    // Should be in ascending order: -10, -3, 0, 2, 5
+    assert_eq!(id_values, vec![-10, -3, 0, 2, 5], "Negative rowids should also be ordered");
+}


### PR DESCRIPTION
## Summary

SQLite guarantees that tables with INTEGER PRIMARY KEY return rows in rowid order when no ORDER BY is specified. This is because INTEGER PRIMARY KEY is an alias for the rowid, and the B-tree naturally stores rows in rowid order.

Before this fix, VibeSQL returned rows in insertion order, causing 8+ TCL test failures including:
- `intpkey-1.11`, `intpkey-1.16` - SELECT * returns wrong order
- `intpkey-2.3`, `intpkey-2.4.2`, `intpkey-2.4.3` - SELECT with rowid column
- `intpkey-2.7` - UPDATE affects ordering
- `intpkey-8.1`, `intpkey-8.2` - INSERT INTO ... SELECT ordering

## Changes

- Added `sort_rows_by_integer_primary_key()` helper function in `table.rs`
- Applied implicit rowid sorting at all table scan return points when:
  - Table has INTEGER PRIMARY KEY (`rowid_alias_column` is set)
  - No explicit ORDER BY is specified
- Sorting is applied to all scan paths: SIMD columnar, cached columnar, direct row filtering, generic predicate, and full table scan

## Test Plan

- [x] Added 6 new tests in `integer_primary_key_order_tests.rs`:
  - `test_select_star_returns_rowid_order`
  - `test_select_rowid_returns_rowid_order`
  - `test_select_with_where_returns_rowid_order`
  - `test_explicit_order_by_overrides_implicit`
  - `test_non_integer_primary_key_no_implicit_order`
  - `test_integer_primary_key_with_negative_values`
- [x] All 2,271 executor lib tests pass
- [x] All 6 new tests pass

## Examples

```sql
CREATE TABLE t1(a INTEGER PRIMARY KEY, b, c);
INSERT INTO t1 VALUES(5, 'hello', 'world');
INSERT INTO t1 VALUES(6, 'second', 'entry');
INSERT INTO t1 VALUES(4, 'one', 'two');

SELECT * FROM t1;
-- Before: 5 hello world | 6 second entry | 4 one two (insertion order)
-- After:  4 one two | 5 hello world | 6 second entry (rowid order)
```

Closes #4926