### PR TITLE
feat(mvcc): add on-demand vacuum_mvcc for old-version garbage collection

### DIFF
--- a/crates/vibesql-storage/src/database/tests/mod.rs
+++ b/crates/vibesql-storage/src/database/tests/mod.rs
@@ -2,3 +2,4 @@
 pub mod core_tests;
 pub mod indexes;
 pub mod reset_catalog;
+pub mod vacuum;

--- a/crates/vibesql-storage/src/database/tests/vacuum.rs
+++ b/crates/vibesql-storage/src/database/tests/vacuum.rs
@@ -1,0 +1,208 @@
+// ============================================================================
+// MVCC Vacuum Tests (#5208 — MVCC Phase 1d follow-up)
+// ============================================================================
+//
+// Tests for the on-demand MVCC garbage-collection API exposed at the
+// `Database::vacuum_mvcc` level. These tests cover both feature states
+// — the off-state must be a strict no-op (returning 0), and the on-state
+// must reclaim old versions while preserving query correctness.
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_types::{DataType, SqlValue};
+
+use crate::database::Database;
+use crate::row::Row;
+
+fn make_users_table(db: &mut Database) {
+    let columns = vec![
+        ColumnSchema::new("id".to_string(), DataType::Integer, false),
+        ColumnSchema::new("name".to_string(), DataType::Varchar { max_length: Some(50) }, true),
+    ];
+    let schema = TableSchema::with_primary_key(
+        "users".to_string(),
+        columns,
+        vec!["id".to_string()],
+    );
+    db.create_table(schema).unwrap();
+}
+
+fn user_row(id: i64, name: &str) -> Row {
+    Row::from_vec(vec![SqlValue::Integer(id), SqlValue::Varchar(arcstr::ArcStr::from(name))])
+}
+
+#[test]
+fn vacuum_mvcc_on_empty_database_returns_zero() {
+    // Trivial smoke test: a brand-new database has nothing to GC,
+    // regardless of feature state.
+    let mut db = Database::new();
+    let reclaimed = db.vacuum_mvcc().unwrap();
+    assert_eq!(reclaimed, 0);
+}
+
+#[test]
+fn vacuum_mvcc_with_no_stamped_tombstones_is_a_noop() {
+    // Off-state contract: when no rows have xmax stamped (which is the
+    // case in the off-state — the executor never stamps), vacuum is a
+    // no-op. Run on a populated table and verify the row count is
+    // unchanged.
+    let mut db = Database::new();
+    make_users_table(&mut db);
+    db.insert_row("users", user_row(1, "Alice")).unwrap();
+    db.insert_row("users", user_row(2, "Bob")).unwrap();
+    db.insert_row("users", user_row(3, "Charlie")).unwrap();
+
+    let reclaimed = db.vacuum_mvcc().unwrap();
+    assert_eq!(reclaimed, 0);
+
+    let table = db.get_table("users").unwrap();
+    assert_eq!(table.row_count(), 3);
+}
+
+#[test]
+fn vacuum_mvcc_refuses_to_run_inside_transaction() {
+    // v1 contract: vacuum cannot run while a transaction is active.
+    let mut db = Database::new();
+    make_users_table(&mut db);
+    db.begin_transaction().unwrap();
+    let err = db.vacuum_mvcc().expect_err("vacuum must refuse mid-transaction");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("vacuum_mvcc"),
+        "error message should mention vacuum_mvcc, got: {msg}"
+    );
+    // Clean up so we don't leak the active txn into subsequent tests.
+    db.rollback_transaction().unwrap();
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn vacuum_mvcc_reclaims_committed_deletions() {
+    // With MVCC on, perform an autocommit-style INSERT + DELETE pair
+    // outside any explicit transaction. The DELETE path stamps xmax
+    // (when mvcc_enabled) which the GC sweep can then reclaim.
+    //
+    // Note: under the current single-writer write-path, DELETE both
+    // stamps xmax AND bitmap-deletes the row, so the row is already
+    // out of `scan_live_vec` results. The GC sweep is still
+    // exercising the right primitive — it finds the stamped row in
+    // the deletion bitmap, but the test below uses a hand-stamped
+    // row to give the sweep something to physically reclaim.
+    let mut db = Database::new();
+    make_users_table(&mut db);
+    db.insert_row("users", user_row(1, "Alice")).unwrap();
+    db.insert_row("users", user_row(2, "Bob")).unwrap();
+    db.insert_row("users", user_row(3, "Charlie")).unwrap();
+
+    // Stamp row 1 with a committed xmax directly on the table layer
+    // to simulate a deferred-tombstone state without depending on
+    // the executor's specific write-path semantics.
+    {
+        let table = db.get_table_mut("users").unwrap();
+        table.stamp_row_xmax_inplace(1, 1);
+    }
+
+    // No active transaction, so horizon = next_transaction_id = 1.
+    // Row 1 has xmax = 1, which is NOT < 1, so it should NOT be
+    // reclaimed yet.
+    assert_eq!(db.compute_gc_horizon(), 1);
+    let reclaimed = db.vacuum_mvcc().unwrap();
+    assert_eq!(reclaimed, 0, "row at horizon boundary must be retained");
+
+    // Now begin + commit a no-op txn to advance the watermark, then
+    // GC: horizon = 2, row 1's xmax = 1 < 2, so it's reclaimable.
+    db.begin_transaction().unwrap();
+    db.commit_transaction().unwrap();
+    assert_eq!(db.compute_gc_horizon(), 2);
+
+    let reclaimed = db.vacuum_mvcc().unwrap();
+    assert_eq!(reclaimed, 1, "row stamped before horizon must be reclaimed");
+
+    // Other rows should still be present.
+    let table = db.get_table("users").unwrap();
+    assert_eq!(table.row_count(), 2);
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn vacuum_mvcc_preserves_subsequent_query_correctness() {
+    // After vacuum, the table must remain queryable and the indexes
+    // must still resolve PK lookups correctly. This is the primary
+    // safety property: GC must not break correctness for subsequent
+    // reads.
+    let mut db = Database::new();
+    make_users_table(&mut db);
+    db.insert_row("users", user_row(1, "Alice")).unwrap();
+    db.insert_row("users", user_row(2, "Bob")).unwrap();
+    db.insert_row("users", user_row(3, "Charlie")).unwrap();
+    db.insert_row("users", user_row(4, "Dave")).unwrap();
+
+    // Tombstone rows 0 and 2 directly.
+    {
+        let table = db.get_table_mut("users").unwrap();
+        table.stamp_row_xmax_inplace(0, 1);
+        table.stamp_row_xmax_inplace(2, 1);
+    }
+
+    // Advance horizon past 1.
+    db.begin_transaction().unwrap();
+    db.commit_transaction().unwrap();
+
+    let reclaimed = db.vacuum_mvcc().unwrap();
+    assert_eq!(reclaimed, 2);
+
+    // The surviving rows (id = 2, id = 4) must remain queryable via
+    // their PK and produce the expected values.
+    let table = db.get_table("users").unwrap();
+    assert_eq!(table.row_count(), 2);
+
+    // Use the PK index to look up surviving rows.
+    let pk_index =
+        table.primary_key_index().expect("PK index must survive GC compaction");
+    assert!(pk_index.contains_key(&vec![SqlValue::Integer(2)]));
+    assert!(pk_index.contains_key(&vec![SqlValue::Integer(4)]));
+    assert!(
+        !pk_index.contains_key(&vec![SqlValue::Integer(1)]),
+        "reclaimed row's PK must be gone from index"
+    );
+    assert!(
+        !pk_index.contains_key(&vec![SqlValue::Integer(3)]),
+        "reclaimed row's PK must be gone from index"
+    );
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn vacuum_mvcc_horizon_held_back_by_active_transaction() {
+    // Even when there's a stamped tombstone that would otherwise be
+    // reclaimable, an active transaction holds the GC horizon back so
+    // that transaction's snapshot remains stable.
+    //
+    // Setup: insert 3 rows in txn 1, commit. Stamp row 0's xmax = 1
+    // (simulating a committed delete). Then begin txn 2 and try to
+    // vacuum from outside? No — vacuum refuses inside a txn.
+    //
+    // Instead we check `compute_gc_horizon` while a txn is active to
+    // confirm the horizon is held back (the vacuum API itself
+    // wouldn't run here).
+    let mut db = Database::new();
+    make_users_table(&mut db);
+    db.insert_row("users", user_row(1, "Alice")).unwrap();
+
+    {
+        let table = db.get_table_mut("users").unwrap();
+        table.stamp_row_xmax_inplace(0, 1);
+    }
+
+    // Without an active txn: horizon = next_id (= 1 — no committed
+    // txns yet), so the stamp at xmax = 1 is NOT reclaimable.
+    assert_eq!(db.compute_gc_horizon(), 1);
+
+    // Begin a transaction: the horizon must now reflect this txn's
+    // xmin_active, which is held BACK from advancing past it.
+    db.begin_transaction().unwrap();
+    let horizon_during_txn = db.compute_gc_horizon();
+    let snap = db.current_snapshot().unwrap();
+    assert_eq!(horizon_during_txn, snap.xmin_active);
+
+    db.commit_transaction().unwrap();
+}

--- a/crates/vibesql-storage/src/database/transaction_api.rs
+++ b/crates/vibesql-storage/src/database/transaction_api.rs
@@ -133,6 +133,106 @@ impl Database {
         self.lifecycle.transaction_manager().capture_commit_time_snapshot()
     }
 
+    /// Compute the MVCC garbage-collection horizon.
+    ///
+    /// See [`crate::database::transactions::TransactionManager::compute_gc_horizon`].
+    /// Mostly useful for tests and diagnostics; production callers
+    /// should prefer [`Self::vacuum_mvcc`], which uses this horizon
+    /// internally.
+    pub fn compute_gc_horizon(&self) -> crate::row::TxnId {
+        self.lifecycle.transaction_manager().compute_gc_horizon()
+    }
+
+    /// MVCC vacuum: reclaim space from row versions whose deletion is
+    /// provably invisible to every active and future transaction.
+    ///
+    /// # Phase 1d follow-up (#5208)
+    ///
+    /// This is the "minimum viable" MVCC GC: a single, on-demand sweep
+    /// across all tables. It is **not** automatic and does **not**
+    /// integrate with WAL checkpoints or background tasks — those are
+    /// tracked as follow-up work in #5208 itself.
+    ///
+    /// # Semantics
+    ///
+    /// 1. Compute the GC horizon (see
+    ///    [`TransactionManager::compute_gc_horizon`]).
+    /// 2. For each table, call [`Table::gc_old_versions(horizon)`].
+    /// 3. If any table reclaimed rows, rebuild its user-defined indexes
+    ///    (B-tree indexes managed at the Database level) to keep them
+    ///    consistent with the now-compacted row vector.
+    ///
+    /// # Refused while a transaction is active
+    ///
+    /// Returns [`StorageError::TransactionError`] when called inside an
+    /// active transaction. v1 deliberately does **not** mix GC with
+    /// in-flight writes: doing so safely requires deferring the
+    /// underlying bitmap-delete on UPDATE/DELETE so the GC sweep can
+    /// observe the tombstones, which is a larger change than this
+    /// follow-up. Callers that want to run GC mid-transaction should
+    /// COMMIT first.
+    ///
+    /// # Off-state (`mvcc_enabled` feature OFF)
+    ///
+    /// Returns `Ok(0)` immediately. No row in the off-state carries an
+    /// MVCC tombstone, so there is nothing to reclaim. The API is
+    /// stable across feature configurations.
+    ///
+    /// # Returns
+    ///
+    /// The total number of row versions reclaimed across all tables.
+    ///
+    /// # Example
+    ///
+    /// ```text
+    /// // After a long-running write workload:
+    /// let reclaimed = db.vacuum_mvcc()?;
+    /// eprintln!("Reclaimed {reclaimed} old row versions");
+    /// ```
+    ///
+    /// [`TransactionManager::compute_gc_horizon`]: crate::database::transactions::TransactionManager::compute_gc_horizon
+    /// [`Table::gc_old_versions(horizon)`]: crate::Table::gc_old_versions
+    pub fn vacuum_mvcc(&mut self) -> Result<usize, StorageError> {
+        if self.in_transaction() {
+            return Err(StorageError::TransactionError(
+                "vacuum_mvcc cannot run while a transaction is active; COMMIT first".to_string(),
+            ));
+        }
+
+        // Off-state fast path: no MVCC stamping ever happened, so nothing
+        // to reclaim. Keeps the iteration overhead off the hot path when
+        // the feature is compiled out.
+        if !crate::mvcc::mvcc_enabled() {
+            return Ok(0);
+        }
+
+        let horizon = self.lifecycle.transaction_manager().compute_gc_horizon();
+
+        let table_names: Vec<String> = self.tables.keys().cloned().collect();
+        let mut total_reclaimed = 0usize;
+
+        for name in table_names {
+            let reclaimed = {
+                let table = match self.tables.get_mut(&name) {
+                    Some(t) => t,
+                    None => continue,
+                };
+                table.gc_old_versions(horizon)
+            };
+            if reclaimed > 0 {
+                total_reclaimed += reclaimed;
+                // GC may have triggered compaction, which shuffles physical
+                // row indices. Database-level user indexes must be rebuilt
+                // to track the new positions — same pattern as the DELETE
+                // path's `if delete_result.compacted` branch.
+                self.rebuild_indexes(&name);
+                self.invalidate_columnar_cache(&name);
+            }
+        }
+
+        Ok(total_reclaimed)
+    }
+
     /// Create a savepoint within the current transaction
     pub fn create_savepoint(&mut self, name: String) -> Result<(), StorageError> {
         self.lifecycle.transaction_manager_mut().create_savepoint(name)

--- a/crates/vibesql-storage/src/database/transactions.rs
+++ b/crates/vibesql-storage/src/database/transactions.rs
@@ -305,6 +305,54 @@ impl TransactionManager {
         }
     }
 
+    /// Compute the MVCC garbage-collection horizon.
+    ///
+    /// Returns the lowest [`TxnId`] that is **still potentially needed**
+    /// by some active reader. Any row whose `xmax` is committed and
+    /// strictly less than this value is provably invisible to every
+    /// current and future transaction, and may therefore be physically
+    /// reclaimed.
+    ///
+    /// # Semantics
+    ///
+    /// - If a transaction is active, the horizon is its snapshot's
+    ///   `xmin_active`. Under single-writer that's `txn_id + 1`, so any
+    ///   `xmax <= txn_id` (i.e. any committed deletion) would still
+    ///   technically need to be visible to the active reader if it's
+    ///   examining a pre-delete state... wait — under single-writer,
+    ///   the active txn IS the deleter, so this case is effectively
+    ///   handled by holding the horizon back to the active txn's own
+    ///   xmin_active and refusing to reclaim rows whose `xmax` equals
+    ///   the active txn id.
+    /// - If no transaction is active, the horizon is `next_transaction_id`
+    ///   (one past the highest allocated id). Under single-writer with no
+    ///   active txn, every committed deletion is invisible to every
+    ///   reader that *could* now start (since any new BEGIN would
+    ///   snapshot with an even-higher `xmin_active`), so anything stamped
+    ///   so far is safe to reclaim.
+    ///
+    /// **Multi-writer note:** when concurrent transactions are
+    /// supported, this becomes `min(xmin_active across all active txns)`
+    /// — the same primitive, computed over the active-txn registry.
+    /// The single-writer code path here naturally generalizes; the
+    /// signature does not change.
+    ///
+    /// # Phase 1d follow-up (#5208)
+    ///
+    /// This is the first half of the GC primitive. The second half is
+    /// [`Table::gc_old_versions`], which uses this horizon to pick rows
+    /// to physically reclaim. See [`crate::Database::vacuum_mvcc`] for
+    /// the user-facing entry point.
+    ///
+    /// [`Table::gc_old_versions`]: crate::Table::gc_old_versions
+    /// [`crate::Database::vacuum_mvcc`]: crate::Database
+    pub fn compute_gc_horizon(&self) -> TxnId {
+        match &self.transaction_state {
+            TransactionState::Active { snapshot, .. } => snapshot.xmin_active,
+            TransactionState::None => self.next_transaction_id,
+        }
+    }
+
     /// Capture a fresh "commit-time" MVCC snapshot.
     ///
     /// Phase 1d (#5151) FK deferred-replay coordination: when a deferred
@@ -566,5 +614,76 @@ mod snapshot_capture_tests {
             my_row.visible_to(snap),
             "#5207 widening: a txn's own writes (xmin = self) must be visible"
         );
+    }
+
+    // ========================================================================
+    // GC horizon tests (#5208 — MVCC Phase 1d follow-up)
+    // ========================================================================
+
+    #[test]
+    fn gc_horizon_with_no_transactions_is_next_txn_id() {
+        // Fresh manager: next_transaction_id = 1, no active txn.
+        // Horizon should be 1 — every committed xmax is < 1 is impossible
+        // (no commits have happened), so nothing is reclaimable, which
+        // is the correct behavior on an empty database.
+        let mgr = TransactionManager::new();
+        assert_eq!(mgr.compute_gc_horizon(), 1);
+    }
+
+    #[test]
+    fn gc_horizon_after_committed_txn_includes_that_txn() {
+        // After a transaction commits, its id (1) is < next_transaction_id (2),
+        // and there is no active reader, so anything that txn stamped is
+        // safe to reclaim. Horizon = 2.
+        let (catalog, tables) = empty_catalog_and_tables();
+        let mut mgr = TransactionManager::new();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
+        mgr.commit_transaction().unwrap();
+        assert_eq!(mgr.compute_gc_horizon(), 2);
+    }
+
+    #[test]
+    fn gc_horizon_with_active_transaction_uses_xmin_active() {
+        // While a transaction is active, the horizon must NOT advance
+        // past that transaction's snapshot's `xmin_active`, or we would
+        // risk reclaiming rows the active reader can still see.
+        // Single-writer: snapshot.xmin_active = txn_id + 1 = 2.
+        let (catalog, tables) = empty_catalog_and_tables();
+        let mut mgr = TransactionManager::new();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
+        let horizon = mgr.compute_gc_horizon();
+        let snap = mgr.current_snapshot().unwrap();
+        assert_eq!(horizon, snap.xmin_active);
+        assert_eq!(horizon, 2);
+    }
+
+    #[test]
+    fn gc_horizon_advances_across_committed_transactions() {
+        // Two committed transactions then no active: horizon = 3.
+        let (catalog, tables) = empty_catalog_and_tables();
+        let mut mgr = TransactionManager::new();
+        for _ in 0..2 {
+            mgr.begin_transaction(&catalog, &tables).unwrap();
+            mgr.commit_transaction().unwrap();
+        }
+        assert_eq!(mgr.compute_gc_horizon(), 3);
+    }
+
+    #[test]
+    fn gc_horizon_held_back_by_oldest_active_reader() {
+        // Two transactions committed, then a third starts and stays active.
+        // Horizon must be that third's `xmin_active`, not advance past it.
+        let (catalog, tables) = empty_catalog_and_tables();
+        let mut mgr = TransactionManager::new();
+        for _ in 0..2 {
+            mgr.begin_transaction(&catalog, &tables).unwrap();
+            mgr.commit_transaction().unwrap();
+        }
+        // Third txn begins (txn_id = 3), and stays active.
+        mgr.begin_transaction(&catalog, &tables).unwrap();
+        let horizon = mgr.compute_gc_horizon();
+        // Snapshot's xmin_active = txn_id + 1 = 4 under single-writer
+        // self-write widening (#5207).
+        assert_eq!(horizon, 4);
     }
 }

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -1274,6 +1274,90 @@ impl Table {
         self.indexes.rebuild(&self.schema, &self.rows);
     }
 
