### PR TITLE
fix(window): complete TOTAL(), misuse detection, VALUES support, and NTILE fixes

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -81,6 +81,12 @@ pub enum ExecutorError {
     MisuseOfWindowFunction {
         function_name: String,
     },
+    /// Misuse of aliased window function (SQLite-compatible error)
+    /// e.g., ORDER BY (SELECT m) where m is an alias for a window function like count() OVER()
+    /// Format: "misuse of aliased window function X"
+    MisuseOfAliasedWindowFunction {
+        alias_name: String,
+    },
     UnsupportedExpression(String),
     UnsupportedFeature(String),
     /// SQLite-compatible error message (output as-is without prefix)
@@ -605,6 +611,10 @@ impl std::fmt::Display for ExecutorError {
             ExecutorError::MisuseOfWindowFunction { function_name } => {
                 // SQLite-compatible error message format
                 write!(f, "misuse of window function {}()", function_name)
+            }
+            ExecutorError::MisuseOfAliasedWindowFunction { alias_name } => {
+                // SQLite-compatible error message format
+                write!(f, "misuse of aliased window function {}", alias_name)
             }
             ExecutorError::UnsupportedExpression(msg) => {
                 write!(

--- a/crates/vibesql-executor/src/evaluator/window/aggregates.rs
+++ b/crates/vibesql-executor/src/evaluator/window/aggregates.rs
@@ -166,6 +166,70 @@ where
     }
 }
 
+/// Evaluate TOTAL aggregate window function over a frame
+///
+/// Like SUM but returns 0.0 instead of NULL for empty sets (SQLite compatible).
+/// Always returns a real (float) value.
+/// Supports FILTER clause for conditional aggregation.
+/// Supports EXCLUDE clause via frame_indices iterator.
+pub fn evaluate_total_window<F, I>(
+    partition: &Partition,
+    frame_indices: I,
+    arg_expr: &Expression,
+    filter: Option<&Expression>,
+    eval_fn: F,
+) -> SqlValue
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+    I: IntoIterator<Item = usize>,
+{
+    let mut sum = 0.0f64;
+
+    for idx in frame_indices {
+        if idx >= partition.len() {
+            continue;
+        }
+
+        let row = &partition.rows[idx];
+
+        // Check FILTER condition first
+        if !passes_filter(filter, row, &eval_fn) {
+            continue;
+        }
+
+        if let Ok(val) = eval_fn(arg_expr, row) {
+            match val {
+                SqlValue::Integer(n) => {
+                    sum += n as f64;
+                }
+                SqlValue::Smallint(n) => {
+                    sum += n as f64;
+                }
+                SqlValue::Bigint(n) => {
+                    sum += n as f64;
+                }
+                SqlValue::Numeric(n) => {
+                    sum += n;
+                }
+                SqlValue::Float(n) => {
+                    sum += n as f64;
+                }
+                SqlValue::Real(n) => {
+                    sum += n as f64;
+                }
+                SqlValue::Double(n) => {
+                    sum += n;
+                }
+                SqlValue::Null => {} // Ignore NULL
+                _ => {}              // Ignore non-numeric values
+            }
+        }
+    }
+
+    // TOTAL always returns a real value, 0.0 for empty sets (never NULL)
+    SqlValue::Numeric(sum)
+}
+
 /// Evaluate AVG aggregate window function over a frame
 ///
 /// Computes average of numeric values in the frame, ignoring NULLs.

--- a/crates/vibesql-executor/src/evaluator/window/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/window/mod.rs
@@ -28,7 +28,7 @@ mod value;
 // Re-export public API
 pub use aggregates::{
     evaluate_avg_window, evaluate_count_window, evaluate_group_concat_window, evaluate_max_window,
-    evaluate_min_window, evaluate_sum_window,
+    evaluate_min_window, evaluate_sum_window, evaluate_total_window,
 };
 pub use frames::{calculate_frame, calculate_frame_with_exclusion, validate_frame, FrameResult};
 pub use partitioning::{partition_rows, Partition};

--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -155,6 +155,13 @@ impl SelectExecutor<'_> {
             }
         }
 
