### PR TITLE
feat(mvcc): widen snapshots for autocommit + in-txn self-write visibility

### DIFF
--- a/crates/vibesql-executor/src/mvcc.rs
+++ b/crates/vibesql-executor/src/mvcc.rs
@@ -1,34 +1,40 @@
 //! Executor-side MVCC helpers.
 //!
-//! # Phase 1d of #5136
+//! # Phase 1d of #5136 (+ follow-up #5207)
 //!
 //! Phase 1d wires the storage-layer `Row::visible_to(&snapshot)` predicate
 //! into the SELECT scan boundary and the FK deferred-replay coordinator.
 //! This module centralizes the "which snapshot should this read use?"
 //! decision so individual scan paths don't have to repeat it.
 //!
+//! Follow-up #5207 closes the two visibility gaps left open by the
+//! initial Phase 1d PR — see the module-level note on [`read_snapshot`].
+//!
 //! ## When MVCC is off (default)
 //!
 //! With the `mvcc_enabled` feature OFF (the default), [`read_snapshot`]
-//! returns [`TxnSnapshot::empty`] and the storage-layer scan helpers
+//! returns a default snapshot and the storage-layer scan helpers
 //! (`Table::scan_visible_vec`, `Table::scan_visible`) ignore the snapshot
 //! entirely. Behavior is bit-for-bit identical to pre-MVCC reads.
 //!
 //! ## When MVCC is on
 //!
-//! With the feature ON, [`read_snapshot`] returns the active transaction's
-//! BEGIN-time snapshot when in a transaction, or [`TxnSnapshot::empty`]
-//! for auto-commit reads.
+//! With the feature ON, [`read_snapshot`] returns:
 //!
-//! Empty-snapshot semantics under MVCC ON deserve a note: an empty
-//! snapshot has `xmax_committed = 0`, which means only rows with
-//! `xmin = PRE_MVCC_TXN_ID` (= 0) are visible. Under Phase 1c's write
-//! semantics, autocommit inserts also keep the pre-MVCC sentinel (no
-//! txn id to stamp with), so this remains consistent: autocommit reads
-//! see autocommit writes plus pre-MVCC data. The complete story for
-//! "autocommit reads should see all committed transactional writes too"
-//! is deferred — see the Phase 1d follow-up issues for autocommit
-//! snapshot widening.
+//! - **Inside a transaction**: the transaction's BEGIN-time snapshot
+//!   (so reads see a stable snapshot-isolation view across the txn).
+//!   Self-writes pass `is_committed(self)` because the BEGIN-time
+//!   snapshot is widened by [`TransactionManager::capture_snapshot`] to
+//!   set `xmax_committed = txn_id` (see the follow-up #5207 fix).
+//! - **Outside a transaction (autocommit)**: a freshly-captured
+//!   commit-time snapshot, treating every transaction id allocated so
+//!   far as committed. This is the autocommit-snapshot-widening fix
+//!   from #5207: autocommit reads see writes from every txn that has
+//!   already committed, including the transactional inserts that
+//!   stamped `xmin = txn_id`.
+//!
+//! [`TransactionManager::capture_snapshot`]:
+//!     vibesql_storage::database::transactions::TransactionManager::capture_snapshot
 
 use vibesql_storage::{Database, TxnSnapshot};
 
@@ -36,7 +42,21 @@ use vibesql_storage::{Database, TxnSnapshot};
 ///
 /// - In a transaction: returns the transaction's BEGIN-time snapshot
 ///   (so reads see a stable snapshot-isolation view).
-/// - Outside a transaction (auto-commit): returns [`TxnSnapshot::empty`].
+/// - Outside a transaction (autocommit): returns a freshly-captured
+///   commit-time snapshot via
+///   [`Database::capture_commit_time_snapshot`], which treats every
+///   already-allocated transaction id as committed.
+///
+/// # Why autocommit synthesizes a commit-time snapshot
+///
+/// Each autocommit statement is, semantically, its own one-statement
+/// transaction. Statement N+1 must see writes that statement N
+/// committed. Under Phase 1c's stamping rules, transactional writes
+/// carry `xmin = txn_id > 0`, and the pre-fix empty snapshot
+/// (`xmax_committed = 0`) made them invisible. By synthesizing a
+/// commit-time snapshot at every autocommit read, we observe everything
+/// that has finished committing so far — exactly the "see your own
+/// writes" semantics autocommit needs.
 ///
 /// With the `mvcc_enabled` feature OFF, the storage-layer visibility
 /// filter is a no-op, so the returned value is informationally
