### PR TITLE
fix(update): defer UNIQUE/PK checks to statement end (#5137)

### DIFF
--- a/crates/vibesql-executor/src/update/constraints.rs
+++ b/crates/vibesql-executor/src/update/constraints.rs
@@ -40,6 +40,22 @@ impl<'a> ConstraintValidator<'a> {
         Ok(())
     }
 
+    /// Validate non-uniqueness constraints (NOT NULL, CHECK) for an updated row.
+    ///
+    /// This is the per-row half of constraint validation. PK and UNIQUE checks must be
+    /// deferred to a post-statement pass (see [`super::index_sync::validate_post_statement_uniqueness`])
+    /// to match SQLite's deferred UNIQUE semantics — e.g. `UPDATE p SET a = a - 1` must
+    /// succeed even when intermediate states transiently duplicate keys.
+    pub fn validate_row_skip_uniqueness(
+        &self,
+        table_name: &str,
+        new_row: &vibesql_storage::Row,
+    ) -> Result<(), ExecutorError> {
+        self.validate_not_null(table_name, new_row)?;
+        self.validate_check_constraints(new_row)?;
+        Ok(())
+    }
+
     /// Validate row against user-defined UNIQUE indexes
     /// This is separate from validate_row to allow access to db
     pub fn validate_unique_indexes(

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -24,7 +24,7 @@ use super::{
     from_clause::{apply_update_from_matches, execute_update_from_join},
     index_sync::{
         find_conflicting_rows_for_update, resolve_cross_update_conflicts_for_replace,
-        validate_cross_update_uniqueness,
+        validate_cross_update_uniqueness, validate_post_statement_uniqueness,
     },
     row_selector::RowSelector,
     triggers,
@@ -331,11 +331,12 @@ pub(super) fn execute_internal(
                 ForeignKeyValidator::validate_constraints(database, table_name, &new_row.values)?;
             }
         } else {
-            // Default: validate all constraints
-            constraint_validator.validate_row(table, table_name, row_index, &new_row, &row)?;
-
-            // Validate user-defined UNIQUE indexes (CREATE UNIQUE INDEX)
-            constraint_validator.validate_unique_indexes(database, table_name, &new_row, &row)?;
+            // Default: validate NOT NULL and CHECK per-row.
+            // PRIMARY KEY / UNIQUE checks are deferred to a post-statement pass
+            // (see validate_post_statement_uniqueness below). This matches SQLite's
+            // deferred UNIQUE semantics — e.g. `UPDATE p SET a = a - 1` must succeed
+            // even when intermediate states transiently duplicate keys (issue #5137).
+            constraint_validator.validate_row_skip_uniqueness(table_name, &new_row)?;
 
             // Enforce FOREIGN KEY constraints (child table)
             if !schema.foreign_keys.is_empty() {
@@ -352,6 +353,28 @@ pub(super) fn execute_internal(
     // Skip for REPLACE mode since conflicts will be resolved by deletion.
     if !use_replace && !use_ignore && updates.len() > 1 {
         validate_cross_update_uniqueness(&updates, schema)?;
+    }
+
+    // Deferred uniqueness check (issue #5137): validate PK / UNIQUE / user-defined unique
+    // indexes against the post-statement table state. Rows that are themselves being
+    // updated to a different key are excluded from "existing" entries, allowing
+    // statements like `UPDATE p SET a = a - 1` to succeed even when intermediate
+    // states transiently duplicate keys.
+    //
+    // Skipped for IGNORE/REPLACE since those modes use per-row validation/resolution.
+    if !use_replace && !use_ignore && !updates.is_empty() {
+        // Re-borrow the table — `database` may have been mutated above for REPLACE,
+        // and we need an immutable read of the current PK/UNIQUE indexes.
+        let table_for_check = database
+            .get_table(table_name)
+            .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+        validate_post_statement_uniqueness(
+            &updates,
+            schema,
+            table_for_check,
+            database,
+            table_name,
+        )?;
     }
 
     // For REPLACE: handle cross-update conflicts by keeping only the last update

--- a/crates/vibesql-executor/src/update/index_sync.rs
+++ b/crates/vibesql-executor/src/update/index_sync.rs
@@ -3,6 +3,7 @@
 //! This module handles:
 //! - Detecting conflicting rows for UPDATE OR REPLACE operations
 //! - Cross-update uniqueness validation (preventing multiple rows from getting same PK)
+//! - Post-statement uniqueness validation (deferred PK/UNIQUE checks against final state)
 //! - Resolving cross-update conflicts for REPLACE mode
 
 use std::collections::{HashMap, HashSet};
@@ -261,4 +262,255 @@ pub(super) fn resolve_cross_update_conflicts_for_replace(
     }
 
     indices_to_delete
+}
+
+/// Validate uniqueness against the post-statement table state (deferred PK/UNIQUE check).
+///
+/// SQLite defers UNIQUE constraint checks until the end of the statement. This means a
+/// statement like `UPDATE p SET a = a - 1` succeeds even when intermediate states transiently
+/// duplicate keys, as long as the final state has no duplicates.
+///
+/// This function implements that semantic. It checks each pending update's new PK / UNIQUE
+/// values against the table's current index state, but excludes any "conflict" with a row
+/// that is itself being updated to a different key in this same statement (because that row
+/// is being moved away from the conflicting key).
+///
+/// Cross-update conflicts (multiple updates landing on the same key) are caught separately
+/// by [`validate_cross_update_uniqueness`], which must be called before this function.
+///
+/// # Arguments
+/// * `updates` - All pending updates: (row_index, old_row, new_row, changed_columns, updates_pk)
+/// * `schema` - Table schema (for PK/UNIQUE constraint metadata)
+/// * `table` - Storage table reference (for accessing PK/UNIQUE hash indexes)
+/// * `database` - Database reference (for accessing user-defined UNIQUE indexes)
+/// * `table_name` - Canonical table name
+pub(super) fn validate_post_statement_uniqueness(
+    updates: &[(usize, Row, Row, HashSet<usize>, bool)],
+    schema: &TableSchema,
+    table: &Table,
+    database: &Database,
+    table_name: &str,
+) -> Result<(), ExecutorError> {
+    // Build a map of (updated_row_index -> new PK values) so we can identify rows that
+    // are being moved away from their original key.
+    let pk_indices_opt = schema.get_primary_key_indices();
+    let mut updated_new_pk: HashMap<usize, Vec<SqlValue>> = HashMap::new();
+    if let Some(ref pk_indices) = pk_indices_opt {
+        for (row_index, _old_row, new_row, _changed, _upd_pk) in updates {
+            let new_pk: Vec<SqlValue> =
+                pk_indices.iter().map(|&i| new_row.values[i].clone()).collect();
+            updated_new_pk.insert(*row_index, new_pk);
+        }
+    }
+
+    // PRIMARY KEY: for each pending update, check the new PK against the table's PK index.
+    // If a conflicting row exists, only error if that row is NOT being updated to a different key
+    // (because rows in the update set will be moved away; only their FINAL state matters).
+    if let Some(ref pk_indices) = pk_indices_opt {
+        if let Some(pk_index) = table.primary_key_index() {
+            for (row_index, old_row, new_row, _changed, _upd_pk) in updates {
+                let new_pk: Vec<SqlValue> =
+                    pk_indices.iter().map(|&i| new_row.values[i].clone()).collect();
+                let old_pk: Vec<SqlValue> =
+                    pk_indices.iter().map(|&i| old_row.values[i].clone()).collect();
+
+                // No-op update for PK: skip
+                if new_pk == old_pk {
+                    continue;
+                }
+
+                if let Some(&existing_idx) = pk_index.get(&new_pk) {
+                    // Self: this row already had this PK
+                    if existing_idx == *row_index {
+                        continue;
+                    }
+
+                    // If the conflicting row is itself being updated to a different PK,
+                    // it's being moved away — not a real conflict.
+                    if let Some(other_new_pk) = updated_new_pk.get(&existing_idx) {
+                        if other_new_pk != &new_pk {
+                            continue;
+                        }
+                        // Otherwise the other row's new PK equals our new PK — that's a
+                        // cross-update collision, which validate_cross_update_uniqueness
+                        // should have already caught. Fall through to error for safety.
+                    }
+
+                    let pk_col_names: Vec<String> =
+                        schema.primary_key.as_ref().unwrap().clone();
+                    let qualified_cols: Vec<String> = pk_col_names
+                        .iter()
+                        .map(|col| format!("{}.{}", schema.name, col))
+                        .collect();
+                    return Err(ExecutorError::ConstraintViolation(format!(
+                        "UNIQUE constraint failed: {}",
+                        qualified_cols.join(", ")
+                    )));
+                }
+            }
+        }
+    }
+
+    // UNIQUE constraints (table-level): same logic as PK.
+    let unique_constraint_indices = schema.get_unique_constraint_indices();
+    let unique_indexes = table.unique_indexes();
+    for (constraint_idx, unique_indices) in unique_constraint_indices.iter().enumerate() {
+        if constraint_idx >= unique_indexes.len() {
+            continue; // No backing hash index — fallback path is not deferred-aware
+        }
+        let unique_index = &unique_indexes[constraint_idx];
+
+        // Build map of (updated_row_index -> new unique values) for this constraint
+        let mut updated_new_unique: HashMap<usize, Vec<SqlValue>> = HashMap::new();
+        for (row_index, _old_row, new_row, _changed, _upd_pk) in updates {
+            let new_uv: Vec<SqlValue> =
+                unique_indices.iter().map(|&i| new_row.values[i].clone()).collect();
+            updated_new_unique.insert(*row_index, new_uv);
+        }
+
+        for (row_index, old_row, new_row, _changed, _upd_pk) in updates {
+            let new_uv: Vec<SqlValue> =
+                unique_indices.iter().map(|&i| new_row.values[i].clone()).collect();
+            let old_uv: Vec<SqlValue> =
+                unique_indices.iter().map(|&i| old_row.values[i].clone()).collect();
+
+            // NULL values are exempt (NULL != NULL in SQL)
+            if new_uv.contains(&SqlValue::Null) {
+                continue;
+            }
+
+            // No-op for this constraint
+            if new_uv == old_uv {
+                continue;
+            }
+
+            if let Some(&existing_idx) = unique_index.get(&new_uv) {
+                if existing_idx == *row_index {
+                    continue;
+                }
+                if let Some(other_new_uv) = updated_new_unique.get(&existing_idx) {
+                    if other_new_uv != &new_uv {
+                        continue;
+                    }
+                }
+                let unique_col_names: Vec<String> =
+                    schema.unique_constraints[constraint_idx].clone();
+                let qualified_cols: Vec<String> = unique_col_names
+                    .iter()
+                    .map(|col| format!("{}.{}", schema.name, col))
+                    .collect();
+                return Err(ExecutorError::ConstraintViolation(format!(
+                    "UNIQUE constraint failed: {}",
+                    qualified_cols.join(", ")
+                )));
+            }
+        }
+    }
+
+    // User-defined UNIQUE indexes (CREATE UNIQUE INDEX).
+    for index_name in database.list_indexes_for_table(table_name) {
+        let index_metadata = match database.get_index(&index_name) {
+            Some(m) => m,
+            None => continue,
+        };
+        if !index_metadata.unique {
+            continue;
+        }
+
+        // Resolve column indices for this index. Skip expression indexes (handled separately).
+        let mut col_idxs: Vec<usize> = Vec::with_capacity(index_metadata.columns.len());
+        let mut is_expression_index = false;
+        for ic in &index_metadata.columns {
+            if ic.get_expression().is_some() {
+                is_expression_index = true;
+                break;
+            }
+            let cn = match ic.column_name() {
+                Some(n) => n,
+                None => {
+                    is_expression_index = true;
+                    break;
+                }
+            };
+            match schema.get_column_index(cn) {
+                Some(ci) => col_idxs.push(ci),
+                None => {
+                    is_expression_index = true;
+                    break;
+                }
+            }
+        }
+        if is_expression_index {
+            continue;
+        }
+
+        // Build map of (updated_row_index -> new index key values) for this index
+        let mut updated_new_key: HashMap<usize, Vec<SqlValue>> = HashMap::new();
+        for (row_index, _old_row, new_row, _changed, _upd_pk) in updates {
+            let nk: Vec<SqlValue> =
+                col_idxs.iter().map(|&i| new_row.values[i].clone()).collect();
+            updated_new_key.insert(*row_index, nk);
+        }
+
+        let index_data = match database.get_index_data(&index_name) {
+            Some(d) => d,
+            None => continue,
+        };
+
+        for (row_index, old_row, new_row, _changed, _upd_pk) in updates {
+            let new_key: Vec<SqlValue> =
+                col_idxs.iter().map(|&i| new_row.values[i].clone()).collect();
+            let old_key: Vec<SqlValue> =
+                col_idxs.iter().map(|&i| old_row.values[i].clone()).collect();
+
+            // NULL values are exempt
+            if new_key.contains(&SqlValue::Null) {
+                continue;
+            }
+
+            // No-op
+            if new_key == old_key {
+                continue;
+            }
+
+            // Get all rows that currently hold this key
+            let conflicting_rows = match index_data.get(&new_key) {
+                Some(v) => v,
+                None => continue,
+            };
+
+            // Check each conflicting row index: skip self and rows being moved off this key
+            let mut real_conflict = false;
+            for existing_idx in &conflicting_rows {
+                if *existing_idx == *row_index {
+                    continue;
+                }
+                if let Some(other_new_key) = updated_new_key.get(existing_idx) {
+                    if other_new_key != &new_key {
+                        // This row is being moved away — not a conflict
+                        continue;
+                    }
+                }
+                real_conflict = true;
+                break;
+            }
+
+            if real_conflict {
+                let columns_str = index_metadata
+                    .columns
+                    .iter()
+                    .map(|col| {
+                        format!("{}.{}", table_name, col.column_name().unwrap_or("?"))
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(ExecutorError::ConstraintViolation(format!(
+                    "UNIQUE constraint failed: {}",
+                    columns_str
+                )));
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/crates/vibesql-executor/tests/update_deferred_uniqueness_tests.rs
+++ b/crates/vibesql-executor/tests/update_deferred_uniqueness_tests.rs
@@ -1,0 +1,304 @@
+//! Regression tests for issue #5137: deferred UNIQUE / PRIMARY KEY checks during UPDATE
+//!
+//! SQLite defers UNIQUE constraint checks until statement end, so updates that shift PK
+//! values within the existing key space — `UPDATE p SET a = a - 1`, swap-via-temp,
+//! composite PK shifts — must succeed when the *final* state has no duplicates, even
+//! if intermediate states transiently duplicate keys.
+//!
+//! These tests verify both:
+//! 1. Statements that previously produced spurious "UNIQUE constraint failed" errors
+//!    now succeed and produce the expected final state.
+//! 2. Statements that produce a genuine final-state duplicate still fail, with the
+//!    error reported at the end of the statement (post-statement deferred check).
+
+use vibesql_executor::{
+    CreateTableExecutor, DeleteExecutor, ExecutorError, InsertExecutor, UpdateExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Run a sequence of SQL statements (`;`-separated), panicking on failure.
+fn run_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        execute_statement(&stmt, db);
+    }
+}
+
+/// Run a single UPDATE statement, returning the result so tests can assert success/failure.
+fn run_update(db: &mut Database, sql: &str) -> Result<usize, ExecutorError> {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse UPDATE");
+    match stmt {
+        vibesql_ast::Statement::Update(u) => UpdateExecutor::execute(&u, db),
+        other => panic!("Expected UPDATE statement, got {:?}", other),
+    }
+}
+
+fn execute_statement(stmt: &vibesql_ast::Statement, db: &mut Database) {
+    use vibesql_ast::Statement;
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(s, db).expect("CREATE TABLE failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, s).expect("INSERT failed");
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(s, db).expect("DELETE failed");
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(s, db).expect("UPDATE failed");
+        }
+        Statement::CreateIndex(s) => {
+            vibesql_executor::CreateIndexExecutor::execute(s, db).expect("CREATE INDEX failed");
+        }
+        _ => panic!("Unsupported statement type in test helper"),
+    }
+}
+
+fn get_rows(db: &Database, table: &str) -> Vec<Vec<SqlValue>> {
+    db.get_table(table)
+        .expect("table not found")
+        .scan()
+        .iter()
+        .map(|r| r.values.to_vec())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Issue reproducer: `UPDATE p SET a = a - 1`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pk_shift_decrement_succeeds() {
+    // From the issue body: must succeed in SQLite, currently errors in VibeSQL.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE p(a INTEGER PRIMARY KEY, b TEXT); \
+         INSERT INTO p VALUES (0, 'zero'); \
+         INSERT INTO p VALUES (1, 'one');",
+    );
+
+    let count = run_update(&mut db, "UPDATE p SET a = a - 1").expect(
+        "UPDATE p SET a = a - 1 should succeed; intermediate UNIQUE collisions must be \
+         deferred until statement end (issue #5137)",
+    );
+    assert_eq!(count, 2);
+
+    let rows = get_rows(&db, "p");
+    assert_eq!(rows.len(), 2);
+    // Row order in storage matches insertion order; values verify the shift happened.
+    assert_eq!(rows[0][0], SqlValue::Integer(-1));
+    assert_eq!(rows[1][0], SqlValue::Integer(0));
+}
+
+#[test]
+fn pk_shift_increment_succeeds() {
+    // Mirror of the decrement case — `UPDATE p SET a = a + 1` shifts upward, transiently
+    // collides between rows, must still succeed.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE p(a INTEGER PRIMARY KEY, b TEXT); \
+         INSERT INTO p VALUES (1, 'one'); \
+         INSERT INTO p VALUES (2, 'two'); \
+         INSERT INTO p VALUES (3, 'three');",
+    );
+
+    let count = run_update(&mut db, "UPDATE p SET a = a + 1").expect("PK increment should succeed");
+    assert_eq!(count, 3);
+
+    let rows = get_rows(&db, "p");
+    let pks: Vec<i64> = rows
+        .iter()
+        .map(|r| match r[0] {
+            SqlValue::Integer(n) => n,
+            _ => panic!("expected integer pk"),
+        })
+        .collect();
+    assert_eq!(pks, vec![2, 3, 4]);
+}
+
+#[test]
+fn pk_negation_succeeds() {
+    // `UPDATE t SET a = -a` is the classic swap-via-temp case: rows (1,2) become (-1,-2)
+    // with no key reuse, but if checks aren't deferred the intermediate states can still
+    // confuse a naive implementation.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT); \
+         INSERT INTO t VALUES (1, 'one'); \
+         INSERT INTO t VALUES (2, 'two');",
+    );
+
+    let count = run_update(&mut db, "UPDATE t SET a = -a").expect("PK negation should succeed");
+    assert_eq!(count, 2);
+
+    let rows = get_rows(&db, "t");
+    let pks: Vec<i64> = rows
+        .iter()
+        .map(|r| match r[0] {
+            SqlValue::Integer(n) => n,
+            _ => panic!("expected integer pk"),
+        })
+        .collect();
+    assert_eq!(pks, vec![-1, -2]);
+}
+
+// ---------------------------------------------------------------------------
+// Composite PK shifts
+// ---------------------------------------------------------------------------
+
+#[test]
+fn composite_pk_shift_succeeds() {
+    // Composite PK (a,b) — shift one column. Intermediate states transiently duplicate
+    // (a,b) pairs across rows but the final state is unique.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE c(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a, b)); \
+         INSERT INTO c VALUES (1, 0, 'r1'); \
+         INSERT INTO c VALUES (1, 1, 'r2'); \
+         INSERT INTO c VALUES (1, 2, 'r3');",
+    );
+
+    let count = run_update(&mut db, "UPDATE c SET b = b - 1").expect(
+        "Composite PK shift on column b should succeed — final keys (1,-1)(1,0)(1,1) are \
+         unique",
+    );
+    assert_eq!(count, 3);
+
+    let rows = get_rows(&db, "c");
+    let pairs: Vec<(i64, i64)> = rows
+        .iter()
+        .map(|r| match (&r[0], &r[1]) {
+            (SqlValue::Integer(a), SqlValue::Integer(b)) => (*a, *b),
+            _ => panic!("expected integer columns"),
+        })
+        .collect();
+    assert_eq!(pairs, vec![(1, -1), (1, 0), (1, 1)]);
+}
+
+// ---------------------------------------------------------------------------
+// User-defined UNIQUE index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unique_index_shift_succeeds() {
+    // `CREATE UNIQUE INDEX` exercises the user-defined UNIQUE index path
+    // (database.list_indexes_for_table → index_data.get) which is separate from
+    // the table-level UNIQUE constraint hash index path.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE u(id INTEGER PRIMARY KEY, k INTEGER); \
+         CREATE UNIQUE INDEX u_k ON u(k); \
+         INSERT INTO u VALUES (1, 10); \
+         INSERT INTO u VALUES (2, 20); \
+         INSERT INTO u VALUES (3, 30);",
+    );
+
+    let count = run_update(&mut db, "UPDATE u SET k = k - 10")
+        .expect("Shift on a UNIQUE-indexed column must succeed when final state is unique");
+    assert_eq!(count, 3);
+
+    let rows = get_rows(&db, "u");
+    let ks: Vec<i64> = rows
+        .iter()
+        .map(|r| match r[1] {
+            SqlValue::Integer(n) => n,
+            _ => panic!("expected integer k"),
+        })
+        .collect();
+    assert_eq!(ks, vec![0, 10, 20]);
+}
+
+// ---------------------------------------------------------------------------
+// Genuine final-state collisions still fail
+// ---------------------------------------------------------------------------
+
+#[test]
+fn genuine_collision_still_fails() {
+    // `UPDATE t SET a = 5` on multiple rows produces a real final-state duplicate.
+    // The cross-update validator catches this case — verify it still errors after the
+    // deferred-uniqueness refactor.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER UNIQUE); \
+         INSERT INTO t VALUES (1, 10); \
+         INSERT INTO t VALUES (2, 20);",
+    );
+
+    let result = run_update(&mut db, "UPDATE t SET a = 5 WHERE id IN (1, 2)");
+    assert!(result.is_err(), "Genuine UNIQUE final-state collision must still error");
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        msg.contains("UNIQUE constraint failed") || msg.contains("multiple rows"),
+        "Error should mention UNIQUE; got {}",
+        msg
+    );
+
+    // Table state should be unchanged.
+    let rows = get_rows(&db, "t");
+    let avals: Vec<i64> = rows
+        .iter()
+        .map(|r| match r[1] {
+            SqlValue::Integer(n) => n,
+            _ => panic!(),
+        })
+        .collect();
+    assert_eq!(avals, vec![10, 20]);
+}
+
+#[test]
+fn collision_with_unmoved_row_still_fails() {
+    // `UPDATE t SET a = 10 WHERE id = 2` lands on the existing PK of row id=1.
+    // Row id=1 is NOT in the update set, so the deferred check should still detect
+    // the collision against it.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT); \
+         INSERT INTO t VALUES (10, 'ten'); \
+         INSERT INTO t VALUES (20, 'twenty');",
+    );
+
+    let result = run_update(&mut db, "UPDATE t SET a = 10 WHERE a = 20");
+    assert!(
+        result.is_err(),
+        "UPDATE landing on an unmoved row's PK must still produce a UNIQUE error"
+    );
+}
+
+#[test]
+fn no_op_assignment_succeeds() {
+    // `UPDATE t SET a = a` should be a no-op for PK and not trigger any UNIQUE error.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT); \
+         INSERT INTO t VALUES (1, 'one'); \
+         INSERT INTO t VALUES (2, 'two');",
+    );
+
+    let count = run_update(&mut db, "UPDATE t SET a = a").expect("a = a should succeed");
+    assert_eq!(count, 2);
+
+    let rows = get_rows(&db, "t");
+    let pks: Vec<i64> = rows
+        .iter()
+        .map(|r| match r[0] {
+            SqlValue::Integer(n) => n,
+            _ => panic!(),
+        })
+        .collect();
+    assert_eq!(pks, vec![1, 2]);
+}


