### PR TITLE
fix(window): pre-compute aggregates in OVER (PARTITION BY/ORDER BY/frame)

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -297,6 +297,14 @@ impl SelectExecutor<'_> {
             Vec::new()
         };
 
+        // Extract aggregates from window function PARTITION BY/ORDER BY/frame for
+        // pre-computation during GROUP BY. This allows queries like:
+        //   SELECT max(b) OVER (ORDER BY max(c)) FROM t GROUP BY b
+        // where the window's ORDER BY references an aggregate output that must be
+        // computed per group. See issue #5106.
+        let window_aggregates =
+            crate::select::order::extract_window_aggregates(&stmt.select_list);
+
         // Column pruning optimization (#4355, #4377)
         // After JOIN completes, project only the columns needed for aggregation.
         // This reduces memory and CPU overhead significantly for multi-way JOINs.
@@ -311,6 +319,12 @@ impl SelectExecutor<'_> {
 
             // Also collect columns from ORDER BY aggregates
             for agg_expr in &order_by_aggregates {
+                collect_columns_from_expr(agg_expr, &mut required_columns);
+            }
+
+            // Also collect columns from window function aggregates (PARTITION BY,
+            // ORDER BY, frame) so they survive column pruning. See issue #5106.
+            for agg_expr in &window_aggregates {
                 collect_columns_from_expr(agg_expr, &mut required_columns);
             }
 
@@ -541,6 +555,20 @@ impl SelectExecutor<'_> {
                             row_values.push(agg_value);
                         }
 
+                        // Compute window-function aggregates and append them to row
+                        // values. The window evaluator references these via the
+                        // aggregate result schema. See issue #5106.
+                        for win_agg_expr in &window_aggregates {
+                            let agg_value = self.evaluate_with_aggregates_and_grouping(
+                                win_agg_expr,
+                                &group_rows,
+                                &group_key,
+                                &evaluator,
+                                &grouping_context,
+                            )?;
+                            row_values.push(agg_value);
+                        }
+
                         let row = vibesql_storage::Row::new(row_values);
 
                         // Track memory for aggregation result row