@@ -44,5 +64,8 @@ use vibesql_storage::{Database, TxnSnapshot};
 /// way to thread the right snapshot into scan code.
 #[inline]
 pub fn read_snapshot(db: &Database) -> TxnSnapshot {
-    db.current_snapshot().cloned().unwrap_or_else(TxnSnapshot::empty)
+    match db.current_snapshot() {
+        Some(snap) => snap.clone(),
+        None => db.capture_commit_time_snapshot(),
+    }
 }

--- a/crates/vibesql-executor/tests/mvcc_autocommit_snapshot_tests.rs
+++ b/crates/vibesql-executor/tests/mvcc_autocommit_snapshot_tests.rs
@@ -1,0 +1,292 @@
+//! Integration tests for Phase 1d follow-up #5207 — autocommit snapshot
+//! widening (see-your-own-writes).
+//!
+//! Phase 1d's initial PR (#5209) made the in-transaction BEGIN-time
+//! snapshot stable across reads (correct for repeatable-read). It also
+//! left two gaps that this follow-up closes:
+//!
+//! 1. **Autocommit sees prior transactional commits**: with the
+//!    pre-1207 `read_snapshot` returning `TxnSnapshot::empty()` for
+//!    autocommit reads (`xmax_committed = 0`), MVCC-stamped rows from
+//!    *committed* transactions were invisible to autocommit reads. The
+//!    fix synthesizes a commit-time-style snapshot at every autocommit
+//!    read so reads see everything that has committed so far.
+//! 2. **A transaction sees its own writes**: with the pre-1207 BEGIN
+//!    snapshot setting `xmax_committed = txn_id - 1`, a row stamped
+//!    with `xmin = txn_id` failed the `xmin <= xmax_committed` clause.
+//!    The fix widens the BEGIN-time snapshot to set
+//!    `xmax_committed = txn_id` so self-writes pass `is_committed(self)`.
+//!
+//! # Why these tests use tables without a PRIMARY KEY
+//!
+//! Phase 1d's `try_primary_key_lookup` fast path (in `select/scan/table.rs`)
+//! reads via the PK index and goes through `table.get_row()`, which does
+//! NOT consult MVCC visibility — that's the gap tracked in follow-up
+//! issue #5204 (Index/PK lookup visibility). To assert the *autocommit-
+//! snapshot* invariant the tests must take the full-scan code path. So
+//! these tests deliberately avoid `INTEGER PRIMARY KEY` and use a
+//! non-keyed `id INTEGER` column instead.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p vibesql-executor --test mvcc_autocommit_snapshot_tests
+//! cargo test -p vibesql-executor --test mvcc_autocommit_snapshot_tests \
+//!     --features mvcc_enabled
+//! ```
+
+use vibesql_ast::{SelectStmt, Statement};
+use vibesql_executor::{
+    BeginTransactionExecutor, CommitExecutor, CreateTableExecutor, DeleteExecutor, InsertExecutor,
+    SelectExecutor, UpdateExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+// ============================================================================
+// Helpers (kept local to this file — the read-path tests have their own
+// equivalents; duplicating these here keeps the test file self-contained).
+// ============================================================================
+
+fn exec(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).expect("UPDATE failed");
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).expect("DELETE failed");
+        }
+        Statement::BeginTransaction(s) => {
+            BeginTransactionExecutor::execute(&s, db).expect("BEGIN failed");
+        }
+        Statement::Commit(s) => {
+            CommitExecutor::execute(&s, db).expect("COMMIT failed");
+        }
+        other => panic!("unsupported statement in test helper: {:?}", other),
+    }
+}
+
+fn select(db: &mut Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    let select_stmt: SelectStmt = match stmt {
+        Statement::Select(s) => *s,
+        other => panic!("expected SELECT, got {:?}", other),
+    };
+    let executor = SelectExecutor::new(db);
+    let rows = executor.execute(&select_stmt).expect("SELECT failed");
+    rows.into_iter().map(|r| r.values.to_vec()).collect()
+}
+
+/// Build a fresh database with a single non-keyed
+/// `accounts(id INTEGER, balance INTEGER)` table containing the row
+/// `(1, 100)`. The absence of a PRIMARY KEY is deliberate — see the
+/// module doc for why.
+fn db_with_accounts() -> Database {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE accounts (id INTEGER, balance INTEGER)");
+    exec(&mut db, "INSERT INTO accounts VALUES (1, 100)");
+    db
+}
+
+fn integer(v: &SqlValue) -> Option<i64> {
+    match v {
+        SqlValue::Integer(x) => Some(*x),
+        _ => None,
+    }
+}
+
+// ============================================================================
+// Acceptance: autocommit SELECT sees rows committed by previous transactions.
+//
+// This is the autocommit-snapshot-widening invariant. Under the on-state
+// the row is stamped with `xmin = txn_id`, and the autocommit reader's
+// snapshot must treat that txn id as committed.
+// ============================================================================
+
+#[test]
+fn autocommit_select_sees_row_committed_by_prior_transaction() {
+    let mut db = db_with_accounts();
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "INSERT INTO accounts VALUES (2, 200)");
+    exec(&mut db, "COMMIT");
+
+    // The autocommit reader must observe the row committed by the
+    // prior transaction. Under MVCC ON the row carries `xmin = txn_id`,
+    // and the read snapshot must include that txn id as committed.
+    let rows = select(&mut db, "SELECT id, balance FROM accounts");
+    assert_eq!(rows.len(), 2, "autocommit SELECT must see both rows after committed txn");
+    // Sort for deterministic comparison (no PK ordering on this table).
+    let mut sorted: Vec<_> = rows.iter().map(|r| (integer(&r[0]), integer(&r[1]))).collect();
+    sorted.sort();
+    assert_eq!(sorted, vec![(Some(1), Some(100)), (Some(2), Some(200))]);
+}
+
+#[test]
+fn autocommit_select_sees_update_committed_by_prior_transaction() {
+    let mut db = db_with_accounts();
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "UPDATE accounts SET balance = 250 WHERE id = 1");
+    exec(&mut db, "COMMIT");
+
+    // The autocommit reader must observe the updated value. The new
+    // row version is stamped with the txn id; the snapshot must see it.
+    let rows = select(&mut db, "SELECT id, balance FROM accounts");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(integer(&rows[0][0]), Some(1));
+    assert_eq!(integer(&rows[0][1]), Some(250));
+}
+
+#[test]
+fn autocommit_select_sees_delete_committed_by_prior_transaction() {
+    let mut db = db_with_accounts();
+    exec(&mut db, "INSERT INTO accounts VALUES (2, 200)");
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "DELETE FROM accounts WHERE id = 1");
+    exec(&mut db, "COMMIT");
+
+    // The autocommit reader must observe the deletion.
+    let rows = select(&mut db, "SELECT id, balance FROM accounts");
+    assert_eq!(rows.len(), 1, "deleted row must not be visible to subsequent autocommit reads");
+    assert_eq!(integer(&rows[0][0]), Some(2));
+    assert_eq!(integer(&rows[0][1]), Some(200));
+}
+
+// ============================================================================
+// Acceptance: a transaction sees its own INSERT/UPDATE inside the same txn.
+//
+// This is the in-transaction see-your-own-writes invariant. Under the
+// pre-1207 BEGIN-time snapshot (`xmax_committed = txn_id - 1`), a row
+// stamped with `xmin = txn_id` failed the visibility check. The fix is
+// to widen the BEGIN-time snapshot to `xmax_committed = txn_id`.
+// ============================================================================
+
+#[test]
+fn in_transaction_sees_own_insert() {
+    let mut db = db_with_accounts();
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "INSERT INTO accounts VALUES (2, 200)");
+
+    let rows = select(&mut db, "SELECT id, balance FROM accounts");
+    assert_eq!(rows.len(), 2, "txn must see its own INSERT");
+    let mut sorted: Vec<_> = rows.iter().map(|r| (integer(&r[0]), integer(&r[1]))).collect();
+    sorted.sort();
+    assert_eq!(sorted, vec![(Some(1), Some(100)), (Some(2), Some(200))]);
+
+    exec(&mut db, "COMMIT");
+}
+
+#[test]
+fn in_transaction_sees_own_update() {
+    let mut db = db_with_accounts();
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "UPDATE accounts SET balance = 150 WHERE id = 1");
+
+    let rows = select(&mut db, "SELECT id, balance FROM accounts");
+    assert_eq!(rows.len(), 1, "txn must see exactly one row (the updated one)");
+    assert_eq!(integer(&rows[0][1]), Some(150), "txn must observe the new value");
+
+    exec(&mut db, "COMMIT");
+}
+
+#[test]
+fn in_transaction_sees_own_insert_followed_by_update() {
+    let mut db = db_with_accounts();
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "INSERT INTO accounts VALUES (2, 200)");
+    exec(&mut db, "UPDATE accounts SET balance = 250 WHERE id = 2");
+
+    let rows = select(&mut db, "SELECT id, balance FROM accounts WHERE id = 2");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(integer(&rows[0][1]), Some(250));
+
+    exec(&mut db, "COMMIT");
+
+    // After commit, autocommit reader still sees the row.
+    let rows = select(&mut db, "SELECT id, balance FROM accounts WHERE id = 2");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(integer(&rows[0][1]), Some(250));
+}
+
+#[test]
+fn in_transaction_sees_own_delete() {
+    let mut db = db_with_accounts();
+    exec(&mut db, "INSERT INTO accounts VALUES (2, 200)");
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "DELETE FROM accounts WHERE id = 1");
+
+    let rows = select(&mut db, "SELECT id, balance FROM accounts");
+    assert_eq!(rows.len(), 1, "txn must observe its own DELETE");
+    assert_eq!(integer(&rows[0][0]), Some(2));
+
+    exec(&mut db, "COMMIT");
+
+    // After commit, autocommit reader also observes the delete.
+    let rows = select(&mut db, "SELECT id, balance FROM accounts");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(integer(&rows[0][0]), Some(2));
+}
+
+// ============================================================================
+// Acceptance: multi-statement autocommit "see-your-own-writes" — each
+// autocommit statement is its own transaction, and statement N+1 must
+// see writes from statement N.
+// ============================================================================
+
+#[test]
+fn multi_statement_autocommit_sees_prior_writes() {
+    let mut db = db_with_accounts();
+
+    // Each of these runs as its own autocommit "statement-transaction".
+    exec(&mut db, "INSERT INTO accounts VALUES (2, 200)");
+    exec(&mut db, "INSERT INTO accounts VALUES (3, 300)");
+
+    let rows = select(&mut db, "SELECT id, balance FROM accounts");
+    assert_eq!(rows.len(), 3, "all three autocommit inserts must be visible");
+    let mut sorted: Vec<_> = rows.iter().map(|r| integer(&r[0])).collect();
+    sorted.sort();
+    assert_eq!(sorted, vec![Some(1), Some(2), Some(3)]);
+}
+
+#[test]
+fn multi_statement_autocommit_sees_updates_to_pre_mvcc_row() {
+    let mut db = db_with_accounts();
+
+    // First autocommit statement updates the pre-MVCC row. Under MVCC
+    // ON the autocommit UPDATE path may or may not stamp; the
+    // visibility predicate must still let the later SELECT see the
+    // current value.
+    exec(&mut db, "UPDATE accounts SET balance = 999 WHERE id = 1");
+
+    let rows = select(&mut db, "SELECT balance FROM accounts");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(integer(&rows[0][0]), Some(999), "autocommit SELECT must observe autocommit UPDATE");
+}
+
+// ============================================================================
+// Foundation invariant (regression guard) — pre-MVCC rows remain
+// visible after the widening fix. Equivalent to the test in
+// mvcc_read_path_tests.rs but reasserted here so a future change can't
+// quietly regress this file in isolation.
+// ============================================================================
+
+#[test]
+fn autocommit_select_sees_pre_mvcc_rows_after_widening() {
+    let mut db = db_with_accounts();
+    let rows = select(&mut db, "SELECT balance FROM accounts");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(integer(&rows[0][0]), Some(100));
+}

