### PR TITLE
refactor(insert): consolidate parallel FK validators behind shared helper (#5148)

### DIFF
--- a/crates/vibesql-executor/src/foreign_key_check.rs
+++ b/crates/vibesql-executor/src/foreign_key_check.rs
@@ -16,7 +16,7 @@
 //! See issue #5084 for context.
 
 use vibesql_catalog::{ForeignKeyConstraint, TableSchema};
-use vibesql_storage::Database;
+use vibesql_storage::{Database, DeferredFkViolation, DeferredFkViolationKind};
 
 /// Returns `Some` (the child / parent table names to embed in the error) when
 /// the parent table does **not** have a key that exactly covers the FK's
@@ -244,6 +244,141 @@ pub fn resolved_parent_indices_for_fk(
     }
 }
 
+/// Outcome of a single-FK row-existence check on the INSERT path.
+///
+/// Encapsulates the bit-for-bit-identical steps 4-6 that
+/// [`crate::insert::foreign_keys::validate_foreign_key_constraints`] and
+/// [`crate::insert::row_validator::RowValidator::validate_foreign_keys`]
+/// previously performed inline:
+///
+/// 4. Parent-table existence check (collation-aware, via [`fk_values_equal`]).
+/// 5. Self-FK row-self check (Phase C3 of #5085 / fkey8-3.0).
+/// 6. Defer-or-error decision (`in_txn && (initially_deferred || session_defer)`).
+///
+/// The caller is responsible for either pushing the deferred violation onto
+/// the active transaction's queue (after the immutable `&Database` borrow
+/// drops — see #5125 / PR #5141) or returning the immediate error.
+#[derive(Debug)]
+pub(crate) enum FkRowCheck {
+    /// Parent key exists in the parent table, *or* the FK is self-referential
+    /// and the inserted row itself satisfies its own FK (fkey8-3.0). The
+    /// caller should proceed without queueing or erroring.
+    Ok,
+    /// Missing parent row, but the constraint is `INITIALLY DEFERRED` *or*
+    /// the session has `PRAGMA defer_foreign_keys=ON`, *and* a transaction
+    /// is active. The caller must queue this violation onto the
+    /// transaction's deferred-FK queue (after the immutable borrow drops).
+    Deferred(DeferredFkViolation),
+    /// Missing parent row and not deferrable in the current context. The
+    /// caller must return [`ExecutorError::ConstraintViolation`] with the
+    /// FK name (empty string when unnamed), child column list, and parent
+    /// table name. The helper does not construct the error itself so the
+    /// caller-side formatting stays in one place.
+    Violation,
+}
+
+/// Per-FK row-existence check that encapsulates steps 4-6 of the INSERT
+/// FK validation pipeline. Both
+/// [`crate::insert::foreign_keys::validate_foreign_key_constraints`] and
+/// [`crate::insert::row_validator::RowValidator::validate_foreign_keys`]
+/// call this; the caller-side wrapper handles the PRAGMA gate (step 1),
+/// mismatch check (step 2), NULL-skip (step 3), and the post-loop queue
+/// push (step 7).
+///
+/// # Preconditions
+///
+/// * `fk_values` must be non-empty and contain no NULLs — the caller is
+///   responsible for the NULL-skip. (NULL FK values pass FK enforcement
+///   per SQL / SQLite.)
+/// * The PRAGMA `foreign_keys` gate, schema-mismatch check, and parent-table
+///   existence must already be verified by the caller. This helper does
+///   **not** call [`detect_fk_mismatch`] and does **not** look up the
+///   parent table — the caller passes those results in.
+///
+/// # Borrow-checker pattern
+///
+/// Takes `&Database` (not `&mut`), so `RowValidator` (immutable borrow)
+/// keeps working unchanged. When the outcome is [`FkRowCheck::Deferred`],
+/// the caller appends the violation to a local `Vec<DeferredFkViolation>`
+/// accumulator and pushes onto the database's queue *after* the immutable
+/// borrow drops. This preserves the pattern introduced in #5125 / PR #5141.
+pub(crate) fn check_fk_row_existence(
+    db: &Database,
+    table_name: &str,
+    fk: &ForeignKeyConstraint,
+    fk_idx: usize,
+    fk_values: &[vibesql_types::SqlValue],
+    full_row_values: &[vibesql_types::SqlValue],
+) -> Result<FkRowCheck, crate::errors::ExecutorError> {
+    // Parent table is required for the existence scan. Caller has already
+    // confirmed schema mismatch is OK (and a mismatch error path would
+    // have returned before reaching this helper).
+    let parent_table = db.get_table(&fk.parent_table).ok_or_else(|| {
+        crate::errors::ExecutorError::TableNotFound(fk.parent_table.clone())
+    })?;
+
+    let parent_collations = parent_collations_for_fk(db, fk);
+    let parent_indices = resolved_parent_indices_for_fk(db, fk);
+
+    // Step 4: parent-table existence scan.
+    let key_exists = parent_table.scan().iter().any(|parent_row| {
+        parent_indices.iter().zip(fk_values).enumerate().all(
+            |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+                Some(parent_val) => fk_values_equal(
+                    fk_val,
+                    parent_val,
+                    parent_collations.get(i).and_then(|c| c.as_deref()),
+                ),
+                None => false,
+            },
+        )
+    });
+    if key_exists {
+        return Ok(FkRowCheck::Ok);
+    }
+
+    // Step 5: self-FK row-self check (Phase C3 of #5085 / fkey8-3.0).
+    // When the FK points back at the table being inserted into, the row
+    // itself can satisfy the constraint (SQLite checks the parent index
+    // *after* the row is inserted). Mirror that here. Uses
+    // `full_row_values` (not the partial FK extract) so the row
+    // participates in its own FK check.
+    if fk.parent_table.eq_ignore_ascii_case(table_name) {
+        let row_satisfies_fk = parent_indices.iter().zip(fk_values).enumerate().all(
+            |(i, (&parent_idx, fk_val))| match full_row_values.get(parent_idx) {
+                Some(parent_val) => fk_values_equal(
+                    fk_val,
+                    parent_val,
+                    parent_collations.get(i).and_then(|c| c.as_deref()),
+                ),
+                None => false,
+            },
+        );
+        if row_satisfies_fk {
+            return Ok(FkRowCheck::Ok);
+        }
+    }
+
+    // Step 6: defer-or-error decision. Outside a transaction, deferred
+    // constraints still error immediately (matches SQLite — deferred
+    // enforcement requires a transaction context). Mismatch errors are
+    // never deferred, but the caller already filtered those out before
+    // reaching this helper.
+    let session_defer = db.defer_foreign_keys();
+    let in_txn = db.in_transaction();
+    let should_defer = in_txn && (fk.initially_deferred || session_defer);
+    if should_defer {
+        return Ok(FkRowCheck::Deferred(DeferredFkViolation {
+            child_table: table_name.to_string(),
+            fk_index: fk_idx,
+            child_row: full_row_values.to_vec(),
+            kind: DeferredFkViolationKind::ChildInsertOrUpdate,
+        }));
+    }
+
+    Ok(FkRowCheck::Violation)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -303,5 +438,192 @@ mod tests {
         let parent = vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("bar"));
         assert!(!fk_values_equal(&child, &parent, None));
         assert!(!fk_values_equal(&child, &parent, Some("nocase")));
