### PR TITLE
fix(limit): resolve column refs before window-misuse check in LIMIT/OFFSET

### DIFF
--- a/crates/vibesql-executor/src/select/executor/utils.rs
+++ b/crates/vibesql-executor/src/select/executor/utils.rs
@@ -165,6 +165,24 @@ impl SelectExecutor<'_> {
     ) -> Result<usize, crate::errors::ExecutorError> {
         use crate::evaluator::ExpressionEvaluator;
 
+        // Pre-validate column references in LIMIT/OFFSET expressions (#5092).
+        // LIMIT/OFFSET expressions are evaluated against an empty row/schema,
+        // so any column reference is unresolvable. SQLite reports this as
+        // "no such column: X". This pre-check must run BEFORE the evaluator,
+        // otherwise the evaluator's WindowFunction / AggregateFunction arms
+        // fire first and produce a misleading "misuse of window function ..."
+        // error for queries like:
+        //   SELECT count(*) FROM t1 LIMIT nth_value(x, 1) OVER ();
+        let mut col_refs = Vec::new();
+        crate::select::executor::validation::extract_column_refs(expr, &mut col_refs);
+        if let Some(first) = col_refs.into_iter().next() {
+            let column_ref = match first.table {
+                Some(t) => format!("{}.{}", t, first.column),
+                None => first.column,
+            };
+            return Err(crate::errors::ExecutorError::NoSuchColumn { column_ref });
+        }
+
         // Create empty schema and row for expression evaluation
         let empty_schema = vibesql_catalog::TableSchema::new("".to_string(), vec![]);
         let evaluator = ExpressionEvaluator::with_database(&empty_schema, self.database);

--- a/crates/vibesql-executor/src/select/helpers.rs
+++ b/crates/vibesql-executor/src/select/helpers.rs
@@ -96,6 +96,26 @@ fn evaluate_limit_offset_expr_raw(
 ) -> Result<i64, crate::ExecutorError> {
     use crate::evaluator::ExpressionEvaluator;
 
+    // Pre-validate column references in LIMIT/OFFSET expressions (#5092).
+    // LIMIT/OFFSET expressions are evaluated against an empty row/schema, so
+    // any column reference is unresolvable. SQLite reports this as
+    // "no such column: X". This pre-check must run BEFORE the evaluator,
+    // otherwise the evaluator's WindowFunction / AggregateFunction arms can
+    // fire first and produce a misleading "misuse of window function ..."
+    // error for queries like:
+    //   SELECT count(*) FROM t1 LIMIT nth_value(x, 1) OVER ();
+    // The unresolved column `x` should be reported before any window-misuse
+    // diagnosis runs.
+    let mut col_refs = Vec::new();
+    crate::select::executor::validation::extract_column_refs(expr, &mut col_refs);
+    if let Some(first) = col_refs.into_iter().next() {
+        let column_ref = match first.table {
+            Some(t) => format!("{}.{}", t, first.column),
+            None => first.column,
+        };
+        return Err(crate::ExecutorError::NoSuchColumn { column_ref });
+    }
+
     // Create empty schema and row for expression evaluation
     let empty_schema = vibesql_catalog::TableSchema::new("".to_string(), vec![]);
     let evaluator = ExpressionEvaluator::with_database(&empty_schema, database);


### PR DESCRIPTION
## Summary

LIMIT/OFFSET expressions are evaluated against an empty schema/row, so any column reference is unresolvable. The evaluator's `WindowFunction` / `AggregateFunction` match arms previously fired before column resolution, producing a misleading `misuse of window function ...` error for queries like:

```sql
SELECT count(*) FROM t1 LIMIT nth_value(x, 1) OVER ();
```

SQLite reports `no such column: x` — the unresolved column should be diagnosed before any window-misuse check runs.

## Changes

- `crates/vibesql-executor/src/select/helpers.rs`: pre-validate column references in `evaluate_limit_offset_expr_raw` before calling the evaluator.
- `crates/vibesql-executor/src/select/executor/utils.rs`: same pre-validation in `SelectExecutor::eval_limit_offset_expr`.
- Both paths use the existing `extract_column_refs` walker. If any column reference is found, return `ExecutorError::NoSuchColumn` immediately, matching SQLite's error.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| `window1-7.1.5` passes | Yes | Test no longer in failed list; `./scripts/tcltest run --pattern "window1.test"` shows 7.1.5 passing |
| Window1 baseline (228) maintained | Yes | 231 → 233 passed; 41 → 39 failed |
| `LIMIT 1+2`, `LIMIT (SELECT 5)` still work | Yes | `select4.test` (LIMIT/OFFSET coverage) — 123/123 pass |
| No executor regressions | Yes | `cargo test --release -p vibesql-executor` — all 2350+ tests pass |
| Manual repro fixed | Yes | `SELECT count(*) FROM t1 LIMIT nth_value(x, 1) OVER ();` now returns `no such column: x` (was `misuse of window function nth_value()`) |

## Test Plan

- `./scripts/tcltest run --pattern "window1.test"` — 233 passed, 39 failed, 7.1.5 now passing
- `./scripts/tcltest run --pattern "select4.test"` — 123/123 pass (LIMIT/OFFSET regression check)
- `./scripts/tcltest run --pattern "limit*.test"` — 135/146 pass (8 failures are pre-existing on main; verified by stash-and-test)
- `cargo test --release -p vibesql-executor` — all 2350+ tests pass
- Manual: `SELECT count(*) FROM t1 LIMIT nth_value(x, 1) OVER ();` returns SQLite-compatible `no such column: x`

Closes #5092