### PR TITLE
fix(window): per-row offset eval for LAG/LEAD/NTH_VALUE and PRECEDING end boundary

### DIFF
--- a/crates/vibesql-executor/src/evaluator/window/frames.rs
+++ b/crates/vibesql-executor/src/evaluator/window/frames.rs
@@ -748,7 +748,18 @@ fn calculate_rows_boundary(
 
         FrameBound::Preceding(offset_expr) => {
             let offset = get_numeric_offset(offset_expr) as usize;
-            current_row_idx.saturating_sub(offset)
+            if is_start {
+                current_row_idx.saturating_sub(offset)
+            } else {
+                // For end boundary, +1 for exclusive end (Range semantics)
+                // If offset > current_row_idx, the position is before the partition start,
+                // so return 0 (empty frame when combined with any start boundary)
+                if offset > current_row_idx {
+                    0
+                } else {
+                    current_row_idx - offset + 1
+                }
+            }
         }
 
         FrameBound::Following(offset_expr) => {

--- a/crates/vibesql-executor/src/select/window/evaluation.rs
+++ b/crates/vibesql-executor/src/select/window/evaluation.rs
@@ -381,21 +381,7 @@ fn evaluate_window_function_for_partition(
             }
 
             let value_expr = &args[0];
-            let offset = if args.len() > 1 {
-                // Evaluate offset argument (should be constant)
-                let offset_value = evaluator.eval(&args[1], &partition.rows[0])?;
-                match offset_value {
-                    SqlValue::Integer(n) => Some(n),
-                    _ => {
-                        return Err(ExecutorError::UnsupportedExpression(
-                            "LAG offset must be an integer".to_string(),
-                        ))
-                    }
-                }
-            } else {
-                None // Default offset is 1
-            };
-
+            let has_offset = args.len() > 1;
             let default_expr = if args.len() > 2 { Some(&args[2]) } else { None };
 
             // Create closure that evaluates expressions using the evaluator
@@ -407,6 +393,22 @@ fn evaluate_window_function_for_partition(
             // Evaluate LAG for each row in partition
             let mut results = Vec::with_capacity(partition.len());
             for row_idx in 0..partition.len() {
+                // Evaluate offset per row (supports expressions like LAG(b, b))
+                let offset = if has_offset {
+                    let offset_value = evaluator.eval(&args[1], &partition.rows[row_idx])
+                        .map_err(|e| ExecutorError::UnsupportedExpression(format!("{:?}", e)))?;
+                    match offset_value {
+                        SqlValue::Integer(n) => Some(n),
+                        SqlValue::Null => Some(0),
+                        _ => {
+                            return Err(ExecutorError::UnsupportedExpression(
+                                "LAG offset must be an integer".to_string(),
+                            ))
+                        }
+                    }
+                } else {
+                    None // Default offset is 1
+                };
                 let value = crate::evaluator::window::evaluate_lag(
                     partition,
                     row_idx,
@@ -433,21 +435,7 @@ fn evaluate_window_function_for_partition(
             }
 
             let value_expr = &args[0];
-            let offset = if args.len() > 1 {
-                // Evaluate offset argument (should be constant)
-                let offset_value = evaluator.eval(&args[1], &partition.rows[0])?;
-                match offset_value {
-                    SqlValue::Integer(n) => Some(n),
-                    _ => {
-                        return Err(ExecutorError::UnsupportedExpression(
-                            "LEAD offset must be an integer".to_string(),
-                        ))
-                    }
-                }
-            } else {
-                None // Default offset is 1
-            };
-
+            let has_offset = args.len() > 1;
             let default_expr = if args.len() > 2 { Some(&args[2]) } else { None };
 
             // Create closure that evaluates expressions using the evaluator
@@ -459,6 +447,22 @@ fn evaluate_window_function_for_partition(
             // Evaluate LEAD for each row in partition
             let mut results = Vec::with_capacity(partition.len());
             for row_idx in 0..partition.len() {
+                // Evaluate offset per row (supports expressions like LEAD(b, b))
+                let offset = if has_offset {
+                    let offset_value = evaluator.eval(&args[1], &partition.rows[row_idx])
+                        .map_err(|e| ExecutorError::UnsupportedExpression(format!("{:?}", e)))?;
+                    match offset_value {
+                        SqlValue::Integer(n) => Some(n),
+                        SqlValue::Null => Some(0),
+                        _ => {
+                            return Err(ExecutorError::UnsupportedExpression(
+                                "LEAD offset must be an integer".to_string(),
+                            ))
+                        }
+                    }
+                } else {
+                    None // Default offset is 1
+                };
                 let value = crate::evaluator::window::evaluate_lead(
                     partition,
                     row_idx,
@@ -542,27 +546,29 @@ fn evaluate_window_function_for_partition(
 
             let value_expr = &args[0];
 
-            // Evaluate n argument (should be constant integer)
-            let n_value = evaluator.eval(&args[1], &partition.rows[0])?;
-            let n = match n_value {
-                SqlValue::Integer(n) => n,
-                _ => {
-                    return Err(ExecutorError::UnsupportedExpression(
-                        "NTH_VALUE second argument must be an integer".to_string(),
-                    ))
-                }
-            };
-
-            if n < 1 {
-                return Err(ExecutorError::UnsupportedExpression(
-                    format!("NTH_VALUE n must be a positive integer, got {}", n),
-                ));
-            }
-
             // NTH_VALUE respects frame boundaries - evaluate per-row
-            let nth_zero_based = (n - 1) as usize;
+            // The n argument is evaluated per row to support expressions like nth_value(b, b+1)
             let mut results = Vec::with_capacity(partition.len());
             for row_idx in 0..partition.len() {
+                // Evaluate n argument against current row
+                let n_value = evaluator.eval(&args[1], &partition.rows[row_idx])
+                    .map_err(|e| ExecutorError::UnsupportedExpression(format!("{:?}", e)))?;
+                let n = match n_value {
+                    SqlValue::Integer(n) => n,
+                    _ => {
+                        return Err(ExecutorError::UnsupportedExpression(
+                            "NTH_VALUE second argument must be an integer".to_string(),
+                        ))
+                    }
+                };
+
+                if n < 1 {
+                    return Err(ExecutorError::UnsupportedExpression(
+                        format!("NTH_VALUE n must be a positive integer, got {}", n),
+                    ));
+                }
+
+                let nth_zero_based = (n - 1) as usize;
                 let frame_result = calculate_frame_with_exclusion(
                     partition, row_idx, order_by, frame_spec, &eval_fn,
                 );


### PR DESCRIPTION
## Summary

Fixes 324 test failures in `window3.test` (71% -> 91.3% pass rate) by addressing two bugs:

- **PRECEDING end boundary off-by-one**: When `PRECEDING` was used as the end bound (e.g., `ROWS BETWEEN UNBOUNDED PRECEDING AND 4 PRECEDING`), the exclusive end index was not incremented by 1, causing frames to be one row too short or empty. For example, at row index 4 with `4 PRECEDING`, the frame should include row 0 but returned an empty range.

- **Static offset evaluation for LAG/LEAD/NTH_VALUE**: The offset argument (e.g., `LAG(b, b)`, `NTH_VALUE(b, b+1)`) was evaluated once against the first partition row instead of per-row against the current row. This caused all rows to use the first row's value as the offset.

## Test plan

- [x] `cargo test -p vibesql-executor` -- 2318 passed (1 pre-existing timeout failure unrelated to this PR)
- [x] `window3.test` -- 0 failures (down from 324), 1462 passed, 140 skipped
- [x] Manual verification of PRECEDING end bound, LEAD/LAG/NTH_VALUE with dynamic offsets

Closes #5044

Generated with [Claude Code](https://claude.com/claude-code)