### PR TITLE
fix(fkey): persist DEFERRABLE clause and skip auto-save inside txn

### DIFF
--- a/crates/vibesql-cli/src/repl.rs
+++ b/crates/vibesql-cli/src/repl.rs
@@ -82,9 +82,23 @@ impl Repl {
                                 self.formatter.print_result(&result);
 
                                 // Auto-save if database path is provided and this was a
-                                // modification
+                                // modification.
+                                //
+                                // CRITICAL: Skip auto-save while a transaction is open.
+                                // Persisting uncommitted changes turns ROLLBACK into a
+                                // no-op across sessions — the .vbsql dump captures the
+                                // mid-transaction state and the next process loads it
+                                // as committed. Also save on the COMMIT/ROLLBACK
+                                // boundary so the final state is durable.
                                 if let Some(ref path) = self.database_path {
-                                    if is_modification_statement(&line) {
+                                    let in_txn = self.executor.in_transaction();
+                                    let should_save = is_modification_statement(&line) && !in_txn;
+                                    let upper = line.trim().to_uppercase();
+                                    let is_txn_end = !in_txn
+                                        && (upper.starts_with("COMMIT")
+                                            || upper.starts_with("ROLLBACK")
+                                            || upper.starts_with("END"));
+                                    if should_save || is_txn_end {
                                         self.has_modifications = true;
                                         if let Err(e) = self.executor.save_database(path) {
                                             eprintln!(
@@ -95,6 +109,9 @@ impl Repl {
                                                 )
                                             );
                                         }
+                                    } else if is_modification_statement(&line) {
+                                        // Mark dirty so the exit-time save runs.
+                                        self.has_modifications = true;
                                     }
                                 }
                             }

--- a/crates/vibesql-cli/src/script.rs
+++ b/crates/vibesql-cli/src/script.rs
@@ -118,9 +118,31 @@ impl ScriptExecutor {
                     self.formatter.print_result(&result);
                     success_count += 1;
 
-                    // Auto-save after modification statements if database path is provided
+                    // Auto-save after modification statements if database path is provided.
+                    //
+                    // CRITICAL: Skip auto-save while a transaction is open. Persisting
+                    // uncommitted changes turns ROLLBACK into a no-op across CLI
+                    // invocations — the .vbsql dump captures the mid-transaction state
+                    // and the next process loads it as committed. This silently broke
+                    // deferred-FK semantics in the batched TCL shim path (every fkey6
+                    // test that ran ROLLBACK after an INSERT/UPDATE/DELETE was
+                    // observed to have lost data despite the rollback succeeding
+                    // in memory). The next save naturally happens at COMMIT or
+                    // ROLLBACK statement boundary, both of which match
+                    // `is_modification_statement` only if we add them — instead, we
+                    // also force a save when the transaction state transitions back
+                    // to "no active transaction" after this statement.
                     if let Some(ref path) = self.database_path {
-                        if is_modification_statement(stmt) {
+                        let in_txn = self.executor.in_transaction();
+                        let should_save = is_modification_statement(stmt) && !in_txn;
+                        // Also save on the COMMIT/ROLLBACK boundary so the
+                        // post-commit (or post-rollback) state is durable.
+                        let upper = stmt.trim().to_uppercase();
+                        let is_txn_end = !in_txn
+                            && (upper.starts_with("COMMIT")
+                                || upper.starts_with("ROLLBACK")
+                                || upper.starts_with("END"));
+                        if should_save || is_txn_end {
                             if let Err(e) = self.executor.save_database(path) {
                                 eprintln!(
                                     "{}",

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -167,6 +167,17 @@ fn generate_create_table_sql(table: &TableSchema) -> String {
             fk_def.push_str(&format!(" ON UPDATE {}", format_referential_action(&fk.on_update)));
         }
 
+        // Emit DEFERRABLE clause when non-default. Matches SQLite's
+        // sqlite_master format and the `introspection.rs` SHOW CREATE
+        // TABLE wiring landed in Phase C3 of #5085.
+        if fk.is_deferrable {
+            if fk.initially_deferred {
+                fk_def.push_str(" DEFERRABLE INITIALLY DEFERRED");
+            } else {
+                fk_def.push_str(" DEFERRABLE INITIALLY IMMEDIATE");
+            }
+        }
+
         definitions.push(fk_def);
     }
 

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -324,6 +324,23 @@ impl Database {
                             })?;
                         }
                     }
+
+                    // Emit DEFERRABLE clause so deferred-FK semantics survive
+                    // a persistence round-trip. Without this, `.vbsql` dump
+                    // and reload would lose `INITIALLY DEFERRED` and the TCL
+                    // shim's batched-process model would degrade fkey6 tests
+                    // back to immediate enforcement.
+                    if fk.is_deferrable {
+                        if fk.initially_deferred {
+                            write!(writer, " DEFERRABLE INITIALLY DEFERRED").map_err(|e| {
+                                StorageError::NotImplemented(format!("Write error: {}", e))
+                            })?;
+                        } else {
+                            write!(writer, " DEFERRABLE INITIALLY IMMEDIATE").map_err(|e| {
+                                StorageError::NotImplemented(format!("Write error: {}", e))
+                            })?;
+                        }
+                    }
                 }
 
                 // Close the column definitions


### PR DESCRIPTION
## Summary

Two root-cause fixes that close out the deferred-FK COMMIT/ROLLBACK semantics tracked in #5085 (umbrella) and #5182. Both bugs only manifested in the TCL shim's batched/persisted execution model and were invisible to in-memory single-process tests.

### Root cause 1: DEFERRABLE clause not persisted

persistence/save.rs and sqlite_schema::generate_create_table_sql both omitted the DEFERRABLE INITIALLY DEFERRED clause when emitting FK constraints. The catalog correctly stored is_deferrable / initially_deferred (Phase C1, PR #5124), but a persistence round-trip silently degraded every INITIALLY DEFERRED FK back to immediate enforcement. Tests like fkey6-1.6 (rollback after deferred DELETE) failed at the DELETE step with "FOREIGN KEY constraint failed" because the reloaded constraint never went through the deferred queue.

### Root cause 2: Auto-save persists uncommitted state

script.rs and repl.rs auto-saved the database after every INSERT/UPDATE/DELETE. When the user ran BEGIN; DELETE; ROLLBACK, the DELETE triggered a save of the mid-transaction state to .vbsql, then the ROLLBACK only restored memory — the on-disk file already had the post-delete state. The next CLI invocation loaded the .vbsql file as committed state.

Fix: skip auto-save while executor.in_transaction() is true, and trigger a save at the COMMIT/ROLLBACK statement boundary instead. This matches every transactional database's durability model and is required for any test that issues an explicit ROLLBACK.

## TCL pass-count deltas

| File   | Before | After | Delta |
|--------|--------|-------|-------|
| fkey1  | 15/19  | 16/19 | +1    |
| fkey5  | 53/53  | 53/53 | 0     |
| fkey6  | 19/33  | 27/33 | **+8** |
| fkey8  | 10/12  | 12/12 | +2    |

### Tests from #5182's list now passing

- fkey6-1.6 — ROLLBACK after deferred DELETE
- fkey6-1.10.2 — immediate FK rejection after pragma reset
- fkey6-1.22 — COMMIT after deferred chain
- fkey6-3.3.4 — defer + DELETE + trigger
- fkey6-5.1 — deferred INSERT then parent INSERT then COMMIT

### Out of scope — TCL shim batching limitation

The remaining 3.2.1, 3.2.2, 3.3.2, 3.3.3 failures are a TCL-shim limitation, not a DB bug: the shim batches BEGIN+UPDATE+COMMIT into a single subprocess invocation, so errors that SQLite raises at the UPDATE step (immediate RESTRICT enforcement) surface at the COMMIT step in our test path. The DB raises the right error at the right SQL statement — the shim then misattributes which do_catchsql_test consumed it. Worth a separate follow-up issue.

### Out of scope — sqlite3_db_status shim helper

fkey6-1.20, fkey6-1.21 need the sqlite3_db_status TCL helper, which the shim doesn't implement. Also out of scope (TCL helper, not DB behavior).

## Files changed

- crates/vibesql-storage/src/persistence/save.rs — emit DEFERRABLE INITIALLY {DEFERRED,IMMEDIATE} after ON UPDATE clause.
- crates/vibesql-executor/src/sqlite_schema.rs::generate_create_table_sql — same clause for sqlite_master queries.
- crates/vibesql-cli/src/script.rs — skip auto-save while in_transaction(); save on COMMIT/ROLLBACK/END boundary.
- crates/vibesql-cli/src/repl.rs — mirror the script-mode fix in REPL.

## Test plan

- [x] cargo build --release clean
- [x] cargo test --release -p vibesql-storage --lib — 591/591 pass
- [x] cargo test --release -p vibesql-executor — all tests pass (no regressions)
- [x] cargo test --release -p vibesql-cli — all tests pass
- [x] cargo test --release -p vibesql-executor --test foreign_key_deferred_tests — 11/11
- [x] cargo test --release -p vibesql-executor --test foreign_key_deferred_phase_c3_tests — 11/11
- [x] ./scripts/tcltest test fkey6.test → 27/33 (was 19/33)
- [x] ./scripts/tcltest test fkey1.test → 16/19 (was 15/19)
- [x] ./scripts/tcltest test fkey5.test → 53/53 (unchanged)
- [x] ./scripts/tcltest test fkey8.test → 12/12 (was 10/12)
- [x] Smoke-test no regressions in insert/insert2/insert3/update/delete/select1 TCL suites
- [x] trans3.test: 5/8 → 6/8 (one previously-flaky ROLLBACK test now passes)

Closes #5085
Closes #5182

Generated with Claude Code