### PR TITLE
fix(fkey): self-ref multi-row INSERT + tcl-shim multi-table parse

### DIFF
--- a/crates/vibesql-executor/src/foreign_key_check.rs
+++ b/crates/vibesql-executor/src/foreign_key_check.rs
@@ -295,6 +295,18 @@ pub(crate) enum FkRowCheck {
 ///   **not** call [`detect_fk_mismatch`] and does **not** look up the
 ///   parent table — the caller passes those results in.
 ///
+/// # Self-referential multi-row INSERT (fkey1-5.1)
+///
+/// `batch_full_rows` carries the previously-validated rows from the same
+/// multi-row VALUES list. When the FK is self-referential (`fk.parent_table`
+/// equals `table_name`), the self-FK row-self check (step 5) also searches
+/// the batch so row N can resolve its FK against rows 0..N-1 — matching
+/// SQLite's insert-in-declaration-order semantics for
+/// `INSERT INTO t11 VALUES (1,NULL),(2,1),(3,2)` where `t11.parent`
+/// references `t11.x`. Callers that do not stage a batch (e.g. the
+/// bulk-transfer path in `validate_foreign_key_constraints`) pass an
+/// empty slice and get the original single-row behaviour.
+///
 /// # Borrow-checker pattern
 ///
 /// Takes `&Database` (not `&mut`), so `RowValidator` (immutable borrow)
@@ -309,6 +321,7 @@ pub(crate) fn check_fk_row_existence(
     fk_idx: usize,
     fk_values: &[vibesql_types::SqlValue],
     full_row_values: &[vibesql_types::SqlValue],
+    batch_full_rows: &[Vec<vibesql_types::SqlValue>],
 ) -> Result<FkRowCheck, crate::errors::ExecutorError> {
     // Parent table is required for the existence scan. Caller has already
     // confirmed schema mismatch is OK (and a mismatch error path would
@@ -337,24 +350,31 @@ pub(crate) fn check_fk_row_existence(
         return Ok(FkRowCheck::Ok);
     }
 
-    // Step 5: self-FK row-self check (Phase C3 of #5085 / fkey8-3.0).
-    // When the FK points back at the table being inserted into, the row
-    // itself can satisfy the constraint (SQLite checks the parent index
-    // *after* the row is inserted). Mirror that here. Uses
-    // `full_row_values` (not the partial FK extract) so the row
-    // participates in its own FK check.
+    // Step 5: self-FK row-self check (Phase C3 of #5085 / fkey8-3.0) +
+    // multi-row sibling check (fkey1-5.1). When the FK points back at the
+    // table being inserted into, two extra rescue paths apply:
+    //   (a) The row itself can satisfy the constraint — SQLite checks the
+    //       parent index *after* the row is inserted.
+    //   (b) For multi-row INSERTs, an earlier row in the same VALUES list
+    //       may have been the intended parent; SQLite inserts rows in
+    //       declaration order and a later row's FK target can resolve to
+    //       a sibling already inserted in the same statement.
+    // Both checks use full-row values (not the partial FK extract) so the
+    // candidate row participates as a whole row in its own FK check.
     if fk.parent_table.eq_ignore_ascii_case(table_name) {
-        let row_satisfies_fk = parent_indices.iter().zip(fk_values).enumerate().all(
-            |(i, (&parent_idx, fk_val))| match full_row_values.get(parent_idx) {
-                Some(parent_val) => fk_values_equal(
-                    fk_val,
-                    parent_val,
-                    parent_collations.get(i).and_then(|c| c.as_deref()),
-                ),
-                None => false,
-            },
-        );
-        if row_satisfies_fk {
+        let row_matches = |candidate: &[vibesql_types::SqlValue]| -> bool {
+            parent_indices.iter().zip(fk_values).enumerate().all(
+                |(i, (&parent_idx, fk_val))| match candidate.get(parent_idx) {
+                    Some(parent_val) => fk_values_equal(
+                        fk_val,
+                        parent_val,
+                        parent_collations.get(i).and_then(|c| c.as_deref()),
+                    ),
+                    None => false,
+                },
+            )
+        };
+        if row_matches(full_row_values) || batch_full_rows.iter().any(|r| row_matches(r)) {
             return Ok(FkRowCheck::Ok);
         }
     }
@@ -502,7 +522,7 @@ mod tests {
         let full_row = vec![SqlValue::Integer(10), SqlValue::Integer(2)];
         let fk_values = vec![SqlValue::Integer(2)];
 
-        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row).unwrap();
+        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row, &[]).unwrap();
         assert!(matches!(outcome, FkRowCheck::Ok), "expected Ok, got {:?}", outcome);
     }
 
@@ -537,11 +557,66 @@ mod tests {
         let full_row = vec![SqlValue::Integer(5), SqlValue::Integer(5)];
         let fk_values = vec![SqlValue::Integer(5)];
 
-        let outcome = check_fk_row_existence(&db, "t", &fk, 0, &fk_values, &full_row).unwrap();
+        let outcome = check_fk_row_existence(&db, "t", &fk, 0, &fk_values, &full_row, &[]).unwrap();
         assert!(
             matches!(outcome, FkRowCheck::Ok),
             "self-FK row-self check must accept, got {:?}",
             outcome
+        );
+    }
+
+    #[test]
+    fn check_fk_row_existence_ok_self_fk_sibling_in_batch() {
+        // fkey1-5.1: multi-row INSERT into a self-referential parent.
+        // t(x INTEGER PRIMARY KEY, parent INTEGER REFERENCES t(x)).
+        // INSERT VALUES (1, NULL), (2, 1), (3, 2).
+        // Row (2, 1) is validated with batch_full_rows = [(1, NULL)] in scope;
+        // the parent table is still empty, the self-row doesn't match
+        // (parent_idx=0 holds 2, fk_val=1), so the sibling rescue must catch it.
+        let mut db = Database::new();
+        db.set_foreign_keys_enabled(true);
+
+        let fk = ForeignKeyConstraint {
+            name: Some("fk_t_self".to_string()),
+            column_names: vec!["parent".to_string()],
+            column_indices: vec![1],
+            parent_table: "t".to_string(),
+            parent_column_names: vec!["x".to_string()],
+            parent_column_indices: vec![0],
+            on_delete: ReferentialAction::NoAction,
+            on_update: ReferentialAction::NoAction,
+            is_deferrable: false,
+            initially_deferred: false,
+        };
+        let cols = vec![
+            ColumnSchema::new("x".to_string(), DataType::Integer, false),
+            ColumnSchema::new("parent".to_string(), DataType::Integer, true),
+        ];
+        let mut t = TableSchema::with_primary_key("t".to_string(), cols, vec!["x".to_string()]);
+        t.foreign_keys.push(fk.clone());
+        db.create_table(t).unwrap();
+
+        let earlier_row = vec![SqlValue::Integer(1), SqlValue::Null];
+        let batch = vec![earlier_row];
+
+        let full_row = vec![SqlValue::Integer(2), SqlValue::Integer(1)];
+        let fk_values = vec![SqlValue::Integer(1)];
+
+        let outcome =
+            check_fk_row_existence(&db, "t", &fk, 0, &fk_values, &full_row, &batch).unwrap();
+        assert!(
+            matches!(outcome, FkRowCheck::Ok),
+            "multi-row self-FK sibling rescue must accept, got {:?}",
+            outcome
+        );
+
+        // Empty batch (single-row path) must still fail for the same row.
+        let outcome_no_batch =
+            check_fk_row_existence(&db, "t", &fk, 0, &fk_values, &full_row, &[]).unwrap();
+        assert!(
+            matches!(outcome_no_batch, FkRowCheck::Violation),
+            "without batch_full_rows the same row must violate, got {:?}",
+            outcome_no_batch
         );
     }
 
@@ -552,7 +627,7 @@ mod tests {
         let full_row = vec![SqlValue::Integer(10), SqlValue::Integer(999)];
         let fk_values = vec![SqlValue::Integer(999)];
 
-        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row).unwrap();
+        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row, &[]).unwrap();
         assert!(matches!(outcome, FkRowCheck::Violation), "expected Violation, got {:?}", outcome);
     }
 
