### PR TITLE
feat(delete): implement DELETE with ORDER BY LIMIT (SQLite extension)

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -704,6 +704,12 @@ impl<'a, 'arena> Converter<'a, 'arena> {
             table_name: self.resolve(stmt.table_name),
             quoted: stmt.quoted,
             where_clause: stmt.where_clause.as_ref().map(|wc| self.convert_where_clause(wc)),
+            order_by: stmt
+                .order_by
+                .as_ref()
+                .map(|v| v.iter().map(|item| self.convert_order_by_item(item)).collect()),
+            limit: stmt.limit.as_ref().map(|e| self.convert_expression(e)),
+            offset: stmt.offset.as_ref().map(|e| self.convert_expression(e)),
         }
     }
 }

--- a/crates/vibesql-ast/src/arena/dml.rs
+++ b/crates/vibesql-ast/src/arena/dml.rs
@@ -5,7 +5,7 @@
 use bumpalo::collections::Vec as BumpVec;
 
 use super::{
-    expression::Expression,
+    expression::{Expression, OrderByItem},
     interner::Symbol,
     select::{CommonTableExpr, FromClause, SelectStmt},
 };
@@ -180,4 +180,13 @@ pub struct DeleteStmt<'arena> {
     /// Per SQL:1999, quoted identifiers are case-sensitive.
     pub quoted: bool,
     pub where_clause: Option<WhereClause<'arena>>,
+    /// Optional ORDER BY clause (SQLite extension for DELETE)
+    /// When present with LIMIT, deletes rows in the specified order
+    pub order_by: Option<BumpVec<'arena, OrderByItem<'arena>>>,
+    /// Optional LIMIT clause (SQLite extension for DELETE)
+    /// When used with ORDER BY, limits the number of rows deleted
+    pub limit: Option<Expression<'arena>>,
+    /// Optional OFFSET clause (SQLite extension for DELETE)
+    /// When used with ORDER BY and LIMIT, skips rows before deleting
+    pub offset: Option<Expression<'arena>>,
 }

--- a/crates/vibesql-ast/src/dml.rs
+++ b/crates/vibesql-ast/src/dml.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains INSERT, UPDATE, and DELETE statement types.
 
-use crate::{CommonTableExpr, Expression, FromClause, SelectStmt};
+use crate::{CommonTableExpr, Expression, FromClause, OrderByItem, SelectStmt};
 
 // ============================================================================
 // INSERT Statement
@@ -185,4 +185,13 @@ pub struct DeleteStmt {
     /// Per SQL:1999, quoted identifiers are case-sensitive.
     pub quoted: bool,
     pub where_clause: Option<WhereClause>,
+    /// Optional ORDER BY clause (SQLite extension for DELETE)
+    /// When present with LIMIT, deletes rows in the specified order
+    pub order_by: Option<Vec<OrderByItem>>,
+    /// Optional LIMIT clause (SQLite extension for DELETE)
+    /// When used with ORDER BY, limits the number of rows deleted
+    pub limit: Option<Expression>,
+    /// Optional OFFSET clause (SQLite extension for DELETE)
+    /// When used with ORDER BY and LIMIT, skips rows before deleting
+    pub offset: Option<Expression>,
 }

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1078,6 +1078,20 @@ fn walk_delete<V: ExpressionVisitor>(visitor: &mut V, stmt: &DeleteStmt) {
     if let Some(WhereClause::Condition(expr)) = &stmt.where_clause {
         walk_expression(visitor, expr);
     }
+    // Walk ORDER BY expressions
+    if let Some(order_by) = &stmt.order_by {
+        for item in order_by {
+            walk_expression(visitor, &item.expr);
+        }
+    }
+    // Walk LIMIT expression
+    if let Some(limit) = &stmt.limit {
+        walk_expression(visitor, limit);
+    }
+    // Walk OFFSET expression
+    if let Some(offset) = &stmt.offset {
+        walk_expression(visitor, offset);
+    }
 }
 
 // ============================================================================
@@ -1371,6 +1385,18 @@ pub fn transform_delete<V: ExpressionMutVisitor>(visitor: &mut V, stmt: DeleteSt
             }
             other => other,
         }),
