### PR TITLE
fix(tcl): add db eval SQL body form to support windowC tests

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -4168,6 +4168,7 @@ proc sqlite3 {db args} {
 proc db {cmd args} {
     # Default db command - supports multiple call patterns:
     # db eval SQL                    - returns results as list
+    # db eval SQL script             - iterates over rows, setting column names as local vars
     # db eval SQL varname script     - iterates over rows, setting varname array
     # db one SQL                     - returns first column of first row
     switch $cmd {
@@ -4178,6 +4179,41 @@ proc db {cmd args} {
             if {[llength $args] == 1} {
                 # Simple case: just return the results
                 return [execsql $sql]
+            } elseif {[llength $args] == 2} {
+                # Body script case: db eval $sql script
+                # SQLite sets each column name as a local variable in caller's scope
+                set script [lindex $args 1]
+
+                # Execute SQL and get column names + data
+                set raw_result [execsql_with_headers $sql]
+                set headers [lindex $raw_result 0]
+                set rows [lindex $raw_result 1]
+
+                # Iterate over each row
+                foreach row $rows {
+                    # Set each column name as a local variable in caller's scope
+                    set idx 0
+                    foreach col $headers {
+                        uplevel 1 [list set $col [lindex $row $idx]]
+                        incr idx
+                    }
+                    # Execute the script in caller's scope
+                    set code [catch {uplevel 1 $script} msg]
+                    if {$code == 1} {
+                        # Error - propagate
+                        return -code error $msg
+                    } elseif {$code == 2} {
+                        # Return from script
+                        return -code return $msg
+                    } elseif {$code == 3} {
+                        # Break
+                        break
+                    } elseif {$code == 4} {
+                        # Continue
+                        continue
+                    }
+                }
+                return
             } elseif {[llength $args] == 3} {
                 # Iterator case: db eval $sql varname script
                 set varname [lindex $args 1]
@@ -4204,7 +4240,7 @@ proc db {cmd args} {
                 }
                 return
             } else {
-                # Two args case: db eval $sql varname (no script)
+                # Unknown args count - try simple eval
                 return [execsql $sql]
             }
         }


### PR DESCRIPTION
## Summary

- Adds the missing 2-arg `db eval SQL body` form to the TCL test shim, where SQLite sets each column name as a local variable and iterates over rows executing a body script
- This was the root cause of 30 windowC.test failures -- the validation body script was never executed, causing raw SQL results to be returned instead of the expected empty string `{}`
- The group_concat window function implementation itself was already correct; this was purely a test harness gap

## Test Results

- windowC.test: **30 tests fixed** (32 failures -> 2 remaining)
- Remaining 2 failures (2.0, 2.1) are UTF-16 encoding issues unrelated to group_concat
- `cargo test -p vibesql-executor`: all 31 tests pass

Closes #5053

🤖 Generated with [Claude Code](https://claude.com/claude-code)