### PR TITLE
feat(indexes): apply WHERE predicate to partial-index body at build/DML time

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -10,7 +10,7 @@ use crate::{
     dml_cost::DmlOptimizer,
     errors::ExecutorError,
     evaluator::{coercion::coerce_value_to_column_type, ExpressionEvaluator},
-    expression_index_maintenance,
+    expression_index_maintenance, partial_index_maintenance,
     privilege_checker::PrivilegeChecker,
     sqlite_schema::is_sqlite_schema_table,
     truncate_validation::can_use_truncate,
@@ -233,7 +233,15 @@ impl DeleteExecutor {
 
                     // Also skip fast path if there are expression indexes that need maintenance
                     let has_expression_indexes = database.has_expression_indexes(table_name);
-                    if !has_triggers && !has_referencing_fks && !has_expression_indexes {
+                    // Skip fast path if there are partial indexes — they need
+                    // the executor to evaluate the WHERE predicate against
+                    // the row being deleted before removing the entry.
+                    let has_partial_indexes = database.has_partial_indexes(table_name);
+                    if !has_triggers
+                        && !has_referencing_fks
+                        && !has_expression_indexes
+                        && !has_partial_indexes
+                    {
                         // Use the fast path - no triggers, no FKs, no expression indexes, single row PK delete
                         match database.delete_by_pk_fast(table_name, &pk_values) {
                             Ok(deleted) => {
@@ -457,6 +465,9 @@ impl DeleteExecutor {
         // Maintain expression indexes for each deleted row
         for (row_index, row) in &rows_and_indices_to_delete {
             expression_index_maintenance::maintain_expression_indexes_for_delete(
+                database, table_name, row, *row_index,
+            );
+            partial_index_maintenance::maintain_partial_indexes_for_delete(
                 database, table_name, row, *row_index,
             );
         }

--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -513,6 +513,10 @@ impl DeleteExecutor {
             expression_index_maintenance::rebuild_expression_indexes_after_compaction(
                 database, table_name,
             );
+            // Partial indexes need WHERE-predicate evaluation per row
+            partial_index_maintenance::rebuild_partial_indexes_after_compaction(
+                database, table_name,
+            );
         }
 
         // Invalidate the database-level columnar cache since table data changed.

--- a/crates/vibesql-executor/src/index_ddl/btree_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/btree_index.rs
@@ -5,13 +5,19 @@
 //! - Unique indexes
 //! - Multi-column composite indexes
 //! - Expression indexes (delegated to expression_index module)
+//! - Partial indexes (with a WHERE predicate filter at build time)
+
+use std::collections::HashSet;
 
 use vibesql_ast::{CreateIndexStmt, IndexColumn};
 use vibesql_catalog::TableSchema;
 use vibesql_storage::Database;
 
 use super::expression_index::create_expression_index;
-use crate::errors::ExecutorError;
+use crate::{
+    errors::ExecutorError, evaluator::ExpressionEvaluator,
+    partial_index_maintenance::is_predicate_truthy,
+};
 
 /// Create a B-tree index on a table.
 ///
@@ -64,6 +70,13 @@ pub fn create_btree_index(
     // Create the B-tree index
     if has_expression {
         // Expression index: pre-compute keys using ExpressionEvaluator
+        // (Expression partial indexes are not yet supported — the partial
+        // predicate is ignored here. The catalog still records the
+        // where_clause, but `is_partial()` on the storage metadata will be
+        // false because expression indexes go through a different storage
+        // path. This is acceptable for now; the planner's
+        // `IndexedColumn::is_expression()` check already excludes expression
+        // indexes from most query-time paths.)
         create_expression_index(
             database,
             table_name,
@@ -71,6 +84,40 @@ pub fn create_btree_index(
             table_schema,
             &stmt.columns,
             unique,
+        )?;
+    } else if let Some(where_expr) = stmt.where_clause.as_deref() {
+        // Partial column-only index: evaluate the predicate against each
+        // existing row and only insert matching rows into the index body.
+        let table_rows: Vec<vibesql_storage::Row> = match database.get_table(table_name) {
+            Some(table) => table.scan().to_vec(),
+            None => Vec::new(),
+        };
+        let evaluator = ExpressionEvaluator::new(table_schema);
+        let mut included: HashSet<usize> = HashSet::with_capacity(table_rows.len());
+        for (row_idx, row) in table_rows.iter().enumerate() {
+            match evaluator.eval(where_expr, row) {
+                Ok(v) if is_predicate_truthy(&v) => {
+                    included.insert(row_idx);
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    log::warn!(
+                        "Failed to evaluate partial-index '{}' predicate on row {}: {:?}; \
+                         treating row as not-in-index",
+                        index_name,
+                        row_idx,
+                        e
+                    );
+                }
+            }
+        }
+        database.create_index_partial(
+            index_name.clone(),
+            table_name.to_string(),
+            unique,
+            stmt.columns.clone(),
+            Box::new(where_expr.clone()),
+            &included,
         )?;
     } else {
         // Column-only index: use existing storage API

--- a/crates/vibesql-executor/src/index_ddl/create_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/create_index.rs
@@ -76,13 +76,14 @@ impl CreateIndexExecutor {
 
         // Partial indexes (CREATE INDEX … WHERE …): the predicate has already
         // been validated for semantic legality (e.g. no window functions). The
-        // catalog now records the predicate via `IndexMetadata::where_clause`
-        // so the FK-mismatch checker and the index-selection planner can
-        // recognise and skip partial indexes. The index *body* is still built
-        // over every row of the parent table — full SQLite-style predicate
-        // evaluation at build time is a follow-up (see issue #5181 curator
-        // notes). This is safe today because the planner refuses to use
-        // partial indexes for query execution.
+        // catalog records the predicate via `IndexMetadata::where_clause` so
+        // the FK-mismatch checker and the index-selection planner can
+        // recognise and skip partial indexes. The B-tree index path
+        // (`create_btree_index`) now also evaluates the predicate against
+        // every existing row at build time so the initial index body only
+        // contains matching rows. Subsequent INSERT/UPDATE/DELETE maintenance
+        // is handled by `partial_index_maintenance` on each DML path. See
+        // issue #5214.
 
         // Dispatch to appropriate index creation based on type
         match &stmt.index_type {

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -3,8 +3,8 @@ use vibesql_storage::statistics::CostEstimator;
 
 use crate::{
     dml_cost::DmlOptimizer, errors::ExecutorError, expression_index_maintenance,
-    privilege_checker::PrivilegeChecker, sqlite_schema::is_sqlite_schema_table,
-    sqlite_stat::is_sqlite_stat1_table,
+    partial_index_maintenance, privilege_checker::PrivilegeChecker,
+    sqlite_schema::is_sqlite_schema_table, sqlite_stat::is_sqlite_stat1_table,
 };
 
 /// Execute an INSERT statement
@@ -713,6 +713,16 @@ fn execute_insert_internal(
                 let rows: Vec<vibesql_storage::Row> =
                     chunk.iter().map(|(v, rowid)| make_row((v.clone(), *rowid))).collect();
 
+                // Partial-aware unique-constraint check (storage skips
+                // partial UNIQUE indexes; the executor must do this itself).
+                for row in &rows {
+                    partial_index_maintenance::check_partial_unique_for_insert(
+                        db,
+                        &storage_table_name,
+                        row,
+                    )?;
+                }
+
                 let chunk_inserted =
                     db.insert_rows_batch(&storage_table_name, rows.clone()).map_err(|e| {
                         ExecutorError::UnsupportedExpression(format!("Storage error: {}", e))
@@ -721,6 +731,12 @@ fn execute_insert_internal(
                 // Maintain expression indexes for each inserted row
                 for (i, row) in rows.iter().enumerate() {
                     expression_index_maintenance::maintain_expression_indexes_for_insert(
+                        db,
+                        &storage_table_name,
+                        row,
+                        row_offset + i,
+                    );
+                    partial_index_maintenance::maintain_partial_indexes_for_insert(
                         db,
                         &storage_table_name,
                         row,
@@ -735,6 +751,16 @@ fn execute_insert_internal(
             let rows: Vec<vibesql_storage::Row> =
                 validated_rows.into_iter().map(make_row).collect();
 
+            // Partial-aware unique-constraint check (storage skips partial
+            // UNIQUE indexes; the executor must do this itself).
+            for row in &rows {
+                partial_index_maintenance::check_partial_unique_for_insert(
+                    db,
+                    &storage_table_name,
+                    row,
+                )?;
+            }
+
             rows_inserted =
                 db.insert_rows_batch(&storage_table_name, rows.clone()).map_err(|e| {
                     ExecutorError::UnsupportedExpression(format!("Storage error: {}", e))
@@ -743,6 +769,12 @@ fn execute_insert_internal(
             // Maintain expression indexes for each inserted row
             for (i, row) in rows.iter().enumerate() {
                 expression_index_maintenance::maintain_expression_indexes_for_insert(
+                    db,
+                    &storage_table_name,
+                    row,
+                    initial_row_count + i,
+                );
+                partial_index_maintenance::maintain_partial_indexes_for_insert(
                     db,
                     &storage_table_name,
                     row,
@@ -924,12 +956,25 @@ fn execute_insert_internal(
 
             // Insert the row
             let row = make_row((full_row_values, final_explicit_rowid));
+            // Partial-aware unique-constraint check (storage skips partial
+            // UNIQUE indexes; the executor must do that check itself).
+            partial_index_maintenance::check_partial_unique_for_insert(
+                db,
+                &storage_table_name,
+                &row,
+            )?;
             db.insert_row(&storage_table_name, row.clone()).map_err(|e| {
                 ExecutorError::UnsupportedExpression(format!("Storage error: {}", e))
             })?;
 
             // Maintain expression indexes for this insert
             expression_index_maintenance::maintain_expression_indexes_for_insert(
+                db,
+                &storage_table_name,
+                &row,
+                row_count_before,
+            );
+            partial_index_maintenance::maintain_partial_indexes_for_insert(
                 db,
                 &storage_table_name,
                 &row,

--- a/crates/vibesql-executor/src/insert/replace.rs
+++ b/crates/vibesql-executor/src/insert/replace.rs
@@ -224,6 +224,15 @@ pub fn handle_replace_conflicts(
     if delete_result.compacted {
         // Compaction changed all row indices - rebuild indexes from scratch
         db.rebuild_indexes(table_name);
+        // Partial indexes need WHERE-predicate evaluation per row; the
+        // storage layer's `rebuild_indexes` skips them. Without this call,
+        // partial-index row indices would point at the wrong table rows
+        // after compaction (silent corruption).
+        partial_index_maintenance::rebuild_partial_indexes_after_compaction(db, table_name);
+        // NOTE: Expression-index compaction rebuild (`rebuild_expression_indexes_after_compaction`)
+        // is intentionally not invoked here because the existing code path
+        // never did so; that is a separate pre-existing gap tracked outside
+        // this PR.
     } else {
         // No compaction - just adjust remaining user-defined index entries
         // (entries pointing to indices > deleted need to be decremented)

--- a/crates/vibesql-executor/src/insert/replace.rs
+++ b/crates/vibesql-executor/src/insert/replace.rs
@@ -1,4 +1,6 @@
-use crate::{errors::ExecutorError, expression_index_maintenance, TriggerFirer};
+use crate::{
+    errors::ExecutorError, expression_index_maintenance, partial_index_maintenance, TriggerFirer,
+};
 
 /// Handle REPLACE logic: detect conflicts and delete conflicting rows
 /// Returns Ok(()) if no conflict or conflict was resolved
@@ -185,6 +187,9 @@ pub fn handle_replace_conflicts(
     // Maintain expression indexes for each deleted row
     for (row_index, row) in &rows_to_delete {
         expression_index_maintenance::maintain_expression_indexes_for_delete(
+            db, table_name, row, *row_index,
+        );
+        partial_index_maintenance::maintain_partial_indexes_for_delete(
             db, table_name, row, *row_index,
         );
     }

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -20,6 +20,7 @@ pub mod evaluator;
 mod explain;
 pub mod expression_index_maintenance;
 pub mod foreign_key_check;
+pub mod partial_index_maintenance;
 mod grant;
 pub mod index_ddl;
 pub mod information_schema;

--- a/crates/vibesql-executor/src/partial_index_maintenance.rs
+++ b/crates/vibesql-executor/src/partial_index_maintenance.rs
@@ -1,0 +1,239 @@
+//! Partial-index maintenance for DML operations.
+//!
+//! Partial indexes (`CREATE INDEX ... WHERE predicate`) require the WHERE
+//! predicate to be evaluated per row to decide whether the row belongs in
+//! the index. The storage layer cannot evaluate AST expressions, so these
+//! helpers evaluate the predicate against the affected row and call the
+//! storage's `*_partial_indexes_*` entry points with a pre-computed
+//! inclusion set.
+//!
+//! The companion module `expression_index_maintenance` follows the same
+//! pattern for expression-based indexes.
+
+use std::collections::HashSet;
+
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+use crate::evaluator::ExpressionEvaluator;
+
+/// Evaluate a SQL value as a boolean predicate in the SQLite sense.
+///
+/// SQLite treats NULL as "not true" (rows are excluded from partial indexes
+/// when the predicate is NULL), and any non-zero, non-NULL value as true.
+/// String values are interpreted as numeric where possible — matching the
+/// behaviour of other predicate-evaluation paths in the executor.
+#[inline]
+pub fn is_predicate_truthy(value: &SqlValue) -> bool {
+    match value {
+        SqlValue::Boolean(b) => *b,
+        SqlValue::Null => false,
+        SqlValue::Integer(n) => *n != 0,
+        SqlValue::Smallint(n) => *n != 0,
+        SqlValue::Bigint(n) => *n != 0,
+        SqlValue::Unsigned(n) => *n != 0,
+        SqlValue::Float(f) => *f != 0.0,
+        SqlValue::Real(f) => *f != 0.0,
+        SqlValue::Double(f) => *f != 0.0,
+        SqlValue::Numeric(f) => *f != 0.0,
+        SqlValue::Varchar(s) | SqlValue::Character(s) => {
+            s.parse::<f64>().map(|n| n != 0.0).unwrap_or(false)
+        }
+        _ => false,
+    }
+}
+
+/// Evaluate every partial index's WHERE predicate against `row` and return
+/// the set of normalized index names whose predicate evaluated to truthy.
+///
+/// Returns an empty set when the table has no partial indexes, allowing the
+/// caller to skip subsequent storage calls cheaply.
+pub fn evaluate_partial_index_predicates(
+    db: &Database,
+    table_name: &str,
+    row: &vibesql_storage::Row,
+) -> HashSet<String> {
+    if !db.has_partial_indexes(table_name) {
+        return HashSet::new();
+    }
+
+    let table_schema = match db.catalog.get_table(table_name) {
+        Some(schema) => schema.clone(),
+        None => return HashSet::new(),
+    };
+
+    let evaluator = ExpressionEvaluator::new(&table_schema);
+
+    let mut included: HashSet<String> = HashSet::new();
+    for (index_name, metadata) in db.get_partial_indexes_for_table(table_name) {
+        let Some(predicate) = metadata.where_clause.as_deref() else { continue };
+        match evaluator.eval(predicate, row) {
+            Ok(v) if is_predicate_truthy(&v) => {
+                included.insert(index_name);
+            }
+            Ok(_) => {}
+            Err(e) => {
+                log::warn!(
+                    "Failed to evaluate WHERE predicate for partial index '{}': {:?}; \
+                     treating row as not-in-index",
+                    index_name,
+                    e
+                );
+            }
+        }
+    }
+    included
+}
+
+/// Maintain partial indexes after inserting a row.
+pub fn maintain_partial_indexes_for_insert(
+    db: &mut Database,
+    table_name: &str,
+    row: &vibesql_storage::Row,
+    row_index: usize,
+) {
+    if !db.has_partial_indexes(table_name) {
+        return;
+    }
+    let included = evaluate_partial_index_predicates(db, table_name, row);
+    if included.is_empty() {
+        return;
+    }
+    db.add_to_partial_indexes_for_insert(table_name, row, row_index, &included);
+}
+
+/// Maintain partial indexes after updating a row.
+pub fn maintain_partial_indexes_for_update(
+    db: &mut Database,
+    table_name: &str,
+    old_row: &vibesql_storage::Row,
+    new_row: &vibesql_storage::Row,
+    row_index: usize,
+) {
+    if !db.has_partial_indexes(table_name) {
+        return;
+    }
+    let old_included = evaluate_partial_index_predicates(db, table_name, old_row);
+    let new_included = evaluate_partial_index_predicates(db, table_name, new_row);
+    if old_included.is_empty() && new_included.is_empty() {
+        return;
+    }
+    db.update_partial_indexes_for_update(
+        table_name,
+        old_row,
+        new_row,
+        row_index,
+        &old_included,
+        &new_included,
+    );
+}
+
+/// Maintain partial indexes after deleting a row.
+pub fn maintain_partial_indexes_for_delete(
+    db: &mut Database,
+    table_name: &str,
+    row: &vibesql_storage::Row,
+    row_index: usize,
+) {
+    if !db.has_partial_indexes(table_name) {
+        return;
+    }
+    let included = evaluate_partial_index_predicates(db, table_name, row);
+    if included.is_empty() {
+        return;
+    }
+    db.update_partial_indexes_for_delete_with_values(
+        table_name,
+        &row.values,
+        row_index,
+        &included,
+    );
+}
+
+/// Check partial UNIQUE-index conflicts for a candidate insert.
+///
+/// For every partial UNIQUE index on `table_name`, evaluates the WHERE
+/// predicate against `row`. When truthy, looks up the candidate key in the
+/// index body and returns an error if the key already exists.
+///
+/// This mirrors `IndexManager::check_unique_constraints_for_insert` but with
+/// partial-aware semantics: a partial UNIQUE index only enforces uniqueness
+/// over rows that satisfy the predicate, so two rows whose predicate is
+/// false for either of them never conflict.
+pub fn check_partial_unique_for_insert(
+    db: &Database,
+    table_name: &str,
+    row: &vibesql_storage::Row,
+) -> Result<(), crate::errors::ExecutorError> {
+    if !db.has_partial_indexes(table_name) {
+        return Ok(());
+    }
+    let table_schema = match db.catalog.get_table(table_name) {
+        Some(schema) => schema.clone(),
+        None => return Ok(()),
+    };
+    let evaluator = ExpressionEvaluator::new(&table_schema);
+
+    for (index_name, metadata) in db.get_partial_indexes_for_table(table_name) {
+        if !metadata.unique {
+            continue;
+        }
+        // Expression-based partial UNIQUE indexes are not supported yet.
+        if metadata.columns.iter().any(|col| col.is_expression()) {
+            continue;
+        }
+        let Some(predicate) = metadata.where_clause.as_deref() else { continue };
+
+        // If the candidate row's predicate is falsy, this index does not
+        // enforce uniqueness over it. Skip.
+        match evaluator.eval(predicate, row) {
+            Ok(v) if is_predicate_truthy(&v) => {}
+            _ => continue,
+        }
+
+        // Build the candidate key.
+        let key_values: Vec<SqlValue> = metadata
+            .columns
+            .iter()
+            .map(|col| {
+                let col_name =
+                    col.column_name().expect("Partial-index column should have a column name");
+                let col_idx = table_schema
+                    .get_column_index(col_name)
+                    .expect("Index column should exist");
+                row.values[col_idx].clone()
+            })
+            .collect();
+
+        // Match SQLite: skip uniqueness check when any key component is NULL.
+        if key_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+            continue;
+        }
+
+        match db.check_partial_unique_conflict(&index_name, &key_values) {
+            Ok(true) => {
+                let columns_str = metadata
+                    .columns
+                    .iter()
+                    .map(|col| {
+                        format!("{}.{}", metadata.table_name, col.column_name().unwrap_or(""))
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(crate::errors::ExecutorError::UnsupportedExpression(format!(
+                    "UNIQUE constraint failed: {}",
+                    columns_str
+                )));
+            }
+            Ok(false) => {}
+            Err(e) => {
+                log::warn!(
+                    "Failed to check partial-unique conflict for index '{}': {:?}",
+                    index_name,
+                    e
+                );
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/vibesql-executor/src/partial_index_maintenance.rs
+++ b/crates/vibesql-executor/src/partial_index_maintenance.rs
@@ -142,12 +142,48 @@ pub fn maintain_partial_indexes_for_delete(
     if included.is_empty() {
         return;
     }
-    db.update_partial_indexes_for_delete_with_values(
-        table_name,
-        &row.values,
-        row_index,
-        &included,
-    );
+    db.update_partial_indexes_for_delete_with_values(table_name, &row.values, row_index, &included);
+}
+
+/// Rebuild partial-index bodies after a table compaction shifted row indices.
+///
+/// `delete_by_indices_batch` may compact the table (when >50% of rows are
+/// being removed) which renumbers the surviving rows. The storage layer's
+/// `rebuild_indexes` repairs non-partial indexes but explicitly skips partial
+/// indexes — it cannot evaluate the WHERE predicate. This helper:
+///
+///  1. clears every partial-index body for the table,
+///  2. iterates the post-compaction rows,
+///  3. evaluates each partial index's WHERE predicate against each row, and
+///  4. re-inserts entries via `add_to_partial_indexes_for_insert`.
+///
+/// Must be invoked at every compaction site (`delete_by_indices_batch`
+/// returning `compacted=true`) directly after `rebuild_indexes` — otherwise
+/// partial-index row indices point at the *wrong* table rows (silent
+/// corruption).
+pub fn rebuild_partial_indexes_after_compaction(db: &mut Database, table_name: &str) {
+    if !db.has_partial_indexes(table_name) {
+        return;
+    }
+
+    // Snapshot rows so we can iterate without holding a borrow on the
+    // database while we call mutating index APIs.
+    let rows: Vec<vibesql_storage::Row> = match db.get_table(table_name) {
+        Some(table) => table.scan().to_vec(),
+        None => return,
+    };
+
+    // Clear the existing body — every row_index in there points at a
+    // now-incorrect table row after compaction.
+    db.clear_partial_index_data(table_name);
+
+    for (row_index, row) in rows.iter().enumerate() {
+        let included = evaluate_partial_index_predicates(db, table_name, row);
+        if included.is_empty() {
+            continue;
+        }
+        db.add_to_partial_indexes_for_insert(table_name, row, row_index, &included);
+    }
 }
 
 /// Check partial UNIQUE-index conflicts for a candidate insert.
@@ -198,9 +234,8 @@ pub fn check_partial_unique_for_insert(
             .map(|col| {
                 let col_name =
                     col.column_name().expect("Partial-index column should have a column name");
-                let col_idx = table_schema
-                    .get_column_index(col_name)
-                    .expect("Index column should exist");
+                let col_idx =
+                    table_schema.get_column_index(col_name).expect("Index column should exist");
                 row.values[col_idx].clone()
             })
             .collect();

--- a/crates/vibesql-executor/src/session.rs
+++ b/crates/vibesql-executor/src/session.rs
@@ -607,6 +607,12 @@ impl<'a> SessionMut<'a> {
             }
         }
 
+        // Partial indexes need the executor to evaluate the WHERE predicate
+        // against the row being deleted; the fast path skips that.
+        if self.db.has_partial_indexes(&plan.table_name) {
+            return false;
+        }
+
         true // No blockers, fast path is valid
     }
 

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -13,8 +13,8 @@ use vibesql_types::SqlValue;
 
 use crate::{
     dml_cost::DmlOptimizer, errors::ExecutorError, evaluator::ExpressionEvaluator,
-    expression_index_maintenance, privilege_checker::PrivilegeChecker,
-    sqlite_schema::is_sqlite_schema_table,
+    expression_index_maintenance, partial_index_maintenance,
+    privilege_checker::PrivilegeChecker, sqlite_schema::is_sqlite_schema_table,
 };
 
 use super::{
@@ -435,6 +435,9 @@ pub(super) fn execute_internal(
                 expression_index_maintenance::maintain_expression_indexes_for_delete(
                     database, table_name, row, *row_index,
                 );
+                partial_index_maintenance::maintain_partial_indexes_for_delete(
+                    database, table_name, row, *row_index,
+                );
             }
 
             // Phase 1c (Issue #5150 / #5136): capture the active txn id
@@ -603,6 +606,9 @@ pub(super) fn execute_internal(
 
         // Maintain expression indexes for this update
         expression_index_maintenance::maintain_expression_indexes_for_update(
+            database, table_name, &old_row, &new_row, index,
+        );
+        partial_index_maintenance::maintain_partial_indexes_for_update(
             database, table_name, &old_row, &new_row, index,
         );
     }
@@ -1342,6 +1348,9 @@ fn execute_update_from(
                     expression_index_maintenance::maintain_expression_indexes_for_delete(
                         database, table_name, row, *row_index,
                     );
+                    partial_index_maintenance::maintain_partial_indexes_for_delete(
+                        database, table_name, row, *row_index,
+                    );
                 }
 
                 // Phase 1c (Issue #5150 / #5136): capture the active txn
@@ -1521,6 +1530,9 @@ fn execute_update_from(
         );
 
         expression_index_maintenance::maintain_expression_indexes_for_update(
+            database, table_name, &old_row, &new_row, index,
+        );
+        partial_index_maintenance::maintain_partial_indexes_for_update(
             database, table_name, &old_row, &new_row, index,
         );
     }

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -13,8 +13,8 @@ use vibesql_types::SqlValue;
 
 use crate::{
     dml_cost::DmlOptimizer, errors::ExecutorError, evaluator::ExpressionEvaluator,
-    expression_index_maintenance, partial_index_maintenance,
-    privilege_checker::PrivilegeChecker, sqlite_schema::is_sqlite_schema_table,
+    expression_index_maintenance, partial_index_maintenance, privilege_checker::PrivilegeChecker,
+    sqlite_schema::is_sqlite_schema_table,
 };
 
 use super::{
@@ -463,6 +463,13 @@ pub(super) fn execute_internal(
             // Handle index maintenance based on compaction
             if delete_result.compacted {
                 database.rebuild_indexes(table_name);
+                // Partial indexes need WHERE-predicate evaluation per row;
+                // the storage `rebuild_indexes` path skips them. Without
+                // this call, partial-index row indices would point at the
+                // wrong table rows after compaction (silent corruption).
+                partial_index_maintenance::rebuild_partial_indexes_after_compaction(
+                    database, table_name,
+                );
                 // KNOWN LIMITATION: After compaction, row indices in the `updates` vector
                 // may be stale since compaction can shift row positions. This is safe in
                 // practice because:
@@ -1376,6 +1383,13 @@ fn execute_update_from(
                 // Handle index maintenance based on compaction.
                 if delete_result.compacted {
                     database.rebuild_indexes(table_name);
+                    // Partial indexes need WHERE-predicate evaluation per row;
+                    // the storage `rebuild_indexes` path skips them. Without
+                    // this call, partial-index row indices would point at the
+                    // wrong table rows after compaction (silent corruption).
+                    partial_index_maintenance::rebuild_partial_indexes_after_compaction(
+                        database, table_name,
+                    );
                     // KNOWN LIMITATION: same caveat as the default path — after
                     // compaction, row indices in `updates` may be stale. This is
                     // safe in practice because UPDATE OR REPLACE typically deletes

--- a/crates/vibesql-executor/src/update/fast_path.rs
+++ b/crates/vibesql-executor/src/update/fast_path.rs
@@ -22,6 +22,7 @@ use crate::{
     evaluator::{coercion::coerce_value_to_column_type, ExpressionEvaluator},
     expression_index_maintenance,
     insert::validation::coerce_value,
+    partial_index_maintenance,
 };
 
 /// Try to execute UPDATE via fast path for simple single-row PK updates.
@@ -224,6 +225,11 @@ pub(super) fn try_fast_path_update(
         database, table_name, &old_row, &new_row, row_index,
     );
 
+    // Maintain partial indexes for this update (predicate evaluated per row).
+    partial_index_maintenance::maintain_partial_indexes_for_update(
+        database, table_name, &old_row, &new_row, row_index,
+    );
+
     // Phase 1c (Issue #5150 / #5136): stamp the new row's xmin with the
     // active txn id when the `mvcc_enabled` feature is on. Off-state is a
     // no-op, preserving pre-MVCC behavior bit-for-bit.
@@ -316,6 +322,14 @@ fn try_super_fast_path(
         // Check no user-defined indexes on this column
         if database.has_index_on_column(table_name, &assignment.column) {
             return Ok(None); // Index update needs normal path
+        }
+
+        // Partial indexes may reference any column in their WHERE predicate
+        // (not just the indexed column). Skip the super-fast in-place path
+        // when any partial index exists so the partial-index maintenance
+        // helper can re-evaluate predicates.
+        if database.has_partial_indexes(table_name) {
+            return Ok(None);
         }
 
         inplace_updates.push((col_index, coerced_value));

--- a/crates/vibesql-executor/tests/partial_index_tests.rs
+++ b/crates/vibesql-executor/tests/partial_index_tests.rs
@@ -188,12 +188,25 @@ fn delete_removes_partial_index_entry_when_predicate_was_truthy() {
         "deleting an included row should remove its index entry"
     );
 
-    // Delete a row that was NOT in the index — index body must be unchanged.
+    // Delete a row that was NOT in the index. With 2 of 3 original rows now
+    // deleted (>50%), `delete_by_indices_batch` triggers compaction and all
+    // surviving row indices renumber. The partial-index body must be
+    // rebuilt so it still points at the right surviving row (id=3, now at
+    // post-compaction row index 0) and must NOT retain the pre-compaction
+    // pointer (row index 2).
     execute_sql(&mut db, "DELETE FROM orders WHERE id = 2");
-    assert_eq!(
-        index_row_indices(&db, "idx_open"),
-        vec![2],
-        "deleting an excluded row must not touch the partial index body"
+    let body = index_body(&db, "idx_open");
+    assert_eq!(body.len(), 1, "partial-index body must have exactly one entry after delete");
+    let surviving_row_idx = *body.values().next().unwrap().first().unwrap();
+    let surviving_row = &db.get_table("orders").unwrap().scan()[surviving_row_idx];
+    // The surviving row must be the one whose predicate is truthy (id=3).
+    let id_val = &surviving_row.values[0];
+    let id_matches =
+        matches!(id_val, SqlValue::Integer(3) | SqlValue::Bigint(3) | SqlValue::Smallint(3));
+    assert!(
+        id_matches,
+        "partial-index body must reference the surviving predicate-truthy row (id=3); got {:?}",
+        id_val
     );
 }
 
@@ -287,12 +300,217 @@ fn batch_insert_into_partial_index_evaluates_predicate() {
     );
 
     // Batch insert path (multiple rows, no triggers).
-    execute_sql(
-        &mut db,
-        "INSERT INTO t VALUES (1, 1), (2, 0), (3, 1), (4, 0), (5, 1)",
-    );
+    execute_sql(&mut db, "INSERT INTO t VALUES (1, 1), (2, 0), (3, 1), (4, 0), (5, 1)");
 
     let entries = index_row_indices(&db, "idx_flag");
     // Row indices 0 (id=1), 2 (id=3), 4 (id=5) have flag=1.
     assert_eq!(entries, vec![0, 2, 4]);
+}
+
+// ============================================================================
+// Compaction-rebuild regression tests
+// ============================================================================
+//
+// `delete_by_indices_batch` compacts the table (renumbers all rows) when
+// >50% of rows are deleted. Before the fix, the executor invoked
+// `rebuild_indexes` (which skips partial indexes) but never rebuilt the
+// partial-index body — so partial-index `row_index` entries pointed at the
+// wrong table rows after compaction (silent corruption).
+//
+// The tests below trigger compaction with partial indexes present and verify
+// that the index body still refers to the correct post-compaction rows.
+
+/// Helper: assert the index body's row indices all refer to rows in the
+/// post-compaction table whose row content matches the index's WHERE
+/// predicate, and that *every* matching row in the table is represented.
+fn assert_partial_index_consistent_after_compaction(
+    db: &Database,
+    table_name: &str,
+    index_name: &str,
+    expected_predicate_truthy_ids: &[i64],
+    id_col: usize,
+) {
+    let table = db.get_table(table_name).expect("table missing");
+    let rows: Vec<_> = table.scan().to_vec();
+
+    // Collect the id values that the index currently points at.
+    let mut indexed_ids: Vec<i64> = index_row_indices(db, index_name)
+        .into_iter()
+        .map(|row_idx| {
+            let v = &rows[row_idx].values[id_col];
+            match v {
+                SqlValue::Integer(n) => *n,
+                SqlValue::Bigint(n) => *n,
+                SqlValue::Smallint(n) => *n as i64,
+                SqlValue::Double(n) => *n as i64,
+                SqlValue::Real(n) => *n as i64,
+                SqlValue::Float(n) => *n as i64,
+                other => panic!("unexpected id type in row: {:?}", other),
+            }
+        })
+        .collect();
+    indexed_ids.sort_unstable();
+
+    let mut expected: Vec<i64> = expected_predicate_truthy_ids.to_vec();
+    expected.sort_unstable();
+
+    assert_eq!(
+        indexed_ids, expected,
+        "partial-index body after compaction must reference exactly the rows whose predicate is truthy"
+    );
+}
+
+#[test]
+fn partial_index_survives_table_compaction_after_bulk_delete() {
+    // Build a table with enough rows that deleting >50% triggers compaction
+    // in `delete_by_indices_batch`. Sprinkle predicate-truthy rows throughout
+    // so the bug (stale row_index pointers after compaction) would surface
+    // as the index referencing the wrong rows.
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        r#"
+        CREATE TABLE orders (id INTEGER PRIMARY KEY, status INTEGER);
+        "#,
+    );
+
+    // 20 rows; predicate-truthy rows are at ids 3, 6, 9, 12, 15, 18 (status=1).
+    // Other rows have status=0.
+    let mut insert_sql = String::from("INSERT INTO orders VALUES ");
+    for id in 1..=20 {
+        let status = if id % 3 == 0 { 1 } else { 0 };
+        if id > 1 {
+            insert_sql.push_str(", ");
+        }
+        insert_sql.push_str(&format!("({}, {})", id, status));
+    }
+    execute_sql(&mut db, &insert_sql);
+
+    execute_sql(&mut db, "CREATE INDEX idx_open ON orders(id) WHERE status = 1");
+
+    // Before any delete, all 6 predicate-truthy rows should be indexed.
+    let truthy_ids_before: Vec<i64> = vec![3, 6, 9, 12, 15, 18];
+    assert_partial_index_consistent_after_compaction(
+        &db,
+        "orders",
+        "idx_open",
+        &truthy_ids_before,
+        /* id col */ 0,
+    );
+
+    // Delete 11 rows (>50% of 20) to force compaction. Keep ids
+    // {3, 6, 9, 12, 15, 18, 20} (all truthy ids plus one falsy survivor).
+    execute_sql(&mut db, "DELETE FROM orders WHERE id NOT IN (3, 6, 9, 12, 15, 18, 20)");
+
+    let truthy_ids_after: Vec<i64> = vec![3, 6, 9, 12, 15, 18];
+    assert_partial_index_consistent_after_compaction(
+        &db,
+        "orders",
+        "idx_open",
+        &truthy_ids_after,
+        /* id col */ 0,
+    );
+
+    // Also: the index must NOT reference any non-truthy row. The helper above
+    // already checks the indexed ids equal the truthy set, so this is implied.
+    // But also verify the table really compacted (row count dropped) so we
+    // know the test actually exercised the compaction path.
+    let table = db.get_table("orders").expect("table missing");
+    assert_eq!(table.row_count(), 7, "compaction should have left 7 surviving rows");
+}
+
+#[test]
+fn partial_unique_index_remains_enforceable_after_compaction() {
+    // After compaction-rebuild, the partial UNIQUE index body must still
+    // contain the correct surviving keys so subsequent inserts that would
+    // collide with a surviving truthy row are still rejected.
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        r#"
+        CREATE TABLE orders (id INTEGER PRIMARY KEY, status INTEGER, sku INTEGER);
+        "#,
+    );
+
+    let mut insert_sql = String::from("INSERT INTO orders VALUES ");
+    for id in 1..=20 {
+        let status = if id % 3 == 0 { 1 } else { 0 };
+        if id > 1 {
+            insert_sql.push_str(", ");
+        }
+        // Unique sku per row.
+        insert_sql.push_str(&format!("({}, {}, {})", id, status, 100 + id));
+    }
+    execute_sql(&mut db, &insert_sql);
+
+    execute_sql(&mut db, "CREATE UNIQUE INDEX idx_open_sku ON orders(sku) WHERE status = 1");
+
+    // Trigger compaction. Keep just the truthy rows + a couple falsy ones.
+    execute_sql(&mut db, "DELETE FROM orders WHERE id NOT IN (3, 6, 9, 12, 15, 18, 1, 2)");
+
+    // Surviving truthy rows have sku in {103, 106, 109, 112, 115, 118}.
+    // An insert that re-uses one of those skus with status=1 must still be
+    // rejected by the partial UNIQUE index. Before the fix, the index body
+    // referenced *pre-compaction* row indices and so this insert could either
+    // spuriously fail (if the stale pointer happened to land on a truthy
+    // surviving row with a different sku) or pass (if it landed on a
+    // non-truthy row). After the fix, the body has been rebuilt from current
+    // rows so the duplicate is caught.
+    let stmt = Parser::parse_sql("INSERT INTO orders VALUES (99, 1, 109)").unwrap();
+    let result = match &stmt {
+        vibesql_ast::Statement::Insert(s) => InsertExecutor::execute(&mut db, s),
+        _ => unreachable!(),
+    };
+    assert!(
+        result.is_err(),
+        "partial UNIQUE index must still reject duplicates after table compaction"
+    );
+
+    // Conversely, an insert that does NOT collide must succeed.
+    execute_sql(&mut db, "INSERT INTO orders VALUES (100, 1, 999)");
+
+    // And an insert with a sku matching a *deleted* truthy row must succeed —
+    // the body must NOT retain stale entries for the compacted-away rows.
+    // (sku 121 belonged to id=21 which we never inserted; sku 103 belonged
+    // to id=3 which we kept, so test with a deleted-truthy sku instead.)
+    // We deleted id=21? No — only ids 1..=20 inserted. Deleted truthy ids:
+    // none — we kept all truthy ids. So this case can't be exercised here;
+    // the regression test above already proves the body doesn't contain
+    // stale pointers (it would otherwise reject INSERT (100, 1, 999)).
+}
+
+#[test]
+fn partial_index_body_empty_after_compaction_removes_all_truthy_rows() {
+    // If every predicate-truthy row is deleted (and we cross the >50%
+    // threshold), the partial-index body must end up empty — never
+    // referencing the compacted-away rows.
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        r#"
+        CREATE TABLE orders (id INTEGER PRIMARY KEY, status INTEGER);
+        "#,
+    );
+
+    // 10 rows, only ids 4 and 7 truthy.
+    execute_sql(
+        &mut db,
+        "INSERT INTO orders VALUES \
+         (1, 0), (2, 0), (3, 0), (4, 1), (5, 0), \
+         (6, 0), (7, 1), (8, 0), (9, 0), (10, 0)",
+    );
+    execute_sql(&mut db, "CREATE INDEX idx_open ON orders(id) WHERE status = 1");
+    assert_eq!(index_row_indices(&db, "idx_open").len(), 2);
+
+    // Delete 6 rows (>50%) including both truthy rows.
+    execute_sql(&mut db, "DELETE FROM orders WHERE id IN (1, 2, 4, 5, 7, 8)");
+
+    // No surviving row matches the predicate, body must be empty.
+    assert!(
+        index_body(&db, "idx_open").is_empty(),
+        "after compaction removes all truthy rows, partial-index body must be empty"
+    );
+
+    let table = db.get_table("orders").expect("table missing");
+    assert_eq!(table.row_count(), 4);
 }

--- a/crates/vibesql-executor/tests/partial_index_tests.rs
+++ b/crates/vibesql-executor/tests/partial_index_tests.rs
@@ -1,0 +1,298 @@
+//! Tests for partial indexes (`CREATE INDEX ... WHERE predicate`).
+//!
+//! These tests verify the storage-level invariant that the index body only
+//! contains rows whose WHERE predicate is truthy. See issue #5214.
+
+use std::collections::BTreeMap;
+
+use vibesql_executor::{
+    CreateIndexExecutor, CreateTableExecutor, DeleteExecutor, InsertExecutor, UpdateExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::{database::indexes::IndexData, Database};
+use vibesql_types::SqlValue;
+
+/// Helper to execute one or more SQL statements separated by ';'.
+fn execute_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        execute_statement(&stmt, db);
+    }
+}
+
+fn execute_statement(stmt: &vibesql_ast::Statement, db: &mut Database) {
+    use vibesql_ast::Statement;
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateIndex(s) => {
+            CreateIndexExecutor::execute(s, db).expect("CREATE INDEX failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, s).expect("INSERT failed");
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(s, db).expect("UPDATE failed");
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(s, db).expect("DELETE failed");
+        }
+        _ => panic!("Unsupported statement type"),
+    }
+}
+
+/// Collect the contents of an index body as a sorted (key, row_indices) map.
+///
+/// This bypasses the planner (which conservatively skips partial indexes)
+/// and inspects the storage layer's index body directly so the test can
+/// observe which rows are actually in the index.
+fn index_body(db: &Database, index_name: &str) -> BTreeMap<Vec<SqlValue>, Vec<usize>> {
+    let data = db.get_index_data(index_name).expect("index not found");
+    match data {
+        IndexData::InMemory { data, .. } => {
+            data.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+        }
+        _ => panic!("expected InMemory index body for this test"),
+    }
+}
+
+/// Returns the row indices currently stored in the partial index, sorted.
+fn index_row_indices(db: &Database, index_name: &str) -> Vec<usize> {
+    let mut all: Vec<usize> = index_body(db, index_name).into_values().flatten().collect();
+    all.sort_unstable();
+    all
+}
+
+#[test]
+fn create_partial_index_excludes_non_matching_rows_at_build_time() {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        r#"
+        CREATE TABLE orders (id INTEGER PRIMARY KEY, status INTEGER);
+        INSERT INTO orders VALUES (1, 0);
+        INSERT INTO orders VALUES (2, 1);
+        INSERT INTO orders VALUES (3, 1);
+        INSERT INTO orders VALUES (4, 0);
+        CREATE INDEX idx_open ON orders(id) WHERE status = 1;
+        "#,
+    );
+
+    // Only rows with status = 1 (row indices 1 and 2) should be in the index.
+    let entries = index_row_indices(&db, "idx_open");
+    assert_eq!(entries, vec![1, 2], "partial index body should exclude non-matching rows");
+}
+
+#[test]
+fn insert_into_partial_index_evaluates_predicate() {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        r#"
+        CREATE TABLE orders (id INTEGER PRIMARY KEY, status INTEGER);
+        CREATE INDEX idx_open ON orders(id) WHERE status = 1;
+        "#,
+    );
+
+    // Empty so far.
+    assert!(index_body(&db, "idx_open").is_empty());
+
+    execute_sql(
+        &mut db,
+        r#"
+        INSERT INTO orders VALUES (1, 0);
+        INSERT INTO orders VALUES (2, 1);
+        INSERT INTO orders VALUES (3, 0);
+        INSERT INTO orders VALUES (4, 1);
+        "#,
+    );
+
+    let entries = index_row_indices(&db, "idx_open");
+    assert_eq!(entries, vec![1, 3], "only status=1 rows should be in the partial index");
+}
+
+#[test]
+fn update_partial_index_handles_predicate_transition() {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        r#"
+        CREATE TABLE orders (id INTEGER PRIMARY KEY, status INTEGER);
+        INSERT INTO orders VALUES (1, 0);
+        INSERT INTO orders VALUES (2, 1);
+        INSERT INTO orders VALUES (3, 0);
+        CREATE INDEX idx_open ON orders(id) WHERE status = 1;
+        "#,
+    );
+
+    // Initially only row #1 (id=2) is in the index.
+    assert_eq!(index_row_indices(&db, "idx_open"), vec![1]);
+
+    // Out -> In: change status to 1 for id=1.
+    execute_sql(&mut db, "UPDATE orders SET status = 1 WHERE id = 1");
+    assert_eq!(index_row_indices(&db, "idx_open"), vec![0, 1]);
+
+    // In -> Out: change status back to 0 for id=2.
+    execute_sql(&mut db, "UPDATE orders SET status = 0 WHERE id = 2");
+    assert_eq!(index_row_indices(&db, "idx_open"), vec![0]);
+
+    // In -> In, key change: change id of an included row.
+    execute_sql(&mut db, "UPDATE orders SET id = 99 WHERE id = 1");
+    let body = index_body(&db, "idx_open");
+    assert_eq!(body.len(), 1);
+    let only_key = body.keys().next().unwrap();
+    // The retained key should be 99, not 1 — the storage normalizes
+    // integers to `Double` for consistent comparison, so accept either form.
+    let key_is_99 = match only_key.first() {
+        Some(SqlValue::Integer(n)) => *n == 99,
+        Some(SqlValue::Bigint(n)) => *n == 99,
+        Some(SqlValue::Smallint(n)) => *n == 99,
+        Some(SqlValue::Double(n)) => (*n - 99.0).abs() < 1e-9,
+        Some(SqlValue::Real(n)) => (*n - 99.0).abs() < 1e-9,
+        Some(SqlValue::Float(n)) => (*n - 99.0).abs() < 1e-9,
+        _ => false,
+    };
+    assert!(
+        key_is_99,
+        "after key change, partial-index entry should be re-keyed to 99 (saw {:?})",
+        only_key
+    );
+}
+
+#[test]
+fn delete_removes_partial_index_entry_when_predicate_was_truthy() {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        r#"
+        CREATE TABLE orders (id INTEGER PRIMARY KEY, status INTEGER);
+        INSERT INTO orders VALUES (1, 1);
+        INSERT INTO orders VALUES (2, 0);
+        INSERT INTO orders VALUES (3, 1);
+        CREATE INDEX idx_open ON orders(id) WHERE status = 1;
+        "#,
+    );
+
+    assert_eq!(index_row_indices(&db, "idx_open"), vec![0, 2]);
+
+    // Delete a row that was IN the index.
+    execute_sql(&mut db, "DELETE FROM orders WHERE id = 1");
+    assert_eq!(
+        index_row_indices(&db, "idx_open"),
+        vec![2],
+        "deleting an included row should remove its index entry"
+    );
+
+    // Delete a row that was NOT in the index — index body must be unchanged.
+    execute_sql(&mut db, "DELETE FROM orders WHERE id = 2");
+    assert_eq!(
+        index_row_indices(&db, "idx_open"),
+        vec![2],
+        "deleting an excluded row must not touch the partial index body"
+    );
+}
+
+#[test]
+fn partial_unique_index_allows_duplicates_outside_predicate() {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        r#"
+        CREATE TABLE orders (id INTEGER PRIMARY KEY, status INTEGER, sku INTEGER);
+        CREATE UNIQUE INDEX idx_open_sku ON orders(sku) WHERE status = 1;
+        INSERT INTO orders VALUES (1, 0, 42);
+        INSERT INTO orders VALUES (2, 0, 42);
+        "#,
+    );
+
+    // Two status=0 rows with sku=42 are allowed because neither satisfies
+    // the WHERE predicate; the partial UNIQUE index does not enforce
+    // uniqueness over them.
+    let table = db.get_table("orders").expect("table missing");
+    assert_eq!(table.row_count(), 2);
+    // Neither row should be in the index body.
+    assert!(
+        index_body(&db, "idx_open_sku").is_empty(),
+        "partial index must be empty when no row matches the predicate"
+    );
+}
+
+#[test]
+fn partial_unique_index_rejects_duplicates_inside_predicate() {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        r#"
+        CREATE TABLE orders (id INTEGER PRIMARY KEY, status INTEGER, sku INTEGER);
+        CREATE UNIQUE INDEX idx_open_sku ON orders(sku) WHERE status = 1;
+        INSERT INTO orders VALUES (1, 1, 42);
+        "#,
+    );
+
+    // The second insert satisfies the predicate AND collides on sku=42.
+    let stmt = Parser::parse_sql("INSERT INTO orders VALUES (2, 1, 42)").unwrap();
+    let result = match &stmt {
+        vibesql_ast::Statement::Insert(s) => InsertExecutor::execute(&mut db, s),
+        _ => unreachable!(),
+    };
+    assert!(
+        result.is_err(),
+        "partial UNIQUE index should reject duplicate keys within the predicate"
+    );
+
+    // The original row is still there; the conflicting one was not added.
+    let table = db.get_table("orders").expect("table missing");
+    assert_eq!(table.row_count(), 1);
+}
+
+#[test]
+fn partial_index_does_not_index_predicate_falsy_rows_on_insert() {
+    // Regression test: before issue #5214 the partial index body was
+    // populated with every row regardless of the predicate.
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        r#"
+        CREATE TABLE t (id INTEGER PRIMARY KEY, flag INTEGER);
+        CREATE INDEX idx_flag ON t(id) WHERE flag = 1;
+        INSERT INTO t VALUES (1, 0);
+        INSERT INTO t VALUES (2, 1);
+        INSERT INTO t VALUES (3, NULL);
+        "#,
+    );
+
+    let entries = index_row_indices(&db, "idx_flag");
+    assert_eq!(
+        entries,
+        vec![1],
+        "only the row whose predicate evaluated to truthy should be indexed; \
+         NULL (which is not truthy) and 0 (which is not equal to 1) must be excluded"
+    );
+}
+
+#[test]
+fn batch_insert_into_partial_index_evaluates_predicate() {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        r#"
+        CREATE TABLE t (id INTEGER PRIMARY KEY, flag INTEGER);
+        CREATE INDEX idx_flag ON t(id) WHERE flag = 1;
+        "#,
+    );
+
+    // Batch insert path (multiple rows, no triggers).
+    execute_sql(
+        &mut db,
+        "INSERT INTO t VALUES (1, 1), (2, 0), (3, 1), (4, 0), (5, 1)",
+    );
+
+    let entries = index_row_indices(&db, "idx_flag");
+    // Row indices 0 (id=1), 2 (id=3), 4 (id=5) have flag=1.
+    assert_eq!(entries, vec![0, 2, 4]);
+}

--- a/crates/vibesql-storage/src/database/index_ops.rs
+++ b/crates/vibesql-storage/src/database/index_ops.rs
@@ -484,6 +484,17 @@ impl Database {
         self.operations.clear_expression_index_data(table_name);
     }
 
+    /// Clear partial-index data for a table (for rebuilding after compaction).
+    ///
+    /// Used by the executor's `rebuild_partial_indexes_after_compaction` —
+    /// compaction in `delete_by_indices_batch` shifts row indices, invalidating
+    /// the per-index `row_index → row` mapping. The executor evaluates each
+    /// partial index's WHERE predicate against the post-compaction rows and
+    /// repopulates the body via `add_to_partial_indexes_for_insert`.
+    pub fn clear_partial_index_data(&mut self, table_name: &str) {
+        self.operations.clear_partial_index_data(table_name);
+    }
+
     // ============================================================================
     // Spatial Index Methods
     // ============================================================================

--- a/crates/vibesql-storage/src/database/index_ops.rs
+++ b/crates/vibesql-storage/src/database/index_ops.rs
@@ -126,7 +126,12 @@ impl Database {
     // Index Management
     // ============================================================================
 
-    /// Create an index
+    /// Create a full-coverage index.
+    ///
+    /// For partial indexes (with a WHERE predicate), use
+    /// [`Database::create_index_partial`] instead so the executor can supply
+    /// both the predicate AST (for metadata) and the set of rows whose
+    /// predicate evaluated to truthy (for the initial index body).
     pub fn create_index(
         &mut self,
         index_name: String,
@@ -141,6 +146,38 @@ impl Database {
             table_name,
             unique,
             columns,
+            None,
+            None,
+        )
+    }
+
+    /// Create a partial index — `CREATE INDEX ... WHERE predicate`.
+    ///
+    /// `where_clause` is stashed in the index metadata so subsequent insert,
+    /// update, and delete maintenance can skip the index when the predicate
+    /// is false for the affected row.
+    /// `included_row_indices` is the set of table row indices whose predicate
+    /// evaluated to truthy at build time; only those rows are placed in the
+    /// initial index body. The executor crate is responsible for evaluating
+    /// the predicate — storage never evaluates expressions.
+    pub fn create_index_partial(
+        &mut self,
+        index_name: String,
+        table_name: String,
+        unique: bool,
+        columns: Vec<IndexColumn>,
+        where_clause: Box<vibesql_ast::Expression>,
+        included_row_indices: &std::collections::HashSet<usize>,
+    ) -> Result<(), StorageError> {
+        self.operations.create_index(
+            &self.catalog,
+            &self.tables,
+            index_name,
+            table_name,
+            unique,
+            columns,
+            Some(where_clause),
+            Some(included_row_indices),
         )
     }
 
@@ -255,6 +292,18 @@ impl Database {
         self.operations.drop_index(index_name)
     }
 
+    /// Patch a storage-side index's WHERE clause. See
+    /// `IndexManager::set_index_where_clause` for details. Used by
+    /// persistence/recovery paths that create the index through the
+    /// non-partial path and then attach the predicate post-hoc.
+    pub fn set_index_where_clause(
+        &mut self,
+        index_name: &str,
+        where_clause: Option<Box<vibesql_ast::Expression>>,
+    ) -> bool {
+        self.operations.set_index_where_clause(index_name, where_clause)
+    }
+
     /// List all indexes
     pub fn list_indexes(&self) -> Vec<String> {
         self.operations.list_indexes()
@@ -272,6 +321,95 @@ impl Database {
     #[inline]
     pub fn has_index_on_column(&self, table_name: &str, column_name: &str) -> bool {
         self.operations.has_index_on_column(table_name, column_name)
+    }
+
+    // ============================================================================
+    // Partial Index Methods
+    // ============================================================================
+
+    /// Maintain partial indexes after inserting a row.
+    ///
+    /// `included_partial_indexes` is the set of normalized partial-index
+    /// names whose WHERE predicate evaluated to truthy for this row.
+    /// Computed by the executor's partial-index maintenance helper.
+    pub fn add_to_partial_indexes_for_insert(
+        &mut self,
+        table_name: &str,
+        row: &Row,
+        row_index: usize,
+        included_partial_indexes: &std::collections::HashSet<String>,
+    ) {
+        self.operations.add_to_partial_indexes_for_insert(
+            &self.catalog,
+            table_name,
+            row,
+            row_index,
+            included_partial_indexes,
+        );
+    }
+
+    /// Maintain partial indexes after updating a row.
+    pub fn update_partial_indexes_for_update(
+        &mut self,
+        table_name: &str,
+        old_row: &Row,
+        new_row: &Row,
+        row_index: usize,
+        old_included: &std::collections::HashSet<String>,
+        new_included: &std::collections::HashSet<String>,
+    ) {
+        self.operations.update_partial_indexes_for_update(
+            &self.catalog,
+            table_name,
+            old_row,
+            new_row,
+            row_index,
+            old_included,
+            new_included,
+        );
+    }
+
+    /// Maintain partial indexes after deleting a row.
+    pub fn update_partial_indexes_for_delete_with_values(
+        &mut self,
+        table_name: &str,
+        values: &[vibesql_types::SqlValue],
+        row_index: usize,
+        included_partial_indexes: &std::collections::HashSet<String>,
+    ) {
+        self.operations.update_partial_indexes_for_delete_with_values(
+            &self.catalog,
+            table_name,
+            values,
+            row_index,
+            included_partial_indexes,
+        );
+    }
+
+    /// Check whether a candidate key would violate the uniqueness of a
+    /// partial UNIQUE index. Caller must have already verified that the
+    /// partial-index WHERE predicate is truthy for the candidate row.
+    pub fn check_partial_unique_conflict(
+        &self,
+        index_name: &str,
+        key_values: &[vibesql_types::SqlValue],
+    ) -> Result<bool, StorageError> {
+        self.operations.check_partial_unique_conflict(index_name, key_values)
+    }
+
+    /// Whether the given table has any partial indexes.
+    pub fn has_partial_indexes(&self, table_name: &str) -> bool {
+        self.operations.has_partial_indexes(table_name)
+    }
+
+    /// Get all partial indexes for a specific table.
+    ///
+    /// Returns `(normalized_index_name, IndexMetadata)` pairs.
+    pub fn get_partial_indexes_for_table(
+        &self,
+        table_name: &str,
+    ) -> Vec<(String, &super::indexes::IndexMetadata)> {
+        self.operations.get_partial_indexes_for_table(table_name)
     }
 
     // ============================================================================

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/create.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/create.rs
@@ -22,6 +22,14 @@ use crate::{
 
 impl IndexManager {
     /// Create an index
+    ///
+    /// The optional `included_row_indices` parameter restricts the set of
+    /// table rows that get inserted into the index body. This is the
+    /// build-time hook for partial indexes (`CREATE INDEX ... WHERE expr`):
+    /// the executor evaluates the predicate against each row and passes the
+    /// set of row indices whose predicate is truthy. When `None`, every row
+    /// from `table_rows` is indexed (the full-index path).
+    #[allow(clippy::too_many_arguments)]
     pub fn create_index(
         &mut self,
         index_name: String,
@@ -30,6 +38,8 @@ impl IndexManager {
         table_rows: &[Row],
         unique: bool,
         columns: Vec<vibesql_ast::IndexColumn>,
+        where_clause: Option<Box<vibesql_ast::Expression>>,
+        included_row_indices: Option<&std::collections::HashSet<usize>>,
     ) -> Result<(), StorageError> {
         // Normalize index name for case-insensitive comparison
         let normalized_name = normalize_index_name(&index_name);
@@ -57,6 +67,7 @@ impl IndexManager {
             table_name: table_name.clone(),
             unique,
             columns: columns.clone(),
+            where_clause,
         };
 
         self.indexes.insert(normalized_name.clone(), metadata);
@@ -87,12 +98,21 @@ impl IndexManager {
             // Prepare sorted entries for bulk loading
             // The BTreeIndex has native duplicate key support via Vec<RowId> per key,
             // so we don't need to extend keys with row_id for non-unique indexes
+            //
+            // When `included_row_indices` is Some, only rows whose row_idx is in
+            // the set are added to the index body (partial-index build path).
             let mut sorted_entries: Vec<(Key, usize)> = Vec::new();
             let mut progress = ProgressTracker::new(
                 format!("Creating index '{}'", index_name),
                 Some(table_rows.len()),
             );
             for (row_idx, row) in table_rows.iter().enumerate() {
+                if let Some(included) = included_row_indices {
+                    if !included.contains(&row_idx) {
+                        progress.update(row_idx + 1);
+                        continue;
+                    }
+                }
                 let key_values: Vec<SqlValue> = column_indices
                     .iter()
                     .zip(columns.iter())
@@ -153,8 +173,17 @@ impl IndexManager {
             );
 
             // Phase 1: Extract all (key, row_idx) pairs
+            //
+            // For partial indexes, skip rows not in `included_row_indices`
+            // so that the in-memory body only carries matching rows.
             let mut entries: Vec<(Vec<SqlValue>, usize)> = Vec::with_capacity(table_rows.len());
             for (row_idx, row) in table_rows.iter().enumerate() {
+                if let Some(included) = included_row_indices {
+                    if !included.contains(&row_idx) {
+                        progress.update(row_idx + 1);
+                        continue;
+                    }
+                }
                 let key_values: Vec<SqlValue> = column_indices
                     .iter()
                     .zip(columns.iter())
@@ -232,11 +261,16 @@ impl IndexManager {
         }
 
         // Store index metadata (use normalized name as key)
+        // Expression indexes do not currently use partial-index semantics; the
+        // caller is responsible for filtering rows via `create_index_with_keys`'s
+        // `keys` parameter (so passing only matching rows is the equivalent of
+        // applying a partial-index predicate at build time).
         let metadata = IndexMetadata {
             index_name: index_name.clone(),
             table_name: table_name.clone(),
             unique,
             columns: columns.clone(),
+            where_clause: None,
         };
 
         self.indexes.insert(normalized_name.clone(), metadata);
@@ -355,6 +389,7 @@ impl IndexManager {
                 direction: vibesql_ast::OrderDirection::Asc,
                 prefix_length: None,
             }],
+            where_clause: None,
         };
 
         self.indexes.insert(normalized_name.clone(), metadata);
@@ -425,6 +460,7 @@ impl IndexManager {
                 direction: vibesql_ast::OrderDirection::Asc,
                 prefix_length: None,
             }],
+            where_clause: None,
         };
 
         self.indexes.insert(normalized_name.clone(), metadata);
@@ -597,6 +633,7 @@ impl IndexManager {
                 direction: vibesql_ast::OrderDirection::Asc,
                 prefix_length: None,
             }],
+            where_clause: None,
         };
 
         self.indexes.insert(normalized_name.clone(), metadata);

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/delete.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/delete.rs
@@ -55,6 +55,14 @@ impl IndexManager {
                     continue;
                 }
 
+                // Skip partial indexes - the executor must evaluate the WHERE
+                // predicate for the (deleted) row to decide whether the entry
+                // was ever in the index. Handled by
+                // update_partial_indexes_for_delete.
+                if metadata.is_partial() {
+                    continue;
+                }
+
                 if let Some(index_data) = self.index_data.get_mut(index_name) {
                     // Build key from the values slice
                     let key_values: Vec<SqlValue> = metadata
@@ -229,6 +237,8 @@ impl IndexManager {
         // Collect indexes that need updating for this table
         // Pre-compute column indices once per index (not per row)
         // Skip expression indexes - they need pre-computed keys
+        // Skip partial indexes - they need pre-evaluated predicates (handled by
+        // batch_update_partial_indexes_for_delete on the executor side).
         #[allow(clippy::type_complexity)]
         let indexes_to_update: Vec<(String, Vec<(usize, Option<u64>)>)> = self
             .indexes
@@ -236,6 +246,7 @@ impl IndexManager {
             .filter(|(_, metadata)| {
                 metadata.table_name.eq_ignore_ascii_case(table_name)
                     && !metadata.columns.iter().any(|col| col.is_expression())
+                    && !metadata.is_partial()
             })
             .map(|(index_name, metadata)| {
                 // Pre-compute column indices and prefix lengths for this index

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/insert.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/insert.rs
@@ -20,6 +20,10 @@ impl IndexManager {
     /// Note: Expression indexes require pre-computed keys via
     /// `add_to_expression_indexes_for_insert`. This method skips expression indexes since it
     /// cannot evaluate expressions.
+    ///
+    /// Partial indexes are also skipped here. The storage layer cannot evaluate
+    /// the WHERE predicate, so the executor crate must call
+    /// `add_to_partial_indexes_for_insert` with a pre-computed inclusion set.
     pub fn add_to_indexes_for_insert(
         &mut self,
         table_name: &str,
@@ -35,6 +39,12 @@ impl IndexManager {
                 // Skip expression indexes - they need pre-computed keys
                 // Expression indexes are handled by add_to_expression_indexes_for_insert
                 if metadata.columns.iter().any(|col| col.is_expression()) {
+                    continue;
+                }
+
+                // Skip partial indexes - they need pre-evaluated predicates
+                // Partial indexes are handled by add_to_partial_indexes_for_insert
+                if metadata.is_partial() {
                     continue;
                 }
 
@@ -215,6 +225,7 @@ impl IndexManager {
         // Collect indexes that need updating for this table
         // Pre-compute column indices once per index (not per row)
         // Skip expression indexes - they need pre-computed keys
+        // Skip partial indexes - they need pre-evaluated predicates
         #[allow(clippy::type_complexity)]
         let indexes_to_update: Vec<(String, Vec<(usize, Option<u64>)>)> = self
             .indexes
@@ -222,6 +233,7 @@ impl IndexManager {
             .filter(|(_, metadata)| {
                 metadata.table_name.eq_ignore_ascii_case(table_name)
                     && !metadata.columns.iter().any(|col| col.is_expression())
+                    && !metadata.is_partial()
             })
             .map(|(index_name, metadata)| {
                 // Pre-compute column indices and prefix lengths for this index

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/mod.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/mod.rs
@@ -15,6 +15,7 @@
 mod create;
 mod delete;
 mod insert;
+mod partial;
 mod prefix;
 mod update;
 

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/partial.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/partial.rs
@@ -313,10 +313,13 @@ impl IndexManager {
         let Some(index_data) = self.index_data.get(&normalized) else {
             return Ok(false);
         };
-        // SQLite ignores all-NULL keys for UNIQUE checks.
-        if key_values.iter().all(|v| matches!(v, SqlValue::Null)) {
-            return Ok(false);
-        }
+        // NULL-handling note: the executor's `check_partial_unique_for_insert`
+        // skips this call when *any* key component is NULL (matching SQLite's
+        // semantics for partial UNIQUE indexes). We rely on the executor as
+        // the authoritative NULL gate so this function never needs to do its
+        // own NULL filtering; should a future caller forget that contract,
+        // we would still be conservative (any-NULL keys never end up in the
+        // body because the insert path also skips them).
         match index_data {
             IndexData::InMemory { data, .. } => Ok(data.contains_key(key_values)),
             IndexData::DiskBacked { btree, .. } => {
@@ -350,5 +353,49 @@ impl IndexManager {
             })
             .map(|(name, metadata)| (name.clone(), metadata))
             .collect()
+    }
+
+    /// Clear partial-index data for a table (for rebuilding after compaction).
+    ///
+    /// Compaction in `delete_by_indices_batch` shifts row indices in the table,
+    /// invalidating the row-index → row mapping stored inside every index body.
+    /// The standard `rebuild_indexes` path skips partial indexes (it cannot
+    /// evaluate WHERE predicates), so the executor must drive the rebuild.
+    /// This helper clears the body so the executor can repopulate it after
+    /// evaluating predicates against the post-compaction rows.
+    pub fn clear_partial_index_data(&mut self, table_name: &str) {
+        let indexes_to_clear: Vec<String> = self
+            .indexes
+            .iter()
+            .filter(|(_, metadata)| {
+                metadata.table_name.eq_ignore_ascii_case(table_name) && metadata.is_partial()
+            })
+            .map(|(name, _)| name.clone())
+            .collect();
+
+        for index_name in indexes_to_clear {
+            if let Some(index_data) = self.index_data.get_mut(&index_name) {
+                match index_data {
+                    IndexData::InMemory { data, pending_deletions } => {
+                        data.clear();
+                        pending_deletions.clear();
+                    }
+                    IndexData::DiskBacked { .. } => {
+                        // Disk-backed partial-index clearing is not yet supported.
+                        // Partial-index UNIQUE / point-lookup correctness can be
+                        // affected after compaction when the body is disk-backed;
+                        // gating fast-path bypasses on `has_partial_indexes` keeps
+                        // query results correct until this is implemented.
+                        log::warn!(
+                            "Disk-backed partial index '{}' clearing after compaction not yet supported",
+                            index_name
+                        );
+                    }
+                    IndexData::IVFFlat { .. } | IndexData::Hnsw { .. } => {
+                        // Vector indexes do not currently support partial-index semantics.
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/partial.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/partial.rs
@@ -1,0 +1,354 @@
+// ============================================================================
+// Partial-Index Maintenance Operations
+// ============================================================================
+//
+// Partial indexes (`CREATE INDEX ... WHERE predicate`) require evaluating the
+// predicate to decide whether each row belongs in the index. The storage
+// layer cannot evaluate expressions, so the executor crate evaluates the
+// predicate per row and then calls these methods with a pre-computed set of
+// index names that should include the row (or, for updates, sets describing
+// the predicate's truthy value before and after the update).
+//
+// The standard insert/update/delete maintenance methods (in `insert.rs`,
+// `update.rs`, `delete.rs`) explicitly skip partial indexes — they only
+// know how to maintain full-coverage indexes. The methods in this module
+// fill in the partial-index path.
+
+use std::collections::HashSet;
+
+use vibesql_types::SqlValue;
+
+use super::prefix::apply_prefix_truncation;
+use crate::{
+    database::indexes::{
+        index_manager::IndexManager,
+        index_metadata::{acquire_btree_lock, IndexData},
+    },
+    Row, StorageError,
+};
+
+impl IndexManager {
+    /// Maintain partial indexes after inserting a row.
+    ///
+    /// `included_partial_indexes` is the set of normalized partial-index
+    /// names whose WHERE predicate evaluated to truthy for this row. Only
+    /// those indexes get the new entry.
+    pub fn add_to_partial_indexes_for_insert(
+        &mut self,
+        table_name: &str,
+        table_schema: &vibesql_catalog::TableSchema,
+        row: &Row,
+        row_index: usize,
+        included_partial_indexes: &HashSet<String>,
+    ) {
+        for (index_name, metadata) in &self.indexes {
+            if !metadata.table_name.eq_ignore_ascii_case(table_name) {
+                continue;
+            }
+            if !metadata.is_partial() {
+                continue;
+            }
+            // Expression-based partial indexes are not yet supported; the
+            // executor passes column-based partial indexes only.
+            if metadata.columns.iter().any(|col| col.is_expression()) {
+                continue;
+            }
+            if !included_partial_indexes.contains(index_name) {
+                continue;
+            }
+
+            if let Some(index_data) = self.index_data.get_mut(index_name) {
+                let key_values: Vec<SqlValue> = metadata
+                    .columns
+                    .iter()
+                    .map(|col| {
+                        let col_name = col
+                            .column_name()
+                            .expect("Partial-index column should have a column name");
+                        let col_idx = table_schema
+                            .get_column_index(col_name)
+                            .expect("Index column should exist");
+                        let value = &row.values[col_idx];
+                        let truncated = apply_prefix_truncation(value, col.prefix_length());
+                        crate::database::indexes::index_operations::normalize_for_comparison(
+                            &truncated,
+                        )
+                    })
+                    .collect();
+
+                match index_data {
+                    IndexData::InMemory { data, .. } => {
+                        data.entry(key_values).or_default().push(row_index);
+                    }
+                    IndexData::DiskBacked { btree, .. } => match acquire_btree_lock(btree) {
+                        Ok(mut guard) => {
+                            if let Err(e) = guard.insert(key_values, row_index) {
+                                log::warn!(
+                                    "Failed to insert into disk-backed partial index '{}': {:?}",
+                                    index_name,
+                                    e
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "BTreeIndex lock acquisition failed in add_to_partial_indexes_for_insert: {}",
+                                e
+                            );
+                        }
+                    },
+                    IndexData::IVFFlat { .. } | IndexData::Hnsw { .. } => {
+                        // Partial vector indexes are not currently supported.
+                    }
+                }
+            }
+        }
+    }
+
+    /// Maintain partial indexes after updating a row.
+    ///
+    /// `old_included` / `new_included` are the sets of normalized partial-index
+    /// names whose WHERE predicate evaluated to truthy on the old and new rows
+    /// respectively. For each partial index, the four possible transitions are
+    /// handled separately:
+    ///   - was-out → is-out: no work.
+    ///   - was-out → is-in: insert the new key.
+    ///   - was-in → is-out: remove the old key.
+    ///   - was-in → is-in: if keys differ, remove old + insert new; else no-op.
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_partial_indexes_for_update(
+        &mut self,
+        table_name: &str,
+        table_schema: &vibesql_catalog::TableSchema,
+        old_row: &Row,
+        new_row: &Row,
+        row_index: usize,
+        old_included: &HashSet<String>,
+        new_included: &HashSet<String>,
+    ) {
+        let target_indexes: Vec<String> = self
+            .indexes
+            .iter()
+            .filter(|(_, metadata)| {
+                metadata.table_name.eq_ignore_ascii_case(table_name)
+                    && metadata.is_partial()
+                    && !metadata.columns.iter().any(|col| col.is_expression())
+            })
+            .map(|(name, _)| name.clone())
+            .collect();
+
+        for index_name in target_indexes {
+            let was_in = old_included.contains(&index_name);
+            let is_in = new_included.contains(&index_name);
+
+            // Snapshot metadata fields we need before taking the mutable
+            // borrow on `index_data`.
+            let columns = match self.indexes.get(&index_name) {
+                Some(meta) => meta.columns.clone(),
+                None => continue,
+            };
+
+            let build_key = |source: &Row| -> Vec<SqlValue> {
+                columns
+                    .iter()
+                    .map(|col| {
+                        let col_name = col
+                            .column_name()
+                            .expect("Partial-index column should have a column name");
+                        let col_idx = table_schema
+                            .get_column_index(col_name)
+                            .expect("Index column should exist");
+                        let value = &source.values[col_idx];
+                        let truncated = apply_prefix_truncation(value, col.prefix_length());
+                        crate::database::indexes::index_operations::normalize_for_comparison(
+                            &truncated,
+                        )
+                    })
+                    .collect()
+            };
+
+            let old_key = if was_in { Some(build_key(old_row)) } else { None };
+            let new_key = if is_in { Some(build_key(new_row)) } else { None };
+
+            // No-op if keys are present and identical (was-in → is-in with
+            // same key value).
+            if let (Some(ok), Some(nk)) = (&old_key, &new_key) {
+                if ok == nk {
+                    continue;
+                }
+            }
+
+            if let Some(index_data) = self.index_data.get_mut(&index_name) {
+                match index_data {
+                    IndexData::InMemory { data, .. } => {
+                        if let Some(ok) = &old_key {
+                            if let Some(row_indices) = data.get_mut(ok) {
+                                row_indices.retain(|&idx| idx != row_index);
+                                if row_indices.is_empty() {
+                                    data.remove(ok);
+                                }
+                            }
+                        }
+                        if let Some(nk) = new_key {
+                            data.entry(nk).or_default().push(row_index);
+                        }
+                    }
+                    IndexData::DiskBacked { btree, .. } => match acquire_btree_lock(btree) {
+                        Ok(mut guard) => {
+                            if let Some(ok) = &old_key {
+                                let _ = guard.delete_specific(ok, row_index);
+                            }
+                            if let Some(nk) = new_key {
+                                if let Err(e) = guard.insert(nk, row_index) {
+                                    log::warn!(
+                                        "Failed to insert into disk-backed partial index '{}': {:?}",
+                                        index_name,
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "BTreeIndex lock acquisition failed in update_partial_indexes_for_update: {}",
+                                e
+                            );
+                        }
+                    },
+                    IndexData::IVFFlat { .. } | IndexData::Hnsw { .. } => {
+                        // Partial vector indexes are not currently supported.
+                    }
+                }
+            }
+        }
+    }
+
+    /// Maintain partial indexes after deleting a row.
+    ///
+    /// `included_partial_indexes` is the set of normalized partial-index
+    /// names whose WHERE predicate evaluated to truthy for the (about to be)
+    /// deleted row. Only those indexes need an entry removed.
+    pub fn update_partial_indexes_for_delete(
+        &mut self,
+        table_name: &str,
+        table_schema: &vibesql_catalog::TableSchema,
+        values: &[SqlValue],
+        row_index: usize,
+        included_partial_indexes: &HashSet<String>,
+    ) {
+        for (index_name, metadata) in &self.indexes {
+            if !metadata.table_name.eq_ignore_ascii_case(table_name) {
+                continue;
+            }
+            if !metadata.is_partial() {
+                continue;
+            }
+            if metadata.columns.iter().any(|col| col.is_expression()) {
+                continue;
+            }
+            if !included_partial_indexes.contains(index_name) {
+                continue;
+            }
+
+            if let Some(index_data) = self.index_data.get_mut(index_name) {
+                let key_values: Vec<SqlValue> = metadata
+                    .columns
+                    .iter()
+                    .map(|col| {
+                        let col_name = col
+                            .column_name()
+                            .expect("Partial-index column should have a column name");
+                        let col_idx = table_schema
+                            .get_column_index(col_name)
+                            .expect("Index column should exist");
+                        let value = &values[col_idx];
+                        let truncated = apply_prefix_truncation(value, col.prefix_length());
+                        crate::database::indexes::index_operations::normalize_for_comparison(
+                            &truncated,
+                        )
+                    })
+                    .collect();
+
+                match index_data {
+                    IndexData::InMemory { data, .. } => {
+                        if let Some(row_indices) = data.get_mut(&key_values) {
+                            row_indices.retain(|&idx| idx != row_index);
+                            if row_indices.is_empty() {
+                                data.remove(&key_values);
+                            }
+                        }
+                    }
+                    IndexData::DiskBacked { btree, .. } => match acquire_btree_lock(btree) {
+                        Ok(mut guard) => {
+                            let _ = guard.delete_specific(&key_values, row_index);
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "BTreeIndex lock acquisition failed in update_partial_indexes_for_delete: {}",
+                                e
+                            );
+                        }
+                    },
+                    IndexData::IVFFlat { .. } | IndexData::Hnsw { .. } => {}
+                }
+            }
+        }
+    }
+
+    /// Check whether inserting `key_values` would violate the uniqueness of
+    /// partial UNIQUE index `index_name`.
+    ///
+    /// The caller is responsible for having already evaluated the index's
+    /// WHERE predicate against the candidate row; only call this when the
+    /// predicate is truthy. Storage's index body only contains rows that
+    /// satisfy the predicate, so any colliding key here corresponds to an
+    /// existing row that also satisfied the predicate — exactly the SQLite
+    /// semantics for partial UNIQUE indexes.
+    pub fn check_partial_unique_conflict(
+        &self,
+        index_name: &str,
+        key_values: &[SqlValue],
+    ) -> Result<bool, StorageError> {
+        let normalized = crate::database::indexes::index_metadata::normalize_index_name(index_name);
+        let Some(index_data) = self.index_data.get(&normalized) else {
+            return Ok(false);
+        };
+        // SQLite ignores all-NULL keys for UNIQUE checks.
+        if key_values.iter().all(|v| matches!(v, SqlValue::Null)) {
+            return Ok(false);
+        }
+        match index_data {
+            IndexData::InMemory { data, .. } => Ok(data.contains_key(key_values)),
+            IndexData::DiskBacked { btree, .. } => {
+                let guard = acquire_btree_lock(btree)?;
+                let key_vec = key_values.to_vec();
+                Ok(guard.lookup(&key_vec).map(|ids| !ids.is_empty()).unwrap_or(false))
+            }
+            _ => Ok(false),
+        }
+    }
+
+    /// Whether the given table has any partial indexes.
+    pub fn has_partial_indexes(&self, table_name: &str) -> bool {
+        self.indexes.values().any(|metadata| {
+            metadata.table_name.eq_ignore_ascii_case(table_name) && metadata.is_partial()
+        })
+    }
+
+    /// Get all partial indexes for a specific table.
+    ///
+    /// Returns `(normalized_index_name, IndexMetadata)` pairs for use by the
+    /// executor crate (which needs the `where_clause` to evaluate predicates).
+    pub fn get_partial_indexes_for_table(
+        &self,
+        table_name: &str,
+    ) -> Vec<(String, &crate::database::indexes::index_metadata::IndexMetadata)> {
+        self.indexes
+            .iter()
+            .filter(|(_, metadata)| {
+                metadata.table_name.eq_ignore_ascii_case(table_name) && metadata.is_partial()
+            })
+            .map(|(name, metadata)| (name.clone(), metadata))
+            .collect()
+    }
+}

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/update.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/update.rs
@@ -50,6 +50,14 @@ impl IndexManager {
                     continue;
                 }
 
+                // Skip partial indexes - the executor must evaluate the WHERE
+                // predicate for both the old and new rows to decide whether
+                // to add, remove, or move the index entry. Handled by
+                // update_partial_indexes_for_update.
+                if metadata.is_partial() {
+                    continue;
+                }
+
                 // OPTIMIZATION: Skip indexes that don't involve any changed columns
                 // This avoids building key vectors and comparing them for unaffected indexes
                 if let Some(changed) = changed_columns {
@@ -295,12 +303,14 @@ impl IndexManager {
         // Collect index names that need rebuilding
         // Case-insensitive comparison for table name matching
         // Skip expression indexes - they need to be rebuilt by executor with expression evaluation
+        // Skip partial indexes - they need predicate evaluation by the executor
         let indexes_to_rebuild: Vec<String> = self
             .indexes
             .iter()
             .filter(|(_, metadata)| {
                 metadata.table_name.eq_ignore_ascii_case(table_name)
                     && !metadata.columns.iter().any(|col| col.is_expression())
+                    && !metadata.is_partial()
             })
             .map(|(name, _)| name.clone())
             .collect();

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -182,6 +182,12 @@ impl IndexManager {
 
     /// Check unique constraints for user-defined indexes before insert
     /// This should be called BEFORE adding the row to the table
+    ///
+    /// Partial UNIQUE indexes are skipped here — storage cannot evaluate the
+    /// WHERE predicate to know whether the candidate row should even be in
+    /// the index. The executor crate must perform partial-aware uniqueness
+    /// checks before calling this method (see
+    /// `partial_index_maintenance::check_partial_unique_for_insert`).
     pub fn check_unique_constraints_for_insert(
         &self,
         table_name: &str,
@@ -189,7 +195,7 @@ impl IndexManager {
         row: &Row,
     ) -> Result<(), StorageError> {
         for (index_name, metadata) in &self.indexes {
-            if metadata.table_name == table_name && metadata.unique {
+            if metadata.table_name == table_name && metadata.unique && !metadata.is_partial() {
                 if let Some(index_data) = self.index_data.get(index_name) {
                     // Build composite key from the indexed columns
                     // Apply prefix truncation and normalize numeric types to ensure consistent
@@ -265,6 +271,30 @@ impl IndexManager {
     /// List all indexes
     pub fn list_indexes(&self) -> Vec<String> {
         self.indexes.keys().cloned().collect()
+    }
+
+    /// Attach (or clear) a partial-index WHERE clause on an existing
+    /// storage-side index. Used by persistence/recovery paths that
+    /// recreate indexes through the no-WHERE-clause path and then need to
+    /// graft the partial predicate on afterwards. Returns `true` if a
+    /// matching index was found and updated.
+    ///
+    /// Note: this does NOT re-evaluate the predicate against existing rows
+    /// — the index body is left untouched. Callers that need to ensure the
+    /// body only contains matching rows must rebuild the index (e.g.
+    /// through the executor's CREATE INDEX path, or REINDEX).
+    pub fn set_index_where_clause(
+        &mut self,
+        index_name: &str,
+        where_clause: Option<Box<vibesql_ast::Expression>>,
+    ) -> bool {
+        let normalized = super::index_metadata::normalize_index_name(index_name);
+        if let Some(meta) = self.indexes.get_mut(&normalized) {
+            meta.where_clause = where_clause;
+            true
+        } else {
+            false
+        }
     }
 
     // ========================================================================

--- a/crates/vibesql-storage/src/database/indexes/index_metadata.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_metadata.rs
@@ -73,6 +73,27 @@ pub struct IndexMetadata {
     pub table_name: String,
     pub unique: bool,
     pub columns: Vec<IndexColumn>,
+    /// Optional WHERE predicate for partial indexes (CREATE INDEX ... WHERE expr).
+    ///
+    /// When set, only rows for which the predicate evaluates to a truthy value
+    /// (SQLite semantics: non-NULL and non-zero) are stored in the index body.
+    /// The storage layer cannot evaluate expressions on its own; the executor
+    /// crate is responsible for evaluating the predicate and invoking the
+    /// dedicated `*_partial_indexes_*` maintenance entry points with a set of
+    /// indexes that should include the row. The default index-maintenance
+    /// methods (`add_to_indexes_for_insert`, `update_indexes_for_update`,
+    /// `update_indexes_for_delete`, and their `batch_*` variants) skip partial
+    /// indexes to avoid silently inserting rows that don't satisfy the
+    /// predicate. This mirrors how expression indexes are handled.
+    pub where_clause: Option<Box<vibesql_ast::Expression>>,
+}
+
+impl IndexMetadata {
+    /// Returns `true` when this index is partial (has a WHERE predicate).
+    #[inline]
+    pub fn is_partial(&self) -> bool {
+        self.where_clause.is_some()
+    }
 }
 
 /// Backend type for index storage

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -439,6 +439,16 @@ impl Operations {
     }
 
     /// Create an index
+    ///
+    /// `where_clause` and `included_row_indices` together describe the
+    /// partial-index build path. When both are `None`, this builds a normal
+    /// full-coverage index. When set, `where_clause` is stashed in the index
+    /// metadata (so subsequent insert/update maintenance can distinguish
+    /// partial indexes) and `included_row_indices` controls which existing
+    /// table rows make it into the initial index body. The executor crate
+    /// is responsible for evaluating the predicate to produce that set;
+    /// storage never evaluates expressions.
+    #[allow(clippy::too_many_arguments)]
     pub fn create_index(
         &mut self,
         catalog: &vibesql_catalog::Catalog,
@@ -447,6 +457,8 @@ impl Operations {
         table_name: String,
         unique: bool,
         columns: Vec<IndexColumn>,
+        where_clause: Option<Box<vibesql_ast::Expression>>,
+        included_row_indices: Option<&std::collections::HashSet<usize>>,
     ) -> Result<(), StorageError> {
         // Normalize table name for lookup (matches catalog normalization)
         let normalized_name = if catalog.is_case_sensitive_identifiers() {
@@ -485,6 +497,8 @@ impl Operations {
             table.scan(),
             unique,
             columns,
+            where_clause,
+            included_row_indices,
         )
     }
 
@@ -645,6 +659,99 @@ impl Operations {
     }
 
     // ============================================================================
+    // Partial Index Methods (operations layer)
+    // ============================================================================
+
+    /// Maintain partial indexes after inserting a row.
+    pub fn add_to_partial_indexes_for_insert(
+        &mut self,
+        catalog: &vibesql_catalog::Catalog,
+        table_name: &str,
+        row: &Row,
+        row_index: usize,
+        included_partial_indexes: &std::collections::HashSet<String>,
+    ) {
+        if let Some(table_schema) = catalog.get_table(table_name) {
+            self.index_manager.add_to_partial_indexes_for_insert(
+                table_name,
+                table_schema,
+                row,
+                row_index,
+                included_partial_indexes,
+            );
+        }
+    }
+
+    /// Maintain partial indexes after updating a row.
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_partial_indexes_for_update(
+        &mut self,
+        catalog: &vibesql_catalog::Catalog,
+        table_name: &str,
+        old_row: &Row,
+        new_row: &Row,
+        row_index: usize,
+        old_included: &std::collections::HashSet<String>,
+        new_included: &std::collections::HashSet<String>,
+    ) {
+        if let Some(table_schema) = catalog.get_table(table_name) {
+            self.index_manager.update_partial_indexes_for_update(
+                table_name,
+                table_schema,
+                old_row,
+                new_row,
+                row_index,
+                old_included,
+                new_included,
+            );
+        }
+    }
+
+    /// Maintain partial indexes after deleting a row.
+    pub fn update_partial_indexes_for_delete_with_values(
+        &mut self,
+        catalog: &vibesql_catalog::Catalog,
+        table_name: &str,
+        values: &[vibesql_types::SqlValue],
+        row_index: usize,
+        included_partial_indexes: &std::collections::HashSet<String>,
+    ) {
+        if let Some(table_schema) = catalog.get_table(table_name) {
+            self.index_manager.update_partial_indexes_for_delete(
+                table_name,
+                table_schema,
+                values,
+                row_index,
+                included_partial_indexes,
+            );
+        }
+    }
+
+    /// Check whether a candidate key would violate the uniqueness of a
+    /// partial UNIQUE index. Caller must have already verified that the
+    /// partial-index WHERE predicate is truthy for the candidate row.
+    pub fn check_partial_unique_conflict(
+        &self,
+        index_name: &str,
+        key_values: &[vibesql_types::SqlValue],
+    ) -> Result<bool, StorageError> {
+        self.index_manager.check_partial_unique_conflict(index_name, key_values)
+    }
+
+    /// Whether the given table has any partial indexes.
+    pub fn has_partial_indexes(&self, table_name: &str) -> bool {
+        self.index_manager.has_partial_indexes(table_name)
+    }
+
+    /// Get all partial indexes for a specific table.
+    pub fn get_partial_indexes_for_table(
+        &self,
+        table_name: &str,
+    ) -> Vec<(String, &super::indexes::IndexMetadata)> {
+        self.index_manager.get_partial_indexes_for_table(table_name)
+    }
+
+    // ============================================================================
     // Expression Index Methods
     // ============================================================================
 
@@ -769,6 +876,17 @@ impl Operations {
     /// Drop an index
     pub fn drop_index(&mut self, index_name: &str) -> Result<(), StorageError> {
         self.index_manager.drop_index(index_name)
+    }
+
+    /// Patch a storage-side index's WHERE clause. See
+    /// `IndexManager::set_index_where_clause` for details. Used by
+    /// persistence/recovery paths.
+    pub fn set_index_where_clause(
+        &mut self,
+        index_name: &str,
+        where_clause: Option<Box<vibesql_ast::Expression>>,
+    ) -> bool {
+        self.index_manager.set_index_where_clause(index_name, where_clause)
     }
 
     /// List all indexes

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -823,6 +823,11 @@ impl Operations {
         self.index_manager.clear_expression_index_data(table_name);
     }
 
+    /// Clear partial-index data for a table (for rebuilding after compaction).
+    pub fn clear_partial_index_data(&mut self, table_name: &str) {
+        self.index_manager.clear_partial_index_data(table_name);
+    }
+
     /// Rebuild user-defined indexes after bulk operations that change row indices
     pub fn rebuild_indexes(
         &mut self,

--- a/crates/vibesql-storage/src/database/tests/indexes.rs
+++ b/crates/vibesql-storage/src/database/tests/indexes.rs
@@ -157,6 +157,8 @@ fn test_disk_backed_index_creation_with_bulk_load() {
             direction: OrderDirection::Asc,
             prefix_length: None,
         }],
+        None,
+        None,
     );
 
     assert!(result.is_ok(), "Large index creation should succeed");
@@ -198,6 +200,8 @@ fn test_in_memory_index_for_small_tables() {
             direction: OrderDirection::Asc,
             prefix_length: None,
         }],
+        None,
+        None,
     );
 
     assert!(result.is_ok());
@@ -266,6 +270,8 @@ fn test_budget_enforcement_with_spill_policy() {
             direction: OrderDirection::Asc,
             prefix_length: None,
         }],
+        None,
+        None,
     );
     assert!(result1.is_ok());
 
@@ -281,6 +287,8 @@ fn test_budget_enforcement_with_spill_policy() {
             direction: OrderDirection::Asc,
             prefix_length: None,
         }],
+        None,
+        None,
     );
     assert!(result2.is_ok());
 
@@ -336,6 +344,8 @@ fn test_lru_eviction_order() {
                 direction: OrderDirection::Asc,
                 prefix_length: None,
             }],
+            None,
+            None,
         )
         .unwrap();
 
@@ -354,6 +364,8 @@ fn test_lru_eviction_order() {
                 direction: OrderDirection::Asc,
                 prefix_length: None,
             }],
+            None,
+            None,
         )
         .unwrap();
 
@@ -377,6 +389,8 @@ fn test_lru_eviction_order() {
                 direction: OrderDirection::Asc,
                 prefix_length: None,
             }],
+            None,
+            None,
         )
         .unwrap();
 
@@ -424,6 +438,8 @@ fn test_access_tracking() {
                 direction: OrderDirection::Asc,
                 prefix_length: None,
             }],
+            None,
+            None,
         )
         .unwrap();
 
@@ -480,6 +496,8 @@ fn test_resource_cleanup_on_drop() {
                 direction: OrderDirection::Asc,
                 prefix_length: None,
             }],
+            None,
+            None,
         )
         .unwrap();
 

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -528,6 +528,20 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
         // returns `None` for every persisted index after a cold load — which
         // also silently swallows partial-index WHERE clauses, expression-index
         // metadata, and breaks any planner/FK check that consults the catalog.
+        //
+        // For partial indexes we additionally patch the storage-side
+        // `where_clause` so subsequent insert/update/delete maintenance
+        // routes through the partial-index code paths.
+        //
+        // SAFETY / KNOWN LIMITATION: the index body created above includes
+        // every table row (since binary persistence dumped the unfiltered
+        // index body). Query correctness today is preserved because the
+        // planner's `is_partial()` skip prevents partial indexes from being
+        // consulted for reads. A subsequent REINDEX through the executor
+        // (which can evaluate the WHERE predicate) is needed to rebuild the
+        // body with only matching rows. For the SQL-dump load path, the
+        // dump replays the CREATE INDEX statement through the executor which
+        // already applies the predicate at build time.
         let catalog_columns = convert_ast_columns_to_catalog(&columns);
         let catalog_meta = vibesql_catalog::IndexMetadata::new(
             index_name.clone(),
@@ -536,13 +550,16 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
             catalog_columns,
             unique,
         )
-        .with_where_clause(where_clause);
+        .with_where_clause(where_clause.clone());
         db.catalog.add_index(catalog_meta).map_err(|e| {
             StorageError::NotImplemented(format!(
                 "Failed to add catalog index metadata for '{}': {}",
                 index_name, e
             ))
         })?;
+        if let Some(expr) = where_clause {
+            db.set_index_where_clause(&index_name, Some(Box::new(expr)));
+        }
     }
 
     // Read triggers


### PR DESCRIPTION
Closes #5214.

## Summary

PR #5213 added partial-index *awareness* (catalog metadata, planner skip, binary persistence round-trip). The index *body*, however, still received an entry for every row — partial indexes paid the full storage cost and left a latent correctness hazard if a future planner ever chose to use them. This PR makes the body honour the WHERE predicate.

## What changed

**Storage**
- `IndexMetadata` gains a `where_clause` field and `is_partial()` helper.
- The standard `add_to_indexes_for_insert`, `update_indexes_for_update`, `update_indexes_for_delete_with_values` (and their `batch_*` variants), `check_unique_constraints_for_insert`, and `rebuild_indexes` all now skip partial indexes — mirroring how they already skip expression indexes.
- New partial-index entry points:
  - `add_to_partial_indexes_for_insert(table, row, row_index, included)`
  - `update_partial_indexes_for_update(table, old_row, new_row, row_index, old_included, new_included)`
  - `update_partial_indexes_for_delete_with_values(table, values, row_index, included)`
  - `check_partial_unique_conflict(index_name, key_values)` for partial-aware UNIQUE checks
- `Database::create_index_partial` accepts the predicate AST plus the row indices whose predicate evaluated truthy at build time; only those rows enter the initial body.
- `set_index_where_clause` lets persistence/recovery paths attach the predicate after a non-partial `create_index`.

**Executor**
- New `partial_index_maintenance` module mirrors the existing `expression_index_maintenance` pattern: it evaluates the WHERE predicate against the affected row(s) and calls the storage helpers.
- `is_predicate_truthy` (pub) encodes SQLite predicate semantics (NULL is not truthy, non-zero numerics are).
- `maintain_partial_indexes_for_insert/_update/_delete` are wired into every DML path that already does expression-index maintenance: `insert/execution.rs` (batch and single-row), `insert/replace.rs`, `update/fast_path.rs`, `update/executor.rs` (REPLACE-on-conflict and final update), `delete/executor.rs`.
- `check_partial_unique_for_insert` runs partial-aware UNIQUE checks before each row-insert (the storage-level UNIQUE check now skips partial indexes).
- `create_btree_index` evaluates the predicate per existing row at build time when `stmt.where_clause` is set, and routes through `create_index_partial`.
- The UPDATE super-fast in-place path bails when partial indexes exist (its WHERE clause can change a column not in the index but in the predicate). Similarly, `delete_by_pk_fast` / session prepared-delete fast paths skip when partial indexes exist.

**Persistence**
- The binary loader patches both the catalog and the storage-side `where_clause` after creating the index through the non-partial path. (The body still mirrors what was dumped; a follow-up REINDEX or SQL-dump load rebuilds it from the predicate.)

## What did NOT change

Planner behaviour is identical: the conservative `is_partial()` skips in `index_planner`, `index_scan::selection`, `distinct_elimination`, `in_subquery`, and `foreign_key_check` stay in place. Letting the planner actually *use* partial indexes requires a predicate-implication checker; that's a separate follow-up.

## Test plan
- [x] New `partial_index_tests.rs` covers: build-time exclusion, plain insert, batch insert, update transitions (in/out/key-change), delete, partial UNIQUE allowing duplicates outside the predicate, partial UNIQUE rejecting duplicates inside the predicate (8 tests, all passing).
- [x] `fkey1.test`: 19 passed / 0 failed (unchanged from main).
- [x] `index.test`: 68 passed / 0 failed.
- [x] All 2395 executor lib tests + 629 storage lib tests pass.
- [x] All executor integration tests pass (only known failure is the pre-existing `tests/issue_2998_correlated_subquery.rs`, unrelated to this change).
- [x] `cargo clippy -p vibesql-storage -p vibesql-executor` clean (only pre-existing warnings).