### PR TITLE
fix(tests): add missing struct fields to test initializers

### DIFF
--- a/crates/vibesql-ast/tests/statements.rs
+++ b/crates/vibesql-ast/tests/statements.rs
@@ -83,6 +83,9 @@ fn test_create_delete_statement() {
         table_name: "users".to_string(),
         quoted: false,
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
     });
 
     match stmt {

--- a/tests/storage/update_pk_performance.rs
+++ b/tests/storage/update_pk_performance.rs
@@ -61,6 +61,7 @@ fn test_update_with_pk_index_performance() {
                     right: Box::new(Expression::Literal(SqlValue::Integer(1))),
                 },
             }],
+            from_clause: None,
             where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
                 left: Box::new(Expression::ColumnRef(ColumnIdentifier::simple("id", false))),
                 op: BinaryOperator::Equal,


### PR DESCRIPTION
## Summary

Fix test compilation errors caused by missing struct fields in test initializers.

## Problem

Recent PRs added new fields to AST structs but didn't update all test files:

- **PR #4973** (DELETE with ORDER BY LIMIT) added `order_by`, `limit`, `offset` to `DeleteStmt`
- **UPDATE FROM** support added `from_clause` to `UpdateStmt`

This caused `cargo test --workspace` to fail with:
```
error[E0063]: missing fields `limit`, `offset` and `order_by` in initializer of `vibesql_ast::DeleteStmt`
error[E0063]: missing field `from_clause` in initializer of `vibesql_ast::UpdateStmt`
```

## Changes

- `crates/vibesql-ast/tests/statements.rs`: Add `order_by: None`, `limit: None`, `offset: None` to DeleteStmt
- `tests/storage/update_pk_performance.rs`: Add `from_clause: None` to UpdateStmt

## Test Plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --package vibesql-ast` passes