### PR TITLE
feat(parser): accept TEMP/TEMPORARY modifier on CREATE TRIGGER

### DIFF
--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -195,14 +195,21 @@ impl Parser {
                 } else if self.peek_next_keyword(Keyword::Temp)
                     || self.peek_next_keyword(Keyword::Temporary)
                 {
-                    // CREATE TEMP TABLE or CREATE TEMP VIEW / CREATE TEMPORARY TABLE or VIEW
-                    // Check offset 2 to determine if it's TABLE or VIEW
+                    // CREATE TEMP/TEMPORARY followed by TABLE, TRIGGER, or VIEW
+                    // Check offset 2 to determine which object kind follows the modifier
                     if matches!(
                         self.peek_at_offset(2),
                         Token::Keyword { keyword: Keyword::Table, .. }
                     ) {
                         Ok(vibesql_ast::Statement::CreateTable(
                             self.parse_create_table_statement()?,
+                        ))
+                    } else if matches!(
+                        self.peek_at_offset(2),
+                        Token::Keyword { keyword: Keyword::Trigger, .. }
+                    ) {
+                        Ok(vibesql_ast::Statement::CreateTrigger(
+                            self.parse_create_trigger_statement()?,
                         ))
                     } else {
                         Ok(vibesql_ast::Statement::CreateView(self.parse_create_view_statement()?))

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -7,7 +7,7 @@ impl Parser {
     /// Parse CREATE TRIGGER statement
     ///
     /// Syntax:
-    ///   CREATE TRIGGER trigger_name
+    ///   CREATE [TEMP | TEMPORARY] TRIGGER trigger_name
     ///   [{BEFORE | AFTER | INSTEAD OF}] {INSERT | UPDATE | DELETE}
     ///   ON table_name
     ///   [FOR EACH {ROW | STATEMENT}]
@@ -20,6 +20,13 @@ impl Parser {
     ) -> Result<vibesql_ast::CreateTriggerStmt, ParseError> {
         // Expect CREATE keyword
         self.expect_keyword(Keyword::Create)?;
+
+        // Optional TEMP/TEMPORARY modifier, accepted for SQLite compatibility and
+        // ignored: SQLite places TEMP triggers in a session-scoped `temp` schema,
+        // but VibeSQL has no multi-session or ATTACH support, so the trigger is
+        // created as a regular trigger.
+        let _ =
+            self.try_consume_keyword(Keyword::Temp) || self.try_consume_keyword(Keyword::Temporary);
 
         // Expect TRIGGER keyword
         self.expect_keyword(Keyword::Trigger)?;

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -309,3 +309,79 @@ fn test_create_trigger_body_with_string_literal() {
         _ => panic!("Expected CreateTrigger statement"),
     }
 }
+
+#[test]
+fn test_create_temp_trigger_after_insert() {
+    let sql = "CREATE TEMP TRIGGER tr2 AFTER INSERT ON t1 BEGIN UPDATE t1 SET b = 1; END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let stmt = result.unwrap();
+    match stmt {
+        Statement::CreateTrigger(trigger) => {
+            assert_eq!(trigger.trigger_name, "tr2");
+            assert_eq!(trigger.timing, TriggerTiming::After);
+            assert_eq!(trigger.event, TriggerEvent::Insert);
+            assert_eq!(trigger.table_name, "t1");
+        }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+#[test]
+fn test_create_temporary_trigger_after_insert() {
+    let sql = "CREATE TEMPORARY TRIGGER tr2 AFTER INSERT ON t1 BEGIN UPDATE t1 SET b = 1; END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let stmt = result.unwrap();
+    match stmt {
+        Statement::CreateTrigger(trigger) => {
+            assert_eq!(trigger.trigger_name, "tr2");
+            assert_eq!(trigger.timing, TriggerTiming::After);
+            assert_eq!(trigger.event, TriggerEvent::Insert);
+            assert_eq!(trigger.table_name, "t1");
+        }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+#[test]
+fn test_create_temp_trigger_omitted_timing_defaults_to_before() {
+    let sql = "CREATE TEMP TRIGGER tr3 UPDATE ON t1 BEGIN SELECT 1; END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let stmt = result.unwrap();
+    match stmt {
+        Statement::CreateTrigger(trigger) => {
+            assert_eq!(trigger.trigger_name, "tr3");
+            assert_eq!(trigger.timing, TriggerTiming::Before);
+            assert!(matches!(trigger.event, TriggerEvent::Update(None)));
+            assert_eq!(trigger.table_name, "t1");
+        }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+#[test]
+fn test_create_temp_table_and_view_still_parse() {
+    // Regression checks: the CREATE TEMP dispatch must keep routing TABLE and
+    // VIEW correctly after learning about TRIGGER.
+    let table = Parser::parse_sql("CREATE TEMP TABLE t1(a INTEGER);");
+    assert!(
+        matches!(table, Ok(Statement::CreateTable(_))),
+        "CREATE TEMP TABLE failed: {:?}",
+        table
+    );
+
+    let temporary_table = Parser::parse_sql("CREATE TEMPORARY TABLE t1(a INTEGER);");
+    assert!(
+        matches!(temporary_table, Ok(Statement::CreateTable(_))),
+        "CREATE TEMPORARY TABLE failed: {:?}",
+        temporary_table
+    );
+
+    let view = Parser::parse_sql("CREATE TEMP VIEW v1 AS SELECT 1;");
+    assert!(matches!(view, Ok(Statement::CreateView(_))), "CREATE TEMP VIEW failed: {:?}", view);
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3251,7 +3251,7 @@ array set vibesql_skip_tests {
 
     fkey8-5.2 "UPDATE/DELETE PK affinity is fixed (#5145), but schema-reload drops DEFERRABLE INITIALLY DEFERRED so the deferred-INSERT on child fires immediately across CLI invocations — tracked separately in #5172"
 
-    triggerupfrom-2.3 "Cascades from upstream CREATE TEMP TRIGGER feature gap. Test 2.2 needs CREATE TEMP TRIGGER (tracked in #5218) which the parser rejects, leaving the temp tr2 trigger missing; 2.3's expected output assumes 2.2 succeeded. The UPDATE…FROM trigger logic in 2.3 itself works correctly when run in isolation (verified during #5192 builder pass)."
+    triggerupfrom-2.3 "Cascades from auto-skipped test 2.2. CREATE TEMP TRIGGER now parses (#5218), but 2.2 references aux.t3 and is auto-skipped by the ATTACH/aux regex (VibeSQL has no ATTACH/multi-database support), so the rows 2.2 inserts (10 y {}, 20 y {}) never exist and 2.3's expected output cannot match. The UPDATE…FROM trigger logic in 2.3 itself works correctly when run in isolation (verified during #5192 builder pass)."
 }
 
 # Pattern-based skip list for tests with many numbered variants


### PR DESCRIPTION
## Summary

`CREATE TEMP TRIGGER` / `CREATE TEMPORARY TRIGGER` failed with `near "TRIGGER": syntax error` because the CREATE dispatch only routed `CREATE TEMP <x>` to the table parser (for TABLE) or the view parser (everything else). This PR routes `TEMP/TEMPORARY + TRIGGER` to the trigger parser and consumes the modifier there, creating a regular trigger (Option A from the curator enhancement: VibeSQL has no multi-session or ATTACH support, so a separate temp schema is unobservable today).

## Changes

- `crates/vibesql-parser/src/parser/mod.rs` — CREATE TEMP dispatch checks offset 2 for `TRIGGER` and routes to `parse_create_trigger_statement` (TABLE and VIEW routing unchanged)
- `crates/vibesql-parser/src/parser/trigger.rs` — accept optional `TEMP`/`TEMPORARY` between CREATE and TRIGGER, with a comment documenting the consume-and-ignore semantics
- `crates/vibesql-parser/src/tests/trigger.rs` — 4 new tests: TEMP trigger (AFTER), TEMPORARY trigger, TEMP trigger with omitted timing (defaults to BEFORE), and regression checks that CREATE TEMP TABLE / TEMPORARY TABLE / TEMP VIEW still route correctly
- `scripts/tester_vibesql.tcl` — updated `triggerupfrom-2.3` skip rationale: the remaining blocker is the ATTACH/aux auto-skip of test 2.2 (no ATTACH support), not the parser gap; the skip itself stays

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| CREATE TEMP/TEMPORARY TRIGGER parse to CreateTrigger and execute as regular triggers | Pass | New parser unit tests; CLI smoke test: TEMP AFTER INSERT trigger created and fired (UPDATE applied b=99 after INSERT) |
| CREATE TEMP TABLE / TEMP VIEW parsing unchanged | Pass | `test_create_temp_table_and_view_still_parse` regression test |
| Parser unit tests in tests/trigger.rs covering TEMP and TEMPORARY, explicit (AFTER) and omitted timing | Pass | `cargo test -p vibesql-parser` — 1259 passed, 0 failed |
| triggerupfrom-2.3 skip rationale updated to cite the real blocker (2.2 auto-skipped by ATTACH/aux regex); skip stays | Pass | Rationale rewritten in `tester_vibesql.tcl`; skip entry retained |
| `make test-tcl-file FILE=triggerupfrom.test` shows no regressions | Pass | 8 passed, 0 failed, 6 skipped (1.x pass; 2.x skip behavior unchanged) |

## Test Plan

- `cargo test -p vibesql-parser`: 1259 passed, 0 failed
- `cargo check` / `cargo clippy -p vibesql-parser`: clean (remaining warnings are pre-existing in vibesql-ast / from_clause.rs)
- CLI smoke test (debug build): `CREATE TEMP TRIGGER tr2 AFTER INSERT ON t1 BEGIN UPDATE t1 SET b = 99; END;` parses, creates the trigger, and fires on INSERT; `CREATE TEMPORARY TRIGGER` also accepted
- `make test-tcl-file FILE=triggerupfrom.test`: 8 passed / 0 failed / 6 skipped — unchanged skip behavior

Closes #5218