### PR TITLE
feat(parser): support RESTRICT, post-constraint DEFAULT, empty statements (Bucket A of #5071)

### DIFF
--- a/crates/vibesql-cli/src/script.rs
+++ b/crates/vibesql-cli/src/script.rs
@@ -385,9 +385,12 @@ fn parse_statements(script: &str) -> Vec<String> {
         if !in_string && ch == ';' {
             current_statement.push(ch); // Include the semicolon
             if begin_depth == 0 {
-                // Only split if we're not inside a BEGIN...END block
+                // Only split if we're not inside a BEGIN...END block.
+                // SQLite treats consecutive semicolons (";;") and bare ";" as
+                // empty statements (no-ops); reject anything that is purely
+                // whitespace + semicolons so we don't pass it to the parser.
                 let trimmed = current_statement.trim();
-                if !trimmed.is_empty() {
+                if !trimmed.is_empty() && trimmed.chars().any(|c| c != ';' && !c.is_whitespace()) {
                     statements.push(trimmed.to_string());
                 }
                 current_statement.clear();
@@ -461,6 +464,24 @@ mod tests {
     #[test]
     fn test_parse_empty_script() {
         let script = "";
+        let stmts = parse_statements(script);
+        assert_eq!(stmts.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_consecutive_semicolons() {
+        // SQLite treats `;;` and bare `;` as no-ops (empty statements).
+        // We should not pass them to the parser.
+        let script = "CREATE TABLE t1 (a INT);; SELECT 1;";
+        let stmts = parse_statements(script);
+        assert_eq!(stmts.len(), 2);
+        assert_eq!(stmts[0], "CREATE TABLE t1 (a INT);");
+        assert_eq!(stmts[1], "SELECT 1;");
+    }
+
+    #[test]
+    fn test_parse_only_semicolons() {
+        let script = ";;;";
         let stmts = parse_statements(script);
         assert_eq!(stmts.len(), 0);
     }

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -273,7 +273,7 @@ impl Parser {
         Ok(Some(vibesql_ast::ConstraintDeferral { is_deferrable, initially_deferred }))
     }
 
-    /// Parse a single referential action (NO ACTION, CASCADE, SET NULL, SET DEFAULT)
+    /// Parse a single referential action (NO ACTION, CASCADE, RESTRICT, SET NULL, SET DEFAULT)
     fn parse_referential_action(&mut self) -> Result<vibesql_ast::ReferentialAction, ParseError> {
         if self.peek_keyword(Keyword::No) {
             self.advance(); // consume NO
@@ -282,6 +282,9 @@ impl Parser {
         } else if self.peek_keyword(Keyword::Cascade) {
             self.advance(); // consume CASCADE
             Ok(vibesql_ast::ReferentialAction::Cascade)
+        } else if self.peek_keyword(Keyword::Restrict) {
+            self.advance(); // consume RESTRICT
+            Ok(vibesql_ast::ReferentialAction::Restrict)
         } else if self.peek_keyword(Keyword::Set) {
             self.advance(); // consume SET
             if self.peek_keyword(Keyword::Null) {
@@ -295,16 +298,27 @@ impl Parser {
             }
         } else {
             Err(ParseError {
-                message: "Expected NO ACTION, CASCADE, SET NULL, or SET DEFAULT".to_string(),
+                message: "Expected NO ACTION, CASCADE, RESTRICT, SET NULL, or SET DEFAULT"
+                    .to_string(),
             })
         }
     }
 
     /// Parse column-level constraints (PRIMARY KEY, UNIQUE, CHECK, REFERENCES)
+    ///
+    /// Returns the list of parsed constraints plus an optional `DEFAULT` expression
+    /// encountered mid-stream. SQLite grammar allows DEFAULT to appear interleaved
+    /// with column constraints in any order (e.g., `idx UNIQUE DEFAULT NULL`), so
+    /// callers should treat the returned default as additional output and merge it
+    /// with any DEFAULT clause parsed before the constraint list.
     pub(in crate::parser) fn parse_column_constraints(
         &mut self,
-    ) -> Result<Vec<vibesql_ast::ColumnConstraint>, ParseError> {
+    ) -> Result<
+        (Vec<vibesql_ast::ColumnConstraint>, Option<Box<vibesql_ast::Expression>>),
+        ParseError,
+    > {
         let mut constraints = Vec::new();
+        let mut default_value: Option<Box<vibesql_ast::Expression>> = None;
 
         loop {
             // Check for optional CONSTRAINT keyword
@@ -327,6 +341,23 @@ impl Parser {
             };
 
             match self.peek() {
+                Token::Keyword { keyword: Keyword::Default, .. } => {
+                    // DEFAULT clause may appear interleaved with column constraints
+                    // (SQLite grammar). Capture the expression and continue parsing.
+                    if name.is_some() {
+                        return Err(ParseError {
+                            message: "DEFAULT cannot follow CONSTRAINT name".to_string(),
+                        });
+                    }
+                    self.advance(); // consume DEFAULT
+                    let expr = self.parse_expression()?;
+                    if default_value.is_some() {
+                        return Err(ParseError {
+                            message: "Multiple DEFAULT clauses for the same column".to_string(),
+                        });
+                    }
+                    default_value = Some(Box::new(expr));
+                }
                 Token::Keyword { keyword: Keyword::Null, .. } => {
                     // MySQL allows standalone NULL keyword to explicitly indicate nullable column
                     // (which is the default anyway), so we just consume it and skip it
@@ -463,7 +494,7 @@ impl Parser {
             }
         }
 
-        Ok(constraints)
+        Ok((constraints, default_value))
     }
 
     /// Parse table-level constraints (PRIMARY KEY, FOREIGN KEY, UNIQUE, CHECK)

--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -154,8 +154,11 @@ impl Parser {
                 generated_expr = Some(Box::new(expr));
             }
 
-            // Parse optional DEFAULT clause (before COMMENT, per MySQL standard)
-            let default_value = if self.peek_keyword(Keyword::Default) {
+            // Parse optional DEFAULT clause (before COMMENT, per MySQL standard).
+            // SQLite also allows DEFAULT to appear interleaved with column constraints
+            // (e.g. `idx UNIQUE DEFAULT NULL`), so `parse_column_constraints` below may
+            // also consume a DEFAULT clause and return it via its second tuple element.
+            let mut default_value = if self.peek_keyword(Keyword::Default) {
                 self.advance(); // consume DEFAULT
                 Some(Box::new(self.parse_expression()?))
             } else {
@@ -181,8 +184,16 @@ impl Parser {
                 None
             };
 
-            // Parse column constraints (which may include NOT NULL)
-            let constraints = self.parse_column_constraints()?;
+            // Parse column constraints (which may include NOT NULL and an interleaved DEFAULT)
+            let (constraints, mid_default) = self.parse_column_constraints()?;
+            if let Some(d) = mid_default {
+                if default_value.is_some() {
+                    return Err(ParseError {
+                        message: "Multiple DEFAULT clauses for the same column".to_string(),
+                    });
+                }
+                default_value = Some(d);
+            }
 
             // Determine nullability based on constraints
             let nullable = !constraints

--- a/crates/vibesql-parser/src/tests/create_table/constraints_column.rs
+++ b/crates/vibesql-parser/src/tests/create_table/constraints_column.rs
@@ -519,3 +519,79 @@ fn test_parse_on_conflict_column_constraints() {
         _ => panic!("Expected CREATE TABLE statement"),
     }
 }
+
+/// Test ON DELETE/UPDATE RESTRICT (SQLite-supported referential action)
+#[test]
+fn test_parse_references_restrict() {
+    let result = Parser::parse_sql(
+        "CREATE TABLE t(a INTEGER REFERENCES p(x) ON DELETE RESTRICT ON UPDATE RESTRICT)",
+    );
+    assert!(result.is_ok(), "Should parse ON DELETE/UPDATE RESTRICT: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            match &create.columns[0].constraints[0].kind {
+                vibesql_ast::ColumnConstraintKind::References { on_delete, on_update, .. } => {
+                    assert_eq!(on_delete, &Some(vibesql_ast::ReferentialAction::Restrict));
+                    assert_eq!(on_update, &Some(vibesql_ast::ReferentialAction::Restrict));
+                }
+                _ => panic!("Expected REFERENCES constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+/// Test that DEFAULT can appear after column constraints (SQLite grammar).
+/// Example from fkey1-8.1: `idx UNIQUE DEFAULT NULL`
+#[test]
+fn test_parse_default_after_constraint() {
+    let result = Parser::parse_sql("CREATE TABLE t(idx UNIQUE DEFAULT NULL)");
+    assert!(result.is_ok(), "Should parse DEFAULT after UNIQUE: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns[0].constraints.len(), 1);
+            match &create.columns[0].constraints[0].kind {
+                vibesql_ast::ColumnConstraintKind::Unique { .. } => {}
+                _ => panic!("Expected UNIQUE constraint"),
+            }
+            assert!(
+                create.columns[0].default_value.is_some(),
+                "DEFAULT after UNIQUE should be captured on ColumnDef.default_value"
+            );
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+/// Test that DEFAULT can appear interleaved with multiple constraints.
+#[test]
+fn test_parse_default_interleaved_with_constraints() {
+    let result = Parser::parse_sql("CREATE TABLE t(c INT NOT NULL DEFAULT 0 CHECK(c >= 0))");
+    assert!(result.is_ok(), "Should parse interleaved DEFAULT: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert!(create.columns[0].default_value.is_some(), "DEFAULT 0 should be captured");
+            // NOT NULL + CHECK should both appear as constraints
+            assert!(create.columns[0].constraints.iter().any(
+                |c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::NotNull)
+            ));
+            assert!(create.columns[0].constraints.iter().any(
+                |c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Check(_))
+            ));
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+/// Test that providing two DEFAULT clauses for the same column is rejected.
+#[test]
+fn test_parse_default_double_rejected() {
+    let result = Parser::parse_sql("CREATE TABLE t(c INT DEFAULT 0 UNIQUE DEFAULT 1)");
+    assert!(result.is_err(), "Should reject two DEFAULT clauses on the same column");
+}


### PR DESCRIPTION
## Summary

Implements **Bucket A** (parser fixes) of #5071 — the curator decomposed the original FK issue into 4 distinct subsystems and explicitly recommended splitting. This PR addresses the parser-only work (~1 day of scope); the other three buckets are filed as separate sub-issues (see below) so each can be tackled independently.

## Changes

- **`ON DELETE RESTRICT` / `ON UPDATE RESTRICT`**: add `Keyword::Restrict` arm to the recursive-descent parser's `parse_referential_action`. The arena parser, AST, and catalog already supported `Restrict` — only this parser was missing the keyword. Fixes fkey1-9.1.

- **`DEFAULT` interleaved with column constraints** (e.g., `idx UNIQUE DEFAULT NULL`): hoist `DEFAULT` parsing into `parse_column_constraints`. Function now returns `(Vec<ColumnConstraint>, Option<Box<Expression>>)`, with the optional expression carrying any DEFAULT consumed mid-stream. The single caller in `parser/create/table.rs` merges it with any pre-constraint DEFAULT clause and rejects duplicates. Fixes fkey1-8.1's column shape.

- **Empty statements (`;;`, bare `;`)**: SQLite treats these as no-ops; we were passing the standalone `;` to the parser and producing `near ";": syntax error`. The CLI script splitter (`crates/vibesql-cli/src/script.rs`) now skips any token that consists solely of whitespace and semicolons. Unblocks fkey1-8.1's `CREATE TABLE sqlsim4(stat PRIMARY KEY);;` shape and any future test that uses consecutive semicolons.

## Test Plan

- New parser unit tests:
  - `test_parse_references_restrict` — round-trips `ON DELETE RESTRICT ON UPDATE RESTRICT`
  - `test_parse_default_after_constraint` — `idx UNIQUE DEFAULT NULL`
  - `test_parse_default_interleaved_with_constraints` — `c INT NOT NULL DEFAULT 0 CHECK(c >= 0)`
  - `test_parse_default_double_rejected` — two DEFAULTs on the same column produces a parse error
- New CLI script-splitter tests:
  - `test_parse_consecutive_semicolons`
  - `test_parse_only_semicolons`
- All 4918 workspace lib tests pass (no regressions).
- fkey1.test: 14 passing → 16 passing (8.1, 9.1 now pass; 4.2, 5.1, 6.1, 8.3 still failing — these belong to Buckets B/C/D).
- fkey5/fkey6/fkey8 baseline failure counts unchanged (expected — those need Buckets B/C/D).

## Sub-issues filed

Per the curator's recommended decomposition, the remaining three buckets are tracked separately:

- #5084: Bucket B — `foreign key mismatch` error class (~2-3 days)
- #5085: Bucket C — Deferred FK enforcement (`DEFERRABLE INITIALLY DEFERRED` + `PRAGMA defer_foreign_keys`) (~1 week)
- #5087: Bucket D — `PRAGMA table_info`, FK txn state on rollback, skips (~1-2 days)

#5071 is intentionally left open as a tracker for the umbrella effort.

Refs #5071