+    }
+
+    // -----------------------------------------------------------------
+    // check_fk_row_existence tests — one per FkRowCheck variant.
+    // -----------------------------------------------------------------
+
+    use vibesql_catalog::{ColumnSchema, ReferentialAction};
+    use vibesql_storage::Row;
+    use vibesql_types::{DataType, SqlValue};
+
+    fn child_fk() -> ForeignKeyConstraint {
+        ForeignKeyConstraint {
+            name: Some("fk_c_pid".to_string()),
+            column_names: vec!["pid".to_string()],
+            column_indices: vec![1],
+            parent_table: "p".to_string(),
+            parent_column_names: vec!["id".to_string()],
+            parent_column_indices: vec![0],
+            on_delete: ReferentialAction::NoAction,
+            on_update: ReferentialAction::NoAction,
+            is_deferrable: false,
+            initially_deferred: false,
+        }
+    }
+
+    fn setup_parent_child(parent_rows: &[i64]) -> (Database, ForeignKeyConstraint) {
+        let mut db = Database::new();
+        db.set_foreign_keys_enabled(true);
+
+        // Parent: p(id INTEGER PRIMARY KEY)
+        let p = TableSchema::with_primary_key(
+            "p".to_string(),
+            vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+            vec!["id".to_string()],
+        );
+        db.create_table(p).unwrap();
+
+        // Child: c(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id))
+        let child_fk = child_fk();
+        let child_columns = vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("pid".to_string(), DataType::Integer, true),
+        ];
+        let mut c = TableSchema::with_primary_key(
+            "c".to_string(),
+            child_columns,
+            vec!["id".to_string()],
+        );
+        c.foreign_keys.push(child_fk.clone());
+        db.create_table(c).unwrap();
+
+        for id in parent_rows {
+            db.insert_row("p", Row::new(vec![SqlValue::Integer(*id)])).unwrap();
+        }
+
+        (db, child_fk)
+    }
+
+    #[test]
+    fn check_fk_row_existence_ok_parent_exists() {
+        let (db, fk) = setup_parent_child(&[1, 2, 3]);
+        let full_row = vec![SqlValue::Integer(10), SqlValue::Integer(2)];
+        let fk_values = vec![SqlValue::Integer(2)];
+
+        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row).unwrap();
+        assert!(matches!(outcome, FkRowCheck::Ok), "expected Ok, got {:?}", outcome);
+    }
+
+    #[test]
+    fn check_fk_row_existence_ok_self_row_self_check() {
+        // Self-referential FK: t(id INTEGER PRIMARY KEY, parent INTEGER REFERENCES t(id)).
+        // INSERT (5, 5) — the row satisfies its own FK (fkey8-3.0 pattern).
+        let mut db = Database::new();
+        db.set_foreign_keys_enabled(true);
+
+        let fk = ForeignKeyConstraint {
+            name: Some("fk_t_self".to_string()),
+            column_names: vec!["parent".to_string()],
+            column_indices: vec![1],
+            parent_table: "t".to_string(),
+            parent_column_names: vec!["id".to_string()],
+            parent_column_indices: vec![0],
+            on_delete: ReferentialAction::NoAction,
+            on_update: ReferentialAction::NoAction,
+            is_deferrable: false,
+            initially_deferred: false,
+        };
+        let cols = vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("parent".to_string(), DataType::Integer, true),
+        ];
+        let mut t = TableSchema::with_primary_key("t".to_string(), cols, vec!["id".to_string()]);
+        t.foreign_keys.push(fk.clone());
+        db.create_table(t).unwrap();
+        // Parent table is empty — only the row-self check should rescue us.
+
+        let full_row = vec![SqlValue::Integer(5), SqlValue::Integer(5)];
+        let fk_values = vec![SqlValue::Integer(5)];
+
+        let outcome = check_fk_row_existence(&db, "t", &fk, 0, &fk_values, &full_row).unwrap();
+        assert!(
+            matches!(outcome, FkRowCheck::Ok),
+            "self-FK row-self check must accept, got {:?}",
+            outcome
+        );
+    }
+
+    #[test]
+    fn check_fk_row_existence_violation_immediate() {
+        // Missing parent row, no transaction, no deferral — immediate violation.
+        let (db, fk) = setup_parent_child(&[1, 2, 3]);
+        let full_row = vec![SqlValue::Integer(10), SqlValue::Integer(999)];
+        let fk_values = vec![SqlValue::Integer(999)];
+
+        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row).unwrap();
+        assert!(matches!(outcome, FkRowCheck::Violation), "expected Violation, got {:?}", outcome);
+    }
+
+    #[test]
+    fn check_fk_row_existence_violation_when_deferred_outside_transaction() {
+        // INITIALLY DEFERRED but no transaction — should still error immediately
+        // (matches SQLite: deferred enforcement requires a transaction context).
+        // `check_fk_row_existence` reads the `fk` parameter directly (it does
+        // not re-fetch from the catalog), so we only need to flip the local
+        // copy of the constraint here.
+        let (db, mut fk) = setup_parent_child(&[1]);
+        fk.is_deferrable = true;
+        fk.initially_deferred = true;
+
+        let full_row = vec![SqlValue::Integer(10), SqlValue::Integer(999)];
+        let fk_values = vec![SqlValue::Integer(999)];
+
+        assert!(!db.in_transaction(), "test precondition: no transaction");
+        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row).unwrap();
+        assert!(
+            matches!(outcome, FkRowCheck::Violation),
+            "deferred-but-outside-txn must error immediately, got {:?}",
+            outcome
+        );
+    }
+
+    #[test]
+    fn check_fk_row_existence_deferred_initially_deferred_in_txn() {
+        // INITIALLY DEFERRED + transaction active — caller should queue.
+        let (mut db, mut fk) = setup_parent_child(&[1]);
+        fk.is_deferrable = true;
+        fk.initially_deferred = true;
+
+        // Open a transaction so in_transaction() == true.
+        db.begin_transaction().unwrap();
+        assert!(db.in_transaction());
+
+        let full_row = vec![SqlValue::Integer(10), SqlValue::Integer(999)];
+        let fk_values = vec![SqlValue::Integer(999)];
+
+        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row).unwrap();
+        match outcome {
+            FkRowCheck::Deferred(v) => {
+                assert_eq!(v.child_table, "c");
+                assert_eq!(v.fk_index, 0);
+                assert_eq!(v.child_row, full_row);
+                assert_eq!(v.kind, DeferredFkViolationKind::ChildInsertOrUpdate);
+            }
+            other => panic!("expected Deferred, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn check_fk_row_existence_deferred_via_session_pragma() {
+        // Constraint is NOT deferrable, but the session pragma
+        // defer_foreign_keys=ON overrides per-constraint defaults
+        // (and we're inside a transaction).
+        let (mut db, fk) = setup_parent_child(&[1]);
+        db.set_defer_foreign_keys(true);
+
+        db.begin_transaction().unwrap();
+        assert!(db.in_transaction());
+
+        let full_row = vec![SqlValue::Integer(10), SqlValue::Integer(999)];
+        let fk_values = vec![SqlValue::Integer(999)];
+
+        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row).unwrap();
+        assert!(
+            matches!(outcome, FkRowCheck::Deferred(_)),
+            "session pragma must defer, got {:?}",
+            outcome
+        );
     }
 }

