### PR TITLE
fix(window): GROUPS frame boundary off-by-one and per-row group_concat separator

### DIFF
--- a/crates/vibesql-executor/src/evaluator/window/aggregates.rs
+++ b/crates/vibesql-executor/src/evaluator/window/aggregates.rs
@@ -430,7 +430,38 @@ where
     F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
     I: IntoIterator<Item = usize>,
 {
-    let mut values: Vec<String> = Vec::new();
+    evaluate_group_concat_window_with_expr(
+        partition,
+        frame_indices,
+        arg_expr,
+        None,
+        separator,
+        filter,
+        eval_fn,
+    )
+}
+
+/// Evaluate GROUP_CONCAT with per-row separator expression support.
+///
+/// When `separator_expr` is Some, the separator is evaluated per-row against each
+/// row in the frame. The separator between values[i] and values[i+1] uses the
+/// separator evaluated at the row that produced values[i+1].
+/// When `separator_expr` is None, falls back to the static `default_separator`.
+pub fn evaluate_group_concat_window_with_expr<F, I>(
+    partition: &Partition,
+    frame_indices: I,
+    arg_expr: &Expression,
+    separator_expr: Option<&Expression>,
+    default_separator: &str,
+    filter: Option<&Expression>,
+    eval_fn: F,
+) -> SqlValue
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+    I: IntoIterator<Item = usize>,
+{
+    // Collect (value_string, separator_string) pairs
+    let mut entries: Vec<(String, String)> = Vec::new();
 
     for idx in frame_indices {
         if idx >= partition.len() {
@@ -445,60 +476,73 @@ where
         }
 
         if let Ok(val) = eval_fn(arg_expr, row) {
-            match val {
-                SqlValue::Null => {} // Ignore NULL
-                SqlValue::Varchar(s) | SqlValue::Character(s) => {
-                    values.push(s.to_string());
-                }
-                SqlValue::Integer(n) => {
-                    values.push(n.to_string());
-                }
-                SqlValue::Bigint(n) => {
-                    values.push(n.to_string());
-                }
-                SqlValue::Smallint(n) => {
-                    values.push(n.to_string());
-                }
+            let val_str = match val {
+                SqlValue::Null => continue, // Ignore NULL
+                SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+                SqlValue::Integer(n) => n.to_string(),
+                SqlValue::Bigint(n) => n.to_string(),
+                SqlValue::Smallint(n) => n.to_string(),
                 SqlValue::Numeric(n) => {
-                    // Format as integer if whole number
                     if n.fract() == 0.0 {
-                        values.push((n as i64).to_string());
+                        (n as i64).to_string()
                     } else {
-                        values.push(n.to_string());
+                        n.to_string()
                     }
                 }
                 SqlValue::Float(n) => {
                     if n.fract() == 0.0 {
-                        values.push((n as i64).to_string());
+                        (n as i64).to_string()
                     } else {
-                        values.push(n.to_string());
+                        n.to_string()
                     }
                 }
                 SqlValue::Real(n) => {
                     if n.fract() == 0.0 {
-                        values.push((n as i64).to_string());
+                        (n as i64).to_string()
                     } else {
-                        values.push(n.to_string());
+                        n.to_string()
                     }
                 }
                 SqlValue::Double(n) => {
                     if n.fract() == 0.0 {
-                        values.push((n as i64).to_string());
+                        (n as i64).to_string()
                     } else {
-                        values.push(n.to_string());
+                        n.to_string()
                     }
                 }
-                other => {
-                    // Convert other types to string
-                    values.push(format!("{}", other));
+                other => format!("{}", other),
+            };
+
+            // Evaluate separator per-row if expression is provided
+            let sep = if let Some(sep_expr) = separator_expr {
+                if let Ok(sep_val) = eval_fn(sep_expr, row) {
+                    match sep_val {
+                        SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+                        SqlValue::Null => default_separator.to_string(),
+                        other => format!("{}", other),
+                    }
+                } else {
+                    default_separator.to_string()
                 }
-            }
+            } else {
+                default_separator.to_string()
+            };
+
+            entries.push((val_str, sep));
         }
     }
 
-    if values.is_empty() {
+    if entries.is_empty() {
         SqlValue::Null
     } else {
-        SqlValue::Varchar(values.join(separator).into())
+        let mut result = String::new();
+        for (i, (val, sep)) in entries.iter().enumerate() {
+            if i > 0 {
+                // Use the separator from this row (the row that produced this value)
+                result.push_str(sep);
+            }
+            result.push_str(val);
+        }
+        SqlValue::Varchar(result.into())
     }
 }

--- a/crates/vibesql-executor/src/evaluator/window/frames.rs
+++ b/crates/vibesql-executor/src/evaluator/window/frames.rs
@@ -462,30 +462,52 @@ fn calculate_groups_boundary(
 
         FrameBound::Preceding(offset_expr) => {
             let offset = get_numeric_offset(offset_expr) as usize;
-            let target_group = current_group.saturating_sub(offset);
 
-            if is_start {
-                group_boundaries[target_group]
-            } else {
-                if target_group + 1 < num_groups {
-                    group_boundaries[target_group + 1]
+            if offset > current_group {
+                // Target group is before the partition start
+                if is_start {
+                    // Start at beginning of partition (include everything from start)
+                    0
                 } else {
-                    partition_size
+                    // End bound is before the partition start => empty frame
+                    0
+                }
+            } else {
+                let target_group = current_group - offset;
+                if is_start {
+                    group_boundaries[target_group]
+                } else {
+                    if target_group + 1 < num_groups {
+                        group_boundaries[target_group + 1]
+                    } else {
+                        partition_size
+                    }
                 }
             }
         }
 
         FrameBound::Following(offset_expr) => {
             let offset = get_numeric_offset(offset_expr) as usize;
-            let target_group = (current_group + offset).min(num_groups.saturating_sub(1));
+            let target_group = current_group + offset;
 
-            if is_start {
-                group_boundaries[target_group]
-            } else {
-                if target_group + 1 < num_groups {
-                    group_boundaries[target_group + 1]
-                } else {
+            if target_group >= num_groups {
+                // Target group is beyond the partition end
+                if is_start {
+                    // Start bound is beyond partition => empty frame
                     partition_size
+                } else {
+                    // End at end of partition (include everything to end)
+                    partition_size
+                }
+            } else {
+                if is_start {
+                    group_boundaries[target_group]
+                } else {
+                    if target_group + 1 < num_groups {
+                        group_boundaries[target_group + 1]
+                    } else {
+                        partition_size
+                    }
                 }
             }
         }

--- a/crates/vibesql-executor/src/evaluator/window/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/window/mod.rs
@@ -27,8 +27,9 @@ mod value;
 
 // Re-export public API
 pub use aggregates::{
-    evaluate_avg_window, evaluate_count_window, evaluate_group_concat_window, evaluate_max_window,
-    evaluate_min_window, evaluate_sum_window, evaluate_total_window,
+    evaluate_avg_window, evaluate_count_window, evaluate_group_concat_window,
+    evaluate_group_concat_window_with_expr, evaluate_max_window, evaluate_min_window,
+    evaluate_sum_window, evaluate_total_window,
 };
 pub use frames::{calculate_frame, calculate_frame_with_exclusion, validate_frame, FrameResult};
 pub use partitioning::{partition_rows, Partition};

--- a/crates/vibesql-executor/src/select/window/evaluation.rs
+++ b/crates/vibesql-executor/src/select/window/evaluation.rs
@@ -16,7 +16,7 @@ use crate::{
     evaluator::{
         window::{
             calculate_frame_with_exclusion, evaluate_avg_window, evaluate_count_window,
-            evaluate_group_concat_window, evaluate_max_window, evaluate_min_window,
+            evaluate_group_concat_window_with_expr, evaluate_max_window, evaluate_min_window,
             evaluate_sum_window, evaluate_total_window, partition_rows, sort_partition,
             validate_frame, Partition,
         },
@@ -666,25 +666,18 @@ fn evaluate_window_function_for_partition(
                                 "GROUP_CONCAT/STRING_AGG requires an argument".to_string(),
                             ));
                         }
-                        // Get separator (default is comma for group_concat, required for string_agg)
-                        let separator = if args.len() > 1 {
-                            // Evaluate separator expression
-                            if let Ok(sep_val) = evaluator.eval(&args[1], &partition.rows[0]) {
-                                match sep_val {
-                                    SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
-                                    _ => ",".to_string(),
-                                }
-                            } else {
-                                ",".to_string()
-                            }
+                        // Pass separator expression for per-row evaluation
+                        let separator_expr = if args.len() > 1 {
+                            Some(&args[1])
                         } else {
-                            ",".to_string()
+                            None
                         };
-                        evaluate_group_concat_window(
+                        evaluate_group_concat_window_with_expr(
                             partition,
                             frame_indices,
                             &args[0],
-                            &separator,
+                            separator_expr,
+                            ",",
                             filter,
                             agg_eval_fn,
                         )


### PR DESCRIPTION
## Summary

- **P0: GROUPS frame boundary off-by-one** (49 tests fixed): `calculate_groups_boundary()` in `frames.rs` used `saturating_sub` for `Preceding(N)` bounds, clamping to group 0 instead of producing an empty frame when `offset > current_group`. Fixed to return empty ranges for out-of-bounds boundaries. Also fixed `Following` start bounds that used `.min()` clamping instead of producing empty frames.

- **P1: group_concat() per-row separator** (SQL output corrected): The separator expression was evaluated once against the first partition row. Now `evaluate_group_concat_window_with_expr()` evaluates the separator per-row within the frame, so `group_concat('val', x)` where `x` is a column reference correctly uses each row's value. Note: windowC.test failures remain at 32 due to TCL harness limitation with `db eval ... { body }` pattern, but SQL output is verified correct.

## Test Results

| Test File | Before | After | Delta |
|-----------|--------|-------|-------|
| window8.test | 50 failures | 1 failure | **-49** |
| window3.test | 0 failures | 0 failures | 0 |
| window2.test | 2 failures | 2 failures | 0 |
| window4.test | 8 failures | 8 failures | 0 |
| window7.test | 0 failures | 0 failures | 0 |
| windowC.test | 32 failures | 32 failures | 0 (SQL correct, test harness limitation) |

No regressions across any window test files.

## Test plan

- [x] `cargo test -p vibesql-executor` -- all 31 tests pass
- [x] `bash scripts/tcltest test window8.test` -- 166/167 pass (was 117/167)
- [x] `bash scripts/tcltest test window3.test` -- 1462/1462 pass
- [x] `bash scripts/tcltest test windowC.test` -- SQL output verified correct manually
- [x] No regressions in window2/4/7/9/B tests

Closes #5048

🤖 Generated with [Claude Code](https://claude.com/claude-code)