### PR TITLE
fix(fkey): collation-aware comparison in CASCADE/SET NULL/SET DEFAULT helpers

### DIFF
--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -209,6 +209,10 @@ fn queue_orphaned_children(
     fk_idx: usize,
     parent_key_values: &[SqlValue],
 ) {
+    // Resolve parent-side collations up front so the immutable borrow
+    // inside the scan loop only sees the child table (#5147).
+    let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
+
     // Snapshot the orphaned child rows first to release the immutable
     // borrow before queueing (which mutates the transaction state).
     let orphaned: Vec<Vec<SqlValue>> = {
@@ -224,7 +228,16 @@ fn queue_orphaned_children(
                 if child_fk_values.iter().any(|v| matches!(v, SqlValue::Null)) {
                     return None;
                 }
-                if child_fk_values == parent_key_values {
+                let matches = child_fk_values.iter().zip(parent_key_values).enumerate().all(
+                    |(i, (cv, pv))| {
+                        crate::foreign_key_check::fk_values_equal(
+                            cv,
+                            pv,
+                            parent_collations.get(i).and_then(|c| c.as_deref()),
+                        )
+                    },
+                );
+                if matches {
                     Some(child_row.values.to_vec())
                 } else {
                     None
@@ -250,6 +263,10 @@ fn cascade_delete(
     fk: &vibesql_catalog::ForeignKeyConstraint,
     parent_key_values: &[SqlValue],
 ) -> Result<(), ExecutorError> {
+    // Resolve parent-side collations before borrowing the child table so
+    // FK comparisons honor NOCASE/RTRIM (#5147).
+    let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
+
     // Find rows to delete (use scan_live to skip soft-deleted rows)
     let child_table = db.get_table(child_table_name).unwrap();
     let mut rows_to_delete: Vec<vibesql_storage::Row> = Vec::new();
@@ -263,7 +280,16 @@ fn cascade_delete(
             continue;
         }
 
-        if child_fk_values == parent_key_values {
+        let matches = child_fk_values.iter().zip(parent_key_values).enumerate().all(
+            |(i, (cv, pv))| {
+                crate::foreign_key_check::fk_values_equal(
+                    cv,
+                    pv,
+                    parent_collations.get(i).and_then(|c| c.as_deref()),
+                )
+            },
+        );
+        if matches {
             rows_to_delete.push(child_row.clone());
         }
     }
@@ -294,6 +320,10 @@ fn set_null(
     fk: &vibesql_catalog::ForeignKeyConstraint,
     parent_key_values: &[SqlValue],
 ) -> Result<(), ExecutorError> {
+    // Resolve parent-side collations before borrowing the child table so
+    // FK comparisons honor NOCASE/RTRIM (#5147).
+    let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
+
     // Collect indices of rows to update
     let child_table = db.get_table(child_table_name).unwrap();
     let mut rows_to_update: Vec<(usize, vibesql_storage::Row)> = Vec::new();
@@ -308,7 +338,16 @@ fn set_null(
             continue;
         }
 
-        if child_fk_values == parent_key_values {
+        let matches = child_fk_values.iter().zip(parent_key_values).enumerate().all(
+            |(i, (cv, pv))| {
+                crate::foreign_key_check::fk_values_equal(
+                    cv,
+                    pv,
+                    parent_collations.get(i).and_then(|c| c.as_deref()),
+                )
+            },
+        );
+        if matches {
             // Create updated row with FK columns set to NULL
             let mut updated_row = child_row.clone();
             for &fk_col_idx in &fk.column_indices {
@@ -368,6 +407,10 @@ fn set_default(
         default_values.push(default_value);
     }
 
+    // Resolve parent-side collations before borrowing the child table so
+    // FK comparisons honor NOCASE/RTRIM (#5147).
+    let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
+
     // Collect indices of rows to update
     let child_table = db.get_table(child_table_name).unwrap();
     let mut rows_to_update: Vec<(usize, vibesql_storage::Row)> = Vec::new();
@@ -382,7 +425,16 @@ fn set_default(
             continue;
         }
 
-        if child_fk_values == parent_key_values {
+        let matches = child_fk_values.iter().zip(parent_key_values).enumerate().all(
+            |(i, (cv, pv))| {
+                crate::foreign_key_check::fk_values_equal(
+                    cv,
+                    pv,
+                    parent_collations.get(i).and_then(|c| c.as_deref()),
+                )
+            },
+        );
+        if matches {
             // Create updated row with FK columns set to default values
             let mut updated_row = child_row.clone();
             for (i, &fk_col_idx) in fk.column_indices.iter().enumerate() {

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -185,6 +185,12 @@ impl ForeignKeyValidator {
                     continue;
                 }
 
+                // Resolve parent-side collations before borrowing the
+                // child table so the FK comparison honors NOCASE/RTRIM
+                // on the parent key (#5147).
+                let parent_collations =
+                    crate::foreign_key_check::parent_collations_for_fk(db, fk);
+
                 // Get the child table and find matching rows
                 let child_table = db.get_table(&table_name).unwrap();
                 let matching_rows: Vec<(usize, vibesql_storage::Row)> = child_table
@@ -198,7 +204,18 @@ impl ForeignKeyValidator {
                             .map(|&col_idx| child_row.values[col_idx].clone())
                             .collect();
 
-                        if child_fk_values == old_parent_key_values {
+                        let matches = child_fk_values
+                            .iter()
+                            .zip(&old_parent_key_values)
+                            .enumerate()
+                            .all(|(i, (cv, pv))| {
+                                crate::foreign_key_check::fk_values_equal(
+                                    cv,
+                                    pv,
+                                    parent_collations.get(i).and_then(|c| c.as_deref()),
+                                )
+                            });
+                        if matches {
                             Some((idx, child_row.clone()))
                         } else {
                             None

--- a/crates/vibesql-executor/tests/foreign_key_collation_action_tests.rs
+++ b/crates/vibesql-executor/tests/foreign_key_collation_action_tests.rs
@@ -1,0 +1,290 @@
+//! Tests for collation-aware FK action helpers (#5147)
+//!
+//! Verifies that ON DELETE / ON UPDATE action helpers (CASCADE, SET NULL,
+//! SET DEFAULT) honor the parent column's declared collation (NOCASE, RTRIM)
+//! when matching child rows. Prior to #5147 these helpers used strict `==`
+//! comparisons, which caused FK actions to silently skip rows that the
+//! integrity check had already flagged as referring to the deleted/updated
+//! parent.
+
+use vibesql_executor::{CreateTableExecutor, DeleteExecutor, InsertExecutor, UpdateExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn execute_sql(sql: &str) -> Database {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        execute_statement(&stmt, &mut db);
+    }
+    db
+}
+
+fn execute_statement(stmt: &vibesql_ast::Statement, db: &mut Database) {
+    use vibesql_ast::Statement;
+    match stmt {
+        Statement::CreateTable(create_stmt) => {
+            CreateTableExecutor::execute(create_stmt, db).expect("Failed to execute CREATE TABLE");
+        }
+        Statement::Insert(insert_stmt) => {
+            InsertExecutor::execute(db, insert_stmt).expect("Failed to execute INSERT");
+        }
+        Statement::Delete(delete_stmt) => {
+            DeleteExecutor::execute(delete_stmt, db).expect("Failed to execute DELETE");
+        }
+        Statement::Update(update_stmt) => {
+            UpdateExecutor::execute(update_stmt, db).expect("Failed to execute UPDATE");
+        }
+        _ => panic!("Unsupported statement type"),
+    }
+}
+
+fn get_all_rows(db: &Database, table_name: &str) -> Vec<Vec<SqlValue>> {
+    let table = db.get_table(table_name).expect("Table not found");
+    table.scan().iter().map(|row| row.values.to_vec()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// ON DELETE CASCADE
+// ---------------------------------------------------------------------------
+
+#[test]
+fn on_delete_cascade_honors_nocase_collation() {
+    // Parent stores 'A' with NOCASE; child references via lowercase 'a'.
+    // Under strict ==, the cascade helper would not match 'a' to 'A' and
+    // the child row would stick around after DELETE FROM parent.
+    let mut db = execute_sql(
+        r#"
+        CREATE TABLE parent (code VARCHAR(10) COLLATE NOCASE PRIMARY KEY);
+        CREATE TABLE child (
+            id INTEGER PRIMARY KEY,
+            parent_code VARCHAR(10),
+            FOREIGN KEY (parent_code) REFERENCES parent(code) ON DELETE CASCADE
+        );
+        INSERT INTO parent VALUES ('A');
+        INSERT INTO child VALUES (1, 'a');
+        "#,
+    );
+
+    let stmt = Parser::parse_sql("DELETE FROM parent WHERE code = 'A'").unwrap();
+    execute_statement(&stmt, &mut db);
+
+    // Child row should be cascade-deleted even though 'a' != 'A' under strict equality.
+    let rows = get_all_rows(&db, "child");
+    assert!(rows.is_empty(), "expected child row to be cascade-deleted, got {:?}", rows);
+}
+
+#[test]
+fn on_delete_cascade_honors_rtrim_collation() {
+    let mut db = execute_sql(
+        r#"
+        CREATE TABLE parent (code VARCHAR(10) COLLATE RTRIM PRIMARY KEY);
+        CREATE TABLE child (
+            id INTEGER PRIMARY KEY,
+            parent_code VARCHAR(10),
+            FOREIGN KEY (parent_code) REFERENCES parent(code) ON DELETE CASCADE
+        );
+        INSERT INTO parent VALUES ('abc');
+        INSERT INTO child VALUES (1, 'abc   ');
+        "#,
+    );
+
+    let stmt = Parser::parse_sql("DELETE FROM parent WHERE code = 'abc'").unwrap();
+    execute_statement(&stmt, &mut db);
+
+    let rows = get_all_rows(&db, "child");
+    assert!(rows.is_empty(), "expected RTRIM cascade-delete, got {:?}", rows);
+}
+
+// ---------------------------------------------------------------------------
+// ON DELETE SET NULL
+// ---------------------------------------------------------------------------
+
+#[test]
+fn on_delete_set_null_honors_nocase_collation() {
+    let mut db = execute_sql(
+        r#"
+        CREATE TABLE parent (code VARCHAR(10) COLLATE NOCASE PRIMARY KEY);
+        CREATE TABLE child (
+            id INTEGER PRIMARY KEY,
+            parent_code VARCHAR(10),
+            FOREIGN KEY (parent_code) REFERENCES parent(code) ON DELETE SET NULL
+        );
+        INSERT INTO parent VALUES ('A');
+        INSERT INTO child VALUES (1, 'a');
+        "#,
+    );
+
+    let stmt = Parser::parse_sql("DELETE FROM parent WHERE code = 'A'").unwrap();
+    execute_statement(&stmt, &mut db);
+
+    let rows = get_all_rows(&db, "child");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0],
+        vec![SqlValue::Integer(1), SqlValue::Null],
+        "expected NOCASE SET NULL to null out child FK column"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ON DELETE SET DEFAULT
+// ---------------------------------------------------------------------------
+
+#[test]
+fn on_delete_set_default_honors_nocase_collation() {
+    let mut db = execute_sql(
+        r#"
+        CREATE TABLE parent (code VARCHAR(10) COLLATE NOCASE PRIMARY KEY);
+        CREATE TABLE child (
+            id INTEGER PRIMARY KEY,
+            parent_code VARCHAR(10) DEFAULT 'NONE',
+            FOREIGN KEY (parent_code) REFERENCES parent(code) ON DELETE SET DEFAULT
+        );
+        INSERT INTO parent VALUES ('A');
+        INSERT INTO parent VALUES ('NONE');
+        INSERT INTO child VALUES (1, 'a');
+        "#,
+    );
+
+    let stmt = Parser::parse_sql("DELETE FROM parent WHERE code = 'A'").unwrap();
+    execute_statement(&stmt, &mut db);
+
+    let rows = get_all_rows(&db, "child");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0],
+        vec![SqlValue::Integer(1), SqlValue::Varchar(arcstr::ArcStr::from("NONE"))],
+        "expected NOCASE SET DEFAULT to substitute the literal default"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ON UPDATE CASCADE (single shared callsite feeding all UPDATE actions)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn on_update_cascade_honors_nocase_collation() {
+    // Parent has NOCASE on the PK column. Child stores lowercase 'a' but
+    // the PK in the parent is 'A'. An UPDATE that changes the PK must
+    // cascade to the matching child even though strict == would miss.
+    let mut db = execute_sql(
+        r#"
+        CREATE TABLE parent (code VARCHAR(10) COLLATE NOCASE PRIMARY KEY);
+        CREATE TABLE child (
+            id INTEGER PRIMARY KEY,
+            parent_code VARCHAR(10),
+            FOREIGN KEY (parent_code) REFERENCES parent(code) ON UPDATE CASCADE
+        );
+        INSERT INTO parent VALUES ('A');
+        INSERT INTO child VALUES (1, 'a');
+        "#,
+    );
+
+    let stmt = Parser::parse_sql("UPDATE parent SET code = 'Z' WHERE code = 'A'").unwrap();
+    execute_statement(&stmt, &mut db);
+
+    let rows = get_all_rows(&db, "child");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0],
+        vec![SqlValue::Integer(1), SqlValue::Varchar(arcstr::ArcStr::from("Z"))],
+        "expected NOCASE ON UPDATE CASCADE to propagate new parent key"
+    );
+}
+
+#[test]
+fn on_update_set_null_honors_nocase_collation() {
+    let mut db = execute_sql(
+        r#"
+        CREATE TABLE parent (code VARCHAR(10) COLLATE NOCASE PRIMARY KEY);
+        CREATE TABLE child (
+            id INTEGER PRIMARY KEY,
+            parent_code VARCHAR(10),
+            FOREIGN KEY (parent_code) REFERENCES parent(code) ON UPDATE SET NULL
+        );
+        INSERT INTO parent VALUES ('A');
+        INSERT INTO child VALUES (1, 'a');
+        "#,
+    );
+
+    let stmt = Parser::parse_sql("UPDATE parent SET code = 'Z' WHERE code = 'A'").unwrap();
+    execute_statement(&stmt, &mut db);
+
+    let rows = get_all_rows(&db, "child");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0],
+        vec![SqlValue::Integer(1), SqlValue::Null],
+        "expected NOCASE ON UPDATE SET NULL to null out child FK column"
+    );
+}
+
+#[test]
+fn on_update_set_default_honors_nocase_collation() {
+    let mut db = execute_sql(
+        r#"
+        CREATE TABLE parent (code VARCHAR(10) COLLATE NOCASE PRIMARY KEY);
+        CREATE TABLE child (
+            id INTEGER PRIMARY KEY,
+            parent_code VARCHAR(10) DEFAULT 'NONE',
+            FOREIGN KEY (parent_code) REFERENCES parent(code) ON UPDATE SET DEFAULT
+        );
+        INSERT INTO parent VALUES ('A');
+        INSERT INTO parent VALUES ('NONE');
+        INSERT INTO child VALUES (1, 'a');
+        "#,
+    );
+
+    let stmt = Parser::parse_sql("UPDATE parent SET code = 'Z' WHERE code = 'A'").unwrap();
+    execute_statement(&stmt, &mut db);
+
+    let rows = get_all_rows(&db, "child");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0],
+        vec![SqlValue::Integer(1), SqlValue::Varchar(arcstr::ArcStr::from("NONE"))],
+        "expected NOCASE ON UPDATE SET DEFAULT to substitute the literal default"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sanity: binary-collated columns still match exactly (no behavioural drift).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cascade_on_binary_collation_still_strict_equality() {
+    // No COLLATE clause => default (BINARY). 'A' != 'a' so the cascade
+    // helper must NOT match 'a' to 'A' here.
+    let mut db = execute_sql(
+        r#"
+        CREATE TABLE parent (code VARCHAR(10) PRIMARY KEY);
+        CREATE TABLE child (
+            id INTEGER PRIMARY KEY,
+            parent_code VARCHAR(10),
+            FOREIGN KEY (parent_code) REFERENCES parent(code) ON DELETE CASCADE
+        );
+        INSERT INTO parent VALUES ('A');
+        INSERT INTO parent VALUES ('a');
+        INSERT INTO child VALUES (1, 'a');
+        "#,
+    );
+
+    let stmt = Parser::parse_sql("DELETE FROM parent WHERE code = 'A'").unwrap();
+    execute_statement(&stmt, &mut db);
+
+    // Child rows referencing 'a' must remain — only 'A' was deleted.
+    let rows = get_all_rows(&db, "child");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0],
+        vec![SqlValue::Integer(1), SqlValue::Varchar(arcstr::ArcStr::from("a"))],
+        "binary-collated FK must preserve strict equality semantics"
+    );
+}


### PR DESCRIPTION
## Summary

Make the foreign-key action helpers (`ON DELETE` / `ON UPDATE` CASCADE, SET NULL, SET DEFAULT, and deferred NO ACTION queueing) honor declared parent-side `COLLATE` (NOCASE / RTRIM). Before this PR the helpers used strict `==` on `Vec<SqlValue>`, so the integrity check correctly flagged a violation but the action helper found zero matching child rows — leaving the database in an inconsistent state under non-binary collation.

Sibling follow-up to PR #5141 (Phase C3 of #5085), which made the *integrity check* collation-aware via `fk_values_equal` + `parent_collations_for_fk` but explicitly punted the action helpers.

## Changes

- `crates/vibesql-executor/src/delete/integrity.rs` — 4 callsites converted to collation-aware compare:
  - `queue_orphaned_children` (deferred NO ACTION)
  - `cascade_delete` (ON DELETE CASCADE)
  - `set_null` (ON DELETE SET NULL)
  - `set_default` (ON DELETE SET DEFAULT)
- `crates/vibesql-executor/src/update/foreign_keys.rs` — 1 callsite in `check_no_child_references` (feeds ON UPDATE CASCADE / SET NULL / SET DEFAULT / RESTRICT / NO ACTION)
- `crates/vibesql-executor/tests/foreign_key_collation_action_tests.rs` — 8 new integration tests

Each callsite follows the C3 pattern from `delete/integrity.rs:110-134`: resolve `parent_collations_for_fk(db, fk)` up front (before the immutable `db.get_table()` borrow), then use `.zip().enumerate().all(...)` indexed into the collations vector inside the scan loop.

## Why this is safe for binary-collated callers

`fk_values_equal` is a strict superset of `==` for the cases it handles — it returns `true` for anything `==` returns `true` for, plus numeric coercion (`'1'` vs `1`) and NOCASE/RTRIM text matches. The binary-collated case (no collation declared, or explicitly BINARY) hits the early `if child == parent` return path and is byte-identical to the previous behavior. The dedicated `cascade_on_binary_collation_still_strict_equality` test asserts this directly.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Replace strict `==` at the 5 callsites with `fk_values_equal` driven by `parent_collations_for_fk` | done | 5 callsites converted across the 2 files listed in curation |
| Add Rust integration tests covering each action × non-binary collation | done | `foreign_key_collation_action_tests.rs`: 7 NOCASE/RTRIM cases across {ON DELETE, ON UPDATE} × {CASCADE, SET NULL, SET DEFAULT} |
| Sanity-check binary-collated columns still behave identically | done | `cascade_on_binary_collation_still_strict_equality` asserts strict semantics preserved |
| Run TCL fkey suite — confirm no regression | done | `fkey1.test`, `fkey5.test`, `fkey6.test`, `fkey8.test` baseline failures unchanged (no new failures) |
| `cargo test --release -p vibesql-executor --tests` clean | done | 2384 passed; 0 failed across the executor crate |

## Test Plan

- `cargo test -p vibesql-executor --test foreign_key_collation_action_tests` — 8 passed, 0 failed
- `cargo test -p vibesql-executor --tests` — 2384 passed, 0 failed, 2 ignored
- `cargo check -p vibesql-executor` — clean
- TCL fkey suite — pre-existing failures in `fkey1`/`fkey6` are unchanged. Since `fk_values_equal` is a provable superset of `==`, this change cannot introduce a strict-equality regression mathematically — it can only convert previously-failing comparisons into successful matches.

Closes #5147