### PR TITLE
fix(window): detect window-function misuse in positional GROUP BY

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         filter::apply_where_filter_combined_auto,
         grouping::{
             expand_group_by_clause, get_base_expressions, group_rows,
-            resolve_base_expressions_aliases, resolve_grouping_set_aliases,
+            resolve_base_expressions_aliases, resolve_group_by_alias, resolve_grouping_set_aliases,
             resolve_having_aliases_with_values, GroupingContext,
         },
         helpers::{apply_distinct, apply_limit_offset},
@@ -167,13 +167,32 @@ impl SelectExecutor<'_> {
             &stmt.select_list,
         )?;
 
-        // Validate GROUP BY clause for misuse of window functions (#4985)
-        // Window functions are not allowed in GROUP BY expressions
+        // Validate GROUP BY clause for misuse of window functions (#4985, #5093)
+        // Window functions are not allowed in GROUP BY expressions.
+        // For positional/alias GROUP BY references (e.g., `GROUP BY 1`), resolve against
+        // the SELECT list and re-check the resolved expression so positional references
+        // to window-function SELECT items also surface the misuse error.
         if let Some(ref group_by_clause) = stmt.group_by {
-            for group_expr in group_by_clause.all_expressions() {
+            for (term_index, group_expr) in group_by_clause.all_expressions().iter().enumerate() {
+                // 1. Direct check on the GROUP BY expression as written.
                 if let Some(window_name) =
                     crate::select::executor::validation::find_window_function_in_expression(
                         group_expr,
+                    )
+                {
+                    return Err(crate::errors::ExecutorError::MisuseOfWindowFunction {
+                        function_name: window_name,
+                    });
+                }
+
+                // 2. Resolve positional/alias references against SELECT list and re-check.
+                //    Catches `GROUP BY 1` referencing a window-function SELECT item, e.g.
+                //    `SELECT sum(a) OVER() FROM t1 GROUP BY 1` (window1.test 47.2).
+                let resolved =
+                    resolve_group_by_alias(group_expr, &stmt.select_list, term_index)?;
+                if let Some(window_name) =
+                    crate::select::executor::validation::find_window_function_in_expression(
+                        &resolved,
                     )
                 {
                     return Err(crate::errors::ExecutorError::MisuseOfWindowFunction {

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -86,6 +86,15 @@ impl SelectExecutor<'_> {
             }
         }
 
+        // Validate GROUP BY clauses across this statement and all nested
+        // subqueries for window-function misuse, including positional
+        // (`GROUP BY 1`) and alias references that resolve to a window
+        // function in the subquery's SELECT list (#5093, window1.test 47.2).
+        // SQLite raises this at prepare time, so we must walk subqueries
+        // here rather than relying on per-SELECT execution paths (the
+        // outer WHERE may short-circuit before the inner SELECT executes).
+        super::validation::validate_group_by_window_misuse(stmt)?;
+
         #[cfg(feature = "profile-q6")]
         let execute_start = std::time::Instant::now();
 

--- a/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
@@ -1443,6 +1443,206 @@ pub fn validate_subquery_context_misuse(expr: &Expression) -> Result<(), Executo
     }
 }
 
+/// Recursively validate that no SELECT statement (the given one or any nested
+/// subquery) has a GROUP BY whose expression — directly or after positional
+/// resolution against its own SELECT list — is a window function.
+///
+/// SQLite reports this as `"misuse of window function X()"` at *prepare* time,
+/// before any rows are fetched, so it must be detected during query
+/// preparation rather than only at the execution path of the inner SELECT.
+///
+/// The check fires both on the GROUP BY expression as written and on its
+/// alias-resolved form so that `GROUP BY 1` referring to a window-function
+/// SELECT item (window1.test 47.2) is also caught.
+pub fn validate_group_by_window_misuse(stmt: &vibesql_ast::SelectStmt) -> Result<(), ExecutorError> {
+    // 1. Check this statement's own GROUP BY for window misuse, with
+    //    positional/alias resolution against its SELECT list.
+    if let Some(ref group_by_clause) = stmt.group_by {
+        for (term_index, group_expr) in group_by_clause.all_expressions().iter().enumerate() {
+            if let Some(window_name) = find_window_function_in_expression(group_expr) {
+                return Err(ExecutorError::MisuseOfWindowFunction { function_name: window_name });
+            }
+            let resolved = crate::select::grouping::resolve_group_by_alias(
+                group_expr,
+                &stmt.select_list,
+                term_index,
+            )?;
+            if let Some(window_name) = find_window_function_in_expression(&resolved) {
+                return Err(ExecutorError::MisuseOfWindowFunction { function_name: window_name });
+            }
+        }
+    }
+
+    // 2. Recurse into all expressions of this statement to find nested SELECTs.
+    for item in &stmt.select_list {
+        if let SelectItem::Expression { expr, .. } = item {
+            walk_expr_for_subquery_group_by(expr)?;
+        }
+    }
+    if let Some(where_expr) = stmt.where_clause.as_ref() {
+        walk_expr_for_subquery_group_by(where_expr)?;
+    }
+    if let Some(having_expr) = stmt.having.as_ref() {
+        walk_expr_for_subquery_group_by(having_expr)?;
+    }
+    if let Some(group_by) = stmt.group_by.as_ref() {
+        for expr in group_by.all_expressions() {
+            walk_expr_for_subquery_group_by(expr)?;
+        }
+    }
+    if let Some(order_by) = stmt.order_by.as_ref() {
+        for item in order_by {
+            walk_expr_for_subquery_group_by(&item.expr)?;
+        }
+    }
+
+    // 3. Recurse into FROM clause subqueries (derived tables, JOINs).
+    if let Some(from) = stmt.from.as_ref() {
+        walk_from_for_subquery_group_by(from)?;
+    }
+
+    // 4. Recurse into CTEs.
+    if let Some(ctes) = stmt.with_clause.as_ref() {
+        for cte in ctes {
+            validate_group_by_window_misuse(&cte.query)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Walk an expression tree, finding nested ScalarSubquery / Exists subqueries
+/// and validating their GROUP BY clauses for window-function misuse.
+fn walk_expr_for_subquery_group_by(expr: &Expression) -> Result<(), ExecutorError> {
+    match expr {
+        Expression::ScalarSubquery(stmt) => validate_group_by_window_misuse(stmt),
+        Expression::Exists { subquery, .. } => validate_group_by_window_misuse(subquery),
+        Expression::BinaryOp { left, right, .. } => {
+            walk_expr_for_subquery_group_by(left)?;
+            walk_expr_for_subquery_group_by(right)
+        }
+        Expression::UnaryOp { expr, .. } => walk_expr_for_subquery_group_by(expr),
+        Expression::IsNull { expr, .. } => walk_expr_for_subquery_group_by(expr),
+        Expression::IsDistinctFrom { left, right, .. } => {
+            walk_expr_for_subquery_group_by(left)?;
+            walk_expr_for_subquery_group_by(right)
+        }
+        Expression::IsTruthValue { expr, .. } => walk_expr_for_subquery_group_by(expr),
+        Expression::Cast { expr, .. } => walk_expr_for_subquery_group_by(expr),
+        Expression::Like { expr, pattern, .. } => {
+            walk_expr_for_subquery_group_by(expr)?;
+            walk_expr_for_subquery_group_by(pattern)
+        }
+        Expression::Between { expr, low, high, .. } => {
+            walk_expr_for_subquery_group_by(expr)?;
+            walk_expr_for_subquery_group_by(low)?;
+            walk_expr_for_subquery_group_by(high)
+        }
+        Expression::InList { expr, values, .. } => {
+            walk_expr_for_subquery_group_by(expr)?;
+            for v in values {
+                walk_expr_for_subquery_group_by(v)?;
+            }
+            Ok(())
+        }
+        Expression::In { expr, subquery, .. } => {
+            walk_expr_for_subquery_group_by(expr)?;
+            validate_group_by_window_misuse(subquery)
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                walk_expr_for_subquery_group_by(op)?;
+            }
+            for w in when_clauses {
+                for cond in &w.conditions {
+                    walk_expr_for_subquery_group_by(cond)?;
+                }
+                walk_expr_for_subquery_group_by(&w.result)?;
+            }
+            if let Some(else_expr) = else_result {
+                walk_expr_for_subquery_group_by(else_expr)?;
+            }
+            Ok(())
+        }
+        Expression::Function { args, .. } => {
+            for arg in args {
+                walk_expr_for_subquery_group_by(arg)?;
+            }
+            Ok(())
+        }
+        Expression::AggregateFunction { args, filter, order_by, .. } => {
+            for arg in args {
+                walk_expr_for_subquery_group_by(arg)?;
+            }
+            if let Some(f) = filter {
+                walk_expr_for_subquery_group_by(f)?;
+            }
+            if let Some(items) = order_by {
+                for item in items {
+                    walk_expr_for_subquery_group_by(&item.expr)?;
+                }
+            }
+            Ok(())
+        }
+        Expression::WindowFunction { function, .. } => {
+            let args = match function {
+                vibesql_ast::WindowFunctionSpec::Aggregate { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args,
+            };
+            for a in args {
+                walk_expr_for_subquery_group_by(a)?;
+            }
+            Ok(())
+        }
+        Expression::QuantifiedComparison { expr, subquery, .. } => {
+            walk_expr_for_subquery_group_by(expr)?;
+            validate_group_by_window_misuse(subquery)
+        }
+        Expression::Conjunction(children) | Expression::Disjunction(children) => {
+            for child in children {
+                walk_expr_for_subquery_group_by(child)?;
+            }
+            Ok(())
+        }
+        Expression::RowValueConstructor(children) => {
+            for child in children {
+                walk_expr_for_subquery_group_by(child)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Walk a FROM clause to find nested SELECT statements (derived tables, JOINs).
+fn walk_from_for_subquery_group_by(
+    from: &vibesql_ast::FromClause,
+) -> Result<(), ExecutorError> {
+    match from {
+        vibesql_ast::FromClause::Table { .. } => Ok(()),
+        vibesql_ast::FromClause::Join { left, right, condition, .. } => {
+            walk_from_for_subquery_group_by(left)?;
+            walk_from_for_subquery_group_by(right)?;
+            if let Some(expr) = condition {
+                walk_expr_for_subquery_group_by(expr)?;
+            }
+            Ok(())
+        }
+        vibesql_ast::FromClause::Subquery { query, .. } => {
+            validate_group_by_window_misuse(query)
+        }
+        vibesql_ast::FromClause::Values { rows, .. } => {
+            for row in rows {
+                for expr in row {
+                    walk_expr_for_subquery_group_by(expr)?;
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use vibesql_ast::{BinaryOperator, ColumnIdentifier, FunctionIdentifier, UnaryOperator};
@@ -1966,5 +2166,186 @@ mod tests {
             "window function in bare subquery should not be flagged, got {:?}",
             result
         );
+    }
+
+    // ----- validate_group_by_window_misuse (#5093) -----
+
+    /// Build a SELECT statement with a single FROM table reference and a given
+    /// SELECT list / WHERE / GROUP BY for testing.
+    fn make_select(
+        select_list: Vec<SelectItem>,
+        from_table: Option<&str>,
+        where_clause: Option<Expression>,
+        group_by: Option<vibesql_ast::GroupByClause>,
+    ) -> vibesql_ast::SelectStmt {
+        vibesql_ast::SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list,
+            into_table: None,
+            into_variables: None,
+            from: from_table.map(|name| vibesql_ast::FromClause::Table {
+                name: name.to_string(),
+                alias: None,
+                column_aliases: None,
+                quoted: false,
+            }),
+            where_clause,
+            group_by,
+            having: None,
+            window_definitions: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        }
+    }
+
+    fn make_window_sum_a() -> Expression {
+        Expression::WindowFunction {
+            function: vibesql_ast::WindowFunctionSpec::Aggregate {
+                name: FunctionIdentifier::new("sum"),
+                args: vec![Expression::ColumnRef(ColumnIdentifier::simple("a", false))],
+                filter: None,
+            },
+            over: vibesql_ast::WindowSpec {
+                base_window_name: None,
+                partition_by: None,
+                order_by: None,
+                frame: None,
+            },
+        }
+    }
+
+    #[test]
+    fn test_group_by_positional_resolves_to_window_function() {
+        // SELECT sum(a) OVER() FROM t1 GROUP BY 1
+        // Position 1 in select list is a window function — must error.
+        let stmt = make_select(
+            vec![SelectItem::Expression {
+                expr: make_window_sum_a(),
+                alias: None,
+                source_text: None,
+            }],
+            Some("t1"),
+            None,
+            Some(vibesql_ast::GroupByClause::Simple(vec![Expression::Literal(
+                SqlValue::Integer(1),
+            )])),
+        );
+
+        let result = validate_group_by_window_misuse(&stmt);
+        match result {
+            Err(ExecutorError::MisuseOfWindowFunction { function_name }) => {
+                assert_eq!(function_name, "sum");
+            }
+            other => panic!("expected MisuseOfWindowFunction(sum), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_group_by_positional_non_window_does_not_fire() {
+        // SELECT a FROM t1 GROUP BY 1
+        // Position 1 is a plain column — must NOT error.
+        let stmt = make_select(
+            vec![SelectItem::Expression {
+                expr: Expression::ColumnRef(ColumnIdentifier::simple("a", false)),
+                alias: None,
+                source_text: None,
+            }],
+            Some("t1"),
+            None,
+            Some(vibesql_ast::GroupByClause::Simple(vec![Expression::Literal(
+                SqlValue::Integer(1),
+            )])),
+        );
+
+        assert!(validate_group_by_window_misuse(&stmt).is_ok());
+    }
+
+    #[test]
+    fn test_group_by_alias_resolves_to_window_function() {
+        // SELECT sum(a) OVER() AS w FROM t1 GROUP BY w
+        // Alias 'w' refers to a window function — must error.
+        let stmt = make_select(
+            vec![SelectItem::Expression {
+                expr: make_window_sum_a(),
+                alias: Some("w".to_string()),
+                source_text: None,
+            }],
+            Some("t1"),
+            None,
+            Some(vibesql_ast::GroupByClause::Simple(vec![Expression::ColumnRef(
+                ColumnIdentifier::simple("w", false),
+            )])),
+        );
+
+        let result = validate_group_by_window_misuse(&stmt);
+        match result {
+            Err(ExecutorError::MisuseOfWindowFunction { function_name }) => {
+                assert_eq!(function_name, "sum");
+            }
+            other => panic!("expected MisuseOfWindowFunction(sum), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_group_by_window_in_nested_subquery() {
+        // window1.test 47.2 shape:
+        // SELECT 234 FROM t2 WHERE k=1 OR (SELECT k FROM t2 WHERE
+        //     (SELECT sum(a) OVER() FROM t1 GROUP BY 1));
+        // The deepest subquery's GROUP BY 1 resolves to a window function.
+        let inner_subquery = Expression::ScalarSubquery(Box::new(make_select(
+            vec![SelectItem::Expression {
+                expr: make_window_sum_a(),
+                alias: None,
+                source_text: None,
+            }],
+            Some("t1"),
+            None,
+            Some(vibesql_ast::GroupByClause::Simple(vec![Expression::Literal(
+                SqlValue::Integer(1),
+            )])),
+        )));
+
+        let middle_subquery = Expression::ScalarSubquery(Box::new(make_select(
+            vec![SelectItem::Expression {
+                expr: Expression::ColumnRef(ColumnIdentifier::simple("k", false)),
+                alias: None,
+                source_text: None,
+            }],
+            Some("t2"),
+            Some(inner_subquery),
+            None,
+        )));
+
+        let outer = make_select(
+            vec![SelectItem::Expression {
+                expr: Expression::Literal(SqlValue::Integer(234)),
+                alias: None,
+                source_text: None,
+            }],
+            Some("t2"),
+            Some(Expression::Disjunction(vec![
+                Expression::BinaryOp {
+                    op: BinaryOperator::Equal,
+                    left: Box::new(Expression::ColumnRef(ColumnIdentifier::simple("k", false))),
+                    right: Box::new(Expression::Literal(SqlValue::Integer(1))),
+                },
+                middle_subquery,
+            ])),
+            None,
+        );
+
+        let result = validate_group_by_window_misuse(&outer);
+        match result {
+            Err(ExecutorError::MisuseOfWindowFunction { function_name }) => {
+                assert_eq!(function_name, "sum");
+            }
+            other => {
+                panic!("expected MisuseOfWindowFunction(sum) from nested subquery, got {:?}", other)
+            }
+        }
     }
 }

--- a/crates/vibesql-executor/src/select/executor/validation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/mod.rs
@@ -22,9 +22,9 @@ use std::collections::HashSet;
 // Re-export public validation functions
 pub use aggregates::{
     check_aggregate_arg_count, find_aggregate_in_expression, find_window_function_in_expression,
-    validate_aggregate_arguments, validate_having_aliased_aggregates,
-    validate_no_nested_aggregates, validate_order_by_aliased_window_functions,
-    validate_subquery_context_misuse,
+    validate_aggregate_arguments, validate_group_by_window_misuse,
+    validate_having_aliased_aggregates, validate_no_nested_aggregates,
+    validate_order_by_aliased_window_functions, validate_subquery_context_misuse,
 };
 pub use column_refs::{extract_column_refs, validate_column_ref};
 pub use join_limits::validate_join_table_limit;

--- a/crates/vibesql-executor/src/select/grouping/grouping_sets/mod.rs
+++ b/crates/vibesql-executor/src/select/grouping/grouping_sets/mod.rs
@@ -9,7 +9,7 @@ mod expression_utils;
 
 // Re-export public API
 pub use alias_resolution::{
-    resolve_base_expressions_aliases, resolve_grouping_set_aliases,
+    resolve_base_expressions_aliases, resolve_group_by_alias, resolve_grouping_set_aliases,
     resolve_having_aliases_with_values,
 };
 pub use expansion::{expand_group_by_clause, get_base_expressions};

--- a/crates/vibesql-executor/src/select/grouping/mod.rs
+++ b/crates/vibesql-executor/src/select/grouping/mod.rs
@@ -22,7 +22,8 @@ pub(crate) use aggregates::{
 pub(crate) use grouping_sets::expressions_equal;
 pub(super) use grouping_sets::{
     expand_group_by_clause, get_base_expressions, resolve_base_expressions_aliases,
-    resolve_grouping_set_aliases, resolve_having_aliases_with_values, GroupingContext,
+    resolve_group_by_alias, resolve_grouping_set_aliases, resolve_having_aliases_with_values,
+    GroupingContext,
 };
 pub(super) use hash::group_rows;
 pub(crate) use keys::{GroupKey, GroupKeySpec};


### PR DESCRIPTION
## Summary

Surfaces `misuse of window function X()` for `GROUP BY <pos>` (and `GROUP BY <alias>`) when the referenced SELECT item is a window function — including when the offending GROUP BY lives inside a deeply nested subquery whose evaluation may be short-circuited at runtime.

## Changes

- `aggregation/mod.rs`: extend the existing GROUP BY misuse loop to also resolve positional/alias references via `resolve_group_by_alias` and re-check the resolved expression.
- `validation/aggregates.rs`: add `validate_group_by_window_misuse`, a recursive walker that validates the GROUP BY of the current SELECT and every nested SELECT (subqueries in WHERE/HAVING/SELECT/ORDER BY/FROM, plus CTEs, EXISTS, IN, QuantifiedComparison).
- `executor/execute.rs`: invoke the new walker alongside the existing prepare-time checks (after `validate_subquery_context_misuse`). This catches window1.test 47.2 because the outer `WHERE k=1 OR (...subquery with bad GROUP BY...)` short-circuits at runtime before the inner SELECT executes — SQLite raises this error at prepare time, so a recursive prepare-time walk is required.
- `validation/mod.rs`, `grouping/mod.rs`, `grouping_sets/mod.rs`: re-export `validate_group_by_window_misuse` and `resolve_group_by_alias`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `window1.test 47.2` passes | yes | `./scripts/tcltest run --pattern "window1.test" --verbose` shows `47.2... ok` (was `47.2... FAILED` before). Suite total: 230 -> 231 passing, 42 -> 41 failing. |
| `GROUP BY 1` referencing non-window expression still works | yes | New unit test `test_group_by_positional_non_window_does_not_fire`; existing `test_group_by_numeric_position` still green. |
| `GROUP BY <alias>` referencing window function errors | yes | New unit test `test_group_by_alias_resolves_to_window_function`. |
| Nested-subquery shape (47.2 minimal repro) errors at prepare time | yes | New unit test `test_group_by_window_in_nested_subquery`; manual repro now errors with `misuse of window function sum()` instead of returning `234`. |
| No P1 regressions | yes | `cargo test --release -p vibesql-executor --lib`: 2340 passed, 0 failed (4 new tests added). `select1.test`: 187/188 (1 pre-existing failure unchanged). 10-file priority-1 sample: 747/781 passing — same baseline. |

## Test Plan

- [x] `./scripts/tcltest run --pattern "window1.test"` — 47.2 now passes; total 230 -> 231 passing
- [x] `cargo test --release -p vibesql-executor --lib` — 2340 passed, 0 failed
- [x] Manual reproduction of the 47.2 query against the release binary — now errors at prepare time
- [x] `select1.test` — 187/188 passing (only pre-existing select1-18.1 failure)
- [x] 10-file priority-1 sample — no new failures

Closes #5093