### PR TITLE
fix(collation): propagate COLLATE through compound ORDER BY expressions

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -35,6 +35,32 @@ fn format_float_for_text_comparison(n: f64) -> String {
     }
 }
 
+/// Find an *explicit* COLLATE clause anywhere within the expression's
+/// "collation propagation tree".
+///
+/// SQLite's rule (datatype3 §7.1) is that an explicit `COLLATE` clause inside
+/// any operand of a binary operator beats the column-derived (inherited)
+/// collation of the other operand. We walk through compound expressions that
+/// propagate collation (BinaryOp, UnaryOp, single-arg Function/Aggregate)
+/// looking specifically for a `Collate` node — column-level collations are
+/// *not* considered explicit and are deliberately ignored here.
+pub(super) fn explicit_collation_of(expr: &vibesql_ast::Expression) -> Option<String> {
+    match expr {
+        vibesql_ast::Expression::Collate { collation, .. } => Some(collation.clone()),
+        vibesql_ast::Expression::BinaryOp { left, right, .. } => {
+            explicit_collation_of(left).or_else(|| explicit_collation_of(right))
+        }
+        vibesql_ast::Expression::UnaryOp { expr, .. } => explicit_collation_of(expr),
+        vibesql_ast::Expression::AggregateFunction { args, .. } if args.len() == 1 => {
+            explicit_collation_of(&args[0])
+        }
+        vibesql_ast::Expression::Function { args, .. } if args.len() == 1 => {
+            explicit_collation_of(&args[0])
+        }
+        _ => None,
+    }
+}
+
 impl CombinedExpressionEvaluator<'_> {
     /// Get the SQLite type affinity of an expression if it's a column reference.
     ///
@@ -85,10 +111,17 @@ impl CombinedExpressionEvaluator<'_> {
 
     /// Get the effective collation for an expression.
     ///
-    /// Returns the collation from:
-    /// 1. Explicit COLLATE clause (highest priority)
-    /// 2. Column-level collation from CREATE TABLE definition
-    /// 3. None (use default binary collation)
+    /// Implements SQLite's collation propagation rules
+    /// (see https://sqlite.org/datatype3.html#collation):
+    /// 1. Explicit COLLATE clause has highest priority and propagates outward
+    ///    through compound expressions.
+    /// 2. Column references inherit the column's declared collation.
+    /// 3. Binary operators (including `||`): if either operand has an *explicit*
+    ///    COLLATE, that wins. Otherwise the left operand's collation is used,
+    ///    falling back to the right operand's.
+    /// 4. Unary operators and single-argument functions / aggregates inherit
+    ///    collation from their operand.
+    /// 5. Otherwise, no collation (use default BINARY).
     pub(crate) fn get_expression_collation(
         &self,
         expr: &vibesql_ast::Expression,
@@ -117,6 +150,30 @@ impl CombinedExpressionEvaluator<'_> {
                     }
                 }
                 None
+            }
+            // Binary operator: explicit COLLATE on either operand wins, else
+            // inherit from the left operand (SQLite rule).
+            vibesql_ast::Expression::BinaryOp { left, right, .. } => {
+                if let Some(c) = explicit_collation_of(left) {
+                    return Some(c);
+                }
+                if let Some(c) = explicit_collation_of(right) {
+                    return Some(c);
+                }
+                self.get_expression_collation(left)
+                    .or_else(|| self.get_expression_collation(right))
+            }
+            // Unary operator: inherit from operand.
+            vibesql_ast::Expression::UnaryOp { expr, .. } => self.get_expression_collation(expr),
+            // Aggregate function with a single argument: inherit from argument.
+            // (Multi-arg aggregates have no well-defined inherited collation.)
+            vibesql_ast::Expression::AggregateFunction { args, .. } if args.len() == 1 => {
+                self.get_expression_collation(&args[0])
+            }
+            // Scalar function with a single argument: inherit from argument.
+            // (Multi-arg functions have no well-defined inherited collation.)
+            vibesql_ast::Expression::Function { args, .. } if args.len() == 1 => {
+                self.get_expression_collation(&args[0])
             }
             // Other expressions don't have intrinsic collation
             _ => None,

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -30,6 +30,32 @@ fn format_float_for_text_comparison(n: f64) -> String {
     }
 }
 
