### PR TITLE
feat(pragma): add PRAGMA table_info; preserve txn after FK error in batch

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -33,6 +33,71 @@ pub struct QueryResult {
 
 use crate::util::is_memory_database;
 
+/// Render a VibeSQL DataType as a SQLite-flavor declared type string suitable
+/// for `PRAGMA table_info`. SQLite preserves the original CREATE TABLE text,
+/// but VibeSQL doesn't track the literal declaration, so we map back to the
+/// canonical SQLite spelling (`INTEGER`, `REAL`, `TEXT`, `BLOB`, ...).
+fn sqlite_declared_type(
+    data_type: &vibesql_types::DataType,
+    is_exact_integer_type: bool,
+) -> String {
+    use vibesql_types::DataType;
+    match data_type {
+        DataType::Integer => {
+            // SQLite preserves the spelling: only literal "INTEGER" is the
+            // rowid-alias-eligible affinity. We use is_exact_integer_type to
+            // distinguish "INT" (mapped to Integer with is_exact=false) from
+            // the canonical "INTEGER".
+            if is_exact_integer_type {
+                "INTEGER".to_string()
+            } else {
+                "INT".to_string()
+            }
+        }
+        DataType::Smallint => "SMALLINT".to_string(),
+        DataType::Bigint => "BIGINT".to_string(),
+        DataType::Unsigned => "BIGINT UNSIGNED".to_string(),
+        DataType::Numeric { precision, scale } => format!("NUMERIC({},{})", precision, scale),
+        DataType::Decimal { precision, scale } => format!("DECIMAL({},{})", precision, scale),
+        DataType::Float { precision } => format!("FLOAT({})", precision),
+        DataType::Real => "REAL".to_string(),
+        DataType::DoublePrecision => "DOUBLE PRECISION".to_string(),
+        DataType::Character { length } => format!("CHAR({})", length),
+        DataType::Varchar { max_length } => match max_length {
+            Some(len) => format!("VARCHAR({})", len),
+            None => "TEXT".to_string(),
+        },
+        DataType::CharacterLargeObject => "TEXT".to_string(),
+        DataType::Name => "TEXT".to_string(),
+        DataType::Boolean => "BOOLEAN".to_string(),
+        DataType::Date => "DATE".to_string(),
+        DataType::Time { with_timezone } => {
+            if *with_timezone {
+                "TIME WITH TIME ZONE".to_string()
+            } else {
+                "TIME".to_string()
+            }
+        }
+        DataType::Timestamp { with_timezone } => {
+            if *with_timezone {
+                "TIMESTAMP WITH TIME ZONE".to_string()
+            } else {
+                "DATETIME".to_string()
+            }
+        }
+        DataType::Interval { .. } => "INTERVAL".to_string(),
+        DataType::BinaryLargeObject => "BLOB".to_string(),
+        DataType::Bit { length } => match length {
+            Some(len) => format!("BIT({})", len),
+            None => "BIT".to_string(),
+        },
+        DataType::UserDefined { type_name } => type_name.clone(),
+        DataType::Vector { dimensions } => format!("VECTOR({})", dimensions),
+        // Typeless columns (CREATE TABLE t(c)) report empty string in SQLite.
+        DataType::Null => String::new(),
+    }
+}
+
 /// Format SqlValue for output in SQLite-compatible format
 /// - Booleans are displayed as 0/1 instead of FALSE/TRUE
 /// - Other values use their standard Display format
@@ -99,6 +164,11 @@ impl SqlExecutor {
         };
 
         Ok(SqlExecutor { db, timing_enabled: false })
+    }
+
+    /// Returns true if the current session is inside an active transaction.
+    pub fn in_transaction(&self) -> bool {
+        self.db.in_transaction()
     }
 
     pub fn execute(&mut self, sql: &str) -> anyhow::Result<QueryResult> {
@@ -781,6 +851,9 @@ impl SqlExecutor {
             "FOREIGN_KEY_CHECK" => {
                 return self.execute_pragma_foreign_key_check(stmt);
             }
+            "TABLE_INFO" => {
+                return self.execute_pragma_table_info(stmt);
+            }
             _ => {}
         }
 
@@ -1262,6 +1335,127 @@ impl SqlExecutor {
             execution_time_ms: None,
             message: None,
         })
