### PR TITLE
feat(update): implement UPDATE FROM (multi-table UPDATE) syntax

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -675,6 +675,9 @@ impl<'a, 'arena> Converter<'a, 'arena> {
             quoted: stmt.quoted,
             alias: stmt.alias.map(|a| self.resolve(a)),
             assignments: stmt.assignments.iter().map(|a| self.convert_assignment(a)).collect(),
+            from_clause: stmt.from_clause.as_ref().map(|froms| {
+                froms.iter().map(|f| self.convert_from_clause(f)).collect()
+            }),
             where_clause: stmt.where_clause.as_ref().map(|wc| self.convert_where_clause(wc)),
             conflict_clause: stmt.conflict_clause.map(ConflictClause::from),
         }

--- a/crates/vibesql-ast/src/arena/dml.rs
+++ b/crates/vibesql-ast/src/arena/dml.rs
@@ -7,7 +7,7 @@ use bumpalo::collections::Vec as BumpVec;
 use super::{
     expression::Expression,
     interner::Symbol,
-    select::{CommonTableExpr, SelectStmt},
+    select::{CommonTableExpr, FromClause, SelectStmt},
 };
 
 // ============================================================================
@@ -146,6 +146,10 @@ pub struct UpdateStmt<'arena> {
     /// Optional table alias (SQLite extension: UPDATE t1 AS xyz SET ...)
     pub alias: Option<Symbol>,
     pub assignments: BumpVec<'arena, Assignment<'arena>>,
+    /// Optional FROM clause for multi-table UPDATE (SQLite 3.33.0+ / SQL:1999)
+    /// Syntax: UPDATE t1 SET col = t2.val FROM t2 WHERE t1.id = t2.id
+    /// See: <https://www.sqlite.org/lang_update.html#update_from>
+    pub from_clause: Option<BumpVec<'arena, FromClause<'arena>>>,
     pub where_clause: Option<WhereClause<'arena>>,
     /// Optional conflict resolution clause (SQLite extension)
     /// Syntax: UPDATE OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL table SET ...

--- a/crates/vibesql-ast/src/dml.rs
+++ b/crates/vibesql-ast/src/dml.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains INSERT, UPDATE, and DELETE statement types.
 
-use crate::{CommonTableExpr, Expression, SelectStmt};
+use crate::{CommonTableExpr, Expression, FromClause, SelectStmt};
 
 // ============================================================================
 // INSERT Statement
@@ -151,6 +151,10 @@ pub struct UpdateStmt {
     /// Optional table alias (SQLite extension: UPDATE t1 AS xyz SET ...)
     pub alias: Option<String>,
     pub assignments: Vec<Assignment>,
+    /// Optional FROM clause for multi-table UPDATE (SQLite 3.33.0+ / SQL:1999)
+    /// Syntax: UPDATE t1 SET col = t2.val FROM t2 WHERE t1.id = t2.id
+    /// See: <https://www.sqlite.org/lang_update.html#update_from>
+    pub from_clause: Option<Vec<FromClause>>,
     pub where_clause: Option<WhereClause>,
     /// Optional conflict resolution clause (SQLite extension)
     /// Syntax: UPDATE OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL table SET ...

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1062,6 +1062,12 @@ fn walk_update<V: ExpressionVisitor>(visitor: &mut V, stmt: &UpdateStmt) {
             return;
         }
     }
+    // Walk FROM clause (UPDATE FROM syntax)
+    if let Some(froms) = &stmt.from_clause {
+        for from in froms {
+            walk_from_clause(visitor, from);
+        }
+    }
     if let Some(WhereClause::Condition(expr)) = &stmt.where_clause {
         walk_expression(visitor, expr);
     }
