### PR TITLE
feat(fkey): emit "foreign key mismatch" error class for invalid FK targets

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -1120,23 +1120,36 @@ impl SqlExecutor {
                 .collect();
 
             for (fk_id, fk) in fk_constraints.iter().enumerate() {
+                // Mismatch check: if the parent table exists but lacks a key
+                // (PRIMARY KEY / UNIQUE constraint / non-partial UNIQUE INDEX)
+                // covering the FK columns, raise the SQLite-compatible error.
+                // Matches `do_catchsql_test 11.1` in fkey5.test.
+                if let Some((child, parent)) =
+                    vibesql_executor::foreign_key_check::detect_fk_mismatch(
+                        &self.db,
+                        tbl_name,
+                        fk,
+                    )
+                {
+                    anyhow::bail!(
+                        "foreign key mismatch - \"{}\" referencing \"{}\"",
+                        child,
+                        parent
+                    );
+                }
+
                 // Get parent column collations so we can match SQLite's FK comparison rules
                 // (numeric coercion + parent-column collation, e.g. NOCASE).
-                let parent_column_collations: Vec<Option<String>> = if let Some(parent_schema) =
-                    self.db.catalog.get_table(&fk.parent_table)
-                {
-                    fk.parent_column_indices
-                        .iter()
-                        .map(|&idx| {
-                            parent_schema
-                                .columns
-                                .get(idx)
-                                .and_then(|c| c.collation.clone())
-                        })
-                        .collect()
-                } else {
-                    vec![None; fk.parent_column_indices.len()]
-                };
+                // Use the shared resolver so post-reload placeholder indices
+                // do not skew which parent columns we read from.
+                let parent_column_collations: Vec<Option<String>> =
+                    vibesql_executor::foreign_key_check::parent_collations_for_fk(
+                        &self.db, fk,
+                    );
+                let resolved_parent_indices =
+                    vibesql_executor::foreign_key_check::resolved_parent_indices_for_fk(
+                        &self.db, fk,
+                    );
 
                 // Get parent table data
                 let parent_qualified = format!(
@@ -1204,13 +1217,13 @@ impl SqlExecutor {
 
                     // Check if matching parent row exists
                     let found = parent_rows.iter().any(|parent_row| {
-                        fk.parent_column_indices
+                        resolved_parent_indices
                             .iter()
                             .zip(child_values.iter())
                             .enumerate()
                             .all(|(i, (&parent_idx, child_val))| {
                                 if parent_idx < parent_row.values.len() {
-                                    fk_values_equal(
+                                    vibesql_executor::foreign_key_check::fk_values_equal(
                                         child_val,
                                         &parent_row.values[parent_idx],
                                         parent_column_collations
@@ -1262,61 +1275,6 @@ impl SqlExecutor {
             execution_time_ms: None,
             message: None,
         })
-    }
-}
-
-/// SQLite-style equality for FOREIGN KEY comparisons.
-///
-/// SQLite considers a child value to match a parent value when:
-/// - they are equal under VibeSQL's strict typed equality, OR
-/// - both can be coerced to the same numeric value (e.g. INTEGER 88 == TEXT "88"), OR
-/// - both are textual and equal under the parent column's collation (e.g. NOCASE).
-fn fk_values_equal(
-    child: &vibesql_types::SqlValue,
-    parent: &vibesql_types::SqlValue,
-    parent_collation: Option<&str>,
-) -> bool {
-    if child == parent {
-        return true;
-    }
-    if let (Some(c), Some(p)) = (sql_value_as_f64(child), sql_value_as_f64(parent)) {
-        if c == p {
-            return true;
-        }
-    }
-    if let (Some(c), Some(p)) = (sql_value_as_text(child), sql_value_as_text(parent)) {
-        match parent_collation.map(|s| s.to_ascii_lowercase()) {
-            Some(ref name) if name == "nocase" => return c.eq_ignore_ascii_case(p),
-            Some(ref name) if name == "rtrim" => {
-                return c.trim_end_matches(' ') == p.trim_end_matches(' ');
-            }
-            _ => {}
-        }
-    }
-    false
-}
-
-fn sql_value_as_f64(v: &vibesql_types::SqlValue) -> Option<f64> {
-    use vibesql_types::SqlValue::*;
-    match v {
-        Integer(i) => Some(*i as f64),
-        Smallint(i) => Some(*i as f64),
-        Bigint(i) => Some(*i as f64),
-        Unsigned(i) => Some(*i as f64),
-        Float(f) => Some(*f as f64),
-        Real(r) => Some(*r as f64),
-        Double(d) | Numeric(d) => Some(*d),
-        Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
-        Character(s) | Varchar(s) => s.trim().parse::<f64>().ok(),
-        _ => None,
-    }
-}
-
-fn sql_value_as_text(v: &vibesql_types::SqlValue) -> Option<&str> {
-    use vibesql_types::SqlValue::*;
-    match v {
-        Character(s) | Varchar(s) => Some(s.as_str()),
-        _ => None,
     }
 }
 

--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -145,6 +145,14 @@ pub enum ExecutorError {
         to: String,
     },
     ConstraintViolation(String),
+    /// FOREIGN KEY references a parent column set that is not covered by a
+    /// PRIMARY KEY, UNIQUE constraint, or non-partial UNIQUE INDEX in the
+    /// parent table (SQLite-compatible error). Format:
+    /// `foreign key mismatch - "<child>" referencing "<parent>"`
+    ForeignKeyMismatch {
+        child: String,
+        parent: String,
+    },
     MultiplePrimaryKeys,
     CannotDropColumn(String),
     ConstraintNotFound {
@@ -735,6 +743,10 @@ impl std::fmt::Display for ExecutorError {
             }
             ExecutorError::ConstraintViolation(msg) => {
                 write!(f, "{}", vibe_msg!("executor-constraint-violation", message = msg.as_str()))
+            }
+            ExecutorError::ForeignKeyMismatch { child, parent } => {
+                // SQLite-compatible error format from fkey.c::sqlite3FkLocateIndex.
+                write!(f, "foreign key mismatch - \"{}\" referencing \"{}\"", child, parent)
             }
             ExecutorError::MultiplePrimaryKeys => {
                 write!(f, "{}", vibe_msg!("executor-multiple-primary-keys"))

--- a/crates/vibesql-executor/src/foreign_key_check.rs
+++ b/crates/vibesql-executor/src/foreign_key_check.rs
@@ -1,0 +1,307 @@
+//! Shared foreign-key validation helpers.
+//!
+//! This module centralizes two pieces of FK enforcement that must stay in sync
+//! across multiple call sites (INSERT, UPDATE, PRAGMA `foreign_key_check`):
+//!
+//! 1. [`detect_fk_mismatch`] — Verify that the parent table actually has a PK,
+//!    UNIQUE constraint, or non-partial UNIQUE INDEX that *exactly* covers the
+//!    columns referenced by the FK. SQLite raises a `foreign key mismatch`
+//!    error before any row-existence check when no such key exists.
+//! 2. [`fk_values_equal`] — SQLite-style equality for FK comparisons that
+//!    honours numeric coercion as well as the parent column's `NOCASE` /
+//!    `RTRIM` collation. The non-collation logic mirrors VibeSQL's
+//!    [`vibesql_types::SqlValue`] strict equality; the collation logic mirrors
+//!    the helpers used in `select::grouping::aggregates`.
+//!
+//! See issue #5084 for context.
+
+use vibesql_catalog::{ForeignKeyConstraint, TableSchema};
+use vibesql_storage::Database;
+
+/// Returns `Some` (the child / parent table names to embed in the error) when
+/// the parent table does **not** have a key that exactly covers the FK's
+/// referenced columns.
+///
+/// SQLite's rule (see `fkey.c::sqlite3FkLocateIndex`): the parent column list
+/// must match either the PRIMARY KEY or a UNIQUE constraint or a non-partial
+/// UNIQUE INDEX, *as a set* (order-independent, exact coverage — supersets are
+/// not acceptable).
+pub fn detect_fk_mismatch(
+    db: &Database,
+    child_table: &str,
+    fk: &ForeignKeyConstraint,
+) -> Option<(String, String)> {
+    let parent = db.catalog.get_table(&fk.parent_table)?;
+
+    // Resolve parent column indices by name when names are present. The
+    // cached `fk.parent_column_indices` can lag behind the parent schema
+    // when the FK was registered before the parent table existed (e.g. on
+    // SQL-dump reload, where alphabetic sort can place children first).
+    let resolved_indices = resolve_parent_indices(parent, fk);
+
+    if parent_has_matching_key(db, parent, &resolved_indices) {
+        None
+    } else {
+        Some((child_table.to_string(), fk.parent_table.clone()))
+    }
+}
+
+/// Resolve the FK's parent-side column indices, preferring `parent_column_names`
+/// over the cached `parent_column_indices` (which may carry placeholder zeros
+/// when the parent did not yet exist at FK creation time).
+fn resolve_parent_indices(
+    parent: &TableSchema,
+    fk: &ForeignKeyConstraint,
+) -> Vec<usize> {
+    // Names available and non-empty — resolve lazily.
+    let names_usable = !fk.parent_column_names.is_empty()
+        && fk.parent_column_names.iter().any(|n| !n.is_empty());
+    if names_usable {
+        let by_name: Vec<Option<usize>> = fk
+            .parent_column_names
+            .iter()
+            .map(|n| if n.is_empty() { None } else { parent.get_column_index(n) })
+            .collect();
+
+        // Only fall back to indices when *all* names resolved cleanly. A
+        // partial resolution would mix stale placeholders and real indices.
+        if by_name.iter().all(|opt| opt.is_some()) {
+            return by_name.into_iter().map(|opt| opt.unwrap()).collect();
+        }
+
+        // Names don't resolve — likely an empty-FK-list (REFERENCES p1)
+        // pointing at the parent's PK. Fall through to the cached indices.
+    }
+
+    // Empty parent_column_names with a single placeholder index typically
+    // means "REFERENCES <table>" with no column list (defaults to PK).
+    // Substitute the parent's actual PK indices when available.
+    if fk.parent_column_names.iter().all(|n| n.is_empty()) {
+        if let Some(pk_indices) = parent.get_primary_key_indices() {
+            if pk_indices.len() == fk.parent_column_indices.len() {
+                return pk_indices;
+            }
+        }
+    }
+
+    fk.parent_column_indices.clone()
+}
+
+/// True when the parent table exposes a PK / UNIQUE / non-partial UNIQUE INDEX
+/// that exactly covers the supplied column set.
+fn parent_has_matching_key(
+    db: &Database,
+    parent: &TableSchema,
+    parent_indices: &[usize],
+) -> bool {
+    if parent_indices.is_empty() {
+        return false;
+    }
+
+    // 1. PRIMARY KEY exact match (set equality on column indices).
+    if let Some(pk_indices) = parent.get_primary_key_indices() {
+        if column_set_eq(&pk_indices, parent_indices) {
+            return true;
+        }
+    }
+
+    // 2. UNIQUE constraint exact match.
+    for unique_idx_set in parent.get_unique_constraint_indices() {
+        if column_set_eq(&unique_idx_set, parent_indices) {
+            return true;
+        }
+    }
+
+    // 3. Non-partial UNIQUE INDEX exact match. `IndexMetadata` does not yet
+    //    track a `where_clause`, so every UNIQUE index in the catalog is
+    //    treated as full-coverage. Expression indexes can never back an FK.
+    for index in db.catalog.get_table_indexes(&parent.name) {
+        if !index.is_unique || index.has_expression_columns() {
+            continue;
+        }
+        let mut index_col_indices: Vec<usize> = Vec::with_capacity(index.columns.len());
+        let mut all_resolved = true;
+        for col in &index.columns {
+            match col.column_name().and_then(|n| parent.get_column_index(n)) {
+                Some(idx) => index_col_indices.push(idx),
+                None => {
+                    all_resolved = false;
+                    break;
+                }
+            }
+        }
+        if !all_resolved {
+            continue;
+        }
+        if column_set_eq(&index_col_indices, parent_indices) {
+            return true;
+        }
+    }
+
+    // 4. Fallback: a single-column FK against a column that is itself
+    //    declared with column-level UNIQUE is represented in
+    //    `unique_constraints`, so the match succeeds at step 2 above.
+    false
+}
+
+/// Set-equality on column-index slices (order-independent, no duplicates).
+fn column_set_eq(a: &[usize], b: &[usize]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut a_sorted: Vec<usize> = a.to_vec();
+    let mut b_sorted: Vec<usize> = b.to_vec();
+    a_sorted.sort_unstable();
+    b_sorted.sort_unstable();
+    a_sorted == b_sorted
+}
+
+/// SQLite-style equality for FK comparisons that respects the parent column's
+/// collation (NOCASE / RTRIM) on top of strict typed equality and numeric
+/// coercion.
+pub fn fk_values_equal(
+    child: &vibesql_types::SqlValue,
+    parent: &vibesql_types::SqlValue,
+    parent_collation: Option<&str>,
+) -> bool {
+    if child == parent {
+        return true;
+    }
+    if let (Some(c), Some(p)) = (sql_value_as_f64(child), sql_value_as_f64(parent)) {
+        if c == p {
+            return true;
+        }
+    }
+    if let (Some(c), Some(p)) = (sql_value_as_text(child), sql_value_as_text(parent)) {
+        match parent_collation.map(|s| s.to_ascii_lowercase()) {
+            Some(ref name) if name == "nocase" => return c.eq_ignore_ascii_case(p),
+            Some(ref name) if name == "rtrim" => {
+                return c.trim_end_matches(' ') == p.trim_end_matches(' ');
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+fn sql_value_as_f64(v: &vibesql_types::SqlValue) -> Option<f64> {
+    use vibesql_types::SqlValue::*;
+    match v {
+        Integer(i) => Some(*i as f64),
+        Smallint(i) => Some(*i as f64),
+        Bigint(i) => Some(*i as f64),
+        Unsigned(i) => Some(*i as f64),
+        Float(f) => Some(*f as f64),
+        Real(r) => Some(*r as f64),
+        Double(d) | Numeric(d) => Some(*d),
+        Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
+        Character(s) | Varchar(s) => s.trim().parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+fn sql_value_as_text(v: &vibesql_types::SqlValue) -> Option<&str> {
+    use vibesql_types::SqlValue::*;
+    match v {
+        Character(s) | Varchar(s) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+/// Resolve the parent column collations for an FK (ordered to align with
+/// the FK's parent-side columns). Uses [`resolve_parent_indices`] so that
+/// stale placeholder indices left behind after a SQL-dump reload do not
+/// cause us to read collation from the wrong column. Missing parent tables
+/// or out-of-range indices yield `None`.
+pub fn parent_collations_for_fk(
+    db: &Database,
+    fk: &ForeignKeyConstraint,
+) -> Vec<Option<String>> {
+    if let Some(parent) = db.catalog.get_table(&fk.parent_table) {
+        let indices = resolve_parent_indices(parent, fk);
+        indices
+            .iter()
+            .map(|&idx| parent.columns.get(idx).and_then(|c| c.collation.clone()))
+            .collect()
+    } else {
+        vec![None; fk.parent_column_indices.len()]
+    }
+}
+
+/// Public helper — re-exported so callers (INSERT/UPDATE/PRAGMA) can use the
+/// same lazy parent-index resolution as [`detect_fk_mismatch`]. This keeps
+/// row-existence comparisons aligned with mismatch detection so that they
+/// agree on what "the parent FK columns" mean even after a SQL-dump reload
+/// reordered children before parents.
+pub fn resolved_parent_indices_for_fk(
+    db: &Database,
+    fk: &ForeignKeyConstraint,
+) -> Vec<usize> {
+    if let Some(parent) = db.catalog.get_table(&fk.parent_table) {
+        resolve_parent_indices(parent, fk)
+    } else {
+        fk.parent_column_indices.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_set_eq_same_order() {
+        assert!(column_set_eq(&[1, 2, 3], &[1, 2, 3]));
+    }
+
+    #[test]
+    fn column_set_eq_reordered() {
+        assert!(column_set_eq(&[3, 1, 2], &[1, 2, 3]));
+    }
+
+    #[test]
+    fn column_set_eq_different_lengths() {
+        assert!(!column_set_eq(&[1, 2], &[1, 2, 3]));
+    }
+
+    #[test]
+    fn column_set_eq_disjoint() {
+        assert!(!column_set_eq(&[1, 2], &[3, 4]));
+    }
+
+    #[test]
+    fn fk_values_equal_strict() {
+        let v = vibesql_types::SqlValue::Integer(42);
+        assert!(fk_values_equal(&v, &v, None));
+    }
+
+    #[test]
+    fn fk_values_equal_numeric_coercion() {
+        let child = vibesql_types::SqlValue::Integer(88);
+        let parent = vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("88"));
+        assert!(fk_values_equal(&child, &parent, None));
+    }
+
+    #[test]
+    fn fk_values_equal_nocase() {
+        let child = vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Alpha"));
+        let parent = vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("ALPHA"));
+        assert!(fk_values_equal(&child, &parent, Some("NOCASE")));
+        assert!(!fk_values_equal(&child, &parent, None));
+    }
+
+    #[test]
+    fn fk_values_equal_rtrim() {
+        let child = vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("abc"));
+        let parent = vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("abc   "));
+        assert!(fk_values_equal(&child, &parent, Some("rtrim")));
+        assert!(!fk_values_equal(&child, &parent, None));
+    }
+
+    #[test]
+    fn fk_values_equal_distinct() {
+        let child = vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("foo"));
+        let parent = vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("bar"));
+        assert!(!fk_values_equal(&child, &parent, None));
+        assert!(!fk_values_equal(&child, &parent, Some("nocase")));
+    }
+}

--- a/crates/vibesql-executor/src/insert/foreign_keys.rs
+++ b/crates/vibesql-executor/src/insert/foreign_keys.rs
@@ -17,6 +17,14 @@ pub fn validate_foreign_key_constraints(
         .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
 
     for fk in &schema.foreign_keys {
+        // Mismatch check runs before any row-existence test so that bad
+        // FK targets are reported even when the parent table is empty.
+        if let Some((child, parent)) =
+            crate::foreign_key_check::detect_fk_mismatch(db, table_name, fk)
+        {
+            return Err(ExecutorError::ForeignKeyMismatch { child, parent });
+        }
+
         // Extract FK values from the new row
         let fk_values: Vec<vibesql_types::SqlValue> =
             fk.column_indices.iter().map(|&idx| row_values[idx].clone()).collect();
@@ -31,11 +39,22 @@ pub fn validate_foreign_key_constraints(
             .get_table(&fk.parent_table)
             .ok_or_else(|| ExecutorError::TableNotFound(fk.parent_table.clone()))?;
 
+        let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
+        let parent_indices = crate::foreign_key_check::resolved_parent_indices_for_fk(db, fk);
+
         let key_exists = parent_table.scan().iter().any(|parent_row| {
-            fk.parent_column_indices
+            parent_indices
                 .iter()
                 .zip(&fk_values)
-                .all(|(&parent_idx, fk_val)| parent_row.get(parent_idx) == Some(fk_val))
+                .enumerate()
+                .all(|(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+                    Some(parent_val) => crate::foreign_key_check::fk_values_equal(
+                        fk_val,
+                        parent_val,
+                        parent_collations.get(i).and_then(|c| c.as_deref()),
+                    ),
+                    None => false,
+                })
         });
 
         if !key_exists {

--- a/crates/vibesql-executor/src/insert/row_validator.rs
+++ b/crates/vibesql-executor/src/insert/row_validator.rs
@@ -347,12 +347,21 @@ impl<'a> RowValidator<'a> {
         }
 
         for (fk_idx, fk_values) in fk_keys.iter().enumerate() {
-            // Skip if any FK value is NULL (stored as None)
+            let fk = &self.schema.foreign_keys[fk_idx];
+
+            // Mismatch check runs before any row-existence test so that bad
+            // FK targets are reported even when the parent table is empty
+            // (matches SQLite behaviour and fkey1-6.1 / fkey5-11.1).
+            if let Some((child, parent)) =
+                crate::foreign_key_check::detect_fk_mismatch(self.db, self.table_name, fk)
+            {
+                return Err(ExecutorError::ForeignKeyMismatch { child, parent });
+            }
+
+            // Skip row-existence check if any FK value is NULL (stored as None)
             let Some(ref fk_values) = fk_values else {
                 continue;
             };
-
-            let fk = &self.schema.foreign_keys[fk_idx];
 
             // Check if the referenced key exists in the parent table
             let parent_table = self
@@ -360,11 +369,24 @@ impl<'a> RowValidator<'a> {
                 .get_table(&fk.parent_table)
                 .ok_or_else(|| ExecutorError::TableNotFound(fk.parent_table.clone()))?;
 
+            let parent_collations =
+                crate::foreign_key_check::parent_collations_for_fk(self.db, fk);
+            let parent_indices =
+                crate::foreign_key_check::resolved_parent_indices_for_fk(self.db, fk);
+
             let key_exists = parent_table.scan().iter().any(|parent_row| {
-                fk.parent_column_indices
+                parent_indices
                     .iter()
                     .zip(fk_values)
-                    .all(|(&parent_idx, fk_val)| parent_row.get(parent_idx) == Some(fk_val))
+                    .enumerate()
+                    .all(|(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+                        Some(parent_val) => crate::foreign_key_check::fk_values_equal(
+                            fk_val,
+                            parent_val,
+                            parent_collations.get(i).and_then(|c| c.as_deref()),
+                        ),
+                        None => false,
+                    })
             });
 
             if !key_exists {

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -19,6 +19,7 @@ pub mod errors;
 pub mod evaluator;
 mod explain;
 pub mod expression_index_maintenance;
+pub mod foreign_key_check;
 mod grant;
 pub mod index_ddl;
 pub mod information_schema;

--- a/crates/vibesql-executor/src/tests/foreign_key_mismatch.rs
+++ b/crates/vibesql-executor/src/tests/foreign_key_mismatch.rs
@@ -1,0 +1,165 @@
+//! Tests for `foreign key mismatch` error class (issue #5084).
+//!
+//! When an FK references a parent column set that is not covered by a
+//! PRIMARY KEY, UNIQUE constraint, or non-partial UNIQUE INDEX, SQLite
+//! raises `foreign key mismatch - "<child>" referencing "<parent>"`. The
+//! check runs before any row-existence test, so it fires even when the
+//! parent table is empty.
+//!
+//! These tests also cover the RTRIM / NOCASE collation-aware comparison
+//! that the FK validators use during row-existence checks.
+
+use vibesql_ast::Statement;
+use vibesql_storage::Database;
+
+/// Helper to parse and execute SQL — returns either the formatted result or
+/// the `Display` form of the executor error so we can assert on the
+/// SQLite-compatible wording.
+fn exec_sql(db: &mut Database, sql: &str) -> Result<String, String> {
+    let stmt =
+        vibesql_parser::Parser::parse_sql(sql).map_err(|e| format!("Parse error: {:?}", e))?;
+
+    match stmt {
+        Statement::CreateTable(s) => {
+            crate::CreateTableExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        Statement::Insert(s) => crate::InsertExecutor::execute(db, &s)
+            .map(|count| format!("{} row(s) inserted", count))
+            .map_err(|e| e.to_string()),
+        Statement::CreateIndex(s) => crate::CreateIndexExecutor::execute(&s, db)
+            .map(|_| "ok".to_string())
+            .map_err(|e| e.to_string()),
+        _ => Err(format!("Unsupported statement type: {:?}", sql)),
+    }
+}
+
+#[test]
+fn fk_mismatch_when_parent_column_not_unique() {
+    // Mirrors fkey5-11.0/11.1 in SQLite's TCL suite.
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+
+    exec_sql(&mut db, "CREATE TABLE tt(y)").unwrap();
+    exec_sql(&mut db, "CREATE TABLE c11(x REFERENCES tt(y))").unwrap();
+
+    // Insert into the child should now fail with the mismatch error even
+    // though the parent table is empty — because `tt.y` has no UNIQUE/PK.
+    let err = exec_sql(&mut db, "INSERT INTO c11 VALUES(1)").unwrap_err();
+    assert!(
+        err.contains("foreign key mismatch") && err.contains("\"c11\"") && err.contains("\"tt\""),
+        "expected mismatch wording, got: {}",
+        err
+    );
+}
+
+#[test]
+fn fk_mismatch_when_only_partial_unique_index_exists() {
+    // Mirrors fkey1-6.0/6.1: a UNIQUE INDEX with a WHERE clause does not
+    // qualify, but VibeSQL doesn't yet round-trip partial indexes — so for
+    // now we exercise the simpler "no UNIQUE at all" path which the same
+    // code branch produces.
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+
+    exec_sql(&mut db, "CREATE TABLE p1(x, y)").unwrap();
+    exec_sql(&mut db, "INSERT INTO p1 VALUES(1, 1)").unwrap();
+    exec_sql(&mut db, "CREATE TABLE c1(a REFERENCES p1(x))").unwrap();
+
+    let err = exec_sql(&mut db, "INSERT INTO c1 VALUES(1)").unwrap_err();
+    assert!(
+        err.contains("foreign key mismatch") && err.contains("\"c1\"") && err.contains("\"p1\""),
+        "expected mismatch wording, got: {}",
+        err
+    );
+}
+
+#[test]
+fn fk_mismatch_resolved_by_creating_unique_index() {
+    // After we add a non-partial UNIQUE INDEX on the parent column, the
+    // FK insert succeeds. Mirrors fkey1-6.2.
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+
+    exec_sql(&mut db, "CREATE TABLE p1(x, y)").unwrap();
+    exec_sql(&mut db, "INSERT INTO p1 VALUES(1, 1)").unwrap();
+    exec_sql(&mut db, "CREATE TABLE c1(a REFERENCES p1(x))").unwrap();
+    exec_sql(&mut db, "CREATE UNIQUE INDEX p1x2 ON p1(x)").unwrap();
+
+    // Now FK should succeed because p1(x) has a full UNIQUE INDEX.
+    let r = exec_sql(&mut db, "INSERT INTO c1 VALUES(1)");
+    assert!(r.is_ok(), "expected success after UNIQUE INDEX; got: {:?}", r);
+}
+
+#[test]
+fn fk_succeeds_with_primary_key_target() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+
+    exec_sql(&mut db, "CREATE TABLE parent(id INT PRIMARY KEY, name VARCHAR(50))").unwrap();
+    exec_sql(&mut db, "INSERT INTO parent VALUES(1, 'a'), (2, 'b')").unwrap();
+    exec_sql(&mut db, "CREATE TABLE child(pid INT REFERENCES parent(id))").unwrap();
+
+    let r = exec_sql(&mut db, "INSERT INTO child VALUES(1)");
+    assert!(r.is_ok(), "FK against PRIMARY KEY should succeed; got: {:?}", r);
+}
+
+#[test]
+fn fk_succeeds_with_unique_constraint_target() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+
+    exec_sql(&mut db, "CREATE TABLE parent(id INT, code VARCHAR(10) UNIQUE)").unwrap();
+    exec_sql(&mut db, "INSERT INTO parent VALUES(1, 'A'), (2, 'B')").unwrap();
+    exec_sql(&mut db, "CREATE TABLE child(c VARCHAR(10) REFERENCES parent(code))").unwrap();
+
+    let r = exec_sql(&mut db, "INSERT INTO child VALUES('A')");
+    assert!(r.is_ok(), "FK against UNIQUE column should succeed; got: {:?}", r);
+}
+
+#[test]
+fn fk_uses_rtrim_collation_for_parent_match() {
+    // Mirrors fkey5-8.4: when the parent column has RTRIM collation, FK
+    // value comparison must trim trailing spaces. The child value here is
+    // `'abc    '` with trailing spaces, parent has `'abc'` — match should
+    // succeed under RTRIM.
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+
+    exec_sql(
+        &mut db,
+        "CREATE TABLE p20(x VARCHAR(10) COLLATE RTRIM PRIMARY KEY, y VARCHAR(20))",
+    )
+    .unwrap();
+    exec_sql(&mut db, "INSERT INTO p20 VALUES('abc', 'Alpha')").unwrap();
+    exec_sql(
+        &mut db,
+        "CREATE TABLE c21(a VARCHAR(20), b VARCHAR(10) REFERENCES p20(x))",
+    )
+    .unwrap();
+
+    // 'abc    ' should match parent 'abc' under RTRIM collation.
+    let r = exec_sql(&mut db, "INSERT INTO c21 VALUES('alpha', 'abc    ')");
+    assert!(r.is_ok(), "RTRIM-aware FK should succeed; got: {:?}", r);
+}
+
+#[test]
+fn fk_uses_nocase_collation_for_parent_match() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+
+    exec_sql(
+        &mut db,
+        "CREATE TABLE p_nc(x VARCHAR(10) COLLATE NOCASE PRIMARY KEY)",
+    )
+    .unwrap();
+    exec_sql(&mut db, "INSERT INTO p_nc VALUES('Alpha')").unwrap();
+    exec_sql(
+        &mut db,
+        "CREATE TABLE c_nc(a VARCHAR(10) REFERENCES p_nc(x))",
+    )
+    .unwrap();
+
+    // Lowercase 'alpha' should match parent 'Alpha' under NOCASE.
+    let r = exec_sql(&mut db, "INSERT INTO c_nc VALUES('alpha')");
+    assert!(r.is_ok(), "NOCASE-aware FK should succeed; got: {:?}", r);
+}

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -79,6 +79,7 @@ mod error_display;
 mod expression_eval;
 mod expression_index_dml_tests;
 mod expression_index_tests;
+mod foreign_key_mismatch;
 mod fulltext_search;
 mod function_tests;
 mod index_optimization;

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -28,6 +28,14 @@ impl ForeignKeyValidator {
             .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
 
         for fk in &schema.foreign_keys {
+            // Mismatch check runs before any row-existence test so that bad
+            // FK targets are reported even when the parent table is empty.
+            if let Some((child, parent)) =
+                crate::foreign_key_check::detect_fk_mismatch(db, table_name, fk)
+            {
+                return Err(ExecutorError::ForeignKeyMismatch { child, parent });
+            }
+
             // Extract FK values from the new row
             let fk_values: Vec<vibesql_types::SqlValue> =
                 fk.column_indices.iter().map(|&idx| row_values[idx].clone()).collect();
@@ -42,11 +50,22 @@ impl ForeignKeyValidator {
                 .get_table(&fk.parent_table)
                 .ok_or_else(|| ExecutorError::TableNotFound(fk.parent_table.clone()))?;
 
+            let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
+            let parent_indices = crate::foreign_key_check::resolved_parent_indices_for_fk(db, fk);
+
             let key_exists = parent_table.scan().iter().any(|parent_row| {
-                fk.parent_column_indices
+                parent_indices
                     .iter()
                     .zip(&fk_values)
-                    .all(|(&parent_idx, fk_val)| parent_row.get(parent_idx) == Some(fk_val))
+                    .enumerate()
+                    .all(|(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+                        Some(parent_val) => crate::foreign_key_check::fk_values_equal(
+                            fk_val,
+                            parent_val,
+                            parent_collations.get(i).and_then(|c| c.as_deref()),
+                        ),
+                        None => false,
+                    })
             });
 
             if !key_exists {


### PR DESCRIPTION
Closes #5084

## Summary

Bucket B of #5071 — adds the SQLite-compatible `foreign key mismatch` error class for FKs whose parent column set is not covered by a PRIMARY KEY, UNIQUE constraint, or non-partial UNIQUE INDEX.

- New `ExecutorError::ForeignKeyMismatch { child, parent }` formatted as `foreign key mismatch - "<child>" referencing "<parent>"` (matches SQLite `fkey.c::sqlite3FkLocateIndex`).
- Mismatch detection runs **before** any row-existence scan, so it fires even on empty parent tables — matches `fkey1-6.1` / `fkey5-11.1`.
- Coverage rule is set-equality on column indices against the parent's PK / UNIQUE constraints / non-partial UNIQUE INDEX (order-independent, exact coverage — supersets correctly fail).
- Adds SQLite-style FK comparison helper (`fk_values_equal`) honouring numeric coercion + parent-column NOCASE / RTRIM collation, fixing `fkey5-8.3` and `fkey5-8.4`.
- Lazy parent-index resolution (`resolve_parent_indices`) handles SQL-dump reload where children may be sorted before parents and `parent_column_indices` carries placeholder zeros.
- Logic is consolidated into a shared `vibesql_executor::foreign_key_check` module so the four enforcement sites stay in sync:
  - `insert/row_validator.rs`
  - `insert/foreign_keys.rs` (legacy)
  - `update/foreign_keys.rs`
  - `vibesql-cli/src/executor/mod.rs::execute_pragma_foreign_key_check`

## Test plan

- [x] Unit: 7 new tests in `crates/vibesql-executor/src/tests/foreign_key_mismatch.rs` cover PK/UNIQUE/UNIQUE-INDEX targets, RTRIM, NOCASE, and the mismatch error.
- [x] Unit: 9 helper tests in `foreign_key_check::tests` (set equality, numeric coercion, collation comparisons).
- [x] All 2366 `vibesql-executor` lib tests pass (`cargo test -p vibesql-executor --lib -- --test-threads=1`).
- [x] `./scripts/tcltest test fkey5.test`: 50 -> 53 passing (gains: 8.3, 8.4 RTRIM, 11.1 mismatch).
- [x] `./scripts/tcltest test fkey1.test`: unchanged at 14 passing — remaining 6.x failures need partial-index *storage* support (out of scope; tracked by #5091).
- [x] `./scripts/tcltest test where.test`: 168/168 passing (no regression).
- [x] `./scripts/tcltest test select1.test`: 187/188 passing — same as baseline (`select1-18.1` is pre-existing).

## Out of scope

- Partial UNIQUE INDEX exclusion as FK targets — requires `IndexMetadata.where_clause` storage. Once the parser persists the WHERE expression, `parent_has_matching_key` should add `if index.where_clause.is_some() { continue; }`. Tracked under #5091.
- `fkey1-5.1`, `fkey1-4.2`, `fkey1-8.3` — orthogonal issues (cascade ordering, PRAGMA table_info format, corrupted-DB detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)