### PR TITLE
fix(validation): emit misuse-of-aggregate / row-value-misused for bare scalar subqueries

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -87,6 +87,10 @@ pub enum ExecutorError {
     MisuseOfAliasedWindowFunction {
         alias_name: String,
     },
+    /// Row value used in scalar context (SQLite-compatible error)
+    /// e.g., HAVING (SELECT (a, b)) — a row value where a scalar is expected
+    /// Format: "row value misused"
+    RowValueMisused,
     UnsupportedExpression(String),
     UnsupportedFeature(String),
     /// SQLite-compatible error message (output as-is without prefix)
@@ -615,6 +619,10 @@ impl std::fmt::Display for ExecutorError {
             ExecutorError::MisuseOfAliasedWindowFunction { alias_name } => {
                 // SQLite-compatible error message format
                 write!(f, "misuse of aliased window function {}", alias_name)
+            }
+            ExecutorError::RowValueMisused => {
+                // SQLite-compatible error message format
+                write!(f, "row value misused")
             }
             ExecutorError::UnsupportedExpression(msg) => {
                 write!(

--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -153,6 +153,11 @@ impl SelectExecutor<'_> {
                     function_name: window_name,
                 });
             }
+
+            // Check for aggregates/windows inside bare scalar subqueries
+            // in HAVING (e.g. `HAVING (SELECT (a, b))` triggers row-value-misused;
+            // `HAVING (SELECT sum(x))` triggers misuse of aggregate). #5069
+            crate::select::executor::validation::validate_subquery_context_misuse(having_expr)?;
         }
 
         // Validate ORDER BY for misuse of aliased window functions (#5036)

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -66,6 +66,26 @@ impl SelectExecutor<'_> {
         // SELECT (SELECT count(x) FROM t35b) FROM t35a; is valid in SQLite.
         super::validation::validate_aggregate_subquery_outer_refs(stmt, self.database)?;
 
+        // Validate bare scalar subqueries in the SELECT list / ORDER BY for
+        // misuse of aggregate / window / row-value (#5069). A "bare" scalar
+        // subquery (no FROM) re-borrows the outer aggregation context, so any
+        // aggregate inside it is a misuse of the outer scope.
+        // Examples:
+        //   SELECT ntile((SELECT sum(x))) OVER (ORDER BY x) FROM t1;
+        //     → "misuse of aggregate: sum()"
+        //   ... ORDER BY (SELECT (a, b))
+        //     → "row value misused"
+        for item in &stmt.select_list {
+            if let vibesql_ast::SelectItem::Expression { expr, .. } = item {
+                super::validation::validate_subquery_context_misuse(expr)?;
+            }
+        }
+        if let Some(order_by) = stmt.order_by.as_deref() {
+            for item in order_by {
+                super::validation::validate_subquery_context_misuse(&item.expr)?;
+            }
+        }
+
         #[cfg(feature = "profile-q6")]
         let execute_start = std::time::Instant::now();
 

--- a/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
@@ -1093,6 +1093,356 @@ fn find_aliased_window_misuse_in_order_by(
     }
 }
 