+    }
+
+    /// PRAGMA table_info(table_name) - SQLite-compatible
+    ///
+    /// Returns one row per column with:
+    ///   cid (0-based column index), name, type (declared SQL type, may be ""),
+    ///   notnull (0 or 1), dflt_value (default expression text or NULL),
+    ///   pk (0 if not PK, else 1-based position within PK).
+    ///
+    /// Schema-qualified syntax is accepted: `PRAGMA main.table_info(t)`. VibeSQL
+    /// only carries a single schema, so any other schema yields an empty result
+    /// (matching the SQLite behavior of "no such table" being silent for
+    /// table_info on missing tables).
+    fn execute_pragma_table_info(
+        &self,
+        stmt: &vibesql_ast::PragmaStmt,
+    ) -> anyhow::Result<QueryResult> {
+        let columns = vec![
+            "cid".to_string(),
+            "name".to_string(),
+            "type".to_string(),
+            "notnull".to_string(),
+            "dflt_value".to_string(),
+            "pk".to_string(),
+        ];
+
+        let table_name = match &stmt.value {
+            Some(vibesql_ast::PragmaValue::Identifier(name)) => name.clone(),
+            Some(vibesql_ast::PragmaValue::String(name)) => name.clone(),
+            _ => {
+                // No table argument supplied - return empty (SQLite behavior)
+                return Ok(QueryResult {
+                    columns,
+                    rows: Vec::new(),
+                    row_count: 0,
+                    execution_time_ms: None,
+                    message: None,
+                });
+            }
+        };
+
+        // Schema-qualified pragma handling. Only "main" or the current schema
+        // refer to the available schema; anything else returns an empty result
+        // (SQLite returns no rows for a missing table in table_info, no error).
+        let current_schema = self.db.catalog.get_current_schema().to_string();
+        if let Some(ref schema) = stmt.database {
+            let is_current = schema.eq_ignore_ascii_case(&current_schema)
+                || schema.eq_ignore_ascii_case("main");
+            if !is_current {
+                return Ok(QueryResult {
+                    columns,
+                    rows: Vec::new(),
+                    row_count: 0,
+                    execution_time_ms: None,
+                    message: None,
+                });
+            }
+        }
+
+        let schema = match self.db.catalog.get_table(&table_name) {
+            Some(s) => s,
+            None => {
+                // SQLite returns empty result for table_info on a missing table.
+                return Ok(QueryResult {
+                    columns,
+                    rows: Vec::new(),
+                    row_count: 0,
+                    execution_time_ms: None,
+                    message: None,
+                });
+            }
+        };
+
+        // Build a name->pk-position map (1-based) for primary key lookups.
+        // For composite keys, the position is the column's position within
+        // the declared primary-key column list.
+        let pk_positions: std::collections::HashMap<String, usize> =
+            match schema.primary_key.as_ref() {
+                Some(pk_cols) => pk_cols
+                    .iter()
+                    .enumerate()
+                    .map(|(i, name)| (name.clone(), i + 1))
+                    .collect(),
+                None => std::collections::HashMap::new(),
+            };
+
+        let mut rows: Vec<Vec<Option<String>>> = Vec::with_capacity(schema.columns.len());
+        for (cid, column) in schema.columns.iter().enumerate() {
+            // Type column: SQLite reports the declared type as supplied in the
+            // CREATE TABLE statement. We don't preserve the verbatim text, so
+            // we map our DataType back to the canonical SQLite-flavor name.
+            let type_str = sqlite_declared_type(&column.data_type, column.is_exact_integer_type);
+
+            // notnull: 1 if NOT NULL, else 0. SQLite implicitly marks INTEGER
+            // PRIMARY KEY rowid alias columns as NOT NULL.
+            let notnull = if !column.nullable { 1 } else { 0 };
+
+            // dflt_value: render the default expression as SQL text, or NULL.
+            let dflt_value: Option<String> = column.default_value.as_ref().map(|e| {
+                use vibesql_ast::pretty_print::ToSql;
+                e.to_sql()
+            });
+
+            // pk: 1-based position within the primary key, or 0 if not PK.
+            let pk = pk_positions
+                .get(&column.name)
+                .copied()
+                .unwrap_or(0);
+
+            rows.push(vec![
+                Some(cid.to_string()),
+                Some(column.name.clone()),
+                Some(type_str),
+                Some(notnull.to_string()),
+                dflt_value,
+                Some(pk.to_string()),
+            ]);
+        }
+
+        let row_count = rows.len();
+        Ok(QueryResult { columns, rows, row_count, execution_time_ms: None, message: None })
     }
 }
 

