### PR TITLE
feat(mvcc): Phase 1b - TxnSnapshot + Row::visible_to predicate

### DIFF
--- a/crates/vibesql-storage/src/database/transactions.rs
+++ b/crates/vibesql-storage/src/database/transactions.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use crate::{wal::TransactionDurability, Row, StorageError, Table};
+use crate::{mvcc::TxnSnapshot, row::TxnId, wal::TransactionDurability, Row, StorageError, Table};
 
 /// A single change made during a transaction
 #[derive(Debug, Clone)]
@@ -92,6 +92,21 @@ pub enum TransactionState {
         /// by replacing the entire transaction state; `ROLLBACK TO`
         /// truncates back to the savepoint's `deferred_fk_snapshot_index`.
         deferred_fk_violations: Vec<DeferredFkViolation>,
+        /// MVCC snapshot captured at `BEGIN` (Phase 1b of #5136).
+        ///
+        /// Captured once at transaction start and held for the entire
+        /// transaction lifetime. All reads within the transaction
+        /// consult the same snapshot, giving snapshot-isolation
+        /// semantics independent of concurrent commits.
+        ///
+        /// **Phase 1b note:** this field is captured but **not yet
+        /// consulted by any read path**. Phase 1d wires the
+        /// `Table::scan_visible(&snapshot)` boundary. Until then this
+        /// field is dead state at runtime — kept here so Phase 1c can
+        /// stamp `xmin = id` and Phase 1d has the snapshot to read with.
+        ///
+        /// See [`crate::mvcc::TxnSnapshot`] for the predicate contract.
+        snapshot: TxnSnapshot,
     },
 }
 
@@ -142,6 +157,16 @@ impl TransactionManager {
                 let transaction_id = self.next_transaction_id;
                 self.next_transaction_id += 1;
 
+                // Capture the MVCC snapshot **before** publishing the
+                // new transaction id. The `in_progress` set is computed
+                // from currently-active transactions (just this one
+                // would be self, which we deliberately exclude — a
+                // transaction always sees its own writes). Under the
+                // current single-writer model, in_progress is always
+                // empty at BEGIN; this will need to change when Raft +
+                // multi-writer arrives in later phases.
+                let snapshot = Self::capture_snapshot(transaction_id);
+
                 self.transaction_state = TransactionState::Active {
                     id: transaction_id,
                     original_catalog,
@@ -150,6 +175,7 @@ impl TransactionManager {
                     changes: Vec::new(),
                     durability,
                     deferred_fk_violations: Vec::new(),
+                    snapshot,
                 };
                 Ok(())
             }
@@ -157,6 +183,37 @@ impl TransactionManager {
                 Err(StorageError::TransactionError("Transaction already active".to_string()))
             }
         }
+    }
+
+    /// Build the MVCC snapshot for a transaction with id `txn_id`.
+    ///
+    /// **Phase 1b semantics (single-writer):** there are no other
+    /// concurrently-active transactions to put in `in_progress`. The
+    /// snapshot is:
+    ///
+    /// - `xmin_active = txn_id` — the next-to-allocate id (one past the
+    ///   high-water mark from the caller's perspective). This makes the
+    ///   `xmax > xmin_active` clause in [`Row::visible_to`] only true
+    ///   for transactions that started *after* us, which is the correct
+    ///   behavior with no concurrent peers.
+    /// - `xmax_committed = txn_id - 1` — every transaction allocated
+    ///   before us has, by the single-writer invariant, already finished
+    ///   (committed or rolled back). For the rolled-back case, the
+    ///   rollback path replaces tables wholesale, so no `xmin = rolled_back_id`
+    ///   row exists in storage and the predicate correctness is preserved.
+    /// - `in_progress = ∅` — no concurrent transactions.
+    ///
+    /// **Future (multi-writer / Raft):** when concurrent transactions
+    /// become possible, this method becomes the chokepoint where the
+    /// `in_progress` set is populated from the active-transactions
+    /// registry. The caller signature does not need to change.
+    ///
+    /// [`Row::visible_to`]: crate::Row::visible_to
+    fn capture_snapshot(txn_id: TxnId) -> TxnSnapshot {
+        // For txn_id = 1 (the first ever), xmax_committed = 0 means
+        // "only pre-MVCC rows are visible" — exactly right.
+        let xmax_committed = txn_id.saturating_sub(1);
+        TxnSnapshot::new(txn_id, xmax_committed, std::collections::HashSet::new())
     }
 
     /// Commit the current transaction