@@ -1329,6 +1335,9 @@ pub fn transform_update<V: ExpressionMutVisitor>(visitor: &mut V, stmt: UpdateSt
             .into_iter()
             .map(|a| Assignment { column: a.column, value: transform_expression(visitor, a.value) })
             .collect(),
+        from_clause: stmt.from_clause.map(|froms| {
+            froms.into_iter().map(|f| transform_from_clause(visitor, f)).collect()
+        }),
         where_clause: stmt.where_clause.map(|w| match w {
             WhereClause::Condition(expr) => {
                 WhereClause::Condition(transform_expression(visitor, expr))

--- a/crates/vibesql-executor/benches/sysbench_benchmark.rs
+++ b/crates/vibesql-executor/benches/sysbench_benchmark.rs
@@ -195,6 +195,7 @@ fn bind_update(stmt: &UpdateStmt, params: &[SqlValue]) -> UpdateStmt {
                 value: bind_expression(&a.value, params),
             })
             .collect(),
+        from_clause: stmt.from_clause.clone(), // UPDATE FROM not used in sysbench
         where_clause: bind_where_clause(&stmt.where_clause, params),
         conflict_clause: stmt.conflict_clause.clone(),
     }

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -60,6 +60,7 @@ fn test_after_update_trigger_fires() {
                 arcstr::ArcStr::from("alice_updated"),
             )),
         }],
+        from_clause: None,
         where_clause: Some(vibesql_ast::WhereClause::Condition(
             vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Equal,
@@ -131,6 +132,7 @@ fn test_before_update_trigger_fires() {
                 arcstr::ArcStr::from("alice_updated"),
             )),
         }],
