### PR TITLE
feat(mvcc): thread visibility filter through DML read sites (#5205)

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -269,6 +269,12 @@ impl DeleteExecutor {
             .get_table(table_name)
             .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
 
+        // Phase 1d follow-up (#5205): capture the active MVCC snapshot
+        // once so both the PK fast path and the WHERE-clause scan agree
+        // on visibility. Off-state collapses to the pre-MVCC live-row
+        // filter; the snapshot argument is ignored by the storage layer.
+        let snapshot = crate::mvcc::read_snapshot(database);
+
         // Execute CTEs if present (WITH clause support)
         let cte_results = if let Some(ref cte_list) = stmt.with_clause {
             Some(crate::select::cte::execute_ctes(cte_list, |cte_query, prior_ctes| {
@@ -337,9 +343,15 @@ impl DeleteExecutor {
 
                     if let Some(pk_index) = table.primary_key_index() {
                         if let Some(&row_index) = pk_index.get(&pk_values) {
-                            // Found the row via index - single row to delete
-                            rows_and_indices_to_delete
-                                .push((row_index, table.scan()[row_index].clone()));
+                            // Phase 1d follow-up (#5205): the PK fast
+                            // path must honor MVCC visibility — a row
+                            // whose xmax is committed under our snapshot
+                            // must not be picked for DELETE. Off-state
+                            // collapses to a deletion-bitmap check.
+                            if table.is_row_visible(row_index, &snapshot) {
+                                rows_and_indices_to_delete
+                                    .push((row_index, table.scan()[row_index].clone()));
+                            }
                         }
                         // If not found, rows_and_indices_to_delete stays empty (no rows to delete)
                     } else {
@@ -349,6 +361,7 @@ impl DeleteExecutor {
                             &stmt.where_clause,
                             &mut evaluator,
                             &mut rows_and_indices_to_delete,
+                            &snapshot,
                         )?;
                     }
                 } else {
@@ -358,6 +371,7 @@ impl DeleteExecutor {
                         &stmt.where_clause,
                         &mut evaluator,
                         &mut rows_and_indices_to_delete,
+                        &snapshot,
                     )?;
                 }
             } else {
@@ -367,6 +381,7 @@ impl DeleteExecutor {
                     &stmt.where_clause,
                     &mut evaluator,
                     &mut rows_and_indices_to_delete,
+                    &snapshot,
                 )?;
             }
         } else {
@@ -376,6 +391,7 @@ impl DeleteExecutor {
                 &stmt.where_clause,
                 &mut evaluator,
                 &mut rows_and_indices_to_delete,
+                &snapshot,
             )?;
         }
 
@@ -694,15 +710,19 @@ impl DeleteExecutor {
         }
     }
 
-    /// Collect rows using table scan (fallback when PK optimization can't be used)
+    /// Collect rows using table scan (fallback when PK optimization can't be used).
+    ///
+    /// Phase 1d follow-up (#5205): uses `scan_visible(snapshot)` so the
+    /// WHERE-clause scan honors MVCC visibility. Off-state reduces to
+    /// `scan_live` (deletion-bitmap filter), preserving pre-MVCC semantics.
     fn collect_rows_with_scan(
         table: &vibesql_storage::Table,
         where_clause: &Option<vibesql_ast::WhereClause>,
         evaluator: &mut ExpressionEvaluator,
         rows_and_indices: &mut Vec<(usize, vibesql_storage::Row)>,
+        snapshot: &vibesql_storage::TxnSnapshot,
     ) -> Result<(), ExecutorError> {
-        // Use scan_live() to skip already-deleted rows
-        for (index, row) in table.scan_live() {
+        for (index, row) in table.scan_visible(snapshot) {
             // Clear CSE cache before evaluating each row to prevent column values
             // from being incorrectly cached across different rows
             evaluator.clear_cse_cache();

--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -60,6 +60,14 @@ pub fn check_no_child_references(
     let session_defer = db.defer_foreign_keys();
     let in_txn = db.in_transaction();
 
+    // Phase 1d follow-up (#5205): capture the active snapshot once so
+    // every child-reference scan in this DELETE path sees a consistent
+    // MVCC view. With the `mvcc_enabled` feature OFF, `scan_visible`
+    // reduces to `scan_live` (deleted-bitmap filter only) and the
+    // snapshot is unused — behavior is bit-for-bit identical to the
+    // previous `scan_live()` callers.
+    let snapshot = crate::mvcc::read_snapshot(db);
+
     // Collect all child tables that reference this parent row
     // We need to collect first to avoid borrowing issues when we mutate.
     //
@@ -110,10 +118,12 @@ pub fn check_no_child_references(
             let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
 
             // Check if any row in the child table references this parent
-            // row's FK-target columns. Use scan_live() to skip
-            // soft-deleted rows.
+            // row's FK-target columns. Phase 1d follow-up (#5205): use
+            // `scan_visible(&snapshot)` so the MVCC visibility filter
+            // applies. With MVCC OFF, this reduces to `scan_live` and
+            // behavior is unchanged.
             let child_table = db.get_table(&table_name).unwrap();
-            let has_references = child_table.scan_live().any(|(_, child_row)| {
+            let has_references = child_table.scan_visible(&snapshot).any(|(_, child_row)| {
                 let child_fk_values: Vec<SqlValue> =
                     fk.column_indices.iter().map(|&idx| child_row.values[idx].clone()).collect();
 
@@ -213,6 +223,10 @@ fn queue_orphaned_children(
     // inside the scan loop only sees the child table (#5147).
     let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
 
+    // Phase 1d follow-up (#5205): respect MVCC visibility when
+    // identifying orphaned children. Off-state collapses to scan_live.
+    let snapshot = crate::mvcc::read_snapshot(db);
+
     // Snapshot the orphaned child rows first to release the immutable
     // borrow before queueing (which mutates the transaction state).
     let orphaned: Vec<Vec<SqlValue>> = {
@@ -221,7 +235,7 @@ fn queue_orphaned_children(
             None => return,
         };
         child_table
-            .scan_live()
+            .scan_visible(&snapshot)
             .filter_map(|(_, child_row)| {
                 let child_fk_values: Vec<SqlValue> =
                     fk.column_indices.iter().map(|&idx| child_row.values[idx].clone()).collect();
@@ -267,11 +281,15 @@ fn cascade_delete(
     // FK comparisons honor NOCASE/RTRIM (#5147).
     let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
 
-    // Find rows to delete (use scan_live to skip soft-deleted rows)
+    // Phase 1d follow-up (#5205): respect MVCC visibility when picking
+    // CASCADE-delete targets. Off-state collapses to scan_live.
+    let snapshot = crate::mvcc::read_snapshot(db);
+
+    // Find rows to delete (visibility-filtered).
     let child_table = db.get_table(child_table_name).unwrap();
     let mut rows_to_delete: Vec<vibesql_storage::Row> = Vec::new();
 
-    for (_, child_row) in child_table.scan_live() {
+    for (_, child_row) in child_table.scan_visible(&snapshot) {
         let child_fk_values: Vec<SqlValue> =
             fk.column_indices.iter().map(|&idx| child_row.values[idx].clone()).collect();
 
@@ -334,12 +352,15 @@ fn set_null(
     // FK comparisons honor NOCASE/RTRIM (#5147).
     let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
 
-    // Collect indices of rows to update
+    // Phase 1d follow-up (#5205): respect MVCC visibility when picking
+    // SET NULL targets. Off-state collapses to scan_live.
+    let snapshot = crate::mvcc::read_snapshot(db);
+
+    // Collect indices of rows to update.
     let child_table = db.get_table(child_table_name).unwrap();
     let mut rows_to_update: Vec<(usize, vibesql_storage::Row)> = Vec::new();
 
-    // Use scan_live() to skip deleted rows and get correct physical indices
-    for (idx, child_row) in child_table.scan_live() {
+    for (idx, child_row) in child_table.scan_visible(&snapshot) {
         let child_fk_values: Vec<SqlValue> =
             fk.column_indices.iter().map(|&idx| child_row.values[idx].clone()).collect();
 
@@ -429,12 +450,15 @@ fn set_default(
     // FK comparisons honor NOCASE/RTRIM (#5147).
     let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
 
-    // Collect indices of rows to update
+    // Phase 1d follow-up (#5205): respect MVCC visibility when picking
+    // SET DEFAULT targets. Off-state collapses to scan_live.
+    let snapshot = crate::mvcc::read_snapshot(db);
+
+    // Collect indices of rows to update.
     let child_table = db.get_table(child_table_name).unwrap();
     let mut rows_to_update: Vec<(usize, vibesql_storage::Row)> = Vec::new();
 
-    // Use scan_live() to skip deleted rows and get correct physical indices
-    for (idx, child_row) in child_table.scan_live() {
+    for (idx, child_row) in child_table.scan_visible(&snapshot) {
         let child_fk_values: Vec<SqlValue> =
             fk.column_indices.iter().map(|&idx| child_row.values[idx].clone()).collect();
 

--- a/crates/vibesql-executor/src/foreign_key_check.rs
+++ b/crates/vibesql-executor/src/foreign_key_check.rs
@@ -335,18 +335,49 @@ pub(crate) fn check_fk_row_existence(
     let parent_indices = resolved_parent_indices_for_fk(db, fk);
 
     // Step 4: parent-table existence scan.
-    let key_exists = parent_table.scan().iter().any(|parent_row| {
-        parent_indices.iter().zip(fk_values).enumerate().all(
-            |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
-                Some(parent_val) => fk_values_equal(
-                    fk_val,
-                    parent_val,
-                    parent_collations.get(i).and_then(|c| c.as_deref()),
-                ),
-                None => false,
-            },
-        )
-    });
+    //
+    // Phase 1d follow-up (#5205): under MVCC the parent-existence check
+    // must respect the active snapshot — an INSERT on the child must not
+    // "see" a parent row inserted by an uncommitted concurrent
+    // transaction (it would otherwise let the child slip past FK
+    // enforcement only to be orphaned at the other side's rollback).
+    // Off-state (`mvcc_enabled` OFF): the previous code scanned every
+    // physical row via `scan()` (including bitmap-deleted ones); we
+    // preserve that exactly with `#[cfg]`-gated branches.
+    let snapshot = crate::mvcc::read_snapshot(db);
+    let key_exists = {
+        #[cfg(feature = "mvcc_enabled")]
+        {
+            parent_table.scan_visible(&snapshot).any(|(_, parent_row)| {
+                parent_indices.iter().zip(fk_values).enumerate().all(
+                    |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+                        Some(parent_val) => fk_values_equal(
+                            fk_val,
+                            parent_val,
+                            parent_collations.get(i).and_then(|c| c.as_deref()),
+                        ),
+                        None => false,
+                    },
+                )
+            })
+        }
+        #[cfg(not(feature = "mvcc_enabled"))]
+        {
+            let _ = &snapshot;
+            parent_table.scan().iter().any(|parent_row| {
+                parent_indices.iter().zip(fk_values).enumerate().all(
+                    |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+                        Some(parent_val) => fk_values_equal(
+                            fk_val,
+                            parent_val,
+                            parent_collations.get(i).and_then(|c| c.as_deref()),
+                        ),
+                        None => false,
+                    },
+                )
+            })
+        }
+    };
     if key_exists {
         return Ok(FkRowCheck::Ok);
     }

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -189,9 +189,15 @@ pub(super) fn execute_internal(
         );
     }
 
-    // Step 4: Select rows to update using RowSelector
+    // Step 4: Select rows to update using RowSelector.
+    //
+    // Phase 1d follow-up (#5205): thread the active MVCC snapshot into
+    // row selection so the WHERE-clause scan + PK fast path honor
+    // visibility. Off-state collapses to the pre-MVCC live-row filter.
+    let snapshot = crate::mvcc::read_snapshot(database);
     let row_selector = RowSelector::new(schema);
-    let candidate_rows = row_selector.select_rows(table, &stmt.where_clause, &mut evaluator)?;
+    let candidate_rows =
+        row_selector.select_rows(table, &stmt.where_clause, &mut evaluator, &snapshot)?;
 
     // Estimate DML cost for query analysis and optimization decisions
     if std::env::var("DML_COST_DEBUG").is_ok() && !candidate_rows.is_empty() {

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -68,18 +68,50 @@ impl ForeignKeyValidator {
             let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
             let parent_indices = crate::foreign_key_check::resolved_parent_indices_for_fk(db, fk);
 
-            let key_exists = parent_table.scan().iter().any(|parent_row| {
-                parent_indices.iter().zip(&fk_values).enumerate().all(
-                    |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
-                        Some(parent_val) => crate::foreign_key_check::fk_values_equal(
-                            fk_val,
-                            parent_val,
-                            parent_collations.get(i).and_then(|c| c.as_deref()),
-                        ),
-                        None => false,
-                    },
-                )
-            });
+            // Phase 1d follow-up (#5205): the parent-existence check on
+            // the UPDATE path must honor MVCC visibility for the same
+            // reason as INSERT — an uncommitted concurrent INSERT on the
+            // parent must not satisfy this child's FK. Off-state
+            // (`mvcc_enabled` OFF) preserves the previous `scan().iter()`
+            // semantics (including bitmap-deleted physical rows).
+            let snapshot = crate::mvcc::read_snapshot(db);
+            let key_exists = {
+                #[cfg(feature = "mvcc_enabled")]
+                {
+                    parent_table.scan_visible(&snapshot).any(|(_, parent_row)| {
+                        parent_indices.iter().zip(&fk_values).enumerate().all(
+                            |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+                                Some(parent_val) => {
+                                    crate::foreign_key_check::fk_values_equal(
+                                        fk_val,
+                                        parent_val,
+                                        parent_collations.get(i).and_then(|c| c.as_deref()),
+                                    )
+                                }
+                                None => false,
+                            },
+                        )
+                    })
+                }
+                #[cfg(not(feature = "mvcc_enabled"))]
+                {
+                    let _ = &snapshot;
+                    parent_table.scan().iter().any(|parent_row| {
+                        parent_indices.iter().zip(&fk_values).enumerate().all(
+                            |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+                                Some(parent_val) => {
+                                    crate::foreign_key_check::fk_values_equal(
+                                        fk_val,
+                                        parent_val,
+                                        parent_collations.get(i).and_then(|c| c.as_deref()),
+                                    )
+                                }
+                                None => false,
+                            },
+                        )
+                    })
+                }
+            };
 
             if key_exists {
                 continue;
@@ -191,37 +223,67 @@ impl ForeignKeyValidator {
                 let parent_collations =
                     crate::foreign_key_check::parent_collations_for_fk(db, fk);
 
-                // Get the child table and find matching rows
+                // Get the child table and find matching rows.
+                //
+                // Phase 1d follow-up (#5205): the child-reference scan
+                // must respect MVCC visibility. A child row that has been
+                // deleted by a concurrent committed transaction must not
+                // count as "referencing" the parent under our snapshot.
+                // Equally, our own in-txn child writes participate via
+                // the widened BEGIN-time snapshot (#5223). Off-state
+                // (`mvcc_enabled` OFF) preserves the pre-MVCC behavior of
+                // walking every physical row via `scan().iter()`.
+                let snapshot = crate::mvcc::read_snapshot(db);
                 let child_table = db.get_table(&table_name).unwrap();
-                let matching_rows: Vec<(usize, vibesql_storage::Row)> = child_table
-                    .scan()
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(idx, child_row)| {
-                        let child_fk_values: Vec<vibesql_types::SqlValue> = fk
-                            .column_indices
+                let matches_fk = |child_row: &vibesql_storage::Row| -> bool {
+                    let child_fk_values: Vec<vibesql_types::SqlValue> = fk
+                        .column_indices
+                        .iter()
+                        .map(|&col_idx| child_row.values[col_idx].clone())
+                        .collect();
+                    child_fk_values
+                        .iter()
+                        .zip(&old_parent_key_values)
+                        .enumerate()
+                        .all(|(i, (cv, pv))| {
+                            crate::foreign_key_check::fk_values_equal(
+                                cv,
+                                pv,
+                                parent_collations.get(i).and_then(|c| c.as_deref()),
+                            )
+                        })
+                };
+                let matching_rows: Vec<(usize, vibesql_storage::Row)> = {
+                    #[cfg(feature = "mvcc_enabled")]
+                    {
+                        child_table
+                            .scan_visible(&snapshot)
+                            .filter_map(|(idx, child_row)| {
+                                if matches_fk(child_row) {
+                                    Some((idx, child_row.clone()))
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect()
+                    }
+                    #[cfg(not(feature = "mvcc_enabled"))]
+                    {
+                        let _ = &snapshot;
+                        child_table
+                            .scan()
                             .iter()
-                            .map(|&col_idx| child_row.values[col_idx].clone())
-                            .collect();
-
-                        let matches = child_fk_values
-                            .iter()
-                            .zip(&old_parent_key_values)
                             .enumerate()
-                            .all(|(i, (cv, pv))| {
-                                crate::foreign_key_check::fk_values_equal(
-                                    cv,
-                                    pv,
-                                    parent_collations.get(i).and_then(|c| c.as_deref()),
-                                )
-                            });
-                        if matches {
-                            Some((idx, child_row.clone()))
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
+                            .filter_map(|(idx, child_row)| {
+                                if matches_fk(child_row) {
+                                    Some((idx, child_row.clone()))
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect()
+                    }
+                };
 
                 if !matching_rows.is_empty() {
                     // Check the referential action

--- a/crates/vibesql-executor/src/update/row_selector.rs
+++ b/crates/vibesql-executor/src/update/row_selector.rs
@@ -1,6 +1,7 @@
 //! Row selection logic for UPDATE operations
 
 use vibesql_ast::{BinaryOperator, Expression};
+use vibesql_storage::TxnSnapshot;
 use vibesql_types::SqlValue;
 
 use crate::{
@@ -21,14 +22,19 @@ impl<'a> RowSelector<'a> {
         Self { schema }
     }
 
-    /// Select rows to update based on WHERE clause
+    /// Select rows to update based on WHERE clause.
     ///
-    /// Uses primary key index optimization when possible, otherwise falls back to table scan.
+    /// Uses primary key index optimization when possible, otherwise falls back
+    /// to table scan. Both paths honor the MVCC `snapshot`: the PK fast path
+    /// calls `Table::is_row_visible` and the fallback scan uses
+    /// `Table::scan_visible`. With `mvcc_enabled` OFF, both reduce to the
+    /// pre-MVCC live-row check.
     pub fn select_rows(
         &self,
         table: &vibesql_storage::Table,
         where_clause: &Option<vibesql_ast::WhereClause>,
         evaluator: &mut ExpressionEvaluator,
+        snapshot: &TxnSnapshot,
     ) -> Result<Vec<(usize, vibesql_storage::Row)>, ExecutorError> {
         // Try to use primary key index for fast lookup
         if let Some(vibesql_ast::WhereClause::Condition(where_expr)) = where_clause {
@@ -55,6 +61,14 @@ impl<'a> RowSelector<'a> {
                 // Use primary key index for O(1) lookup
                 if let Some(pk_index) = table.primary_key_index() {
                     if let Some(&row_index) = pk_index.get(&pk_values) {
+                        // Phase 1d follow-up (#5205): the PK fast path must
+                        // honor MVCC visibility — a row whose xmax is
+                        // committed (tombstone) under our snapshot must not
+                        // be selected for UPDATE. Off-state collapses to a
+                        // deletion-bitmap check.
+                        if !table.is_row_visible(row_index, snapshot) {
+                            return Ok(vec![]);
+                        }
                         // Found the row via index - single row to update
                         // Clone and set row_id for ROWID pseudo-column support
                         let mut cloned_row = table.scan()[row_index].clone();
@@ -72,7 +86,7 @@ impl<'a> RowSelector<'a> {
         }
 
         // Fall back to table scan
-        Self::collect_candidate_rows(table, where_clause, evaluator)
+        Self::collect_candidate_rows(table, where_clause, evaluator, snapshot)
     }
 
     /// Analyze WHERE expression to see if it can use primary key index for fast lookup
@@ -201,16 +215,20 @@ impl<'a> RowSelector<'a> {
         }
     }
 
-    /// Collect candidate rows that match the WHERE clause (fallback for non-indexed queries)
+    /// Collect candidate rows that match the WHERE clause (fallback for non-indexed queries).
+    ///
+    /// Phase 1d follow-up (#5205): uses `scan_visible(snapshot)` so the
+    /// WHERE-clause scan honors MVCC visibility. Off-state reduces to
+    /// `scan_live` (deletion-bitmap filter), preserving pre-MVCC semantics.
     fn collect_candidate_rows(
         table: &vibesql_storage::Table,
         where_clause: &Option<vibesql_ast::WhereClause>,
         evaluator: &mut ExpressionEvaluator,
+        snapshot: &TxnSnapshot,
     ) -> Result<Vec<(usize, vibesql_storage::Row)>, ExecutorError> {
         let mut candidate_rows = Vec::new();
 
-        // Use scan_live() to skip deleted rows and get correct physical indices
-        for (row_index, row) in table.scan_live() {
+        for (row_index, row) in table.scan_visible(snapshot) {
             // Clear CSE cache before evaluating each row to prevent column values
             // from being incorrectly cached across different rows
             evaluator.clear_cse_cache();

--- a/crates/vibesql-executor/tests/mvcc_dml_visibility_tests.rs
+++ b/crates/vibesql-executor/tests/mvcc_dml_visibility_tests.rs
@@ -1,0 +1,392 @@
+//! Integration tests for Phase 1d follow-up (#5205 of #5136):
+//! extending `Row::visible_to` filtering to the read sites embedded in
+//! INSERT / UPDATE / DELETE.
+//!
+//! The contract these tests pin down:
+//!
+//! - **FK parent-existence checks** (INSERT/UPDATE): when MVCC is ON, a
+//!   parent row that is tombstoned from our snapshot's perspective must
+//!   not be treated as a valid parent for a new child row.
+//! - **FK child-reference scans** (DELETE/UPDATE): when MVCC is ON, a
+//!   child row that has been tombstoned must not be treated as a
+//!   referencing row that would block parent deletion / parent key
+//!   update.
+//! - **UPDATE/DELETE row selection**: the WHERE-clause scan + PK fast
+//!   path must honor MVCC visibility. A row that has been deleted (and
+//!   tombstoned) must not be re-picked by a subsequent UPDATE/DELETE.
+//!
+//! Off-state (`mvcc_enabled` OFF): the visibility predicate collapses to
+//! the deletion-bitmap check, so every test must continue to pass with
+//! identical semantics. On-state contracts that *require* the
+//! visibility filter to fire are gated behind
+//! `#[cfg(feature = "mvcc_enabled")]`.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p vibesql-executor --test mvcc_dml_visibility_tests
+//! cargo test -p vibesql-executor --test mvcc_dml_visibility_tests --features mvcc_enabled
+//! ```
+
+use vibesql_ast::{SelectStmt, Statement};
+use vibesql_executor::{
+    BeginTransactionExecutor, CommitExecutor, CreateTableExecutor, DeleteExecutor, InsertExecutor,
+    SelectExecutor, UpdateExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn exec(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).expect("UPDATE failed");
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).expect("DELETE failed");
+        }
+        Statement::BeginTransaction(s) => {
+            BeginTransactionExecutor::execute(&s, db).expect("BEGIN failed");
+        }
+        Statement::Commit(s) => {
+            CommitExecutor::execute(&s, db).expect("COMMIT failed");
+        }
+        other => panic!("unsupported statement in test helper: {:?}", other),
+    }
+}
+
+fn enable_fks(db: &mut Database) {
+    db.set_foreign_keys_enabled(true);
+}
+
+fn try_exec(db: &mut Database, sql: &str) -> Result<(), String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("{:?}", e))?;
+    match stmt {
+        Statement::Insert(s) => InsertExecutor::execute(db, &s)
+            .map(|_| ())
+            .map_err(|e| format!("{:?}", e)),
+        Statement::Update(s) => UpdateExecutor::execute(&s, db)
+            .map(|_| ())
+            .map_err(|e| format!("{:?}", e)),
+        Statement::Delete(s) => DeleteExecutor::execute(&s, db)
+            .map(|_| ())
+            .map_err(|e| format!("{:?}", e)),
+        other => panic!("try_exec only supports INSERT/UPDATE/DELETE, got {:?}", other),
+    }
+}
+
+fn select(db: &mut Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    let select_stmt: SelectStmt = match stmt {
+        Statement::Select(s) => *s,
+        other => panic!("expected SELECT, got {:?}", other),
+    };
+    let executor = SelectExecutor::new(db);
+    let rows = executor.execute(&select_stmt).expect("SELECT failed");
+    rows.into_iter().map(|r| r.values.to_vec()).collect()
+}
+
+// ============================================================================
+// Off-state baseline: each of these tests must pass without the feature
+// flag too, because off-state semantics are by contract bit-for-bit
+// identical to pre-MVCC.
+// ============================================================================
+
+#[test]
+fn insert_fk_parent_existing_row_passes() {
+    // Smoke: a child INSERT with a matching pre-MVCC parent must succeed.
+    let mut db = Database::new();
+    enable_fks(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY, name TEXT)");
+    exec(&mut db, "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id))");
+    exec(&mut db, "INSERT INTO parent VALUES (1, 'alpha')");
+    try_exec(&mut db, "INSERT INTO child VALUES (10, 1)").expect("child insert should succeed");
+    let rows = select(&mut db, "SELECT id FROM child WHERE pid = 1");
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn insert_fk_parent_missing_row_fails() {
+    // Smoke: a child INSERT against a missing parent must fail.
+    let mut db = Database::new();
+    enable_fks(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY, name TEXT)");
+    exec(&mut db, "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id))");
+    let err = try_exec(&mut db, "INSERT INTO child VALUES (10, 99)")
+        .expect_err("missing parent must reject child");
+    assert!(err.contains("FOREIGN KEY"), "got error: {err}");
+}
+
+#[test]
+fn delete_parent_with_no_children_succeeds() {
+    // Smoke: parent DELETE with no referencing child rows must succeed.
+    let mut db = Database::new();
+    enable_fks(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY, name TEXT)");
+    exec(&mut db, "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id))");
+    exec(&mut db, "INSERT INTO parent VALUES (1, 'alpha')");
+    try_exec(&mut db, "DELETE FROM parent WHERE id = 1").expect("delete should succeed");
+    let rows = select(&mut db, "SELECT COUNT(*) FROM parent");
+    assert_eq!(rows[0][0], SqlValue::Integer(0));
+}
+
+#[test]
+fn delete_parent_with_orphan_child_blocked() {
+    // Smoke: parent DELETE with a referencing child row must fail
+    // (NO ACTION is the default and not deferred outside a txn).
+    let mut db = Database::new();
+    enable_fks(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY, name TEXT)");
+    exec(&mut db, "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id))");
+    exec(&mut db, "INSERT INTO parent VALUES (1, 'alpha')");
+    exec(&mut db, "INSERT INTO child VALUES (10, 1)");
+    let err = try_exec(&mut db, "DELETE FROM parent WHERE id = 1")
+        .expect_err("referenced parent must not be deletable");
+    assert!(err.contains("FOREIGN KEY"), "got error: {err}");
+}
+
+#[test]
+fn delete_parent_succeeds_after_child_deleted() {
+    // After deleting the child row, the parent must become deletable.
+    // The DELETE child-reference scan must treat the tombstoned child
+    // as "absent" for FK purposes — this is the off-state regression
+    // guard.
+    let mut db = Database::new();
+    enable_fks(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY, name TEXT)");
+    exec(&mut db, "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id))");
+    exec(&mut db, "INSERT INTO parent VALUES (1, 'alpha')");
+    exec(&mut db, "INSERT INTO child VALUES (10, 1)");
+    exec(&mut db, "DELETE FROM child WHERE id = 10");
+    try_exec(&mut db, "DELETE FROM parent WHERE id = 1")
+        .expect("parent should be deletable after child gone");
+}
+
+#[test]
+fn update_picks_only_live_rows() {
+    // Smoke: UPDATE WHERE matching a row that was already deleted
+    // returns zero rows updated (the row is tombstoned).
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE items (id INTEGER PRIMARY KEY, qty INTEGER)");
+    exec(&mut db, "INSERT INTO items VALUES (1, 10)");
+    exec(&mut db, "INSERT INTO items VALUES (2, 20)");
+    exec(&mut db, "DELETE FROM items WHERE id = 1");
+    try_exec(&mut db, "UPDATE items SET qty = 99 WHERE id = 1").expect("update zero rows is ok");
+    // Row 2 still at its original value.
+    let rows = select(&mut db, "SELECT qty FROM items WHERE id = 2");
+    assert_eq!(rows[0][0], SqlValue::Integer(20));
+    let count = select(&mut db, "SELECT COUNT(*) FROM items");
+    assert_eq!(count[0][0], SqlValue::Integer(1));
+}
+
+#[test]
+fn delete_picks_only_live_rows() {
+    // Smoke: DELETE WHERE matching a row that was already deleted is a
+    // no-op.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE items (id INTEGER PRIMARY KEY, qty INTEGER)");
+    exec(&mut db, "INSERT INTO items VALUES (1, 10)");
+    exec(&mut db, "DELETE FROM items WHERE id = 1");
+    try_exec(&mut db, "DELETE FROM items WHERE id = 1").expect("second delete is no-op");
+    let count = select(&mut db, "SELECT COUNT(*) FROM items");
+    assert_eq!(count[0][0], SqlValue::Integer(0));
+}
+
+#[test]
+fn cascade_delete_in_autocommit_still_works() {
+    // ON DELETE CASCADE must continue to wipe children in autocommit
+    // mode under both feature states (off-state regression guard for
+    // the cascade path's scan_live → scan_visible switch).
+    let mut db = Database::new();
+    enable_fks(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+    exec(
+        &mut db,
+        "CREATE TABLE child (
+            id INTEGER PRIMARY KEY,
+            pid INTEGER REFERENCES parent(id) ON DELETE CASCADE
+        )",
+    );
+    exec(&mut db, "INSERT INTO parent VALUES (1)");
+    exec(&mut db, "INSERT INTO child VALUES (10, 1)");
+    exec(&mut db, "INSERT INTO child VALUES (11, 1)");
+    try_exec(&mut db, "DELETE FROM parent WHERE id = 1").expect("cascade delete should succeed");
+    let count = select(&mut db, "SELECT COUNT(*) FROM child");
+    assert_eq!(count[0][0], SqlValue::Integer(0));
+}
+
+#[test]
+fn set_null_in_autocommit_still_works() {
+    // ON DELETE SET NULL must wipe child FK columns (off-state guard
+    // for the set_null scan_live → scan_visible switch).
+    let mut db = Database::new();
+    enable_fks(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+    exec(
+        &mut db,
+        "CREATE TABLE child (
+            id INTEGER PRIMARY KEY,
+            pid INTEGER REFERENCES parent(id) ON DELETE SET NULL
+        )",
+    );
+    exec(&mut db, "INSERT INTO parent VALUES (1)");
+    exec(&mut db, "INSERT INTO child VALUES (10, 1)");
+    try_exec(&mut db, "DELETE FROM parent WHERE id = 1").expect("set-null delete should succeed");
+    let rows = select(&mut db, "SELECT pid FROM child WHERE id = 10");
+    assert_eq!(rows[0][0], SqlValue::Null);
+}
+
+// ============================================================================
+// On-state: visibility filter actually fires inside DML.
+//
+// Acceptance criterion from the issue body:
+//   "With mvcc_enabled ON: integration test demonstrating an UPDATE
+//    inside a transaction respects snapshot-isolation when computing
+//    its WHERE clause."
+// ============================================================================
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn update_in_txn_where_clause_sees_pre_mvcc_rows() {
+    // Pre-MVCC rows (xmin = sentinel) must remain selectable by a
+    // WHERE clause from inside a transaction — the visibility filter
+    // must not drop them on the floor.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE items (id INTEGER PRIMARY KEY, qty INTEGER)");
+    for i in 1..=5 {
+        exec(&mut db, &format!("INSERT INTO items VALUES ({i}, {i})"));
+    }
+
+    exec(&mut db, "BEGIN");
+    try_exec(&mut db, "UPDATE items SET qty = 100 WHERE id BETWEEN 2 AND 4")
+        .expect("update should succeed");
+    // Reads inside the same txn see the updated rows (#5223 widening).
+    let rows = select(&mut db, "SELECT qty FROM items WHERE id = 3");
+    assert_eq!(rows[0][0], SqlValue::Integer(100));
+    exec(&mut db, "COMMIT");
+
+    let rows = select(&mut db, "SELECT qty FROM items WHERE id = 3");
+    assert_eq!(rows[0][0], SqlValue::Integer(100));
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn update_in_txn_skips_already_deleted_row() {
+    // Inside a transaction, an UPDATE WHERE that targets a row deleted
+    // earlier in the same txn must affect zero rows — see-your-own-deletes
+    // semantics under the widened BEGIN snapshot (#5223).
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE items (id INTEGER PRIMARY KEY, qty INTEGER)");
+    exec(&mut db, "INSERT INTO items VALUES (1, 10)");
+    exec(&mut db, "INSERT INTO items VALUES (2, 20)");
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "DELETE FROM items WHERE id = 1");
+    // The deleted row must not be selectable for UPDATE anymore.
+    try_exec(&mut db, "UPDATE items SET qty = 99 WHERE id = 1").expect("zero-row update ok");
+    let rows = select(&mut db, "SELECT COUNT(*) FROM items WHERE qty = 99");
+    assert_eq!(rows[0][0], SqlValue::Integer(0), "no row should have qty=99");
+    exec(&mut db, "COMMIT");
+
+    let rows = select(&mut db, "SELECT COUNT(*) FROM items");
+    assert_eq!(rows[0][0], SqlValue::Integer(1));
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn delete_in_txn_skips_already_deleted_row() {
+    // Same contract as the UPDATE case but for the DELETE path's PK
+    // fast path + WHERE scan.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE items (id INTEGER PRIMARY KEY, qty INTEGER)");
+    exec(&mut db, "INSERT INTO items VALUES (1, 10)");
+    exec(&mut db, "INSERT INTO items VALUES (2, 20)");
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "DELETE FROM items WHERE id = 1");
+    // The deleted row's PK must not be re-selected by a second DELETE
+    // (no error, just zero rows affected).
+    try_exec(&mut db, "DELETE FROM items WHERE id = 1").expect("idempotent delete is ok");
+    exec(&mut db, "COMMIT");
+
+    let rows = select(&mut db, "SELECT COUNT(*) FROM items");
+    assert_eq!(rows[0][0], SqlValue::Integer(1));
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn fk_parent_existence_check_in_txn_sees_self_insert() {
+    // A child INSERT inside the same transaction must see a parent
+    // INSERTed earlier in the same transaction — the FK parent-existence
+    // scan flows through the BEGIN-time snapshot widened in #5223.
+    let mut db = Database::new();
+    enable_fks(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+    exec(&mut db, "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id))");
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "INSERT INTO parent VALUES (42)");
+    try_exec(&mut db, "INSERT INTO child VALUES (1, 42)")
+        .expect("child should see parent inserted in same txn");
+    exec(&mut db, "COMMIT");
+
+    let rows = select(&mut db, "SELECT pid FROM child WHERE id = 1");
+    assert_eq!(rows[0][0], SqlValue::Integer(42));
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn fk_parent_existence_check_after_self_delete() {
+    // Inside a transaction: INSERT a parent, DELETE it, then attempt to
+    // INSERT a child referencing the (now-tombstoned) parent. The child
+    // INSERT must fail because the parent is no longer visible to the
+    // txn's own snapshot.
+    let mut db = Database::new();
+    enable_fks(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+    exec(&mut db, "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id))");
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "INSERT INTO parent VALUES (7)");
+    exec(&mut db, "DELETE FROM parent WHERE id = 7");
+    // The parent row is now tombstoned from this txn's snapshot.
+    let err = try_exec(&mut db, "INSERT INTO child VALUES (1, 7)")
+        .expect_err("child must not see tombstoned parent");
+    assert!(err.contains("FOREIGN KEY"), "got error: {err}");
+    // Cleanup: rollback to keep the test self-contained.
+    exec(&mut db, "COMMIT");
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn delete_parent_in_txn_after_child_deleted_in_same_txn() {
+    // Inside a transaction: DELETE the only child row, then DELETE the
+    // parent. The parent's NO ACTION child-reference scan must treat
+    // the tombstoned child as absent under the widened BEGIN snapshot,
+    // so the parent DELETE succeeds.
+    let mut db = Database::new();
+    enable_fks(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+    exec(&mut db, "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id))");
+    exec(&mut db, "INSERT INTO parent VALUES (1)");
+    exec(&mut db, "INSERT INTO child VALUES (10, 1)");
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "DELETE FROM child WHERE id = 10");
+    try_exec(&mut db, "DELETE FROM parent WHERE id = 1")
+        .expect("parent must be deletable after child gone in same txn");
+    exec(&mut db, "COMMIT");
+
+    let pcount = select(&mut db, "SELECT COUNT(*) FROM parent");
+    assert_eq!(pcount[0][0], SqlValue::Integer(0));
+}


### PR DESCRIPTION
## Summary

Phase 1d follow-up of #5136 (Closes #5205). PR #5222 wired `Row::visible_to` into the SELECT scan boundary (index scans, PK fast path, UNIQUE constraint scans). PR #5223 widened the autocommit / BEGIN-time snapshots so reads see prior commits and the txn's own writes. This PR extends the visibility filter into the read sites embedded inside INSERT / UPDATE / DELETE.

## Read sites visibility-filtered

- **`foreign_key_check::check_fk_row_existence`** — the parent-existence scan shared by the bulk-transfer FK validator and the `RowValidator` now uses `scan_visible(&snapshot)`. With `mvcc_enabled` OFF the previous `scan().iter()` semantics are preserved exactly via `#[cfg]` gating.
- **`update/foreign_keys::collect_constraints`** — UPDATE parent-existence check now flows through `scan_visible`.
- **`update/foreign_keys::check_no_child_references`** — the child-reference scan that drives CASCADE/SET NULL/SET DEFAULT/RESTRICT/NO ACTION now uses `scan_visible`.
- **`delete/integrity` helpers** — every `scan_live()` call site in `cascade_delete` / `set_null` / `set_default` / `queue_orphaned_children` / `check_no_child_references` switched to `scan_visible(&snapshot)`. With MVCC OFF, `scan_visible` collapses to `scan_live` so off-state behavior is bit-for-bit identical.
- **`update/row_selector::select_rows`** — the PK fast path consults `Table::is_row_visible`; the fallback scan uses `scan_visible`. The signature gained a `&TxnSnapshot` parameter; the caller (`update/executor`) threads `read_snapshot(database)`.
- **`delete/executor`** — the PK fast path now visibility-checks the matched row index; `collect_rows_with_scan` switched from `scan_live` to `scan_visible`. Snapshot captured once and reused across PK lookup / scan fallback / ORDER BY scan.

The pattern is the one established by #5151 / #5222: capture `crate::mvcc::read_snapshot(db)` at the top of the read region, then use `scan_visible(&snapshot)` / `is_row_visible(idx, &snapshot)` at every chokepoint.

## Tests

New file `crates/vibesql-executor/tests/mvcc_dml_visibility_tests.rs` with 15 tests:

- **9 off-state regression guards** (always-run): FK parent-existence passes/fails, parent DELETE blocked by orphan, parent DELETE succeeds after child deleted, UPDATE/DELETE pick only live rows, CASCADE/SET NULL still work in autocommit.
- **6 on-state visibility tests** (gated on `mvcc_enabled`):
  - UPDATE WHERE inside a txn sees pre-MVCC rows (the issue's primary acceptance criterion).
  - UPDATE/DELETE WHERE inside a txn skip rows already deleted in the same txn (#5223 see-your-own-writes).
  - FK parent-existence inside a txn sees parents the txn itself inserted.
  - FK parent-existence inside a txn rejects children for a parent the txn already deleted.
  - Parent DELETE succeeds inside a txn after the only child was deleted in the same txn.

## Test plan

- [x] `cargo test --lib -p vibesql-executor` — 2395 passed, 0 failed
- [x] `cargo test --lib -p vibesql-executor --features mvcc_enabled` — 2395 passed, 0 failed
- [x] `cargo test -p vibesql-executor` (all integration tests) — 3552 passed, 0 failed
- [x] `cargo test -p vibesql-executor --features mvcc_enabled` — 3568 passed, 0 failed
- [x] `cargo test --lib --workspace` — clean both feature states
- [x] Targeted FK and MVCC integration tests pass both feature states

Closes #5205

🤖 Generated with [Claude Code](https://claude.com/claude-code)