### PR TITLE
fix(comparison): apply TEXT/Numeric affinity coercion to non-column expressions

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -210,6 +210,26 @@ impl CombinedExpressionEvaluator<'_> {
         }
     }
 
+    /// Check if a SqlValue is numeric (INTEGER, REAL, or NUMERIC storage class).
+    ///
+    /// Used by `apply_affinity_for_comparison` to detect numeric values produced by
+    /// non-literal expressions (e.g., aggregate function results like `count(*)`,
+    /// arithmetic like `1+1`, scalar subqueries) so that TEXT-affinity coercion
+    /// applies to them, mirroring SQLite's affinity rules.
+    fn is_numeric_value(val: &SqlValue) -> bool {
+        matches!(
+            val,
+            SqlValue::Integer(_)
+                | SqlValue::Smallint(_)
+                | SqlValue::Bigint(_)
+                | SqlValue::Unsigned(_)
+                | SqlValue::Float(_)
+                | SqlValue::Real(_)
+                | SqlValue::Double(_)
+                | SqlValue::Numeric(_)
+        )
+    }
+
     /// Try to convert a string SqlValue to a numeric SqlValue.
     /// Returns the original value if the string doesn't look like a number.
     /// This implements SQLite's NUMERIC affinity coercion rules.
@@ -249,11 +269,18 @@ impl CombinedExpressionEvaluator<'_> {
         let left_affinity = self.get_expression_affinity(left_expr);
         let right_affinity = self.get_expression_affinity(right_expr);
 
-        // Case 1: Left is TEXT column, right is numeric literal
-        // SQLite converts numeric literals to text for comparison with TEXT columns.
+        // Case 1: Left is TEXT column, right is a non-column numeric value.
+        // SQLite converts numeric values to text for comparison with TEXT columns.
+        // This applies to numeric literals AND non-column numeric expressions
+        // (aggregates like count(*), arithmetic like 1+1, function calls, scalar subqueries).
+        // It does NOT apply to column refs (those have a column affinity, even if NONE);
+        // TEXT-column vs NONE-column produces strict type-class inequality per whereB.test.
         // Floats must preserve their decimal representation (10.0 → "10.0", not "10")
         // so that TEXT '10' != REAL 10.0 (different string representations).
