### PR TITLE
fix(window): recurse through all expression variants for window detection (#5095)

### DIFF
--- a/crates/vibesql-executor/src/select/projection.rs
+++ b/crates/vibesql-executor/src/select/projection.rs
@@ -286,7 +286,14 @@ pub(crate) fn project_row_combined(
     Ok(result)
 }
 
-/// Evaluate an expression, checking for window functions first
+/// Evaluate an expression, checking for window functions first.
+///
+/// Strategy: if the expression contains any window function (anywhere in its
+/// tree), recursively substitute every `WindowFunction` node with the
+/// pre-computed value (as a literal) and evaluate the rewritten expression.
+/// This handles arbitrarily nested expressions like
+/// `count() OVER () LIKE lead(x) OVER (...)` (issue #5095) without needing a
+/// special case per Expression variant.
 pub(super) fn evaluate_expression_with_windows(
     expr: &vibesql_ast::Expression,
     row: &vibesql_storage::Row,
@@ -295,74 +302,57 @@ pub(super) fn evaluate_expression_with_windows(
 ) -> Result<vibesql_types::SqlValue, crate::errors::ExecutorError> {
     use vibesql_ast::Expression;
 
-    match expr {
-        Expression::WindowFunction { function, over } => {
-            // Look up the pre-computed value for this window function
-            let key = WindowFunctionKey::from_expression(function, over);
-            if let Some(&col_idx) = window_mapping.get(&key) {
-                // Extract the pre-computed value from the appended column
-                let value = row.values.get(col_idx).cloned().ok_or({
-                    crate::errors::ExecutorError::ColumnIndexOutOfBounds { index: col_idx }
-                })?;
-                Ok(value)
-            } else {
-                Err(crate::errors::ExecutorError::UnsupportedExpression(format!(
-                    "Window function not found in mapping: {:?}",
-                    expr
-                )))
-            }
-        }
-        Expression::BinaryOp { left, right, op } => {
-            // For expressions containing window functions in binary operations,
-            // we need to recursively substitute window function values
-            let left_substituted = substitute_window_functions(left, row, window_mapping)?;
-            let right_substituted = substitute_window_functions(right, row, window_mapping)?;
-
-            // Build a new binary expression with substituted values and evaluate it
-            let new_expr = Expression::BinaryOp {
-                left: Box::new(left_substituted),
-                right: Box::new(right_substituted),
-                op: *op,
-            };
-            evaluator.eval(&new_expr, row)
-        }
-        Expression::UnaryOp { expr: inner, op } => {
-            // Similar substitution for unary operations
-            let inner_substituted = substitute_window_functions(inner, row, window_mapping)?;
-            let new_expr = Expression::UnaryOp { expr: Box::new(inner_substituted), op: *op };
-            evaluator.eval(&new_expr, row)
-        }
-        Expression::Case { .. } => {
-            // Substitute window functions in CASE expressions before evaluating
-            let substituted = substitute_window_functions(expr, row, window_mapping)?;
-            evaluator.eval(&substituted, row)
-        }
-        Expression::Function { .. } => {
-            // Substitute window functions in function arguments before evaluating
-            let substituted = substitute_window_functions(expr, row, window_mapping)?;
-            evaluator.eval(&substituted, row)
-        }
-        Expression::IsNull { expr: inner, negated } => {
-            // Substitute window functions in IS NULL expressions
-            let inner_substituted = substitute_window_functions(inner, row, window_mapping)?;
-            let new_expr =
-                Expression::IsNull { expr: Box::new(inner_substituted), negated: *negated };
-            evaluator.eval(&new_expr, row)
-        }
-        _ => {
-            // For non-window expressions, use the regular evaluator
-            evaluator.eval(expr, row)
+    // Fast path: top-level window function lookup.
+    if let Expression::WindowFunction { function, over } = expr {
+        let key = WindowFunctionKey::from_expression(function, over);
+        if let Some(&col_idx) = window_mapping.get(&key) {
+            let value = row.values.get(col_idx).cloned().ok_or({
+                crate::errors::ExecutorError::ColumnIndexOutOfBounds { index: col_idx }
+            })?;
+            return Ok(value);
+        } else {
+            return Err(crate::errors::ExecutorError::UnsupportedExpression(format!(
+                "Window function not found in mapping: {:?}",
+                expr
+            )));
         }
     }
+
+    // General path: substitute any nested window functions with literals,
+    // then evaluate the rewritten tree.
+    let substituted = substitute_window_functions(expr, row, window_mapping)?;
+    evaluator.eval(&substituted, row)
 }
 
-/// Substitute window function expressions with literal values from pre-computed results
+/// Substitute window function expressions with literal values from
+/// pre-computed results.
+///
+/// Recurses through every variant that wraps a sub-expression in the *outer*
+/// scope. Subquery-bearing variants (`ScalarSubquery`, `Exists`,
+/// `In { subquery }`, `QuantifiedComparison`) are intentionally not
+/// descended into: a window inside a subquery belongs to the subquery's own
+/// scope, not the outer SELECT's mapping. The OVER clause of a
+/// `WindowFunction` is also not traversed for the same reason.
+///
+/// If a variant is missed, the regular evaluator will eventually encounter a
+/// `WindowFunction` node it cannot resolve and emit a false-positive
+/// "misuse of window function" error (issue #5095).
 fn substitute_window_functions(
     expr: &vibesql_ast::Expression,
     row: &vibesql_storage::Row,
     window_mapping: &HashMap<WindowFunctionKey, usize>,
 ) -> Result<vibesql_ast::Expression, crate::errors::ExecutorError> {
     use vibesql_ast::Expression;
+
+    // Helper: substitute over an Option<Box<Expression>>.
+    let sub_opt_box = |opt: &Option<Box<Expression>>,
+                       row: &vibesql_storage::Row,
+                       wm: &HashMap<WindowFunctionKey, usize>|
+     -> Result<Option<Box<Expression>>, crate::errors::ExecutorError> {
+        opt.as_ref()
+            .map(|e| substitute_window_functions(e, row, wm).map(Box::new))
+            .transpose()
+    };
 
     match expr {
         Expression::WindowFunction { function, over } => {
@@ -389,6 +379,20 @@ fn substitute_window_functions(
                 op: *op,
             })
         }
+        Expression::Conjunction(exprs) => {
+            let subs: Result<Vec<_>, _> = exprs
+                .iter()
+                .map(|e| substitute_window_functions(e, row, window_mapping))
+                .collect();
+            Ok(Expression::Conjunction(subs?))
+        }
+        Expression::Disjunction(exprs) => {
+            let subs: Result<Vec<_>, _> = exprs
+                .iter()
+                .map(|e| substitute_window_functions(e, row, window_mapping))
+                .collect();
+            Ok(Expression::Disjunction(subs?))
+        }
         Expression::UnaryOp { expr: inner, op } => {
             let inner_sub = substitute_window_functions(inner, row, window_mapping)?;
             Ok(Expression::UnaryOp { expr: Box::new(inner_sub), op: *op })
@@ -402,6 +406,37 @@ fn substitute_window_functions(
                 name: name.clone(),
                 args: substituted_args?,
                 character_unit: character_unit.clone(),
+            })
+        }
+        Expression::AggregateFunction { name, distinct, args, order_by, filter } => {
+            let substituted_args: Result<Vec<_>, _> = args
+                .iter()
+                .map(|arg| substitute_window_functions(arg, row, window_mapping))
+                .collect();
+            let substituted_order_by = order_by
+                .as_ref()
+                .map(|items| {
+                    items
+                        .iter()
+                        .map(|item| {
+                            substitute_window_functions(&item.expr, row, window_mapping).map(
+                                |e| vibesql_ast::OrderByItem {
+                                    expr: e,
+                                    direction: item.direction.clone(),
+                                    nulls_order: item.nulls_order,
+                                },
+                            )
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?;
+            let substituted_filter = sub_opt_box(filter, row, window_mapping)?;
+            Ok(Expression::AggregateFunction {
+                name: name.clone(),
+                distinct: *distinct,
+                args: substituted_args?,
+                order_by: substituted_order_by,
+                filter: substituted_filter,
             })
         }
         Expression::Case { operand, when_clauses, else_result } => {
@@ -450,7 +485,126 @@ fn substitute_window_functions(
             let inner_sub = substitute_window_functions(inner, row, window_mapping)?;
             Ok(Expression::IsNull { expr: Box::new(inner_sub), negated: *negated })
         }
-        // For all other expressions (literals, column refs, etc.), no substitution needed
+        Expression::IsDistinctFrom { left, right, negated } => {
+            let left_sub = substitute_window_functions(left, row, window_mapping)?;
+            let right_sub = substitute_window_functions(right, row, window_mapping)?;
+            Ok(Expression::IsDistinctFrom {
+                left: Box::new(left_sub),
+                right: Box::new(right_sub),
+                negated: *negated,
+            })
+        }
+        Expression::IsTruthValue { expr: inner, truth_value, negated } => {
+            let inner_sub = substitute_window_functions(inner, row, window_mapping)?;
+            Ok(Expression::IsTruthValue {
+                expr: Box::new(inner_sub),
+                truth_value: *truth_value, // TruthValue: Copy
+                negated: *negated,
+            })
+        }
+        Expression::Cast { expr: inner, data_type } => {
+            let inner_sub = substitute_window_functions(inner, row, window_mapping)?;
+            Ok(Expression::Cast { expr: Box::new(inner_sub), data_type: data_type.clone() })
+        }
+        Expression::Like { expr: inner, pattern, negated, escape } => {
+            let inner_sub = substitute_window_functions(inner, row, window_mapping)?;
+            let pattern_sub = substitute_window_functions(pattern, row, window_mapping)?;
+            let escape_sub = sub_opt_box(escape, row, window_mapping)?;
+            Ok(Expression::Like {
+                expr: Box::new(inner_sub),
+                pattern: Box::new(pattern_sub),
+                negated: *negated,
+                escape: escape_sub,
+            })
+        }
+        Expression::Glob { expr: inner, pattern, negated, escape } => {
+            let inner_sub = substitute_window_functions(inner, row, window_mapping)?;
+            let pattern_sub = substitute_window_functions(pattern, row, window_mapping)?;
+            let escape_sub = sub_opt_box(escape, row, window_mapping)?;
+            Ok(Expression::Glob {
+                expr: Box::new(inner_sub),
+                pattern: Box::new(pattern_sub),
+                negated: *negated,
+                escape: escape_sub,
+            })
+        }
+        Expression::InList { expr: inner, values, negated } => {
+            let inner_sub = substitute_window_functions(inner, row, window_mapping)?;
+            let value_subs: Result<Vec<_>, _> = values
+                .iter()
+                .map(|v| substitute_window_functions(v, row, window_mapping))
+                .collect();
+            Ok(Expression::InList {
+                expr: Box::new(inner_sub),
+                values: value_subs?,
+                negated: *negated,
+            })
+        }
+        Expression::In { expr: inner, subquery, negated } => {
+            // Only the LHS is in the outer scope; the subquery has its own scope
+            // and will be re-planned independently.
+            let inner_sub = substitute_window_functions(inner, row, window_mapping)?;
+            Ok(Expression::In {
+                expr: Box::new(inner_sub),
+                subquery: subquery.clone(),
+                negated: *negated,
+            })
+        }
+        Expression::QuantifiedComparison { expr: inner, op, quantifier, subquery } => {
+            // Only the LHS is in the outer scope.
+            let inner_sub = substitute_window_functions(inner, row, window_mapping)?;
+            Ok(Expression::QuantifiedComparison {
+                expr: Box::new(inner_sub),
+                op: op.clone(),
+                quantifier: quantifier.clone(),
+                subquery: subquery.clone(),
+            })
+        }
+        Expression::Between { expr: inner, low, high, negated, symmetric } => {
+            let inner_sub = substitute_window_functions(inner, row, window_mapping)?;
+            let low_sub = substitute_window_functions(low, row, window_mapping)?;
+            let high_sub = substitute_window_functions(high, row, window_mapping)?;
+            Ok(Expression::Between {
+                expr: Box::new(inner_sub),
+                low: Box::new(low_sub),
+                high: Box::new(high_sub),
+                negated: *negated,
+                symmetric: *symmetric,
+            })
+        }
+        Expression::Position { substring, string, character_unit } => {
+            let substring_sub = substitute_window_functions(substring, row, window_mapping)?;
+            let string_sub = substitute_window_functions(string, row, window_mapping)?;
+            Ok(Expression::Position {
+                substring: Box::new(substring_sub),
+                string: Box::new(string_sub),
+                character_unit: character_unit.clone(),
+            })
+        }
+        Expression::Trim { position, removal_char, string } => {
+            let removal_sub = sub_opt_box(removal_char, row, window_mapping)?;
+            let string_sub = substitute_window_functions(string, row, window_mapping)?;
+            Ok(Expression::Trim {
+                position: position.clone(),
+                removal_char: removal_sub,
+                string: Box::new(string_sub),
+            })
+        }
+        Expression::Extract { field, expr: inner } => {
+            let inner_sub = substitute_window_functions(inner, row, window_mapping)?;
+            Ok(Expression::Extract { field: field.clone(), expr: Box::new(inner_sub) })
+        }
+        Expression::Interval { value, unit, leading_precision, fractional_precision } => {
+            let value_sub = substitute_window_functions(value, row, window_mapping)?;
+            Ok(Expression::Interval {
+                value: Box::new(value_sub),
+                unit: unit.clone(),
+                leading_precision: *leading_precision,
+                fractional_precision: *fractional_precision,
+            })
+        }
+        // Subquery-bearing and leaf expressions are returned unchanged. A
+        // window inside a subquery belongs to the subquery's own scope.
         _ => Ok(expr.clone()),
     }
 }

--- a/crates/vibesql-executor/src/select/window/collection.rs
+++ b/crates/vibesql-executor/src/select/window/collection.rs
@@ -104,7 +104,21 @@ pub(super) fn collect_window_functions(
     Ok(window_functions)
 }
 
-/// Recursively collect window functions from an expression
+/// Recursively collect window functions from an expression.
+///
+/// We must descend into every variant that wraps a sub-expression which can
+/// legally contain a top-level window function. If a variant is missed, the
+/// window evaluator (`combined/eval.rs`) will fail to find the window in
+/// `window_mapping` and emit a false-positive
+/// `MisuseOfWindowFunction` (issue #5095).
+///
+/// We intentionally do NOT descend into `ScalarSubquery`, `In { subquery }`,
+/// `Exists`, or `QuantifiedComparison` — windows inside those subqueries
+/// belong to the subquery's own scope and are collected when that SELECT is
+/// planned. We also do not descend into the OVER clause itself
+/// (`WindowFunction.over`) because windows nested inside an OVER clause's
+/// PARTITION BY / ORDER BY are evaluated as part of the outer window's frame
+/// computation, not as separate top-level windows.
 fn collect_from_expression(
     expr: &Expression,
     select_index: usize,
@@ -133,12 +147,37 @@ fn collect_from_expression(
             collect_from_expression(left, select_index, window_map, window_functions)?;
             collect_from_expression(right, select_index, window_map, window_functions)?;
         }
+        Expression::Conjunction(exprs) | Expression::Disjunction(exprs) => {
+            for e in exprs {
+                collect_from_expression(e, select_index, window_map, window_functions)?;
+            }
+        }
         Expression::UnaryOp { expr, .. } => {
             collect_from_expression(expr, select_index, window_map, window_functions)?;
         }
         Expression::Function { args, .. } => {
             for arg in args {
                 collect_from_expression(arg, select_index, window_map, window_functions)?;
+            }
+        }
+        Expression::AggregateFunction { args, order_by, filter, .. } => {
+            // A regular aggregate's arguments cannot contain a window function
+            // per SQL spec, but recursing here is harmless and future-proof.
+            for arg in args {
+                collect_from_expression(arg, select_index, window_map, window_functions)?;
+            }
+            if let Some(items) = order_by {
+                for item in items {
+                    collect_from_expression(
+                        &item.expr,
+                        select_index,
+                        window_map,
+                        window_functions,
+                    )?;
+                }
+            }
+            if let Some(f) = filter {
+                collect_from_expression(f, select_index, window_map, window_functions)?;
             }
         }
         Expression::Case { operand, when_clauses, else_result } => {
@@ -158,6 +197,62 @@ fn collect_from_expression(
         Expression::IsNull { expr, .. } => {
             collect_from_expression(expr, select_index, window_map, window_functions)?;
         }
+        Expression::IsDistinctFrom { left, right, .. } => {
+            collect_from_expression(left, select_index, window_map, window_functions)?;
+            collect_from_expression(right, select_index, window_map, window_functions)?;
+        }
+        Expression::IsTruthValue { expr, .. } => {
+            collect_from_expression(expr, select_index, window_map, window_functions)?;
+        }
+        Expression::Cast { expr, .. } => {
+            collect_from_expression(expr, select_index, window_map, window_functions)?;
+        }
+        Expression::Like { expr, pattern, escape, .. }
+        | Expression::Glob { expr, pattern, escape, .. } => {
+            collect_from_expression(expr, select_index, window_map, window_functions)?;
+            collect_from_expression(pattern, select_index, window_map, window_functions)?;
+            if let Some(esc) = escape {
+                collect_from_expression(esc, select_index, window_map, window_functions)?;
+            }
+        }
+        Expression::InList { expr, values, .. } => {
+            collect_from_expression(expr, select_index, window_map, window_functions)?;
+            for v in values {
+                collect_from_expression(v, select_index, window_map, window_functions)?;
+            }
+        }
+        Expression::In { expr, .. } => {
+            // Only the LHS is in the outer scope; the subquery has its own scope.
+            collect_from_expression(expr, select_index, window_map, window_functions)?;
+        }
+        Expression::QuantifiedComparison { expr, .. } => {
+            // Only the LHS is in the outer scope; the subquery has its own scope.
+            collect_from_expression(expr, select_index, window_map, window_functions)?;
+        }
+        Expression::Between { expr, low, high, .. } => {
+            collect_from_expression(expr, select_index, window_map, window_functions)?;
+            collect_from_expression(low, select_index, window_map, window_functions)?;
+            collect_from_expression(high, select_index, window_map, window_functions)?;
+        }
+        Expression::Position { substring, string, .. } => {
+            collect_from_expression(substring, select_index, window_map, window_functions)?;
+            collect_from_expression(string, select_index, window_map, window_functions)?;
+        }
+        Expression::Trim { removal_char, string, .. } => {
+            if let Some(rc) = removal_char {
+                collect_from_expression(rc, select_index, window_map, window_functions)?;
+            }
+            collect_from_expression(string, select_index, window_map, window_functions)?;
+        }
+        Expression::Extract { expr, .. } => {
+            collect_from_expression(expr, select_index, window_map, window_functions)?;
+        }
+        Expression::Interval { value, .. } => {
+            collect_from_expression(value, select_index, window_map, window_functions)?;
+        }
+        // Leaves and subquery-bearing variants we deliberately do not descend
+        // into. Subquery variants (ScalarSubquery, Exists) have their own
+        // scope; literal/column/placeholder/etc. variants have no children.
         _ => {}
     }
     Ok(())

--- a/crates/vibesql-executor/src/select/window/detection.rs
+++ b/crates/vibesql-executor/src/select/window/detection.rs
@@ -10,15 +10,37 @@ pub(in crate::select) fn has_window_functions(select_list: &[SelectItem]) -> boo
     })
 }
 
-/// Check if an expression contains a window function
+/// Check if an expression contains a window function in the current scope.
+///
+/// Mirrors the recursion shape of
+/// `crate::select::window::collection::collect_from_expression` so that this
+/// detection function and the collector agree on which expressions contain a
+/// window function. If they diverge, queries can be routed to a non-window
+/// executor and then trip the window evaluator's misuse-of-window check on a
+/// legitimate window expression (issue #5095).
+///
+/// Subquery variants (`ScalarSubquery`, `In { subquery }`, `Exists`,
+/// `QuantifiedComparison`) are intentionally treated as leaves: a window
+/// inside a subquery belongs to the subquery's own scope, not the outer
+/// SELECT's.
 pub(in crate::select) fn expression_has_window_function(expr: &Expression) -> bool {
     match expr {
         Expression::WindowFunction { .. } => true,
         Expression::BinaryOp { left, right, .. } => {
             expression_has_window_function(left) || expression_has_window_function(right)
         }
+        Expression::Conjunction(exprs) | Expression::Disjunction(exprs) => {
+            exprs.iter().any(expression_has_window_function)
+        }
         Expression::UnaryOp { expr, .. } => expression_has_window_function(expr),
         Expression::Function { args, .. } => args.iter().any(expression_has_window_function),
+        Expression::AggregateFunction { args, order_by, filter, .. } => {
+            args.iter().any(expression_has_window_function)
+                || order_by.as_ref().is_some_and(|items| {
+                    items.iter().any(|i| expression_has_window_function(&i.expr))
+                })
+                || filter.as_ref().is_some_and(|f| expression_has_window_function(f))
+        }
         Expression::Case { operand, when_clauses, else_result } => {
             operand.as_ref().is_some_and(|e| expression_has_window_function(e))
                 || when_clauses.iter().any(|when_clause| {
@@ -28,6 +50,37 @@ pub(in crate::select) fn expression_has_window_function(expr: &Expression) -> bo
                 || else_result.as_ref().is_some_and(|e| expression_has_window_function(e))
         }
         Expression::IsNull { expr, .. } => expression_has_window_function(expr),
+        Expression::IsDistinctFrom { left, right, .. } => {
+            expression_has_window_function(left) || expression_has_window_function(right)
+        }
+        Expression::IsTruthValue { expr, .. } => expression_has_window_function(expr),
+        Expression::Cast { expr, .. } => expression_has_window_function(expr),
+        Expression::Like { expr, pattern, escape, .. }
+        | Expression::Glob { expr, pattern, escape, .. } => {
+            expression_has_window_function(expr)
+                || expression_has_window_function(pattern)
+                || escape.as_ref().is_some_and(|e| expression_has_window_function(e))
+        }
+        Expression::InList { expr, values, .. } => {
+            expression_has_window_function(expr)
+                || values.iter().any(expression_has_window_function)
+        }
+        Expression::In { expr, .. } => expression_has_window_function(expr),
+        Expression::QuantifiedComparison { expr, .. } => expression_has_window_function(expr),
+        Expression::Between { expr, low, high, .. } => {
+            expression_has_window_function(expr)
+                || expression_has_window_function(low)
+                || expression_has_window_function(high)
+        }
+        Expression::Position { substring, string, .. } => {
+            expression_has_window_function(substring) || expression_has_window_function(string)
+        }
+        Expression::Trim { removal_char, string, .. } => {
+            removal_char.as_ref().is_some_and(|e| expression_has_window_function(e))
+                || expression_has_window_function(string)
+        }
+        Expression::Extract { expr, .. } => expression_has_window_function(expr),
+        Expression::Interval { value, .. } => expression_has_window_function(value),
         _ => false,
     }
 }


### PR DESCRIPTION
## Summary

The window-function detector (`detection.rs`), collector (`collection.rs`), and projection-time substituter (`projection.rs`) all walked the AST but only recursed through a handful of `Expression` variants (`BinaryOp`, `UnaryOp`, `Function`, `Case`, `IsNull`). Any window function reachable only through `Conjunction`, `Disjunction`, `AggregateFunction`, `Cast`, `Like`, `Glob`, `InList`, `Between`, `Position`, `Trim`, `Extract`, `Interval`, `IsDistinctFrom`, `IsTruthValue`, `In` (LHS), or `QuantifiedComparison` (LHS) was invisible to all three passes.

Result: queries like
```sql
SELECT count() OVER () LIKE lead(102030) OVER (
    ORDER BY sum('abcdef' COLLATE nocase) IN (SELECT 54321)
) FROM t1;
```
were routed away from the window executor, then later tripped the evaluator's `"misuse of window function"` guard on a perfectly legal window expression (window1 test 65.4).

Fix: mirror the same recursion shape across all three files so they agree on which expressions contain windows in the current scope.

## Scope decisions

- Subquery-bearing variants (`ScalarSubquery`, `Exists`, `In { subquery }`, `QuantifiedComparison`) are deliberately treated as leaves: a window inside a subquery belongs to the subquery's own scope and is collected when that SELECT is planned.
- The `OVER` clause itself is not traversed: windows nested inside an OVER's PARTITION BY / ORDER BY are evaluated as part of the outer window's frame computation.

`projection.rs` also gets a small refactor: instead of switch-casing per-variant before delegating to `substitute_window_functions`, the top-level evaluator now does one fast-path lookup for a bare window function and otherwise delegates the entire tree to the substituter. This eliminates the duplicate variant list that was the source of the original bug.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test -p vibesql-executor --lib -j 2` -> 2350 passed, 0 failed
- [x] `./scripts/tcltest test window1.test` -> 243 passed (up from 230 on main), 29 failed (down from 42), zero new failures
- [x] window1-65.4 specifically now passes
- [x] No conflict with PR #5119 (#5094 inverse-case validator) -- those changes touch validation/aggregates.rs; this PR only touches window detection/collection/projection
- [x] 12 additional window1 tests now pass as a side-effect (7.1.5, 11.1, 39.3, 39.4, 42.2, 42.3, 47.2, 54.4, 62.4, 64.2, 64.3, 64.4) -- all previously gated on the same recursion gap

Closes #5095

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>