### PR TITLE
fix(window): thread full expression evaluator through window pipeline

### DIFF
--- a/crates/vibesql-executor/src/evaluator/window/frames.rs
+++ b/crates/vibesql-executor/src/evaluator/window/frames.rs
@@ -11,9 +11,10 @@ use vibesql_ast::{
 };
 use vibesql_types::SqlValue;
 
+use vibesql_storage::Row;
+
 use super::partitioning::Partition;
 use super::sorting::compare_values;
-use super::utils::evaluate_expression_with_map;
 
 /// Validate a window frame specification, returning an error if invalid.
 ///
@@ -108,12 +109,19 @@ fn evaluate_offset_expr(expr: &Expression) -> Result<Option<f64>, String> {
 ///
 /// Returns a `Range<usize>` representing the [start, end) indices of rows in the frame.
 /// Supports ROWS, RANGE, and GROUPS frame semantics.
-pub fn calculate_frame(
+///
+/// The `eval_fn` closure evaluates ORDER BY expressions against rows,
+/// supporting complex expressions (BinaryOp, Function, etc.).
+pub fn calculate_frame<F>(
     partition: &Partition,
     current_row_idx: usize,
     order_by: &Option<Vec<OrderByItem>>,
     frame_spec: &Option<WindowFrame>,
-) -> Range<usize> {
+    eval_fn: &F,
+) -> Range<usize>
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     let partition_size = partition.len();
 
     // Default frame depends on whether there's an ORDER BY:
@@ -134,6 +142,7 @@ pub fn calculate_frame(
                     order_by,
                     &FrameBound::UnboundedPreceding,
                     &Some(FrameBound::CurrentRow),
+                    eval_fn,
                 );
             } else {
                 // Default without ORDER BY: entire partition
@@ -147,12 +156,22 @@ pub fn calculate_frame(
         FrameUnit::Rows => {
             calculate_rows_frame(partition, current_row_idx, &frame.start, &frame.end)
         }
-        FrameUnit::Range => {
-            calculate_range_frame(partition, current_row_idx, order_by, &frame.start, &frame.end)
-        }
-        FrameUnit::Groups => {
-            calculate_groups_frame(partition, current_row_idx, order_by, &frame.start, &frame.end)
-        }
+        FrameUnit::Range => calculate_range_frame(
+            partition,
+            current_row_idx,
+            order_by,
+            &frame.start,
+            &frame.end,
+            eval_fn,
+        ),
+        FrameUnit::Groups => calculate_groups_frame(
+            partition,
+            current_row_idx,
+            order_by,
+            &frame.start,
+            &frame.end,
+            eval_fn,
+        ),
     }
 }
 
@@ -190,13 +209,17 @@ fn calculate_rows_frame(
 /// - CURRENT ROW: All rows with same ORDER BY values (peers)
 /// - N PRECEDING: Rows where ORDER BY value >= current_value - N
 /// - N FOLLOWING: Rows where ORDER BY value <= current_value + N
-fn calculate_range_frame(
+fn calculate_range_frame<F>(
     partition: &Partition,
     current_row_idx: usize,
     order_by: &Option<Vec<OrderByItem>>,
     start: &FrameBound,
     end: &Option<FrameBound>,
-) -> Range<usize> {
+    eval_fn: &F,
+) -> Range<usize>
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     let partition_size = partition.len();
 
     if partition_size == 0 || current_row_idx >= partition_size {
@@ -211,9 +234,7 @@ fn calculate_range_frame(
 
     // Get the current row's ORDER BY value (use first ORDER BY expression)
     let current_row = &partition.rows[current_row_idx];
-    let current_value =
-        evaluate_expression_with_map(&order_items[0].expr, current_row, &partition.column_map)
-            .unwrap_or(SqlValue::Null);
+    let current_value = eval_fn(&order_items[0].expr, current_row).unwrap_or(SqlValue::Null);
 
     // Calculate start boundary
     let start_idx = calculate_range_boundary(
@@ -223,6 +244,7 @@ fn calculate_range_frame(
         &current_value,
         start,
         true,
+        eval_fn,
     );
 
     // Calculate end boundary
@@ -234,10 +256,11 @@ fn calculate_range_frame(
             &current_value,
             end_bound,
             false,
+            eval_fn,
         ),
         None => {
             // Default: CURRENT ROW - find last peer
-            find_last_peer(partition, current_row_idx, order_items) + 1
+            find_last_peer(partition, current_row_idx, order_items, eval_fn) + 1
         }
     };
 
@@ -253,14 +276,18 @@ fn calculate_range_frame(
 /// Note: The meaning of PRECEDING/FOLLOWING depends on sort direction:
 /// - ASC: PRECEDING = smaller values, FOLLOWING = larger values
 /// - DESC: PRECEDING = larger values, FOLLOWING = smaller values
-fn calculate_range_boundary(
+fn calculate_range_boundary<F>(
     partition: &Partition,
     current_row_idx: usize,
     order_items: &[OrderByItem],
     current_value: &SqlValue,
     bound: &FrameBound,
     is_start: bool,
-) -> usize {
+    eval_fn: &F,
+) -> usize
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     use vibesql_ast::OrderDirection;
 
     let partition_size = partition.len();
@@ -276,10 +303,10 @@ fn calculate_range_boundary(
         FrameBound::CurrentRow => {
             if is_start {
                 // Find first peer (row with same ORDER BY values)
-                find_first_peer(partition, current_row_idx, order_items)
+                find_first_peer(partition, current_row_idx, order_items, eval_fn)
             } else {
                 // Find last peer + 1 (exclusive end)
-                find_last_peer(partition, current_row_idx, order_items) + 1
+                find_last_peer(partition, current_row_idx, order_items, eval_fn) + 1
             }
         }
 
@@ -298,16 +325,16 @@ fn calculate_range_boundary(
                 // For DESC: find first row where value <= target (target is larger, comes first)
                 // For ASC: find first row where value >= target (target is smaller, comes first)
                 if is_desc {
-                    find_first_row_le_desc(partition, order_items, &target_value)
+                    find_first_row_le_desc(partition, order_items, &target_value, eval_fn)
                 } else {
-                    find_first_row_ge(partition, order_items, &target_value)
+                    find_first_row_ge(partition, order_items, &target_value, eval_fn)
                 }
             } else {
                 // Find the boundary row and return exclusive end
                 if is_desc {
-                    find_last_row_ge_desc(partition, order_items, &target_value) + 1
+                    find_last_row_ge_desc(partition, order_items, &target_value, eval_fn) + 1
                 } else {
-                    find_last_row_le(partition, order_items, &target_value) + 1
+                    find_last_row_le(partition, order_items, &target_value, eval_fn) + 1
                 }
             }
         }
@@ -327,16 +354,16 @@ fn calculate_range_boundary(
                 // For DESC: find first row where value <= target (target is smaller, comes later)
                 // For ASC: find first row where value >= target (target is larger, comes later)
                 if is_desc {
-                    find_first_row_le_desc(partition, order_items, &target_value)
+                    find_first_row_le_desc(partition, order_items, &target_value, eval_fn)
                 } else {
-                    find_first_row_ge(partition, order_items, &target_value)
+                    find_first_row_ge(partition, order_items, &target_value, eval_fn)
                 }
             } else {
                 // Find the boundary row and return exclusive end
                 if is_desc {
-                    find_last_row_ge_desc(partition, order_items, &target_value) + 1
+                    find_last_row_ge_desc(partition, order_items, &target_value, eval_fn) + 1
                 } else {
-                    find_last_row_le(partition, order_items, &target_value) + 1
+                    find_last_row_le(partition, order_items, &target_value, eval_fn) + 1
                 }
             }
         }
@@ -350,13 +377,17 @@ fn calculate_range_boundary(
 /// - CURRENT ROW: Current peer group
 /// - N PRECEDING: N peer groups before current
 /// - N FOLLOWING: N peer groups after current
-fn calculate_groups_frame(
+fn calculate_groups_frame<F>(
     partition: &Partition,
     current_row_idx: usize,
     order_by: &Option<Vec<OrderByItem>>,
     start: &FrameBound,
     end: &Option<FrameBound>,
-) -> Range<usize> {
+    eval_fn: &F,
+) -> Range<usize>
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     let partition_size = partition.len();
 
     if partition_size == 0 || current_row_idx >= partition_size {
@@ -370,7 +401,7 @@ fn calculate_groups_frame(
     };
 
     // Build peer group boundaries
-    let group_boundaries = build_group_boundaries(partition, order_items);
+    let group_boundaries = build_group_boundaries(partition, order_items, eval_fn);
     let current_group = find_group_for_row(&group_boundaries, current_row_idx);
 
     // Calculate start boundary
@@ -462,7 +493,14 @@ fn calculate_groups_boundary(
 }
 
 /// Build a list of peer group start indices
-fn build_group_boundaries(partition: &Partition, order_items: &[OrderByItem]) -> Vec<usize> {
+fn build_group_boundaries<F>(
+    partition: &Partition,
+    order_items: &[OrderByItem],
+    eval_fn: &F,
+) -> Vec<usize>
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     let mut boundaries = vec![0];
 
     for i in 1..partition.len() {
@@ -472,12 +510,8 @@ fn build_group_boundaries(partition: &Partition, order_items: &[OrderByItem]) ->
         // Check if this row starts a new group (different ORDER BY values)
         let mut is_new_group = false;
         for item in order_items {
-            let prev_val =
-                evaluate_expression_with_map(&item.expr, prev_row, &partition.column_map)
-                    .unwrap_or(SqlValue::Null);
-            let curr_val =
-                evaluate_expression_with_map(&item.expr, curr_row, &partition.column_map)
-                    .unwrap_or(SqlValue::Null);
+            let prev_val = eval_fn(&item.expr, prev_row).unwrap_or(SqlValue::Null);
+            let curr_val = eval_fn(&item.expr, curr_row).unwrap_or(SqlValue::Null);
             if compare_values(&prev_val, &curr_val) != Ordering::Equal {
                 is_new_group = true;
                 break;
@@ -503,11 +537,15 @@ fn find_group_for_row(group_boundaries: &[usize], row_idx: usize) -> usize {
 }
 
 /// Find the first peer (row with same ORDER BY values as current)
-fn find_first_peer(
+fn find_first_peer<F>(
     partition: &Partition,
     current_row_idx: usize,
     order_items: &[OrderByItem],
-) -> usize {
+    eval_fn: &F,
+) -> usize
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     let current_row = &partition.rows[current_row_idx];
 
     for i in (0..current_row_idx).rev() {
@@ -515,11 +553,8 @@ fn find_first_peer(
         let mut is_peer = true;
 
         for item in order_items {
-            let curr_val =
-                evaluate_expression_with_map(&item.expr, current_row, &partition.column_map)
-                    .unwrap_or(SqlValue::Null);
-            let row_val = evaluate_expression_with_map(&item.expr, row, &partition.column_map)
-                .unwrap_or(SqlValue::Null);
+            let curr_val = eval_fn(&item.expr, current_row).unwrap_or(SqlValue::Null);
+            let row_val = eval_fn(&item.expr, row).unwrap_or(SqlValue::Null);
             if compare_values(&curr_val, &row_val) != Ordering::Equal {
                 is_peer = false;
                 break;
@@ -535,11 +570,15 @@ fn find_first_peer(
 }
 
 /// Find the last peer (row with same ORDER BY values as current)
-fn find_last_peer(
+fn find_last_peer<F>(
     partition: &Partition,
     current_row_idx: usize,
     order_items: &[OrderByItem],
-) -> usize {
+    eval_fn: &F,
+) -> usize
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     let current_row = &partition.rows[current_row_idx];
 
     for i in (current_row_idx + 1)..partition.len() {
@@ -547,11 +586,8 @@ fn find_last_peer(
         let mut is_peer = true;
 
         for item in order_items {
-            let curr_val =
-                evaluate_expression_with_map(&item.expr, current_row, &partition.column_map)
-                    .unwrap_or(SqlValue::Null);
-            let row_val = evaluate_expression_with_map(&item.expr, row, &partition.column_map)
-                .unwrap_or(SqlValue::Null);
+            let curr_val = eval_fn(&item.expr, current_row).unwrap_or(SqlValue::Null);
+            let row_val = eval_fn(&item.expr, row).unwrap_or(SqlValue::Null);
             if compare_values(&curr_val, &row_val) != Ordering::Equal {
                 is_peer = false;
                 break;
@@ -567,14 +603,17 @@ fn find_last_peer(
 }
 
 /// Find the first row where ORDER BY value >= target
-fn find_first_row_ge(
+fn find_first_row_ge<F>(
     partition: &Partition,
     order_items: &[OrderByItem],
     target: &SqlValue,
-) -> usize {
+    eval_fn: &F,
+) -> usize
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     for (i, row) in partition.rows.iter().enumerate() {
-        let val = evaluate_expression_with_map(&order_items[0].expr, row, &partition.column_map)
-            .unwrap_or(SqlValue::Null);
+        let val = eval_fn(&order_items[0].expr, row).unwrap_or(SqlValue::Null);
         if compare_values(&val, target) != Ordering::Less {
             return i;
         }
@@ -583,18 +622,17 @@ fn find_first_row_ge(
 }
 
 /// Find the last row where ORDER BY value <= target
-fn find_last_row_le(
+fn find_last_row_le<F>(
     partition: &Partition,
     order_items: &[OrderByItem],
     target: &SqlValue,
-) -> usize {
+    eval_fn: &F,
+) -> usize
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     for i in (0..partition.len()).rev() {
-        let val = evaluate_expression_with_map(
-            &order_items[0].expr,
-            &partition.rows[i],
-            &partition.column_map,
-        )
-        .unwrap_or(SqlValue::Null);
+        let val = eval_fn(&order_items[0].expr, &partition.rows[i]).unwrap_or(SqlValue::Null);
         if compare_values(&val, target) != Ordering::Greater {
             return i;
         }
@@ -606,14 +644,17 @@ fn find_last_row_le(
 ///
 /// In a DESC-sorted partition, values decrease as we go through the rows.
 /// This finds the first row (smallest index) where value <= target.
-fn find_first_row_le_desc(
+fn find_first_row_le_desc<F>(
     partition: &Partition,
     order_items: &[OrderByItem],
     target: &SqlValue,
-) -> usize {
+    eval_fn: &F,
+) -> usize
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     for (i, row) in partition.rows.iter().enumerate() {
-        let val = evaluate_expression_with_map(&order_items[0].expr, row, &partition.column_map)
-            .unwrap_or(SqlValue::Null);
+        let val = eval_fn(&order_items[0].expr, row).unwrap_or(SqlValue::Null);
         if compare_values(&val, target) != Ordering::Greater {
             return i;
         }
@@ -625,18 +666,17 @@ fn find_first_row_le_desc(
 ///
 /// In a DESC-sorted partition, values decrease as we go through the rows.
 /// This finds the last row (largest index) where value >= target.
-fn find_last_row_ge_desc(
+fn find_last_row_ge_desc<F>(
     partition: &Partition,
     order_items: &[OrderByItem],
     target: &SqlValue,
-) -> usize {
+    eval_fn: &F,
+) -> usize
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     for i in (0..partition.len()).rev() {
-        let val = evaluate_expression_with_map(
-            &order_items[0].expr,
-            &partition.rows[i],
-            &partition.column_map,
-        )
-        .unwrap_or(SqlValue::Null);
+        let val = eval_fn(&order_items[0].expr, &partition.rows[i]).unwrap_or(SqlValue::Null);
         if compare_values(&val, target) != Ordering::Less {
             return i;
         }
@@ -739,12 +779,16 @@ impl FrameResult {
     /// Check if a row index should be included in the frame calculation
     ///
     /// Takes into account both the frame range and the EXCLUDE clause.
-    pub fn includes(
+    pub fn includes<F>(
         &self,
         row_idx: usize,
         partition: &Partition,
         order_by: &Option<Vec<OrderByItem>>,
-    ) -> bool {
+        eval_fn: &F,
+    ) -> bool
+    where
+        F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+    {
         // First check if row is in the frame range
         if !self.range.contains(&row_idx) {
             return false;
@@ -758,13 +802,13 @@ impl FrameResult {
 
             Some(FrameExclude::Group) => {
                 // Exclude current row and all its peers (rows with same ORDER BY values)
-                !is_peer(row_idx, self.current_row_idx, partition, order_by)
+                !is_peer(row_idx, self.current_row_idx, partition, order_by, eval_fn)
             }
 
             Some(FrameExclude::Ties) => {
                 // Exclude peers of current row, but include current row itself
                 row_idx == self.current_row_idx
-                    || !is_peer(row_idx, self.current_row_idx, partition, order_by)
+                    || !is_peer(row_idx, self.current_row_idx, partition, order_by, eval_fn)
             }
         }
     }
@@ -772,25 +816,33 @@ impl FrameResult {
     /// Get an iterator over all included row indices
     ///
     /// This filters out excluded rows based on the EXCLUDE clause.
-    pub fn included_indices<'a>(
+    pub fn included_indices<'a, F>(
         &'a self,
         partition: &'a Partition,
         order_by: &'a Option<Vec<OrderByItem>>,
-    ) -> impl Iterator<Item = usize> + 'a {
-        self.range.clone().filter(move |&idx| self.includes(idx, partition, order_by))
+        eval_fn: &'a F,
+    ) -> impl Iterator<Item = usize> + 'a
+    where
+        F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+    {
+        self.range.clone().filter(move |&idx| self.includes(idx, partition, order_by, eval_fn))
     }
 }
 
 /// Calculate frame with exclusion information
 ///
 /// Returns a FrameResult that includes both the range and exclusion info.
-pub fn calculate_frame_with_exclusion(
+pub fn calculate_frame_with_exclusion<F>(
     partition: &Partition,
     current_row_idx: usize,
     order_by: &Option<Vec<OrderByItem>>,
     frame_spec: &Option<WindowFrame>,
-) -> FrameResult {
-    let range = calculate_frame(partition, current_row_idx, order_by, frame_spec);
+    eval_fn: &F,
+) -> FrameResult
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
+    let range = calculate_frame(partition, current_row_idx, order_by, frame_spec, eval_fn);
     let exclude = frame_spec.as_ref().and_then(|f| f.exclude);
 
     FrameResult { range, exclude, current_row_idx }
@@ -800,12 +852,16 @@ pub fn calculate_frame_with_exclusion(
 ///
 /// Rows are considered peers if they have identical values for all ORDER BY expressions.
 /// If there's no ORDER BY clause, all rows are considered peers.
-fn is_peer(
+fn is_peer<F>(
     row_idx_a: usize,
     row_idx_b: usize,
     partition: &Partition,
     order_by: &Option<Vec<OrderByItem>>,
-) -> bool {
+    eval_fn: &F,
+) -> bool
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     // Same row is always a peer of itself
     if row_idx_a == row_idx_b {
         return true;
@@ -827,10 +883,8 @@ fn is_peer(
 
     // Compare all ORDER BY expressions
     for order_item in order_items {
-        let val_a = evaluate_expression_with_map(&order_item.expr, row_a, &partition.column_map)
-            .unwrap_or(SqlValue::Null);
-        let val_b = evaluate_expression_with_map(&order_item.expr, row_b, &partition.column_map)
-            .unwrap_or(SqlValue::Null);
+        let val_a = eval_fn(&order_item.expr, row_a).unwrap_or(SqlValue::Null);
+        let val_b = eval_fn(&order_item.expr, row_b).unwrap_or(SqlValue::Null);
 
         if compare_values(&val_a, &val_b) != Ordering::Equal {
             return false;

--- a/crates/vibesql-executor/src/evaluator/window/ranking.rs
+++ b/crates/vibesql-executor/src/evaluator/window/ranking.rs
@@ -4,12 +4,11 @@
 
 use std::cmp::Ordering;
 
-use vibesql_ast::OrderByItem;
+use vibesql_ast::{Expression, OrderByItem};
+use vibesql_storage::Row;
 use vibesql_types::SqlValue;
 
-use super::{
-    partitioning::Partition, sorting::compare_values, utils::evaluate_expression_with_map,
-};
+use super::{partitioning::Partition, sorting::compare_values};
 
 /// Evaluate ROW_NUMBER() window function
 ///
@@ -31,7 +30,17 @@ pub fn evaluate_row_number(partition: &Partition) -> Vec<SqlValue> {
 /// Example for scores [95, 90, 90, 85]: ranks are [1, 2, 2, 4]
 ///
 /// Requires ORDER BY clause - partitions must be pre-sorted.
-pub fn evaluate_rank(partition: &Partition, order_by: &Option<Vec<OrderByItem>>) -> Vec<SqlValue> {
+///
+/// The `eval_fn` closure evaluates ORDER BY expressions against rows,
+/// supporting complex expressions (BinaryOp, Function, etc.).
+pub fn evaluate_rank<F>(
+    partition: &Partition,
+    order_by: &Option<Vec<OrderByItem>>,
+    eval_fn: F,
+) -> Vec<SqlValue>
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     // RANK requires ORDER BY
     if order_by.is_none() || order_by.as_ref().unwrap().is_empty() {
         // Without ORDER BY, all rows get rank 1
@@ -50,12 +59,8 @@ pub fn evaluate_rank(partition: &Partition, order_by: &Option<Vec<OrderByItem>>)
             // Check if ORDER BY values differ
             let mut values_differ = false;
             for order_item in order_items {
-                let val_curr =
-                    evaluate_expression_with_map(&order_item.expr, row, &partition.column_map)
-                        .unwrap_or(SqlValue::Null);
-                let val_prev =
-                    evaluate_expression_with_map(&order_item.expr, prev_row, &partition.column_map)
-                        .unwrap_or(SqlValue::Null);
+                let val_curr = eval_fn(&order_item.expr, row).unwrap_or(SqlValue::Null);
+                let val_prev = eval_fn(&order_item.expr, prev_row).unwrap_or(SqlValue::Null);
 
                 if compare_values(&val_curr, &val_prev) != Ordering::Equal {
                     values_differ = true;
@@ -85,10 +90,17 @@ pub fn evaluate_rank(partition: &Partition, order_by: &Option<Vec<OrderByItem>>)
 /// Example for scores [95, 90, 90, 85]: ranks are [1, 2, 2, 3]
 ///
 /// Requires ORDER BY clause - partitions must be pre-sorted.
-pub fn evaluate_dense_rank(
+///
+/// The `eval_fn` closure evaluates ORDER BY expressions against rows,
+/// supporting complex expressions (BinaryOp, Function, etc.).
+pub fn evaluate_dense_rank<F>(
     partition: &Partition,
     order_by: &Option<Vec<OrderByItem>>,
-) -> Vec<SqlValue> {
+    eval_fn: F,
+) -> Vec<SqlValue>
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     // DENSE_RANK requires ORDER BY
     if order_by.is_none() || order_by.as_ref().unwrap().is_empty() {
         // Without ORDER BY, all rows get rank 1
@@ -107,12 +119,8 @@ pub fn evaluate_dense_rank(
             // Check if ORDER BY values differ
             let mut values_differ = false;
             for order_item in order_items {
-                let val_curr =
-                    evaluate_expression_with_map(&order_item.expr, row, &partition.column_map)
-                        .unwrap_or(SqlValue::Null);
-                let val_prev =
-                    evaluate_expression_with_map(&order_item.expr, prev_row, &partition.column_map)
-                        .unwrap_or(SqlValue::Null);
+                let val_curr = eval_fn(&order_item.expr, row).unwrap_or(SqlValue::Null);
+                let val_prev = eval_fn(&order_item.expr, prev_row).unwrap_or(SqlValue::Null);
 
                 if compare_values(&val_curr, &val_prev) != Ordering::Equal {
                     values_differ = true;
@@ -145,10 +153,17 @@ pub fn evaluate_dense_rank(
 ///   - percent_rank: [0.0, 0.333..., 0.333..., 1.0]
 ///
 /// Requires ORDER BY clause - partitions must be pre-sorted.
-pub fn evaluate_percent_rank(
+///
+/// The `eval_fn` closure evaluates ORDER BY expressions against rows,
+/// supporting complex expressions (BinaryOp, Function, etc.).
+pub fn evaluate_percent_rank<F>(
     partition: &Partition,
     order_by: &Option<Vec<OrderByItem>>,
-) -> Vec<SqlValue> {
+    eval_fn: F,
+) -> Vec<SqlValue>
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     let n = partition.len();
 
     // Single row partition - return 0.0
@@ -157,7 +172,7 @@ pub fn evaluate_percent_rank(
     }
 
     // Get ranks first (reuse RANK logic)
-    let ranks = evaluate_rank(partition, order_by);
+    let ranks = evaluate_rank(partition, order_by, eval_fn);
 
     // Convert ranks to percent_rank: (rank - 1) / (n - 1)
     let denominator = (n - 1) as f64;
@@ -189,10 +204,17 @@ pub fn evaluate_percent_rank(
 ///   - cume_dist: [0.25, 0.75, 0.75, 1.0]
 ///
 /// Requires ORDER BY clause - partitions must be pre-sorted.
-pub fn evaluate_cume_dist(
+///
+/// The `eval_fn` closure evaluates ORDER BY expressions against rows,
+/// supporting complex expressions (BinaryOp, Function, etc.).
+pub fn evaluate_cume_dist<F>(
     partition: &Partition,
     order_by: &Option<Vec<OrderByItem>>,
-) -> Vec<SqlValue> {
+    eval_fn: F,
+) -> Vec<SqlValue>
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     let n = partition.len();
 
     // Empty partition - shouldn't happen but handle gracefully
@@ -224,12 +246,8 @@ pub fn evaluate_cume_dist(
 
             let mut differs = false;
             for order_item in order_items {
-                let val_curr =
-                    evaluate_expression_with_map(&order_item.expr, curr_row, &partition.column_map)
-                        .unwrap_or(SqlValue::Null);
-                let val_next =
-                    evaluate_expression_with_map(&order_item.expr, next_row, &partition.column_map)
-                        .unwrap_or(SqlValue::Null);
+                let val_curr = eval_fn(&order_item.expr, curr_row).unwrap_or(SqlValue::Null);
+                let val_next = eval_fn(&order_item.expr, next_row).unwrap_or(SqlValue::Null);
 
                 if compare_values(&val_curr, &val_next) != Ordering::Equal {
                     differs = true;

--- a/crates/vibesql-executor/src/evaluator/window/sorting.rs
+++ b/crates/vibesql-executor/src/evaluator/window/sorting.rs
@@ -4,16 +4,24 @@
 
 use std::cmp::Ordering;
 
-use vibesql_ast::{OrderByItem, OrderDirection};
+use vibesql_ast::{Expression, OrderByItem, OrderDirection};
+use vibesql_storage::Row;
 use vibesql_types::SqlValue;
 
-use super::{partitioning::Partition, utils::evaluate_expression_with_map};
+use super::partitioning::Partition;
 
 /// Sort a partition by ORDER BY clauses
 ///
 /// Sorts rows within a partition according to ORDER BY specification.
 /// Also keeps original_indices in sync with the sorted rows.
-pub fn sort_partition(partition: &mut Partition, order_by: &Option<Vec<OrderByItem>>) {
+///
+/// The `eval_fn` closure is used to evaluate ORDER BY expressions against rows.
+/// This supports complex expressions (BinaryOp, Function, etc.), not just literals
+/// and column references.
+pub fn sort_partition<F>(partition: &mut Partition, order_by: &Option<Vec<OrderByItem>>, eval_fn: F)
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+{
     // If no ORDER BY, keep original order
     let Some(order_items) = order_by else {
         return;
@@ -28,13 +36,10 @@ pub fn sort_partition(partition: &mut Partition, order_by: &Option<Vec<OrderByIt
 
     // Sort indices by evaluating order expressions on the rows
     let rows = &partition.rows; // Borrow for comparison only
-    let column_map = &partition.column_map;
     indices.sort_by(|&a, &b| {
         for order_item in order_items {
-            let val_a = evaluate_expression_with_map(&order_item.expr, &rows[a], column_map)
-                .unwrap_or(SqlValue::Null);
-            let val_b = evaluate_expression_with_map(&order_item.expr, &rows[b], column_map)
-                .unwrap_or(SqlValue::Null);
+            let val_a = eval_fn(&order_item.expr, &rows[a]).unwrap_or(SqlValue::Null);
+            let val_b = eval_fn(&order_item.expr, &rows[b]).unwrap_or(SqlValue::Null);
 
             let cmp = compare_values(&val_a, &val_b);
 

--- a/crates/vibesql-executor/src/evaluator/window/tests/frames.rs
+++ b/crates/vibesql-executor/src/evaluator/window/tests/frames.rs
@@ -8,12 +8,17 @@ fn make_test_rows(values: Vec<i64>) -> Vec<Row> {
     values.into_iter().map(|v| Row::new(vec![SqlValue::Integer(v)])).collect()
 }
 
+/// Simple eval_fn for tests
+fn test_eval_fn(expr: &Expression, row: &Row) -> Result<SqlValue, String> {
+    evaluate_expression(expr, row)
+}
+
 #[test]
 fn test_calculate_frame_default() {
     let partition = Partition::new(make_test_rows(vec![1, 2, 3, 4, 5]));
 
     // Default frame WITHOUT ORDER BY: entire partition
-    let frame = calculate_frame(&partition, 2, &None, &None);
+    let frame = calculate_frame(&partition, 2, &None, &None, &test_eval_fn);
 
     assert_eq!(frame, 0..5); // Entire partition (no ORDER BY)
 }
@@ -29,7 +34,7 @@ fn test_calculate_frame_unbounded_preceding() {
         exclude: None,
     };
 
-    let frame = calculate_frame(&partition, 2, &None, &Some(frame_spec));
+    let frame = calculate_frame(&partition, 2, &None, &Some(frame_spec), &test_eval_fn);
 
     assert_eq!(frame, 0..3); // Rows 0, 1, 2
 }
@@ -45,7 +50,7 @@ fn test_calculate_frame_preceding() {
         exclude: None,
     };
 
-    let frame = calculate_frame(&partition, 3, &None, &Some(frame_spec));
+    let frame = calculate_frame(&partition, 3, &None, &Some(frame_spec), &test_eval_fn);
 
     // 2 PRECEDING from row 3 is row 1, so rows 1, 2, 3
     assert_eq!(frame, 1..4);
@@ -62,7 +67,7 @@ fn test_calculate_frame_following() {
         exclude: None,
     };
 
-    let frame = calculate_frame(&partition, 1, &None, &Some(frame_spec));
+    let frame = calculate_frame(&partition, 1, &None, &Some(frame_spec), &test_eval_fn);
 
     // Current row 1 to 2 FOLLOWING (row 3), so rows 1, 2, 3
     assert_eq!(frame, 1..4);
@@ -79,7 +84,7 @@ fn test_calculate_frame_unbounded_following() {
         exclude: None,
     };
 
-    let frame = calculate_frame(&partition, 2, &None, &Some(frame_spec));
+    let frame = calculate_frame(&partition, 2, &None, &Some(frame_spec), &test_eval_fn);
 
     // Current row 2 to end: rows 2, 3, 4
     assert_eq!(frame, 2..5);

--- a/crates/vibesql-executor/src/evaluator/window/tests/ranking.rs
+++ b/crates/vibesql-executor/src/evaluator/window/tests/ranking.rs
@@ -8,6 +8,11 @@ fn make_test_rows(values: Vec<i64>) -> Vec<Row> {
     values.into_iter().map(|v| Row::new(vec![SqlValue::Integer(v)])).collect()
 }
 
+/// Simple eval_fn for tests: evaluates expressions using the test evaluator
+fn test_eval_fn(expr: &Expression, row: &Row) -> Result<SqlValue, String> {
+    evaluate_expression(expr, row)
+}
+
 // ===== ROW_NUMBER Tests =====
 
 #[test]
@@ -38,7 +43,7 @@ fn test_rank_with_ties() {
         nulls_order: None,
     }]);
 
-    let result = evaluate_rank(&partition, &order_by);
+    let result = evaluate_rank(&partition, &order_by, test_eval_fn);
 
     assert_eq!(result.len(), 4);
     assert_eq!(result[0], SqlValue::Integer(1)); // 95 -> rank 1
@@ -57,7 +62,7 @@ fn test_rank_no_ties() {
         nulls_order: None,
     }]);
 
-    let result = evaluate_rank(&partition, &order_by);
+    let result = evaluate_rank(&partition, &order_by, test_eval_fn);
 
     assert_eq!(result.len(), 4);
     assert_eq!(result[0], SqlValue::Integer(1));
@@ -70,7 +75,7 @@ fn test_rank_no_ties() {
 fn test_rank_without_order_by() {
     let partition = Partition::new(make_test_rows(vec![10, 20, 30]));
 
-    let result = evaluate_rank(&partition, &None);
+    let result = evaluate_rank(&partition, &None, test_eval_fn);
 
     // Without ORDER BY, all rows get rank 1
     assert_eq!(result.len(), 3);
@@ -93,7 +98,7 @@ fn test_dense_rank_with_ties() {
         nulls_order: None,
     }]);
 
-    let result = evaluate_dense_rank(&partition, &order_by);
+    let result = evaluate_dense_rank(&partition, &order_by, test_eval_fn);
 
     assert_eq!(result.len(), 4);
     assert_eq!(result[0], SqlValue::Integer(1)); // 95 -> rank 1
@@ -114,7 +119,7 @@ fn test_dense_rank_multiple_tie_groups() {
         nulls_order: None,
     }]);
 
-    let result = evaluate_dense_rank(&partition, &order_by);
+    let result = evaluate_dense_rank(&partition, &order_by, test_eval_fn);
 
     assert_eq!(result.len(), 7);
     assert_eq!(result[0], SqlValue::Integer(1));

--- a/crates/vibesql-executor/src/evaluator/window/utils.rs
+++ b/crates/vibesql-executor/src/evaluator/window/utils.rs
@@ -1,21 +1,17 @@
 //! Utility functions for window function evaluation
 //!
-//! This module provides expression evaluation for window function frame calculations.
-//! The `evaluate_expression_with_map` function supports column name resolution via
-//! a pre-built column name to index mapping.
+//! This module provides helper functions for window function evaluation.
 
 use vibesql_ast::Expression;
-use vibesql_storage::Row;
 use vibesql_types::SqlValue;
 
-/// Evaluate expression with column name mapping support
+/// Simple expression evaluator for tests
 ///
-/// This version accepts a column name to index mapping for resolving named columns.
-pub fn evaluate_expression_with_map(
-    expr: &Expression,
-    row: &Row,
-    column_map: &std::collections::HashMap<String, usize>,
-) -> Result<SqlValue, String> {
+/// This version uses index-based column resolution (columns named "0", "1", etc.)
+/// and only handles Literal and ColumnRef expressions. It is used as a test-only
+/// eval_fn for unit tests where the full CombinedExpressionEvaluator is not available.
+#[cfg(test)]
+pub fn evaluate_expression(expr: &Expression, row: &vibesql_storage::Row) -> Result<SqlValue, String> {
     match expr {
         Expression::Literal(val) => Ok(val.clone()),
         Expression::ColumnRef(col_id) => {
@@ -26,33 +22,12 @@ pub fn evaluate_expression_with_map(
                     .cloned()
                     .ok_or_else(|| format!("Column index {} out of bounds", index))
             } else {
-                // Try to find column name in the mapping
-                if let Some(&index) = column_map.get(column) {
-                    row.get(index)
-                        .cloned()
-                        .ok_or_else(|| format!("Column index {} out of bounds", index))
-                } else if let Some(&index) = column_map.get(&column.to_lowercase()) {
-                    row.get(index)
-                        .cloned()
-                        .ok_or_else(|| format!("Column index {} out of bounds", index))
-                } else {
-                    // Fallback: assume first column
-                    // This is a limitation - proper implementation should use schema
-                    row.get(0).cloned().ok_or_else(|| "Row has no columns".to_string())
-                }
+                // Fallback: assume first column (for simple test cases)
+                row.get(0).cloned().ok_or_else(|| "Row has no columns".to_string())
             }
         }
-        _ => Err("Unsupported expression in window function".to_string()),
+        _ => Err("Unsupported expression in test evaluator".to_string()),
     }
-}
-
-/// Simple expression evaluator for tests
-///
-/// This version uses index-based column resolution (columns named "0", "1", etc.)
-/// without requiring a column name mapping.
-#[cfg(test)]
-pub fn evaluate_expression(expr: &Expression, row: &Row) -> Result<SqlValue, String> {
-    evaluate_expression_with_map(expr, row, &std::collections::HashMap::new())
 }
 
 /// Evaluate default value expression

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -161,8 +161,18 @@ pub(super) fn apply_window_functions_to_aggregates(
 
         let order_by_ref = order_by_items.clone();
 
+        // Create the eval_fn closure for sorting, ranking, and frame calculations
+        let agg_eval_fn = |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
+            evaluator.clear_cse_cache();
+            evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
+        };
+
         for partition in &mut partitions {
-            sort_partition(partition, &order_by_ref);
+            let sort_eval_fn = |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
+                evaluator.clear_cse_cache();
+                evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
+            };
+            sort_partition(partition, &order_by_ref, sort_eval_fn);
         }
 
         // Compute window function values for each partition
@@ -196,13 +206,16 @@ pub(super) fn apply_window_functions_to_aggregates(
                             row_idx,
                             &order_by_ref,
                             &win_func.window_spec.frame,
+                            &agg_eval_fn,
                         );
-                        let frame_indices = frame_result.included_indices(partition, &order_by_ref);
+                        let frame_indices =
+                            frame_result.included_indices(partition, &order_by_ref, &agg_eval_fn);
 
-                        let eval_fn = |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
-                            evaluator.clear_cse_cache();
-                            evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
-                        };
+                        let inner_eval_fn =
+                            |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
+                                evaluator.clear_cse_cache();
+                                evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
+                            };
 
                         let value = match win_func.func_name.to_uppercase().as_str() {
                             "COUNT" => evaluate_count_window(
@@ -210,20 +223,36 @@ pub(super) fn apply_window_functions_to_aggregates(
                                 frame_indices,
                                 Some(&arg_expr),
                                 None,
-                                eval_fn,
+                                inner_eval_fn,
                             ),
-                            "SUM" => {
-                                evaluate_sum_window(partition, frame_indices, &arg_expr, None, eval_fn)
-                            }
-                            "AVG" => {
-                                evaluate_avg_window(partition, frame_indices, &arg_expr, None, eval_fn)
-                            }
-                            "MIN" => {
-                                evaluate_min_window(partition, frame_indices, &arg_expr, None, eval_fn)
-                            }
-                            "MAX" => {
-                                evaluate_max_window(partition, frame_indices, &arg_expr, None, eval_fn)
-                            }
+                            "SUM" => evaluate_sum_window(
+                                partition,
+                                frame_indices,
+                                &arg_expr,
+                                None,
+                                inner_eval_fn,
+                            ),
+                            "AVG" => evaluate_avg_window(
+                                partition,
+                                frame_indices,
+                                &arg_expr,
+                                None,
+                                inner_eval_fn,
+                            ),
+                            "MIN" => evaluate_min_window(
+                                partition,
+                                frame_indices,
+                                &arg_expr,
+                                None,
+                                inner_eval_fn,
+                            ),
+                            "MAX" => evaluate_max_window(
+                                partition,
+                                frame_indices,
+                                &arg_expr,
+                                None,
+                                inner_eval_fn,
+                            ),
                             other => {
                                 return Err(ExecutorError::UnsupportedExpression(format!(
                                     "Unsupported aggregate window function: {}",
@@ -238,22 +267,19 @@ pub(super) fn apply_window_functions_to_aggregates(
                 WindowFunctionType::Ranking => {
                     let values = match win_func.func_name.to_uppercase().as_str() {
                         "ROW_NUMBER" => evaluate_row_number(partition),
-                        "RANK" => evaluate_rank(partition, &order_by_ref),
-                        "DENSE_RANK" => evaluate_dense_rank(partition, &order_by_ref),
-                        "PERCENT_RANK" => evaluate_percent_rank(partition, &order_by_ref),
-                        "CUME_DIST" => evaluate_cume_dist(partition, &order_by_ref),
+                        "RANK" => evaluate_rank(partition, &order_by_ref, &agg_eval_fn),
+                        "DENSE_RANK" => evaluate_dense_rank(partition, &order_by_ref, &agg_eval_fn),
+                        "PERCENT_RANK" => {
+                            evaluate_percent_rank(partition, &order_by_ref, &agg_eval_fn)
+                        }
+                        "CUME_DIST" => evaluate_cume_dist(partition, &order_by_ref, &agg_eval_fn),
                         "NTILE" => {
                             // NTILE requires a constant argument
                             if partition.is_empty() {
                                 vec![]
                             } else {
                                 let n_val = if !mapped_args.is_empty() {
-                                    let eval_fn =
-                                        |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
-                                            evaluator.clear_cse_cache();
-                                            evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
-                                        };
-                                    eval_fn(&mapped_args[0], &partition.rows[0])
+                                    agg_eval_fn(&mapped_args[0], &partition.rows[0])
                                         .ok()
                                         .and_then(|v| match v {
                                             SqlValue::Integer(n) => Some(n),

--- a/crates/vibesql-executor/src/select/window/evaluation.rs
+++ b/crates/vibesql-executor/src/select/window/evaluation.rs
@@ -82,12 +82,42 @@ pub(super) fn evaluate_single_window_function(
         // Threshold: parallelize if total rows > sort threshold AND partitions > 1
         if partitions.len() > 1 && config.should_parallelize_sort(rows.len()) {
             let order_by = &win_func.window_spec.order_by;
+            // Get components for thread-local evaluators
+            let sort_components = evaluator.get_parallel_components();
             partitions.par_iter_mut().for_each(|partition| {
-                sort_partition(partition, order_by);
+                let (
+                    schema,
+                    database,
+                    outer_row,
+                    outer_schema,
+                    window_mapping,
+                    cte_context,
+                    enable_cse,
+                ) = sort_components;
+                let local_evaluator = CombinedExpressionEvaluator::from_parallel_components(
+                    schema,
+                    database,
+                    outer_row,
+                    outer_schema,
+                    window_mapping,
+                    cte_context,
+                    enable_cse,
+                );
+                let sort_eval_fn =
+                    |expr: &Expression, row: &vibesql_storage::Row| -> Result<SqlValue, String> {
+                        local_evaluator.clear_cse_cache();
+                        local_evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
+                    };
+                sort_partition(partition, order_by, sort_eval_fn);
             });
         } else {
             for partition in &mut partitions {
-                sort_partition(partition, &win_func.window_spec.order_by);
+                let sort_eval_fn =
+                    |expr: &Expression, row: &vibesql_storage::Row| -> Result<SqlValue, String> {
+                        evaluator.clear_cse_cache();
+                        evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
+                    };
+                sort_partition(partition, &win_func.window_spec.order_by, sort_eval_fn);
             }
         }
     }
@@ -95,7 +125,12 @@ pub(super) fn evaluate_single_window_function(
     #[cfg(not(feature = "parallel"))]
     {
         for partition in &mut partitions {
-            sort_partition(partition, &win_func.window_spec.order_by);
+            let sort_eval_fn =
+                |expr: &Expression, row: &vibesql_storage::Row| -> Result<SqlValue, String> {
+                    evaluator.clear_cse_cache();
+                    evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
+                };
+            sort_partition(partition, &win_func.window_spec.order_by, sort_eval_fn);
         }
     }
 
@@ -248,6 +283,13 @@ fn evaluate_window_function_for_partition(
     frame_spec: &Option<vibesql_ast::WindowFrame>,
     evaluator: &CombinedExpressionEvaluator,
 ) -> Result<Vec<SqlValue>, ExecutorError> {
+    // Create the eval_fn closure that uses the full evaluator
+    let eval_fn =
+        |expr: &Expression, row: &vibesql_storage::Row| -> Result<SqlValue, String> {
+            evaluator.clear_cse_cache();
+            evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
+        };
+
     // Handle ranking functions (they don't use frames)
     let results = match func_name.to_uppercase().as_str() {
         "ROW_NUMBER" => {
@@ -264,7 +306,7 @@ fn evaluate_window_function_for_partition(
                     function_name: "rank".to_string(),
                 });
             }
-            crate::evaluator::window::evaluate_rank(partition, order_by)
+            crate::evaluator::window::evaluate_rank(partition, order_by, &eval_fn)
         }
         "DENSE_RANK" => {
             if !args.is_empty() {
@@ -272,7 +314,7 @@ fn evaluate_window_function_for_partition(
                     function_name: "dense_rank".to_string(),
                 });
             }
-            crate::evaluator::window::evaluate_dense_rank(partition, order_by)
+            crate::evaluator::window::evaluate_dense_rank(partition, order_by, &eval_fn)
         }
         "PERCENT_RANK" => {
             if !args.is_empty() {
@@ -280,7 +322,7 @@ fn evaluate_window_function_for_partition(
                     function_name: "percent_rank".to_string(),
                 });
             }
-            crate::evaluator::window::evaluate_percent_rank(partition, order_by)
+            crate::evaluator::window::evaluate_percent_rank(partition, order_by, &eval_fn)
         }
         "CUME_DIST" => {
             if !args.is_empty() {
@@ -288,7 +330,7 @@ fn evaluate_window_function_for_partition(
                     function_name: "cume_dist".to_string(),
                 });
             }
-            crate::evaluator::window::evaluate_cume_dist(partition, order_by)
+            crate::evaluator::window::evaluate_cume_dist(partition, order_by, &eval_fn)
         }
         "NTILE" => {
             if args.len() != 1 {
@@ -514,13 +556,13 @@ fn evaluate_window_function_for_partition(
             for row_idx in 0..partition.len() {
                 // Calculate frame for this row with exclusion support
                 let frame_result =
-                    calculate_frame_with_exclusion(partition, row_idx, order_by, frame_spec);
+                    calculate_frame_with_exclusion(partition, row_idx, order_by, frame_spec, &eval_fn);
 
                 // Get the iterator of included indices (applies EXCLUDE filtering)
-                let frame_indices = frame_result.included_indices(partition, order_by);
+                let frame_indices = frame_result.included_indices(partition, order_by, &eval_fn);
 
                 // Create closure that evaluates expressions using the evaluator
-                let eval_fn = |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
+                let agg_eval_fn = |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
                     // Clear CSE cache before evaluating each row to prevent column values
                     // from being incorrectly cached across different rows
                     evaluator.clear_cse_cache();
@@ -540,7 +582,7 @@ fn evaluate_window_function_for_partition(
                         } else {
                             Some(&args[0])
                         };
-                        evaluate_count_window(partition, frame_indices, arg_expr, filter, eval_fn)
+                        evaluate_count_window(partition, frame_indices, arg_expr, filter, agg_eval_fn)
                     }
                     "SUM" => {
                         if args.is_empty() {
@@ -548,7 +590,7 @@ fn evaluate_window_function_for_partition(
                                 "SUM requires an argument".to_string(),
                             ));
                         }
-                        evaluate_sum_window(partition, frame_indices, &args[0], filter, eval_fn)
+                        evaluate_sum_window(partition, frame_indices, &args[0], filter, agg_eval_fn)
                     }
                     "AVG" => {
                         if args.is_empty() {
@@ -556,7 +598,7 @@ fn evaluate_window_function_for_partition(
                                 "AVG requires an argument".to_string(),
                             ));
                         }
-                        evaluate_avg_window(partition, frame_indices, &args[0], filter, eval_fn)
+                        evaluate_avg_window(partition, frame_indices, &args[0], filter, agg_eval_fn)
                     }
                     "MIN" => {
                         if args.is_empty() {
@@ -564,7 +606,7 @@ fn evaluate_window_function_for_partition(
                                 "MIN requires an argument".to_string(),
                             ));
                         }
-                        evaluate_min_window(partition, frame_indices, &args[0], filter, eval_fn)
+                        evaluate_min_window(partition, frame_indices, &args[0], filter, agg_eval_fn)
                     }
                     "MAX" => {
                         if args.is_empty() {
@@ -572,7 +614,7 @@ fn evaluate_window_function_for_partition(
                                 "MAX requires an argument".to_string(),
                             ));
                         }
-                        evaluate_max_window(partition, frame_indices, &args[0], filter, eval_fn)
+                        evaluate_max_window(partition, frame_indices, &args[0], filter, agg_eval_fn)
                     }
                     "GROUP_CONCAT" | "STRING_AGG" => {
                         if args.is_empty() {
@@ -600,7 +642,7 @@ fn evaluate_window_function_for_partition(
                             &args[0],
                             &separator,
                             filter,
-                            eval_fn,
+                            agg_eval_fn,
                         )
                     }
                     _ => {


### PR DESCRIPTION
## Summary

- Replaces the limited `evaluate_expression_with_map` evaluator (which only handled `Literal` and `ColumnRef` expressions) with the full `CombinedExpressionEvaluator` via `eval_fn` closures throughout the window function pipeline
- Threads `eval_fn` through `sort_partition`, ranking functions (`evaluate_rank`, `evaluate_dense_rank`, `evaluate_percent_rank`, `evaluate_cume_dist`), and all frame calculation functions (`calculate_frame`, `calculate_frame_with_exclusion`, peer/boundary helpers)
- Fixes window functions silently returning wrong results when PARTITION BY or ORDER BY clauses contain complex expressions (e.g., `b%10`, `a+b`)

## Impact

- **Before**: Any non-trivial expression in PARTITION BY or ORDER BY was silently evaluated as `NULL` via `.unwrap_or(SqlValue::Null)`, causing sorting to be a no-op, all ranks to be 1, and frame boundaries to be wrong
- **After**: Complex expressions are evaluated correctly using the same full evaluator that `partition_rows` already uses
- **Test improvement**: window3.test goes from 784 pass / 678 fail to 993 pass / 469 fail (+209 tests fixed)

## Files changed

| File | Change |
|------|--------|
| `sorting.rs` | Added `eval_fn` parameter to `sort_partition` |
| `ranking.rs` | Added `eval_fn` parameter to `evaluate_rank`, `evaluate_dense_rank`, `evaluate_percent_rank`, `evaluate_cume_dist` |
| `frames.rs` | Added `eval_fn` parameter to `calculate_frame`, `calculate_frame_with_exclusion`, `FrameResult::includes`, `included_indices`, and all helper functions |
| `utils.rs` | Removed unused `evaluate_expression_with_map` (kept test-only `evaluate_expression`) |
| `evaluation.rs` | Updated all callsites to pass `eval_fn` closures |
| `aggregation/window.rs` | Updated all callsites to pass `eval_fn` closures |
| `tests/ranking.rs` | Updated test calls with `eval_fn` parameter |
| `tests/frames.rs` | Updated test calls with `eval_fn` parameter |

## Test plan

- [x] `cargo test -p vibesql-executor` -- all 2288+ tests pass, zero failures
- [x] `bash scripts/tcltest test window3.test` -- 993 pass (up from 784), 469 fail (down from 678)
- [x] Manual verification: `PARTITION BY b%10`, `ORDER BY b%10` with `rank()`, `dense_rank()` produce correct results

Closes #5022

🤖 Generated with [Claude Code](https://claude.com/claude-code)