### PR TITLE
feat(rowvalue): implement row value (tuple) comparisons

### DIFF
--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -692,6 +692,17 @@ impl ExpressionEvaluator<'_> {
             }
 
             vibesql_ast::Expression::IsDistinctFrom { left, right, negated } => {
+                // Handle row value constructor IS [NOT] DISTINCT FROM
+                // (a, b) IS (c, d) is equivalent to (a, b) IS NOT DISTINCT FROM (c, d)
+                // SQLite: a IS b returns TRUE if both are NULL or both are equal (not NULL-propagating)
+                if let (
+                    vibesql_ast::Expression::RowValueConstructor(left_exprs),
+                    vibesql_ast::Expression::RowValueConstructor(right_exprs),
+                ) = (left.as_ref(), right.as_ref())
+                {
+                    return self.eval_row_value_is_distinct(left_exprs, right_exprs, *negated, row);
+                }
+
                 let left_val = self.eval(left, row)?;
                 let right_val = self.eval(right, row)?;
                 let is_distinct = super::super::core::values_are_distinct(&left_val, &right_val);
@@ -1160,7 +1171,7 @@ impl ExpressionEvaluator<'_> {
     ///
     /// NULL handling: If any element comparison involves NULL, the result follows
     /// SQL three-valued logic (NULL propagates unless short-circuited by a definite result).
-    fn eval_row_value_comparison(
+    pub(super) fn eval_row_value_comparison(
         &self,
         left_exprs: &[vibesql_ast::Expression],
         op: &vibesql_ast::BinaryOperator,
@@ -1356,5 +1367,68 @@ impl ExpressionEvaluator<'_> {
             // For < or >, all equal means FALSE
             Ok(SqlValue::Boolean(false))
         }
+    }
+
+    /// Evaluate row value IS [NOT] DISTINCT FROM comparison
+    ///
+    /// In SQLite:
+    /// - `(a, b) IS (c, d)` means `(a, b) IS NOT DISTINCT FROM (c, d)`
+    ///   Returns TRUE if a IS c AND b IS d (NULL-safe equality, NULL IS NULL = TRUE)
+    /// - `(a, b) IS NOT (c, d)` means `(a, b) IS DISTINCT FROM (c, d)`
+    ///   Returns TRUE if any element is distinct (NULL IS NOT NULL = TRUE)
+    ///
+    /// Note: This differs from `=` comparison where NULL = NULL returns NULL
+    fn eval_row_value_is_distinct(
+        &self,
+        left_exprs: &[vibesql_ast::Expression],
+        right_exprs: &[vibesql_ast::Expression],
+        negated: bool,
+        row: &vibesql_storage::Row,
+    ) -> Result<SqlValue, ExecutorError> {
+        // Row values must have the same number of elements
+        if left_exprs.len() != right_exprs.len() {
+            return Err(ExecutorError::UnsupportedExpression(format!(
+                "Row value constructor size mismatch: left has {} elements, right has {}",
+                left_exprs.len(),
+                right_exprs.len()
+            )));
+        }
+
+        // Empty row values are not allowed
+        if left_exprs.is_empty() {
+            return Err(ExecutorError::UnsupportedExpression(
+                "Empty row value constructors are not allowed".to_string(),
+            ));
+        }
+
+        // Evaluate all elements and check distinctness
+        // IS NOT DISTINCT FROM (negated=true in SQLite's IS syntax):
+        //   All elements must be "not distinct" (NULL-safe equal)
+        // IS DISTINCT FROM (negated=false in SQLite's IS NOT syntax):
+        //   At least one element must be "distinct"
+        for (left_expr, right_expr) in left_exprs.iter().zip(right_exprs.iter()) {
+            let left_val = self.eval(left_expr, row)?;
+            let right_val = self.eval(right_expr, row)?;
+
+            let is_distinct = super::super::core::values_are_distinct(&left_val, &right_val);
+
+            if negated {
+                // IS NOT DISTINCT FROM: all must be not distinct
+                // If any is distinct, return FALSE
+                if is_distinct {
+                    return Ok(SqlValue::Boolean(false));
+                }
+            } else {
+                // IS DISTINCT FROM: if any is distinct, return TRUE
+                if is_distinct {
+                    return Ok(SqlValue::Boolean(true));
+                }
+            }
+        }
+
+        // If we get here:
+        // - For IS NOT DISTINCT FROM (negated=true): all were not distinct → TRUE
+        // - For IS DISTINCT FROM (negated=false): none were distinct → FALSE
+        Ok(SqlValue::Boolean(negated))
     }
 }

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -34,6 +34,20 @@ impl ExpressionEvaluator<'_> {
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
         use vibesql_types::SqlValue;
 
