### PR TITLE
fix(fkey): gate FK enforcement on PRAGMA foreign_keys setting

### DIFF
--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -25,6 +25,11 @@ pub fn check_no_child_references(
     parent_table_name: &str,
     parent_row: &vibesql_storage::Row,
 ) -> Result<(), ExecutorError> {
+    // Skip FK enforcement when PRAGMA foreign_keys is OFF (default)
+    if !db.foreign_keys_enabled() {
+        return Ok(());
+    }
+
     let parent_schema = db
         .catalog
         .get_table(parent_table_name)

--- a/crates/vibesql-executor/src/delete/tests/truncate_optimization.rs
+++ b/crates/vibesql-executor/src/delete/tests/truncate_optimization.rs
@@ -64,6 +64,7 @@ fn test_truncate_optimization_basic() {
 #[test]
 fn test_truncate_blocked_by_fk_reference() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     // Create parent table with primary key
     let parent_schema = TableSchema::with_primary_key(

--- a/crates/vibesql-executor/src/insert/foreign_keys.rs
+++ b/crates/vibesql-executor/src/insert/foreign_keys.rs
@@ -6,6 +6,11 @@ pub fn validate_foreign_key_constraints(
     table_name: &str,
     row_values: &[vibesql_types::SqlValue],
 ) -> Result<(), ExecutorError> {
+    // Skip FK enforcement when PRAGMA foreign_keys is OFF (default)
+    if !db.foreign_keys_enabled() {
+        return Ok(());
+    }
+
     let schema = db
         .catalog
         .get_table(table_name)

--- a/crates/vibesql-executor/src/insert/row_validator.rs
+++ b/crates/vibesql-executor/src/insert/row_validator.rs
@@ -341,6 +341,11 @@ impl<'a> RowValidator<'a> {
         &self,
         fk_keys: &[Option<Vec<vibesql_types::SqlValue>>],
     ) -> Result<(), ExecutorError> {
+        // Skip FK enforcement when PRAGMA foreign_keys is OFF (default)
+        if !self.db.foreign_keys_enabled() {
+            return Ok(());
+        }
+
         for (fk_idx, fk_values) in fk_keys.iter().enumerate() {
             // Skip if any FK value is NULL (stored as None)
             let Some(ref fk_values) = fk_values else {

--- a/crates/vibesql-executor/src/tests/alter_table_constraints.rs
+++ b/crates/vibesql-executor/src/tests/alter_table_constraints.rs
@@ -31,6 +31,7 @@ fn exec_sql(db: &mut Database, sql: &str) -> Result<String, String> {
 #[test]
 fn test_alter_table_add_primary_key_single_column() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE users (id INT, name VARCHAR(100))").unwrap();
     exec_sql(&mut db, "INSERT INTO users VALUES (1, 'Alice'), (2, 'Bob')").unwrap();
@@ -52,6 +53,7 @@ fn test_alter_table_add_primary_key_single_column() {
 #[test]
 fn test_alter_table_add_primary_key_composite() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE order_items (order_id INT, item_id INT, quantity INT)")
         .unwrap();
@@ -80,6 +82,7 @@ fn test_alter_table_add_primary_key_composite() {
 #[test]
 fn test_alter_table_add_primary_key_already_exists() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))").unwrap();
 
@@ -91,6 +94,7 @@ fn test_alter_table_add_primary_key_already_exists() {
 #[test]
 fn test_alter_table_add_foreign_key_basic() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     // Create parent and child tables
     exec_sql(&mut db, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))").unwrap();
@@ -117,6 +121,7 @@ fn test_alter_table_add_foreign_key_basic() {
 #[test]
 fn test_alter_table_add_foreign_key_with_constraint_name() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))").unwrap();
     exec_sql(&mut db, "CREATE TABLE orders (id INT PRIMARY KEY, user_id INT)").unwrap();
@@ -132,6 +137,7 @@ fn test_alter_table_add_foreign_key_with_constraint_name() {
 #[test]
 fn test_alter_table_drop_foreign_key() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))").unwrap();
     exec_sql(&mut db, "CREATE TABLE orders (id INT PRIMARY KEY, user_id INT)").unwrap();
@@ -157,6 +163,7 @@ fn test_alter_table_drop_foreign_key() {
 #[test]
 fn test_foreign_key_null_values_allowed() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))").unwrap();
     exec_sql(&mut db, "CREATE TABLE orders (id INT PRIMARY KEY, user_id INT)").unwrap();
@@ -173,6 +180,7 @@ fn test_foreign_key_null_values_allowed() {
 #[test]
 fn test_foreign_key_cascade_delete() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))").unwrap();
     exec_sql(&mut db, "CREATE TABLE orders (id INT PRIMARY KEY, user_id INT)").unwrap();
@@ -198,6 +206,7 @@ fn test_foreign_key_cascade_delete() {
 #[test]
 fn test_foreign_key_restrict_delete() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))").unwrap();
     exec_sql(&mut db, "CREATE TABLE orders (id INT PRIMARY KEY, user_id INT)").unwrap();
@@ -224,6 +233,7 @@ fn test_foreign_key_restrict_delete() {
 #[test]
 fn test_foreign_key_set_null() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))").unwrap();
     exec_sql(&mut db, "CREATE TABLE orders (id INT PRIMARY KEY, user_id INT)").unwrap();
@@ -252,6 +262,7 @@ fn test_foreign_key_set_null() {
 #[test]
 fn test_foreign_key_self_reference() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE employees (id INT PRIMARY KEY, manager_id INT)").unwrap();
 
@@ -279,6 +290,7 @@ fn test_foreign_key_self_reference() {
 #[test]
 fn test_foreign_key_composite() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE courses (dept VARCHAR(10), course_num INT, title VARCHAR(100), PRIMARY KEY (dept, course_num))").unwrap();
     exec_sql(&mut db, "CREATE TABLE enrollments (student_id INT, dept VARCHAR(10), course_num INT, grade VARCHAR(2))").unwrap();
@@ -303,6 +315,7 @@ fn test_foreign_key_composite() {
 #[test]
 fn test_foreign_key_update_cascade() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))").unwrap();
     exec_sql(&mut db, "CREATE TABLE orders (id INT PRIMARY KEY, user_id INT)").unwrap();
@@ -333,6 +346,7 @@ fn test_foreign_key_update_cascade() {
 #[test]
 fn test_cascading_foreign_keys_multi_level() {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
 
     exec_sql(&mut db, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))").unwrap();
     exec_sql(&mut db, "CREATE TABLE orders (id INT PRIMARY KEY, user_id INT)").unwrap();

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -17,6 +17,11 @@ impl ForeignKeyValidator {
         table_name: &str,
         row_values: &[vibesql_types::SqlValue],
     ) -> Result<(), ExecutorError> {
+        // Skip FK enforcement when PRAGMA foreign_keys is OFF (default)
+        if !db.foreign_keys_enabled() {
+            return Ok(());
+        }
+
         let schema = db
             .catalog
             .get_table(table_name)
@@ -68,6 +73,11 @@ impl ForeignKeyValidator {
         parent_row: &vibesql_storage::Row,
         new_parent_row: &vibesql_storage::Row,
     ) -> Result<(), ExecutorError> {
+        // Skip FK enforcement when PRAGMA foreign_keys is OFF (default)
+        if !db.foreign_keys_enabled() {
+            return Ok(());
+        }
+
         let parent_schema = db
             .catalog
             .get_table(parent_table_name)

--- a/crates/vibesql-executor/tests/foreign_key_set_default_tests.rs
+++ b/crates/vibesql-executor/tests/foreign_key_set_default_tests.rs
@@ -11,6 +11,7 @@ use vibesql_types::SqlValue;
 /// Helper to execute SQL and return the database
 fn execute_sql(sql: &str) -> Database {
     let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
     // Split by semicolon and parse/execute each statement
     for sql_stmt in sql.split(';') {
         let trimmed = sql_stmt.trim();


### PR DESCRIPTION
## Summary

- Gate all FK enforcement (insert, update, delete, truncate) on `db.foreign_keys_enabled()`
- Default is OFF per SQLite compatibility — tests that need FK enforcement now explicitly enable it
- 7 files changed, +41 lines

## Test plan

- [x] All executor lib tests pass (2319)
- [x] All executor integration tests pass (foreign_key_tests, truncate_tests, etc.)
- [ ] fkey5/fkey1 TCL test improvements

Closes #5055

🤖 Generated with [Claude Code](https://claude.com/claude-code)