### PR TITLE
fix(window): COUNT()/COUNT(*) over post-aggregate frames now counts all frame rows

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -309,13 +309,33 @@ pub(super) fn apply_window_functions_to_aggregates(
                             };
 
                         let value = match win_func.func_name.to_uppercase().as_str() {
-                            "COUNT" => evaluate_count_window(
-                                partition,
-                                frame_indices,
-                                Some(&arg_expr),
-                                None,
-                                inner_eval_fn,
-                            ),
+                            "COUNT" => {
+                                // COUNT(*) or COUNT() should count all rows in the
+                                // frame (passing `None`). Only when there is a real
+                                // argument do we delegate to the synthetic
+                                // `arg_expr` referencing the post-aggregation result
+                                // column. Mirrors the non-aggregate path in
+                                // crates/vibesql-executor/src/select/window/evaluation.rs.
+                                let count_arg = if win_func.args.is_empty()
+                                    || matches!(&win_func.args[0], Expression::Wildcard)
+                                    || matches!(
+                                        &win_func.args[0],
+                                        Expression::ColumnRef(col_id)
+                                            if col_id.column_canonical() == "*"
+                                    )
+                                {
+                                    None // COUNT(*) / COUNT() - count all rows
+                                } else {
+                                    Some(&arg_expr)
+                                };
+                                evaluate_count_window(
+                                    partition,
+                                    frame_indices,
+                                    count_arg,
+                                    None,
+                                    inner_eval_fn,
+                                )
+                            }
                             "SUM" => evaluate_sum_window(
                                 partition,
                                 frame_indices,

--- a/crates/vibesql-executor/src/tests/select_window_aggregate.rs
+++ b/crates/vibesql-executor/src/tests/select_window_aggregate.rs
@@ -810,3 +810,82 @@ fn test_window_function_avg_sum_with_frame() {
         panic!("Expected SELECT statement");
     }
 }
+
+/// Regression test for the post-aggregate COUNT() OVER () dispatch bug.
+///
+/// Before the fix, `aggregation/window.rs` always passed a synthetic
+/// `Some(&col{select_index})` argument to `evaluate_count_window`, even for
+/// `COUNT()` / `COUNT(*)`. The synthetic placeholder column held the window
+/// function's own (still-NULL) output slot at evaluation time, so
+/// `COUNT(non-null)` returned 0 on every row.
+///
+/// Mirrors SQLite's `window1.test` test 64.3.
+#[test]
+fn test_count_no_arg_window_with_group_by() {
+    use vibesql_storage::Row;
+    let mut db = Database::new();
+
+    let schema = TableSchema::new(
+        "T1".to_string(),
+        vec![
+            ColumnSchema::new("A".to_string(), DataType::Integer, false),
+            ColumnSchema::new(
+                "B".to_string(),
+                DataType::Varchar { max_length: Some(50) },
+                false,
+            ),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("T1").unwrap();
+    for (i, s) in ["abcd", "BCDE", "cdef", "DEFG"].iter().enumerate() {
+        table
+            .insert(Row::new(vec![
+                SqlValue::Integer((i + 1) as i64),
+                SqlValue::Varchar(arcstr::ArcStr::from(*s)),
+            ]))
+            .unwrap();
+    }
+
+    let executor = SelectExecutor::new(&db);
+
+    // COUNT() OVER () with GROUP BY rowid - the window fires after grouping.
+    // Each of the 4 grouped rows should see count = 4.
+    let query = "SELECT count() OVER (), a FROM t1 GROUP BY a ORDER BY a";
+    let stmt = Parser::parse_sql(query).unwrap();
+
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let rows = executor.execute(&select_stmt).unwrap();
+        assert_eq!(rows.len(), 4);
+        for row in &rows {
+            assert_eq!(
+                row.values[0],
+                SqlValue::Integer(4),
+                "COUNT() OVER () with GROUP BY must count all aggregated rows, got {:?}",
+                row.values[0]
+            );
+        }
+    } else {
+        panic!("Expected SELECT statement");
+    }
+
+    // COUNT(*) OVER () should behave identically.
+    let executor = SelectExecutor::new(&db);
+    let query = "SELECT count(*) OVER (), a FROM t1 GROUP BY a ORDER BY a";
+    let stmt = Parser::parse_sql(query).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let rows = executor.execute(&select_stmt).unwrap();
+        assert_eq!(rows.len(), 4);
+        for row in &rows {
+            assert_eq!(
+                row.values[0],
+                SqlValue::Integer(4),
+                "COUNT(*) OVER () with GROUP BY must count all aggregated rows, got {:?}",
+                row.values[0]
+            );
+        }
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the post-aggregate window dispatch bug for `COUNT()` / `COUNT(*)`
identified by the Curator on #5068 (bucket A).

`crates/vibesql-executor/src/select/executor/aggregation/window.rs`
unconditionally passed a synthetic `col{select_index}` argument to
`evaluate_count_window`, even when the original window expression was
`COUNT()` or `COUNT(*)`. That synthetic column held the window
function's own (still-NULL) output slot at evaluation time, so
`COUNT(non-null)` returned 0 on every row.

The fix mirrors the existing pattern in
`crates/vibesql-executor/src/select/window/evaluation.rs:687-699`,
which already handles empty args / `Wildcard` / `ColumnRef("*")` by
passing `None` to `evaluate_count_window` (count all rows in frame).

## Changes

- `crates/vibesql-executor/src/select/executor/aggregation/window.rs` —
  COUNT branch in the `Aggregate` dispatch now substitutes `None` for
  no-arg / `*` cases.
- `crates/vibesql-executor/src/tests/select_window_aggregate.rs` —
  regression test `test_count_no_arg_window_with_group_by` covers both
  `COUNT() OVER ()` and `COUNT(*) OVER ()` after a `GROUP BY`.

## Test Results

- All 60 vibesql-executor window unit tests pass.
- New regression test passes.
- TCL `window1.test`: 224 → 225 passing (test 79.3 now passes; 64.3 /
  64.4 now produce the correct count value but still fail on row
  ordering, which is bucket B / a separate issue).
- TCL `window2.test`, `window3.test`, `window4.test`, `window7.test`,
  `windowA.test`, `windowB.test`, `window9.test`: no changes vs main
  (no regressions).

## Out-of-Scope (Sub-Issues Filed)

The Curator's analysis showed the original issue conflated several
unrelated buckets. Sub-issues were filed for the deferred work:

- #5077 — Bucket B: COLLATE-aware ORDER BY in outer SELECT
- #5078 — Bucket C: EXPLAIN QUERY PLAN output format mismatch
- #5079 — Bucket D: `IS TRUE` / `IS FALSE` semantics
- #5080 — Bucket F: window correctness — UNION/scalar-subquery/FILTER
- #5081 — Bucket E: type coercion in window context

Test 79.3's RANGE-over-aggregated-row case (the second part of bucket
A) is fixed by this PR as a side-effect of the COUNT fix — once
`COUNT(*)` is dispatched correctly with `None`, the synthetic
ORDER-BY-column issue does not surface.

## Test Plan

- [x] `cargo test -p vibesql-executor --lib window` — 60 pass
- [x] `cargo test -p vibesql-executor --lib test_count_no_arg_window_with_group_by` — pass
- [x] `./scripts/tcltest test window1.test` — 224 → 225 passes, no regressions
- [x] `./scripts/tcltest test window2.test` / `window4.test` / others — no regressions
- [ ] `make test-tcl` (P1 suite) — running in parallel; will report any regressions in PR comment if found

Closes #5068