### PR TITLE
fix(window): FIRST_VALUE/LAST_VALUE/NTH_VALUE frame boundary handling

### DIFF
--- a/crates/vibesql-executor/src/evaluator/window/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/window/mod.rs
@@ -14,7 +14,7 @@
 //! - `frames` - Frame boundary calculation (ROWS mode)
 //! - `ranking` - Ranking functions (ROW_NUMBER, RANK, DENSE_RANK, NTILE)
 //! - `aggregates` - Aggregate window functions (COUNT, SUM, AVG, MIN, MAX)
-//! - `value` - Value access functions (LAG, LEAD, FIRST_VALUE, LAST_VALUE)
+//! - `value` - Value access functions (LAG, LEAD)
 //! - `utils` - Shared utility functions
 
 mod aggregates;
@@ -38,7 +38,7 @@ pub use ranking::{
 };
 pub use sorting::{compare_values, sort_partition};
 pub use value::{
-    evaluate_first_value, evaluate_lag, evaluate_last_value, evaluate_lead, evaluate_nth_value,
+    evaluate_lag, evaluate_lead,
 };
 
 #[cfg(test)]

--- a/crates/vibesql-executor/src/evaluator/window/value.rs
+++ b/crates/vibesql-executor/src/evaluator/window/value.rs
@@ -1,7 +1,8 @@
 //! Value window functions
 //!
-//! Implements LAG, LEAD, FIRST_VALUE, and LAST_VALUE for accessing values from other rows in the
-//! partition.
+//! Implements LAG and LEAD for accessing values from other rows in the partition.
+//! FIRST_VALUE, LAST_VALUE, and NTH_VALUE are evaluated inline at the dispatch sites
+//! with frame-aware logic (see evaluation.rs and aggregation/window.rs).
 
 use vibesql_ast::Expression;
 use vibesql_types::SqlValue;
@@ -108,108 +109,7 @@ where
     }
 }
 
