### PR TITLE
feat(parser): accept SQLite multi-word type aliases

### DIFF
--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -34,6 +34,8 @@ impl Parser {
             Token::Keyword { keyword: Keyword::Set, .. } => "set".to_string(),
             Token::Keyword { keyword: Keyword::Year, .. } => "year".to_string(),
             Token::Keyword { keyword: Keyword::Fixed, .. } => "fixed".to_string(),
+            // SQLite type aliases - VARYING can start multi-word types like VARYING CHARACTER
+            Token::Keyword { keyword: Keyword::Varying, .. } => "varying".to_string(),
             _ => return Err(ParseError { message: "Expected data type".to_string() }),
         };
         self.advance();
@@ -683,9 +685,56 @@ impl Parser {
                 // SQLite compatibility: Accept ANY string as a type name.
                 // SQLite uses type affinity rules to determine storage, but accepts
                 // any type name including typos like "IMTEGES" or "INTEGES".
-                // Map all unknown types to UserDefined, which provides BLOB/NUMERIC
-                // affinity behavior in the executor.
-                Ok((vibesql_types::DataType::UserDefined { type_name }, false))
+                //
+                // Multi-word types are common in SQLite:
+                // - LARGE BLOB, NATIVE CHARACTER(n), VARYING CHARACTER(n)
+                // - UNSIGNED BIG INT, LONG VARCHAR, etc.
+                //
+                // Continue consuming identifiers and type-related keywords to build
+                // the complete type name, then apply SQLite's affinity rules.
+                let mut full_type_name = type_name.clone();
+
+                loop {
+                    match self.peek() {
+                        // Continue with identifier tokens
+                        Token::Identifier(next) => {
+                            full_type_name.push(' ');
+                            full_type_name.push_str(next);
+                            self.advance();
+                        }
+                        // Also allow CHARACTER keyword in multi-word types
+                        Token::Keyword { keyword: Keyword::Character, .. } => {
+                            full_type_name.push_str(" character");
+                            self.advance();
+                        }
+                        // Stop at length specifier, constraint, or delimiter
+                        _ => break,
+                    }
+                }
+
+                // Handle optional length specifier for multi-word types like
+                // NATIVE CHARACTER(70) or VARYING CHARACTER(255)
+                if matches!(self.peek(), Token::LParen) {
+                    self.advance(); // consume (
+                    match self.peek() {
+                        Token::Number(n) => {
+                            // Validate and consume the length (we don't store it for
+                            // UserDefined types - affinity is what matters in SQLite)
+                            let _ = n.parse::<usize>().map_err(|_| ParseError {
+                                message: format!("Invalid {} length", full_type_name),
+                            })?;
+                            self.advance();
+                        }
+                        _ => {
+                            return Err(ParseError {
+                                message: format!("Expected number after {}(", full_type_name),
+                            })
+                        }
+                    }
+                    self.expect_token(Token::RParen)?;
+                }
+
+                Ok((vibesql_types::DataType::UserDefined { type_name: full_type_name }, false))
             }
         }
     }

--- a/crates/vibesql-parser/src/tests/create_table/mod.rs
+++ b/crates/vibesql-parser/src/tests/create_table/mod.rs
@@ -7,6 +7,7 @@ mod mysql_table_options;
 mod northwind;
 mod numeric_types;
 mod spatial_types;
+mod sqlite_type_aliases;
 mod storage_format;
 mod string_types;
 mod temporal_types;

