### PR TITLE
fix(parser): emit 'unsupported use of NULLS FIRST/LAST' outside ORDER BY (#5188)

### DIFF
--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -94,6 +94,8 @@ impl Parser {
                 vibesql_ast::OrderDirection::Asc
             };
 
+            self.reject_nulls_in_index_position()?;
+
             return Ok(vibesql_ast::IndexColumn::new_expression(expr, direction));
         }
 
@@ -160,6 +162,8 @@ impl Parser {
                     vibesql_ast::OrderDirection::Asc
                 };
 
+                self.reject_nulls_in_index_position()?;
+
                 return Ok(vibesql_ast::IndexColumn::new_expression(expr, direction));
             }
         } else {
@@ -176,6 +180,10 @@ impl Parser {
         } else {
             vibesql_ast::OrderDirection::Asc // Default for constraints
         };
+
+        // Reject `NULLS FIRST` / `NULLS LAST` here too — same SQLite rule as in
+        // CREATE INDEX column specs (see `parse_index_column_list`).
+        self.reject_nulls_in_index_position()?;
 
         Ok(vibesql_ast::IndexColumn::Column { column_name, direction, prefix_length })
     }

--- a/crates/vibesql-parser/src/parser/expressions/functions/window.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/window.rs
@@ -216,7 +216,29 @@ impl Parser {
                         vibesql_ast::OrderDirection::Asc // Default
                     };
 
