### PR TITLE
fix(index): improve expression index support and error handling

### DIFF
--- a/crates/vibesql-ast/tests/statements.rs
+++ b/crates/vibesql-ast/tests/statements.rs
@@ -64,6 +64,7 @@ fn test_create_update_statement() {
             column: "name".to_string(),
             value: Expression::Literal(SqlValue::Varchar(StringValue::from("Bob"))),
         }],
+        from_clause: None,
         where_clause: None,
         conflict_clause: None,
     });

--- a/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
@@ -5,7 +5,7 @@
 //! Also includes skip-scan optimization for queries filtering on non-prefix columns.
 //! Supports expression indexes (functional indexes) like CREATE INDEX idx ON t(lower(name)).
 
-use vibesql_ast::{Expression, IndexColumn};
+use vibesql_ast::{pretty_print::ToSql, Expression, IndexColumn};
 use vibesql_catalog::TableSchema;
 use vibesql_storage::{
     statistics::{AccessMethod, CostEstimator},
@@ -140,13 +140,15 @@ pub(crate) fn should_use_index_scan(
                     order_items
                         .iter()
                         .map(|item| {
+                            // For expression indexes, ORDER BY may use expressions (e.g., length(a))
+                            // We use to_sql() to convert the expression to a string representation
+                            // The actual string is only used for metadata; the important part
+                            // is the direction for determining scan order
                             let col_name = match &item.expr {
                                 Expression::ColumnRef(col_id) => {
                                     col_id.column_canonical().to_string()
                                 }
-                                _ => unreachable!(
-                                    "can_use_index_for_order_by ensures simple column refs"
-                                ),
+                                expr => expr.to_sql(),
                             };
                             (col_name, item.direction.clone())
                         })
@@ -944,13 +946,15 @@ pub(crate) fn cost_based_index_selection(
                     order_items
                         .iter()
                         .map(|item| {
+                            // For expression indexes, ORDER BY may use expressions (e.g., length(a))
+                            // We use to_sql() to convert the expression to a string representation
+                            // The actual string is only used for metadata; the important part
+                            // is the direction for determining scan order
                             let col_name = match &item.expr {
                                 Expression::ColumnRef(col_id) => {
                                     col_id.column_canonical().to_string()
                                 }
-                                _ => unreachable!(
-                                    "can_use_index_for_order_by ensures simple column refs"
-                                ),
+                                expr => expr.to_sql(),
                             };
                             (col_name, item.direction.clone())
                         })

--- a/crates/vibesql-executor/tests/conflict_resolution_tests.rs
+++ b/crates/vibesql-executor/tests/conflict_resolution_tests.rs
@@ -223,6 +223,7 @@ fn test_update_or_ignore_primary_key_conflict() {
 
     // Try UPDATE OR IGNORE to change Alice's id to 2 (conflicts with Bob)
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         table_name: "users".to_string(),
         quoted: false,
         alias: None,
@@ -268,6 +269,7 @@ fn test_update_or_ignore_unique_constraint_conflict() {
 
     // Try UPDATE OR IGNORE to change Alice's email to Bob's (conflicts with UNIQUE)
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         table_name: "users".to_string(),
         quoted: false,
         alias: None,
@@ -303,6 +305,7 @@ fn test_update_or_ignore_no_conflict() {
 
     // UPDATE OR IGNORE with no conflicts should work normally
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         table_name: "users".to_string(),
         quoted: false,
         alias: None,
@@ -344,6 +347,7 @@ fn test_update_or_replace_primary_key_conflict() {
 
     // UPDATE OR REPLACE to change Alice's id to 2 (should delete Bob first)
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         table_name: "users".to_string(),
         quoted: false,
         alias: None,
@@ -386,6 +390,7 @@ fn test_update_or_replace_unique_constraint_conflict() {
 
     // UPDATE OR REPLACE to change Alice's email to Bob's (should delete Bob first)
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         table_name: "users".to_string(),
         quoted: false,
         alias: None,
@@ -429,6 +434,7 @@ fn test_update_or_replace_no_conflict() {
 
     // UPDATE OR REPLACE with no conflicts should work normally without deleting anyone
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         table_name: "users".to_string(),
         quoted: false,
         alias: None,
@@ -497,6 +503,7 @@ fn test_update_or_ignore_not_null_violation() {
 
     // Try UPDATE OR IGNORE to set email to NULL (NOT NULL violation)
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         table_name: "users".to_string(),
         quoted: false,
         alias: None,

--- a/crates/vibesql-executor/tests/update_basic_tests.rs
+++ b/crates/vibesql-executor/tests/update_basic_tests.rs
@@ -12,6 +12,7 @@ fn test_update_all_rows() {
     setup_test_table(&mut db);
 
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -39,6 +40,7 @@ fn test_update_with_where_clause() {
     setup_test_table(&mut db);
 
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -80,6 +82,7 @@ fn test_update_multiple_columns() {
     setup_test_table(&mut db);
 
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -120,6 +123,7 @@ fn test_update_with_expression() {
 
     // Give everyone a 10% raise: salary = salary * 110 DIV 100
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -158,6 +162,7 @@ fn test_update_table_not_found() {
     let mut db = Database::new();
 
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "nonexistent".to_string(),
@@ -177,6 +182,7 @@ fn test_update_column_not_found() {
     setup_test_table(&mut db);
 
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -199,6 +205,7 @@ fn test_update_no_matching_rows() {
     setup_test_table(&mut db);
 
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),

--- a/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
@@ -52,6 +52,7 @@ fn test_update_invalidates_columnar_cache() {
 
     // Execute UPDATE - give Alice a raise
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -121,6 +122,7 @@ fn test_update_invalidates_prewarmed_cache() {
 
     // UPDATE to change Bob's salary
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -164,6 +166,7 @@ fn test_update_all_rows_invalidates_cache() {
 
     // UPDATE all rows - give everyone the same salary
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -199,6 +202,7 @@ fn test_update_no_match_does_not_invalidate_cache() {
 
     // UPDATE with WHERE clause that matches no rows
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -241,6 +245,7 @@ fn test_multiple_updates_invalidate_cache() {
 
     // First UPDATE
     let stmt1 = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -269,6 +274,7 @@ fn test_multiple_updates_invalidate_cache() {
 
     // Second UPDATE
     let stmt2 = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -313,6 +319,7 @@ fn test_update_multiple_columns_invalidates_cache() {
 
     // UPDATE multiple columns at once
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),

--- a/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
@@ -18,6 +18,7 @@ fn test_update_check_constraint_passes() {
 
     // Update to valid price (should succeed)
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "products".to_string(),
@@ -43,6 +44,7 @@ fn test_update_check_constraint_violation() {
 
     // Try to update to negative price (should fail)
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "products".to_string(),
@@ -76,6 +78,7 @@ fn test_update_check_constraint_with_null() {
 
     // Update to NULL (should succeed - NULL is treated as UNKNOWN which passes CHECK)
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "products".to_string(),
@@ -105,6 +108,7 @@ fn test_update_check_constraint_with_expression() {
 
     // Update bonus to still be less than salary (should succeed)
     let stmt1 = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -120,6 +124,7 @@ fn test_update_check_constraint_with_expression() {
 
     // Try to update bonus to be >= salary (should fail)
     let stmt2 = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),

--- a/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
@@ -183,6 +183,7 @@ pub fn create_update_with_id_clause(
             column: column.to_string(),
             value: Expression::Literal(value),
         }],
+        from_clause: None,
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
             left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
                 "id", false,

--- a/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
@@ -160,6 +160,7 @@ fn test_update_unique_constraint_composite() {
 
     // Try to update Bob to have the same first_name and last_name as Alice (should fail)
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "users".to_string(),

--- a/crates/vibesql-executor/tests/update_default_tests.rs
+++ b/crates/vibesql-executor/tests/update_default_tests.rs
@@ -29,6 +29,7 @@ fn test_update_with_default_value() {
 
     // UPDATE users SET name = DEFAULT WHERE id = 1
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "users".to_string(),
@@ -79,6 +80,7 @@ fn test_update_default_no_default_value_defined() {
 
     // UPDATE users SET name = DEFAULT WHERE id = 1
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "users".to_string(),

--- a/crates/vibesql-executor/tests/update_onepass_tests.rs
+++ b/crates/vibesql-executor/tests/update_onepass_tests.rs
@@ -101,6 +101,7 @@ fn test_onepass_multiple_literal_assignments() {
 
     // UPDATE items SET name = 'Updated', price = 999, quantity = 50 WHERE id = 1
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "items".to_string(),
@@ -151,6 +152,7 @@ fn test_onepass_single_literal_assignment() {
 
     // UPDATE items SET price = 777 WHERE id = 2
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "items".to_string(),
@@ -183,6 +185,7 @@ fn test_onepass_pk_not_found_returns_zero() {
 
     // UPDATE items SET price = 999 WHERE id = 999 (non-existent)
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "items".to_string(),
@@ -224,6 +227,7 @@ fn test_onepass_not_null_constraint_enforced() {
 
     // Try to set NOT NULL column to NULL
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "required".to_string(),
@@ -257,6 +261,7 @@ fn test_composite_pk_update_both_columns_specified() {
 
     // UPDATE order_items SET quantity = 99 WHERE order_id = 1 AND item_id = 1
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "order_items".to_string(),
@@ -306,6 +311,7 @@ fn test_composite_pk_update_reversed_order() {
     // UPDATE order_items SET price = 500 WHERE item_id = 2 AND order_id = 1
     // (columns in reverse order from PK definition)
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "order_items".to_string(),
@@ -350,6 +356,7 @@ fn test_composite_pk_partial_match_uses_scan() {
     // UPDATE order_items SET quantity = 1 WHERE order_id = 1
     // Only one PK column specified - should update multiple rows
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "order_items".to_string(),
@@ -385,6 +392,7 @@ fn test_composite_pk_not_found_returns_zero() {
 
     // UPDATE order_items SET quantity = 999 WHERE order_id = 99 AND item_id = 99
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "order_items".to_string(),
@@ -423,6 +431,7 @@ fn test_composite_pk_multiple_columns_updated() {
 
     // UPDATE order_items SET quantity = 100, price = 1000 WHERE order_id = 2 AND item_id = 1
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "order_items".to_string(),

--- a/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
@@ -64,6 +64,7 @@ fn test_update_with_subquery_multiple_rows_uses_first() {
     });
 
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -156,6 +157,7 @@ fn test_update_with_subquery_multiple_columns_error() {
     });
 
     let stmt = UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),

--- a/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
@@ -130,6 +130,7 @@ fn create_update_stmt(
         alias: None,
         table_name: table_name.to_string(),
         assignments: vec![Assignment { column: column.to_string(), value }],
+        from_clause: None,
         where_clause,
         conflict_clause: None,
     }
@@ -148,6 +149,7 @@ fn create_multi_column_update_stmt(
             .into_iter()
             .map(|(col, val)| Assignment { column: col.to_string(), value: val })
             .collect(),
+        from_clause: None,
         where_clause: None,
         conflict_clause: None,
     }

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
@@ -60,6 +60,7 @@ fn test_update_where_scalar_subquery_equal() {
 
     // UPDATE employees SET salary = 55000 WHERE salary = (SELECT min_salary FROM config)
     let stmt = vibesql_ast::UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -147,6 +148,7 @@ fn test_update_where_scalar_subquery_less_than() {
 
     // UPDATE employees SET bonus = 5000 WHERE salary < (SELECT AVG(salary) FROM employees)
     let stmt = vibesql_ast::UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -226,6 +228,7 @@ fn test_update_where_subquery_returns_null() {
 
     // UPDATE employees SET salary = 60000 WHERE salary < (SELECT max_salary FROM config)
     let stmt = vibesql_ast::UpdateStmt { with_clause: None,
+        from_clause: None,
         table_name: "employees".to_string(),
         quoted: false,
         alias: None,
@@ -317,6 +320,7 @@ fn test_update_where_subquery_with_aggregate() {
 
     // UPDATE items SET discounted = TRUE WHERE price = (SELECT MAX(price) FROM items)
     let stmt = vibesql_ast::UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "items".to_string(),
@@ -443,6 +447,7 @@ fn test_update_where_and_set_both_use_subqueries() {
     // UPDATE employees SET salary = (SELECT target FROM salary_targets) WHERE dept_id IN (SELECT
     // dept_id FROM active_depts)
     let stmt = vibesql_ast::UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
@@ -75,6 +75,7 @@ fn test_update_where_in_subquery() {
 
     // UPDATE employees SET salary = 80000 WHERE dept_id IN (SELECT dept_id FROM active_depts)
     let stmt = vibesql_ast::UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -166,6 +167,7 @@ fn test_update_where_not_in_subquery() {
 
     // UPDATE employees SET active = FALSE WHERE dept_id NOT IN (SELECT dept_id FROM active_depts)
     let stmt = vibesql_ast::UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -250,6 +252,7 @@ fn test_update_where_subquery_empty_result() {
 
     // UPDATE employees SET active = FALSE WHERE dept_id IN (SELECT dept_id FROM inactive_depts)
     let stmt = vibesql_ast::UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -351,6 +354,7 @@ fn test_update_where_complex_subquery_condition() {
     // UPDATE employees SET salary = 70000 WHERE dept_id IN (SELECT dept_id FROM departments WHERE
     // budget > 80000)
     let stmt = vibesql_ast::UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),
@@ -446,6 +450,7 @@ fn test_update_where_multiple_rows_in_subquery() {
 
     // UPDATE employees SET active = FALSE WHERE dept_id IN (SELECT dept_id FROM active_depts)
     let stmt = vibesql_ast::UpdateStmt { with_clause: None,
+        from_clause: None,
         quoted: false,
         alias: None,
         table_name: "employees".to_string(),

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -2,6 +2,21 @@
 
 use super::super::*;
 
+/// Validate that constraint columns do not contain expressions.
+/// SQLite prohibits expressions in PRIMARY KEY and UNIQUE constraints.
+fn validate_no_expressions_in_constraint(
+    columns: &[vibesql_ast::IndexColumn],
+) -> Result<(), ParseError> {
+    for col in columns {
+        if matches!(col, vibesql_ast::IndexColumn::Expression { .. }) {
+            return Err(ParseError {
+                message: "expressions prohibited in PRIMARY KEY and UNIQUE constraints".to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
 impl Parser {
     /// Parse an optional ON CONFLICT clause for constraints
     /// Returns None if no ON CONFLICT clause is present
@@ -457,6 +472,8 @@ impl Parser {
                 }
 
                 self.expect_token(Token::RParen)?;
+                // Validate no expressions in PRIMARY KEY constraint
+                validate_no_expressions_in_constraint(&columns)?;
                 // Parse optional ON CONFLICT clause
                 let on_conflict = self.parse_constraint_conflict_clause()?;
                 vibesql_ast::TableConstraintKind::PrimaryKey { columns, on_conflict }
@@ -554,6 +571,8 @@ impl Parser {
                 }
 
                 self.expect_token(Token::RParen)?;
+                // Validate no expressions in UNIQUE constraint
+                validate_no_expressions_in_constraint(&columns)?;
                 // Parse optional ON CONFLICT clause
                 let on_conflict = self.parse_constraint_conflict_clause()?;
                 vibesql_ast::TableConstraintKind::Unique { columns, on_conflict }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3005,9 +3005,9 @@ array set vibesql_skip_tests {
 # Pattern-based skip list for tests with many numbered variants
 variable vibesql_skip_patterns {
     {orderby8-1. "ORDER BY with many columns - stress test"}
-    {indexexpr1- "Many tests check EXPLAIN QUERY PLAN output format"}
-    {indexexpr2- "Many tests check EXPLAIN QUERY PLAN output format"}
-    {indexexpr3- "Many tests check EXPLAIN QUERY PLAN output format"}
+    {indexexpr1- "EXPLAIN output format differs (tests check COVERING INDEX output)"}
+    {indexexpr2- "EXPLAIN output format differs (tests check COVERING INDEX output)"}
+    {indexexpr3- "EXPLAIN output format differs (tests check COVERING INDEX output)"}
     {orderbyA- "ORDER BY optimization differs"}
     {boundary1- "Boundary condition tests - stress test"}
     {boundary2- "Boundary condition tests - stress test"}


### PR DESCRIPTION
## Summary

This PR improves expression index support in VibeSQL by fixing panics and adding proper error handling:

- **Fix ORDER BY with expression indexes**: Previously, using `ORDER BY length(a)` with an index on `length(a)` would panic at runtime. Now it correctly uses the expression index for sorting.
  
- **Proper error for expressions in constraints**: When attempting `CREATE TABLE t(x, y, UNIQUE(y, substr(x,1,5)))`, SQLite returns "expressions prohibited in PRIMARY KEY and UNIQUE constraints". VibeSQL now returns the same error instead of panicking.

## Changes

- `crates/vibesql-executor/src/select/scan/index_scan/selection.rs`: Handle expression ORDER BY items using `to_sql()` instead of panicking with `unreachable!()`
- `crates/vibesql-parser/src/parser/create/constraints.rs`: Add validation to reject expressions in PRIMARY KEY and UNIQUE constraints at parse time
- `scripts/tester_vibesql.tcl`: Update skip patterns with accurate reasons
- Various test files: Add missing `from_clause: None` field to UpdateStmt fixtures (fixes pre-existing test compilation issue from UPDATE FROM feature)

## Test Plan

- [x] Manual testing of expression index ORDER BY: `CREATE INDEX t1alen ON t1(length(a)); SELECT length(a) FROM t1 ORDER BY length(a);` works correctly
- [x] Manual testing of constraint error: `CREATE TABLE e1(x,y,UNIQUE(y,substr(x,1,5)));` returns proper error message
- [x] All Rust tests pass (`cargo test --release`)
- [x] Build succeeds (`cargo build --release`)

Closes #4957