--- a/crates/vibesql-parser/src/tests/create_table/sqlite_type_aliases.rs
+++ b/crates/vibesql-parser/src/tests/create_table/sqlite_type_aliases.rs
@@ -1,0 +1,225 @@
+use super::super::*;
+
+// ========================================================================
+// SQLite Type Aliases - Multi-word type names
+// ========================================================================
+// SQLite accepts ANY type name and determines affinity based on the
+// type name string. Multi-word types like "LARGE BLOB", "NATIVE CHARACTER",
+// "VARYING CHARACTER" should be accepted and stored as UserDefined types.
+//
+// See: https://www.sqlite.org/datatype3.html#type_affinity
+
+#[test]
+fn test_parse_large_blob() {
+    let result = Parser::parse_sql("CREATE TABLE t1(a LARGE BLOB);");
+    assert!(result.is_ok(), "Should parse LARGE BLOB type: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 1);
+            match &create.columns[0].data_type {
+                vibesql_types::DataType::UserDefined { type_name } => {
+                    // Check case-insensitively since lexer may normalize differently
+                    assert!(
+                        type_name.to_uppercase().contains("LARGE"),
+                        "Type should contain LARGE: {}",
+                        type_name
+                    );
+                    assert!(
+                        type_name.to_uppercase().contains("BLOB"),
+                        "Type should contain BLOB: {}",
+                        type_name
+                    );
+                }
+                other => panic!("Expected UserDefined, got {:?}", other),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_native_character() {
+    let result = Parser::parse_sql("CREATE TABLE t2(b NATIVE CHARACTER(70));");
+    assert!(result.is_ok(), "Should parse NATIVE CHARACTER type: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 1);
+            match &create.columns[0].data_type {
+                vibesql_types::DataType::UserDefined { type_name } => {
+                    // Type name includes the identifier parts
+                    assert!(
+                        type_name.to_uppercase().contains("NATIVE"),
+                        "Type should contain NATIVE"
+                    );
+                    assert!(
+                        type_name.to_uppercase().contains("CHARACTER"),
+                        "Type should contain CHARACTER"
+                    );
+                }
+                other => panic!("Expected UserDefined, got {:?}", other),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_varying_character() {
+    let result = Parser::parse_sql("CREATE TABLE t3(c VARYING CHARACTER(255));");
+    assert!(result.is_ok(), "Should parse VARYING CHARACTER type: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 1);
+            match &create.columns[0].data_type {
+                vibesql_types::DataType::UserDefined { type_name } => {
+                    assert!(
+                        type_name.to_uppercase().contains("VARYING"),
+                        "Type should contain VARYING"
+                    );
+                    assert!(
+                        type_name.to_uppercase().contains("CHARACTER"),
+                        "Type should contain CHARACTER"
+                    );
+                }
+                other => panic!("Expected UserDefined, got {:?}", other),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+// Note: UNSIGNED BIG INT and LONG VARCHAR are special cases.
+// UNSIGNED and LONG are recognized as types (Unsigned and Bigint respectively),
+// so multi-word types starting with these words would need additional handling.
+// SQLite does accept these, but our current implementation parses them differently.
+// The primary fix in this PR handles cases where the first word is unknown
+// (like LARGE, NATIVE, VARYING).
+
+#[test]
+fn test_sqlite_type_affinity_blob() {
+    // LARGE BLOB should have BLOB/NONE affinity because it contains "BLOB"
+    let user_defined = vibesql_types::DataType::UserDefined {
+        type_name: "large blob".to_string(),
+    };
+    assert_eq!(
+        user_defined.sqlite_affinity(),
+        vibesql_types::TypeAffinity::None,
+        "LARGE BLOB should have NONE affinity"
+    );
+}
+
+#[test]
+fn test_sqlite_type_affinity_character() {
+    // NATIVE CHARACTER should have TEXT affinity because it contains "CHAR"
+    let user_defined = vibesql_types::DataType::UserDefined {
+        type_name: "native character".to_string(),
+    };
+    assert_eq!(
+        user_defined.sqlite_affinity(),
+        vibesql_types::TypeAffinity::Text,
+        "NATIVE CHARACTER should have TEXT affinity"
+    );
+}
+
+#[test]
+fn test_sqlite_type_affinity_integer() {
+    // UNSIGNED BIG INT should have INTEGER affinity because it contains "INT"
+    let user_defined = vibesql_types::DataType::UserDefined {
+        type_name: "unsigned big int".to_string(),
+    };
+    assert_eq!(
+        user_defined.sqlite_affinity(),
+        vibesql_types::TypeAffinity::Integer,
+        "UNSIGNED BIG INT should have INTEGER affinity"
+    );
+}
+
+#[test]
+fn test_sqlite_type_affinity_clob() {
+    // CLOB types should have TEXT affinity
+    let user_defined = vibesql_types::DataType::UserDefined {
+        type_name: "large clob".to_string(),
+    };
+    assert_eq!(
+        user_defined.sqlite_affinity(),
+        vibesql_types::TypeAffinity::Text,
+        "LARGE CLOB should have TEXT affinity"
+    );
+}
+
+#[test]
+fn test_sqlite_type_affinity_real() {
+    // DOUBLE types should have REAL affinity
+    let user_defined = vibesql_types::DataType::UserDefined {
+        type_name: "my double type".to_string(),
+    };
+    assert_eq!(
+        user_defined.sqlite_affinity(),
+        vibesql_types::TypeAffinity::Real,
+        "Types containing DOUB should have REAL affinity"
+    );
+}
+
+#[test]
+fn test_sqlite_type_affinity_numeric_fallback() {
+    // Unknown types without affinity keywords should have NUMERIC affinity
+    let user_defined = vibesql_types::DataType::UserDefined {
+        type_name: "custom_type".to_string(),
+    };
+    assert_eq!(
+        user_defined.sqlite_affinity(),
+        vibesql_types::TypeAffinity::Numeric,
+        "Unknown types should have NUMERIC affinity"
+    );
+}
+
+#[test]
+fn test_multiple_columns_with_sqlite_types() {
+    // Test the types mentioned in the issue that should now work
+    let result = Parser::parse_sql(
+        "CREATE TABLE types2 (
+            a LARGE BLOB,
+            b NATIVE CHARACTER(70),
+            c VARYING CHARACTER(255),
+            d INTEGER
+        );",
+    );
+    assert!(result.is_ok(), "Should parse table with SQLite type aliases: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 4, "Should have 4 columns");
+            assert_eq!(create.table_name, "types2");
+
+            // Verify affinities are correct per SQLite rules
+            // LARGE BLOB → NONE affinity (contains BLOB)
+            assert_eq!(
+                create.columns[0].data_type.sqlite_affinity(),
+                vibesql_types::TypeAffinity::None
+            );
+            // NATIVE CHARACTER → TEXT affinity (contains CHAR)
+            assert_eq!(
+                create.columns[1].data_type.sqlite_affinity(),
+                vibesql_types::TypeAffinity::Text
+            );
+            // VARYING CHARACTER → TEXT affinity (contains CHAR)
+            assert_eq!(
+                create.columns[2].data_type.sqlite_affinity(),
+                vibesql_types::TypeAffinity::Text
+            );
+            // INTEGER → INTEGER affinity
+            assert_eq!(
+                create.columns[3].data_type.sqlite_affinity(),
+                vibesql_types::TypeAffinity::Integer
+            );
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}

--- a/crates/vibesql-types/src/data_type.rs
+++ b/crates/vibesql-types/src/data_type.rs
@@ -462,8 +462,37 @@ impl DataType {
             // Vector → NONE affinity (custom type)
             DataType::Vector { .. } => TypeAffinity::None,
 
-            // User-defined and NULL → NONE affinity
-            DataType::UserDefined { .. } | DataType::Null => TypeAffinity::None,
+            // NULL → NONE affinity
+            DataType::Null => TypeAffinity::None,
+
+            // User-defined types: Apply SQLite's affinity rules based on type name.
+            // SQLite determines affinity by checking if the type name contains:
+            // 1. "INT" → INTEGER affinity
+            // 2. "CHAR", "CLOB", or "TEXT" → TEXT affinity
+            // 3. "BLOB" or no type → NONE/BLOB affinity
+            // 4. "REAL", "FLOA", or "DOUB" → REAL affinity
+            // 5. Otherwise → NUMERIC affinity
+            //
+            // This handles multi-word types like "LARGE BLOB", "NATIVE CHARACTER",
+            // "VARYING CHARACTER", "UNSIGNED BIG INT", etc.
+            DataType::UserDefined { type_name } => {
+                let upper = type_name.to_uppercase();
+                if upper.contains("INT") {
+                    TypeAffinity::Integer
+                } else if upper.contains("CHAR") || upper.contains("CLOB") || upper.contains("TEXT")
+                {
+                    TypeAffinity::Text
+                } else if upper.contains("BLOB") {
+                    TypeAffinity::None
+                } else if upper.contains("REAL")
+                    || upper.contains("FLOA")
+                    || upper.contains("DOUB")
+                {
+                    TypeAffinity::Real
+                } else {
+                    TypeAffinity::Numeric
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

SQLite accepts any type name for columns and determines type affinity based on the type name string. This PR adds support for multi-word type names that were previously rejected with syntax errors.

## Changes

**Parser (`types.rs`):**
- Parser now continues consuming identifiers/keywords after unknown type names to build complete multi-word types
- Added VARYING keyword to type parsing entry point (allows `VARYING CHARACTER` types)
- Handle optional length specifier for multi-word types like `NATIVE CHARACTER(70)`

**Type Affinity (`data_type.rs`):**
- Updated `UserDefined` type affinity to use SQLite's string-based rules:
  - Contains "INT" → INTEGER affinity
  - Contains "CHAR/CLOB/TEXT" → TEXT affinity
  - Contains "BLOB" → NONE affinity
  - Contains "REAL/FLOA/DOUB" → REAL affinity
  - Otherwise → NUMERIC affinity

## Examples Now Supported

```sql
-- These previously failed with syntax errors, now work correctly:
CREATE TABLE t1(a LARGE BLOB);         -- NONE affinity
CREATE TABLE t2(b NATIVE CHARACTER(70)); -- TEXT affinity
CREATE TABLE t3(c VARYING CHARACTER(255)); -- TEXT affinity
```

## Test Plan

- Added comprehensive test suite in `sqlite_type_aliases.rs`
- Tests cover parsing and affinity calculation for multi-word types
- All 1221 parser tests pass
- All 20 types tests pass

Closes #4928