+        // Validate ORDER BY for misuse of aliased window functions (#5036)
+        // e.g., ORDER BY (SELECT m) where m is an alias for count(*) OVER()
+        crate::select::executor::validation::validate_order_by_aliased_window_functions(
+            stmt.order_by.as_deref(),
+            &stmt.select_list,
+        )?;
+
         // Validate GROUP BY clause for misuse of window functions (#4985)
         // Window functions are not allowed in GROUP BY expressions
         if let Some(ref group_by_clause) = stmt.group_by {

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -747,13 +747,76 @@ impl SelectExecutor<'_> {
         // Handle standalone VALUES statements (Issue #4546)
         // VALUES(1,2), (3,4) returns rows directly without a SELECT list
         if let Some(values_rows) = &stmt.values {
-            let from_result = crate::select::scan::values::execute_values(
-                values_rows,
-                "_values_",
-                None,
-                Some(self.database),
-            )?;
-            let mut results = from_result.into_rows();
+            // Issue #5036: Check if any VALUES row contains window functions
+            // If so, evaluate those rows via SELECT-without-FROM path which supports
+            // window function evaluation, rather than the plain VALUES evaluator
+            let has_windows = values_rows.iter().any(|row| {
+                row.iter().any(crate::select::window::expression_has_window_function)
+            });
+
+            let mut results = if has_windows {
+                let mut all_rows = Vec::with_capacity(values_rows.len());
+                for row_exprs in values_rows {
+                    let row_has_window = row_exprs
+                        .iter()
+                        .any(crate::select::window::expression_has_window_function);
+                    if row_has_window {
+                        // Construct a SELECT <expr1>, <expr2>, ... statement
+                        // and execute via the window-aware path
+                        let select_list: Vec<vibesql_ast::SelectItem> = row_exprs
+                            .iter()
+                            .enumerate()
+                            .map(|(i, expr)| vibesql_ast::SelectItem::Expression {
+                                expr: expr.clone(),
+                                alias: Some(format!("column{}", i + 1)),
+                                source_text: None,
+                            })
+                            .collect();
+                        let temp_stmt = vibesql_ast::SelectStmt {
+                            with_clause: None,
+                            distinct: false,
+                            select_list,
+                            into_table: None,
+                            into_variables: None,
+                            from: None,
+                            where_clause: None,
+                            group_by: None,
+                            having: None,
+                            window_definitions: None,
+                            order_by: None,
+                            limit: None,
+                            offset: None,
+                            set_operation: None,
+                            values: None,
+                        };
+                        let row_results = self.execute_select_without_from(&temp_stmt)?;
+                        all_rows.extend(row_results);
+                    } else {
+                        // No window functions - evaluate normally
+                        let schema = crate::schema::CombinedSchema::empty();
+                        let empty_row = vibesql_storage::Row::new(vec![]);
+                        let evaluator = crate::evaluator::CombinedExpressionEvaluator::with_database(
+                            &schema,
+                            self.database,
+                        );
+                        let mut values = Vec::with_capacity(row_exprs.len());
+                        for expr in row_exprs {
+                            let value = evaluator.eval(expr, &empty_row)?;
+                            values.push(value);
+                        }
+                        all_rows.push(vibesql_storage::Row::new(values));
+                    }
+                }
+                all_rows
+            } else {
+                let from_result = crate::select::scan::values::execute_values(
+                    values_rows,
+                    "_values_",
+                    None,
+                    Some(self.database),
+                )?;
+                from_result.into_rows()
+            };
 
             // Issue #4696: If there's a set_operation, don't apply ORDER BY or LIMIT/OFFSET here
             // Let the caller handle them after set operations are processed

--- a/crates/vibesql-executor/src/select/executor/nonagg/materialized.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/materialized.rs
@@ -61,6 +61,13 @@ impl SelectExecutor<'_> {
             self.outer_schema,
         )?;
 
+        // Validate ORDER BY for misuse of aliased window functions (#5036)
+        // e.g., ORDER BY (SELECT m) where m is an alias for count(*) OVER()
+        super::super::validation::validate_order_by_aliased_window_functions(
+            stmt.order_by.as_deref(),
+            &stmt.select_list,
+        )?;
+
         // Phase D: Use iterator-based execution for simple queries
         // This provides memory efficiency and early termination for LIMIT queries
         if Self::can_use_iterator_execution(stmt) {

--- a/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
@@ -977,6 +977,122 @@ pub fn validate_having_aliased_aggregates(
     Ok(())
 }
 
+/// Build a set of window function alias names from the SELECT list
+///
+/// A "window alias" is an alias that refers to an expression containing
+/// a window function, e.g., `count(*) OVER() AS m` makes `m` a window alias.
+pub fn build_window_aliases(select_list: &[SelectItem]) -> HashSet<String> {
+    let mut aliases = HashSet::new();
+
+    for item in select_list {
+        if let SelectItem::Expression { expr, alias: Some(alias_name), .. } = item {
+            if expression_contains_window_function(expr) {
+                // Store alias in lowercase for case-insensitive matching
+                aliases.insert(alias_name.to_lowercase());
+            }
+        }
+    }
+
+    aliases
+}
+
+/// Check if an expression contains a window function
+fn expression_contains_window_function(expr: &Expression) -> bool {
+    match expr {
+        Expression::WindowFunction { .. } => true,
+        Expression::BinaryOp { left, right, .. } => {
+            expression_contains_window_function(left)
+                || expression_contains_window_function(right)
+        }
+        Expression::UnaryOp { expr, .. } => expression_contains_window_function(expr),
+        Expression::Cast { expr, .. } => expression_contains_window_function(expr),
+        Expression::Function { args, .. } => {
+            args.iter().any(expression_contains_window_function)
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            operand.as_ref().is_some_and(|e| expression_contains_window_function(e))
+                || when_clauses.iter().any(|w| {
+                    w.conditions.iter().any(expression_contains_window_function)
+                        || expression_contains_window_function(&w.result)
+                })
+                || else_result.as_ref().is_some_and(|e| expression_contains_window_function(e))
+        }
+        // Subqueries have their own scope
+        Expression::ScalarSubquery(_) | Expression::Exists { .. } => false,
+        _ => false,
+    }
+}
+
+/// Validate ORDER BY clause for misuse of aliased window functions
+///
+/// In SQLite, `ORDER BY (SELECT alias)` where alias refers to a window function is an error:
+/// "misuse of aliased window function <alias>"
+///
+/// This happens when ORDER BY contains a scalar subquery like `(SELECT m)` and `m` is
+/// an alias for a window function expression in the SELECT list.
+pub fn validate_order_by_aliased_window_functions(
+    order_by: Option<&[vibesql_ast::OrderByItem]>,
+    select_list: &[SelectItem],
+) -> Result<(), ExecutorError> {
+    let Some(order_items) = order_by else {
+        return Ok(());
+    };
+
+    let window_aliases = build_window_aliases(select_list);
+    if window_aliases.is_empty() {
+        return Ok(());
+    }
+
+    for item in order_items {
+        if let Some(alias_name) =
+            find_aliased_window_misuse_in_order_by(&item.expr, &window_aliases)
+        {
+            return Err(ExecutorError::MisuseOfAliasedWindowFunction { alias_name });
+        }
+    }
+
+    Ok(())
+}
+
+/// Find misuse of aliased window functions in ORDER BY expressions
+///
+/// Detects scalar subqueries like `(SELECT m)` where `m` matches a window function alias.
+fn find_aliased_window_misuse_in_order_by(
+    expr: &Expression,
+    window_aliases: &HashSet<String>,
+) -> Option<String> {
+    match expr {
+        Expression::ScalarSubquery(select_stmt) => {
+            // Check if the scalar subquery is a simple `(SELECT alias)` pattern
+            if select_stmt.select_list.len() == 1
+                && select_stmt.from.is_none()
+                && select_stmt.where_clause.is_none()
+            {
+                if let SelectItem::Expression {
+                    expr: Expression::ColumnRef(col_id), ..
+                } = &select_stmt.select_list[0]
+                {
+                    if col_id.table_canonical().is_none() {
+                        let col_name = col_id.column_canonical().to_lowercase();
+                        if window_aliases.contains(&col_name) {
+                            return Some(col_name);
+                        }
+                    }
+                }
+            }
+            None
+        }
+        Expression::BinaryOp { left, right, .. } => {
+            find_aliased_window_misuse_in_order_by(left, window_aliases)
+                .or_else(|| find_aliased_window_misuse_in_order_by(right, window_aliases))
+        }
+        Expression::UnaryOp { expr, .. } => {
+            find_aliased_window_misuse_in_order_by(expr, window_aliases)
+        }
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use vibesql_ast::{BinaryOperator, ColumnIdentifier, FunctionIdentifier, UnaryOperator};

--- a/crates/vibesql-executor/src/select/executor/validation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/mod.rs
@@ -23,7 +23,7 @@ use std::collections::HashSet;
 pub use aggregates::{
     check_aggregate_arg_count, find_aggregate_in_expression, find_window_function_in_expression,
     validate_aggregate_arguments, validate_having_aliased_aggregates,
-    validate_no_nested_aggregates,
+    validate_no_nested_aggregates, validate_order_by_aliased_window_functions,
 };
 pub use column_refs::{extract_column_refs, validate_column_ref};
 pub use join_limits::validate_join_table_limit;

--- a/crates/vibesql-executor/src/select/window/evaluation.rs
+++ b/crates/vibesql-executor/src/select/window/evaluation.rs
@@ -17,7 +17,8 @@ use crate::{
         window::{
             calculate_frame_with_exclusion, evaluate_avg_window, evaluate_count_window,
             evaluate_group_concat_window, evaluate_max_window, evaluate_min_window,
-            evaluate_sum_window, partition_rows, sort_partition, validate_frame, Partition,
+            evaluate_sum_window, evaluate_total_window, partition_rows, sort_partition,
+            validate_frame, Partition,
         },
         CombinedExpressionEvaluator,
     },
@@ -338,22 +339,34 @@ fn evaluate_window_function_for_partition(
                     function_name: "ntile".to_string(),
                 });
             }
-            // Handle empty partition
-            if partition.is_empty() {
-                return Ok(vec![]);
-            }
-            // Evaluate the NTILE argument (should be a constant)
-            let n_value = evaluator.eval(&args[0], &partition.rows[0])?;
+            // Evaluate the NTILE argument first (even for empty partitions)
+            // to ensure validation errors like ntile(0) are always reported
+            let eval_row = if partition.is_empty() {
+                &vibesql_storage::Row::new(vec![])
+            } else {
+                &partition.rows[0]
+            };
+            let n_value = evaluator.eval(&args[0], eval_row)?;
             let n = match n_value {
                 vibesql_types::SqlValue::Integer(n) => n,
                 _ => {
-                    return Err(ExecutorError::UnsupportedExpression(
-                        "NTILE argument must be an integer".to_string(),
+                    return Err(ExecutorError::SqliteCompatError(
+                        "argument of ntile must be a positive integer".to_string(),
                     ))
                 }
             };
+            // Validate ntile argument is positive (even for empty partitions)
+            if n <= 0 {
+                return Err(ExecutorError::SqliteCompatError(
+                    "argument of ntile must be a positive integer".to_string(),
+                ));
+            }
+            // Handle empty partition after validation
+            if partition.is_empty() {
+                return Ok(vec![]);
+            }
             crate::evaluator::window::evaluate_ntile(partition, n)
-                .map_err(ExecutorError::UnsupportedExpression)?
+                .map_err(ExecutorError::SqliteCompatError)?
         }
         "LAG" => {
             // LAG(expr [, offset [, default]])
@@ -615,6 +628,14 @@ fn evaluate_window_function_for_partition(
                             ));
                         }
                         evaluate_max_window(partition, frame_indices, &args[0], filter, agg_eval_fn)
+                    }
+                    "TOTAL" => {
+                        if args.is_empty() {
+                            return Err(ExecutorError::UnsupportedExpression(
+                                "TOTAL requires an argument".to_string(),
+                            ));
+                        }
+                        evaluate_total_window(partition, frame_indices, &args[0], filter, agg_eval_fn)
                     }
                     "GROUP_CONCAT" | "STRING_AGG" => {
                         if args.is_empty() {


### PR DESCRIPTION
## Summary

Fixes 4 categories of window function edge cases from issue #5036, improving window1.test pass rate from 58.0% to 60.6% (9 additional tests passing):

- **TOTAL() window function**: Added `evaluate_total_window()` that returns `0.0` for empty sets (unlike SUM which returns NULL), matching SQLite semantics
- **Aliased window function misuse**: New `MisuseOfAliasedWindowFunction` error variant detecting `ORDER BY (SELECT alias)` where alias references a window function
- **VALUES clause window functions**: `VALUES(count(*)OVER())` was incorrectly rejected; now evaluates through the window-aware SELECT path
- **NTILE error fixes**: Fixed error message prefix and moved argument validation before empty partition check

## Test plan

- [x] All 116 integration tests pass (window_functions, select_without_from, aggregate_patterns, cte, set_operations, etc.)
- [x] window1.test: 211 passed / 61 failed (was 202/70) -- 9 tests fixed
- [x] No regressions detected

Closes #5036

🤖 Generated with [Claude Code](https://claude.com/claude-code)