### PR TITLE
fix(window): GROUP_CONCAT dispatch and RANGE ORDER BY validation

### DIFF
--- a/crates/vibesql-executor/src/evaluator/window/frames.rs
+++ b/crates/vibesql-executor/src/evaluator/window/frames.rs
@@ -36,6 +36,49 @@ pub fn validate_frame(frame_spec: &Option<WindowFrame>) -> Result<(), String> {
     Ok(())
 }
 
+/// Validate that RANGE frames with offset PRECEDING/FOLLOWING have exactly one ORDER BY column.
+///
+/// Per the SQL standard and SQLite behavior, RANGE with numeric offsets (N PRECEDING or
+/// N FOLLOWING) requires exactly one ORDER BY expression. Without ORDER BY, or with
+/// multiple ORDER BY columns, an error is returned.
+pub fn validate_range_order_by(
+    frame_spec: &Option<WindowFrame>,
+    order_by: &Option<Vec<OrderByItem>>,
+) -> Result<(), String> {
+    let frame = match frame_spec {
+        Some(f) => f,
+        None => return Ok(()),
+    };
+
+    // Only applies to RANGE frames
+    if !matches!(frame.unit, FrameUnit::Range) {
+        return Ok(());
+    }
+
+    // Check if either bound uses a numeric offset (N PRECEDING or N FOLLOWING)
+    let has_offset_bound = matches!(
+        frame.start,
+        FrameBound::Preceding(_) | FrameBound::Following(_)
+    ) || frame
+        .end
+        .as_ref()
+        .is_some_and(|end| matches!(end, FrameBound::Preceding(_) | FrameBound::Following(_)));
+
+    if !has_offset_bound {
+        return Ok(());
+    }
+
+    // RANGE with offset requires exactly one ORDER BY column
+    let order_by_count = order_by.as_ref().map_or(0, |items| items.len());
+    if order_by_count != 1 {
+        return Err(
+            "RANGE with offset PRECEDING/FOLLOWING requires one ORDER BY expression".to_string(),
+        );
+    }
+
+    Ok(())
+}
+
 /// Validate a single frame bound
 fn validate_frame_bound(bound: &FrameBound, is_start: bool) -> Result<(), String> {
     match bound {

--- a/crates/vibesql-executor/src/evaluator/window/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/window/mod.rs
@@ -31,7 +31,7 @@ pub use aggregates::{
     evaluate_group_concat_window_with_expr, evaluate_max_window, evaluate_min_window,
     evaluate_sum_window, evaluate_total_window,
 };
-pub use frames::{calculate_frame, calculate_frame_with_exclusion, validate_frame, FrameResult};
+pub use frames::{calculate_frame, calculate_frame_with_exclusion, validate_frame, validate_range_order_by, FrameResult};
 pub use partitioning::{partition_rows, Partition};
 pub use ranking::{
     evaluate_cume_dist, evaluate_dense_rank, evaluate_ntile, evaluate_percent_rank, evaluate_rank,

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -20,10 +20,11 @@ use crate::{
     evaluator::{
         window::{
             calculate_frame_with_exclusion, evaluate_avg_window, evaluate_count_window,
-            evaluate_cume_dist, evaluate_dense_rank, evaluate_lag, evaluate_lead,
-            evaluate_max_window, evaluate_min_window, evaluate_ntile, evaluate_percent_rank,
-            evaluate_rank, evaluate_row_number, evaluate_sum_window, partition_rows,
-            sort_partition, validate_frame,
+            evaluate_cume_dist, evaluate_dense_rank, evaluate_group_concat_window_with_expr,
+            evaluate_lag, evaluate_lead, evaluate_max_window, evaluate_min_window,
+            evaluate_ntile, evaluate_percent_rank, evaluate_rank, evaluate_row_number,
+            evaluate_sum_window, evaluate_total_window, partition_rows, sort_partition,
+            validate_frame, validate_range_order_by,
         },
         CombinedExpressionEvaluator,
     },
@@ -212,6 +213,9 @@ pub(super) fn apply_window_functions_to_aggregates(
     for win_func in &window_funcs {
         // Validate frame specification (checks for non-negative offsets, etc.)
         validate_frame(&win_func.window_spec.frame).map_err(ExecutorError::SqliteCompatError)?;
+        // Validate RANGE with offset requires exactly one ORDER BY expression
+        validate_range_order_by(&win_func.window_spec.frame, &win_func.window_spec.order_by)
+            .map_err(ExecutorError::SqliteCompatError)?;
 
         // For partition/order expressions, we need to map them to column indices
         // in the aggregate result schema. Create column reference expressions.
@@ -335,6 +339,30 @@ pub(super) fn apply_window_functions_to_aggregates(
                                 None,
                                 inner_eval_fn,
                             ),
+                            "TOTAL" => evaluate_total_window(
+                                partition,
+                                frame_indices,
+                                &arg_expr,
+                                None,
+                                inner_eval_fn,
+                            ),
+                            "GROUP_CONCAT" | "STRING_AGG" => {
+                                // Use separator expression if present (second arg)
+                                let separator_expr = if mapped_args.len() > 1 {
+                                    Some(&mapped_args[1])
+                                } else {
+                                    None
+                                };
+                                evaluate_group_concat_window_with_expr(
+                                    partition,
+                                    frame_indices,
+                                    &arg_expr,
+                                    separator_expr,
+                                    ",",
+                                    None,
+                                    inner_eval_fn,
+                                )
+                            }
                             other => {
                                 return Err(ExecutorError::UnsupportedExpression(format!(
                                     "Unsupported aggregate window function: {}",

--- a/crates/vibesql-executor/src/select/window/evaluation.rs
+++ b/crates/vibesql-executor/src/select/window/evaluation.rs
@@ -18,7 +18,7 @@ use crate::{
             calculate_frame_with_exclusion, evaluate_avg_window, evaluate_count_window,
             evaluate_group_concat_window_with_expr, evaluate_max_window, evaluate_min_window,
             evaluate_sum_window, evaluate_total_window, partition_rows, sort_partition,
-            validate_frame, Partition,
+            validate_frame, validate_range_order_by, Partition,
         },
         CombinedExpressionEvaluator,
     },
@@ -50,6 +50,9 @@ pub(super) fn evaluate_single_window_function(
 ) -> Result<WindowEvaluationResult, ExecutorError> {
     // Validate frame specification (checks for non-negative offsets, etc.)
     validate_frame(&win_func.window_spec.frame).map_err(ExecutorError::SqliteCompatError)?;
+    // Validate RANGE with offset requires exactly one ORDER BY expression
+    validate_range_order_by(&win_func.window_spec.frame, &win_func.window_spec.order_by)
+        .map_err(ExecutorError::SqliteCompatError)?;
 
     // Extract function details including optional FILTER clause
     let (func_name, args, filter) = match &win_func.function_spec {


### PR DESCRIPTION
## Summary

- Add GROUP_CONCAT/STRING_AGG and TOTAL to the aggregate window function dispatch in `apply_window_functions_to_aggregates` (the post-GROUP BY window path), which was missing these functions while the main window evaluation path already handled them
- Add `validate_range_order_by` to enforce that RANGE frames with numeric offset bounds (N PRECEDING/N FOLLOWING) require exactly one ORDER BY expression, matching SQLite/SQL standard behavior

## Test Results

- **windowerr**: 2 failures -> 0 failures (tests 1.7, 1.8 now pass)
- **window9 test 4.1.2**: No longer errors with "Unsupported aggregate window function: GROUP_CONCAT" -- GROUP_CONCAT now dispatches correctly
- All 2319 executor unit tests pass, 0 regressions

## Test plan

- [x] `cargo test -p vibesql-executor` -- all 2319 tests pass
- [x] `make test-tcl-file FILE=windowerr.test` -- 12/12 pass (was 10/12)
- [x] `make test-tcl-file FILE=window9.test` -- GROUP_CONCAT dispatch confirmed working

Closes #5056

🤖 Generated with [Claude Code](https://claude.com/claude-code)