+        order_by: stmt.order_by.map(|items| {
+            items
+                .into_iter()
+                .map(|item| crate::OrderByItem {
+                    expr: transform_expression(visitor, item.expr),
+                    direction: item.direction,
+                    nulls_order: item.nulls_order,
+                })
+                .collect()
+        }),
+        limit: stmt.limit.map(|e| transform_expression(visitor, e)),
+        offset: stmt.offset.map(|e| transform_expression(visitor, e)),
     }
 }
 

--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -153,7 +153,12 @@ impl DeleteExecutor {
 
         // Fast path: DELETE FROM table (no WHERE clause)
         // Use TRUNCATE-style optimization for 100-1000x performance improvement
-        if stmt.where_clause.is_none() && can_use_truncate(database, &stmt.table_name)? {
+        // Only use truncate if there's no ORDER BY or LIMIT (which would restrict which rows to delete)
+        if stmt.where_clause.is_none()
+            && stmt.order_by.is_none()
+            && stmt.limit.is_none()
+            && can_use_truncate(database, &stmt.table_name)?
+        {
             return execute_truncate(database, &stmt.table_name);
         }
 
@@ -265,18 +270,32 @@ impl DeleteExecutor {
         // Try to use primary key index for fast lookup
         let mut rows_and_indices_to_delete: Vec<(usize, vibesql_storage::Row)> = Vec::new();
 
-        if let Some(vibesql_ast::WhereClause::Condition(where_expr)) = &stmt.where_clause {
-            // Try primary key optimization
-            if let Some(pk_values) = Self::extract_primary_key_lookup(where_expr, &schema) {
-                if let Some(pk_index) = table.primary_key_index() {
-                    if let Some(&row_index) = pk_index.get(&pk_values) {
-                        // Found the row via index - single row to delete
-                        rows_and_indices_to_delete
-                            .push((row_index, table.scan()[row_index].clone()));
+        // For ORDER BY in DELETE, we need to skip PK optimization and do a full scan
+        // because we need all matching rows to sort them properly
+        let has_order_by = stmt.order_by.is_some();
+
+        if !has_order_by {
+            if let Some(vibesql_ast::WhereClause::Condition(where_expr)) = &stmt.where_clause {
+                // Try primary key optimization
+                if let Some(pk_values) = Self::extract_primary_key_lookup(where_expr, &schema) {
+                    if let Some(pk_index) = table.primary_key_index() {
+                        if let Some(&row_index) = pk_index.get(&pk_values) {
+                            // Found the row via index - single row to delete
+                            rows_and_indices_to_delete
+                                .push((row_index, table.scan()[row_index].clone()));
+                        }
+                        // If not found, rows_and_indices_to_delete stays empty (no rows to delete)
+                    } else {
+                        // No PK index, fall through to table scan below
+                        Self::collect_rows_with_scan(
+                            table,
+                            &stmt.where_clause,
+                            &mut evaluator,
+                            &mut rows_and_indices_to_delete,
+                        )?;
                     }
-                    // If not found, rows_and_indices_to_delete stays empty (no rows to delete)
                 } else {
-                    // No PK index, fall through to table scan below
+                    // Can't extract PK lookup, fall through to table scan
                     Self::collect_rows_with_scan(
                         table,
                         &stmt.where_clause,
@@ -285,7 +304,7 @@ impl DeleteExecutor {
                     )?;
                 }
             } else {
-                // Can't extract PK lookup, fall through to table scan
+                // No WHERE clause - collect all rows
                 Self::collect_rows_with_scan(
                     table,
                     &stmt.where_clause,
@@ -294,12 +313,24 @@ impl DeleteExecutor {
                 )?;
             }
         } else {
-            // No WHERE clause - collect all rows
+            // ORDER BY present - must do full scan to get all rows for sorting
             Self::collect_rows_with_scan(
                 table,
                 &stmt.where_clause,
                 &mut evaluator,
                 &mut rows_and_indices_to_delete,
+            )?;
+        }
+
+        // Apply ORDER BY sorting and LIMIT/OFFSET (SQLite extension)
+        if let Some(ref order_by) = stmt.order_by {
+            Self::apply_order_by_and_limit(
+                &mut rows_and_indices_to_delete,
+                order_by,
+                &stmt.limit,
+                &stmt.offset,
+                &schema,
+                &evaluator,
             )?;
         }
 
@@ -622,6 +653,121 @@ impl DeleteExecutor {
             if should_delete {
                 rows_and_indices.push((index, row.clone()));
             }
+        }
+
+        Ok(())
+    }
+
+    /// Apply ORDER BY sorting and LIMIT/OFFSET to the collected rows
+    /// This implements the SQLite extension for DELETE with ORDER BY LIMIT
+    fn apply_order_by_and_limit(
+        rows_and_indices: &mut Vec<(usize, vibesql_storage::Row)>,
+        order_by: &[vibesql_ast::OrderByItem],
+        limit: &Option<vibesql_ast::Expression>,
+        offset: &Option<vibesql_ast::Expression>,
+        _schema: &vibesql_catalog::TableSchema,
+        evaluator: &ExpressionEvaluator,
+    ) -> Result<(), ExecutorError> {
+        use vibesql_ast::OrderDirection;
+        use vibesql_types::SqlValue;
+
+        // Sort rows by ORDER BY columns
+        rows_and_indices.sort_by(|a, b| {
+            for item in order_by {
+                // Evaluate the ORDER BY expression for both rows
+                let val_a = evaluator.eval(&item.expr, &a.1).unwrap_or(SqlValue::Null);
+                let val_b = evaluator.eval(&item.expr, &b.1).unwrap_or(SqlValue::Null);
+
+                // Compare values with proper NULL handling
+                // NULLS FIRST: nulls come first (default for DESC)
+                // NULLS LAST: nulls come last (default for ASC)
+                let nulls_first = match item.nulls_order {
+                    Some(vibesql_ast::NullsOrder::First) => true,
+                    Some(vibesql_ast::NullsOrder::Last) => false,
+                    None => matches!(item.direction, OrderDirection::Desc),
+                };
+
+                let cmp = match (&val_a, &val_b) {
+                    (SqlValue::Null, SqlValue::Null) => std::cmp::Ordering::Equal,
+                    (SqlValue::Null, _) => {
+                        if nulls_first {
+                            std::cmp::Ordering::Less
+                        } else {
+                            std::cmp::Ordering::Greater
+                        }
+                    }
+                    (_, SqlValue::Null) => {
+                        if nulls_first {
+                            std::cmp::Ordering::Greater
+                        } else {
+                            std::cmp::Ordering::Less
+                        }
+                    }
+                    _ => val_a.partial_cmp(&val_b).unwrap_or(std::cmp::Ordering::Equal),
+                };
+
+                // Apply direction
+                let cmp = match item.direction {
+                    OrderDirection::Desc => cmp.reverse(),
+                    OrderDirection::Asc => cmp,
+                };
+
+                if cmp != std::cmp::Ordering::Equal {
+                    return cmp;
+                }
+            }
+            std::cmp::Ordering::Equal
+        });
+
+        // Evaluate OFFSET expression if present
+        let offset_val = if let Some(ref offset_expr) = offset {
+            // Evaluate the offset expression without a row context
+            // (it should be a constant or simple expression)
+            let empty_row = vibesql_storage::Row::new(vec![]);
+            match evaluator.eval(offset_expr, &empty_row)? {
+                SqlValue::Integer(n) if n >= 0 => n as usize,
+                SqlValue::Bigint(n) if n >= 0 => n as usize,
+                SqlValue::Null => 0, // NULL offset treated as 0
+                _ => {
+                    return Err(ExecutorError::TypeError(
+                        "OFFSET value must be a non-negative integer".to_string(),
+                    ))
+                }
+            }
+        } else {
+            0
+        };
+
+        // Evaluate LIMIT expression if present
+        let limit_val = if let Some(ref limit_expr) = limit {
+            let empty_row = vibesql_storage::Row::new(vec![]);
+            match evaluator.eval(limit_expr, &empty_row)? {
+                SqlValue::Integer(n) if n >= 0 => Some(n as usize),
+                SqlValue::Bigint(n) if n >= 0 => Some(n as usize),
+                SqlValue::Integer(-1) | SqlValue::Bigint(-1) => None, // -1 means no limit (SQLite extension)
+                SqlValue::Null => None, // NULL limit treated as no limit
+                _ => {
+                    return Err(ExecutorError::TypeError(
+                        "LIMIT value must be a non-negative integer".to_string(),
+                    ))
+                }
+            }
+        } else {
+            None
+        };
+
+        // Apply OFFSET: skip first N rows
+        if offset_val > 0 {
+            if offset_val >= rows_and_indices.len() {
+                rows_and_indices.clear();
+            } else {
+                rows_and_indices.drain(..offset_val);
+            }
+        }
+
+        // Apply LIMIT: keep only first N rows
+        if let Some(limit) = limit_val {
+            rows_and_indices.truncate(limit);
         }
 
         Ok(())

--- a/crates/vibesql-executor/src/delete/tests/basic.rs
+++ b/crates/vibesql-executor/src/delete/tests/basic.rs
@@ -18,6 +18,9 @@ fn test_delete_all_rows() {
         table_name: "users".to_string(),
         quoted: false,
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -44,6 +47,9 @@ fn test_delete_with_simple_where() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -81,6 +87,9 @@ fn test_delete_with_boolean_where() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Boolean(true))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -116,6 +125,9 @@ fn test_delete_multiple_rows() {
             op: BinaryOperator::GreaterThan,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/src/delete/tests/edge_cases.rs
+++ b/crates/vibesql-executor/src/delete/tests/edge_cases.rs
@@ -17,6 +17,9 @@ fn test_delete_table_not_found() {
         table_name: "nonexistent".to_string(),
         quoted: false,
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let result = DeleteExecutor::execute(&stmt, &mut db);
@@ -41,6 +44,9 @@ fn test_delete_no_matching_rows() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(999))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -68,6 +74,9 @@ fn test_delete_from_empty_table() {
         table_name: "empty_users".to_string(),
         quoted: false,
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -92,6 +101,9 @@ fn test_delete_column_not_found() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     // Column validation happens upfront - should return NoSuchColumn error

--- a/crates/vibesql-executor/src/delete/tests/subqueries.rs
+++ b/crates/vibesql-executor/src/delete/tests/subqueries.rs
@@ -224,6 +224,9 @@ mod in_subquery {
                 subquery,
                 negated: false,
             })),
+            order_by: None,
+            limit: None,
+            offset: None,
         };
 
         let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -289,6 +292,9 @@ mod in_subquery {
                 subquery,
                 negated: true,
             })),
+            order_by: None,
+            limit: None,
+            offset: None,
         };
 
         let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -365,6 +371,9 @@ mod scalar_subquery {
                 op: vibesql_ast::BinaryOperator::LessThan,
                 right: Box::new(Expression::ScalarSubquery(subquery)),
             })),
+            order_by: None,
+            limit: None,
+            offset: None,
         };
 
         let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -443,6 +452,9 @@ mod scalar_subquery {
                 op: vibesql_ast::BinaryOperator::Equal,
                 right: Box::new(Expression::ScalarSubquery(subquery)),
             })),
