### PR TITLE
perf(storage): incremental columnar maintenance for INSERT/UPDATE

### DIFF
--- a/crates/vibesql-ast/src/ddl/table.rs
+++ b/crates/vibesql-ast/src/ddl/table.rs
@@ -74,9 +74,9 @@ pub enum StorageFormat {
     /// Optimized for OLAP workloads: fast scans, aggregations.
     /// Eliminates row-to-columnar conversion overhead for analytical queries.
     ///
-    /// **Warning**: Each write operation (INSERT/UPDATE/DELETE) triggers a
-    /// full rebuild of the columnar representation. Only use for tables that
-    /// are bulk-loaded and rarely modified.
+    /// INSERT and UPDATE operations maintain the columnar representation
+    /// incrementally (O(m) per row where m = columns). DELETE triggers a
+    /// full rebuild. Suitable for analytical tables with moderate writes.
     Columnar,
 }
 

--- a/crates/vibesql-storage/src/columnar/data.rs
+++ b/crates/vibesql-storage/src/columnar/data.rs
@@ -253,4 +253,476 @@ impl ColumnData {
             _ => None,
         }
     }
+
+    /// Append a SQL value to this column, mutating the underlying vectors in place.
+    ///
+    /// Uses `Arc::make_mut` to get mutable access to the underlying vectors.
+    /// If there are no other references (strong count == 1), this is zero-copy.
+    /// If there are outstanding read snapshots, the vectors are cloned on first write
+    /// (copy-on-write semantics), preserving snapshot isolation.
+    ///
+    /// # Arguments
+    /// * `value` - The SQL value to append
+    ///
+    /// # Returns
+    /// * `Ok(())` on success
+    /// * `Err(String)` if the value type doesn't match the column type
+    pub fn push_value(&mut self, value: &SqlValue) -> Result<(), String> {
+        match self {
+            ColumnData::Int64 { values, nulls } => match value {
+                SqlValue::Integer(v) => {
+                    Arc::make_mut(values).push(*v);
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Bigint(v) => {
+                    Arc::make_mut(values).push(*v);
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Smallint(v) => {
+                    Arc::make_mut(values).push(*v as i64);
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values).push(0);
+                    Arc::make_mut(nulls).push(true);
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Int64, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Float64 { values, nulls } => match value {
+                SqlValue::Float(v) => {
+                    Arc::make_mut(values).push(*v as f64);
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Double(v) => {
+                    Arc::make_mut(values).push(*v);
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Real(v) => {
+                    Arc::make_mut(values).push(*v as f64);
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Numeric(v) => {
+                    Arc::make_mut(values).push(*v);
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Unsigned(v) => {
+                    Arc::make_mut(values).push(*v as f64);
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values).push(0.0);
+                    Arc::make_mut(nulls).push(true);
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Float64, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::String { values, nulls } => match value {
+                SqlValue::Varchar(v) => {
+                    Arc::make_mut(values).push(Arc::from(v.as_str()));
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Character(v) => {
+                    Arc::make_mut(values).push(Arc::from(v.as_str()));
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values).push(Arc::from(""));
+                    Arc::make_mut(nulls).push(true);
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected String, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Bool { values, nulls } => match value {
+                SqlValue::Boolean(v) => {
+                    Arc::make_mut(values).push(*v);
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values).push(false);
+                    Arc::make_mut(nulls).push(true);
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Bool, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Date { values, nulls } => match value {
+                SqlValue::Date(v) => {
+                    Arc::make_mut(values).push(*v);
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values).push(Date::new(1970, 1, 1).unwrap());
+                    Arc::make_mut(nulls).push(true);
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Date, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Time { values, nulls } => match value {
+                SqlValue::Time(v) => {
+                    Arc::make_mut(values).push(*v);
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values).push(Time::new(0, 0, 0, 0).unwrap());
+                    Arc::make_mut(nulls).push(true);
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Time, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Timestamp { values, nulls } => match value {
+                SqlValue::Timestamp(v) => {
+                    Arc::make_mut(values).push(*v);
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Null => {
+                    let date = Date::new(1970, 1, 1).unwrap();
+                    let time = Time::new(0, 0, 0, 0).unwrap();
+                    Arc::make_mut(values).push(Timestamp::new(date, time));
+                    Arc::make_mut(nulls).push(true);
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Timestamp, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Interval { values, nulls } => match value {
+                SqlValue::Interval(v) => {
+                    Arc::make_mut(values).push(v.clone());
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values).push(Interval::new("0".to_string()));
+                    Arc::make_mut(nulls).push(true);
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Interval, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Vector { values, nulls } => match value {
+                SqlValue::Vector(v) => {
+                    Arc::make_mut(values).push(v.clone());
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values).push(Vec::new());
+                    Arc::make_mut(nulls).push(true);
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Vector, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Blob { values, nulls } => match value {
+                SqlValue::Blob(v) => {
+                    Arc::make_mut(values).push(v.clone());
+                    Arc::make_mut(nulls).push(false);
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values).push(Vec::new());
+                    Arc::make_mut(nulls).push(true);
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Blob, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+        }
+        Ok(())
+    }
+
+    /// Remove the value at the given index from this column.
+    ///
+    /// Uses swap-remove semantics for O(1) removal when order doesn't matter,
+    /// but this method preserves order using regular remove (O(n)).
+    /// For deletion-heavy workloads, consider using a deletion bitmap instead.
+    ///
+    /// # Arguments
+    /// * `index` - The index of the value to remove
+    ///
+    /// # Panics
+    /// Panics if `index` is out of bounds
+    pub fn remove_at(&mut self, index: usize) {
+        match self {
+            ColumnData::Int64 { values, nulls } => {
+                Arc::make_mut(values).remove(index);
+                Arc::make_mut(nulls).remove(index);
+            }
+            ColumnData::Float64 { values, nulls } => {
+                Arc::make_mut(values).remove(index);
+                Arc::make_mut(nulls).remove(index);
+            }
+            ColumnData::String { values, nulls } => {
+                Arc::make_mut(values).remove(index);
+                Arc::make_mut(nulls).remove(index);
+            }
+            ColumnData::Bool { values, nulls } => {
+                Arc::make_mut(values).remove(index);
+                Arc::make_mut(nulls).remove(index);
+            }
+            ColumnData::Date { values, nulls } => {
+                Arc::make_mut(values).remove(index);
+                Arc::make_mut(nulls).remove(index);
+            }
+            ColumnData::Time { values, nulls } => {
+                Arc::make_mut(values).remove(index);
+                Arc::make_mut(nulls).remove(index);
+            }
+            ColumnData::Timestamp { values, nulls } => {
+                Arc::make_mut(values).remove(index);
+                Arc::make_mut(nulls).remove(index);
+            }
+            ColumnData::Interval { values, nulls } => {
+                Arc::make_mut(values).remove(index);
+                Arc::make_mut(nulls).remove(index);
+            }
+            ColumnData::Vector { values, nulls } => {
+                Arc::make_mut(values).remove(index);
+                Arc::make_mut(nulls).remove(index);
+            }
+            ColumnData::Blob { values, nulls } => {
+                Arc::make_mut(values).remove(index);
+                Arc::make_mut(nulls).remove(index);
+            }
+        }
+    }
+
+    /// Update the value at the given index in this column.
+    ///
+    /// Uses `Arc::make_mut` for copy-on-write semantics.
+    ///
+    /// # Arguments
+    /// * `index` - The index of the value to update
+    /// * `value` - The new SQL value
+    ///
+    /// # Returns
+    /// * `Ok(())` on success
+    /// * `Err(String)` if the value type doesn't match the column type
+    pub fn set_value(&mut self, index: usize, value: &SqlValue) -> Result<(), String> {
+        match self {
+            ColumnData::Int64 { values, nulls } => match value {
+                SqlValue::Integer(v) => {
+                    Arc::make_mut(values)[index] = *v;
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Bigint(v) => {
+                    Arc::make_mut(values)[index] = *v;
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Smallint(v) => {
+                    Arc::make_mut(values)[index] = *v as i64;
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values)[index] = 0;
+                    Arc::make_mut(nulls)[index] = true;
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Int64, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Float64 { values, nulls } => match value {
+                SqlValue::Float(v) => {
+                    Arc::make_mut(values)[index] = *v as f64;
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Double(v) => {
+                    Arc::make_mut(values)[index] = *v;
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Real(v) => {
+                    Arc::make_mut(values)[index] = *v as f64;
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Numeric(v) => {
+                    Arc::make_mut(values)[index] = *v;
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Unsigned(v) => {
+                    Arc::make_mut(values)[index] = *v as f64;
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values)[index] = 0.0;
+                    Arc::make_mut(nulls)[index] = true;
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Float64, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::String { values, nulls } => match value {
+                SqlValue::Varchar(v) => {
+                    Arc::make_mut(values)[index] = Arc::from(v.as_str());
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Character(v) => {
+                    Arc::make_mut(values)[index] = Arc::from(v.as_str());
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values)[index] = Arc::from("");
+                    Arc::make_mut(nulls)[index] = true;
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected String, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Bool { values, nulls } => match value {
+                SqlValue::Boolean(v) => {
+                    Arc::make_mut(values)[index] = *v;
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values)[index] = false;
+                    Arc::make_mut(nulls)[index] = true;
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Bool, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Date { values, nulls } => match value {
+                SqlValue::Date(v) => {
+                    Arc::make_mut(values)[index] = *v;
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values)[index] = Date::new(1970, 1, 1).unwrap();
+                    Arc::make_mut(nulls)[index] = true;
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Date, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Time { values, nulls } => match value {
+                SqlValue::Time(v) => {
+                    Arc::make_mut(values)[index] = *v;
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values)[index] = Time::new(0, 0, 0, 0).unwrap();
+                    Arc::make_mut(nulls)[index] = true;
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Time, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Timestamp { values, nulls } => match value {
+                SqlValue::Timestamp(v) => {
+                    Arc::make_mut(values)[index] = *v;
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Null => {
+                    let date = Date::new(1970, 1, 1).unwrap();
+                    let time = Time::new(0, 0, 0, 0).unwrap();
+                    Arc::make_mut(values)[index] = Timestamp::new(date, time);
+                    Arc::make_mut(nulls)[index] = true;
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Timestamp, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Interval { values, nulls } => match value {
+                SqlValue::Interval(v) => {
+                    Arc::make_mut(values)[index] = v.clone();
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values)[index] = Interval::new("0".to_string());
+                    Arc::make_mut(nulls)[index] = true;
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Interval, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Vector { values, nulls } => match value {
+                SqlValue::Vector(v) => {
+                    Arc::make_mut(values)[index] = v.clone();
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values)[index] = Vec::new();
+                    Arc::make_mut(nulls)[index] = true;
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Vector, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+            ColumnData::Blob { values, nulls } => match value {
+                SqlValue::Blob(v) => {
+                    Arc::make_mut(values)[index] = v.clone();
+                    Arc::make_mut(nulls)[index] = false;
+                }
+                SqlValue::Null => {
+                    Arc::make_mut(values)[index] = Vec::new();
+                    Arc::make_mut(nulls)[index] = true;
+                }
+                other => {
+                    return Err(format!(
+                        "Type mismatch: expected Blob, got {}",
+                        other.type_name()
+                    ));
+                }
+            },
+        }
+        Ok(())
+    }
 }

--- a/crates/vibesql-storage/src/columnar/mod.rs
+++ b/crates/vibesql-storage/src/columnar/mod.rs
@@ -369,4 +369,313 @@ mod tests {
             panic!("Expected String column data");
         }
     }
+
+    // ========================================================================
+    // Incremental columnar maintenance tests
+    // ========================================================================
+
+    #[test]
+    fn test_append_row_to_empty_table() {
+        let column_names = vec!["id".to_string(), "name".to_string()];
+        let mut columnar = ColumnarTable::from_rows(&[], &column_names).unwrap();
+        assert_eq!(columnar.row_count(), 0);
+
+        let row = Row::new(vec![
+            SqlValue::Integer(1),
+            SqlValue::Varchar(arcstr::ArcStr::from("Alice")),
+        ]);
+        columnar.append_row(&row).unwrap();
+
+        assert_eq!(columnar.row_count(), 1);
+        let id_col = columnar.get_column("id").unwrap();
+        assert_eq!(id_col.get(0), SqlValue::Integer(1));
+        let name_col = columnar.get_column("name").unwrap();
+        assert_eq!(name_col.get(0), SqlValue::Varchar(arcstr::ArcStr::from("Alice")));
+    }
+
+    #[test]
+    fn test_append_row_to_existing_table() {
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1), SqlValue::Double(3.14)]),
+            Row::new(vec![SqlValue::Integer(2), SqlValue::Double(2.71)]),
+        ];
+        let column_names = vec!["id".to_string(), "value".to_string()];
+        let mut columnar = ColumnarTable::from_rows(&rows, &column_names).unwrap();
+        assert_eq!(columnar.row_count(), 2);
+
+        // Append a third row
+        let new_row = Row::new(vec![SqlValue::Integer(3), SqlValue::Double(1.41)]);
+        columnar.append_row(&new_row).unwrap();
+
+        assert_eq!(columnar.row_count(), 3);
+        let id_col = columnar.get_column("id").unwrap();
+        assert_eq!(id_col.get(2), SqlValue::Integer(3));
+        let value_col = columnar.get_column("value").unwrap();
+        assert_eq!(value_col.get(2), SqlValue::Double(1.41));
+    }
+
+    #[test]
+    fn test_append_row_with_nulls() {
+        let rows = vec![Row::new(vec![SqlValue::Integer(1)])];
+        let column_names = vec!["id".to_string()];
+        let mut columnar = ColumnarTable::from_rows(&rows, &column_names).unwrap();
+
+        let null_row = Row::new(vec![SqlValue::Null]);
+        columnar.append_row(&null_row).unwrap();
+
+        assert_eq!(columnar.row_count(), 2);
+        let id_col = columnar.get_column("id").unwrap();
+        assert!(!id_col.is_null(0));
+        assert!(id_col.is_null(1));
+    }
+
+    #[test]
+    fn test_append_rows_batch() {
+        let initial = vec![Row::new(vec![SqlValue::Integer(1)])];
+        let column_names = vec!["id".to_string()];
+        let mut columnar = ColumnarTable::from_rows(&initial, &column_names).unwrap();
+
+        let new_rows = vec![
+            Row::new(vec![SqlValue::Integer(2)]),
+            Row::new(vec![SqlValue::Integer(3)]),
+            Row::new(vec![SqlValue::Integer(4)]),
+        ];
+        columnar.append_rows(&new_rows).unwrap();
+
+        assert_eq!(columnar.row_count(), 4);
+        let id_col = columnar.get_column("id").unwrap();
+        for i in 0..4 {
+            assert_eq!(id_col.get(i), SqlValue::Integer(i as i64 + 1));
+        }
+    }
+
+    #[test]
+    fn test_update_row_at() {
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar(arcstr::ArcStr::from("Alice"))]),
+            Row::new(vec![SqlValue::Integer(2), SqlValue::Varchar(arcstr::ArcStr::from("Bob"))]),
+        ];
+        let column_names = vec!["id".to_string(), "name".to_string()];
+        let mut columnar = ColumnarTable::from_rows(&rows, &column_names).unwrap();
+
+        // Update second row
+        let updated = Row::new(vec![
+            SqlValue::Integer(2),
+            SqlValue::Varchar(arcstr::ArcStr::from("Charlie")),
+        ]);
+        columnar.update_row_at(1, &updated).unwrap();
+
+        assert_eq!(columnar.row_count(), 2);
+        let name_col = columnar.get_column("name").unwrap();
+        assert_eq!(name_col.get(0), SqlValue::Varchar(arcstr::ArcStr::from("Alice")));
+        assert_eq!(name_col.get(1), SqlValue::Varchar(arcstr::ArcStr::from("Charlie")));
+    }
+
+    #[test]
+    fn test_remove_row_at() {
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1)]),
+            Row::new(vec![SqlValue::Integer(2)]),
+            Row::new(vec![SqlValue::Integer(3)]),
+        ];
+        let column_names = vec!["id".to_string()];
+        let mut columnar = ColumnarTable::from_rows(&rows, &column_names).unwrap();
+
+        // Remove middle row
+        columnar.remove_row_at(1).unwrap();
+
+        assert_eq!(columnar.row_count(), 2);
+        let id_col = columnar.get_column("id").unwrap();
+        assert_eq!(id_col.get(0), SqlValue::Integer(1));
+        assert_eq!(id_col.get(1), SqlValue::Integer(3));
+    }
+
+    #[test]
+    fn test_remove_rows_sorted() {
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1)]),
+            Row::new(vec![SqlValue::Integer(2)]),
+            Row::new(vec![SqlValue::Integer(3)]),
+            Row::new(vec![SqlValue::Integer(4)]),
+        ];
+        let column_names = vec!["id".to_string()];
+        let mut columnar = ColumnarTable::from_rows(&rows, &column_names).unwrap();
+
+        // Remove rows at index 1 and 3
+        columnar.remove_rows_sorted(&[1, 3]).unwrap();
+
+        assert_eq!(columnar.row_count(), 2);
+        let id_col = columnar.get_column("id").unwrap();
+        assert_eq!(id_col.get(0), SqlValue::Integer(1));
+        assert_eq!(id_col.get(1), SqlValue::Integer(3));
+    }
+
+    #[test]
+    fn test_clear_columnar_table() {
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1)]),
+            Row::new(vec![SqlValue::Integer(2)]),
+        ];
+        let column_names = vec!["id".to_string()];
+        let mut columnar = ColumnarTable::from_rows(&rows, &column_names).unwrap();
+
+        columnar.clear();
+        assert_eq!(columnar.row_count(), 0);
+        assert_eq!(columnar.column_count(), 1); // column_names preserved
+    }
+
+    #[test]
+    fn test_append_then_to_rows_round_trip() {
+        let column_names = vec!["id".to_string(), "value".to_string(), "name".to_string()];
+        let mut columnar = ColumnarTable::from_rows(&[], &column_names).unwrap();
+
+        // Build table incrementally via append
+        let rows = vec![
+            Row::new(vec![
+                SqlValue::Integer(1),
+                SqlValue::Double(3.14),
+                SqlValue::Varchar(arcstr::ArcStr::from("Alice")),
+            ]),
+            Row::new(vec![
+                SqlValue::Integer(2),
+                SqlValue::Null,
+                SqlValue::Varchar(arcstr::ArcStr::from("Bob")),
+            ]),
+            Row::new(vec![SqlValue::Integer(3), SqlValue::Double(2.71), SqlValue::Null]),
+        ];
+
+        for row in &rows {
+            columnar.append_row(row).unwrap();
+        }
+
+        // Convert back to rows
+        let reconstructed = columnar.to_rows();
+        assert_eq!(reconstructed.len(), 3);
+
+        // Verify round trip
+        for (orig, recon) in rows.iter().zip(reconstructed.iter()) {
+            assert_eq!(orig.len(), recon.len());
+            for i in 0..orig.len() {
+                match (orig.get(i), recon.get(i)) {
+                    (Some(SqlValue::Integer(a)), Some(SqlValue::Integer(b))) => {
+                        assert_eq!(a, b);
+                    }
+                    (Some(SqlValue::Double(a)), Some(SqlValue::Double(b))) => {
+                        assert!((a - b).abs() < 1e-10);
+                    }
+                    (Some(SqlValue::Varchar(a)), Some(SqlValue::Varchar(b))) => {
+                        assert_eq!(a, b);
+                    }
+                    (Some(SqlValue::Null), Some(SqlValue::Null)) => {}
+                    (a, b) => {
+                        panic!("Mismatch at column {}: {:?} vs {:?}", i, a, b);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_column_data_push_value() {
+        use std::sync::Arc;
+
+        // Test push_value for Int64
+        let mut col = ColumnData::Int64 {
+            values: Arc::new(vec![1, 2]),
+            nulls: Arc::new(vec![false, false]),
+        };
+        col.push_value(&SqlValue::Integer(3)).unwrap();
+        assert_eq!(col.len(), 3);
+        assert_eq!(col.get(2), SqlValue::Integer(3));
+
+        // Test push_value for String
+        let mut col = ColumnData::String {
+            values: Arc::new(vec![Arc::from("hello")]),
+            nulls: Arc::new(vec![false]),
+        };
+        col.push_value(&SqlValue::Varchar(arcstr::ArcStr::from("world")))
+            .unwrap();
+        assert_eq!(col.len(), 2);
+        assert_eq!(col.get(1), SqlValue::Varchar(arcstr::ArcStr::from("world")));
+
+        // Test push_value with NULL
+        col.push_value(&SqlValue::Null).unwrap();
+        assert_eq!(col.len(), 3);
+        assert!(col.is_null(2));
+    }
+
+    #[test]
+    fn test_column_data_set_value() {
+        use std::sync::Arc;
+
+        let mut col = ColumnData::Int64 {
+            values: Arc::new(vec![1, 2, 3]),
+            nulls: Arc::new(vec![false, false, false]),
+        };
+
+        // Update middle value
+        col.set_value(1, &SqlValue::Integer(42)).unwrap();
+        assert_eq!(col.get(0), SqlValue::Integer(1));
+        assert_eq!(col.get(1), SqlValue::Integer(42));
+        assert_eq!(col.get(2), SqlValue::Integer(3));
+
+        // Set to NULL
+        col.set_value(0, &SqlValue::Null).unwrap();
+        assert!(col.is_null(0));
+        assert_eq!(col.get(1), SqlValue::Integer(42));
+    }
+
+    #[test]
+    fn test_column_data_remove_at() {
+        use std::sync::Arc;
+
+        let mut col = ColumnData::Int64 {
+            values: Arc::new(vec![10, 20, 30, 40]),
+            nulls: Arc::new(vec![false, false, false, false]),
+        };
+
+        col.remove_at(1);
+        assert_eq!(col.len(), 3);
+        assert_eq!(col.get(0), SqlValue::Integer(10));
+        assert_eq!(col.get(1), SqlValue::Integer(30));
+        assert_eq!(col.get(2), SqlValue::Integer(40));
+    }
+
+    #[test]
+    fn test_snapshot_isolation_on_append() {
+        // Create a columnar table and take a snapshot
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1)]),
+            Row::new(vec![SqlValue::Integer(2)]),
+        ];
+        let column_names = vec!["id".to_string()];
+        let mut columnar = ColumnarTable::from_rows(&rows, &column_names).unwrap();
+
+        // Take a "snapshot" by cloning (simulates Arc sharing)
+        let snapshot = columnar.clone();
+
+        // Append to original
+        columnar
+            .append_row(&Row::new(vec![SqlValue::Integer(3)]))
+            .unwrap();
+
+        // Original should have 3 rows
+        assert_eq!(columnar.row_count(), 3);
+
+        // Snapshot should still have 2 rows (copy-on-write via Arc::make_mut)
+        assert_eq!(snapshot.row_count(), 2);
+    }
+
+    #[test]
+    fn test_type_mismatch_error() {
+        let rows = vec![Row::new(vec![SqlValue::Integer(1)])];
+        let column_names = vec!["id".to_string()];
+        let mut columnar = ColumnarTable::from_rows(&rows, &column_names).unwrap();
+
+        // Try to append a string to an integer column
+        let bad_row = Row::new(vec![SqlValue::Varchar(arcstr::ArcStr::from("not a number"))]);
+        let result = columnar.append_row(&bad_row);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Type mismatch"));
+    }
 }

--- a/crates/vibesql-storage/src/columnar/table.rs
+++ b/crates/vibesql-storage/src/columnar/table.rs
@@ -229,9 +229,175 @@ impl ColumnarTable {
         self.columns.get(name)
     }
 
+    /// Get mutable column data by name
+    pub fn get_column_mut(&mut self, name: &str) -> Option<&mut ColumnData> {
+        self.columns.get_mut(name)
+    }
+
     /// Get all column names
     pub fn column_names(&self) -> &[String] {
         &self.column_names
+    }
+
+    /// Append a single row to the columnar table incrementally.
+    ///
+    /// This is O(m) where m = number of columns, compared to O(n * m) for a full rebuild.
+    /// Uses `Arc::make_mut` on each column for copy-on-write semantics, so outstanding
+    /// read snapshots (via `Arc<ColumnarTable>`) remain valid and unmodified.
+    ///
+    /// # Arguments
+    /// * `row` - The row to append
+    /// * `column_names` - Column names corresponding to the row values
+    ///
+    /// # Returns
+    /// * `Ok(())` on success
+    /// * `Err(String)` if column count mismatch or type mismatch
+    pub fn append_row(&mut self, row: &crate::Row) -> Result<(), String> {
+        if row.len() != self.column_names.len() {
+            return Err(format!(
+                "Row has {} columns, expected {}",
+                row.len(),
+                self.column_names.len()
+            ));
+        }
+
+        // Handle empty table: need to initialize columns from the row
+        if self.columns.is_empty() && !self.column_names.is_empty() {
+            // Infer column types from row values
+            let col_types: Vec<_> = row
+                .values
+                .iter()
+                .map(|v| ColumnTypeClass::from_sql_value(v))
+                .collect();
+
+            // Create columns using ColumnBuilder for initial row
+            for (col_idx, col_name) in self.column_names.iter().enumerate() {
+                let mut builder = ColumnBuilder::new(col_types[col_idx], 1);
+                builder.push(&row.values[col_idx])?;
+                self.columns.insert(col_name.clone(), builder.build());
+            }
+
+            self.row_count = 1;
+            return Ok(());
+        }
+
+        // Append to existing columns
+        for (col_idx, col_name) in self.column_names.iter().enumerate() {
+            let column = self.columns.get_mut(col_name).ok_or_else(|| {
+                format!("Column '{}' not found in columnar table", col_name)
+            })?;
+            column.push_value(&row.values[col_idx])?;
+        }
+
+        self.row_count += 1;
+        Ok(())
+    }
+
+    /// Append multiple rows to the columnar table incrementally.
+    ///
+    /// This is O(batch_size * m) where m = number of columns, compared to
+    /// O(n * m) for a full rebuild from all rows.
+    ///
+    /// # Arguments
+    /// * `rows` - Slice of rows to append
+    ///
+    /// # Returns
+    /// * `Ok(())` on success
+    /// * `Err(String)` if column count mismatch or type mismatch
+    pub fn append_rows(&mut self, rows: &[crate::Row]) -> Result<(), String> {
+        for row in rows {
+            self.append_row(row)?;
+        }
+        Ok(())
+    }
+
+    /// Update a row at the given index in the columnar table.
+    ///
+    /// This is O(m) where m = number of columns.
+    ///
+    /// # Arguments
+    /// * `index` - Row index to update
+    /// * `row` - New row values
+    ///
+    /// # Returns
+    /// * `Ok(())` on success
+    /// * `Err(String)` if index out of bounds or type mismatch
+    pub fn update_row_at(&mut self, index: usize, row: &crate::Row) -> Result<(), String> {
+        if index >= self.row_count {
+            return Err(format!(
+                "Row index {} out of bounds (row_count: {})",
+                index, self.row_count
+            ));
+        }
+        if row.len() != self.column_names.len() {
+            return Err(format!(
+                "Row has {} columns, expected {}",
+                row.len(),
+                self.column_names.len()
+            ));
+        }
+
+        for (col_idx, col_name) in self.column_names.iter().enumerate() {
+            let column = self.columns.get_mut(col_name).ok_or_else(|| {
+                format!("Column '{}' not found in columnar table", col_name)
+            })?;
+            column.set_value(index, &row.values[col_idx])?;
+        }
+
+        Ok(())
+    }
+
+    /// Remove a row at the given index from the columnar table.
+    ///
+    /// This shifts all subsequent rows down by one. For bulk deletions,
+    /// consider using `remove_rows_sorted` instead.
+    ///
+    /// # Arguments
+    /// * `index` - Row index to remove
+    ///
+    /// # Returns
+    /// * `Ok(())` on success
+    /// * `Err(String)` if index out of bounds
+    pub fn remove_row_at(&mut self, index: usize) -> Result<(), String> {
+        if index >= self.row_count {
+            return Err(format!(
+                "Row index {} out of bounds (row_count: {})",
+                index, self.row_count
+            ));
+        }
+
+        for col_name in self.column_names.clone() {
+            if let Some(column) = self.columns.get_mut(&col_name) {
+                column.remove_at(index);
+            }
+        }
+
+        self.row_count -= 1;
+        Ok(())
+    }
+
+    /// Remove multiple rows by sorted indices (must be sorted in ascending order).
+    ///
+    /// Removes from the end first to avoid index shifting issues.
+    ///
+    /// # Arguments
+    /// * `indices` - Row indices to remove, sorted in ascending order
+    ///
+    /// # Returns
+    /// * `Ok(())` on success
+    /// * `Err(String)` if any index is out of bounds
+    pub fn remove_rows_sorted(&mut self, indices: &[usize]) -> Result<(), String> {
+        // Remove from the end first to avoid index invalidation
+        for &index in indices.iter().rev() {
+            self.remove_row_at(index)?;
+        }
+        Ok(())
+    }
+
+    /// Clear all data from the columnar table, keeping column names.
+    pub fn clear(&mut self) {
+        self.columns.clear();
+        self.row_count = 0;
     }
 
     /// Estimate the memory size of this columnar table in bytes

--- a/crates/vibesql-storage/src/database/cache.rs
+++ b/crates/vibesql-storage/src/database/cache.rs
@@ -36,7 +36,16 @@ impl Database {
         &self,
         table_name: &str,
     ) -> Result<Option<Arc<crate::ColumnarTable>>, StorageError> {
-        // Check cache first
+        // For native columnar tables, return data directly from the table
+        // (no cache needed -- data is always hot and maintained incrementally)
+        if let Some(table) = self.get_table(table_name) {
+            if table.is_native_columnar() {
+                let columnar = table.scan_columnar()?;
+                return Ok(Some(Arc::new(columnar)));
+            }
+        }
+
+        // Check cache first (for row-oriented tables)
         if let Some(cached) = self.columnar_cache.get(table_name) {
             return Ok(Some(cached));
         }
@@ -59,7 +68,17 @@ impl Database {
     ///
     /// Called automatically when a table is modified (INSERT/UPDATE/DELETE)
     /// to ensure the cache doesn't serve stale data.
+    ///
+    /// For native columnar tables, this is a no-op since the columnar data
+    /// is maintained incrementally by the Table itself during DML operations.
     pub fn invalidate_columnar_cache(&self, table_name: &str) {
+        // For native columnar tables, skip invalidation -- they maintain
+        // their own columnar data incrementally during INSERT/UPDATE/DELETE
+        if let Some(table) = self.get_table(table_name) {
+            if table.is_native_columnar() {
+                return;
+            }
+        }
         self.columnar_cache.invalidate(table_name);
     }
 

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -66,6 +66,19 @@ use vibesql_types::SqlValue;
 
 use crate::{Row, StorageError};
 
+/// Compute the columnar index for a given physical row index.
+///
+/// The columnar table only stores live (non-deleted) rows, so the columnar
+/// index is the physical index minus the count of deleted rows before it.
+///
+/// This is a free function to avoid borrow conflicts when both `self.deleted`
+/// and `self.native_columnar` need to be accessed simultaneously.
+#[inline]
+fn columnar_index_in(deleted: &[bool], physical_index: usize) -> usize {
+    let deleted_before = deleted[..physical_index].iter().filter(|&&d| d).count();
+    physical_index - deleted_before
+}
+
 /// Result of a delete operation, indicating how many rows were deleted
 /// and whether table compaction occurred.
 ///
@@ -109,14 +122,17 @@ impl DeleteResult {
 /// - **Row-oriented (default)**: Traditional row storage, optimized for OLTP
 /// - **Columnar**: Native column storage, optimized for OLAP with zero conversion overhead
 ///
-/// ## Columnar Storage Limitations
+/// ## Columnar Storage
 ///
-/// **IMPORTANT**: Columnar tables are optimized for read-heavy analytical workloads.
-/// Each INSERT/UPDATE/DELETE operation triggers a full rebuild of the columnar
-/// representation (O(n) cost). This makes columnar tables unsuitable for:
-/// - High-frequency INSERT workloads
-/// - OLTP use cases with frequent writes
-/// - Streaming inserts
+/// Columnar tables maintain their columnar representation incrementally:
+/// - **INSERT**: O(m) append per row where m = number of columns (no full rebuild)
+/// - **UPDATE**: O(m) in-place column update (no full rebuild)
+/// - **DELETE**: Full rebuild (O(n * m)) since deletion requires row compaction
+/// - **TRUNCATE**: O(1) clear
+///
+/// This makes columnar tables viable for moderate write workloads, not just
+/// bulk-loaded analytical data. The row store is maintained alongside the
+/// columnar store for indexing and constraint validation.
 ///
 /// **Recommended use cases for columnar tables**:
 /// - Bulk-loaded analytical data (load once, query many times)
@@ -251,7 +267,8 @@ impl Table {
     /// Insert a row into the table
     ///
     /// For row-oriented tables, rows are stored directly in a Vec.
-    /// For columnar tables, rows are buffered and the columnar data is rebuilt.
+    /// For columnar tables, the row is appended to the columnar data incrementally
+    /// (O(m) where m = columns, instead of O(n * m) full rebuild).
     pub fn insert(&mut self, row: Row) -> Result<(), StorageError> {
         // Normalize and validate row (column count, type checking, NULL checking, value
         // normalization)
@@ -283,10 +300,12 @@ impl Table {
             }
         }
 
-        // For native columnar tables, rebuild columnar data
-        // Note: Database-level columnar cache invalidation is handled by the executor
-        if self.native_columnar.is_some() {
-            self.rebuild_native_columnar()?;
+        // For native columnar tables, incrementally append to columnar data
+        // This is O(m) per row instead of O(n*m) full rebuild
+        if let Some(ref mut columnar) = self.native_columnar {
+            columnar.append_row(&normalized_row).map_err(|e| {
+                StorageError::Other(format!("Columnar append failed: {}", e))
+            })?;
         }
 
         Ok(())
@@ -321,7 +340,7 @@ impl Table {
     /// - **Pre-allocation**: Vector capacity is reserved upfront
     /// - **Batch normalization**: Rows are validated/normalized together
     /// - **Deferred index updates**: Indexes are rebuilt once after all inserts
-    /// - **Single cache invalidation**: Columnar cache invalidated once at end
+    /// - **Incremental columnar**: For native columnar tables, appends O(batch * m) instead of O(n * m) rebuild
     /// - **Statistics update once**: Stats marked stale only at completion
     ///
     /// # Arguments
@@ -406,10 +425,14 @@ impl Table {
         }
 
         // Phase 7: Handle columnar storage
-        // For native columnar tables, rebuild columnar data
-        // Note: Database-level columnar cache invalidation is handled by the executor
-        if self.native_columnar.is_some() {
-            self.rebuild_native_columnar()?;
+        // For native columnar tables, incrementally append new rows to columnar data
+        // This is O(batch_size * m) instead of O(n * m) full rebuild
+        if let Some(ref mut columnar) = self.native_columnar {
+            for row in &self.rows[start_index..] {
+                columnar.append_row(row).map_err(|e| {
+                    StorageError::Other(format!("Columnar append failed: {}", e))
+                })?;
+            }
         }
 
         Ok(row_count)
@@ -723,10 +746,12 @@ impl Table {
         // Update indexes (delegate to IndexManager)
         self.indexes.update_for_update(&self.schema, &old_row, &normalized_row, index);
 
-        // For native columnar tables, rebuild columnar data
-        // Note: Database-level columnar cache invalidation is handled by the executor
-        if self.native_columnar.is_some() {
-            self.rebuild_native_columnar()?;
+        // For native columnar tables, incrementally update the columnar row
+        if let Some(ref mut columnar) = self.native_columnar {
+            let columnar_idx = columnar_index_in(&self.deleted, index);
+            columnar.update_row_at(columnar_idx, &normalized_row).map_err(|e| {
+                StorageError::Other(format!("Columnar update failed: {}", e))
+            })?;
         }
 
         Ok(())
@@ -779,13 +804,15 @@ impl Table {
             &affected_indexes,
         );
 
-        // Update the row (move ownership, no clone needed)
+        // Update the row
         self.rows[index] = normalized_row;
 
-        // For native columnar tables, rebuild columnar data
-        // Note: Database-level columnar cache invalidation is handled by the executor
-        if self.native_columnar.is_some() {
-            self.rebuild_native_columnar()?;
+        // For native columnar tables, incrementally update the columnar row
+        if let Some(ref mut columnar) = self.native_columnar {
+            let columnar_idx = columnar_index_in(&self.deleted, index);
+            columnar.update_row_at(columnar_idx, &self.rows[index]).map_err(|e| {
+                StorageError::Other(format!("Columnar update failed: {}", e))
+            })?;
         }
 
         Ok(())
@@ -822,7 +849,13 @@ impl Table {
         // Update the row (direct move, no validation)
         self.rows[index] = new_row;
 
-        // Note: Database-level columnar cache invalidation is handled by the executor
+        // For native columnar tables, incrementally update the columnar row
+        // (Row-oriented tables rely on Database::invalidate_columnar_cache from the executor)
+        if let Some(ref mut columnar) = self.native_columnar {
+            let columnar_idx = columnar_index_in(&self.deleted, index);
+            // Ignore errors in unchecked path (matching the no-validation contract)
+            let _ = columnar.update_row_at(columnar_idx, &self.rows[index]);
+        }
     }
 
     /// Update a single column value in-place without cloning the row
@@ -852,7 +885,15 @@ impl Table {
     ) {
         self.rows[row_index].values[col_index] = new_value;
 
-        // Note: Database-level columnar cache invalidation is handled by the executor
+        // For native columnar tables, update the specific column value incrementally
+        // (Row-oriented tables rely on Database::invalidate_columnar_cache from the executor)
+        if let Some(ref mut columnar) = self.native_columnar {
+            let columnar_idx = columnar_index_in(&self.deleted, row_index);
+            let col_name = &self.schema.columns[col_index].name;
+            if let Some(column) = columnar.get_column_mut(col_name) {
+                let _ = column.set_value(columnar_idx, &self.rows[row_index].values[col_index]);
+            }
+        }
     }
 
     /// Delete rows matching a predicate


### PR DESCRIPTION
## Summary

- Replace O(n*m) full columnar rebuild on every INSERT/UPDATE with incremental O(m) operations for native columnar tables
- Add `push_value`/`set_value`/`remove_at` methods to `ColumnData` using `Arc::make_mut` for copy-on-write snapshot isolation
- Add `append_row`/`update_row_at`/`remove_row_at` to `ColumnarTable` for incremental maintenance
- Make `Database::invalidate_columnar_cache()` a no-op for native columnar tables (they maintain their own data)
- DELETE still uses full rebuild (row compaction requires index recalculation)

Phase 1 of #5034. Makes native columnar tables viable for moderate write workloads.

## Test plan

- [x] 14 new unit tests covering incremental append, update, remove, batch append, round-trip consistency, snapshot isolation, type mismatch errors
- [x] All 584 existing storage unit tests pass
- [x] All 16 integration tests pass
- [x] All 13 persistence tests pass
- [x] All 15 doc-tests pass
- [x] Full workspace compiles cleanly

Closes #5034

🤖 Generated with [Claude Code](https://claude.com/claude-code)