### PR TITLE
test(tcl): normalize whitespace in do_eqp_test for multi-line plans

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3750,10 +3750,12 @@ proc do_eqp_test {name sql expected} {
     set eqp_sql "EXPLAIN QUERY PLAN $sql"
 
     if {[catch {
-        # Use execsql directly since db is our proc alias
+        # Use execsql directly since db is our proc alias.
+        # execsql returns one item per output row; preserve newlines so the
+        # multi-line tree (QUERY PLAN header + |--/`-- entries) stays intact.
+        # Whitespace gets normalized below before glob matching.
         set rows [execsql $eqp_sql]
-        set result [join $rows " "]
-        set result [string trim $result]
+        set result [join $rows "\n"]
     } err]} {
         # Query execution error
         incr test_results(failed)
@@ -3769,16 +3771,28 @@ proc do_eqp_test {name sql expected} {
         set expected_clean [string range $expected_clean 1 end-1]
     }
 
-    # Perform glob matching on the full result
-    if {[string match $expected_clean $result]} {
+    # Normalize whitespace in both expected and actual so cosmetic formatting
+    # differences (newlines vs spaces, indentation) don't cause spurious failures.
+    # SQLite's own tester normalizes EQP output before comparison; do the same:
+    # collapse all whitespace runs (including newlines) to a single space, then trim.
+    regsub -all {\s+} $expected_clean " " expected_norm
+    set expected_norm [string trim $expected_norm]
+    regsub -all {\s+} $result " " result_norm
+    set result_norm [string trim $result_norm]
+
+    # Perform glob matching on the normalized full result
+    if {[string match $expected_norm $result_norm]} {
         incr test_results(passed)
         return
     }
 
-    # Try matching against each line of the result
+    # Fallback: match against each (raw) line of the result, trimmed.
+    # This preserves backwards compatibility with single-line expected patterns
+    # that previously matched against a particular row.
     foreach line [split $result "\n"] {
         set line [string trim $line]
-        if {[string match $expected_clean $line]} {
+        if {[string match $expected_clean $line] || \
+            [string match $expected_norm $line]} {
             incr test_results(passed)
             return
         }
@@ -3786,10 +3800,10 @@ proc do_eqp_test {name sql expected} {
 
     # Failed to match
     incr test_results(failed)
-    lappend test_results(failures) [list $name "EQP mismatch. Expected: '$expected_clean', Got: '$result'"]
+    lappend test_results(failures) [list $name "EQP mismatch. Expected: '$expected_norm', Got: '$result_norm'"]
     puts "! $name FAILED (EQP pattern mismatch)"
-    puts "  EQP Expected: '$expected_clean'"
-    puts "  EQP Got:      '$result'"
+    puts "  EQP Expected: '$expected_norm'"
+    puts "  EQP Got:      '$result_norm'"
 }
 
 proc do_realnum_test {name script expected} {


### PR DESCRIPTION
## Summary

The TCL harness's `do_eqp_test` joined EXPLAIN QUERY PLAN rows with a single space and then glob-matched against expected patterns that literally contain newlines. As a result, multi-line query-plan expectations failed even when the engine output was correct.

This PR mirrors SQLite's own tester behavior: collapse all whitespace runs (newlines + indentation) to a single space in **both** the expected pattern and the actual result before glob-matching. The per-line fallback is preserved for backwards compatibility with single-line patterns.

## Context

Per curator investigation on #5072, this issue had two distinct sub-problems with very different scopes:

1. **Format problem (this PR)** — purely harness-side. The Rust formatter at `ExplainResult::to_sqlite_eqp` and the CLI already produce correct multi-line SQLite-style output. Only the TCL test runner was collapsing rows.
2. **Planner problem (split to #5075)** — real engine work for cases where the planner falls back to TEMP B-TREE when an index would suffice (nullable-pinned ORDER BY, window pushdown, LIKE/GLOB → range). This needs careful work to avoid P1 regressions and is tracked separately.

## Changes

- `scripts/tester_vibesql.tcl::do_eqp_test`:
  - Join rows with `\n` instead of a single space (preserve plan structure)
  - Collapse runs of whitespace to a single space in both expected pattern and actual result before glob match
  - Update failure message to show the normalized form

## Test Plan

Before fix:
```
! like3-5.101 FAILED (EQP pattern mismatch)
! like3-5.121 FAILED (EQP pattern mismatch)
! like3-5.123 FAILED (EQP pattern mismatch)
! like3-5.201 FAILED (EQP pattern mismatch)
! like3-5.211 FAILED (EQP pattern mismatch)   <- planner issue, out of scope
```

After fix:
```
! like3-5.211 FAILED (EQP pattern mismatch)   <- still failing; tracked in #5075
```

- [x] like3-5.101, 5.121, 5.123, 5.201 now pass
- [x] like3-5.211 continues to fail (planner work; tracked in #5075)
- [x] No regressions in `eqp.test`, `eqp2.test`, `indexA.test`, `cost.test`, `count.test`, `in4.test`, `where.test`, `where2.test`, `bloom1.test` (verified with stashed-baseline comparison)
- [x] No regressions in `nulls1.test`, `windowpushd.test` (same pass/fail counts before and after)

## Follow-up

- #5075 — Planner work to use indexes for ORDER BY when leading nullable cols are pinned by IN/equality (covers nulls1 5.x/6.x/9.4, windowpushd 1.4 + 2.x, like3-5.211)

Closes #5072