+        // Handle row value constructor BETWEEN
+        // (a, b) BETWEEN (low_a, low_b) AND (high_a, high_b)
+        // is equivalent to: (a, b) >= (low_a, low_b) AND (a, b) <= (high_a, high_b)
+        if let (
+            vibesql_ast::Expression::RowValueConstructor(expr_exprs),
+            vibesql_ast::Expression::RowValueConstructor(low_exprs),
+            vibesql_ast::Expression::RowValueConstructor(high_exprs),
+        ) = (expr, low, high)
+        {
+            return self.eval_row_value_between(
+                expr_exprs, low_exprs, high_exprs, negated, symmetric, row,
+            );
+        }
+
         let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
 
         // Get effective collation: explicit COLLATE or column-level collation
@@ -725,6 +739,93 @@ impl ExpressionEvaluator<'_> {
                 Ok(vibesql_types::SqlValue::Null)
             } else {
                 Ok(vibesql_types::SqlValue::Boolean(negated))
+            }
+        }
+    }
+
+    /// Evaluate row value BETWEEN predicate
+    ///
+    /// `(a, b) BETWEEN (low_a, low_b) AND (high_a, high_b)`
+    /// is equivalent to: `(a, b) >= (low_a, low_b) AND (a, b) <= (high_a, high_b)`
+    ///
+    /// NULL handling follows the standard row value comparison semantics.
+    fn eval_row_value_between(
+        &self,
+        expr_exprs: &[vibesql_ast::Expression],
+        low_exprs: &[vibesql_ast::Expression],
+        high_exprs: &[vibesql_ast::Expression],
+        negated: bool,
+        symmetric: bool,
+        row: &vibesql_storage::Row,
+    ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        use vibesql_types::SqlValue;
+
+        // Row values must have the same number of elements
+        if expr_exprs.len() != low_exprs.len() || expr_exprs.len() != high_exprs.len() {
+            return Err(ExecutorError::UnsupportedExpression(format!(
+                "Row value constructor size mismatch in BETWEEN: expr has {} elements, low has {}, high has {}",
+                expr_exprs.len(),
+                low_exprs.len(),
+                high_exprs.len()
+            )));
+        }
+
+        if expr_exprs.is_empty() {
+            return Err(ExecutorError::UnsupportedExpression(
+                "Empty row value constructors are not allowed".to_string(),
+            ));
+        }
+
+        // Determine effective bounds (swap if symmetric and low > high)
+        let (effective_low, effective_high) = if symmetric {
+            let gt_op = vibesql_ast::BinaryOperator::GreaterThan;
+            let low_gt_high =
+                self.eval_row_value_comparison(low_exprs, &gt_op, high_exprs, row)?;
+
+            if matches!(low_gt_high, SqlValue::Boolean(true)) {
+                (high_exprs, low_exprs) // Swap
+            } else {
+                (low_exprs, high_exprs)
+            }
+        } else {
+            (low_exprs, high_exprs)
+        };
+
+        if negated {
+            // NOT BETWEEN: expr < low OR expr > high
+            let lt_op = vibesql_ast::BinaryOperator::LessThan;
+            let gt_op = vibesql_ast::BinaryOperator::GreaterThan;
+
+            let lt_low =
+                self.eval_row_value_comparison(expr_exprs, &lt_op, effective_low, row)?;
+            let gt_high =
+                self.eval_row_value_comparison(expr_exprs, &gt_op, effective_high, row)?;
+
+            // OR logic with three-valued semantics
+            match (&lt_low, &gt_high) {
+                (SqlValue::Boolean(true), _) | (_, SqlValue::Boolean(true)) => {
+                    Ok(SqlValue::Boolean(true))
+                }
+                (SqlValue::Boolean(false), SqlValue::Boolean(false)) => Ok(SqlValue::Boolean(false)),
+                _ => Ok(SqlValue::Null),
+            }
+        } else {
+            // BETWEEN: expr >= low AND expr <= high
+            let ge_op = vibesql_ast::BinaryOperator::GreaterThanOrEqual;
+            let le_op = vibesql_ast::BinaryOperator::LessThanOrEqual;
+
+            let ge_low =
+                self.eval_row_value_comparison(expr_exprs, &ge_op, effective_low, row)?;
+            let le_high =
+                self.eval_row_value_comparison(expr_exprs, &le_op, effective_high, row)?;
+
+            // AND logic with three-valued semantics
+            match (&ge_low, &le_high) {
+                (SqlValue::Boolean(true), SqlValue::Boolean(true)) => Ok(SqlValue::Boolean(true)),
+                (SqlValue::Boolean(false), _) | (_, SqlValue::Boolean(false)) => {
+                    Ok(SqlValue::Boolean(false))
+                }
+                _ => Ok(SqlValue::Null),
             }
         }
     }

