### PR TITLE
fix(operators): support BLOB for unary +/- and TEXT/Numeric vs BLOB ordering

### DIFF
--- a/crates/vibesql-executor/src/evaluator/compiled.rs
+++ b/crates/vibesql-executor/src/evaluator/compiled.rs
@@ -742,6 +742,41 @@ impl CompiledPredicate {
                 s.trim().parse::<f64>().map(|x| Self::apply_range_op(x, op, *y)).ok()
             }
 
+            // BLOB vs BLOB - bytewise comparison (SQLite memcmp semantics)
+            (SqlValue::Blob(x), SqlValue::Blob(y)) => Some(Self::apply_range_op(x, op, y)),
+
+            // BLOB vs TEXT - SQLite type ordering: TEXT < BLOB (no coercion)
+            (SqlValue::Blob(_), SqlValue::Varchar(_) | SqlValue::Character(_)) => {
+                // BLOB > TEXT, so any > / >= is true; any < / <= is false
+                Some(matches!(op, RangeOp::GreaterThan | RangeOp::GreaterThanOrEqual))
+            }
+            (SqlValue::Varchar(_) | SqlValue::Character(_), SqlValue::Blob(_)) => {
+                // TEXT < BLOB, so any < / <= is true; any > / >= is false
+                Some(matches!(op, RangeOp::LessThan | RangeOp::LessThanOrEqual))
+            }
+
+            // BLOB vs Numeric - SQLite type ordering: Numeric < BLOB (no coercion)
+            (
+                SqlValue::Blob(_),
+                SqlValue::Integer(_)
+                | SqlValue::Smallint(_)
+                | SqlValue::Bigint(_)
+                | SqlValue::Float(_)
+                | SqlValue::Real(_)
+                | SqlValue::Double(_)
+                | SqlValue::Numeric(_),
+            ) => Some(matches!(op, RangeOp::GreaterThan | RangeOp::GreaterThanOrEqual)),
+            (
+                SqlValue::Integer(_)
+                | SqlValue::Smallint(_)
+                | SqlValue::Bigint(_)
+                | SqlValue::Float(_)
+                | SqlValue::Real(_)
+                | SqlValue::Double(_)
+                | SqlValue::Numeric(_),
+                SqlValue::Blob(_),
+            ) => Some(matches!(op, RangeOp::LessThan | RangeOp::LessThanOrEqual)),
+
             // Type mismatch - fall back to None (needs full evaluation)
             _ => None,
         }
@@ -919,5 +954,82 @@ mod tests {
             &SqlValue::Integer(85),
         );
         assert_eq!(result, Some(true), "Real(678.28) > Integer(85) should be true");