+            order_by: None,
+            limit: None,
+            offset: None,
         };
 
         let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -512,6 +524,9 @@ mod scalar_subquery {
                 op: vibesql_ast::BinaryOperator::GreaterThan,
                 right: Box::new(Expression::ScalarSubquery(subquery)),
             })),
+            order_by: None,
+            limit: None,
+            offset: None,
         };
 
         let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -580,6 +595,9 @@ mod empty_subquery {
                 subquery,
                 negated: false,
             })),
+            order_by: None,
+            limit: None,
+            offset: None,
         };
 
         let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -665,6 +683,9 @@ mod complex_subquery {
                 subquery,
                 negated: false,
             })),
+            order_by: None,
+            limit: None,
+            offset: None,
         };
 
         let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/src/delete/tests/truncate_optimization.rs
+++ b/crates/vibesql-executor/src/delete/tests/truncate_optimization.rs
@@ -47,6 +47,9 @@ fn test_truncate_optimization_basic() {
         table_name: "large_table".to_string(),
         quoted: false,
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -119,6 +122,9 @@ fn test_truncate_blocked_by_fk_reference() {
         table_name: "parent".to_string(),
         quoted: false,
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let result = DeleteExecutor::execute(&stmt, &mut db);
@@ -188,6 +194,9 @@ fn test_truncate_allowed_when_no_fk_references() {
         table_name: "parent".to_string(),
         quoted: false,
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -248,6 +257,9 @@ fn test_truncate_blocked_by_delete_trigger() {
         table_name: "test_table".to_string(),
         quoted: false,
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -306,6 +318,9 @@ fn test_truncate_allowed_with_insert_trigger() {
         table_name: "test_table".to_string(),
         quoted: false,
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let deleted = DeleteExecutor::execute(&stmt, &mut db).unwrap();
@@ -350,6 +365,9 @@ fn test_truncate_performance() {
         table_name: "large_table".to_string(),
         quoted: false,
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     // Time the deletion

--- a/crates/vibesql-executor/src/tests/not_operator_tests.rs
+++ b/crates/vibesql-executor/src/tests/not_operator_tests.rs
@@ -251,6 +251,9 @@ fn test_not_in_delete_where() {
                 )),
             }),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
     };
 
     let deleted_count = delete::DeleteExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/src/tests/triggers/delete.rs
+++ b/crates/vibesql-executor/src/tests/triggers/delete.rs
@@ -65,6 +65,9 @@ fn test_after_delete_trigger_fires() {
                 )),
             },
         )),
