### PR TITLE
feat(mvcc): stamp xmin/xmax on INSERT/UPDATE/DELETE behind mvcc_enabled

### DIFF
--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -72,6 +72,11 @@ default = ["parallel", "spatial", "native-columnar"]
 parallel = ["rayon", "crossbeam-deque"]
 # Spatial/geospatial query support (optional, reduces binary size)
 spatial = ["geo", "rstar"]
+# MVCC machinery toggle (Phase 1 of #5136). Off by default.
+# Phase 1c enables write-path xmin/xmax stamping in INSERT/UPDATE/DELETE
+# when this flag is on; reads are still unfiltered until Phase 1d.
+# See `crates/vibesql-storage/Cargo.toml` for full documentation.
+mvcc_enabled = ["vibesql-storage/mvcc_enabled"]
 
 # VibeSQL performance features (for benchmarks)
 # Native columnar execution (Phase 2b - zero row materialization)

--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -461,10 +461,31 @@ impl DeleteExecutor {
             );
         }
 
+        // Phase 1c (Issue #5150 / #5136): stamp xmax on every row about
+        // to be bitmap-deleted with the active txn id when the
+        // `mvcc_enabled` feature is on. Fetched BEFORE the mutable borrow
+        // of `table_mut`. We keep the physical bitmap delete in place;
+        // Phase 1d's visibility filter will eventually treat the xmax
+        // stamp as the canonical deletion record. Off-state: no stamp,
+        // bit-for-bit pre-MVCC behavior.
+        #[cfg(feature = "mvcc_enabled")]
+        let mvcc_delete_txn_id = database.transaction_id();
+
         // Step 5b: Actually delete the rows using fast path (no table scan needed)
         let table_mut = database
             .get_table_mut(table_name)
             .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+
+        // Stamp xmax in-place on each row BEFORE bitmap-deleting. The
+        // bitmap delete leaves the row in `self.rows`, so the xmax field
+        // is observable via `Table::scan()` (which returns the raw rows
+        // slice including bitmap-deleted entries).
+        #[cfg(feature = "mvcc_enabled")]
+        if let Some(id) = mvcc_delete_txn_id {
+            for &idx in &deleted_indices {
+                table_mut.stamp_row_xmax_inplace(idx, id);
+            }
+        }
 
         // Use delete_by_indices_batch for O(d) instead of O(n) where d = deletes
         // The batch version pre-computes schema lookups for internal hash indexes,

--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -300,6 +300,16 @@ fn cascade_delete(
         check_no_child_references(db, child_table_name, child_row)?;
     }
 
+    // Phase 1c (Issue #5150 / #5136) note: FK cascade DELETE uses the
+    // content-matching `delete_where` predicate (not index-based), so we
+    // can't pre-stamp xmax on specific row indices the way the primary
+    // DELETE path does. With `mvcc_enabled` ON, cascade-deleted rows
+    // currently get a bitmap-delete but NO xmax stamp. Phase 1d will
+    // either thread snapshot-aware deletion through here or refactor
+    // cascade to use index-based deletion so the stamping helper applies.
+    // This is a known minor gap; cascade DELETE in a transaction with
+    // mvcc_enabled is uncommon and the off-state behavior is unchanged.
+
     // Now delete the child rows
     let child_table_mut = db.get_table_mut(child_table_name).unwrap();
     for row_to_delete in &rows_to_delete {
@@ -355,6 +365,14 @@ fn set_null(
             }
             rows_to_update.push((idx, updated_row));
         }
+    }
+
+    // Phase 1c (Issue #5150 / #5136): stamp xmin on every FK-cascaded
+    // SET NULL new row version. Off-state is a no-op.
+    let txn_id = db.transaction_id();
+    for (_, updated_row) in rows_to_update.iter_mut() {
+        vibesql_storage::stamp_xmin_for_write(updated_row, txn_id);
+        updated_row.xmax = None;
     }
 
     // Now update the rows
@@ -442,6 +460,14 @@ fn set_default(
             }
             rows_to_update.push((idx, updated_row));
         }
+    }
+
+    // Phase 1c (Issue #5150 / #5136): stamp xmin on every FK-cascaded
+    // SET DEFAULT new row version. Off-state is a no-op.
+    let txn_id = db.transaction_id();
+    for (_, updated_row) in rows_to_update.iter_mut() {
+        vibesql_storage::stamp_xmin_for_write(updated_row, txn_id);
+        updated_row.xmax = None;
     }
 
     // Now update the rows

--- a/crates/vibesql-executor/src/insert/replace.rs
+++ b/crates/vibesql-executor/src/insert/replace.rs
@@ -193,10 +193,25 @@ pub fn handle_replace_conflicts(
     let mut deleted_indices: Vec<usize> = rows_to_delete.iter().map(|(idx, _)| *idx).collect();
     deleted_indices.sort_unstable();
 
+    // Phase 1c (Issue #5150 / #5136): capture the active txn id before
+    // taking the mutable borrow on `table_mut`. The REPLACE-conflict path
+    // bitmap-deletes the conflicting old version; we stamp xmax on the
+    // tombstone when MVCC is on so visibility-aware reads (Phase 1d) can
+    // tell who superseded the row.
+    #[cfg(feature = "mvcc_enabled")]
+    let mvcc_delete_txn_id = db.transaction_id();
+
     // Delete the conflicting rows using the fast path
     let table_mut = db
         .get_table_mut(table_name)
         .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+
+    #[cfg(feature = "mvcc_enabled")]
+    if let Some(id) = mvcc_delete_txn_id {
+        for &idx in &deleted_indices {
+            table_mut.stamp_row_xmax_inplace(idx, id);
+        }
+    }
 
     let delete_result = table_mut.delete_by_indices_batch(&deleted_indices);
 

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -437,10 +437,23 @@ pub(super) fn execute_internal(
                 );
             }
 