+    /// MVCC garbage collection: physically remove row versions whose
+    /// deletion is committed and provably invisible to every active
+    /// reader.
+    ///
+    /// # Phase 1d follow-up (#5208)
+    ///
+    /// Walks every row currently in storage and, for any row whose
+    /// `xmax = Some(t)` with `t < horizon`, marks it for bitmap
+    /// deletion. `horizon` is computed by
+    /// [`TransactionManager::compute_gc_horizon`] — see its docs for
+    /// the meaning of "horizon."
+    ///
+    /// **What does NOT count as reclaimable:**
+    /// - Rows with `xmax = None` (still live) — never removed by GC.
+    /// - Rows with `xmax = Some(t)` where `t >= horizon` — some active
+    ///   or future reader may still need to see this row, so we leave
+    ///   it alone.
+    /// - Rows already in the deletion bitmap — counted as "already
+    ///   reclaimed."
+    ///
+    /// **Off-state (`mvcc_enabled` feature OFF):** this method is still
+    /// callable, but rows constructed by the executor have
+    /// `xmax = None` in the off-state, so the sweep finds nothing and
+    /// returns 0. Calling this is therefore harmless when MVCC is
+    /// disabled — useful for keeping the public API surface stable
+    /// across feature configurations.
+    ///
+    /// # Returns
+    ///
+    /// The number of rows newly marked deletable by this call. If that
+    /// crossed the compaction threshold (> 50% deleted), the underlying
+    /// row vector is compacted before returning, and the
+    /// [`DeleteResult::compacted`] bit is implicit in the caller's
+    /// follow-up: the caller should call
+    /// [`Database::rebuild_indexes`] on the table when this returns
+    /// non-zero, to keep user-defined B-tree indexes in sync.
+    ///
+    /// # Performance
+    ///
+    /// O(n) scan over physical rows. There is no incremental
+    /// bookkeeping — v1 GC is a single sweep. Future phases can add
+    /// per-table "needs-GC" flags / smaller per-page sweeps.
+    ///
+    /// [`TransactionManager::compute_gc_horizon`]: crate::database::transactions::TransactionManager::compute_gc_horizon
+    /// [`Database::rebuild_indexes`]: crate::Database
+    /// [`DeleteResult::compacted`]: crate::table::DeleteResult
+    pub fn gc_old_versions(&mut self, horizon: crate::row::TxnId) -> usize {
+        // Off-state: no row in the off-state carries an xmax stamp
+        // (the executor's `stamp_xmax_for_write` is a no-op when the
+        // feature is off), so the sweep predicate would find nothing.
+        // Short-circuit to skip the iteration entirely; this keeps the
+        // public API surface stable while paying zero cost when MVCC
+        // is compiled out.
+        if !cfg!(feature = "mvcc_enabled") {
+            let _ = horizon;
+            return 0;
+        }
+
+        // PRE_MVCC_TXN_ID (= 0) is the "no deleter / always committed"
+        // sentinel. The horizon is always >= 1 in any non-empty manager
+        // (next_transaction_id starts at 1), so the strict `<` check
+        // below treats sentinel-stamped deletes (which shouldn't happen
+        // in practice) as not-reclaimable — defensive against bizarre
+        // states.
+        let mut indices_to_gc: Vec<usize> = Vec::new();
+        for (idx, row) in self.rows.iter().enumerate() {
+            if self.deleted[idx] {
+                continue;
+            }
+            if let Some(xmax) = row.xmax {
+                if xmax != crate::row::PRE_MVCC_TXN_ID && xmax < horizon {
+                    indices_to_gc.push(idx);
+                }
+            }
+        }
+
+        if indices_to_gc.is_empty() {
+            return 0;
+        }
+
+        let result = self.delete_by_indices(&indices_to_gc);
+        result.deleted_count
+    }
+
     /// Check if a row at the given index is deleted
     #[inline]
     pub fn is_deleted(&self, idx: usize) -> bool {
@@ -1581,5 +1665,108 @@ mod tests {
         assert_eq!(pk_index.get(&vec![SqlValue::Integer(2)]), Some(&1));
         assert_eq!(pk_index.get(&vec![SqlValue::Integer(3)]), Some(&2));
         assert_eq!(pk_index.get(&vec![SqlValue::Integer(4)]), Some(&3));
+    }
+
+    // ========================================================================
+    // GC tests (#5208 — MVCC Phase 1d follow-up)
+    // ========================================================================
+
+    #[test]
+    fn gc_off_state_returns_zero() {
+        // Off-state: no rows carry an xmax stamp, so GC has nothing to do.
+        // The early-return in `gc_old_versions` should fire and report 0.
+        let mut table = create_test_table();
+        table.insert(create_row(1, "Alice")).unwrap();
+        table.insert(create_row(2, "Bob")).unwrap();
+        let reclaimed = table.gc_old_versions(100);
+        assert_eq!(reclaimed, 0);
+        // No rows should have been removed.
+        assert_eq!(table.row_count(), 2);
+    }
+
+    #[cfg(feature = "mvcc_enabled")]
+    #[test]
+    fn gc_reclaims_only_rows_with_xmax_below_horizon() {
+        // Three rows: one with xmax = 5 (committed before horizon),
+        // one with xmax = 10 (still in horizon — must be retained),
+        // one with xmax = None (live — must be retained).
+        let mut table = create_test_table();
+        table.insert(create_row(1, "Alice")).unwrap();
+        table.insert(create_row(2, "Bob")).unwrap();
+        table.insert(create_row(3, "Charlie")).unwrap();
+
+        // Stamp xmax directly on the underlying rows to simulate
+        // Phase 1c's UPDATE/DELETE having stamped tombstones.
+        table.stamp_row_xmax_inplace(0, 5);
+        table.stamp_row_xmax_inplace(1, 10);
+        // Row 2 left with xmax = None.
+
+        let reclaimed = table.gc_old_versions(8);
+        // Only row 0 (xmax = 5 < horizon = 8) should have been reclaimed.
+        assert_eq!(reclaimed, 1);
+        // The other two should still be present (one tombstoned, one live).
+        assert_eq!(table.row_count(), 2);
+    }
+
+    #[cfg(feature = "mvcc_enabled")]
+    #[test]
+    fn gc_reclaims_nothing_when_horizon_is_zero() {
+        // Horizon = 0 means "no reader can possibly be done with anything"
+        // — every committed deletion must be retained. The strict `<`
+        // comparison combined with the sentinel check guarantees nothing
+        // is reclaimed even if a row was somehow stamped with xmax = 0
+        // (which would be a bug; the sentinel means "no deleter").
+        let mut table = create_test_table();
+        table.insert(create_row(1, "Alice")).unwrap();
+        table.stamp_row_xmax_inplace(0, 5);
+
+        let reclaimed = table.gc_old_versions(0);
+        assert_eq!(reclaimed, 0);
+        assert_eq!(table.row_count(), 1);
+    }
+
+    #[cfg(feature = "mvcc_enabled")]
+    #[test]
+    fn gc_skips_rows_already_in_deletion_bitmap() {
+        // Row 0 is in the bitmap from a prior DELETE; row 1 has xmax
+        // stamped but no bitmap mark (the deferred case Phase 1e will
+        // produce). GC should reclaim row 1 only.
+        let mut table = create_test_table();
+        table.insert(create_row(1, "Alice")).unwrap();
+        table.insert(create_row(2, "Bob")).unwrap();
+        // Bitmap-delete row 0 the "normal" way (also stamps it in the
+        // index manager, so PK lookup is consistent).
+        let _ = table.delete_by_indices(&[0]);
+        // Row 1: stamp tombstone but don't bitmap-delete.
+        table.stamp_row_xmax_inplace(1, 4);
+
+        let reclaimed = table.gc_old_versions(10);
+        // Row 0 was already deleted — not counted again. Row 1 is now
+        // bitmap-deleted by GC.
+        assert_eq!(reclaimed, 1);
+        // Both physical slots are now in the deletion bitmap; row_count
+        // (live rows) is 0.
+        assert_eq!(table.row_count(), 0);
+    }
+
+    #[cfg(feature = "mvcc_enabled")]
+    #[test]
+    fn gc_respects_horizon_boundary() {
+        // Boundary: xmax == horizon is NOT reclaimed (only strictly less).
+        // This matches the semantics of `xmin_active`: a row whose
+        // deleter id equals an active reader's xmin_active could still
+        // be in that reader's snapshot under some future visibility
+        // rule, so we err on the side of retaining it.
+        let mut table = create_test_table();
+        table.insert(create_row(1, "Alice")).unwrap();
+        table.stamp_row_xmax_inplace(0, 7);
+
+        // Horizon == 7: row is NOT reclaimed.
+        let reclaimed = table.gc_old_versions(7);
+        assert_eq!(reclaimed, 0);
+
+        // Horizon == 8: row IS reclaimed.
+        let reclaimed = table.gc_old_versions(8);
+        assert_eq!(reclaimed, 1);
     }
 }