+    }
+
+    #[test]
+    fn test_compare_range_blob_vs_blob() {
+        // BLOB vs BLOB - bytewise comparison (SQLite memcmp semantics)
+        // Verified: SELECT x'616263' >= x'6162' → 1
+        let abc = SqlValue::Blob(vec![0x61, 0x62, 0x63]);
+        let ab = SqlValue::Blob(vec![0x61, 0x62]);
+        assert_eq!(
+            CompiledPredicate::compare_range(&abc, RangeOp::GreaterThanOrEqual, &ab),
+            Some(true)
+        );
+        assert_eq!(
+            CompiledPredicate::compare_range(&ab, RangeOp::LessThan, &abc),
+            Some(true)
+        );
+        assert_eq!(
+            CompiledPredicate::compare_range(&abc, RangeOp::LessThan, &ab),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn test_compare_range_blob_vs_text() {
+        // SQLite type ordering: TEXT < BLOB
+        // Verified: SELECT 'abc' >= x'6162' → 0; SELECT x'616263' >= 'abc' → 1
+        let blob = SqlValue::Blob(vec![0x61, 0x62]);
+        let text = SqlValue::Varchar(arcstr::ArcStr::from("abc"));
+
+        // BLOB > TEXT
+        assert_eq!(
+            CompiledPredicate::compare_range(&blob, RangeOp::GreaterThan, &text),
+            Some(true)
+        );
+        assert_eq!(
+            CompiledPredicate::compare_range(&blob, RangeOp::GreaterThanOrEqual, &text),
+            Some(true)
+        );
+        assert_eq!(
+            CompiledPredicate::compare_range(&blob, RangeOp::LessThan, &text),
+            Some(false)
+        );
+        // TEXT < BLOB
+        assert_eq!(
+            CompiledPredicate::compare_range(&text, RangeOp::LessThan, &blob),
+            Some(true)
+        );
+        assert_eq!(
+            CompiledPredicate::compare_range(&text, RangeOp::GreaterThanOrEqual, &blob),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn test_compare_range_blob_vs_numeric() {
+        // SQLite type ordering: Numeric < BLOB (no coercion across storage classes)
+        let blob = SqlValue::Blob(vec![0x00]);
+        // BLOB > Integer
+        assert_eq!(
+            CompiledPredicate::compare_range(&blob, RangeOp::GreaterThan, &SqlValue::Integer(99)),
+            Some(true)
+        );
+        // Integer < BLOB
+        assert_eq!(
+            CompiledPredicate::compare_range(&SqlValue::Integer(99), RangeOp::LessThan, &blob),
+            Some(true)
+        );
+        // Real < BLOB
+        assert_eq!(
+            CompiledPredicate::compare_range(&SqlValue::Real(0.5), RangeOp::LessThanOrEqual, &blob),
+            Some(true)
+        );
+        // BLOB not less than Numeric
+        assert_eq!(
+            CompiledPredicate::compare_range(&blob, RangeOp::LessThan, &SqlValue::Real(0.5)),
+            Some(false)
+        );
     }
 }

--- a/crates/vibesql-executor/src/evaluator/expressions/operators.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/operators.rs
@@ -47,6 +47,10 @@ pub(crate) fn eval_unary_op(
         (Plus, SqlValue::Character(s)) => Ok(SqlValue::Character(s.clone())),
         (Plus, SqlValue::Varchar(s)) => Ok(SqlValue::Varchar(s.clone())),
 
+        // Unary plus on BLOB - identity operation (SQLite behavior)
+        // SQLite: SELECT typeof(+x'616263') → 'blob'; SELECT quote(+x'616263') → X'616263'
+        (Plus, SqlValue::Blob(b)) => Ok(SqlValue::Blob(b.clone())),
+
         // Unary minus on text types - convert to number first (SQLite behavior)
         // SQLite converts strings to numbers before applying unary minus:
         // - Numeric strings: '-123' → Integer(-123), '-3.14' → Real(-3.14)
@@ -59,6 +63,10 @@ pub(crate) fn eval_unary_op(
                 Ok(SqlValue::Integer(-int_val))
             }
         }
+
+        // Unary minus on BLOB - SQLite coerces non-numeric BLOB to 0 then negates → Integer(0)
+        // SQLite: SELECT typeof(-x'616263') → 'integer'; SELECT -x'616263' → 0
+        (Minus, SqlValue::Blob(_)) => Ok(SqlValue::Integer(0)),
 
         // Unary NOT - logical negation
         // Per SQL standard three-valued logic:
@@ -324,6 +332,36 @@ mod tests {
             eval_unary_op(&UnaryOperator::Minus, &SqlValue::Character(arcstr::ArcStr::from("42")))
                 .unwrap(),
             SqlValue::Integer(-42)
+        );
+    }
+
+    #[test]
+    fn test_unary_plus_on_blob() {
+        // SQLite behavior: unary + on BLOB returns the BLOB unchanged (identity)
+        // Verified: SELECT typeof(+x'616263') → 'blob'; SELECT quote(+x'616263') → X'616263'
+        let bytes = vec![0x61u8, 0x62, 0x63];
+        assert_eq!(
+            eval_unary_op(&UnaryOperator::Plus, &SqlValue::Blob(bytes.clone())).unwrap(),
+            SqlValue::Blob(bytes)
+        );
+        // Empty BLOB is preserved
+        assert_eq!(
+            eval_unary_op(&UnaryOperator::Plus, &SqlValue::Blob(vec![])).unwrap(),
+            SqlValue::Blob(vec![])
+        );
+    }
+
+    #[test]
+    fn test_unary_minus_on_blob() {
+        // SQLite behavior: unary - on a non-numeric BLOB coerces to 0 then negates → Integer(0)
+        // Verified: SELECT typeof(-x'616263') → 'integer'; SELECT -x'616263' → 0
+        assert_eq!(
+            eval_unary_op(&UnaryOperator::Minus, &SqlValue::Blob(vec![0x61, 0x62, 0x63])).unwrap(),
+            SqlValue::Integer(0)
+        );
+        assert_eq!(
+            eval_unary_op(&UnaryOperator::Minus, &SqlValue::Blob(vec![])).unwrap(),
+            SqlValue::Integer(0)
         );
     }
 }

--- a/crates/vibesql-executor/src/evaluator/operators/comparison/equality.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/comparison/equality.rs
@@ -234,4 +234,42 @@ mod tests {
             SqlValue::Boolean(false)
         );
     }