+            // Phase 1c (Issue #5150 / #5136): capture the active txn id
+            // before the mutable borrow so we can stamp xmax on the
+            // REPLACE-conflict tombstones when MVCC is on.
+            #[cfg(feature = "mvcc_enabled")]
+            let mvcc_delete_txn_id = database.transaction_id();
+
             // Delete conflicting rows
             let table_mut = database
                 .get_table_mut(table_name)
                 .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+
+            #[cfg(feature = "mvcc_enabled")]
+            if let Some(id) = mvcc_delete_txn_id {
+                for &idx in &rows_to_delete_for_replace {
+                    table_mut.stamp_row_xmax_inplace(idx, id);
+                }
+            }
 
             let delete_result = table_mut.delete_by_indices_batch(&rows_to_delete_for_replace);
 
@@ -524,6 +537,20 @@ pub(super) fn execute_internal(
 
     // Step 8: Apply all updates (after evaluation phase completes)
     let update_count = updates.len();
+
+    // Phase 1c (Issue #5150 / #5136): stamp xmin on every new row with
+    // the active txn id when the `mvcc_enabled` feature is on. We must
+    // fetch the txn id here, *before* taking the mutable borrow on
+    // `table_mut`, because `database.transaction_id()` borrows the
+    // database immutably. When the feature is off this is a no-op so
+    // the off-state matches main bit-for-bit.
+    let txn_id = database.transaction_id();
+    for u in updates.iter_mut() {
+        vibesql_storage::stamp_xmin_for_write(&mut u.new_row, txn_id);
+        // The new version is by definition live; xmax must be None
+        // regardless of feature state.
+        u.new_row.xmax = None;
+    }
 
     // Get mutable table reference
     let table_mut = database
@@ -1317,10 +1344,23 @@ fn execute_update_from(
                     );
                 }
 
+                // Phase 1c (Issue #5150 / #5136): capture the active txn
+                // id before the mutable borrow so we can stamp xmax on
+                // the REPLACE-conflict tombstones when MVCC is on.
+                #[cfg(feature = "mvcc_enabled")]
+                let mvcc_delete_txn_id = database.transaction_id();
+
                 // Delete conflicting rows
                 let table_mut = database
                     .get_table_mut(table_name)
                     .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+
+                #[cfg(feature = "mvcc_enabled")]
+                if let Some(id) = mvcc_delete_txn_id {
+                    for &idx in &rows_to_delete_for_replace {
+                        table_mut.stamp_row_xmax_inplace(idx, id);
+                    }
+                }
 
                 let delete_result = table_mut.delete_by_indices_batch(&rows_to_delete_for_replace);
 
