### PR TITLE
fix(union): match SQLite last-occurrence wins dedup for cross-class numerics

### DIFF
--- a/crates/vibesql-executor/src/select/set_operations.rs
+++ b/crates/vibesql-executor/src/select/set_operations.rs
@@ -152,14 +152,30 @@ pub(super) fn apply_set_operation(
                 // dedup and sorting so that cross-type numerics (e.g. Real(30.0) and
                 // Numeric(30.0) produced by sum() OVER()) are treated as equal and
                 // sort by their numeric magnitude.
-                let mut result = left;
-                result.extend(right);
+                //
+                // Dedup precedence: last-occurrence wins. SQLite's UNION uses an
+                // ephemeral B-tree with `OP_IdxInsert` semantics that *overwrite*
+                // an existing entry whose key compares equal — even when the new
+                // row's storage class differs (e.g. `INTEGER 0` vs `REAL 0.0`).
+                // Concretely, `SELECT 0 UNION SELECT 0.0` returns `0.0` (REAL),
+                // not `0` (INTEGER). To match this, walk the combined rows in
+                // order, replacing any previously-seen row with the same
+                // normalized key. (See window9.test 8.4 / issue #5105.)
+                let mut combined = left;
+                combined.extend(right);
 
-                let mut seen = HashSet::new();
-                result.retain(|row| {
+                let mut index_by_key: HashMap<Vec<vibesql_types::SqlValue>, usize> =
+                    HashMap::new();
+                let mut result: Vec<vibesql_storage::Row> = Vec::with_capacity(combined.len());
+                for row in combined {
                     let key = normalize_row_for_comparison(&row.values, collations);
-                    seen.insert(key)
-                });
+                    if let Some(&idx) = index_by_key.get(&key) {
+                        result[idx] = row;
+                    } else {
+                        index_by_key.insert(key, result.len());
+                        result.push(row);
+                    }
+                }
 
                 result.sort_by(|a, b| {
                     let ka = normalize_row_for_comparison(&a.values, collations);

--- a/tests/executor/set_operations.rs
+++ b/tests/executor/set_operations.rs
@@ -227,3 +227,45 @@ fn test_e2e_set_operations() {
             .unwrap();
     assert_eq!(results.len(), 3);
 }
+
+/// Regression test for issue #5105 (window9.test 8.4):
+/// UNION dedup of cross-class numerics must follow SQLite's "last-occurrence
+/// wins" rule when the operands have the same numeric magnitude but different
+/// storage classes. SQLite's ephemeral B-tree uses `OP_IdxInsert` semantics
+/// that overwrite existing entries with the new (right-arm) value.
+///
+/// Concretely: `SELECT 0 UNION SELECT 0.0` returns `0.0` (REAL), not `0` (INTEGER).
+#[test]
+fn test_union_dedup_storage_class_last_wins() {
+    let db = Database::new();
+
+    // Right-arm REAL should win over left-arm INTEGER for same magnitude.
+    let results = execute_select(&db, "SELECT 0 UNION SELECT 0.0;").unwrap();
+    assert_eq!(results.len(), 1);
+    match &results[0].values[0] {
+        SqlValue::Real(_) | SqlValue::Float(_) | SqlValue::Double(_) | SqlValue::Numeric(_) => {}
+        other => panic!(
+            "Expected REAL-class value for `SELECT 0 UNION SELECT 0.0`, got {:?}",
+            other
+        ),
+    }
+
+    // Right-arm INTEGER should win over left-arm REAL for same magnitude.
+    let results = execute_select(&db, "SELECT 0.0 UNION SELECT 0;").unwrap();
+    assert_eq!(results.len(), 1);
+    match &results[0].values[0] {
+        SqlValue::Integer(_) | SqlValue::Bigint(_) | SqlValue::Smallint(_) => {}
+        other => panic!(
+            "Expected INTEGER-class value for `SELECT 0.0 UNION SELECT 0`, got {:?}",
+            other
+        ),
+    }
+
+    // Three-arm chain: ((0 UNION 0.0) UNION 0) → final right arm INTEGER wins.
+    let results = execute_select(&db, "SELECT 0 UNION SELECT 0.0 UNION SELECT 0;").unwrap();
+    assert_eq!(results.len(), 1);
+    match &results[0].values[0] {
+        SqlValue::Integer(_) | SqlValue::Bigint(_) | SqlValue::Smallint(_) => {}
+        other => panic!("Expected INTEGER-class value for chained UNION, got {:?}", other),
+    }
+}


### PR DESCRIPTION
Closes #5105.

## Summary

`window9.test 8.4` was failing with output `0` / `0.0` (INTEGER then REAL) instead of the expected `0.0` / `0.0` (REAL both rows). Root cause confirmed: VibeSQL's UNION dedup kept the first-seen row, but SQLite's ephemeral B-tree (via `OP_IdxInsert`) keeps the *last-inserted* row when two values have the same normalized key but different storage classes.

Concretely:
- `SELECT 0 UNION SELECT 0.0` -> SQLite returns `REAL 0.0`; we returned `INTEGER 0`.
- `SELECT 0.0 UNION SELECT 0` -> SQLite returns `INTEGER 0`; we returned `REAL 0.0`.

Both arms have the same numeric magnitude, so dedup collapses them to one row -- but which row's storage class survives depends on insertion order, and SQLite picks the right (later-inserted) arm.

## Fix

In `crates/vibesql-executor/src/select/set_operations.rs`, replaced the `HashSet::insert`-based dedup with a single linear pass that uses a `HashMap<key, index>` to overwrite any previously-seen row with the same normalized key. This gives "last-occurrence wins" semantics matching SQLite.

INTERSECT and EXCEPT branches were left unchanged -- they have different (left-side-wins) precedence rules.

## Root cause confirmation

- Curator's hypothesis: "UNION result-column type unification (REAL union INTEGER should yield REAL)."
- Verified against SQLite: partially correct but more nuanced -- SQLite doesn't unify column *types* across arms; it preserves whichever storage class is kept by the dedup B-tree, which depends on which arm is inserted last. So `SELECT 0 UNION SELECT 0.0` -> REAL, but `SELECT 0.0 UNION SELECT 0` -> INTEGER.
- The symptom on current main matches the curator's updated description: `0` then `0.0` (not the original `0 1` boolean shape).

## Verification

**Direct repro**:
```sql
CREATE TABLE t1(a, b);
INSERT INTO t1 VALUES(1, 2), (3, 4);
CREATE VIEW v1 AS SELECT 0 AS x UNION SELECT count() OVER() FROM (SELECT 0) ORDER BY 1;
SELECT(SELECT x UNION SELECT sum(avg((SELECT x FROM v1))) OVER()) FROM v1;
```

| | Before fix | After fix | SQLite reference |
|---|---|---|---|
| Row 1 | `0` (int) | `0.0` (real) | `0.0` (real) |
| Row 2 | `0.0` (real) | `0.0` (real) | `0.0` (real) |

**Test results**:
- `make test-tcl-file FILE=window9.test`: 8.4 now passes; remaining 1.4/3.4/5.1.2/7.2/7.3 are pre-existing and unrelated (verified by stashing the fix and re-running).
- `make test-tcl-file FILE=select4.test`: 123/123 pass (UNION/INTERSECT/EXCEPT coverage).
- `cargo test --release -p vibesql-executor --tests`: 2375 unit tests pass + all integration tests pass.
- New regression test `test_union_dedup_storage_class_last_wins` in `tests/executor/set_operations.rs` covers the three storage-class-precedence cases.

## Files changed

- `crates/vibesql-executor/src/select/set_operations.rs` (+22, -6) -- UNION dedup logic
- `tests/executor/set_operations.rs` (+42, 0) -- new regression test

## Test plan

- [x] window9.test 8.4 passes
- [x] No regressions in select4.test (set ops)
- [x] No regressions in vibesql-executor cargo test suite
- [x] New regression unit test added and passing