### PR TITLE
fix(evaluator): binary IS/= Boolean↔Integer must use i==1, not i!=0

### DIFF
--- a/crates/vibesql-executor/src/evaluator/core.rs
+++ b/crates/vibesql-executor/src/evaluator/core.rs
@@ -117,25 +117,39 @@ pub(crate) fn values_are_equal(
         (Character(a), Varchar(b)) | (Varchar(a), Character(b)) => a == b,
         (Boolean(a), Boolean(b)) => a == b,
 
-        // SQLite compatibility: Boolean/Integer comparisons
-        // In SQLite, FALSE == 0 and TRUE == non-zero
+        // SQLite compatibility: Boolean/Integer comparisons.
+        //
+        // SQLite has no separate boolean storage class — TRUE is stored as the
+        // integer 1 and FALSE as the integer 0. For binary `=` and binary `IS`
+        // (IS NOT DISTINCT FROM) semantics, TRUE must therefore compare equal
+        // only to the literal integer 1, not to any non-zero integer. The
+        // truth-value operator `IS TRUE` (handled separately in
+        // expressions/eval.rs) is the only place where non-zero integers are
+        // treated as truthy — that operator must not be conflated with `=` or
+        // binary `IS` here.
+        //
+        // Examples (binary IS / =):
+        //   500 IS TRUE  -> false  (500 != 1)
+        //   1   IS TRUE  -> true   (1 == 1)
+        //   0   IS FALSE -> true   (0 == 0)
+        //   2   IS TRUE  -> false  (2 != 1)
         (Boolean(b), Integer(i)) | (Integer(i), Boolean(b)) => {
             if *b {
-                *i != 0
+                *i == 1
             } else {
                 *i == 0
             }
         }
         (Boolean(b), Bigint(i)) | (Bigint(i), Boolean(b)) => {
             if *b {
-                *i != 0
+                *i == 1
             } else {
                 *i == 0
             }
         }
         (Boolean(b), Smallint(i)) | (Smallint(i), Boolean(b)) => {
             if *b {
-                *i != 0
+                *i == 1
             } else {
                 *i == 0
             }


### PR DESCRIPTION
## Summary

SQLite stores TRUE as integer 1 and FALSE as integer 0. The binary `=` and binary `IS` (IS NOT DISTINCT FROM) operators must therefore compare TRUE to the literal 1 only — not to any non-zero integer. Previously `Boolean(true) == Integer(500)` returned true because `values_are_equal` used `*i != 0`, conflating binary IS with the truth-value `IS TRUE` operator.

## Changes

- `crates/vibesql-executor/src/evaluator/core.rs` — Boolean↔Integer / Bigint / Smallint arms in `values_are_equal` now use `*i == 1` for TRUE comparisons. Added explanatory comment distinguishing binary IS / = from `IS TRUE` / `IS FALSE` (which lives in `expressions/eval.rs` and correctly treats non-zero as truthy).

## Test plan

- [x] cargo test --release -p vibesql-executor --lib — 2350 passed, 0 failed
- [x] tcltest windowD.test — 13/13 pass (was 9/13; 2.1, 2.2, 2.5, 2.6 now pass)
- [x] tcltest where.test — 168/168 pass (no regression)

## Note

select1-18.1 fails on this branch but also fails on bare main (pre-existing, unrelated error "no such column: x"). Worth a separate investigation but does not block this PR.

Closes #5079