### PR TITLE
fix(persistence): trust magic bytes over .db extension to fix CI on main

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -64,8 +64,15 @@ impl SqlExecutor {
                     Ok(db) => db,
                     Err(ref e) if e.to_string().contains("SQLite database detected") => {
                         // Auto-import SQLite database
-                        let result = crate::sqlite_io::import_sqlite(&db_path)
-                            .map_err(|e| anyhow::anyhow!("Failed to import SQLite database: {}", e))?;
+                        let result = crate::sqlite_io::import_sqlite(&db_path).map_err(|e| {
+                            anyhow::anyhow!(
+                                "Failed to read binary SQLite database at {}: {}. \
+                                 If this file is a VibeSQL SQL dump, rename it with a .sql extension \
+                                 to load it in SQL dump format.",
+                                db_path,
+                                e
+                            )
+                        })?;
                         for warning in &result.warnings {
                             eprintln!("{}", warning);
                         }

--- a/crates/vibesql-storage/src/persistence/mod.rs
+++ b/crates/vibesql-storage/src/persistence/mod.rs
@@ -101,15 +101,14 @@ pub enum PersistenceFormat {
 fn detect_format<P: AsRef<Path>>(path: P) -> Result<PersistenceFormat, crate::StorageError> {
     let path_ref = path.as_ref();
 
-    // For .vbsqlz, we know it's compressed
-    if let Some(ext) = path_ref.extension() {
-        match ext.to_str() {
-            Some("vbsqlz") => return Ok(PersistenceFormat::BinaryCompressed),
-            Some("json") => return Ok(PersistenceFormat::Json),
-            Some("sql") => return Ok(PersistenceFormat::Sql),
-            Some("db") | Some("sqlite") | Some("sqlite3") => {
-                return Ok(PersistenceFormat::Sqlite)
-            }
+    // Format hints from extension. Non-SQLite extensions are trusted; SQLite-style
+    // extensions (.db/.sqlite/.sqlite3) require a magic-number check below, since
+    // VibeSQL also writes SQL dumps to .db when the user passes `--database X.db`.
+    if let Some(ext) = path_ref.extension().and_then(|e| e.to_str()) {
+        match ext {
+            "vbsqlz" => return Ok(PersistenceFormat::BinaryCompressed),
+            "json" => return Ok(PersistenceFormat::Json),
+            "sql" => return Ok(PersistenceFormat::Sql),
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

CI on `main` has been failing since 2026-04-26. The auto-detect logic in `Database::load` short-circuited on the `.db`/`.sqlite`/`.sqlite3` extension and returned `PersistenceFormat::Sqlite` without checking file content. But VibeSQL itself writes a SQL dump to `.db` when invoked with `--database X.db`, so the next CLI run misidentified its own dump as a corrupted SQLite file and aborted with `Failed to import SQLite database: file is not a database`.

## Changes

- `crates/vibesql-storage/src/persistence/mod.rs`: drop the unconditional `.db / .sqlite / .sqlite3 → Sqlite` mapping in `detect_format`. The existing `SQLite format 3\0` magic-byte check still correctly identifies real SQLite files; non-SQLite content with those extensions falls through to the rest of the detection chain (binary, compressed, JSON, default SQL).
- `crates/vibesql-cli/src/executor/mod.rs`: when SQLite import fails, include the file path and hint that renaming the file to `.sql` will load it as a SQL dump. Required to satisfy `test_binary_file_error_message`'s assertion about a helpful error.

## Test plan

- [x] `cargo test --release --test persistence_test` — 5/5 pass (was 1/5)
- [x] `cargo test --release -p vibesql --test sqlite_roundtrip` — 12/12 pass (no regressions in SQLite import/export)
- [x] `cargo test --release -p vibesql-cli` — passes
- [x] `cargo test --release -p vibesql-storage --lib` — 579/579 pass

## Root cause

Introduced in b80cef73 (2026-04-26) which added auto-detection of SQLite files. The extension-based short-circuit was added without anticipating that VibeSQL itself writes non-SQLite content to `.db` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)