+        order_by: None,
+        limit: None,
+        offset: None,
     };
     DeleteExecutor::execute(&delete, &mut db).expect("Failed to delete");
 
@@ -129,6 +132,9 @@ fn test_before_delete_trigger_fires() {
                 )),
             },
         )),
+        order_by: None,
+        limit: None,
+        offset: None,
     };
     DeleteExecutor::execute(&delete, &mut db).expect("Failed to delete");
 

--- a/crates/vibesql-parser/src/arena_parser/delete.rs
+++ b/crates/vibesql-parser/src/arena_parser/delete.rs
@@ -1,6 +1,7 @@
 //! Arena-allocated DELETE statement parsing.
 
-use vibesql_ast::arena::{DeleteStmt, WhereClause};
+use bumpalo::collections::Vec as BumpVec;
+use vibesql_ast::arena::{DeleteStmt, NullsOrder, OrderByItem, OrderDirection, WhereClause};
 
 use super::ArenaParser;
 use crate::{keywords::Keyword, token::Token, ParseError};
@@ -66,11 +67,95 @@ impl<'arena> ArenaParser<'arena> {
             None
         };
 
+        // Parse optional ORDER BY clause (SQLite extension)
+        let order_by = if self.try_consume_keyword(Keyword::Order) {
+            self.consume_keyword(Keyword::By)?;
+            Some(self.parse_delete_order_by_clause()?)
+        } else {
+            None
+        };
+
+        // Parse optional LIMIT clause (SQLite extension, supports comma syntax)
+        let (limit, offset_from_limit) = if self.try_consume_keyword(Keyword::Limit) {
+            let first_expr = self.parse_expression()?;
+
+            if self.try_consume(&Token::Comma) {
+                let second_expr = self.parse_expression()?;
+                // LIMIT offset,count syntax
+                (Some(second_expr), Some(first_expr))
+            } else {
+                (Some(first_expr), None)
+            }
+        } else {
+            (None, None)
+        };
+
+        // Parse optional OFFSET clause (only if not already set via comma syntax)
+        let offset = if offset_from_limit.is_some() {
+            offset_from_limit
+        } else if self.try_consume_keyword(Keyword::Offset) {
+            Some(self.parse_expression()?)
+        } else {
+            None
+        };
+
         // Consume optional semicolon
         self.try_consume(&Token::Semicolon);
 
