### PR TITLE
fix(executor): apply SQLite truthiness rules in UPDATE/DELETE WHERE clauses

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -3,6 +3,7 @@
 use vibesql_ast::DeleteStmt;
 use vibesql_catalog::TableIdentifier;
 use vibesql_storage::Database;
+use vibesql_types::SqlValue;
 
 use super::integrity::check_no_child_references;
 use crate::{
@@ -605,7 +606,8 @@ impl DeleteExecutor {
                     vibesql_ast::WhereClause::Condition(where_expr) => {
                         // Propagate errors from eval() - don't silently swallow them
                         let result = evaluator.eval(where_expr, row)?;
-                        matches!(result, vibesql_types::SqlValue::Boolean(true))
+                        // SQLite treats non-zero numeric values as TRUE
+                        is_truthy(&result)
                     }
                     vibesql_ast::WhereClause::CurrentOf(_cursor_name) => {
                         return Err(ExecutorError::UnsupportedFeature(
@@ -722,11 +724,9 @@ fn execute_delete_on_view(
         for row in &all_rows.rows {
             let matches = match &stmt.where_clause {
                 Some(vibesql_ast::WhereClause::Condition(expr)) => {
-                    match evaluator.eval(expr, row)? {
-                        vibesql_types::SqlValue::Boolean(b) => b,
-                        vibesql_types::SqlValue::Null => false,
-                        _ => false,
-                    }
+                    let result = evaluator.eval(expr, row)?;
+                    // SQLite treats non-zero numeric values as TRUE
+                    is_truthy(&result)
                 }
                 None => true, // No WHERE clause - delete all rows
                 Some(vibesql_ast::WhereClause::CurrentOf(_)) => {
@@ -780,4 +780,35 @@ fn build_view_schema(
         .collect();
 
     Ok(vibesql_catalog::TableSchema::new(view_def.name.clone(), columns))
+}
+
+/// Check if a SqlValue is truthy using SQLite truthiness rules.
+///
+/// SQLite rules:
+/// - `Boolean(true)` → true
+/// - `Boolean(false)` → false
+/// - `Null` → false (NULL is not truthy for WHERE clause purposes)
+/// - `0` and `0.0` → false
+/// - Any other numeric value → true
+/// - Strings → parse leading numeric, non-zero is true, 0 or non-numeric is false
+fn is_truthy(value: &SqlValue) -> bool {
+    use SqlValue::*;
+    match value {
+        Boolean(b) => *b,
+        Null => false, // NULL is not truthy for row selection
+        // Integer types: 0 is false, non-zero is true
+        Integer(n) => *n != 0,
+        Smallint(n) => *n != 0,
+        Bigint(n) => *n != 0,
+        Unsigned(n) => *n != 0,
+        // Floating point types: 0.0 is false, non-zero is true
+        Float(f) => *f != 0.0,
+        Real(f) => *f != 0.0,
+        Double(f) => *f != 0.0,
+        Numeric(f) => *f != 0.0,
+        // String types: SQLite parses leading numeric portion
+        Varchar(s) | Character(s) => crate::evaluator::operators::is_truthy_string(s),
+        // Other types are not truthy (conservative default)
+        _ => false,
+    }
 }

--- a/crates/vibesql-executor/src/update/row_selector.rs
+++ b/crates/vibesql-executor/src/update/row_selector.rs
@@ -1,6 +1,7 @@
 //! Row selection logic for UPDATE operations
 
 use vibesql_ast::{BinaryOperator, Expression};
+use vibesql_types::SqlValue;
 
 use crate::{errors::ExecutorError, evaluator::ExpressionEvaluator};
 
@@ -203,8 +204,9 @@ impl<'a> RowSelector<'a> {
                 match where_clause {
                     vibesql_ast::WhereClause::Condition(where_expr) => {
                         let result = evaluator.eval(where_expr, row)?;
-                        // SQL semantics: only TRUE (not NULL) causes update
-                        matches!(result, vibesql_types::SqlValue::Boolean(true))
+                        // SQL semantics: only truthy values cause update
+                        // SQLite treats non-zero numeric values as TRUE
+                        is_truthy(&result)
                     }
                     vibesql_ast::WhereClause::CurrentOf(cursor_name) => {
                         // TODO: Implement cursor support for positioned UPDATE/DELETE
@@ -244,5 +246,36 @@ impl<'a> RowSelector<'a> {
         }
 
         Ok(candidate_rows)
+    }
+}
+
+/// Check if a SqlValue is truthy using SQLite truthiness rules.
+///
+/// SQLite rules:
+/// - `Boolean(true)` → true
+/// - `Boolean(false)` → false
+/// - `Null` → false (NULL is not truthy for WHERE clause purposes)
+/// - `0` and `0.0` → false
+/// - Any other numeric value → true
+/// - Strings → parse leading numeric, non-zero is true, 0 or non-numeric is false
+fn is_truthy(value: &SqlValue) -> bool {
+    use SqlValue::*;
+    match value {
+        Boolean(b) => *b,
+        Null => false, // NULL is not truthy for row selection
+        // Integer types: 0 is false, non-zero is true
+        Integer(n) => *n != 0,
+        Smallint(n) => *n != 0,
+        Bigint(n) => *n != 0,
+        Unsigned(n) => *n != 0,
+        // Floating point types: 0.0 is false, non-zero is true
+        Float(f) => *f != 0.0,
+        Real(f) => *f != 0.0,
+        Double(f) => *f != 0.0,
+        Numeric(f) => *f != 0.0,
+        // String types: SQLite parses leading numeric portion
+        Varchar(s) | Character(s) => crate::evaluator::operators::is_truthy_string(s),
+        // Other types are not truthy (conservative default)
+        _ => false,
     }
 }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1691,7 +1691,6 @@ array set vibesql_skip_tests {
     where7-3.2 "EXPLAIN QUERY PLAN output format is SQLite-specific"
     update-13.3 "sqlite3_limit API not implemented"
     update-15.1 "CAST syntax difference from SQLite"
-    update-17.10 "Expression indexes are not yet supported"
     update-20.20 "Uses TEMP TABLE from ifcapable tempdb block"
     update-20.30 "Cascades from update-20.20 TEMP TABLE failure"
     update-21.3 "min/max UPDATE optimization differs from SQLite"


### PR DESCRIPTION
## Summary
- Fix UPDATE and DELETE WHERE clause evaluation to properly handle SQLite truthiness rules
- Add `is_truthy()` helper function that treats non-zero numeric values as truthy (SQLite behavior)
- Enable the `update-17.10` TCL test which uses `WHERE 3` with expression indexes

## Changes
- `crates/vibesql-executor/src/update/row_selector.rs`: Add SQLite truthiness support in UPDATE row selection
- `crates/vibesql-executor/src/delete/executor.rs`: Add SQLite truthiness support in DELETE row selection  
- `scripts/tester_vibesql.tcl`: Remove skip entry for `update-17.10` test

## Test plan
- [x] `make test-tcl-file FILE=update.test` passes (125/134 tests, 9 skipped)
- [x] `cargo test --release` passes
- [x] Manual verification: `UPDATE t1 SET x=2, y=3 WHERE 3` now correctly updates rows

Closes #4944

🤖 Generated with [Claude Code](https://claude.com/claude-code)