### PR TITLE
feat(mvcc): enable SIMD/columnar fast paths under mvcc_enabled

### DIFF
--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -573,23 +573,41 @@ pub(crate) fn execute_table_scan(
                     );
                 }
 
-                // Phase 1d of #5136: SIMD/columnar fast paths bypass per-row
-                // visibility checks. When the MVCC feature is OFF this is fine
-                // — visibility is a no-op. When ON, fall through to the
-                // row-based path which honors `visible_to` per row. Tracked
-                // in the follow-up "MVCC + SIMD columnar fast path"
-                // optimization issue.
-                #[cfg(not(feature = "mvcc_enabled"))]
-                let mvcc_on = false;
-                #[cfg(feature = "mvcc_enabled")]
-                let mvcc_on = true;
+                // Phase 1d of #5136: SIMD/columnar fast paths originally
+                // bypassed per-row visibility checks. PR #5209 gated them to
+                // MVCC-OFF only as a conservative first step. Issue #5206
+                // (this code) re-enables them under MVCC-ON by applying a
+                // post-SIMD `is_row_visible` filter — Approach A from the
+                // issue. A follow-up tracks Approach B (pre-computed
+                // visibility bitmap ANDed into the SIMD predicate mask),
+                // which removes the post-filter pass entirely.
+                //
+                // Snapshot is captured here so both fast paths share it; with
+                // the `mvcc_enabled` feature OFF this reduces to the cheap
+                // bitmap-only check inside `Table::is_row_visible` and the
+                // snapshot is unused.
+                let snapshot = crate::mvcc::read_snapshot(database);
 
                 // For native columnar tables, use SIMD filtering on typed columns
