### PR TITLE
fix(tcl-shim): ignore conflict clauses inside CREATE TRIGGER bodies

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3140,7 +3140,6 @@ array set vibesql_skip_tests {
     fkey5-7.2 "Cascades from skipped fkey5-7.1 (INSERT OR IGNORE with FK violation)"
     fkey5-7.3 "Cascades from skipped fkey5-7.1 (INSERT OR IGNORE with FK violation)"
 
-    fkey8-2.3.1 "WITHOUT ROWID + AFTER DELETE trigger doing INSERT OR REPLACE on parent (out of scope for #5126; trigger/WITHOUT-ROWID interaction)"
     fkey8-5.2 "UPDATE/DELETE PK affinity is fixed (#5145), but schema-reload drops DEFERRABLE INITIALLY DEFERRED so the deferred-INSERT on child fires immediately across CLI invocations — tracked separately in #5172"
 }
 
@@ -3322,8 +3321,24 @@ proc uses_sqlite_internals {script} {
         return [list 1 "uses EXPLAIN opcode checking (SQLite VDBE-specific)"]
     }
 
-    # UPDATE/INSERT OR REPLACE/IGNORE/ABORT conflict resolution - not fully supported
-    if {[regexp -nocase {(?:UPDATE|INSERT)\s+OR\s+(?:REPLACE|IGNORE|ABORT|ROLLBACK|FAIL)\s} $script]} {
+    # UPDATE/INSERT OR REPLACE/IGNORE/ABORT conflict resolution - not fully supported.
+    #
+    # IMPORTANT: This filter must NOT match conflict clauses that appear inside
+    # CREATE TRIGGER bodies. The trigger body's SQL only fires when the outer
+    # statement triggers it (e.g., AFTER DELETE), and VibeSQL handles those
+    # nested INSERT/UPDATE OR REPLACE statements correctly. Matching trigger-body
+    # text caused false-positive skips that omitted whole test setup blocks and
+    # cascaded into "no such table" failures in dependent tests (e.g. fkey8-2.3.1
+    # depends on fkey8-2.3.0 setup whose trigger body uses INSERT OR REPLACE).
+    #
+    # Specific failing top-level conflict-clause cases are already triaged
+    # individually in vibesql_skip_tests (e.g. insert-6.3, insert-6.4,
+    # fkey5-7.1..7.3) — do not broaden this filter to compensate.
+    set script_outer $script
+    regsub -all -nocase \
+        {CREATE\s+(?:TEMP\s+|TEMPORARY\s+)?TRIGGER[^;]*?BEGIN\s+.*?END\s*;} \
+        $script_outer "" script_outer
+    if {[regexp -nocase {(?:UPDATE|INSERT)\s+OR\s+(?:REPLACE|IGNORE|ABORT|ROLLBACK|FAIL)\s} $script_outer]} {
         return [list 1 "uses conflict resolution clause (not fully supported)"]
     }
 


### PR DESCRIPTION
## Summary

- Narrows the `uses_sqlite_internals` conflict-clause regex in `scripts/tester_vibesql.tcl` so it no longer matches `INSERT/UPDATE OR REPLACE/IGNORE/ABORT/ROLLBACK/FAIL` text that appears inside `CREATE TRIGGER ... BEGIN ... END;` bodies. The whole-script match was silently omitting the `fkey8-2.3.0` setup (whose AFTER DELETE trigger contains `INSERT OR REPLACE INTO p3`), causing the dependent `fkey8-2.3.1` test to run against an empty DB and fail with `no such table: p3` instead of the expected `FOREIGN KEY constraint failed`.
- Removes the now-redundant `fkey8-2.3.1` entry from `vibesql_skip_tests`. With its setup actually running, the executor correctly raises the FK violation (NO ACTION fires before the AFTER DELETE trigger, so the REPLACE path is never reached — already-correct behavior).
- Adds a comment block at the filter explaining why trigger bodies must be excluded, so future contributors do not broaden the regex again.

The executor itself was never broken (curator confirmed via direct CLI repro). This is a test-runner-only fix.

Closes #5146

## Test plan

- [x] `./scripts/tcltest test fkey8.test` (native TCL mode) — `2.3.0... ok`, `2.3.1... ok`. 12 passed / 20 skipped, 0 failed.
- [x] `cargo test --release -p vibesql-executor --tests` — all suites green.
- [x] `fkey1`, `fkey5`, `fkey6` regression check — identical pass/fail counts as `origin/main` (no new failures from the narrowed filter).
- [x] `insert.test`, `insert2.test` regression check — identical pass/fail counts as `origin/main`. Existing named skips (`insert-6.3`, `insert-6.4`) still match via `vibesql_skip_tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)