### PR TITLE
fix(sqlite-compat): window1.test quick wins — parser holes, COLLATE-through-aggregate IN, view error prefix

### DIFF
--- a/crates/vibesql-executor/src/advanced_objects/views.rs
+++ b/crates/vibesql-executor/src/advanced_objects/views.rs
@@ -22,10 +22,15 @@ pub fn execute_create_view(stmt: &CreateViewStmt, db: &mut Database) -> Result<(
     // This ensures views with SELECT * preserve original column names
     // Use simple column names (without table prefix) for view schema compatibility
     let columns = if stmt.columns.is_none() {
-        // Execute the query once to derive column names
+        // Execute the query once to derive column names.
+        // SQLite-compatible: errors surfaced while compiling a view's query are
+        // prefixed with the view name (e.g. "error in view a: 1st ORDER BY term
+        // does not match any column in the result set").
         use crate::select::SelectExecutor;
         let executor = SelectExecutor::new(db);
-        let result = executor.execute_with_simple_columns(&stmt.query)?;
+        let result = executor.execute_with_simple_columns(&stmt.query).map_err(|e| {
+            ExecutorError::SqliteCompatError(format!("error in view {}: {}", stmt.view_name, e))
+        })?;
         Some(result.columns)
     } else {
         stmt.columns.clone()

--- a/crates/vibesql-executor/src/evaluator/casting.rs
+++ b/crates/vibesql-executor/src/evaluator/casting.rs
@@ -709,6 +709,45 @@ pub(crate) fn cast_value(
             _ => Ok(SqlValue::Blob(vec![])), // SQLite: Default to empty blob
         },
 
+        // CAST to a user-defined / unknown type name (SQLite compatibility):
+        // SQLite accepts any type name in CAST and applies its type-affinity
+        // rules derived from the name (e.g. CAST(x AS banana) → NUMERIC).
+        UserDefined { .. } => match target_type.sqlite_affinity() {
+            vibesql_types::TypeAffinity::Integer => cast_value(value, &Integer, sql_mode),
+            vibesql_types::TypeAffinity::Text => {
+                cast_value(value, &Varchar { max_length: None }, sql_mode)
+            }
+            vibesql_types::TypeAffinity::None => cast_value(value, &BinaryLargeObject, sql_mode),
+            vibesql_types::TypeAffinity::Real => cast_value(value, &DoublePrecision, sql_mode),
+            vibesql_types::TypeAffinity::Numeric => {
+                // SQLite NUMERIC cast: text converts to INTEGER when the value
+                // is integral and representable losslessly, otherwise REAL;
+                // non-numeric text converts to 0.
+                let numeric_from_text = |s: &str| -> vibesql_types::SqlValue {
+                    let (i, f, is_float) = string_to_number(s);
+                    if is_float {
+                        if f == f.trunc() && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+                            SqlValue::Integer(f as i64)
+                        } else {
+                            SqlValue::Double(f)
+                        }
+                    } else {
+                        SqlValue::Integer(i)
+                    }
+                };
+                match value {
+                    SqlValue::Varchar(s) | SqlValue::Character(s) => Ok(numeric_from_text(s)),
+                    SqlValue::Blob(bytes) => {
+                        let text = std::str::from_utf8(bytes).unwrap_or("");
+                        Ok(numeric_from_text(text))
+                    }
+                    SqlValue::Boolean(b) => Ok(SqlValue::Integer(if *b { 1 } else { 0 })),
+                    // Values that already have a numeric storage class keep it
+                    other => Ok(other.clone()),
+                }
+            }
+        },
+
         // Unsupported target types
         _ => Err(ExecutorError::UnsupportedFeature(format!(
             "CAST to {:?} not yet implemented",

--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -243,6 +243,15 @@ where
     };
     let recursive_query = &set_op.right;
 
+    // SQLite compatibility: window functions are not allowed in the recursive
+    // part of a recursive CTE (window1.test 15.0). SQLite reports the exact
+    // error "cannot use window functions in recursive queries".
+    if crate::select::window::has_window_functions(&recursive_query.select_list) {
+        return Err(ExecutorError::SqliteCompatError(
+            "cannot use window functions in recursive queries".to_string(),
+        ));
+    }
+
     // Try static validation first (works for explicit column lists and VALUES)
     // This provides better SQLite compatibility by catching errors at prepare time
     // rather than waiting until runtime

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/subquery.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/subquery.rs
@@ -78,8 +78,7 @@ fn scalar_subquery_needs_outer_rows(expr: &vibesql_ast::Expression) -> bool {
             })
         }
         Expression::BinaryOp { left, right, .. } => {
-            scalar_subquery_needs_outer_rows(left)
-                || scalar_subquery_needs_outer_rows(right)
+            scalar_subquery_needs_outer_rows(left) || scalar_subquery_needs_outer_rows(right)
         }
         Expression::UnaryOp { expr, .. } => scalar_subquery_needs_outer_rows(expr),
         Expression::Cast { expr, .. } => scalar_subquery_needs_outer_rows(expr),
@@ -111,9 +110,7 @@ fn bare_subquery_inner_has_outer_aggregate(expr: &vibesql_ast::Expression) -> bo
             if filter.as_ref().is_some_and(|f| any_column_ref(f)) {
                 return true;
             }
-            if order_by
-                .as_ref()
-                .is_some_and(|items| items.iter().any(|i| any_column_ref(&i.expr)))
+            if order_by.as_ref().is_some_and(|items| items.iter().any(|i| any_column_ref(&i.expr)))
             {
                 return true;
             }
@@ -159,9 +156,7 @@ fn any_column_ref(expr: &vibesql_ast::Expression) -> bool {
 
     match expr {
         Expression::ColumnRef(_) => true,
-        Expression::BinaryOp { left, right, .. } => {
-            any_column_ref(left) || any_column_ref(right)
-        }
+        Expression::BinaryOp { left, right, .. } => any_column_ref(left) || any_column_ref(right),
         Expression::UnaryOp { expr, .. } => any_column_ref(expr),
         Expression::Cast { expr, .. } => any_column_ref(expr),
         Expression::IsNull { expr, .. } => any_column_ref(expr),
@@ -175,15 +170,12 @@ fn any_column_ref(expr: &vibesql_ast::Expression) -> bool {
         }
         Expression::Case { operand, when_clauses, else_result } => {
             operand.as_ref().is_some_and(|e| any_column_ref(e))
-                || when_clauses.iter().any(|w| {
-                    w.conditions.iter().any(any_column_ref)
-                        || any_column_ref(&w.result)
-                })
+                || when_clauses
+                    .iter()
+                    .any(|w| w.conditions.iter().any(any_column_ref) || any_column_ref(&w.result))
                 || else_result.as_ref().is_some_and(|e| any_column_ref(e))
         }
-        Expression::Like { expr, pattern, .. } => {
-            any_column_ref(expr) || any_column_ref(pattern)
-        }
+        Expression::Like { expr, pattern, .. } => any_column_ref(expr) || any_column_ref(pattern),
         Expression::Between { expr, low, high, .. } => {
             any_column_ref(expr) || any_column_ref(low) || any_column_ref(high)
         }
@@ -192,6 +184,36 @@ fn any_column_ref(expr: &vibesql_ast::Expression) -> bool {
         }
         // Don't descend into nested subqueries or window functions (own scope).
         _ => false,
+    }
+}
+
+/// Normalize a value for comparison under a named collation.
+///
+/// NOCASE: uppercase strings for case-insensitive comparison.
+/// RTRIM: trim trailing whitespace.
+/// Any other (or no) collation leaves the value unchanged (BINARY semantics).
+fn transform_for_collation(
+    val: vibesql_types::SqlValue,
+    collation: Option<&str>,
+) -> vibesql_types::SqlValue {
+    use vibesql_types::SqlValue;
+    let Some(collation_name) = collation else {
+        return val;
+    };
+    if collation_name.eq_ignore_ascii_case("nocase") {
+        match val {
+            SqlValue::Varchar(s) => SqlValue::Varchar(arcstr::ArcStr::from(s.to_uppercase())),
+            SqlValue::Character(s) => SqlValue::Character(arcstr::ArcStr::from(s.to_uppercase())),
+            other => other,
+        }
+    } else if collation_name.eq_ignore_ascii_case("rtrim") {
+        match val {
+            SqlValue::Varchar(s) => SqlValue::Varchar(arcstr::ArcStr::from(s.trim_end())),
+            SqlValue::Character(s) => SqlValue::Character(arcstr::ArcStr::from(s.trim_end())),
+            other => other,
+        }
+    } else {
+        val
     }
 }
 
@@ -214,6 +236,12 @@ pub(super) fn evaluate_in(
     // Evaluate left-hand expression (which may be an aggregate)
     let left_val =
         executor.evaluate_with_aggregates(left_expr, group_rows, group_key, evaluator)?;
+
+    // Effective collation of the LHS — explicit COLLATE clauses propagate
+    // through single-argument aggregates (SQLite datatype3 §7.1), so e.g.
+    // max(c1 COLLATE nocase) IN (SELECT 'aBCd') compares case-insensitively.
+    let collation = evaluator.get_expression_collation(left_expr);
+    let left_val = transform_for_collation(left_val, collation.as_deref());
 
     // Execute subquery to get values to compare against
     let database = executor.database;
@@ -246,8 +274,8 @@ pub(super) fn evaluate_in(
             continue;
         }
 
-        // Compare using equality
-        if left_val == *subquery_val {
+        // Compare using equality (under the LHS collation, if any)
+        if left_val == transform_for_collation(subquery_val.clone(), collation.as_deref()) {
             return Ok(vibesql_types::SqlValue::Boolean(!negated));
         }
     }

--- a/crates/vibesql-executor/src/select/executor/nonagg/without_from.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/without_from.rs
@@ -64,6 +64,20 @@ impl SelectExecutor<'_> {
         // Check if we have outer context (for correlated subqueries)
         let has_outer_context = self.outer_row.is_some() && self.outer_schema.is_some();
 
+        // SQLite allows the WHERE clause of a FROM-less SELECT to reference
+        // select-list aliases, e.g. `SELECT (SELECT '') x WHERE x+x` (window1.test
+        // 15.2). Without outer context, a column reference in WHERE can only
+        // resolve to a select-list alias, so evaluate the select list first and
+        // bind the aliases for the WHERE evaluation.
+        if let Some(where_clause) = &stmt.where_clause {
+            if !has_outer_context
+                && !has_window_functions(&stmt.select_list)
+                && self.expression_references_column(where_clause)
+            {
+                return self.execute_select_without_from_alias_where(stmt, where_clause);
+            }
+        }
+
         // Evaluate WHERE clause first - if it's false, return empty result (SQLite compatibility)
         // This handles cases like `SELECT 99 WHERE 0` which should return no rows
         if let Some(where_clause) = &stmt.where_clause {
@@ -171,6 +185,86 @@ impl SelectExecutor<'_> {
         Ok(apply_limit_offset(result, limit, offset))
     }
 
+    /// Execute a FROM-less SELECT whose WHERE clause references select-list
+    /// aliases (SQLite compatibility, e.g. `SELECT (SELECT '') x WHERE x+x`).
+    ///
+    /// Evaluates the select list first, binds each item's alias as a column in
+    /// a synthetic single-row schema, then evaluates the WHERE clause against
+    /// that row. Column references that don't match an alias produce the same
+    /// "column not found" error as before.
+    fn execute_select_without_from_alias_where(
+        &self,
+        stmt: &vibesql_ast::SelectStmt,
+        where_clause: &vibesql_ast::Expression,
+    ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
+        let empty_schema = vibesql_catalog::TableSchema::new("".to_string(), vec![]);
+        let evaluator = ExpressionEvaluator::with_database(&empty_schema, self.database);
+        let empty_row = vibesql_storage::Row::new(vec![]);
+
+        // Evaluate the select list and collect alias bindings
+        let mut values = Vec::new();
+        let mut alias_columns = Vec::new();
+        for item in &stmt.select_list {
+            match item {
+                vibesql_ast::SelectItem::Wildcard { .. }
+                | vibesql_ast::SelectItem::QualifiedWildcard { .. } => {
+                    return Err(ExecutorError::UnsupportedFeature(
+                        "SELECT * and qualified wildcards require FROM clause".to_string(),
+                    ));
+                }
+                vibesql_ast::SelectItem::Expression { expr, alias, .. } => {
+                    if self.expression_references_column(expr) {
+                        return Err(ExecutorError::UnsupportedFeature(
+                            "Column reference requires FROM clause".to_string(),
+                        ));
+                    }
+                    let value = evaluator.eval(expr, &empty_row)?;
+                    let column_name = alias.clone().unwrap_or_default();
+                    let data_type = crate::select::cte::infer_type_from_value(&value);
+                    alias_columns.push(vibesql_catalog::ColumnSchema::new(
+                        column_name,
+                        data_type,
+                        true,
+                    ));
+                    values.push(value);
+                }
+            }
+        }
+
+        // Evaluate WHERE with the aliases bound as columns of a single row
+        let alias_schema = vibesql_catalog::TableSchema::new("".to_string(), alias_columns);
+        let where_evaluator = ExpressionEvaluator::with_database(&alias_schema, self.database);
+        let result_row = vibesql_storage::Row::new(values);
+        let where_result = where_evaluator.eval(where_clause, &result_row)?;
+
+        let is_truthy = match &where_result {
+            vibesql_types::SqlValue::Boolean(b) => *b,
+            vibesql_types::SqlValue::Null => false,
+            vibesql_types::SqlValue::Integer(n) => *n != 0,
+            vibesql_types::SqlValue::Smallint(n) => *n != 0,
+            vibesql_types::SqlValue::Bigint(n) => *n != 0,
+            vibesql_types::SqlValue::Float(f) => *f != 0.0,
+            vibesql_types::SqlValue::Real(f) => *f != 0.0,
+            vibesql_types::SqlValue::Double(f) => *f != 0.0,
+            vibesql_types::SqlValue::Numeric(n) => *n != 0.0,
+            // Non-numeric, non-NULL values follow SQLite numeric coercion:
+            // strings coerce to their numeric prefix (0 when non-numeric)
+            vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
+                crate::evaluator::casting::string_to_number(s).1 != 0.0
+            }
+            _ => true,
+        };
+
+        if !is_truthy {
+            return Ok(vec![]);
+        }
+
+        let result = vec![result_row];
+        let limit = evaluate_limit(&stmt.limit, self.database)?;
+        let offset = evaluate_offset(&stmt.offset, self.database)?;
+        Ok(apply_limit_offset(result, limit, offset))
+    }
+
     /// Execute SELECT without FROM clause that contains window functions
     ///
     /// Window functions without FROM clause operate on a single implicit row.
@@ -206,8 +300,12 @@ impl SelectExecutor<'_> {
 
         // Process window functions - this adds computed values to each row
         // and returns a mapping from WindowFunctionKey to column index
-        let (rows_with_windows, window_mapping) =
-            evaluate_window_functions(rows, &stmt.select_list, stmt.window_definitions.as_ref(), &evaluator)?;
+        let (rows_with_windows, window_mapping) = evaluate_window_functions(
+            rows,
+            &stmt.select_list,
+            stmt.window_definitions.as_ref(),
+            &evaluator,
+        )?;
         rows = rows_with_windows;
 
         // Now evaluate the SELECT list with the window mapping

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -130,3 +130,4 @@ mod truncate_table_tests;
 mod unique_index_tests;
 mod vector_distance_operators;
 mod view_tests;
+mod window1_quick_wins;

--- a/crates/vibesql-executor/src/tests/window1_quick_wins.rs
+++ b/crates/vibesql-executor/src/tests/window1_quick_wins.rs
@@ -1,0 +1,184 @@
+//! Regression tests for the window1.test quick-win fixes (issue #5190)
+//!
+//! Covers:
+//! - 65.2/65.3: COLLATE propagating through an aggregate into an IN comparison
+//! - 15.0: exact SQLite error for window functions in recursive CTEs
+//! - 15.2: FROM-less SELECT whose WHERE references a select-list alias
+//! - 32.10: CREATE VIEW errors prefixed with "error in view <name>: "
+//! - 61.1: CAST to an unknown type name applies SQLite affinity rules
+
+use vibesql_ast::Statement;
+use vibesql_parser::Parser;
+
+use super::super::*;
+
+fn execute_sql(
+    db: &mut vibesql_storage::Database,
+    sql: &str,
+) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| ExecutorError::ParseError(format!("{:?}", e)))?;
+    match stmt {
+        Statement::CreateTable(create_stmt) => {
+            CreateTableExecutor::execute(&create_stmt, db)?;
+            Ok(vec![])
+        }
+        Statement::Insert(insert_stmt) => {
+            InsertExecutor::execute(db, &insert_stmt)?;
+            Ok(vec![])
+        }
+        Statement::CreateView(view_stmt) => {
+            crate::advanced_objects::execute_create_view(&view_stmt, db)?;
+            Ok(vec![])
+        }
+        Statement::Select(select_stmt) => Ok(SelectExecutor::new(db).execute(&select_stmt)?),
+        other => {
+            Err(ExecutorError::UnsupportedFeature(format!("Unsupported statement: {:?}", other)))
+        }
+    }
+}
+
+// ------------------------------------------------------------------------
+// 65.2 / 65.3 — COLLATE through aggregate into IN
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_collate_nocase_through_aggregate_into_in_subquery() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(c1 VARCHAR(10))").unwrap();
+    execute_sql(&mut db, "INSERT INTO t1 VALUES('abcd')").unwrap();
+
+    // window1.test 65.2: max(c1 COLLATE nocase) must compare case-insensitively
+    let rows =
+        execute_sql(&mut db, "SELECT max(c1 COLLATE nocase) IN (SELECT 'aBCd') FROM t1").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(
+        matches!(
+            rows[0].values[0],
+            vibesql_types::SqlValue::Boolean(true) | vibesql_types::SqlValue::Integer(1)
+        ),
+        "expected truthy IN result, got {:?}",
+        rows[0].values[0]
+    );
+}
+
+#[test]
+fn test_aggregate_in_subquery_without_collate_stays_binary() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(c1 VARCHAR(10))").unwrap();
+    execute_sql(&mut db, "INSERT INTO t1 VALUES('abcd')").unwrap();
+
+    // Without COLLATE nocase, BINARY comparison must NOT match
+    let rows = execute_sql(&mut db, "SELECT max(c1) IN (SELECT 'aBCd') FROM t1").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(
+        matches!(
+            rows[0].values[0],
+            vibesql_types::SqlValue::Boolean(false) | vibesql_types::SqlValue::Integer(0)
+        ),
+        "expected falsy IN result, got {:?}",
+        rows[0].values[0]
+    );
+}
+
+// ------------------------------------------------------------------------
+// 15.0 — window functions in recursive CTEs
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_window_function_in_recursive_cte_errors_with_sqlite_message() {
+    let mut db = vibesql_storage::Database::new();
+    let err = execute_sql(
+        &mut db,
+        "WITH RECURSIVE q(x, rn) AS (
+            SELECT 1, 1
+            UNION ALL
+            SELECT x+1, ROW_NUMBER() OVER (ORDER BY x) FROM q WHERE x < 3
+         )
+         SELECT * FROM q",
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "cannot use window functions in recursive queries");
+}
+
+// ------------------------------------------------------------------------
+// 15.2 — FROM-less SELECT with alias referenced from WHERE
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_fromless_select_alias_in_where_falsy() {
+    let mut db = vibesql_storage::Database::new();
+    // ''+'' coerces to 0 → WHERE is false → no rows (window1.test 15.2)
+    let rows = execute_sql(&mut db, "SELECT (SELECT '') x WHERE x+x").unwrap();
+    assert!(rows.is_empty(), "expected no rows, got {:?}", rows);
+}
+
+#[test]
+fn test_fromless_select_alias_in_where_truthy() {
+    let mut db = vibesql_storage::Database::new();
+    let rows = execute_sql(&mut db, "SELECT (SELECT 1) x WHERE x+x").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(1));
+}
+
+#[test]
+fn test_fromless_select_where_unknown_column_still_errors() {
+    let mut db = vibesql_storage::Database::new();
+    let result = execute_sql(&mut db, "SELECT 1 x WHERE y");
+    assert!(result.is_err(), "unknown column in WHERE should still error");
+}
+
+// ------------------------------------------------------------------------
+// 32.10 — CREATE VIEW error prefix
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_create_view_error_is_prefixed_with_view_name() {
+    let mut db = vibesql_storage::Database::new();
+    // Invalid ORDER BY term in a compound view query (window1.test 32.10 shape)
+    let err = execute_sql(
+        &mut db,
+        "CREATE VIEW a AS SELECT NULL INTERSECT SELECT NULL ORDER BY s() OVER R",
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.starts_with("error in view a: "),
+        "expected 'error in view a: ' prefix, got: {msg}"
+    );
+}
+
+// ------------------------------------------------------------------------
+// 61.1 — CAST to unknown type names (SQLite affinity rules)
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_cast_to_unknown_typename_numeric_affinity() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Non-numeric text → 0 (NUMERIC affinity)
+    let rows = execute_sql(&mut db, "SELECT CAST('seventeen' AS banana)").unwrap();
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(0));
+
+    // Integral text → INTEGER
+    let rows = execute_sql(&mut db, "SELECT CAST('5' AS banana)").unwrap();
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(5));
+
+    // Fractional text → REAL
+    let rows = execute_sql(&mut db, "SELECT CAST('1.5' AS banana)").unwrap();
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Double(1.5));
+
+    // Numeric values keep their storage class
+    let rows = execute_sql(&mut db, "SELECT CAST(7 AS banana)").unwrap();
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(7));
+}
+
+#[test]
+fn test_cast_empty_typename_passes_value_through_sum() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a)").unwrap();
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(5),(NULL),('seventeen')").unwrap();
+
+    // window1.test 61.1 inner fragment: sum over CAST(a AS ) must execute
+    let rows = execute_sql(&mut db, "SELECT sum(CAST(a AS )) FROM t1").unwrap();
+    assert_eq!(rows.len(), 1, "sum(CAST(a AS )) should produce one row");
+}

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -677,8 +677,8 @@ impl<'arena> ArenaParser<'arena> {
         if matches!(self.peek(), Token::LParen) {
             self.advance();
 
-            // Check for subquery
-            if self.peek_keyword(Keyword::Select) {
+            // Check for subquery (SELECT or WITH-prefixed SELECT)
+            if self.peek_keyword(Keyword::Select) || self.peek_keyword(Keyword::With) {
                 let subquery = self.parse_select_statement()?;
                 self.expect_token(Token::RParen)?;
                 return Ok(Expression::Extended(
@@ -986,7 +986,13 @@ impl<'arena> ArenaParser<'arena> {
         let expr_ref = self.arena.alloc(expr);
 
         self.consume_keyword(Keyword::As)?;
-        let data_type = self.parse_data_type()?;
+        // SQLite tolerates a missing type name: CAST(x AS ) parses with
+        // no affinity (treated like CAST(x AS ANY) — value passes through).
+        let data_type = if matches!(self.peek(), Token::RParen) {
+            vibesql_types::DataType::BinaryLargeObject
+        } else {
+            self.parse_data_type()?
+        };
 
         self.expect_token(Token::RParen)?;
 

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -650,7 +650,10 @@ impl<'arena> ArenaParser<'arena> {
         // Check for alias
         // Issue #4448: If AS is present, an alias MUST follow
         let has_as = self.try_consume_keyword(Keyword::As);
-        let alias = if let Token::Identifier(alias) = self.peek() {
+        let alias = if self.peek_index_hint() && !has_as {
+            // SQLite index hint (INDEXED BY x / NOT INDEXED), not an alias
+            None
+        } else if let Token::Identifier(alias) = self.peek() {
             // Make sure it's not a keyword that would start a new clause
             if !matches!(
                 self.peek(),
@@ -690,7 +693,54 @@ impl<'arena> ArenaParser<'arena> {
         // Parse optional column aliases: (col1, col2, ...)
         let column_aliases = if alias.is_some() { self.parse_column_alias_list()? } else { None };
 
+        // Parse and ignore SQLite index hints: INDEXED BY <name> / NOT INDEXED
+        self.parse_index_hint()?;
+
         Ok(FromClause::Table { name, alias, column_aliases, quoted })
+    }
+
+    /// Check if the upcoming tokens form a SQLite index hint:
+    /// `INDEXED BY <name>` or `NOT INDEXED`.
+    ///
+    /// Note: INDEXED is not a keyword in our lexer, so it arrives as an
+    /// identifier token (lowercased by the lexer).
+    fn peek_index_hint(&self) -> bool {
+        match self.peek() {
+            Token::Identifier(id) if id.eq_ignore_ascii_case("indexed") => {
+                self.peek_next_keyword(Keyword::By)
+            }
+            Token::Keyword { keyword: Keyword::Not, .. } => {
+                matches!(self.peek_next(), Token::Identifier(id) if id.eq_ignore_ascii_case("indexed"))
+            }
+            _ => false,
+        }
+    }
+
+    /// Parse and ignore SQLite index hints: `INDEXED BY <index-name>` or
+    /// `NOT INDEXED`. VibeSQL's planner chooses indexes independently, so the
+    /// hint is accepted for SQLite compatibility but has no effect on planning.
+    fn parse_index_hint(&mut self) -> Result<(), ParseError> {
+        if !self.peek_index_hint() {
+            return Ok(());
+        }
+        if self.peek_keyword(Keyword::Not) {
+            self.advance(); // consume NOT
+            self.advance(); // consume INDEXED
+            return Ok(());
+        }
+        self.advance(); // consume INDEXED
+        self.advance(); // consume BY
+        match self.peek() {
+            Token::Identifier(_) | Token::DelimitedIdentifier(_) => {
+                self.advance();
+                Ok(())
+            }
+            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                self.advance();
+                Ok(())
+            }
+            _ => Err(ParseError { message: "Expected index name after INDEXED BY".to_string() }),
+        }
     }
 
     /// Parse GROUP BY clause.

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -280,6 +280,7 @@ impl Parser {
 
                     if self.peek_keyword(Keyword::Select)
                         || self.peek_keyword(Keyword::Values)
+                        || self.peek_keyword(Keyword::With)
                         || is_subquery_through_parens
                     {
                         // It's a subquery: NOT IN (SELECT ...) or NOT IN ((SELECT ...))
@@ -496,6 +497,7 @@ impl Parser {
 
                 if self.peek_keyword(Keyword::Select)
                     || self.peek_keyword(Keyword::Values)
+                    || self.peek_keyword(Keyword::With)
                     || is_subquery_through_parens
                 {
                     // It's a subquery: IN (SELECT ...) or IN ((SELECT ...))

--- a/crates/vibesql-parser/src/parser/expressions/special_forms.rs
+++ b/crates/vibesql-parser/src/parser/expressions/special_forms.rs
@@ -155,8 +155,14 @@ impl Parser {
                 // Expect AS keyword
                 self.expect_keyword(Keyword::As)?;
 
-                // Parse the target data type
-                let data_type = self.parse_data_type()?;
+                // Parse the target data type.
+                // SQLite tolerates a missing type name: CAST(x AS ) parses with
+                // no affinity (treated like CAST(x AS ANY) — value passes through).
+                let data_type = if matches!(self.peek(), Token::RParen) {
+                    vibesql_types::DataType::BinaryLargeObject
+                } else {
+                    self.parse_data_type()?
+                };
 
                 // Expect closing parenthesis
                 self.expect_token(Token::RParen)?;

--- a/crates/vibesql-parser/src/parser/expressions/subqueries.rs
+++ b/crates/vibesql-parser/src/parser/expressions/subqueries.rs
@@ -26,9 +26,9 @@ impl Parser {
                 self.advance(); // consume '('
 
                 // Check if this is a scalar subquery by peeking at next token
-                // Both SELECT and VALUES can be scalar subqueries
-                if self.peek_keyword(Keyword::Select) {
-                    // It's a scalar subquery: (SELECT ...)
+                // SELECT, WITH (CTE-prefixed SELECT), and VALUES can all be scalar subqueries
+                if self.peek_keyword(Keyword::Select) || self.peek_keyword(Keyword::With) {
+                    // It's a scalar subquery: (SELECT ...) or (WITH ... SELECT ...)
                     let select_stmt = self.parse_select_statement()?;
                     self.expect_token(Token::RParen)?;
                     Ok(Some(vibesql_ast::Expression::ScalarSubquery(Box::new(select_stmt))))

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -342,6 +342,7 @@ impl Parser {
                     self.peek(),
                     Token::Identifier(_) | Token::DelimitedIdentifier(_)
                 ) && !self.is_join_keyword()
+                    && !self.peek_index_hint()
                 {
                     // Implicit alias (no AS keyword) - but not a JOIN keyword
                     match self.peek() {
@@ -355,6 +356,7 @@ impl Parser {
                 } else if matches!(self.peek(), Token::Keyword { keyword: _, .. })
                     && !self.is_join_keyword()
                     && !self.is_clause_keyword()
+                    && !self.peek_index_hint()
                 {
                     // Allow non-reserved keywords as implicit aliases (e.g., FROM t m)
                     // Keywords like M, YEAR, etc. can be used as aliases
@@ -376,6 +378,9 @@ impl Parser {
                 let column_aliases =
                     if alias.is_some() { self.parse_column_alias_list()? } else { None };
 
+                // Parse and ignore SQLite index hints: INDEXED BY <name> / NOT INDEXED
+                self.parse_index_hint()?;
+
                 Ok(vibesql_ast::FromClause::Table {
                     name: table.full_name(),
                     alias,
@@ -395,6 +400,7 @@ impl Parser {
                     self.peek(),
                     Token::Identifier(_) | Token::DelimitedIdentifier(_)
                 ) && !self.is_join_keyword()
+                    && !self.peek_index_hint()
                 {
                     match self.peek() {
                         Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
@@ -411,6 +417,9 @@ impl Parser {
                 let column_aliases =
                     if alias.is_some() { self.parse_column_alias_list()? } else { None };
 
+                // Parse and ignore SQLite index hints: INDEXED BY <name> / NOT INDEXED
+                self.parse_index_hint()?;
+
                 Ok(vibesql_ast::FromClause::Table {
                     name: table.full_name(),
                     alias,
@@ -421,6 +430,50 @@ impl Parser {
             _ => Err(ParseError {
                 message: "Expected table name or subquery in FROM clause".to_string(),
             }),
+        }
+    }
+
+    /// Check if the upcoming tokens form a SQLite index hint:
+    /// `INDEXED BY <name>` or `NOT INDEXED`.
+    ///
+    /// Note: INDEXED is not a keyword in our lexer, so it arrives as an
+    /// identifier token (lowercased by the lexer).
+    pub(crate) fn peek_index_hint(&self) -> bool {
+        match self.peek() {
+            Token::Identifier(id) if id.eq_ignore_ascii_case("indexed") => {
+                self.peek_next_keyword(Keyword::By)
+            }
+            Token::Keyword { keyword: Keyword::Not, .. } => {
+                matches!(self.peek_next(), Token::Identifier(id) if id.eq_ignore_ascii_case("indexed"))
+            }
+            _ => false,
+        }
+    }
+
+    /// Parse and ignore SQLite index hints: `INDEXED BY <index-name>` or
+    /// `NOT INDEXED`. VibeSQL's planner chooses indexes independently, so the
+    /// hint is accepted for SQLite compatibility but has no effect on planning.
+    pub(crate) fn parse_index_hint(&mut self) -> Result<(), ParseError> {
+        if !self.peek_index_hint() {
+            return Ok(());
+        }
+        if self.peek_keyword(Keyword::Not) {
+            self.advance(); // consume NOT
+            self.advance(); // consume INDEXED
+            return Ok(());
+        }
+        self.advance(); // consume INDEXED
+        self.advance(); // consume BY
+        match self.peek() {
+            Token::Identifier(_) | Token::DelimitedIdentifier(_) => {
+                self.advance();
+                Ok(())
+            }
+            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                self.advance();
+                Ok(())
+            }
+            _ => Err(ParseError { message: "Expected index name after INDEXED BY".to_string() }),
         }
     }
 

--- a/crates/vibesql-parser/src/tests/cast.rs
+++ b/crates/vibesql-parser/src/tests/cast.rs
@@ -278,3 +278,36 @@ fn test_parse_cast_signed_cross_join_subquery() {
     );
     assert!(result.is_ok(), "CAST AS SIGNED with CROSS JOIN subquery should parse: {:?}", result);
 }
+
+#[test]
+fn test_parse_cast_empty_typename() {
+    // SQLite tolerates a missing type name: CAST(x AS ) parses with no
+    // affinity (treated like CAST(x AS ANY)). From window1.test 61.1.
+    let result = Parser::parse_sql("SELECT CAST(a AS ) FROM t1;");
+    assert!(result.is_ok(), "CAST with empty type name should parse: {:?}", result);
+
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match &select.select_list[0] {
+            vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                vibesql_ast::Expression::Cast { data_type, .. } => {
+                    assert_eq!(
+                        data_type,
+                        &vibesql_types::DataType::BinaryLargeObject,
+                        "empty type name should map to no-affinity (BLOB) cast"
+                    );
+                }
+                _ => panic!("Expected CAST expression, got {:?}", expr),
+            },
+            _ => panic!("Expected expression"),
+        },
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_parse_cast_empty_typename_in_aggregate() {
+    // Regression for window1.test 61.1 (fuzz-derived): CAST(a AS ) inside sum()
+    let result = Parser::parse_sql("SELECT sum(CAST(a AS )) FROM t1;");
+    assert!(result.is_ok(), "sum(CAST(a AS )) should parse: {:?}", result);
+}

--- a/crates/vibesql-parser/src/tests/select/index_hints.rs
+++ b/crates/vibesql-parser/src/tests/select/index_hints.rs
@@ -1,0 +1,117 @@
+//! Tests for SQLite index hints in FROM clauses: INDEXED BY / NOT INDEXED
+//!
+//! VibeSQL parses and ignores these hints (the planner chooses indexes
+//! independently). Regression coverage for window1.test 77.2.
+
+use super::super::*;
+
+fn assert_table_from(sql: &str, expected_name: &str, expected_alias: Option<&str>) {
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "should parse: {sql}: {:?}", result);
+    match result.unwrap() {
+        vibesql_ast::Statement::Select(select) => match select.from {
+            Some(vibesql_ast::FromClause::Table { name, alias, .. }) => {
+                assert_eq!(name, expected_name);
+                assert_eq!(alias.as_deref(), expected_alias);
+            }
+            other => panic!("Expected Table FROM clause, got {:?}", other),
+        },
+        other => panic!("Expected SELECT statement, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_indexed_by_hint_is_ignored() {
+    assert_table_from("SELECT * FROM t1 INDEXED BY t1x;", "t1", None);
+}
+
+#[test]
+fn test_indexed_by_hint_with_where() {
+    // window1.test 77.2 shape: INDEXED BY followed by GROUP BY
+    let result =
+        Parser::parse_sql("SELECT max(x) FILTER (WHERE true) FROM t1 INDEXED BY t1x GROUP BY x;");
+    assert!(result.is_ok(), "INDEXED BY with GROUP BY should parse: {:?}", result);
+}
+
+#[test]
+fn test_indexed_by_hint_after_alias() {
+    assert_table_from("SELECT * FROM t1 AS a INDEXED BY t1x;", "t1", Some("a"));
+}
+
+#[test]
+fn test_not_indexed_hint_is_ignored() {
+    assert_table_from("SELECT * FROM t1 NOT INDEXED;", "t1", None);
+}
+
+#[test]
+fn test_not_indexed_hint_with_where() {
+    let result = Parser::parse_sql("SELECT * FROM t1 NOT INDEXED WHERE x > 1;");
+    assert!(result.is_ok(), "NOT INDEXED with WHERE should parse: {:?}", result);
+}
+
+#[test]
+fn test_indexed_as_plain_alias_still_works() {
+    // "indexed" not followed by BY is a regular implicit alias
+    assert_table_from("SELECT * FROM t1 indexed;", "t1", Some("indexed"));
+}
+
+#[test]
+fn test_with_scalar_subquery_in_expression() {
+    // window1.test 15.2: WITH-prefixed scalar subquery in an expression
+    let result =
+        Parser::parse_sql("SELECT( WITH c AS( VALUES(1) ) SELECT '' FROM c,c ) x WHERE x+x;");
+    assert!(result.is_ok(), "WITH scalar subquery should parse: {:?}", result);
+    match result.unwrap() {
+        vibesql_ast::Statement::Select(select) => match &select.select_list[0] {
+            vibesql_ast::SelectItem::Expression { expr, alias, .. } => {
+                assert_eq!(alias.as_deref(), Some("x"));
+                assert!(
+                    matches!(expr, vibesql_ast::Expression::ScalarSubquery(_)),
+                    "Expected scalar subquery, got {:?}",
+                    expr
+                );
+            }
+            other => panic!("Expected expression select item, got {:?}", other),
+        },
+        other => panic!("Expected SELECT statement, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_with_subquery_in_in_predicate() {
+    let result = Parser::parse_sql("SELECT 1 WHERE 1 IN (WITH c AS (VALUES(1)) SELECT * FROM c);");
+    assert!(result.is_ok(), "IN (WITH ... SELECT ...) should parse: {:?}", result);
+}
+
+// ============================================================================
+// Arena parser mirrors
+// ============================================================================
+
+#[test]
+fn test_arena_indexed_by_hint_is_ignored() {
+    let result = crate::arena_parser::parse_select_to_owned("SELECT * FROM t1 INDEXED BY t1x");
+    assert!(result.is_ok(), "arena parser should accept INDEXED BY: {:?}", result);
+}
+
+#[test]
+fn test_arena_not_indexed_hint_is_ignored() {
+    let result = crate::arena_parser::parse_select_to_owned("SELECT * FROM t1 NOT INDEXED");
+    assert!(result.is_ok(), "arena parser should accept NOT INDEXED: {:?}", result);
+}
+
+#[test]
+fn test_arena_cast_empty_typename() {
+    let result = crate::arena_parser::parse_select_to_owned("SELECT CAST(a AS ) FROM t1");
+    assert!(result.is_ok(), "arena parser should accept CAST(a AS ): {:?}", result);
+}
+
+#[test]
+fn test_arena_with_scalar_subquery_in_expression() {
+    // Note: the arena parser does not yet support VALUES as a CTE body
+    // (it falls back to the standard parser in production), so this uses a
+    // SELECT-bodied CTE to exercise the WITH-scalar-subquery path.
+    let result = crate::arena_parser::parse_select_to_owned(
+        "SELECT( WITH c AS( SELECT 1 ) SELECT '' FROM c ) x",
+    );
+    assert!(result.is_ok(), "arena parser should accept WITH scalar subquery: {:?}", result);
+}

--- a/crates/vibesql-parser/src/tests/select/mod.rs
+++ b/crates/vibesql-parser/src/tests/select/mod.rs
@@ -5,5 +5,6 @@ mod concat;
 mod derived_columns;
 mod extract;
 mod filters;
+mod index_hints;
 mod keyword_as_identifier;
 mod position;

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -4083,7 +4083,7 @@ proc match_regex_pattern {result expected} {
 # Returns 1 if supported, 0 if not
 proc check_single_capability {cap} {
     # Capabilities we don't support (unsupported_caps means NOT supported)
-    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab fts3 fts4 fts5 datetime datetime_time datetime_funcs trigger conflict hiddencolumns}
+    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 datetime datetime_time datetime_funcs trigger conflict hiddencolumns}
 
     # Handle negated capability (e.g., !autovacuum)
     set negate 0
@@ -4166,7 +4166,7 @@ proc eval_capability_expr {expr} {
 }
 
 proc capable {capability} {
-    set skip_caps {wal vacuum_incr autovacuum stat4 stat3}
+    set skip_caps {wal vacuum_incr autovacuum stat4 stat3 rtree}
     return [expr {$capability ni $skip_caps}]
 }
 


### PR DESCRIPTION
## Summary

Lands the quick-wins bucket from the #5190 curator triage of window1.test. Native-TCL failures drop **24 → 17** (248 → 254 passed, 76 skipped); the 17 remaining failures are all in the deferred buckets, each now tracked by a dedicated follow-up issue (#5230, #5231, #5232, #5233 — together they cover every remaining failure, so this PR closes the umbrella).

## Changes

- **Parser (mirrored in arena parser)**
  - `CAST(x AS )` with an empty type name parses as a no-affinity cast, like `CAST(x AS ANY)` (test 61.1)
  - `INDEXED BY <name>` / `NOT INDEXED` table hints are parsed and ignored — VibeSQL plans independently (test 77.2)
  - WITH-prefixed scalar subqueries allowed in expressions and IN predicates: `SELECT (WITH c AS (...) SELECT ...)` (test 15.2)
- **Executor**
  - Explicit COLLATE propagates through single-argument aggregates into IN-subquery comparisons: `max(c1 COLLATE nocase) IN (SELECT 'aBCd')` → 1 (tests 65.2/65.3)
  - CREATE VIEW compile errors are prefixed with `error in view <name>: ` (test 32.10)
  - Window functions in the recursive arm of a recursive CTE raise SQLite's exact error `cannot use window functions in recursive queries` (test 15.0)
  - FROM-less SELECTs can reference select-list aliases from WHERE: `SELECT (SELECT '') x WHERE x+x` (test 15.2)
  - CAST to unknown type names applies SQLite affinity rules instead of erroring (`CAST('5' AS banana)` → 5) (test 61.1)
- **TCL shim**: `rtree` marked unsupported so `ifcapable rtree` blocks skip (test 40.1)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Triage complete, categorized by root cause | ✅ | Done by curator in #5190 comment; this PR implements the quick-win buckets |
| 2-4 narrower sub-issues filed | ✅ | #5230 (EQP 23.x), #5231 (resolver 6.2/25.x), #5232 (agg+window 44.x/53.0/61.x/71.0), #5233 (RETURNING-via-trigger 73.x) |
| window1.test pass count rises | ✅ | 248 → 254 passed, 24 → 17 failed (`./scripts/tcltest test window1.test`, native mode) |
| No regressions in sibling window files | ✅ | window2 (63/0), window3 (1462/0), window8 (176/5 — identical failure list on main), view.test/select1.test/cast.test identical to main |
| Rust regression tests per fix | ✅ | 12 new parser tests (`tests/select/index_hints.rs`, `tests/cast.rs`, incl. arena mirrors), 9 new executor tests (`tests/window1_quick_wins.rs`) |
| Lib tests green | ✅ | `cargo test -p vibesql-parser -p vibesql-executor --lib`: 1269 + 2404 passed, 0 failed |

## Test Plan

- `./scripts/tcltest test window1.test` — 254 passed / 17 failed / 76 skipped (baseline: 248/24/76)
- Per-test spot checks via the release binary for 15.0, 15.2, 32.10, 61.1, 65.2, 65.3, 77.2
- `cargo test -p vibesql-parser -p vibesql-executor --lib` green; `cargo clippy` introduces no new warnings in touched files
- window2/3/8 + view/select1/cast TCL files compared against a main-built binary — identical results

## Remaining failures (all tracked)

| Bucket | Tests | Follow-up |
|--------|-------|-----------|
| EQP plan introspection | 23.2-23.6 | #5230 |
| Outer-ref/window resolution | 6.2, 25.1, 25.2 | #5231 |
| Aggregate+window interaction | 44.2.2/44.3.2/44.4.2, 53.0, 61.4.2, 71.0, 61.1 (residual output mismatch) | #5232 |
| RETURNING via INSTEAD OF trigger | 73.2, 73.4 | #5233 |

Closes #5190