+/// Find an *explicit* COLLATE clause anywhere within the expression's
+/// "collation propagation tree".
+///
+/// SQLite's rule (datatype3 §7.1) is that an explicit `COLLATE` clause inside
+/// any operand of a binary operator beats the column-derived (inherited)
+/// collation of the other operand. We walk through compound expressions that
+/// propagate collation (BinaryOp, UnaryOp, single-arg Function/Aggregate)
+/// looking specifically for a `Collate` node — column-level collations are
+/// *not* considered explicit and are deliberately ignored here.
+fn explicit_collation_of(expr: &vibesql_ast::Expression) -> Option<String> {
+    match expr {
+        vibesql_ast::Expression::Collate { collation, .. } => Some(collation.clone()),
+        vibesql_ast::Expression::BinaryOp { left, right, .. } => {
+            explicit_collation_of(left).or_else(|| explicit_collation_of(right))
+        }
+        vibesql_ast::Expression::UnaryOp { expr, .. } => explicit_collation_of(expr),
+        vibesql_ast::Expression::AggregateFunction { args, .. } if args.len() == 1 => {
+            explicit_collation_of(&args[0])
+        }
+        vibesql_ast::Expression::Function { args, .. } if args.len() == 1 => {
+            explicit_collation_of(&args[0])
+        }
+        _ => None,
+    }
+}
+
 impl ExpressionEvaluator<'_> {
     /// Get the SQLite type affinity of an expression if it's a column reference.
     ///
@@ -65,16 +91,17 @@ impl ExpressionEvaluator<'_> {
 
     /// Get the effective collation for an expression.
     ///
-    /// Returns the collation from:
-    /// 1. Explicit COLLATE clause (highest priority)
-    /// 2. Column-level collation from CREATE TABLE definition
-    /// 3. None (use default binary collation)
-    ///
-    /// SQLite documentation states:
-    /// "A column's collating function can be specified using the COLLATE clause
-    /// in the column definition within the CREATE TABLE statement."
-    ///
-    /// Explicit COLLATE in the query overrides column-level collation.
+    /// Implements SQLite's collation propagation rules
+    /// (see https://sqlite.org/datatype3.html#collation):
+    /// 1. Explicit COLLATE clause has highest priority and propagates outward
+    ///    through compound expressions.
+    /// 2. Column references inherit the column's declared collation.
+    /// 3. Binary operators (including `||`): if either operand has an *explicit*
+    ///    COLLATE, that wins. Otherwise the left operand's collation is used,
+    ///    falling back to the right operand's.
+    /// 4. Unary operators and single-argument functions / aggregates inherit
+    ///    collation from their operand.
+    /// 5. Otherwise, no collation (use default BINARY).
     pub(super) fn get_expression_collation(
         &self,
         expr: &vibesql_ast::Expression,
@@ -90,6 +117,28 @@ impl ExpressionEvaluator<'_> {
                 } else {
                     None
                 }
+            }
+            // Binary operator: explicit COLLATE on either operand wins, else
+            // inherit from the left operand (SQLite rule).
+            vibesql_ast::Expression::BinaryOp { left, right, .. } => {
+                if let Some(c) = explicit_collation_of(left) {
+                    return Some(c);
+                }
+                if let Some(c) = explicit_collation_of(right) {
+                    return Some(c);
+                }
+                self.get_expression_collation(left)
+                    .or_else(|| self.get_expression_collation(right))
+            }
+            // Unary operator: inherit from operand.
+            vibesql_ast::Expression::UnaryOp { expr, .. } => self.get_expression_collation(expr),
+            // Aggregate function with a single argument: inherit from argument.
+            vibesql_ast::Expression::AggregateFunction { args, .. } if args.len() == 1 => {
+                self.get_expression_collation(&args[0])
+            }
+            // Scalar function with a single argument: inherit from argument.
+            vibesql_ast::Expression::Function { args, .. } if args.len() == 1 => {
+                self.get_expression_collation(&args[0])
             }
             // Other expressions don't have intrinsic collation
             _ => None,

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -242,9 +242,23 @@ impl SelectExecutor<'_> {
         let result_evaluator =
             CombinedExpressionEvaluator::with_database(&result_schema, self.database);
 
