### PR TITLE
feat(fkey): catalog metadata + PRAGMA defer_foreign_keys (Phase C1 of #5085)

### DIFF
--- a/crates/vibesql-catalog/src/foreign_key.rs
+++ b/crates/vibesql-catalog/src/foreign_key.rs
@@ -9,6 +9,23 @@ pub struct ForeignKeyConstraint {
     pub parent_column_indices: Vec<usize>,
     pub on_delete: ReferentialAction,
     pub on_update: ReferentialAction,
+    /// Whether the constraint is DEFERRABLE (SQL:1999 / SQLite).
+    ///
+    /// When `true`, the constraint can be deferred until COMMIT-time. When
+    /// `false` (the default for SQLite-style FKs), enforcement is immediate.
+    ///
+    /// Phase C1 of #5085 only stores this metadata; the runtime enforcement
+    /// timing change ships in Phase C2.
+    pub is_deferrable: bool,
+    /// Whether the deferrable constraint is INITIALLY DEFERRED.
+    ///
+    /// Only meaningful when `is_deferrable` is `true`. `true` corresponds to
+    /// `INITIALLY DEFERRED`; `false` corresponds to `INITIALLY IMMEDIATE`
+    /// (SQL default for deferrable constraints).
+    ///
+    /// Phase C1 of #5085 only stores this metadata; the runtime enforcement
+    /// timing change ships in Phase C2.
+    pub initially_deferred: bool,
 }
 
 /// Referential action for foreign key constraints.

--- a/crates/vibesql-catalog/src/tests.rs
+++ b/crates/vibesql-catalog/src/tests.rs
@@ -242,6 +242,8 @@ mod catalog_tests {
             parent_column_indices: vec![0],
             on_delete: ReferentialAction::Cascade,
             on_update: ReferentialAction::NoAction,
+            is_deferrable: false,
+            initially_deferred: false,
         };
 
         let mut schema = TableSchema::with_foreign_keys("orders".to_string(), columns, vec![fk]);
@@ -281,6 +283,8 @@ mod catalog_tests {
             parent_column_indices: vec![0],
             on_delete: ReferentialAction::Cascade,
             on_update: ReferentialAction::NoAction,
+            is_deferrable: false,
+            initially_deferred: false,
         };
 
         let mut schema = TableSchema::with_foreign_keys("orders".to_string(), columns, vec![fk]);
@@ -461,6 +465,8 @@ mod catalog_tests {
             parent_column_indices: vec![0],
             on_delete: ReferentialAction::Cascade,
             on_update: ReferentialAction::NoAction,
+            is_deferrable: false,
+            initially_deferred: false,
         };
 
         // Create a check constraint: age >= 18

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -913,6 +913,20 @@ impl SqlExecutor {
                         message: None,
                     })
                 }