### PR DESCRIPTION
## Summary

Phase 1d follow-up of #5136 — adds the minimum-viable GC primitive for MVCC tombstones so the storage layer can reclaim provably-invisible row versions on demand.

Closes #5208.

### What this adds

- **`TransactionManager::compute_gc_horizon`** — the lowest `TxnId` that is still potentially needed by any active reader. Under single-writer this is either the active txn's `snapshot.xmin_active` (if a txn is active) or `next_transaction_id` (if not). Multi-writer becomes `min(xmin_active across all active txns)` at the same callsite — signature unchanged.
- **`Table::gc_old_versions(horizon)`** — sweeps the table for rows whose `xmax = Some(t)` with `t < horizon` and bitmap-deletes them via the existing `delete_by_indices` primitive. Off-state (`mvcc_enabled` OFF) short-circuits to zero because no row carries an `xmax` stamp.
- **`Database::vacuum_mvcc()`** — the on-demand entry point. Refuses to run while a transaction is active (v1 deliberately does not mix GC with in-flight writes), iterates every table, rebuilds user-defined B-tree indexes for any table whose physical layout shifted, and returns the total count reclaimed.

### Scope / non-goals

This is the "minimum viable GC" called out in the issue body:

- **No automatic triggering.** No WAL-checkpoint hook, no background task, no row-count threshold trigger. Callers invoke `vacuum_mvcc()` explicitly.
- **No deferred bitmap-delete-on-write.** Today's MVCC DELETE both stamps `xmax` AND bitmap-deletes the row, so the GC sweep mostly operates on hand-stamped state in tests. The primitive is in place for Phase 1e to defer the bitmap-delete; nothing in this PR changes the write path.
- **No concurrent/incremental GC.** A single full sweep across all tables; future phases can add per-page sweeps and incremental bookkeeping.

### Off-state preservation

Verified that with `mvcc_enabled = OFF` (the default):
- `vacuum_mvcc()` returns `Ok(0)` immediately without iterating tables.
- `Table::gc_old_versions(horizon)` short-circuits to zero before scanning.
- Every existing test still passes (640 lib tests, identical to main).

### Test coverage

| Layer | Tests added |
|---|---|
| `TransactionManager` | 5 `gc_horizon_*` tests |
| `Table` | 5 `gc_*` tests (1 off-state, 4 mvcc_enabled-gated) |
| `Database` | 6 `vacuum_mvcc_*` tests (3 off-state, 3 mvcc_enabled-gated) |

All 16 new tests pass under both feature configurations.

## Test plan

- [x] `cargo test -p vibesql-storage --lib` — 640 passed
- [x] `cargo test -p vibesql-storage --lib --features mvcc_enabled` — 648 passed (8 extra from feature-gated tests)
- [x] `cargo test -p vibesql-executor --lib` — 2395 passed (no executor regressions)
- [x] `cargo build --workspace` — clean (no new warnings)
- [x] `cargo clippy -p vibesql-storage --lib` — no new warnings (25 → 25)