### PR TITLE
fix(parser): underscore numeric literals and CURRENT as identifier

### DIFF
--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -404,7 +404,7 @@ impl Keyword {
             Keyword::Current | Keyword::Exclude | Keyword::Filter | Keyword::Following |
             Keyword::Groups | Keyword::No | Keyword::Others | Keyword::Over |
             Keyword::Partition | Keyword::Preceding | Keyword::Range | Keyword::Ties |
-            Keyword::Unbounded | Keyword::First | Keyword::Last
+            Keyword::Unbounded | Keyword::Window | Keyword::First | Keyword::Last
         )
     }
 }

--- a/crates/vibesql-parser/src/lexer/numbers.rs
+++ b/crates/vibesql-parser/src/lexer/numbers.rs
@@ -3,11 +3,13 @@ use crate::token::Token;
 
 impl<'a> Lexer<'a> {
     /// Tokenize a number literal.
-    /// Supports integers, decimals, scientific notation (E-notation), and hex literals.
-    /// Examples: 42, 3.14, 2.5E+10, 1.2E-5, .2E+2, 0x1A, 0xFF
+    /// Supports integers, decimals, scientific notation (E-notation), hex literals,
+    /// and underscore-separated digits (e.g., 1_000_000).
+    /// Examples: 42, 3.14, 2.5E+10, 1.2E-5, .2E+2, 0x1A, 0xFF, 10_000_000_000
     pub(super) fn tokenize_number(&mut self) -> Result<Token, LexerError> {
         let start = self.position();
         let mut has_dot = false;
+        let mut has_underscore = false;
 
         // Handle leading decimal point (e.g., .5)
         if !self.is_eof() && self.current_char() == '.' {
@@ -28,6 +30,12 @@ impl<'a> Lexer<'a> {
         while !self.is_eof() {
             let ch = self.current_char();
             if ch.is_ascii_digit() {
+                self.advance();
+            } else if ch == '_' && !has_dot {
+                // SQLite 3.46+ supports underscores as digit separators in integer literals
+                // e.g., 1_000_000_000, 10_000
+                // Only allowed between digits, not in decimal/float parts
+                has_underscore = true;
                 self.advance();
             } else if ch == '.' && !has_dot {
                 has_dot = true;
@@ -71,7 +79,13 @@ impl<'a> Lexer<'a> {
         }
 
         let number = self.slice_from(start).to_string();
-        Ok(Token::Number(number))
+        // Strip underscores from the token value so downstream sees a plain number
+        if has_underscore {
+            let stripped = number.replace('_', "");
+            Ok(Token::Number(stripped))
+        } else {
+            Ok(Token::Number(number))
+        }
     }
 
     /// Tokenize a hexadecimal literal (0x... or 0X...).
@@ -257,6 +271,33 @@ mod tests {
             let mut lexer = Lexer::new(input);
             let result = lexer.tokenize();
             assert!(result.is_err(), "Expected error for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn test_underscore_separated_integers() {
+        // SQLite 3.46+ supports underscores as digit separators in integer literals
+        let test_cases = vec![
+            ("1_000", "1000"),
+            ("1_000_000", "1000000"),
+            ("10_000_000_000", "10000000000"),
+            ("1_2_3", "123"),
+            ("100_00", "10000"),
+        ];
+
+        for (input, expected) in test_cases {
+            let mut lexer = Lexer::new(input);
+            let tokens =
+                lexer.tokenize().unwrap_or_else(|_| panic!("Failed to tokenize: {}", input));
+
+            assert_eq!(tokens.len(), 2, "Input: {}", input);
+
+            match &tokens[0] {
+                Token::Number(n) => assert_eq!(n, expected, "Input: {}", input),
+                other => panic!("Expected Number token for {}, got {:?}", input, other),
+            }
+
+            assert_eq!(tokens[1], Token::Eof);
         }
     }
 }

--- a/crates/vibesql-parser/src/parser/expressions/special_forms.rs
+++ b/crates/vibesql-parser/src/parser/expressions/special_forms.rs
@@ -45,41 +45,49 @@ impl Parser {
                 if let Token::Identifier(ref id) = self.peek() {
                     // Build the original name by combining CURRENT with the suffix
                     let suffix = id.clone();
-                    let function_name = match id.to_uppercase().as_str() {
+                    match id.to_uppercase().as_str() {
                         "_DATE" => {
                             self.advance(); // consume _DATE
-                            format!("CURRENT{}", suffix)
+                            let function_name = format!("CURRENT{}", suffix);
+                            Ok(Some(vibesql_ast::Expression::Function {
+                                name: vibesql_ast::FunctionIdentifier::new(&function_name),
+                                args: vec![],
+                                character_unit: None,
+                            }))
                         }
                         "_TIME" => {
                             self.advance(); // consume _TIME
-                            format!("CURRENT{}", suffix)
+                            let function_name = format!("CURRENT{}", suffix);
+                            Ok(Some(vibesql_ast::Expression::Function {
+                                name: vibesql_ast::FunctionIdentifier::new(&function_name),
+                                args: vec![],
+                                character_unit: None,
+                            }))
                         }
                         "_TIMESTAMP" => {
                             self.advance(); // consume _TIMESTAMP
-                            format!("CURRENT{}", suffix)
+                            let function_name = format!("CURRENT{}", suffix);
+                            Ok(Some(vibesql_ast::Expression::Function {
+                                name: vibesql_ast::FunctionIdentifier::new(&function_name),
+                                args: vec![],
+                                character_unit: None,
+                            }))
                         }
                         _ => {
-                            return Err(ParseError {
-                                message: format!(
-                                    "Expected DATE, TIME, or TIMESTAMP after CURRENT, found {}",
-                                    id
-                                ),
-                            })
+                            // Not a CURRENT_DATE/TIME/TIMESTAMP — treat CURRENT as
+                            // a regular identifier (column name). CURRENT is already
+                            // listed in can_be_identifier().
+                            Ok(Some(vibesql_ast::Expression::ColumnRef(
+                                vibesql_ast::ColumnIdentifier::simple("current", false),
+                            )))
                         }
-                    };
-
-                    Ok(Some(vibesql_ast::Expression::Function {
-                        name: vibesql_ast::FunctionIdentifier::new(&function_name),
-                        args: vec![],
-                        character_unit: None,
-                    }))
+                    }
                 } else {
-                    Err(ParseError {
-                        message: format!(
-                            "Expected identifier after CURRENT, found {:?}",
-                            self.peek()
-                        ),
-                    })
+                    // Next token is not an identifier (e.g., comma, RParen) —
+                    // treat CURRENT as a column name reference.
+                    Ok(Some(vibesql_ast::Expression::ColumnRef(
+                        vibesql_ast::ColumnIdentifier::simple("current", false),
+                    )))
                 }
             }
             // CAST expression: CAST(expr AS data_type)


### PR DESCRIPTION
## Summary

Fixes three parser issues causing window1.test failures:

- **Underscore-separated numeric literals**: The lexer now handles SQLite 3.46+ syntax like `10_000_000_000` by accepting underscores between digits and stripping them from the token value
- **CURRENT as identifier**: The `CURRENT` keyword can now be used as a column name; previously it always expected `_DATE`/`_TIME`/`_TIMESTAMP` suffix and errored on bare usage
- **WINDOW as identifier**: Added `Keyword::Window` to `can_be_identifier()` so tables can have columns named `window`

Reduces window1.test failures from 61 to 58 (fixes tests 21.0, 21.1, 79.2).

Closes #5054

## Test plan

- [x] All 1240 vibesql-parser tests pass
- [x] All vibesql-executor tests pass
- [x] window1.test failures reduced from 61 to 58
- [x] New unit test for underscore-separated integer literals
- [x] Tests 21.0, 21.1 (CURRENT/WINDOW as column names) now pass
- [x] Test 79.2 (10_000_000_000 in frame offset) now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)