-/// Evaluate FIRST_VALUE() value window function
-///
-/// Returns the value of the expression evaluated on the first row of the partition.
-/// Useful for getting the initial value in an ordered partition.
-///
-/// Signature: FIRST_VALUE(expr)
-/// - expr: Expression to evaluate on the first row
-///
-/// Example: FIRST_VALUE(price) OVER (PARTITION BY product ORDER BY date)
-/// Example: FIRST_VALUE(salary) OVER (PARTITION BY department ORDER BY hire_date)
-///
-/// Note: Typically used with ORDER BY to get the "earliest" value according to ordering.
-pub fn evaluate_first_value<F>(
-    partition: &Partition,
-    value_expr: &Expression,
-    eval_fn: F,
-) -> Result<SqlValue, String>
-where
-    F: Fn(&Expression, &vibesql_storage::Row) -> Result<SqlValue, String>,
-{
-    // Get the first row in the partition
-    if let Some(first_row) = partition.rows.first() {
-        eval_fn(value_expr, first_row)
-    } else {
-        // Empty partition - return NULL
-        Ok(SqlValue::Null)
-    }
-}
-
-/// Evaluate LAST_VALUE() value window function
-///
-/// Returns the value of the expression evaluated on the last row of the partition.
-/// Useful for getting the final value in an ordered partition.
-///
-/// Signature: LAST_VALUE(expr)
-/// - expr: Expression to evaluate on the last row
-///
-/// Example: LAST_VALUE(price) OVER (PARTITION BY product ORDER BY date)
-/// Example: LAST_VALUE(status) OVER (PARTITION BY order_id ORDER BY timestamp)
-///
-/// Note: With default frame (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
-/// LAST_VALUE returns the current row's value. To get the actual last value in the
-/// partition, use frame: RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING.
-/// This implementation always returns the last row in the partition.
-pub fn evaluate_last_value<F>(
-    partition: &Partition,
-    value_expr: &Expression,
-    eval_fn: F,
-) -> Result<SqlValue, String>
-where
-    F: Fn(&Expression, &vibesql_storage::Row) -> Result<SqlValue, String>,
-{
-    // Get the last row in the partition
-    if let Some(last_row) = partition.rows.last() {
-        eval_fn(value_expr, last_row)
-    } else {
-        // Empty partition - return NULL
-        Ok(SqlValue::Null)
-    }
-}
-
-/// Evaluate NTH_VALUE() value window function
-///
-/// Returns the value of the expression from the Nth row in the window frame.
-/// N is 1-based (NTH_VALUE(expr, 1) returns the first row's value).
-///
-/// Signature: NTH_VALUE(expr, n)
-/// - expr: Expression to evaluate on the Nth row
-/// - n: 1-based row position (must be positive integer)
-///
-/// Example: NTH_VALUE(price, 2) OVER (ORDER BY date) -- returns 2nd row's price
-/// Example: NTH_VALUE(name, 1) OVER (PARTITION BY dept ORDER BY salary DESC)
-///
-/// Returns NULL if N is out of bounds or if the partition has fewer than N rows.
-pub fn evaluate_nth_value<F>(
-    partition: &Partition,
-    n: i64,
-    value_expr: &Expression,
-    eval_fn: F,
-) -> Result<SqlValue, String>
-where
-    F: Fn(&Expression, &vibesql_storage::Row) -> Result<SqlValue, String>,
-{
-    // N must be positive (1-based indexing)
-    if n < 1 {
-        return Err(format!("NTH_VALUE n must be a positive integer, got {}", n));
-    }
-
-    // Convert to 0-based index
-    let idx = (n - 1) as usize;
-
-    // Check if index is within partition bounds
-    if idx >= partition.len() {
-        // Out of bounds - return NULL
-        return Ok(SqlValue::Null);
-    }
-
-    // Get value from the Nth row
-    if let Some(row) = partition.rows.get(idx) {
-        eval_fn(value_expr, row)
-    } else {
-        // Should not happen if bounds check is correct
-        Ok(SqlValue::Null)
-    }
-}
+// Note: FIRST_VALUE, LAST_VALUE, and NTH_VALUE are now evaluated inline at the
+// dispatch sites (evaluation.rs and aggregation/window.rs) using frame-aware logic
+// via calculate_frame_with_exclusion + included_indices. The previous implementations
+// here operated on the entire partition without respecting frame boundaries.

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -20,11 +20,10 @@ use crate::{
     evaluator::{
         window::{
             calculate_frame_with_exclusion, evaluate_avg_window, evaluate_count_window,
-            evaluate_cume_dist, evaluate_dense_rank, evaluate_first_value, evaluate_lag,
-            evaluate_last_value, evaluate_lead, evaluate_max_window, evaluate_min_window,
-            evaluate_nth_value, evaluate_ntile, evaluate_percent_rank, evaluate_rank,
-            evaluate_row_number, evaluate_sum_window, partition_rows, sort_partition,
-            validate_frame,
+            evaluate_cume_dist, evaluate_dense_rank, evaluate_lag, evaluate_lead,
+            evaluate_max_window, evaluate_min_window, evaluate_ntile, evaluate_percent_rank,
+            evaluate_rank, evaluate_row_number, evaluate_sum_window, partition_rows,
+            sort_partition, validate_frame,
         },
         CombinedExpressionEvaluator,
     },
@@ -458,21 +457,48 @@ pub(super) fn apply_window_functions_to_aggregates(
                         "FIRST_VALUE" => {
                             let value_expr =
                                 if !mapped_args.is_empty() { &mapped_args[0] } else { &arg_expr };
-                            let value = evaluate_first_value(partition, value_expr, eval_fn)
-                                .map_err(ExecutorError::UnsupportedExpression)?;
                             for row_idx in 0..partition.len() {
+                                let frame_result = calculate_frame_with_exclusion(
+                                    partition,
+                                    row_idx,
+                                    &order_by_ref,
+                                    &win_func.window_spec.frame,
+                                    &eval_fn,
+                                );
+                                let value = if let Some(first_idx) = frame_result
+                                    .included_indices(partition, &order_by_ref, &eval_fn)
+                                    .next()
+                                {
+                                    eval_fn(value_expr, &partition.rows[first_idx])
+                                        .unwrap_or(SqlValue::Null)
+                                } else {
+                                    SqlValue::Null
+                                };
                                 results_with_indices
-                                    .push((partition.original_indices[row_idx], value.clone()));
+                                    .push((partition.original_indices[row_idx], value));
                             }
                         }
                         "LAST_VALUE" => {
                             let value_expr =
                                 if !mapped_args.is_empty() { &mapped_args[0] } else { &arg_expr };
-                            let value = evaluate_last_value(partition, value_expr, eval_fn)
-                                .map_err(ExecutorError::UnsupportedExpression)?;
                             for row_idx in 0..partition.len() {
+                                let frame_result = calculate_frame_with_exclusion(
+                                    partition,
+                                    row_idx,
+                                    &order_by_ref,
+                                    &win_func.window_spec.frame,
+                                    &eval_fn,
+                                );
+                                let value = frame_result
+                                    .included_indices(partition, &order_by_ref, &eval_fn)
+                                    .last()
+                                    .map(|last_idx| {
+                                        eval_fn(value_expr, &partition.rows[last_idx])
+                                            .unwrap_or(SqlValue::Null)
+                                    })
+                                    .unwrap_or(SqlValue::Null);
                                 results_with_indices
-                                    .push((partition.original_indices[row_idx], value.clone()));
+                                    .push((partition.original_indices[row_idx], value));
                             }
                         }
                         "NTH_VALUE" => {
@@ -489,11 +515,25 @@ pub(super) fn apply_window_functions_to_aggregates(
                             } else {
                                 1
                             };
-                            let value = evaluate_nth_value(partition, n, value_expr, eval_fn)
-                                .map_err(ExecutorError::UnsupportedExpression)?;
+                            let nth_zero_based = (n - 1).max(0) as usize;
                             for row_idx in 0..partition.len() {
+                                let frame_result = calculate_frame_with_exclusion(
+                                    partition,
+                                    row_idx,
+                                    &order_by_ref,
+                                    &win_func.window_spec.frame,
+                                    &eval_fn,
+                                );
+                                let value = frame_result
+                                    .included_indices(partition, &order_by_ref, &eval_fn)
+                                    .nth(nth_zero_based)
+                                    .map(|nth_idx| {
+                                        eval_fn(value_expr, &partition.rows[nth_idx])
+                                            .unwrap_or(SqlValue::Null)
+                                    })
+                                    .unwrap_or(SqlValue::Null);
                                 results_with_indices
-                                    .push((partition.original_indices[row_idx], value.clone()));
+                                    .push((partition.original_indices[row_idx], value));
                             }
                         }
                         other => {

--- a/crates/vibesql-executor/src/select/window/evaluation.rs
+++ b/crates/vibesql-executor/src/select/window/evaluation.rs
@@ -469,20 +469,23 @@ fn evaluate_window_function_for_partition(
 
             let value_expr = &args[0];
 
-            // Create closure that evaluates expressions using the evaluator
-            let eval_fn = |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
-                evaluator.clear_cse_cache();
-                evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
-            };
-
-            // FIRST_VALUE returns the same value for all rows in the partition
-            // (the value from the first row)
-            let value =
-                crate::evaluator::window::evaluate_first_value(partition, value_expr, eval_fn)
-                    .map_err(ExecutorError::UnsupportedExpression)?;
-
-            // Return the same value for all rows
-            vec![value; partition.len()]
+            // FIRST_VALUE respects frame boundaries - evaluate per-row
+            let mut results = Vec::with_capacity(partition.len());
+            for row_idx in 0..partition.len() {
+                let frame_result = calculate_frame_with_exclusion(
+                    partition, row_idx, order_by, frame_spec, &eval_fn,
+                );
+                let value = if let Some(first_idx) =
+                    frame_result.included_indices(partition, order_by, &eval_fn).next()
+                {
+                    eval_fn(value_expr, &partition.rows[first_idx])
+                        .unwrap_or(SqlValue::Null)
+                } else {
+                    SqlValue::Null
+                };
+                results.push(value);
+            }
+            results
         }
         "LAST_VALUE" => {
             // LAST_VALUE(expr)
@@ -494,20 +497,23 @@ fn evaluate_window_function_for_partition(
 
             let value_expr = &args[0];
 
-            // Create closure that evaluates expressions using the evaluator
-            let eval_fn = |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
-                evaluator.clear_cse_cache();
-                evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
-            };
-
-            // LAST_VALUE returns the same value for all rows in the partition
-            // (the value from the last row)
-            let value =
-                crate::evaluator::window::evaluate_last_value(partition, value_expr, eval_fn)
-                    .map_err(ExecutorError::UnsupportedExpression)?;
-
-            // Return the same value for all rows
-            vec![value; partition.len()]
+            // LAST_VALUE respects frame boundaries - evaluate per-row
+            let mut results = Vec::with_capacity(partition.len());
+            for row_idx in 0..partition.len() {
+                let frame_result = calculate_frame_with_exclusion(
+                    partition, row_idx, order_by, frame_spec, &eval_fn,
+                );
+                let value = frame_result
+                    .included_indices(partition, order_by, &eval_fn)
+                    .last()
+                    .map(|last_idx| {
+                        eval_fn(value_expr, &partition.rows[last_idx])
+                            .unwrap_or(SqlValue::Null)
+                    })
+                    .unwrap_or(SqlValue::Null);
+                results.push(value);
+            }
+            results
         }
         "NTH_VALUE" => {
             // NTH_VALUE(expr, n)
@@ -534,19 +540,30 @@ fn evaluate_window_function_for_partition(
                 }
             };
 
-            // Create closure that evaluates expressions using the evaluator
-            let eval_fn = |expr: &Expression, row: &Row| -> Result<SqlValue, String> {
-                evaluator.clear_cse_cache();
-                evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
-            };
+            if n < 1 {
+                return Err(ExecutorError::UnsupportedExpression(
+                    format!("NTH_VALUE n must be a positive integer, got {}", n),
+                ));
+            }
 
-            // NTH_VALUE returns the value from the Nth row for all rows in the partition
-            let value =
-                crate::evaluator::window::evaluate_nth_value(partition, n, value_expr, eval_fn)
-                    .map_err(ExecutorError::UnsupportedExpression)?;
-
-            // Return the same value for all rows
-            vec![value; partition.len()]
+            // NTH_VALUE respects frame boundaries - evaluate per-row
+            let nth_zero_based = (n - 1) as usize;
+            let mut results = Vec::with_capacity(partition.len());
+            for row_idx in 0..partition.len() {
+                let frame_result = calculate_frame_with_exclusion(
+                    partition, row_idx, order_by, frame_spec, &eval_fn,
+                );
+                let value = frame_result
+                    .included_indices(partition, order_by, &eval_fn)
+                    .nth(nth_zero_based)
+                    .map(|nth_idx| {
+                        eval_fn(value_expr, &partition.rows[nth_idx])
+                            .unwrap_or(SqlValue::Null)
+                    })
+                    .unwrap_or(SqlValue::Null); // NULL if frame has fewer than N rows
+                results.push(value);
+            }
+            results
         }
         _ => {
             // Handle aggregate functions that use frames

--- a/tests/executor/window_functions.rs
+++ b/tests/executor/window_functions.rs
@@ -564,14 +564,15 @@ fn test_window_last_value() {
         // Should have 4 rows
         assert_eq!(result.len(), 4);
 
-        // Engineering rows should have lowest_salary = 95000 (Bob is last in DESC order)
-        assert_eq!(result[0].values[3], SqlValue::Integer(95000));
-        assert_eq!(result[1].values[3], SqlValue::Integer(95000));
+        // With default frame (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+        // LAST_VALUE returns the current row's value (last in the frame so far)
+        // Engineering: Alice (120000) then Bob (95000) in DESC order
+        assert_eq!(result[0].values[3], SqlValue::Integer(120000)); // frame: [Alice] → 120000
+        assert_eq!(result[1].values[3], SqlValue::Integer(95000));  // frame: [Alice, Bob] → 95000
 
-        // Sales rows should have lowest_salary = 85000 (Carol is last in DESC order)
-        // When sorted by salary DESC: Dave (90000) comes before Carol (85000)
-        assert_eq!(result[2].values[3], SqlValue::Integer(85000));
-        assert_eq!(result[3].values[3], SqlValue::Integer(85000));
+        // Sales: Dave (90000) then Carol (85000) in DESC order
+        assert_eq!(result[2].values[3], SqlValue::Integer(90000));  // frame: [Dave] → 90000
+        assert_eq!(result[3].values[3], SqlValue::Integer(85000));  // frame: [Dave, Carol] → 85000
 
         println!("✅ LAST_VALUE test works!");
     } else {


### PR DESCRIPTION
## Summary

- **FIRST_VALUE**, **LAST_VALUE**, and **NTH_VALUE** window functions now correctly respect frame boundaries instead of always computing over the entire partition
- Fixed the bug in both dispatch sites: `evaluation.rs` (primary window path) and `aggregation/window.rs` (GROUP BY + window path)
- Removed the now-unused partition-level helper functions from `value.rs` since the frame-aware logic is inlined at each call site

## Root Cause

All three functions computed a single value from the whole partition and broadcast it to every row. They never called `calculate_frame_with_exclusion`. This meant:
- `LAST_VALUE(x) OVER (ORDER BY y)` returned the last row of the partition for every row, instead of the current row's value (default frame ends at CURRENT ROW)
- `NTH_VALUE(x, n)` returned NULL or wrong values when the frame didn't include n rows yet
- Frame specs like `ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING` were completely ignored

## Fix

Refactored FIRST_VALUE, LAST_VALUE, and NTH_VALUE to loop per-row and compute frame boundaries via `calculate_frame_with_exclusion` + `included_indices`, matching the existing pattern used by aggregate window functions (SUM, COUNT, etc.).

## Test Results

**window3.test TCL conformance**: 993 passed (62.0%) -> 1138 passed (71.0%) -- **+145 tests passing**

Closes #5032

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)