### PR TITLE
feat(collation): add RTRIM collation support

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -818,6 +818,27 @@ impl CombinedExpressionEvaluator<'_> {
                                     other => other.clone(),
                                 };
                                 (left_transformed, right_transformed)
+                            } else if collation_lower == "rtrim" {
+                                // For RTRIM collation, trim trailing whitespace from both string values
+                                let left_transformed = match &left_val {
+                                    SqlValue::Varchar(s) => {
+                                        SqlValue::Varchar(arcstr::ArcStr::from(s.trim_end()))
+                                    }
+                                    SqlValue::Character(s) => {
+                                        SqlValue::Character(arcstr::ArcStr::from(s.trim_end()))
+                                    }
+                                    other => other.clone(),
+                                };
+                                let right_transformed = match &right_val {
+                                    SqlValue::Varchar(s) => {
+                                        SqlValue::Varchar(arcstr::ArcStr::from(s.trim_end()))
+                                    }
+                                    SqlValue::Character(s) => {
+                                        SqlValue::Character(arcstr::ArcStr::from(s.trim_end()))
+                                    }
+                                    other => other.clone(),
+                                };
+                                (left_transformed, right_transformed)
                             } else {
                                 // For BINARY or other collations, use values as-is
                                 (left_val, right_val)

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -41,7 +41,9 @@ impl CombinedExpressionEvaluator<'_> {
         let low_val = self.eval(low, row)?;
         let high_val = self.eval(high, row)?;
 
-        // Apply collation transformation if needed (for NOCASE, uppercase all strings)
+        // Apply collation transformation if needed
+        // NOCASE: uppercase all strings for case-insensitive comparison
+        // RTRIM: trim trailing whitespace from all strings
         let transform_for_collation = |val: SqlValue, collation_name: &str| -> SqlValue {
             if collation_name.eq_ignore_ascii_case("nocase") {
                 match val {
@@ -50,6 +52,16 @@ impl CombinedExpressionEvaluator<'_> {
                     }
                     SqlValue::Character(s) => {
                         SqlValue::Character(arcstr::ArcStr::from(s.to_uppercase()))
+                    }
+                    other => other,
+                }
+            } else if collation_name.eq_ignore_ascii_case("rtrim") {
+                match val {
+                    SqlValue::Varchar(s) => {
+                        SqlValue::Varchar(arcstr::ArcStr::from(s.trim_end()))
+                    }
+                    SqlValue::Character(s) => {
+                        SqlValue::Character(arcstr::ArcStr::from(s.trim_end()))
                     }
                     other => other,
                 }

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -534,6 +534,19 @@ impl ExpressionEvaluator<'_> {
                                     other => other.clone(),
                                 };
                                 (left_transformed, right_transformed)
+                            } else if collation_lower == "rtrim" {
+                                // For RTRIM collation, trim trailing whitespace from both string values
+                                let left_transformed = match &left_val {
+                                    SqlValue::Varchar(s) => SqlValue::Varchar(arcstr::ArcStr::from(s.trim_end())),
+                                    SqlValue::Character(s) => SqlValue::Character(arcstr::ArcStr::from(s.trim_end())),
+                                    other => other.clone(),
+                                };
+                                let right_transformed = match &right_val {
+                                    SqlValue::Varchar(s) => SqlValue::Varchar(arcstr::ArcStr::from(s.trim_end())),
+                                    SqlValue::Character(s) => SqlValue::Character(arcstr::ArcStr::from(s.trim_end())),
+                                    other => other.clone(),
+                                };
+                                (left_transformed, right_transformed)
                             } else {
                                 // For BINARY or other collations, use values as-is
                                 (left_val, right_val)

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -43,7 +43,9 @@ impl ExpressionEvaluator<'_> {
         let low_val = self.eval(low, row)?;
         let high_val = self.eval(high, row)?;
 
-        // Apply collation transformation if needed (for NOCASE, uppercase all strings)
+        // Apply collation transformation if needed
+        // NOCASE: uppercase all strings for case-insensitive comparison
+        // RTRIM: trim trailing whitespace from all strings
         let transform_for_collation = |val: SqlValue, collation_name: &str| -> SqlValue {
             if collation_name.eq_ignore_ascii_case("nocase") {
                 match val {
@@ -52,6 +54,16 @@ impl ExpressionEvaluator<'_> {
                     }
                     SqlValue::Character(s) => {
                         SqlValue::Character(arcstr::ArcStr::from(s.to_uppercase()))
+                    }
+                    other => other,
+                }
+            } else if collation_name.eq_ignore_ascii_case("rtrim") {
+                match val {
+                    SqlValue::Varchar(s) => {
+                        SqlValue::Varchar(arcstr::ArcStr::from(s.trim_end()))
+                    }
+                    SqlValue::Character(s) => {
+                        SqlValue::Character(arcstr::ArcStr::from(s.trim_end()))
                     }
                     other => other,
                 }

--- a/crates/vibesql-executor/src/select/order/comparison.rs
+++ b/crates/vibesql-executor/src/select/order/comparison.rs
@@ -13,6 +13,7 @@ use super::SortKey;
 /// Apply collation transformation to a SQL value for comparison.
 ///
 /// For NOCASE collation, string values are uppercased for case-insensitive comparison.
+/// For RTRIM collation, trailing whitespace is removed from string values.
 /// Other values are returned unchanged.
 fn apply_collation<'a>(
     val: &'a vibesql_types::SqlValue,
@@ -29,6 +30,20 @@ fn apply_collation<'a>(
                 vibesql_types::SqlValue::Character(s) => {
                     Cow::Owned(vibesql_types::SqlValue::Character(arcstr::ArcStr::from(
                         s.to_uppercase(),
+                    )))
+                }
+                other => Cow::Borrowed(other),
+            }
+        } else if coll.eq_ignore_ascii_case("rtrim") {
+            match val {
+                vibesql_types::SqlValue::Varchar(s) => {
+                    Cow::Owned(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(
+                        s.trim_end(),
+                    )))
+                }
+                vibesql_types::SqlValue::Character(s) => {
+                    Cow::Owned(vibesql_types::SqlValue::Character(arcstr::ArcStr::from(
+                        s.trim_end(),
                     )))
                 }
                 other => Cow::Borrowed(other),


### PR DESCRIPTION
## Summary

- Implements RTRIM collation for SQLite compatibility
- RTRIM collation ignores trailing whitespace when comparing strings (e.g., `'abc' = 'abc  '` is true)
- Adds support in WHERE clauses, ORDER BY, and BETWEEN predicates
- Updates both single and combined expression evaluators

## Changes

1. **WHERE comparisons**: RTRIM collation now trims trailing whitespace before string comparison
2. **ORDER BY sorting**: RTRIM collation groups strings by their trimmed values
3. **BETWEEN predicates**: RTRIM collation applies to all three operands

## Test Plan

- [x] Manual testing with RTRIM collation in WHERE clause
- [x] Manual testing with RTRIM collation in ORDER BY
- [x] All unit tests pass
- [ ] TCL test suite (collation tests require custom collation registration which is a TCL-specific feature)

## Notes

Column-level collation (defined in CREATE TABLE) is working for SELECT expressions but not for WHERE predicates - this is tracked separately from this PR.

Closes #4948

🤖 Generated with [Claude Code](https://claude.com/claude-code)