### PR TITLE
perf(columnar): extend vectorized execution to LEFT/RIGHT JOINs and ORDER BY

### DIFF
--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
@@ -8,10 +8,11 @@ use std::collections::HashMap;
 use vibesql_ast::{FromClause, JoinType, SelectItem};
 
 use super::join_helpers::{
-    build_combined_schema, extract_equijoin_conditions, extract_join_conditions,
-    extract_non_join_predicates, flatten_join_tree_simple, flatten_join_tree_with_types,
-    has_cross_join_with_on_condition, is_columnar_supported_join, is_column_in_table,
-    is_column_in_tables, resolve_join_column_indices, EquiJoinCondition,
+    build_combined_schema, expression_has_is_null, extract_equijoin_conditions,
+    extract_join_conditions, extract_non_join_predicates, flatten_join_tree_simple,
+    flatten_join_tree_with_types, has_cross_join_with_on_condition, has_outer_join,
+    is_columnar_supported_join, is_column_in_table, is_column_in_tables,
+    resolve_join_column_indices, EquiJoinCondition,
 };
 use crate::{
     errors::ExecutorError,
@@ -114,6 +115,22 @@ impl SelectExecutor<'_> {
         if has_cross_join_with_on_condition(from_clause) {
             log::debug!("Columnar join: CROSS JOIN with ON condition detected, falling back");
             return Ok(None);
+        }
+
+        // Outer joins with IS NULL / IS NOT NULL in WHERE clause need row-oriented execution.
+        // The columnar SIMD filter does not support null-testing predicates (IS NULL / IS NOT NULL),
+        // so they are silently dropped during predicate extraction. For outer joins this causes
+        // incorrect results — e.g., anti-join pattern `LEFT JOIN ... WHERE t2.col IS NULL` would
+        // return all rows instead of only unmatched rows.
+        if has_outer_join(from_clause) {
+            if let Some(ref where_clause) = stmt.where_clause {
+                if expression_has_is_null(where_clause) {
+                    log::debug!(
+                        "Columnar join: outer join with IS NULL/IS NOT NULL in WHERE, falling back"
+                    );
+                    return Ok(None);
+                }
+            }
         }
 
         // Flatten the join tree to get all tables with their join types

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
@@ -5,13 +5,13 @@
 
 use std::collections::HashMap;
 
-use vibesql_ast::{FromClause, SelectItem};
+use vibesql_ast::{FromClause, JoinType, SelectItem};
 
 use super::join_helpers::{
     build_combined_schema, extract_equijoin_conditions, extract_join_conditions,
-    extract_non_join_predicates, flatten_join_tree_simple, has_cross_join_with_on_condition,
-    is_column_in_table, is_column_in_tables, is_inner_or_cross_join_only,
-    resolve_join_column_indices, EquiJoinCondition,
+    extract_non_join_predicates, flatten_join_tree_simple, flatten_join_tree_with_types,
+    has_cross_join_with_on_condition, is_columnar_supported_join, is_column_in_table,
+    is_column_in_tables, resolve_join_column_indices, EquiJoinCondition,
 };
 use crate::{
     errors::ExecutorError,
@@ -20,7 +20,9 @@ use crate::{
     schema::CombinedSchema,
     select::{
         columnar, cte::CteResult, executor::builder::SelectExecutor, helpers::apply_distinct,
-        join::hash_join::columnar as columnar_join, projection::project_row_combined,
+        join::hash_join::columnar as columnar_join,
+        order::{apply_order_by, RowWithSortKeys},
+        projection::project_row_combined,
     },
 };
 
@@ -79,20 +81,6 @@ impl SelectExecutor<'_> {
             return Ok(None);
         }
 
-        // LIMIT/OFFSET queries need special handling - fall back to row-oriented
-        // TODO: Add LIMIT support to columnar join path
-        if stmt.limit.is_some() || stmt.offset.is_some() {
-            log::debug!("Columnar join: skipping - LIMIT/OFFSET not supported");
-            return Ok(None);
-        }
-
-        // ORDER BY requires sorting after projection - fall back to row-oriented (#4552)
-        // The row-oriented path handles ORDER BY correctly via apply_sorting()
-        if stmt.order_by.is_some() {
-            log::debug!("Columnar join: skipping - ORDER BY not supported");
-            return Ok(None);
-        }
-
         // ROWID pseudo-column references require row-oriented execution (#4370)
         // Columnar batches don't track per-row ROWIDs, so we fall back when ROWID is referenced
         if select_list_has_rowid(&stmt.select_list) {
@@ -113,10 +101,11 @@ impl SelectExecutor<'_> {
             return Ok(None);
         }
 
-        // Only handle INNER and CROSS joins - LEFT, RIGHT, FULL need special handling
+        // Only handle supported join types (INNER, CROSS, LEFT OUTER, RIGHT OUTER)
+        // FULL OUTER, SEMI, and ANTI joins fall back to row-oriented execution
         // CROSS joins are included because comma-separated tables (FROM a, b) parse as CROSS JOIN
-        if !is_inner_or_cross_join_only(from_clause) {
-            log::debug!("Columnar join: only INNER/CROSS joins are supported, falling back");
+        if !is_columnar_supported_join(from_clause) {
+            log::debug!("Columnar join: unsupported join type (FULL/SEMI/ANTI), falling back");
             return Ok(None);
         }
 
@@ -127,7 +116,11 @@ impl SelectExecutor<'_> {
             return Ok(None);
         }
 
-        // Flatten the join tree to get all tables
+        // Flatten the join tree to get all tables with their join types
+        let mut table_refs_with_types = Vec::new();
+        flatten_join_tree_with_types(from_clause, &mut table_refs_with_types);
+
+        // Also flatten without types for backward compatibility with condition extraction
         let mut table_refs = Vec::new();
         flatten_join_tree_simple(from_clause, &mut table_refs);
 
@@ -142,6 +135,10 @@ impl SelectExecutor<'_> {
             log::debug!("Columnar join: skipping - contains subqueries");
             return Ok(None);
         }
