### PR TITLE
fix(wal): increment explicit_flushes before notifying sync waiters

### DIFF
--- a/crates/vibesql-storage/src/wal/engine.rs
+++ b/crates/vibesql-storage/src/wal/engine.rs
@@ -383,6 +383,7 @@ mod native {
                                 &stats,
                                 &mut pending_notifiers,
                                 true,
+                                false,
                             );
                             last_flush = Instant::now();
                         }
@@ -394,9 +395,9 @@ mod native {
                             &stats,
                             &mut pending_notifiers,
                             false,
+                            true,
                         );
                         last_flush = Instant::now();
-                        stats.lock().explicit_flushes += 1;
                     }
                     Ok(WalMessage::FlushAndNotify(notifier)) => {
                         pending_notifiers.push(notifier);
@@ -406,9 +407,9 @@ mod native {
                             &stats,
                             &mut pending_notifiers,
                             false,
+                            true,
                         );
                         last_flush = Instant::now();
-                        stats.lock().explicit_flushes += 1;
                     }
                     Ok(WalMessage::Shutdown) => {
                         // Flush remaining entries before shutdown
@@ -417,6 +418,7 @@ mod native {
                             &mut batch,
                             &stats,
                             &mut pending_notifiers,
+                            false,
                             false,
                         );
                         break;
@@ -429,6 +431,7 @@ mod native {
                                 &mut batch,
                                 &stats,
                                 &mut pending_notifiers,
+                                false,
                                 false,
                             );
                             stats.lock().time_flushes += 1;
@@ -443,6 +446,7 @@ mod native {
                             &stats,
                             &mut pending_notifiers,
                             false,
+                            false,
                         );
                         break;
                     }
@@ -453,14 +457,30 @@ mod native {
         }
 
         /// Flush a batch of entries to disk
+        ///
+        /// `is_explicit_flush` indicates the flush was triggered by an explicit
+        /// `WalMessage::Flush` or `WalMessage::FlushAndNotify`. The
+        /// `explicit_flushes` counter is incremented under the same stats-lock
+        /// acquisition that updates the other counters, and crucially BEFORE
+        /// waiters are notified. This guarantees that any caller waking from
+        /// `FlushNotifier::wait()` observes the updated counter on a subsequent
+        /// `stats.lock()`.
         fn flush_batch<W: Write + Seek>(
             writer: &mut WalWriter<W>,
             batch: &mut Vec<WalEntry>,
             stats: &Arc<Mutex<PersistenceStats>>,
             pending_notifiers: &mut Vec<FlushNotifier>,
             is_count_flush: bool,
+            is_explicit_flush: bool,
         ) {
             if batch.is_empty() {
+                // An explicit sync on an empty WAL still counts as an explicit
+                // flush. Increment the counter under the stats lock BEFORE
+                // notifying waiters so the happens-before edge into the caller
+                // includes the counter update.
+                if is_explicit_flush {
+                    stats.lock().explicit_flushes += 1;
+                }
                 // Still notify waiters even if batch is empty
                 for notifier in pending_notifiers.drain(..) {
                     notifier.notify();
@@ -498,6 +518,9 @@ mod native {
                 stats.bytes_written += bytes_written;
                 if is_count_flush {
                     stats.count_flushes += 1;
+                }
+                if is_explicit_flush {
+                    stats.explicit_flushes += 1;
                 }
                 stats.record_flush_latency(flush_duration);
             }


### PR DESCRIPTION
## Summary

- Closes #5177.
- Fixes a race condition where `PersistenceEngine::sync()` could return before the WAL writer thread had incremented `explicit_flushes`, causing intermittent CI failures in `test_force_durable_triggers_sync`.
- Threads an `is_explicit_flush: bool` parameter into `flush_batch` so the counter is bumped under the same `stats.lock()` acquisition that updates `entries_written` / `batches_written` / `bytes_written` / `count_flushes`, BEFORE waiters are drained and notified.
- Empty-batch early-return path also handles the increment, so an explicit sync on an empty WAL is still counted.

## Why

`WalMessage::FlushAndNotify(...)` previously called `flush_batch` (which drains `pending_notifiers` and releases each waiter) and only afterwards executed `stats.lock().explicit_flushes += 1`. The caller in `engine.sync()` could therefore wake from `notifier.wait()` and read `persistence_stats()` before the bg thread reacquired the stats lock. The same shape existed for `WalMessage::Flush`. The new invariant: the stats-lock acquisition that bumps `explicit_flushes` happens-before `cvar.notify_all()`, so the counter is always observed updated when `sync()` returns.

## Test plan

- [x] Reproduced the race locally by inserting a 5 ms `thread::sleep` between the original `flush_batch` call and the post-hoc `explicit_flushes += 1` in the `FlushAndNotify` arm. Target test failed 10/10 runs (release build).
- [x] With the fix applied (sleep removed), `cargo test --release -p vibesql-storage --lib test_force_durable_triggers_sync -- --test-threads=8` passes 50/50 runs.
- [x] Re-inserting the same 5 ms sleep after `flush_batch` (with the new in-lock increment) still passes 10/10 runs — confirms the counter is observed regardless of bg-thread jitter.
- [x] Full `cargo test --release -p vibesql-storage --lib` suite: 622/622 pass.

## Acceptance criteria satisfied

- [x] `explicit_flushes` incremented under the same `stats.lock()` that updates other counters, before any `notifier.notify()`.
- [x] Both `WalMessage::Flush` and `WalMessage::FlushAndNotify` arms get the increment; timeout / count-triggered / shutdown / disconnect flushes do not.
- [x] Empty-batch early-return path increments when invoked from an explicit-flush request.
- [x] Target test no longer flaky; no regression in other persistence tests.