--- a/crates/vibesql-executor/tests/mvcc_read_path_tests.rs
+++ b/crates/vibesql-executor/tests/mvcc_read_path_tests.rs
@@ -119,34 +119,19 @@ fn transactional_writes_visible_after_commit() {
     // The committing transaction's own writes must be visible to
     // subsequent autocommit reads. With MVCC ON the new row is stamped
     // with the txn's id, so the snapshot used at read time must see it.
+    //
+    // #5207 fix: `read_snapshot` for autocommit now synthesizes a
+    // commit-time snapshot that treats every allocated txn id as
+    // committed, so the row stamped with `xmin = txn_id` is visible.
     let mut db = db_with_accounts();
 
     exec(&mut db, "BEGIN");
     exec(&mut db, "INSERT INTO accounts VALUES (2, 200)");
     exec(&mut db, "COMMIT");
 
-    // After commit, autocommit read should see the new row.
-    // Note: Phase 1d's empty-snapshot semantics may hide MVCC-stamped
-    // rows from autocommit reads. This is a known follow-up tracked
-    // in the autocommit-snapshot-widening issue. For now, document
-    // the actual behavior:
     let rows = select(&mut db, "SELECT balance FROM accounts WHERE id = 2");
-
-    #[cfg(not(feature = "mvcc_enabled"))]
-    {
-        // Off-state: definitely visible.
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0][0], SqlValue::Integer(200));
-    }
-    #[cfg(feature = "mvcc_enabled")]
-    {
-        // On-state: with the empty autocommit snapshot, MVCC-stamped
-        // rows are invisible. This is the conservative Phase 1d
-        // baseline — autocommit-snapshot widening is a tracked
-        // follow-up. Document the current behavior.
-        let _ = rows; // Either result is acceptable for this phase;
-                      // the next phase will tighten this contract.
-    }
+    assert_eq!(rows.len(), 1, "autocommit SELECT after committed txn must see the new row");
+    assert_eq!(rows[0][0], SqlValue::Integer(200));
 }
 
 // ============================================================================