+
+        // Extract join types for the chain (first table has no join type)
+        let join_types: Vec<Option<JoinType>> =
+            table_refs_with_types.iter().map(|(_, jt)| jt.clone()).collect();
 
         log::info!(
             "Columnar join: attempting {} table join ({:?})",
@@ -211,7 +208,7 @@ impl SelectExecutor<'_> {
 
         // Execute joins in sequence, building up the result batch
         let joined_batch =
-            match self.execute_columnar_join_chain(&batches, &join_conditions, &combined_schema) {
+            match self.execute_columnar_join_chain(&batches, &join_conditions, &combined_schema, &join_types) {
                 Ok(Some(batch)) => batch,
                 Ok(None) => {
                     log::debug!("Columnar join: join chain execution returned None");
@@ -271,7 +268,19 @@ impl SelectExecutor<'_> {
 
         if has_group_by {
             // Execute GROUP BY aggregation
-            self.execute_columnar_join_group_by(stmt, &filtered_batch, &combined_schema)
+            let result = self.execute_columnar_join_group_by(stmt, &filtered_batch, &combined_schema);
+
+            // Apply ORDER BY to GROUP BY results if needed (#5033)
+            if let Ok(Some(rows)) = result {
+                if let Some(order_by) = &stmt.order_by {
+                    let sorted = self.apply_columnar_join_order_by(rows, order_by, &stmt.select_list, &combined_schema)?;
+                    Ok(Some(sorted))
+                } else {
+                    Ok(Some(rows))
+                }
+            } else {
+                result
+            }
         } else {
             // No GROUP BY - convert to rows and apply projection
 
@@ -292,7 +301,15 @@ impl SelectExecutor<'_> {
                     filtered_batch
                 };
                 let rows = final_batch.to_rows()?;
-                Ok(Some(rows))
+
+                // Apply ORDER BY if present (#5033)
+                let final_rows = if let Some(order_by) = &stmt.order_by {
+                    self.apply_columnar_join_order_by(rows, order_by, &stmt.select_list, &combined_schema)?
+                } else {
+                    rows
+                };
+
+                Ok(Some(final_rows))
             } else {
                 // Check if SELECT list contains aggregate functions
                 // Aggregates without GROUP BY need special handling (fall back to row-oriented)
@@ -338,12 +355,23 @@ impl SelectExecutor<'_> {
                 let final_rows =
                     if stmt.distinct { apply_distinct(projected_rows) } else { projected_rows };
 
-                Ok(Some(final_rows))
+                // Apply ORDER BY if present (#5033)
+                let sorted_rows = if let Some(order_by) = &stmt.order_by {
+                    self.apply_columnar_join_order_by(final_rows, order_by, &stmt.select_list, &combined_schema)?
+                } else {
+                    final_rows
+                };
+
+                Ok(Some(sorted_rows))
             }
         }
     }
 
     /// Execute a chain of hash joins on columnar batches
+    ///
+    /// The `join_types` parameter contains the join type for each table in the chain.
+    /// The first entry is always `None` (the leftmost table has no join type).
+    /// Each subsequent entry specifies how that table joins to the already-joined tables.
     pub(super) fn execute_columnar_join_chain(
         &self,
         batches: &[(
@@ -354,6 +382,7 @@ impl SelectExecutor<'_> {
         )],
         join_conditions: &[EquiJoinCondition],
         combined_schema: &CombinedSchema,
+        join_types: &[Option<JoinType>],
     ) -> Result<Option<columnar::ColumnarBatch>, ExecutorError> {
         if batches.is_empty() {
             return Ok(None);
@@ -370,8 +399,14 @@ impl SelectExecutor<'_> {
         let mut joined_tables: Vec<&str> = vec![batches[0].1.as_deref().unwrap_or(&batches[0].0)];
 
         // Join subsequent tables
-        for (table_name, alias, batch, schema) in batches.iter().skip(1) {
+        for (i, (table_name, alias, batch, schema)) in batches.iter().enumerate().skip(1) {
             let table_ref = alias.as_deref().unwrap_or(table_name.as_str());
+
+            // Get the join type for this table (default to Inner for backward compatibility)
+            let jt = join_types
+                .get(i)
+                .and_then(|jt| jt.clone())
+                .unwrap_or(JoinType::Inner);
 
             // Find a join condition that connects this table to already-joined tables
             let join_cond = join_conditions.iter().find(|cond| {
@@ -406,6 +441,17 @@ impl SelectExecutor<'_> {
             let join_cond = match join_cond {
                 Some(cond) => cond,
                 None => {
+                    // CROSS JOIN doesn't need a join condition
+                    if matches!(jt, JoinType::Cross) {
+                        log::debug!(
+                            "Columnar join: CROSS JOIN '{}' with {:?} (no condition needed)",
+                            table_ref,
+                            joined_tables
+                        );
+                        // For cross join without condition, fall back to row-oriented
+                        // since columnar cross join is not implemented
+                        return Ok(None);
+                    }
                     log::debug!(
                         "Columnar join: no join condition found connecting '{}' to {:?}",
                         table_ref,
@@ -425,26 +471,94 @@ impl SelectExecutor<'_> {
             )?;
 
             log::debug!(
-                "Columnar join: joining '{}' (col {}) with '{}' (col {})",
+                "Columnar join: {:?} joining '{}' (col {}) with '{}' (col {})",
+                jt,
                 joined_tables.join(", "),
                 left_col_idx,
                 table_ref,
                 right_col_idx
             );
 
-            // Execute the hash join
-            current_batch = columnar_join::columnar_hash_join_inner(
-                &current_batch,
-                batch,
-                left_col_idx,
-                right_col_idx,
-            )?;
+            // Execute the hash join based on join type
+            current_batch = match jt {
+                JoinType::Inner | JoinType::Cross => {
+                    columnar_join::columnar_hash_join_inner(
+                        &current_batch,
+                        batch,
+                        left_col_idx,
+                        right_col_idx,
+                    )?
+                }
+                JoinType::LeftOuter => {
+                    columnar_join::columnar_hash_join_left_outer(
+                        &current_batch,
+                        batch,
+                        left_col_idx,
+                        right_col_idx,
+                    )?
+                }
+                JoinType::RightOuter => {
+                    columnar_join::columnar_hash_join_right_outer(
+                        &current_batch,
+                        batch,
+                        left_col_idx,
+                        right_col_idx,
+                    )?
+                }
+                _ => {
+                    // FullOuter, Semi, Anti - not supported, fall back
+                    log::debug!(
+                        "Columnar join: unsupported join type {:?} for '{}', falling back",
+                        jt,
+                        table_ref
+                    );
+                    return Ok(None);
+                }
+            };
 
             // Update tracking
             joined_tables.push(table_ref);
         }
 
         Ok(Some(current_batch))
+    }
+
+    /// Apply ORDER BY sorting to rows produced by the columnar join path (#5033)
+    ///
+    /// This wraps rows as RowWithSortKeys, applies the ORDER BY logic from the
+    /// order module, then unwraps back to plain rows.
+    fn apply_columnar_join_order_by(
+        &self,
+        rows: Vec<vibesql_storage::Row>,
+        order_by: &[vibesql_ast::OrderByItem],
+        select_list: &[SelectItem],
+        combined_schema: &CombinedSchema,
+    ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
+        if rows.is_empty() {
+            return Ok(rows);
+        }
+
+        log::debug!(
+            "Columnar join: applying ORDER BY to {} rows",
+            rows.len()
+        );
+
+        // Wrap rows as RowWithSortKeys (with None sort keys - apply_order_by will compute them)
+        let rows_with_keys: Vec<RowWithSortKeys> =
+            rows.into_iter().map(|r| (r, None)).collect();
+
+        // Create evaluator for ORDER BY expression evaluation
+        // SAFETY: combined_schema lives for the duration of this function call
+        let schema_ref: &'static CombinedSchema =
+            unsafe { std::mem::transmute(combined_schema) };
+        let evaluator =
+            CombinedExpressionEvaluator::with_database(schema_ref, self.database);
+
+        // Apply ORDER BY sorting
+        let sorted = apply_order_by(rows_with_keys, order_by, &evaluator, select_list)?;
+
+        // Unwrap back to plain rows
+        Ok(sorted.into_iter().map(|(row, _)| row).collect())
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -26,6 +26,28 @@ pub(super) fn is_inner_or_cross_join_only(from: &FromClause) -> bool {
     }
 }
 
+/// Check if a FROM clause only contains join types supported by the columnar path
+///
+/// Supported join types:
+/// - INNER JOIN (explicit `JOIN ... ON` syntax)
+/// - CROSS JOIN (comma-separated tables `FROM a, b`)
+/// - LEFT OUTER JOIN (preserves all left rows, NULLs for unmatched right)
+/// - RIGHT OUTER JOIN (preserves all right rows, NULLs for unmatched left)
+///
+/// FULL OUTER, SEMI, and ANTI joins are not yet supported in the columnar path.
+pub(super) fn is_columnar_supported_join(from: &FromClause) -> bool {
+    match from {
+        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => true,
+        FromClause::Join { left, right, join_type, .. } => {
+            matches!(
+                join_type,
+                JoinType::Inner | JoinType::Cross | JoinType::LeftOuter | JoinType::RightOuter
+            ) && is_columnar_supported_join(left)
+                && is_columnar_supported_join(right)
+        }
+    }
+}
+
 /// Check if a FROM clause contains a CROSS JOIN with a join condition
 ///
 /// CROSS JOIN with ON condition is semantically invalid SQL.
@@ -72,6 +94,63 @@ pub(super) fn flatten_join_tree_simple(from: &FromClause, tables: &mut Vec<Simpl
     }
 }
 
+/// Flatten a join tree into a list of table references with their join types.
+///
+/// The first table in the list has no join type (it's the leftmost table in the tree).
+/// Each subsequent table has the JoinType that connects it to the previously joined tables.
+///
+/// For a query like `FROM a INNER JOIN b ON ... LEFT JOIN c ON ...`, this produces:
+/// - (a_info, None)
+/// - (b_info, Some(Inner))
+/// - (c_info, Some(LeftOuter))
+pub(super) fn flatten_join_tree_with_types(
+    from: &FromClause,
+    tables: &mut Vec<(SimpleTableRef, Option<JoinType>)>,
+) {
+    match from {
+        FromClause::Table { name, alias, .. } => {
+            tables.push(((name.clone(), alias.clone(), false), None));
+        }
+        FromClause::Subquery { alias, .. } => {
+            tables.push(((alias.clone(), Some(alias.clone()), true), None));
+        }
+        FromClause::Values { alias, .. } => {
+            tables.push(((alias.clone(), Some(alias.clone()), true), None));
+        }
+        FromClause::Join { left, right, join_type, .. } => {
+            flatten_join_tree_with_types(left, tables);
+            // The right side of this join node gets the join type
+            match right.as_ref() {
+                FromClause::Table { name, alias, .. } => {
+                    tables.push(((name.clone(), alias.clone(), false), Some(join_type.clone())));
+                }
+                FromClause::Subquery { alias, .. } => {
+                    tables.push((
+                        (alias.clone(), Some(alias.clone()), true),
+                        Some(join_type.clone()),
+                    ));
+                }
+                FromClause::Values { alias, .. } => {
+                    tables.push((
+                        (alias.clone(), Some(alias.clone()), true),
+                        Some(join_type.clone()),
+                    ));
+                }
+                FromClause::Join { .. } => {
+                    // Nested join on the right side - flatten it but mark the first
+                    // entry with this join's type
+                    let start_idx = tables.len();
+                    flatten_join_tree_with_types(right, tables);
+                    // Override the join type of the first table from the nested join
+                    if start_idx < tables.len() {
+                        tables[start_idx].1 = Some(join_type.clone());
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Equi-join condition: left_table.left_column = right_table.right_column
 #[derive(Debug, Clone)]
 pub(super) struct EquiJoinCondition {
@@ -86,9 +165,12 @@ pub(super) fn extract_join_conditions(from: &FromClause, conditions: &mut Vec<Eq
     match from {
         FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => {}
         FromClause::Join { left, right, condition, join_type, .. } => {
-            // Only handle INNER and CROSS joins in columnar path
-            // OUTER joins need special handling and are not supported
-            if !matches!(join_type, JoinType::Inner | JoinType::Cross) {
+            // Handle INNER, CROSS, LEFT OUTER, and RIGHT OUTER joins in columnar path
+            // FULL OUTER, SEMI, and ANTI joins are not supported
+            if !matches!(
+                join_type,
+                JoinType::Inner | JoinType::Cross | JoinType::LeftOuter | JoinType::RightOuter
+            ) {
                 return;
             }
 

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -48,6 +48,41 @@ pub(super) fn is_columnar_supported_join(from: &FromClause) -> bool {
     }
 }
 
+/// Check if a FROM clause contains any outer join (LEFT, RIGHT, or FULL OUTER)
+///
+/// Used to detect when WHERE clause predicates like IS NULL / IS NOT NULL
+/// need special handling, since the columnar SIMD filter doesn't support
+/// null-testing predicates and would silently drop them.
+pub(super) fn has_outer_join(from: &FromClause) -> bool {
+    match from {
+        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => false,
+        FromClause::Join { left, right, join_type, .. } => {
+            matches!(
+                join_type,
+                JoinType::LeftOuter | JoinType::RightOuter | JoinType::FullOuter
+            ) || has_outer_join(left)
+                || has_outer_join(right)
+        }
+    }
+}
+
+/// Check if an expression contains IS NULL or IS NOT NULL predicates
+///
+/// The columnar SIMD filter path does not support IS NULL / IS NOT NULL predicates,
+/// so they are silently dropped. For outer joins this produces incorrect results
+/// because post-join null-testing (e.g., anti-join pattern `LEFT JOIN ... WHERE right.col IS NULL`)
+/// is essential for correctness.
+pub(super) fn expression_has_is_null(expr: &Expression) -> bool {
+    match expr {
+        Expression::IsNull { .. } => true,
+        Expression::BinaryOp { left, right, .. } => {
+            expression_has_is_null(left) || expression_has_is_null(right)
+        }
+        Expression::UnaryOp { expr, .. } => expression_has_is_null(expr),
+        _ => false,
+    }
+}
+
 /// Check if a FROM clause contains a CROSS JOIN with a join condition
 ///
 /// CROSS JOIN with ON condition is semantically invalid SQL.


### PR DESCRIPTION
## Summary

Closes #5033 (Phases 1-2)

- **Phase 1**: Wire existing LEFT/RIGHT OUTER hash join implementations into the columnar execution path. The implementations already existed in `select/join/hash_join/columnar/` but were not connected to `try_columnar_join_execution()`.
- **Phase 2**: Remove ORDER BY and LIMIT/OFFSET bail-outs from the columnar join path. ORDER BY sorting is now applied after the columnar join produces rows via `apply_order_by()`. LIMIT/OFFSET was already handled by the `execute.rs` wrapper.
- Also fixes a pre-existing build issue in `vibesql-bench-common` (missing `RngExt` import for rand 0.10 API).

## Changes

- `join_helpers.rs`: Add `is_columnar_supported_join()` (accepts Inner, Cross, LeftOuter, RightOuter), `flatten_join_tree_with_types()` to track JoinType per table, update `extract_join_conditions()` for outer joins
- `join.rs`: Remove ORDER BY/LIMIT bail-outs, dispatch to `columnar_hash_join_left_outer`/`right_outer` based on JoinType, add `apply_columnar_join_order_by()` helper
- `vibesql-bench-common/tpch/data.rs`: Add missing `RngExt` import

## Test plan

- [x] All 2,288 executor lib tests pass
- [x] All 202 join-related tests pass
- [x] All 32 ORDER BY tests pass (including `test_order_by_with_join_issue_4552`)
- [x] All 4 columnar hash join tests pass (inner, left outer, right outer, null handling)
- [ ] Run TPC-H Q13 (LEFT OUTER JOIN) to verify columnar execution
- [ ] Run TPC-H Q3 with ORDER BY + LIMIT to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)