### PR TITLE
fix(parser): allow keywords as identifiers and add ANY data type

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -1277,6 +1277,7 @@ impl<'arena> ArenaParser<'arena> {
             Token::Keyword { keyword: Keyword::Interval, .. } => "INTERVAL".to_string(),
             Token::Keyword { keyword: Keyword::Character, .. } => "CHARACTER".to_string(),
             Token::Keyword { keyword: Keyword::Boolean, .. } => "BOOLEAN".to_string(),
+            Token::Keyword { keyword: Keyword::Any, .. } => "ANY".to_string(),
             _ => return Err(ParseError { message: self.peek().syntax_error() }),
         };
         self.advance();
@@ -1362,7 +1363,7 @@ impl<'arena> ArenaParser<'arena> {
             }
             "UNSIGNED" => Ok(vibesql_types::DataType::Unsigned),
             "SIGNED" => Ok(vibesql_types::DataType::Integer),
-            "BLOB" => Ok(vibesql_types::DataType::BinaryLargeObject),
+            "BLOB" | "ANY" => Ok(vibesql_types::DataType::BinaryLargeObject),
             "CHAR" => {
                 // Parse optional length
                 let length = if self.try_consume(&Token::LParen) {

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -547,15 +547,25 @@ impl<'arena> ArenaParser<'arena> {
                         self.expect_token(Token::LParen)?;
                         let mut columns = BumpVec::new_in(self.arena);
                         loop {
-                            if let Token::Identifier(name) = self.peek() {
-                                let name = name.clone();
-                                self.advance();
-                                columns.push(self.intern(&name));
-                            } else {
-                                return Err(ParseError {
-                                    message: "Expected column name in USING clause".to_string(),
-                                });
-                            }
+                            let name = match self.peek() {
+                                Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
+                                    let n = name.clone();
+                                    self.advance();
+                                    n
+                                }
+                                // Allow unreserved keywords as column names
+                                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                                    let n = format!("{}", kw).to_lowercase();
+                                    self.advance();
+                                    n
+                                }
+                                _ => {
+                                    return Err(ParseError {
+                                        message: "Expected column name in USING clause".to_string(),
+                                    });
+                                }
+                            };
+                            columns.push(self.intern(&name));
                             if !self.try_consume(&Token::Comma) {
                                 break;
                             }

--- a/crates/vibesql-parser/src/arena_parser/update.rs
+++ b/crates/vibesql-parser/src/arena_parser/update.rs
@@ -149,6 +149,12 @@ impl<'arena> ArenaParser<'arena> {
                     self.advance();
                     self.intern("rowid")
                 }
+                // Allow unreserved keywords as column names
+                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                    let col_name = format!("{}", kw).to_lowercase();
+                    self.advance();
+                    self.intern(&col_name)
+                }
                 _ => {
                     return Err(ParseError {
                         message: "Expected column name in SET clause".to_string(),

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -396,7 +396,14 @@ impl Keyword {
             // Join keywords: SQLite allows these as identifiers (table/column/function names)
             // when not in a join context. SQLite TCL tests (func8.test) use these extensively.
             Keyword::Cross | Keyword::Full | Keyword::Inner | Keyword::Left |
-            Keyword::Natural | Keyword::Outer | Keyword::Right
+            Keyword::Natural | Keyword::Outer | Keyword::Right |
+            // Window function keywords: These are contextual in window frame specifications
+            // but can be used as identifiers elsewhere. SQLite TCL tests (window1.test)
+            // create tables with these as column names.
+            Keyword::Current | Keyword::Exclude | Keyword::Filter | Keyword::Following |
+            Keyword::Groups | Keyword::No | Keyword::Others | Keyword::Over |
+            Keyword::Partition | Keyword::Preceding | Keyword::Range | Keyword::Ties |
+            Keyword::Unbounded | Keyword::First | Keyword::Last
         )
     }
 }

--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -36,6 +36,8 @@ impl Parser {
             Token::Keyword { keyword: Keyword::Fixed, .. } => "fixed".to_string(),
             // SQLite type aliases - VARYING can start multi-word types like VARYING CHARACTER
             Token::Keyword { keyword: Keyword::Varying, .. } => "varying".to_string(),
+            // SQLite ANY type - represents any type, stored with no affinity
+            Token::Keyword { keyword: Keyword::Any, .. } => "any".to_string(),
             _ => return Err(ParseError { message: "Expected data type".to_string() }),
         };
         self.advance();
@@ -681,6 +683,9 @@ impl Parser {
                 Ok((vibesql_types::DataType::BinaryLargeObject, false))
             }
             "CLOB" => Ok((vibesql_types::DataType::CharacterLargeObject, false)),
+            // SQLite ANY type - represents any type, stored with BLOB affinity (no type affinity)
+            // This allows expressions like CAST(x AS ANY) to return the original type
+            "ANY" => Ok((vibesql_types::DataType::BinaryLargeObject, false)),
             _ => {
                 // SQLite compatibility: Accept ANY string as a type name.
                 // SQLite uses type affinity rules to determine storage, but accepts

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -57,6 +57,12 @@ impl Parser {
                     p.advance();
                     Ok("rowid".to_string())
                 }
+                // Allow unreserved keywords as column names
+                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                    let name = format!("{}", kw).to_lowercase();
+                    p.advance();
+                    Ok(name)
+                }
                 _ => Err(ParseError { message: "Expected column name".to_string() }),
             })?;
             self.expect_token(Token::RParen)?;
