### PR TITLE
fix(executor): columnar JOIN sort-then-project + outer-join matched NULL preservation

### DIFF
--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
@@ -413,8 +413,22 @@ impl SelectExecutor<'_> {
                 let buffer_pool = self.database.query_buffer_pool();
 
                 let rows = filtered_batch.to_rows()?;
-                let mut projected_rows = Vec::with_capacity(rows.len());
-                for row in &rows {
+
+                // Apply ORDER BY BEFORE projection so sort expressions can reference
+                // columns from the full combined schema (e.g. `ORDER BY c` where `c`
+                // is not in the SELECT list). The row-oriented path in
+                // `nonagg/materialized.rs` follows the same sort-then-project order.
+                // See issue #5189: projecting first produced "Column index out of
+                // bounds" errors when ORDER BY referenced columns dropped by the
+                // projection.
+                let sorted_rows = if let Some(order_by) = &stmt.order_by {
+                    self.apply_columnar_join_order_by(rows, order_by, &stmt.select_list, &combined_schema)?
+                } else {
+                    rows
+                };
+
+                let mut projected_rows = Vec::with_capacity(sorted_rows.len());
+                for row in &sorted_rows {
                     let projected = project_row_combined(
                         row,
                         &stmt.select_list,
@@ -430,14 +444,7 @@ impl SelectExecutor<'_> {
                 let final_rows =
                     if stmt.distinct { apply_distinct(projected_rows) } else { projected_rows };
 
-                // Apply ORDER BY if present (#5033)
-                let sorted_rows = if let Some(order_by) = &stmt.order_by {
-                    self.apply_columnar_join_order_by(final_rows, order_by, &stmt.select_list, &combined_schema)?
-                } else {
-                    final_rows
-                };
-
-                Ok(Some(sorted_rows))
+                Ok(Some(final_rows))
             }
         }
     }

--- a/crates/vibesql-executor/src/select/join/hash_join/columnar/mod.rs
+++ b/crates/vibesql-executor/src/select/join/hash_join/columnar/mod.rs
@@ -374,4 +374,50 @@ mod tests {
         assert!(matches!(bob.get(2), Some(vibesql_types::SqlValue::Null)));
         assert!(matches!(bob.get(3), Some(vibesql_types::SqlValue::Null)));
     }
+
+    /// Regression test for issue #5189: LEFT OUTER JOIN must preserve pre-existing
+    /// NULL values in matched rows. Previously, `gather_column_with_nulls` ignored
+    /// the source's null bitmap and unconditionally wrote `false` (not-null) for
+    /// every matched index, so a NULL value in the matched right-side data was
+    /// rendered as the type's default placeholder (e.g. `0` for Int64).
+    #[test]
+    fn test_columnar_hash_join_left_outer_preserves_matched_nulls() {
+        // Left: a single row with key 'X'
+        let left_columns = vec![ColumnArray::String(Arc::new(vec!["X".into()]), None)];
+        let left_batch =
+            ColumnarBatch::from_columns(left_columns, Some(vec!["x".into()])).unwrap();
+
+        // Right: three rows all matching key 'X', but row index 1 has c = NULL.
+        // c is the value column (col 0), d is the join key (col 1).
+        let right_columns = vec![
+            ColumnArray::Int64(
+                Arc::new(vec![5, 0, 7]),                  // 0 is placeholder for NULL
+                Some(Arc::new(vec![false, true, false])), // row 1 is NULL
+            ),
+            ColumnArray::String(
+                Arc::new(vec!["X".into(), "X".into(), "X".into()]),
+                None,
+            ),
+        ];
+        let right_batch =
+            ColumnarBatch::from_columns(right_columns, Some(vec!["c".into(), "d".into()]))
+                .unwrap();
+
+        // LEFT JOIN t1 ON d = x — three matches.
+        // left key col = 0 (x), right key col = 1 (d).
+        let result = columnar_hash_join_left_outer(&left_batch, &right_batch, 0, 1).unwrap();
+        assert_eq!(result.row_count(), 3);
+
+        let rows = result.to_rows().unwrap();
+        // Result columns are: x (0), c (1), d (2). Exactly one c must be NULL.
+        let null_c_count = rows
+            .iter()
+            .filter(|r| matches!(r.get(1), Some(vibesql_types::SqlValue::Null)))
+            .count();
+        assert_eq!(
+            null_c_count, 1,
+            "matched-row NULL in c must be preserved; got rows: {:?}",
+            rows
+        );
+    }
 }

