### PR TITLE
fix(persistence): persist CREATE TRIGGER in SQL-dump format

### DIFF
--- a/crates/vibesql-catalog/src/store/tables.rs
+++ b/crates/vibesql-catalog/src/store/tables.rs
@@ -451,6 +451,7 @@ mod tests {
             when_condition: None,
             triggered_action: TriggerAction::RawSql("".to_string()),
             enabled: true,
+            sql_definition: None,
         };
         catalog.create_trigger(trigger).unwrap();
 
@@ -491,6 +492,7 @@ mod tests {
             when_condition: None,
             triggered_action: TriggerAction::RawSql("".to_string()),
             enabled: true,
+            sql_definition: None,
         };
         catalog.create_trigger(trigger).unwrap();
 
@@ -523,6 +525,7 @@ mod tests {
                 when_condition: None,
                 triggered_action: TriggerAction::RawSql("".to_string()),
                 enabled: true,
+                sql_definition: None,
             };
             catalog.create_trigger(trigger).unwrap();
         }
@@ -564,6 +567,7 @@ mod tests {
             when_condition: None,
             triggered_action: TriggerAction::RawSql("".to_string()),
             enabled: true,
+            sql_definition: None,
         };
         let trigger2 = TriggerDefinition {
             name: "tr2".to_string(),
@@ -574,6 +578,7 @@ mod tests {
             when_condition: None,
             triggered_action: TriggerAction::RawSql("".to_string()),
             enabled: true,
+            sql_definition: None,
         };
         catalog.create_trigger(trigger1).unwrap();
         catalog.create_trigger(trigger2).unwrap();

--- a/crates/vibesql-catalog/src/trigger.rs
+++ b/crates/vibesql-catalog/src/trigger.rs
@@ -21,10 +21,15 @@ pub struct TriggerDefinition {
     pub triggered_action: TriggerAction,
     /// Whether trigger is enabled (default: true)
     pub enabled: bool,
+    /// Optional original SQL definition string (for persistence/serialization).
+    /// When `Some`, the SQL-dump persistence path will emit this verbatim so the
+    /// trigger can be reconstructed across CLI invocations. When `None`, the
+    /// SQL-dump path has no reliable way to round-trip the trigger.
+    pub sql_definition: Option<String>,
 }
 
 impl TriggerDefinition {
-    /// Create a new trigger definition
+    /// Create a new trigger definition (without preserved SQL text)
     pub fn new(
         name: String,
         timing: TriggerTiming,
@@ -43,6 +48,35 @@ impl TriggerDefinition {
             when_condition,
             triggered_action,
             enabled: true, // Default to enabled
+            sql_definition: None,
+        }
+    }
+
+    /// Create a new trigger definition with the original SQL text preserved.
+    ///
+    /// The `sql_definition` is used by the SQL-dump persistence path to emit a
+    /// reconstructible `CREATE TRIGGER` statement. Mirrors
+    /// [`crate::ViewDefinition::new_with_sql`].
+    pub fn new_with_sql(
+        name: String,
+        timing: TriggerTiming,
+        event: TriggerEvent,
+        table_name: String,
+        granularity: TriggerGranularity,
+        when_condition: Option<Box<vibesql_ast::Expression>>,
+        triggered_action: TriggerAction,
+        sql_definition: String,
+    ) -> Self {
+        TriggerDefinition {
+            name,
+            timing,
+            event,
+            table_name,
+            granularity,
+            when_condition,
+            triggered_action,
+            enabled: true,
+            sql_definition: Some(sql_definition),
         }
     }
 

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -215,8 +215,13 @@ impl SqlExecutor {
                 }
             }
             vibesql_ast::Statement::CreateTrigger(trigger_stmt) => {
-                match vibesql_executor::TriggerExecutor::create_trigger(&mut self.db, &trigger_stmt)
-                {
+                // Pass original SQL so the trigger survives SQL-dump persistence
+                // (mirrors the sql_definition handling for views above).
+                match vibesql_executor::TriggerExecutor::create_trigger_with_sql(
+                    &mut self.db,
+                    &trigger_stmt,
+                    Some(sql),
+                ) {
                     Ok(_) => {
                         result.row_count = 0; // DDL doesn't return rows
                     }

--- a/crates/vibesql-executor/src/persistence.rs
+++ b/crates/vibesql-executor/src/persistence.rs
@@ -10,7 +10,7 @@ use vibesql_storage::Database;
 
 use crate::{
     CreateIndexExecutor, CreateTableExecutor, ExecutorError, InsertExecutor, RoleExecutor,
-    SchemaExecutor, UpdateExecutor, ViewExecutor,
+    SchemaExecutor, TriggerExecutor, UpdateExecutor, ViewExecutor,
 };
 
 /// Load database from SQL dump file
@@ -113,6 +113,14 @@ fn execute_statement_for_load(
             // Store original SQL for sqlite_master compatibility
             view_stmt.sql_definition = Some(original_sql.to_string());
             ViewExecutor::execute_create_view(&view_stmt, db)?;
+        }
+        vibesql_ast::Statement::CreateTrigger(trigger_stmt) => {
+            // Preserve the original SQL on the catalog TriggerDefinition so that
+            // a subsequent save_sql_dump can re-emit the trigger verbatim. Without
+            // this, triggers would survive one round-trip (because we just executed
+            // CREATE TRIGGER) but would be lost on the *next* save because the
+            // catalog entry would have no sql_definition.
+            TriggerExecutor::create_trigger_with_sql(db, &trigger_stmt, Some(original_sql))?;
         }
         vibesql_ast::Statement::CreateRole(role_stmt) => {
             RoleExecutor::execute_create_role(&role_stmt, db)?;

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -557,6 +557,7 @@ mod tests {
                 " BEGIN INSERT INTO audit VALUES (NEW.id); END".to_string(),
             ),
             enabled: true,
+            sql_definition: None,
         };
 
         let sql = generate_create_trigger_sql(&trigger);
@@ -580,6 +581,7 @@ mod tests {
             when_condition: None,
             triggered_action: TriggerAction::RawSql(" BEGIN SELECT 1; END".to_string()),
             enabled: true,
+            sql_definition: None,
         };
 
         let sql = generate_create_trigger_sql(&trigger);
@@ -603,6 +605,7 @@ mod tests {
                 " BEGIN DELETE FROM base_table WHERE id = OLD.id; END".to_string(),
             ),
             enabled: true,
+            sql_definition: None,
         };
 
         let sql = generate_create_trigger_sql(&trigger);

--- a/crates/vibesql-executor/src/trigger_ddl.rs
+++ b/crates/vibesql-executor/src/trigger_ddl.rs
@@ -14,10 +14,29 @@ use crate::errors::ExecutorError;
 pub struct TriggerExecutor;
 
 impl TriggerExecutor {
-    /// Execute a CREATE TRIGGER statement
+    /// Execute a CREATE TRIGGER statement.
+    ///
+    /// This is a convenience wrapper around [`TriggerExecutor::create_trigger_with_sql`]
+    /// that does not preserve the original SQL text. Triggers created via this path
+    /// will not survive SQL-dump persistence round-trips.
     pub fn create_trigger(
         db: &mut Database,
         stmt: &CreateTriggerStmt,
+    ) -> Result<String, ExecutorError> {
+        Self::create_trigger_with_sql(db, stmt, None)
+    }
+
+    /// Execute a CREATE TRIGGER statement, optionally preserving the original SQL text
+    /// for SQL-dump persistence.
+    ///
+    /// When `original_sql` is `Some`, the SQL is stored on the catalog
+    /// [`TriggerDefinition`] so it can be re-emitted verbatim by `save_sql_dump`.
+    /// This is the path used by the CLI / Python / WASM frontends, which are the
+    /// only callers that have access to the original textual SQL.
+    pub fn create_trigger_with_sql(
+        db: &mut Database,
+        stmt: &CreateTriggerStmt,
+        original_sql: Option<&str>,
     ) -> Result<String, ExecutorError> {
         // INSTEAD OF triggers can only be created on views
         // BEFORE and AFTER triggers can only be created on tables
@@ -36,16 +55,28 @@ impl TriggerExecutor {
             }
         }
 
-        // Create trigger definition from statement
-        let trigger = TriggerDefinition::new(
-            stmt.trigger_name.clone(),
-            stmt.timing.clone(),
-            stmt.event.clone(),
-            stmt.table_name.clone(),
-            stmt.granularity.clone(),
-            stmt.when_condition.clone(),
-            stmt.triggered_action.clone(),
-        );
+        // Create trigger definition from statement, preserving original SQL when available
+        let trigger = match original_sql {
+            Some(sql) => TriggerDefinition::new_with_sql(
+                stmt.trigger_name.clone(),
+                stmt.timing.clone(),
+                stmt.event.clone(),
+                stmt.table_name.clone(),
+                stmt.granularity.clone(),
+                stmt.when_condition.clone(),
+                stmt.triggered_action.clone(),
+                sql.to_string(),
+            ),
+            None => TriggerDefinition::new(
+                stmt.trigger_name.clone(),
+                stmt.timing.clone(),
+                stmt.event.clone(),
+                stmt.table_name.clone(),
+                stmt.granularity.clone(),
+                stmt.when_condition.clone(),
+                stmt.triggered_action.clone(),
+            ),
+        };
 
         // Store in catalog
         db.catalog.create_trigger(trigger)?;

--- a/crates/vibesql-storage/src/persistence/load.rs
+++ b/crates/vibesql-storage/src/persistence/load.rs
@@ -86,6 +86,10 @@ pub fn read_sql_dump<P: AsRef<Path>>(path: P) -> Result<String, StorageError> {
 /// - Multi-line statements
 /// - Statement termination by semicolon
 /// - String literals (preserves content within quotes)
+/// - `CREATE TRIGGER ... BEGIN ... END;` blocks where embedded semicolons inside
+///   the trigger body must NOT terminate the outer statement. We track BEGIN/END
+///   nesting depth (matched as whole-word identifiers, case-insensitively) and
+///   only honor `;` as a terminator at depth 0.
 ///
 /// # Returns
 /// A vector of SQL statement strings, trimmed and ready to parse
@@ -95,6 +99,9 @@ pub fn parse_sql_statements(content: &str) -> Result<Vec<String>, StorageError> 
     let mut in_string = false;
     let mut string_char = ' ';
     let mut escape_next = false;
+    // BEGIN/END nesting depth. While > 0, semicolons inside the trigger body do
+    // not terminate the outer statement.
+    let mut begin_depth: u32 = 0;
 
     for line in content.lines() {
         let trimmed = line.trim();
@@ -123,6 +130,30 @@ pub fn parse_sql_statements(content: &str) -> Result<Vec<String>, StorageError> 
                 break;
             }
 
+            // Detect BEGIN/END as whole-word, case-insensitive identifiers when
+            // not inside a string literal. Track nesting depth so `;` inside a
+            // trigger body doesn't prematurely terminate the CREATE TRIGGER.
+            if !in_string && ch.is_ascii_alphabetic() {
+                let prev_is_ident = i > 0
+                    && (chars[i - 1].is_ascii_alphanumeric() || chars[i - 1] == '_');
+                if !prev_is_ident {
+                    if let Some(consumed) = match_keyword(&chars, i, "BEGIN") {
+                        begin_depth += 1;
+                        current_statement.push_str("BEGIN");
+                        i += consumed;
+                        continue;
+                    }
+                    if let Some(consumed) = match_keyword(&chars, i, "END") {
+                        if begin_depth > 0 {
+                            begin_depth -= 1;
+                        }
+                        current_statement.push_str("END");
+                        i += consumed;
+                        continue;
+                    }
+                }
+            }
+
             match ch {
                 '\\' if in_string && string_char == '\'' => {
                     current_statement.push(ch);
@@ -137,7 +168,7 @@ pub fn parse_sql_statements(content: &str) -> Result<Vec<String>, StorageError> 
                     in_string = false;
                     current_statement.push(ch);
                 }
-                ';' if !in_string => {
+                ';' if !in_string && begin_depth == 0 => {
                     current_statement.push(ch);
                     // Statement complete
                     if !current_statement.trim().is_empty() {
@@ -164,6 +195,30 @@ pub fn parse_sql_statements(content: &str) -> Result<Vec<String>, StorageError> 
     }
 
     Ok(statements)
+}
+
+/// Match a keyword (case-insensitively) at position `i` in `chars`, ensuring that the
+/// character after the keyword is not part of an identifier (so e.g. "BEGINNING" does
+/// not match "BEGIN"). Returns the number of characters consumed if matched.
+fn match_keyword(chars: &[char], i: usize, keyword: &str) -> Option<usize> {
+    let kw_chars: Vec<char> = keyword.chars().collect();
+    if i + kw_chars.len() > chars.len() {
+        return None;
+    }
+    for (k, kc) in kw_chars.iter().enumerate() {
+        if chars[i + k].to_ascii_uppercase() != *kc {
+            return None;
+        }
+    }
+    // Ensure the next character is not part of an identifier
+    let next_idx = i + kw_chars.len();
+    if next_idx < chars.len() {
+        let nc = chars[next_idx];
+        if nc.is_ascii_alphanumeric() || nc == '_' {
+            return None;
+        }
+    }
+    Some(kw_chars.len())
 }
 
 #[cfg(test)]
@@ -258,6 +313,57 @@ mod tests {
         assert_eq!(statements.len(), 1);
         assert!(statements[0].contains("'Alice'"));
         assert!(!statements[0].contains("Add first user"));
+    }
+
+    #[test]
+    fn test_parse_create_trigger_body_with_semicolons() {
+        // Trigger bodies contain BEGIN ... END; with embedded semicolons that must
+        // NOT split the outer statement.
+        let content = r#"
+CREATE TABLE t(a, b);
+CREATE TRIGGER tr AFTER INSERT ON t BEGIN
+  INSERT INTO t VALUES(99, 99);
+  UPDATE t SET b = 1 WHERE a = 0;
+END;
+INSERT INTO t VALUES(1, 1);
+"#;
+        let statements = parse_sql_statements(content).unwrap();
+        assert_eq!(statements.len(), 3, "got: {:#?}", statements);
+        assert!(statements[0].contains("CREATE TABLE"));
+        assert!(statements[1].contains("CREATE TRIGGER"));
+        assert!(statements[1].contains("BEGIN"));
+        assert!(statements[1].contains("END"));
+        // Both inner statements must remain inside the trigger body
+        assert!(statements[1].contains("INSERT INTO t VALUES(99, 99)"));
+        assert!(statements[1].contains("UPDATE t SET b = 1"));
+        assert!(statements[2].contains("INSERT INTO t VALUES(1, 1)"));
+    }
+
+    #[test]
+    fn test_parse_nested_begin_end() {
+        // Nested BEGIN/END must balance correctly.
+        let content = r#"
+CREATE TRIGGER tr AFTER INSERT ON t BEGIN
+  BEGIN
+    INSERT INTO t VALUES(1);
+  END;
+  INSERT INTO t VALUES(2);
+END;
+SELECT 1;
+"#;
+        let statements = parse_sql_statements(content).unwrap();
+        assert_eq!(statements.len(), 2);
+        assert!(statements[0].contains("CREATE TRIGGER"));
+        assert!(statements[1].trim().starts_with("SELECT 1"));
+    }
+
+    #[test]
+    fn test_parse_begin_keyword_does_not_match_beginning() {
+        // "BEGINNING" is an identifier, not a BEGIN keyword.
+        let content = r#"INSERT INTO t VALUES('BEGINNING');
+SELECT 1;"#;
+        let statements = parse_sql_statements(content).unwrap();
+        assert_eq!(statements.len(), 2);
     }
 
     #[test]

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -473,6 +473,41 @@ impl Database {
         writeln!(writer)
             .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
 
+        // Export triggers
+        //
+        // Triggers must be emitted *after* views so that INSTEAD OF triggers (which
+        // require their target view to already exist) can be reconstructed when the
+        // dump is reloaded. We can only round-trip triggers whose original SQL text
+        // was preserved on creation; without that text we have no way to reproduce
+        // the BEGIN ... END action body, so we skip with a comment instead of writing
+        // garbage that would fail to parse on reload.
+        writeln!(writer, "-- Triggers")
+            .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+        for trigger_name in self.catalog.list_triggers() {
+            if let Some(trigger_def) = self.catalog.get_trigger(&trigger_name) {
+                match trigger_def.sql_definition.as_ref() {
+                    Some(sql) => {
+                        let sql = sql.trim_end_matches(';').trim();
+                        writeln!(writer, "{};", sql).map_err(|e| {
+                            StorageError::NotImplemented(format!("Write error: {}", e))
+                        })?;
+                    }
+                    None => {
+                        writeln!(
+                            writer,
+                            "-- Skipped trigger '{}' (no preserved SQL text)",
+                            trigger_def.name
+                        )
+                        .map_err(|e| {
+                            StorageError::NotImplemented(format!("Write error: {}", e))
+                        })?;
+                    }
+                }
+            }
+        }
+        writeln!(writer)
+            .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+
         writeln!(writer, "-- End of dump")
             .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
 


### PR DESCRIPTION
## Summary

`Database::save_sql_dump()` previously emitted `-- Views` but **omitted all triggers**, so triggers vanished on every save. Because each TCL `do_execsql_test` block runs in a fresh `vibesql` process sharing one `.vbsql` file, triggers created in batch N disappeared before batch N+1.

This PR closes the loop:

- `TriggerDefinition` carries an optional `sql_definition` string (mirroring `ViewDefinition`).
- The CLI captures the original `CREATE TRIGGER` SQL when executing the statement; the `load_sql_dump` path does the same when re-executing on load.
- `save_sql_dump` emits a `-- Triggers` block *after* views, so `INSTEAD OF` triggers find their target view on reload.
- `parse_sql_statements` now tracks `BEGIN`/`END` nesting depth so the `;` inside a trigger body does not split the outer `CREATE TRIGGER` statement. Whole-word, case-insensitive matching prevents identifiers like `BEGINNING` from being misinterpreted as `BEGIN`.

## Scope

This PR addresses **bucket A** of #5073's three identified failure modes (per the curator's analysis). Two sub-issues track the remaining two buckets, which live in different code paths:

- #5082: bucket B — thread trigger context through `UPDATE … FROM` synthetic SELECT
- #5083: bucket C — declare `hiddencolumns` capability unsupported in TCL shim

A is the highest-leverage fix because **every** TCL test that creates a trigger and runs another batch was affected, not just `triggerupfrom`.

## Changes

- `crates/vibesql-catalog/src/trigger.rs` — add `sql_definition: Option<String>` and `new_with_sql(...)` constructor on `TriggerDefinition`.
- `crates/vibesql-executor/src/trigger_ddl.rs` — add `create_trigger_with_sql(...)` that captures original SQL; preserve back-compat by keeping `create_trigger(...)` calling through with `None`.
- `crates/vibesql-cli/src/executor/mod.rs` — pass `Some(sql)` when handling `Statement::CreateTrigger`.
- `crates/vibesql-executor/src/persistence.rs` — handle `CreateTrigger` in `execute_statement_for_load` (was previously falling into the catch-all error arm), preserving original SQL.
- `crates/vibesql-storage/src/persistence/save.rs` — emit `-- Triggers` block.
- `crates/vibesql-storage/src/persistence/load.rs` — track `BEGIN`/`END` nesting so semicolons in trigger bodies don't split statements.
- `crates/vibesql-catalog/src/store/tables.rs`, `crates/vibesql-executor/src/sqlite_schema.rs` — add `sql_definition: None` to existing `TriggerDefinition` struct literals (test code).

## Test Plan

- [x] Two-batch CLI repro: `CREATE TRIGGER` in batch 1 persists and fires in batch 2.
- [x] `INSTEAD OF` trigger on a view round-trips through SQL dump.
- [x] `triggerupfrom 4.2` now passes (was failing).
- [x] `window1 73.5` (`DROP TRIGGER x1`) now passes (was failing).
- [x] New unit tests in `persistence/load.rs` cover `BEGIN`/`END` semicolon tracking, nested blocks, and `BEGINNING != BEGIN`.
- [x] 26 trigger lib tests, 41 catalog tests, 61 storage persistence tests, 2,319 executor tests all pass.
- [x] `view.test` TCL: 24 passing, 0 failing — no regression.
- [ ] CI green (4 pre-existing `vibesql-cli/tests/persistence_test.rs` failures are unrelated and fixed by #5074).

## Tests Newly Surfacing Bucket-B Errors (not regressions)

These previously appeared to pass or fail with different errors because the trigger was silently lost between batches. With the trigger now persisted, the underlying bucket-B (`UPDATE … FROM` trigger context) bug is properly exposed. Tracked in #5082:

- `triggerupfrom 1.1`, `1.2`, `1.3`, `2.3`, `4.3` — `Unsupported expression: PseudoVariable { pseudo_table: New, ... }` and `no such column: map.k`
- `window1 73.4` — UPDATE FROM with INSTEAD OF trigger and window function

Closes #5073