@@ -1428,6 +1468,17 @@ fn execute_update_from(
 
     // Apply all updates
     let update_count = updates.len();
+
+    // Phase 1c (Issue #5150 / #5136): stamp xmin on every new row with
+    // the active txn id when the `mvcc_enabled` feature is on. Fetch the
+    // txn id before taking the mutable borrow on `table_mut`. Off-state
+    // is a no-op.
+    let txn_id = database.transaction_id();
+    for u in updates.iter_mut() {
+        vibesql_storage::stamp_xmin_for_write(&mut u.new_row, txn_id);
+        u.new_row.xmax = None;
+    }
+
     let table_mut = database
         .get_table_mut(table_name)
         .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;

--- a/crates/vibesql-executor/src/update/fast_path.rs
+++ b/crates/vibesql-executor/src/update/fast_path.rs
@@ -224,6 +224,13 @@ pub(super) fn try_fast_path_update(
         database, table_name, &old_row, &new_row, row_index,
     );
 
+    // Phase 1c (Issue #5150 / #5136): stamp the new row's xmin with the
+    // active txn id when the `mvcc_enabled` feature is on. Off-state is a
+    // no-op, preserving pre-MVCC behavior bit-for-bit.
+    let txn_id = database.transaction_id();
+    vibesql_storage::stamp_xmin_for_write(&mut new_row, txn_id);
+    new_row.xmax = None;
+
     // Apply the update directly (transfers ownership of new_row, no clone needed)
     let table_mut = database
         .get_table_mut(table_name)
@@ -319,6 +326,13 @@ fn try_super_fast_path(
         return Ok(None); // No updates to apply
     }
 
+    // Phase 1c (Issue #5150 / #5136): the super-fast in-place path doesn't
+    // produce a "new row" object — it mutates column values directly. To
+    // record the MVCC version transition we stamp xmin on the same physical
+    // row after applying the column writes. Off-state: no stamping.
+    #[cfg(feature = "mvcc_enabled")]
+    let txn_id = database.transaction_id();
+
     let table_mut = database
         .get_table_mut(table_name)
         .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
@@ -326,6 +340,16 @@ fn try_super_fast_path(
     // Apply all column updates in-place (no row cloning!)
     for (col_index, new_value) in inplace_updates {
         table_mut.update_column_inplace(row_index, col_index, new_value);
+    }
+
+    // Stamp xmin on the in-place row. The row also remains live, so xmax
+    // is left at its current value (typically None; if it had previously
+    // been stamped by a rolled-back delete we'd be losing that, but the
+    // rollback path restores tables wholesale, so this can't actually
+    // arise — see TransactionManager::rollback_transaction).
+    #[cfg(feature = "mvcc_enabled")]
+    if let Some(id) = txn_id {
+        table_mut.stamp_row_xmin_inplace(row_index, id);
     }
 
     Ok(Some(1))

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -371,8 +371,16 @@ impl ForeignKeyValidator {
             }
         }
 
-        // Apply cascade updates
-        for (table_name, updates) in cascade_updates {
+        // Apply cascade updates. Phase 1c (Issue #5150 / #5136): stamp
+        // xmin on every cascade-update new row version. Off-state is a
+        // no-op. We capture the txn id once outside the per-table loop
+        // since the txn doesn't change within an UPDATE.
+        let txn_id = db.transaction_id();
+        for (table_name, mut updates) in cascade_updates {
+            for (_row_idx, new_row) in updates.iter_mut() {
+                vibesql_storage::stamp_xmin_for_write(new_row, txn_id);
+                new_row.xmax = None;
+            }
             let child_table = db.get_table_mut(&table_name).unwrap();
             for (row_idx, new_row) in updates {
                 child_table

--- a/crates/vibesql-executor/tests/mvcc_stamping_tests.rs
+++ b/crates/vibesql-executor/tests/mvcc_stamping_tests.rs
@@ -1,0 +1,393 @@
+//! Integration tests for Phase 1c (#5150 of #5136) write-path MVCC stamping.
+//!
+//! These tests cover the contract documented on [`vibesql_storage::mvcc`]'s
+//! Phase 1c helpers (`stamp_xmin_for_write`, `stamp_xmax_for_write`):
+//!
+//! - With the `mvcc_enabled` feature OFF (default): INSERT, UPDATE and
+//!   DELETE produce rows with the pre-MVCC sentinel
+//!   (`xmin = PRE_MVCC_TXN_ID = 0`, `xmax = None`). Bit-for-bit pre-MVCC
+//!   behavior.
+//! - With the feature ON and an active transaction: INSERT stamps
+//!   `xmin = current_txn_id`; UPDATE stamps `xmin = current_txn_id` on
+//!   the in-place new row; DELETE stamps `xmax = current_txn_id` on the
+//!   bitmap-deleted row (still observable via `Table::scan()`).
+//!
+//! The feature-ON assertions are wrapped in `#[cfg(feature = "mvcc_enabled")]`
+//! so the file compiles and runs cleanly under both `cargo test` (off-state)
+//! and `cargo test --features mvcc_enabled` (on-state).
+//!
+//! Run with:
+//! ```text
+//! cargo test -p vibesql-executor --test mvcc_stamping_tests
+//! cargo test -p vibesql-executor --test mvcc_stamping_tests --features mvcc_enabled
+//! ```
+
+use vibesql_ast::Statement;
+use vibesql_executor::{CreateTableExecutor, DeleteExecutor, InsertExecutor, UpdateExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row, PRE_MVCC_TXN_ID};
+use vibesql_types::SqlValue;
+
+/// Execute one SQL statement against `db`. Limited to the statement kinds
+/// our stamping tests need.
+fn exec(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).expect("UPDATE failed");
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).expect("DELETE failed");
+        }
+        other => panic!("unsupported statement in test helper: {:?}", other),
+    }
+}
+
+/// Build a fresh database with a single `users(id INTEGER PRIMARY KEY, name VARCHAR)`
+/// table containing a few rows.
+fn db_with_users() -> Database {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(50))");
+    exec(&mut db, "INSERT INTO users VALUES (1, 'Alice')");
+    exec(&mut db, "INSERT INTO users VALUES (2, 'Bob')");
+    exec(&mut db, "INSERT INTO users VALUES (3, 'Charlie')");
+    db
+}
+
+/// Helper: pull the raw rows slice from `users` (includes bitmap-deleted
+/// rows so we can inspect tombstone stamps after DELETE).
+fn raw_rows<'a>(db: &'a Database, table: &str) -> &'a [Row] {
+    db.get_table(table).expect("table missing").scan()
+}
+
+// ============================================================================
+// Off-state (no feature flag) tests — always compiled.
+//
+// These assert the "bit-for-bit pre-MVCC" contract: regardless of whether
+// the feature is on or off, autocommit writes outside an explicit
+// transaction must produce rows with the pre-MVCC sentinel. Phase 1c's
+// txn-id stamping only kicks in when a transaction is active.
+// ============================================================================
+
+#[test]
+fn insert_outside_txn_uses_pre_mvcc_sentinel() {
+    let db = db_with_users();
+    for row in raw_rows(&db, "USERS") {
+        assert_eq!(
+            row.xmin, PRE_MVCC_TXN_ID,
+            "autocommit INSERT must produce xmin = PRE_MVCC_TXN_ID regardless of feature flag"
+        );
+        assert_eq!(row.xmax, None, "fresh INSERT must produce xmax = None");
+    }
+}
+
+#[test]
+fn update_outside_txn_keeps_pre_mvcc_sentinel_on_new_version() {
+    let mut db = db_with_users();
+    exec(&mut db, "UPDATE users SET name = 'Alice2' WHERE id = 1");
+
+    // Find the (now-updated) row for id=1 and inspect it. The fast path
+    // overwrites the row in place, so we look up by primary key value.
+    let updated = raw_rows(&db, "USERS")
+        .iter()
+        .find(|r| matches!(r.values.first(), Some(SqlValue::Integer(1))))
+        .expect("id=1 row should still exist");
+    assert_eq!(
+        updated.xmin, PRE_MVCC_TXN_ID,
+        "autocommit UPDATE must leave xmin = PRE_MVCC_TXN_ID outside a transaction"
+    );
+    assert_eq!(updated.xmax, None, "live updated row must have xmax = None");
+}
+
+#[test]
+fn delete_outside_txn_keeps_pre_mvcc_xmax() {
+    let mut db = db_with_users();
+    exec(&mut db, "DELETE FROM users WHERE id = 2");
+
+    // After DELETE, the row remains in the raw rows slice (bitmap deleted),
+    // so we can still inspect its xmax. Outside a transaction, we expect
+    // it to remain None (pre-MVCC behavior).
+    let deleted_row = raw_rows(&db, "USERS")
+        .iter()
+        .find(|r| matches!(r.values.first(), Some(SqlValue::Integer(2))))
+        .expect("bitmap-deleted row id=2 should still be in raw rows");
+    assert_eq!(
+        deleted_row.xmax, None,
+        "autocommit DELETE outside a transaction must leave xmax = None"
+    );
+}
+
+// ============================================================================
+// Off-state (feature OFF only) tests — assert the "no stamping at all" path.
+//
+// Even inside an explicit transaction, with the feature OFF we must NOT
+// stamp xmin/xmax — the v7 storage format keeps working but visibility
+// semantics are unchanged from pre-MVCC.
+// ============================================================================
+
+#[cfg(not(feature = "mvcc_enabled"))]
+#[test]
+fn insert_in_txn_off_state_uses_pre_mvcc_sentinel() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(50))");
+    db.begin_transaction().unwrap();
+    exec(&mut db, "INSERT INTO users VALUES (1, 'Alice')");
+    let xmin_after_insert = raw_rows(&db, "USERS")[0].xmin;
+    db.commit_transaction().unwrap();
+
+    assert_eq!(
+        xmin_after_insert, PRE_MVCC_TXN_ID,
+        "with mvcc_enabled OFF, INSERT inside a txn must leave xmin = PRE_MVCC_TXN_ID"
+    );
+}
+
+#[cfg(not(feature = "mvcc_enabled"))]
+#[test]
+fn delete_in_txn_off_state_keeps_xmax_none() {
+    let mut db = db_with_users();
+    db.begin_transaction().unwrap();
+    exec(&mut db, "DELETE FROM users WHERE id = 1");
+
+    let row = raw_rows(&db, "USERS")
+        .iter()
+        .find(|r| matches!(r.values.first(), Some(SqlValue::Integer(1))))
+        .expect("bitmap-deleted row should still be in raw rows");
+    let xmax = row.xmax;
+    db.commit_transaction().unwrap();
+
+    assert_eq!(xmax, None, "with mvcc_enabled OFF, DELETE must leave xmax = None even inside a txn");
+}
+
+#[cfg(not(feature = "mvcc_enabled"))]
+#[test]
+fn update_in_txn_off_state_keeps_pre_mvcc_xmin() {
+    let mut db = db_with_users();
+    db.begin_transaction().unwrap();
+    exec(&mut db, "UPDATE users SET name = 'Alice2' WHERE id = 1");
+
+    let updated = raw_rows(&db, "USERS")
+        .iter()
+        .find(|r| matches!(r.values.first(), Some(SqlValue::Integer(1))))
+        .cloned()
+        .expect("id=1 row should still exist");
+    db.commit_transaction().unwrap();
+
+    assert_eq!(
+        updated.xmin, PRE_MVCC_TXN_ID,
+        "with mvcc_enabled OFF, UPDATE must leave xmin = PRE_MVCC_TXN_ID even inside a txn"
+    );
+}
+
+// ============================================================================
+// On-state (feature ON only) tests — assert the actual stamping behavior.
+//
+// These are the new Phase 1c invariants the issue asks for. Each test
+// runs inside an explicit transaction so a real txn id is in scope.
+// ============================================================================
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn insert_in_txn_stamps_xmin_with_current_txn_id() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(50))");
+
+    db.begin_transaction().unwrap();
+    let txn_id = db.transaction_id().expect("txn id must exist inside BEGIN");
+    exec(&mut db, "INSERT INTO users VALUES (1, 'Alice')");
+    exec(&mut db, "INSERT INTO users VALUES (2, 'Bob')");
+
+    let rows = raw_rows(&db, "USERS");
+    assert_eq!(rows.len(), 2, "two rows inserted");
+    for row in rows {
+        assert_eq!(
+            row.xmin, txn_id,
+            "every newly INSERTed row must carry xmin = current_txn_id"
+        );
+        assert_eq!(row.xmax, None, "new rows must have xmax = None");
+    }
+
+    db.commit_transaction().unwrap();
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn update_in_txn_stamps_xmin_on_new_version() {
+    // Set up rows in an initial transaction so they have a known xmin.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(50))");
+    db.begin_transaction().unwrap();
+    let inserter_txn = db.transaction_id().unwrap();
+    exec(&mut db, "INSERT INTO users VALUES (1, 'Alice')");
+    db.commit_transaction().unwrap();
+
+    // Now UPDATE in a second transaction. The new row version should be
+    // stamped with the *updater's* txn id, not the inserter's.
+    db.begin_transaction().unwrap();
+    let updater_txn = db.transaction_id().unwrap();
+    assert_ne!(inserter_txn, updater_txn, "second txn id should differ");
+    exec(&mut db, "UPDATE users SET name = 'Alice2' WHERE id = 1");
+
+    let updated = raw_rows(&db, "USERS")
+        .iter()
+        .find(|r| matches!(r.values.first(), Some(SqlValue::Integer(1))))
+        .cloned()
+        .expect("id=1 row must exist after update");
+
+    db.commit_transaction().unwrap();
+
+    assert_eq!(
+        updated.xmin, updater_txn,
+        "UPDATE must stamp the new row version's xmin with the UPDATER's txn id"
+    );
+    assert_eq!(updated.xmax, None, "live new version must have xmax = None");
+    assert_eq!(
+        updated.values[1],
+        SqlValue::Varchar(arcstr::ArcStr::from("Alice2")),
+        "sanity: the update did change the value"
+    );
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn delete_in_txn_stamps_xmax_on_tombstone() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(50))");
+
+    db.begin_transaction().unwrap();
+    let inserter_txn = db.transaction_id().unwrap();
+    exec(&mut db, "INSERT INTO users VALUES (1, 'Alice')");
+    exec(&mut db, "INSERT INTO users VALUES (2, 'Bob')");
+    db.commit_transaction().unwrap();
+
+    // Now DELETE in a second transaction. The bitmap-deleted row should
+    // have xmax stamped with the deleter's txn id, observable via
+    // `Table::scan()` which returns ALL rows including bitmap-deleted.
+    db.begin_transaction().unwrap();
+    let deleter_txn = db.transaction_id().unwrap();
+    assert_ne!(inserter_txn, deleter_txn);
+    exec(&mut db, "DELETE FROM users WHERE id = 1");
+
+    let tombstone = raw_rows(&db, "USERS")
+        .iter()
+        .find(|r| matches!(r.values.first(), Some(SqlValue::Integer(1))))
+        .cloned()
+        .expect("bitmap-deleted row id=1 should still be in raw rows");
+
+    db.commit_transaction().unwrap();
+
+    assert_eq!(
+        tombstone.xmin, inserter_txn,
+        "deleted row's xmin must still be the original inserter's txn id"
+    );
+    assert_eq!(
+        tombstone.xmax,
+        Some(deleter_txn),
+        "DELETE must stamp xmax = current_txn_id on the bitmap-deleted row"
+    );
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn batch_insert_in_txn_stamps_all_rows_with_same_xmin() {
+    // INSERT ... VALUES (...), (...), (...) goes through the batch path
+    // (`insert_rows_batch`). Each row must get the same xmin.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(50))");
+    db.begin_transaction().unwrap();
+    let txn_id = db.transaction_id().unwrap();
+    exec(
+        &mut db,
+        "INSERT INTO users VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')",
+    );
+
+    let rows: Vec<Row> = raw_rows(&db, "USERS").to_vec();
+    db.commit_transaction().unwrap();
+
+    assert_eq!(rows.len(), 5);
+    for row in &rows {
+        assert_eq!(
+            row.xmin, txn_id,
+            "every row in a batch INSERT must carry the same xmin = current_txn_id"
+        );
+    }
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn autocommit_insert_with_feature_on_uses_pre_mvcc_sentinel() {
+    // Phase 1c conservative choice: with no active transaction, we leave
+    // the pre-MVCC sentinel. Documented in the helper contract; this test
+    // pins that behavior so it doesn't drift.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(50))");
+    exec(&mut db, "INSERT INTO users VALUES (1, 'Alice')");
+
+    let row = &raw_rows(&db, "USERS")[0];
+    assert_eq!(
+        row.xmin, PRE_MVCC_TXN_ID,
+        "autocommit INSERT (no active txn) keeps the pre-MVCC sentinel even with feature on"
+    );
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn rollback_discards_stamped_rows() {
+    // The existing rollback path restores `original_tables` wholesale,
+    // so any xmin/xmax stamping done by the aborted transaction is
+    // discarded along with the rows themselves. This test pins that
+    // behavior — the snapshot-isolation predicate relies on it (see
+    // mvcc.rs::writer_aborted_modeling_note).
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(50))");
+
+    db.begin_transaction().unwrap();
+    exec(&mut db, "INSERT INTO users VALUES (1, 'Alice')");
+    assert_eq!(raw_rows(&db, "USERS").len(), 1);
+    db.rollback_transaction().unwrap();
+
+    assert_eq!(
+        raw_rows(&db, "USERS").len(),
+        0,
+        "rollback must discard all rows the aborted txn inserted, stamps and all"
+    );
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn second_transaction_sees_committed_rows_with_first_xmin() {
+    // After the first transaction commits, its txn id is "committed
+    // forever" — Phase 1b's TxnSnapshot::is_committed treats it as
+    // visible. Pin that rows stamped in txn 1 retain their xmin after
+    // txn 2 starts and commits its own changes.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(50))");
+
+    db.begin_transaction().unwrap();
+    let txn1 = db.transaction_id().unwrap();
+    exec(&mut db, "INSERT INTO users VALUES (1, 'Alice')");
+    db.commit_transaction().unwrap();
+
+    db.begin_transaction().unwrap();
+    let txn2 = db.transaction_id().unwrap();
+    assert!(txn2 > txn1);
+    exec(&mut db, "INSERT INTO users VALUES (2, 'Bob')");
+    db.commit_transaction().unwrap();
+
+    let rows = raw_rows(&db, "USERS");
+    let alice = rows
+        .iter()
+        .find(|r| matches!(r.values.first(), Some(SqlValue::Integer(1))))
+        .unwrap();
+    let bob = rows
+        .iter()
+        .find(|r| matches!(r.values.first(), Some(SqlValue::Integer(2))))
+        .unwrap();
+    assert_eq!(alice.xmin, txn1, "Alice's xmin should still reflect the inserter");
+    assert_eq!(bob.xmin, txn2, "Bob's xmin should reflect his own inserter");
+}

--- a/crates/vibesql-storage/src/database/index_ops.rs
+++ b/crates/vibesql-storage/src/database/index_ops.rs
@@ -1051,11 +1051,26 @@ impl Database {
             phase_times[2] = ps.elapsed().as_nanos(); // wal
         }
 
+        // Phase 1c (Issue #5150 / #5136): capture the current txn id
+        // before taking the mutable borrow on `table_mut`, so we can stamp
+        // xmax on the about-to-be-bitmap-deleted row when MVCC is on.
+        // Off-state is a no-op via the feature-gated branch below.
+        #[cfg(feature = "mvcc_enabled")]
+        let mvcc_delete_txn_id = self.transaction_id();
+
         // Now delete the row (this updates the internal PK hash index)
         let phase_start = start.map(|_| Instant::now());
         let table_mut = self
             .get_table_mut(table_name)
             .ok_or_else(|| StorageError::TableNotFound(table_name.to_string()))?;
+
+        // Stamp xmax in-place on the row BEFORE bitmap-deleting. The
+        // bitmap mark preserves the row data (including xmax) in
+        // `Table::scan()`, so the tombstone is observable for Phase 1d.
+        #[cfg(feature = "mvcc_enabled")]
+        if let Some(id) = mvcc_delete_txn_id {
+            table_mut.stamp_row_xmax_inplace(row_index, id);
+        }
 
         let delete_result = table_mut.delete_by_indices(&[row_index]);
 

--- a/crates/vibesql-storage/src/database/table_api.rs
+++ b/crates/vibesql-storage/src/database/table_api.rs
@@ -332,7 +332,20 @@ impl Database {
     /// Insert a row into a table
     ///
     /// Temporary tables (in the "temp" schema) are not persisted to WAL.
-    pub fn insert_row(&mut self, table_name: &str, row: Row) -> Result<(), StorageError> {
+    ///
+    /// # MVCC (Phase 1c of #5136)
+    ///
+    /// When the `mvcc_enabled` feature is on and a transaction is active,
+    /// the new row is stamped with `xmin = current_txn_id` before storage.
+    /// When the feature is off (default) the row keeps the pre-MVCC
+    /// sentinel `xmin = 0` and behavior is bit-for-bit identical to
+    /// pre-MVCC. See [`crate::mvcc::stamp_xmin_for_write`].
+    pub fn insert_row(&mut self, table_name: &str, mut row: Row) -> Result<(), StorageError> {
+        // Phase 1c: stamp xmin with the active txn id when MVCC is on.
+        // No-op when the feature is off, so the off-state matches main.
+        let txn_id = self.transaction_id();
+        crate::mvcc::stamp_xmin_for_write(&mut row, txn_id);
+
         let row_index =
             self.operations.insert_row(&self.catalog, &mut self.tables, table_name, row.clone())?;
 
@@ -398,10 +411,19 @@ impl Database {
     pub fn insert_rows_batch(
         &mut self,
         table_name: &str,
-        rows: Vec<Row>,
+        mut rows: Vec<Row>,
     ) -> Result<usize, StorageError> {
         if rows.is_empty() {
             return Ok(0);
+        }
+
+        // Phase 1c (Issue #5150 / #5136): stamp xmin on every new row with
+        // the active txn id when the `mvcc_enabled` feature is on. When
+        // the feature is off this is a no-op (rows keep their constructor
+        // default `xmin = PRE_MVCC_TXN_ID`), so the off-state matches main.
+        let txn_id = self.transaction_id();
+        for row in rows.iter_mut() {
+            crate::mvcc::stamp_xmin_for_write(row, txn_id);
         }
 
         let row_indices = self.operations.insert_rows_batch(
@@ -583,6 +605,18 @@ impl Database {
             new_row.set(col_index, new_value.clone())?;
             changed_columns.insert(col_index);
         }
+
+        // Phase 1c (Issue #5150 / #5136): stamp the new row's xmin with
+        // the active txn id when MVCC is on. The new row is by definition
+        // not deleted, so xmax stays `None` regardless of feature state.
+        //
+        // Note: this fast path overwrites the row in-place. Phase 1c does
+        // NOT preserve the old version as a tombstone here — Phase 1d will
+        // revisit if true two-version retention is required for snapshot
+        // isolation across UPDATE.
+        let txn_id = self.transaction_id();
+        crate::mvcc::stamp_xmin_for_write(&mut new_row, txn_id);
+        new_row.xmax = None;
 
         // Third phase: write data (mutable borrow)
         let table_mut = self.get_table_mut(table_name).unwrap();

--- a/crates/vibesql-storage/src/lib.rs
+++ b/crates/vibesql-storage/src/lib.rs
@@ -47,7 +47,7 @@ pub use database::{
 };
 pub use error::{StorageError, StorageResult};
 pub use index::{extract_mbr_from_sql_value, SpatialIndex, SpatialIndexEntry};
-pub use mvcc::TxnSnapshot;
+pub use mvcc::{mvcc_enabled, stamp_xmax_for_write, stamp_xmin_for_write, TxnSnapshot};
 pub use persistence::load::{parse_sql_statements, read_sql_dump};
 pub use query_buffer_pool::{
     QueryBufferPool, QueryBufferPoolStats, RowBufferGuard, ValueBufferGuard,

--- a/crates/vibesql-storage/src/mvcc.rs
+++ b/crates/vibesql-storage/src/mvcc.rs
@@ -214,6 +214,91 @@ impl TxnSnapshot {
     }
 }
 
+// ============================================================================
+// Write-path stamping helpers (Phase 1c of #5136)
+// ============================================================================
+//
+// These helpers are the single source of truth for "should this write stamp
+// xmin/xmax with the current transaction id?". The decision is gated on the
+// `mvcc_enabled` feature flag:
+//
+// - Feature OFF (default): all helpers are no-ops. Rows pass through with
+//   their constructor defaults (xmin = PRE_MVCC_TXN_ID, xmax = None). This
+//   preserves bit-for-bit pre-MVCC behavior.
+// - Feature ON: when called with `Some(txn_id)`, the helpers stamp the
+//   row with the active transaction id. When called with `None` (autocommit
+//   path with no active transaction), the row keeps the pre-MVCC sentinel.
+//   Phase 1d will revisit autocommit semantics; this is the conservative
+//   choice for Phase 1c.
+//
+// The helpers operate by `&mut Row` so the caller can choose where they
+// fit into the write pipeline (validators may run before or after
+// stamping; the stamp is purely additive to existing row state).
+
+use crate::row::Row;
+
+/// Stamp `row.xmin = txn_id` (when MVCC is enabled and a transaction is
+/// active). For INSERT / UPDATE-new-version writes.
+///
+/// With the `mvcc_enabled` feature OFF this is a no-op — the row keeps
+/// whatever `xmin` it came in with, which for executor-produced rows is
+/// always [`PRE_MVCC_TXN_ID`](crate::row::PRE_MVCC_TXN_ID).
+///
+/// With the feature ON and `txn_id = Some(t)`, the row's xmin field is
+/// set to `t`. With the feature ON and `txn_id = None` (no active
+/// transaction at write time — e.g. autocommit) the row is left with
+/// the pre-MVCC sentinel; Phase 1d will revisit autocommit semantics.
+#[inline]
+pub fn stamp_xmin_for_write(row: &mut Row, txn_id: Option<TxnId>) {
+    #[cfg(feature = "mvcc_enabled")]
+    {
+        if let Some(id) = txn_id {
+            row.xmin = id;
+        }
+    }
+    #[cfg(not(feature = "mvcc_enabled"))]
+    {
+        // Suppress unused-variable warnings in the off-state.
+        let _ = (row, txn_id);
+    }
+}
+
+/// Stamp `row.xmax = Some(txn_id)` (when MVCC is enabled and a
+/// transaction is active). For UPDATE-old-version and DELETE writes.
+///
+/// With the `mvcc_enabled` feature OFF this is a no-op — the row keeps
+/// `xmax = None`, matching the pre-MVCC contract that "live rows have no
+/// deleter."
+///
+/// With the feature ON and `txn_id = Some(t)`, the row's xmax field is
+/// set to `Some(t)`. The physical storage layer continues to remove or
+/// overwrite the row as before; the stamp is purely additive metadata
+/// that Phase 1d's visibility filter will consult. With the feature ON
+/// and `txn_id = None` (autocommit), the row is left with `xmax = None`.
+#[inline]
+pub fn stamp_xmax_for_write(row: &mut Row, txn_id: Option<TxnId>) {
+    #[cfg(feature = "mvcc_enabled")]
+    {
+        if let Some(id) = txn_id {
+            row.xmax = Some(id);
+        }
+    }
+    #[cfg(not(feature = "mvcc_enabled"))]
+    {
+        let _ = (row, txn_id);
+    }
+}
+
+/// Returns true when the `mvcc_enabled` feature is compiled in.
+///
+/// This is a compile-time constant exposed as a runtime fn so callers
+/// outside this crate can branch on feature state without re-declaring
+/// the `#[cfg]` themselves.
+#[inline]
+pub const fn mvcc_enabled() -> bool {
+    cfg!(feature = "mvcc_enabled")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -258,5 +343,95 @@ mod tests {
         assert_eq!(s.xmin_active, s2.xmin_active);
         assert_eq!(s.xmax_committed, s2.xmax_committed);
         assert_eq!(s.in_progress, s2.in_progress);
+    }
+
+    // ========================================================================
+    // Write-path stamping helpers (Phase 1c of #5136)
+    // ========================================================================
+    //
+    // These tests check the contract documented on `stamp_xmin_for_write` and
+    // `stamp_xmax_for_write`: both helpers are no-ops without the feature
+    // flag, and stamp the row's MVCC fields when the flag is on AND a txn
+    // id is supplied.
+
+    use vibesql_types::SqlValue;
+
+    use crate::row::PRE_MVCC_TXN_ID;
+
+    fn fresh_row() -> Row {
+        Row::new(vec![SqlValue::Integer(42)])
+    }
+
+    #[test]
+    fn stamp_xmin_with_none_is_noop() {
+        let mut r = fresh_row();
+        stamp_xmin_for_write(&mut r, None);
+        assert_eq!(r.xmin, PRE_MVCC_TXN_ID);
+    }
+
+    #[test]
+    fn stamp_xmax_with_none_is_noop() {
+        let mut r = fresh_row();
+        stamp_xmax_for_write(&mut r, None);
+        assert_eq!(r.xmax, None);
+    }
+
+    #[cfg(not(feature = "mvcc_enabled"))]
+    #[test]
+    fn stamp_xmin_off_state_is_noop_even_with_some() {
+        // With feature OFF, even Some(t) must be ignored — this preserves
+        // bit-for-bit pre-MVCC row construction.
+        let mut r = fresh_row();
+        stamp_xmin_for_write(&mut r, Some(7));
+        assert_eq!(r.xmin, PRE_MVCC_TXN_ID, "xmin must remain pre-MVCC sentinel");
+    }
+
+    #[cfg(not(feature = "mvcc_enabled"))]
+    #[test]
+    fn stamp_xmax_off_state_is_noop_even_with_some() {
+        let mut r = fresh_row();
+        stamp_xmax_for_write(&mut r, Some(7));
+        assert_eq!(r.xmax, None, "xmax must remain None");
+    }
+
+    #[cfg(feature = "mvcc_enabled")]
+    #[test]
+    fn stamp_xmin_on_state_writes_txn_id() {
+        let mut r = fresh_row();
+        stamp_xmin_for_write(&mut r, Some(42));
+        assert_eq!(r.xmin, 42);
+        assert_eq!(r.xmax, None, "stamping xmin must not touch xmax");
+    }
+
+    #[cfg(feature = "mvcc_enabled")]
+    #[test]
+    fn stamp_xmax_on_state_writes_txn_id() {
+        let mut r = fresh_row();
+        stamp_xmax_for_write(&mut r, Some(99));
+        assert_eq!(r.xmax, Some(99));
+        assert_eq!(r.xmin, PRE_MVCC_TXN_ID, "stamping xmax must not touch xmin");
+    }
+
+    #[cfg(feature = "mvcc_enabled")]
+    #[test]
+    fn stamp_both_xmin_and_xmax_independently() {
+        // Models the UPDATE old-version case: caller may want both fields
+        // stamped on the same row (e.g. for a two-version replay buffer).
+        let mut r = fresh_row();
+        stamp_xmin_for_write(&mut r, Some(3));
+        stamp_xmax_for_write(&mut r, Some(7));
+        assert_eq!(r.xmin, 3);
+        assert_eq!(r.xmax, Some(7));
+    }
+
+    #[test]
+    fn mvcc_enabled_const_matches_feature() {
+        // Sanity check: the const fn agrees with the cfg() the rest of the
+        // module uses. Keeps the helper from drifting if the feature name
+        // changes.
+        #[cfg(feature = "mvcc_enabled")]
+        assert!(mvcc_enabled());
+        #[cfg(not(feature = "mvcc_enabled"))]
+        assert!(!mvcc_enabled());
     }
 }

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -896,6 +896,45 @@ impl Table {
         }
     }
 
+    /// Stamp the xmin field of an in-storage row in place.
+    ///
+    /// Used by Phase 1c (#5150 of #5136) super-fast UPDATE paths that
+    /// mutate individual column values in-place (no row clone) and so
+    /// can't go through the normal `update_row*` flow which stamps the
+    /// new row before insertion.
+    ///
+    /// The caller is responsible for gating on the `mvcc_enabled` feature
+    /// (see [`crate::mvcc::stamp_xmin_for_write`]) — this method
+    /// unconditionally writes the field. It is a no-op if `row_index` is
+    /// out of bounds, mirroring the unchecked-style contract of
+    /// `update_column_inplace`.
+    #[inline]
+    pub fn stamp_row_xmin_inplace(&mut self, row_index: usize, txn_id: crate::row::TxnId) {
+        if let Some(row) = self.rows.get_mut(row_index) {
+            row.xmin = txn_id;
+        }
+    }
+
+    /// Stamp the xmax field of an in-storage row in place.
+    ///
+    /// Used by Phase 1c (#5150 of #5136) DELETE paths that bitmap-mark
+    /// rows as deleted (rather than physically removing them) — the xmax
+    /// stamp is the MVCC-visible deletion record that Phase 1d's
+    /// visibility filter will consult. With the `mvcc_enabled` feature
+    /// off this method should not be called (callers branch on the
+    /// feature flag); with the feature on it records `xmax = Some(txn_id)`
+    /// so the row, while still bitmap-deleted today, also carries a
+    /// proper MVCC tombstone.
+    ///
+    /// The caller is responsible for gating on the feature flag. The
+    /// method is a no-op if `row_index` is out of bounds.
+    #[inline]
+    pub fn stamp_row_xmax_inplace(&mut self, row_index: usize, txn_id: crate::row::TxnId) {
+        if let Some(row) = self.rows.get_mut(row_index) {
+            row.xmax = Some(txn_id);
+        }
+    }
+
     /// Delete rows matching a predicate
     ///
     /// Uses O(1) bitmap marking for each deleted row instead of O(n) Vec::remove().


### PR DESCRIPTION
## Summary

Phase 1c of #5136 wires the MVCC write path. With the `mvcc_enabled` feature **OFF** (default), behavior is bit-for-bit identical to pre-MVCC — every row keeps `xmin = PRE_MVCC_TXN_ID`, `xmax = None`. With the feature **ON** and an active transaction, INSERT stamps `xmin = current_txn_id`, UPDATE stamps the new row version's `xmin`, and DELETE stamps `xmax` on the (still bitmap-deleted) row.

Reads remain unfiltered — Phase 1d will wire `Row::visible_to` into the scan boundary. Stamping is observable via `Row` inspection but does not change query results.

## Changes

- New helpers in `vibesql_storage::mvcc`: `stamp_xmin_for_write`, `stamp_xmax_for_write`, `mvcc_enabled()`. Single chokepoint for the feature gate.
- New `Table` methods: `stamp_row_xmin_inplace`, `stamp_row_xmax_inplace` for fast-path UPDATE and DELETE bitmap tombstones.
- `vibesql-executor` crate now declares the `mvcc_enabled` feature, forwarding to `vibesql-storage`.
- Wired stamping at every INSERT/UPDATE/DELETE write boundary in both crates (see commit message for the full list of touched entry points).
- Known minor gaps documented in code: FK cascade DELETE (content-match `delete_where`) and the TRUNCATE-style full-table fast path do not stamp. Phase 1d revisit.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| INSERT stamps `xmin = current_txn_id` when MVCC ON | OK | `insert_in_txn_stamps_xmin_with_current_txn_id` + `batch_insert_in_txn_stamps_all_rows_with_same_xmin` |
| UPDATE stamps `xmin` on new row version when MVCC ON | OK | `update_in_txn_stamps_xmin_on_new_version` |
| DELETE stamps `xmax` on bitmap-deleted row when MVCC ON | OK | `delete_in_txn_stamps_xmax_on_tombstone` |
| Feature OFF: bit-for-bit pre-MVCC (no xmin/xmax stamping) | OK | `insert_in_txn_off_state_uses_pre_mvcc_sentinel`, `update_in_txn_off_state_keeps_pre_mvcc_xmin`, `delete_in_txn_off_state_keeps_xmax_none` |
| Feature OFF: workspace lib suite green | OK | `cargo test --workspace --lib --release` clean (matches main; pre-existing #2998 correlated-subquery failure is unrelated) |
| Feature ON: workspace lib suite green | OK | `cargo test --workspace --lib --release --features mvcc_enabled` clean |
| Rollback discards stamped rows | OK | `rollback_discards_stamped_rows` (snapshot isolation predicate's "revert on abort" path remains correct) |
| Autocommit (no active txn) keeps pre-MVCC sentinel even with feature on | OK | `autocommit_insert_with_feature_on_uses_pre_mvcc_sentinel` |
| Cross-transaction xmin separation | OK | `second_transaction_sees_committed_rows_with_first_xmin` |

## Test Plan

Off-state (default):
- [x] `cargo test --workspace --lib --release` — green
- [x] `cargo test -p vibesql-executor --release --test mvcc_stamping_tests` — 6/6 pass

On-state (`--features mvcc_enabled`):
- [x] `cargo test --workspace --lib --release --features mvcc_enabled` — green (the storage crate gains 1 extra test under the feature)
- [x] `cargo test -p vibesql-executor --release --test mvcc_stamping_tests --features mvcc_enabled` — 10/10 pass

Both modes:
- [x] `cargo clippy --workspace --lib` and `cargo clippy --workspace --lib --features mvcc_enabled` — no errors

## Scope Notes

This PR intentionally does NOT include:
- WAL_VERSION bump from v1 to v2 (the Phase 1a judge flagged this for Phase 1c, but the user's prompt simplified scope to "stamping observable via Row inspection" — the WAL still serializes the row's `values` field only, and Phase 1d will revisit WAL changes when the reader needs them).
- Write-write conflict detection (deferred to Phase 1d alongside read-path snapshot enforcement).
- FK cascade DELETE stamping (uses content-match `delete_where`; documented inline as a Phase 1d follow-up).
- TRUNCATE-style full-table fast path stamping (the table is wiped; documented as a GC-style follow-up).

Closes #5150