@@ -571,7 +646,7 @@ mod tests {
         let fk_values = vec![SqlValue::Integer(999)];
 
         assert!(!db.in_transaction(), "test precondition: no transaction");
-        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row).unwrap();
+        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row, &[]).unwrap();
         assert!(
             matches!(outcome, FkRowCheck::Violation),
             "deferred-but-outside-txn must error immediately, got {:?}",
@@ -593,7 +668,7 @@ mod tests {
         let full_row = vec![SqlValue::Integer(10), SqlValue::Integer(999)];
         let fk_values = vec![SqlValue::Integer(999)];
 
-        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row).unwrap();
+        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row, &[]).unwrap();
         match outcome {
             FkRowCheck::Deferred(v) => {
                 assert_eq!(v.child_table, "c");
@@ -619,7 +694,7 @@ mod tests {
         let full_row = vec![SqlValue::Integer(10), SqlValue::Integer(999)];
         let fk_values = vec![SqlValue::Integer(999)];
 
-        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row).unwrap();
+        let outcome = check_fk_row_existence(&db, "c", &fk, 0, &fk_values, &full_row, &[]).unwrap();
         assert!(
             matches!(outcome, FkRowCheck::Deferred(_)),
             "session pragma must defer, got {:?}",

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -232,6 +232,10 @@ fn execute_insert_internal(
     } else {
         vec![Vec::new(); schema.get_unique_constraint_indices().len()]
     }; // Track UNIQUE values for each constraint
+    // Track previously-validated full rows for self-referential FK lookups
+    // (fkey1-5.1: `INSERT INTO t VALUES (1,NULL),(2,1),(3,2)` where t.parent
+    // references t.x — row N must find its parent among rows 0..N-1).
+    let mut batch_full_rows: Vec<Vec<vibesql_types::SqlValue>> = Vec::new();
 
     // Check if IGNORE conflict clause is set - if so, skip rows with constraint violations
     // Also treat ON CONFLICT ... DO NOTHING as equivalent to IGNORE
@@ -586,6 +590,7 @@ fn execute_insert_internal(
             &storage_table_name,
             &primary_key_values,
             &unique_constraint_values,
+            &batch_full_rows,
             skip_duplicate_checks,
         );
 
@@ -629,6 +634,10 @@ fn execute_insert_internal(
         for v in validation_result.deferred_fk_violations {
             db.queue_deferred_fk_violation(v);
         }
+
+        // Track row for self-referential FK lookups by later rows in the
+        // same batch (see fkey1-5.1 note above).
+        batch_full_rows.push(full_row_values.clone());
 
         // Store validated row for insertion (with optional explicit rowid)
         validated_rows.push((full_row_values, explicit_rowid));

--- a/crates/vibesql-executor/src/insert/foreign_keys.rs
+++ b/crates/vibesql-executor/src/insert/foreign_keys.rs
@@ -54,7 +54,11 @@ pub fn validate_foreign_key_constraints(
         }
 
         // Steps 4-6: shared per-FK row-existence + self-FK + defer decision.
-        match check_fk_row_existence(db, table_name, fk, fk_idx, &fk_values, row_values)? {
+        // The bulk-transfer path validates one row at a time and does not
+        // stage a batch, so pass an empty slice for `batch_full_rows`. The
+        // multi-row self-FK sibling rescue (fkey1-5.1) only triggers on
+        // the `RowValidator` VALUES-list path.
+        match check_fk_row_existence(db, table_name, fk, fk_idx, &fk_values, row_values, &[])? {
             FkRowCheck::Ok => continue,
             FkRowCheck::Deferred(v) => {
                 deferred.push(v);

--- a/crates/vibesql-executor/src/insert/row_validator.rs
+++ b/crates/vibesql-executor/src/insert/row_validator.rs
@@ -27,6 +27,12 @@ pub struct RowValidator<'a> {
     batch_pk_values: &'a [Vec<vibesql_types::SqlValue>],
     /// Track UNIQUE values from batch for duplicate detection
     batch_unique_values: &'a [Vec<Vec<vibesql_types::SqlValue>>],
+    /// Previously validated full rows from this multi-row INSERT batch.
+    /// Used by self-referential FK validation so row N can find its parent
+    /// among earlier rows in the same VALUES list (e.g. fkey1-5.1:
+    /// `INSERT INTO t11 VALUES (1, NULL), (2, 1), (3, 2);` where t11.parent
+    /// references t11.x — row (2, 1) must see the just-validated (1, NULL)).
+    batch_full_rows: &'a [Vec<vibesql_types::SqlValue>],
     /// Skip PK/UNIQUE duplicate checks (for REPLACE conflict clause)
     skip_duplicate_checks: bool,
 }
@@ -38,9 +44,18 @@ impl<'a> RowValidator<'a> {
         table_name: &'a str,
         batch_pk_values: &'a [Vec<vibesql_types::SqlValue>],
         batch_unique_values: &'a [Vec<Vec<vibesql_types::SqlValue>>],
+        batch_full_rows: &'a [Vec<vibesql_types::SqlValue>],
         skip_duplicate_checks: bool,
     ) -> Self {
-        Self { db, schema, table_name, batch_pk_values, batch_unique_values, skip_duplicate_checks }
+        Self {
+            db,
+            schema,
+            table_name,
+            batch_pk_values,
+            batch_unique_values,
+            batch_full_rows,
+            skip_duplicate_checks,
+        }
     }
 
     /// Validate all constraints in a single pass through the row
@@ -397,6 +412,10 @@ impl<'a> RowValidator<'a> {
             };
 
             // Steps 4-6: shared per-FK row-existence + self-FK + defer decision.
+            // `batch_full_rows` carries the previously-validated rows from the
+            // same multi-row VALUES list so self-referential FKs can resolve
+            // against siblings (fkey1-5.1: `INSERT INTO t11 VALUES
+            // (1,NULL),(2,1),(3,2)` with t11.parent REFERENCES t11.x).
             match crate::foreign_key_check::check_fk_row_existence(
                 self.db,
                 self.table_name,
@@ -404,6 +423,7 @@ impl<'a> RowValidator<'a> {
                 fk_idx,
                 fk_values,
                 full_row_values,
+                self.batch_full_rows,
             )? {
                 crate::foreign_key_check::FkRowCheck::Ok => continue,
                 crate::foreign_key_check::FkRowCheck::Deferred(v) => {

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1393,15 +1393,35 @@ proc parse_result {output} {
     # NOTE: This function is kept for backwards compatibility but parse_raw_result
     # should be preferred as it correctly handles NULL vs 'NULL' string distinction
     # Errors in output are translated to SQLite-compatible format
+    #
+    # VibeSQL emits one boxed table per result-producing statement, e.g.:
+    #   +----+
+    #   | x  |     <- header (between separators 1 and 2)
+    #   +----+
+    #   | 1  |     <- data row (after separator 2, before separator 3)
+    #   +----+
+    #   1 rows
+    #
+    # When a batch contains multiple result-producing statements (common when
+    # transactions are batched through `flush_batch` and PRAGMA reads are
+    # interleaved), the output contains multiple such tables back-to-back.
+    # We reset the per-table separator counter on the "N rows" trailer (or on
+    # the next leading separator after a 3rd separator) so the header of each
+    # subsequent table is correctly skipped instead of being captured as data.
+    # Without this, fkey6-1.10.1 saw the literal column name `defer_foreign_keys`
+    # appended between each pragma read in the result list.
     set data {}
     set lines [split $output "\n"]
-    set header_seen 0
     set separator_count 0
 
     foreach line $lines {
-        # Skip empty lines and row count lines
+        # Skip empty lines
         if {[string trim $line] eq ""} continue
-        if {[regexp {^\d+ rows?$} $line]} continue
+        # `N rows` marks the end of a table — reset for the next one
+        if {[regexp {^\d+ rows?$} $line]} {
+            set separator_count 0
+            continue
+        }
         if {[regexp {^=+$} $line]} continue
         if {[regexp {^Error} $line]} {
             # Translate error to SQLite format before raising
@@ -1410,7 +1430,14 @@ proc parse_result {output} {
 
         # Count separators - header is between 1st and 2nd separator
         if {[regexp {^\+[-+]+\+$} $line]} {
-            incr separator_count
+            # If we already saw the closing separator of the previous table
+            # (count==3) and no `N rows` trailer arrived (e.g. trimmed), the
+            # next `+---+` is the top of a new table.
+            if {$separator_count >= 3} {
+                set separator_count 1
+            } else {
+                incr separator_count
+            }
             continue
         }
 


### PR DESCRIPTION
## Summary

Two surgical fixes for two of the four remaining tests in umbrella #5071. Both originally appeared in the issue's 16-test target list.

- **fkey1-5.1** (FK semantic): Self-referential FK validation in multi-row INSERT now consults already-validated rows in the same `VALUES` list, not just the row being validated. `INSERT INTO t11 VALUES (1,NULL),(2,1),(3,2)` now succeeds when `t11.parent REFERENCES t11.x`.
- **fkey6-1.10.1** (TCL shim): `parse_result` reset its header-skip counter per result set so batched transactions with multiple `PRAGMA` reads no longer leak column names into the TCL result list.

## Pass rate deltas

| File | Before | After | Delta |
|---|---|---|---|
| fkey1 | 15/26 | 16/26 | +1 |
| fkey5 | 53/58 | 53/58 | 0 |
| fkey6 | 19/38 | 20/38 | +1 |
| fkey8 | 12/32 | 12/32 | 0 |

Lib tests: vibesql-executor 2384/2384, vibesql-storage 591/591. No P1 regression detected.

## Out of scope (follow-ups warranted)

The remaining failures across fkey1/6 fall outside the original 16-test target list:

- **fkey1-6.0/6.1/6.2**: Blocked by missing partial-index support (`CREATE INDEX ... WHERE`); the FK mismatch test (6.1) only fails because the parent table never gets created.
- **fkey6-1.6/1.10.2/1.22/3.2.1/3.2.2/3.3.2/3.3.4/5.1**: Deferred-FK semantic edges left after Phase C2 (#5125).
- **fkey6-1.20/1.21**: `sqlite3_db_status` TCL helper not implemented in the shim.
- **fkey6-2.4/2.5/2.6**: Cascade from a setup test that fails on `INSERT OR IGNORE` semantics around UNIQUE-with-NULL.

This PR uses "Implements part of" so #5071 stays open as the umbrella tracker.

## Test plan

- [x] cargo build --release clean
- [x] cargo test --release -p vibesql-executor --lib -> 2384/2384
- [x] cargo test --release -p vibesql-storage --lib -> 591/591
- [x] ./scripts/tcltest run --pattern fkey1.test -> 16/26 (was 15/26)
- [x] ./scripts/tcltest run --pattern fkey5.test -> 53/58 (unchanged)
- [x] ./scripts/tcltest run --pattern fkey6.test -> 20/38 (was 19/38)
- [x] ./scripts/tcltest run --pattern fkey8.test -> 12/32 (unchanged)

Implements part of #5071

Generated with Claude Code