### PR TITLE
fix(update): defer UNIQUE/PK checks in UPDATE FROM (#5140)

### DIFF
--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -29,6 +29,7 @@ use super::{
     row_selector::RowSelector,
     triggers,
     value_updater::ValueUpdater,
+    PendingUpdate,
 };
 
 /// Internal implementation supporting both schema caching, procedural context, and trigger
@@ -239,8 +240,8 @@ pub(super) fn execute_internal(
     let use_replace = matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Replace));
 
     // Step 6: Build list of updates (two-phase execution for SQL semantics)
-    // Each update consists of: (row_index, old_row, new_row, changed_columns, updates_pk)
-    let mut updates: Vec<(usize, Row, Row, HashSet<usize>, bool)> = Vec::new();
+    // Each `PendingUpdate` carries: row_index, old_row, new_row, changed_columns, updates_pk.
+    let mut updates: Vec<PendingUpdate> = Vec::new();
 
     // Track rows to delete for REPLACE conflict resolution (before applying updates)
     let mut rows_to_delete_for_replace: Vec<usize> = Vec::new();
@@ -360,7 +361,13 @@ pub(super) fn execute_internal(
             }
         }
 
-        updates.push((row_index, row.clone(), new_row, changed_columns, updates_pk));
+        updates.push(PendingUpdate {
+            row_index,
+            old_row: row.clone(),
+            new_row,
+            changed_columns,
+            updates_pk,
+        });
     }
 
     // Cross-update uniqueness validation: check if multiple updates would produce
