### PR TITLE
feat(in-subquery): support row-value LHS for IN with multi-column subquery

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs
@@ -113,6 +113,19 @@ impl CombinedExpressionEvaluator<'_> {
         ))?;
         let sql_mode = database.sql_mode();
 
+        // Handle row value IN subquery: (a, b) IN (SELECT x, y FROM t)
+        // SQL:1999 Section 8.4 - Row value left-hand side requires the subquery's
+        // column count to match the row arity, and matching is done element-wise.
+        if let vibesql_ast::Expression::RowValueConstructor(expr_elements) = expr {
+            return self.eval_row_value_in_subquery(
+                expr_elements,
+                subquery,
+                negated,
+                row,
+                database,
+            );
+        }
+
         // Evaluate the left-hand expression
         let expr_val = self.eval(expr, row)?;
 
@@ -218,13 +231,13 @@ impl CombinedExpressionEvaluator<'_> {
                         // actually references columns from the outer scope (e.g.,
                         // unqualified column refs in nested derived tables).
                         // Retry with outer context for column resolution.
-                        let merged_schema =
-                            if !self.schema.table_schemas.is_empty() || self.outer_schema.is_some()
-                            {
-                                Some(build_merged_outer_schema(self.schema, self.outer_schema))
-                            } else {
-                                None
-                            };
+                        let merged_schema = if !self.schema.table_schemas.is_empty()
+                            || self.outer_schema.is_some()
+                        {
+                            Some(build_merged_outer_schema(self.schema, self.outer_schema))
+                        } else {
+                            None
+                        };
 
                         let merged_row = if merged_schema.is_some() {
                             Some(build_merged_outer_row(row, self.outer_row))
@@ -237,18 +250,11 @@ impl CombinedExpressionEvaluator<'_> {
                         {
                             if let Some(cte_ctx) = self.cte_context {
                                 crate::select::SelectExecutor::new_with_outer_and_cte_and_depth(
-                                    database,
-                                    outer_row,
-                                    schema,
-                                    cte_ctx,
-                                    self.depth,
+                                    database, outer_row, schema, cte_ctx, self.depth,
                                 )
                             } else {
                                 crate::select::SelectExecutor::new_with_outer_context_and_depth(
-                                    database,
-                                    outer_row,
-                                    schema,
-                                    self.depth,
+                                    database, outer_row, schema, self.depth,
                                 )
                             }
                         } else if let Some(cte_ctx) = self.cte_context {
@@ -263,11 +269,7 @@ impl CombinedExpressionEvaluator<'_> {
                         let column_count = if !rows.is_empty() {
                             rows[0].values.len()
                         } else {
-                            compute_select_list_column_count(
-                                subquery,
-                                database,
-                                self.cte_context,
-                            )?
+                            compute_select_list_column_count(subquery, database, self.cte_context)?
                         };
 
                         if column_count != 1 {
@@ -374,6 +376,167 @@ impl CombinedExpressionEvaluator<'_> {
 
         // For correlated subqueries, use linear search (they change each time)
         eval_in_linear(&expr_val, &rows, negated, sql_mode, left_affinity, subquery_affinity)
+    }
+
+    /// Evaluate row value IN subquery: `(a, b) IN (SELECT x, y FROM t)`
+    ///
+    /// SQL:1999 Section 8.4: Row value IN predicate
+    /// A row value matches if it equals any row from the subquery, with matching
+    /// performed element-wise (lhs[i] = rhs[i] for all i).
+    ///
+    /// Behavior:
+    /// - The subquery must produce exactly the same number of columns as the row
+    ///   value's arity; otherwise returns SubqueryColumnCountMismatch.
+    /// - NULL semantics follow SQL three-valued logic. Any NULL on either side of
+    ///   an element comparison makes the row's match UNKNOWN. If no row matches
+    ///   exactly and any NULL was seen, the result is NULL.
+    /// - Empty subquery results: `(...) IN ()` is FALSE, `(...) NOT IN ()` is TRUE.
+    fn eval_row_value_in_subquery(
+        &self,
+        expr_elements: &[vibesql_ast::Expression],
+        subquery: &vibesql_ast::SelectStmt,
+        negated: bool,
+        row: &vibesql_storage::Row,
+        database: &vibesql_storage::Database,
+    ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        use vibesql_types::SqlValue;
+
+        let expected_columns = expr_elements.len();
+
+        // Empty row values are not allowed
+        if expected_columns == 0 {
+            return Err(ExecutorError::UnsupportedExpression(
+                "Empty row value constructors are not allowed".to_string(),
+            ));
+        }
+
+        // Evaluate all elements of the left row value
+        let mut expr_values = Vec::with_capacity(expected_columns);
+        let mut has_null_element = false;
+        for elem_expr in expr_elements {
+            let val = self.eval(elem_expr, row)?;
+            if matches!(val, SqlValue::Null) {
+                has_null_element = true;
+            }
+            expr_values.push(val);
+        }
+
+        // Execute the subquery. We always run with outer/CTE context available
+        // because correlated row-value IN subqueries are common (and the cost of
+        // building the merged context is negligible for these queries).
+        let merged_schema = if !self.schema.table_schemas.is_empty() || self.outer_schema.is_some()
+        {
+            Some(build_merged_outer_schema(self.schema, self.outer_schema))
+        } else {
+            None
+        };
+        let merged_row = if merged_schema.is_some() {
+            Some(build_merged_outer_row(row, self.outer_row))
+        } else {
+            None
+        };
+
+        let select_executor =
+            if let (Some(ref schema), Some(ref outer_row)) = (&merged_schema, &merged_row) {
+                if let Some(cte_ctx) = self.cte_context {
+                    crate::select::SelectExecutor::new_with_outer_and_cte_and_depth(
+                        database, outer_row, schema, cte_ctx, self.depth,
+                    )
+                } else {
+                    crate::select::SelectExecutor::new_with_outer_context_and_depth(
+                        database, outer_row, schema, self.depth,
+                    )
+                }
+            } else if let Some(cte_ctx) = self.cte_context {
+                crate::select::SelectExecutor::new_with_cte_and_depth(database, cte_ctx, self.depth)
+            } else {
+                crate::select::SelectExecutor::new_with_depth(database, self.depth)
+            };
+
+        let rows = select_executor.execute(subquery)?;
+
+        // Validate column count - must match the row value arity
+        let column_count = if !rows.is_empty() {
+            rows[0].values.len()
+        } else {
+            compute_select_list_column_count(subquery, database, self.cte_context)?
+        };
+
+        if column_count != expected_columns {
+            return Err(ExecutorError::SubqueryColumnCountMismatch {
+                expected: expected_columns,
+                actual: column_count,
+            });
+        }
+
+        // Empty subquery result: (...) IN () = FALSE, (...) NOT IN () = TRUE
+        if rows.is_empty() {
+            return Ok(SqlValue::Boolean(negated));
+        }
+
+        let sql_mode = database.sql_mode();
+        let mut found_null_in_subquery = false;
+
+        // Compare with each row from the subquery using element-wise equality
+        for subquery_row in &rows {
+            let mut all_equal = true;
+            let mut has_null_comparison = false;
+
+            for (i, expr_val) in expr_values.iter().enumerate() {
+                let subquery_val = subquery_row
+                    .get(i)
+                    .ok_or(ExecutorError::ColumnIndexOutOfBounds { index: i })?;
+
+                // NULL on either side propagates as UNKNOWN for this element
+                if matches!(expr_val, SqlValue::Null) || matches!(subquery_val, SqlValue::Null) {
+                    has_null_comparison = true;
+                    if matches!(subquery_val, SqlValue::Null) {
+                        found_null_in_subquery = true;
+                    }
+                    continue;
+                }
+
+                let eq_result = ExpressionEvaluator::eval_binary_op_static(
+                    expr_val,
+                    &vibesql_ast::BinaryOperator::Equal,
+                    subquery_val,
+                    sql_mode.clone(),
+                )?;
+
+                match eq_result {
+                    SqlValue::Boolean(true) => {
+                        // Equal at this position - continue
+                    }
+                    SqlValue::Boolean(false) => {
+                        // Not equal - this row can't match
+                        all_equal = false;
+                        break;
+                    }
+                    SqlValue::Null => {
+                        has_null_comparison = true;
+                    }
+                    _ => {
+                        return Err(ExecutorError::TypeError(format!(
+                            "Comparison returned non-boolean: {:?}",
+                            eq_result
+                        )));
+                    }
+                }
+            }
+
+            if all_equal && !has_null_comparison {
+                // Found an exact match
+                return Ok(SqlValue::Boolean(!negated));
+            }
+        }
+
+        // No exact match found
+        if has_null_element || found_null_in_subquery {
+            // Any NULL involvement makes the result UNKNOWN
+            Ok(SqlValue::Null)
+        } else {
+            Ok(SqlValue::Boolean(negated))
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -30,13 +30,19 @@ pub(super) fn validate_where_clause_subqueries(
     use vibesql_ast::Expression;
 
     match expr {
-        Expression::In { subquery, .. } => {
-            // Validate that the subquery returns exactly 1 column (scalar subquery requirement)
+        Expression::In { expr: lhs, subquery, .. } => {
+            // For row-value LHS, the subquery must return the same number of columns
+            // as the row value's arity (SQL:1999 Section 8.4). For scalar LHS, the
+            // subquery must return exactly 1 column.
             // Issue #3562: Pass CTE context so CTEs can be resolved
+            let expected = match lhs.as_ref() {
+                Expression::RowValueConstructor(elements) => elements.len(),
+                _ => 1,
+            };
             let column_count = compute_select_list_column_count(subquery, database, cte_results)?;
-            if column_count != 1 {
+            if column_count != expected {
                 return Err(ExecutorError::SubqueryColumnCountMismatch {
-                    expected: 1,
+                    expected,
                     actual: column_count,
                 });
             }


### PR DESCRIPTION
## Summary
Adds SQL:1999 row-value IN predicate support: `(a, b) IN (SELECT x, y FROM t)`. VibeSQL previously rejected such queries because validation insisted IN-subqueries return exactly 1 column. The fix detects a `RowValueConstructor` LHS, requires the subquery's column count to match the row arity, and routes evaluation through a new element-wise equality helper with proper NULL semantics.

## Changes
- `crates/vibesql-executor/src/select/executor/nonagg/validation.rs`: For `Expression::In`, expected column count is now `lhs.elements.len()` when the LHS is a `RowValueConstructor` (1 otherwise).
- `crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs`: New `eval_row_value_in_subquery` helper runs the subquery with outer/CTE context (for correlated cases) and compares each subquery row against the row-value LHS position-by-position using the binary-equal operator.
- NULL semantics: any NULL element makes that row's match UNKNOWN; if no exact match and any NULL was seen, the result is NULL (three-valued logic). Empty subquery: `(...) IN ()` is FALSE, `(...) NOT IN ()` is TRUE.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `(a,b) IN (SELECT x,y …)` no longer errors with "sub-select returns 2 columns - expected 1" | ✅ | window2.test 6.2 passes (full file 63/63 pass) |
| Direct test (window2 6.2) passes | ✅ | `./scripts/tcltest run --pattern window2.test` → 63 passed, 0 failed |
| Bonus: window1 39.3, 39.4, 42.2, 42.3 also pass | ✅ | None of those test numbers appear in the failed list for window1.test (failed list scanned for `^- 39\.|^- 42\.` returns nothing) |
| Code compiles cleanly | ✅ | `cargo check -p vibesql-executor` clean (only pre-existing warnings in unrelated files) |

## Test Plan
- `./scripts/tcltest run --pattern "window2.test"` → 63/63 passed (including 6.2)
- `./scripts/tcltest run --pattern "window1.test"` → 234/348 passed; window1 39.3, 39.4, 42.2, 42.3 are not in the failed list (bonus tests fixed as predicted by curator)
- `cargo check -p vibesql-executor` and `cargo clippy -p vibesql-executor` clean

## Notes
- P1 conformance shows 35 pre-existing failures unrelated to this change (joins, selectB transforms, where3-1.2, etc.); none are introduced by this PR.
- The bonus tests called out by the curator (window1 39.3, 39.4, 42.2, 42.3) are confirmed fixed.

Closes #5107