+        from_clause: None,
         where_clause: Some(vibesql_ast::WhereClause::Condition(
             vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Equal,

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -24,6 +24,7 @@ use super::{
     constraints::ConstraintValidator,
     fast_path,
     foreign_keys::ForeignKeyValidator,
+    from_clause::{apply_update_from_matches, execute_update_from_join},
     index_sync::{
         find_conflicting_rows_for_update, resolve_cross_update_conflicts_for_replace,
         validate_cross_update_uniqueness,
@@ -162,7 +163,26 @@ pub(super) fn execute_internal(
     // SQLite validates expressions at preparation time, not execution time.
     // This ensures errors like "no such column: x" are raised even when
     // no rows match the WHERE clause.
-    validate_set_expressions(schema, &stmt.assignments, database)?;
+    // Note: Skip validation for UPDATE FROM since the SET expressions can reference
+    // columns from the FROM tables, which will be validated during synthetic SELECT.
+    if stmt.from_clause.is_none() {
+        validate_set_expressions(schema, &stmt.assignments, database)?;
+    }
+
+    // Step 3.6: Handle UPDATE FROM (multi-table UPDATE) if FROM clause is present
+    // This uses a completely different code path that builds a synthetic SELECT
+    // to join tables and compute SET values in the joined context.
+    if let Some(ref from_clauses) = stmt.from_clause {
+        return execute_update_from(
+            stmt,
+            from_clauses,
+            database,
+            schema,
+            table_name,
+            has_triggers,
+            &pk_indices,
+        );
+    }
 
     // Step 4: Select rows to update using RowSelector
     let row_selector = RowSelector::new(schema);
@@ -1017,4 +1037,167 @@ fn apply_generated_columns_for_update(
     }
 
     Ok(())
+}
+
+/// Execute UPDATE FROM (multi-table UPDATE) - SQLite 3.33.0+ syntax
+///
+/// This handles UPDATE statements with FROM clause that join other tables:
+/// ```sql
+/// UPDATE t1 SET col = t2.val FROM t2 WHERE t1.id = t2.id;
+/// ```
+///
+/// The implementation:
+/// 1. Builds a synthetic SELECT joining target table with FROM tables
+/// 2. Computes SET expression values in the joined context
+/// 3. Applies the pre-computed values to target rows
+fn execute_update_from(
+    stmt: &UpdateStmt,
+    from_clauses: &[vibesql_ast::FromClause],
+    database: &mut Database,
+    schema: &vibesql_catalog::TableSchema,
+    table_name: &str,
+    has_triggers: bool,
+    pk_indices: &Option<Vec<usize>>,
+) -> Result<usize, ExecutorError> {
+    // Execute the join and get matched rows with computed SET values
+    let join_result = execute_update_from_join(stmt, from_clauses, database, schema)?;
+
+    // Fire BEFORE STATEMENT triggers if needed
+    if has_triggers {
+        crate::TriggerFirer::execute_before_statement_triggers(
+            database,
+            table_name,
+            vibesql_ast::TriggerEvent::Update(None),
+        )?;
+    }
+
+    // Convert join results to update operations
+    let updates = apply_update_from_matches(&join_result.matched_rows, &stmt.assignments, schema)?;
+
+    if updates.is_empty() {
+        // Fire AFTER STATEMENT triggers even when no rows matched
+        if has_triggers {
+            crate::TriggerFirer::execute_after_statement_triggers(
+                database,
+                table_name,
+                vibesql_ast::TriggerEvent::Update(None),
+            )?;
+        }
+        return Ok(0);
+    }
+
+    // Validate constraints for each update
+    let table = database
+        .get_table(table_name)
+        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+    let constraint_validator = ConstraintValidator::new(schema);
+
+    for (row_index, old_row, new_row, _changed_columns, _updates_pk) in &updates {
+        // Validate all constraints
+        constraint_validator.validate_row(table, table_name, *row_index, new_row, old_row)?;
+        constraint_validator.validate_unique_indexes(database, table_name, new_row, old_row)?;
+
+        // Validate foreign key constraints
+        if !schema.foreign_keys.is_empty() {
+            ForeignKeyValidator::validate_constraints(database, table_name, &new_row.values)?;
+        }
+    }
+
+    // Cross-update uniqueness validation
+    if updates.len() > 1 {
+        validate_cross_update_uniqueness(&updates, schema)?;
+    }
+
+    // Handle CASCADE updates for primary key changes
+    for (_row_index, old_row, new_row, _changed_columns, updates_pk) in &updates {
+        if *updates_pk {
+            ForeignKeyValidator::check_no_child_references(database, table_name, old_row, new_row)?;
+        }
+    }
+
+    // Fire BEFORE UPDATE triggers
+    if has_triggers {
+        for (_row_index, old_row, new_row, _changed_columns, _updates_pk) in &updates {
+            crate::TriggerFirer::execute_before_triggers(
+                database,
+                table_name,
+                vibesql_ast::TriggerEvent::Update(None),
+                Some(old_row),
+                Some(new_row),
+            )?;
+        }
+    }
+
+    // Apply all updates
+    let update_count = updates.len();
+    let table_mut = database
+        .get_table_mut(table_name)
+        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+
+    let mut index_updates = Vec::new();
+    for (index, old_row, new_row, changed_columns, _updates_pk) in &updates {
+        table_mut
+            .update_row_selective(*index, new_row.clone(), changed_columns)
+            .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+
+        index_updates.push((*index, old_row.clone(), new_row.clone(), changed_columns.clone()));
+    }
+
+    // Fire AFTER UPDATE triggers
+    if has_triggers {
+        for (_index, old_row, new_row, _changed_columns) in &index_updates {
+            crate::TriggerFirer::execute_after_triggers(
+                database,
+                table_name,
+                vibesql_ast::TriggerEvent::Update(None),
+                Some(old_row),
+                Some(new_row),
+            )?;
+        }
+    }
+
+    // Update indexes
+    for (index, old_row, new_row, changed_columns) in index_updates {
+        database.update_indexes_for_update(
+            table_name,
+            &old_row,
+            &new_row,
+            index,
+            Some(&changed_columns),
+        );
+
+        expression_index_maintenance::maintain_expression_indexes_for_update(
+            database,
+            table_name,
+            &old_row,
+            &new_row,
+            index,
+        );
+    }
+
+    // Invalidate columnar cache
+    if update_count > 0 {
+        database.invalidate_columnar_cache(table_name);
+    }
+
+    // Fire AFTER STATEMENT triggers
+    if has_triggers {
+        crate::TriggerFirer::execute_after_statement_triggers(
+            database,
+            table_name,
+            vibesql_ast::TriggerEvent::Update(None),
+        )?;
+    }
+
+    // Check assertions
+    if let Err(assertion_error) =
+        crate::advanced_objects::AssertionChecker::check_all_assertions(database)
+    {
+        return Err(assertion_error);
+    }
+
+    // Mark pk_indices as used (it's available for future enhancements)
+    let _ = pk_indices;
+
+    Ok(update_count)
 }

--- a/crates/vibesql-executor/src/update/from_clause.rs
+++ b/crates/vibesql-executor/src/update/from_clause.rs
@@ -1,0 +1,361 @@
+//! UPDATE FROM clause handling
+//!
+//! This module implements SQLite's UPDATE FROM syntax (added in SQLite 3.33.0),
+//! which allows multi-table UPDATE statements:
+//!
+//! ```sql
+//! UPDATE t1 SET col = t2.val FROM t2 WHERE t1.id = t2.id;
+//! ```
+//!
+//! The FROM clause specifies additional tables to join with the target table.
+//! Values from these tables can be used in both SET expressions and WHERE clause.
+
+use std::collections::{HashMap, HashSet};
+
+use vibesql_ast::{
+    Assignment, ColumnIdentifier, Expression, FromClause, JoinType, SelectItem, SelectStmt,
+    UpdateStmt, WhereClause,
+};
+use vibesql_catalog::TableSchema;
+use vibesql_storage::{Database, Row};
+use vibesql_types::SqlValue;
+
+use crate::errors::ExecutorError;
+
+/// Result of executing the join between target table and FROM tables
+pub struct UpdateFromJoinResult {
+    /// Target table row index and the computed SET values for each matched row
+    pub matched_rows: Vec<UpdateFromMatch>,
+}
+
+/// A single matched row from the UPDATE FROM join
+pub struct UpdateFromMatch {
+    /// Physical row index in the target table
+    pub row_index: usize,
+    /// Original row from target table
+    pub target_row: Row,
+    /// Computed values for each SET assignment (in order)
+    pub set_values: Vec<SqlValue>,
+}
+
+/// Execute the join for UPDATE FROM and return matched rows with computed SET values
+///
+/// This builds and executes a synthetic SELECT that:
+/// 1. Joins the target table with all FROM tables
+/// 2. Computes SET expression values as part of the SELECT
+/// 3. Returns the target row index and computed values for each match
+pub fn execute_update_from_join(
+    stmt: &UpdateStmt,
+    from_clauses: &[FromClause],
+    database: &Database,
+    target_schema: &TableSchema,
+) -> Result<UpdateFromJoinResult, ExecutorError> {
+    let target_table_name = &target_schema.name;
+    let target_alias = stmt.alias.clone();
+    let target_prefix = target_alias.clone().unwrap_or_else(|| target_table_name.clone());
+
+    // Determine how to identify target rows:
+    // - For WITHOUT ROWID tables: use PRIMARY KEY columns
+    // - For regular tables: use rowid
+    let pk_columns = get_pk_column_names(target_schema);
+    let use_rowid = !target_schema.without_rowid && pk_columns.is_empty();
+
+    // Build SELECT list:
+    // 1. Target table identifier columns (rowid or PK columns)
+    // 2. Each SET expression value (computed using joined context)
+    let mut select_list = Vec::new();
+    let num_id_columns: usize;
+
+    if use_rowid {
+        // Use rowid for regular tables
+        select_list.push(SelectItem::Expression {
+            expr: Expression::ColumnRef(ColumnIdentifier::qualified(
+                &target_prefix,
+                false,
+                "rowid",
+                false,
+            )),
+            alias: Some("__target_rowid__".to_string()),
+            source_text: None,
+        });
+        num_id_columns = 1;
+    } else {
+        // Use PRIMARY KEY columns for WITHOUT ROWID tables or tables with explicit PK
+        for (i, pk_col) in pk_columns.iter().enumerate() {
+            select_list.push(SelectItem::Expression {
+                expr: Expression::ColumnRef(ColumnIdentifier::qualified(
+                    &target_prefix,
+                    false,
+                    pk_col,
+                    false,
+                )),
+                alias: Some(format!("__target_pk_{}__", i)),
+                source_text: None,
+            });
+        }
+        num_id_columns = pk_columns.len();
+    }
+
+    // Add each SET expression to be computed in the join context
+    for (i, assignment) in stmt.assignments.iter().enumerate() {
+        select_list.push(SelectItem::Expression {
+            expr: assignment.value.clone(),
+            alias: Some(format!("__set_{}__", i)),
+            source_text: None,
+        });
+    }
+
+    // Build FROM clause: target_table [alias], from_clause1, from_clause2, ...
+    let target_from = FromClause::Table {
+        name: target_table_name.clone(),
+        alias: target_alias,
+        column_aliases: None,
+        quoted: stmt.quoted,
+    };
+
+    // Combine the target table with FROM clauses
+    // For JOIN-type FROM clauses, we need to extract the leftmost table and
+    // cross-join with target, then reattach the rest of the join structure.
+    // This ensures `t5, m1 LEFT JOIN m2` behaves as `(t5 CROSS JOIN m1) LEFT JOIN m2`
+    let mut combined_from = target_from;
+    for from_clause in from_clauses {
+        combined_from = combine_with_from_clause(combined_from, from_clause.clone());
+    }
+
+    // Build WHERE clause from UPDATE's WHERE clause
+    let where_clause = stmt.where_clause.as_ref().and_then(|wc| match wc {
+        WhereClause::Condition(expr) => Some(expr.clone()),
+        WhereClause::CurrentOf(_) => None, // Not supported with UPDATE FROM
+    });
+
+    // Build the synthetic SELECT statement
+    let select_stmt = SelectStmt {
+        with_clause: stmt.with_clause.clone(),
+        select_list,
+        distinct: false,
+        into_table: None,
+        into_variables: None,
+        from: Some(combined_from),
+        where_clause,
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+        set_operation: None,
+        values: None,
+    };
+
+    // Execute the SELECT
+    let executor = crate::SelectExecutor::new(database);
+    let rows = executor.execute(&select_stmt)?;
+
+    // Build a map from identifier values to SET values
+    // Key: either rowid (as single-element vec) or PK column values
+    let num_assignments = stmt.assignments.len();
+    let mut id_to_set_values: HashMap<Vec<SqlValue>, Vec<SqlValue>> = HashMap::new();
+
+    for row in rows {
+        // Extract identifier values (first num_id_columns values)
+        let id_values: Vec<SqlValue> = row.values[..num_id_columns].to_vec();
+
+        // Skip NULL identifiers
+        if id_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+            continue;
+        }
+
+        // Only keep first match per identifier (SQLite semantics)
+        if id_to_set_values.contains_key(&id_values) {
+            continue;
+        }
+
+        // Extract SET values
+        let set_values: Vec<SqlValue> = (0..num_assignments)
+            .map(|i| {
+                row.values
+                    .get(num_id_columns + i)
+                    .cloned()
+                    .unwrap_or(SqlValue::Null)
+            })
+            .collect();
+
+        id_to_set_values.insert(id_values, set_values);
+    }
+
+    // Now scan the target table to find matching rows
+    let target_table = database
+        .get_table(target_table_name)
+        .ok_or_else(|| ExecutorError::TableNotFound(target_table_name.clone()))?;
+
+    let mut matched_rows = Vec::new();
+
+    // Get PK column indices for lookup
+    let pk_indices: Vec<usize> = if use_rowid {
+        vec![] // Not used when using rowid
+    } else {
+        pk_columns
+            .iter()
+            .filter_map(|name| target_schema.get_column_index(name))
+            .collect()
+    };
+
+    for (row_index, target_row) in target_table.scan().iter().enumerate() {
+        // Build identifier for this row
+        let id_values: Vec<SqlValue> = if use_rowid {
+            // Use the row's rowid
+            let rowid = target_row
+                .row_id
+                .map(|id| SqlValue::Integer(id as i64))
+                .unwrap_or_else(|| SqlValue::Integer((row_index + 1) as i64));
+            vec![rowid]
+        } else {
+            // Use PK column values
+            pk_indices
+                .iter()
+                .map(|&idx| target_row.get(idx).cloned().unwrap_or(SqlValue::Null))
+                .collect()
+        };
+
+        // Check if this row matches any from the join result
+        if let Some(set_values) = id_to_set_values.remove(&id_values) {
+            matched_rows.push(UpdateFromMatch {
+                row_index,
+                target_row: target_row.clone(),
+                set_values,
+            });
+        }
+    }
+
+    Ok(UpdateFromJoinResult { matched_rows })
+}
+
+/// Get the PRIMARY KEY column names for a table
+fn get_pk_column_names(schema: &TableSchema) -> Vec<String> {
+    // Primary key is stored as Option<Vec<String>> in TableSchema
+    schema.primary_key.clone().unwrap_or_default()
+}
+
+/// Combine the accumulated FROM clause with a new FROM clause
+///
+/// For simple tables, this creates a CROSS JOIN.
+/// For JOIN-type FROM clauses, this extracts the leftmost table, cross-joins with it,
+/// then reattaches the rest of the join structure. This matches SQLite's parsing
+/// of comma-separated FROM items: `t1, t2 LEFT JOIN t3` = `(t1 CROSS JOIN t2) LEFT JOIN t3`
+fn combine_with_from_clause(accumulated: FromClause, from_clause: FromClause) -> FromClause {
+    match from_clause {
+        // For a simple table, just cross join
+        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => {
+            FromClause::Join {
+                left: Box::new(accumulated),
+                right: Box::new(from_clause),
+                join_type: JoinType::Cross,
+                condition: None,
+                using_columns: None,
+                natural: false,
+                alias: None,
+            }
+        }
+        // For a JOIN, we need to inject the accumulated clause on the left side
+        FromClause::Join {
+            left,
+            right,
+            join_type,
+            condition,
+            using_columns,
+            natural,
+            alias,
+        } => {
+            // Recursively combine with the left side of the join
+            let new_left = combine_with_from_clause(accumulated, *left);
+            FromClause::Join {
+                left: Box::new(new_left),
+                right,
+                join_type,
+                condition,
+                using_columns,
+                natural,
+                alias,
+            }
+        }
+    }
+}
+
+/// Apply UPDATE FROM matches to build update operations
+///
+/// Takes the matched rows with pre-computed SET values and creates
+/// (row_index, old_row, new_row, changed_columns) tuples for the executor.
+pub fn apply_update_from_matches(
+    matches: &[UpdateFromMatch],
+    assignments: &[Assignment],
+    target_schema: &TableSchema,
+) -> Result<Vec<(usize, Row, Row, HashSet<usize>, bool)>, ExecutorError> {
+    let pk_indices = target_schema.get_primary_key_indices();
+    let mut updates = Vec::with_capacity(matches.len());
+
+    for m in matches {
+        let mut new_row = m.target_row.clone();
+        let mut changed_columns = HashSet::new();
+        let mut updates_pk = false;
+
+        for (i, assignment) in assignments.iter().enumerate() {
+            // Handle rowid assignment specially
+            let col_name_lower = assignment.column.to_lowercase();
+            let is_rowid =
+                col_name_lower == "rowid" || col_name_lower == "_rowid_" || col_name_lower == "oid";
+
+            if is_rowid {
+                // Handle rowid update
+                if let Some(ipk_col_idx) = target_schema.rowid_alias_column {
+                    new_row
+                        .set(ipk_col_idx, m.set_values[i].clone())
+                        .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+                    changed_columns.insert(ipk_col_idx);
+                    if pk_indices.as_ref().is_some_and(|pk| pk.contains(&ipk_col_idx)) {
+                        updates_pk = true;
+                    }
+                } else {
+                    // Update virtual rowid
+                    let new_rowid = match &m.set_values[i] {
+                        SqlValue::Integer(id) => *id as u64,
+                        SqlValue::Bigint(id) => *id as u64,
+                        other => {
+                            return Err(ExecutorError::UnsupportedExpression(format!(
+                                "ROWID must be an integer, got {:?}",
+                                other
+                            )));
+                        }
+                    };
+                    new_row.row_id = Some(new_rowid);
+                }
+                continue;
+            }
+
+            // Find column index
+            let col_index = target_schema.get_column_index(&assignment.column).ok_or_else(|| {
+                ExecutorError::NoSuchColumn { column_ref: assignment.column.clone() }
+            })?;
+
+            // Coerce value to column type
+            let coerced_value = crate::insert::validation::coerce_value(
+                m.set_values[i].clone(),
+                &target_schema.columns[col_index].data_type,
+            )?;
+
+            new_row
+                .set(col_index, coerced_value)
+                .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+            changed_columns.insert(col_index);
+
+            // Check if this column is part of primary key
+            if let Some(ref pk) = pk_indices {
+                if pk.contains(&col_index) {
+                    updates_pk = true;
+                }
+            }
+        }
+
+        updates.push((m.row_index, m.target_row.clone(), new_row, changed_columns, updates_pk));
+    }
+
+    Ok(updates)
+}

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -27,6 +27,7 @@ mod constraints;
 mod executor;
 mod fast_path;
 mod foreign_keys;
+mod from_clause;
 mod index_sync;
 mod row_selector;
 mod triggers;
@@ -93,6 +94,7 @@ impl UpdateExecutor {
     ///         column: "salary".to_string(),
     ///         value: Expression::Literal(SqlValue::Integer(60000)),
     ///     }],
+    ///     from_clause: None,
     ///     where_clause: None,
     ///     conflict_clause: None,
     /// };

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -490,7 +490,7 @@ impl<'arena> ArenaParser<'arena> {
     }
 
     /// Parse FROM clause.
-    fn parse_from_clause(&mut self) -> Result<FromClause<'arena>, ParseError> {
+    pub(crate) fn parse_from_clause(&mut self) -> Result<FromClause<'arena>, ParseError> {
         let mut from = self.parse_table_reference()?;
 
         // Parse JOINs

--- a/crates/vibesql-parser/src/arena_parser/update.rs
+++ b/crates/vibesql-parser/src/arena_parser/update.rs
@@ -84,6 +84,21 @@ impl<'arena> ArenaParser<'arena> {
         // Parse assignments
         let assignments = self.parse_assignments()?;
 
+        // Parse optional FROM clause (SQLite 3.33.0+ UPDATE FROM syntax)
+        // Syntax: UPDATE t1 SET col = t2.val FROM t2 [, t3 ...] WHERE ...
+        let from_clause = if self.try_consume_keyword(Keyword::From) {
+            let mut froms = BumpVec::new_in(self.arena);
+            loop {
+                froms.push(self.parse_from_clause()?);
+                if !self.try_consume(&Token::Comma) {
+                    break;
+                }
+            }
+            Some(froms)
+        } else {
+            None
+        };
+
         // Parse optional WHERE clause
         let where_clause = if self.try_consume_keyword(Keyword::Where) {
             // Check for WHERE CURRENT OF cursor_name
@@ -110,7 +125,7 @@ impl<'arena> ArenaParser<'arena> {
         // Consume optional semicolon
         self.try_consume(&Token::Semicolon);
 
-        let stmt = UpdateStmt { with_clause: None, table_name, quoted, alias, assignments, where_clause, conflict_clause };
+        let stmt = UpdateStmt { with_clause: None, table_name, quoted, alias, assignments, from_clause, where_clause, conflict_clause };
 
         Ok(self.arena.alloc(stmt))
     }

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -100,6 +100,24 @@ impl Parser {
             }
         }
 
+        // Parse optional FROM clause (SQLite 3.33.0+ UPDATE FROM syntax)
+        // Syntax: UPDATE t1 SET col = t2.val FROM t2 [, t3 ...] WHERE ...
+        let from_clause = if self.peek_keyword(Keyword::From) {
+            self.consume_keyword(Keyword::From)?;
+            let mut froms = Vec::new();
+            loop {
+                froms.push(self.parse_from_clause()?);
+                if matches!(self.peek(), Token::Comma) {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+            Some(froms)
+        } else {
+            None
+        };
+
         // Parse optional WHERE clause
         let where_clause = if self.peek_keyword(Keyword::Where) {
             self.consume_keyword(Keyword::Where)?;
@@ -126,6 +144,7 @@ impl Parser {
             quoted,
             alias,
             assignments,
+            from_clause,
             where_clause,
             conflict_clause,
         })
@@ -222,6 +241,24 @@ impl Parser {
             }
         }
 
+        // Parse optional FROM clause (SQLite 3.33.0+ UPDATE FROM syntax)
+        // Syntax: UPDATE t1 SET col = t2.val FROM t2 [, t3 ...] WHERE ...
+        let from_clause = if self.peek_keyword(Keyword::From) {
+            self.consume_keyword(Keyword::From)?;
+            let mut froms = Vec::new();
+            loop {
+                froms.push(self.parse_from_clause()?);
+                if matches!(self.peek(), Token::Comma) {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+            Some(froms)
+        } else {
+            None
+        };
+
         // Parse optional WHERE clause
         let where_clause = if self.peek_keyword(Keyword::Where) {
             self.consume_keyword(Keyword::Where)?;
@@ -247,6 +284,7 @@ impl Parser {
             quoted,
             alias,
             assignments,
+            from_clause,
             where_clause,
             conflict_clause,
         })

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3047,9 +3047,6 @@ variable vibesql_skip_patterns {
     {types2- "Type handling differs"}
     {unique2- "UNIQUE constraint handling differs"}
     {utf16align- "UTF16 alignment test - encoding differs"}
-    {upfrom1- "UPDATE FROM not fully supported"}
-    {upfrom2- "UPDATE FROM not fully supported"}
-    {upfrom3- "UPDATE FROM not fully supported"}
     {subquery- "Subquery handling differs"}
     {resolver01- "Name resolution handling differs"}
     {table- "Table creation error messages differ"}


### PR DESCRIPTION
## Summary
- Implements SQLite 3.33.0's UPDATE FROM syntax for multi-table UPDATE statements
- Adds `from_clause` field to `UpdateStmt` AST in both heap and arena variants
- Parses FROM clause after SET assignments in UPDATE statements  
- Creates synthetic SELECT to evaluate SET expressions in joined context
- Supports WITHOUT ROWID tables, table aliases, and complex JOINs in FROM clause

## Test plan
- [x] All existing unit tests pass (2286 executor tests, 1224 parser tests)
- [x] upfrom1.test: 18/22 (82%) passing - failures are tuple assignment syntax (separate feature)
- [x] Cargo build succeeds
- [ ] Full CI suite

## Notes
- Tuple assignment syntax `SET (a, b) = (...)` is tracked separately - not part of UPDATE FROM
- Pre-existing clippy warning in `OnConflictAction` enum is unrelated to this change

Closes #4950

🤖 Generated with [Claude Code](https://claude.com/claude-code)