+
+    #[test]
+    fn test_blob_vs_text_type_ordering() {
+        // SQLite type ordering: TEXT < BLOB
+        // 'abc' < x'6162' (TEXT is less than any BLOB)
+        // Equality across storage classes is always false.
+        // Verified: SELECT 'abc' = x'616263' → 0
+        let text = SqlValue::Varchar(arcstr::ArcStr::from("abc"));
+        let blob = SqlValue::Blob(vec![0x61, 0x62, 0x63]);
+        assert_eq!(equal(&text, &blob).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(equal(&blob, &text).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(not_equal(&text, &blob).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(not_equal(&blob, &text).unwrap(), SqlValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_blob_vs_numeric_type_ordering() {
+        // SQLite type ordering: INTEGER/REAL < BLOB
+        // Numeric storage class is never equal to BLOB storage class.
+        let blob = SqlValue::Blob(vec![0x01]);
+        assert_eq!(equal(&SqlValue::Integer(1), &blob).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(equal(&blob, &SqlValue::Integer(1)).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(equal(&SqlValue::Real(1.0), &blob).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(equal(&blob, &SqlValue::Real(1.0)).unwrap(), SqlValue::Boolean(false));
+    }
+
+    #[test]
+    fn test_blob_vs_blob_bytewise() {
+        // BLOB vs BLOB: SQLite uses memcmp/bytewise comparison
+        // Verified: SELECT x'616263' = x'616263' → 1
+        let a = SqlValue::Blob(vec![0x61, 0x62, 0x63]);
+        let b = SqlValue::Blob(vec![0x61, 0x62, 0x63]);
+        assert_eq!(equal(&a, &b).unwrap(), SqlValue::Boolean(true));
+
+        let c = SqlValue::Blob(vec![0x61, 0x62]);
+        assert_eq!(equal(&a, &c).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(not_equal(&a, &c).unwrap(), SqlValue::Boolean(true));
+    }
 }

--- a/crates/vibesql-executor/src/evaluator/operators/comparison/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/comparison/mod.rs
@@ -220,6 +220,7 @@ where
             Integer(_) | Smallint(_) | Bigint(_) | Float(_) | Real(_) | Double(_) | Numeric(_)
         )
     };
+    let is_blob = |v: &SqlValue| matches!(v, Blob(_));
 
     // SQLite type ordering: INTEGER/REAL < TEXT
     // No coercion - different storage classes are NOT equal
@@ -233,7 +234,30 @@ where
         return Ok(Boolean(predicate(std::cmp::Ordering::Greater)));
     }
 
+    // SQLite type ordering: NULL < INTEGER/REAL < TEXT < BLOB
+    // BLOB is greater than any non-BLOB storage class.
+    // Verified: SELECT 'abc' >= x'6162' → 0, SELECT x'616263' >= 'abc' → 1
+    if is_string(left) && is_blob(right) {
+        // TEXT < BLOB
+        return Ok(Boolean(predicate(std::cmp::Ordering::Less)));
+    }
+    if is_blob(left) && is_string(right) {
+        // BLOB > TEXT
+        return Ok(Boolean(predicate(std::cmp::Ordering::Greater)));
+    }
+    if is_numeric(left) && is_blob(right) {
+        // Numeric < BLOB
+        return Ok(Boolean(predicate(std::cmp::Ordering::Less)));
+    }
+    if is_blob(left) && is_numeric(right) {
+        // BLOB > Numeric
+        return Ok(Boolean(predicate(std::cmp::Ordering::Greater)));
+    }
+
     match (left, right) {
+        // BLOB vs BLOB - bytewise comparison (SQLite memcmp behavior)
+        (Blob(a), Blob(b)) => Ok(Boolean(predicate(a.cmp(b)))),
+
         // Integer comparisons
         (Integer(a), Integer(b)) => Ok(Boolean(predicate(a.cmp(b)))),
 

--- a/crates/vibesql-executor/src/evaluator/operators/comparison/ordering.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/comparison/ordering.rs
@@ -285,4 +285,56 @@ mod tests {
             SqlValue::Boolean(true)
         );
     }
+
+    #[test]
+    fn test_text_vs_blob_ordering() {
+        // SQLite type ordering: TEXT < BLOB
+        // Verified: SELECT 'abc' >= x'6162' → 0; SELECT x'616263' >= 'abc' → 1
+        let text = SqlValue::Varchar(arcstr::ArcStr::from("abc"));
+        let blob = SqlValue::Blob(vec![0x61, 0x62]);
+
+        // 'abc' < x'6162' → true (TEXT < BLOB)
+        assert_eq!(less_than(&text, &blob).unwrap(), SqlValue::Boolean(true));
+        // 'abc' >= x'6162' → false
+        assert_eq!(greater_than_or_equal(&text, &blob).unwrap(), SqlValue::Boolean(false));
+        // x'6162' > 'abc' → true (BLOB > TEXT)
+        assert_eq!(greater_than(&blob, &text).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(greater_than_or_equal(&blob, &text).unwrap(), SqlValue::Boolean(true));
+        // Character (CHAR) behaves like Varchar (TEXT storage class)
+        let chr = SqlValue::Character(arcstr::ArcStr::from("abc"));
+        assert_eq!(less_than(&chr, &blob).unwrap(), SqlValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_numeric_vs_blob_ordering() {
+        // SQLite type ordering: INTEGER/REAL < BLOB
+        let blob = SqlValue::Blob(vec![0x00]);
+        assert_eq!(less_than(&SqlValue::Integer(99), &blob).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(greater_than(&blob, &SqlValue::Integer(99)).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(less_than(&SqlValue::Real(0.5), &blob).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(greater_than(&blob, &SqlValue::Real(0.5)).unwrap(), SqlValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_blob_vs_blob_ordering_bytewise() {
+        // BLOB vs BLOB: SQLite uses memcmp (bytewise lex order)
+        // Verified: SELECT x'616263' >= x'6162' → 1 (longer prefix-equal blob is greater)
+        let abc = SqlValue::Blob(vec![0x61, 0x62, 0x63]);
+        let ab = SqlValue::Blob(vec![0x61, 0x62]);
+        assert_eq!(greater_than(&abc, &ab).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(greater_than_or_equal(&abc, &ab).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(less_than(&ab, &abc).unwrap(), SqlValue::Boolean(true));
+
+        // Differing byte: 0x61 < 0x62
+        let a = SqlValue::Blob(vec![0x61]);
+        let b = SqlValue::Blob(vec![0x62]);
+        assert_eq!(less_than(&a, &b).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(greater_than(&b, &a).unwrap(), SqlValue::Boolean(true));
+
+        // Equal blobs
+        let equal_a = SqlValue::Blob(vec![0x01, 0x02]);
+        let equal_b = SqlValue::Blob(vec![0x01, 0x02]);
+        assert_eq!(greater_than_or_equal(&equal_a, &equal_b).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(less_than_or_equal(&equal_a, &equal_b).unwrap(), SqlValue::Boolean(true));
+    }
 }


### PR DESCRIPTION
## Summary

The 10 `like3.test` failures attributed to LIKE/GLOB-on-BLOB are actually two adjacent operator gaps exercised by the test setup. LIKE/GLOB themselves already coerce BLOB→string correctly (since #4913).

- **Bucket A (8 tests)** — Unary `+` on BLOB raised `TypeMismatch`. SQLite treats unary `+` on BLOB as identity (`typeof(+x'616263') → 'blob'`). Added `Plus/Blob` and `Minus/Blob` arms in `eval_unary_op`. Minus on a non-numeric BLOB coerces to `Integer(0)` to match `SELECT -x'616263' → 0`.
- **Bucket B (2 tests)** — `Varchar >= Blob` and `Blob >= Blob` raised `TypeMismatch`. Extended the type-ordering block in `compare()` per SQLite's `NULL < INTEGER/REAL < TEXT < BLOB`, plus a Blob-vs-Blob bytewise arm. Mirrored the same arms in `CompiledPredicate::compare_range` so the fast-path filter (used by index scans on these queries) doesn't fall to `None` and silently drop rows.

## Changes

- `crates/vibesql-executor/src/evaluator/expressions/operators.rs` — `Plus/Blob` (identity) and `Minus/Blob` (Integer(0)) arms + tests.
- `crates/vibesql-executor/src/evaluator/operators/comparison/mod.rs` — TEXT-vs-BLOB / Numeric-vs-BLOB type-ordering arms and Blob-vs-Blob bytewise arm.
- `crates/vibesql-executor/src/evaluator/operators/comparison/equality.rs` — unit tests for new equality cases (cross-class != BLOB, Blob-vs-Blob bytewise eq).
- `crates/vibesql-executor/src/evaluator/operators/comparison/ordering.rs` — unit tests for new ordering cases.
- `crates/vibesql-executor/src/evaluator/compiled.rs` — same BLOB arms in the compiled fast-path `compare_range` (`values_equal` already falls back to PartialEq, which handles Blob-vs-Blob).

Total: 264 insertions across 5 files (about 65 lines of source, the rest unit tests).

## Test Plan

- [x] All 10 originally listed `like3` tests pass: `1.2, 2.1, 2.2, 2.3, 2.4, 2.5, 3.1ck, 3.2ck, 4.1ck, 4.2ck`.
- [x] The 5 `like3-5.x` EQP-pattern-mismatch failures are unchanged (out of scope, separate bucket).
- [x] All 2330 `vibesql-executor` unit tests pass.
- [x] New unit tests added for unary +/- on BLOB, TEXT-vs-BLOB / Numeric-vs-BLOB ordering and equality, Blob-vs-Blob bytewise comparison, and `compare_range` fast-path BLOB cases.

Closes #5070