--- a/crates/vibesql-cli/src/script.rs
+++ b/crates/vibesql-cli/src/script.rs
@@ -136,12 +136,24 @@ impl ScriptExecutor {
                         vibe_msg!("script-error", index = (idx + 1) as i64, error = e.to_string())
                     );
                     error_count += 1;
-                    // SQLite compatibility: Stop on first error (issue #4731)
-                    // SQLite's TCL interface and CLI stop execution when a statement fails.
-                    // Previously, we continued executing remaining statements which caused
-                    // bugs like catchsql { CREATE TABLE t1; INSERT... } where CREATE fails
-                    // but INSERT succeeds, adding duplicate rows.
-                    break;
+                    // SQLite compatibility:
+                    //   - Outside a transaction: stop on first error (issue #4731).
+                    //     SQLite's TCL interface and CLI both stop execution on
+                    //     statement error so that scripts like
+                    //     `catchsql { CREATE TABLE t1; INSERT... }` don't continue
+                    //     executing remaining statements after a failure.
+                    //   - Inside an active transaction: keep running so that
+                    //     subsequent statements (typically ROLLBACK or COMMIT)
+                    //     can still execute. SQLite leaves the transaction in
+                    //     a failed state after a constraint violation; the
+                    //     caller is expected to ROLLBACK explicitly. If we
+                    //     stopped on the failed statement we'd terminate the
+                    //     CLI process and lose the in-memory transaction state,
+                    //     making the explicit ROLLBACK arrive at a fresh
+                    //     process with no active transaction (issue #5087).
+                    if !self.executor.in_transaction() {
+                        break;
+                    }
                 }
             }
         }

--- a/crates/vibesql-parser/src/arena_parser/ddl.rs
+++ b/crates/vibesql-parser/src/arena_parser/ddl.rs
@@ -1057,6 +1057,13 @@ impl<'arena> ArenaParser<'arena> {
                 let sym = self.interner.intern(&ident);
                 Ok(PragmaValue::Identifier(sym))
             }
+            Token::DelimitedIdentifier(ident) => {
+                // Accept double-quoted/bracketed/backtick identifiers as
+                // PRAGMA arguments (e.g. `PRAGMA table_info("name with space")`).
+                self.advance();
+                let sym = self.interner.intern(&ident);
+                Ok(PragmaValue::Identifier(sym))
+            }
             Token::Keyword { keyword: kw, .. } => {
                 self.advance();
                 let sym = self.interner.intern(&kw.to_string());

--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -813,6 +813,13 @@ impl Parser {
                 self.advance();
                 Ok(vibesql_ast::PragmaValue::Identifier(ident))
             }
+            Token::DelimitedIdentifier(ident) => {
+                // Accept double-quoted/bracketed/backtick identifiers as PRAGMA
+                // arguments, e.g. `PRAGMA table_info("weird name")` or
+                // `PRAGMA table_info="""1"` (a table named `"1`).
+                self.advance();
+                Ok(vibesql_ast::PragmaValue::Identifier(ident))
+            }
             Token::Keyword { keyword: kw, .. } => {
                 // Allow keywords like ON, OFF, TRUE, FALSE as identifiers
                 self.advance();

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1101,7 +1101,7 @@ proc execsql {sql {db ""}} {
                 }
                 continue  ;# Check for more statements
             }
-            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys)} [string trim $sql]]} {
+            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|table_info)} [string trim $sql]]} {
                 # This PRAGMA is supported (with =value) - stop stripping
                 break
             } else {
@@ -1178,6 +1178,20 @@ proc execsql {sql {db ""}} {
             return {Count VirtualMachine Start Stop}
         }
         # Other EXPLAIN queries fall through to run normally with SQLite-compatible VM output
+    }
+
+    # Standalone ROLLBACK with no batched-transaction context: treat as a
+    # silent no-op. After a constraint violation in a previous batch, test
+    # files often issue `db eval {ROLLBACK}` to clean up the connection's
+    # transaction state. In SQLite this is harmless because the connection
+    # carries the transaction across statements; in VibeSQL each batch runs
+    # as a separate process so the "phantom" rollback would otherwise hit a
+    # fresh process with no active transaction and crash the test runner.
+    if {!$::in_transaction} {
+        set sql_trim_upper [string toupper [string trim $sql " \t\n;"]]
+        if {$sql_trim_upper eq "ROLLBACK" || $sql_trim_upper eq "ROLLBACK TRANSACTION"} {
+            return {}
+        }
     }
 
     # Handle transaction batching
