### PR TITLE
chore(fuzz): bump rusqlite 0.31 -> 0.40 and fix bit-rotted fuzz targets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,26 @@ updates:
       prefix: "chore(deps)"
       include: "scope"
 
+  # Cargo dependency updates for the fuzz workspace (separate cargo workspace,
+  # cannot inherit [workspace.dependencies] from the root)
+  - package-ecosystem: "cargo"
+    directory: "/fuzz"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "loom:review-requested"
+    reviewers:
+      - "rwalters"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
   # npm/pnpm dependency updates for web-demo
   - package-ecosystem: "npm"
     directory: "/web-demo"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -26,6 +26,7 @@ jobs:
           - sql_parser
           - expr_eval
           - type_convert
+          - differential_sqlite
     steps:
       - name: Free disk space
         run: |
@@ -66,6 +67,11 @@ jobs:
           key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
           restore-keys: |
             fuzz-corpus-${{ matrix.target }}-
+
+      - name: Check all fuzz targets compile
+        run: |
+          cd fuzz
+          cargo +nightly check --bins
 
       - name: Run fuzzer - ${{ matrix.target }}
         id: fuzz

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -29,7 +29,7 @@ path = "../crates/vibesql-types"
 
 # SQLite for differential testing
 [dependencies.rusqlite]
-version = "0.31"
+version = "0.40"
 features = ["bundled"]
 
 # Prevent this from interfering with workspaces

--- a/fuzz/fuzz_targets/differential_sqlite.rs
+++ b/fuzz/fuzz_targets/differential_sqlite.rs
@@ -141,13 +141,14 @@ fn vibesql_value_to_string(value: &SqlValue) -> String {
         SqlValue::Float(f) => format!("{:.6}", f),
         SqlValue::Real(f) => format!("{:.6}", f),
         SqlValue::Double(f) => format!("{:.6}", f),
-        SqlValue::Character(s) | SqlValue::Varchar(s) => s.clone(),
+        SqlValue::Character(s) | SqlValue::Varchar(s) => s.to_string(),
         SqlValue::Boolean(b) => if *b { "1" } else { "0" }.to_string(),
         SqlValue::Date(d) => format!("{}", d),
         SqlValue::Time(t) => format!("{}", t),
         SqlValue::Timestamp(ts) => format!("{}", ts),
         SqlValue::Interval(i) => format!("{}", i),
         SqlValue::Vector(v) => format!("VECTOR({} dims)", v.len()),
+        SqlValue::Blob(b) => format!("BLOB({} bytes)", b.len()),
     }
 }
 

--- a/fuzz/fuzz_targets/type_coercion.rs
+++ b/fuzz/fuzz_targets/type_coercion.rs
@@ -66,10 +66,10 @@ impl From<&FuzzValue> for SqlValue {
             FuzzValue::Unsigned(v) => SqlValue::Unsigned(*v),
             FuzzValue::Numeric(v) => SqlValue::Numeric(*v),
             FuzzValue::Float(v) => SqlValue::Float(*v),
-            FuzzValue::Real(v) => SqlValue::Real(*v),
+            FuzzValue::Real(v) => SqlValue::Real(f64::from(*v)),
             FuzzValue::Double(v) => SqlValue::Double(*v),
-            FuzzValue::Character(v) => SqlValue::Character(v.clone()),
-            FuzzValue::Varchar(v) => SqlValue::Varchar(v.clone()),
+            FuzzValue::Character(v) => SqlValue::Character(v.as_str().into()),
+            FuzzValue::Varchar(v) => SqlValue::Varchar(v.as_str().into()),
             FuzzValue::Boolean(v) => SqlValue::Boolean(*v),
             FuzzValue::Date { year, month, day } => {
                 // Normalize month and day to valid ranges


### PR DESCRIPTION
## Summary

The fuzz crate (a standalone cargo workspace) pinned rusqlite 0.31, so the `differential_sqlite` target compared VibeSQL against bundled SQLite 3.45.0 while the rest of the repo tests against 3.53.x. Worse, the target had bit-rotted: it no longer compiled due to `vibesql-types::SqlValue` changes, and nothing in CI ever built it. This PR bumps rusqlite to 0.40 (drop-in, no API migration needed), repairs the bit-rotted targets, and hardens CI so they cannot silently rot again.

## Changes

- `fuzz/Cargo.toml`: rusqlite `0.31` -> `0.40` (resolves to rusqlite 0.40.1 / libsqlite3-sys 0.38.1, bundled SQLite 3.53.x)
- `fuzz/fuzz_targets/differential_sqlite.rs`: `s.clone()` -> `s.to_string()` for `ArcStr` variants; add missing `SqlValue::Blob` match arm
- `fuzz/fuzz_targets/type_coercion.rs`: fix the same `ArcStr` bit-rot plus an `f32`->`f64` widening for `SqlValue::Real` (surfaced by `cargo check --bins`; required for the acceptance criterion that all six targets compile)
- `.github/workflows/fuzz.yml`: add `differential_sqlite` to the weekly matrix and a `cargo +nightly check --bins` step so every fuzz target (including unfuzzed ones) is compile-checked
- `.github/dependabot.yml`: add a cargo entry for `directory: "/fuzz"` (it cannot inherit root `[workspace.dependencies]`, so it needs its own coverage)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| rusqlite 0.40 required; fresh resolution yields 0.40.x / libsqlite3-sys 0.38.x | Pass | `cargo tree -p rusqlite` shows rusqlite v0.40.1 with libsqlite3-sys 0.38.1 (bundled SQLite 3.53.x) |
| `cd fuzz && cargo check --bins` succeeds (all six targets) | Pass | Ran locally; finished cleanly after also fixing pre-existing `type_coercion` bit-rot |
| Dependabot covers the `/fuzz` cargo workspace | Pass | New `package-ecosystem: cargo` entry for `directory: "/fuzz"`, mirroring root entry (weekly, grouped, same labels/reviewers) |
| Root workspace `Cargo.toml`/`Cargo.lock` untouched | Pass | `git diff --stat` touches only `fuzz/` and `.github/`; `fuzz/Cargo.lock` left untracked by design |

## Test Plan

- `cd fuzz && cargo check --bins` passes (all six fuzz targets compile)
- Smoke-ran the differential target: `cargo +nightly fuzz run differential_sqlite -- -max_total_time=30`. The target builds and runs correctly against SQLite 3.53.x — and immediately proved its worth by finding a pre-existing VibeSQL lexer panic (non-char-boundary slice on multi-byte UTF-8 identifiers, `lexer/mod.rs:368`). Filed separately as #5236; out of scope here.
- `git status` confirms no root `Cargo.lock` changes and no committed `fuzz/Cargo.lock`

Closes #5228