### PR TITLE
fix(without-rowid): enforce WITHOUT ROWID table constraints

### DIFF
--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -207,6 +207,13 @@ impl CreateTableExecutor {
         // Apply constraint results to schema (sets PK, unique, and check constraints)
         ConstraintValidator::apply_to_schema(&mut table_schema, &constraint_result);
 
+        // WITHOUT ROWID tables must have a PRIMARY KEY (SQLite requirement, Issue #4953)
+        if stmt.without_rowid && table_schema.primary_key.is_none() {
+            return Err(ExecutorError::ConstraintViolation(
+                "WITHOUT ROWID tables must have a PRIMARY KEY".to_string(),
+            ));
+        }
+
         // Detect INTEGER PRIMARY KEY for SQLite rowid aliasing (Issue #4536)
         // In SQLite, a single-column PRIMARY KEY with exactly "INTEGER" type is an alias for rowid.
         // The column's value IS the rowid, and SELECT rowid returns this column's value.

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -512,15 +512,52 @@ impl CombinedExpressionEvaluator<'_> {
 
                 // SQLite compatibility: Handle ROWID pseudo-column
                 // ROWID, _rowid_, and oid are aliases that return the row's unique identifier
+                // WITHOUT ROWID tables do NOT have the rowid pseudo-column (Issue #4953)
                 let column_lower = column.to_lowercase();
                 if column_lower == "rowid" || column_lower == "_rowid_" || column_lower == "oid" {
                     // First check if schema has a real column with this name
                     if self.get_column_index_cached(table, column).is_none() {
+                        // Check if the table is WITHOUT ROWID - if so, error
+                        let table_id = table.map(vibesql_catalog::TableIdentifier::from);
+                        if let Some(ref table_id) = table_id {
+                            if let Some((_, table_schema)) =
+                                self.schema.table_schemas.get(table_id)
+                            {
+                                if table_schema.without_rowid {
+                                    return Err(ExecutorError::ColumnNotFound {
+                                        column_name: column.to_string(),
+                                        table_name: table_id.display().to_string(),
+                                        searched_tables: vec![table_id.display().to_string()],
+                                        available_columns: table_schema
+                                            .columns
+                                            .iter()
+                                            .map(|c| c.name.clone())
+                                            .collect(),
+                                    });
+                                }
+                            }
+                        } else {
+                            // Unqualified rowid - check if any table in scope is WITHOUT ROWID
+                            for (tid, (_, table_schema)) in &self.schema.table_schemas {
+                                if table_schema.without_rowid {
+                                    return Err(ExecutorError::ColumnNotFound {
+                                        column_name: column.to_string(),
+                                        table_name: tid.display().to_string(),
+                                        searched_tables: self.schema.table_names(),
+                                        available_columns: table_schema
+                                            .columns
+                                            .iter()
+                                            .map(|c| c.name.clone())
+                                            .collect(),
+                                    });
+                                }
+                            }
+                        }
+
                         // Issue #4536: Check for INTEGER PRIMARY KEY alias column
                         // If the table has an INTEGER PRIMARY KEY, it acts as an alias for rowid.
                         // The column's value IS the rowid, so return that column's value.
                         // Look up the table's schema to find rowid_alias_column
-                        let table_id = table.map(vibesql_catalog::TableIdentifier::from);
                         if let Some(table_id) = table_id {
                             if let Some((start_idx, table_schema)) =
                                 self.schema.table_schemas.get(&table_id)

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -966,10 +966,26 @@ impl ExpressionEvaluator<'_> {
         // SQLite compatibility: Handle ROWID pseudo-column
         // ROWID, _rowid_, and oid are aliases that return the row's unique identifier
         // Note: We check real columns first - real columns take precedence over ROWID
+        // WITHOUT ROWID tables do NOT have the rowid pseudo-column (Issue #4953)
         let column_lower = column.to_lowercase();
         if column_lower == "rowid" || column_lower == "_rowid_" || column_lower == "oid" {
             // First check if schema has a real column with this name
             if self.schema.get_column_index(column).is_none() {
+                // WITHOUT ROWID tables do not have the rowid pseudo-column
+                if self.schema.without_rowid {
+                    return Err(ExecutorError::ColumnNotFound {
+                        column_name: column.to_string(),
+                        table_name: self.schema.name.clone(),
+                        searched_tables: vec![self.schema.name.clone()],
+                        available_columns: self
+                            .schema
+                            .columns
+                            .iter()
+                            .map(|c| c.name.clone())
+                            .collect(),
+                    });
+                }
+
                 // Issue #4536: Check for INTEGER PRIMARY KEY alias column
                 // If the table has an INTEGER PRIMARY KEY, it acts as an alias for rowid.
                 // The column's value IS the rowid, so return that column's value.

--- a/crates/vibesql-executor/src/select/executor/fast_path/helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path/helpers.rs
@@ -121,12 +121,31 @@ impl SelectExecutor<'_> {
                 if schema.get_column_index(table, column).is_none() {
                     // SQLite compatibility: Allow ROWID pseudo-column references
                     // Only if there's no actual column with that name (real columns take precedence)
+                    // WITHOUT ROWID tables do NOT have the rowid pseudo-column (Issue #4953)
                     let lower = column.to_lowercase();
                     let is_rowid_alias = lower == "rowid" || lower == "_rowid_" || lower == "oid";
                     if is_rowid_alias {
                         // Verify the qualifier matches a table in the schema (if qualified)
                         if let Some(qualifier) = table {
                             let qualifier_lower = qualifier.to_lowercase();
+                            // Check if the qualified table is a WITHOUT ROWID table
+                            for (table_id, (_, table_schema)) in &schema.table_schemas {
+                                if table_id.canonical() == qualifier_lower
+                                    && table_schema.without_rowid
+                                {
+                                    // WITHOUT ROWID tables do not have rowid pseudo-column
+                                    return Err(ExecutorError::ColumnNotFound {
+                                        column_name: column.to_string(),
+                                        table_name: qualifier.to_string(),
+                                        searched_tables: vec![qualifier.to_string()],
+                                        available_columns: table_schema
+                                            .columns
+                                            .iter()
+                                            .map(|c| c.name.clone())
+                                            .collect(),
+                                    });
+                                }
+                            }
                             let table_exists = schema
                                 .table_schemas
                                 .keys()
@@ -136,7 +155,23 @@ impl SelectExecutor<'_> {
                             }
                         } else {
                             // Unqualified ROWID is valid if there's at least one table in scope
+                            // AND none of the tables are WITHOUT ROWID
                             if !schema.table_schemas.is_empty() {
+                                // Check if any table in scope is WITHOUT ROWID
+                                for (table_id, (_, table_schema)) in &schema.table_schemas {
+                                    if table_schema.without_rowid {
+                                        return Err(ExecutorError::ColumnNotFound {
+                                            column_name: column.to_string(),
+                                            table_name: table_id.display().to_string(),
+                                            searched_tables: schema.table_names(),
+                                            available_columns: table_schema
+                                                .columns
+                                                .iter()
+                                                .map(|c| c.name.clone())
+                                                .collect(),
+                                        });
+                                    }
+                                }
                                 return Ok(());
                             }
                         }

--- a/crates/vibesql-executor/src/select/executor/validation/column_refs.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/column_refs.rs
@@ -206,10 +206,29 @@ pub fn validate_column_ref(
 
     // SQLite compatibility: Allow ROWID pseudo-column references
     // Only if there's no actual column with that name (real columns take precedence)
+    // WITHOUT ROWID tables do NOT have the rowid pseudo-column (Issue #4953)
     if is_rowid_pseudo_column(&col_ref.column) {
         // Verify the qualifier matches a table in the schema (if qualified)
         if let Some(ref qualifier) = col_ref.table {
             let qualifier_lower = qualifier.to_lowercase();
+
+            // Check if the qualified table is a WITHOUT ROWID table
+            for (table_id, (_, table_schema)) in &schema.table_schemas {
+                if table_id.canonical() == qualifier_lower && table_schema.without_rowid {
+                    // WITHOUT ROWID tables do not have rowid pseudo-column
+                    return Err(ExecutorError::ColumnNotFound {
+                        column_name: col_ref.column.clone(),
+                        table_name: qualifier.clone(),
+                        searched_tables: vec![qualifier.clone()],
+                        available_columns: table_schema
+                            .columns
+                            .iter()
+                            .map(|c| c.name.clone())
+                            .collect(),
+                    });
+                }
+            }
+
             let table_exists =
                 schema.table_schemas.keys().any(|k| k.canonical() == qualifier_lower);
             let table_in_outer = outer_schema.is_some_and(|outer| {
@@ -220,7 +239,28 @@ pub fn validate_column_ref(
             }
         } else {
             // Unqualified ROWID is valid if there's at least one table in scope
+            // AND none of the tables are WITHOUT ROWID
             if !schema.table_schemas.is_empty() {
+                // Check if any table in scope is WITHOUT ROWID
+                let has_without_rowid_table =
+                    schema.table_schemas.values().any(|(_, ts)| ts.without_rowid);
+                if has_without_rowid_table {
+                    // Get the first WITHOUT ROWID table for error message
+                    if let Some((table_id, (_, table_schema))) =
+                        schema.table_schemas.iter().find(|(_, (_, ts))| ts.without_rowid)
+                    {
+                        return Err(ExecutorError::ColumnNotFound {
+                            column_name: col_ref.column.clone(),
+                            table_name: table_id.display().to_string(),
+                            searched_tables: schema.table_names(),
+                            available_columns: table_schema
+                                .columns
+                                .iter()
+                                .map(|c| c.name.clone())
+                                .collect(),
+                        });
+                    }
+                }
                 return Ok(());
             }
         }


### PR DESCRIPTION
## Summary

Implement proper WITHOUT ROWID table support per SQLite specification:

1. **PRIMARY KEY requirement validation**: WITHOUT ROWID tables MUST have a PRIMARY KEY - returns error during CREATE TABLE if missing

2. **Block rowid pseudo-column access**: `rowid`, `_rowid_`, and `oid` are not available for WITHOUT ROWID tables - returns "column not found" error for any rowid access

## Changes

- `create_table.rs`: Add PRIMARY KEY validation for WITHOUT ROWID tables
- `column_refs.rs`: Block rowid validation for WITHOUT ROWID tables  
- `expressions/eval.rs`: Block rowid in single-row evaluator
- `combined/eval.rs`: Block rowid in combined evaluator
- `fast_path/helpers.rs`: Block rowid in fast path validation

## Test Plan

Verified test cases:
- [x] WITHOUT ROWID without PRIMARY KEY → error
- [x] WITHOUT ROWID with single-column PRIMARY KEY → works
- [x] WITHOUT ROWID with composite PRIMARY KEY → works
- [x] SELECT rowid/_rowid_/oid from WITHOUT ROWID table → error
- [x] Qualified rowid (t1.rowid) on WITHOUT ROWID table → error
- [x] Normal tables still have working rowid access
- [x] All existing tests pass

Closes #4953