-        if left_affinity == Some(TypeAffinity::Text) && self.is_numeric_literal(right_expr) {
+        if left_affinity == Some(TypeAffinity::Text)
+            && right_affinity.is_none()
+            && Self::is_numeric_value(&right_val)
+        {
             let right_as_text = match &right_val {
                 SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
                 SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
@@ -276,9 +303,12 @@ impl CombinedExpressionEvaluator<'_> {
             return (left_val, right_as_text);
         }
 
-        // Case 2: Right is TEXT column, left is numeric literal
+        // Case 2: Right is TEXT column, left is a non-column numeric value.
         // Same as Case 1 but symmetric - floats must preserve decimal representation.
-        if right_affinity == Some(TypeAffinity::Text) && self.is_numeric_literal(left_expr) {
+        if right_affinity == Some(TypeAffinity::Text)
+            && left_affinity.is_none()
+            && Self::is_numeric_value(&left_val)
+        {
             let left_as_text = match &left_val {
                 SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
                 SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -175,6 +175,26 @@ impl ExpressionEvaluator<'_> {
         }
     }
 
+    /// Check if a SqlValue is numeric (INTEGER, REAL, or NUMERIC storage class).
+    ///
+    /// Used by `apply_affinity_for_comparison` to detect numeric values produced by
+    /// non-literal expressions (e.g., aggregate function results like `count(*)`,
+    /// arithmetic like `1+1`, scalar subqueries) so that TEXT-affinity coercion
+    /// applies to them, mirroring SQLite's affinity rules.
+    fn is_numeric_value(val: &SqlValue) -> bool {
+        matches!(
+            val,
+            SqlValue::Integer(_)
+                | SqlValue::Smallint(_)
+                | SqlValue::Bigint(_)
+                | SqlValue::Unsigned(_)
+                | SqlValue::Float(_)
+                | SqlValue::Real(_)
+                | SqlValue::Double(_)
+                | SqlValue::Numeric(_)
+        )
+    }
+
     /// Try to convert a string SqlValue to a numeric SqlValue.
     /// Returns the original value if the string doesn't look like a number.
     /// This implements SQLite's NUMERIC affinity coercion rules.
@@ -214,11 +234,18 @@ impl ExpressionEvaluator<'_> {
         let left_affinity = self.get_expression_affinity(left_expr);
         let right_affinity = self.get_expression_affinity(right_expr);
 
-        // Case 1: Left is TEXT column, right is numeric literal
-        // SQLite converts numeric literals to text for comparison with TEXT columns.
+        // Case 1: Left is TEXT column, right is a non-column numeric value.
+        // SQLite converts numeric values to text for comparison with TEXT columns.
+        // This applies to numeric literals AND non-column numeric expressions
+        // (aggregates like count(*), arithmetic like 1+1, function calls, scalar subqueries).
+        // It does NOT apply to column refs (those have a column affinity, even if NONE);
+        // TEXT-column vs NONE-column produces strict type-class inequality per whereB.test.
         // Floats must preserve their decimal representation (10.0 → "10.0", not "10")
         // so that TEXT '10' != REAL 10.0 (different string representations).
-        if left_affinity == Some(TypeAffinity::Text) && self.is_numeric_literal(right_expr) {
+        if left_affinity == Some(TypeAffinity::Text)
+            && right_affinity.is_none()
+            && Self::is_numeric_value(&right_val)
+        {
             let right_as_text = match &right_val {
                 SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
                 SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
@@ -241,9 +268,12 @@ impl ExpressionEvaluator<'_> {
             return (left_val, right_as_text);
         }
 
-        // Case 2: Right is TEXT column, left is numeric literal
+        // Case 2: Right is TEXT column, left is a non-column numeric value.
         // Same as Case 1 but symmetric - floats must preserve decimal representation.
-        if right_affinity == Some(TypeAffinity::Text) && self.is_numeric_literal(left_expr) {
+        if right_affinity == Some(TypeAffinity::Text)
+            && left_affinity.is_none()
+            && Self::is_numeric_value(&left_val)
+        {
             let left_as_text = match &left_val {
                 SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
                 SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),


### PR DESCRIPTION
## Summary

\`apply_affinity_for_comparison\` previously only coerced TEXT-vs-numeric when one side was a numeric literal (\`is_numeric_literal\`). Aggregate function results (\`count(*)\`, \`sum(...)\`), arithmetic (\`1+1\`), function calls, and scalar subqueries that produce numeric values were left at their numeric storage class, producing strict storage-class inequality when compared to TEXT-affinity column values — even though SQLite's affinity rules say a TEXT column compared to a numeric value should coerce the numeric value to TEXT.

## Changes

The fix replaces \`is_numeric_literal(right_expr)\` with two conditions: right side has NO affinity (i.e. is not a column ref) AND the resulting value is numeric. This widens coverage to all non-column numeric expressions while preserving the column-vs-column path (column refs have affinity NONE, even untyped, which produces the strict type-class inequality \`whereB.test\` relies on).

Adds an \`is_numeric_value\` helper that checks all numeric storage classes (Integer/Smallint/Bigint/Unsigned/Float/Real/Double/Numeric). Both \`combined/eval.rs\` and \`expressions/eval.rs\` updated symmetrically.

## Test plan

- [x] \`window9.test 4.1.1, 4.1.2\` now pass (was failing on aggregate-result vs TEXT column comparison)
- [x] \`window9.test 8.4\` remains failing — separate root cause (UNION + nested aggregate + window-over-subquery), tracked as **#5105**
- [x] \`where.test\` 168/168 pass (no regression)
- [x] \`select1.test\` 187/188 (only failure is pre-existing select1-18.1)
- [x] \`cargo test --release -p vibesql-executor --lib\` — 2350 passed

Closes #5081