@@ -185,6 +191,12 @@ impl Parser {
                     p.advance();
                     Ok("rowid".to_string())
                 }
+                // Allow unreserved keywords as column names
+                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                    let name = format!("{}", kw).to_lowercase();
+                    p.advance();
+                    Ok(name)
+                }
                 _ => Err(ParseError { message: "Expected column name".to_string() }),
             })?;
             self.expect_token(Token::RParen)?;
@@ -280,6 +292,12 @@ impl Parser {
                 Token::Keyword { keyword: Keyword::Rowid, .. } => {
                     p.advance();
                     Ok("rowid".to_string())
+                }
+                // Allow unreserved keywords as column names
+                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                    let name = format!("{}", kw).to_lowercase();
+                    p.advance();
+                    Ok(name)
                 }
                 _ => Err(ParseError { message: "Expected column name".to_string() }),
             })?;

--- a/crates/vibesql-parser/src/parser/select/list.rs
+++ b/crates/vibesql-parser/src/parser/select/list.rs
@@ -37,6 +37,11 @@ impl Parser {
                     columns.push(id.clone());
                     self.advance();
                 }
+                // Allow unreserved keywords as column names
+                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                    columns.push(format!("{}", kw).to_lowercase());
+                    self.advance();
+                }
                 _ => {
                     return Err(ParseError {
                         message: "Expected column name in derived column list".to_string(),

--- a/crates/vibesql-parser/src/parser/select/statement.rs
+++ b/crates/vibesql-parser/src/parser/select/statement.rs
@@ -456,8 +456,14 @@ impl Parser {
 
             // Parse comma-separated list of column identifiers
             let cols = self.parse_comma_separated_list(|p| match p.peek() {
-                Token::Identifier(col) => {
+                Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
                     let name = col.clone();
+                    p.advance();
+                    Ok(name)
+                }
+                // Allow unreserved keywords as column names
+                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                    let name = format!("{}", kw).to_lowercase();
                     p.advance();
                     Ok(name)
                 }

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -78,6 +78,12 @@ impl Parser {
                     self.advance();
                     "rowid".to_string()
                 }
+                // Allow unreserved keywords as column names
+                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                    let col_name = format!("{}", kw).to_lowercase();
+                    self.advance();
+                    col_name
+                }
                 _ => {
                     return Err(ParseError {
                         message: "Expected column name in SET clause".to_string(),
@@ -221,6 +227,12 @@ impl Parser {
                 Token::Keyword { keyword: Keyword::Rowid, .. } => {
                     self.advance();
                     "rowid".to_string()
+                }
+                // Allow unreserved keywords as column names
+                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                    let col_name = format!("{}", kw).to_lowercase();
+                    self.advance();
+                    col_name
                 }
                 _ => {
                     return Err(ParseError {

--- a/crates/vibesql-parser/src/parser/view.rs
+++ b/crates/vibesql-parser/src/parser/view.rs
@@ -62,6 +62,11 @@ impl Parser {
                         cols.push(name.clone());
                         self.advance();
                     }
+                    // Allow unreserved keywords as column names
+                    Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                        cols.push(format!("{}", kw).to_lowercase());
+                        self.advance();
+                    }
                     _ => {
                         return Err(ParseError {
                             message: "Expected column name in view column list".to_string(),


### PR DESCRIPTION
## Summary
- Add window-related keywords (CURRENT, EXCLUDE, FILTER, FOLLOWING, GROUPS, NO, OTHERS, OVER, PARTITION, PRECEDING, RANGE, TIES, UNBOUNDED, FIRST, LAST) to `can_be_identifier()` so they can be used as column/table names
- Add `ANY` data type support for SQLite compatibility (maps to BLOB affinity)
- Update column name parsing in multiple parser locations to accept keywords that can be identifiers

## Test plan
- [x] All 1238 parser tests pass
- [x] All 8 doc tests pass
- [x] TCL test window1.test 21.0, 21.1, 28.x, 29.x now pass (parser syntax errors resolved)
- [x] TCL test nulls1.test 3.2 now passes
- [x] Manual verification: `CREATE TABLE first(nulls, last)` works
- [x] Manual verification: `CREATE TABLE t(d ANY)` works
- [x] Manual verification: `INSERT INTO first(last, nulls) VALUES(...)` works

Closes #4992

🤖 Generated with [Claude Code](https://claude.com/claude-code)