@@ -639,7 +667,23 @@ impl SelectExecutor<'_> {
                 };
 
                 if include_group {
-                    let row = vibesql_storage::Row::new(aggregate_results);
+                    // No GROUP BY columns and no ORDER BY aggregates in this path,
+                    // but we still need to append window-function aggregates so the
+                    // window evaluator can reference them. See issue #5106.
+                    let mut row_values = aggregate_results;
+
+                    for win_agg_expr in &window_aggregates {
+                        let agg_value = self.evaluate_with_aggregates_and_grouping(
+                            win_agg_expr,
+                            &group_rows,
+                            &group_key,
+                            &evaluator,
+                            &grouping_context,
+                        )?;
+                        row_values.push(agg_value);
+                    }
+
+                    let row = vibesql_storage::Row::new(row_values);
 
                     // Track memory for aggregation result row
                     let row_memory = std::mem::size_of::<vibesql_storage::Row>()
@@ -660,7 +704,9 @@ impl SelectExecutor<'_> {
 
         // Apply window functions that wrap aggregates (e.g., AVG(SUM(x)) OVER (...))
         // This must happen after GROUP BY but before ORDER BY
-        // Pass GROUP BY expressions so window ORDER BY/PARTITION BY can reference them
+        // Pass GROUP BY expressions so window ORDER BY/PARTITION BY can reference them.
+        // Pass window_aggregates and order_by_aggregates count so window evaluator can
+        // map references to the pre-computed hidden columns. See issue #5106.
         let result_rows = if window::has_aggregate_window_functions(&expanded_select_list) {
             window::apply_window_functions_to_aggregates(
                 result_rows,
@@ -668,13 +714,16 @@ impl SelectExecutor<'_> {
                 self.database,
                 stmt.window_definitions.as_ref(),
                 &group_by_exprs,
+                order_by_aggregates.len(),
+                &window_aggregates,
             )?
         } else {
             result_rows
         };
 
-        // Calculate count of hidden columns (GROUP BY + ORDER BY aggregates)
-        let hidden_col_count = group_by_exprs.len() + order_by_aggregates.len();
+        // Calculate count of hidden columns (GROUP BY + ORDER BY aggregates + window aggregates)
+        let hidden_col_count =
+            group_by_exprs.len() + order_by_aggregates.len() + window_aggregates.len();
 
         // Apply ORDER BY if present
         // Note: For scalar aggregates (no GROUP BY), ORDER BY is skipped because:

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -193,15 +193,21 @@ fn collect_window_functions(
 /// the inner values (e.g., for LEAD(x), each row has the x value).
 /// This function applies the window function over these values.
 ///
-/// `group_by_exprs` contains the GROUP BY expressions. Their evaluated values are
-/// appended as hidden columns after the SELECT items in each row. This allows
-/// window ORDER BY / PARTITION BY clauses to reference GROUP BY columns.
+/// Hidden column layout in each row (after the SELECT items):
+/// 1. `group_by_exprs` (count: G)
+/// 2. `order_by_aggregates` (count: order_by_aggregates_count) — pre-computed
+///    aggregates from the outer SQL ORDER BY (not used here, but skip past them)
+/// 3. `window_aggregates` (count: W) — pre-computed aggregates from the window's
+///    PARTITION BY/ORDER BY/frame (used to support `OVER (ORDER BY <agg>)`).
+///    See issue #5106.
 pub(super) fn apply_window_functions_to_aggregates(
     mut rows: Vec<Row>,
     select_list: &[SelectItem],
     database: &vibesql_storage::Database,
     window_definitions: Option<&Vec<WindowDefinition>>,
     group_by_exprs: &[Expression],
+    order_by_aggregates_count: usize,
+    window_aggregates: &[Expression],
 ) -> Result<Vec<Row>, ExecutorError> {
     let window_funcs = collect_window_functions(select_list, window_definitions)?;
 
@@ -211,7 +217,13 @@ pub(super) fn apply_window_functions_to_aggregates(
 
     // Build a schema for the aggregate result rows
     // Each column corresponds to a SELECT list item, plus hidden GROUP BY columns
-    let result_schema = build_aggregate_result_schema(select_list, group_by_exprs);
+    // and window-aggregate columns.
+    let result_schema = build_aggregate_result_schema(
+        select_list,
+        group_by_exprs,
+        order_by_aggregates_count,
+        window_aggregates,
+    );
     let evaluator = CombinedExpressionEvaluator::with_database(&result_schema, database);
 
     // Process each window function
@@ -226,7 +238,18 @@ pub(super) fn apply_window_functions_to_aggregates(
         // in the aggregate result schema. Create column reference expressions.
         let partition_exprs: Option<Vec<Expression>> =
             win_func.window_spec.partition_by.as_ref().map(|exprs| {
-                exprs.iter().map(|e| map_expr_to_result_column(e, select_list, group_by_exprs)).collect::<Vec<_>>()
+                exprs
+                    .iter()
+                    .map(|e| {
+                        map_expr_to_result_column(
+                            e,
+                            select_list,
+                            group_by_exprs,
+                            order_by_aggregates_count,
+                            window_aggregates,
+                        )
+                    })
+                    .collect::<Vec<_>>()
             });
 
         // Partition the rows
@@ -243,7 +266,13 @@ pub(super) fn apply_window_functions_to_aggregates(
                 items
                     .iter()
                     .map(|item| vibesql_ast::OrderByItem {
-                        expr: map_expr_to_result_column(&item.expr, select_list, group_by_exprs),
+                        expr: map_expr_to_result_column(
+                            &item.expr,
+                            select_list,
+                            group_by_exprs,
+                            order_by_aggregates_count,
+                            window_aggregates,
+                        ),
                         direction: item.direction.clone(),
                         nulls_order: item.nulls_order,
                     })
@@ -285,7 +314,15 @@ pub(super) fn apply_window_functions_to_aggregates(
             let mapped_args: Vec<Expression> = win_func
                 .args
                 .iter()
-                .map(|arg| map_expr_to_result_column(arg, select_list, group_by_exprs))
+                .map(|arg| {
+                    map_expr_to_result_column(
+                        arg,
+                        select_list,
+                        group_by_exprs,
+                        order_by_aggregates_count,
+                        window_aggregates,
+                    )
+                })
                 .collect();
 
             // Evaluate the window function for each row in the partition
@@ -615,11 +652,14 @@ pub(super) fn apply_window_functions_to_aggregates(
 /// Build a schema for aggregate result rows
 ///
 /// Uses consistent column naming: col0, col1, col2, ... so column references work correctly.
-/// Includes hidden columns for GROUP BY expressions (appended after SELECT items)
-/// so that window ORDER BY / PARTITION BY can reference GROUP BY columns.
+/// Includes hidden columns for GROUP BY expressions, ORDER BY aggregates, and window
+/// aggregates (in that order, appended after SELECT items) so that window
+/// ORDER BY / PARTITION BY clauses can reference any of them.
 fn build_aggregate_result_schema(
     select_list: &[SelectItem],
     group_by_exprs: &[Expression],
+    order_by_aggregates_count: usize,
+    window_aggregates: &[Expression],
 ) -> CombinedSchema {
     let mut columns = Vec::new();
 
@@ -637,6 +677,29 @@ fn build_aggregate_result_schema(
     // Use consistent col{idx} naming so make_result_col_ref() references work.
     for i in 0..group_by_exprs.len() {
         let column_name = format!("col{}", select_list.len() + i);
+        columns.push(ColumnSchema::new(
+            column_name,
+            DataType::Varchar { max_length: Some(255) },
+            true,
+        ));
+    }
+
+    // Hidden ORDER BY aggregate columns (used by outer SQL ORDER BY, but referenced
+    // here only to keep schema column count aligned with row width).
+    let order_by_offset = select_list.len() + group_by_exprs.len();
+    for i in 0..order_by_aggregates_count {
+        let column_name = format!("col{}", order_by_offset + i);
+        columns.push(ColumnSchema::new(
+            column_name,
+            DataType::Varchar { max_length: Some(255) },
+            true,
+        ));
+    }
+
+    // Hidden window-aggregate columns (used by window's PARTITION BY/ORDER BY/frame).
+    let window_offset = order_by_offset + order_by_aggregates_count;
+    for i in 0..window_aggregates.len() {
+        let column_name = format!("col{}", window_offset + i);
         columns.push(ColumnSchema::new(
             column_name,
             DataType::Varchar { max_length: Some(255) },
@@ -666,15 +729,20 @@ fn build_aggregate_result_schema(
 
 /// Map an expression to a column reference in the result schema
 ///
-/// For expressions that appear in the SELECT list or GROUP BY, we create a ColumnRef
-/// that references the computed value. For others, we return the expression as-is.
+/// For expressions that appear in the SELECT list, GROUP BY, or window aggregates,
+/// we create a ColumnRef that references the computed value. For others, we return
+/// the expression as-is.
 ///
-/// GROUP BY expressions are stored as hidden columns at positions
-/// `select_list.len() + i` in the aggregate result rows.
+/// Hidden column layout (after SELECT items):
+/// - GROUP BY expressions at positions `select_list.len() + i`
+/// - ORDER BY aggregates at positions `select_list.len() + G + i`
+/// - Window aggregates at positions `select_list.len() + G + O + i`
 fn map_expr_to_result_column(
     expr: &Expression,
     select_list: &[SelectItem],
     group_by_exprs: &[Expression],
+    order_by_aggregates_count: usize,
+    window_aggregates: &[Expression],
 ) -> Expression {
     // Helper to create a column ref for the synthetic result schema.
     // The schema uses col0, col1, col2, ... naming, so we always use that format.
@@ -778,6 +846,17 @@ fn map_expr_to_result_column(
                     return make_result_col_ref(select_count + i);
                 }
             }
+        }
+    }
+
+    // Check window-function aggregate expressions (stored as hidden columns after
+    // GROUP BY and ORDER BY aggregate columns). This enables window ORDER BY /
+    // PARTITION BY clauses that reference aggregates like `OVER (ORDER BY max(c))`.
+    // See issue #5106.
+    let window_agg_offset = select_count + group_by_exprs.len() + order_by_aggregates_count;
+    for (i, win_agg_expr) in window_aggregates.iter().enumerate() {
+        if expressions_match(expr, win_agg_expr) {
+            return make_result_col_ref(window_agg_offset + i);
         }
     }
 

--- a/crates/vibesql-executor/src/select/order/mod.rs
+++ b/crates/vibesql-executor/src/select/order/mod.rs
@@ -19,8 +19,9 @@ use crate::{errors::ExecutorError, evaluator::CombinedExpressionEvaluator};
 
 // Re-export public API
 pub(crate) use resolution::{
-    extract_order_by_aggregates, resolve_order_by_alias, resolve_order_by_for_aggregates,
-    resolve_where_aliases, resolve_where_aliases_with_schema, select_list_has_aliases,
+    extract_order_by_aggregates, extract_window_aggregates, resolve_order_by_alias,
+    resolve_order_by_for_aggregates, resolve_where_aliases, resolve_where_aliases_with_schema,
+    select_list_has_aliases,
 };
 
 /// Sort key for ORDER BY: (value, direction, nulls_order, collation)

--- a/crates/vibesql-executor/src/select/order/resolution.rs
+++ b/crates/vibesql-executor/src/select/order/resolution.rs
@@ -1342,6 +1342,63 @@ pub(crate) fn extract_order_by_aggregates(
     aggregates
 }
 
+/// Extract aggregate expressions from window function PARTITION BY/ORDER BY clauses
+/// in the SELECT list. These need to be pre-computed during GROUP BY so the window
+/// evaluator (which runs after aggregation) can reference them.
+///
+/// Example:
+/// ```sql
+/// SELECT max(b) OVER (ORDER BY max(c)) FROM t GROUP BY b;
+/// ```
+/// Here `max(c)` inside the OVER clause must be pre-computed per group, then the window
+/// evaluator can sort by that pre-computed value.
+///
+/// Returns a vector of unique aggregate expressions used in any window's PARTITION BY,
+/// ORDER BY, or frame offset.
+pub(crate) fn extract_window_aggregates(
+    select_list: &[vibesql_ast::SelectItem],
+) -> Vec<vibesql_ast::Expression> {
+    use vibesql_ast::{Expression, SelectItem};
+
+    let mut aggregates = Vec::new();
+
+    for item in select_list {
+        if let SelectItem::Expression { expr: Expression::WindowFunction { over, .. }, .. } =
+            item
+        {
+            // PARTITION BY expressions
+            if let Some(partition_by) = &over.partition_by {
+                for p_expr in partition_by {
+                    collect_aggregates_from_expr(p_expr, &mut aggregates);
+                }
+            }
+            // ORDER BY expressions
+            if let Some(order_by) = &over.order_by {
+                for ob_item in order_by {
+                    collect_aggregates_from_expr(&ob_item.expr, &mut aggregates);
+                }
+            }
+            // Frame offset expressions (e.g., `ROWS BETWEEN sum(x) PRECEDING ...`)
+            if let Some(frame) = &over.frame {
+                if let vibesql_ast::FrameBound::Preceding(e)
+                | vibesql_ast::FrameBound::Following(e) = &frame.start
+                {
+                    collect_aggregates_from_expr(e, &mut aggregates);
+                }
+                if let Some(end) = &frame.end {
+                    if let vibesql_ast::FrameBound::Preceding(e)
+                    | vibesql_ast::FrameBound::Following(e) = end
+                    {
+                        collect_aggregates_from_expr(e, &mut aggregates);
+                    }
+                }
+            }
+        }
+    }
+
+    aggregates
+}
+
 /// Recursively collect aggregate function expressions from an expression tree.
 fn collect_aggregates_from_expr(
     expr: &vibesql_ast::Expression,

--- a/crates/vibesql-executor/src/tests/select_window_aggregate.rs
+++ b/crates/vibesql-executor/src/tests/select_window_aggregate.rs
@@ -889,3 +889,65 @@ fn test_count_no_arg_window_with_group_by() {
         panic!("Expected SELECT statement");
     }
 }
+
+/// Regression test for issue #5106: window OVER (ORDER BY <aggregate>)
+///
+/// When a window's ORDER BY references an aggregate output (e.g.
+/// `ORDER BY max(c)` after a GROUP BY), the running aggregate must be applied in
+/// the order produced by the aggregate expression, not the entire post-aggregate
+/// row set. Previously the window evaluator could not resolve the aggregate
+/// reference inside OVER(...) so the ORDER BY was effectively ignored, producing
+/// a constant value per row instead of the running aggregate.
+///
+/// Mirrors window4.test test 4.2.
+#[test]
+fn test_window_order_by_references_aggregate_5106() {
+    let mut db = Database::new();
+
+    let schema = TableSchema::new(
+        "TTT".to_string(),
+        vec![
+            ColumnSchema::new("B".to_string(), DataType::Integer, false),
+            ColumnSchema::new("C".to_string(), DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("TTT").unwrap();
+    use vibesql_storage::Row;
+    table.insert(Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(1)])).unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(2), SqlValue::Integer(2)])).unwrap();
+    table.insert(Row::new(vec![SqlValue::Integer(3), SqlValue::Integer(3)])).unwrap();
+
+    let executor = SelectExecutor::new(&db);
+    let query = "SELECT max(b) OVER (ORDER BY max(c)) FROM ttt GROUP BY b";
+    let stmt = Parser::parse_sql(query).unwrap();
+
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let rows = executor.execute(&select_stmt).unwrap();
+        // Default RANGE frame is UNBOUNDED PRECEDING TO CURRENT ROW.
+        // Groups (b=1,c=1), (b=2,c=2), (b=3,c=3); ordered by max(c) ASC.
+        // Running max(b) = 1, 2, 3.
+        assert_eq!(rows.len(), 3);
+        assert_eq!(
+            rows[0].values[0],
+            SqlValue::Integer(1),
+            "Window ORDER BY max(c) ignored: row 0 expected 1, got {:?}",
+            rows[0].values[0]
+        );
+        assert_eq!(
+            rows[1].values[0],
+            SqlValue::Integer(2),
+            "Window ORDER BY max(c) ignored: row 1 expected 2, got {:?}",
+            rows[1].values[0]
+        );
+        assert_eq!(
+            rows[2].values[0],
+            SqlValue::Integer(3),
+            "Window ORDER BY max(c) ignored: row 2 expected 3, got {:?}",
+            rows[2].values[0]
+        );
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}


### PR DESCRIPTION
## Summary

- When an OVER clause references an aggregate output (e.g. `max(b) OVER (ORDER BY max(c))` after `GROUP BY b`), the window evaluator runs after aggregation and could not resolve the aggregate reference. The reference silently collapsed, leaving the window with no effective ORDER BY and returning a constant value per row.
- Fix: extract aggregates from each window's `PARTITION BY`, `ORDER BY`, and frame-offset expressions; pre-compute them per group during `GROUP BY`; append the results to each row as hidden columns. The window evaluator's expression-to-result-column mapper now resolves OVER-clause aggregate references to those hidden slots.
- Scope: `select/executor/aggregation/{mod.rs,window.rs}` and a small helper in `select/order/resolution.rs`. No changes to `select/window/{detection,collection}.rs` or `select/projection.rs` (those were just refactored in #5121).

## Test plan

- [x] `./scripts/tcltest test window4.test` — 4.2 now passes (Got 1 2 3 vs. previous 3 3 3); 12.1/12.2/12.3 are pre-existing unrelated failures.
- [x] `cargo test -p vibesql-executor --lib -j 2` — 2375 passed, 0 failed (added regression test `test_window_order_by_references_aggregate_5106`).
- [x] No regressions in `window1`, `window2`, `window3`, `windowB` TCL suites (failure sets identical to baseline on main).
- [x] Manual edge cases: `ORDER BY max(c)+0`, `PARTITION BY max(c) > 1`, `ORDER BY max(c), min(c)`.

Closes #5106