### PR TITLE
fix(like): reject empty and multi-character ESCAPE strings

### DIFF
--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -437,8 +437,8 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
                             let mut chars = s.chars();
                             match (chars.next(), chars.next()) {
                                 (Some(c), None) => Some(c), // Exactly one character
-                                (None, _) => None,          // Empty string
                                 _ => {
+                                    // Empty string or multi-character string: error per SQLite
                                     return Err(ExecutorError::SqliteCompatError(
                                         "ESCAPE expression must be a single character".to_string(),
                                     ))

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -224,8 +224,8 @@ impl CombinedExpressionEvaluator<'_> {
                     let mut chars = s.chars();
                     match (chars.next(), chars.next()) {
                         (Some(c), None) => Some(c), // Exactly one character
-                        (None, _) => None,          // Empty string
                         _ => {
+                            // Empty string or multi-character string: error per SQLite
                             return Err(ExecutorError::SqliteCompatError(
                                 "ESCAPE expression must be a single character".to_string(),
                             ))

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -505,9 +505,8 @@ impl ExpressionEvaluator<'_> {
                     let mut chars = s.chars();
                     match (chars.next(), chars.next()) {
                         (Some(c), None) => Some(c), // Exactly one character
-                        (None, _) => None,          // Empty string
                         _ => {
-                            // SQLite requires escape character to be exactly one character
+                            // Empty string or multi-character string: error per SQLite
                             return Err(ExecutorError::SqliteCompatError(
                                 "ESCAPE expression must be a single character".to_string(),
                             ))

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/pattern_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/pattern_funcs.rs
@@ -60,16 +60,24 @@ pub(crate) fn like(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     // Optional escape character (3rd argument)
     let escape_char: Option<char> = if args.len() >= 3 {
         match &args[2] {
-            SqlValue::Varchar(s) | SqlValue::Character(s) if s.len() == 1 => s.chars().next(),
-            SqlValue::Integer(n) => {
-                let s = n.to_string();
-                if s.len() == 1 {
-                    s.chars().next()
-                } else {
-                    None
+            SqlValue::Null => return Ok(SqlValue::Null),
+            SqlValue::Varchar(s) | SqlValue::Character(s) => {
+                let mut chars = s.chars();
+                match (chars.next(), chars.next()) {
+                    (Some(c), None) => Some(c), // Exactly one character
+                    _ => {
+                        // Empty string or multi-character string: error per SQLite
+                        return Err(ExecutorError::SqliteCompatError(
+                            "ESCAPE expression must be a single character".to_string(),
+                        ));
+                    }
                 }
             }
-            _ => None,
+            _ => {
+                return Err(ExecutorError::SqliteCompatError(
+                    "ESCAPE expression must be a single character".to_string(),
+                ));
+            }
         }
     } else {
         None

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs
@@ -218,8 +218,8 @@ pub(super) fn evaluate(
                         let mut chars = s.chars();
                         match (chars.next(), chars.next()) {
                             (Some(c), None) => Some(c), // Exactly one character
-                            (None, _) => None,          // Empty string
                             _ => {
+                                // Empty string or multi-character string: error per SQLite
                                 return Err(ExecutorError::SqliteCompatError(
                                     "ESCAPE expression must be a single character".to_string(),
                                 ))


### PR DESCRIPTION
## Summary

Fixes the LIKE ESCAPE clause to properly reject empty and multi-character strings per SQLite behavior.

## Changes

- Updated ESCAPE validation in 5 evaluation paths to consistently reject empty strings
- Previously, `ESCAPE ''` was silently treated as "no escape character"
- Now both `ESCAPE ''` and `ESCAPE 'ab'` return error: "ESCAPE expression must be a single character"

## Files Modified

- `crates/vibesql-executor/src/evaluator/arena.rs`
- `crates/vibesql-executor/src/evaluator/combined/predicates.rs`
- `crates/vibesql-executor/src/evaluator/expressions/predicates.rs`
- `crates/vibesql-executor/src/evaluator/functions/sqlite_compat/pattern_funcs.rs`
- `crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs`

## Test Plan

- [x] `cargo test --workspace` passes
- [x] TCL tests `expr-10.1` and `expr-10.2` now pass
- [x] Valid single-character ESCAPE still works: `SELECT 'a_c' LIKE 'a\_c' ESCAPE '\';` returns 1

Closes #4921