-        let stmt = DeleteStmt { with_clause: None, only, table_name, quoted, where_clause };
+        let stmt = DeleteStmt {
+            with_clause: None,
+            only,
+            table_name,
+            quoted,
+            where_clause,
+            order_by,
+            limit,
+            offset,
+        };
 
         Ok(self.arena.alloc(stmt))
+    }
+
+    /// Parse ORDER BY clause for DELETE statement
+    fn parse_delete_order_by_clause(
+        &mut self,
+    ) -> Result<BumpVec<'arena, OrderByItem<'arena>>, ParseError> {
+        let mut items = BumpVec::new_in(self.arena);
+
+        loop {
+            let expr = self.parse_expression()?;
+            let direction = if self.try_consume_keyword(Keyword::Desc) {
+                OrderDirection::Desc
+            } else {
+                self.try_consume_keyword(Keyword::Asc);
+                OrderDirection::Asc
+            };
+
+            // Parse optional NULLS FIRST/LAST
+            let nulls_order = if self.try_consume_keyword(Keyword::Nulls) {
+                if self.try_consume_keyword(Keyword::First) {
+                    Some(NullsOrder::First)
+                } else if self.try_consume_keyword(Keyword::Last) {
+                    Some(NullsOrder::Last)
+                } else {
+                    return Err(ParseError {
+                        message: format!(
+                            "Expected FIRST or LAST after NULLS, found {}",
+                            self.peek().syntax_error()
+                        ),
+                    });
+                }
+            } else {
+                None
+            };
+
+            items.push(OrderByItem { expr, direction, nulls_order });
+
+            if !self.try_consume(&Token::Comma) {
+                break;
+            }
+        }
+
+        Ok(items)
     }
 }

