### PR TITLE
feat(planner): implicit-outer-aggregate-collapse + correlated window subquery

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
@@ -345,6 +345,36 @@ fn collect_correlation_refs_from_expr(
             collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
             collect_correlation_refs(subquery, outer_schema, subquery_tables, refs);
         }
+        // Window functions: check args, PARTITION BY, ORDER BY for outer column refs.
+        // Without this, queries like `(SELECT min(a) OVER ())` over a correlated `a`
+        // would compute an empty correlation set, producing the same cache key for
+        // every outer row and returning the first row's value to all subsequent rows
+        // (window4.test 12.1 — issue #5104).
+        vibesql_ast::Expression::WindowFunction { function, over } => {
+            let args = match function {
+                vibesql_ast::WindowFunctionSpec::Aggregate { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args,
+            };
+            for arg in args {
+                collect_correlation_refs_from_expr(arg, outer_schema, subquery_tables, refs);
+            }
+            if let Some(partition_by) = &over.partition_by {
+                for p in partition_by {
+                    collect_correlation_refs_from_expr(p, outer_schema, subquery_tables, refs);
+                }
+            }
+            if let Some(order_by) = &over.order_by {
+                for ob_item in order_by {
+                    collect_correlation_refs_from_expr(
+                        &ob_item.expr,
+                        outer_schema,
+                        subquery_tables,
+                        refs,
+                    );
+                }
+            }
+        }
         // Literals and other expressions don't contribute to correlation
         _ => {}
     }

--- a/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
@@ -2,6 +2,251 @@
 
 use super::super::builder::SelectExecutor;
 