--- a/crates/vibesql-executor/src/insert/foreign_keys.rs
+++ b/crates/vibesql-executor/src/insert/foreign_keys.rs
@@ -1,6 +1,7 @@
-use vibesql_storage::{DeferredFkViolation, DeferredFkViolationKind};
+use vibesql_storage::DeferredFkViolation;
 
 use crate::errors::ExecutorError;
+use crate::foreign_key_check::{check_fk_row_existence, FkRowCheck};
 
 /// Validate FOREIGN KEY constraints for a new row.
 ///
@@ -9,18 +10,23 @@ use crate::errors::ExecutorError;
 /// active), a missing parent row is queued onto the transaction's
 /// deferred-FK queue instead of returning an immediate error. The
 /// queue is drained and re-checked at COMMIT.
+///
+/// Steps 4-6 (parent-existence scan, self-FK row-self check, defer-or-error)
+/// are factored into [`check_fk_row_existence`] and shared with
+/// [`super::row_validator::RowValidator::validate_foreign_keys`]. This wrapper
+/// handles the PRAGMA gate, schema-mismatch check, NULL-skip, and the
+/// post-loop queue push (deferred violations are accumulated locally and
+/// pushed *after* the immutable `&Database` borrow drops, preserving the
+/// pattern introduced in #5125 / PR #5141).
 pub fn validate_foreign_key_constraints(
     db: &mut vibesql_storage::Database,
     table_name: &str,
     row_values: &[vibesql_types::SqlValue],
 ) -> Result<(), ExecutorError> {
-    // Skip FK enforcement when PRAGMA foreign_keys is OFF (default)
+    // Step 1: skip FK enforcement when PRAGMA foreign_keys is OFF (default).
     if !db.foreign_keys_enabled() {
         return Ok(());
     }
-
-    let session_defer = db.defer_foreign_keys();
-    let in_txn = db.in_transaction();
 
     let schema = db
         .catalog
@@ -31,8 +37,8 @@ pub fn validate_foreign_key_constraints(
     let mut deferred: Vec<DeferredFkViolation> = Vec::new();
 
     for (fk_idx, fk) in schema.foreign_keys.iter().enumerate() {
-        // Mismatch check runs before any row-existence test so that bad
-        // FK targets are reported even when the parent table is empty.
+        // Step 2: mismatch check runs before any row-existence test so that
+        // bad FK targets are reported even when the parent table is empty.
         // Mismatch is never deferred (matches SQLite behaviour).
         if let Some((child, parent)) =
             crate::foreign_key_check::detect_fk_mismatch(db, table_name, fk)
@@ -40,81 +46,32 @@ pub fn validate_foreign_key_constraints(
             return Err(ExecutorError::ForeignKeyMismatch { child, parent });
         }
 
-        // Extract FK values from the new row
+        // Step 3: extract FK values from the new row and skip if any are NULL.
         let fk_values: Vec<vibesql_types::SqlValue> =
             fk.column_indices.iter().map(|&idx| row_values[idx].clone()).collect();
-
-        // If any part of the foreign key is NULL, the constraint is not violated.
         if fk_values.iter().any(|v| v.is_null()) {
             continue;
         }
 
-        // Check if the referenced key exists in the parent table
-        let parent_table = db
-            .get_table(&fk.parent_table)
-            .ok_or_else(|| ExecutorError::TableNotFound(fk.parent_table.clone()))?;
-
-        let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
-        let parent_indices = crate::foreign_key_check::resolved_parent_indices_for_fk(db, fk);
-
-        let key_exists = parent_table.scan().iter().any(|parent_row| {
-            parent_indices.iter().zip(&fk_values).enumerate().all(|(i, (&parent_idx, fk_val))| {
-                match parent_row.get(parent_idx) {
-                    Some(parent_val) => crate::foreign_key_check::fk_values_equal(
-                        fk_val,
-                        parent_val,
-                        parent_collations.get(i).and_then(|c| c.as_deref()),
-                    ),
-                    None => false,
-                }
-            })
-        });
-
-        if key_exists {
-            continue;
-        }
-
-        // Phase C3 of #5085 / fkey8-3.0: self-referential FK. When the FK
-        // points back at the table being inserted into, the row itself
-        // can satisfy the constraint (e.g. INSERT ... VALUES (1, 'a',
-        // 'a', 'a', 'a') with FK(b, c) REFERENCES self(d, e)). SQLite
-        // checks the parent index *after* the row is inserted, so the
-        // row participates in its own FK check. Mirror that here.
-        if fk.parent_table.eq_ignore_ascii_case(table_name) {
-            let row_satisfies_fk = parent_indices.iter().zip(&fk_values).enumerate().all(
-                |(i, (&parent_idx, fk_val))| match row_values.get(parent_idx) {
-                    Some(parent_val) => crate::foreign_key_check::fk_values_equal(
-                        fk_val,
-                        parent_val,
-                        parent_collations.get(i).and_then(|c| c.as_deref()),
-                    ),
-                    None => false,
-                },
-            );
-            if row_satisfies_fk {
+        // Steps 4-6: shared per-FK row-existence + self-FK + defer decision.
+        match check_fk_row_existence(db, table_name, fk, fk_idx, &fk_values, row_values)? {
+            FkRowCheck::Ok => continue,
+            FkRowCheck::Deferred(v) => {
+                deferred.push(v);
                 continue;
             }
+            FkRowCheck::Violation => {
+                return Err(ExecutorError::ConstraintViolation(format!(
+                    "FOREIGN KEY constraint '{}' violated: key ({}) not found in table '{}'",
+                    fk.name.as_deref().unwrap_or(""),
+                    fk.column_names.join(", "),
+                    fk.parent_table
+                )));
+            }
         }
-
-        let should_defer = in_txn && (fk.initially_deferred || session_defer);
-        if should_defer {
-            deferred.push(DeferredFkViolation {
-                child_table: table_name.to_string(),
-                fk_index: fk_idx,
-                child_row: row_values.to_vec(),
-                kind: DeferredFkViolationKind::ChildInsertOrUpdate,
-            });
-            continue;
-        }
-
-        return Err(ExecutorError::ConstraintViolation(format!(
-            "FOREIGN KEY constraint \'{}\' violated: key ({}) not found in table \'{}\'",
-            fk.name.as_deref().unwrap_or(""),
-            fk.column_names.join(", "),
-            fk.parent_table
-        )));
     }
 
+    // Step 7: push deferred violations after the immutable borrow drops.
     for v in deferred {
         db.queue_deferred_fk_violation(v);
     }

--- a/crates/vibesql-executor/src/insert/row_validator.rs
+++ b/crates/vibesql-executor/src/insert/row_validator.rs
@@ -356,26 +356,32 @@ impl<'a> RowValidator<'a> {
     /// [`DeferredFkViolation`] is appended to `deferred_violations` and
     /// the caller pushes it onto the active transaction's queue. The
     /// queue is drained and re-checked at COMMIT.
+    ///
+    /// Steps 4-6 (parent-existence scan, self-FK row-self check,
+    /// defer-or-error) are factored into
+    /// [`crate::foreign_key_check::check_fk_row_existence`] and shared with
+    /// the free-function [`super::foreign_keys::validate_foreign_key_constraints`].
+    /// This wrapper handles the PRAGMA gate, schema-mismatch check, and the
+    /// NULL-skip (via the `Option` representation of `fk_keys`); the caller
+    /// drains `deferred_violations` after our immutable `&Database` borrow
+    /// drops (preserves the pattern from #5125 / PR #5141).
     fn validate_foreign_keys(
         &self,
         full_row_values: &[vibesql_types::SqlValue],
         fk_keys: &[Option<Vec<vibesql_types::SqlValue>>],
         deferred_violations: &mut Vec<DeferredFkViolation>,
     ) -> Result<(), ExecutorError> {
-        // Skip FK enforcement when PRAGMA foreign_keys is OFF (default)
+        // Step 1: skip FK enforcement when PRAGMA foreign_keys is OFF (default).
         if !self.db.foreign_keys_enabled() {
             return Ok(());
         }
 
-        let session_defer = self.db.defer_foreign_keys();
-        let in_txn = self.db.in_transaction();
-
         for (fk_idx, fk_values) in fk_keys.iter().enumerate() {
             let fk = &self.schema.foreign_keys[fk_idx];
 
-            // Mismatch check runs before any row-existence test so that bad
-            // FK targets are reported even when the parent table is empty
-            // (matches SQLite behaviour and fkey1-6.1 / fkey5-11.1).
+            // Step 2: mismatch check runs before any row-existence test so
+            // that bad FK targets are reported even when the parent table is
+            // empty (matches SQLite behaviour and fkey1-6.1 / fkey5-11.1).
             // Mismatch is a schema-level error and is *never* deferred:
             // SQLite reports it immediately even with INITIALLY DEFERRED.
             if let Some((child, parent)) =
@@ -384,80 +390,35 @@ impl<'a> RowValidator<'a> {
                 return Err(ExecutorError::ForeignKeyMismatch { child, parent });
             }
 
-            // Skip row-existence check if any FK value is NULL (stored as None)
+            // Step 3: skip row-existence check if any FK value is NULL
+            // (stored as None by the column-pass phase).
             let Some(ref fk_values) = fk_values else {
                 continue;
             };
 
-            // Check if the referenced key exists in the parent table
-            let parent_table = self
-                .db
-                .get_table(&fk.parent_table)
-                .ok_or_else(|| ExecutorError::TableNotFound(fk.parent_table.clone()))?;
-
-            let parent_collations = crate::foreign_key_check::parent_collations_for_fk(self.db, fk);
-            let parent_indices =
-                crate::foreign_key_check::resolved_parent_indices_for_fk(self.db, fk);
-
-            let key_exists = parent_table.scan().iter().any(|parent_row| {
-                parent_indices.iter().zip(fk_values).enumerate().all(
-                    |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
-                        Some(parent_val) => crate::foreign_key_check::fk_values_equal(
-                            fk_val,
-                            parent_val,
-                            parent_collations.get(i).and_then(|c| c.as_deref()),
-                        ),
-                        None => false,
-                    },
-                )
-            });
-
-            if key_exists {
-                continue;
-            }
-
-            // Phase C3 of #5085 / fkey8-3.0: self-referential FK. When the
-            // FK points back at the table being inserted into, the row
-            // itself can satisfy the constraint (SQLite checks the parent
-            // index *after* the row is inserted). Mirror that here.
-            if fk.parent_table.eq_ignore_ascii_case(self.table_name) {
-                let row_satisfies_fk = parent_indices.iter().zip(fk_values).enumerate().all(
-                    |(i, (&parent_idx, fk_val))| match full_row_values.get(parent_idx) {
-                        Some(parent_val) => crate::foreign_key_check::fk_values_equal(
-                            fk_val,
-                            parent_val,
-                            parent_collations.get(i).and_then(|c| c.as_deref()),
-                        ),
-                        None => false,
-                    },
-                );
-                if row_satisfies_fk {
+            // Steps 4-6: shared per-FK row-existence + self-FK + defer decision.
+            match crate::foreign_key_check::check_fk_row_existence(
+                self.db,
+                self.table_name,
+                fk,
+                fk_idx,
+                fk_values,
+                full_row_values,
+            )? {
+                crate::foreign_key_check::FkRowCheck::Ok => continue,
+                crate::foreign_key_check::FkRowCheck::Deferred(v) => {
+                    deferred_violations.push(v);
                     continue;
                 }
+                crate::foreign_key_check::FkRowCheck::Violation => {
+                    return Err(ExecutorError::ConstraintViolation(format!(
+                        "FOREIGN KEY constraint '{}' violated: key ({}) not found in table '{}'",
+                        fk.name.as_deref().unwrap_or(""),
+                        fk.column_names.join(", "),
+                        fk.parent_table
+                    )));
+                }
             }
-
-            // FK row-existence violation. Defer if the constraint is
-            // INITIALLY DEFERRED or the session has defer_foreign_keys=ON,
-            // *and* we're inside a transaction. Outside a transaction we
-            // fall through to the immediate-error path, matching SQLite:
-            // deferred enforcement requires a transaction context.
-            let should_defer = in_txn && (fk.initially_deferred || session_defer);
-            if should_defer {
-                deferred_violations.push(DeferredFkViolation {
-                    child_table: self.table_name.to_string(),
-                    fk_index: fk_idx,
-                    child_row: full_row_values.to_vec(),
-                    kind: vibesql_storage::DeferredFkViolationKind::ChildInsertOrUpdate,
-                });
-                continue;
-            }
-
-            return Err(ExecutorError::ConstraintViolation(format!(
-                "FOREIGN KEY constraint '{}' violated: key ({}) not found in table '{}'",
-                fk.name.as_deref().unwrap_or(""),
-                fk.column_names.join(", "),
-                fk.parent_table
-            )));
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Extract steps 4-6 of the INSERT FK validation pipeline (parent-existence scan + self-FK row-self check + defer-or-error decision) into a shared `pub(crate)` helper `foreign_key_check::check_fk_row_existence` returning a `FkRowCheck` enum. Both `insert/foreign_keys.rs::validate_foreign_key_constraints` (bulk-transfer path) and `insert/row_validator.rs::RowValidator::validate_foreign_keys` (single-row VALUES path) now route through the helper instead of running the duplicated logic inline.

Phase C3 of #5085 (PR #5141) added the self-FK row-self check (fkey8-3.0) to **both** paths because they sit on different INSERT pipelines and would otherwise drift; the judge accepted the duplication mid-rollout and flagged this consolidation follow-up.

This is a **pure refactor** — zero observable behaviour change.

## Why this is safe

The helper is a strict consolidation of the previously bit-for-bit-identical inline logic at:
- `insert/foreign_keys.rs` lines 52-115 (steps 4-6 of the bulk-transfer path)
- `insert/row_validator.rs` lines 392-460 (steps 4-6 of the single-row path)

Five behavioural invariants preserved (verified by existing tests + TCL parity):

1. **Error messages identical** — same `ExecutorError::ForeignKeyMismatch` and `ExecutorError::ConstraintViolation` format strings, including the `fk.name.as_deref().unwrap_or("")` empty-string fallback for unnamed FKs. The caller still constructs the violation error (the helper just signals `FkRowCheck::Violation`), so no error-message formatting moved.
2. **Defer-or-error decision identical** — `in_txn && (fk.initially_deferred || session_defer)`. Outside a transaction, deferred constraints still error immediately (matches SQLite).
3. **Mismatch never deferred** — the caller-side wrapper still runs `detect_fk_mismatch` *before* invoking the helper.
4. **Self-FK row-self check uses `full_row_values`** — not the partial FK extract; the row participates in its own FK check (fkey8-3.0).
5. **Borrow-checker pattern from #5125 / PR #5141** — the helper takes `&Database` (not `&mut`), so `RowValidator`'s immutable borrow keeps working. Deferred violations are accumulated in a local `Vec<DeferredFkViolation>` and pushed *after* the immutable borrow drops in both callers.

## What was deliberately NOT changed

- **The two INSERT pipelines themselves** — per the issue's implementation hint, bulk-transfer vs. single-row are separate by design. Only the per-FK validation step is consolidated.
- **`RowValidator`'s six-phase structure** — phases 1-5 (NOT NULL / PK / UNIQUE / CHECK / unique-indexes) are untouched.
- **`ValidationResult`'s public fields** — no API surface change.
- **No new `pub` API** — the helper and `FkRowCheck` enum are both `pub(crate)`.

## Changes

- `crates/vibesql-executor/src/foreign_key_check.rs` — Add `FkRowCheck` enum + `check_fk_row_existence` helper (`pub(crate)`); +6 unit tests covering each variant.
- `crates/vibesql-executor/src/insert/foreign_keys.rs` — Replace inline steps 4-6 with a call to the helper (123 LOC -> 80 LOC).
- `crates/vibesql-executor/src/insert/row_validator.rs` — Replace `validate_foreign_keys` body's inline steps 4-6 with the same helper call (phases 1-5 untouched).

Diff stats: `+386 / -146`; net deletion of ~92 LOC in the two `insert/*` files (helper adds new code with documentation + tests).

## Test Plan

- [x] All 6 new `FkRowCheck` unit tests pass:
  - `Ok` (parent exists)
  - `Ok` (self-FK row-self / fkey8-3.0 pattern)
  - `Violation` (immediate, no defer)
  - `Violation` (deferred constraint but outside transaction)
  - `Deferred` (`INITIALLY DEFERRED` + in-txn)
  - `Deferred` (session pragma `defer_foreign_keys=ON` + in-txn)
- [x] Full executor test suite passes: `cargo test --release -p vibesql-executor --tests` — 3464 passed, 0 failed, 2 ignored (matches `origin/main` baseline).
- [x] FK integration test files all pass unchanged:
  - `foreign_key_tests` (1/1)
  - `foreign_key_deferred_tests` (11/11)
  - `foreign_key_deferred_phase_c3_tests` (11/11) — includes `self_referential_fk_insert_self_satisfying_row_succeeds` (fkey8-3.0)
  - `foreign_key_set_default_tests` (7/7)
  - `foreign_key_collation_action_tests`
- [x] TCL fkey suite pass counts **identical** to `origin/main` before and after:

| File   | Total | Pass | Fail | Skip | Setup-fail |
|--------|-------|------|------|------|------------|
| fkey1  | 23    | 7    | 14   | 2    | 1          |
| fkey5  | 61    | 8    | 10   | 43   | 0          |
| fkey6  | 25    | 4    | 13   | 8    | 1          |
| fkey7  | 9     | 2    | 4    | 3    | 1          |
| fkey8  | 8     | 2    | 5    | 1    | 0          |

- [x] No new `pub` API surface — grep for `pub fn` / `pub enum` in the diff shows only `pub(crate)` items.

## References

- Closes #5148
- Follow-up from PR #5141 (Phase C3 of #5085) — judge-flagged consolidation
- Precedent pattern: PR #5176 (closing #5147) — analogous shared-helper consolidation for FK action helpers

Closes #5148