--- a/crates/vibesql-executor/src/select/join/hash_join/columnar/output.rs
+++ b/crates/vibesql-executor/src/select/join/hash_join/columnar/output.rs
@@ -227,7 +227,7 @@ pub(crate) fn gather_column_with_nulls(
     indices: &[u32],
 ) -> Result<ColumnArray, ExecutorError> {
     match column {
-        ColumnArray::Int64(values, _existing_nulls) => {
+        ColumnArray::Int64(values, existing_nulls) => {
             let mut gathered = Vec::with_capacity(indices.len());
             let mut nulls = Vec::with_capacity(indices.len());
 
@@ -236,14 +236,18 @@ pub(crate) fn gather_column_with_nulls(
                     gathered.push(0); // placeholder
                     nulls.push(true);
                 } else {
-                    gathered.push(values[idx as usize]);
-                    nulls.push(false);
+                    let i = idx as usize;
+                    gathered.push(values[i]);
+                    // Preserve source NULL bits (issue #5189) — without this,
+                    // pre-existing NULLs in matched rows of an outer join were
+                    // dropped and rendered as the default placeholder value (0).
+                    nulls.push(existing_nulls.as_ref().is_some_and(|n| n[i]));
                 }
             }
 
             Ok(ColumnArray::Int64(Arc::new(gathered), Some(Arc::new(nulls))))
         }
-        ColumnArray::Int32(values, _existing_nulls) => {
+        ColumnArray::Int32(values, existing_nulls) => {
             let mut gathered = Vec::with_capacity(indices.len());
             let mut nulls = Vec::with_capacity(indices.len());
 
@@ -252,14 +256,15 @@ pub(crate) fn gather_column_with_nulls(
                     gathered.push(0);
                     nulls.push(true);
                 } else {
-                    gathered.push(values[idx as usize]);
-                    nulls.push(false);
+                    let i = idx as usize;
+                    gathered.push(values[i]);
+                    nulls.push(existing_nulls.as_ref().is_some_and(|n| n[i]));
                 }
             }
 
             Ok(ColumnArray::Int32(Arc::new(gathered), Some(Arc::new(nulls))))
         }
-        ColumnArray::Float64(values, _existing_nulls) => {
+        ColumnArray::Float64(values, existing_nulls) => {
             let mut gathered = Vec::with_capacity(indices.len());
             let mut nulls = Vec::with_capacity(indices.len());
 
@@ -268,14 +273,15 @@ pub(crate) fn gather_column_with_nulls(
                     gathered.push(0.0);
                     nulls.push(true);
                 } else {
-                    gathered.push(values[idx as usize]);
-                    nulls.push(false);
+                    let i = idx as usize;
+                    gathered.push(values[i]);
+                    nulls.push(existing_nulls.as_ref().is_some_and(|n| n[i]));
                 }
             }
 
             Ok(ColumnArray::Float64(Arc::new(gathered), Some(Arc::new(nulls))))
         }
-        ColumnArray::Float32(values, _existing_nulls) => {
+        ColumnArray::Float32(values, existing_nulls) => {
             let mut gathered = Vec::with_capacity(indices.len());
             let mut nulls = Vec::with_capacity(indices.len());
 
@@ -284,14 +290,15 @@ pub(crate) fn gather_column_with_nulls(
                     gathered.push(0.0);
                     nulls.push(true);
                 } else {
-                    gathered.push(values[idx as usize]);
-                    nulls.push(false);
+                    let i = idx as usize;
+                    gathered.push(values[i]);
+                    nulls.push(existing_nulls.as_ref().is_some_and(|n| n[i]));
                 }
             }
 
             Ok(ColumnArray::Float32(Arc::new(gathered), Some(Arc::new(nulls))))
         }
-        ColumnArray::String(values, _existing_nulls) => {
+        ColumnArray::String(values, existing_nulls) => {
             let mut gathered: Vec<std::sync::Arc<str>> = Vec::with_capacity(indices.len());
             let mut nulls = Vec::with_capacity(indices.len());
 
@@ -300,14 +307,15 @@ pub(crate) fn gather_column_with_nulls(
                     gathered.push(Arc::from(""));
                     nulls.push(true);
                 } else {
-                    gathered.push(values[idx as usize].clone());
-                    nulls.push(false);
+                    let i = idx as usize;
+                    gathered.push(values[i].clone());
+                    nulls.push(existing_nulls.as_ref().is_some_and(|n| n[i]));
                 }
             }
 
             Ok(ColumnArray::String(Arc::new(gathered), Some(Arc::new(nulls))))
         }
-        ColumnArray::FixedString(values, _existing_nulls) => {
+        ColumnArray::FixedString(values, existing_nulls) => {
             let mut gathered: Vec<std::sync::Arc<str>> = Vec::with_capacity(indices.len());
             let mut nulls = Vec::with_capacity(indices.len());
 
@@ -316,14 +324,15 @@ pub(crate) fn gather_column_with_nulls(
                     gathered.push(Arc::from(""));
                     nulls.push(true);
                 } else {
-                    gathered.push(values[idx as usize].clone());
-                    nulls.push(false);
+                    let i = idx as usize;
+                    gathered.push(values[i].clone());
+                    nulls.push(existing_nulls.as_ref().is_some_and(|n| n[i]));
                 }
             }
 
             Ok(ColumnArray::FixedString(Arc::new(gathered), Some(Arc::new(nulls))))
         }
-        ColumnArray::Date(values, _existing_nulls) => {
+        ColumnArray::Date(values, existing_nulls) => {
             let mut gathered = Vec::with_capacity(indices.len());
             let mut nulls = Vec::with_capacity(indices.len());
 
@@ -332,14 +341,15 @@ pub(crate) fn gather_column_with_nulls(
                     gathered.push(0);
                     nulls.push(true);
                 } else {
-                    gathered.push(values[idx as usize]);
-                    nulls.push(false);
+                    let i = idx as usize;
+                    gathered.push(values[i]);
+                    nulls.push(existing_nulls.as_ref().is_some_and(|n| n[i]));
                 }
             }
 
             Ok(ColumnArray::Date(Arc::new(gathered), Some(Arc::new(nulls))))
         }
-        ColumnArray::Timestamp(values, _existing_nulls) => {
+        ColumnArray::Timestamp(values, existing_nulls) => {
             let mut gathered = Vec::with_capacity(indices.len());
             let mut nulls = Vec::with_capacity(indices.len());
 
@@ -348,14 +358,15 @@ pub(crate) fn gather_column_with_nulls(
                     gathered.push(0);
                     nulls.push(true);
                 } else {
-                    gathered.push(values[idx as usize]);
-                    nulls.push(false);
+                    let i = idx as usize;
+                    gathered.push(values[i]);
+                    nulls.push(existing_nulls.as_ref().is_some_and(|n| n[i]));
                 }
             }
 
             Ok(ColumnArray::Timestamp(Arc::new(gathered), Some(Arc::new(nulls))))
         }
-        ColumnArray::Boolean(values, _existing_nulls) => {
+        ColumnArray::Boolean(values, existing_nulls) => {
             let mut gathered = Vec::with_capacity(indices.len());
             let mut nulls = Vec::with_capacity(indices.len());
 
@@ -364,8 +375,9 @@ pub(crate) fn gather_column_with_nulls(
                     gathered.push(0);
                     nulls.push(true);
                 } else {
-                    gathered.push(values[idx as usize]);
-                    nulls.push(false);
+                    let i = idx as usize;
+                    gathered.push(values[i]);
+                    nulls.push(existing_nulls.as_ref().is_some_and(|n| n[i]));
                 }
             }
 


### PR DESCRIPTION
## Summary

Two related bugs in the columnar JOIN path (introduced by #5039) caused
`nulls1.test 10.20-10.51` to fail:

1. **Sort-then-project ordering (the primary OOB).** The non-`SELECT *`,
   non-GROUP-BY branch of `execute_columnar_join` projected rows *before*
   applying ORDER BY, while the ORDER BY evaluator stayed bound to the
   full combined join schema. References like `ORDER BY c` (where `c`
   was dropped by the projection) resolved to a column index past the
   end of the projected row and produced `Column index N out of bounds`.
   The row-oriented path in `nonagg/materialized.rs` already sorts
   before projecting against the join schema; reorder the columnar
   branch to match.

2. **Matched-row NULL preservation in LEFT/RIGHT OUTER joins.** After
   (1) was fixed, `10.30-10.42` still failed because the outer-join
   gather function `gather_column_with_nulls` ignored the source
   column's null bitmap and unconditionally wrote `false` (not-null) for
   every matched index. Pre-existing NULLs in matched rows were therefore
   rendered as the type's default placeholder value (e.g. `0` for
   `Int64`, `""` for `String`). Propagate the source null bit when the
   gather index is not `u32::MAX` (the outer-join "no match" sentinel).

Adds a regression unit test for the matched-row NULL path.

Closes #5189

## Test plan

- [x] `./scripts/tcltest test nulls1.test` — passing tests went from
      53 -> 60 (all seven 10.20/10.30/10.40/10.41/10.42/10.50/10.51 now
      pass; remaining 2.2, 3.1.12, 5.4 are pre-existing failures
      unrelated to this fix).
- [x] `cargo test --release -p vibesql-executor --lib` — 2393 passing,
      0 failing (was 2392; +1 new regression test).
- [x] `cargo test --release --workspace --lib` — no failures.
- [x] `./scripts/tcltest test join.test` — 174/178 (same as baseline,
      same three pre-existing failures: join-2.4, join-2.5, join-7.1).
- [x] `./scripts/tcltest test join2.test` — 44/48 (same as baseline,
      same two pre-existing failures: 4.3.1, 11.1).
- [x] `./scripts/tcltest test orderby1.test` — 38/64, 0 failures.
- [x] Curator's reduced reproducer
      `SELECT c FROM t1 INNER JOIN t2 ON d=x ORDER BY c;` now returns
      the expected single row without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)