### PR DESCRIPTION
## Summary

`UPDATE p SET a = a - 1` on a table with `PRIMARY KEY(a)` fired `UNIQUE constraint failed: p.a` mid-statement, even though SQLite defers the check until statement end and the final state has no duplicates. This blocks fkey6.test section 3 setup, which gates the deferred-RESTRICT path PR #5133 just shipped.

## Fix

Split constraint validation in the default UPDATE path:

1. **Per-row pass** (`validate_row_skip_uniqueness`): validates NOT NULL / CHECK only.
2. **Cross-update pass** (existing `validate_cross_update_uniqueness`): catches multiple updates landing on the same key.
3. **Post-statement pass** (NEW `validate_post_statement_uniqueness` in `update/index_sync.rs`): validates PK, table UNIQUE constraints, and user-defined UNIQUE indexes against the final table state. When checking a candidate's new key against the existing index, rows that are themselves being updated to a *different* key are excluded — they're being moved away, so they don't constitute a real conflict.

IGNORE / REPLACE paths are unchanged (separate conflict-resolution semantics). UPDATE FROM keeps its per-row check (separate code path, out of scope).

The fix is purposely analogous to the deferred-FK queue in PR #5133, but scoped to a single statement and drained at statement end (in the executor) rather than at transaction end.

