### PR TITLE
chore(deps): consolidate rusqlite under [workspace.dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 glob = "0.3"
 md-5 = "0.11"
-rusqlite = { version = "0.40", features = ["bundled"] }
+rusqlite = { workspace = true }
 vibesql-cli = { version = "0.1.4", path = "crates/vibesql-cli" }
 chrono = "0.4"
 
@@ -90,6 +90,12 @@ repository = "https://github.com/rjwalters/vibesql"
 [workspace.dependencies]
 # Will add dependencies as needed for each phase
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
+
+# Centralized so dependabot's grouped cargo updates touch a single declaration
+# — historically the root Cargo.toml drifted from the crates whenever dependabot
+# bumped rusqlite (see merged #4634 and #5170). Crates inherit via
+# `rusqlite = { workspace = true, ... }` and add `optional = true` where needed.
+rusqlite = { version = "0.40", features = ["bundled"] }
 
 # Test declarations for integration tests
 

--- a/crates/vibesql-bench-common/Cargo.toml
+++ b/crates/vibesql-bench-common/Cargo.toml
@@ -37,6 +37,6 @@ vibesql-storage = { version = "0.1.4", path = "../vibesql-storage", optional = t
 arcstr = { version = "1.2", optional = true }
 
 # Comparison engine dependencies (optional)
-rusqlite = { version = "0.40", features = ["bundled"], optional = true }
+rusqlite = { workspace = true, optional = true }
 duckdb = { version = "1.1", features = ["bundled"], optional = true }
 mysql = { version = "28.0", optional = true }

--- a/crates/vibesql-cli/Cargo.toml
+++ b/crates/vibesql-cli/Cargo.toml
@@ -35,7 +35,7 @@ atty = "0.2"
 toml = "1.1"
 dirs = "6.0"
 regex = "1.10"
-rusqlite = { version = "0.40", features = ["bundled"] }
+rusqlite = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -39,7 +39,7 @@ md-5 = "0.11"
 arrow = "58.1"
 
 # Optional comparison engine dependencies
-rusqlite = { version = "0.40", features = ["bundled"], optional = true }
+rusqlite = { workspace = true, optional = true }
 duckdb = { version = "1.1", features = ["bundled"], optional = true }
 mysql = { version = "28.0", optional = true }
 

--- a/crates/vibesql-server/Cargo.toml
+++ b/crates/vibesql-server/Cargo.toml
@@ -97,7 +97,7 @@ reqwest = { version = "0.13", features = ["stream", "query"] }
 vibesql-bench-common = { version = "0.1.4", path = "../vibesql-bench-common", features = ["vibesql", "sqlite"] }
 # Additional dependencies for server benchmarks (moved from vibesql-executor)
 rand_chacha = "0.10"
-rusqlite = { version = "0.40", features = ["bundled"] }
+rusqlite = { workspace = true }
 
 [[bench]]
 name = "subscription_fanout"


### PR DESCRIPTION
## Summary

Eliminates the recurring root-vs-crates `rusqlite` drift that has broken main CI twice (merged #4634, fixed again in #5170).

**The pattern**: dependabot's grouped cargo update bumps `rusqlite` in every workspace member's `Cargo.toml` but consistently leaves the root's dev-dependency entry behind. Result: root requires `^0.39` (→ libsqlite3-sys 0.37) while crates require `^0.40` (→ libsqlite3-sys 0.38), both linking to the same native `sqlite3` library, and cargo refuses to resolve.

**The fix**: declare rusqlite once in `[workspace.dependencies]` at the workspace root. All five consumers (root dev-dep + 4 crates) inherit via `rusqlite = { workspace = true, ... }`. Dependabot now updates a single declaration; drift becomes structurally impossible.

## Changes

| File | Before | After |
|---|---|---|
| `Cargo.toml` (root) | adds `rusqlite = { version = "0.40", features = ["bundled"] }` to `[workspace.dependencies]` | (new) |
| `Cargo.toml` (root dev-dep) | `version = "0.40", features = ["bundled"]` | `workspace = true` |
| `crates/vibesql-bench-common/Cargo.toml` | `version = "0.40", features = ["bundled"], optional = true` | `workspace = true, optional = true` |
| `crates/vibesql-cli/Cargo.toml` | `version = "0.40", features = ["bundled"]` | `workspace = true` |
| `crates/vibesql-executor/Cargo.toml` | `version = "0.40", features = ["bundled"], optional = true` | `workspace = true, optional = true` |
| `crates/vibesql-server/Cargo.toml` | `version = "0.40", features = ["bundled"]` | `workspace = true` |

Same version, same `bundled` feature, same `optional` flags — purely a structural consolidation.

## Test plan

- [x] Local: `cargo check --workspace --tests --no-default-features --features parallel,spatial` succeeds
- [ ] CI: `test` job continues to pass (#5170 already verified the rusqlite + downstream stack compiles)

## Why this is the right fix

Dependabot for cargo handles `[workspace.dependencies]` natively — when a dep lives there, the grouped update touches one line. Alternative approaches (CI lint checking version drift; restricting dependabot groups via patterns; manual sync PRs after each rusqlite bump) all paper over the underlying issue: having the same dep declared independently in 5 places guarantees recurring drift. Inheriting from one workspace declaration is the standard idiom for shared workspace dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)