### PR TITLE
feat(fkey): self-FK + deferral introspection (Phase C3 of #5085)

### DIFF
--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -31,19 +31,10 @@ pub fn check_no_child_references(
         return Ok(());
     }
 
-    let parent_schema = db
+    let _parent_schema = db
         .catalog
         .get_table(parent_table_name)
         .ok_or_else(|| ExecutorError::TableNotFound(parent_table_name.to_string()))?;
-
-    // This check is only meaningful if the parent table has a primary key.
-    let pk_indices = match parent_schema.get_primary_key_indices() {
-        Some(indices) => indices,
-        None => return Ok(()),
-    };
-
-    let parent_key_values: Vec<SqlValue> =
-        pk_indices.iter().map(|&idx| parent_row.values[idx].clone()).collect();
 
     // Optimization: Check if any table in the database has foreign keys at all
     let has_any_fks = db.catalog.list_tables().iter().any(|table_name| {
@@ -70,12 +61,20 @@ pub fn check_no_child_references(
     let in_txn = db.in_transaction();
 
     // Collect all child tables that reference this parent row
-    // We need to collect first to avoid borrowing issues when we mutate
+    // We need to collect first to avoid borrowing issues when we mutate.
+    //
+    // Phase C3 of #5085 / fkey8-3.1: each FK supplies its own
+    // `parent_column_indices`, which may differ from the parent's PRIMARY
+    // KEY (e.g. `FOREIGN KEY(b, c) REFERENCES self(d, e)` where d/e are
+    // backed by a UNIQUE INDEX rather than the PK). The FK match must
+    // therefore extract `parent_key_values` from the FK's *parent-side*
+    // columns, not from the parent's PK.
     let mut actions_to_perform: Vec<(
         String,
         vibesql_catalog::ForeignKeyConstraint,
         usize,
         ReferentialAction,
+        Vec<SqlValue>, // parent_key_values for THIS FK
     )> = Vec::new();
 
     for table_name in db.catalog.list_tables() {
@@ -91,8 +90,28 @@ pub fn check_no_child_references(
                 continue;
             }
 
-            // Check if any row in the child table references the parent row
-            // Use scan_live() to skip soft-deleted rows
+            // Resolve the FK's parent-side column indices and extract the
+            // values from the parent row being deleted.
+            let parent_indices = crate::foreign_key_check::resolved_parent_indices_for_fk(db, fk);
+            if parent_indices.is_empty()
+                || parent_indices.iter().any(|&idx| idx >= parent_row.values.len())
+            {
+                continue;
+            }
+            let fk_parent_key_values: Vec<SqlValue> =
+                parent_indices.iter().map(|&idx| parent_row.values[idx].clone()).collect();
+
+            // Skip if the parent-side key values are NULL — NULLs don't
+            // participate in FK matching.
+            if fk_parent_key_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+                continue;
+            }
+
+            let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
+
+            // Check if any row in the child table references this parent
+            // row's FK-target columns. Use scan_live() to skip
+            // soft-deleted rows.
             let child_table = db.get_table(&table_name).unwrap();
             let has_references = child_table.scan_live().any(|(_, child_row)| {
                 let child_fk_values: Vec<SqlValue> =
@@ -103,7 +122,15 @@ pub fn check_no_child_references(
                     return false;
                 }
 
-                child_fk_values == parent_key_values
+                child_fk_values.iter().zip(&fk_parent_key_values).enumerate().all(
+                    |(i, (cv, pv))| {
+                        crate::foreign_key_check::fk_values_equal(
+                            cv,
+                            pv,
+                            parent_collations.get(i).and_then(|c| c.as_deref()),
+                        )
+                    },
+                )
             });
 
             if has_references {
@@ -112,13 +139,14 @@ pub fn check_no_child_references(
                     fk.clone(),
                     fk_idx,
                     fk.on_delete.clone(),
+                    fk_parent_key_values,
                 ));
             }
         }
     }
 
     // Now perform the actions
-    for (child_table_name, fk, fk_idx, action) in actions_to_perform {
+    for (child_table_name, fk, fk_idx, action, parent_key_values) in actions_to_perform {
         match action {
             ReferentialAction::Restrict => {
                 // RESTRICT is immediate by default, but the session

--- a/crates/vibesql-executor/src/insert/foreign_keys.rs
+++ b/crates/vibesql-executor/src/insert/foreign_keys.rs
@@ -74,6 +74,28 @@ pub fn validate_foreign_key_constraints(
             continue;
         }
 
+        // Phase C3 of #5085 / fkey8-3.0: self-referential FK. When the FK
+        // points back at the table being inserted into, the row itself
+        // can satisfy the constraint (e.g. INSERT ... VALUES (1, 'a',
+        // 'a', 'a', 'a') with FK(b, c) REFERENCES self(d, e)). SQLite
+        // checks the parent index *after* the row is inserted, so the
+        // row participates in its own FK check. Mirror that here.
+        if fk.parent_table.eq_ignore_ascii_case(table_name) {
+            let row_satisfies_fk = parent_indices.iter().zip(&fk_values).enumerate().all(
+                |(i, (&parent_idx, fk_val))| match row_values.get(parent_idx) {
+                    Some(parent_val) => crate::foreign_key_check::fk_values_equal(
+                        fk_val,
+                        parent_val,
+                        parent_collations.get(i).and_then(|c| c.as_deref()),
+                    ),
+                    None => false,
+                },
+            );
+            if row_satisfies_fk {
+                continue;
+            }
+        }
+
         let should_defer = in_txn && (fk.initially_deferred || session_defer);
         if should_defer {
             deferred.push(DeferredFkViolation {

--- a/crates/vibesql-executor/src/insert/row_validator.rs
+++ b/crates/vibesql-executor/src/insert/row_validator.rs
@@ -416,6 +416,26 @@ impl<'a> RowValidator<'a> {
                 continue;
             }
 
+            // Phase C3 of #5085 / fkey8-3.0: self-referential FK. When the
+            // FK points back at the table being inserted into, the row
+            // itself can satisfy the constraint (SQLite checks the parent
+            // index *after* the row is inserted). Mirror that here.
+            if fk.parent_table.eq_ignore_ascii_case(self.table_name) {
+                let row_satisfies_fk = parent_indices.iter().zip(fk_values).enumerate().all(
+                    |(i, (&parent_idx, fk_val))| match full_row_values.get(parent_idx) {
+                        Some(parent_val) => crate::foreign_key_check::fk_values_equal(
+                            fk_val,
+                            parent_val,
+                            parent_collations.get(i).and_then(|c| c.as_deref()),
+                        ),
+                        None => false,
+                    },
+                );
+                if row_satisfies_fk {
+                    continue;
+                }
+            }
+
             // FK row-existence violation. Defer if the constraint is
             // INITIALLY DEFERRED or the session has defer_foreign_keys=ON,
             // *and* we're inside a transaction. Outside a transaction we

--- a/crates/vibesql-executor/src/introspection.rs
+++ b/crates/vibesql-executor/src/introspection.rs
@@ -383,6 +383,20 @@ impl<'a> IntrospectionExecutor<'a> {
             // Add ON UPDATE action
             fk_def.push_str(&format!(" ON UPDATE {}", format_referential_action(&fk.on_update)));
 
+            // Phase C3 of #5085: emit deferral state when non-default.
+            // The default for SQLite is NOT DEFERRABLE; we omit that case
+            // to keep CREATE TABLE output minimal. When the constraint is
+            // DEFERRABLE we emit `DEFERRABLE INITIALLY DEFERRED` or
+            // `DEFERRABLE INITIALLY IMMEDIATE`, matching SQLite's
+            // sqlite_master format.
+            if fk.is_deferrable {
+                if fk.initially_deferred {
+                    fk_def.push_str(" DEFERRABLE INITIALLY DEFERRED");
+                } else {
+                    fk_def.push_str(" DEFERRABLE INITIALLY IMMEDIATE");
+                }
+            }
+
             definitions.push(fk_def);
         }
 

--- a/crates/vibesql-executor/tests/foreign_key_deferred_phase_c3_tests.rs
+++ b/crates/vibesql-executor/tests/foreign_key_deferred_phase_c3_tests.rs
@@ -1,0 +1,387 @@
+//! Tests for Phase C3 of #5085 — deferred FK edge cases.
+//!
+//! Covers:
+//!
+//! 1. End-to-end savepoint queue truncation: a deferred violation is queued
+//!    inside a savepoint, then `ROLLBACK TO SAVEPOINT` discards it; the
+//!    outer COMMIT must succeed (Phase C2 wired the snapshot index;
+//!    Phase C3 verifies the integration end-to-end).
+//! 2. `DEFERRABLE INITIALLY IMMEDIATE` defers when the session pragma
+//!    `defer_foreign_keys=ON` is set, mirroring SQLite's documented
+//!    behaviour (the session pragma overrides per-constraint defaults).
+//! 3. `DEFERRABLE INITIALLY IMMEDIATE` enforces immediately when the
+//!    session pragma is OFF (the constraint default).
+//! 4. Self-referential FK INSERT (`fkey8-3.0`): a single row that
+//!    satisfies its own self-FK must succeed.
+//! 5. Self-referential FK DELETE (`fkey8-3.1`): deleting the last
+//!    surviving parent of a self-FK row must fail when the FK references
+//!    a non-PK key.
+//! 6. `SHOW CREATE TABLE` emits `DEFERRABLE INITIALLY {DEFERRED,IMMEDIATE}`
+//!    for FKs whose deferral state is non-default; omits the clause for
+//!    NOT-DEFERRABLE FKs.
+
+use vibesql_ast::Statement;
+use vibesql_executor::{
+    BeginTransactionExecutor, CommitExecutor, CreateIndexExecutor, CreateTableExecutor,
+    DeleteExecutor, InsertExecutor, IntrospectionExecutor, ReleaseSavepointExecutor,
+    RollbackExecutor, RollbackToSavepointExecutor, SavepointExecutor, UpdateExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn run(db: &mut Database, sql: &str) -> Result<String, String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("parse error: {:?}", e))?;
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::CreateIndex(s) => CreateIndexExecutor::execute(&s, db)
+            .map(|_| String::new())
+            .map_err(|e| e.to_string()),
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::BeginTransaction(s) => {
+            BeginTransactionExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        Statement::Commit(s) => CommitExecutor::execute(&s, db).map_err(|e| e.to_string()),
+        Statement::Rollback(s) => RollbackExecutor::execute(&s, db).map_err(|e| e.to_string()),
+        Statement::Savepoint(s) => SavepointExecutor::execute(&s, db).map_err(|e| e.to_string()),
+        Statement::RollbackToSavepoint(s) => {
+            RollbackToSavepointExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        Statement::ReleaseSavepoint(s) => {
+            ReleaseSavepointExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        other => Err(format!("unsupported statement type in test helper: {:?}", other)),
+    }
+}
+
+fn fresh_db() -> Database {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    db
+}
+
+// ---------------------------------------------------------------------------
+// 1. End-to-end savepoint queue truncation (Phase C2 integration verified
+//    end-to-end here).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn savepoint_rollback_discards_deferred_violation_then_commit_succeeds() {
+    // The exact scenario the issue calls out: queue a deferred FK
+    // violation inside a savepoint, ROLLBACK TO the savepoint, then
+    // COMMIT. The COMMIT must succeed because the queued violation is
+    // discarded together with the savepoint's row mutations.
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+
+    run(&mut db, "INSERT INTO p VALUES (1)").unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+    run(&mut db, "SAVEPOINT sp1").unwrap();
+
+    // Queue the violation inside the savepoint.
+    run(&mut db, "INSERT INTO c VALUES (10, 999)").expect("deferred INSERT must succeed");
+    assert_eq!(db.deferred_fk_violations().len(), 1, "violation must be queued");
+
+    // ROLLBACK TO the savepoint — the queue must be truncated.
+    run(&mut db, "ROLLBACK TO SAVEPOINT sp1").unwrap();
+    assert_eq!(
+        db.deferred_fk_violations().len(),
+        0,
+        "ROLLBACK TO SAVEPOINT must truncate the deferred-FK queue"
+    );
+
+    // COMMIT must succeed: there is no outstanding violation.
+    run(&mut db, "COMMIT").expect("COMMIT must succeed after the violation is discarded");
+
+    let c = db.get_table("c").unwrap();
+    assert_eq!(c.scan().len(), 0, "rolled-back child row must not be visible");
+}
+
+#[test]
+fn nested_savepoint_only_inner_violations_discarded() {
+    // Outer SAVEPOINT contains one queued violation; inner SAVEPOINT
+    // contains a second. Rolling back to the inner savepoint discards
+    // only the inner violation; rolling back to the outer discards both.
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+
+    run(&mut db, "SAVEPOINT outer_sp").unwrap();
+    run(&mut db, "INSERT INTO c VALUES (1, 100)").unwrap();
+    assert_eq!(db.deferred_fk_violations().len(), 1);
+
+    run(&mut db, "SAVEPOINT inner_sp").unwrap();
+    run(&mut db, "INSERT INTO c VALUES (2, 200)").unwrap();
+    run(&mut db, "INSERT INTO c VALUES (3, 300)").unwrap();
+    assert_eq!(db.deferred_fk_violations().len(), 3);
+
+    // Rollback inner only.
+    run(&mut db, "ROLLBACK TO SAVEPOINT inner_sp").unwrap();
+    assert_eq!(
+        db.deferred_fk_violations().len(),
+        1,
+        "ROLLBACK TO inner must discard only inner violations"
+    );
+
+    // Rollback outer next.
+    run(&mut db, "ROLLBACK TO SAVEPOINT outer_sp").unwrap();
+    assert_eq!(
+        db.deferred_fk_violations().len(),
+        0,
+        "ROLLBACK TO outer must discard the remaining violation"
+    );
+
+    run(&mut db, "COMMIT").expect("COMMIT must succeed once all violations rolled back");
+}
+
+// ---------------------------------------------------------------------------
+// 2. DEFERRABLE INITIALLY IMMEDIATE: session pragma overrides constraint
+//    default.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn initially_immediate_defers_when_session_pragma_enabled() {
+    // Per SQLite documentation: `PRAGMA defer_foreign_keys=ON` defers
+    // *all* FK checks for the duration of the current transaction,
+    // including INITIALLY IMMEDIATE. Confirm VibeSQL matches.
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY IMMEDIATE)",
+    )
+    .unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+    db.set_defer_foreign_keys(true);
+
+    // Without the session pragma this would fail immediately. With the
+    // pragma it must be queued for COMMIT-time re-check.
+    run(&mut db, "INSERT INTO c VALUES (1, 99)")
+        .expect("INITIALLY IMMEDIATE must defer when defer_foreign_keys=ON");
+    assert_eq!(db.deferred_fk_violations().len(), 1);
+
+    // The pragma stays effective: COMMIT then re-validates.
+    let err = run(&mut db, "COMMIT").expect_err("COMMIT must fail with unresolved violation");
+    assert!(err.contains("FOREIGN KEY"));
+}
+
+#[test]
+fn initially_immediate_enforces_immediately_without_session_pragma() {
+    // Default behaviour: INITIALLY IMMEDIATE acts like a non-deferrable
+    // constraint when `defer_foreign_keys=OFF` (the SQL default).
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY IMMEDIATE)",
+    )
+    .unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+    // No pragma; constraint default takes effect.
+    let err = run(&mut db, "INSERT INTO c VALUES (1, 99)")
+        .expect_err("INITIALLY IMMEDIATE must fail at INSERT when session pragma is off");
+    assert!(err.contains("FOREIGN KEY"));
+    assert_eq!(
+        db.deferred_fk_violations().len(),
+        0,
+        "INITIALLY IMMEDIATE must not queue a violation when pragma is off"
+    );
+    run(&mut db, "ROLLBACK").unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 3. Self-referential FK INSERT (fkey8-3.0).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn self_referential_fk_insert_self_satisfying_row_succeeds() {
+    // Mirror of fkey8-3.0: a row whose FK columns refer back to its own
+    // candidate key columns must be insertable when no prior parent row
+    // exists. SQLite checks the parent index after the row is inserted;
+    // VibeSQL's row-existence check now considers the new row itself
+    // when child_table == parent_table.
+    let mut db = fresh_db();
+    run(
+        &mut db,
+        "CREATE TABLE t2 (a INTEGER PRIMARY KEY, b TEXT, c TEXT, d TEXT, e TEXT, FOREIGN KEY(b, c) REFERENCES t2(d, e))",
+    )
+    .unwrap();
+    run(&mut db, "CREATE UNIQUE INDEX idx_t2_de ON t2(d, e)").unwrap();
+
+    // First row: b/c match its own d/e — must succeed.
+    run(&mut db, "INSERT INTO t2 VALUES (1, 'one', 'one', 'one', 'one')")
+        .expect("self-satisfying self-FK row must insert");
+
+    // Second row: b/c match row 1's d/e.
+    run(&mut db, "INSERT INTO t2 VALUES (2, 'one', 'one', 'one', 'two')")
+        .expect("second row referencing existing parent must insert");
+
+    let t2 = db.get_table("t2").unwrap();
+    assert_eq!(t2.scan().len(), 2);
+}
+
+#[test]
+fn self_referential_fk_insert_with_no_match_fails() {
+    // The self-FK fix must NOT silently allow rows whose b/c columns
+    // do not match any (d, e) values — including their own.
+    let mut db = fresh_db();
+    run(
+        &mut db,
+        "CREATE TABLE t2 (a INTEGER PRIMARY KEY, b TEXT, c TEXT, d TEXT, e TEXT, FOREIGN KEY(b, c) REFERENCES t2(d, e))",
+    )
+    .unwrap();
+    run(&mut db, "CREATE UNIQUE INDEX idx_t2_de ON t2(d, e)").unwrap();
+
+    let err = run(&mut db, "INSERT INTO t2 VALUES (1, 'x', 'y', 'a', 'b')")
+        .expect_err("non-matching self-FK row must fail");
+    assert!(err.contains("FOREIGN KEY"));
+}
+
+// ---------------------------------------------------------------------------
+// 4. Self-referential DELETE (fkey8-3.1).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn self_referential_fk_delete_orphans_child_row_fails() {
+    // Mirror of fkey8-3.1. After the two inserts, deleting the only
+    // row whose (d, e) matches row-2's (b, c) must fail with NO ACTION.
+    let mut db = fresh_db();
+    run(
+        &mut db,
+        "CREATE TABLE t2 (a INTEGER PRIMARY KEY, b TEXT, c TEXT, d TEXT, e TEXT, FOREIGN KEY(b, c) REFERENCES t2(d, e))",
+    )
+    .unwrap();
+    run(&mut db, "CREATE UNIQUE INDEX idx_t2_de ON t2(d, e)").unwrap();
+    run(&mut db, "INSERT INTO t2 VALUES (1, 'one', 'one', 'one', 'one')").unwrap();
+    // Row 2's b/c reference row 1's d/e (NOT row 2's own d/e).
+    run(&mut db, "INSERT INTO t2 VALUES (2, 'one', 'one', 'two', 'two')").unwrap();
+
+    let err = run(&mut db, "DELETE FROM t2 WHERE a = 1")
+        .expect_err("DELETE that orphans a self-referencing child must fail");
+    assert!(err.contains("FOREIGN KEY"));
+}
+
+// ---------------------------------------------------------------------------
+// 5. SHOW CREATE TABLE deferral output.
+// ---------------------------------------------------------------------------
+
+fn show_create(db: &Database, table: &str) -> String {
+    let sql = format!("SHOW CREATE TABLE {}", table);
+    let stmt = Parser::parse_sql(&sql).expect("parse SHOW CREATE TABLE");
+    let s = match stmt {
+        Statement::ShowCreateTable(s) => s,
+        other => panic!("expected SHOW CREATE TABLE, got {:?}", other),
+    };
+    let executor = IntrospectionExecutor::new(db);
+    let result = executor.execute_show_create_table(&s).expect("show create table");
+    let row = &result.rows[0];
+    match row.values.get(1) {
+        Some(SqlValue::Varchar(v)) => v.to_string(),
+        other => panic!("unexpected value for Create Table column: {:?}", other),
+    }
+}
+
+#[test]
+fn show_create_table_emits_initially_deferred() {
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+
+    let sql = show_create(&mut db, "c");
+    assert!(
+        sql.contains("DEFERRABLE INITIALLY DEFERRED"),
+        "expected DEFERRABLE INITIALLY DEFERRED in SHOW CREATE TABLE output, got: {}",
+        sql
+    );
+}
+
+#[test]
+fn show_create_table_emits_initially_immediate_for_deferrable_fk() {
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY IMMEDIATE)",
+    )
+    .unwrap();
+
+    let sql = show_create(&mut db, "c");
+    assert!(
+        sql.contains("DEFERRABLE INITIALLY IMMEDIATE"),
+        "expected DEFERRABLE INITIALLY IMMEDIATE in SHOW CREATE TABLE output, got: {}",
+        sql
+    );
+}
+
+#[test]
+fn show_create_table_omits_deferral_for_non_deferrable_fk() {
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(&mut db, "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id))").unwrap();
+
+    let sql = show_create(&mut db, "c");
+    assert!(
+        !sql.contains("DEFERRABLE"),
+        "non-deferrable FK must not emit a DEFERRABLE clause; got: {}",
+        sql
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Resolution scenario from the issue body — deferred FK violation that
+//    becomes valid before COMMIT.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deferred_fk_violation_resolved_by_later_parent_insert_commits() {
+    // Acceptance criterion: "Rust unit test: deferred FK violation that
+    // becomes valid before COMMIT (parent inserted later) commits
+    // successfully." There is already an analogous test in
+    // foreign_key_deferred_tests.rs; this version exercises the
+    // session-pragma path (rather than INITIALLY DEFERRED) to broaden
+    // coverage.
+    let mut db = fresh_db();
+    run(&mut db, "CREATE TABLE p (id INTEGER PRIMARY KEY)").unwrap();
+    run(&mut db, "CREATE TABLE c (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id))").unwrap();
+
+    run(&mut db, "BEGIN").unwrap();
+    db.set_defer_foreign_keys(true);
+
+    run(&mut db, "INSERT INTO c VALUES (1, 42)").unwrap();
+    run(&mut db, "INSERT INTO p VALUES (42)").unwrap();
+
+    run(&mut db, "COMMIT").expect("COMMIT must succeed once parent is inserted");
+
+    let c = db.get_table("c").unwrap();
+    let p = db.get_table("p").unwrap();
+    assert_eq!(c.scan().len(), 1);
+    assert_eq!(p.scan().len(), 1);
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3139,6 +3139,9 @@ array set vibesql_skip_tests {
 
     fkey5-7.2 "Cascades from skipped fkey5-7.1 (INSERT OR IGNORE with FK violation)"
     fkey5-7.3 "Cascades from skipped fkey5-7.1 (INSERT OR IGNORE with FK violation)"
+
+    fkey8-2.3.1 "WITHOUT ROWID + AFTER DELETE trigger doing INSERT OR REPLACE on parent (out of scope for #5126; trigger/WITHOUT-ROWID interaction)"
+    fkey8-5.2 "UPDATE WHERE evaluation against TEXT-stored numeric value diverges inside a transaction (separate UPDATE engine bug; tracked outside #5126; analogous to #5137)"
 }
 
 # Pattern-based skip list for tests with many numbered variants


### PR DESCRIPTION
## Summary

Phase C3 of Bucket C (#5085, parent #5071) — final cleanup of the deferred-FK rollout. Builds on Phase C1 (#5124) and Phase C2 (#5133, both merged).

This PR addresses the four remaining `fkey8` failures called out in #5126:
- **fkey8-3.0**: self-referential FK INSERT now considers the row itself as a candidate parent.
- **fkey8-3.1**: parent-side FK enforcement now uses each FK's own `parent_column_indices` (not the parent's PK), so FKs that target a non-PK candidate key are enforced on DELETE.
- **fkey8-2.3.1, fkey8-5.2**: documented in `scripts/tester_vibesql.tcl` skip list with concrete next-step pointers (per acceptance criterion).

Plus the two introspection / verification items the issue calls out:
- **`SHOW CREATE TABLE`** now emits `DEFERRABLE INITIALLY {DEFERRED,IMMEDIATE}` for FKs whose deferral state is non-default.
- **Savepoint queue truncation** (already wired by Phase C2 via `Savepoint::deferred_fk_snapshot_index`) is verified end-to-end with new Rust integration tests, including nested savepoints.

## INITIALLY IMMEDIATE gating

The Phase C2 gating logic (`in_txn && (fk.initially_deferred || session_defer)`) already matches SQLite docs:
- `DEFERRABLE INITIALLY IMMEDIATE` enforces immediately when `PRAGMA defer_foreign_keys=OFF` (the default).
- `PRAGMA defer_foreign_keys=ON` defers *all* FK checks for the transaction, including INITIALLY IMMEDIATE.

Two new tests pin both directions explicitly so this is regression-protected.

## Files changed

- `crates/vibesql-executor/src/insert/foreign_keys.rs` — self-FK row-self check.
- `crates/vibesql-executor/src/insert/row_validator.rs` — parallel self-FK row-self check.
- `crates/vibesql-executor/src/delete/integrity.rs` — parent-side FK key extraction now per-FK using `resolved_parent_indices_for_fk` instead of parent PK; collation-aware comparison via `fk_values_equal`.
- `crates/vibesql-executor/src/introspection.rs` — emit DEFERRABLE clause in SHOW CREATE TABLE.
- `crates/vibesql-executor/tests/foreign_key_deferred_phase_c3_tests.rs` — 11 new integration tests.
- `scripts/tester_vibesql.tcl` — skip list entries for fkey8-2.3.1 and fkey8-5.2 with documented reasons.

## Test plan

- [x] **11 new integration tests** in `foreign_key_deferred_phase_c3_tests.rs`.
- [x] All 23 existing `foreign_key_deferred_tests.rs` tests pass (Phase C2 regression check).
- [x] `cargo test --release -p vibesql-executor --tests` — clean.
- [x] `cargo test --release -p vibesql-storage --tests` — clean (582 + 16 + 13 pass).

## TCL acceptance test results

| File         | Before | After | Notes                                          |
|--------------|--------|-------|------------------------------------------------|
| fkey1.test   | 15/19  | 15/19 | No change; pre-existing failures unrelated     |
| fkey5.test   | 53/53  | 53/53 | No regression                                  |
| fkey6.test   | 18/33  | 19/33 | +1 (self-FK fix surfaces fkey6-3.3.4)          |
| fkey7.test   | 0/0    | 0/0   | Empty under tcl runner                         |
| fkey8.test   | 8/12   | 10/10 | +2 (3.0, 3.1); 2.3.1 + 5.2 skip-listed         |

Specifically advanced fkey8 cases: **3.0** and **3.1** now pass.

Documented out-of-scope:
- **fkey8-2.3.1** — WITHOUT ROWID + AFTER DELETE trigger doing INSERT OR REPLACE on parent. Separate trigger/WITHOUT-ROWID interaction bug.
- **fkey8-5.2** — UPDATE WHERE evaluation against TEXT-stored numeric value diverges *inside a transaction*; the SELECT path matches the same comparison. Analogous in shape to the UPDATE-engine bug fixed in #5137 but on the WHERE-eval side. Should be filed as a follow-up issue.

Sanity:
- `make test-tcl-file FILE=insert.test` — 50/51 (pre-existing partial-index skip)
- `make test-tcl-file FILE=delete.test` — 44/44

## Notable design decisions

1. **Self-FK row-self check is implemented in both `insert/foreign_keys.rs` and `insert/row_validator.rs`** because both row validators carry parallel FK-existence logic; keeping them in lock-step is safer than introducing a shared helper at this point in the rollout.

2. **The DELETE-side fix changes the loop signature** to carry per-FK `parent_key_values` through `actions_to_perform`. The previous single-PK extraction at the top of `check_no_child_references` only ever worked when FKs referenced the parent's PK columns exactly; non-PK candidate keys silently bypassed FK enforcement. The new loop honours each FK's own parent-side columns and applies collation-aware comparison via `fk_values_equal`.

3. **CASCADE/SET NULL/SET DEFAULT helpers** still take `parent_key_values` as `&[SqlValue]` and continue to use exact equality (`==`). Switching them to `fk_values_equal` would broaden semantics; the current scope only fixes the matching for RESTRICT/NO ACTION on non-PK FK targets. Wider collation-aware cascade can be a follow-up.

Closes #5126

🤖 Generated with [Claude Code](https://claude.com/claude-code)