## Test plan

- [x] **8 new regression tests** in `crates/vibesql-executor/tests/update_deferred_uniqueness_tests.rs`:
  - issue reproducer `UPDATE p SET a = a - 1`
  - PK increment shift, PK negation, composite PK shift
  - user-defined UNIQUE index shift
  - genuine final-state collision (still errors)
  - collision with an unmoved row (still errors)
  - `UPDATE t SET a = a` no-op
- [x] `cargo test --release -p vibesql-executor --tests` — all 2375 unit tests + all integration tests pass, 0 failures
- [x] `cargo test --release -p vibesql-storage --tests` — all pass, 0 failures
- [x] `make test-tcl-file FILE=fkey6.test` before/after: **15 -> 16 passing** (+1, -1 failure). Section 3 setup advances; remaining failures are FK-related (out of scope, PR #5133 territory).
- [x] `make test-tcl-file FILE=update.test` — 123/134 pass, 1 failure pre-existing (partial indexes unsupported)
- [x] `make test-tcl-file FILE=index.test` — 68/68 non-skipped pass, 0 failures
- [x] `make test-tcl-file FILE=insert.test` — 50/51 non-skipped pass, 1 failure pre-existing (partial indexes)

## Notes

- Did **not** touch FK code in `delete/integrity.rs` or `update/foreign_keys.rs` — that's PR #5133's territory.
- Verified that `.loom/scripts/worktree.sh` *does* now attempt submodule init (loom#3250 ref); a partial failure occurred for two submodules but `git submodule update --init --recursive` inside the worktree completed successfully.
- The deferred-UNIQUE queue lives implicitly in the existing `updates: Vec<(usize, Row, Row, ...)>` collection in `executor::execute_internal` — no new state struct needed. The new function reads it after cross-update validation.

Closes #5137