--- a/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
@@ -26,6 +26,11 @@ impl ExpressionEvaluator<'_> {
             "IN with subquery requires database reference".to_string(),
         ))?;
 
+        // Handle row value IN subquery: (a, b) IN (SELECT x, y FROM t)
+        if let vibesql_ast::Expression::RowValueConstructor(expr_elements) = expr {
+            return self.eval_row_value_in_subquery(expr_elements, subquery, negated, row, database);
+        }
+
         let expr_val = self.eval(expr, row)?;
 
         // Convert TableSchema to CombinedSchema for outer context
@@ -426,6 +431,172 @@ impl ExpressionEvaluator<'_> {
                 Self::eval_binary_op_static(left, op, right, vibesql_types::SqlMode::default())
             },
         )
+    }
+
+    /// Evaluate row value IN subquery: (a, b) IN (SELECT x, y FROM t)
+    ///
+    /// SQL:1999 Section 8.4: Row value IN predicate
+    /// A row value matches if it equals any row from the subquery.
+    fn eval_row_value_in_subquery(
+        &self,
+        expr_elements: &[vibesql_ast::Expression],
+        subquery: &vibesql_ast::SelectStmt,
+        negated: bool,
+        row: &vibesql_storage::Row,
+        database: &vibesql_storage::Database,
+    ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        use vibesql_types::SqlValue;
+
+        let expected_columns = expr_elements.len();
+
+        // Evaluate all elements of the left row value
+        let mut expr_values = Vec::with_capacity(expected_columns);
+        let mut has_null_element = false;
+
+        for elem_expr in expr_elements {
+            let val = self.eval(elem_expr, row)?;
+            if matches!(val, SqlValue::Null) {
+                has_null_element = true;
+            }
+            expr_values.push(val);
+        }
+
+        // Convert TableSchema to CombinedSchema for outer context
+        let table_name_for_outer = self
+            .table_alias
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(|| self.schema.name.clone());
+        let outer_combined =
+            crate::schema::CombinedSchema::from_table(table_name_for_outer, self.schema.clone());
+
+        // Check if this is a correlated subquery
+        let is_correlated = crate::correlation::is_correlated(subquery, &outer_combined);
+
+        // Execute the subquery
+        let rows = if !is_correlated {
+            let cache_key = compute_subquery_hash(subquery);
+            let cached_result = self.subquery_cache.borrow().peek(&cache_key).cloned();
+
+            if let Some(cached_rows) = cached_result {
+                cached_rows
+            } else {
+                let select_executor = if let Some(cte_ctx) = self.cte_context {
+                    crate::select::SelectExecutor::new_with_cte_and_depth(database, cte_ctx, self.depth)
+                } else {
+                    crate::select::SelectExecutor::new_with_depth(database, self.depth)
+                };
+                let executed_rows = select_executor.execute(subquery)?;
+                self.subquery_cache.borrow_mut().put(cache_key, executed_rows.clone());
+                executed_rows
+            }
+        } else {
+            let select_executor = if let Some(cte_ctx) = self.cte_context {
+                crate::select::SelectExecutor::new_with_cte_and_depth(database, cte_ctx, self.depth)
+            } else {
+                crate::select::SelectExecutor::new_with_outer_context_and_depth(
+                    database,
+                    row,
+                    &outer_combined,
+                    self.depth,
+                )
+            };
+            select_executor.execute(subquery)?
+        };
+
+        // Validate column count
+        let column_count = if !rows.is_empty() {
+            rows[0].values.len()
+        } else {
+            crate::evaluator::combined::subqueries::schema_utils::compute_select_list_column_count(
+                subquery,
+                database,
+                self.cte_context,
+            )?
+        };
+
+        if column_count != expected_columns {
+            return Err(ExecutorError::SubqueryColumnCountMismatch {
+                expected: expected_columns,
+                actual: column_count,
+            });
+        }
+
+        // Empty subquery result
+        if rows.is_empty() {
+            return Ok(SqlValue::Boolean(negated));
+        }
+
+        // If the row value has a NULL element, handle specially
+        // NULL IN (empty set) → FALSE, but we already handled empty set above
+        // NULL IN (non-empty set) → depends on matches
+
+        let mut found_null_in_subquery = false;
+
+        // Compare with each row from subquery
+        for subquery_row in &rows {
+            // Check if this row matches using row value equality
+            let mut all_equal = true;
+            let mut has_null_comparison = false;
+
+            for (i, expr_val) in expr_values.iter().enumerate() {
+                let subquery_val = subquery_row
+                    .get(i)
+                    .ok_or(ExecutorError::ColumnIndexOutOfBounds { index: i })?;
+
+                // Check for NULL
+                if matches!(expr_val, SqlValue::Null) || matches!(subquery_val, SqlValue::Null) {
+                    has_null_comparison = true;
+                    if matches!(subquery_val, SqlValue::Null) {
+                        found_null_in_subquery = true;
+                    }
+                    // Can't determine equality with NULL - continue to check other elements
+                    continue;
+                }
+
+                // Compare values
+                let eq_result = self.eval_binary_op(
+                    expr_val,
+                    &vibesql_ast::BinaryOperator::Equal,
+                    subquery_val,
+                )?;
+
+                match eq_result {
+                    SqlValue::Boolean(true) => {
+                        // Elements are equal, continue checking
+                    }
+                    SqlValue::Boolean(false) => {
+                        // Elements differ, this row doesn't match
+                        all_equal = false;
+                        break;
+                    }
+                    SqlValue::Null => {
+                        // Comparison returned NULL
+                        has_null_comparison = true;
+                    }
+                    _ => {
+                        return Err(ExecutorError::TypeError(format!(
+                            "Comparison returned non-boolean: {:?}",
+                            eq_result
+                        )));
+                    }
+                }
+            }
+
+            if all_equal && !has_null_comparison {
+                // Found a match!
+                return Ok(SqlValue::Boolean(!negated));
+            }
+        }
+
+        // No exact match found
+        if has_null_element || found_null_in_subquery {
+            // NULL in either side means result is NULL (unless we found an exact match above)
+            Ok(SqlValue::Null)
+        } else {
+            // No match found
+            Ok(SqlValue::Boolean(negated))
+        }
     }
 }
 

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3038,7 +3038,6 @@ variable vibesql_skip_patterns {
     {altertab3- "ALTER TABLE features differ"}
     {alterlegacy- "ALTER TABLE legacy tests differ"}
     {rowid- "ROWID behavior differs"}
-    {rowvalue- "Row value behavior differs"}
     {without_rowid1- "WITHOUT ROWID tables not fully supported"}
     {without_rowid2- "WITHOUT ROWID tables not fully supported"}
     {without_rowid5- "WITHOUT ROWID tables not fully supported"}


### PR DESCRIPTION
## Summary
- Implements SQL:1999 row value constructor comparisons
- Row value equality/inequality: `(a, b) = (1, 2)`, `(a, b) <> (c, d)`
- Row value ordering: `(a, b) < (c, d)`, `(a, b) >= (c, d)`
- Row value IS/IS NOT: `(a, b) IS (c, d)` with NULL-safe semantics
- Row value BETWEEN: `(a, b) BETWEEN (low_a, low_b) AND (high_a, high_b)`
- Row value IN with subquery: `(a, b) IN (SELECT x, y FROM t)`

## Test plan
- [x] All Rust unit tests pass (`cargo test --release`)
- [x] rowvalue.test TCL tests enabled (176/298 pass, 59%)
- [x] Manual testing of row value operations

## Implementation details

### Files changed:
- `crates/vibesql-executor/src/evaluator/expressions/eval.rs`: Add `eval_row_value_is_distinct()` for IS/IS NOT
- `crates/vibesql-executor/src/evaluator/expressions/predicates.rs`: Add `eval_row_value_between()` for BETWEEN
- `crates/vibesql-executor/src/evaluator/expressions/subqueries.rs`: Add `eval_row_value_in_subquery()` for IN
- `scripts/tester_vibesql.tcl`: Remove rowvalue- skip pattern to enable tests

### Remaining work (future issues):
- Multi-column scalar subqueries used as row values: `(SELECT x, y) = (SELECT a, b)`
- Row value comparisons in WHERE clause query optimization
- UPDATE SET (a, b) = ... syntax

Closes #4956

🤖 Generated with [Claude Code](https://claude.com/claude-code)