### PR TITLE
test(tcl): mark hiddencolumns capability as unsupported

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3910,7 +3910,7 @@ proc match_regex_pattern {result expected} {
 # Returns 1 if supported, 0 if not
 proc check_single_capability {cap} {
     # Capabilities we don't support (unsupported_caps means NOT supported)
-    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab fts3 fts4 fts5 datetime datetime_time datetime_funcs trigger conflict}
+    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab fts3 fts4 fts5 datetime datetime_time datetime_funcs trigger conflict hiddencolumns}
 
     # Handle negated capability (e.g., !autovacuum)
     set negate 0


### PR DESCRIPTION
## Summary

Append `hiddencolumns` to the `unsupported_caps` list in `scripts/tester_vibesql.tcl` so the TCL shim correctly reports it as unsupported. VibeSQL does not implement SQLite's hidden column suppression from `SELECT *`, so test files using `ifcapable hiddencolumns` should take the `-hc-disabled` branch.

## Changes

- `scripts/tester_vibesql.tcl:3913` — added `hiddencolumns` to `unsupported_caps`

## Test plan

- [x] `./scripts/tcltest run --pattern "triggerupfrom.test"` — `4.1-hc-enabled` no longer in failure list (now skipped, `4.1-hc-disabled` runs and passes)
- [x] Other failures in this file (1.1, 1.2, 1.3, 2.3, 4.3) are pre-existing and unrelated to this change

Closes #5083