-                // This avoids SqlValue overhead by working directly on i64/f64/String arrays
-                if !mvcc_on
-                    && table.is_native_columnar()
-                    && all_rows.len() >= SIMD_COLUMNAR_THRESHOLD
-                {
+                // This avoids SqlValue overhead by working directly on i64/f64/String arrays.
+                //
+                // MVCC safety (Issue #5206): the `native_columnar` mirror
+                // holds exactly the bitmap-live rows — INSERT appends to it,
+                // DELETE/UPDATE bitmap-deletes trigger a rebuild that excludes
+                // tombstoned rows, and ROLLBACK restores the BEGIN-time table
+                // clone (including the mirror). Under the current single-writer
+                // transaction model every bitmap-live row is visible to the
+                // active reader's snapshot: own-txn writes are visible (#5223),
+                // and any other writer must have committed before this
+                // reader's snapshot was captured. So this path needs no
+                // per-row visibility post-filter to match the row-by-row
+                // path's output. NOTE: if concurrent writers are ever
+                // introduced, this argument breaks and the post-filter from
+                // `filter_with_cached_columnar` must be applied here too
+                // (the rows materialized by `ColumnarTable::to_rows` carry
+                // the always-visible pre-MVCC sentinel, so they cannot be
+                // re-checked after materialization).
+                if table.is_native_columnar() && all_rows.len() >= SIMD_COLUMNAR_THRESHOLD {
                     if let Ok(mut filtered_rows) =
                         filter_with_simd_columnar(table, &column_predicates)
                     {
@@ -612,12 +630,20 @@ pub(crate) fn execute_table_scan(
                 // For row-oriented tables, use cached columnar filter with late materialization
                 // Issue #4136: Use database columnar cache for SIMD filtering, clone only passing
                 // rows
-                if !mvcc_on && all_rows.len() >= SIMD_COLUMNAR_THRESHOLD {
+                //
+                // Issue #5206: under MVCC-ON, `filter_with_cached_columnar`
+                // applies `Table::is_row_visible(idx, &snapshot)` as a
+                // post-SIMD filter so that rows tombstoned by concurrent
+                // writers or written by uncommitted/future txns are not
+                // surfaced through the columnar fast path.
+                if all_rows.len() >= SIMD_COLUMNAR_THRESHOLD {
                     if let Ok(mut filtered_rows) = filter_with_cached_columnar(
                         database,
+                        table,
                         table_name,
                         all_rows,
                         &column_predicates,
+                        &snapshot,
                     ) {
                         // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
                         if order_by.is_none() {
@@ -644,7 +670,8 @@ pub(crate) fn execute_table_scan(
                 // Issue #4370: Preserve row_id for ROWID pseudo-column support
                 // Issue #4536: Preserve explicit row_id from INSERT INTO t(rowid, ...) VALUES(...)
                 // Phase 1d of #5136: also apply MVCC visibility when feature is on.
-                let snapshot = crate::mvcc::read_snapshot(database);
+                // Issue #5206: snapshot is already captured above (shared with the
+                // columnar fast paths) so we just reuse it here.
                 let mut filtered_rows: Vec<_> = indices
                     .into_iter()
                     .filter(|&idx| table.is_row_visible(idx, &snapshot))
@@ -800,16 +827,36 @@ fn filter_with_simd_columnar(
 /// - New: Filter on columnar (cached), clone only 150K passing = 150K clones
 /// - Expected: 5x reduction in memory allocation overhead
 ///
+/// # MVCC visibility (Issue #5206)
+///
+/// When the `mvcc_enabled` feature is ON, SIMD/columnar filtering on its
+/// own would surface rows that should be hidden from `snapshot` (rows
+/// created by uncommitted/future txns, or tombstoned by a concurrent
+/// writer). To stay correct, this function applies
+/// [`Table::is_row_visible`](vibesql_storage::Table::is_row_visible) as a
+/// post-SIMD filter on the indices that pass the predicate evaluation.
+/// This is Approach A from issue #5206; a follow-up tracks the more
+/// invasive Approach B (pre-computed visibility bitmap ANDed into the
+/// SIMD predicate mask, removing the post-filter pass entirely).
+///
+/// With the feature OFF, `Table::is_row_visible` collapses to the
+/// existing not-deletion-bitmap-tombstoned check, so behavior is
+/// identical to pre-MVCC.
+///
 /// # Arguments
 /// * `database` - Database containing the columnar cache
+/// * `table` - Table reference for `is_row_visible` lookups
 /// * `table_name` - Name of the table (for cache lookup)
 /// * `live_rows` - Reference to live rows (already collected but not yet cloned into result)
 /// * `predicates` - Column predicates for SIMD filtering
+/// * `snapshot` - MVCC snapshot for visibility filtering (ignored under `mvcc_enabled = OFF`)
 fn filter_with_cached_columnar(
     database: &vibesql_storage::Database,
+    table: &vibesql_storage::Table,
     table_name: &str,
     live_rows: &[vibesql_storage::Row],
     predicates: &[ColumnPredicate],
+    snapshot: &vibesql_storage::TxnSnapshot,
 ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
     // Step 1: Get cached columnar data from database
     // This uses the LRU columnar cache - if cached, this is O(1) Arc clone
@@ -862,8 +909,16 @@ fn filter_with_cached_columnar(
     // This is the payoff - we only clone passing_indices.len() rows instead of all rows
     // Issue #4370: Preserve row_id for ROWID pseudo-column support
     // Issue #4536: Preserve explicit row_id from INSERT INTO t(rowid, ...) VALUES(...)
+    // Issue #5206: Apply MVCC visibility as a post-SIMD filter (Approach A).
+    //
+    // The Step-2 invariant (`batch.row_count() == live_rows.len()`) plus the
+    // fact that `live_rows` is `table.scan()` in physical order means that
+    // each index produced by SIMD is also a valid physical row index for
+    // `table.is_row_visible`. With `mvcc_enabled` OFF, `is_row_visible`
+    // reduces to the not-deletion-bitmap-tombstoned check (cheap).
     let filtered_rows: Vec<vibesql_storage::Row> = passing_indices
         .into_iter()
+        .filter(|&idx| table.is_row_visible(idx, snapshot))
         .filter_map(|idx| {
             live_rows.get(idx).map(|row| {
                 let mut cloned = row.clone();

--- a/crates/vibesql-executor/tests/mvcc_simd_columnar_visibility_tests.rs
+++ b/crates/vibesql-executor/tests/mvcc_simd_columnar_visibility_tests.rs
@@ -1,0 +1,363 @@
+//! Issue #5206: SIMD/columnar fast-path visibility under MVCC.
+//!
+//! Phase 1d (#5151) of #5136 gated the SIMD/columnar fast paths in
+//! `select::scan::table` to MVCC-OFF only, because the original fast
+//! paths bypassed `Row::visible_to` and would surface rows that the
+//! current snapshot must not see (uncommitted/future-txn writes, or
+//! tombstones from a concurrent writer).
+//!
+//! Issue #5206 re-enables these fast paths under `mvcc_enabled = ON` by
+//! applying an `is_row_visible` post-filter on the SIMD-passing indices
+//! (Approach A from the issue). These tests pin that behavior.
+//!
+//! ## Why the table is sized at ≥500 rows
+//!
+//! The columnar fast paths are gated by `SIMD_COLUMNAR_THRESHOLD = 500`
+//! in `select::scan::table`. Below that, the row-by-row path is used
+//! (which has always honored visibility). To exercise the SIMD-cached
+//! columnar path, every test must populate enough live rows to cross
+//! that threshold.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p vibesql-executor --test mvcc_simd_columnar_visibility_tests
+//! cargo test -p vibesql-executor --test mvcc_simd_columnar_visibility_tests --features mvcc_enabled
+//! ```
+
+use vibesql_ast::{SelectStmt, Statement};
+use vibesql_executor::{
+    BeginTransactionExecutor, CommitExecutor, CreateTableExecutor, DeleteExecutor, InsertExecutor,
+    SelectExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Cross this to engage the SIMD/cached-columnar fast path in
+/// `select::scan::table::execute_table_scan`.
+const SIMD_THRESHOLD: usize = 500;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn exec(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).expect("DELETE failed");
+        }
+        Statement::BeginTransaction(s) => {
+            BeginTransactionExecutor::execute(&s, db).expect("BEGIN failed");
+        }
+        Statement::Commit(s) => {
+            CommitExecutor::execute(&s, db).expect("COMMIT failed");
+        }
+        other => panic!("unsupported statement in test helper: {:?}", other),
+    }
+}
+
+fn select(db: &mut Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    let select_stmt: SelectStmt = match stmt {
+        Statement::Select(s) => *s,
+        other => panic!("expected SELECT, got {:?}", other),
+    };
+    let executor = SelectExecutor::new(db);
+    let rows = executor.execute(&select_stmt).expect("SELECT failed");
+    rows.into_iter().map(|r| r.values.to_vec()).collect()
+}
+
+/// Build a database with a `metrics(id INTEGER PRIMARY KEY, bucket INTEGER, value INTEGER)`
+/// table holding `count` pre-MVCC rows. Each row has:
+///   - `id = i` (1..=count)
+///   - `bucket = i % 10`
+///   - `value = i * 2`
+///
+/// `count` should be ≥ `SIMD_THRESHOLD` so subsequent SELECTs engage the
+/// columnar fast path.
+fn db_with_metrics(count: usize) -> Database {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE metrics (id INTEGER PRIMARY KEY, bucket INTEGER, value INTEGER)");
+    for i in 1..=count {
+        let sql = format!("INSERT INTO metrics VALUES ({}, {}, {})", i, i % 10, i * 2);
+        exec(&mut db, &sql);
+    }
+    db
+}
+
+/// Same shape as [`db_with_metrics`], but the table uses **native columnar
+/// storage** (`STORAGE = COLUMNAR`). This exercises the
+/// `filter_with_simd_columnar` fast path in `select::scan::table` (the
+/// `is_native_columnar()` branch) instead of the cached-columnar path.
+fn db_with_columnar_metrics(count: usize) -> Database {
+    let mut db = Database::new();
+    exec(
+        &mut db,
+        "CREATE TABLE metrics (id INTEGER PRIMARY KEY, bucket INTEGER, value INTEGER) STORAGE = COLUMNAR",
+    );
+    for i in 1..=count {
+        let sql = format!("INSERT INTO metrics VALUES ({}, {}, {})", i, i % 10, i * 2);
+        exec(&mut db, &sql);
+    }
+    db
+}
+
+// ============================================================================
+// Off-state + on-state common: the columnar fast path returns the same
+// results as the row-by-row path on pre-MVCC data. This is the safety
+// net for both feature states.
+// ============================================================================
+
+#[test]
+fn columnar_fast_path_filter_returns_correct_rows_on_pre_mvcc_data() {
+    // Populate enough rows to trip the SIMD threshold.
+    let row_count = SIMD_THRESHOLD * 2; // 1000
+    let mut db = db_with_metrics(row_count);
+
+    // WHERE bucket = 3 should match exactly one tenth of rows.
+    let rows = select(&mut db, "SELECT id FROM metrics WHERE bucket = 3");
+    assert_eq!(
+        rows.len(),
+        row_count / 10,
+        "columnar fast path must return all pre-MVCC rows matching the predicate"
+    );
+
+    // All ids should satisfy id % 10 == 3.
+    for r in &rows {
+        match r[0] {
+            SqlValue::Integer(id) => assert_eq!(id % 10, 3, "id={}", id),
+            ref other => panic!("expected Integer id, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn columnar_fast_path_respects_deletion_bitmap() {
+    // Pre-existing semantics: the bitmap-deleted rows must never be
+    // surfaced even by the columnar fast path. This is enforced by
+    // `Table::is_row_visible` (which is now applied as a post-filter
+    // under MVCC-ON, and was always the contract under MVCC-OFF via
+    // `scan_columnar`'s deletion filtering).
+    let row_count = SIMD_THRESHOLD * 2; // 1000
+    let mut db = db_with_metrics(row_count);
+
+    // Delete all rows in bucket 3 (= 100 rows).
+    exec(&mut db, "DELETE FROM metrics WHERE bucket = 3");
+
+    // SELECT on bucket 3 must now return zero rows.
+    let rows = select(&mut db, "SELECT id FROM metrics WHERE bucket = 3");
+    assert_eq!(rows.len(), 0, "deleted rows must not be visible through the columnar fast path");
+
+    // And bucket 4 should still return its full share.
+    let rows = select(&mut db, "SELECT id FROM metrics WHERE bucket = 4");
+    assert_eq!(rows.len(), row_count / 10);
+}
+
+// ============================================================================
+// On-state: transactional inserts/deletes are observed correctly through
+// the columnar fast path. These checks are only assertable when
+// `Row::visible_to` is actually consulted — i.e., under
+// `mvcc_enabled = ON`. Under MVCC-OFF, the inner snapshot argument is
+// inert and the assertions still hold because `is_row_visible` reduces
+// to the deletion-bitmap check.
+// ============================================================================
+
+#[test]
+fn columnar_fast_path_sees_committed_transactional_insert() {
+    // Insert ≥ SIMD_THRESHOLD pre-MVCC rows, then commit a transactional
+    // INSERT that adds one more matching row. After commit, the autocommit
+    // SELECT (which now synthesizes a commit-time snapshot — fix from
+    // #5207) must see the new row through the columnar fast path.
+    let row_count = SIMD_THRESHOLD * 2; // 1000
+    let mut db = db_with_metrics(row_count);
+
+    // Baseline: bucket 7 has 100 rows.
+    let baseline = select(&mut db, "SELECT id FROM metrics WHERE bucket = 7");
+    assert_eq!(baseline.len(), row_count / 10);
+
+    // Commit a transactional INSERT that matches bucket = 7.
+    let new_id = (row_count + 7) as i64; // 1007 -> bucket = 7
+    exec(&mut db, "BEGIN");
+    exec(&mut db, &format!("INSERT INTO metrics VALUES ({}, 7, {})", new_id, new_id * 2));
+    exec(&mut db, "COMMIT");
+
+    let after = select(&mut db, "SELECT id FROM metrics WHERE bucket = 7");
+    assert_eq!(
+        after.len(),
+        baseline.len() + 1,
+        "columnar fast path must see the committed transactional insert"
+    );
+    let ids: Vec<i64> = after
+        .iter()
+        .map(|r| match r[0] {
+            SqlValue::Integer(v) => v,
+            ref other => panic!("expected Integer, got {:?}", other),
+        })
+        .collect();
+    assert!(ids.contains(&new_id));
+}
+
+#[test]
+fn columnar_fast_path_hides_rows_tombstoned_by_committed_delete() {
+    // Issue #5206 invariant: a committed DELETE inside a txn must hide
+    // its rows from subsequent autocommit reads going through the
+    // columnar fast path. Without the post-SIMD `is_row_visible` filter
+    // this would silently expose tombstoned rows.
+    let row_count = SIMD_THRESHOLD * 2;
+    let mut db = db_with_metrics(row_count);
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "DELETE FROM metrics WHERE bucket = 5");
+    exec(&mut db, "COMMIT");
+
+    let after = select(&mut db, "SELECT id FROM metrics WHERE bucket = 5");
+    assert_eq!(
+        after.len(),
+        0,
+        "columnar fast path must hide rows tombstoned by a committed transactional DELETE"
+    );
+
+    // Sanity: rows in other buckets are unaffected.
+    let other = select(&mut db, "SELECT id FROM metrics WHERE bucket = 6");
+    assert_eq!(other.len(), row_count / 10);
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn columnar_fast_path_in_txn_sees_pre_begin_data() {
+    // Snapshot-isolation foundation: a txn's BEGIN-time snapshot must
+    // observe every pre-MVCC row through the columnar fast path. This is
+    // the cross-feature invariant — if it ever broke, every analytical
+    // query inside a transaction would silently start returning empty.
+    let row_count = SIMD_THRESHOLD * 2;
+    let mut db = db_with_metrics(row_count);
+
+    exec(&mut db, "BEGIN");
+    let rows = select(&mut db, "SELECT id FROM metrics WHERE bucket = 2");
+    assert_eq!(
+        rows.len(),
+        row_count / 10,
+        "txn snapshot must see all pre-MVCC rows through the columnar fast path"
+    );
+    exec(&mut db, "COMMIT");
+}
+
+// ============================================================================
+// Native columnar storage (`STORAGE = COLUMNAR`): the
+// `filter_with_simd_columnar` fast path. The `native_columnar` mirror
+// holds exactly the bitmap-live rows (inserts append, deletes rebuild,
+// rollback restores the BEGIN-time clone), and under the single-writer
+// model every bitmap-live row is visible to the active reader — so this
+// path runs unfiltered under MVCC-ON. These tests pin that equivalence
+// with the row-by-row path.
+// ============================================================================
+
+#[test]
+fn native_columnar_fast_path_filter_returns_correct_rows() {
+    let row_count = SIMD_THRESHOLD * 2; // 1000
+    let mut db = db_with_columnar_metrics(row_count);
+
+    let rows = select(&mut db, "SELECT id FROM metrics WHERE bucket = 3");
+    assert_eq!(
+        rows.len(),
+        row_count / 10,
+        "native columnar fast path must return all rows matching the predicate"
+    );
+    for r in &rows {
+        match r[0] {
+            SqlValue::Integer(id) => assert_eq!(id % 10, 3, "id={}", id),
+            ref other => panic!("expected Integer id, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn native_columnar_fast_path_sees_committed_transactional_insert() {
+    let row_count = SIMD_THRESHOLD * 2;
+    let mut db = db_with_columnar_metrics(row_count);
+
+    let baseline = select(&mut db, "SELECT id FROM metrics WHERE bucket = 7");
+    assert_eq!(baseline.len(), row_count / 10);
+
+    let new_id = (row_count + 7) as i64; // bucket = 7
+    exec(&mut db, "BEGIN");
+    exec(&mut db, &format!("INSERT INTO metrics VALUES ({}, 7, {})", new_id, new_id * 2));
+    exec(&mut db, "COMMIT");
+
+    let after = select(&mut db, "SELECT id FROM metrics WHERE bucket = 7");
+    assert_eq!(
+        after.len(),
+        baseline.len() + 1,
+        "native columnar fast path must see the committed transactional insert"
+    );
+}
+
+#[test]
+fn native_columnar_fast_path_hides_rows_deleted_in_committed_txn() {
+    let row_count = SIMD_THRESHOLD * 2;
+    let mut db = db_with_columnar_metrics(row_count);
+
+    exec(&mut db, "BEGIN");
+    exec(&mut db, "DELETE FROM metrics WHERE bucket = 5");
+    exec(&mut db, "COMMIT");
+
+    let after = select(&mut db, "SELECT id FROM metrics WHERE bucket = 5");
+    assert_eq!(
+        after.len(),
+        0,
+        "native columnar fast path must hide rows deleted by a committed transactional DELETE"
+    );
+
+    let other = select(&mut db, "SELECT id FROM metrics WHERE bucket = 6");
+    assert_eq!(other.len(), row_count / 10);
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn native_columnar_fast_path_sees_own_txn_insert() {
+    let row_count = SIMD_THRESHOLD * 2;
+    let mut db = db_with_columnar_metrics(row_count);
+
+    exec(&mut db, "BEGIN");
+    let new_id = (row_count + 9) as i64; // bucket = 9
+    exec(&mut db, &format!("INSERT INTO metrics VALUES ({}, 9, {})", new_id, new_id * 2));
+
+    let in_txn = select(&mut db, "SELECT id FROM metrics WHERE bucket = 9");
+    assert_eq!(
+        in_txn.len(),
+        row_count / 10 + 1,
+        "txn must see its own INSERT through the native columnar fast path"
+    );
+
+    exec(&mut db, "COMMIT");
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn columnar_fast_path_sees_own_txn_insert() {
+    // #5207 + #5206: a txn must see its own writes in subsequent reads.
+    // Exercise that through the columnar fast path by inserting > 0
+    // matching rows inside a txn and then SELECTing within the same txn.
+    let row_count = SIMD_THRESHOLD * 2;
+    let mut db = db_with_metrics(row_count);
+
+    exec(&mut db, "BEGIN");
+    let new_id = (row_count + 9) as i64; // bucket = 9
+    exec(&mut db, &format!("INSERT INTO metrics VALUES ({}, 9, {})", new_id, new_id * 2));
+
+    let in_txn = select(&mut db, "SELECT id FROM metrics WHERE bucket = 9");
+    assert_eq!(
+        in_txn.len(),
+        row_count / 10 + 1,
+        "txn must see its own INSERT through the columnar fast path"
+    );
+
+    exec(&mut db, "COMMIT");
+}


### PR DESCRIPTION
Closes #5206

## Summary

Phase 1d (#5151) conservatively gated the SIMD-columnar and cached-columnar fast paths in `execute_table_scan` to MVCC-OFF because they bypassed per-row visibility checks. This PR re-enables them under `mvcc_enabled` using **Approach A** from the issue (per-row visibility post-filter on SIMD-passing indices):

- `filter_with_cached_columnar` now takes the table and MVCC snapshot and applies `Table::is_row_visible(idx, &snapshot)` as a post-SIMD filter on passing indices. The Step-2 invariant (`batch.row_count() == live_rows.len()`, physical scan order) guarantees the SIMD indices are valid physical row indices for visibility lookup. With the feature OFF, `is_row_visible` reduces to the existing deletion-bitmap check, so MVCC-OFF behavior and performance are unchanged.
- The native-columnar (`STORAGE = COLUMNAR`) path runs unfiltered: the `native_columnar` mirror holds exactly the bitmap-live rows (inserts append, deletes trigger rebuild, rollback restores the BEGIN-time clone), and under the current single-writer transaction model every bitmap-live row is visible to the active reader's snapshot. This argument is documented inline with an explicit warning for if concurrent writers are ever introduced.
- The snapshot is captured once at the scan boundary and shared by the fast paths and the row-by-row fallback.

Approach B (pre-computed visibility bitmap ANDed into the SIMD predicate selection vector) is left as a follow-up optimization.

## Tests

New integration suite `crates/vibesql-executor/tests/mvcc_simd_columnar_visibility_tests.rs` pins visibility semantics through both fast paths (tables sized above `SIMD_COLUMNAR_THRESHOLD = 500` to actually engage them):

- predicate correctness on pre-MVCC data (both paths)
- deletion-bitmap rows stay hidden
- committed transactional INSERT becomes visible
- committed transactional DELETE tombstones stay hidden
- (mvcc_enabled only) in-txn snapshot sees pre-BEGIN data; txn sees its own INSERT through both fast paths

## Validation

- `cargo test --workspace --lib --release` — green (637/637 storage, 2395/2395 executor, all other crates pass)
- `cargo test --features vibesql-executor/mvcc_enabled --workspace --lib --release` — green
- `cargo test --release -p vibesql-executor --test mvcc_simd_columnar_visibility_tests` — 7/7 pass
- same with `--features mvcc_enabled` — 10/10 pass
- `cargo fmt --check -p vibesql-executor` — clean

## Pre-existing issues (not addressed here)

- `vibesql-storage::persistence::tests::json_persistence::test_json_datetime_alias_behavior` is flaky under parallel runs: it writes to the hardcoded shared path `/tmp/test_datetime_alias.json` and races with concurrent test processes. Passes in isolation and in the final full run.
- `cargo clippy --tests` denies `clippy::approx_constant` at `crates/vibesql-executor/src/evaluator/expressions/operators.rs:339` (literal `-3.14`) — pre-existing on main, file untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)