-                order_items.push(vibesql_ast::OrderByItem { expr, direction, nulls_order: None });
+                // Window ORDER BY supports NULLS FIRST/LAST (SQL:2003).
+                let nulls_order =
+                    if matches!(self.peek(), Token::Keyword { keyword: Keyword::Nulls, .. }) {
+                        self.advance(); // consume NULLS
+                        if matches!(self.peek(), Token::Keyword { keyword: Keyword::First, .. }) {
+                            self.advance();
+                            Some(vibesql_ast::NullsOrder::First)
+                        } else if matches!(
+                            self.peek(),
+                            Token::Keyword { keyword: Keyword::Last, .. }
+                        ) {
+                            self.advance();
+                            Some(vibesql_ast::NullsOrder::Last)
+                        } else {
+                            return Err(ParseError {
+                                message: "Expected FIRST or LAST after NULLS".to_string(),
+                            });
+                        }
+                    } else {
+                        None
+                    };
+
+                order_items.push(vibesql_ast::OrderByItem { expr, direction, nulls_order });
 
                 if matches!(self.peek(), Token::Comma) {
                     self.advance();
@@ -532,8 +554,34 @@ impl Parser {
                                 vibesql_ast::OrderDirection::Asc
                             };
 
-                        order_items
-                            .push(vibesql_ast::OrderByItem { expr, direction, nulls_order: None });
+                        // Window ORDER BY supports NULLS FIRST/LAST (SQL:2003).
+                        let nulls_order = if matches!(
+                            self.peek(),
+                            Token::Keyword { keyword: Keyword::Nulls, .. }
+                        ) {
+                            self.advance(); // consume NULLS
+                            if matches!(
+                                self.peek(),
+                                Token::Keyword { keyword: Keyword::First, .. }
+                            ) {
+                                self.advance();
+                                Some(vibesql_ast::NullsOrder::First)
+                            } else if matches!(
+                                self.peek(),
+                                Token::Keyword { keyword: Keyword::Last, .. }
+                            ) {
+                                self.advance();
+                                Some(vibesql_ast::NullsOrder::Last)
+                            } else {
+                                return Err(ParseError {
+                                    message: "Expected FIRST or LAST after NULLS".to_string(),
+                                });
+                            }
+                        } else {
+                            None
+                        };
+
+                        order_items.push(vibesql_ast::OrderByItem { expr, direction, nulls_order });
 
                         if matches!(self.peek(), Token::Comma) {
                             self.advance();

--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -400,6 +400,35 @@ impl Parser {
     /// SQLite allows expressions without parentheses, so we must detect when
     /// the token cannot be a column name (e.g., numeric literals) and parse
     /// as an expression instead.
+    /// Reject `NULLS FIRST` / `NULLS LAST` modifiers in positions where SQLite
+    /// accepts them syntactically but rejects them semantically (CREATE INDEX
+    /// column specs, PRIMARY KEY / UNIQUE constraint column specs, ON CONFLICT
+    /// upsert targets).
+    ///
+    /// Emits SQLite's canonical error string `unsupported use of NULLS FIRST`
+    /// or `unsupported use of NULLS LAST` so the TCL test suite's
+    /// error-message assertions match (nulls1.test 3.1.*).
+    pub(in crate::parser) fn reject_nulls_in_index_position(
+        &mut self,
+    ) -> Result<(), ParseError> {
+        if self.peek_keyword(Keyword::Nulls) {
+            self.advance(); // consume NULLS
+            let position = if self.peek_keyword(Keyword::First) {
+                "FIRST"
+            } else if self.peek_keyword(Keyword::Last) {
+                "LAST"
+            } else {
+                return Err(ParseError {
+                    message: "Expected FIRST or LAST after NULLS".to_string(),
+                });
+            };
+            return Err(ParseError {
+                message: format!("unsupported use of NULLS {}", position),
+            });
+        }
+        Ok(())
+    }
+
     fn parse_index_column_list(&mut self) -> Result<Vec<vibesql_ast::IndexColumn>, ParseError> {
         let mut columns = Vec::new();
         loop {
@@ -428,6 +457,8 @@ impl Parser {
                     vibesql_ast::OrderDirection::Asc
                 };
 
+                self.reject_nulls_in_index_position()?;
+
                 columns.push(vibesql_ast::IndexColumn::new_expression(expr, direction));
             } else if matches!(
                 self.peek(),
@@ -448,6 +479,8 @@ impl Parser {
                 } else {
                     vibesql_ast::OrderDirection::Asc
                 };
+
+                self.reject_nulls_in_index_position()?;
 
                 columns.push(vibesql_ast::IndexColumn::new_expression(expr, direction));
             } else {
@@ -496,6 +529,8 @@ impl Parser {
                     } else {
                         vibesql_ast::OrderDirection::Asc
                     };
+
+                    self.reject_nulls_in_index_position()?;
 
                     columns.push(vibesql_ast::IndexColumn::new_expression(expr, direction));
 
@@ -574,6 +609,8 @@ impl Parser {
                             vibesql_ast::OrderDirection::Asc
                         };
 
+                        self.reject_nulls_in_index_position()?;
+
                         columns.push(vibesql_ast::IndexColumn::new_expression(expr, direction));
 
                         if self.peek() == &Token::Comma {
@@ -607,6 +644,12 @@ impl Parser {
                 } else {
                     vibesql_ast::OrderDirection::Asc // Default
                 };
+
+                // SQLite's grammar accepts NULLS FIRST/LAST in index column
+                // specifications syntactically, then rejects them with a
+                // specific error message. Match that behavior so error-message
+                // assertions in the TCL test suite (nulls1.test) pass.
+                self.reject_nulls_in_index_position()?;
 
                 columns.push(vibesql_ast::IndexColumn::Column {
                     column_name,

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -380,17 +380,46 @@ impl Parser {
             self.advance(); // consume CONFLICT
 
             // Parse optional conflict target (column list)
+            //
+            // SQLite's grammar for an upsert conflict target allows each
+            // column to be followed by an optional `COLLATE name` and an
+            // optional `ASC | DESC`. It also accepts `NULLS FIRST | LAST`
+            // syntactically and then rejects it with the canonical
+            // "unsupported use of NULLS FIRST/LAST" error. We mirror that
+            // behavior so nulls1.test 3.1.11 / 3.1.12 see the expected
+            // error message.
             let conflict_target = if matches!(self.peek(), Token::LParen) {
                 self.advance(); // consume (
-                let cols = self.parse_comma_separated_list(|p| match p.peek() {
-                    Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
-                        let name = col.clone();
-                        p.advance();
-                        Ok(name)
+                let cols = self.parse_comma_separated_list(|p| {
+                    let name = match p.peek() {
+                        Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
+                            let name = col.clone();
+                            p.advance();
+                            name
+                        }
+                        _ => {
+                            return Err(ParseError {
+                                message: "Expected column name in ON CONFLICT".to_string(),
+                            });
+                        }
+                    };
+
+                    // Optional COLLATE collation_name
+                    if p.peek_keyword(Keyword::Collate) {
+                        p.advance(); // consume COLLATE
+                        let _collation = p.parse_identifier()?;
                     }
-                    _ => Err(ParseError {
-                        message: "Expected column name in ON CONFLICT".to_string(),
-                    }),
+
+                    // Optional ASC | DESC
+                    if p.peek_keyword(Keyword::Asc) || p.peek_keyword(Keyword::Desc) {
+                        p.advance();
+                    }
+
+                    // SQLite accepts NULLS here only to emit a specific
+                    // error message.
+                    p.reject_nulls_in_index_position()?;
+
+                    Ok(name)
                 })?;
                 self.expect_token(Token::RParen)?;
                 Some(cols)

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -413,6 +413,11 @@ proc translate_error_to_sqlite {vibesql_error} {
     if {[regexp -nocase {^Parse error: (too many terms in ORDER BY clause)$} $error_msg -> parse_msg]} {
         return $parse_msg
     }
+    # Unsupported use of NULLS FIRST/LAST in index/constraint/upsert positions
+    # (nulls1.test 3.1.*) — SQLite returns this verbatim, not wrapped.
+    if {[regexp -nocase {^Parse error: (unsupported use of NULLS (?:FIRST|LAST))$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
     # Fallback for other parse errors (e.g., descriptive messages like "Expected identifier")
     if {[regexp -nocase {^Parse error: (.+)$} $error_msg -> parse_msg]} {
         return "near \"$parse_msg\": syntax error"


### PR DESCRIPTION
## Summary

This PR is the **builder's decomposition pass on epic #4986** (TCL Test Suite: Path to 100% Pass Rate). It does two things:

1. **Decomposes the remaining ~81 P2 failures into 5 new sub-issues** so each is single-PR sized.
2. **Implements the single highest-impact sub-issue (#5188)** — NULLS FIRST/LAST error message — proving the decomposition works. Adds ~18 passing tests.

## Decomposition (epic #4986)

Re-ran P2 against `main` (3ff16771): 81 failures span 11 distinct test families. Three are already covered by existing sub-issues (#5181, #5186, #5187). Five new sub-issues filed:

| Sub-issue | Family | Tests | Status |
|---|---|---|---|
| **#5188** (this PR) | NULLS error message in CREATE INDEX / PRIMARY KEY / UNIQUE / ON CONFLICT / window ORDER BY | ~17 | Landing in this PR |
| #5189 | nulls1.test 10.20-10.51 — Column index OOB | ~7 | Filed |
| #5190 | window1.test correctness sweep | ~24 | Filed (needs further triage) |
| #5191 | window9/B/C/pushd frame edge cases | ~12 | Filed |
| #5192 | collateB / triggerupfrom micro-tail | ~3 | Filed |

Existing umbrellas/sub-issues (open):
- #5181 — fkey1 partial index (3 tests)
- #5186 — fkey6 batched-txn shim (4 tests)
- #5187 — fkey6 sqlite3_db_status shim (2 tests)
- #5071 — FK umbrella (closing as #5181/5186/5187 close)

## What this PR fixes (#5188)

SQLite's grammar accepts \`NULLS FIRST/LAST\` in index column specs, primary-key/unique constraints, ON CONFLICT upsert targets, and window OVER ORDER BY. In the first three positions it rejects them semantically with \`unsupported use of NULLS FIRST/LAST\`. In window ORDER BY they're accepted.

VibeSQL's parser previously emitted a generic \`near \"NULLS\": syntax error\` in all of these positions. This broke:
- \`nulls1.test\` 3.1.1-3.1.12, 8.0 (expected the specific error)
- \`window8.test\` 4.3.1-4.5.2, 6.1, 6.2 (expected NULLS FIRST/LAST inside \`OVER (... ORDER BY ...)\` to be valid)

### Changes

- New \`Parser::reject_nulls_in_index_position\` helper in \`parser/index.rs\` that consumes \`NULLS FIRST|LAST\` and returns the canonical SQLite error.
- Call sites added in:
  - \`parse_index_column_list\` (CREATE INDEX, all 5 ASC/DESC slots)
  - \`parse_index_column_spec\` (PRIMARY KEY / UNIQUE, all 3 ASC/DESC slots)
  - \`parse_on_clause_for_insert\` upsert target (also expanded the conflict-target grammar to accept optional \`COLLATE\` / \`ASC\` / \`DESC\` so we can reach the NULLS position cleanly).
- Added real NULLS FIRST/LAST support to \`parse_window_spec\` and \`parse_window_definitions\` (was previously discarding the modifier silently).
- Updated \`scripts/tester_vibesql.tcl::translate_error_to_sqlite\` to pass \`unsupported use of NULLS FIRST/LAST\` through verbatim instead of wrapping it.

## Test results

| Suite | Before | After |
|---|---|---|
| P2 nulls1.test | 41/63 | 53/63 |
| P2 window8.test | 4/15 (11 failing) | 10/15 (5 failing) |
| P2 overall | 3402 passed / 81 failed | 3420 passed / 63 failed |
| Parser unit tests | 1248/1248 | 1248/1248 |
| P1 | (pre-existing 72 failures on main) | (same 72) |

Verified P1 failures pre-exist \`main\` by stash-comparing select1-18.1 and orderby1-4.0.

## Test plan

- [x] \`cargo test -p vibesql-parser --release\` — 1248 tests pass
- [x] \`bash scripts/tcltest run --pattern \"nulls1.test\"\` — 53/63 (was 41/63)
- [x] \`bash scripts/tcltest run --pattern \"window8.test\"\` — 10/15 (was 4/15)
- [x] \`bash scripts/tcltest run --pattern \"window2.test\"\` — 63/67 (unchanged)
- [x] \`bash scripts/tcltest run --pattern \"orderby1.test\"\` — same as main (37/64)
- [x] Full P2 run — 3420/4984 passing (was 3402/4984)

Closes #5188.
Implements part of #4986.