@@ -3087,6 +3101,7 @@ array set vibesql_skip_tests {
     window1-11.4 "Expression indexes with window functions not supported"
 
     fkey1-3.5 "Uses sqlite3_db_status internal API"
+    fkey1-8.3 "Tests SQLite-internal B-tree corruption via PRAGMA writable_schema + REINDEX (not portable to VibeSQL)"
     fkey6-1.3 "Uses sqlite3_db_status internal API"
     fkey6-1.5.1 "Uses sqlite3_db_status internal API"
     fkey6-1.5.2 "Uses sqlite3_db_status internal API"


### PR DESCRIPTION
Closes #5087 (Bucket D of #5071).

## Summary

Implements three of the four items in Bucket D plus the parser/shim plumbing they depend on.

### 1. PRAGMA table_info(table)
New `execute_pragma_table_info` in `crates/vibesql-cli/src/executor/mod.rs` emits SQLite-compatible columns: `(cid, name, type, notnull, dflt_value, pk)`. Schema-qualified syntax (`PRAGMA main.table_info(t)`) is accepted. Missing tables return an empty result (not an error) to match SQLite. Since VibeSQL doesn't preserve the verbatim CREATE TABLE type text, we map `DataType` back to canonical SQLite spellings via a new `sqlite_declared_type` helper.

### 2. Auto-rollback on FK violation
**Approach taken**: rather than changing storage to leave the transaction open after a constraint failure (which would ripple through every constraint-violation path), the fix lives in `ScriptExecutor::execute_script`: inside an active transaction we no longer abort the batch on the first failing statement, so a subsequent ROLLBACK can still execute. Outside a transaction we keep the SQLite-CLI stop-on-first-error behavior from #4731. Combined with `tester_vibesql.tcl` swallowing a stray standalone ROLLBACK when no batch transaction is in progress (the per-batch process model would otherwise crash), `fkey6-1.6` no longer crashes with "No active transaction to rollback".

This is a different shape than the issue's original proposal (it doesn't surface a "failed transaction" state to user code) but it removes the symptom that blocks #5085 and the rest of fkey6.

### 3. fkey1-8.3 skip
Added to the skip list in `scripts/tester_vibesql.tcl` with rationale: SQLite-internal B-tree corruption test using `PRAGMA writable_schema` + REINDEX; not portable to VibeSQL.

### 4. Parser
Accept `DelimitedIdentifier` as a PRAGMA argument in both parsers so `PRAGMA table_info("name with space")` parses.

## Acceptance criteria

- [x] `fkey1-4.2` passes (PRAGMA table_info output)
- [x] `fkey6-1.6` no longer crashes with "No active transaction to rollback" (now fails with normal "FOREIGN KEY constraint failed", which is a separate shape issue)
- [x] `fkey1-8.3` documented skip
- [ ] `fkey8-2.3.1` / `fkey8-3.1` — depend on Bucket C (WITHOUT ROWID + AFTER DELETE trigger interactions); not addressed in this PR
- [ ] `fkey5-8.7` — depends on Buckets B+C; not addressed

## Test plan

- [x] `cargo build -j 2`
- [x] `cargo test -p vibesql-executor --lib -j 2` (2350 passed, 0 failed)
- [x] `cargo test -p vibesql-storage --lib -j 2` (587 passed, 0 failed)
- [x] `cargo test -p vibesql-parser --lib -j 2` (1248 passed, 0 failed)
- [x] `cargo test -p vibesql-cli -j 2 --tests` (114 + 5 passed, 0 failed)
- [x] `./scripts/tcltest test fkey1.test` — fkey1-4.2 passes; fkey1-8.3 now skipped (no longer counted as failure)
- [x] `./scripts/tcltest test fkey6.test` — no "No active transaction to rollback" crashes; fkey6-1.6 fails differently now (FK comparison semantics, distinct issue)
- [x] Manual: `PRAGMA table_info(t)` returns correct cid/name/type/notnull/dflt_value/pk

## Notes for reviewer

- PR #5120 (FK mismatch error class) refactors `crates/vibesql-cli/src/executor/mod.rs` in nearby but distinct regions — it deletes `fk_values_equal` after the spot where this PR appends `execute_pragma_table_info`. Whichever lands first will create a small textual conflict at the bottom of `impl SqlExecutor`; the resolution is mechanical.
- The "stop on error inside transaction" relaxation is scoped to `ScriptExecutor::execute_script`. Any callers that rely on the old hard-stop behavior inside a transaction would now see a different failure shape, but I couldn't find any in tree.