### PR TITLE
fix(parser): lex non-ASCII identifiers, fix char-boundary panic in error tokens

### DIFF
--- a/crates/vibesql-parser/src/lexer/identifiers.rs
+++ b/crates/vibesql-parser/src/lexer/identifiers.rs
@@ -17,12 +17,20 @@ impl<'a> Lexer<'a> {
     /// but identifiers preserve their original case from the SQL text. This matches
     /// SQLite's behavior where `SELECT col FROM t` returns "col" as the column name
     /// (preserving the case from the query for display purposes).
+    ///
+    /// **Non-ASCII handling**: SQLite treats any byte >= 0x80 as an identifier
+    /// character (its `IdChar` macro), so identifiers like `tՑ` or `t1Ցam` are
+    /// valid. We match that by accepting any non-ASCII char as an identifier
+    /// continuation character. `advance()` steps by `char::len_utf8()`, so slice
+    /// boundaries always stay on UTF-8 char boundaries.
     pub(super) fn tokenize_identifier_or_keyword(&mut self) -> Result<Token, LexerError> {
         let start = self.position();
 
         while !self.is_eof() {
             let ch = self.current_char();
-            if ch.is_ascii_alphanumeric() || ch == '_' {
+            // Note: at EOF current_char() returns '\0' (ASCII), but the loop
+            // already guards with !self.is_eof(), so termination is unaffected.
+            if ch.is_ascii_alphanumeric() || ch == '_' || !ch.is_ascii() {
                 self.advance();
             } else {
                 break;
@@ -39,7 +47,12 @@ impl<'a> Lexer<'a> {
             for (i, b) in text.bytes().enumerate() {
                 upper_buf[i] = b.to_ascii_uppercase();
             }
-            // SAFETY: Converting ASCII to uppercase produces valid UTF-8.
+            // SAFETY: `to_ascii_uppercase` maps ASCII bytes to ASCII bytes and
+            // leaves non-ASCII bytes (>= 0x80) unchanged, so the buffer is a
+            // byte-for-byte copy of valid UTF-8 except for ASCII case changes,
+            // which preserves UTF-8 validity. (Keywords are all pure ASCII, so
+            // an identifier containing non-ASCII bytes can never falsely match
+            // a keyword.)
             let upper = unsafe { std::str::from_utf8_unchecked(&upper_buf[..text.len()]) };
 
             // Try keyword lookup first (case-insensitive)

--- a/crates/vibesql-parser/src/lexer/mod.rs
+++ b/crates/vibesql-parser/src/lexer/mod.rs
@@ -227,6 +227,10 @@ impl<'a> Lexer<'a> {
                     Ok(Token::Symbol(':'))
                 }
             }
+            // SQLite treats any non-ASCII character as an identifier character
+            // (its IdChar macro accepts all bytes >= 0x80), so a leading
+            // multi-byte UTF-8 char starts an identifier (e.g. `SELECT Ցam`).
+            ch if !ch.is_ascii() => self.tokenize_identifier_or_keyword(),
             _ => {
                 // SQLite-compatible error: extract a token-like span for "near" message
                 let token = self.extract_error_token();
@@ -357,8 +361,10 @@ impl<'a> Lexer<'a> {
             if b.is_ascii_alphanumeric() || b == b'_' || b == b'#' || b == b'$' || b == b'@' {
                 end += 1;
             } else if end == start {
-                // Include at least one character
-                end += 1;
+                // Include at least one character. Advance by the character's
+                // full UTF-8 width (not one byte) so the slice below never
+                // lands inside a multi-byte character.
+                end += self.input[start..].chars().next().map_or(1, char::len_utf8);
                 break;
             } else {
                 break;
@@ -556,5 +562,35 @@ impl<'a> Lexer<'a> {
 
         // Use NamedPlaceholder - the name includes :: prefix for uniqueness
         Ok(Token::NamedPlaceholder(name))
+    }
+}
+
+#[cfg(test)]
+mod extract_error_token_tests {
+    use super::Lexer;
+
+    /// `extract_error_token` is the only place in the lexer that does its own
+    /// byte arithmetic before slicing. Via the public API it can no longer be
+    /// reached with a non-ASCII start char (non-ASCII now lexes as an
+    /// identifier), so exercise the char-boundary hardening directly.
+    #[test]
+    fn test_extract_error_token_multibyte_start_does_not_panic() {
+        // 2-byte UTF-8 (U+0551) at the error position
+        let lexer = Lexer::new("Ցam");
+        assert_eq!(lexer.extract_error_token(), "Ց");
+
+        // 4-byte UTF-8 as the only (and final) character in the input
+        let lexer = Lexer::new("😀");
+        assert_eq!(lexer.extract_error_token(), "😀");
+    }
+
+    #[test]
+    fn test_extract_error_token_ascii_unchanged() {
+        let lexer = Lexer::new("#1 rest");
+        assert_eq!(lexer.extract_error_token(), "#1");
+
+        // Single non-token ASCII char still captured
+        let lexer = Lexer::new("^");
+        assert_eq!(lexer.extract_error_token(), "^");
     }
 }

--- a/crates/vibesql-parser/src/tests/lexer/errors.rs
+++ b/crates/vibesql-parser/src/tests/lexer/errors.rs
@@ -10,3 +10,15 @@ fn test_tokenize_invalid_character() {
     let err = result.unwrap_err();
     assert!(err.message.contains("Expected variable name after @"));
 }
+
+#[test]
+fn test_error_token_with_multibyte_char_does_not_panic() {
+    // `$` followed by a non-placeholder char takes the extract_error_token
+    // path; a multi-byte char right after the `$` must not cause a
+    // non-char-boundary slice panic (issue #5236)
+    let mut lexer = Lexer::new("SELECT $Ց");
+    let result = lexer.tokenize();
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.near_token.as_deref(), Some("$"));
+}

--- a/crates/vibesql-parser/src/tests/lexer/identifiers.rs
+++ b/crates/vibesql-parser/src/tests/lexer/identifiers.rs
@@ -32,6 +32,123 @@ fn test_tokenize_identifier_starting_with_underscore() {
 }
 
 // ============================================================================
+// Multi-byte UTF-8 Identifier Tests (issue #5236)
+//
+// SQLite treats any byte >= 0x80 as an identifier character (its IdChar
+// macro), so identifiers may contain arbitrary non-ASCII characters.
+// ============================================================================
+
+#[test]
+fn test_tokenize_multibyte_identifier_middle() {
+    // Fuzzer reproducer: `t1Ցam` used to panic on a non-char-boundary slice.
+    // It must lex as ONE identifier (matching SQLite), not split at `Ց`.
+    let mut lexer = Lexer::new("t1Ցam");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::Identifier("t1Ցam".to_string()));
+    assert_eq!(tokens[1], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_multibyte_identifier_leading() {
+    // A leading multi-byte char starts an identifier
+    let mut lexer = Lexer::new("Ցam");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::Identifier("Ցam".to_string()));
+    assert_eq!(tokens[1], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_multibyte_identifier_at_end_of_input() {
+    // Multi-byte char as the final bytes of input, no trailing whitespace
+    let mut lexer = Lexer::new("t1Ց");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::Identifier("t1Ց".to_string()));
+    assert_eq!(tokens[1], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_identifier_with_4byte_utf8() {
+    // 4-byte UTF-8 sequence (U+1F600) inside an identifier
+    let mut lexer = Lexer::new("table😀x");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::Identifier("table😀x".to_string()));
+    assert_eq!(tokens[1], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_mixed_ascii_multibyte_identifier() {
+    let mut lexer = Lexer::new("tableՑ_2");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::Identifier("tableՑ_2".to_string()));
+    assert_eq!(tokens[1], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_multibyte_identifier_stack_buffer_path() {
+    // Exactly 32 bytes (16 x 2-byte chars): exercises the stack-buffer
+    // keyword-lookup path with non-ASCII bytes (must not corrupt UTF-8)
+    let ident = "Ց".repeat(16);
+    assert_eq!(ident.len(), 32);
+    let mut lexer = Lexer::new(&ident);
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::Identifier(ident.clone()));
+}
+
+#[test]
+fn test_tokenize_long_multibyte_identifier_heap_fallback() {
+    // > 32 bytes: exercises the heap-allocation keyword-lookup fallback
+    let ident = format!("col_{}", "Ց".repeat(20)); // 4 + 40 = 44 bytes
+    let mut lexer = Lexer::new(&ident);
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::Identifier(ident.clone()));
+}
+
+#[test]
+fn test_tokenize_select_with_multibyte_identifier() {
+    // Full fuzzer reproducer statement: must tokenize without panicking,
+    // with `t1Ցam` as a single identifier (SQLite reports
+    // "no such column: t1Ցam" — a semantic error, not a parse error)
+    let mut lexer = Lexer::new("SELECT t1Ցam;");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(
+        tokens[0],
+        Token::Keyword { keyword: Keyword::Select, original: "SELECT".to_string() }
+    );
+    assert_eq!(tokens[1], Token::Identifier("t1Ցam".to_string()));
+    assert_eq!(tokens[2], Token::Semicolon);
+}
+
+#[test]
+fn test_tokenize_create_table_with_multibyte_identifier() {
+    // `CREATE TABLE tՑ(x INT)` is valid in SQLite
+    let mut lexer = Lexer::new("CREATE TABLE tՑ(x INT)");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(
+        tokens[0],
+        Token::Keyword { keyword: Keyword::Create, original: "CREATE".to_string() }
+    );
+    assert_eq!(
+        tokens[1],
+        Token::Keyword { keyword: Keyword::Table, original: "TABLE".to_string() }
+    );
+    assert_eq!(tokens[2], Token::Identifier("tՑ".to_string()));
+    assert_eq!(tokens[3], Token::LParen);
+}
+
+#[test]
+fn test_keyword_matching_unchanged_for_ascii() {
+    // ASCII keyword recognition must be unaffected by non-ASCII support
+    let mut lexer = Lexer::new("select Select SELECT");
+    let tokens = lexer.tokenize().unwrap();
+    for (i, original) in ["select", "Select", "SELECT"].iter().enumerate() {
+        assert_eq!(
+            tokens[i],
+            Token::Keyword { keyword: Keyword::Select, original: original.to_string() }
+        );
+    }
+}
+
+// ============================================================================
 // Delimited Identifier Tests
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Fixes a fuzzer-found lexer panic on multi-byte UTF-8 characters in identifiers. SQLite treats any byte >= 0x80 as an identifier character (its `IdChar` macro), but VibeSQL's lexer only accepted ASCII alphanumerics/underscore. A char like `Ց` (U+0551) fell through to the error path, where `extract_error_token()` advanced one byte into the character and panicked on a non-char-boundary slice.

## Changes

- `lexer/identifiers.rs`: accept non-ASCII chars as identifier continuation characters in `tokenize_identifier_or_keyword()`; extend the SAFETY comment on the stack-buffer uppercase path to document why non-ASCII bytes preserve UTF-8 validity (`to_ascii_uppercase` leaves bytes >= 0x80 unchanged; all keywords are pure ASCII so no false keyword matches)
- `lexer/mod.rs`: route a leading non-ASCII char to identifier tokenization in `next_token()` (guard arm before the `_` catch-all)
- `lexer/mod.rs`: harden `extract_error_token()` to advance by the full UTF-8 char width (`char::len_utf8`) instead of one byte, so the error-path slice can never land mid-character (defense in depth — this was the only unsafe slice site per the curator's audit)
- Regression tests in `tests/lexer/identifiers.rs` (10 new tests) and `tests/lexer/errors.rs`, plus direct unit tests for `extract_error_token()` in `lexer/mod.rs` (the function is no longer reachable with a non-ASCII start char via the public API)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SELECT t1Ցam` no longer panics; lexes as single `Identifier` | Pass | `test_tokenize_select_with_multibyte_identifier`; CLI: `echo 'SELECT t1Ցam;' \| target/debug/vibesql` returns a normal semantic error (no panic) |
| `SELECT Ցam` (leading multi-byte) lexes as single identifier | Pass | `test_tokenize_multibyte_identifier_leading`; verified via CLI |
| `CREATE TABLE tՑ(x INT); SELECT * FROM tՑ;` round-trips | Pass | Verified end-to-end via CLI: CREATE + INSERT + SELECT returns the inserted row |
| `extract_error_token()` cannot slice mid-character | Pass | Arithmetic fixed to use `char::len_utf8`; direct unit tests with 2-byte and 4-byte UTF-8 (`test_extract_error_token_multibyte_start_does_not_panic`); public error path covered by `test_error_token_with_multibyte_char_does_not_panic` (`SELECT $Ց`) |
| Existing lexer tests pass; ASCII keyword matching unchanged | Pass | `cargo test -p vibesql-parser --lib`: 1298 passed, 0 failed; `test_keyword_matching_unchanged_for_ascii` |

Edge cases covered: multi-byte char as final bytes of input (no trailing whitespace), 4-byte UTF-8 (`😀`) in identifier, mixed ASCII/non-ASCII (`tableՑ_2`), 32-byte stack-buffer boundary with non-ASCII bytes, >32-byte heap fallback path.

## Test Plan

- `cargo test -p vibesql-parser --lib` — 1298 passed, 0 failed
- `cargo check` / `cargo clippy -p vibesql-parser` — clean (remaining warnings are pre-existing in `vibesql-ast` and `from_clause.rs`, untouched by this PR)
- Manual CLI verification of the exact 31-byte fuzz input from the issue (hex bytes piped to `target/debug/vibesql`) — parse handled without panic
- Differential fuzz re-run (`cargo +nightly fuzz run differential_sqlite`) left for CI/follow-up since the crash artifact from #5237 is not committed; the reproducer is covered by the new regression tests and manual CLI check

Closes #5236