### PR TITLE
fix(parser): correct || operator precedence to match SQLite

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -420,23 +420,39 @@ impl<'arena> ArenaParser<'arena> {
         Ok(left)
     }
 
-    /// Parse additive expression.
+    /// Parse additive expression (handles +, -).
+    /// Per SQLite, || has higher precedence than + and -, so it's handled in parse_concat_expression.
     fn parse_additive_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
-        let mut left = self.parse_multiplicative_expression()?;
+        let mut left = self.parse_concat_expression()?;
 
         loop {
             let op = match self.peek() {
                 Token::Symbol('+') => BinaryOperator::Plus,
                 Token::Symbol('-') => BinaryOperator::Minus,
-                Token::Operator(MultiCharOperator::Concat) => BinaryOperator::Concat,
                 _ => break,
             };
             self.advance();
 
-            let right = self.parse_multiplicative_expression()?;
+            let right = self.parse_concat_expression()?;
             let left_ref = self.arena.alloc(left);
             let right_ref = self.arena.alloc(right);
             left = Expression::BinaryOp { op, left: left_ref, right: right_ref };
+        }
+
+        Ok(left)
+    }
+
+    /// Parse string concatenation expression (handles ||).
+    /// Per SQLite, || has higher precedence than + and -, but lower than * / %.
+    fn parse_concat_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        let mut left = self.parse_multiplicative_expression()?;
+
+        while self.peek() == &Token::Operator(MultiCharOperator::Concat) {
+            self.advance();
+            let right = self.parse_multiplicative_expression()?;
+            let left_ref = self.arena.alloc(left);
+            let right_ref = self.arena.alloc(right);
+            left = Expression::BinaryOp { op: BinaryOperator::Concat, left: left_ref, right: right_ref };
         }
 
         Ok(left)

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -139,26 +139,44 @@ impl Parser {
         Ok(left)
     }
 
-    /// Parse additive expression (handles +, -, and ||)
+    /// Parse additive expression (handles +, -)
+    /// Per SQLite, || has higher precedence than + and -, so it's handled in parse_concat_expression
     pub(super) fn parse_additive_expression(
         &mut self,
     ) -> Result<vibesql_ast::Expression, ParseError> {
-        let mut left = self.parse_multiplicative_expression()?;
+        let mut left = self.parse_concat_expression()?;
 
         loop {
             let op = match self.peek() {
                 Token::Symbol('+') => vibesql_ast::BinaryOperator::Plus,
                 Token::Symbol('-') => vibesql_ast::BinaryOperator::Minus,
-                Token::Operator(crate::token::MultiCharOperator::Concat) => {
-                    vibesql_ast::BinaryOperator::Concat
-                }
                 _ => break,
             };
             self.advance();
 
-            let right = self.parse_multiplicative_expression()?;
+            let right = self.parse_concat_expression()?;
             left = vibesql_ast::Expression::BinaryOp {
                 op,
+                left: Box::new(left),
+                right: Box::new(right),
+            };
+        }
+
+        Ok(left)
+    }
+
+    /// Parse string concatenation expression (handles ||)
+    /// Per SQLite, || has higher precedence than + and -, but lower than * / %
+    pub(super) fn parse_concat_expression(
+        &mut self,
+    ) -> Result<vibesql_ast::Expression, ParseError> {
+        let mut left = self.parse_multiplicative_expression()?;
+
+        while self.peek() == &Token::Operator(crate::token::MultiCharOperator::Concat) {
+            self.advance();
+            let right = self.parse_multiplicative_expression()?;
+            left = vibesql_ast::Expression::BinaryOp {
+                op: vibesql_ast::BinaryOperator::Concat,
                 left: Box::new(left),
                 right: Box::new(right),
             };

--- a/crates/vibesql-parser/src/tests/select/concat.rs
+++ b/crates/vibesql-parser/src/tests/select/concat.rs
@@ -42,24 +42,25 @@ fn test_parse_concat_with_literals() {
 
 #[test]
 fn test_parse_concat_precedence() {
-    // || should have same precedence as + and -
+    // Per SQLite, || has HIGHER precedence than + and -
+    // So "a + b || c" should parse as "a + (b || c)"
     let sql = "SELECT a + b || c FROM t";
     let stmt = Parser::parse_sql(sql).unwrap();
 
     match stmt {
         vibesql_ast::Statement::Select(select) => {
-            // Should parse as (a + b) || c
+            // Should parse as a + (b || c)
             match &select.select_list[0] {
                 vibesql_ast::SelectItem::Expression { expr, .. } => {
                     match expr {
-                        vibesql_ast::Expression::BinaryOp { left, op, .. } => {
-                            assert_eq!(*op, vibesql_ast::BinaryOperator::Concat);
-                            // Left should be (a + b)
-                            match &**left {
+                        vibesql_ast::Expression::BinaryOp { right, op, .. } => {
+                            assert_eq!(*op, vibesql_ast::BinaryOperator::Plus);
+                            // Right should be (b || c)
+                            match &**right {
                                 vibesql_ast::Expression::BinaryOp { op: inner_op, .. } => {
-                                    assert_eq!(*inner_op, vibesql_ast::BinaryOperator::Plus);
+                                    assert_eq!(*inner_op, vibesql_ast::BinaryOperator::Concat);
                                 }
-                                _ => panic!("Expected BinaryOp for left side"),
+                                _ => panic!("Expected BinaryOp for right side"),
                             }
                         }
                         _ => panic!("Expected BinaryOp expression"),

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2122,7 +2122,6 @@ array set vibesql_skip_tests {
     orderby1-1.103 "Uses eqp proc - EXPLAIN QUERY PLAN wrapper"
 
     expr-1.135 "printf %c on large integer differs from SQLite"
-    expr-2.2 "Precedence of - with || differs from SQLite"
     expr-6.4 "NOT NULL literal optimization differs"
     expr-6.21 "COALESCE with NOT IN differs"
     expr-6.22 "COALESCE with NOT IN differs"


### PR DESCRIPTION
## Summary

Fixes operator precedence so that `||` (string concatenation) has higher precedence than `+` and `-` (additive operators), matching SQLite's documented behavior.

**Before this fix:**
- `1 - 2 || 'x'` → `-1x` (text) - parsed as `(1 - 2) || 'x'`

**After this fix:**
- `1 - 2 || 'x'` → `-1` (integer) - parsed as `1 - (2 || 'x')`, matching SQLite

## Changes

- Added `parse_concat_expression()` to both parsers (arena_parser and standard parser)
- Moved `||` handling from additive expression level to a new concat expression level
- Updated `test_parse_concat_precedence` unit test to expect the correct SQLite behavior
- Removed `expr-2.2` from the TCL test skip list

## Test Plan

- [x] Parser unit tests pass: `cargo test --release -p vibesql-parser`
- [x] expr.test TCL tests pass: `make test-tcl-file FILE=expr.test` (635 tests pass)
- [x] Manual verification: `SELECT 1 - 2 || 'x'` returns `-1` (matching SQLite)

Closes #4955