+/// Check if an expression contains any column reference (recursively).
+///
+/// Used by `validate_subquery_context_misuse` to determine whether an
+/// aggregate inside a bare (FROM-less) scalar subquery references columns
+/// from the outer scope — those references are what make the aggregate a
+/// "misuse" of the outer aggregation context.
+fn expression_contains_column_ref(expr: &Expression) -> bool {
+    match expr {
+        Expression::ColumnRef(_) => true,
+        Expression::BinaryOp { left, right, .. } => {
+            expression_contains_column_ref(left) || expression_contains_column_ref(right)
+        }
+        Expression::UnaryOp { expr, .. } => expression_contains_column_ref(expr),
+        Expression::IsNull { expr, .. } => expression_contains_column_ref(expr),
+        Expression::IsDistinctFrom { left, right, .. } => {
+            expression_contains_column_ref(left) || expression_contains_column_ref(right)
+        }
+        Expression::IsTruthValue { expr, .. } => expression_contains_column_ref(expr),
+        Expression::Cast { expr, .. } => expression_contains_column_ref(expr),
+        Expression::Function { args, .. }
+        | Expression::AggregateFunction { args, .. } => {
+            args.iter().any(expression_contains_column_ref)
+        }
+        Expression::Like { expr, pattern, .. } => {
+            expression_contains_column_ref(expr) || expression_contains_column_ref(pattern)
+        }
+        Expression::Between { expr, low, high, .. } => {
+            expression_contains_column_ref(expr)
+                || expression_contains_column_ref(low)
+                || expression_contains_column_ref(high)
+        }
+        Expression::InList { expr, values, .. } => {
+            expression_contains_column_ref(expr) || values.iter().any(expression_contains_column_ref)
+        }
+        Expression::In { expr, .. } => expression_contains_column_ref(expr),
+        Expression::Case { operand, when_clauses, else_result } => {
+            operand.as_ref().is_some_and(|e| expression_contains_column_ref(e))
+                || when_clauses.iter().any(|w| {
+                    w.conditions.iter().any(expression_contains_column_ref)
+                        || expression_contains_column_ref(&w.result)
+                })
+                || else_result.as_ref().is_some_and(|e| expression_contains_column_ref(e))
+        }
+        Expression::Conjunction(children) | Expression::Disjunction(children) => {
+            children.iter().any(expression_contains_column_ref)
+        }
+        Expression::RowValueConstructor(children) => {
+            children.iter().any(expression_contains_column_ref)
+        }
+        Expression::Position { substring, string, .. } => {
+            expression_contains_column_ref(substring) || expression_contains_column_ref(string)
+        }
+        Expression::Trim { removal_char, string, .. } => {
+            removal_char.as_ref().is_some_and(|e| expression_contains_column_ref(e))
+                || expression_contains_column_ref(string)
+        }
+        Expression::Extract { expr, .. } => expression_contains_column_ref(expr),
+        Expression::Interval { value, .. } => expression_contains_column_ref(value),
+        Expression::QuantifiedComparison { expr, .. } => expression_contains_column_ref(expr),
+        // Subqueries have their own scope — don't recurse
+        Expression::ScalarSubquery(_) | Expression::Exists { .. } => false,
+        // Window function: only check args, not the OVER clause
+        Expression::WindowFunction { function, .. } => {
+            let args = match function {
+                vibesql_ast::WindowFunctionSpec::Aggregate { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args,
+            };
+            args.iter().any(expression_contains_column_ref)
+        }
+        _ => false,
+    }
+}
+
+/// Find the first aggregate function whose args/order_by/filter reference a
+/// column. Returns the function name if found, None otherwise.
+///
+/// This is used inside bare (FROM-less) scalar subqueries: any column there
+/// is necessarily an outer reference, so an aggregate referencing one is a
+/// misuse of the outer aggregation context.
+fn find_outer_referencing_aggregate(expr: &Expression) -> Option<String> {
+    match expr {
+        Expression::AggregateFunction { name, args, order_by, filter, .. } => {
+            let arg_refs = args.iter().any(expression_contains_column_ref);
+            let order_refs = order_by.as_ref().is_some_and(|items| {
+                items.iter().any(|item| expression_contains_column_ref(&item.expr))
+            });
+            let filter_refs =
+                filter.as_ref().is_some_and(|f| expression_contains_column_ref(f));
+            if arg_refs || order_refs || filter_refs {
+                return Some(name.to_string());
+            }
+            // Recurse into args in case there's a deeper aggregate
+            for arg in args {
+                if let Some(found) = find_outer_referencing_aggregate(arg) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Expression::Function { name, args, .. } => {
+            if is_aggregate_function(name.as_str()) {
+                let upper = name.to_uppercase();
+                let is_scalar_minmax =
+                    matches!(upper.as_str(), "MIN" | "MAX") && args.len() > 1;
+                if !is_scalar_minmax {
+                    let arg_refs = args.iter().any(expression_contains_column_ref);
+                    if arg_refs {
+                        return Some(name.to_string());
+                    }
+                }
+            }
+            for arg in args {
+                if let Some(found) = find_outer_referencing_aggregate(arg) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Expression::BinaryOp { left, right, .. } => find_outer_referencing_aggregate(left)
+            .or_else(|| find_outer_referencing_aggregate(right)),
+        Expression::UnaryOp { expr, .. } => find_outer_referencing_aggregate(expr),
+        Expression::Cast { expr, .. } => find_outer_referencing_aggregate(expr),
+        Expression::IsNull { expr, .. } => find_outer_referencing_aggregate(expr),
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                if let Some(found) = find_outer_referencing_aggregate(op) {
+                    return Some(found);
+                }
+            }
+            for w in when_clauses {
+                for cond in &w.conditions {
+                    if let Some(found) = find_outer_referencing_aggregate(cond) {
+                        return Some(found);
+                    }
+                }
+                if let Some(found) = find_outer_referencing_aggregate(&w.result) {
+                    return Some(found);
+                }
+            }
+            if let Some(else_expr) = else_result {
+                find_outer_referencing_aggregate(else_expr)
+            } else {
+                None
+            }
+        }
+        Expression::Conjunction(children) | Expression::Disjunction(children) => {
+            for c in children {
+                if let Some(found) = find_outer_referencing_aggregate(c) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Expression::Between { expr, low, high, .. } => find_outer_referencing_aggregate(expr)
+            .or_else(|| find_outer_referencing_aggregate(low))
+            .or_else(|| find_outer_referencing_aggregate(high)),
+        Expression::InList { expr, values, .. } => {
+            if let Some(found) = find_outer_referencing_aggregate(expr) {
+                return Some(found);
+            }
+            for v in values {
+                if let Some(found) = find_outer_referencing_aggregate(v) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Expression::In { expr, .. } => find_outer_referencing_aggregate(expr),
+        Expression::Like { expr, pattern, .. } => find_outer_referencing_aggregate(expr)
+            .or_else(|| find_outer_referencing_aggregate(pattern)),
+        // Don't recurse into nested scalar subqueries here — those are validated
+        // by separate calls to validate_subquery_context_misuse.
+        Expression::ScalarSubquery(_) | Expression::Exists { .. } => None,
+        _ => None,
+    }
+}
+
+/// Detect aggregate / row-value misuse inside *bare* scalar subqueries.
+///
+/// SQLite has a special rule: when a scalar subquery has no FROM clause and
+/// its body contains an aggregate function whose argument or FILTER references
+/// an *outer* column, the aggregate implicitly borrows the outer aggregation
+/// context. SQLite reports this as `"misuse of aggregate: X()"`.
+///
+/// Examples that trigger this rule:
+/// - `WHERE (SELECT AVG(0) FILTER(WHERE outer.c))`  → "misuse of aggregate: AVG()"
+/// - `ntile((SELECT sum(x))) OVER (...)`             → "misuse of aggregate: sum()"
+///
+/// Additionally, when a bare scalar subquery's sole projection is a
+/// `RowValueConstructor` with multiple elements, that's `RowValueMisused`
+/// (a row value where a scalar is required).
+///
+/// Note: pure *window* functions inside bare scalar subqueries are NOT flagged
+/// here — SQLite allows them (they are evaluated row-by-row against the outer
+/// scope). Misuse for window functions is detected through other paths
+/// (WHERE-clause walker, GROUP BY positional refs, etc.).
+///
+/// This walker is meant to be called on expressions appearing in the outer
+/// scope — typically WHERE, HAVING, ORDER BY, or arguments to outer functions.
+/// It deliberately does NOT recurse into scalar subqueries that have a FROM
+/// clause (those have their own aggregation context and are validated
+/// independently).
+///
+/// To preserve SQLite's exact error text (which uses the function name as
+/// originally written by the user), we walk the inner expression and report
+/// the first such aggregate's name.
+pub fn validate_subquery_context_misuse(expr: &Expression) -> Result<(), ExecutorError> {
+    match expr {
+        Expression::ScalarSubquery(stmt) => {
+            // Only "bare" subqueries (no FROM) re-borrow the outer context.
+            if stmt.from.is_none() {
+                // Check for row value misuse (sole projection is a row value
+                // constructor with multiple elements).
+                if stmt.select_list.len() == 1 {
+                    if let SelectItem::Expression {
+                        expr: Expression::RowValueConstructor(items),
+                        ..
+                    } = &stmt.select_list[0]
+                    {
+                        if items.len() > 1 {
+                            return Err(ExecutorError::RowValueMisused);
+                        }
+                    }
+                }
+
+                // Check each projection for an aggregate function. We only
+                // flag aggregates whose body references something outside the
+                // bare subquery's own scope (i.e., references a column — the
+                // bare subquery has no tables, so any column is an outer ref).
+                for item in &stmt.select_list {
+                    if let SelectItem::Expression { expr: inner, .. } = item {
+                        if let Some(name) = find_outer_referencing_aggregate(inner) {
+                            return Err(ExecutorError::MisuseOfAggregateContext {
+                                function_name: name,
+                            });
+                        }
+                    }
+                }
+
+                // Recurse into nested expressions inside the bare subquery's
+                // SELECT list as well — e.g. (SELECT (SELECT sum(x)))
+                for item in &stmt.select_list {
+                    if let SelectItem::Expression { expr: inner, .. } = item {
+                        validate_subquery_context_misuse(inner)?;
+                    }
+                }
+            }
+            Ok(())
+        }
+        // For non-subquery expressions, recurse into their children. We do
+        // NOT recurse into AggregateFunction / WindowFunction children here —
+        // those are checked by their own dedicated validators which understand
+        // the surrounding context (FILTER, ORDER BY, etc.).
+        Expression::BinaryOp { left, right, .. } => {
+            validate_subquery_context_misuse(left)?;
+            validate_subquery_context_misuse(right)
+        }
+        Expression::UnaryOp { expr, .. } => validate_subquery_context_misuse(expr),
+        Expression::IsNull { expr, .. } => validate_subquery_context_misuse(expr),
+        Expression::IsDistinctFrom { left, right, .. } => {
+            validate_subquery_context_misuse(left)?;
+            validate_subquery_context_misuse(right)
+        }
+        Expression::IsTruthValue { expr, .. } => validate_subquery_context_misuse(expr),
+        Expression::Cast { expr, .. } => validate_subquery_context_misuse(expr),
+        Expression::Like { expr, pattern, .. } => {
+            validate_subquery_context_misuse(expr)?;
+            validate_subquery_context_misuse(pattern)
+        }
+        Expression::Between { expr, low, high, .. } => {
+            validate_subquery_context_misuse(expr)?;
+            validate_subquery_context_misuse(low)?;
+            validate_subquery_context_misuse(high)
+        }
+        Expression::InList { expr, values, .. } => {
+            validate_subquery_context_misuse(expr)?;
+            for v in values {
+                validate_subquery_context_misuse(v)?;
+            }
+            Ok(())
+        }
+        Expression::In { expr, .. } => validate_subquery_context_misuse(expr),
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                validate_subquery_context_misuse(op)?;
+            }
+            for w in when_clauses {
+                for cond in &w.conditions {
+                    validate_subquery_context_misuse(cond)?;
+                }
+                validate_subquery_context_misuse(&w.result)?;
+            }
+            if let Some(else_expr) = else_result {
+                validate_subquery_context_misuse(else_expr)?;
+            }
+            Ok(())
+        }
+        Expression::Function { args, .. } => {
+            for arg in args {
+                validate_subquery_context_misuse(arg)?;
+            }
+            Ok(())
+        }
+        Expression::AggregateFunction { args, filter, order_by, .. } => {
+            for arg in args {
+                validate_subquery_context_misuse(arg)?;
+            }
+            if let Some(f) = filter {
+                validate_subquery_context_misuse(f)?;
+            }
+            if let Some(items) = order_by {
+                for item in items {
+                    validate_subquery_context_misuse(&item.expr)?;
+                }
+            }
+            Ok(())
+        }
+        Expression::WindowFunction { function, .. } => {
+            // Only recurse into the function's arguments — the OVER clause has
+            // its own context and may legally contain aggregates / nested
+            // subqueries (window functions are evaluated AFTER aggregation).
+            let args = match function {
+                vibesql_ast::WindowFunctionSpec::Aggregate { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args,
+            };
+            for a in args {
+                validate_subquery_context_misuse(a)?;
+            }
+            Ok(())
+        }
+        Expression::QuantifiedComparison { expr, .. } => validate_subquery_context_misuse(expr),
+        Expression::Conjunction(children) | Expression::Disjunction(children) => {
+            for child in children {
+                validate_subquery_context_misuse(child)?;
+            }
+            Ok(())
+        }
+        Expression::RowValueConstructor(children) => {
+            for child in children {
+                validate_subquery_context_misuse(child)?;
+            }
+            Ok(())
+        }
+        // Leaf expressions and EXISTS (which has its own scope) — nothing to check
+        _ => Ok(()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use vibesql_ast::{BinaryOperator, ColumnIdentifier, FunctionIdentifier, UnaryOperator};
@@ -1471,5 +1821,150 @@ mod tests {
         assert!(aliases.contains("m")); // min(f1) AS m is an aggregate alias
         assert!(!aliases.contains("col2")); // f2 AS col2 is NOT an aggregate alias
         assert!(aliases.contains("m2")); // coalesce(min(f1)+5, 11) contains an aggregate
+    }
+
+    // Helper to build a bare scalar subquery with a given SELECT list.
+    fn make_bare_subquery(select_list: Vec<SelectItem>) -> Expression {
+        Expression::ScalarSubquery(Box::new(vibesql_ast::SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list,
+            into_table: None,
+            into_variables: None,
+            from: None,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            window_definitions: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        }))
+    }
+
+    #[test]
+    fn test_subquery_misuse_aggregate_with_outer_filter_ref() {
+        // (SELECT AVG(0) FILTER(WHERE outer_col)) — bare subquery, FILTER ref outer col
+        // Expected: misuse of aggregate: AVG()
+        let inner_agg = Expression::AggregateFunction {
+            name: FunctionIdentifier::new("AVG"),
+            distinct: false,
+            args: vec![Expression::Literal(SqlValue::Integer(0))],
+            order_by: None,
+            filter: Some(Box::new(Expression::ColumnRef(ColumnIdentifier::simple(
+                "outer_col", false,
+            )))),
+        };
+        let subquery = make_bare_subquery(vec![SelectItem::Expression {
+            expr: inner_agg,
+            alias: None,
+            source_text: None,
+        }]);
+
+        let result = validate_subquery_context_misuse(&subquery);
+        match result {
+            Err(ExecutorError::MisuseOfAggregateContext { function_name }) => {
+                assert_eq!(function_name, "AVG");
+            }
+            other => panic!("expected MisuseOfAggregateContext(AVG), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_subquery_misuse_aggregate_with_outer_arg_ref() {
+        // (SELECT sum(x)) — bare subquery, sum's arg is an outer column ref
+        // Expected: misuse of aggregate: sum()
+        let inner_agg = Expression::AggregateFunction {
+            name: FunctionIdentifier::new("sum"),
+            distinct: false,
+            args: vec![Expression::ColumnRef(ColumnIdentifier::simple("x", false))],
+            order_by: None,
+            filter: None,
+        };
+        let subquery = make_bare_subquery(vec![SelectItem::Expression {
+            expr: inner_agg,
+            alias: None,
+            source_text: None,
+        }]);
+
+        let result = validate_subquery_context_misuse(&subquery);
+        match result {
+            Err(ExecutorError::MisuseOfAggregateContext { function_name }) => {
+                assert_eq!(function_name, "sum");
+            }
+            other => panic!("expected MisuseOfAggregateContext(sum), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_subquery_misuse_aggregate_with_constant_args_does_not_fire() {
+        // (SELECT sum(0)) — bare subquery whose aggregate has no column refs.
+        // Should NOT error (no outer reference).
+        let inner_agg = Expression::AggregateFunction {
+            name: FunctionIdentifier::new("sum"),
+            distinct: false,
+            args: vec![Expression::Literal(SqlValue::Integer(0))],
+            order_by: None,
+            filter: None,
+        };
+        let subquery = make_bare_subquery(vec![SelectItem::Expression {
+            expr: inner_agg,
+            alias: None,
+            source_text: None,
+        }]);
+
+        let result = validate_subquery_context_misuse(&subquery);
+        assert!(result.is_ok(), "constant aggregate in bare subquery should be OK");
+    }
+
+    #[test]
+    fn test_subquery_row_value_misused() {
+        // (SELECT (a, b)) — bare subquery returning a row value where a scalar
+        // is expected. Expected: row value misused.
+        let row_value = Expression::RowValueConstructor(vec![
+            Expression::ColumnRef(ColumnIdentifier::simple("a", false)),
+            Expression::ColumnRef(ColumnIdentifier::simple("b", false)),
+        ]);
+        let subquery = make_bare_subquery(vec![SelectItem::Expression {
+            expr: row_value,
+            alias: None,
+            source_text: None,
+        }]);
+
+        let result = validate_subquery_context_misuse(&subquery);
+        assert!(matches!(result, Err(ExecutorError::RowValueMisused)));
+    }
+
+    #[test]
+    fn test_subquery_window_function_does_not_fire() {
+        // (SELECT count(a) OVER ()) — bare subquery with a window function
+        // referencing outer column. SQLite allows this; we should NOT flag it.
+        let inner_window = Expression::WindowFunction {
+            function: vibesql_ast::WindowFunctionSpec::Aggregate {
+                name: FunctionIdentifier::new("count"),
+                args: vec![Expression::ColumnRef(ColumnIdentifier::simple("a", false))],
+                filter: None,
+            },
+            over: vibesql_ast::WindowSpec {
+                base_window_name: None,
+                partition_by: None,
+                order_by: None,
+                frame: None,
+            },
+        };
+        let subquery = make_bare_subquery(vec![SelectItem::Expression {
+            expr: inner_window,
+            alias: None,
+            source_text: None,
+        }]);
+
+        let result = validate_subquery_context_misuse(&subquery);
+        assert!(
+            result.is_ok(),
+            "window function in bare subquery should not be flagged, got {:?}",
+            result
+        );
     }
 }

--- a/crates/vibesql-executor/src/select/executor/validation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/mod.rs
@@ -24,6 +24,7 @@ pub use aggregates::{
     check_aggregate_arg_count, find_aggregate_in_expression, find_window_function_in_expression,
     validate_aggregate_arguments, validate_having_aliased_aggregates,
     validate_no_nested_aggregates, validate_order_by_aliased_window_functions,
+    validate_subquery_context_misuse,
 };
 pub use column_refs::{extract_column_refs, validate_column_ref};
 pub use join_limits::validate_join_table_limit;
@@ -128,6 +129,12 @@ pub fn validate_select_columns_with_context(
         if let Some(window_name) = find_window_function_in_expression(where_expr) {
             return Err(ExecutorError::MisuseOfWindowFunction { function_name: window_name });
         }
+
+        // Check for aggregates/windows inside bare scalar subqueries in WHERE
+        // (e.g. `WHERE (SELECT AVG(0) FILTER(WHERE outer.c))`). The bare
+        // subquery has no FROM clause so its aggregate borrows the outer
+        // aggregation context, which SQLite reports as a misuse.
+        validate_subquery_context_misuse(where_expr)?;
     }
 
     // Validate SELECT list column references (only procedure variables allowed)

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -286,13 +286,15 @@ proc translate_error_to_sqlite {vibesql_error} {
     # VibeSQL now produces these exact formats, so pass through if already correct:
 
     # "misuse of aggregate: X()" - for execution context errors (ORDER BY, etc.)
+    # SQLite preserves the function-name case as written in the SQL, so pass through verbatim.
     if {[regexp -nocase {^misuse of aggregate:\s*([A-Za-z_]+)\(\)$} $error_msg -> func_name]} {
-        return "misuse of aggregate: [string tolower $func_name]()"
+        return "misuse of aggregate: ${func_name}()"
     }
 
     # "misuse of aggregate function X()" - for name resolution errors (nested aggregates, WHERE)
+    # SQLite preserves the function-name case as written in the SQL, so pass through verbatim.
     if {[regexp -nocase {^misuse of aggregate function\s*([A-Za-z_]+)\(\)$} $error_msg -> func_name]} {
-        return "misuse of aggregate function [string tolower $func_name]()"
+        return "misuse of aggregate function ${func_name}()"
     }
 
     # "misuse of aliased aggregate X" - for aliased aggregate misuse in HAVING


### PR DESCRIPTION
## Summary

Implements bucket 2 (aggregates in bare scalar subqueries) and bucket 3 (row-value misused) of #5069. SQLite emits \`misuse of aggregate: X()\` when a scalar subquery has no FROM clause and its body contains an aggregate that references outer-scope columns; and \`row value misused\` when such a bare subquery's sole projection is a multi-element row value. VibeSQL was previously silent on both forms.

The new walker \`validate_subquery_context_misuse\` is wired into the existing WHERE/HAVING/SELECT-list/ORDER BY validation paths. It deliberately:
- Ignores window functions in bare subqueries (SQLite allows them)
- Does not recurse into subqueries that have their own FROM clause (they have their own scope)
- Only flags aggregates whose args/order_by/filter contain a column reference, since the bare subquery has no tables of its own and any column ref is by definition outer

Also fixes \`scripts/tester_vibesql.tcl\` to preserve the original-case function name in \"misuse of aggregate\" error translations (was forcing lowercase), so tests like \`window1-38.10\` that expect \`AVG()\` (uppercase) match.

## Tests now passing in \`window1.test\` (224 → 228)

- 38.10 — \`WHERE (SELECT AVG(0) FILTER(WHERE t1.c1))\`
- 38.30 — same pattern with AVG(1)
- 51.1 — \`HAVING (SELECT (sum(...), sum(...)))\` → row value misused
- 59.1 — \`ntile((SELECT sum(x))) OVER (...)\`
- 75.1 — \`count((SELECT count(a0.a+a0.b) ORDER BY ...))\` (already worked at runtime; confirmed passing here)

## Tests deferred to sub-issues

- 11.1 — \`CREATE INDEX … WHERE\` parser support → #5091
- 7.1.5 — error ordering for column resolution in LIMIT → #5092
- 47.2 — positional GROUP BY referencing window function → #5093
- 61.4.3 — window-query ORDER BY rejecting non-window aggregates → #5094
- 65.4 — pre-existing false-positive (windows in OVER ORDER BY) → #5095

## Test plan

- [x] \`cargo test --release -p vibesql-executor\` — all unit tests pass, including 5 new ones for the validator
- [x] \`./scripts/tcltest run --pattern \"window1.test\"\` — 224 → 228 passing, 48 → 44 failing
- [x] No regressions in baseline-checked suites: select1 (1 pre-existing failure unchanged), filter1 (13 unchanged), aggorderby (5 unchanged)
- [x] Multi-suite spot check (where, orderby1, func, having, count) — totals match prior runs

Closes #5069