@@ -211,6 +268,24 @@ impl TransactionManager {
     pub fn get_durability(&self) -> Option<TransactionDurability> {
         match &self.transaction_state {
             TransactionState::Active { durability, .. } => Some(*durability),
+            TransactionState::None => None,
+        }
+    }
+
+    /// Get the MVCC snapshot for the current transaction (if any).
+    ///
+    /// Returns the snapshot captured at `BEGIN` time. The same snapshot
+    /// is returned on every call within a transaction — capture is
+    /// per-transaction, not per-statement.
+    ///
+    /// **Phase 1b note:** no callers consume this yet. Phase 1d will
+    /// thread it through the scan path so SELECT/JOIN/subquery reads
+    /// get snapshot-isolation semantics.
+    ///
+    /// See [`crate::mvcc::TxnSnapshot`].
+    pub fn current_snapshot(&self) -> Option<&TxnSnapshot> {
+        match &self.transaction_state {
+            TransactionState::Active { snapshot, .. } => Some(snapshot),
             TransactionState::None => None,
         }
     }
@@ -329,5 +404,125 @@ impl TransactionManager {
 impl Default for TransactionManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod snapshot_capture_tests {
+    //! Tests for MVCC snapshot capture (Phase 1b of #5136).
+    //!
+    //! These tests cover the contract that `begin_transaction` captures
+    //! a [`TxnSnapshot`] exactly once, that the snapshot reflects the
+    //! current `next_transaction_id` watermark, and that multiple reads
+    //! within the same transaction see the same snapshot.
+
+    use super::*;
+
+    fn empty_catalog_and_tables() -> (vibesql_catalog::Catalog, HashMap<String, Table>) {
+        (vibesql_catalog::Catalog::new(), HashMap::new())
+    }
+
+    #[test]
+    fn first_transaction_snapshot_has_xmax_committed_zero() {
+        // First-ever transaction: xmax_committed should be 0 (only
+        // pre-MVCC sentinel rows are visible to it), xmin_active should
+        // equal our own id (1).
+        let (catalog, tables) = empty_catalog_and_tables();
+        let mut mgr = TransactionManager::new();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
+
+        let snap = mgr.current_snapshot().expect("snapshot present after BEGIN");
+        assert_eq!(snap.xmin_active, 1);
+        assert_eq!(snap.xmax_committed, 0);
+        assert!(snap.in_progress.is_empty());
+    }
+
+    #[test]
+    fn second_transaction_snapshot_sees_first_as_committed() {
+        // Second transaction's snapshot should include the first txn's
+        // id in the "committed" range (xmax_committed >= 1).
+        let (catalog, tables) = empty_catalog_and_tables();
+        let mut mgr = TransactionManager::new();
+
+        mgr.begin_transaction(&catalog, &tables).unwrap();
+        mgr.commit_transaction().unwrap();
+
+        mgr.begin_transaction(&catalog, &tables).unwrap();
+        let snap = mgr.current_snapshot().expect("second snapshot present");
+        assert_eq!(snap.xmin_active, 2);
+        assert_eq!(snap.xmax_committed, 1);
+        assert!(snap.in_progress.is_empty());
+    }
+
+    #[test]
+    fn snapshot_stable_across_multiple_reads_within_transaction() {
+        // The snapshot is captured once at BEGIN; subsequent reads must
+        // return the same data. This is the snapshot-isolation contract.
+        let (catalog, tables) = empty_catalog_and_tables();
+        let mut mgr = TransactionManager::new();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
+
+        let snap1 = mgr.current_snapshot().cloned().unwrap();
+        let snap2 = mgr.current_snapshot().cloned().unwrap();
+        let snap3 = mgr.current_snapshot().cloned().unwrap();
+
+        assert_eq!(snap1.xmin_active, snap2.xmin_active);
+        assert_eq!(snap1.xmin_active, snap3.xmin_active);
+        assert_eq!(snap1.xmax_committed, snap2.xmax_committed);
+        assert_eq!(snap1.xmax_committed, snap3.xmax_committed);
+        assert_eq!(snap1.in_progress, snap2.in_progress);
+        assert_eq!(snap1.in_progress, snap3.in_progress);
+    }
+
+    #[test]
+    fn no_snapshot_outside_transaction() {
+        let mgr = TransactionManager::new();
+        assert!(mgr.current_snapshot().is_none());
+    }
+
+    #[test]
+    fn rolled_back_transaction_still_advances_watermark() {
+        // Even rolled-back transactions consume a TxnId, so the next
+        // transaction's snapshot xmax_committed includes them. The
+        // rollback path replaces tables wholesale, so no rows stamped
+        // with the rolled-back id remain, preserving predicate
+        // correctness.
+        let (mut catalog, mut tables) = empty_catalog_and_tables();
+        let mut mgr = TransactionManager::new();
+
+        mgr.begin_transaction(&catalog, &tables).unwrap();
+        mgr.rollback_transaction(&mut catalog, &mut tables).unwrap();
+
+        mgr.begin_transaction(&catalog, &tables).unwrap();
+        let snap = mgr.current_snapshot().unwrap();
+        // First txn id was 1 (rolled back). Second txn id is 2.
+        assert_eq!(snap.xmin_active, 2);
+        assert_eq!(snap.xmax_committed, 1);
+    }
+
+    #[test]
+    fn snapshot_visibility_integration() {
+        // End-to-end sanity check: a row stamped with the *current*
+        // active transaction's id (Phase 1c will do this) should NOT
+        // be visible to that transaction's own snapshot under this
+        // predicate — that's intentional. Phase 1c/1d will introduce a
+        // separate "is my own write" check that bypasses snapshot
+        // visibility. Documenting that gap here.
+        let (catalog, tables) = empty_catalog_and_tables();
+        let mut mgr = TransactionManager::new();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
+        let my_id = mgr.transaction_id().unwrap();
+        let snap = mgr.current_snapshot().unwrap();
+
+        // A row stamped with our own id: my_id > xmax_committed
+        // (== my_id - 1), so visible_to returns false. Phase 1c's
+        // "see my own writes" path will be a separate clause.
+        let mut my_row = crate::Row::new(vec![vibesql_types::SqlValue::Integer(1)]);
+        my_row.xmin = my_id;
+        assert!(
+            !my_row.visible_to(snap),
+            "Phase 1b predicate intentionally does not show transactions \
+             their own writes; Phase 1c will add a separate clause for that"
+        );
     }
 }

--- a/crates/vibesql-storage/src/lib.rs
+++ b/crates/vibesql-storage/src/lib.rs
@@ -15,6 +15,7 @@ pub mod columnar_cache;
 pub mod database;
 pub mod error;
 pub mod index;
+pub mod mvcc;
 pub mod page;
 pub mod persistence;
 pub mod progress;
@@ -46,6 +47,7 @@ pub use database::{
 };
 pub use error::{StorageError, StorageResult};
 pub use index::{extract_mbr_from_sql_value, SpatialIndex, SpatialIndexEntry};
+pub use mvcc::TxnSnapshot;
 pub use persistence::load::{parse_sql_statements, read_sql_dump};
 pub use query_buffer_pool::{
     QueryBufferPool, QueryBufferPoolStats, RowBufferGuard, ValueBufferGuard,

--- a/crates/vibesql-storage/src/mvcc.rs
+++ b/crates/vibesql-storage/src/mvcc.rs
@@ -1,0 +1,262 @@
+//! MVCC (Multi-Version Concurrency Control) snapshot machinery.
+//!
+//! # Phase 1b of #5136
+//!
+//! This module is the second of four sequential PRs decomposing MVCC
+//! Phase 1 from the umbrella issue #5136:
+//!
+//! - **Phase 1a** ([PR #5142]) — added `xmin`/`xmax` fields to [`Row`] and
+//!   the v6→v7 persistence shim. Inert at the executor level.
+//! - **Phase 1b** (this PR, #5149) — introduces [`TxnSnapshot`] and the
+//!   [`Row::visible_to`] predicate. Snapshot capture is wired into
+//!   `TransactionState::Active`, but **nothing reads it yet**. The
+//!   predicate is pure-function and has no callers in this PR; Phase 1c
+//!   and Phase 1d wire up the writer and reader respectively.
+//! - **Phase 1c** (#5150, future) — write-path `xmin`/`xmax` stamping on
+//!   INSERT/UPDATE/DELETE.
+//! - **Phase 1d** (#5151, future) — read-path visibility filtering on
+//!   SELECT scans; cross-snapshot FK deferred-replay coordination; flips
+//!   the `mvcc_enabled` feature flag on.
+//!
+//! # API surface (kept minimal on purpose)
+//!
+//! - [`TxnSnapshot`] — a captured view of which transactions are
+//!   committed-as-of-then. Plain data, `Clone + Debug`.
+//! - [`TxnSnapshot::empty`] — the "everything pre-MVCC is visible, nothing
+//!   else is" snapshot used by non-transactional reads and as the default
+//!   in transactions that haven't yet captured one.
+//! - [`Row::visible_to`] — `&self, &TxnSnapshot -> bool`. The single
+//!   visibility predicate.
+//!
+//! Phase 1c/1d should not need to expand this surface — they only need to
+//! call `Row::visible_to(snapshot)` from the scan boundary and to pass the
+//! `TransactionState::Active.snapshot` field into reads.
+//!
+//! # Visibility predicate contract
+//!
+//! A row `r` with `(r.xmin, r.xmax)` is **visible to** a snapshot `s`
+//! iff all three of these hold:
+//!
+//! 1. `r.xmin <= s.xmax_committed` — the row's creator committed before
+//!    our snapshot was taken (or `r.xmin` is the pre-MVCC sentinel `0`,
+//!    which is `<= s.xmax_committed` for any non-zero snapshot).
+//! 2. `r.xmin` is **not** in `s.in_progress` — the row's creator was
+//!    still mid-flight when our snapshot was taken, so under snapshot
+//!    isolation we don't see it.
+//! 3. Either `r.xmax` is `None` (still live), OR `r.xmax > s.xmin_active`
+//!    (deletion happened after the oldest still-running txn at snapshot
+//!    time, so it can't have been committed before our snapshot), OR
+//!    `r.xmax` is in `s.in_progress` (the deleter was still mid-flight,
+//!    so the delete isn't yet visible to us).
+//!
+//! The third clause is intentionally optimistic: it errs on the side of
+//! **showing** rows that *might* have been deleted by a concurrent
+//! transaction. Snapshot isolation forbids the opposite (hiding rows
+//! that were definitely live at snapshot time), but allows showing rows
+//! that have been concurrently deleted. Phase 1c's commit path is what
+//! resolves the "definitely committed" status; this predicate operates
+//! purely on the snapshot data it was given.
+//!
+//! # Abort handling
+//!
+//! This phase does **not** model transaction abort/rollback in the
+//! snapshot data. A snapshot only carries information about
+//! committed-or-still-running transactions. If a transaction aborts,
+//! Phase 1c is responsible for either:
+//!
+//! - Reverting the `xmin`/`xmax` stamps it made (current `rollback_transaction`
+//!   already restores `original_tables` from snapshot, which discards
+//!   any stamping), OR
+//! - Adding an `aborted: HashSet<TxnId>` field to [`TxnSnapshot`] and
+//!   extending the predicate with an "ignore writes from aborted txns"
+//!   clause.
+//!
+//! The current snapshot-isolation semantics — combined with
+//! `TransactionManager::rollback_transaction` restoring full table
+//! snapshots — make the "revert on abort" path the simpler choice; Phase
+//! 1c will document its final decision.
+//!
+//! [PR #5142]: https://github.com/rjwalters/vibesql/pull/5142
+//! [`Row`]: crate::Row
+//! [`Row::visible_to`]: crate::Row::visible_to
+
+use std::collections::HashSet;
+
+use crate::row::TxnId;
+
+/// A point-in-time snapshot of the set of transactions visible to a
+/// reader under snapshot isolation.
+///
+/// A `TxnSnapshot` is captured **once per transaction at `BEGIN`** and
+/// held for the lifetime of that transaction (see
+/// [`TransactionState::Active`]). All reads within the transaction
+/// consult the same snapshot, so a transaction sees a stable view of the
+/// database regardless of concurrent commits.
+///
+/// # Fields
+///
+/// - [`xmin_active`](Self::xmin_active) — the lowest [`TxnId`] that was
+///   **still running** at snapshot time. Any row whose `xmax > xmin_active`
+///   was deleted by a transaction that started after our snapshot's
+///   oldest concurrent peer, and thus may not yet have been committed
+///   when we took our snapshot.
+/// - [`xmax_committed`](Self::xmax_committed) — the largest [`TxnId`]
+///   that had **already committed** at snapshot time. Rows whose
+///   `xmin > xmax_committed` were definitely created after our snapshot
+///   and are invisible.
+/// - [`in_progress`](Self::in_progress) — the set of transactions that
+///   were still running at snapshot time. Writes by these transactions
+///   are invisible to us regardless of where their `TxnId` falls
+///   relative to `xmin_active` / `xmax_committed`.
+///
+/// # Phase 1b note
+///
+/// This struct is intentionally `Clone` (cheap modulo the `HashSet`) so
+/// `TransactionState::Active` can hold it by value without lifetime
+/// gymnastics. The `in_progress` set is typically small (one per
+/// concurrent active transaction); in single-writer workloads it is
+/// usually empty.
+///
+/// [`TxnId`]: crate::row::TxnId
+/// [`TransactionState::Active`]: crate::database::TransactionState
+#[derive(Debug, Clone, Default)]
+pub struct TxnSnapshot {
+    /// Lowest `TxnId` of any transaction that was still running when
+    /// this snapshot was captured. A row with `xmax > xmin_active` was
+    /// deleted by a transaction that didn't exist (or wasn't yet
+    /// committed) when our snapshot was taken, so the deletion is not
+    /// yet visible to us.
+    ///
+    /// If no transactions were active at capture time, this is set to
+    /// the next [`TxnId`] that *would* be allocated (i.e., one past the
+    /// high-water mark), making the `xmax > xmin_active` clause always
+    /// fail — which is the correct behavior: with no concurrent
+    /// transactions, any deletion we see is definitely committed.
+    pub xmin_active: TxnId,
+    /// Largest `TxnId` that had committed at snapshot time. Rows with
+    /// `xmin > xmax_committed` were created after our snapshot and are
+    /// invisible.
+    ///
+    /// Note that the pre-MVCC sentinel ([`PRE_MVCC_TXN_ID`] = 0) is `<=`
+    /// any `xmax_committed >= 0`, so legacy rows are always visible.
+    ///
+    /// [`PRE_MVCC_TXN_ID`]: crate::row::PRE_MVCC_TXN_ID
+    pub xmax_committed: TxnId,
+    /// Set of transactions that were still running at snapshot time.
+    /// Writes (and deletions) by these transactions are invisible to us
+    /// under snapshot isolation, even if their `TxnId` is `<=`
+    /// `xmax_committed` (which can happen if they had started before
+    /// some transaction we *can* see).
+    ///
+    /// This set never contains the snapshot's own transaction id: a
+    /// transaction always sees its own writes (currently handled at the
+    /// catalog/table layer; Phase 1c will reconcile this with the
+    /// `xmin == self.txn_id` case if it changes).
+    pub in_progress: HashSet<TxnId>,
+}
+
+impl TxnSnapshot {
+    /// Create a snapshot in which **no MVCC versioning is active**.
+    ///
+    /// This is the snapshot used by:
+    ///
+    /// - Auto-commit reads (no enclosing transaction).
+    /// - Pre-MVCC code paths (the `mvcc_enabled` feature is off).
+    /// - As a placeholder default before a real snapshot is captured.
+    ///
+    /// With this snapshot, only rows stamped with
+    /// [`PRE_MVCC_TXN_ID`](crate::row::PRE_MVCC_TXN_ID) (== `0`) and a
+    /// `None` `xmax` are visible. The `xmax_committed = 0` field makes
+    /// every non-sentinel `xmin` fail the visibility check, which is
+    /// safe-by-default — code that hasn't been migrated to capture real
+    /// snapshots will see exactly the rows it saw before Phase 1.
+    pub fn empty() -> Self {
+        TxnSnapshot {
+            xmin_active: 0,
+            xmax_committed: 0,
+            in_progress: HashSet::new(),
+        }
+    }
+
+    /// Create a snapshot from the explicit components.
+    ///
+    /// Intended for tests and for the transaction manager's capture
+    /// logic; production code should prefer the manager-driven helpers
+    /// in `database::transactions`.
+    pub fn new(
+        xmin_active: TxnId,
+        xmax_committed: TxnId,
+        in_progress: HashSet<TxnId>,
+    ) -> Self {
+        TxnSnapshot { xmin_active, xmax_committed, in_progress }
+    }
+
+    /// Returns `true` if `txn` was committed-as-of this snapshot.
+    ///
+    /// A transaction is considered committed iff:
+    /// - its `TxnId` is `<= xmax_committed`, AND
+    /// - it is not in the `in_progress` set.
+    ///
+    /// The pre-MVCC sentinel ([`PRE_MVCC_TXN_ID`](crate::row::PRE_MVCC_TXN_ID)
+    /// = 0) is always considered committed.
+    #[inline]
+    pub fn is_committed(&self, txn: TxnId) -> bool {
+        if txn == crate::row::PRE_MVCC_TXN_ID {
+            return true;
+        }
+        txn <= self.xmax_committed && !self.in_progress.contains(&txn)
+    }
+
+    /// Returns `true` if `txn` was still running at snapshot time.
+    #[inline]
+    pub fn is_in_progress(&self, txn: TxnId) -> bool {
+        self.in_progress.contains(&txn)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_snapshot_treats_only_pre_mvcc_as_committed() {
+        let s = TxnSnapshot::empty();
+        assert!(s.is_committed(0));
+        assert!(!s.is_committed(1));
+        assert!(!s.is_committed(100));
+        assert!(!s.is_in_progress(0));
+        assert!(!s.is_in_progress(1));
+    }
+
+    #[test]
+    fn is_committed_pre_mvcc_sentinel_is_always_visible() {
+        let mut in_progress = HashSet::new();
+        in_progress.insert(0); // Even if someone weirdly puts 0 in in_progress,
+                               // the sentinel rule wins.
+        let s = TxnSnapshot::new(1, 50, in_progress);
+        assert!(s.is_committed(0));
+    }
+
+    #[test]
+    fn is_committed_respects_in_progress_set() {
+        let mut in_progress = HashSet::new();
+        in_progress.insert(5);
+        let s = TxnSnapshot::new(5, 10, in_progress);
+        assert!(s.is_committed(3), "txn 3 < xmax_committed and not in_progress");
+        assert!(!s.is_committed(5), "txn 5 is in_progress");
+        assert!(s.is_committed(10), "txn 10 == xmax_committed and not in_progress");
+        assert!(!s.is_committed(11), "txn 11 > xmax_committed");
+    }
+
+    #[test]
+    fn snapshot_clones_cheaply() {
+        let mut in_progress = HashSet::new();
+        in_progress.insert(7);
+        in_progress.insert(8);
+        let s = TxnSnapshot::new(7, 12, in_progress);
+        let s2 = s.clone();
+        assert_eq!(s.xmin_active, s2.xmin_active);
+        assert_eq!(s.xmax_committed, s2.xmax_committed);
+        assert_eq!(s.in_progress, s2.in_progress);
+    }
+}

--- a/crates/vibesql-storage/src/row.rs
+++ b/crates/vibesql-storage/src/row.rs
@@ -462,6 +462,76 @@ impl Row {
             _ => std::hint::unreachable_unchecked(),
         }
     }
+
+    // ========================================================================
+    // MVCC Visibility (Phase 1b of #5136)
+    //
+    // These methods interpret the `xmin`/`xmax` fields added in Phase 1a
+    // against a captured [`TxnSnapshot`]. Currently called only from unit
+    // tests — Phase 1d will wire `visible_to` into the scan boundary in
+    // `Table::scan*`. See `crate::mvcc` for the full design notes.
+    // ========================================================================
+
+    /// Returns `true` if this row version is visible to a reader holding
+    /// `snapshot` under snapshot isolation.
+    ///
+    /// See [`crate::mvcc`] for the full predicate contract. In summary,
+    /// the row is visible iff all three hold:
+    ///
+    /// 1. The creator (`xmin`) was committed-as-of the snapshot:
+    ///    `xmin <= snapshot.xmax_committed` AND `xmin` not in
+    ///    `snapshot.in_progress`. The pre-MVCC sentinel
+    ///    [`PRE_MVCC_TXN_ID`] (= 0) is always treated as committed.
+    /// 2. (Implied by clause 1) If the creator is the pre-MVCC sentinel,
+    ///    clause 1 is satisfied trivially.
+    /// 3. The deleter (`xmax`), if any, is **not** committed-as-of the
+    ///    snapshot. Concretely, the row is visible if `xmax.is_none()`,
+    ///    or `xmax > snapshot.xmin_active` (delete happened by a
+    ///    transaction that started after our snapshot's oldest concurrent
+    ///    peer), or `xmax` is in `snapshot.in_progress` (deleter was
+    ///    still running at snapshot time).
+    ///
+    /// # Phase 1b note
+    ///
+    /// This is a pure-function predicate — it doesn't read any global
+    /// state. Phase 1c starts producing rows with non-sentinel
+    /// `xmin`/`xmax`; Phase 1d starts calling this from the scan path.
+    /// Until then, every row created via [`Row::new`] / [`Row::from_vec`]
+    /// has `xmin = PRE_MVCC_TXN_ID, xmax = None`, so this method always
+    /// returns `true` for them.
+    #[inline]
+    pub fn visible_to(&self, snapshot: &crate::mvcc::TxnSnapshot) -> bool {
+        // Clause 1: creator must be committed-as-of the snapshot.
+        // The pre-MVCC sentinel is always committed (see TxnSnapshot::is_committed).
+        if !snapshot.is_committed(self.xmin) {
+            return false;
+        }
+
+        // Clause 3: if there's a deleter, it must NOT be committed-as-of
+        // the snapshot for us to still see the row.
+        match self.xmax {
+            None => true,
+            Some(deleter) => {
+                // Row is still visible if:
+                //   - the deleter started after our snapshot's xmin_active
+                //     (so the delete can't have been committed before us), OR
+                //   - the deleter was in_progress at snapshot time, OR
+                //   - the deleter is the pre-MVCC sentinel — which would be
+                //     bizarre (xmax = 0 means "deleted by no one") but is
+                //     handled defensively by treating sentinel-as-committed,
+                //     making the row invisible. This matches "PRE_MVCC means
+                //     definitely committed" and avoids accidental visibility.
+                if deleter > snapshot.xmin_active {
+                    return true;
+                }
+                if snapshot.is_in_progress(deleter) {
+                    return true;
+                }
+                // Deleter is committed-as-of snapshot → row is invisible.
+                false
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -536,6 +606,200 @@ mod tests {
         let row = Row::from_vec(vec![SqlValue::Integer(42)]);
         unsafe {
             row.get_string_unchecked(0); // Should panic in debug mode
+        }
+    }
+
+    // ========================================================================
+    // MVCC visibility predicate tests (Phase 1b of #5136)
+    // ========================================================================
+
+    mod visibility {
+        use std::collections::HashSet;
+
+        use super::super::*;
+        use crate::mvcc::TxnSnapshot;
+
+        /// Helper: build a row with explicit MVCC fields.
+        fn row_with(xmin: TxnId, xmax: Option<TxnId>) -> Row {
+            let mut r = Row::new(vec![SqlValue::Integer(0)]);
+            r.xmin = xmin;
+            r.xmax = xmax;
+            r
+        }
+
+        /// Helper: snapshot with `in_progress` set built from a slice.
+        fn snap(xmin_active: TxnId, xmax_committed: TxnId, in_progress: &[TxnId]) -> TxnSnapshot {
+            TxnSnapshot::new(xmin_active, xmax_committed, in_progress.iter().copied().collect())
+        }
+
+        #[test]
+        fn pre_mvcc_row_visible_under_empty_snapshot() {
+            // Legacy rows (xmin = 0, xmax = None) — the constructor default —
+            // are visible to every snapshot, including the empty one used
+            // by pre-MVCC code paths and auto-commit reads.
+            let r = Row::new(vec![SqlValue::Integer(42)]);
+            assert!(r.visible_to(&TxnSnapshot::empty()));
+        }
+
+        #[test]
+        fn pre_mvcc_row_visible_under_active_snapshot() {
+            let r = row_with(PRE_MVCC_TXN_ID, None);
+            let s = snap(5, 10, &[5, 7]);
+            assert!(r.visible_to(&s));
+        }
+
+        #[test]
+        fn row_visible_when_creator_committed_pre_snapshot() {
+            // Writer txn 3 committed before snapshot (xmax_committed = 10),
+            // not in in_progress → visible.
+            let r = row_with(3, None);
+            let s = snap(5, 10, &[5, 7]);
+            assert!(r.visible_to(&s));
+        }
+
+        #[test]
+        fn row_invisible_when_creator_in_progress() {
+            // Writer txn 7 was still running at snapshot time → invisible
+            // (this is the snapshot-isolation rule: concurrent writers don't
+            // affect each other's reads).
+            let r = row_with(7, None);
+            let s = snap(5, 10, &[5, 7]);
+            assert!(!r.visible_to(&s));
+        }
+
+        #[test]
+        fn row_invisible_when_creator_after_snapshot_high_watermark() {
+            // Writer txn 20 > xmax_committed = 10 → creator hadn't committed
+            // when we took the snapshot → invisible.
+            let r = row_with(20, None);
+            let s = snap(5, 10, &[5, 7]);
+            assert!(!r.visible_to(&s));
+        }
+
+        #[test]
+        fn row_visible_when_creator_equals_high_watermark() {
+            // Edge case: xmin == xmax_committed should be visible (committed
+            // exactly at the boundary).
+            let r = row_with(10, None);
+            let s = snap(5, 10, &[5, 7]);
+            assert!(r.visible_to(&s));
+        }
+
+        #[test]
+        fn row_invisible_when_deleter_committed_pre_snapshot() {
+            // Creator committed (xmin = 3 <= 10), deleter committed (xmax =
+            // Some(4) <= xmin_active = 5, not in_progress) → row is gone as
+            // far as this snapshot is concerned.
+            let r = row_with(3, Some(4));
+            let s = snap(5, 10, &[5, 7]);
+            assert!(!r.visible_to(&s));
+        }
+
+        #[test]
+        fn row_visible_when_deleter_after_snapshot_oldest_active() {
+            // Deleter xmax = 9 > xmin_active = 5 → delete happened after
+            // our snapshot's oldest concurrent peer started, so we don't
+            // see the delete yet.
+            let r = row_with(3, Some(9));
+            let s = snap(5, 10, &[5, 7]);
+            assert!(r.visible_to(&s));
+        }
+
+        #[test]
+        fn row_visible_when_deleter_still_in_progress() {
+            // Deleter xmax = 5 is in in_progress → the delete is still
+            // mid-flight at snapshot time → we still see the row.
+            let r = row_with(3, Some(5));
+            let s = snap(5, 10, &[5, 7]);
+            assert!(r.visible_to(&s));
+        }
+
+        #[test]
+        fn row_visible_when_deleter_eq_xmin_active_but_in_progress() {
+            // Boundary: deleter == xmin_active and is in in_progress → the
+            // in_progress check is what saves us (the > xmin_active check
+            // alone would be false).
+            let r = row_with(3, Some(5));
+            let s = snap(5, 10, &[5]);
+            assert!(r.visible_to(&s));
+        }
+
+        #[test]
+        fn row_invisible_when_deleter_eq_xmin_active_not_in_progress() {
+            // Boundary: deleter == xmin_active but NOT in in_progress.
+            // This is a slightly artificial case (xmin_active should be the
+            // *lowest* active id, so if 5 isn't active, xmin_active should
+            // be > 5 — but we still cover the predicate behavior).
+            let r = row_with(3, Some(5));
+            let s = snap(5, 10, &[7]);
+            assert!(!r.visible_to(&s));
+        }
+
+        #[test]
+        fn updated_row_chain_only_new_version_visible() {
+            // Models an UPDATE: txn 6 superseded a row by stamping xmax = 6
+            // on the old version and inserting a new version with xmin = 6.
+            // From a snapshot taken AFTER txn 6 committed, only the new
+            // version should be visible.
+            let old = row_with(3, Some(6));
+            let new = row_with(6, None);
+            let s = snap(10, 10, &[]); // No concurrent activity.
+            assert!(!old.visible_to(&s));
+            assert!(new.visible_to(&s));
+        }
+
+        #[test]
+        fn updated_row_chain_concurrent_snapshot_sees_old_version() {
+            // Same setup as above, but our snapshot was taken WHILE txn 6
+            // was still in-progress. We should see the old version (the
+            // delete is from a concurrent writer), not the new version.
+            let old = row_with(3, Some(6));
+            let new = row_with(6, None);
+            let mut in_progress = HashSet::new();
+            in_progress.insert(6);
+            let s = TxnSnapshot::new(6, 5, in_progress);
+            assert!(old.visible_to(&s));
+            assert!(!new.visible_to(&s));
+        }
+
+        #[test]
+        fn empty_snapshot_hides_all_mvcc_rows() {
+            // The empty snapshot has xmax_committed = 0, so any non-sentinel
+            // xmin is > xmax_committed → invisible. This is the conservative
+            // default: code that hasn't migrated to capture real snapshots
+            // sees only pre-MVCC rows.
+            assert!(!row_with(1, None).visible_to(&TxnSnapshot::empty()));
+            assert!(!row_with(42, None).visible_to(&TxnSnapshot::empty()));
+            assert!(row_with(0, None).visible_to(&TxnSnapshot::empty()));
+        }
+
+        #[test]
+        fn deleter_with_pre_mvcc_sentinel_treated_as_committed() {
+            // Defensive case: xmax = Some(0) is bizarre (means "deleted by
+            // nobody") but we treat the sentinel as definitely-committed,
+            // so the row is invisible. This avoids accidental visibility
+            // from buggy callers stamping `Some(0)` instead of `None`.
+            let r = row_with(1, Some(0));
+            let s = snap(5, 10, &[]);
+            // xmax = 0 < xmin_active = 5, not in_progress → invisible.
+            assert!(!r.visible_to(&s));
+        }
+
+        #[test]
+        fn writer_aborted_modeling_note() {
+            // Phase 1b deliberately does NOT carry an `aborted` set on
+            // TxnSnapshot. The current `TransactionManager::rollback`
+            // restores `original_tables` wholesale, which discards any
+            // xmin/xmax stamping the aborted txn did. So at the predicate
+            // level there is no "writer aborted" case to test — the rows
+            // simply don't exist after rollback.
+            //
+            // This test exists to document the design decision. Phase 1c
+            // will either confirm "revert on abort" or introduce the
+            // `aborted` set and a corresponding predicate clause.
+            let r = row_with(3, None);
+            let s = snap(5, 10, &[]);
+            assert!(r.visible_to(&s));
         }
     }
 


### PR DESCRIPTION
## Summary

**Phase 1b of the curator-decomposed #5136 (parent: #4460).** Second of four sequential PRs that together implement MVCC Phase 1.

> **The umbrella issue does not close on merge of this PR alone.** Phase 1b only adds the snapshot machinery and the visibility predicate — no scan or write path consults them yet. Phases 1c/1d follow as separate PRs:
> - **1c** (#5150) — write-path stamping: INSERT/UPDATE/DELETE start setting real `xmin`/`xmax` from the active transaction.
> - **1d** (#5151) — read-path visibility filtering + FK deferred-replay snapshot switch. This is the PR that actually flips the `mvcc_enabled` flag on.

## What this PR does

- **New module `crate::mvcc`** containing `TxnSnapshot { xmin_active, xmax_committed, in_progress: HashSet<TxnId> }` with `empty()`, `new()`, `is_committed()`, and `is_in_progress()` helpers. Re-exported from the crate root as `vibesql_storage::TxnSnapshot`.
- **`Row::visible_to(&TxnSnapshot) -> bool`** in `crates/vibesql-storage/src/row.rs`. Pure-function predicate implementing the snapshot-isolation contract:
  1. `xmin` committed-as-of snapshot (`<= xmax_committed`, not in `in_progress`); pre-MVCC sentinel `xmin = 0` always passes.
  2. Either `xmax.is_none()`, OR `xmax > xmin_active`, OR `xmax` is in `in_progress` (deleter still mid-flight at snapshot time).
- **`TransactionState::Active.snapshot` field** captured at `BEGIN` via a new `TransactionManager::capture_snapshot(txn_id)` helper. Under the current single-writer model, `in_progress` is always empty and `xmax_committed = txn_id - 1`. The chokepoint is annotated so multi-writer (Raft) can plug in by populating `in_progress` from the active-txn registry without changing call sites.
- **`TransactionManager::current_snapshot() -> Option<&TxnSnapshot>`** accessor for Phase 1d to read.

## Files changed (4 files, +724 / -1)

- `crates/vibesql-storage/src/mvcc.rs` — **new**, the `TxnSnapshot` type + 4 unit tests.
- `crates/vibesql-storage/src/row.rs` — `visible_to` predicate + 14 unit tests covering every predicate clause and the update-chain visibility cases.
- `crates/vibesql-storage/src/database/transactions.rs` — `snapshot` field on `Active`, `capture_snapshot` helper, `current_snapshot` accessor + 6 unit tests for capture/stability/watermark advancement.
- `crates/vibesql-storage/src/lib.rs` — `pub mod mvcc;` + `pub use mvcc::TxnSnapshot;`.

## Tests added (24, all passing)

**`mvcc::tests` (4)**
- `empty_snapshot_treats_only_pre_mvcc_as_committed`
- `is_committed_pre_mvcc_sentinel_is_always_visible`
- `is_committed_respects_in_progress_set`
- `snapshot_clones_cheaply`

**`row::tests::visibility` (14)** — covers every predicate clause:
- Pre-MVCC rows visible under empty/active snapshot (2)
- Writer committed pre-snapshot / in-progress / after-snapshot-high-watermark (3)
- Writer committed exactly at high-watermark boundary (1)
- Deleter committed pre-snapshot (invisible) / after `xmin_active` (visible) / in-progress (visible) (3)
- Deleter at `xmin_active` boundary with/without `in_progress` (2)
- Update-chain: new version visible / old version visible under concurrent snapshot (2)
- Empty snapshot hides all MVCC rows + deleter-with-PRE_MVCC-sentinel handled defensively (2)
- `writer_aborted_modeling_note` — design-decision pin: Phase 1b deliberately does NOT carry an `aborted` set; rollback restores `original_tables` wholesale, which discards stamping. Phase 1c will confirm or revisit.

**`database::transactions::snapshot_capture_tests` (6)**
- `first_transaction_snapshot_has_xmax_committed_zero`
- `second_transaction_snapshot_sees_first_as_committed`
- `snapshot_stable_across_multiple_reads_within_transaction` — the snapshot-isolation contract
- `no_snapshot_outside_transaction`
- `rolled_back_transaction_still_advances_watermark`
- `snapshot_visibility_integration` — pins that Phase 1b's predicate intentionally does NOT show a transaction its own writes (Phase 1c will add that separate clause)

## Validation

- `cargo test -p vibesql-storage --lib --release`: **617 passed, 0 failed**.
- `cargo test -p vibesql-executor --lib --release`: **2391 passed, 0 failed**.
- `cargo test --workspace --lib --release`: clean across all packages.
- `cargo build --workspace --release --features mvcc_enabled`: clean. The flag remains inert at the executor level — this PR adds no code paths gated on it, consistent with the spec.
- No clippy warnings on the new code.
- TCL P1 unaffected: Phase 1b is invisible to SQL semantics (no scan or write path reads the snapshot or the predicate yet).

## Phase 1c/1d API surface notes

The API surface is deliberately small so the follow-up phases can plug in without expanding it:

- **`Row::visible_to(&snapshot)`** is `&self -> bool` and pure. Phase 1d can drop it directly into any `Table::scan_visible(snapshot)` chokepoint (or filter at the iterator/columnar boundary).
- **`TransactionState::Active.snapshot`** is plumbed through `Clone + Debug`. Phase 1c reads `id` for `xmin = id` stamping; Phase 1d reads `snapshot` for visibility filtering. No more state added to the variant by 1c or 1d unless `aborted: HashSet<TxnId>` becomes necessary.
- **`TxnSnapshot`** is re-exported as `vibesql_storage::TxnSnapshot` for the executor crate to depend on directly.

## Out of scope (per the issue)

- Write-path `xmin`/`xmax` stamping in INSERT/UPDATE/DELETE — Phase 1c.
- Read-path `visible_to` filtering in SELECT — Phase 1d.
- FK deferred-replay snapshot coordination — Phase 1d.
- WAL serialization of snapshot data — punted because nothing currently reads the snapshot post-recovery; if Phase 1c/1d need it, they can bump `WAL_VERSION` then.
- Old-version garbage collection — separate follow-up.

Closes #5149

🤖 Generated with [Claude Code](https://claude.com/claude-code)