### PR TITLE
fix(ci): unbreak main — align rusqlite + restore spatial/MVCC/md-5 fits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 glob = "0.3"
 md-5 = "0.11"
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 vibesql-cli = { version = "0.1.4", path = "crates/vibesql-cli" }
 chrono = "0.4"
 

--- a/crates/vibesql-storage/src/index/spatial.rs
+++ b/crates/vibesql-storage/src/index/spatial.rs
@@ -65,7 +65,7 @@ impl SpatialIndex {
     /// Query the spatial index for geometries intersecting the given MBR
     /// Returns a vector of row IDs that potentially match
     pub fn locate_in_envelope(&self, mbr: &AABB<[f64; 2]>) -> Vec<usize> {
-        self.rtree.locate_in_envelope(mbr).map(|entry| entry.row_id).collect()
+        self.rtree.locate_in_envelope(*mbr).map(|entry| entry.row_id).collect()
     }
 
     /// Query the spatial index for geometries containing the given point

--- a/tests/ddl/alter_table.rs
+++ b/tests/ddl/alter_table.rs
@@ -26,30 +26,20 @@ fn create_populated_table(db: &mut Database) {
 
     // Insert test data
     let table = db.get_table_mut("users").unwrap();
-    let row1 = Row {
-        values: vec![
-            SqlValue::Integer(1),
-            SqlValue::Varchar(StringValue::from("Alice")),
-            SqlValue::Integer(30),
-            SqlValue::Varchar(StringValue::from("alice@example.com")),
-        ]
-        .into(),
-        row_id: None,
-        row_ids: None,
-    };
+    let row1 = Row::new(vec![
+        SqlValue::Integer(1),
+        SqlValue::Varchar(StringValue::from("Alice")),
+        SqlValue::Integer(30),
+        SqlValue::Varchar(StringValue::from("alice@example.com")),
+    ]);
     table.insert(row1).expect("Failed to insert row");
 
-    let row2 = Row {
-        values: vec![
-            SqlValue::Integer(2),
-            SqlValue::Varchar(StringValue::from("Bob")),
-            SqlValue::Integer(25),
-            SqlValue::Varchar(StringValue::from("bob@example.com")),
-        ]
-        .into(),
-        row_id: None,
-        row_ids: None,
-    };
+    let row2 = Row::new(vec![
+        SqlValue::Integer(2),
+        SqlValue::Varchar(StringValue::from("Bob")),
+        SqlValue::Integer(25),
+        SqlValue::Varchar(StringValue::from("bob@example.com")),
+    ]);
     table.insert(row2).expect("Failed to insert row");
 }
 
@@ -285,17 +275,12 @@ fn test_set_not_null_with_nulls_error() {
 
     // Insert row with NULL in email
     let table = db.get_table_mut("users").unwrap();
-    let row = Row {
-        values: vec![
-            SqlValue::Integer(1),
-            SqlValue::Varchar(StringValue::from("Alice")),
-            SqlValue::Integer(30),
-            SqlValue::Null, // NULL email
-        ]
-        .into(),
-        row_id: None,
-        row_ids: None,
-    };
+    let row = Row::new(vec![
+        SqlValue::Integer(1),
+        SqlValue::Varchar(StringValue::from("Alice")),
+        SqlValue::Integer(30),
+        SqlValue::Null, // NULL email
+    ]);
     table.insert(row).expect("Failed to insert row");
 
     let sql = "ALTER TABLE users ALTER COLUMN email SET NOT NULL";

--- a/tests/z_compliance/sqllogictest_benchmark.rs
+++ b/tests/z_compliance/sqllogictest_benchmark.rs
@@ -174,7 +174,7 @@ impl SqliteDB {
                 hasher.update(key);
                 hasher.update("\n");
             }
-            let hash = format!("{:x}", hasher.finalize());
+            let hash: String = hasher.finalize().iter().map(|b| format!("{:02x}", b)).collect();
             let hash_string = format!("{} values hashing to {}", total_values, hash);
             Ok(DBOutput::Rows {
                 types: vec![DefaultColumnType::Text],
@@ -342,7 +342,7 @@ impl VibeSqlDB {
                 hasher.update(key);
                 hasher.update("\n");
             }
-            let hash = format!("{:x}", hasher.finalize());
+            let hash: String = hasher.finalize().iter().map(|b| format!("{:02x}", b)).collect();
             let hash_string = format!("{} values hashing to {}", total_values, hash);
             Ok(DBOutput::Rows {
                 types: vec![DefaultColumnType::Text],

--- a/tests/z_compliance/sqllogictest_sqlite.rs
+++ b/tests/z_compliance/sqllogictest_sqlite.rs
@@ -44,7 +44,7 @@ impl SqliteDB {
                 hasher.update(key);
                 hasher.update("\n");
             }
-            let hash = format!("{:x}", hasher.finalize());
+            let hash: String = hasher.finalize().iter().map(|b| format!("{:02x}", b)).collect();
             let hash_string = format!("{} values hashing to {}", total_values, hash);
             Ok(DBOutput::Rows {
                 types: vec![DefaultColumnType::Text],


### PR DESCRIPTION
## Summary

Main CI's `test` job has been failing since #5163. The visible error is a `cargo` resolver failure:

```
package `libsqlite3-sys v0.37.0` ... satisfies dependency `rusqlite = "^0.39"` of package `vibesql`
package `libsqlite3-sys v0.38.1` ... satisfies dependency `rusqlite = "^0.40"` of package `vibesql-executor`
note: only one package in the dependency graph may specify the same links value
```

That resolver error masks three other regressions that only surface once the workspace successfully resolves. **Five fixes**, all minimal and behavior-preserving:

| # | File | Fix | Cause |
|---|------|-----|-------|
| 1 | `Cargo.toml` | rusqlite `0.39` → `0.40` (root dev-dep) | #5163 dependabot bump updated crates but missed root; same recurring drift as merged #4634 |
| 2 | `crates/vibesql-storage/src/index/spatial.rs:68` | `mbr` → `*mbr` | rstar 0.13 `locate_in_envelope` takes value, not reference (cargo's own hint) |
| 3 | `tests/ddl/alter_table.rs` (3 sites) | `Row { … }` → `Row::new(…)` | MVCC Phase 1a #5142 added `xmin`/`xmax`; tests still used struct literals |
| 4 | `tests/z_compliance/sqllogictest_sqlite.rs:47` | manual hex via iter | md-5 0.11 `finalize()` returns `hybrid_array::Array` (no `LowerHex` impl) |
| 5 | `tests/z_compliance/sqllogictest_benchmark.rs` (2 sites) | same as 4 | same |

The hex idiom in 4/5 is copied verbatim from the already-in-tree usage at `crates/vibesql-executor/src/select/grouping/aggregates.rs:485`.

## Test plan

- [x] Local: `cargo check --workspace --tests --no-default-features --features parallel,spatial` succeeds (no errors, only pre-existing unused-import warnings)
- [ ] CI: `test` job goes from `fail` → `pass`
- [ ] CI: `verify-benchmark-queries` continues to pass

## Follow-ups (not in this PR)

- Dependabot is grouping crate Cargo.toml bumps for `rusqlite` without including the root Cargo.toml. Adjust `.github/dependabot.yml` to keep root in sync, or add a CI lint that rejects rusqlite version drift between root and crates. (Same recurrence as #4634.)
- Several `unused import: \`Rng\`` warnings remain across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)