+/// Check whether an expression contains a *bare* (FROM-less) scalar subquery
+/// whose body has an aggregate referencing an outer column. This triggers
+/// SQLite's implicit-outer-aggregate-collapse semantics (#5104).
+///
+/// "Outer column" inside a bare subquery means *any* column reference (since
+/// the subquery has no tables of its own). We check the aggregate's args, its
+/// FILTER clause, and its ORDER BY items.
+fn expression_contains_outer_aggregate_collapse(expr: &vibesql_ast::Expression) -> bool {
+    use vibesql_ast::Expression;
+
+    match expr {
+        Expression::ScalarSubquery(stmt) => {
+            // Bare (FROM-less) subquery: an aggregate in the projection that
+            // references a column is necessarily outer-correlated (no inner
+            // tables) → triggers collapse.
+            if stmt.from.is_none() {
+                for item in &stmt.select_list {
+                    if let vibesql_ast::SelectItem::Expression { expr: inner, .. } = item {
+                        if expr_has_column_referencing_aggregate(inner) {
+                            return true;
+                        }
+                        // Recurse: nested scalar subqueries.
+                        if expression_contains_outer_aggregate_collapse(inner) {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            // FROM-bearing subquery: only recurse into the SELECT list to
+            // find further bare-subquery collapse triggers. We do NOT walk
+            // into FROM/WHERE/HAVING/ORDER-BY of FROM-bearing subqueries
+            // here because we lack schema information to disambiguate
+            // which columns resolve to inner vs outer scope. Without that
+            // disambiguation, recursing too deeply produces false positives
+            // (e.g. `SELECT (SELECT sum(x) FROM t2) FROM t1` would falsely
+            // match if we treated any aggregate-with-column-ref as a
+            // trigger). Issue #5104's window1.test 57.3 case (which
+            // requires deep cross-scope analysis) is handled by a follow-up.
+            stmt.select_list.iter().any(|item| match item {
+                vibesql_ast::SelectItem::Expression { expr: inner, .. } => {
+                    expression_contains_outer_aggregate_collapse(inner)
+                }
+                _ => false,
+            })
+        }
+        // Recurse into compound expressions.
+        Expression::BinaryOp { left, right, .. } => {
+            expression_contains_outer_aggregate_collapse(left)
+                || expression_contains_outer_aggregate_collapse(right)
+        }
+        Expression::UnaryOp { expr, .. } => expression_contains_outer_aggregate_collapse(expr),
+        Expression::Cast { expr, .. } => expression_contains_outer_aggregate_collapse(expr),
+        Expression::IsNull { expr, .. } => expression_contains_outer_aggregate_collapse(expr),
+        Expression::Like { expr, pattern, .. } => {
+            expression_contains_outer_aggregate_collapse(expr)
+                || expression_contains_outer_aggregate_collapse(pattern)
+        }
+        Expression::Between { expr, low, high, .. } => {
+            expression_contains_outer_aggregate_collapse(expr)
+                || expression_contains_outer_aggregate_collapse(low)
+                || expression_contains_outer_aggregate_collapse(high)
+        }
+        Expression::InList { expr, values, .. } => {
+            expression_contains_outer_aggregate_collapse(expr)
+                || values.iter().any(expression_contains_outer_aggregate_collapse)
+        }
+        Expression::In { expr, .. } => expression_contains_outer_aggregate_collapse(expr),
+        Expression::Case { operand, when_clauses, else_result } => {
+            operand
+                .as_ref()
+                .is_some_and(|e| expression_contains_outer_aggregate_collapse(e))
+                || when_clauses.iter().any(|w| {
+                    w.conditions.iter().any(expression_contains_outer_aggregate_collapse)
+                        || expression_contains_outer_aggregate_collapse(&w.result)
+                })
+                || else_result
+                    .as_ref()
+                    .is_some_and(|e| expression_contains_outer_aggregate_collapse(e))
+        }
+        Expression::Function { args, .. } => {
+            args.iter().any(expression_contains_outer_aggregate_collapse)
+        }
+        Expression::AggregateFunction { args, filter, order_by, .. } => {
+            // The collapse pattern only triggers from a bare scalar subquery,
+            // so an aggregate at this level is the *outer* aggregate (already
+            // handled by `has_aggregates`). We only recurse to find subqueries
+            // that themselves trigger the pattern (e.g. `min(...((SELECT avg(a))))`).
+            args.iter().any(expression_contains_outer_aggregate_collapse)
+                || filter
+                    .as_ref()
+                    .is_some_and(|f| expression_contains_outer_aggregate_collapse(f))
+                || order_by.as_ref().is_some_and(|items| {
+                    items.iter().any(|i| expression_contains_outer_aggregate_collapse(&i.expr))
+                })
+        }
+        Expression::WindowFunction { function, over, .. } => {
+            // Window function: check the function's args AND the OVER clause's
+            // PARTITION BY / ORDER BY / frame, since the example in #5104
+            // (window1.test 57.3) places the collapse-trigger inside the
+            // ORDER BY of a window function.
+            let args = match function {
+                vibesql_ast::WindowFunctionSpec::Aggregate { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args,
+            };
+            if args.iter().any(expression_contains_outer_aggregate_collapse) {
+                return true;
+            }
+            if let Some(partition_by) = &over.partition_by {
+                if partition_by.iter().any(expression_contains_outer_aggregate_collapse) {
+                    return true;
+                }
+            }
+            if let Some(order_by) = &over.order_by {
+                if order_by
+                    .iter()
+                    .any(|item| expression_contains_outer_aggregate_collapse(&item.expr))
+                {
+                    return true;
+                }
+            }
+            false
+        }
+        Expression::QuantifiedComparison { expr, .. } => {
+            expression_contains_outer_aggregate_collapse(expr)
+        }
+        // EXISTS has its own scope — don't recurse into it.
+        // Other leaf expressions can't contain a scalar subquery.
+        _ => false,
+    }
+}
+
+/// Check whether an expression contains an aggregate function whose arguments,
+/// FILTER, or ORDER BY items reference a column. Inside a bare (FROM-less)
+/// scalar subquery, *any* column reference is necessarily an outer reference.
+fn expr_has_column_referencing_aggregate(expr: &vibesql_ast::Expression) -> bool {
+    use vibesql_ast::Expression;
+
+    match expr {
+        Expression::AggregateFunction { args, filter, order_by, .. } => {
+            if args.iter().any(expression_contains_column_ref_simple) {
+                return true;
+            }
+            if filter.as_ref().is_some_and(|f| expression_contains_column_ref_simple(f)) {
+                return true;
+            }
+            if order_by.as_ref().is_some_and(|items| {
+                items.iter().any(|i| expression_contains_column_ref_simple(&i.expr))
+            }) {
+                return true;
+            }
+            // An outer aggregate doesn't itself match, but it might have a
+            // nested aggregate inside its args.
+            args.iter().any(expr_has_column_referencing_aggregate)
+        }
+        Expression::Function { name, args, .. }
+            if matches!(
+                name.to_uppercase().as_str(),
+                "COUNT" | "SUM" | "AVG" | "TOTAL" | "MIN" | "MAX" | "GROUP_CONCAT" | "STRING_AGG"
+            ) =>
+        {
+            // Old Function variant aggregate. min/max with >1 args are scalar.
+            let upper = name.to_uppercase();
+            let is_scalar_minmax = matches!(upper.as_str(), "MIN" | "MAX") && args.len() > 1;
+            if !is_scalar_minmax && args.iter().any(expression_contains_column_ref_simple) {
+                return true;
+            }
+            args.iter().any(expr_has_column_referencing_aggregate)
+        }
+        Expression::BinaryOp { left, right, .. } => {
+            expr_has_column_referencing_aggregate(left)
+                || expr_has_column_referencing_aggregate(right)
+        }
+        Expression::UnaryOp { expr, .. } => expr_has_column_referencing_aggregate(expr),
+        Expression::Cast { expr, .. } => expr_has_column_referencing_aggregate(expr),
+        Expression::IsNull { expr, .. } => expr_has_column_referencing_aggregate(expr),
+        Expression::Function { args, .. } => {
+            args.iter().any(expr_has_column_referencing_aggregate)
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            operand.as_ref().is_some_and(|e| expr_has_column_referencing_aggregate(e))
+                || when_clauses.iter().any(|w| {
+                    w.conditions.iter().any(expr_has_column_referencing_aggregate)
+                        || expr_has_column_referencing_aggregate(&w.result)
+                })
+                || else_result.as_ref().is_some_and(|e| expr_has_column_referencing_aggregate(e))
+        }
+        // Don't descend into inner subqueries / window functions — they have
+        // their own scope. Stop here.
+        _ => false,
+    }
+}
+
+/// Simple recursive column-reference check (no scope analysis — we're already
+/// inside a bare subquery so any column ref is necessarily an outer one).
+fn expression_contains_column_ref_simple(expr: &vibesql_ast::Expression) -> bool {
+    use vibesql_ast::Expression;
+
+    match expr {
+        Expression::ColumnRef(_) => true,
+        Expression::BinaryOp { left, right, .. } => {
+            expression_contains_column_ref_simple(left)
+                || expression_contains_column_ref_simple(right)
+        }
+        Expression::UnaryOp { expr, .. } => expression_contains_column_ref_simple(expr),
+        Expression::Cast { expr, .. } => expression_contains_column_ref_simple(expr),
+        Expression::IsNull { expr, .. } => expression_contains_column_ref_simple(expr),
+        Expression::Function { args, .. } => {
+            args.iter().any(expression_contains_column_ref_simple)
+        }
+        Expression::AggregateFunction { args, filter, order_by, .. } => {
+            args.iter().any(expression_contains_column_ref_simple)
+                || filter.as_ref().is_some_and(|f| expression_contains_column_ref_simple(f))
+                || order_by.as_ref().is_some_and(|items| {
+                    items.iter().any(|i| expression_contains_column_ref_simple(&i.expr))
+                })
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            operand.as_ref().is_some_and(|e| expression_contains_column_ref_simple(e))
+                || when_clauses.iter().any(|w| {
+                    w.conditions.iter().any(expression_contains_column_ref_simple)
+                        || expression_contains_column_ref_simple(&w.result)
+                })
+                || else_result.as_ref().is_some_and(|e| expression_contains_column_ref_simple(e))
+        }
+        Expression::Like { expr, pattern, .. } => {
+            expression_contains_column_ref_simple(expr)
+                || expression_contains_column_ref_simple(pattern)
+        }
+        Expression::Between { expr, low, high, .. } => {
+            expression_contains_column_ref_simple(expr)
+                || expression_contains_column_ref_simple(low)
+                || expression_contains_column_ref_simple(high)
+        }
+        Expression::InList { expr, values, .. } => {
+            expression_contains_column_ref_simple(expr)
+                || values.iter().any(expression_contains_column_ref_simple)
+        }
+        // Don't descend into nested subqueries (separate scope).
+        _ => false,
+    }
+}
+
 impl SelectExecutor<'_> {
     /// Check if SELECT list contains aggregate functions
     pub(in crate::select::executor) fn has_aggregates(
@@ -110,6 +355,34 @@ impl SelectExecutor<'_> {
             // contain aggregates
             _ => false,
         }
+    }
+
+    /// Detect SQLite's implicit-outer-aggregate-collapse pattern (#5104).
+    ///
+    /// Returns true when the SELECT list contains a *bare* (FROM-less) scalar
+    /// subquery whose body has an aggregate function referencing an outer
+    /// column. SQLite collapses the outer query into a single-row aggregate
+    /// in this case, with the inner aggregate computed over all outer rows.
+    ///
+    /// Examples that match:
+    /// - `SELECT (SELECT avg(a)) FROM t2`               — bare aggregate, outer-correlated
+    /// - `SELECT (SELECT sum(y) FILTER(WHERE x>0)) FROM t` — outer-correlated via FILTER
+    ///
+    /// Examples that do NOT match (return false):
+    /// - `SELECT (SELECT 1) FROM t`                   — no aggregate
+    /// - `SELECT (SELECT min(a) OVER ()) FROM t`      — window, not bare aggregate
+    /// - `SELECT (SELECT avg(x) FROM other) FROM t`   — has FROM, not bare
+    /// - `SELECT avg(a) FROM t`                       — top-level aggregate (already handled)
+    pub(in crate::select::executor) fn select_list_has_outer_aggregate_collapse(
+        &self,
+        select_list: &[vibesql_ast::SelectItem],
+    ) -> bool {
+        select_list.iter().any(|item| match item {
+            vibesql_ast::SelectItem::Expression { expr, .. } => {
+                expression_contains_outer_aggregate_collapse(expr)
+            }
+            _ => false,
+        })
     }
 
     /// Check if statement is a simple COUNT(*) query that can use fast path

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
@@ -715,6 +715,53 @@ pub(super) fn evaluate(
         }
     }
 
+    // Issue #4930 / #5104: outer-correlated aggregate. When the aggregate's
+    // argument references only outer columns, iterate over all outer rows
+    // instead of `group_rows`. This is the inner-evaluation path used by
+    // SQLite's implicit-outer-aggregate-collapse: outer query collapses to
+    // one row, and the inner aggregate runs over all outer rows.
+    //
+    // Previously only GROUP_CONCAT/STRING_AGG implemented this path; here we
+    // generalize it to all aggregates (AVG, SUM, MIN, MAX, COUNT, ...) so
+    // `SELECT (SELECT avg(a)) FROM t2` produces a single 2.0 row instead of
+    // averaging one row at a time. (window4.test 12.2)
+    let has_outer_context_for_collapse = evaluator.get_outer_schema().is_some();
+    let is_outer_only = expression_refs_only_outer_columns(
+        &args[0],
+        evaluator.get_schema(),
+        has_outer_context_for_collapse,
+    );
+    if is_outer_only {
+        if let (Some(outer_rows), Some(outer_schema)) =
+            (evaluator.get_outer_rows(), evaluator.get_outer_schema())
+        {
+            for outer_row in outer_rows.iter() {
+                evaluator.clear_cse_cache();
+                // FILTER inside the inner aggregate may reference the same
+                // outer column. Evaluate it against the outer row using the
+                // outer schema; on failure (e.g. references inner columns),
+                // fall back to skipping the filter (no rows to filter from).
+                if let Some(filter_expr) = filter {
+                    let filter_val = evaluate_expr_against_outer_row(
+                        filter_expr,
+                        outer_row,
+                        outer_schema,
+                    )?;
+                    if !executor.is_truthy(&filter_val)? {
+                        continue;
+                    }
+                }
+                let value =
+                    evaluate_expr_against_outer_row(&args[0], outer_row, outer_schema)?;
+                acc.accumulate(&value);
+            }
+            let result = acc.finalize()?;
+            executor.get_aggregate_cache().borrow_mut().insert(cache_key, result.clone());
+            return Ok(result);
+        }
+        // Fall through to normal path if outer_rows not available
+    }
+
     // Try to compile CASE expression for fast-path evaluation (#3079)
     // This optimization helps TPC-DS Q2 which has 7 SUM(CASE...) aggregates
     // For ~14K rows × 7 aggregates = ~98K evaluations, compiled CASE avoids:

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/subquery.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/subquery.rs
@@ -14,6 +14,14 @@ use crate::{
 /// `a` from the row where `a` has its maximum value, not just the first row.
 ///
 /// See issue #4683 for details.
+///
+/// **Issue #5104 — implicit-outer-aggregate-collapse**: When the scalar
+/// subquery is *bare* (no FROM) and its body contains an aggregate referencing
+/// outer columns, SQLite collapses the outer query into a single-row aggregate
+/// with the inner aggregate computed over all outer rows. We propagate
+/// `group_rows` as `outer_rows` to the inner subquery's evaluator so the
+/// existing #4930 inner-aggregate path can iterate them. Without this, the
+/// inner aggregate would only see the representative row (1 row → wrong avg).
 pub(super) fn evaluate_scalar(
     executor: &SelectExecutor,
     expr: &vibesql_ast::Expression,
@@ -30,9 +38,160 @@ pub(super) fn evaluate_scalar(
     };
 
     if let Some(row) = representative_row {
+        // Issue #5104: when the subquery is a bare scalar subquery whose body
+        // has an aggregate referencing an outer column, override `outer_rows`
+        // with the current group's rows so the inner aggregate can iterate
+        // them (via the #4930 outer-correlated-aggregate path). For other
+        // subqueries the parent evaluator's outer_rows are preserved.
+        if scalar_subquery_needs_outer_rows(expr) {
+            let mut overridden = evaluator.clone_for_new_expression();
+            overridden.set_outer_rows(group_rows);
+            return overridden.eval(expr, row);
+        }
         evaluator.eval(expr, row)
     } else {
         Ok(vibesql_types::SqlValue::Null)
+    }
+}
+
+/// Check whether `expr` is a scalar subquery (or a compound expression
+/// containing one) that needs `outer_rows` set to the current group's rows
+/// for SQLite's implicit-outer-aggregate-collapse semantics (#5104).
+///
+/// The pattern: a bare (FROM-less) scalar subquery whose body contains an
+/// aggregate function whose argument / FILTER / ORDER BY references an outer
+/// column. Inside a bare subquery, *any* column reference is necessarily an
+/// outer reference, so we just check for any column ref in the aggregate.
+fn scalar_subquery_needs_outer_rows(expr: &vibesql_ast::Expression) -> bool {
+    use vibesql_ast::Expression;
+
+    match expr {
+        Expression::ScalarSubquery(stmt) => {
+            if stmt.from.is_some() {
+                return false;
+            }
+            stmt.select_list.iter().any(|item| match item {
+                vibesql_ast::SelectItem::Expression { expr: inner, .. } => {
+                    bare_subquery_inner_has_outer_aggregate(inner)
+                }
+                _ => false,
+            })
+        }
+        Expression::BinaryOp { left, right, .. } => {
+            scalar_subquery_needs_outer_rows(left)
+                || scalar_subquery_needs_outer_rows(right)
+        }
+        Expression::UnaryOp { expr, .. } => scalar_subquery_needs_outer_rows(expr),
+        Expression::Cast { expr, .. } => scalar_subquery_needs_outer_rows(expr),
+        Expression::IsNull { expr, .. } => scalar_subquery_needs_outer_rows(expr),
+        Expression::Function { args, .. } => args.iter().any(scalar_subquery_needs_outer_rows),
+        Expression::Case { operand, when_clauses, else_result } => {
+            operand.as_ref().is_some_and(|e| scalar_subquery_needs_outer_rows(e))
+                || when_clauses.iter().any(|w| {
+                    w.conditions.iter().any(scalar_subquery_needs_outer_rows)
+                        || scalar_subquery_needs_outer_rows(&w.result)
+                })
+                || else_result.as_ref().is_some_and(|e| scalar_subquery_needs_outer_rows(e))
+        }
+        _ => false,
+    }
+}
+
+/// Inside a bare scalar subquery, check whether `expr` contains an aggregate
+/// whose args/filter/order_by reference any column (which is necessarily an
+/// outer reference — bare subqueries have no inner columns).
+fn bare_subquery_inner_has_outer_aggregate(expr: &vibesql_ast::Expression) -> bool {
+    use vibesql_ast::Expression;
+
+    match expr {
+        Expression::AggregateFunction { args, filter, order_by, .. } => {
+            if args.iter().any(any_column_ref) {
+                return true;
+            }
+            if filter.as_ref().is_some_and(|f| any_column_ref(f)) {
+                return true;
+            }
+            if order_by
+                .as_ref()
+                .is_some_and(|items| items.iter().any(|i| any_column_ref(&i.expr)))
+            {
+                return true;
+            }
+            args.iter().any(bare_subquery_inner_has_outer_aggregate)
+        }
+        Expression::Function { name, args, .. } => {
+            // Old Function variant for aggregate names
+            let upper = name.to_uppercase();
+            let is_agg = matches!(
+                upper.as_str(),
+                "COUNT" | "SUM" | "AVG" | "TOTAL" | "MIN" | "MAX" | "GROUP_CONCAT" | "STRING_AGG"
+            );
+            let is_scalar_minmax = matches!(upper.as_str(), "MIN" | "MAX") && args.len() > 1;
+            if is_agg && !is_scalar_minmax && args.iter().any(any_column_ref) {
+                return true;
+            }
+            args.iter().any(bare_subquery_inner_has_outer_aggregate)
+        }
+        Expression::BinaryOp { left, right, .. } => {
+            bare_subquery_inner_has_outer_aggregate(left)
+                || bare_subquery_inner_has_outer_aggregate(right)
+        }
+        Expression::UnaryOp { expr, .. } => bare_subquery_inner_has_outer_aggregate(expr),
+        Expression::Cast { expr, .. } => bare_subquery_inner_has_outer_aggregate(expr),
+        Expression::IsNull { expr, .. } => bare_subquery_inner_has_outer_aggregate(expr),
+        Expression::Case { operand, when_clauses, else_result } => {
+            operand.as_ref().is_some_and(|e| bare_subquery_inner_has_outer_aggregate(e))
+                || when_clauses.iter().any(|w| {
+                    w.conditions.iter().any(bare_subquery_inner_has_outer_aggregate)
+                        || bare_subquery_inner_has_outer_aggregate(&w.result)
+                })
+                || else_result.as_ref().is_some_and(|e| bare_subquery_inner_has_outer_aggregate(e))
+        }
+        // Don't descend into nested subqueries / window functions (own scope).
+        _ => false,
+    }
+}
+
+/// Recursively check whether `expr` contains any column reference. Used inside
+/// bare subqueries where any column ref is necessarily outer.
+fn any_column_ref(expr: &vibesql_ast::Expression) -> bool {
+    use vibesql_ast::Expression;
+
+    match expr {
+        Expression::ColumnRef(_) => true,
+        Expression::BinaryOp { left, right, .. } => {
+            any_column_ref(left) || any_column_ref(right)
+        }
+        Expression::UnaryOp { expr, .. } => any_column_ref(expr),
+        Expression::Cast { expr, .. } => any_column_ref(expr),
+        Expression::IsNull { expr, .. } => any_column_ref(expr),
+        Expression::Function { args, .. } => args.iter().any(any_column_ref),
+        Expression::AggregateFunction { args, filter, order_by, .. } => {
+            args.iter().any(any_column_ref)
+                || filter.as_ref().is_some_and(|f| any_column_ref(f))
+                || order_by
+                    .as_ref()
+                    .is_some_and(|items| items.iter().any(|i| any_column_ref(&i.expr)))
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            operand.as_ref().is_some_and(|e| any_column_ref(e))
+                || when_clauses.iter().any(|w| {
+                    w.conditions.iter().any(any_column_ref)
+                        || any_column_ref(&w.result)
+                })
+                || else_result.as_ref().is_some_and(|e| any_column_ref(e))
+        }
+        Expression::Like { expr, pattern, .. } => {
+            any_column_ref(expr) || any_column_ref(pattern)
+        }
+        Expression::Between { expr, low, high, .. } => {
+            any_column_ref(expr) || any_column_ref(low) || any_column_ref(high)
+        }
+        Expression::InList { expr, values, .. } => {
+            any_column_ref(expr) || values.iter().any(any_column_ref)
+        }
+        // Don't descend into nested subqueries or window functions (own scope).
+        _ => false,
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -157,7 +157,10 @@ impl SelectExecutor<'_> {
             // Check for aggregates/windows inside bare scalar subqueries
             // in HAVING (e.g. `HAVING (SELECT (a, b))` triggers row-value-misused;
             // `HAVING (SELECT sum(x))` triggers misuse of aggregate). #5069
-            crate::select::executor::validation::validate_subquery_context_misuse(having_expr)?;
+            crate::select::executor::validation::validate_subquery_context_misuse(
+                having_expr,
+                crate::select::executor::validation::SubqueryContext::WhereOrEqual,
+            )?;
         }
 
         // Validate ORDER BY for misuse of aliased window functions (#5036)

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -67,22 +67,36 @@ impl SelectExecutor<'_> {
         super::validation::validate_aggregate_subquery_outer_refs(stmt, self.database)?;
 
         // Validate bare scalar subqueries in the SELECT list / ORDER BY for
-        // misuse of aggregate / window / row-value (#5069). A "bare" scalar
-        // subquery (no FROM) re-borrows the outer aggregation context, so any
-        // aggregate inside it is a misuse of the outer scope.
-        // Examples:
-        //   SELECT ntile((SELECT sum(x))) OVER (ORDER BY x) FROM t1;
-        //     → "misuse of aggregate: sum()"
-        //   ... ORDER BY (SELECT (a, b))
-        //     → "row value misused"
+        // misuse of aggregate / window / row-value (#5069, refined #5104).
+        //
+        // A "bare" scalar subquery (no FROM) re-borrows the outer aggregation
+        // context. SQLite has two distinct behaviors depending on where the
+        // subquery appears:
+        //
+        // * SELECT-list (#5104): `SELECT (SELECT avg(a)) FROM t2` is allowed —
+        //   the outer query implicitly collapses to a single-row aggregate. We
+        //   pass `SubqueryContext::SelectList` so the validator skips the
+        //   "misuse of aggregate" rejection in this position.
+        // * WHERE / HAVING / ORDER BY (and arguments to outer functions): an
+        //   outer-correlated aggregate inside a bare scalar subquery is still
+        //   a misuse and must be rejected. We pass `WhereOrEqual` for ORDER BY
+        //   to preserve SQLite's rejection there.
+        //
+        // Row-value misuse (`(SELECT (a, b))`) is detected in both contexts.
         for item in &stmt.select_list {
             if let vibesql_ast::SelectItem::Expression { expr, .. } = item {
-                super::validation::validate_subquery_context_misuse(expr)?;
+                super::validation::validate_subquery_context_misuse(
+                    expr,
+                    super::validation::SubqueryContext::SelectList,
+                )?;
             }
         }
         if let Some(order_by) = stmt.order_by.as_deref() {
             for item in order_by {
-                super::validation::validate_subquery_context_misuse(&item.expr)?;
+                super::validation::validate_subquery_context_misuse(
+                    &item.expr,
+                    super::validation::SubqueryContext::WhereOrEqual,
+                )?;
             }
         }
 
@@ -973,6 +987,21 @@ impl SelectExecutor<'_> {
         let has_window_funcs = self.has_window_functions(&stmt.select_list);
         let has_distinct_aggregates = self.has_distinct_aggregates(&stmt.select_list);
 
+        // Issue #5104: implicit-outer-aggregate-collapse requires the
+        // aggregation pipeline. The columnar pipelines do not support this
+        // semantic, so fall back to the row-oriented path which routes
+        // through `execute_with_aggregation`.
+        if !has_aggregates
+            && !has_group_by
+            && self.select_list_has_outer_aggregate_collapse(&stmt.select_list)
+        {
+            log::debug!(
+                "{} pipeline: implicit-outer-aggregate-collapse — falling back to row-oriented",
+                strategy_name
+            );
+            return Ok(None);
+        }
+
         // Create the pipeline
         let pipeline = create_pipeline();
 
@@ -1228,7 +1257,18 @@ impl SelectExecutor<'_> {
         let has_aggregates = self.has_aggregates(&stmt.select_list) || stmt.having.is_some();
         let has_group_by = stmt.group_by.is_some();
 
-        if has_aggregates || has_group_by {
+        // Issue #5104: SQLite's implicit-outer-aggregate-collapse semantics.
+        // When the SELECT list contains a bare scalar subquery whose body has
+        // an aggregate referencing an outer column, the outer query collapses
+        // into a single-row aggregate (with the inner aggregate computed over
+        // all outer rows). Route through the aggregation pipeline so the
+        // single-group grand-total path runs and `outer_rows` is wired through
+        // to the inner subquery.
+        let has_implicit_collapse = !has_aggregates
+            && !has_group_by
+            && self.select_list_has_outer_aggregate_collapse(&stmt.select_list);
+
+        if has_aggregates || has_group_by || has_implicit_collapse {
             self.execute_with_aggregation(stmt, cte_results)
         } else if let Some(from_clause) = &stmt.from {
             // Re-enabled predicate pushdown for all queries (issue #1902)

--- a/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
@@ -1451,20 +1451,61 @@ fn find_outer_referencing_aggregate(expr: &Expression) -> Option<String> {
     })
 }
 
+/// Context in which a subquery appears, controlling how
+/// `validate_subquery_context_misuse` treats outer-correlated aggregates inside
+/// bare scalar subqueries.
+///
+/// SQLite has two distinct behaviors for a bare scalar subquery whose body
+/// contains an aggregate referencing an *outer* column:
+///
+/// 1. **WHERE / HAVING / ORDER BY** (and arguments to other outer functions):
+///    SQLite raises `"misuse of aggregate: X()"`. The outer aggregation context
+///    is not implicitly borrowed in these positions.
+///
+/// 2. **SELECT list** (issue #5104): SQLite implicitly collapses the outer
+///    query into a single-row aggregate, with the inner aggregate computed
+///    over all outer rows. The aggregate is *not* a misuse here — it's
+///    well-defined and produces a single output row.
+///
+/// We therefore parameterize the validator on context: SELECT-list calls pass
+/// [`SubqueryContext::SelectList`] to skip the outer-correlated-aggregate
+/// rejection (it will be handled by the implicit-collapse path). All other
+/// callers pass [`SubqueryContext::WhereOrEqual`] to preserve the SQLite
+/// rejection.
+///
+/// Row-value misuse is checked in *both* contexts — `(SELECT (a, b))` is
+/// always an error regardless of where the subquery appears.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubqueryContext {
+    /// Bare scalar subquery in WHERE, HAVING, ORDER BY, or as an argument to
+    /// an outer function. Outer-correlated aggregates → "misuse of aggregate".
+    WhereOrEqual,
+    /// Bare scalar subquery in the SELECT list. Outer-correlated aggregates
+    /// trigger SQLite's implicit-outer-aggregate-collapse instead of a misuse
+    /// error (#5104).
+    SelectList,
+}
+
 /// Detect aggregate / row-value misuse inside *bare* scalar subqueries.
 ///
 /// SQLite has a special rule: when a scalar subquery has no FROM clause and
 /// its body contains an aggregate function whose argument or FILTER references
 /// an *outer* column, the aggregate implicitly borrows the outer aggregation
-/// context. SQLite reports this as `"misuse of aggregate: X()"`.
+/// context. SQLite reports this as `"misuse of aggregate: X()"` *unless* the
+/// subquery appears in the SELECT list, where it instead triggers
+/// implicit-outer-aggregate-collapse (#5104).
 ///
-/// Examples that trigger this rule:
+/// Examples that trigger this rule (in WHERE/HAVING/ORDER BY context):
 /// - `WHERE (SELECT AVG(0) FILTER(WHERE outer.c))`  → "misuse of aggregate: AVG()"
 /// - `ntile((SELECT sum(x))) OVER (...)`             → "misuse of aggregate: sum()"
 ///
+/// In SELECT-list context (#5104), the same patterns are *allowed* and trigger
+/// outer-aggregate collapse:
+/// - `SELECT (SELECT avg(a)) FROM t2` → outer collapses to single row
+///
 /// Additionally, when a bare scalar subquery's sole projection is a
 /// `RowValueConstructor` with multiple elements, that's `RowValueMisused`
-/// (a row value where a scalar is required).
+/// (a row value where a scalar is required) — checked in both contexts.
 ///
 /// Note: pure *window* functions inside bare scalar subqueries are NOT flagged
 /// here — SQLite allows them (they are evaluated row-by-row against the outer
@@ -1472,7 +1513,8 @@ fn find_outer_referencing_aggregate(expr: &Expression) -> Option<String> {
 /// (WHERE-clause walker, GROUP BY positional refs, etc.).
 ///
 /// This walker is meant to be called on expressions appearing in the outer
-/// scope — typically WHERE, HAVING, ORDER BY, or arguments to outer functions.
+/// scope — typically WHERE, HAVING, ORDER BY, or arguments to outer functions
+/// (with `WhereOrEqual`), or the SELECT list (with `SelectList`).
 /// It deliberately does NOT recurse into scalar subqueries that have a FROM
 /// clause (those have their own aggregation context and are validated
 /// independently).
@@ -1480,13 +1522,17 @@ fn find_outer_referencing_aggregate(expr: &Expression) -> Option<String> {
 /// To preserve SQLite's exact error text (which uses the function name as
 /// originally written by the user), we walk the inner expression and report
 /// the first such aggregate's name.
-pub fn validate_subquery_context_misuse(expr: &Expression) -> Result<(), ExecutorError> {
+pub fn validate_subquery_context_misuse(
+    expr: &Expression,
+    context: SubqueryContext,
+) -> Result<(), ExecutorError> {
     match expr {
         Expression::ScalarSubquery(stmt) => {
             // Only "bare" subqueries (no FROM) re-borrow the outer context.
             if stmt.from.is_none() {
                 // Check for row value misuse (sole projection is a row value
-                // constructor with multiple elements).
+                // constructor with multiple elements). This is an error in
+                // any context.
                 if stmt.select_list.len() == 1 {
                     if let SelectItem::Expression {
                         expr: Expression::RowValueConstructor(items),
@@ -1503,21 +1549,30 @@ pub fn validate_subquery_context_misuse(expr: &Expression) -> Result<(), Executo
                 // flag aggregates whose body references something outside the
                 // bare subquery's own scope (i.e., references a column — the
                 // bare subquery has no tables, so any column is an outer ref).
-                for item in &stmt.select_list {
-                    if let SelectItem::Expression { expr: inner, .. } = item {
-                        if let Some(name) = find_outer_referencing_aggregate(inner) {
-                            return Err(ExecutorError::MisuseOfAggregateContext {
-                                function_name: name,
-                            });
+                //
+                // In SELECT-list context, this is *not* a misuse; it triggers
+                // implicit-outer-aggregate-collapse instead (#5104). Skip the
+                // rejection so the executor's collapse path can handle it.
+                if context == SubqueryContext::WhereOrEqual {
+                    for item in &stmt.select_list {
+                        if let SelectItem::Expression { expr: inner, .. } = item {
+                            if let Some(name) = find_outer_referencing_aggregate(inner) {
+                                return Err(ExecutorError::MisuseOfAggregateContext {
+                                    function_name: name,
+                                });
+                            }
                         }
                     }
                 }
 
                 // Recurse into nested expressions inside the bare subquery's
-                // SELECT list as well — e.g. (SELECT (SELECT sum(x)))
+                // SELECT list as well — e.g. (SELECT (SELECT sum(x))).
+                // Inner subqueries inherit the same context: nested bare
+                // subqueries in a SELECT-list context still treat their own
+                // SELECT-list position as SELECT-list.
                 for item in &stmt.select_list {
                     if let SelectItem::Expression { expr: inner, .. } = item {
-                        validate_subquery_context_misuse(inner)?;
+                        validate_subquery_context_misuse(inner, context)?;
                     }
                 }
             }
@@ -1528,65 +1583,68 @@ pub fn validate_subquery_context_misuse(expr: &Expression) -> Result<(), Executo
         // those are checked by their own dedicated validators which understand
         // the surrounding context (FILTER, ORDER BY, etc.).
         Expression::BinaryOp { left, right, .. } => {
-            validate_subquery_context_misuse(left)?;
-            validate_subquery_context_misuse(right)
+            validate_subquery_context_misuse(left, context)?;
+            validate_subquery_context_misuse(right, context)
         }
-        Expression::UnaryOp { expr, .. } => validate_subquery_context_misuse(expr),
-        Expression::IsNull { expr, .. } => validate_subquery_context_misuse(expr),
+        Expression::UnaryOp { expr, .. } => validate_subquery_context_misuse(expr, context),
+        Expression::IsNull { expr, .. } => validate_subquery_context_misuse(expr, context),
         Expression::IsDistinctFrom { left, right, .. } => {
-            validate_subquery_context_misuse(left)?;
-            validate_subquery_context_misuse(right)
+            validate_subquery_context_misuse(left, context)?;
+            validate_subquery_context_misuse(right, context)
         }
-        Expression::IsTruthValue { expr, .. } => validate_subquery_context_misuse(expr),
-        Expression::Cast { expr, .. } => validate_subquery_context_misuse(expr),
+        Expression::IsTruthValue { expr, .. } => validate_subquery_context_misuse(expr, context),
+        Expression::Cast { expr, .. } => validate_subquery_context_misuse(expr, context),
         Expression::Like { expr, pattern, .. } => {
-            validate_subquery_context_misuse(expr)?;
-            validate_subquery_context_misuse(pattern)
+            validate_subquery_context_misuse(expr, context)?;
+            validate_subquery_context_misuse(pattern, context)
         }
         Expression::Between { expr, low, high, .. } => {
-            validate_subquery_context_misuse(expr)?;
-            validate_subquery_context_misuse(low)?;
-            validate_subquery_context_misuse(high)
+            validate_subquery_context_misuse(expr, context)?;
+            validate_subquery_context_misuse(low, context)?;
+            validate_subquery_context_misuse(high, context)
         }
         Expression::InList { expr, values, .. } => {
-            validate_subquery_context_misuse(expr)?;
+            validate_subquery_context_misuse(expr, context)?;
             for v in values {
-                validate_subquery_context_misuse(v)?;
+                validate_subquery_context_misuse(v, context)?;
             }
             Ok(())
         }
-        Expression::In { expr, .. } => validate_subquery_context_misuse(expr),
+        Expression::In { expr, .. } => validate_subquery_context_misuse(expr, context),
         Expression::Case { operand, when_clauses, else_result } => {
             if let Some(op) = operand {
-                validate_subquery_context_misuse(op)?;
+                validate_subquery_context_misuse(op, context)?;
             }
             for w in when_clauses {
                 for cond in &w.conditions {
-                    validate_subquery_context_misuse(cond)?;
+                    validate_subquery_context_misuse(cond, context)?;
                 }
-                validate_subquery_context_misuse(&w.result)?;
+                validate_subquery_context_misuse(&w.result, context)?;
             }
             if let Some(else_expr) = else_result {
-                validate_subquery_context_misuse(else_expr)?;
+                validate_subquery_context_misuse(else_expr, context)?;
             }
             Ok(())
         }
         Expression::Function { args, .. } => {
             for arg in args {
-                validate_subquery_context_misuse(arg)?;
+                validate_subquery_context_misuse(arg, context)?;
             }
             Ok(())
         }
         Expression::AggregateFunction { args, filter, order_by, .. } => {
+            // Aggregate function arguments are evaluated in WHERE/HAVING-like
+            // context (their value must be a scalar). Subqueries inside their
+            // args are NOT in SELECT-list position, so reset context.
             for arg in args {
-                validate_subquery_context_misuse(arg)?;
+                validate_subquery_context_misuse(arg, SubqueryContext::WhereOrEqual)?;
             }
             if let Some(f) = filter {
-                validate_subquery_context_misuse(f)?;
+                validate_subquery_context_misuse(f, SubqueryContext::WhereOrEqual)?;
             }
             if let Some(items) = order_by {
                 for item in items {
-                    validate_subquery_context_misuse(&item.expr)?;
+                    validate_subquery_context_misuse(&item.expr, SubqueryContext::WhereOrEqual)?;
                 }
             }
             Ok(())
@@ -1595,26 +1653,30 @@ pub fn validate_subquery_context_misuse(expr: &Expression) -> Result<(), Executo
             // Only recurse into the function's arguments — the OVER clause has
             // its own context and may legally contain aggregates / nested
             // subqueries (window functions are evaluated AFTER aggregation).
+            // Window function arguments are like aggregate-function arguments
+            // (must be scalar) — reset context to WhereOrEqual.
             let args = match function {
                 vibesql_ast::WindowFunctionSpec::Aggregate { args, .. }
                 | vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
                 | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args,
             };
             for a in args {
-                validate_subquery_context_misuse(a)?;
+                validate_subquery_context_misuse(a, SubqueryContext::WhereOrEqual)?;
             }
             Ok(())
         }
-        Expression::QuantifiedComparison { expr, .. } => validate_subquery_context_misuse(expr),
+        Expression::QuantifiedComparison { expr, .. } => {
+            validate_subquery_context_misuse(expr, context)
+        }
         Expression::Conjunction(children) | Expression::Disjunction(children) => {
             for child in children {
-                validate_subquery_context_misuse(child)?;
+                validate_subquery_context_misuse(child, context)?;
             }
             Ok(())
         }
         Expression::RowValueConstructor(children) => {
             for child in children {
-                validate_subquery_context_misuse(child)?;
+                validate_subquery_context_misuse(child, context)?;
             }
             Ok(())
         }
@@ -2242,19 +2304,31 @@ mod tests {
             source_text: None,
         }]);
 
-        let result = validate_subquery_context_misuse(&subquery);
+        // WhereOrEqual context: SQLite reports "misuse of aggregate" here.
+        let result = validate_subquery_context_misuse(&subquery, SubqueryContext::WhereOrEqual);
         match result {
             Err(ExecutorError::MisuseOfAggregateContext { function_name }) => {
                 assert_eq!(function_name, "AVG");
             }
             other => panic!("expected MisuseOfAggregateContext(AVG), got {:?}", other),
         }
+
+        // SelectList context (#5104): allowed — triggers implicit-collapse
+        // instead of erroring.
+        let result_select_list =
+            validate_subquery_context_misuse(&subquery, SubqueryContext::SelectList);
+        assert!(
+            result_select_list.is_ok(),
+            "SelectList context should allow outer-correlated aggregate, got {:?}",
+            result_select_list
+        );
     }
 
     #[test]
     fn test_subquery_misuse_aggregate_with_outer_arg_ref() {
         // (SELECT sum(x)) — bare subquery, sum's arg is an outer column ref
-        // Expected: misuse of aggregate: sum()
+        // Expected: misuse of aggregate: sum() in WhereOrEqual context;
+        // allowed in SelectList context (#5104).
         let inner_agg = Expression::AggregateFunction {
             name: FunctionIdentifier::new("sum"),
             distinct: false,
@@ -2268,19 +2342,27 @@ mod tests {
             source_text: None,
         }]);
 
-        let result = validate_subquery_context_misuse(&subquery);
+        let result = validate_subquery_context_misuse(&subquery, SubqueryContext::WhereOrEqual);
         match result {
             Err(ExecutorError::MisuseOfAggregateContext { function_name }) => {
                 assert_eq!(function_name, "sum");
             }
             other => panic!("expected MisuseOfAggregateContext(sum), got {:?}", other),
         }
+
+        let result_select_list =
+            validate_subquery_context_misuse(&subquery, SubqueryContext::SelectList);
+        assert!(
+            result_select_list.is_ok(),
+            "SelectList context should allow outer-correlated aggregate, got {:?}",
+            result_select_list
+        );
     }
 
     #[test]
     fn test_subquery_misuse_aggregate_with_constant_args_does_not_fire() {
         // (SELECT sum(0)) — bare subquery whose aggregate has no column refs.
-        // Should NOT error (no outer reference).
+        // Should NOT error in either context (no outer reference).
         let inner_agg = Expression::AggregateFunction {
             name: FunctionIdentifier::new("sum"),
             distinct: false,
@@ -2294,14 +2376,17 @@ mod tests {
             source_text: None,
         }]);
 
-        let result = validate_subquery_context_misuse(&subquery);
+        let result = validate_subquery_context_misuse(&subquery, SubqueryContext::WhereOrEqual);
         assert!(result.is_ok(), "constant aggregate in bare subquery should be OK");
+        let result_select =
+            validate_subquery_context_misuse(&subquery, SubqueryContext::SelectList);
+        assert!(result_select.is_ok(), "constant aggregate in SelectList should be OK");
     }
 
     #[test]
     fn test_subquery_row_value_misused() {
         // (SELECT (a, b)) — bare subquery returning a row value where a scalar
-        // is expected. Expected: row value misused.
+        // is expected. Expected: row value misused — in BOTH contexts.
         let row_value = Expression::RowValueConstructor(vec![
             Expression::ColumnRef(ColumnIdentifier::simple("a", false)),
             Expression::ColumnRef(ColumnIdentifier::simple("b", false)),
@@ -2312,8 +2397,16 @@ mod tests {
             source_text: None,
         }]);
 
-        let result = validate_subquery_context_misuse(&subquery);
+        let result = validate_subquery_context_misuse(&subquery, SubqueryContext::WhereOrEqual);
         assert!(matches!(result, Err(ExecutorError::RowValueMisused)));
+
+        let result_select =
+            validate_subquery_context_misuse(&subquery, SubqueryContext::SelectList);
+        assert!(
+            matches!(result_select, Err(ExecutorError::RowValueMisused)),
+            "row value misuse should still error in SelectList, got {:?}",
+            result_select
+        );
     }
 
     #[test]
@@ -2339,7 +2432,7 @@ mod tests {
             source_text: None,
         }]);
 
-        let result = validate_subquery_context_misuse(&subquery);
+        let result = validate_subquery_context_misuse(&subquery, SubqueryContext::WhereOrEqual);
         assert!(
             result.is_ok(),
             "window function in bare subquery should not be flagged, got {:?}",

--- a/crates/vibesql-executor/src/select/executor/validation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/mod.rs
@@ -25,7 +25,7 @@ pub use aggregates::{
     validate_aggregate_arguments, validate_group_by_window_misuse,
     validate_having_aliased_aggregates, validate_no_nested_aggregates,
     validate_order_by_aliased_window_functions, validate_subquery_context_misuse,
-    validate_window_query_order_by_aggregates,
+    validate_window_query_order_by_aggregates, SubqueryContext,
 };
 pub use column_refs::{extract_column_refs, validate_column_ref};
 pub use join_limits::validate_join_table_limit;
@@ -135,7 +135,7 @@ pub fn validate_select_columns_with_context(
         // (e.g. `WHERE (SELECT AVG(0) FILTER(WHERE outer.c))`). The bare
         // subquery has no FROM clause so its aggregate borrows the outer
         // aggregation context, which SQLite reports as a misuse.
-        validate_subquery_context_misuse(where_expr)?;
+        validate_subquery_context_misuse(where_expr, SubqueryContext::WhereOrEqual)?;
     }
 
     // Validate SELECT list column references (only procedure variables allowed)


### PR DESCRIPTION
## Summary

Implements SQLite's implicit-outer-aggregate-collapse semantics for bare scalar subqueries containing outer-correlated aggregates, and fixes correlated re-evaluation of scalar subqueries containing window functions.

Closes #5104 (partial — see "Out of scope" below).

### Tests fixed
- `window4.test 12.1` — `SELECT (SELECT min(a) OVER ()) FROM t2` now returns `1 2 3` (was `1 1 1`)
- `window4.test 12.2` — `SELECT (SELECT avg(a)) FROM t2` now returns single row `2.0` (was rejected as "misuse of aggregate")
- `window4.test 12.3` — companion to 12.2

### Out of scope (deferred to follow-up)
- `window1.test 57.3` — outer-correlated `sum(y)` inside a window function's `ORDER BY` collapse pattern. Requires schema-aware scope analysis across nested FROM-bearing subqueries. The issue's "Decomposition Recommendation" explicitly allowed splitting; this PR is PR-A in that split. A follow-up issue should be filed for 57.3.

## Implementation

### Validator becomes context-aware (`validation/aggregates.rs`)
`validate_subquery_context_misuse` now takes a `SubqueryContext` parameter:
- `SelectList`: skip the outer-correlated-aggregate rejection (implicit collapse handles it).
- `WhereOrEqual`: preserve SQLite's "misuse of aggregate" rejection in WHERE / HAVING / ORDER BY / aggregate-args / window-args.

Row-value misuse (`(SELECT (a, b))`) is rejected in both contexts. PR #5096 tests are extended to cover both contexts.

### Detection (`aggregation/detection.rs`)
New `select_list_has_outer_aggregate_collapse` walks the SELECT list looking for bare (FROM-less) scalar subqueries whose body contains an aggregate referencing a column. Inside a bare subquery any column ref is necessarily outer.

### Routing (`execute.rs`)
When the detection fires, route through `execute_with_aggregation` even without an outer aggregate or GROUP BY, so the single-group grand-total path runs and `outer_rows` is wired through. Columnar pipelines fall back to the row-oriented path.

### Inner aggregate evaluation (`aggregation/evaluation/aggregate_function.rs`)
Generalizes #4930's GROUP_CONCAT/STRING_AGG outer-correlated path to all aggregates (AVG, SUM, MIN, MAX, COUNT, ...) — when the argument references only outer columns, iterate over outer rows instead of group rows.

### Subquery dispatch (`aggregation/evaluation/subquery.rs`)
For bare scalar subqueries that match the collapse pattern, override `outer_rows` with the current group's rows so the inner aggregate sees the full outer row set rather than only the representative row.

### Correlation walker (`evaluator/combined/subqueries/correlation.rs`)
Walker now descends into `WindowFunction` args / PARTITION BY / ORDER BY. Without this, `(SELECT min(a) OVER ())` over a correlated `a` produced an empty correlation set and the same cache key for every outer row (12.1's `1 1 1` symptom).

## Test plan

- [x] `make test-tcl-file FILE=window4.test` — 216/216 pass. 12.1 / 12.2 / 12.3 all pass.
- [x] `make test-tcl-file FILE=window1.test` — 246/272 pass (same as main). 57.3 still fails per "Out of scope" above; no regression.
- [x] `cargo test --release -p vibesql-executor --tests` — all suites pass (0 failures across 40+ test binaries, including the 2375-test main suite).
- [x] WHERE / HAVING / ORDER BY misuse-of-aggregate path preserved (PR #5096 tests extended for both contexts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)