@@ -408,7 +415,7 @@ pub(super) fn execute_internal(
         rows_to_delete_for_replace.dedup();
 
         // Filter out any rows that we're going to update (shouldn't delete our own rows)
-        let update_indices: HashSet<usize> = updates.iter().map(|(idx, _, _, _, _)| *idx).collect();
+        let update_indices: HashSet<usize> = updates.iter().map(|u| u.row_index).collect();
         rows_to_delete_for_replace.retain(|idx| !update_indices.contains(idx));
 
         if !rows_to_delete_for_replace.is_empty() {
@@ -470,9 +477,14 @@ pub(super) fn execute_internal(
 
     // Step 7: Handle CASCADE updates for primary key changes (before triggers)
     // This must happen after validation but before applying parent updates
-    for (_row_index, old_row, new_row, _changed_columns, updates_pk) in &updates {
-        if *updates_pk {
-            ForeignKeyValidator::check_no_child_references(database, table_name, old_row, new_row)?;
+    for u in &updates {
+        if u.updates_pk {
+            ForeignKeyValidator::check_no_child_references(
+                database,
+                table_name,
+                &u.old_row,
+                &u.new_row,
+            )?;
         }
     }
 
@@ -480,8 +492,8 @@ pub(super) fn execute_internal(
     if !updates.is_empty() {
         // Compute aggregate changed columns across all updates
         let mut all_changed_columns = HashSet::new();
-        for (_, _, _, changed_cols, _) in &updates {
-            all_changed_columns.extend(changed_cols.iter().copied());
+        for u in &updates {
+            all_changed_columns.extend(u.changed_columns.iter().copied());
         }
 
         let optimizer = DmlOptimizer::new(database, table_name);
@@ -502,13 +514,13 @@ pub(super) fn execute_internal(
 
     // Fire BEFORE UPDATE triggers for all rows (before database mutation)
     if has_triggers {
-        for (_row_index, old_row, new_row, _changed_columns, _updates_pk) in &updates {
+        for u in &updates {
             crate::TriggerFirer::execute_before_triggers(
                 database,
                 table_name,
                 vibesql_ast::TriggerEvent::Update(None),
-                Some(old_row),
-                Some(new_row),
+                Some(&u.old_row),
+                Some(&u.new_row),
             )?;
         }
     }
@@ -523,12 +535,17 @@ pub(super) fn execute_internal(
 
     // Collect the updates first
     let mut index_updates = Vec::new();
-    for (index, old_row, new_row, changed_columns, _updates_pk) in &updates {
+    for u in &updates {
         table_mut
-            .update_row_selective(*index, new_row.clone(), changed_columns)
+            .update_row_selective(u.row_index, u.new_row.clone(), &u.changed_columns)
             .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
 
-        index_updates.push((*index, old_row.clone(), new_row.clone(), changed_columns.clone()));
+        index_updates.push((
+            u.row_index,
+            u.old_row.clone(),
+            u.new_row.clone(),
+            u.changed_columns.clone(),
+        ));
     }
 
     // Fire AFTER UPDATE triggers for all updated rows
@@ -1138,57 +1155,93 @@ fn execute_update_from(
         return Ok(0);
     }
 
-    // Validate constraints for each update
-    let table = database
-        .get_table(table_name)
-        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+    // Validate constraints for each update.
+    //
+    // Issue #5140: PRIMARY KEY / UNIQUE checks are deferred to a post-statement pass
+    // (matching the default UPDATE path's #5137 fix in PR #5138). The per-row
+    // `validate_row_skip_uniqueness` enforces NOT NULL / CHECK only; deferred-aware
+    // PK / UNIQUE / user-defined-unique-index validation runs after the loop via
+    // `validate_post_statement_uniqueness`. Without this, statements like
+    //     UPDATE p SET a = a + delta.shift FROM delta WHERE p.a = delta.id
+    // fail with a spurious "UNIQUE constraint failed" when intermediate states
+    // transiently duplicate keys.
+    //
+    // UPDATE FROM does not support OR IGNORE / OR REPLACE conflict clauses, so the
+    // gating used by the default path (`!use_replace && !use_ignore`) is not needed
+    // here — every UPDATE FROM uses the deferred-UNIQUE path.
     let constraint_validator = ConstraintValidator::new(schema);
 
     // Phase C2 of #5085: collect deferred FK violations during the loop
-    // and queue them after the loop ends, since the loop body holds an
-    // immutable borrow of `database` via `table`.
+    // and queue them after the loop ends, since `database` is immutably
+    // borrowed once we re-fetch `table` for the post-statement PK/UNIQUE check.
     let mut pending_deferred_violations: Vec<vibesql_storage::DeferredFkViolation> = Vec::new();
 
-    for (row_index, old_row, new_row, _changed_columns, _updates_pk) in &updates {
-        // Validate all constraints
-        constraint_validator.validate_row(table, table_name, *row_index, new_row, old_row)?;
-        constraint_validator.validate_unique_indexes(database, table_name, new_row, old_row)?;
+    for u in &updates {
+        // Per-row: NOT NULL + CHECK only. PK / UNIQUE deferred to post-statement.
+        constraint_validator.validate_row_skip_uniqueness(table_name, &u.new_row)?;
 
         // Validate foreign key constraints
         if !schema.foreign_keys.is_empty() {
             let deferred =
-                ForeignKeyValidator::collect_constraints(database, table_name, &new_row.values)?;
+                ForeignKeyValidator::collect_constraints(database, table_name, &u.new_row.values)?;
             pending_deferred_violations.extend(deferred);
         }
     }
 
-    // Push deferred FK violations onto the queue now that `table` has
-    // been released.
+    // Push deferred FK violations onto the queue now that the table has not
+    // yet been re-borrowed for the post-statement uniqueness check.
     for v in pending_deferred_violations {
         database.queue_deferred_fk_violation(v);
     }
 
-    // Cross-update uniqueness validation
+    // Cross-update uniqueness validation: catches multiple updates landing on the
+    // same final PK / UNIQUE value (e.g. `UPDATE p SET a = 5 FROM ...` matching
+    // multiple rows). This must run before the post-statement deferred check.
     if updates.len() > 1 {
         validate_cross_update_uniqueness(&updates, schema)?;
     }
 
+    // Deferred uniqueness check (issue #5140 — port of #5138 to UPDATE FROM):
+    // validate PK / UNIQUE / user-defined unique indexes against the post-statement
+    // table state. Rows that are themselves being updated to a different key are
+    // excluded from "existing" entries, allowing cross-row PK shifts via FROM
+    // (`UPDATE p SET a = a + delta.shift FROM delta WHERE p.a = delta.id`) to
+    // succeed even when intermediate states transiently duplicate keys.
+    if !updates.is_empty() {
+        // Re-borrow the table — the FK queue push above released the prior immutable borrow.
+        let table_for_check = database
+            .get_table(table_name)
+            .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+        validate_post_statement_uniqueness(
+            &updates,
+            schema,
+            table_for_check,
+            database,
+            table_name,
+        )?;
+    }
+
     // Handle CASCADE updates for primary key changes
-    for (_row_index, old_row, new_row, _changed_columns, updates_pk) in &updates {
-        if *updates_pk {
-            ForeignKeyValidator::check_no_child_references(database, table_name, old_row, new_row)?;
+    for u in &updates {
+        if u.updates_pk {
+            ForeignKeyValidator::check_no_child_references(
+                database,
+                table_name,
+                &u.old_row,
+                &u.new_row,
+            )?;
         }
     }
 
     // Fire BEFORE UPDATE triggers
     if has_triggers {
-        for (_row_index, old_row, new_row, _changed_columns, _updates_pk) in &updates {
+        for u in &updates {
             crate::TriggerFirer::execute_before_triggers(
                 database,
                 table_name,
                 vibesql_ast::TriggerEvent::Update(None),
-                Some(old_row),
-                Some(new_row),
+                Some(&u.old_row),
+                Some(&u.new_row),
             )?;
         }
     }
@@ -1200,12 +1253,17 @@ fn execute_update_from(
         .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
 
     let mut index_updates = Vec::new();
-    for (index, old_row, new_row, changed_columns, _updates_pk) in &updates {
+    for u in &updates {
         table_mut
-            .update_row_selective(*index, new_row.clone(), changed_columns)
+            .update_row_selective(u.row_index, u.new_row.clone(), &u.changed_columns)
             .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
 
-        index_updates.push((*index, old_row.clone(), new_row.clone(), changed_columns.clone()));
+        index_updates.push((
+            u.row_index,
+            u.old_row.clone(),
+            u.new_row.clone(),
+            u.changed_columns.clone(),
+        ));
     }
 
     // Fire AFTER UPDATE triggers

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -1166,9 +1166,18 @@ fn execute_update_from(
     // fail with a spurious "UNIQUE constraint failed" when intermediate states
     // transiently duplicate keys.
     //
-    // UPDATE FROM does not support OR IGNORE / OR REPLACE conflict clauses, so the
-    // gating used by the default path (`!use_replace && !use_ignore`) is not needed
-    // here — every UPDATE FROM uses the deferred-UNIQUE path.
+    // The default UPDATE path gates the deferred-UNIQUE pass on
+    // `!use_replace && !use_ignore` because OR IGNORE / OR REPLACE need per-row
+    // skip / evict semantics that don't match the post-statement model. The
+    // UPDATE FROM path here unconditionally uses the deferred-UNIQUE pass: although
+    // the parser accepts `UPDATE OR IGNORE ... FROM` and `UPDATE OR REPLACE ... FROM`
+    // (populating `stmt.conflict_clause`), this dispatch path silently drops the
+    // conflict clause — meaning IGNORE/REPLACE semantics aren't honored on
+    // UPDATE FROM today. This is a pre-existing limitation (predates #5140; the
+    // dispatch on line ~179 above never inspects `stmt.conflict_clause` before
+    // calling `execute_update_from`).
+    // TODO(#5144): honor `stmt.conflict_clause` on UPDATE FROM (skip-on-IGNORE,
+    // evict-on-REPLACE) and gate the deferred-UNIQUE pass accordingly.
     let constraint_validator = ConstraintValidator::new(schema);
 
     // Phase C2 of #5085: collect deferred FK violations during the loop

--- a/crates/vibesql-executor/src/update/from_clause.rs
+++ b/crates/vibesql-executor/src/update/from_clause.rs
@@ -20,6 +20,7 @@ use vibesql_catalog::TableSchema;
 use vibesql_storage::{Database, Row};
 use vibesql_types::SqlValue;
 
+use super::PendingUpdate;
 use crate::errors::ExecutorError;
 
 /// Result of executing the join between target table and FROM tables
@@ -297,13 +298,13 @@ fn combine_with_from_clause(accumulated: FromClause, from_clause: FromClause) ->
 
 /// Apply UPDATE FROM matches to build update operations
 ///
-/// Takes the matched rows with pre-computed SET values and creates
-/// (row_index, old_row, new_row, changed_columns) tuples for the executor.
-pub fn apply_update_from_matches(
+/// Takes the matched rows with pre-computed SET values and produces a
+/// `Vec<PendingUpdate>` for the executor's two-phase apply step.
+pub(super) fn apply_update_from_matches(
     matches: &[UpdateFromMatch],
     assignments: &[Assignment],
     target_schema: &TableSchema,
-) -> Result<Vec<(usize, Row, Row, HashSet<usize>, bool)>, ExecutorError> {
+) -> Result<Vec<PendingUpdate>, ExecutorError> {
     let pk_indices = target_schema.get_primary_key_indices();
     let mut updates = Vec::with_capacity(matches.len());
 
@@ -370,7 +371,13 @@ pub fn apply_update_from_matches(
             }
         }
 
-        updates.push((m.row_index, m.target_row.clone(), new_row, changed_columns, updates_pk));
+        updates.push(PendingUpdate {
+            row_index: m.row_index,
+            old_row: m.target_row.clone(),
+            new_row,
+            changed_columns,
+            updates_pk,
+        });
     }
 
     Ok(updates)

--- a/crates/vibesql-executor/src/update/index_sync.rs
+++ b/crates/vibesql-executor/src/update/index_sync.rs
@@ -12,6 +12,7 @@ use vibesql_catalog::TableSchema;
 use vibesql_storage::{Database, Row, Table};
 use vibesql_types::SqlValue;
 
+use super::PendingUpdate;
 use crate::errors::ExecutorError;
 
 /// Find row indices that would conflict with an updated row (for REPLACE conflict resolution)
@@ -123,14 +124,15 @@ pub(super) fn find_conflicting_rows_for_update(
 /// This catches cases like `UPDATE t SET pk = 1` when multiple rows are being updated -
 /// all rows would end up with the same PK value, violating the UNIQUE constraint.
 pub(super) fn validate_cross_update_uniqueness(
-    updates: &[(usize, Row, Row, HashSet<usize>, bool)],
+    updates: &[PendingUpdate],
     schema: &TableSchema,
 ) -> Result<(), ExecutorError> {
     // Check PRIMARY KEY uniqueness across updates
     if let Some(pk_indices) = schema.get_primary_key_indices() {
         let mut seen_pks: HashSet<Vec<SqlValue>> = HashSet::new();
 
-        for (_row_index, _old_row, new_row, _changed_columns, _updates_pk) in updates {
+        for update in updates {
+            let new_row = &update.new_row;
             let pk_values: Vec<SqlValue> =
                 pk_indices.iter().map(|&idx| new_row.values[idx].clone()).collect();
 
@@ -155,7 +157,8 @@ pub(super) fn validate_cross_update_uniqueness(
     for (constraint_idx, unique_indices) in unique_constraint_indices.iter().enumerate() {
         let mut seen_values: HashSet<Vec<SqlValue>> = HashSet::new();
 
-        for (_row_index, _old_row, new_row, _changed_columns, _updates_pk) in updates {
+        for update in updates {
+            let new_row = &update.new_row;
             let unique_values: Vec<SqlValue> =
                 unique_indices.iter().map(|&idx| new_row.values[idx].clone()).collect();
 
@@ -185,7 +188,7 @@ pub(super) fn validate_cross_update_uniqueness(
 /// This ensures that when multiple rows are updated to the same PK/UNIQUE value,
 /// only the last one (in order of processing) survives - matching SQLite's behavior.
 pub(super) fn resolve_cross_update_conflicts_for_replace(
-    updates: &mut Vec<(usize, Row, Row, HashSet<usize>, bool)>,
+    updates: &mut Vec<PendingUpdate>,
     schema: &TableSchema,
 ) -> Vec<usize> {
     let mut indices_to_delete = Vec::new();
@@ -196,16 +199,16 @@ pub(super) fn resolve_cross_update_conflicts_for_replace(
         // Map: PK values -> (position in updates list, row_index)
         let mut pk_map: HashMap<Vec<SqlValue>, (usize, usize)> = HashMap::new();
 
-        for (pos, (row_index, _old_row, new_row, _changed_columns, _updates_pk)) in
-            updates.iter().enumerate()
-        {
+        for (pos, update) in updates.iter().enumerate() {
             // Skip if already marked for removal
             if indices_to_remove.contains(&pos) {
                 continue;
             }
 
-            let pk_values: Vec<SqlValue> =
-                pk_indices.iter().map(|&idx| new_row.values[idx].clone()).collect();
+            let pk_values: Vec<SqlValue> = pk_indices
+                .iter()
+                .map(|&idx| update.new_row.values[idx].clone())
+                .collect();
 
             // Skip NULL PKs
             if pk_values.contains(&SqlValue::Null) {
@@ -217,7 +220,7 @@ pub(super) fn resolve_cross_update_conflicts_for_replace(
                 indices_to_remove.insert(*prev_pos);
                 indices_to_delete.push(*prev_row_index);
             }
-            pk_map.insert(pk_values, (pos, *row_index));
+            pk_map.insert(pk_values, (pos, update.row_index));
         }
     }
 
@@ -226,16 +229,16 @@ pub(super) fn resolve_cross_update_conflicts_for_replace(
     for unique_indices in unique_constraint_indices.iter() {
         let mut unique_map: HashMap<Vec<SqlValue>, (usize, usize)> = HashMap::new();
 
-        for (pos, (row_index, _old_row, new_row, _changed_columns, _updates_pk)) in
-            updates.iter().enumerate()
-        {
+        for (pos, update) in updates.iter().enumerate() {
             // Skip if already marked for removal
             if indices_to_remove.contains(&pos) {
                 continue;
             }
 
-            let unique_values: Vec<SqlValue> =
-                unique_indices.iter().map(|&idx| new_row.values[idx].clone()).collect();
+            let unique_values: Vec<SqlValue> = unique_indices
+                .iter()
+                .map(|&idx| update.new_row.values[idx].clone())
+                .collect();
 
             // Skip if any value is NULL
             if unique_values.contains(&SqlValue::Null) {
@@ -249,7 +252,7 @@ pub(super) fn resolve_cross_update_conflicts_for_replace(
                     indices_to_delete.push(*prev_row_index);
                 }
             }
-            unique_map.insert(unique_values, (pos, *row_index));
+            unique_map.insert(unique_values, (pos, update.row_index));
         }
     }
 
@@ -279,13 +282,13 @@ pub(super) fn resolve_cross_update_conflicts_for_replace(
 /// by [`validate_cross_update_uniqueness`], which must be called before this function.
 ///
 /// # Arguments
-/// * `updates` - All pending updates: (row_index, old_row, new_row, changed_columns, updates_pk)
+/// * `updates` - All pending updates (`PendingUpdate`: row_index, old_row, new_row, changed_columns, updates_pk)
 /// * `schema` - Table schema (for PK/UNIQUE constraint metadata)
 /// * `table` - Storage table reference (for accessing PK/UNIQUE hash indexes)
 /// * `database` - Database reference (for accessing user-defined UNIQUE indexes)
 /// * `table_name` - Canonical table name
 pub(super) fn validate_post_statement_uniqueness(
-    updates: &[(usize, Row, Row, HashSet<usize>, bool)],
+    updates: &[PendingUpdate],
     schema: &TableSchema,
     table: &Table,
     database: &Database,
@@ -296,10 +299,10 @@ pub(super) fn validate_post_statement_uniqueness(
     let pk_indices_opt = schema.get_primary_key_indices();
     let mut updated_new_pk: HashMap<usize, Vec<SqlValue>> = HashMap::new();
     if let Some(ref pk_indices) = pk_indices_opt {
-        for (row_index, _old_row, new_row, _changed, _upd_pk) in updates {
+        for u in updates {
             let new_pk: Vec<SqlValue> =
-                pk_indices.iter().map(|&i| new_row.values[i].clone()).collect();
-            updated_new_pk.insert(*row_index, new_pk);
+                pk_indices.iter().map(|&i| u.new_row.values[i].clone()).collect();
+            updated_new_pk.insert(u.row_index, new_pk);
         }
     }
 
@@ -308,11 +311,11 @@ pub(super) fn validate_post_statement_uniqueness(
     // (because rows in the update set will be moved away; only their FINAL state matters).
     if let Some(ref pk_indices) = pk_indices_opt {
         if let Some(pk_index) = table.primary_key_index() {
-            for (row_index, old_row, new_row, _changed, _upd_pk) in updates {
+            for u in updates {
                 let new_pk: Vec<SqlValue> =
-                    pk_indices.iter().map(|&i| new_row.values[i].clone()).collect();
+                    pk_indices.iter().map(|&i| u.new_row.values[i].clone()).collect();
                 let old_pk: Vec<SqlValue> =
-                    pk_indices.iter().map(|&i| old_row.values[i].clone()).collect();
+                    pk_indices.iter().map(|&i| u.old_row.values[i].clone()).collect();
 
                 // No-op update for PK: skip
                 if new_pk == old_pk {
@@ -321,7 +324,7 @@ pub(super) fn validate_post_statement_uniqueness(
 
                 if let Some(&existing_idx) = pk_index.get(&new_pk) {
                     // Self: this row already had this PK
-                    if existing_idx == *row_index {
+                    if existing_idx == u.row_index {
                         continue;
                     }
 
@@ -362,17 +365,17 @@ pub(super) fn validate_post_statement_uniqueness(
 
         // Build map of (updated_row_index -> new unique values) for this constraint
         let mut updated_new_unique: HashMap<usize, Vec<SqlValue>> = HashMap::new();
-        for (row_index, _old_row, new_row, _changed, _upd_pk) in updates {
+        for u in updates {
             let new_uv: Vec<SqlValue> =
-                unique_indices.iter().map(|&i| new_row.values[i].clone()).collect();
-            updated_new_unique.insert(*row_index, new_uv);
+                unique_indices.iter().map(|&i| u.new_row.values[i].clone()).collect();
+            updated_new_unique.insert(u.row_index, new_uv);
         }
 
-        for (row_index, old_row, new_row, _changed, _upd_pk) in updates {
+        for u in updates {
             let new_uv: Vec<SqlValue> =
-                unique_indices.iter().map(|&i| new_row.values[i].clone()).collect();
+                unique_indices.iter().map(|&i| u.new_row.values[i].clone()).collect();
             let old_uv: Vec<SqlValue> =
-                unique_indices.iter().map(|&i| old_row.values[i].clone()).collect();
+                unique_indices.iter().map(|&i| u.old_row.values[i].clone()).collect();
 
             // NULL values are exempt (NULL != NULL in SQL)
             if new_uv.contains(&SqlValue::Null) {
@@ -385,7 +388,7 @@ pub(super) fn validate_post_statement_uniqueness(
             }
 
             if let Some(&existing_idx) = unique_index.get(&new_uv) {
-                if existing_idx == *row_index {
+                if existing_idx == u.row_index {
                     continue;
                 }
                 if let Some(other_new_uv) = updated_new_unique.get(&existing_idx) {
@@ -446,10 +449,10 @@ pub(super) fn validate_post_statement_uniqueness(
 
         // Build map of (updated_row_index -> new index key values) for this index
         let mut updated_new_key: HashMap<usize, Vec<SqlValue>> = HashMap::new();
-        for (row_index, _old_row, new_row, _changed, _upd_pk) in updates {
+        for u in updates {
             let nk: Vec<SqlValue> =
-                col_idxs.iter().map(|&i| new_row.values[i].clone()).collect();
-            updated_new_key.insert(*row_index, nk);
+                col_idxs.iter().map(|&i| u.new_row.values[i].clone()).collect();
+            updated_new_key.insert(u.row_index, nk);
         }
 
         let index_data = match database.get_index_data(&index_name) {
@@ -457,11 +460,11 @@ pub(super) fn validate_post_statement_uniqueness(
             None => continue,
         };
 
-        for (row_index, old_row, new_row, _changed, _upd_pk) in updates {
+        for u in updates {
             let new_key: Vec<SqlValue> =
-                col_idxs.iter().map(|&i| new_row.values[i].clone()).collect();
+                col_idxs.iter().map(|&i| u.new_row.values[i].clone()).collect();
             let old_key: Vec<SqlValue> =
-                col_idxs.iter().map(|&i| old_row.values[i].clone()).collect();
+                col_idxs.iter().map(|&i| u.old_row.values[i].clone()).collect();
 
             // NULL values are exempt
             if new_key.contains(&SqlValue::Null) {
@@ -482,7 +485,7 @@ pub(super) fn validate_post_statement_uniqueness(
             // Check each conflicting row index: skip self and rows being moved off this key
             let mut real_conflict = false;
             for existing_idx in &conflicting_rows {
-                if *existing_idx == *row_index {
+                if *existing_idx == u.row_index {
                     continue;
                 }
                 if let Some(other_new_key) = updated_new_key.get(existing_idx) {

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -33,10 +33,42 @@ mod row_selector;
 mod triggers;
 mod value_updater;
 
+use std::collections::HashSet;
+
 use vibesql_ast::UpdateStmt;
-use vibesql_storage::Database;
+use vibesql_storage::{Database, Row};
 
 use crate::errors::ExecutorError;
+
+/// One pending UPDATE row, collected in the first phase of two-phase UPDATE
+/// execution and applied in the second phase.
+///
+/// Both the default UPDATE path (`executor::execute_internal`) and the
+/// `UPDATE ... FROM ...` path (`executor::execute_update_from`) collect a
+/// `Vec<PendingUpdate>` before validating constraints and writing rows back.
+///
+/// This was previously an anonymous 5-tuple
+/// `(usize, Row, Row, HashSet<usize>, bool)`. The judge on PR #5138 flagged
+/// the tuple as load-bearing once a second consumer existed (UPDATE FROM, in
+/// PR for issue #5140). Naming the fields makes call sites self-documenting
+/// and prevents accidental positional confusion when the shape grows.
+#[derive(Debug, Clone)]
+pub(super) struct PendingUpdate {
+    /// Index of the row in the target table's storage (the rowid in storage
+    /// order, used by `update_row_selective` and index maintenance).
+    pub row_index: usize,
+    /// Original row state — needed for PK/UNIQUE self-check and trigger OLD.
+    pub old_row: Row,
+    /// New row state after assignments (and generated-column recomputation).
+    pub new_row: Row,
+    /// Column indices whose value changed; passed to `update_row_selective`
+    /// and index maintenance so unchanged columns are skipped.
+    pub changed_columns: HashSet<usize>,
+    /// True if any assignment touches a PRIMARY KEY column (or the rowid
+    /// alias for INTEGER PRIMARY KEY tables). Used to gate child-reference
+    /// FK checks.
+    pub updates_pk: bool,
+}
 
 // Re-export for external use
 pub use triggers::execute_update_with_trigger_context;

--- a/crates/vibesql-executor/tests/update_deferred_uniqueness_tests.rs
+++ b/crates/vibesql-executor/tests/update_deferred_uniqueness_tests.rs
@@ -302,3 +302,247 @@ fn no_op_assignment_succeeds() {
         .collect();
     assert_eq!(pks, vec![1, 2]);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #5140: UPDATE FROM (multi-table UPDATE) — same deferred-UNIQUE bug class
+// ---------------------------------------------------------------------------
+//
+// PR #5138 fixed the default UPDATE path for #5137 by deferring PK / UNIQUE
+// checks to a post-statement pass. The judge on that PR flagged that the
+// UPDATE FROM path (`execute_update_from`) still ran per-row UNIQUE checks
+// inside the apply loop and would exhibit the same bug class. These tests
+// mirror the default-path tests above against the FROM-clause form.
+
+#[test]
+fn update_from_pk_shift_succeeds() {
+    // The exact reproducer from the issue body: a PK shift driven by a join
+    // against a delta table. Without deferred UNIQUE checks, the second row's
+    // new PK collides with the first row's not-yet-shifted PK.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE p(a INTEGER PRIMARY KEY, b TEXT); \
+         CREATE TABLE delta(id INTEGER, shift INTEGER); \
+         INSERT INTO p VALUES (0, 'zero'); \
+         INSERT INTO p VALUES (1, 'one'); \
+         INSERT INTO delta VALUES (0, -1); \
+         INSERT INTO delta VALUES (1, -1);",
+    );
+
+    let count = run_update(
+        &mut db,
+        "UPDATE p SET a = a + delta.shift FROM delta WHERE p.a = delta.id",
+    )
+    .expect(
+        "UPDATE FROM with PK shift driven by joined delta should succeed; intermediate \
+         UNIQUE collisions must be deferred until statement end (issue #5140)",
+    );
+    assert_eq!(count, 2);
+
+    let rows = get_rows(&db, "p");
+    assert_eq!(rows.len(), 2);
+    // Storage order matches insertion order: row 0 (a=0) -> -1, row 1 (a=1) -> 0
+    assert_eq!(rows[0][0], SqlValue::Integer(-1));
+    assert_eq!(rows[0][1], SqlValue::Varchar("zero".into()));
+    assert_eq!(rows[1][0], SqlValue::Integer(0));
+    assert_eq!(rows[1][1], SqlValue::Varchar("one".into()));
+}
+
+#[test]
+fn update_from_pk_negation_succeeds() {
+    // Mirror of `pk_negation_succeeds` (default path) using UPDATE FROM. The delta
+    // table here just supplies a literal -1 multiplier per row, but the key shape
+    // is the same: rows transition through transiently-overlapping PK values
+    // before settling in their final unique state.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT); \
+         CREATE TABLE m(id INTEGER, mult INTEGER); \
+         INSERT INTO t VALUES (1, 'one'); \
+         INSERT INTO t VALUES (2, 'two'); \
+         INSERT INTO m VALUES (1, -1); \
+         INSERT INTO m VALUES (2, -1);",
+    );
+
+    let count = run_update(
+        &mut db,
+        "UPDATE t SET a = t.a * m.mult FROM m WHERE t.a = m.id",
+    )
+    .expect("UPDATE FROM with PK negation should succeed");
+    assert_eq!(count, 2);
+
+    let pks: Vec<i64> = get_rows(&db, "t")
+        .iter()
+        .map(|r| match r[0] {
+            SqlValue::Integer(n) => n,
+            _ => panic!("expected integer pk"),
+        })
+        .collect();
+    assert_eq!(pks, vec![-1, -2]);
+}
+
+#[test]
+fn update_from_genuine_collision_still_fails() {
+    // Two delta rows steer two distinct source rows to the same final PK value.
+    // The cross-update validator must still catch this even though no per-row
+    // check fires.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE p(a INTEGER PRIMARY KEY, b TEXT); \
+         CREATE TABLE delta(id INTEGER, target INTEGER); \
+         INSERT INTO p VALUES (1, 'one'); \
+         INSERT INTO p VALUES (2, 'two'); \
+         INSERT INTO delta VALUES (1, 99); \
+         INSERT INTO delta VALUES (2, 99);",
+    );
+
+    let result = run_update(
+        &mut db,
+        "UPDATE p SET a = delta.target FROM delta WHERE p.a = delta.id",
+    );
+    assert!(
+        result.is_err(),
+        "Genuine UNIQUE final-state collision via UPDATE FROM must still error"
+    );
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        msg.contains("UNIQUE constraint failed") || msg.contains("multiple rows"),
+        "Error should mention UNIQUE; got {}",
+        msg
+    );
+
+    // Table state should be unchanged (both rows still have their original PKs).
+    let pks: Vec<i64> = get_rows(&db, "p")
+        .iter()
+        .map(|r| match r[0] {
+            SqlValue::Integer(n) => n,
+            _ => panic!(),
+        })
+        .collect();
+    assert_eq!(pks, vec![1, 2]);
+}
+
+#[test]
+fn update_from_collision_with_unmoved_row_still_fails() {
+    // Only one row in `p` is updated (a=2 -> a=10); the row at a=10 is NOT in
+    // the update set, so the deferred check must still flag the collision
+    // against it.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE p(a INTEGER PRIMARY KEY, b TEXT); \
+         CREATE TABLE delta(id INTEGER, target INTEGER); \
+         INSERT INTO p VALUES (10, 'ten'); \
+         INSERT INTO p VALUES (20, 'twenty'); \
+         INSERT INTO delta VALUES (20, 10);",
+    );
+
+    let result = run_update(
+        &mut db,
+        "UPDATE p SET a = delta.target FROM delta WHERE p.a = delta.id",
+    );
+    assert!(
+        result.is_err(),
+        "UPDATE FROM landing on an unmoved row's PK must still produce a UNIQUE error"
+    );
+}
+
+#[test]
+fn update_from_unique_index_shift_succeeds() {
+    // Exercise the user-defined UNIQUE index branch of validate_post_statement_uniqueness
+    // through UPDATE FROM. Without the deferred semantics the shift would falsely error
+    // on the index_data lookup.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE u(id INTEGER PRIMARY KEY, k INTEGER); \
+         CREATE UNIQUE INDEX u_k ON u(k); \
+         CREATE TABLE delta(id INTEGER, shift INTEGER); \
+         INSERT INTO u VALUES (1, 10); \
+         INSERT INTO u VALUES (2, 20); \
+         INSERT INTO u VALUES (3, 30); \
+         INSERT INTO delta VALUES (1, -10); \
+         INSERT INTO delta VALUES (2, -10); \
+         INSERT INTO delta VALUES (3, -10);",
+    );
+
+    let count = run_update(
+        &mut db,
+        "UPDATE u SET k = u.k + delta.shift FROM delta WHERE u.id = delta.id",
+    )
+    .expect("UPDATE FROM shift on a UNIQUE-indexed column must succeed when final state is unique");
+    assert_eq!(count, 3);
+
+    let ks: Vec<i64> = get_rows(&db, "u")
+        .iter()
+        .map(|r| match r[1] {
+            SqlValue::Integer(n) => n,
+            _ => panic!("expected integer k"),
+        })
+        .collect();
+    assert_eq!(ks, vec![0, 10, 20]);
+}
+
+#[test]
+fn update_from_no_match_succeeds_unchanged() {
+    // Regression guard: when the FROM-clause join produces zero matches, no rows
+    // should be touched and no UNIQUE errors should fire. Previously this path
+    // already worked, but wrapping it confirms the deferred check correctly
+    // short-circuits on an empty updates list.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE p(a INTEGER PRIMARY KEY, b TEXT); \
+         CREATE TABLE delta(id INTEGER, shift INTEGER); \
+         INSERT INTO p VALUES (1, 'one'); \
+         INSERT INTO p VALUES (2, 'two');",
+    );
+
+    let count =
+        run_update(&mut db, "UPDATE p SET a = a + delta.shift FROM delta WHERE p.a = delta.id")
+            .expect("UPDATE FROM with empty join result should succeed with 0 affected rows");
+    assert_eq!(count, 0);
+
+    let pks: Vec<i64> = get_rows(&db, "p")
+        .iter()
+        .map(|r| match r[0] {
+            SqlValue::Integer(n) => n,
+            _ => panic!(),
+        })
+        .collect();
+    assert_eq!(pks, vec![1, 2]);
+}
+
+#[test]
+fn update_from_non_pk_change_still_works() {
+    // Regression guard: UPDATE FROM that touches only a non-PK column must continue
+    // to succeed (deferred-UNIQUE refactor must not regress the common case).
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE p(a INTEGER PRIMARY KEY, b TEXT); \
+         CREATE TABLE delta(id INTEGER, label TEXT); \
+         INSERT INTO p VALUES (1, 'one'); \
+         INSERT INTO p VALUES (2, 'two'); \
+         INSERT INTO delta VALUES (1, 'uno'); \
+         INSERT INTO delta VALUES (2, 'dos');",
+    );
+
+    let count = run_update(
+        &mut db,
+        "UPDATE p SET b = delta.label FROM delta WHERE p.a = delta.id",
+    )
+    .expect("UPDATE FROM on non-PK column should succeed");
+    assert_eq!(count, 2);
+
+    let labels: Vec<String> = get_rows(&db, "p")
+        .iter()
+        .map(|r| match &r[1] {
+            SqlValue::Varchar(s) => s.to_string(),
+            _ => panic!(),
+        })
+        .collect();
+    assert_eq!(labels, vec!["uno", "dos"]);
+}

--- a/crates/vibesql-executor/tests/update_deferred_uniqueness_tests.rs
+++ b/crates/vibesql-executor/tests/update_deferred_uniqueness_tests.rs
@@ -546,3 +546,44 @@ fn update_from_non_pk_change_still_works() {
         .collect();
     assert_eq!(labels, vec!["uno", "dos"]);
 }
+
+#[test]
+fn update_from_composite_pk_shift_succeeds() {
+    // Composite PK (a,b) shift driven by UPDATE FROM. Mirrors the default-path
+    // `composite_pk_shift_succeeds` test against the FROM-clause form: a join-driven
+    // shift on column `b` produces intermediate states that transiently duplicate
+    // (a,b) pairs, but the final state is unique. Deferred-UNIQUE semantics must hold
+    // for composite PKs through the UPDATE FROM path as well.
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE c(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a, b)); \
+         CREATE TABLE delta(id INTEGER, shift INTEGER); \
+         INSERT INTO c VALUES (1, 0, 'r1'); \
+         INSERT INTO c VALUES (1, 1, 'r2'); \
+         INSERT INTO c VALUES (1, 2, 'r3'); \
+         INSERT INTO delta VALUES (0, -1); \
+         INSERT INTO delta VALUES (1, -1); \
+         INSERT INTO delta VALUES (2, -1);",
+    );
+
+    let count = run_update(
+        &mut db,
+        "UPDATE c SET b = c.b + delta.shift FROM delta WHERE c.b = delta.id",
+    )
+    .expect(
+        "UPDATE FROM composite-PK shift on column b should succeed — final keys \
+         (1,-1)(1,0)(1,1) are unique even though intermediate states duplicate.",
+    );
+    assert_eq!(count, 3);
+
+    let rows = get_rows(&db, "c");
+    let pairs: Vec<(i64, i64)> = rows
+        .iter()
+        .map(|r| match (&r[0], &r[1]) {
+            (SqlValue::Integer(a), SqlValue::Integer(b)) => (*a, *b),
+            _ => panic!("expected integer columns"),
+        })
+        .collect();
+    assert_eq!(pairs, vec![(1, -1), (1, 0), (1, 1)]);
+}


### PR DESCRIPTION
Closes #5140

Follow-up flagged by the judge on PR #5138. The fix for #5137 was scoped
to the default UPDATE path; the `UPDATE ... FROM` path still ran per-row
`validate_row` + `validate_unique_indexes`, so the same mid-statement
UNIQUE-failure bug class survived there.

This PR has two parts (in this order):

## Part A — `PendingUpdate` typedef refactor

Per judge feedback on #5138, the load-bearing `(usize, Row, Row,
HashSet<usize>, bool)` tuple is promoted to a named struct
`update::PendingUpdate` once UPDATE FROM becomes the second consumer.

```rust
pub(super) struct PendingUpdate {
    pub row_index: usize,        // storage rowid for update_row_selective
    pub old_row: Row,             // for PK/UNIQUE self-check + trigger OLD
    pub new_row: Row,             // post-assignment row
    pub changed_columns: HashSet<usize>,  // for selective writes + index maintenance
    pub updates_pk: bool,         // gates child-reference FK checks
}
```

Touches:

- `crates/vibesql-executor/src/update/mod.rs` — definition.
- `crates/vibesql-executor/src/update/from_clause.rs` —
  `apply_update_from_matches` now returns `Vec<PendingUpdate>`. Also
  tightened visibility from `pub` to `pub(super)` (only used inside
  `update`).
- `crates/vibesql-executor/src/update/index_sync.rs` — all three
  validators (`validate_cross_update_uniqueness`,
  `resolve_cross_update_conflicts_for_replace`,
  `validate_post_statement_uniqueness`) take `&[PendingUpdate]` /
  `&mut Vec<PendingUpdate>` instead of the tuple.
- `crates/vibesql-executor/src/update/executor.rs` — both consumers
  (`execute_internal` and `execute_update_from`) now use named-field
  access (`u.row_index`, `u.new_row`, etc.) at all destructuring sites.

The shape is preserved exactly; this is a mechanical rename.

## Part B — UPDATE FROM deferred-UNIQUE extension

In `execute_update_from`:

1. Replace per-row `validate_row` + `validate_unique_indexes` with
   `validate_row_skip_uniqueness` (NOT NULL / CHECK only).
2. After the existing cross-update uniqueness check, add a single call
   to `validate_post_statement_uniqueness(&updates, schema, table,
   database, table_name)` against a freshly re-borrowed table.

UPDATE FROM does not support OR IGNORE / OR REPLACE, so the
`!use_replace && !use_ignore` gating used by the default path is not
needed — every UPDATE FROM goes through the deferred-UNIQUE path.

The reusable `validate_post_statement_uniqueness` validator (added in
#5138) already handles the moved-away-row exemption, so this is a
near-mechanical port.

## Reproducer

```sql
CREATE TABLE p(a INTEGER PRIMARY KEY, b TEXT);
CREATE TABLE delta(id INTEGER, shift INTEGER);
INSERT INTO p VALUES (0, 'zero'), (1, 'one');
INSERT INTO delta VALUES (0, -1), (1, -1);
UPDATE p SET a = a + delta.shift FROM delta WHERE p.a = delta.id;
```

| | Before | After |
|--|--|--|
| Result | `Err: UNIQUE constraint failed: p.a` | `Ok(2)` |
| Final state | unchanged: `(0,'zero'),(1,'one')` | `(-1,'zero'),(0,'one')` |

## Tests

7 new regression tests in
`crates/vibesql-executor/tests/update_deferred_uniqueness_tests.rs`,
mirroring the default-path tests added by #5138:

- `update_from_pk_shift_succeeds` — the issue reproducer
- `update_from_pk_negation_succeeds` — `t.a * m.mult` via FROM
- `update_from_genuine_collision_still_fails` — two delta rows steer to
  the same final PK; cross-update validator catches it
- `update_from_collision_with_unmoved_row_still_fails` — UPDATE FROM
  landing on an unmoved row's PK still errors at deferred-check time
- `update_from_unique_index_shift_succeeds` — exercises the user-defined
  UNIQUE index branch
- `update_from_no_match_succeeds_unchanged` — empty-join guard
- `update_from_non_pk_change_still_works` — non-PK column regression
  guard

## Test plan

- [x] Reproducer SQL succeeds with final state `(-1,'zero'),(0,'one')`
      (verified by `update_from_pk_shift_succeeds`)
- [x] `cargo test --release -p vibesql-executor --tests` clean (all
      previous tests pass; 15/15 in `update_deferred_uniqueness_tests`)
- [x] `cargo test --release -p vibesql-storage --tests` clean
- [x] `make test-tcl-file FILE=update.test` — 123/124 (same as main; the
      one failure is `update-18.10`, partial-index, pre-existing)
- [x] `make test-tcl-file FILE=upfrom1.test` — 19/22 (identical to
      main; pre-existing failures unrelated to deferred-UNIQUE)
- [x] `make test-tcl-file FILE=upfrom2/3/4.test` — identical
      pass-counts to main (pre-existing)
- [x] `make test-tcl-file FILE=index.test` / `insert.test` — identical
      to main
- [x] `make test-tcl-file FILE=fkey6.test` — identical to main (18/38)

## Notes

- Pre-existing workspace-level issues (unrelated to this PR): a
  `LowerHex` build error in the `sqllogictest_sqlite` test target and a
  clippy `approximate_constant` (PI) error in
  `evaluator/expressions/operators.rs`. Both are present on `origin/main`
  at `ceb468a1` and were not introduced or affected by this PR.
- Part A (typedef refactor) is in scope per the curator's acceptance
  criteria — UPDATE FROM is the second consumer, so this is the
  natural moment to rename, per judge feedback on #5138.