+                "DEFER_FOREIGN_KEYS" => {
+                    // SQLite-compatible PRAGMA defer_foreign_keys.
+                    // Phase C1 of #5085: store/read the flag and auto-reset
+                    // at COMMIT/ROLLBACK. Runtime semantic change (deferring
+                    // FK violations until COMMIT) ships in Phase C2.
+                    self.db.set_defer_foreign_keys(bool_value);
+                    Ok(QueryResult {
+                        rows: Vec::new(),
+                        columns: Vec::new(),
+                        row_count: 0,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
                 _ => {
                     // Unknown pragma - silently ignore for SQLite compatibility
                     Ok(QueryResult {
@@ -983,6 +997,18 @@ impl SqlExecutor {
                     let value = if self.db.foreign_keys_enabled() { "1" } else { "0" };
                     Ok(QueryResult {
                         columns: vec!["foreign_keys".to_string()],
+                        rows: vec![vec![Some(value.to_string())]],
+                        row_count: 1,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "DEFER_FOREIGN_KEYS" => {
+                    // SQLite-compatible PRAGMA defer_foreign_keys read.
+                    // Defaults to 0 and auto-resets at COMMIT/ROLLBACK.
+                    let value = if self.db.defer_foreign_keys() { "1" } else { "0" };
+                    Ok(QueryResult {
+                        columns: vec!["defer_foreign_keys".to_string()],
                         rows: vec![vec![Some(value.to_string())]],
                         row_count: 1,
                         execution_time_ms: None,

--- a/crates/vibesql-executor/src/alter/constraints.rs
+++ b/crates/vibesql-executor/src/alter/constraints.rs
@@ -94,7 +94,7 @@ pub(super) fn execute_add_constraint(
             references_columns,
             on_delete,
             on_update,
-            ..
+            deferral,
         } => {
             // Convert AST ReferentialAction to catalog ReferentialAction
             let convert_action = |action: &Option<vibesql_ast::ReferentialAction>| match action {
@@ -158,6 +158,10 @@ pub(super) fn execute_add_constraint(
                 parent_column_indices.push(idx);
             }
 
+            let (is_deferrable, initially_deferred) = deferral
+                .map(|d| (d.is_deferrable, d.initially_deferred))
+                .unwrap_or((false, false));
+
             let fk = ForeignKeyConstraint {
                 name: stmt.constraint.name.clone(),
                 column_names: columns.clone(),
@@ -167,6 +171,8 @@ pub(super) fn execute_add_constraint(
                 parent_column_indices,
                 on_delete: convert_action(on_delete),
                 on_update: convert_action(on_update),
+                is_deferrable,
+                initially_deferred,
             };
 
             let table = database

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -240,7 +240,7 @@ impl CreateTableExecutor {
                 references_columns,
                 on_delete,
                 on_update,
-                ..
+                deferral,
             } = &constraint.kind
             {
                 // Resolve column indices for FK columns
@@ -314,6 +314,10 @@ impl CreateTableExecutor {
                     parent_column_indices
                 };
 
+                let (is_deferrable, initially_deferred) = deferral
+                    .map(|d| (d.is_deferrable, d.initially_deferred))
+                    .unwrap_or((false, false));
+
                 let fk = vibesql_catalog::ForeignKeyConstraint {
                     name: constraint.name.clone(),
                     column_names: fk_columns.clone(),
@@ -323,6 +327,8 @@ impl CreateTableExecutor {
                     parent_column_indices: effective_parent_indices,
                     on_delete: convert_action(on_delete),
                     on_update: convert_action(on_update),
+                    is_deferrable,
+                    initially_deferred,
                 };
 
                 table_schema.add_foreign_key(fk)?;
@@ -345,7 +351,7 @@ impl CreateTableExecutor {
                     column: ref_column,
                     on_delete,
                     on_update,
-                    ..
+                    deferral,
                 } = &constraint.kind
                 {
                     let col_idx =
@@ -403,6 +409,10 @@ impl CreateTableExecutor {
                             }
                         };
 
+                    let (is_deferrable, initially_deferred) = deferral
+                        .map(|d| (d.is_deferrable, d.initially_deferred))
+                        .unwrap_or((false, false));
+
                     let fk = vibesql_catalog::ForeignKeyConstraint {
                         name: constraint.name.clone(),
                         column_names: vec![col_def.name.clone()],
@@ -412,6 +422,8 @@ impl CreateTableExecutor {
                         parent_column_indices: vec![parent_col_idx],
                         on_delete: convert_action(on_delete),
                         on_update: convert_action(on_update),
+                        is_deferrable,
+                        initially_deferred,
                     };
 
                     column_level_fks.push(fk);

--- a/crates/vibesql-executor/src/delete/tests/truncate_optimization.rs
+++ b/crates/vibesql-executor/src/delete/tests/truncate_optimization.rs
@@ -97,6 +97,8 @@ fn test_truncate_blocked_by_fk_reference() {
             parent_column_indices: vec![0],
             on_delete: ReferentialAction::NoAction,
             on_update: ReferentialAction::NoAction,
+            is_deferrable: false,
+            initially_deferred: false,
         }],
     );
     db.create_table(child_schema).unwrap();
@@ -173,6 +175,8 @@ fn test_truncate_allowed_when_no_fk_references() {
             parent_column_indices: vec![0],
             on_delete: ReferentialAction::NoAction,
             on_update: ReferentialAction::NoAction,
+            is_deferrable: false,
+            initially_deferred: false,
         }],
     );
     db.create_table(child_schema).unwrap();

--- a/crates/vibesql-executor/tests/truncate_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/truncate_columnar_cache_tests.rs
@@ -248,6 +248,8 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
             parent_column_indices: vec![0],
             on_delete: ReferentialAction::Cascade,
             on_update: ReferentialAction::NoAction,
+            is_deferrable: false,
+            initially_deferred: false,
         }],
     );
     db.create_table(child_schema).unwrap();

--- a/crates/vibesql-executor/tests/truncate_tests.rs
+++ b/crates/vibesql-executor/tests/truncate_tests.rs
@@ -420,6 +420,8 @@ fn test_truncate_blocked_by_fk_references() {
             parent_column_indices: vec![0],
             on_delete: ReferentialAction::NoAction,
             on_update: ReferentialAction::NoAction,
+            is_deferrable: false,
+            initially_deferred: false,
         }],
     );
     db.create_table(child_schema).unwrap();

--- a/crates/vibesql-server/src/http/graphql/relationships.rs
+++ b/crates/vibesql-server/src/http/graphql/relationships.rs
@@ -387,6 +387,8 @@ mod tests {
             parent_column_indices: vec![0],
             on_delete: ReferentialAction::NoAction,
             on_update: ReferentialAction::NoAction,
+            is_deferrable: false,
+            initially_deferred: false,
         });
         schemas.insert("posts".to_string(), posts_schema);
 

--- a/crates/vibesql-storage/src/database/session.rs
+++ b/crates/vibesql-storage/src/database/session.rs
@@ -167,6 +167,30 @@ impl Database {
         );
     }
 
+    /// Get the defer_foreign_keys PRAGMA setting (SQLite compatibility).
+    ///
+    /// When ON, enforcement of all foreign key constraints is delayed until
+    /// the outermost transaction is committed. Per SQLite, this pragma
+    /// defaults to OFF and is automatically reset to OFF at every COMMIT or
+    /// ROLLBACK (see `fkey6-1.10.1`).
+    ///
+    /// **Phase C1 of #5085**: this method only stores/returns the flag. The
+    /// runtime change (queueing FK violations until commit) lands in Phase C2.
+    pub fn defer_foreign_keys(&self) -> bool {
+        match self.get_session_variable("DEFER_FOREIGN_KEYS") {
+            Some(vibesql_types::SqlValue::Integer(n)) => *n != 0,
+            _ => false, // Default: OFF (SQLite compatibility)
+        }
+    }
+
+    /// Set the defer_foreign_keys PRAGMA setting (SQLite compatibility).
+    pub fn set_defer_foreign_keys(&mut self, value: bool) {
+        self.set_session_variable(
+            "DEFER_FOREIGN_KEYS",
+            vibesql_types::SqlValue::Integer(if value { 1 } else { 0 }),
+        );
+    }
+
     // ============================================================================
     // SQLite stat1 Storage (SQLite Compatibility)
     // ============================================================================

--- a/crates/vibesql-storage/src/database/transaction_api.rs
+++ b/crates/vibesql-storage/src/database/transaction_api.rs
@@ -56,6 +56,11 @@ impl Database {
 
         self.lifecycle.transaction_manager_mut().commit_transaction()?;
 
+        // SQLite: PRAGMA defer_foreign_keys is automatically reset to OFF at
+        // every COMMIT (R-21752-26913, fkey6-1.10.1). This is a session-level
+        // flag, so reset it here regardless of FK enforcement state.
+        self.set_defer_foreign_keys(false);
+
         // Emit WAL entry for persistence
         if let Some(txn_id) = txn_id {
             self.emit_wal_op(WalOp::TxnCommit { txn_id });
@@ -84,6 +89,10 @@ impl Database {
         let txn_id = self.transaction_id();
 
         self.lifecycle.perform_rollback(&mut self.catalog, &mut self.tables)?;
+
+        // SQLite: PRAGMA defer_foreign_keys is automatically reset to OFF at
+        // every COMMIT or ROLLBACK (R-21752-26913, fkey6-1.10.1).
+        self.set_defer_foreign_keys(false);
 
         // Emit WAL entry for persistence
         if let Some(txn_id) = txn_id {

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -48,6 +48,7 @@ set ::pragma_case_sensitive_like 0 ;# Default: OFF (case-insensitive LIKE)
 set ::pragma_count_changes 0       ;# Default: OFF (UPDATE/DELETE return nothing)
 set ::pragma_reverse_unordered_selects 0  ;# Default: OFF (normal row order)
 set ::pragma_foreign_keys 0              ;# Default: OFF (SQLite default)
+set ::pragma_defer_foreign_keys 0        ;# Default: OFF; auto-resets at COMMIT/ROLLBACK
 
 # DQS (Double-Quoted Strings) mode tracking
 # When enabled, double-quoted strings are treated as string literals instead of identifiers
@@ -846,6 +847,13 @@ proc build_pragma_prefix {} {
     if {$::pragma_foreign_keys != 0} {
         append prefix "PRAGMA foreign_keys=$::pragma_foreign_keys;\n"
     }
+    # Include defer_foreign_keys if it's been set to ON.
+    # Per SQLite, this pragma auto-resets at every COMMIT or ROLLBACK; the
+    # shim's `track_pragma_setting` clears `::pragma_defer_foreign_keys` when
+    # it sees those statements so subsequent batches don't re-apply ON.
+    if {$::pragma_defer_foreign_keys != 0} {
+        append prefix "PRAGMA defer_foreign_keys=$::pragma_defer_foreign_keys;\n"
+    }
     return $prefix
 }
 
@@ -919,7 +927,9 @@ proc track_pragma_setting {sql} {
     }
 
     # Look for foreign_keys settings (find all occurrences, use last one)
-    set matches [regexp -all -inline -nocase {PRAGMA\s+(?:database\.)?foreign_keys\s*[=(]\s*(\w+)\s*[)]?} $sql]
+    # Note: `(?<!_)` style lookbehind isn't portable to TCL regex; use a word
+    # boundary anchor `\m` (start-of-word) to avoid matching `defer_foreign_keys`.
+    set matches [regexp -all -inline -nocase {PRAGMA\s+(?:database\.)?\mforeign_keys\s*[=(]\s*(\w+)\s*[)]?} $sql]
     foreach {match value} $matches {
         set upper [string toupper $value]
         if {$upper eq "ON" || $upper eq "TRUE" || $upper eq "YES" || $value eq "1"} {
@@ -928,6 +938,25 @@ proc track_pragma_setting {sql} {
             set ::pragma_foreign_keys 0
         }
         set found 1
+    }
+
+    # Look for defer_foreign_keys settings (find all occurrences, use last one)
+    set matches [regexp -all -inline -nocase {PRAGMA\s+(?:database\.)?defer_foreign_keys\s*[=(]\s*(\w+)\s*[)]?} $sql]
+    foreach {match value} $matches {
+        set upper [string toupper $value]
+        if {$upper eq "ON" || $upper eq "TRUE" || $upper eq "YES" || $value eq "1"} {
+            set ::pragma_defer_foreign_keys 1
+        } else {
+            set ::pragma_defer_foreign_keys 0
+        }
+        set found 1
+    }
+
+    # SQLite auto-resets defer_foreign_keys at every COMMIT or ROLLBACK
+    # (R-21752-26913). Mirror that here so re-emitted PRAGMAs don't carry over
+    # across the boundary in subsequent CLI process invocations.
+    if {[regexp -nocase {(?:^|;)\s*(?:COMMIT|ROLLBACK)\s*(?:;|$)} $sql]} {
+        set ::pragma_defer_foreign_keys 0
     }
 
     return $found
@@ -1101,7 +1130,7 @@ proc execsql {sql {db ""}} {
                 }
                 continue  ;# Check for more statements
             }
-            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|table_info)} [string trim $sql]]} {
+            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|table_info)} [string trim $sql]]} {
                 # This PRAGMA is supported (with =value) - stop stripping
                 break
             } else {
@@ -1565,7 +1594,7 @@ proc execsql2 {sql {db ""}} {
     set sql_upper [string toupper [string trim $sql]]
     if {[string match "PRAGMA*" $sql_upper]} {
         # Allow supported PRAGMAs through
-        if {[regexp -nocase {^PRAGMA\s+(?:database\.)?(full_column_names|short_column_names|foreign_key_list|foreign_key_check|foreign_keys)} $sql]} {
+        if {[regexp -nocase {^PRAGMA\s+(?:database\.)?(full_column_names|short_column_names|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys)} $sql]} {
             # Pass through to VibeSQL - these are supported
         } else {
             return {}  ;# Skip unsupported PRAGMA statements
@@ -4199,6 +4228,7 @@ proc sqlite3 {db args} {
     set ::pragma_case_sensitive_like 0
     set ::pragma_reverse_unordered_selects 0
     set ::pragma_foreign_keys 0
+    set ::pragma_defer_foreign_keys 0
     set ::dqs_dml_mode 0  ;# Reset DQS mode for new database
 
     # Create db command alias - if name is not "db" (which already exists)
@@ -4496,6 +4526,7 @@ proc reset_db {} {
     set ::pragma_case_sensitive_like 0
     set ::pragma_reverse_unordered_selects 0
     set ::pragma_foreign_keys 0
+    set ::pragma_defer_foreign_keys 0
 }
 
 proc forcedelete {args} {


### PR DESCRIPTION
Closes Phase C1 of #5085. Phases C2 and C3 to follow as separate issues/PRs.

Parent: #5071 Bucket C. Depends on landed #5087 (Bucket D, auto-rollback) and #5084 (Bucket B, FK mismatch error class).

## Summary

Phase C1 wires catalog schema and PRAGMA plumbing for deferred foreign keys. **No semantic change to FK enforcement timing yet** — that ships in Phase C2 along with the per-transaction violation queue and COMMIT-time enforcement.

- `vibesql_catalog::ForeignKeyConstraint` gains `is_deferrable: bool` and `initially_deferred: bool`. The AST already carried `ConstraintDeferral` (parsed in #5088); this PR finally lands it in the catalog.
- CREATE TABLE (both table-level FOREIGN KEY constraints and column-level REFERENCES) and ALTER TABLE ADD CONSTRAINT now propagate the deferral mode. Defaults to `(false, false)` (NOT DEFERRABLE INITIALLY IMMEDIATE) when omitted, matching SQLite.
- `Database::defer_foreign_keys()` / `set_defer_foreign_keys()` mirror the existing `foreign_keys_enabled()` API on the storage session. Backed by a session variable keyed `DEFER_FOREIGN_KEYS`.
- `PRAGMA defer_foreign_keys` set/read implemented in the CLI executor (parallel to `PRAGMA foreign_keys`).
- Auto-reset to OFF in `Database::commit_transaction` and `Database::rollback_transaction` (SQLite R-21752-26913 / fkey6-1.10.1: "automatically switched off at each COMMIT or ROLLBACK").

### Test infrastructure

Tester shim `scripts/tester_vibesql.tcl`:
- Adds `defer_foreign_keys` to the supported-PRAGMA regexes (was being silently stripped by the unsupported-PRAGMA filter).
- Tracks `::pragma_defer_foreign_keys` across CLI process invocations and re-emits it as a prefix.
- Clears the tracked value when COMMIT or ROLLBACK appears in the SQL, mirroring the in-process auto-reset.
- Anchors the existing `foreign_keys` regex with `\m` (start-of-word) so it can't accidentally collapse `defer_foreign_keys` matches.

## Acceptance — Phase C1

- [x] `fkey6-1.0` returns `0` (was returning empty before).
- [x] `PRAGMA defer_foreign_keys` round-trips ON/OFF.
- [x] Auto-reset on COMMIT and ROLLBACK confirmed manually:
  ```
  BEGIN; PRAGMA defer_foreign_keys=ON; PRAGMA defer_foreign_keys; COMMIT; PRAGMA defer_foreign_keys;
  -- 1, then 0
  ```

The full `fkey6-1.10.1` test still requires deferred FK enforcement timing to pass end-to-end (it transitively depends on `fkey6-1.6` which needs Phase C2's COMMIT-time validation queue). The pragma read/write piece tested by 1.10.1 works correctly in isolation; it's the surrounding transaction with deferred-FK violations that needs C2.

## Out of scope (Phase C2 / C3)

- Per-transaction `Vec<DeferredFkViolation>` queue.
- INSERT/UPDATE/DELETE FK validators pushing to the queue when `initially_deferred` or `defer_foreign_keys=ON`.
- COMMIT-time drain + re-validation.
- Savepoint integration of the deferred queue.
- DEFERRABLE INITIALLY IMMEDIATE / SET CONSTRAINTS edge cases.
- `PRAGMA foreign_key_list` doesn't yet expose deferral state — left for C2/C3 once the runtime semantics ship.

## Test plan

- [x] `cargo build -j 2 --offline` clean.
- [x] `cargo test -p vibesql-catalog -j 2`: 41 passed.
- [x] `cargo test -p vibesql-executor --lib -j 2`: 2374 passed, 0 failed.
- [x] `cargo test -p vibesql-executor --tests -j 2`: integration tests passing.
- [x] `cargo test -p vibesql-storage --lib -j 2`: 587 passed.
- [x] `cargo test -p vibesql-cli -j 2`: 114 + 5 passed.
- [x] `cargo test -p vibesql-server --lib -j 2`: 405 passed.
- [x] `./scripts/tcltest test fkey6.test`: `fkey6-1.0` now passes (Phase C1 acceptance).
- [x] `./scripts/tcltest test fkey5.test`: 53/53 (no regression vs PR #5120 baseline).
- [x] `./scripts/tcltest test fkey1.test`: 15/26 (one better than PR #5120's 14, no regression).
- [x] `./scripts/tcltest test fkey8.test`: 7 passed, 5 failed (2.3.1, 3.0, 3.1, 5.0, 5.2) — same as the curator-noted baseline; these need Phase C2's deferred enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)