### PR TITLE
feat(fkey): deferred FK violation queue + COMMIT-time enforcement (Phase C2 of #5085)

### DIFF
--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -1,6 +1,7 @@
 //! Foreign key integrity checking and enforcement for DELETE operations
 
 use vibesql_catalog::ReferentialAction;
+use vibesql_storage::{DeferredFkViolation, DeferredFkViolationKind};
 use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;
@@ -56,11 +57,18 @@ pub fn check_no_child_references(
         return Ok(());
     }
 
+    // Phase C2: cache session defer + transaction state. RESTRICT is
+    // *never* deferred even with INITIALLY DEFERRED (per SQLite docs);
+    // only NO ACTION can be deferred.
+    let session_defer = db.defer_foreign_keys();
+    let in_txn = db.in_transaction();
+
     // Collect all child tables that reference this parent row
     // We need to collect first to avoid borrowing issues when we mutate
     let mut actions_to_perform: Vec<(
         String,
         vibesql_catalog::ForeignKeyConstraint,
+        usize,
         ReferentialAction,
     )> = Vec::new();
 
@@ -71,7 +79,7 @@ pub fn check_no_child_references(
             continue;
         }
 
-        for fk in &child_schema.foreign_keys {
+        for (fk_idx, fk) in child_schema.foreign_keys.iter().enumerate() {
             // Use case-insensitive comparison for SQL identifier matching
             if !fk.parent_table.eq_ignore_ascii_case(parent_table_name) {
                 continue;
@@ -93,21 +101,42 @@ pub fn check_no_child_references(
             });
 
             if has_references {
-                actions_to_perform.push((table_name.clone(), fk.clone(), fk.on_delete.clone()));
+                actions_to_perform.push((
+                    table_name.clone(),
+                    fk.clone(),
+                    fk_idx,
+                    fk.on_delete.clone(),
+                ));
             }
         }
     }
 
     // Now perform the actions
-    for (child_table_name, fk, action) in actions_to_perform {
+    for (child_table_name, fk, fk_idx, action) in actions_to_perform {
         match action {
-            ReferentialAction::NoAction | ReferentialAction::Restrict => {
-                // Fail with constraint violation
+            ReferentialAction::Restrict => {
+                // RESTRICT is immediate, never deferred (SQLite docs).
                 return Err(ExecutorError::ConstraintViolation(format!(
                     "FOREIGN KEY constraint violation: cannot delete or update a parent row when a foreign key constraint exists. The conflict occurred in table \'{}\', constraint \'{}\'.",
                     child_table_name,
                     fk.name.as_deref().unwrap_or(""),
                 )));
+            }
+            ReferentialAction::NoAction => {
+                // NO ACTION can be deferred (Phase C2 of #5085). Queue
+                // every orphaned child row so that COMMIT-time re-check
+                // verifies each one finds a parent. If not deferred,
+                // fail immediately as before.
+                let should_defer = in_txn && (fk.initially_deferred || session_defer);
+                if should_defer {
+                    queue_orphaned_children(db, &child_table_name, &fk, fk_idx, &parent_key_values);
+                } else {
+                    return Err(ExecutorError::ConstraintViolation(format!(
+                        "FOREIGN KEY constraint violation: cannot delete or update a parent row when a foreign key constraint exists. The conflict occurred in table \'{}\', constraint \'{}\'.",
+                        child_table_name,
+                        fk.name.as_deref().unwrap_or(""),
+                    )));
+                }
             }
             ReferentialAction::Cascade => {
                 // Delete child rows that reference the parent
@@ -125,6 +154,50 @@ pub fn check_no_child_references(
     }
 
     Ok(())
+}
+
+/// Queue every orphaned child row (referencing the deleted parent) onto
+/// the transaction's deferred FK violation queue. Used by NO ACTION
+/// when the constraint is deferred (Phase C2 of #5085).
+fn queue_orphaned_children(
+    db: &mut vibesql_storage::Database,
+    child_table_name: &str,
+    fk: &vibesql_catalog::ForeignKeyConstraint,
+    fk_idx: usize,
+    parent_key_values: &[SqlValue],
+) {
+    // Snapshot the orphaned child rows first to release the immutable
+    // borrow before queueing (which mutates the transaction state).
+    let orphaned: Vec<Vec<SqlValue>> = {
+        let child_table = match db.get_table(child_table_name) {
+            Some(t) => t,
+            None => return,
+        };
+        child_table
+            .scan_live()
+            .filter_map(|(_, child_row)| {
+                let child_fk_values: Vec<SqlValue> =
+                    fk.column_indices.iter().map(|&idx| child_row.values[idx].clone()).collect();
+                if child_fk_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+                    return None;
+                }
+                if child_fk_values == parent_key_values {
+                    Some(child_row.values.to_vec())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    };
+
+    for row_values in orphaned {
+        db.queue_deferred_fk_violation(DeferredFkViolation {
+            child_table: child_table_name.to_string(),
+            fk_index: fk_idx,
+            child_row: row_values,
+            kind: DeferredFkViolationKind::ChildInsertOrUpdate,
+        });
+    }
 }
 
 /// Delete child rows that reference a deleted parent row (CASCADE action)

--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -57,9 +57,15 @@ pub fn check_no_child_references(
         return Ok(());
     }
 
-    // Phase C2: cache session defer + transaction state. RESTRICT is
-    // *never* deferred even with INITIALLY DEFERRED (per SQLite docs);
-    // only NO ACTION can be deferred.
+    // Phase C2: cache session defer + transaction state.
+    //
+    // RESTRICT is never deferred by `INITIALLY DEFERRED` on the
+    // constraint (per SQLite docs), but the session pragma
+    // `defer_foreign_keys=ON` *does* delay RESTRICT until COMMIT
+    // (EVIDENCE-OF R-18981-16292; see fkey6-3.2.3).
+    //
+    // NO ACTION can be deferred by either INITIALLY DEFERRED or the
+    // session pragma.
     let session_defer = db.defer_foreign_keys();
     let in_txn = db.in_transaction();
 
@@ -115,12 +121,21 @@ pub fn check_no_child_references(
     for (child_table_name, fk, fk_idx, action) in actions_to_perform {
         match action {
             ReferentialAction::Restrict => {
-                // RESTRICT is immediate, never deferred (SQLite docs).
-                return Err(ExecutorError::ConstraintViolation(format!(
-                    "FOREIGN KEY constraint violation: cannot delete or update a parent row when a foreign key constraint exists. The conflict occurred in table \'{}\', constraint \'{}\'.",
-                    child_table_name,
-                    fk.name.as_deref().unwrap_or(""),
-                )));
+                // RESTRICT is immediate by default, but the session
+                // pragma `defer_foreign_keys=ON` delays it until COMMIT
+                // (EVIDENCE-OF R-18981-16292; see fkey6-3.2.3 and
+                // fkey6-3.3.4). Per-constraint INITIALLY DEFERRED does
+                // *not* defer RESTRICT — only the session pragma does.
+                let should_defer = in_txn && session_defer;
+                if should_defer {
+                    queue_orphaned_children(db, &child_table_name, &fk, fk_idx, &parent_key_values);
+                } else {
+                    return Err(ExecutorError::ConstraintViolation(format!(
+                        "FOREIGN KEY constraint violation: cannot delete or update a parent row when a foreign key constraint exists. The conflict occurred in table \'{}\', constraint \'{}\'.",
+                        child_table_name,
+                        fk.name.as_deref().unwrap_or(""),
+                    )));
+                }
             }
             ReferentialAction::NoAction => {
                 // NO ACTION can be deferred (Phase C2 of #5085). Queue

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -608,6 +608,7 @@ fn execute_insert_internal(
         }
 
         let validation_result = validator.validate(&full_row_values)?;
+        drop(validator); // release the immutable &Database borrow before the queue push below
 
         // Track PK values for batch duplicate checking (using pre-extracted keys)
         if let Some(pk_values) = validation_result.primary_key {
@@ -620,6 +621,13 @@ fn execute_insert_internal(
             if let Some(values) = unique_values {
                 unique_constraint_values[constraint_idx].push(values);
             }
+        }
+
+        // Phase C2 of #5085: queue any FK violations that were deferred
+        // (INITIALLY DEFERRED constraint or PRAGMA defer_foreign_keys=ON)
+        // onto the active transaction's deferred-FK queue.
+        for v in validation_result.deferred_fk_violations {
+            db.queue_deferred_fk_violation(v);
         }
 
         // Store validated row for insertion (with optional explicit rowid)

--- a/crates/vibesql-executor/src/insert/foreign_keys.rs
+++ b/crates/vibesql-executor/src/insert/foreign_keys.rs
@@ -1,8 +1,16 @@
+use vibesql_storage::{DeferredFkViolation, DeferredFkViolationKind};
+
 use crate::errors::ExecutorError;
 
-/// Validate FOREIGN KEY constraints for a new row
+/// Validate FOREIGN KEY constraints for a new row.
+///
+/// Phase C2 of #5085: when the constraint is `INITIALLY DEFERRED` or
+/// the session has `PRAGMA defer_foreign_keys=ON` (and a transaction is
+/// active), a missing parent row is queued onto the transaction's
+/// deferred-FK queue instead of returning an immediate error. The
+/// queue is drained and re-checked at COMMIT.
 pub fn validate_foreign_key_constraints(
-    db: &vibesql_storage::Database,
+    db: &mut vibesql_storage::Database,
     table_name: &str,
     row_values: &[vibesql_types::SqlValue],
 ) -> Result<(), ExecutorError> {
@@ -11,14 +19,21 @@ pub fn validate_foreign_key_constraints(
         return Ok(());
     }
 
+    let session_defer = db.defer_foreign_keys();
+    let in_txn = db.in_transaction();
+
     let schema = db
         .catalog
         .get_table(table_name)
-        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?
+        .clone();
 
-    for fk in &schema.foreign_keys {
+    let mut deferred: Vec<DeferredFkViolation> = Vec::new();
+
+    for (fk_idx, fk) in schema.foreign_keys.iter().enumerate() {
         // Mismatch check runs before any row-existence test so that bad
         // FK targets are reported even when the parent table is empty.
+        // Mismatch is never deferred (matches SQLite behaviour).
         if let Some((child, parent)) =
             crate::foreign_key_check::detect_fk_mismatch(db, table_name, fk)
         {
@@ -43,28 +58,43 @@ pub fn validate_foreign_key_constraints(
         let parent_indices = crate::foreign_key_check::resolved_parent_indices_for_fk(db, fk);
 
         let key_exists = parent_table.scan().iter().any(|parent_row| {
-            parent_indices
-                .iter()
-                .zip(&fk_values)
-                .enumerate()
-                .all(|(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+            parent_indices.iter().zip(&fk_values).enumerate().all(|(i, (&parent_idx, fk_val))| {
+                match parent_row.get(parent_idx) {
                     Some(parent_val) => crate::foreign_key_check::fk_values_equal(
                         fk_val,
                         parent_val,
                         parent_collations.get(i).and_then(|c| c.as_deref()),
                     ),
                     None => false,
-                })
+                }
+            })
         });
 
-        if !key_exists {
-            return Err(ExecutorError::ConstraintViolation(format!(
-                "FOREIGN KEY constraint \'{}\' violated: key ({}) not found in table \'{}\'",
-                fk.name.as_deref().unwrap_or(""),
-                fk.column_names.join(", "),
-                fk.parent_table
-            )));
+        if key_exists {
+            continue;
         }
+
+        let should_defer = in_txn && (fk.initially_deferred || session_defer);
+        if should_defer {
+            deferred.push(DeferredFkViolation {
+                child_table: table_name.to_string(),
+                fk_index: fk_idx,
+                child_row: row_values.to_vec(),
+                kind: DeferredFkViolationKind::ChildInsertOrUpdate,
+            });
+            continue;
+        }
+
+        return Err(ExecutorError::ConstraintViolation(format!(
+            "FOREIGN KEY constraint \'{}\' violated: key ({}) not found in table \'{}\'",
+            fk.name.as_deref().unwrap_or(""),
+            fk.column_names.join(", "),
+            fk.parent_table
+        )));
+    }
+
+    for v in deferred {
+        db.queue_deferred_fk_violation(v);
     }
 
     Ok(())

--- a/crates/vibesql-executor/src/insert/row_validator.rs
+++ b/crates/vibesql-executor/src/insert/row_validator.rs
@@ -1,3 +1,5 @@
+use vibesql_storage::DeferredFkViolation;
+
 use crate::errors::ExecutorError;
 
 /// Pre-built index keys extracted during validation
@@ -9,6 +11,11 @@ pub struct ValidationResult {
     pub unique_keys: Vec<Option<Vec<vibesql_types::SqlValue>>>,
     /// Foreign key values (one per FK, empty if FK has NULL)
     pub foreign_keys: Vec<Option<Vec<vibesql_types::SqlValue>>>,
+    /// FK violations that were deferred (because the constraint is
+    /// `INITIALLY DEFERRED` or `PRAGMA defer_foreign_keys=ON`). The
+    /// caller must push these onto the active transaction's queue
+    /// before inserting the row. See Phase C2 of #5085.
+    pub deferred_fk_violations: Vec<DeferredFkViolation>,
 }
 
 /// Single-pass row validator that checks all constraints and extracts index keys
@@ -47,6 +54,7 @@ impl<'a> RowValidator<'a> {
             primary_key: None,
             unique_keys: vec![None; self.schema.unique_constraints.len()],
             foreign_keys: vec![None; self.schema.foreign_keys.len()],
+            deferred_fk_violations: Vec::new(),
         };
 
         // Phase 1: Single pass through columns for NOT NULL, PK, UNIQUE, FK extraction
@@ -74,7 +82,11 @@ impl<'a> RowValidator<'a> {
         }
 
         // Phase 6: Validate FOREIGN KEY references (uses pre-extracted keys)
-        self.validate_foreign_keys(&result.foreign_keys)?;
+        self.validate_foreign_keys(
+            row_values,
+            &result.foreign_keys,
+            &mut result.deferred_fk_violations,
+        )?;
 
         Ok(result)
     }
@@ -336,15 +348,27 @@ impl<'a> RowValidator<'a> {
         )
     }
 
-    /// Phase 6: Validate FOREIGN KEY references using pre-extracted keys
+    /// Phase 6: Validate FOREIGN KEY references using pre-extracted keys.
+    ///
+    /// Per Phase C2 of #5085, when the constraint is `INITIALLY DEFERRED`
+    /// or the session has `PRAGMA defer_foreign_keys=ON`, a missing
+    /// parent row is *not* an immediate error: instead a
+    /// [`DeferredFkViolation`] is appended to `deferred_violations` and
+    /// the caller pushes it onto the active transaction's queue. The
+    /// queue is drained and re-checked at COMMIT.
     fn validate_foreign_keys(
         &self,
+        full_row_values: &[vibesql_types::SqlValue],
         fk_keys: &[Option<Vec<vibesql_types::SqlValue>>],
+        deferred_violations: &mut Vec<DeferredFkViolation>,
     ) -> Result<(), ExecutorError> {
         // Skip FK enforcement when PRAGMA foreign_keys is OFF (default)
         if !self.db.foreign_keys_enabled() {
             return Ok(());
         }
+
+        let session_defer = self.db.defer_foreign_keys();
+        let in_txn = self.db.in_transaction();
 
         for (fk_idx, fk_values) in fk_keys.iter().enumerate() {
             let fk = &self.schema.foreign_keys[fk_idx];
@@ -352,6 +376,8 @@ impl<'a> RowValidator<'a> {
             // Mismatch check runs before any row-existence test so that bad
             // FK targets are reported even when the parent table is empty
             // (matches SQLite behaviour and fkey1-6.1 / fkey5-11.1).
+            // Mismatch is a schema-level error and is *never* deferred:
+            // SQLite reports it immediately even with INITIALLY DEFERRED.
             if let Some((child, parent)) =
                 crate::foreign_key_check::detect_fk_mismatch(self.db, self.table_name, fk)
             {
@@ -369,34 +395,49 @@ impl<'a> RowValidator<'a> {
                 .get_table(&fk.parent_table)
                 .ok_or_else(|| ExecutorError::TableNotFound(fk.parent_table.clone()))?;
 
-            let parent_collations =
-                crate::foreign_key_check::parent_collations_for_fk(self.db, fk);
+            let parent_collations = crate::foreign_key_check::parent_collations_for_fk(self.db, fk);
             let parent_indices =
                 crate::foreign_key_check::resolved_parent_indices_for_fk(self.db, fk);
 
             let key_exists = parent_table.scan().iter().any(|parent_row| {
-                parent_indices
-                    .iter()
-                    .zip(fk_values)
-                    .enumerate()
-                    .all(|(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+                parent_indices.iter().zip(fk_values).enumerate().all(
+                    |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
                         Some(parent_val) => crate::foreign_key_check::fk_values_equal(
                             fk_val,
                             parent_val,
                             parent_collations.get(i).and_then(|c| c.as_deref()),
                         ),
                         None => false,
-                    })
+                    },
+                )
             });
 
-            if !key_exists {
-                return Err(ExecutorError::ConstraintViolation(format!(
-                    "FOREIGN KEY constraint '{}' violated: key ({}) not found in table '{}'",
-                    fk.name.as_deref().unwrap_or(""),
-                    fk.column_names.join(", "),
-                    fk.parent_table
-                )));
+            if key_exists {
+                continue;
             }
+
+            // FK row-existence violation. Defer if the constraint is
+            // INITIALLY DEFERRED or the session has defer_foreign_keys=ON,
+            // *and* we're inside a transaction. Outside a transaction we
+            // fall through to the immediate-error path, matching SQLite:
+            // deferred enforcement requires a transaction context.
+            let should_defer = in_txn && (fk.initially_deferred || session_defer);
+            if should_defer {
+                deferred_violations.push(DeferredFkViolation {
+                    child_table: self.table_name.to_string(),
+                    fk_index: fk_idx,
+                    child_row: full_row_values.to_vec(),
+                    kind: vibesql_storage::DeferredFkViolationKind::ChildInsertOrUpdate,
+                });
+                continue;
+            }
+
+            return Err(ExecutorError::ConstraintViolation(format!(
+                "FOREIGN KEY constraint '{}' violated: key ({}) not found in table '{}'",
+                fk.name.as_deref().unwrap_or(""),
+                fk.column_names.join(", "),
+                fk.parent_table
+            )));
         }
 
         Ok(())

--- a/crates/vibesql-executor/src/transaction.rs
+++ b/crates/vibesql-executor/src/transaction.rs
@@ -43,14 +43,134 @@ impl BeginTransactionExecutor {
 pub struct CommitExecutor;
 
 impl CommitExecutor {
-    /// Execute a COMMIT statement
+    /// Execute a COMMIT statement.
+    ///
+    /// Phase C2 of #5085: drains the transaction's deferred FK
+    /// violation queue and re-checks each entry against the current
+    /// parent state. If any deferred violation still holds, the COMMIT
+    /// fails and the transaction is rolled back, matching SQLite
+    /// semantics ("FOREIGN KEY constraint failed" raised at COMMIT).
     pub fn execute(_stmt: &CommitStmt, db: &mut Database) -> Result<String, ExecutorError> {
+        // Drain and re-validate deferred FK violations before commit.
+        let pending = db.take_deferred_fk_violations();
+        if let Some(err_msg) = check_deferred_fk_violations(db, &pending) {
+            // Deferred violation still holds at COMMIT — abort the
+            // commit and roll back. SQLite raises "FOREIGN KEY
+            // constraint failed" here; auto-rollback follows the same
+            // convention as Bucket D (#5087, merged 17f23988).
+            //
+            // We ignore the rollback's own error: if rollback also
+            // fails, the original FK error is the more useful one.
+            let _ = db.rollback_transaction();
+            return Err(ExecutorError::ConstraintViolation(err_msg));
+        }
+
         db.commit_transaction().map_err(|e| {
             ExecutorError::StorageError(format!("Failed to commit transaction: {}", e))
         })?;
 
         Ok("Transaction committed".to_string())
     }
+}
+
+/// Re-validate every deferred FK violation against the current parent
+/// state. Returns `Some(error_message)` for the first entry that still
+/// fails; returns `None` when every entry has been satisfied (because
+/// the parent row was inserted later, the child row was deleted, etc.).
+fn check_deferred_fk_violations(
+    db: &Database,
+    pending: &[vibesql_storage::DeferredFkViolation],
+) -> Option<String> {
+    use crate::foreign_key_check::{
+        fk_values_equal, parent_collations_for_fk, resolved_parent_indices_for_fk,
+    };
+
+    for violation in pending {
+        let child_schema = match db.catalog.get_table(&violation.child_table) {
+            Some(s) => s,
+            None => {
+                // Child table was dropped during the transaction —
+                // there is no row left to violate the constraint.
+                continue;
+            }
+        };
+        let fk = match child_schema.foreign_keys.get(violation.fk_index) {
+            Some(fk) => fk,
+            None => continue, // FK index out of range — schema changed
+        };
+
+        // 1) Child-side check: does a row matching this snapshot still
+        //    exist in the child table? If the user has since deleted or
+        //    updated the offending child row, the violation is moot.
+        let child_table = match db.get_table(&violation.child_table) {
+            Some(t) => t,
+            None => continue,
+        };
+
+        // Take FK column values from the snapshot of the child row.
+        let snapshot_fk_values: Vec<vibesql_types::SqlValue> = fk
+            .column_indices
+            .iter()
+            .map(|&idx| {
+                violation.child_row.get(idx).cloned().unwrap_or(vibesql_types::SqlValue::Null)
+            })
+            .collect();
+
+        // NULLs in the FK columns mean the constraint never applied.
+        if snapshot_fk_values.iter().any(|v| v.is_null()) {
+            continue;
+        }
+
+        // Does *any* live child row still carry these FK values? If
+        // not, the conflict has been resolved (child deleted/updated).
+        let child_still_present = child_table.scan_live().any(|(_, child_row)| {
+            fk.column_indices.iter().enumerate().all(|(i, &col_idx)| {
+                match child_row.values.get(col_idx) {
+                    Some(v) => v == &snapshot_fk_values[i],
+                    None => false,
+                }
+            })
+        });
+        if !child_still_present {
+            continue;
+        }
+
+        // 2) Parent-side check: does a parent row now exist that
+        //    matches the FK columns?
+        let parent_table = match db.get_table(&fk.parent_table) {
+            Some(t) => t,
+            None => {
+                // Parent table missing — definitely a violation.
+                return Some(format!(
+                    "FOREIGN KEY constraint failed: parent table '{}' missing at COMMIT",
+                    fk.parent_table
+                ));
+            }
+        };
+
+        let parent_collations = parent_collations_for_fk(db, fk);
+        let parent_indices = resolved_parent_indices_for_fk(db, fk);
+
+        let key_exists = parent_table.scan().iter().any(|parent_row| {
+            parent_indices.iter().zip(&snapshot_fk_values).enumerate().all(
+                |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+                    Some(parent_val) => fk_values_equal(
+                        fk_val,
+                        parent_val,
+                        parent_collations.get(i).and_then(|c| c.as_deref()),
+                    ),
+                    None => false,
+                },
+            )
+        });
+
+        if !key_exists {
+            // Match SQLite's wording for deferred FK failure at commit.
+            return Some("FOREIGN KEY constraint failed".to_string());
+        }
+    }
+
+    None
 }
 
 /// Executor for ROLLBACK statements

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -245,6 +245,12 @@ pub(super) fn execute_internal(
     // Track rows to delete for REPLACE conflict resolution (before applying updates)
     let mut rows_to_delete_for_replace: Vec<usize> = Vec::new();
 
+    // Phase C2 of #5085: collect deferred FK violations during the loop
+    // and queue them after the loop ends, since the loop body holds an
+    // immutable borrow of `database` (via `table`) and queueing requires
+    // `&mut database`.
+    let mut pending_deferred_violations: Vec<vibesql_storage::DeferredFkViolation> = Vec::new();
+
     for (row_index, row) in candidate_rows {
         // Clear CSE cache before evaluating assignment expressions for this row
         // to prevent cached column values from previous rows
@@ -312,13 +318,13 @@ pub(super) fn execute_internal(
 
             // Validate foreign key constraints
             if !schema.foreign_keys.is_empty() {
-                let fk_result = ForeignKeyValidator::validate_constraints(
+                match ForeignKeyValidator::collect_constraints(
                     database,
                     table_name,
                     &new_row.values,
-                );
-                if fk_result.is_err() {
-                    continue; // Skip this row
+                ) {
+                    Ok(deferred) => pending_deferred_violations.extend(deferred),
+                    Err(_) => continue, // Skip this row
                 }
             }
         } else if use_replace {
@@ -328,7 +334,12 @@ pub(super) fn execute_internal(
 
             // Validate foreign key constraints
             if !schema.foreign_keys.is_empty() {
-                ForeignKeyValidator::validate_constraints(database, table_name, &new_row.values)?;
+                let deferred = ForeignKeyValidator::collect_constraints(
+                    database,
+                    table_name,
+                    &new_row.values,
+                )?;
+                pending_deferred_violations.extend(deferred);
             }
         } else {
             // Default: validate all constraints
@@ -339,7 +350,12 @@ pub(super) fn execute_internal(
 
             // Enforce FOREIGN KEY constraints (child table)
             if !schema.foreign_keys.is_empty() {
-                ForeignKeyValidator::validate_constraints(database, table_name, &new_row.values)?;
+                let deferred = ForeignKeyValidator::collect_constraints(
+                    database,
+                    table_name,
+                    &new_row.values,
+                )?;
+                pending_deferred_violations.extend(deferred);
             }
         }
 
@@ -419,6 +435,14 @@ pub(super) fn execute_internal(
                 .get_table(table_name)
                 .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
         }
+    }
+
+    // Phase C2 of #5085: push deferred FK violations collected during
+    // per-row validation onto the active transaction's queue. The
+    // immutable borrows of `database` (via `table`) used during
+    // validation have been released by this point.
+    for v in pending_deferred_violations {
+        database.queue_deferred_fk_violation(v);
     }
 
     // Step 7: Handle CASCADE updates for primary key changes (before triggers)
@@ -1097,6 +1121,11 @@ fn execute_update_from(
         .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
     let constraint_validator = ConstraintValidator::new(schema);
 
+    // Phase C2 of #5085: collect deferred FK violations during the loop
+    // and queue them after the loop ends, since the loop body holds an
+    // immutable borrow of `database` via `table`.
+    let mut pending_deferred_violations: Vec<vibesql_storage::DeferredFkViolation> = Vec::new();
+
     for (row_index, old_row, new_row, _changed_columns, _updates_pk) in &updates {
         // Validate all constraints
         constraint_validator.validate_row(table, table_name, *row_index, new_row, old_row)?;
@@ -1104,8 +1133,16 @@ fn execute_update_from(
 
         // Validate foreign key constraints
         if !schema.foreign_keys.is_empty() {
-            ForeignKeyValidator::validate_constraints(database, table_name, &new_row.values)?;
+            let deferred =
+                ForeignKeyValidator::collect_constraints(database, table_name, &new_row.values)?;
+            pending_deferred_violations.extend(deferred);
         }
+    }
+
+    // Push deferred FK violations onto the queue now that `table` has
+    // been released.
+    for v in pending_deferred_violations {
+        database.queue_deferred_fk_violation(v);
     }
 
     // Cross-update uniqueness validation

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -1,6 +1,6 @@
 //! Foreign key constraint validation for UPDATE operations
 
-use vibesql_storage::Database;
+use vibesql_storage::{Database, DeferredFkViolation, DeferredFkViolationKind};
 
 use crate::errors::ExecutorError;
 
@@ -8,28 +8,43 @@ use crate::errors::ExecutorError;
 pub struct ForeignKeyValidator;
 
 impl ForeignKeyValidator {
-    /// Validate FOREIGN KEY constraints for a new row
+    /// Validate FOREIGN KEY constraints for a new row, returning any
+    /// deferred violations rather than queueing them directly.
     ///
     /// Checks that all foreign key values in the row reference existing parent rows.
     /// NULL values in foreign keys are allowed (not considered violations).
-    pub fn validate_constraints(
+    ///
+    /// Phase C2 of #5085: when the constraint is `INITIALLY DEFERRED`
+    /// or the session has `PRAGMA defer_foreign_keys=ON` (and a
+    /// transaction is active), a missing parent row produces a
+    /// `DeferredFkViolation` in the returned vector instead of an
+    /// immediate `Err`. The caller must push the returned violations
+    /// onto the transaction queue once any immutable borrow of
+    /// `database` is released.
+    pub fn collect_constraints(
         db: &Database,
         table_name: &str,
         row_values: &[vibesql_types::SqlValue],
-    ) -> Result<(), ExecutorError> {
+    ) -> Result<Vec<DeferredFkViolation>, ExecutorError> {
+        let mut deferred: Vec<DeferredFkViolation> = Vec::new();
+
         // Skip FK enforcement when PRAGMA foreign_keys is OFF (default)
         if !db.foreign_keys_enabled() {
-            return Ok(());
+            return Ok(deferred);
         }
+
+        let session_defer = db.defer_foreign_keys();
+        let in_txn = db.in_transaction();
 
         let schema = db
             .catalog
             .get_table(table_name)
             .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
 
-        for fk in &schema.foreign_keys {
+        for (fk_idx, fk) in schema.foreign_keys.iter().enumerate() {
             // Mismatch check runs before any row-existence test so that bad
             // FK targets are reported even when the parent table is empty.
+            // Mismatch is never deferred (matches SQLite behaviour).
             if let Some((child, parent)) =
                 crate::foreign_key_check::detect_fk_mismatch(db, table_name, fk)
             {
@@ -54,31 +69,42 @@ impl ForeignKeyValidator {
             let parent_indices = crate::foreign_key_check::resolved_parent_indices_for_fk(db, fk);
 
             let key_exists = parent_table.scan().iter().any(|parent_row| {
-                parent_indices
-                    .iter()
-                    .zip(&fk_values)
-                    .enumerate()
-                    .all(|(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+                parent_indices.iter().zip(&fk_values).enumerate().all(
+                    |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
                         Some(parent_val) => crate::foreign_key_check::fk_values_equal(
                             fk_val,
                             parent_val,
                             parent_collations.get(i).and_then(|c| c.as_deref()),
                         ),
                         None => false,
-                    })
+                    },
+                )
             });
 
-            if !key_exists {
-                return Err(ExecutorError::ConstraintViolation(format!(
-                    "FOREIGN KEY constraint \'{}\' violated: key ({}) not found in table \'{}\'",
-                    fk.name.as_deref().unwrap_or(""),
-                    fk.column_names.join(", "),
-                    fk.parent_table
-                )));
+            if key_exists {
+                continue;
             }
+
+            let should_defer = in_txn && (fk.initially_deferred || session_defer);
+            if should_defer {
+                deferred.push(DeferredFkViolation {
+                    child_table: table_name.to_string(),
+                    fk_index: fk_idx,
+                    child_row: row_values.to_vec(),
+                    kind: DeferredFkViolationKind::ChildInsertOrUpdate,
+                });
+                continue;
+            }
+
+            return Err(ExecutorError::ConstraintViolation(format!(
+                "FOREIGN KEY constraint \'{}\' violated: key ({}) not found in table \'{}\'",
+                fk.name.as_deref().unwrap_or(""),
+                fk.column_names.join(", "),
+                fk.parent_table
+            )));
         }
 
-        Ok(())
+        Ok(deferred)
     }
 
     /// Check that no child tables reference a row that is about to be deleted or updated.
@@ -127,8 +153,22 @@ impl ForeignKeyValidator {
             return Ok(());
         }
 
+        // Phase C2 of #5085: cache session defer + transaction state.
+        let session_defer = db.defer_foreign_keys();
+        let in_txn = db.in_transaction();
+
         // Collect cascade updates to apply after scanning (to avoid borrow checker issues)
         let mut cascade_updates: Vec<(String, Vec<(usize, vibesql_storage::Row)>)> = Vec::new();
+
+        // Phase C2: collected NO ACTION orphans to queue after scanning
+        // (queueing requires &mut Database, which conflicts with the
+        // catalog/table borrows held inside the scan loop).
+        let mut deferred_parent_orphans: Vec<(
+            String,
+            vibesql_catalog::ForeignKeyConstraint,
+            usize,
+            Vec<(usize, vibesql_storage::Row)>,
+        )> = Vec::new();
 
         // Scan all tables in the database to find foreign keys that reference this table.
         for table_name in db.catalog.list_tables() {
@@ -139,7 +179,7 @@ impl ForeignKeyValidator {
                 continue;
             }
 
-            for fk in &child_schema.foreign_keys {
+            for (fk_idx, fk) in child_schema.foreign_keys.iter().enumerate() {
                 // Use case-insensitive comparison for SQL identifier matching
                 if !fk.parent_table.eq_ignore_ascii_case(parent_table_name) {
                     continue;
@@ -263,14 +303,34 @@ impl ForeignKeyValidator {
 
                             cascade_updates.push((table_name.clone(), updated_rows));
                         }
-                        vibesql_catalog::ReferentialAction::NoAction
-                        | vibesql_catalog::ReferentialAction::Restrict => {
-                            // Block the update when child references exist
+                        vibesql_catalog::ReferentialAction::Restrict => {
+                            // RESTRICT is immediate, never deferred.
                             return Err(ExecutorError::ConstraintViolation(format!(
                                 "FOREIGN KEY constraint violation: cannot update a parent row when a foreign key constraint exists. The conflict occurred in table \'{}\', constraint \'{}\'.",
                                 table_name,
                                 fk.name.as_deref().unwrap_or(""),
                             )));
+                        }
+                        vibesql_catalog::ReferentialAction::NoAction => {
+                            // NO ACTION can be deferred (Phase C2 of
+                            // #5085). When deferred, queue every
+                            // orphaned child row for COMMIT-time
+                            // re-validation; otherwise fail immediately.
+                            let should_defer = in_txn && (fk.initially_deferred || session_defer);
+                            if should_defer {
+                                deferred_parent_orphans.push((
+                                    table_name.clone(),
+                                    fk.clone(),
+                                    fk_idx,
+                                    matching_rows.clone(),
+                                ));
+                            } else {
+                                return Err(ExecutorError::ConstraintViolation(format!(
+                                    "FOREIGN KEY constraint violation: cannot update a parent row when a foreign key constraint exists. The conflict occurred in table \'{}\', constraint \'{}\'.",
+                                    table_name,
+                                    fk.name.as_deref().unwrap_or(""),
+                                )));
+                            }
                         }
                     }
                 }
@@ -287,6 +347,19 @@ impl ForeignKeyValidator {
             }
             // Rebuild indexes after updates (following the same pattern as DELETE operations)
             db.rebuild_indexes(&table_name);
+        }
+
+        // Phase C2 of #5085: queue NO ACTION orphans onto the deferred
+        // FK queue for COMMIT-time re-validation.
+        for (table_name, _fk, fk_idx, matching_rows) in deferred_parent_orphans {
+            for (_row_idx, child_row) in matching_rows {
+                db.queue_deferred_fk_violation(DeferredFkViolation {
+                    child_table: table_name.clone(),
+                    fk_index: fk_idx,
+                    child_row: child_row.values.to_vec(),
+                    kind: DeferredFkViolationKind::ChildInsertOrUpdate,
+                });
+            }
         }
 
         Ok(())

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -304,12 +304,29 @@ impl ForeignKeyValidator {
                             cascade_updates.push((table_name.clone(), updated_rows));
                         }
                         vibesql_catalog::ReferentialAction::Restrict => {
-                            // RESTRICT is immediate, never deferred.
-                            return Err(ExecutorError::ConstraintViolation(format!(
-                                "FOREIGN KEY constraint violation: cannot update a parent row when a foreign key constraint exists. The conflict occurred in table \'{}\', constraint \'{}\'.",
-                                table_name,
-                                fk.name.as_deref().unwrap_or(""),
-                            )));
+                            // RESTRICT is immediate by default, but the
+                            // session pragma `defer_foreign_keys=ON`
+                            // delays it until COMMIT (EVIDENCE-OF
+                            // R-18981-16292; see fkey6-3.2.3). Per-
+                            // constraint INITIALLY DEFERRED does *not*
+                            // defer RESTRICT — only the session pragma
+                            // does. Mirrors the DELETE-side handling in
+                            // delete/integrity.rs.
+                            let should_defer = in_txn && session_defer;
+                            if should_defer {
+                                deferred_parent_orphans.push((
+                                    table_name.clone(),
+                                    fk.clone(),
+                                    fk_idx,
+                                    matching_rows.clone(),
+                                ));
+                            } else {
+                                return Err(ExecutorError::ConstraintViolation(format!(
+                                    "FOREIGN KEY constraint violation: cannot update a parent row when a foreign key constraint exists. The conflict occurred in table \'{}\', constraint \'{}\'.",
+                                    table_name,
+                                    fk.name.as_deref().unwrap_or(""),
+                                )));
+                            }
                         }
                         vibesql_catalog::ReferentialAction::NoAction => {
                             // NO ACTION can be deferred (Phase C2 of

--- a/crates/vibesql-executor/tests/foreign_key_deferred_tests.rs
+++ b/crates/vibesql-executor/tests/foreign_key_deferred_tests.rs
@@ -1,0 +1,344 @@
+//! Tests for deferred FOREIGN KEY enforcement (Phase C2 of #5085).
+//!
+//! These tests cover:
+//! 1. INITIALLY DEFERRED FK constraints — child INSERT with missing parent
+//!    succeeds initially and is re-checked at COMMIT.
+//! 2. PRAGMA defer_foreign_keys=ON — session flag defers all FK checks
+//!    until COMMIT (and is auto-reset on COMMIT, see fkey6-1.10.1).
+//! 3. ROLLBACK TO savepoint — discards deferred violations queued after
+//!    the savepoint.
+//! 4. ROLLBACK — discards the entire deferred queue.
+//! 5. Resolution — a deferred violation that is later "fixed" (parent
+//!    inserted, or child deleted) does *not* abort the COMMIT.
+
+use vibesql_ast::Statement;
+use vibesql_executor::{
+    BeginTransactionExecutor, CommitExecutor, CreateTableExecutor, DeleteExecutor, InsertExecutor,
+    ReleaseSavepointExecutor, RollbackExecutor, RollbackToSavepointExecutor, SavepointExecutor,
+    UpdateExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+/// Execute a single SQL statement, panicking on parse failure but
+/// returning the executor result so callers can assert on success or
+/// failure.
+fn run(db: &mut Database, sql: &str) -> Result<String, String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("parse error: {:?}", e))?;
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::BeginTransaction(s) => {
+            BeginTransactionExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        Statement::Commit(s) => CommitExecutor::execute(&s, db).map_err(|e| e.to_string()),
+        Statement::Rollback(s) => RollbackExecutor::execute(&s, db).map_err(|e| e.to_string()),
+        Statement::Savepoint(s) => SavepointExecutor::execute(&s, db).map_err(|e| e.to_string()),
+        Statement::RollbackToSavepoint(s) => {
+            RollbackToSavepointExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        Statement::ReleaseSavepoint(s) => {
+            ReleaseSavepointExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        other => Err(format!("unsupported statement type in test helper: {:?}", other)),
+    }
+}
+
+fn fresh_db() -> Database {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    db
+}
+
+// ---------------------------------------------------------------------------
+// 1. INITIALLY DEFERRED constraint defers child INSERT until COMMIT
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deferred_child_insert_without_parent_fails_at_commit() {
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+
+    // INSERT into child WITHOUT a matching parent — must succeed
+    // (deferred), not fail immediately.
+    run(&mut db, "INSERT INTO c VALUES (1, 99)").expect("deferred INSERT must succeed");
+
+    // The violation must be queued.
+    assert_eq!(db.deferred_fk_violations().len(), 1, "deferred FK violation must be queued");
+
+    // COMMIT must fail because the violation was never resolved.
+    let err = run(&mut db, "COMMIT").expect_err("COMMIT must fail when FK still violated");
+    assert!(err.contains("FOREIGN KEY"), "expected FK error message, got: {}", err);
+
+    // Auto-rollback: child row must NOT be present in the committed state.
+    assert!(!db.in_transaction(), "transaction must be auto-rolled back after failed COMMIT");
+    let c = db.get_table("c").expect("table c");
+    assert_eq!(c.scan().len(), 0, "child row must be rolled back");
+}
+
+#[test]
+fn deferred_child_insert_with_parent_inserted_later_commits() {
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+
+    // Insert child first — would normally fail, but is deferred.
+    run(&mut db, "INSERT INTO c VALUES (1, 42)").unwrap();
+    // Now insert the parent — resolves the deferred violation.
+    run(&mut db, "INSERT INTO p VALUES (42)").unwrap();
+
+    // COMMIT must succeed because the parent now exists.
+    run(&mut db, "COMMIT").expect("COMMIT must succeed when violation resolved");
+
+    let c = db.get_table("c").unwrap();
+    let p = db.get_table("p").unwrap();
+    assert_eq!(c.scan().len(), 1);
+    assert_eq!(p.scan().len(), 1);
+}
+
+#[test]
+fn deferred_child_insert_followed_by_child_delete_commits() {
+    // If the offending child row is deleted before COMMIT, the deferred
+    // violation must NOT abort the commit.
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+    run(&mut db, "INSERT INTO c VALUES (1, 7)").unwrap();
+    // Resolve the violation by deleting the offending child row.
+    run(&mut db, "DELETE FROM c WHERE id = 1").unwrap();
+
+    run(&mut db, "COMMIT").expect("COMMIT must succeed when child deleted before commit");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Non-deferred FK constraints still fail immediately
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_deferrable_fk_still_fails_immediately() {
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(&mut db, "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id))").unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+    let err = run(&mut db, "INSERT INTO c VALUES (1, 99)")
+        .expect_err("non-deferrable FK must fail at INSERT, not at COMMIT");
+    assert!(err.contains("FOREIGN KEY"));
+    assert_eq!(
+        db.deferred_fk_violations().len(),
+        0,
+        "non-deferrable FK violation must not be queued"
+    );
+    run(&mut db, "ROLLBACK").unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 3. PRAGMA defer_foreign_keys=ON defers all FK checks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pragma_defer_foreign_keys_defers_non_deferrable_fk() {
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    // Note: NO `DEFERRABLE INITIALLY DEFERRED` clause — relies on the
+    // session flag.
+    run(&mut db, "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id))").unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+    db.set_defer_foreign_keys(true);
+
+    // INSERT that would normally fail must now succeed.
+    run(&mut db, "INSERT INTO c VALUES (1, 99)").unwrap();
+    assert_eq!(db.deferred_fk_violations().len(), 1);
+
+    // COMMIT fails, transaction auto-rolls back.
+    let err = run(&mut db, "COMMIT").expect_err("COMMIT must fail with unresolved violation");
+    assert!(err.contains("FOREIGN KEY"));
+}
+
+#[test]
+fn pragma_defer_foreign_keys_resets_at_commit() {
+    // Per fkey6-1.10.1: defer_foreign_keys is automatically reset to
+    // OFF on every COMMIT.
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(&mut db, "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id))").unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+    db.set_defer_foreign_keys(true);
+    assert!(db.defer_foreign_keys());
+
+    // No violation pending — commit succeeds.
+    run(&mut db, "INSERT INTO p VALUES (1)").unwrap();
+    run(&mut db, "COMMIT").unwrap();
+
+    // The flag must now be OFF.
+    assert!(
+        !db.defer_foreign_keys(),
+        "defer_foreign_keys must reset to OFF at COMMIT (fkey6-1.10.1)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. ROLLBACK / SAVEPOINT semantics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rollback_clears_deferred_fk_queue() {
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+    run(&mut db, "INSERT INTO c VALUES (1, 99)").unwrap();
+    assert_eq!(db.deferred_fk_violations().len(), 1);
+
+    run(&mut db, "ROLLBACK").unwrap();
+    // The transaction is gone — queue must be empty.
+    assert_eq!(db.deferred_fk_violations().len(), 0);
+}
+
+#[test]
+fn savepoint_rollback_discards_violations_queued_after_savepoint() {
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+
+    // Queue one violation BEFORE the savepoint (this one survives ROLLBACK TO).
+    run(&mut db, "INSERT INTO c VALUES (1, 100)").unwrap();
+    assert_eq!(db.deferred_fk_violations().len(), 1);
+
+    run(&mut db, "SAVEPOINT sp1").unwrap();
+
+    // Queue two more violations AFTER the savepoint.
+    run(&mut db, "INSERT INTO c VALUES (2, 200)").unwrap();
+    run(&mut db, "INSERT INTO c VALUES (3, 300)").unwrap();
+    assert_eq!(db.deferred_fk_violations().len(), 3);
+
+    // ROLLBACK TO drops the two post-savepoint violations.
+    run(&mut db, "ROLLBACK TO SAVEPOINT sp1").unwrap();
+    assert_eq!(
+        db.deferred_fk_violations().len(),
+        1,
+        "ROLLBACK TO must truncate the deferred queue back to the savepoint"
+    );
+
+    // Resolve the surviving violation.
+    run(&mut db, "INSERT INTO p VALUES (100)").unwrap();
+    run(&mut db, "COMMIT").expect("COMMIT must succeed once surviving violation is resolved");
+}
+
+#[test]
+fn release_savepoint_keeps_deferred_violations() {
+    // RELEASE SAVEPOINT does NOT discard the queue — entries propagate
+    // to the outer scope and are re-checked at COMMIT.
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+    run(&mut db, "SAVEPOINT sp1").unwrap();
+    run(&mut db, "INSERT INTO c VALUES (1, 7)").unwrap();
+    assert_eq!(db.deferred_fk_violations().len(), 1);
+
+    run(&mut db, "RELEASE SAVEPOINT sp1").unwrap();
+    assert_eq!(
+        db.deferred_fk_violations().len(),
+        1,
+        "RELEASE SAVEPOINT must NOT discard deferred violations"
+    );
+
+    // The unresolved violation must still abort the COMMIT.
+    let err = run(&mut db, "COMMIT").expect_err("commit must fail");
+    assert!(err.contains("FOREIGN KEY"));
+}
+
+// ---------------------------------------------------------------------------
+// 5. Multi-row scenarios
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multiple_deferred_violations_first_unresolved_fails_commit() {
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+    run(&mut db, "INSERT INTO c VALUES (1, 10)").unwrap();
+    run(&mut db, "INSERT INTO c VALUES (2, 20)").unwrap();
+    run(&mut db, "INSERT INTO c VALUES (3, 30)").unwrap();
+    assert_eq!(db.deferred_fk_violations().len(), 3);
+
+    // Resolve only TWO of the three.
+    run(&mut db, "INSERT INTO p VALUES (10)").unwrap();
+    run(&mut db, "INSERT INTO p VALUES (20)").unwrap();
+
+    let err = run(&mut db, "COMMIT")
+        .expect_err("COMMIT must fail when at least one deferred violation remains");
+    assert!(err.contains("FOREIGN KEY"));
+}
+
+#[test]
+fn outside_transaction_deferred_constraint_still_enforced_immediately() {
+    // Deferred enforcement requires a transaction context. Outside a
+    // transaction (auto-commit), an INITIALLY DEFERRED constraint must
+    // still fail immediately.
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+
+    let err = run(&mut db, "INSERT INTO c VALUES (1, 99)")
+        .expect_err("auto-commit INSERT with no parent must fail immediately");
+    assert!(err.contains("FOREIGN KEY"));
+}

--- a/crates/vibesql-storage/src/database/mod.rs
+++ b/crates/vibesql-storage/src/database/mod.rs
@@ -35,4 +35,7 @@ pub use index_ops::{
 pub use indexes::{IndexData, IndexManager, IndexMetadata, OwnedStreamingRangeScan};
 pub use operations::SpatialIndexMetadata as OperationsSpatialIndexMetadata;
 pub use resource_tracker::{IndexBackend, IndexStats, ResourceTracker};
-pub use transactions::{Savepoint, TransactionChange, TransactionManager, TransactionState};
+pub use transactions::{
+    DeferredFkViolation, DeferredFkViolationKind, Savepoint, TransactionChange, TransactionManager,
+    TransactionState,
+};

--- a/crates/vibesql-storage/src/database/transaction_api.rs
+++ b/crates/vibesql-storage/src/database/transaction_api.rs
@@ -5,7 +5,7 @@
 // This module provides transaction management methods for the Database struct.
 // Methods are implemented via an impl block on the Database type.
 
-use super::transactions::TransactionChange;
+use super::transactions::{DeferredFkViolation, TransactionChange};
 use super::Database;
 use crate::wal::{DurabilityMode, TransactionDurability, WalOp};
 use crate::StorageError;
@@ -158,5 +158,34 @@ impl Database {
     /// Release (destroy) a named savepoint
     pub fn release_savepoint(&mut self, name: String) -> Result<(), StorageError> {
         self.lifecycle.transaction_manager_mut().release_savepoint(name)
+    }
+
+    // ============================================================================
+    // Deferred FK Violation Queue (Phase C2 of #5085)
+    // ============================================================================
+
+    /// Push a deferred FK violation onto the active transaction's queue.
+    ///
+    /// Called by FK validators in the executor when a constraint is
+    /// `DEFERRABLE INITIALLY DEFERRED` or the session has
+    /// `PRAGMA defer_foreign_keys=ON`. The COMMIT path drains the queue
+    /// and re-checks each violation against the current parent state.
+    pub fn queue_deferred_fk_violation(&mut self, violation: DeferredFkViolation) {
+        self.lifecycle.transaction_manager_mut().queue_deferred_fk_violation(violation);
+    }
+
+    /// Drain the deferred FK violation queue for COMMIT-time
+    /// re-validation. The executor calls this just before
+    /// [`commit_transaction`] and aborts the commit (rolling back) if
+    /// any violation still holds against the current parent state.
+    pub fn take_deferred_fk_violations(&mut self) -> Vec<DeferredFkViolation> {
+        self.lifecycle.transaction_manager_mut().take_deferred_fk_violations()
+    }
+
+    /// Read-only view of the deferred FK violation queue. Returns an
+    /// empty slice when no transaction is active. Used by the
+    /// `sqlite3_db_status DBSTATUS_DEFERRED_FKS` PRAGMA bridge.
+    pub fn deferred_fk_violations(&self) -> &[DeferredFkViolation] {
+        self.lifecycle.transaction_manager().deferred_fk_violations()
     }
 }

--- a/crates/vibesql-storage/src/database/transactions.rs
+++ b/crates/vibesql-storage/src/database/transactions.rs
@@ -15,12 +15,55 @@ pub enum TransactionChange {
     Delete { table_name: String, row: Row },
 }
 
+/// A foreign-key violation that has been deferred until COMMIT.
+///
+/// Phase C2 of #5085 introduces this queue: when a FK constraint is
+/// `DEFERRABLE INITIALLY DEFERRED` (or the session has
+/// `PRAGMA defer_foreign_keys=ON`), child-side INSERT/UPDATE/DELETE
+/// validators push a `DeferredFkViolation` instead of failing eagerly.
+/// The queue is drained at COMMIT time and each entry is re-checked
+/// against the current parent state; commit fails if any violation
+/// still holds.
+#[derive(Debug, Clone)]
+pub struct DeferredFkViolation {
+    /// The child table whose row may violate the FK.
+    pub child_table: String,
+    /// Index of the FK constraint within `child_table`'s schema.
+    pub fk_index: usize,
+    /// The child row values at the time the violation was queued.
+    /// Stored as a flat `Vec<SqlValue>` (rather than `Row`) because the
+    /// commit-time re-check only needs the raw FK column values.
+    pub child_row: Vec<vibesql_types::SqlValue>,
+    /// True when the source operation was a DELETE/UPDATE on the parent
+    /// (referential-action queue entry). False when the source was an
+    /// INSERT/UPDATE on the child (existence-check queue entry). The
+    /// commit-time drain treats these symmetrically: parent-side entries
+    /// look for *any* surviving child row that still references missing
+    /// parent values; child-side entries look up the child row by FK
+    /// values. Phase C2 only emits child-side entries — parent-side
+    /// queueing remains immediate (RESTRICT/NO ACTION) and is left to
+    /// Phase C3.
+    pub kind: DeferredFkViolationKind,
+}
+
+/// Origin of a deferred FK violation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeferredFkViolationKind {
+    /// Child INSERT or UPDATE created a row whose FK columns do not
+    /// (yet) match any parent row.
+    ChildInsertOrUpdate,
+}
+
 /// A savepoint within a transaction
 #[derive(Debug, Clone)]
 pub struct Savepoint {
     pub name: String,
     /// Index in the changes vector where this savepoint was created
     pub snapshot_index: usize,
+    /// Index in the deferred FK violation queue where this savepoint was
+    /// created. ROLLBACK TO truncates the queue back to this index so
+    /// that violations queued after the savepoint are discarded.
+    pub deferred_fk_snapshot_index: usize,
 }
 
 /// Transaction state
@@ -43,6 +86,12 @@ pub enum TransactionState {
         changes: Vec<TransactionChange>,
         /// Durability hint for this transaction
         durability: TransactionDurability,
+        /// Queue of deferred FK violations to re-check at COMMIT.
+        ///
+        /// See [`DeferredFkViolation`]. ROLLBACK clears this implicitly
+        /// by replacing the entire transaction state; `ROLLBACK TO`
+        /// truncates back to the savepoint's `deferred_fk_snapshot_index`.
+        deferred_fk_violations: Vec<DeferredFkViolation>,
     },
 }
 
@@ -100,6 +149,7 @@ impl TransactionManager {
                     savepoints: Vec::new(),
                     changes: Vec::new(),
                     durability,
+                    deferred_fk_violations: Vec::new(),
                 };
                 Ok(())
             }
@@ -171,8 +221,12 @@ impl TransactionManager {
             TransactionState::None => {
                 Err(StorageError::TransactionError("No active transaction".to_string()))
             }
-            TransactionState::Active { savepoints, changes, .. } => {
-                let savepoint = Savepoint { name, snapshot_index: changes.len() };
+            TransactionState::Active { savepoints, changes, deferred_fk_violations, .. } => {
+                let savepoint = Savepoint {
+                    name,
+                    snapshot_index: changes.len(),
+                    deferred_fk_snapshot_index: deferred_fk_violations.len(),
+                };
                 savepoints.push(savepoint);
                 Ok(())
             }
@@ -188,7 +242,7 @@ impl TransactionManager {
             TransactionState::None => {
                 Err(StorageError::TransactionError("No active transaction".to_string()))
             }
-            TransactionState::Active { savepoints, changes, .. } => {
+            TransactionState::Active { savepoints, changes, deferred_fk_violations, .. } => {
                 // Find the savepoint
                 let savepoint_idx =
                     savepoints.iter().position(|sp| sp.name == name).ok_or_else(|| {
@@ -196,15 +250,58 @@ impl TransactionManager {
                     })?;
 
                 let snapshot_index = savepoints[savepoint_idx].snapshot_index;
+                let deferred_fk_snapshot_index =
+                    savepoints[savepoint_idx].deferred_fk_snapshot_index;
 
                 // Collect changes to undo (from snapshot_index to end)
                 let changes_to_undo: Vec<_> = changes.drain(snapshot_index..).collect();
+
+                // Discard deferred FK violations queued after the savepoint.
+                // Any violation pushed since the savepoint is rolled back along
+                // with the underlying child mutation.
+                deferred_fk_violations.truncate(deferred_fk_snapshot_index);
 
                 // Destroy later savepoints
                 savepoints.truncate(savepoint_idx + 1);
 
                 Ok(changes_to_undo)
             }
+        }
+    }
+
+    /// Push a deferred FK violation onto the active transaction's queue.
+    ///
+    /// Silently ignores the call when no transaction is active — the
+    /// session-level `defer_foreign_keys=ON` semantics only apply inside
+    /// an explicit transaction.
+    pub fn queue_deferred_fk_violation(&mut self, violation: DeferredFkViolation) {
+        if let TransactionState::Active { deferred_fk_violations, .. } = &mut self.transaction_state
+        {
+            deferred_fk_violations.push(violation);
+        }
+    }
+
+    /// Drain the deferred FK violation queue, returning the queued
+    /// entries. Used at COMMIT time to re-validate violations against
+    /// current parent state.
+    pub fn take_deferred_fk_violations(&mut self) -> Vec<DeferredFkViolation> {
+        match &mut self.transaction_state {
+            TransactionState::Active { deferred_fk_violations, .. } => {
+                std::mem::take(deferred_fk_violations)
+            }
+            TransactionState::None => Vec::new(),
+        }
+    }
+
+    /// Read-only access to the deferred FK violation queue (for status
+    /// pragmas and debugging). Returns an empty slice when no
+    /// transaction is active.
+    pub fn deferred_fk_violations(&self) -> &[DeferredFkViolation] {
+        match &self.transaction_state {
+            TransactionState::Active { deferred_fk_violations, .. } => {
+                deferred_fk_violations.as_slice()
+            }
+            TransactionState::None => &[],
         }
     }
 

--- a/crates/vibesql-storage/src/lib.rs
+++ b/crates/vibesql-storage/src/lib.rs
@@ -40,8 +40,9 @@ pub use columnar::{ColumnData, ColumnarTable};
 pub use columnar_cache::{CacheStats, ColumnarCache};
 pub use database::{
     print_delete_profile_summary, reset_delete_profile_stats, Database, DatabaseConfig,
-    DeleteProfileStats, IndexData, IndexManager, IndexMetadata, OwnedStreamingRangeScan,
-    SpatialIndexMetadata, SpillPolicy, TransactionState, DELETE_PROFILE_STATS,
+    DeferredFkViolation, DeferredFkViolationKind, DeleteProfileStats, IndexData, IndexManager,
+    IndexMetadata, OwnedStreamingRangeScan, SpatialIndexMetadata, SpillPolicy, TransactionState,
+    DELETE_PROFILE_STATS,
 };
 pub use error::{StorageError, StorageResult};
 pub use index::{extract_mbr_from_sql_value, SpatialIndex, SpatialIndexEntry};

--- a/tests/common/referential_integrity_fixtures.rs
+++ b/tests/common/referential_integrity_fixtures.rs
@@ -22,7 +22,13 @@ use vibesql_types::{DataType, SqlValue, StringValue};
 /// Create a standard parent table with a primary key
 ///
 /// Creates a table with columns: ID (INTEGER, PK), NAME (VARCHAR(50), nullable)
+///
+/// Also enables `PRAGMA foreign_keys=ON` on the database so that the FK
+/// enforcement codepath actually runs (SQLite compatibility: FKs default
+/// to OFF, see PR #5060). This matches what `foreign_key_set_default_tests`
+/// does in the executor crate.
 pub fn create_parent_table(db: &mut Database, table_name: &str) {
+    db.set_foreign_keys_enabled(true);
     let schema = TableSchema::with_primary_key(
         table_name.to_string(),
         vec![
@@ -45,6 +51,7 @@ pub fn create_child_table(
     on_delete: ReferentialAction,
     on_update: ReferentialAction,
 ) {
+    db.set_foreign_keys_enabled(true);
     let columns = vec![
         ColumnSchema::new("ID".to_string(), DataType::Integer, false),
         ColumnSchema::new("PARENT_ID".to_string(), DataType::Integer, true),
@@ -60,6 +67,8 @@ pub fn create_child_table(
         parent_column_indices: vec![0],
         on_delete: on_delete.clone(),
         on_update: on_update.clone(),
+        is_deferrable: false,
+        initially_deferred: false,
     };
 
     let mut schema =
@@ -83,6 +92,7 @@ pub fn create_child_table_with_default(
     on_update: ReferentialAction,
     default_value: i64,
 ) {
+    db.set_foreign_keys_enabled(true);
     let mut parent_id_column = ColumnSchema::new("PARENT_ID".to_string(), DataType::Integer, true);
     parent_id_column.set_default(Expression::Literal(SqlValue::Integer(default_value)));
 
@@ -101,6 +111,8 @@ pub fn create_child_table_with_default(
         parent_column_indices: vec![0],
         on_delete: on_delete.clone(),
         on_update: on_update.clone(),
+        is_deferrable: false,
+        initially_deferred: false,
     };
 
     let mut schema =
@@ -115,6 +127,7 @@ pub fn create_child_table_with_default(
 /// Creates a table with columns: ID (INTEGER, PK), MANAGER_ID (INTEGER, nullable, self-FK), NAME
 /// (VARCHAR(50))
 pub fn create_self_referential_employee_table(db: &mut Database) {
+    db.set_foreign_keys_enabled(true);
     let columns = vec![
         ColumnSchema::new("ID".to_string(), DataType::Integer, false),
         ColumnSchema::new("MANAGER_ID".to_string(), DataType::Integer, true),
@@ -130,6 +143,8 @@ pub fn create_self_referential_employee_table(db: &mut Database) {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     };
 
     let mut schema =
@@ -143,6 +158,7 @@ pub fn create_self_referential_employee_table(db: &mut Database) {
 /// Parent: DEPT_ID (INTEGER), EMP_ID (INTEGER), NAME (VARCHAR), composite PK on (DEPT_ID, EMP_ID)
 /// Child: ID (INTEGER, PK), PARENT_DEPT_ID (INTEGER), PARENT_EMP_ID (INTEGER), multi-column FK
 pub fn create_multi_column_parent_child_tables(db: &mut Database) {
+    db.set_foreign_keys_enabled(true);
     // Create parent with composite primary key
     let parent_schema = TableSchema::with_primary_key(
         "PARENT".to_string(),
@@ -175,6 +191,8 @@ pub fn create_multi_column_parent_child_tables(db: &mut Database) {
         parent_column_indices: vec![0, 1],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     };
 
     let mut schema =
@@ -207,6 +225,8 @@ pub fn create_multiple_parent_child_tables(db: &mut Database) {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     };
 
     let fk2 = ForeignKeyConstraint {
@@ -218,6 +238,8 @@ pub fn create_multiple_parent_child_tables(db: &mut Database) {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     };
 
     let mut schema =

--- a/tests/storage/referential_integrity.rs
+++ b/tests/storage/referential_integrity.rs
@@ -474,6 +474,8 @@ fn test_circular_foreign_keys() {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     };
 
     let columns_b = vec![
@@ -496,6 +498,8 @@ fn test_circular_foreign_keys() {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     };
 
     let columns_c = vec![
@@ -514,6 +518,8 @@ fn test_circular_foreign_keys() {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     });
     // This should succeed - no cycle yet
     db.create_table(schema_c).unwrap();
@@ -540,6 +546,8 @@ fn test_circular_foreign_keys() {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     });
     schema_x.foreign_keys.push(ForeignKeyConstraint {
         name: Some("FK_X_A".to_string()),
@@ -550,6 +558,8 @@ fn test_circular_foreign_keys() {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     });
     // This creates X → C → A → B (no cycle from this table's perspective)
     db.create_table(schema_x).unwrap();
@@ -600,6 +610,8 @@ fn test_circular_foreign_keys() {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     });
     db2.create_table(schema_q).unwrap();
 
@@ -627,6 +639,8 @@ fn test_circular_foreign_keys() {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     });
     // Self-reference should be ALLOWED (e.g., employee table with manager_id)
     let result = db2.create_table(schema_r);
@@ -664,6 +678,8 @@ fn test_circular_foreign_keys() {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     });
     db3.create_table(schema_t2).unwrap();
 
@@ -685,6 +701,8 @@ fn test_circular_foreign_keys() {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     });
     db3.create_table(schema_t3).unwrap();
 
@@ -709,6 +727,8 @@ fn test_circular_foreign_keys() {
         parent_column_indices: vec![0],
         on_delete: ReferentialAction::NoAction,
         on_update: ReferentialAction::NoAction,
+        is_deferrable: false,
+        initially_deferred: false,
     });
 
     // This MUST fail - creating cycle T1→T3→T2→T1


### PR DESCRIPTION
## Summary

Phase C2 of Bucket C (#5085, parent #5071): runtime semantic change for deferred foreign keys.

- Adds a `Vec<DeferredFkViolation>` queue to `TransactionState::Active` and exposes `queue_deferred_fk_violation`, `take_deferred_fk_violations`, and `deferred_fk_violations` on `Database` / `TransactionManager`.
- INSERT / UPDATE / DELETE FK validators now defer violations onto the queue when the constraint is `INITIALLY DEFERRED` *or* the session has `PRAGMA defer_foreign_keys=ON` (and a transaction is active), instead of returning an immediate error.
- `CommitExecutor` drains the queue *before* the manager-level commit and re-validates each entry against the current parent state using `foreign_key_check.rs` (from #5120). Auto-rollback on remaining violations matches Bucket D (#5087) semantics.
- Savepoint discard mirrors the existing `Savepoint::snapshot_index` pattern: a `deferred_fk_snapshot_index` is recorded at savepoint creation and the queue truncates back on `ROLLBACK TO SAVEPOINT`. `RELEASE SAVEPOINT` is a no-op for the queue (entries propagate outward).
- RESTRICT defers when `PRAGMA defer_foreign_keys=ON` is set in the session and a transaction is active (EVIDENCE-OF R-18981-16292; see fkey6-3.2.3). Per-constraint `INITIALLY DEFERRED` does *not* defer RESTRICT — only the session pragma does. NO ACTION can be deferred by either mechanism.

## Curator clarifications addressed

1. **Queue ownership vs. drain location**: queue lives on `TransactionManager` (`transactions.rs`); drain happens in `CommitExecutor::execute` (`crates/vibesql-executor/src/transaction.rs`) where the live catalog and tables are available. Re-validation calls `take_deferred_fk_violations()` *before* `db.commit_transaction()`.
2. **Savepoint pattern**: matches the existing `snapshot_index` convention at `transactions.rs:175` — record queue length on create, truncate on rollback, no-op on release.

## Judge feedback addressed (commit b5bf69ff)

Judge correctly flagged that the original implementation hard-coded RESTRICT as "always immediate", which is inverted from SQLite's documented behaviour. EVIDENCE-OF R-18981-16292 (verified against `docs/reference/sqlite/test/fkey6.test` section 3) requires `PRAGMA defer_foreign_keys=ON` to delay RESTRICT to COMMIT.

Fix: the RESTRICT branch in both `crates/vibesql-executor/src/delete/integrity.rs` and `crates/vibesql-executor/src/update/foreign_keys.rs` now mirrors the NO ACTION queueing path when `in_txn && session_defer` is true, otherwise behaves as before (immediate error). Manually verified end-to-end: DELETE/UPDATE with RESTRICT under `PRAGMA defer_foreign_keys=1` succeeds inside the transaction, COMMIT then either fails ("FOREIGN KEY constraint failed") if the child is still orphaned, or succeeds if a later trigger/INSERT replaces the parent (matches fkey6-3.3.4 semantics).

## Test plan

- [x] 11 new integration tests in `crates/vibesql-executor/tests/foreign_key_deferred_tests.rs` — INITIALLY DEFERRED success/failure, PRAGMA defer_foreign_keys + auto-reset (fkey6-1.10.1), ROLLBACK clearing queue, ROLLBACK TO SAVEPOINT truncation, RELEASE SAVEPOINT propagation, multi-row scenarios, auto-commit immediate enforcement.
- [x] 47 existing FK + savepoint + cascade integration tests pass.
- [x] 21 FK + transaction unit tests pass.
- [x] vibesql-executor lib tests: all pass.
- [x] vibesql-storage lib tests: 582 + 16 + 13 pass (after fix).

## TCL acceptance test results (after fix)

The judge correctly noted that the SQLite TCL corpus is in fact present (as a git submodule under `docs/reference/sqlite`). After initialising the submodule and rebuilding the CLI:

| File | Pass | Fail | Skip | Notes |
|------|------|------|------|-------|
| fkey1.test | 15 | 4 | 7 | All failures are pre-existing and unrelated to defer/RESTRICT (fkey1-5.1: self-FK with cross-row CASCADE; 6.0: partial index unsupported; 6.1/6.2: error-message wording for missing-table) |
| fkey2.test | 0 | 0 | 0 | Empty/skipped under tcl runner |
| fkey3.test | 0 | 0 | 0 | Empty/skipped under tcl runner |
| fkey4.test | 0 | 0 | 0 | Empty/skipped under tcl runner |
| fkey5.test | 53 | 0 | 5 | All pass |
| fkey6.test | 15 | 18 | 5 | Same pass/fail pattern before and after the fix (see below) |
| fkey7.test | 0 | 0 | 0 | Skipped (test runner harness limitation) |
| fkey8.test | 8 | 4 | 20 | Pre-existing failures: 2.3.1, 3.0/3.1 (WITHOUT ROWID + self-FK), 5.2 (text/integer affinity in DEFERRABLE INITIALLY DEFERRED) |

### fkey6.test analysis

The full fkey6.test pass/fail line is unchanged (15 pass / 18 fail) before and after the RESTRICT-defer fix because the fkey6 section 3 setup runs `UPDATE p2 SET a=a-1` (i.e., decrementing the PRIMARY KEY across multiple rows) at test 3.2.1, which surfaces a separate pre-existing UPDATE-engine bug — VibeSQL fires `UNIQUE constraint failed: p2.a` mid-statement when row a=2 is rewritten to a=1 before row a=1 is rewritten to a=0 (see fkey6 3.2.x output). Once test 3.2 corrupts the test state, every later test in section 3 trips on the wrong baseline. This is independent of FK defer.

I verified the RESTRICT-defer fix does work in isolation by replaying the fkey6-3.3.4 scenario directly through the CLI (not through the TCL harness), confirming the fix produces the expected `0 one 1 deleted!` final state. See the commit message for the manual verification commands.

The remaining UPDATE-PK-cycle bug is out of scope for this PR. I am not fixing it inline (scope discipline). It should be filed as a follow-up issue and given priority alongside Phase C3.

## Notes / scope additions

- Updated `tests/common/referential_integrity_fixtures.rs` and `tests/storage/referential_integrity.rs` to add the new `is_deferrable: false` and `initially_deferred: false` fields to `ForeignKeyConstraint` literals. PR #5124 missed these fixtures, breaking the workspace test build. The fixtures also now call `db.set_foreign_keys_enabled(true)` (matching the `foreign_key_set_default_tests` pattern from #5060), exposing 15 pre-existing tests that had been silently broken since #5060 added the `foreign_keys` PRAGMA gate.
- The pre-existing `tests/z_compliance/sqllogictest_benchmark.rs` `LowerHex` build failure (md5 dep version mismatch) is unrelated to this PR and is left for a separate cleanup.

## Phase C dependency chain

- Phase C1 (#5124, merged): catalog metadata + PRAGMA flag.
- **Phase C2 (this PR)**: queue + COMMIT-time enforcement.
- Phase C3 (#5126, blocked on this): builds on the C2 queue.

Closes #5125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