@@ -167,29 +152,16 @@ fn balance(db: &mut Database) -> Option<i64> {
 #[cfg(feature = "mvcc_enabled")]
 #[test]
 fn snapshot_isolation_select_sees_stable_view_across_concurrent_commit() {
-    // This is the canonical SI demonstration: txn A reads, then a
-    // concurrent committed change happens (modelled here by a separate
-    // Database instance — single-threaded but simulating two commits),
-    // then txn A reads again and must see the BEGIN-time value.
+    // After #5207's widening, the BEGIN-time snapshot now treats the
+    // active txn's own id as committed, so the txn's UPDATE is visible
+    // to subsequent reads within the same txn. This is the
+    // "see-your-own-writes" rule.
     //
-    // Single-process model: we can simulate this within one `Database`
-    // by carefully ordering BEGIN, autocommit-write, SELECT-in-txn.
-    // Because Phase 1c keeps autocommit writes on the pre-MVCC sentinel,
-    // an autocommit insert *would* be visible to a later txn's snapshot.
-    // To exercise the snapshot-isolation invariant on MVCC-stamped rows
-    // we must use a second transaction for the writer.
-    //
-    // The flow:
-    //   1. BEGIN tx_A (snapshot captured)
-    //   2. SELECT in tx_A — sees pre-MVCC sentinel row (balance=100)
-    //   3. Within tx_A's lifetime, a separate transaction tx_B would
-    //      need to BEGIN/UPDATE/COMMIT concurrently. The single-writer
-    //      model of `Database` does not allow this in-process. The
-    //      multi-writer scenario is a future-phase test.
-    //
-    // What we CAN demonstrate today: tx_A's own writes are visible to
-    // tx_A's snapshot (the standard "see-your-own-writes" rule), and
-    // pre-MVCC rows remain visible across the txn boundary.
+    // The "stable view across concurrent commits" guarantee proper
+    // (no peer-commits leak into the snapshot) still requires the
+    // multi-writer model to actually exercise — the single-writer
+    // `Database` cannot interleave BEGIN/UPDATE/COMMIT operations
+    // in-process. That cross-txn invariant is a future-phase test.
     let mut db = db_with_accounts();
     exec(&mut db, "BEGIN");
     assert_eq!(balance(&mut db), Some(100), "pre-MVCC row visible at txn start");
@@ -197,23 +169,13 @@ fn snapshot_isolation_select_sees_stable_view_across_concurrent_commit() {
     // tx_A's own UPDATE: stamps xmin=tx_A on new row, xmax=tx_A on old.
     exec(&mut db, "UPDATE accounts SET balance = 150 WHERE id = 1");
 
-    // SELECT in tx_A: should see its own write. Whether the new row
-    // (xmin=tx_A) is visible depends on `visible_to(snapshot)` where
-    // snapshot.xmax_committed = tx_A - 1 = 0. The new row's xmin = tx_A
-    // > 0 — so under strict snapshot isolation, tx_A does NOT see it.
-    //
-    // This is the well-known "see your own writes" gap that Phase 1d
-    // does not yet close — it requires either (a) widening the snapshot
-    // to include `self.txn_id`, or (b) a separate "is self-write" pass
-    // in the predicate. Documenting the current behavior here so the
-    // follow-up has a precise reproducer:
+    // After #5207, the txn must see its own write.
     let after_update = balance(&mut db);
-    // Document the observed value without asserting a specific one —
-    // the contract being tested is "the transaction's view is stable",
-    // not the specifics of self-write visibility (which is a known
-    // follow-up). The important assertion is that we don't crash and
-    // the system remains consistent.
-    let _ = after_update;
+    assert_eq!(
+        after_update,
+        Some(150),
+        "#5207: a txn must see its own UPDATE in subsequent reads"
+    );
 
     exec(&mut db, "COMMIT");
 }
@@ -273,10 +235,9 @@ fn fk_deferred_replay_uses_commit_time_snapshot() {
     exec(&mut db, "COMMIT");
 
     let rows = select(&mut db, "SELECT id, p FROM child");
-    // Note: under the current empty-autocommit-snapshot model, the
-    // child row stamped with the txn id may not be visible to the
-    // post-commit autocommit SELECT. Either result is acceptable for
-    // this phase; the test's job is to confirm the COMMIT path runs
-    // through `capture_commit_time_snapshot` without panicking.
-    let _ = rows;
+    // #5207: autocommit reads now use a commit-time-style snapshot, so
+    // the child row stamped with the prior txn's id is visible.
+    assert_eq!(rows.len(), 1, "child row inserted by committed txn must be visible");
+    assert_eq!(rows[0][0], SqlValue::Integer(10));
+    assert_eq!(rows[0][1], SqlValue::Integer(1));
 }

--- a/crates/vibesql-storage/src/database/transactions.rs
+++ b/crates/vibesql-storage/src/database/transactions.rs
@@ -157,14 +157,14 @@ impl TransactionManager {
                 let transaction_id = self.next_transaction_id;
                 self.next_transaction_id += 1;
 
-                // Capture the MVCC snapshot **before** publishing the
-                // new transaction id. The `in_progress` set is computed
-                // from currently-active transactions (just this one
-                // would be self, which we deliberately exclude — a
-                // transaction always sees its own writes). Under the
-                // current single-writer model, in_progress is always
-                // empty at BEGIN; this will need to change when Raft +
-                // multi-writer arrives in later phases.
+                // Capture the MVCC snapshot for this transaction. The
+                // `in_progress` set is computed from currently-active
+                // transactions; the txn deliberately treats *itself* as
+                // committed (see [`Self::capture_snapshot`] for the
+                // #5207 self-write widening). Under the current
+                // single-writer model, in_progress is always empty at
+                // BEGIN; this will need to change when Raft + multi-
+                // writer arrives in later phases.
                 let snapshot = Self::capture_snapshot(transaction_id);
 
                 self.transaction_state = TransactionState::Active {
@@ -187,33 +187,48 @@ impl TransactionManager {
 
     /// Build the MVCC snapshot for a transaction with id `txn_id`.
     ///
-    /// **Phase 1b semantics (single-writer):** there are no other
-    /// concurrently-active transactions to put in `in_progress`. The
-    /// snapshot is:
+    /// **Single-writer semantics with #5207 self-write widening:** there
+    /// are no other concurrently-active transactions to put in
+    /// `in_progress`. The snapshot is:
     ///
-    /// - `xmin_active = txn_id` — the next-to-allocate id (one past the
-    ///   high-water mark from the caller's perspective). This makes the
-    ///   `xmax > xmin_active` clause in [`Row::visible_to`] only true
-    ///   for transactions that started *after* us, which is the correct
-    ///   behavior with no concurrent peers.
-    /// - `xmax_committed = txn_id - 1` — every transaction allocated
-    ///   before us has, by the single-writer invariant, already finished
-    ///   (committed or rolled back). For the rolled-back case, the
-    ///   rollback path replaces tables wholesale, so no `xmin = rolled_back_id`
-    ///   row exists in storage and the predicate correctness is preserved.
+    /// - `xmin_active = txn_id + 1` — one past the snapshot's own
+    ///   transaction id. Any row whose `xmax` value falls in
+    ///   `(xmin_active, ∞)` was deleted by a *later* transaction (one
+    ///   that hadn't yet been allocated when our snapshot was taken).
+    ///   Under the single-writer model this set is currently empty, but
+    ///   the bookkeeping keeps the `xmax > xmin_active` clause in
+    ///   [`Row::visible_to`] semantically correct.
+    /// - `xmax_committed = txn_id` — every transaction id allocated so
+    ///   far, **including our own**, is treated as committed-as-of this
+    ///   snapshot. This is the #5207 "see your own writes" widening:
+    ///   a row stamped with `xmin = txn_id` (the active transaction's
+    ///   own write) passes `is_committed(self)` and is therefore visible
+    ///   to subsequent reads within the same transaction. The same
+    ///   widening makes prior-transaction writes visible too — which is
+    ///   the correct snapshot-isolation behavior in single-writer
+    ///   (every "prior" transaction has already finished by the time
+    ///   the next one starts).
     /// - `in_progress = ∅` — no concurrent transactions.
     ///
     /// **Future (multi-writer / Raft):** when concurrent transactions
     /// become possible, this method becomes the chokepoint where the
     /// `in_progress` set is populated from the active-transactions
-    /// registry. The caller signature does not need to change.
+    /// registry. Transactions that started after this one but committed
+    /// before this one's reads must be invisible under SI; concurrent
+    /// transactions go in `in_progress`. The signature does not change.
     ///
     /// [`Row::visible_to`]: crate::Row::visible_to
     fn capture_snapshot(txn_id: TxnId) -> TxnSnapshot {
-        // For txn_id = 1 (the first ever), xmax_committed = 0 means
-        // "only pre-MVCC rows are visible" — exactly right.
-        let xmax_committed = txn_id.saturating_sub(1);
-        TxnSnapshot::new(txn_id, xmax_committed, std::collections::HashSet::new())
+        // #5207: widen `xmax_committed` to include the txn's own id so
+        // self-writes (xmin = txn_id) are visible. Under single-writer
+        // this is safe because there are no concurrent peers. Multi-
+        // writer will need to model the "still-running peers" set in
+        // `in_progress` instead.
+        TxnSnapshot::new(
+            txn_id.saturating_add(1),
+            txn_id,
+            std::collections::HashSet::new(),
+        )
     }
 
     /// Commit the current transaction
@@ -450,24 +465,26 @@ mod snapshot_capture_tests {
     }
 
     #[test]
-    fn first_transaction_snapshot_has_xmax_committed_zero() {
-        // First-ever transaction: xmax_committed should be 0 (only
-        // pre-MVCC sentinel rows are visible to it), xmin_active should
-        // equal our own id (1).
+    fn first_transaction_snapshot_includes_self_as_committed() {
+        // #5207: the BEGIN-time snapshot must treat its own txn id as
+        // committed so self-writes (xmin = txn_id) are visible to the
+        // txn's own reads. For the first-ever transaction (txn_id = 1):
+        //   - xmax_committed = 1 (self counts as committed)
+        //   - xmin_active = 2 (one past self)
         let (catalog, tables) = empty_catalog_and_tables();
         let mut mgr = TransactionManager::new();
         mgr.begin_transaction(&catalog, &tables).unwrap();
 
         let snap = mgr.current_snapshot().expect("snapshot present after BEGIN");
-        assert_eq!(snap.xmin_active, 1);
-        assert_eq!(snap.xmax_committed, 0);
+        assert_eq!(snap.xmin_active, 2);
+        assert_eq!(snap.xmax_committed, 1);
         assert!(snap.in_progress.is_empty());
     }
 
     #[test]
-    fn second_transaction_snapshot_sees_first_as_committed() {
-        // Second transaction's snapshot should include the first txn's
-        // id in the "committed" range (xmax_committed >= 1).
+    fn second_transaction_snapshot_sees_first_and_self_as_committed() {
+        // Second transaction's snapshot should include both the first
+        // txn's id AND its own id in the "committed" range.
         let (catalog, tables) = empty_catalog_and_tables();
         let mut mgr = TransactionManager::new();
 
@@ -476,8 +493,9 @@ mod snapshot_capture_tests {
 
         mgr.begin_transaction(&catalog, &tables).unwrap();
         let snap = mgr.current_snapshot().expect("second snapshot present");
-        assert_eq!(snap.xmin_active, 2);
-        assert_eq!(snap.xmax_committed, 1);
+        // #5207: xmax_committed = self (= 2), xmin_active = self + 1 (= 3)
+        assert_eq!(snap.xmin_active, 3);
+        assert_eq!(snap.xmax_committed, 2);
         assert!(snap.in_progress.is_empty());
     }
 
@@ -523,33 +541,30 @@ mod snapshot_capture_tests {
         mgr.begin_transaction(&catalog, &tables).unwrap();
         let snap = mgr.current_snapshot().unwrap();
         // First txn id was 1 (rolled back). Second txn id is 2.
-        assert_eq!(snap.xmin_active, 2);
-        assert_eq!(snap.xmax_committed, 1);
+        // #5207: xmax_committed = self (= 2), xmin_active = self + 1 (= 3).
+        assert_eq!(snap.xmin_active, 3);
+        assert_eq!(snap.xmax_committed, 2);
     }
 
     #[test]
-    fn snapshot_visibility_integration() {
-        // End-to-end sanity check: a row stamped with the *current*
-        // active transaction's id (Phase 1c will do this) should NOT
-        // be visible to that transaction's own snapshot under this
-        // predicate — that's intentional. Phase 1c/1d will introduce a
-        // separate "is my own write" check that bypasses snapshot
-        // visibility. Documenting that gap here.
+    fn snapshot_visibility_integration_self_writes_visible() {
+        // #5207: the BEGIN-time snapshot now treats the active txn's
+        // own id as committed, so a row stamped with that txn's id is
+        // visible to the transaction's own reads. This is the
+        // "see-your-own-writes" invariant.
         let (catalog, tables) = empty_catalog_and_tables();
         let mut mgr = TransactionManager::new();
         mgr.begin_transaction(&catalog, &tables).unwrap();
         let my_id = mgr.transaction_id().unwrap();
         let snap = mgr.current_snapshot().unwrap();
 
-        // A row stamped with our own id: my_id > xmax_committed
-        // (== my_id - 1), so visible_to returns false. Phase 1c's
-        // "see my own writes" path will be a separate clause.
+        // A row stamped with our own id: my_id == xmax_committed under
+        // the #5207-widened snapshot, so visible_to returns true.
         let mut my_row = crate::Row::new(vec![vibesql_types::SqlValue::Integer(1)]);
         my_row.xmin = my_id;
         assert!(
-            !my_row.visible_to(snap),
-            "Phase 1b predicate intentionally does not show transactions \
-             their own writes; Phase 1c will add a separate clause for that"
+            my_row.visible_to(snap),
+            "#5207 widening: a txn's own writes (xmin = self) must be visible"
         );
     }
 }


### PR DESCRIPTION
## Summary

Phase 1d's initial PR (#5209) made the BEGIN-time snapshot stable across reads (correct for repeatable-read), but left two visibility gaps under MVCC ON. This PR closes both via the option-A widening described in the issue:

1. **Autocommit SELECT now sees rows committed by prior transactions.**
   `read_snapshot` (executor `mvcc.rs`) now returns `Database::capture_commit_time_snapshot()` outside a transaction, so autocommit reads see every txn id allocated so far as committed.
2. **A transaction now sees its own writes.**
   `TransactionManager::capture_snapshot` (storage `transactions.rs`) sets `xmax_committed = txn_id` and `xmin_active = txn_id + 1` so the BEGIN snapshot treats the active txn's own id as committed.

Both fixes are safe under the single-writer model — there are no concurrent peers whose writes could leak into our view. Multi-writer / Raft will need to model the still-running peer set in `in_progress`; that work is gated on Raft and remains future scope.

## What changed

### `crates/vibesql-executor/src/mvcc.rs`
- `read_snapshot`: when not in a transaction, synthesize a commit-time snapshot via `Database::capture_commit_time_snapshot()` instead of returning `TxnSnapshot::empty()`. Module doc updated.

### `crates/vibesql-storage/src/database/transactions.rs`
- `TransactionManager::capture_snapshot`: widen `xmax_committed` from `txn_id - 1` to `txn_id`, and `xmin_active` from `txn_id` to `txn_id + 1`. Doc updated to reflect new semantics and multi-writer migration path.
- Updated `snapshot_capture_tests` to assert the new (post-#5207) snapshot field values, including `snapshot_visibility_integration_self_writes_visible` which now positively asserts that a row stamped with the active txn's id is visible.

### `crates/vibesql-executor/tests/mvcc_autocommit_snapshot_tests.rs` (new)
Integration test file covering the new invariants:
- `autocommit_select_sees_row_committed_by_prior_transaction` — the canonical autocommit-widening case.
- `autocommit_select_sees_update_committed_by_prior_transaction` — UPDATE visibility.
- `autocommit_select_sees_delete_committed_by_prior_transaction` — DELETE visibility.
- `in_transaction_sees_own_insert` / `_own_update` / `_own_delete` — the see-your-own-writes invariants.
- `in_transaction_sees_own_insert_followed_by_update` — multiple chained self-writes.
- `multi_statement_autocommit_sees_prior_writes` — the prompt's specific scenario.
- `multi_statement_autocommit_sees_updates_to_pre_mvcc_row` — pre-MVCC interaction.
- `autocommit_select_sees_pre_mvcc_rows_after_widening` — regression guard.

Note: these tests deliberately use a non-keyed `id INTEGER` (not `INTEGER PRIMARY KEY`) so the SELECT path exercises the full-scan visibility filter rather than the PK-lookup fast path. The PK-lookup-bypass is the gap tracked in follow-up #5204.

### `crates/vibesql-executor/tests/mvcc_read_path_tests.rs`
Tightened the previously-documented "either result acceptable" cases to positively assert the post-fix behavior:
- `transactional_writes_visible_after_commit` now asserts the new row is visible.
- `snapshot_isolation_select_sees_stable_view_across_concurrent_commit` now asserts the in-txn UPDATE is observed by subsequent reads in the same txn.
- `fk_deferred_replay_uses_commit_time_snapshot` now asserts the post-commit child row is visible.

## Verification

- `cargo test --workspace --lib --release` (off-state): green
- `cargo test --workspace --lib --release --features vibesql-executor/mvcc_enabled`: green
- `cargo test -p vibesql-executor --test mvcc_autocommit_snapshot_tests --release`: 10/10
- `cargo test -p vibesql-executor --test mvcc_autocommit_snapshot_tests --release --features mvcc_enabled`: 10/10
- `cargo test -p vibesql-executor --test mvcc_read_path_tests --release`: 3/3 (off), 6/6 (on)
- `cargo test -p vibesql-executor --test mvcc_stamping_tests --release`: 6/6 (off), 10/10 (on)
- `cargo clippy -p vibesql-storage -p vibesql-executor --lib --release` (both states): no new warnings introduced

## Acceptance criteria (from #5207)

- [x] A transaction sees its own INSERT/UPDATE inside the same txn — `in_transaction_sees_own_insert`, `_own_update`, `_own_insert_followed_by_update`.
- [x] Autocommit SELECT sees rows committed by previous transactions — `autocommit_select_sees_row_committed_by_prior_transaction`, `_update_committed`, `_delete_committed`.
- [x] All existing tests still pass (off-state and on-state) — workspace lib tests green under both feature flags.

Closes #5207.

## Test plan

- [x] `cargo test --workspace --lib --release` — green
- [x] `cargo test --workspace --lib --release --features vibesql-executor/mvcc_enabled` — green
- [x] `cargo test -p vibesql-executor --release --tests` — green (off + on)
- [x] `cargo clippy -p vibesql-storage -p vibesql-executor --lib --release` — no new warnings (off + on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)