### PR TITLE
fix(sqlite-compat): INDEXED BY with nonexistent index errors "no such index: X"

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -494,7 +494,7 @@ impl<'a, 'arena> Converter<'a, 'arena> {
 
     fn convert_from_clause(&self, from: &arena_select::FromClause<'arena>) -> FromClause {
         match from {
-            arena_select::FromClause::Table { name, alias, column_aliases, quoted } => {
+            arena_select::FromClause::Table { name, alias, column_aliases, quoted, index_hint } => {
                 FromClause::Table {
                     name: self.resolve(*name),
                     alias: self.resolve_opt(*alias),
@@ -502,6 +502,12 @@ impl<'a, 'arena> Converter<'a, 'arena> {
                         .as_ref()
                         .map(|cols| cols.iter().map(|s| self.resolve(*s)).collect()),
                     quoted: *quoted,
+                    index_hint: index_hint.as_ref().map(|hint| match hint {
+                        arena_select::IndexHint::IndexedBy(sym) => {
+                            crate::IndexHint::IndexedBy(self.resolve(*sym))
+                        }
+                        arena_select::IndexHint::NotIndexed => crate::IndexHint::NotIndexed,
+                    }),
                 }
             }
             arena_select::FromClause::Join {

--- a/crates/vibesql-ast/src/arena/select.rs
+++ b/crates/vibesql-ast/src/arena/select.rs
@@ -99,6 +99,17 @@ pub enum SelectItem<'arena> {
     },
 }
 
+/// SQLite index hint on a FROM-clause table reference (arena variant).
+///
+/// Mirrors `crate::IndexHint` with the index name interned as a `Symbol`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum IndexHint {
+    /// `INDEXED BY <index-name>`
+    IndexedBy(Symbol),
+    /// `NOT INDEXED`
+    NotIndexed,
+}
+
 /// FROM clause
 #[derive(Debug, Clone, PartialEq)]
 pub enum FromClause<'arena> {
@@ -109,6 +120,8 @@ pub enum FromClause<'arena> {
         column_aliases: Option<BumpVec<'arena, Symbol>>,
         /// Whether the identifier was quoted (delimited) in the original SQL.
         quoted: bool,
+        /// SQLite index hint: `INDEXED BY <name>` / `NOT INDEXED`.
+        index_hint: Option<IndexHint>,
     },
     Join {
         left: &'arena FromClause<'arena>,

--- a/crates/vibesql-ast/src/lib.rs
+++ b/crates/vibesql-ast/src/lib.rs
@@ -198,8 +198,8 @@ pub use operators::{BinaryOperator, UnaryOperator};
 pub use revoke::{CascadeOption, RevokeStmt};
 pub use select::{
     CommonTableExpr, CteMaterialization, FromClause, GroupByClause, GroupingElement, GroupingSet,
-    JoinType, MixedGroupingItem, NullsOrder, OrderByItem, OrderDirection, SelectItem, SelectStmt,
-    SetOperation, SetOperator, WindowDefinition,
+    IndexHint, JoinType, MixedGroupingItem, NullsOrder, OrderByItem, OrderDirection, SelectItem,
+    SelectStmt, SetOperation, SetOperator, WindowDefinition,
 };
 pub use statement::Statement;
 

--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -978,7 +978,7 @@ impl ToSql for SelectItem {
 impl ToSql for FromClause {
     fn to_sql(&self) -> String {
         match self {
-            FromClause::Table { name, alias, column_aliases, quoted } => {
+            FromClause::Table { name, alias, column_aliases, quoted, index_hint } => {
                 // Format name with quotes if it was originally quoted
                 let mut result = if *quoted {
                     format!("\"{}\"", name.replace('"', "\"\""))
@@ -990,6 +990,15 @@ impl ToSql for FromClause {
                     if let Some(cols) = column_aliases {
                         result.push_str(&format!(" ({})", cols.join(", ")));
                     }
+                }
+                match index_hint {
+                    Some(crate::IndexHint::IndexedBy(idx)) => {
+                        result.push_str(&format!(" INDEXED BY {}", format_identifier(idx)));
+                    }
+                    Some(crate::IndexHint::NotIndexed) => {
+                        result.push_str(" NOT INDEXED");
+                    }
+                    None => {}
                 }
                 result
             }
@@ -1247,6 +1256,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -1285,6 +1295,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -1321,6 +1332,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -1347,12 +1359,14 @@ mod tests {
     fn test_join() {
         let from = FromClause::Join {
             left: Box::new(FromClause::Table {
+                index_hint: None,
                 name: "orders".to_string(),
                 alias: Some("o".to_string()),
                 column_aliases: None,
                 quoted: false,
             }),
             right: Box::new(FromClause::Table {
+                index_hint: None,
                 name: "customers".to_string(),
                 alias: Some("c".to_string()),
                 column_aliases: None,

--- a/crates/vibesql-ast/src/select.rs
+++ b/crates/vibesql-ast/src/select.rs
@@ -286,6 +286,21 @@ pub enum SelectItem {
     Expression { expr: Expression, alias: Option<String>, source_text: Option<String> },
 }
 
+/// SQLite index hint on a FROM-clause table reference.
+///
+/// `INDEXED BY <name>` requires the named index to exist on that table;
+/// `NOT INDEXED` disables index use in SQLite. VibeSQL's planner chooses
+/// indexes independently, so the hint is validated for SQLite compatibility
+/// (a nonexistent index raises `no such index: <name>`) but has no effect
+/// on plan selection.
+#[derive(Debug, Clone, PartialEq)]
+pub enum IndexHint {
+    /// `INDEXED BY <index-name>`
+    IndexedBy(String),
+    /// `NOT INDEXED`
+    NotIndexed,
+}
+
 /// FROM clause
 #[derive(Debug, Clone, PartialEq)]
 pub enum FromClause {
@@ -300,6 +315,9 @@ pub enum FromClause {
         /// - `true`: Quoted identifier (case-sensitive), e.g., `"MyTable"`
         /// - `false`: Unquoted identifier (case-insensitive), e.g., `MyTable`
         quoted: bool,
+        /// SQLite index hint: `INDEXED BY <name>` / `NOT INDEXED`.
+        /// Validated at execution time; ignored by the planner.
+        index_hint: Option<IndexHint>,
     },
     Join {
         left: Box<FromClause>,

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1168,8 +1168,8 @@ pub fn transform_select<V: ExpressionMutVisitor>(visitor: &mut V, stmt: SelectSt
 /// Transform a FROM clause
 fn transform_from_clause<V: ExpressionMutVisitor>(visitor: &mut V, from: FromClause) -> FromClause {
     match from {
-        FromClause::Table { name, alias, column_aliases, quoted } => {
-            FromClause::Table { name, alias, column_aliases, quoted }
+        FromClause::Table { name, alias, column_aliases, quoted, index_hint } => {
+            FromClause::Table { name, alias, column_aliases, quoted, index_hint }
         }
         FromClause::Subquery { query, alias, column_aliases } => FromClause::Subquery {
             query: Box::new(transform_select(visitor, *query)),

--- a/crates/vibesql-ast/tests/complex_expressions.rs
+++ b/crates/vibesql-ast/tests/complex_expressions.rs
@@ -76,6 +76,7 @@ fn test_scalar_subquery() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "employees".to_string(),
             alias: None,
             column_aliases: None,
@@ -115,6 +116,7 @@ fn test_in_expression() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "departments".to_string(),
             alias: None,
             column_aliases: None,
@@ -153,6 +155,7 @@ fn test_not_in_expression() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "excluded".to_string(),
             alias: None,
             column_aliases: None,

--- a/crates/vibesql-ast/tests/select_stmt.rs
+++ b/crates/vibesql-ast/tests/select_stmt.rs
@@ -107,6 +107,7 @@ fn test_select_from_table() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,
@@ -138,6 +139,7 @@ fn test_select_with_where() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,
@@ -172,6 +174,7 @@ fn test_select_with_order_by() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,
@@ -213,6 +216,7 @@ fn test_select_distinct() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,
@@ -248,6 +252,7 @@ fn test_select_with_group_by() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "orders".to_string(),
             alias: None,
             column_aliases: None,
@@ -277,6 +282,7 @@ fn test_select_with_having() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "sales".to_string(),
             alias: None,
             column_aliases: None,
@@ -316,6 +322,7 @@ fn test_select_with_limit() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "products".to_string(),
             alias: None,
             column_aliases: None,
@@ -343,6 +350,7 @@ fn test_select_with_offset() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "items".to_string(),
             alias: None,
             column_aliases: None,
@@ -370,6 +378,7 @@ fn test_order_by_desc() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "posts".to_string(),
             alias: None,
             column_aliases: None,
@@ -399,12 +408,14 @@ fn test_order_by_desc() {
 fn test_inner_join() {
     let from = FromClause::Join {
         left: Box::new(FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,
             quoted: false,
         }),
         right: Box::new(FromClause::Table {
+            index_hint: None,
             name: "orders".to_string(),
             alias: None,
             column_aliases: None,
@@ -434,12 +445,14 @@ fn test_inner_join() {
 fn test_left_outer_join() {
     let from = FromClause::Join {
         left: Box::new(FromClause::Table {
+            index_hint: None,
             name: "customers".to_string(),
             alias: None,
             column_aliases: None,
             quoted: false,
         }),
         right: Box::new(FromClause::Table {
+            index_hint: None,
             name: "orders".to_string(),
             alias: None,
             column_aliases: None,
@@ -461,12 +474,14 @@ fn test_left_outer_join() {
 fn test_right_outer_join() {
     let from = FromClause::Join {
         left: Box::new(FromClause::Table {
+            index_hint: None,
             name: "products".to_string(),
             alias: None,
             column_aliases: None,
             quoted: false,
         }),
         right: Box::new(FromClause::Table {
+            index_hint: None,
             name: "categories".to_string(),
             alias: None,
             column_aliases: None,
@@ -488,12 +503,14 @@ fn test_right_outer_join() {
 fn test_full_outer_join() {
     let from = FromClause::Join {
         left: Box::new(FromClause::Table {
+            index_hint: None,
             name: "table1".to_string(),
             alias: None,
             column_aliases: None,
             quoted: false,
         }),
         right: Box::new(FromClause::Table {
+            index_hint: None,
             name: "table2".to_string(),
             alias: None,
             column_aliases: None,
@@ -515,12 +532,14 @@ fn test_full_outer_join() {
 fn test_cross_join() {
     let from = FromClause::Join {
         left: Box::new(FromClause::Table {
+            index_hint: None,
             name: "colors".to_string(),
             alias: None,
             column_aliases: None,
             quoted: false,
         }),
         right: Box::new(FromClause::Table {
+            index_hint: None,
             name: "sizes".to_string(),
             alias: None,
             column_aliases: None,
@@ -553,6 +572,7 @@ fn test_from_subquery() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,
@@ -587,6 +607,7 @@ fn test_from_subquery() {
 #[test]
 fn test_table_with_alias() {
     let from = FromClause::Table {
+        index_hint: None,
         name: "employees".to_string(),
         alias: Some("e".to_string()),
         column_aliases: None,

--- a/crates/vibesql-executor/benches/sysbench_benchmark.rs
+++ b/crates/vibesql-executor/benches/sysbench_benchmark.rs
@@ -162,6 +162,7 @@ fn bind_select(stmt: &SelectStmt, params: &[SqlValue]) -> SelectStmt {
         group_by: stmt.group_by.clone(),
         having: stmt.having.clone(),
         order_by: stmt.order_by.clone(),
+        window_definitions: stmt.window_definitions.clone(),
         limit: stmt.limit.clone(),
         offset: stmt.offset.clone(),
         set_operation: stmt.set_operation.clone(),

--- a/crates/vibesql-executor/src/cache/parameterized.rs
+++ b/crates/vibesql-executor/src/cache/parameterized.rs
@@ -564,6 +564,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "tab".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -617,6 +618,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "tab".to_string(),
                 alias: None,
                 column_aliases: None,

--- a/crates/vibesql-executor/src/cache/query_signature.rs
+++ b/crates/vibesql-executor/src/cache/query_signature.rs
@@ -1146,6 +1146,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "tab".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -1180,6 +1181,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "tab".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -1228,6 +1230,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "tab".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -1262,6 +1265,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "tab".to_string(),
                 alias: None,
                 column_aliases: None,

--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -523,6 +523,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "tab0".to_string(),
                 alias: None,
                 column_aliases: None,

--- a/crates/vibesql-executor/src/cursor.rs
+++ b/crates/vibesql-executor/src/cursor.rs
@@ -329,6 +329,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "employees".to_string(),
                 alias: None,
                 column_aliases: None,

--- a/crates/vibesql-executor/src/delete/tests/subqueries.rs
+++ b/crates/vibesql-executor/src/delete/tests/subqueries.rs
@@ -197,6 +197,7 @@ mod in_subquery {
                 source_text: None,
             }],
             from: Some(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: "inactive_depts".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -267,6 +268,7 @@ mod in_subquery {
                 source_text: None,
             }],
             from: Some(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: "active_depts".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -348,6 +350,7 @@ mod scalar_subquery {
                 source_text: None,
             }],
             from: Some(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: "employees".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -431,6 +434,7 @@ mod scalar_subquery {
                 source_text: None,
             }],
             from: Some(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: "items".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -505,6 +509,7 @@ mod scalar_subquery {
                 source_text: None,
             }],
             from: Some(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: "config".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -578,6 +583,7 @@ mod empty_subquery {
                 source_text: None,
             }],
             from: Some(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: "old_depts".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -658,6 +664,7 @@ mod complex_subquery {
                 source_text: None,
             }],
             from: Some(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: "inactive_customers".to_string(),
                 alias: None,
                 column_aliases: None,

--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -368,6 +368,12 @@ pub enum ExecutorError {
     NoSuchFunction {
         function_name: String,
     },
+    /// No such index (SQLite-compatible error, e.g. INDEXED BY with an
+    /// unknown index or an index on a different table)
+    /// Format: "no such index: X"
+    NoSuchIndex {
+        index_name: String,
+    },
     Other(String),
 }
 
@@ -1282,6 +1288,10 @@ impl std::fmt::Display for ExecutorError {
                     "{}",
                     vibe_msg!("executor-no-such-function", function_name = function_name.as_str())
                 )
+            }
+            ExecutorError::NoSuchIndex { index_name } => {
+                // SQLite-compatible error message format
+                write!(f, "no such index: {}", index_name)
             }
             ExecutorError::Other(msg) => {
                 write!(f, "{}", vibe_msg!("executor-other", message = msg.as_str()))

--- a/crates/vibesql-executor/src/insert/bulk_transfer.rs
+++ b/crates/vibesql-executor/src/insert/bulk_transfer.rs
@@ -288,6 +288,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "source".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -316,6 +317,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "source".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -344,6 +346,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "source".to_string(),
                 alias: None,
                 column_aliases: None,

--- a/crates/vibesql-executor/src/optimizer/adaptive/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/adaptive/mod.rs
@@ -137,6 +137,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -201,6 +202,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "orders".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -252,6 +254,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "orders".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -285,12 +288,14 @@ mod tests {
                 left: Box::new(FromClause::Join {
                     left: Box::new(FromClause::Join {
                         left: Box::new(FromClause::Table {
+                            index_hint: None,
                             name: "t1".to_string(),
                             alias: None,
                             column_aliases: None,
                             quoted: false,
                         }),
                         right: Box::new(FromClause::Table {
+                            index_hint: None,
                             name: "t2".to_string(),
                             alias: None,
                             column_aliases: None,
@@ -303,6 +308,7 @@ mod tests {
                         alias: None,
                     }),
                     right: Box::new(FromClause::Table {
+                        index_hint: None,
                         name: "t3".to_string(),
                         alias: None,
                         column_aliases: None,
@@ -315,6 +321,7 @@ mod tests {
                     alias: None,
                 }),
                 right: Box::new(FromClause::Table {
+                    index_hint: None,
                     name: "t4".to_string(),
                     alias: None,
                     column_aliases: None,
@@ -360,6 +367,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "orders".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -400,6 +408,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "orders".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -442,6 +451,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -468,6 +478,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,

--- a/crates/vibesql-executor/src/optimizer/adaptive/strategy.rs
+++ b/crates/vibesql-executor/src/optimizer/adaptive/strategy.rs
@@ -339,6 +339,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: table.to_string(),
                 alias: None,
                 column_aliases: None,
@@ -382,6 +383,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(FromClause::Table {
+                index_hint: None,
                 name: table.to_string(),
                 alias: None,
                 column_aliases: None,

--- a/crates/vibesql-executor/src/optimizer/distinct_elimination.rs
+++ b/crates/vibesql-executor/src/optimizer/distinct_elimination.rs
@@ -364,6 +364,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: table.to_string(),
                 alias: None,
                 column_aliases: None,

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
@@ -430,6 +430,7 @@ pub(super) fn rewrite_from_clause(
     match from {
         vibesql_ast::FromClause::Table { name, alias, quoted, .. } => {
             vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: name.clone(),
                 alias: alias.clone(),
                 column_aliases: None,

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
@@ -209,6 +209,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: table.to_string(),
                 alias: None,
                 column_aliases: None,
@@ -591,6 +592,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: Some(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: table.to_string(),
                 alias: Some(alias.to_string()),
                 column_aliases: None,

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/scalar_decorrelation.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/scalar_decorrelation.rs
@@ -230,6 +230,7 @@ fn try_decorrelate_subquery(
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: inner_table.clone(),
             alias: original_alias, // Keep original alias so aggregate's column refs work
             column_aliases: None,
@@ -271,6 +272,7 @@ fn try_decorrelate_subquery(
 
     // Build the CTE table reference for joining
     let cte_table = FromClause::Table {
+        index_hint: None,
         name: cte_alias.clone(),
         alias: None,
         column_aliases: None,

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/exists.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/exists.rs
@@ -138,6 +138,7 @@ fn try_convert_simple_exists_to_join(
 
     // Create the right side of the join
     let right_from = FromClause::Table {
+        index_hint: None,
         name: table_name,
         alias: effective_alias,
         column_aliases: None,

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
@@ -239,6 +239,7 @@ pub(super) fn try_convert_in_to_join(
 
     // Create the right side of the join
     let right_from = FromClause::Table {
+        index_hint: None,
         name: table_name,
         alias: effective_alias,
         column_aliases: None,

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/tests.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/tests.rs
@@ -6,7 +6,13 @@ use vibesql_types::SqlValue;
 use super::*;
 
 fn simple_table_from(name: &str) -> FromClause {
-    FromClause::Table { name: name.to_string(), alias: None, column_aliases: None, quoted: false }
+    FromClause::Table {
+        index_hint: None,
+        name: name.to_string(),
+        alias: None,
+        column_aliases: None,
+        quoted: false,
+    }
 }
 
 fn column_ref(column: &str) -> Expression {
@@ -319,6 +325,7 @@ fn test_nested_in_subquery_self_join_column_qualification() {
 
 fn table_from_with_alias(name: &str, alias: &str) -> FromClause {
     FromClause::Table {
+        index_hint: None,
         name: name.to_string(),
         alias: Some(alias.to_string()),
         column_aliases: None,

--- a/crates/vibesql-executor/src/optimizer/table_elimination/tests.rs
+++ b/crates/vibesql-executor/src/optimizer/table_elimination/tests.rs
@@ -127,6 +127,7 @@ mod eliminate_unused_tables_tests {
 
     fn make_table(name: &str, alias: Option<&str>) -> FromClause {
         FromClause::Table {
+            index_hint: None,
             name: name.to_string(),
             alias: alias.map(|a| a.to_string()),
             column_aliases: None,

--- a/crates/vibesql-executor/src/optimizer/table_elimination/transform.rs
+++ b/crates/vibesql-executor/src/optimizer/table_elimination/transform.rs
@@ -36,6 +36,7 @@ pub(super) fn rebuild_from_clause(tables: &[TableInfo]) -> Option<FromClause> {
     let mut iter = tables.iter();
     let first = iter.next()?;
     let mut result = FromClause::Table {
+        index_hint: None,
         name: first.name.clone(),
         alias: first.alias.clone(),
         column_aliases: None,
@@ -46,6 +47,7 @@ pub(super) fn rebuild_from_clause(tables: &[TableInfo]) -> Option<FromClause> {
         result = FromClause::Join {
             left: Box::new(result),
             right: Box::new(FromClause::Table {
+                index_hint: None,
                 name: table.name.clone(),
                 alias: table.alias.clone(),
                 column_aliases: None,
@@ -78,6 +80,7 @@ pub(super) fn build_exists_checks(eliminated: &[EliminatedTable]) -> Vec<Express
                 into_table: None,
                 into_variables: None,
                 from: Some(FromClause::Table {
+                    index_hint: None,
                     name: table.name.clone(),
                     alias: table.alias.clone(),
                     column_aliases: None,

--- a/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
@@ -1049,6 +1049,7 @@ mod tests {
     /// Build a one-table FROM clause referring to the named table.
     fn from_table(name: &str) -> FromClause {
         FromClause::Table {
+            index_hint: None,
             name: name.to_string(),
             alias: None,
             column_aliases: None,

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -21,10 +21,10 @@ use crate::{
         window::{
             calculate_frame_with_exclusion, evaluate_avg_window, evaluate_count_window,
             evaluate_cume_dist, evaluate_dense_rank, evaluate_group_concat_window_with_expr,
-            evaluate_lag, evaluate_lead, evaluate_max_window, evaluate_min_window,
-            evaluate_ntile, evaluate_percent_rank, evaluate_rank, evaluate_row_number,
-            evaluate_sum_window, evaluate_total_window, partition_rows, sort_partition,
-            validate_frame, validate_range_order_by,
+            evaluate_lag, evaluate_lead, evaluate_max_window, evaluate_min_window, evaluate_ntile,
+            evaluate_percent_rank, evaluate_rank, evaluate_row_number, evaluate_sum_window,
+            evaluate_total_window, partition_rows, sort_partition, validate_frame,
+            validate_range_order_by,
         },
         CombinedExpressionEvaluator,
     },
@@ -80,14 +80,11 @@ fn build_window_map(
     let mut resolved_map: HashMap<String, WindowSpec> = HashMap::new();
 
     if let Some(defs) = window_definitions {
-        let raw_map: HashMap<String, &WindowSpec> = defs
-            .iter()
-            .map(|def| (def.name.to_lowercase(), &def.spec))
-            .collect();
+        let raw_map: HashMap<String, &WindowSpec> =
+            defs.iter().map(|def| (def.name.to_lowercase(), &def.spec)).collect();
 
         for def in defs {
-            let resolved =
-                resolve_window_spec_recursive(&def.spec, &raw_map, &resolved_map)?;
+            let resolved = resolve_window_spec_recursive(&def.spec, &raw_map, &resolved_map)?;
             resolved_map.insert(def.name.to_lowercase(), resolved);
         }
     }
@@ -130,9 +127,9 @@ fn resolve_window_spec(
 ) -> Result<WindowSpec, ExecutorError> {
     match &spec.base_window_name {
         Some(base_name) => {
-            let base_spec = window_map.get(&base_name.to_lowercase()).ok_or_else(|| {
-                ExecutorError::Other(format!("no such window: {}", base_name))
-            })?;
+            let base_spec = window_map
+                .get(&base_name.to_lowercase())
+                .ok_or_else(|| ExecutorError::Other(format!("no such window: {}", base_name)))?;
 
             Ok(WindowSpec {
                 base_window_name: None,
@@ -155,8 +152,7 @@ fn collect_window_functions(
 
     for (idx, item) in select_list.iter().enumerate() {
         if let SelectItem::Expression {
-            expr: Expression::WindowFunction { function, over },
-            ..
+            expr: Expression::WindowFunction { function, over }, ..
         } = item
         {
             let (func_name, func_type, args) = match function {
@@ -359,8 +355,7 @@ pub(super) fn apply_window_functions_to_aggregates(
                                         &win_func.args[0],
                                         Expression::ColumnRef(col_id)
                                             if col_id.column_canonical() == "*"
-                                    )
-                                {
+                                    ) {
                                     None // COUNT(*) / COUNT() - count all rows
                                 } else {
                                     Some(&arg_expr)
@@ -488,12 +483,12 @@ pub(super) fn apply_window_functions_to_aggregates(
                             let value_expr =
                                 if !mapped_args.is_empty() { &mapped_args[0] } else { &arg_expr };
                             let offset = if mapped_args.len() > 1 && !partition.is_empty() {
-                                eval_fn(&mapped_args[1], &partition.rows[0])
-                                    .ok()
-                                    .and_then(|v| match v {
+                                eval_fn(&mapped_args[1], &partition.rows[0]).ok().and_then(|v| {
+                                    match v {
                                         SqlValue::Integer(n) => Some(n),
                                         _ => None,
-                                    })
+                                    }
+                                })
                             } else {
                                 None
                             };
@@ -518,12 +513,12 @@ pub(super) fn apply_window_functions_to_aggregates(
                             let value_expr =
                                 if !mapped_args.is_empty() { &mapped_args[0] } else { &arg_expr };
                             let offset = if mapped_args.len() > 1 && !partition.is_empty() {
-                                eval_fn(&mapped_args[1], &partition.rows[0])
-                                    .ok()
-                                    .and_then(|v| match v {
+                                eval_fn(&mapped_args[1], &partition.rows[0]).ok().and_then(|v| {
+                                    match v {
                                         SqlValue::Integer(n) => Some(n),
                                         _ => None,
-                                    })
+                                    }
+                                })
                             } else {
                                 None
                             };
@@ -781,9 +776,10 @@ fn map_expr_to_result_column(
             // SELECT list expression.
             if let Expression::ColumnRef(col_id) = expr {
                 if let Expression::ColumnRef(select_col_id) = select_expr {
-                    if col_id.column_canonical().eq_ignore_ascii_case(
-                        select_col_id.column_canonical(),
-                    ) {
+                    if col_id
+                        .column_canonical()
+                        .eq_ignore_ascii_case(select_col_id.column_canonical())
+                    {
                         return make_result_col_ref(idx);
                     }
                 }
@@ -839,10 +835,7 @@ fn map_expr_to_result_column(
         // Also check column name match for GROUP BY column references
         if let Expression::ColumnRef(col_id) = expr {
             if let Expression::ColumnRef(gb_col_id) = gb_expr {
-                if col_id
-                    .column_canonical()
-                    .eq_ignore_ascii_case(gb_col_id.column_canonical())
-                {
+                if col_id.column_canonical().eq_ignore_ascii_case(gb_col_id.column_canonical()) {
                     return make_result_col_ref(select_count + i);
                 }
             }
@@ -865,8 +858,7 @@ fn map_expr_to_result_column(
     // the GROUP BY context), so if ORDER BY references the same expression, we can use that slot.
     for (idx, item) in select_list.iter().enumerate() {
         if let SelectItem::Expression {
-            expr: Expression::WindowFunction { function, .. },
-            ..
+            expr: Expression::WindowFunction { function, .. }, ..
         } = item
         {
             let win_args = match function {
@@ -903,8 +895,7 @@ fn expressions_match(expr1: &Expression, expr2: &Expression) -> bool {
                 a.canonical().eq_ignore_ascii_case(b.canonical())
             } else {
                 // If either lacks a table qualifier, just compare column names
-                a.column_canonical()
-                    .eq_ignore_ascii_case(b.column_canonical())
+                a.column_canonical().eq_ignore_ascii_case(b.column_canonical())
             }
         }
         // Literals: compare by value
@@ -915,10 +906,9 @@ fn expressions_match(expr1: &Expression, expr2: &Expression) -> bool {
             Expression::BinaryOp { left: l2, op: op2, right: r2 },
         ) => op1 == op2 && expressions_match(l1, l2) && expressions_match(r1, r2),
         // Unary operations: compare recursively
-        (
-            Expression::UnaryOp { op: op1, expr: e1 },
-            Expression::UnaryOp { op: op2, expr: e2 },
-        ) => op1 == op2 && expressions_match(e1, e2),
+        (Expression::UnaryOp { op: op1, expr: e1 }, Expression::UnaryOp { op: op2, expr: e2 }) => {
+            op1 == op2 && expressions_match(e1, e2)
+        }
         // Functions: compare by name and arguments
         (
             Expression::Function { name: n1, args: a1, .. },
@@ -930,12 +920,8 @@ fn expressions_match(expr1: &Expression, expr2: &Expression) -> bool {
         }
         // Aggregate functions: compare by name and arguments
         (
-            Expression::AggregateFunction {
-                name: n1, args: a1, distinct: d1, ..
-            },
-            Expression::AggregateFunction {
-                name: n2, args: a2, distinct: d2, ..
-            },
+            Expression::AggregateFunction { name: n1, args: a1, distinct: d1, .. },
+            Expression::AggregateFunction { name: n2, args: a2, distinct: d2, .. },
         ) => {
             n1.canonical() == n2.canonical()
                 && d1 == d2

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -58,6 +58,12 @@ impl SelectExecutor<'_> {
         // This catches queries like SELECT * FROM t, t, t, ... (65+ times)
         super::validation::validate_join_table_limit(stmt)?;
 
+        // Validate SQLite index hints (issue #5235)
+        // INDEXED BY must name an index that exists on that table; SQLite
+        // reports "no such index: X" at prepare time. The hint is otherwise
+        // ignored by the planner (PR #5234).
+        super::validation::validate_index_hints(stmt, self.database)?;
+
         // Validate aggregates with outer column references in subqueries (issue #4853)
         // This catches the specific case where a scalar subquery appears as an argument
         // to an outer aggregate function, and the subquery's aggregate references an
@@ -793,16 +799,15 @@ impl SelectExecutor<'_> {
             // Issue #5036: Check if any VALUES row contains window functions
             // If so, evaluate those rows via SELECT-without-FROM path which supports
             // window function evaluation, rather than the plain VALUES evaluator
-            let has_windows = values_rows.iter().any(|row| {
-                row.iter().any(crate::select::window::expression_has_window_function)
-            });
+            let has_windows = values_rows
+                .iter()
+                .any(|row| row.iter().any(crate::select::window::expression_has_window_function));
 
             let mut results = if has_windows {
                 let mut all_rows = Vec::with_capacity(values_rows.len());
                 for row_exprs in values_rows {
-                    let row_has_window = row_exprs
-                        .iter()
-                        .any(crate::select::window::expression_has_window_function);
+                    let row_has_window =
+                        row_exprs.iter().any(crate::select::window::expression_has_window_function);
                     if row_has_window {
                         // Construct a SELECT <expr1>, <expr2>, ... statement
                         // and execute via the window-aware path
@@ -838,10 +843,11 @@ impl SelectExecutor<'_> {
                         // No window functions - evaluate normally
                         let schema = crate::schema::CombinedSchema::empty();
                         let empty_row = vibesql_storage::Row::new(vec![]);
-                        let evaluator = crate::evaluator::CombinedExpressionEvaluator::with_database(
-                            &schema,
-                            self.database,
-                        );
+                        let evaluator =
+                            crate::evaluator::CombinedExpressionEvaluator::with_database(
+                                &schema,
+                                self.database,
+                            );
                         let mut values = Vec::with_capacity(row_exprs.len());
                         for expr in row_exprs {
                             let value = evaluator.eval(expr, &empty_row)?;

--- a/crates/vibesql-executor/src/select/executor/memory_tests.rs
+++ b/crates/vibesql-executor/src/select/executor/memory_tests.rs
@@ -126,6 +126,7 @@ mod integration_tests {
             distinct: false,
             select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
             from: Some(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: "small_table".to_string(),
                 alias: None,
                 column_aliases: None,
@@ -203,12 +204,14 @@ mod integration_tests {
             select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
             from: Some(vibesql_ast::FromClause::Join {
                 left: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     name: "t1".to_string(),
                     alias: None,
                     column_aliases: None,
                     quoted: false,
                 }),
                 right: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     name: "t2".to_string(),
                     alias: None,
                     column_aliases: None,
@@ -248,12 +251,14 @@ mod integration_tests {
             select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
             from: Some(vibesql_ast::FromClause::Join {
                 left: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     name: "t1".to_string(),
                     alias: None,
                     column_aliases: None,
                     quoted: false,
                 }),
                 right: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     name: "t2".to_string(),
                     alias: None,
                     column_aliases: None,

--- a/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
@@ -1060,11 +1060,9 @@ pub fn validate_window_query_order_by_aggregates(
     }
 
     for item in order_items {
-        if let Some(name) = find_outer_correlated_agg_in_order_by_subquery(
-            &item.expr,
-            outer_schema,
-            database,
-        ) {
+        if let Some(name) =
+            find_outer_correlated_agg_in_order_by_subquery(&item.expr, outer_schema, database)
+        {
             return Err(ExecutorError::MisuseOfAggregateContext { function_name: name });
         }
     }
@@ -1085,20 +1083,15 @@ fn find_outer_correlated_agg_in_order_by_subquery(
             // FROM clause. If we cannot determine it (e.g. nested subquery in
             // FROM), fall through to None — be conservative and don't flag
             // anything we can't prove correlated.
-            let inner_columns = collect_from_clause_column_names(
-                stmt.from.as_ref(),
-                database,
-            )?;
+            let inner_columns = collect_from_clause_column_names(stmt.from.as_ref(), database)?;
 
             // Walk the subquery's SELECT list looking for aggregate functions
             // whose column args resolve to the outer scope.
             for item in &stmt.select_list {
                 if let SelectItem::Expression { expr: inner, .. } = item {
-                    if let Some(name) = find_outer_correlated_aggregate(
-                        inner,
-                        &inner_columns,
-                        outer_schema,
-                    ) {
+                    if let Some(name) =
+                        find_outer_correlated_aggregate(inner, &inner_columns, outer_schema)
+                    {
                         return Some(name);
                     }
                 }
@@ -1109,10 +1102,9 @@ fn find_outer_correlated_agg_in_order_by_subquery(
         // expression may e.g. add a constant to a subquery: `(SELECT sum(a)
         // FROM t2) + 1`).
         Expression::BinaryOp { left, right, .. } => {
-            find_outer_correlated_agg_in_order_by_subquery(left, outer_schema, database)
-                .or_else(|| {
-                    find_outer_correlated_agg_in_order_by_subquery(right, outer_schema, database)
-                })
+            find_outer_correlated_agg_in_order_by_subquery(left, outer_schema, database).or_else(
+                || find_outer_correlated_agg_in_order_by_subquery(right, outer_schema, database),
+            )
         }
         Expression::UnaryOp { expr, .. } => {
             find_outer_correlated_agg_in_order_by_subquery(expr, outer_schema, database)
@@ -1191,7 +1183,13 @@ fn find_outer_correlated_aggregate(
 ) -> Option<String> {
     match expr {
         Expression::AggregateFunction { name, args, order_by, filter, .. } => {
-            if aggregate_args_correlate_outer(args, order_by.as_deref(), filter.as_deref(), inner_columns, outer_schema) {
+            if aggregate_args_correlate_outer(
+                args,
+                order_by.as_deref(),
+                filter.as_deref(),
+                inner_columns,
+                outer_schema,
+            ) {
                 return Some(name.to_string());
             }
             // Recurse into args in case there's a deeper aggregate (which
@@ -1208,12 +1206,12 @@ fn find_outer_correlated_aggregate(
         Expression::Function { name, args, .. } => {
             if is_aggregate_function(name.as_str()) {
                 let upper = name.to_uppercase();
-                let is_scalar_minmax =
-                    matches!(upper.as_str(), "MIN" | "MAX") && args.len() > 1;
+                let is_scalar_minmax = matches!(upper.as_str(), "MIN" | "MAX") && args.len() > 1;
                 if !is_scalar_minmax {
-                    if args.iter().any(|a| {
-                        column_ref_resolves_to_outer(a, inner_columns, outer_schema)
-                    }) {
+                    if args
+                        .iter()
+                        .any(|a| column_ref_resolves_to_outer(a, inner_columns, outer_schema))
+                    {
                         return Some(name.to_string());
                     }
                 }
@@ -1239,13 +1237,17 @@ fn find_outer_correlated_aggregate(
         }
         Expression::Case { operand, when_clauses, else_result } => {
             if let Some(op) = operand {
-                if let Some(found) = find_outer_correlated_aggregate(op, inner_columns, outer_schema) {
+                if let Some(found) =
+                    find_outer_correlated_aggregate(op, inner_columns, outer_schema)
+                {
                     return Some(found);
                 }
             }
             for w in when_clauses {
                 for cond in &w.conditions {
-                    if let Some(found) = find_outer_correlated_aggregate(cond, inner_columns, outer_schema) {
+                    if let Some(found) =
+                        find_outer_correlated_aggregate(cond, inner_columns, outer_schema)
+                    {
                         return Some(found);
                     }
                 }
@@ -1276,17 +1278,13 @@ fn aggregate_args_correlate_outer(
     inner_columns: &HashSet<String>,
     outer_schema: &CombinedSchema,
 ) -> bool {
-    let arg_correlated = args
-        .iter()
-        .any(|a| column_ref_resolves_to_outer(a, inner_columns, outer_schema));
+    let arg_correlated =
+        args.iter().any(|a| column_ref_resolves_to_outer(a, inner_columns, outer_schema));
     let order_correlated = order_by.is_some_and(|items| {
-        items
-            .iter()
-            .any(|i| column_ref_resolves_to_outer(&i.expr, inner_columns, outer_schema))
+        items.iter().any(|i| column_ref_resolves_to_outer(&i.expr, inner_columns, outer_schema))
     });
-    let filter_correlated = filter.is_some_and(|f| {
-        column_ref_resolves_to_outer(f, inner_columns, outer_schema)
-    });
+    let filter_correlated =
+        filter.is_some_and(|f| column_ref_resolves_to_outer(f, inner_columns, outer_schema));
     arg_correlated || order_correlated || filter_correlated
 }
 
@@ -1327,24 +1325,24 @@ fn column_ref_resolves_to_outer(
             args.iter().any(|a| column_ref_resolves_to_outer(a, inner_columns, outer_schema))
         }
         Expression::Case { operand, when_clauses, else_result } => {
-            operand.as_ref().is_some_and(|e| {
-                column_ref_resolves_to_outer(e, inner_columns, outer_schema)
-            }) || when_clauses.iter().any(|w| {
-                w.conditions
-                    .iter()
-                    .any(|c| column_ref_resolves_to_outer(c, inner_columns, outer_schema))
-                    || column_ref_resolves_to_outer(&w.result, inner_columns, outer_schema)
-            }) || else_result.as_ref().is_some_and(|e| {
-                column_ref_resolves_to_outer(e, inner_columns, outer_schema)
-            })
+            operand
+                .as_ref()
+                .is_some_and(|e| column_ref_resolves_to_outer(e, inner_columns, outer_schema))
+                || when_clauses.iter().any(|w| {
+                    w.conditions
+                        .iter()
+                        .any(|c| column_ref_resolves_to_outer(c, inner_columns, outer_schema))
+                        || column_ref_resolves_to_outer(&w.result, inner_columns, outer_schema)
+                })
+                || else_result
+                    .as_ref()
+                    .is_some_and(|e| column_ref_resolves_to_outer(e, inner_columns, outer_schema))
         }
         Expression::IsNull { expr, .. } => {
             column_ref_resolves_to_outer(expr, inner_columns, outer_schema)
         }
         Expression::Conjunction(children) | Expression::Disjunction(children) => {
-            children
-                .iter()
-                .any(|c| column_ref_resolves_to_outer(c, inner_columns, outer_schema))
+            children.iter().any(|c| column_ref_resolves_to_outer(c, inner_columns, outer_schema))
         }
         // Don't recurse into nested subqueries — their scope is independent.
         _ => false,
@@ -2457,6 +2455,7 @@ mod tests {
             into_table: None,
             into_variables: None,
             from: from_table.map(|name| vibesql_ast::FromClause::Table {
+                index_hint: None,
                 name: name.to_string(),
                 alias: None,
                 column_aliases: None,

--- a/crates/vibesql-executor/src/select/executor/validation/index_hints.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/index_hints.rs
@@ -1,0 +1,106 @@
+//! Validation of SQLite index hints (`INDEXED BY` / `NOT INDEXED`)
+//!
+//! SQLite validates `INDEXED BY <name>` at prepare time: the named index must
+//! exist and must be an index on the table it is attached to, otherwise the
+//! statement fails with `no such index: <name>`. VibeSQL's planner chooses
+//! indexes independently, so after validation the hint is simply ignored
+//! (matching the intent of PR #5234); this module only provides the
+//! SQLite-compatible error behavior (issue #5235).
+//!
+//! `NOT INDEXED` never errors.
+
+use vibesql_ast::{FromClause, IndexHint, SelectStmt};
+
+use crate::errors::ExecutorError;
+
+/// Validate all `INDEXED BY` hints in a SELECT statement's FROM tree.
+///
+/// Walks the FROM clause recursively (through JOIN branches, derived-table
+/// subqueries, and VALUES), plus CTE bodies and set-operation arms, so the
+/// whole statement is validated up front like SQLite's prepare step —
+/// subquery execution may otherwise be short-circuited before its hints are
+/// seen.
+///
+/// Errors with `ExecutorError::NoSuchIndex` (rendered as
+/// `no such index: <name>`) when an `INDEXED BY` hint names an index that
+/// does not exist or that belongs to a different table. A hint on a CTE name
+/// also errors, matching SQLite (a CTE is not a real table, so no index can
+/// belong to it).
+pub fn validate_index_hints(
+    stmt: &SelectStmt,
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    // CTE names visible to this statement's FROM clause: a table reference
+    // that resolves to a CTE can never carry a valid INDEXED BY hint.
+    let mut cte_names: Vec<String> = Vec::new();
+    if let Some(ctes) = &stmt.with_clause {
+        for cte in ctes {
+            // Validate hints inside the CTE body itself
+            validate_index_hints(&cte.query, database)?;
+            cte_names.push(cte.name.to_lowercase());
+        }
+    }
+
+    if let Some(from) = &stmt.from {
+        validate_from_clause(from, &cte_names, database)?;
+    }
+
+    // Set-operation arms (UNION / INTERSECT / EXCEPT)
+    if let Some(set_op) = &stmt.set_operation {
+        validate_index_hints(&set_op.right, database)?;
+    }
+
+    Ok(())
+}
+
+/// Recursively validate index hints in a FROM clause tree.
+fn validate_from_clause(
+    from: &FromClause,
+    cte_names: &[String],
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    match from {
+        FromClause::Table { name, index_hint, .. } => {
+            if let Some(IndexHint::IndexedBy(index_name)) = index_hint {
+                validate_indexed_by(name, index_name, cte_names, database)?;
+            }
+            Ok(())
+        }
+        FromClause::Join { left, right, .. } => {
+            validate_from_clause(left, cte_names, database)?;
+            validate_from_clause(right, cte_names, database)
+        }
+        FromClause::Subquery { query, .. } => validate_index_hints(query, database),
+        FromClause::Values { .. } => Ok(()),
+    }
+}
+
+/// Validate a single `INDEXED BY` hint against the catalog.
+fn validate_indexed_by(
+    table_name: &str,
+    index_name: &str,
+    cte_names: &[String],
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    let no_such_index = || ExecutorError::NoSuchIndex { index_name: index_name.to_string() };
+
+    // A CTE shadows any same-named real table; an index can never belong to
+    // a CTE, so INDEXED BY on a CTE reference always fails (SQLite parity).
+    let table_lower = table_name.to_lowercase();
+    if cte_names.contains(&table_lower) {
+        return Err(no_such_index());
+    }
+
+    let metadata = database.get_index(index_name).ok_or_else(no_such_index)?;
+
+    // The index must be on this specific table (case-insensitive). Accept
+    // both the full FROM name and its unqualified tail so schema-qualified
+    // references like `main.t1 INDEXED BY t1x` canonicalize correctly.
+    let index_table_lower = metadata.table_name.to_lowercase();
+    let unqualified_lower = table_lower.rsplit('.').next().unwrap_or(&table_lower);
+    if index_table_lower != table_lower && index_table_lower != unqualified_lower {
+        return Err(no_such_index());
+    }
+
+    Ok(())
+}

--- a/crates/vibesql-executor/src/select/executor/validation/join_limits.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/join_limits.rs
@@ -55,6 +55,7 @@ mod tests {
         // Create a SELECT with 64 tables (exactly at limit) - should pass
         // SELECT * FROM t1, t2, t3, ... (64 times)
         let mut from: FromClause = FromClause::Table {
+            index_hint: None,
             name: "t1".to_string(),
             alias: None,
             column_aliases: None,
@@ -64,6 +65,7 @@ mod tests {
             from = FromClause::Join {
                 left: Box::new(from),
                 right: Box::new(FromClause::Table {
+                    index_hint: None,
                     name: format!("t{}", i),
                     alias: None,
                     column_aliases: None,
@@ -101,6 +103,7 @@ mod tests {
     fn test_join_table_limit_exceeds_limit() {
         // Create a SELECT with 65 tables (exceeds limit) - should fail
         let mut from: FromClause = FromClause::Table {
+            index_hint: None,
             name: "t1".to_string(),
             alias: None,
             column_aliases: None,
@@ -110,6 +113,7 @@ mod tests {
             from = FromClause::Join {
                 left: Box::new(from),
                 right: Box::new(FromClause::Table {
+                    index_hint: None,
                     name: format!("t{}", i),
                     alias: None,
                     column_aliases: None,

--- a/crates/vibesql-executor/src/select/executor/validation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/mod.rs
@@ -14,6 +14,7 @@
 
 mod aggregates;
 mod column_refs;
+mod index_hints;
 mod join_limits;
 mod schema;
 
@@ -28,6 +29,7 @@ pub use aggregates::{
     validate_window_query_order_by_aggregates, SubqueryContext,
 };
 pub use column_refs::{extract_column_refs, validate_column_ref};
+pub use index_hints::validate_index_hints;
 pub use join_limits::validate_join_table_limit;
 pub use schema::validate_aggregate_subquery_outer_refs;
 use vibesql_ast::{Expression, SelectItem};

--- a/crates/vibesql-executor/src/select/scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/mod.rs
@@ -130,7 +130,7 @@ where
 
     // Fall back to standard execution (recursive left-deep joins)
     match from {
-        vibesql_ast::FromClause::Table { name, alias, column_aliases, quoted } => {
+        vibesql_ast::FromClause::Table { index_hint: _, name, alias, column_aliases, quoted } => {
             // Create TableIdentifier with proper case semantics based on quoted flag
             let identifier = TableIdentifier::new(name, *quoted);
             table::execute_table_scan_with_identifier(

--- a/crates/vibesql-executor/src/select/window/collection.rs
+++ b/crates/vibesql-executor/src/select/window/collection.rs
@@ -16,10 +16,8 @@ fn build_window_map(
 
     if let Some(defs) = window_definitions {
         // First, build a raw map for lookups during resolution
-        let raw_map: HashMap<String, &WindowSpec> = defs
-            .iter()
-            .map(|def| (def.name.to_lowercase(), &def.spec))
-            .collect();
+        let raw_map: HashMap<String, &WindowSpec> =
+            defs.iter().map(|def| (def.name.to_lowercase(), &def.spec)).collect();
 
         // Then resolve each definition, potentially recursively
         for def in defs {
@@ -71,9 +69,9 @@ fn resolve_window_spec(
     match &spec.base_window_name {
         Some(base_name) => {
             // Look up the already-resolved base window definition
-            let base_spec = window_map.get(&base_name.to_lowercase()).ok_or_else(|| {
-                ExecutorError::Other(format!("no such window: {}", base_name))
-            })?;
+            let base_spec = window_map
+                .get(&base_name.to_lowercase())
+                .ok_or_else(|| ExecutorError::Other(format!("no such window: {}", base_name)))?;
 
             // Merge: inherit from base, override with any values from current spec
             Ok(WindowSpec {
@@ -188,7 +186,12 @@ fn collect_from_expression(
                 for cond in &when_clause.conditions {
                     collect_from_expression(cond, select_index, window_map, window_functions)?;
                 }
-                collect_from_expression(&when_clause.result, select_index, window_map, window_functions)?;
+                collect_from_expression(
+                    &when_clause.result,
+                    select_index,
+                    window_map,
+                    window_functions,
+                )?;
             }
             if let Some(else_expr) = else_result {
                 collect_from_expression(else_expr, select_index, window_map, window_functions)?;

--- a/crates/vibesql-executor/src/tests/aggregate_caching.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_caching.rs
@@ -98,6 +98,7 @@ fn test_repeated_count_star_cached() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -179,6 +180,7 @@ fn test_repeated_sum_cached() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,
@@ -306,6 +308,7 @@ fn test_cache_cleared_between_groups() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "items".to_string(),
             alias: None,
@@ -411,6 +414,7 @@ fn test_distinct_aggregates_not_confused() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "values".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/aggregate_count_sum_avg_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_count_sum_avg_tests.rs
@@ -66,6 +66,7 @@ fn test_count_star_no_group_by() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "users".to_string(),
             alias: None,
@@ -149,6 +150,7 @@ fn test_sum_no_group_by() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,
@@ -232,6 +234,7 @@ fn test_count_with_nulls() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "data".to_string(),
             alias: None,
@@ -315,6 +318,7 @@ fn test_sum_with_nulls() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "amounts".to_string(),
             alias: None,
@@ -400,6 +404,7 @@ fn test_avg_function() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "scores".to_string(),
             alias: None,
@@ -484,6 +489,7 @@ fn test_avg_with_nulls() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "ratings".to_string(),
             alias: None,
@@ -571,6 +577,7 @@ fn test_count_column_all_nulls() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "null_data".to_string(),
             alias: None,
@@ -607,6 +614,7 @@ fn test_count_column_all_nulls() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "null_data".to_string(),
             alias: None,
@@ -683,6 +691,7 @@ fn test_count_star_in_simple_case_expression() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "data".to_string(),
             alias: None,
@@ -762,6 +771,7 @@ fn test_count_star_in_searched_case_expression() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "items".to_string(),
             alias: None,
@@ -831,6 +841,7 @@ fn test_count_star_in_arithmetic_expression() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "records".to_string(),
             alias: None,
@@ -905,6 +916,7 @@ fn test_count_star_in_case_then_clause() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -990,6 +1002,7 @@ fn test_count_star_in_nested_case_expression() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "nested".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/aggregate_distinct.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_distinct.rs
@@ -106,6 +106,7 @@ fn test_count_distinct_basic() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,
@@ -168,6 +169,7 @@ fn test_count_distinct_vs_count_all() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,
@@ -217,6 +219,7 @@ fn test_sum_distinct() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,
@@ -280,6 +283,7 @@ fn test_sum_distinct_vs_sum_all() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,
@@ -331,6 +335,7 @@ fn test_avg_distinct() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,
@@ -378,6 +383,7 @@ fn test_min_distinct() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,
@@ -425,6 +431,7 @@ fn test_max_distinct() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,
@@ -492,6 +499,7 @@ fn test_count_distinct_with_nulls() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -572,6 +580,7 @@ fn test_distinct_all_same_value() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -647,6 +656,7 @@ fn test_distinct_empty_table() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "empty_test".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/aggregate_edge_case_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_edge_case_tests.rs
@@ -69,6 +69,7 @@ fn test_avg_precision_decimal() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "prices".to_string(),
             alias: None,
@@ -160,6 +161,7 @@ fn test_sum_mixed_numeric_types() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "mixed_amounts".to_string(),
             alias: None,
@@ -272,6 +274,7 @@ fn test_aggregate_with_case_expression() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "transactions".to_string(),
             alias: None,
@@ -338,6 +341,7 @@ fn test_max_with_unary_plus() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "tab0".to_string(),
             alias: None,
@@ -402,6 +406,7 @@ fn test_max_with_unary_minus() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "tab0".to_string(),
             alias: None,
@@ -467,6 +472,7 @@ fn test_count_with_not() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "tab0".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/aggregate_group_by_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_group_by_tests.rs
@@ -92,6 +92,7 @@ fn test_group_by_select_alias() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,
@@ -219,6 +220,7 @@ fn test_group_by_numeric_position() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,
@@ -336,6 +338,7 @@ fn test_group_by_with_count() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/aggregate_having_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_having_tests.rs
@@ -157,6 +157,7 @@ fn test_having_clause() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "sales".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/aggregate_min_max_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_min_max_tests.rs
@@ -68,6 +68,7 @@ fn test_min_function() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "temps".to_string(),
             alias: None,
@@ -151,6 +152,7 @@ fn test_max_function() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "temps".to_string(),
             alias: None,
@@ -237,6 +239,7 @@ fn test_min_max_on_strings() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "names".to_string(),
             alias: None,
@@ -278,6 +281,7 @@ fn test_min_max_on_strings() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "names".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/between_predicates.rs
+++ b/crates/vibesql-executor/src/tests/between_predicates.rs
@@ -93,6 +93,7 @@ fn test_between_integer() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "users".to_string(),
             alias: None,
@@ -201,6 +202,7 @@ fn test_not_between() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "products".to_string(),
             alias: None,
@@ -275,6 +277,7 @@ fn test_between_boundary_inclusive() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "DATA".to_string(),
             alias: None,
@@ -379,6 +382,7 @@ fn test_between_with_column_references() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "ranges".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/comparison_ops.rs
+++ b/crates/vibesql-executor/src/tests/comparison_ops.rs
@@ -31,6 +31,7 @@ fn test_greater_than_comparison() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "nums".to_string(),
             alias: None,
@@ -83,6 +84,7 @@ fn test_less_than_comparison() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "nums".to_string(),
             alias: None,
@@ -137,6 +139,7 @@ fn test_not_equal_comparison() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "nums".to_string(),
             alias: None,
@@ -192,6 +195,7 @@ fn test_less_than_or_equal_comparison() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "nums".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/count_star_fast_path.rs
+++ b/crates/vibesql-executor/src/tests/count_star_fast_path.rs
@@ -59,6 +59,7 @@ fn test_count_star_fast_path_simple() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test_table".to_string(),
             alias: None,
@@ -112,6 +113,7 @@ fn test_count_star_fast_path_empty_table() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "empty_table".to_string(),
             alias: None,
@@ -183,6 +185,7 @@ fn test_count_star_with_where_no_fast_path() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test_table".to_string(),
             alias: None,
@@ -301,6 +304,7 @@ fn test_count_star_with_group_by_no_fast_path() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test_table".to_string(),
             alias: None,
@@ -366,6 +370,7 @@ fn test_count_star_distinct_no_fast_path() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test_table".to_string(),
             alias: None,
@@ -429,6 +434,7 @@ fn test_count_column_no_fast_path() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test_table".to_string(),
             alias: None,
@@ -490,6 +496,7 @@ fn test_count_star_with_alias() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test_table".to_string(),
             alias: None,
@@ -576,6 +583,7 @@ fn test_count_star_multiple_select_items_no_fast_path() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test_table".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/index_hint_validation.rs
+++ b/crates/vibesql-executor/src/tests/index_hint_validation.rs
@@ -1,0 +1,199 @@
+//! Tests for SQLite index hint validation (issue #5235)
+//!
+//! `INDEXED BY <name>` must name an index that exists on that specific
+//! table, otherwise SQLite fails at prepare time with `no such index: <name>`.
+//! `NOT INDEXED` never errors. VibeSQL validates the hint and then ignores it
+//! for planning (PR #5234).
+
+use vibesql_ast::{IndexColumn, OrderDirection};
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+use crate::{errors::ExecutorError, select::SelectExecutor};
+
+/// Create a test database with two tables (t1, t2) and an index on each.
+///
+/// - `t1(x INTEGER, y INTEGER)` with index `t1x` on `x`
+/// - `t2(a INTEGER)` with index `t2a` on `a`
+fn create_test_db() -> Database {
+    let mut db = Database::new();
+    db.catalog.set_case_sensitive_identifiers(false);
+
+    let t1 = TableSchema::new(
+        "t1".to_string(),
+        vec![
+            ColumnSchema::new("x".to_string(), DataType::Integer, false),
+            ColumnSchema::new("y".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(t1).unwrap();
+    db.insert_row("t1", Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(10)])).unwrap();
+    db.insert_row("t1", Row::new(vec![SqlValue::Integer(2), SqlValue::Integer(20)])).unwrap();
+
+    let t2 = TableSchema::new(
+        "t2".to_string(),
+        vec![ColumnSchema::new("a".to_string(), DataType::Integer, false)],
+    );
+    db.create_table(t2).unwrap();
+    db.insert_row("t2", Row::new(vec![SqlValue::Integer(1)])).unwrap();
+
+    db.create_index(
+        "t1x".to_string(),
+        "t1".to_string(),
+        false,
+        vec![IndexColumn::Column {
+            column_name: "x".to_string(),
+            prefix_length: None,
+            direction: OrderDirection::Asc,
+        }],
+    )
+    .unwrap();
+
+    db.create_index(
+        "t2a".to_string(),
+        "t2".to_string(),
+        false,
+        vec![IndexColumn::Column {
+            column_name: "a".to_string(),
+            prefix_length: None,
+            direction: OrderDirection::Asc,
+        }],
+    )
+    .unwrap();
+
+    db
+}
+
+/// Execute a SELECT statement and return the result.
+fn run_select(db: &Database, sql: &str) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for {sql}: {e:?}"));
+    match stmt {
+        vibesql_ast::Statement::Select(select) => SelectExecutor::new(db).execute(&select),
+        other => panic!("Expected SELECT statement, got {other:?}"),
+    }
+}
+
+/// Assert that a query fails with exactly `no such index: <name>`.
+fn assert_no_such_index(db: &Database, sql: &str, index_name: &str) {
+    let result = run_select(db, sql);
+    match result {
+        Err(ExecutorError::NoSuchIndex { index_name: name }) => {
+            assert_eq!(name, index_name);
+        }
+        other => panic!("Expected NoSuchIndex error for {sql}, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_indexed_by_valid_index_succeeds() {
+    let db = create_test_db();
+    let rows = run_select(&db, "SELECT * FROM t1 INDEXED BY t1x WHERE x = 1").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0], SqlValue::Integer(1));
+}
+
+#[test]
+fn test_indexed_by_valid_index_unchanged_results() {
+    let db = create_test_db();
+    let with_hint = run_select(&db, "SELECT x, y FROM t1 INDEXED BY t1x ORDER BY x").unwrap();
+    let without_hint = run_select(&db, "SELECT x, y FROM t1 ORDER BY x").unwrap();
+    assert_eq!(with_hint, without_hint);
+}
+
+#[test]
+fn test_indexed_by_nonexistent_index_errors() {
+    let db = create_test_db();
+    assert_no_such_index(&db, "SELECT * FROM t1 INDEXED BY no_such_index", "no_such_index");
+}
+
+#[test]
+fn test_no_such_index_error_message_format() {
+    let db = create_test_db();
+    let err = run_select(&db, "SELECT * FROM t1 INDEXED BY nope").unwrap_err();
+    assert_eq!(err.to_string(), "no such index: nope");
+}
+
+#[test]
+fn test_indexed_by_index_on_wrong_table_errors() {
+    let db = create_test_db();
+    // t2a exists, but on t2 - not on t1
+    assert_no_such_index(&db, "SELECT * FROM t1 INDEXED BY t2a", "t2a");
+}
+
+#[test]
+fn test_not_indexed_never_errors() {
+    let db = create_test_db();
+    let rows = run_select(&db, "SELECT * FROM t1 NOT INDEXED").unwrap();
+    assert_eq!(rows.len(), 2);
+}
+
+#[test]
+fn test_indexed_by_case_insensitive_index_name() {
+    let db = create_test_db();
+    let rows = run_select(&db, "SELECT * FROM t1 INDEXED BY T1X WHERE x = 2").unwrap();
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn test_indexed_by_with_table_alias() {
+    let db = create_test_db();
+    let rows = run_select(&db, "SELECT a.x FROM t1 AS a INDEXED BY t1x WHERE a.x = 1").unwrap();
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn test_indexed_by_inside_join_branch_errors() {
+    let db = create_test_db();
+    assert_no_such_index(
+        &db,
+        "SELECT * FROM t1 JOIN t2 INDEXED BY missing_idx ON t1.x = t2.a",
+        "missing_idx",
+    );
+}
+
+#[test]
+fn test_indexed_by_inside_join_branch_valid_succeeds() {
+    let db = create_test_db();
+    let rows = run_select(&db, "SELECT * FROM t1 JOIN t2 INDEXED BY t2a ON t1.x = t2.a").unwrap();
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn test_indexed_by_on_cte_name_errors() {
+    let db = create_test_db();
+    // c is a CTE, not a real table; no index can belong to it.
+    // SQLite: "no such index: t1x" (the hint cannot apply to a CTE).
+    assert_no_such_index(&db, "WITH c AS (SELECT * FROM t1) SELECT * FROM c INDEXED BY t1x", "t1x");
+}
+
+#[test]
+fn test_indexed_by_inside_cte_body_is_validated() {
+    let db = create_test_db();
+    assert_no_such_index(
+        &db,
+        "WITH c AS (SELECT * FROM t1 INDEXED BY missing_idx) SELECT * FROM c",
+        "missing_idx",
+    );
+}
+
+#[test]
+fn test_indexed_by_in_union_arm_errors() {
+    let db = create_test_db();
+    assert_no_such_index(
+        &db,
+        "SELECT x FROM t1 UNION ALL SELECT a FROM t2 INDEXED BY missing_idx",
+        "missing_idx",
+    );
+}
+
+#[test]
+fn test_indexed_by_in_from_subquery_errors() {
+    let db = create_test_db();
+    assert_no_such_index(
+        &db,
+        "SELECT * FROM (SELECT * FROM t1 INDEXED BY missing_idx) AS sub",
+        "missing_idx",
+    );
+}

--- a/crates/vibesql-executor/src/tests/join_aggregation.rs
+++ b/crates/vibesql-executor/src/tests/join_aggregation.rs
@@ -165,12 +165,14 @@ fn test_inner_join_with_group_by_count() {
             ],
             from: Some(vibesql_ast::FromClause::Join {
                 left: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "departments".to_string(),
                     alias: Some("d".to_string()),
                     column_aliases: None,
                 }),
                 right: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "employees".to_string(),
                     alias: Some("e".to_string()),
@@ -279,12 +281,14 @@ fn test_left_join_with_group_by_avg_salary() {
             ],
             from: Some(vibesql_ast::FromClause::Join {
                 left: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "departments".to_string(),
                     alias: Some("d".to_string()),
                     column_aliases: None,
                 }),
                 right: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "employees".to_string(),
                     alias: Some("e".to_string()),
@@ -394,12 +398,14 @@ fn test_join_group_by_with_having() {
             ],
             from: Some(vibesql_ast::FromClause::Join {
                 left: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "departments".to_string(),
                     alias: Some("d".to_string()),
                     column_aliases: None,
                 }),
                 right: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "employees".to_string(),
                     alias: Some("e".to_string()),
@@ -521,12 +527,14 @@ fn test_join_group_by_multiple_aggregates() {
             ],
             from: Some(vibesql_ast::FromClause::Join {
                 left: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "departments".to_string(),
                     alias: Some("d".to_string()),
                     column_aliases: None,
                 }),
                 right: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "employees".to_string(),
                     alias: Some("e".to_string()),

--- a/crates/vibesql-executor/src/tests/limit_offset.rs
+++ b/crates/vibesql-executor/src/tests/limit_offset.rs
@@ -13,6 +13,7 @@ fn make_pagination_stmt(limit: Option<usize>, offset: Option<usize>) -> vibesql_
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "users".to_string(),
             alias: None,
@@ -226,12 +227,14 @@ fn test_limit_with_inner_join() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "orders".to_string(),
                 alias: None,
@@ -341,12 +344,14 @@ fn test_offset_with_inner_join() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "orders".to_string(),
                 alias: None,
@@ -456,12 +461,14 @@ fn test_limit_offset_with_inner_join() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "orders".to_string(),
                 alias: None,

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -82,6 +82,7 @@ mod expression_index_tests;
 mod foreign_key_mismatch;
 mod fulltext_search;
 mod function_tests;
+mod index_hint_validation;
 mod index_optimization;
 mod index_scan_tests;
 mod issue_938_integer_type_preservation;

--- a/crates/vibesql-executor/src/tests/natural_join.rs
+++ b/crates/vibesql-executor/src/tests/natural_join.rs
@@ -122,12 +122,14 @@ fn test_natural_join_single_common_column() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t1".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t2".to_string(),
                 alias: None,
@@ -267,12 +269,14 @@ fn test_natural_join_respects_collation() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "people".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "greetings".to_string(),
                 alias: None,
@@ -375,12 +379,14 @@ fn test_using_join_respects_collation() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "people".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "greetings".to_string(),
                 alias: None,
@@ -485,24 +491,28 @@ fn test_issue_4843_inner_join_using_with_nested_left_join_nulls() {
 
     // Build the nested join structure
     let t5_ref = vibesql_ast::FromClause::Table {
+        index_hint: None,
         quoted: false,
         name: "t5".to_string(),
         alias: None,
         column_aliases: None,
     };
     let t4_ref = vibesql_ast::FromClause::Table {
+        index_hint: None,
         quoted: false,
         name: "t4".to_string(),
         alias: None,
         column_aliases: None,
     };
     let t3_ref = vibesql_ast::FromClause::Table {
+        index_hint: None,
         quoted: false,
         name: "t3".to_string(),
         alias: None,
         column_aliases: None,
     };
     let t2_ref = vibesql_ast::FromClause::Table {
+        index_hint: None,
         quoted: false,
         name: "t2".to_string(),
         alias: None,

--- a/crates/vibesql-executor/src/tests/not_operator_tests.rs
+++ b/crates/vibesql-executor/src/tests/not_operator_tests.rs
@@ -71,6 +71,7 @@ fn test_not_in_select_where() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "tab0".to_string(),
             alias: None,
@@ -157,6 +158,7 @@ fn test_not_with_equality() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "tab0".to_string(),
             alias: None,
@@ -271,6 +273,7 @@ fn test_not_in_delete_where() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "tab0".to_string(),
             alias: None,
@@ -348,6 +351,7 @@ fn test_not_with_null() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "tab0".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/operator_edge_cases/comparison_operators.rs
+++ b/crates/vibesql-executor/src/tests/operator_edge_cases/comparison_operators.rs
@@ -30,6 +30,7 @@ fn test_nested_comparisons() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/phase3_join_optimization.rs
+++ b/crates/vibesql-executor/src/tests/phase3_join_optimization.rs
@@ -87,12 +87,14 @@ fn test_hash_join_from_where_equijoin_no_on_clause() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t1".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t2".to_string(),
                 alias: None,
@@ -215,12 +217,14 @@ fn test_hash_join_multiple_equijoins_in_where() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t1".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t2".to_string(),
                 alias: None,
@@ -336,12 +340,14 @@ fn test_cascading_joins_with_where_equijoins() {
             left: Box::new(vibesql_ast::FromClause::Join {
                 left: Box::new(vibesql_ast::FromClause::Join {
                     left: Box::new(vibesql_ast::FromClause::Table {
+                        index_hint: None,
                         quoted: false,
                         name: "t1".to_string(),
                         alias: None,
                         column_aliases: None,
                     }),
                     right: Box::new(vibesql_ast::FromClause::Table {
+                        index_hint: None,
                         quoted: false,
                         name: "t2".to_string(),
                         alias: None,
@@ -354,6 +360,7 @@ fn test_cascading_joins_with_where_equijoins() {
                     alias: None,
                 }),
                 right: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "t3".to_string(),
                     alias: None,
@@ -366,6 +373,7 @@ fn test_cascading_joins_with_where_equijoins() {
                 alias: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t4".to_string(),
                 alias: None,
@@ -502,12 +510,14 @@ fn test_hash_join_with_on_clause_and_where_equijoins() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t1".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t2".to_string(),
                 alias: None,
@@ -647,12 +657,14 @@ fn test_multi_column_hash_join_composite_keys() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "sales".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "inventory".to_string(),
                 alias: None,
@@ -820,12 +832,14 @@ fn test_star_join_select5_pattern() {
                     left: Box::new(vibesql_ast::FromClause::Join {
                         left: Box::new(vibesql_ast::FromClause::Join {
                             left: Box::new(vibesql_ast::FromClause::Table {
+                                index_hint: None,
                                 quoted: false,
                                 name: "t1".to_string(),
                                 alias: None,
                                 column_aliases: None,
                             }),
                             right: Box::new(vibesql_ast::FromClause::Table {
+                                index_hint: None,
                                 quoted: false,
                                 name: "t2".to_string(),
                                 alias: None,
@@ -838,6 +852,7 @@ fn test_star_join_select5_pattern() {
                             alias: None,
                         }),
                         right: Box::new(vibesql_ast::FromClause::Table {
+                            index_hint: None,
                             quoted: false,
                             name: "t3".to_string(),
                             alias: None,
@@ -850,6 +865,7 @@ fn test_star_join_select5_pattern() {
                         alias: None,
                     }),
                     right: Box::new(vibesql_ast::FromClause::Table {
+                        index_hint: None,
                         quoted: false,
                         name: "t4".to_string(),
                         alias: None,
@@ -862,6 +878,7 @@ fn test_star_join_select5_pattern() {
                     alias: None,
                 }),
                 right: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "t5".to_string(),
                     alias: None,
@@ -874,6 +891,7 @@ fn test_star_join_select5_pattern() {
                 alias: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t6".to_string(),
                 alias: None,

--- a/crates/vibesql-executor/src/tests/predicate_pushdown.rs
+++ b/crates/vibesql-executor/src/tests/predicate_pushdown.rs
@@ -59,6 +59,7 @@ fn test_table_local_predicate_applied_at_scan() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -141,12 +142,14 @@ fn test_multi_table_with_local_predicates() {
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Join {
                 left: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "t1".to_string(),
                     alias: None,
                     column_aliases: None,
                 }),
                 right: Box::new(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "t2".to_string(),
                     alias: None,
@@ -159,6 +162,7 @@ fn test_multi_table_with_local_predicates() {
                 alias: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t3".to_string(),
                 alias: None,
@@ -293,12 +297,14 @@ fn test_table_local_predicate_with_explicit_join() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "orders".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "customers".to_string(),
                 alias: None,
@@ -407,6 +413,7 @@ fn test_table_local_predicate_with_multiple_conditions() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "products".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/predicate_tests/between_predicate.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/between_predicate.rs
@@ -34,6 +34,7 @@ fn test_between_with_null_expr() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -92,6 +93,7 @@ fn test_not_between() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -149,6 +151,7 @@ fn test_between_boundary_values() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -209,6 +212,7 @@ fn test_not_between_with_null_bound() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -268,6 +272,7 @@ fn test_between_with_null_bound() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -330,6 +335,7 @@ fn test_not_between_with_null_lower_bound() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -394,6 +400,7 @@ fn test_not_negative_literal_between_null_bounds() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "tab0".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/predicate_tests/in_predicate.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/in_predicate.rs
@@ -37,6 +37,7 @@ fn test_in_list_basic() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -96,6 +97,7 @@ fn test_not_in_list() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -153,6 +155,7 @@ fn test_in_list_with_null_value() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -210,6 +213,7 @@ fn test_in_list_with_null_in_list() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -268,6 +272,7 @@ fn test_empty_in_list() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -322,6 +327,7 @@ fn test_empty_not_in_list() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -383,6 +389,7 @@ fn test_null_in_empty_subquery() {
                     distinct: false,
                     select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
                     from: Some(vibesql_ast::FromClause::Table {
+                        index_hint: None,
                         quoted: false,
                         name: "empty_table".to_string(),
                         alias: None,
@@ -455,6 +462,7 @@ fn test_null_not_in_empty_subquery() {
                     distinct: false,
                     select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
                     from: Some(vibesql_ast::FromClause::Table {
+                        index_hint: None,
                         quoted: false,
                         name: "empty_table".to_string(),
                         alias: None,
@@ -528,6 +536,7 @@ fn test_value_in_empty_subquery() {
                     distinct: false,
                     select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
                     from: Some(vibesql_ast::FromClause::Table {
+                        index_hint: None,
                         quoted: false,
                         name: "empty_table".to_string(),
                         alias: None,

--- a/crates/vibesql-executor/src/tests/predicate_tests/in_subquery_multi_column_validation.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/in_subquery_multi_column_validation.rs
@@ -50,6 +50,7 @@ fn test_in_subquery_wildcard_multi_column_rejected() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -64,6 +65,7 @@ fn test_in_subquery_wildcard_multi_column_rejected() {
                 distinct: false,
                 select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }], /* * expands to 2 columns! */
                 from: Some(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "t1".to_string(),
                     alias: None,
@@ -146,6 +148,7 @@ fn test_in_subquery_explicit_multi_column_rejected() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -175,6 +178,7 @@ fn test_in_subquery_explicit_multi_column_rejected() {
                     },
                 ],
                 from: Some(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "t1".to_string(),
                     alias: None,
@@ -257,6 +261,7 @@ fn test_in_subquery_single_column_accepted() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -277,6 +282,7 @@ fn test_in_subquery_single_column_accepted() {
                     source_text: None,
                 }],
                 from: Some(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "t1".to_string(),
                     alias: None,
@@ -357,6 +363,7 @@ fn test_scalar_subquery_wildcard_multi_column_rejected() {
                 distinct: false,
                 select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }], /* * expands to 2 columns! */
                 from: Some(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "t1".to_string(),
                     alias: None,
@@ -376,6 +383,7 @@ fn test_scalar_subquery_wildcard_multi_column_rejected() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/predicate_tests/like_predicate.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/like_predicate.rs
@@ -52,6 +52,7 @@ fn test_like_wildcard_percent() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -125,6 +126,7 @@ fn test_like_wildcard_underscore() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -198,6 +200,7 @@ fn test_not_like() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -258,6 +261,7 @@ fn test_like_null_pattern() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -316,6 +320,7 @@ fn test_like_null_value() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/procedures/edge_cases.rs
+++ b/crates/vibesql-executor/src/tests/procedures/edge_cases.rs
@@ -382,6 +382,7 @@ fn test_procedural_select_into_single_column() {
                 into_table: None,
                 into_variables: Some(vec!["user_name".to_string()]),
                 from: Some(FromClause::Table {
+                    index_hint: None,
                     name: "users".to_string(),
                     alias: None,
                     column_aliases: None,
@@ -474,6 +475,7 @@ fn test_procedural_select_into_multiple_columns() {
                 into_table: None,
                 into_variables: Some(vec!["user_id_out".to_string(), "user_name".to_string()]),
                 from: Some(FromClause::Table {
+                    index_hint: None,
                     name: "users".to_string(),
                     alias: None,
                     column_aliases: None,
@@ -549,6 +551,7 @@ fn test_procedural_select_into_error_no_rows() {
                 into_table: None,
                 into_variables: Some(vec!["user_name".to_string()]),
                 from: Some(FromClause::Table {
+                    index_hint: None,
                     name: "users".to_string(),
                     alias: None,
                     column_aliases: None,
@@ -637,6 +640,7 @@ fn test_procedural_select_into_error_multiple_rows() {
                 into_table: None,
                 into_variables: Some(vec!["user_name".to_string()]),
                 from: Some(FromClause::Table {
+                    index_hint: None,
                     name: "users".to_string(),
                     alias: None,
                     column_aliases: None,
@@ -715,6 +719,7 @@ fn test_procedural_select_into_error_column_count_mismatch() {
                 into_table: None,
                 into_variables: Some(vec!["user_name".to_string()]),
                 from: Some(FromClause::Table {
+                    index_hint: None,
                     name: "users".to_string(),
                     alias: None,
                     column_aliases: None,

--- a/crates/vibesql-executor/src/tests/quantified_comparison_tests.rs
+++ b/crates/vibesql-executor/src/tests/quantified_comparison_tests.rs
@@ -63,6 +63,7 @@ fn test_all_greater_than_basic() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t2".to_string(),
             alias: None,
@@ -92,6 +93,7 @@ fn test_all_greater_than_basic() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -174,6 +176,7 @@ fn test_any_less_than_basic() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t2".to_string(),
             alias: None,
@@ -203,6 +206,7 @@ fn test_any_less_than_basic() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -286,6 +290,7 @@ fn test_some_equals_basic() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t2".to_string(),
             alias: None,
@@ -315,6 +320,7 @@ fn test_some_equals_basic() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -392,6 +398,7 @@ fn test_all_with_empty_subquery() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t2".to_string(),
             alias: None,
@@ -421,6 +428,7 @@ fn test_all_with_empty_subquery() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -498,6 +506,7 @@ fn test_any_with_empty_subquery() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t2".to_string(),
             alias: None,
@@ -527,6 +536,7 @@ fn test_any_with_empty_subquery() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -611,6 +621,7 @@ fn test_all_with_null_in_subquery() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t2".to_string(),
             alias: None,
@@ -640,6 +651,7 @@ fn test_all_with_null_in_subquery() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -713,6 +725,7 @@ fn test_all_with_null_left_value() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t2".to_string(),
             alias: None,
@@ -742,6 +755,7 @@ fn test_all_with_null_left_value() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/rowid_tests.rs
+++ b/crates/vibesql-executor/src/tests/rowid_tests.rs
@@ -80,6 +80,7 @@ fn test_select_rowid() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -143,6 +144,7 @@ fn test_select_underscore_rowid() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -197,6 +199,7 @@ fn test_select_oid() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -251,6 +254,7 @@ fn test_rowid_case_insensitive() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -321,6 +325,7 @@ fn test_real_rowid_column_takes_precedence() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -378,6 +383,7 @@ fn test_rowid_with_table_alias() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: Some("t".to_string()),
@@ -446,6 +452,7 @@ fn test_explicit_rowid_preserved() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -526,6 +533,7 @@ fn test_mixed_explicit_and_auto_rowid() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -602,6 +610,7 @@ fn test_order_by_rowid() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -670,6 +679,7 @@ fn test_order_by_rowid_desc() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/scalar_subquery_basic_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_basic_tests.rs
@@ -84,6 +84,7 @@ fn test_scalar_subquery_in_where_clause() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "employees".to_string(),
             alias: None,
@@ -108,6 +109,7 @@ fn test_scalar_subquery_in_where_clause() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "employees".to_string(),
             alias: None,
@@ -209,6 +211,7 @@ fn test_scalar_subquery_in_select_list() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "employees".to_string(),
             alias: None,
@@ -253,6 +256,7 @@ fn test_scalar_subquery_in_select_list() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "employees".to_string(),
             alias: None,
@@ -322,6 +326,7 @@ fn test_scalar_subquery_returns_null_when_empty() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "employees".to_string(),
             alias: None,
@@ -358,6 +363,7 @@ fn test_scalar_subquery_returns_null_when_empty() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "employees".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/scalar_subquery_correlated_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_correlated_tests.rs
@@ -97,6 +97,7 @@ fn test_correlated_subquery_uppercase_identifiers_issue_4111() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "ITEM".to_string(),     // UPPERCASE table
             alias: Some("J".to_string()), // UPPERCASE alias
@@ -139,6 +140,7 @@ fn test_correlated_subquery_uppercase_identifiers_issue_4111() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "ITEM".to_string(),
             alias: Some("I".to_string()),
@@ -279,6 +281,7 @@ fn test_correlated_subquery_basic() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "employees".to_string(),
             alias: None,
@@ -326,6 +329,7 @@ fn test_correlated_subquery_basic() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "employees".to_string(),
             alias: Some("e".to_string()),

--- a/crates/vibesql-executor/src/tests/scalar_subquery_error_tests.rs
+++ b/crates/vibesql-executor/src/tests/scalar_subquery_error_tests.rs
@@ -52,6 +52,7 @@ fn test_scalar_subquery_multiple_rows_returns_first() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "employees".to_string(),
             alias: None,
@@ -81,6 +82,7 @@ fn test_scalar_subquery_multiple_rows_returns_first() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "employees".to_string(),
             alias: None,
@@ -163,6 +165,7 @@ fn test_scalar_subquery_error_multiple_columns() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "employees".to_string(),
             alias: None,
@@ -191,6 +194,7 @@ fn test_scalar_subquery_error_multiple_columns() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "employees".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/select_basic_projection.rs
+++ b/crates/vibesql-executor/src/tests/select_basic_projection.rs
@@ -51,6 +51,7 @@ fn test_select_star() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "users".to_string(),
             alias: None,
@@ -136,6 +137,7 @@ fn test_select_specific_columns() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "users".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/select_derived_columns.rs
+++ b/crates/vibesql-executor/src/tests/select_derived_columns.rs
@@ -50,6 +50,7 @@ fn test_select_star_with_derived_columns() {
             alias: Some(vec!["c".to_string(), "d".to_string()]),
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -117,6 +118,7 @@ fn test_select_qualified_star_with_derived_columns() {
             alias: Some(vec!["c".to_string(), "d".to_string()]),
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -185,6 +187,7 @@ fn test_derived_columns_count_mismatch() {
             alias: Some(vec!["c".to_string(), "d".to_string(), "e".to_string()]),
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -258,6 +261,7 @@ fn test_select_distinct_star_with_derived_columns() {
             alias: Some(vec!["c".to_string(), "d".to_string()]),
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -325,6 +329,7 @@ fn test_select_star_alias_with_table_alias() {
             alias: Some(vec!["X".to_string(), "Y".to_string()]),
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: Some("alias_name".to_string()),

--- a/crates/vibesql-executor/src/tests/select_distinct.rs
+++ b/crates/vibesql-executor/src/tests/select_distinct.rs
@@ -76,6 +76,7 @@ fn test_distinct_removes_duplicate_rows() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "products".to_string(),
             alias: None,
@@ -200,6 +201,7 @@ fn test_distinct_with_multiple_columns() {
             },
         ],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "orders".to_string(),
             alias: None,
@@ -293,6 +295,7 @@ fn test_distinct_with_null_values() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "items".to_string(),
             alias: None,
@@ -360,6 +363,7 @@ fn test_distinct_false_preserves_duplicates() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "products".to_string(),
             alias: None,
@@ -451,6 +455,7 @@ fn test_distinct_with_where_clause() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "users".to_string(),
             alias: None,
@@ -550,6 +555,7 @@ fn test_distinct_with_order_by() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "products".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/select_into_tests.rs
+++ b/crates/vibesql-executor/src/tests/select_into_tests.rs
@@ -74,6 +74,7 @@ fn test_select_into_single_row() {
         into_table: Some("target".to_string()),
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "source".to_string(),
             alias: None,
@@ -105,6 +106,7 @@ fn test_select_into_single_row() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "target".to_string(),
             alias: None,
@@ -169,6 +171,7 @@ fn test_select_into_no_rows_error() {
         into_table: Some("target".to_string()),
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "source".to_string(),
             alias: None,
@@ -248,6 +251,7 @@ fn test_select_into_multiple_rows_error() {
         into_table: Some("target".to_string()),
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "source".to_string(),
             alias: None,
@@ -328,6 +332,7 @@ fn test_select_into_with_expressions() {
         into_table: Some("target".to_string()),
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "source".to_string(),
             alias: None,
@@ -356,6 +361,7 @@ fn test_select_into_with_expressions() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "target".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/select_joins.rs
+++ b/crates/vibesql-executor/src/tests/select_joins.rs
@@ -92,12 +92,14 @@ fn test_inner_join_two_tables() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "orders".to_string(),
                 alias: None,
@@ -222,12 +224,14 @@ fn test_right_outer_join() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "orders".to_string(),
                 alias: None,
@@ -359,12 +363,14 @@ fn test_full_outer_join() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "orders".to_string(),
                 alias: None,
@@ -499,12 +505,14 @@ fn test_cross_join() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "products".to_string(),
                 alias: None,
@@ -578,12 +586,14 @@ fn test_cross_join_with_condition_works_like_inner_join() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "users".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "products".to_string(),
                 alias: None,
@@ -724,12 +734,14 @@ fn test_inner_join_null_values_dont_match() {
         ],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t1".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t2".to_string(),
                 alias: None,

--- a/crates/vibesql-executor/src/tests/select_order_by.rs
+++ b/crates/vibesql-executor/src/tests/select_order_by.rs
@@ -59,6 +59,7 @@ fn test_order_by_single_column_asc() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "users".to_string(),
             alias: None,
@@ -158,6 +159,7 @@ fn test_order_by_multiple_columns() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "users".to_string(),
             alias: None,
@@ -272,12 +274,14 @@ fn test_order_by_with_join_issue_4552() {
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Join {
             left: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t1".to_string(),
                 alias: None,
                 column_aliases: None,
             }),
             right: Box::new(vibesql_ast::FromClause::Table {
+                index_hint: None,
                 quoted: false,
                 name: "t2".to_string(),
                 alias: None,
@@ -384,6 +388,7 @@ fn test_order_by_preserved_in_derived_table_issue_4734() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -502,6 +507,7 @@ fn test_outer_order_by_takes_precedence_issue_4734() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/select_where.rs
+++ b/crates/vibesql-executor/src/tests/select_where.rs
@@ -58,6 +58,7 @@ fn test_select_with_where() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "users".to_string(),
             alias: None,
@@ -147,6 +148,7 @@ fn test_select_with_and_condition() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "products".to_string(),
             alias: None,
@@ -242,6 +244,7 @@ fn test_select_with_or_condition() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "items".to_string(),
             alias: None,
@@ -335,6 +338,7 @@ fn test_select_with_null_in_where() {
         distinct: false,
         select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "data".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/select_without_from.rs
+++ b/crates/vibesql-executor/src/tests/select_without_from.rs
@@ -535,6 +535,7 @@ fn test_hex_literal_in_subquery_without_from() {
                     distinct: false,
                     select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
                     from: Some(vibesql_ast::FromClause::Table {
+                        index_hint: None,
                         quoted: false,
                         name: "t1".to_string(),
                         alias: None,
@@ -646,6 +647,7 @@ fn test_binary_literal_in_subquery_without_from() {
                     distinct: false,
                     select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
                     from: Some(vibesql_ast::FromClause::Table {
+                        index_hint: None,
                         quoted: false,
                         name: "t1".to_string(),
                         alias: None,
@@ -725,6 +727,7 @@ fn test_in_subquery_multi_column_empty_table_should_error() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -739,6 +742,7 @@ fn test_in_subquery_multi_column_empty_table_should_error() {
                 distinct: false,
                 select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
                 from: Some(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "t1".to_string(),
                     alias: None,

--- a/crates/vibesql-executor/src/tests/subquery_mysql_compat.rs
+++ b/crates/vibesql-executor/src/tests/subquery_mysql_compat.rs
@@ -62,6 +62,7 @@ fn test_mysql_null_in_empty_subquery() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -84,6 +85,7 @@ fn test_mysql_null_in_empty_subquery() {
                 into_table: None,
                 into_variables: None,
                 from: Some(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "empty".to_string(),
                     alias: None,
@@ -155,6 +157,7 @@ fn test_mysql_null_not_in_empty_subquery() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -177,6 +180,7 @@ fn test_mysql_null_not_in_empty_subquery() {
                 into_table: None,
                 into_variables: None,
                 from: Some(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "empty".to_string(),
                     alias: None,
@@ -257,6 +261,7 @@ fn test_mysql_null_in_non_empty_without_null() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "test".to_string(),
             alias: None,
@@ -279,6 +284,7 @@ fn test_mysql_null_in_non_empty_without_null() {
                 into_table: None,
                 into_variables: None,
                 from: Some(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "values".to_string(),
                     alias: None,
@@ -394,6 +400,7 @@ fn test_mysql_triple_nested_subquery() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "t1".to_string(),
             alias: None,
@@ -418,6 +425,7 @@ fn test_mysql_triple_nested_subquery() {
                     into_table: None,
                     into_variables: None,
                     from: Some(vibesql_ast::FromClause::Table {
+                        index_hint: None,
                         quoted: false,
                         name: "t2".to_string(),
                         alias: None,
@@ -451,6 +459,7 @@ fn test_mysql_triple_nested_subquery() {
                                 into_table: None,
                                 into_variables: None,
                                 from: Some(vibesql_ast::FromClause::Table {
+                                    index_hint: None,
                                     quoted: false,
                                     name: "t3".to_string(),
                                     alias: None,
@@ -562,6 +571,7 @@ fn test_mysql_exists_short_circuit() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "customers".to_string(),
             alias: None,
@@ -579,6 +589,7 @@ fn test_mysql_exists_short_circuit() {
                 into_table: None,
                 into_variables: None,
                 from: Some(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "orders".to_string(),
                     alias: None,
@@ -691,6 +702,7 @@ fn test_mysql_scalar_within_exists() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "products".to_string(),
             alias: None,
@@ -708,6 +720,7 @@ fn test_mysql_scalar_within_exists() {
                 into_table: None,
                 into_variables: None,
                 from: Some(vibesql_ast::FromClause::Table {
+                    index_hint: None,
                     quoted: false,
                     name: "products".to_string(),
                     alias: Some("p".to_string()),
@@ -732,6 +745,7 @@ fn test_mysql_scalar_within_exists() {
                             into_table: None,
                             into_variables: None,
                             from: Some(vibesql_ast::FromClause::Table {
+                                index_hint: None,
                                 quoted: false,
                                 name: "average_price".to_string(),
                                 alias: None,

--- a/crates/vibesql-executor/src/tests/triggers/coordination.rs
+++ b/crates/vibesql-executor/src/tests/triggers/coordination.rs
@@ -206,6 +206,7 @@ fn test_before_trigger_executes_first() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "COUNTER".to_string(),
             alias: None,
@@ -234,6 +235,7 @@ fn test_before_trigger_executes_first() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "USERS".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/triggers/error_handling.rs
+++ b/crates/vibesql-executor/src/tests/triggers/error_handling.rs
@@ -59,6 +59,7 @@ fn test_trigger_failure_causes_rollback() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "USERS".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/tests/triggers/mod.rs
+++ b/crates/vibesql-executor/src/tests/triggers/mod.rs
@@ -97,6 +97,7 @@ pub(super) fn count_audit_rows(db: &Database) -> usize {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             quoted: false,
             name: "AUDIT_LOG".to_string(),
             alias: None,

--- a/crates/vibesql-executor/src/update/from_clause.rs
+++ b/crates/vibesql-executor/src/update/from_clause.rs
@@ -124,6 +124,7 @@ pub fn execute_update_from_join(
 
     // Build FROM clause: target_table [alias], from_clause1, from_clause2, ...
     let target_from = FromClause::Table {
+        index_hint: None,
         name: target_table_name.clone(),
         alias: target_alias,
         column_aliases: None,
@@ -522,15 +523,13 @@ fn substitute_pseudo_vars(
                 .collect::<Result<Vec<_>, _>>()?,
             negated: *negated,
         },
-        Expression::Between { expr: inner, low, high, negated, symmetric } => {
-            Expression::Between {
-                expr: Box::new(substitute_pseudo_vars(inner, trigger_context)?),
-                low: Box::new(substitute_pseudo_vars(low, trigger_context)?),
-                high: Box::new(substitute_pseudo_vars(high, trigger_context)?),
-                negated: *negated,
-                symmetric: *symmetric,
-            }
-        }
+        Expression::Between { expr: inner, low, high, negated, symmetric } => Expression::Between {
+            expr: Box::new(substitute_pseudo_vars(inner, trigger_context)?),
+            low: Box::new(substitute_pseudo_vars(low, trigger_context)?),
+            high: Box::new(substitute_pseudo_vars(high, trigger_context)?),
+            negated: *negated,
+            symmetric: *symmetric,
+        },
         Expression::Cast { expr: inner, data_type } => Expression::Cast {
             expr: Box::new(substitute_pseudo_vars(inner, trigger_context)?),
             data_type: data_type.clone(),

--- a/crates/vibesql-executor/src/update/triggers.rs
+++ b/crates/vibesql-executor/src/update/triggers.rs
@@ -238,6 +238,7 @@ fn collect_view_updates_with_from(
 
     // Build FROM clause: view [AS alias], from_clause1, from_clause2, ...
     let view_from = FromClause::Table {
+        index_hint: None,
         name: view_name.clone(),
         alias: stmt.alias.clone(),
         column_aliases: None,
@@ -341,11 +342,7 @@ fn collect_view_updates_with_from(
                     column_name: assignment.column.clone(),
                     table_name: view_def.name.clone(),
                     searched_tables: vec![view_def.name.clone()],
-                    available_columns: view_schema
-                        .columns
-                        .iter()
-                        .map(|c| c.name.clone())
-                        .collect(),
+                    available_columns: view_schema.columns.iter().map(|c| c.name.clone()).collect(),
                 })?;
             new_row_values[col_idx] = row.values[view_col_count + i].clone();
         }

--- a/crates/vibesql-executor/tests/case_sensitivity_tests.rs
+++ b/crates/vibesql-executor/tests/case_sensitivity_tests.rs
@@ -260,6 +260,7 @@ fn test_view_lookup_case_insensitive_when_enabled() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,
@@ -323,6 +324,7 @@ fn test_drop_view_case_insensitive_when_enabled() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "products".to_string(),
             alias: None,
             column_aliases: None,
@@ -388,6 +390,7 @@ fn test_view_case_sensitive_mode() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,

--- a/crates/vibesql-executor/tests/index_ordering_tests.rs
+++ b/crates/vibesql-executor/tests/index_ordering_tests.rs
@@ -108,6 +108,7 @@ fn test_index_ordering() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,

--- a/crates/vibesql-executor/tests/insert_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/insert_columnar_cache_tests.rs
@@ -275,6 +275,7 @@ fn test_insert_select_invalidates_cache() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "source_products".to_string(),
             alias: None,
             column_aliases: None,

--- a/crates/vibesql-executor/tests/insert_select_tests.rs
+++ b/crates/vibesql-executor/tests/insert_select_tests.rs
@@ -54,6 +54,7 @@ fn test_insert_from_select_basic() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,
@@ -149,6 +150,7 @@ fn test_insert_from_select_with_where() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,
@@ -247,6 +249,7 @@ fn test_insert_from_select_column_mismatch() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,
@@ -374,6 +377,7 @@ fn test_insert_from_select_with_aggregates() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "sales".to_string(),
             alias: None,
             column_aliases: None,

--- a/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
@@ -48,6 +48,7 @@ fn test_update_with_subquery_multiple_rows_uses_first() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "salaries".to_string(),
             alias: None,
             column_aliases: None,
@@ -143,6 +144,7 @@ fn test_update_with_subquery_multiple_columns_error() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "salaries".to_string(),
             alias: None,
             column_aliases: None,

--- a/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
@@ -63,6 +63,7 @@ fn create_scalar_subquery(table_name: &str, column_name: &str) -> Box<vibesql_as
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: table_name.to_string(),
             alias: None,
             column_aliases: None,
@@ -103,6 +104,7 @@ fn create_aggregate_subquery(
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: table_name.to_string(),
             alias: None,
             column_aliases: None,

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
@@ -43,6 +43,7 @@ fn test_update_where_scalar_subquery_equal() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "config".to_string(),
             alias: None,
             column_aliases: None,
@@ -133,6 +134,7 @@ fn test_update_where_scalar_subquery_less_than() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "employees".to_string(),
             alias: None,
             column_aliases: None,
@@ -215,6 +217,7 @@ fn test_update_where_subquery_returns_null() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "config".to_string(),
             alias: None,
             column_aliases: None,
@@ -309,6 +312,7 @@ fn test_update_where_subquery_with_aggregate() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "items".to_string(),
             alias: None,
             column_aliases: None,
@@ -410,6 +414,7 @@ fn test_update_where_and_set_both_use_subqueries() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "salary_targets".to_string(),
             alias: None,
             column_aliases: None,
@@ -438,6 +443,7 @@ fn test_update_where_and_set_both_use_subqueries() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "active_depts".to_string(),
             alias: None,
             column_aliases: None,

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
@@ -58,6 +58,7 @@ fn test_update_where_in_subquery() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "active_depts".to_string(),
             alias: None,
             column_aliases: None,
@@ -152,6 +153,7 @@ fn test_update_where_not_in_subquery() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "active_depts".to_string(),
             alias: None,
             column_aliases: None,
@@ -239,6 +241,7 @@ fn test_update_where_subquery_empty_result() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "inactive_depts".to_string(),
             alias: None,
             column_aliases: None,
@@ -336,6 +339,7 @@ fn test_update_where_complex_subquery_condition() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "departments".to_string(),
             alias: None,
             column_aliases: None,
@@ -441,6 +445,7 @@ fn test_update_where_multiple_rows_in_subquery() {
         into_table: None,
         into_variables: None,
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "active_depts".to_string(),
             alias: None,
             column_aliases: None,

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -693,10 +693,10 @@ impl<'arena> ArenaParser<'arena> {
         // Parse optional column aliases: (col1, col2, ...)
         let column_aliases = if alias.is_some() { self.parse_column_alias_list()? } else { None };
 
-        // Parse and ignore SQLite index hints: INDEXED BY <name> / NOT INDEXED
-        self.parse_index_hint()?;
+        // Parse SQLite index hints: INDEXED BY <name> / NOT INDEXED
+        let index_hint = self.parse_index_hint()?;
 
-        Ok(FromClause::Table { name, alias, column_aliases, quoted })
+        Ok(FromClause::Table { name, alias, column_aliases, quoted, index_hint })
     }
 
     /// Check if the upcoming tokens form a SQLite index hint:
@@ -716,28 +716,33 @@ impl<'arena> ArenaParser<'arena> {
         }
     }
 
-    /// Parse and ignore SQLite index hints: `INDEXED BY <index-name>` or
-    /// `NOT INDEXED`. VibeSQL's planner chooses indexes independently, so the
-    /// hint is accepted for SQLite compatibility but has no effect on planning.
-    fn parse_index_hint(&mut self) -> Result<(), ParseError> {
+    /// Parse SQLite index hints: `INDEXED BY <index-name>` or `NOT INDEXED`.
+    ///
+    /// The hint is carried through the AST so the executor can validate that
+    /// an `INDEXED BY` index exists on the table (SQLite: `no such index: X`).
+    /// VibeSQL's planner chooses indexes independently, so the hint has no
+    /// effect on planning.
+    fn parse_index_hint(&mut self) -> Result<Option<vibesql_ast::arena::IndexHint>, ParseError> {
         if !self.peek_index_hint() {
-            return Ok(());
+            return Ok(None);
         }
         if self.peek_keyword(Keyword::Not) {
             self.advance(); // consume NOT
             self.advance(); // consume INDEXED
-            return Ok(());
+            return Ok(Some(vibesql_ast::arena::IndexHint::NotIndexed));
         }
         self.advance(); // consume INDEXED
         self.advance(); // consume BY
         match self.peek() {
-            Token::Identifier(_) | Token::DelimitedIdentifier(_) => {
+            Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
+                let name = name.clone();
                 self.advance();
-                Ok(())
+                Ok(Some(vibesql_ast::arena::IndexHint::IndexedBy(self.intern(&name))))
             }
             Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                let name = kw.to_string();
                 self.advance();
-                Ok(())
+                Ok(Some(vibesql_ast::arena::IndexHint::IndexedBy(self.intern(&name))))
             }
             _ => Err(ParseError { message: "Expected index name after INDEXED BY".to_string() }),
         }

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -248,6 +248,7 @@ impl Parser {
                         into_table: None,
                         into_variables: None,
                         from: Some(vibesql_ast::FromClause::Table {
+                            index_hint: None,
                             name: table_name,
                             alias: None,
                             column_aliases: None,
@@ -465,6 +466,7 @@ impl Parser {
                     into_table: None,
                     into_variables: None,
                     from: Some(vibesql_ast::FromClause::Table {
+                        index_hint: None,
                         name: table_name,
                         alias: None,
                         column_aliases: None,

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -118,214 +118,213 @@ impl Parser {
 
                 // Check if this is a subquery (starts with SELECT or WITH), VALUES, or a table
                 // reference/JOIN
-                let result = if self.peek_keyword(Keyword::Select)
-                    || self.peek_keyword(Keyword::With)
-                {
-                    // Parse the SELECT statement (subquery, possibly with CTE)
-                    let query = Box::new(self.parse_select_statement()?);
+                let result =
+                    if self.peek_keyword(Keyword::Select) || self.peek_keyword(Keyword::With) {
+                        // Parse the SELECT statement (subquery, possibly with CTE)
+                        let query = Box::new(self.parse_select_statement()?);
 
-                    // Expect closing ')'
-                    match self.peek() {
-                        Token::RParen => {
-                            self.advance();
+                        // Expect closing ')'
+                        match self.peek() {
+                            Token::RParen => {
+                                self.advance();
+                            }
+                            _ => {
+                                return Err(ParseError {
+                                    message: "Expected ')' after subquery".to_string(),
+                                })
+                            }
                         }
-                        _ => {
-                            return Err(ParseError {
-                                message: "Expected ')' after subquery".to_string(),
-                            })
-                        }
-                    }
 
-                    // Support both SQL:1999 (AS required) and MySQL (AS optional) modes
-                    // Parse optional AS keyword
-                    if self.peek_keyword(Keyword::As) {
-                        self.consume_keyword(Keyword::As)?;
-                    }
-
-                    // Parse alias - keywords allowed as aliases (except clause keywords)
-                    // SQLite allows derived tables without aliases; auto-generate if not provided
-                    // SQLite also allows single-quoted strings as aliases (non-standard but common)
-                    let alias = match self.peek() {
-                        Token::Identifier(id)
-                        | Token::DelimitedIdentifier(id)
-                        | Token::String(id) => {
-                            let alias = id.clone();
-                            self.advance();
-                            alias
+                        // Support both SQL:1999 (AS required) and MySQL (AS optional) modes
+                        // Parse optional AS keyword
+                        if self.peek_keyword(Keyword::As) {
+                            self.consume_keyword(Keyword::As)?;
                         }
-                        Token::Keyword { keyword: kw, .. } => {
-                            // Only consume keyword if it looks like it could be an alias
-                            // (not a SQL keyword that starts a new clause)
-                            if !matches!(
-                                kw,
-                                Keyword::Where
-                                    | Keyword::Order
-                                    | Keyword::Limit
-                                    | Keyword::Offset
-                                    | Keyword::Group
-                                    | Keyword::Having
-                                    | Keyword::Union
-                                    | Keyword::Intersect
-                                    | Keyword::Except
-                                    | Keyword::Join
-                                    | Keyword::Inner
-                                    | Keyword::Left
-                                    | Keyword::Right
-                                    | Keyword::Full
-                                    | Keyword::Cross
-                                    | Keyword::Natural
-                                    | Keyword::On
-                                    | Keyword::Using
-                            ) {
-                                let alias = kw.to_string();
+
+                        // Parse alias - keywords allowed as aliases (except clause keywords)
+                        // SQLite allows derived tables without aliases; auto-generate if not provided
+                        // SQLite also allows single-quoted strings as aliases (non-standard but common)
+                        let alias = match self.peek() {
+                            Token::Identifier(id)
+                            | Token::DelimitedIdentifier(id)
+                            | Token::String(id) => {
+                                let alias = id.clone();
                                 self.advance();
                                 alias
-                            } else {
-                                // Generate default alias for clause keywords
+                            }
+                            Token::Keyword { keyword: kw, .. } => {
+                                // Only consume keyword if it looks like it could be an alias
+                                // (not a SQL keyword that starts a new clause)
+                                if !matches!(
+                                    kw,
+                                    Keyword::Where
+                                        | Keyword::Order
+                                        | Keyword::Limit
+                                        | Keyword::Offset
+                                        | Keyword::Group
+                                        | Keyword::Having
+                                        | Keyword::Union
+                                        | Keyword::Intersect
+                                        | Keyword::Except
+                                        | Keyword::Join
+                                        | Keyword::Inner
+                                        | Keyword::Left
+                                        | Keyword::Right
+                                        | Keyword::Full
+                                        | Keyword::Cross
+                                        | Keyword::Natural
+                                        | Keyword::On
+                                        | Keyword::Using
+                                ) {
+                                    let alias = kw.to_string();
+                                    self.advance();
+                                    alias
+                                } else {
+                                    // Generate default alias for clause keywords
+                                    format!(
+                                        "(subquery-{})",
+                                        DERIVED_TABLE_COUNTER.fetch_add(1, Ordering::Relaxed)
+                                    )
+                                }
+                            }
+                            _ => {
+                                // Auto-generate unique alias for SQLite compatibility
                                 format!(
                                     "(subquery-{})",
                                     DERIVED_TABLE_COUNTER.fetch_add(1, Ordering::Relaxed)
                                 )
                             }
-                        }
-                        _ => {
-                            // Auto-generate unique alias for SQLite compatibility
-                            format!(
-                                "(subquery-{})",
-                                DERIVED_TABLE_COUNTER.fetch_add(1, Ordering::Relaxed)
-                            )
-                        }
-                    };
+                        };
 
-                    // Parse optional column aliases: AS alias (col1, col2, ...)
-                    // SQL:1999 Feature E051-09
-                    let column_aliases = self.parse_column_alias_list()?;
+                        // Parse optional column aliases: AS alias (col1, col2, ...)
+                        // SQL:1999 Feature E051-09
+                        let column_aliases = self.parse_column_alias_list()?;
 
-                    vibesql_ast::FromClause::Subquery { query, alias, column_aliases }
-                } else if self.peek_keyword(Keyword::Values) {
-                    // Parse VALUES clause as table constructor
-                    // Example: (VALUES(1,'a'), (2,'b')) AS t(x, y)
-                    let rows = self.parse_values_rows()?;
+                        vibesql_ast::FromClause::Subquery { query, alias, column_aliases }
+                    } else if self.peek_keyword(Keyword::Values) {
+                        // Parse VALUES clause as table constructor
+                        // Example: (VALUES(1,'a'), (2,'b')) AS t(x, y)
+                        let rows = self.parse_values_rows()?;
 
-                    // Expect closing ')'
-                    match self.peek() {
-                        Token::RParen => {
-                            self.advance();
+                        // Expect closing ')'
+                        match self.peek() {
+                            Token::RParen => {
+                                self.advance();
+                            }
+                            _ => {
+                                return Err(ParseError {
+                                    message: "Expected ')' after VALUES clause".to_string(),
+                                })
+                            }
                         }
-                        _ => {
-                            return Err(ParseError {
-                                message: "Expected ')' after VALUES clause".to_string(),
-                            })
-                        }
-                    }
 
-                    // Parse optional AS keyword
-                    if self.peek_keyword(Keyword::As) {
-                        self.consume_keyword(Keyword::As)?;
-                    }
-
-                    // Parse alias (optional for VALUES tables) - keywords allowed as aliases
-                    // If no alias is provided, generate a default one
-                    // SQLite also allows single-quoted strings as aliases (non-standard but common)
-                    let alias = match self.peek() {
-                        Token::Identifier(id)
-                        | Token::DelimitedIdentifier(id)
-                        | Token::String(id) => {
-                            let alias = id.clone();
-                            self.advance();
-                            alias
+                        // Parse optional AS keyword
+                        if self.peek_keyword(Keyword::As) {
+                            self.consume_keyword(Keyword::As)?;
                         }
-                        Token::Keyword { keyword: kw, .. } => {
-                            // Only consume keyword if it looks like it could be an alias
-                            // (not a SQL keyword that starts a new clause)
-                            if !matches!(
-                                kw,
-                                Keyword::Where
-                                    | Keyword::Order
-                                    | Keyword::Limit
-                                    | Keyword::Offset
-                                    | Keyword::Group
-                                    | Keyword::Having
-                                    | Keyword::Union
-                                    | Keyword::Intersect
-                                    | Keyword::Except
-                                    | Keyword::Join
-                                    | Keyword::Inner
-                                    | Keyword::Left
-                                    | Keyword::Right
-                                    | Keyword::Full
-                                    | Keyword::Cross
-                                    | Keyword::Natural
-                                    | Keyword::On
-                                    | Keyword::Using
-                            ) {
-                                let alias = kw.to_string();
+
+                        // Parse alias (optional for VALUES tables) - keywords allowed as aliases
+                        // If no alias is provided, generate a default one
+                        // SQLite also allows single-quoted strings as aliases (non-standard but common)
+                        let alias = match self.peek() {
+                            Token::Identifier(id)
+                            | Token::DelimitedIdentifier(id)
+                            | Token::String(id) => {
+                                let alias = id.clone();
                                 self.advance();
                                 alias
-                            } else {
+                            }
+                            Token::Keyword { keyword: kw, .. } => {
+                                // Only consume keyword if it looks like it could be an alias
+                                // (not a SQL keyword that starts a new clause)
+                                if !matches!(
+                                    kw,
+                                    Keyword::Where
+                                        | Keyword::Order
+                                        | Keyword::Limit
+                                        | Keyword::Offset
+                                        | Keyword::Group
+                                        | Keyword::Having
+                                        | Keyword::Union
+                                        | Keyword::Intersect
+                                        | Keyword::Except
+                                        | Keyword::Join
+                                        | Keyword::Inner
+                                        | Keyword::Left
+                                        | Keyword::Right
+                                        | Keyword::Full
+                                        | Keyword::Cross
+                                        | Keyword::Natural
+                                        | Keyword::On
+                                        | Keyword::Using
+                                ) {
+                                    let alias = kw.to_string();
+                                    self.advance();
+                                    alias
+                                } else {
+                                    // Generate default alias when no explicit alias provided
+                                    "_values_".to_string()
+                                }
+                            }
+                            _ => {
                                 // Generate default alias when no explicit alias provided
                                 "_values_".to_string()
                             }
-                        }
-                        _ => {
-                            // Generate default alias when no explicit alias provided
-                            "_values_".to_string()
-                        }
-                    };
+                        };
 
-                    // Parse optional column aliases: AS alias (col1, col2, ...)
-                    let column_aliases = self.parse_column_alias_list()?;
+                        // Parse optional column aliases: AS alias (col1, col2, ...)
+                        let column_aliases = self.parse_column_alias_list()?;
 
-                    vibesql_ast::FromClause::Values { rows, alias, column_aliases }
-                } else {
-                    // Parenthesized table reference or JOIN expression
-                    // Parse as a FROM clause (which handles JOINs)
-                    let mut from_clause = self.parse_from_clause()?;
+                        vibesql_ast::FromClause::Values { rows, alias, column_aliases }
+                    } else {
+                        // Parenthesized table reference or JOIN expression
+                        // Parse as a FROM clause (which handles JOINs)
+                        let mut from_clause = self.parse_from_clause()?;
 
-                    // Expect closing ')'
-                    match self.peek() {
-                        Token::RParen => {
-                            self.advance();
+                        // Expect closing ')'
+                        match self.peek() {
+                            Token::RParen => {
+                                self.advance();
+                            }
+                            _ => {
+                                return Err(ParseError {
+                                    message: "Expected ')' after parenthesized table reference"
+                                        .to_string(),
+                                })
+                            }
                         }
-                        _ => {
-                            return Err(ParseError {
-                                message: "Expected ')' after parenthesized table reference"
-                                    .to_string(),
-                            })
-                        }
-                    }
 
-                    // Parse optional alias for parenthesized join expressions
-                    // Example: FROM t1 JOIN (t2 JOIN t3 USING(id)) AS j1 ON j1.id=t1.id
-                    if self.peek_keyword(Keyword::As) {
-                        self.consume_keyword(Keyword::As)?;
-                        // Parse alias - must be an identifier or keyword usable as identifier
-                        let alias = self.parse_alias_name()?;
-                        // Set alias on the outermost Join node
-                        if let vibesql_ast::FromClause::Join {
-                            left,
-                            right,
-                            join_type,
-                            condition,
-                            using_columns,
-                            natural,
-                            ..
-                        } = from_clause
-                        {
-                            from_clause = vibesql_ast::FromClause::Join {
+                        // Parse optional alias for parenthesized join expressions
+                        // Example: FROM t1 JOIN (t2 JOIN t3 USING(id)) AS j1 ON j1.id=t1.id
+                        if self.peek_keyword(Keyword::As) {
+                            self.consume_keyword(Keyword::As)?;
+                            // Parse alias - must be an identifier or keyword usable as identifier
+                            let alias = self.parse_alias_name()?;
+                            // Set alias on the outermost Join node
+                            if let vibesql_ast::FromClause::Join {
                                 left,
                                 right,
                                 join_type,
                                 condition,
                                 using_columns,
                                 natural,
-                                alias: Some(alias),
-                            };
+                                ..
+                            } = from_clause
+                            {
+                                from_clause = vibesql_ast::FromClause::Join {
+                                    left,
+                                    right,
+                                    join_type,
+                                    condition,
+                                    using_columns,
+                                    natural,
+                                    alias: Some(alias),
+                                };
+                            }
                         }
-                    }
 
-                    from_clause
-                };
+                        from_clause
+                    };
 
                 Ok(result)
             }
@@ -378,14 +377,15 @@ impl Parser {
                 let column_aliases =
                     if alias.is_some() { self.parse_column_alias_list()? } else { None };
 
-                // Parse and ignore SQLite index hints: INDEXED BY <name> / NOT INDEXED
-                self.parse_index_hint()?;
+                // Parse SQLite index hints: INDEXED BY <name> / NOT INDEXED
+                let index_hint = self.parse_index_hint()?;
 
                 Ok(vibesql_ast::FromClause::Table {
                     name: table.full_name(),
                     alias,
                     column_aliases,
                     quoted: table.is_any_quoted(),
+                    index_hint,
                 })
             }
             // Allow unreserved keywords (like NULLS, TIMESTAMP, etc.) as table names
@@ -417,14 +417,15 @@ impl Parser {
                 let column_aliases =
                     if alias.is_some() { self.parse_column_alias_list()? } else { None };
 
-                // Parse and ignore SQLite index hints: INDEXED BY <name> / NOT INDEXED
-                self.parse_index_hint()?;
+                // Parse SQLite index hints: INDEXED BY <name> / NOT INDEXED
+                let index_hint = self.parse_index_hint()?;
 
                 Ok(vibesql_ast::FromClause::Table {
                     name: table.full_name(),
                     alias,
                     column_aliases,
                     quoted: table.is_any_quoted(),
+                    index_hint,
                 })
             }
             _ => Err(ParseError {
@@ -450,28 +451,35 @@ impl Parser {
         }
     }
 
-    /// Parse and ignore SQLite index hints: `INDEXED BY <index-name>` or
-    /// `NOT INDEXED`. VibeSQL's planner chooses indexes independently, so the
-    /// hint is accepted for SQLite compatibility but has no effect on planning.
-    pub(crate) fn parse_index_hint(&mut self) -> Result<(), ParseError> {
+    /// Parse SQLite index hints: `INDEXED BY <index-name>` or `NOT INDEXED`.
+    ///
+    /// The hint is carried through the AST so the executor can validate that
+    /// an `INDEXED BY` index exists on the table (SQLite: `no such index: X`).
+    /// VibeSQL's planner chooses indexes independently, so the hint has no
+    /// effect on planning.
+    pub(crate) fn parse_index_hint(
+        &mut self,
+    ) -> Result<Option<vibesql_ast::IndexHint>, ParseError> {
         if !self.peek_index_hint() {
-            return Ok(());
+            return Ok(None);
         }
         if self.peek_keyword(Keyword::Not) {
             self.advance(); // consume NOT
             self.advance(); // consume INDEXED
-            return Ok(());
+            return Ok(Some(vibesql_ast::IndexHint::NotIndexed));
         }
         self.advance(); // consume INDEXED
         self.advance(); // consume BY
         match self.peek() {
-            Token::Identifier(_) | Token::DelimitedIdentifier(_) => {
+            Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
+                let name = name.clone();
                 self.advance();
-                Ok(())
+                Ok(Some(vibesql_ast::IndexHint::IndexedBy(name)))
             }
             Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                let name = kw.to_string();
                 self.advance();
-                Ok(())
+                Ok(Some(vibesql_ast::IndexHint::IndexedBy(name)))
             }
             _ => Err(ParseError { message: "Expected index name after INDEXED BY".to_string() }),
         }

--- a/crates/vibesql-parser/src/tests/select/index_hints.rs
+++ b/crates/vibesql-parser/src/tests/select/index_hints.rs
@@ -1,18 +1,29 @@
 //! Tests for SQLite index hints in FROM clauses: INDEXED BY / NOT INDEXED
 //!
-//! VibeSQL parses and ignores these hints (the planner chooses indexes
-//! independently). Regression coverage for window1.test 77.2.
+//! VibeSQL parses these hints and carries them through the AST so the
+//! executor can validate them (issue #5235: `no such index: X`). The planner
+//! chooses indexes independently. Regression coverage for window1.test 77.2.
 
 use super::super::*;
 
 fn assert_table_from(sql: &str, expected_name: &str, expected_alias: Option<&str>) {
+    assert_table_from_with_hint(sql, expected_name, expected_alias, None);
+}
+
+fn assert_table_from_with_hint(
+    sql: &str,
+    expected_name: &str,
+    expected_alias: Option<&str>,
+    expected_hint: Option<vibesql_ast::IndexHint>,
+) {
     let result = Parser::parse_sql(sql);
     assert!(result.is_ok(), "should parse: {sql}: {:?}", result);
     match result.unwrap() {
         vibesql_ast::Statement::Select(select) => match select.from {
-            Some(vibesql_ast::FromClause::Table { name, alias, .. }) => {
+            Some(vibesql_ast::FromClause::Table { name, alias, index_hint, .. }) => {
                 assert_eq!(name, expected_name);
                 assert_eq!(alias.as_deref(), expected_alias);
+                assert_eq!(index_hint, expected_hint);
             }
             other => panic!("Expected Table FROM clause, got {:?}", other),
         },
@@ -21,8 +32,13 @@ fn assert_table_from(sql: &str, expected_name: &str, expected_alias: Option<&str
 }
 
 #[test]
-fn test_indexed_by_hint_is_ignored() {
-    assert_table_from("SELECT * FROM t1 INDEXED BY t1x;", "t1", None);
+fn test_indexed_by_hint_is_captured() {
+    assert_table_from_with_hint(
+        "SELECT * FROM t1 INDEXED BY t1x;",
+        "t1",
+        None,
+        Some(vibesql_ast::IndexHint::IndexedBy("t1x".to_string())),
+    );
 }
 
 #[test]
@@ -35,12 +51,22 @@ fn test_indexed_by_hint_with_where() {
 
 #[test]
 fn test_indexed_by_hint_after_alias() {
-    assert_table_from("SELECT * FROM t1 AS a INDEXED BY t1x;", "t1", Some("a"));
+    assert_table_from_with_hint(
+        "SELECT * FROM t1 AS a INDEXED BY t1x;",
+        "t1",
+        Some("a"),
+        Some(vibesql_ast::IndexHint::IndexedBy("t1x".to_string())),
+    );
 }
 
 #[test]
-fn test_not_indexed_hint_is_ignored() {
-    assert_table_from("SELECT * FROM t1 NOT INDEXED;", "t1", None);
+fn test_not_indexed_hint_is_captured() {
+    assert_table_from_with_hint(
+        "SELECT * FROM t1 NOT INDEXED;",
+        "t1",
+        None,
+        Some(vibesql_ast::IndexHint::NotIndexed),
+    );
 }
 
 #[test]
@@ -88,15 +114,31 @@ fn test_with_subquery_in_in_predicate() {
 // ============================================================================
 
 #[test]
-fn test_arena_indexed_by_hint_is_ignored() {
+fn test_arena_indexed_by_hint_is_captured() {
     let result = crate::arena_parser::parse_select_to_owned("SELECT * FROM t1 INDEXED BY t1x");
     assert!(result.is_ok(), "arena parser should accept INDEXED BY: {:?}", result);
+    match result.unwrap().from {
+        Some(vibesql_ast::FromClause::Table { index_hint, .. }) => {
+            assert_eq!(
+                index_hint,
+                Some(vibesql_ast::IndexHint::IndexedBy("t1x".to_string())),
+                "arena parser should carry the INDEXED BY hint through conversion"
+            );
+        }
+        other => panic!("Expected Table FROM clause, got {:?}", other),
+    }
 }
 
 #[test]
-fn test_arena_not_indexed_hint_is_ignored() {
+fn test_arena_not_indexed_hint_is_captured() {
     let result = crate::arena_parser::parse_select_to_owned("SELECT * FROM t1 NOT INDEXED");
     assert!(result.is_ok(), "arena parser should accept NOT INDEXED: {:?}", result);
+    match result.unwrap().from {
+        Some(vibesql_ast::FromClause::Table { index_hint, .. }) => {
+            assert_eq!(index_hint, Some(vibesql_ast::IndexHint::NotIndexed));
+        }
+        other => panic!("Expected Table FROM clause, got {:?}", other),
+    }
 }
 
 #[test]

--- a/crates/vibesql-storage/src/persistence/tests/json_persistence.rs
+++ b/crates/vibesql-storage/src/persistence/tests/json_persistence.rs
@@ -937,6 +937,7 @@ fn test_json_view_preservation() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "users".to_string(),
             alias: None,
             column_aliases: None,
@@ -1024,6 +1025,7 @@ fn test_json_view_preservation_without_sql_definition() {
         into_table: None,
         into_variables: None,
         from: Some(FromClause::Table {
+            index_hint: None,
             name: "products".to_string(),
             alias: None,
             column_aliases: None,

--- a/tests/executor/count_star.rs
+++ b/tests/executor/count_star.rs
@@ -51,6 +51,7 @@ fn test_count_star_in_multiplication() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "tab2".to_string(),
             alias: None,
             column_aliases: None,
@@ -121,6 +122,7 @@ fn test_count_star_in_addition() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "tab2".to_string(),
             alias: None,
             column_aliases: None,
@@ -203,6 +205,7 @@ fn test_count_star_complex_expression() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "tab2".to_string(),
             alias: None,
             column_aliases: None,
@@ -294,6 +297,7 @@ fn test_count_star_with_unary_operators() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "tab1".to_string(),
             alias: None,
             column_aliases: None,
@@ -368,6 +372,7 @@ fn test_count_star_with_negative_unary() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "tab1".to_string(),
             alias: None,
             column_aliases: None,

--- a/tests/regression/issue_990.rs
+++ b/tests/regression/issue_990.rs
@@ -65,6 +65,7 @@ fn test_issue_990_multiple_unary_plus() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "test".to_string(),
             alias: None,
             column_aliases: None,
@@ -147,6 +148,7 @@ fn test_issue_990_simpler_case() {
             source_text: None,
         }],
         from: Some(vibesql_ast::FromClause::Table {
+            index_hint: None,
             name: "test".to_string(),
             alias: None,
             column_aliases: None,


### PR DESCRIPTION
Closes #5235

## Summary

PR #5234 added parse-and-ignore support for SQLite index hints (`INDEXED BY <name>` / `NOT INDEXED`), discarding the index name at parse time. SQLite validates the hint at prepare time — `SELECT * FROM t1 INDEXED BY no_such_index` fails with `no such index: no_such_index` — while VibeSQL silently succeeded. This PR carries the hint through the AST and validates it at execution entry, per the curator plan on #5235.

- **AST**: new `IndexHint` enum (`IndexedBy(String)` / `NotIndexed`) and `index_hint: Option<IndexHint>` field on `FromClause::Table`, mirrored in the arena AST (`Symbol`-interned name) and plumbed through `arena/convert.rs`, `visitor.rs`, and `pretty_print.rs` (rendered for SQL round-trips).
- **Parsers**: `parse_index_hint()` (both standard and arena parsers) now returns `Option<IndexHint>` and the hint is stored at all three `FromClause::Table` construction sites.
- **Validation**: new `validation/index_hints.rs` called from the `SelectExecutor::execute` preamble (same pattern as `validate_join_table_limit`). Walks the FROM tree recursively (JOIN branches, derived-table subqueries), plus CTE bodies and set-operation arms. An `INDEXED BY` index must exist (`database.get_index`, case-insensitive) **and** belong to that FROM table (schema-qualified names like `main.t1` canonicalize via the unqualified tail); references to CTE names always fail since a CTE shadows any same-named table. `NOT INDEXED` never errors.
- **Error**: new `ExecutorError::NoSuchIndex` rendering exactly `no such index: X` via direct `write!` (the existing `IndexNotFound` renders a different, non-SQLite format and is intentionally not reused).
- **Mechanical churn** (per the issue's scope warning): ~370 construction/pattern sites across ~80 files gained a one-line `index_hint: None,` / `index_hint: _,` — almost entirely test fixtures. The sweep was driven by rustc E0063/E0027 diagnostics so no `match` semantics changed (patterns use `_`, never `None`).

## Acceptance criteria (all verified)

- `SELECT * FROM t1 INDEXED BY no_such_index` fails with exactly `no such index: no_such_index`
- Index existing on a *different* table also fails with `no such index: <name>`
- Valid index on that table executes normally with unchanged results (hint still ignored by planner)
- `NOT INDEXED` never errors
- Hint works through both parser paths (arena conversion asserted in parser tests)
- window1.test 77.2 still passes

## Test plan

- [x] 14 new executor tests (`src/tests/index_hint_validation.rs`): nonexistent index, wrong table, valid index, exact error string, NOT INDEXED, case-insensitive name, alias + hint, hint inside JOIN branch (error + valid), hint on CTE name, hint inside CTE body, UNION arm, FROM subquery
- [x] Parser tests extended (`tests/select/index_hints.rs`, 12 passing) to assert the hint is captured in the AST, including arena-parser conversion
- [x] `cargo test -p vibesql-ast -p vibesql-parser` — all green
- [x] `cargo test -p vibesql-executor --lib` — 2418 passed, 0 failed
- [x] `cargo check --workspace --all-targets` — clean except pre-existing failures (below)
- [x] Manual CLI: `INDEXED BY t1x` succeeds, `INDEXED BY nope` errors `no such index: nope`, `NOT INDEXED` succeeds
- [x] `./scripts/tcltest test window1.test` — 254 passed / 17 failed, identical to the PR #5234 baseline (77.2 passes; the 17 failures are the deferred buckets tracked by #5230–#5233)

## Pre-existing failures (not introduced here)

- `benches/tpcds/*` fail to compile on main (`random_range`/`random_bool`/`sample` missing on `ChaCha8Rng` — rand version mismatch); untouched by this PR.
- `benches/sysbench_benchmark.rs` was missing the `window_definitions` field in a `SelectStmt` literal (pre-existing compile break); fixed here with a one-line addition since it blocked `--all-targets`.

## Out of scope (per curator plan)

- Planner enforcement of `INDEXED BY` / `NOT INDEXED` (VibeSQL plans independently; hint stays advisory)
- `INDEXED BY` in UPDATE/DELETE qualified table names
- Re-validation of cached prepared statements after schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)