--- a/crates/vibesql-parser/src/parser/delete.rs
+++ b/crates/vibesql-parser/src/parser/delete.rs
@@ -45,12 +45,93 @@ impl Parser {
             None
         };
 
+        // Parse optional ORDER BY clause (SQLite extension)
+        let order_by = if self.peek_keyword(Keyword::Order) {
+            self.consume_keyword(Keyword::Order)?;
+            self.expect_keyword(Keyword::By)?;
+
+            let order_items = self.parse_comma_separated_list(|p| {
+                let expr = p.parse_expression()?;
+                let direction = if p.peek_keyword(Keyword::Asc) {
+                    p.consume_keyword(Keyword::Asc)?;
+                    vibesql_ast::OrderDirection::Asc
+                } else if p.peek_keyword(Keyword::Desc) {
+                    p.consume_keyword(Keyword::Desc)?;
+                    vibesql_ast::OrderDirection::Desc
+                } else {
+                    vibesql_ast::OrderDirection::Asc
+                };
+
+                let nulls_order = if p.peek_keyword(Keyword::Nulls) {
+                    p.consume_keyword(Keyword::Nulls)?;
+                    if p.peek_keyword(Keyword::First) {
+                        p.consume_keyword(Keyword::First)?;
+                        Some(vibesql_ast::NullsOrder::First)
+                    } else if p.peek_keyword(Keyword::Last) {
+                        p.consume_keyword(Keyword::Last)?;
+                        Some(vibesql_ast::NullsOrder::Last)
+                    } else {
+                        return Err(ParseError {
+                            message: format!(
+                                "Expected FIRST or LAST after NULLS, found {}",
+                                p.peek().syntax_error()
+                            ),
+                        });
+                    }
+                } else {
+                    None
+                };
+
+                Ok(vibesql_ast::OrderByItem { expr, direction, nulls_order })
+            })?;
+
+            Some(order_items)
+        } else {
+            None
+        };
+
+        // Parse optional LIMIT clause (SQLite extension, supports comma syntax)
+        let (limit, offset_from_limit) = if self.peek_keyword(Keyword::Limit) {
+            self.consume_keyword(Keyword::Limit)?;
+            let first_expr = self.parse_expression()?;
+
+            if matches!(self.peek(), Token::Comma) {
+                self.advance();
+                let second_expr = self.parse_expression()?;
+                // LIMIT offset,count syntax
+                (Some(second_expr), Some(first_expr))
+            } else {
+                (Some(first_expr), None)
+            }
+        } else {
+            (None, None)
+        };
+
+        // Parse optional OFFSET clause (only if not already set via comma syntax)
+        let offset = if offset_from_limit.is_some() {
+            offset_from_limit
+        } else if self.peek_keyword(Keyword::Offset) {
+            self.consume_keyword(Keyword::Offset)?;
+            Some(self.parse_expression()?)
+        } else {
+            None
+        };
+
         // Expect semicolon or EOF
         if matches!(self.peek(), Token::Semicolon) {
             self.advance();
         }
 
-        Ok(vibesql_ast::DeleteStmt { with_clause: None, only, table_name, quoted, where_clause })
+        Ok(vibesql_ast::DeleteStmt {
+            with_clause: None,
+            only,
+            table_name,
+            quoted,
+            where_clause,
+            order_by,
+            limit,
+            offset,
+        })
     }
 
     /// Parse DELETE statement with a pre-parsed WITH clause (CTEs)
@@ -97,6 +178,78 @@ impl Parser {
             None
         };
 
