### PR TITLE
chore(executor): remove dead is_inner_or_cross_join_only function

### DIFF
--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -9,23 +9,6 @@ use vibesql_ast::{BinaryOperator, Expression, FromClause, JoinType};
 
 use crate::{errors::ExecutorError, schema::CombinedSchema, select::columnar};
 
-/// Check if a FROM clause only contains INNER or CROSS joins
-///
-/// CROSS joins are included because:
-/// - Comma-separated tables (`FROM a, b`) are parsed as CROSS joins
-/// - CROSS JOIN with equijoin conditions in WHERE is semantically equivalent to INNER JOIN
-/// - This enables columnar execution for implicit join syntax (e.g., TPC-H Q19)
-pub(super) fn is_inner_or_cross_join_only(from: &FromClause) -> bool {
-    match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => true,
-        FromClause::Join { left, right, join_type, .. } => {
-            matches!(join_type, JoinType::Inner | JoinType::Cross)
-                && is_inner_or_cross_join_only(left)
-                && is_inner_or_cross_join_only(right)
-        }
-    }
-}
-
 /// Check if a FROM clause only contains join types supported by the columnar path
 ///
 /// Supported join types:


### PR DESCRIPTION
## Summary

- Remove the dead `is_inner_or_cross_join_only` function from `join_helpers.rs`, which became unused after PR #5039 replaced it with `is_columnar_supported_join`

Closes #5040

## Test plan

- [x] `cargo test -p vibesql-executor` passes (2318 passed, 1 pre-existing flaky timeout unrelated to this change)
- [x] Verified via grep that `is_inner_or_cross_join_only` has no callers outside its own definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)