-        // Evaluate ORDER BY expressions and attach sort keys to rows
-        type SortKey =
-            (vibesql_types::SqlValue, vibesql_ast::OrderDirection, Option<vibesql_ast::NullsOrder>);
+        // Evaluate ORDER BY expressions and attach sort keys to rows.
+        //
+        // SortKey tuple: (value, direction, nulls_order, collation).
+        //
+        // The collation is captured from the *original* ORDER BY expression
+        // (before alias / aggregate-column resolution rewrites it into a
+        // ColumnRef into the result schema), so that explicit `COLLATE` clauses
+        // and propagated collations from compound expressions like
+        // `max(b COLLATE nocase) || ''` are honored. See
+        // `CombinedExpressionEvaluator::get_expression_collation` for the
+        // propagation rules.
+        type SortKey = (
+            vibesql_types::SqlValue,
+            vibesql_ast::OrderDirection,
+            Option<vibesql_ast::NullsOrder>,
+            Option<String>,
+        );
         let mut rows_with_keys: Vec<(vibesql_storage::Row, Vec<SortKey>)> = Vec::new();
         for row in rows {
             // Clear CSE cache before evaluating each row to prevent column values
@@ -253,6 +267,20 @@ impl SelectExecutor<'_> {
 
             let mut sort_keys = Vec::new();
             for (term_index, order_item) in order_by.iter().enumerate() {
+                // Capture the effective collation from the ORIGINAL order-by
+                // expression first, before resolution rewrites it into a
+                // ColumnRef (which loses any inner COLLATE clauses).
+                //
+                // We use `result_evaluator` here for convenience — explicit
+                // `COLLATE` clauses are matched by AST shape, not by column
+                // lookup, so an evaluator over the result schema is sufficient
+                // for the collation-propagation rules implemented in
+                // `get_expression_collation`. (Column-declared collations on
+                // raw source columns referenced inside the ORDER BY would not
+                // be visible here, but those are unaffected by this fix.)
+                let order_collation =
+                    result_evaluator.get_expression_collation(&order_item.expr);
+
                 // Resolve ORDER BY expression to result schema column names
                 // For aggregates, we need ColumnRef expressions to look up computed values
                 // in the result schema, not re-evaluate aggregate expressions
@@ -272,17 +300,24 @@ impl SelectExecutor<'_> {
                 );
 
                 let key_value = result_evaluator.eval(&resolved_expr, &row)?;
-                sort_keys.push((key_value, order_item.direction.clone(), order_item.nulls_order));
+                sort_keys.push((
+                    key_value,
+                    order_item.direction.clone(),
+                    order_item.nulls_order,
+                    order_collation,
+                ));
             }
             rows_with_keys.push((row, sort_keys));
         }
 
         // Sort using the sort keys with NULLS FIRST/LAST handling
         rows_with_keys.sort_by(|(_, keys_a), (_, keys_b)| {
-            use crate::select::grouping::compare_sql_values;
+            use crate::select::grouping::compare_sql_values_with_collation;
             use vibesql_types::SqlValue;
 
-            for ((val_a, dir, nulls_order), (val_b, _, _)) in keys_a.iter().zip(keys_b.iter()) {
+            for ((val_a, dir, nulls_order, collation), (val_b, _, _, _)) in
+                keys_a.iter().zip(keys_b.iter())
+            {
                 // Handle NULLS FIRST/LAST
                 let (a_is_null, b_is_null) =
                     (matches!(val_a, SqlValue::Null), matches!(val_b, SqlValue::Null));
@@ -312,9 +347,14 @@ impl SelectExecutor<'_> {
                     };
                 }
 
+                let collation_str = collation.as_deref();
                 let cmp = match dir {
-                    vibesql_ast::OrderDirection::Asc => compare_sql_values(val_a, val_b),
-                    vibesql_ast::OrderDirection::Desc => compare_sql_values(val_a, val_b).reverse(),
+                    vibesql_ast::OrderDirection::Asc => {
+                        compare_sql_values_with_collation(val_a, val_b, collation_str)
+                    }
+                    vibesql_ast::OrderDirection::Desc => {
+                        compare_sql_values_with_collation(val_a, val_b, collation_str).reverse()
+                    }
                 };
 
                 if cmp != std::cmp::Ordering::Equal {


### PR DESCRIPTION
## Summary

`get_expression_collation` only handled raw `Collate` and `ColumnRef` nodes, returning `None` for any compound expression. This caused `ORDER BY` clauses with embedded `COLLATE` on aggregates or binary operators (e.g. `ORDER BY max(b COLLATE nocase) || ''`) to silently fall back to default BINARY collation, producing wrong sort order.

This PR implements SQLite's collation propagation rules so that explicit `COLLATE` clauses survive through `BinaryOp`, `UnaryOp`, single-arg function calls, and single-arg aggregate functions.

## Changes

- **`evaluator/combined/eval.rs` and `evaluator/expressions/eval.rs`** (parallel implementations): extend `get_expression_collation` to recurse into compound expressions; add `explicit_collation_of` helper implementing SQLite rule 7.1.2 (an explicit `COLLATE` on either operand of a binary op beats the column-derived collation of the other operand).
- **`select/executor/aggregation/evaluation/mod.rs`**: capture the effective collation from the *original* ORDER BY expression before it is rewritten into a hidden-column `ColumnRef` (which would lose the inner `Collate` node), thread it through the `SortKey` tuple, and use `compare_sql_values_with_collation` in the comparator.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `window1.test` 64.2 passes | OK | No longer in failure list (`./scripts/tcltest test window1.test`) |
| `window1.test` 64.3 passes | OK | No longer in failure list |
| `window1.test` 64.4 passes | OK | No longer in failure list |
| Manual repro `SELECT b\|\|'' FROM t1 ORDER BY b COLLATE nocase\|\|''` | OK | Returns `abcd, BCDE, cdef, DEFG` (was `BCDE, DEFG, abcd, cdef`) |
| Manual repro `SELECT max(b COLLATE nocase) FROM t1 GROUP BY rowid ORDER BY max(b COLLATE nocase)\|\|''` | OK | Returns `abcd, BCDE, cdef, DEFG` |
| No regressions in unit tests | OK | All 2350 `vibesql-executor` unit tests pass |
| `windowB.test` 8.1 passes | NOT FIXED | Different root cause — see Out of Scope below |

## Out of Scope

The curator's analysis listed `windowB.test 8.1` as analogous, but investigation shows it has a different root cause: RANGE-with-numeric-offset frame computation on a TEXT-typed ORDER BY column. The `COLLATE nocase` propagation works correctly here (the existing `Collate` node was never in question for that query); the bug is in how the window frame computes peer membership when the ORDER BY column is TEXT but the frame offset is numeric. This should be tracked as a separate issue.

## Test Plan

- `./scripts/tcltest test window1.test` — failures dropped from 39 to 30 (`64.2/64.3/64.4` plus several other tests that exercise the same code path: `7.1.5, 11.1, 39.3, 39.4, 42.2, 42.3, 47.2, 54.4, 62.4` are no longer failing). Pass count: 233 -> 242 / 348.
- `./scripts/tcltest test windowB.test` — `8.1` still failing (separate root cause noted above), other 33 tests pass.
- `cargo test --package vibesql-executor --lib` — all 2350 tests pass.
- Manual repros from the curator's test plan all return correct results.

Closes #5077