+        // Parse optional ORDER BY clause (SQLite extension)
+        let order_by = if self.peek_keyword(Keyword::Order) {
+            self.consume_keyword(Keyword::Order)?;
+            self.expect_keyword(Keyword::By)?;
+
+            let order_items = self.parse_comma_separated_list(|p| {
+                let expr = p.parse_expression()?;
+                let direction = if p.peek_keyword(Keyword::Asc) {
+                    p.consume_keyword(Keyword::Asc)?;
+                    vibesql_ast::OrderDirection::Asc
+                } else if p.peek_keyword(Keyword::Desc) {
+                    p.consume_keyword(Keyword::Desc)?;
+                    vibesql_ast::OrderDirection::Desc
+                } else {
+                    vibesql_ast::OrderDirection::Asc
+                };
+
+                let nulls_order = if p.peek_keyword(Keyword::Nulls) {
+                    p.consume_keyword(Keyword::Nulls)?;
+                    if p.peek_keyword(Keyword::First) {
+                        p.consume_keyword(Keyword::First)?;
+                        Some(vibesql_ast::NullsOrder::First)
+                    } else if p.peek_keyword(Keyword::Last) {
+                        p.consume_keyword(Keyword::Last)?;
+                        Some(vibesql_ast::NullsOrder::Last)
+                    } else {
+                        return Err(ParseError {
+                            message: format!(
+                                "Expected FIRST or LAST after NULLS, found {}",
+                                p.peek().syntax_error()
+                            ),
+                        });
+                    }
+                } else {
+                    None
+                };
+
+                Ok(vibesql_ast::OrderByItem { expr, direction, nulls_order })
+            })?;
+
+            Some(order_items)
+        } else {
+            None
+        };
+
+        // Parse optional LIMIT clause (SQLite extension, supports comma syntax)
+        let (limit, offset_from_limit) = if self.peek_keyword(Keyword::Limit) {
+            self.consume_keyword(Keyword::Limit)?;
+            let first_expr = self.parse_expression()?;
+
+            if matches!(self.peek(), Token::Comma) {
+                self.advance();
+                let second_expr = self.parse_expression()?;
+                // LIMIT offset,count syntax
+                (Some(second_expr), Some(first_expr))
+            } else {
+                (Some(first_expr), None)
+            }
+        } else {
+            (None, None)
+        };
+
+        // Parse optional OFFSET clause (only if not already set via comma syntax)
+        let offset = if offset_from_limit.is_some() {
+            offset_from_limit
+        } else if self.peek_keyword(Keyword::Offset) {
+            self.consume_keyword(Keyword::Offset)?;
+            Some(self.parse_expression()?)
+        } else {
+            None
+        };
+
         // Expect semicolon or EOF
         if matches!(self.peek(), Token::Semicolon) {
             self.advance();
@@ -108,6 +261,9 @@ impl Parser {
             table_name,
             quoted,
             where_clause,
+            order_by,
+            limit,
+            offset,
         })
     }
 }


### PR DESCRIPTION
## Summary
- Implement SQLite's DELETE with ORDER BY and LIMIT extension
- Add `order_by`, `limit`, `offset` fields to DeleteStmt AST
- Update parser (standard and arena) to parse ORDER BY/LIMIT after WHERE clause
- Update executor to sort and limit rows before deletion
- Fix truncate optimization to skip when ORDER BY/LIMIT is present

## Test plan
- [x] Verify DELETE ORDER BY LIMIT deletes correct rows
- [x] Verify DELETE with WHERE + ORDER BY + LIMIT works
- [x] Verify OFFSET functionality works
- [x] Run existing DELETE test suite - all pass
- [x] Verify truncate optimization is skipped when ORDER BY/LIMIT present

## Example Usage

```sql
-- Delete 2 rows with highest IDs
DELETE FROM t1 ORDER BY id DESC LIMIT 2;

-- Delete oldest 5 inactive users
DELETE FROM users WHERE status = 'inactive' ORDER BY created_at ASC LIMIT 5;

-- Delete rows 4-6 (skip 3, take 3)
DELETE FROM t1 ORDER BY id LIMIT 3 OFFSET 3;
```

Closes #4943

🤖 Generated with [Claude Code](https://claude.com/claude-code)