### PR TITLE
fix(window): correct result ordering for PARTITION BY and ORDER BY

### DIFF
--- a/crates/vibesql-executor/src/evaluator/window/partitioning.rs
+++ b/crates/vibesql-executor/src/evaluator/window/partitioning.rs
@@ -66,6 +66,9 @@ impl Partition {
 ///
 /// Groups rows into partitions based on partition expressions.
 /// If no PARTITION BY clause, all rows go into a single partition.
+///
+/// Partitions are ordered by their key values (using BTreeMap with SqlValue keys
+/// for proper numeric/string ordering), matching SQLite's behavior.
 pub fn partition_rows<F>(
     rows: Vec<Row>,
     partition_by: &Option<Vec<Expression>>,
@@ -83,9 +86,10 @@ where
         return vec![Partition::new(rows)];
     }
 
-    // Group rows by partition key values (use BTreeMap for deterministic ordering)
-    // Track original indices through partitioning
-    let mut partitions_map: std::collections::BTreeMap<Vec<String>, Vec<(usize, Row)>> =
+    // Group rows by partition key values
+    // Use BTreeMap with SqlValue keys for proper value ordering (not string ordering)
+    // This ensures Integer(3) < Integer(7) < Integer(11) as expected
+    let mut partitions_map: std::collections::BTreeMap<Vec<SqlValue>, Vec<(usize, Row)>> =
         std::collections::BTreeMap::new();
 
     for (original_idx, row) in rows.into_iter().enumerate() {
@@ -94,14 +98,13 @@ where
 
         for expr in partition_exprs {
             let value = eval_fn(expr, &row).unwrap_or(SqlValue::Null);
-            // Convert to string for grouping (handles NULL consistently)
-            partition_key.push(format!("{:?}", value));
+            partition_key.push(value);
         }
 
         partitions_map.entry(partition_key).or_default().push((original_idx, row));
     }
 
-    // Convert HashMap to Vec<Partition>, preserving original indices
+    // Convert BTreeMap to Vec<Partition>, preserving sorted partition key order
     partitions_map
         .into_values()
         .map(|rows_with_indices| {

--- a/crates/vibesql-executor/src/select/window/evaluation.rs
+++ b/crates/vibesql-executor/src/select/window/evaluation.rs
@@ -26,15 +26,27 @@ use crate::{
 #[cfg(feature = "parallel")]
 use crate::select::parallel::ParallelConfig;
 
+/// Result from evaluating a window function, including optional row reordering
+pub(super) struct WindowEvaluationResult {
+    /// Window function values in partition order
+    pub values: Vec<SqlValue>,
+    /// Row indices in partition order (if PARTITION BY is present)
+    /// This maps: partition_order_index -> original_row_index
+    pub partition_order: Option<Vec<usize>>,
+}
+
 /// Evaluate a single window function over all rows
 ///
 /// When the `parallel` feature is enabled and there are multiple partitions,
 /// partition sorting is parallelized for better performance on multi-core systems.
+///
+/// Returns values in partition order (grouped by partition, then by ORDER BY within partition)
+/// along with the mapping from partition order to original row indices.
 pub(super) fn evaluate_single_window_function(
     rows: &[Row],
     win_func: &WindowFunctionInfo,
     evaluator: &CombinedExpressionEvaluator,
-) -> Result<Vec<SqlValue>, ExecutorError> {
+) -> Result<WindowEvaluationResult, ExecutorError> {
     // Validate frame specification (checks for non-negative offsets, etc.)
     validate_frame(&win_func.window_spec.frame)
         .map_err(ExecutorError::SqliteCompatError)?;
@@ -173,14 +185,32 @@ pub(super) fn evaluate_single_window_function(
         evaluator,
     )?;
 
-    // Sort by original index to restore original row order
+    // Determine if we have PARTITION BY or ORDER BY - if so, capture the window order
+    let has_partition_by = win_func
+        .window_spec
+        .partition_by
+        .as_ref()
+        .is_some_and(|p| !p.is_empty());
+    let has_order_by = win_func
+        .window_spec
+        .order_by
+        .as_ref()
+        .is_some_and(|o| !o.is_empty());
+
+    // Capture window function order before sorting back to original
+    // This captures the order after partitioning and sorting (the "window order")
+    let partition_order: Option<Vec<usize>> = if has_partition_by || has_order_by {
+        Some(results_with_indices.iter().map(|(idx, _)| *idx).collect())
+    } else {
+        None
+    };
+
+    // Always sort values back to original order for consistent indexing
     let mut results_with_indices = results_with_indices;
     results_with_indices.sort_by_key(|(idx, _)| *idx);
+    let values = results_with_indices.into_iter().map(|(_, result)| result).collect();
 
-    // Extract just the results
-    let all_results = results_with_indices.into_iter().map(|(_, result)| result).collect();
-
-    Ok(all_results)
+    Ok(WindowEvaluationResult { values, partition_order })
 }
 
 /// Sequential evaluation of window function partitions

--- a/crates/vibesql-executor/src/select/window/mod.rs
+++ b/crates/vibesql-executor/src/select/window/mod.rs
@@ -57,22 +57,45 @@ pub(super) fn evaluate_window_functions(
 
     // For each window function, compute values for all rows
     // We'll build a Vec<Vec<SqlValue>> where outer vec is window functions,
-    // inner vec is values for each row
+    // inner vec is values for each row (in partition order if PARTITION BY present)
     let mut window_results: Vec<Vec<::vibesql_types::SqlValue>> = Vec::new();
     let mut window_mapping = HashMap::new();
 
     // Track the column index where window function results start
     let base_column_count = if rows.is_empty() { 0 } else { rows[0].values.len() };
 
+    // Track row reordering from the first window function with PARTITION BY
+    let mut row_reordering: Option<Vec<usize>> = None;
+
     for (idx, win_func) in window_functions.iter().enumerate() {
-        let values = evaluation::evaluate_single_window_function(&rows, win_func, evaluator)?;
-        window_results.push(values);
+        let result = evaluation::evaluate_single_window_function(&rows, win_func, evaluator)?;
+        window_results.push(result.values);
+
+        // Capture row reordering from the first window function that has PARTITION BY
+        if row_reordering.is_none() {
+            row_reordering = result.partition_order;
+        }
 
         // Build mapping: WindowFunctionKey -> column index
         let key =
             WindowFunctionKey::from_expression(&win_func.function_spec, &win_func.window_spec);
         let col_idx = base_column_count + idx;
         window_mapping.insert(key, col_idx);
+    }
+
+    // If we have row reordering (from PARTITION BY), reorder rows and values together
+    if let Some(ref order) = row_reordering {
+        // Reorder rows according to partition order
+        let reordered_rows: Vec<Row> = order.iter().map(|&orig_idx| rows[orig_idx].clone()).collect();
+        rows = reordered_rows;
+
+        // Reorder window results to match the new row order
+        // partition_order[i] = original_idx means position i in partition order came from original_idx
+        // window_results are in original order, so we need: new[i] = old[partition_order[i]]
+        for results in &mut window_results {
+            let reordered: Vec<_> = order.iter().map(|&orig_idx| results[orig_idx].clone()).collect();
+            *results = reordered;
+        }
     }
 
     // Extend each row with window function results

--- a/crates/vibesql-executor/src/select/window/order_by.rs
+++ b/crates/vibesql-executor/src/select/window/order_by.rs
@@ -185,8 +185,10 @@ pub(in crate::select) fn evaluate_order_by_window_functions(
             function_spec: function_spec.clone(),
             window_spec: window_spec.clone(),
         };
-        let values = evaluate_single_window_function(&rows, &win_func_info, evaluator)?;
-        window_results.push(values);
+        let result = evaluate_single_window_function(&rows, &win_func_info, evaluator)?;
+        // Values are in original row order, which matches the input rows
+        // For ORDER BY, we don't need partition ordering since ORDER BY sorts explicitly
+        window_results.push(result.values);
 
         // Build mapping: WindowFunctionKey -> column index
         let col_idx = base_column_count + idx;


### PR DESCRIPTION
## Summary

Fixes window function result ordering to match SQLite's behavior. Window functions with PARTITION BY or ORDER BY now return rows in the correct order:

1. **Rows are grouped by partition** and output in partition key order (using `SqlValue`'s `Ord` implementation for proper numeric ordering)
2. **Within each partition**, rows are ordered by the window function's ORDER BY clause
3. **Window function values** are computed and applied in partition order

## Problem

Previously, VibeSQL returned window function results in original table order:
```sql
SELECT a, sum(b) OVER (PARTITION BY a%2) FROM t1;
-- Got: 0|9, 1|12, 2|9, 3|12, 4|9, 5|12 (interleaved)
```

SQLite groups rows by partition:
```
-- Expected: 0|9, 2|9, 4|9, 1|12, 3|12, 5|12 (grouped)
```

## Changes

- **partitioning.rs**: Use `Vec<SqlValue>` as BTreeMap key for proper value ordering instead of string representation. This fixes the issue where "Integer(11)" sorted before "Integer(3)" lexicographically.

- **evaluation.rs**: Return `WindowEvaluationResult` containing both values and optional partition_order for row reordering.

- **mod.rs**: Reorder rows according to partition order when PARTITION BY or ORDER BY is present in the window specification.

- **order_by.rs**: Update to use new `WindowEvaluationResult` type.

## Test Results

- **window1.test**: 56.6% pass rate (197/348 tests)
- **window3.test**: 48.9% pass rate (784/1602 tests)  
- **All window tests**: 51.4% pass rate (1456/2833 tests)

All Rust tests pass.

Closes #4983