### PR TITLE
feat(explain): emit EQP window-sort entries for OVER clause sorting passes

### DIFF
--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -68,6 +68,10 @@ pub struct PlanNode {
     pub index_predicates: Vec<IndexPredicate>,
     /// Whether this query requires a temp B-tree for ORDER BY
     pub needs_temp_btree_for_order_by: bool,
+    /// Number of distinct window-function sorting passes (PARTITION BY +
+    /// ORDER BY keys) not satisfied by an index. Each contributes one
+    /// `USE TEMP B-TREE FOR ORDER BY` entry in EQP output.
+    pub window_sort_count: usize,
     /// Set operation type for compound queries (UNION, INTERSECT, EXCEPT)
     pub set_operation_type: Option<String>,
     /// Whether this is a compound query root
@@ -86,6 +90,7 @@ impl PlanNode {
             index_name: None,
             index_predicates: Vec::new(),
             needs_temp_btree_for_order_by: false,
+            window_sort_count: 0,
             set_operation_type: None,
             is_compound_query: false,
         }
@@ -498,6 +503,14 @@ fn collect_eqp_entries(node: &PlanNode) -> Vec<String> {
         entries.push(format_sqlite_eqp_node(scan_node));
     }
 
+    // Add one TEMP B-TREE entry per distinct window sort key not satisfied
+    // by an index. Window sorting passes run before the statement-level
+    // ORDER BY, and SQLite never dedups them against it — they are
+    // separate passes.
+    for _ in 0..node.window_sort_count {
+        entries.push("USE TEMP B-TREE FOR ORDER BY".to_string());
+    }
+
     // Add TEMP B-TREE entry if needed for ORDER BY
     if node.needs_temp_btree_for_order_by {
         entries.push("USE TEMP B-TREE FOR ORDER BY".to_string());
@@ -763,6 +776,11 @@ impl ExplainExecutor {
             root.needs_temp_btree_for_order_by = needs_temp;
         }
 
+        // Count window-function sorting passes for EQP output. SQLite emits
+        // one "USE TEMP B-TREE FOR ORDER BY" entry per distinct window sort
+        // key not satisfied by an index (window1.test section 23).
+        root.window_sort_count = Self::count_window_sorts(stmt, database);
+
         // Add WHERE clause info
         if stmt.where_clause.is_some() {
             root.details.push("Filter: <where clause>".to_string());
@@ -854,6 +872,70 @@ impl ExplainExecutor {
         }
 
         Ok(root)
+    }
+
+    /// Count the distinct window-function sorting passes required by the
+    /// SELECT list that are not satisfied by an index.
+    ///
+    /// SQLite semantics (window1.test section 23, `do_ordercount_test`):
+    /// - The sort key for a window is its PARTITION BY expressions (treated
+    ///   as ASC with default null ordering) followed by its ORDER BY items.
+    ///   `OVER (PARTITION BY a ORDER BY b)` and `OVER (ORDER BY a, b)` share
+    ///   the key `(a, b)`.
+    /// - Keys are deduplicated by exact structural equality (including
+    ///   direction and COLLATE); frame clauses are ignored entirely.
+    /// - Windows with neither PARTITION BY nor ORDER BY (`OVER ()`) need no
+    ///   sorting pass.
+    /// - A key satisfied by an index scan order is suppressed (e.g. key
+    ///   `(a, b)` with index `t5ab(a, b)`).
+    fn count_window_sorts(stmt: &SelectStmt, database: &Database) -> usize {
+        let Ok(specs) = crate::select::window::collect_resolved_window_specs(
+            &stmt.select_list,
+            stmt.window_definitions.as_ref(),
+        ) else {
+            // Resolution errors (e.g. unknown named window) surface during
+            // execution; EXPLAIN just shows no window sorts.
+            return 0;
+        };
+
+        let mut distinct_keys: Vec<Vec<vibesql_ast::OrderByItem>> = Vec::new();
+        for spec in &specs {
+            // Combined sort key: PARTITION BY exprs (ASC) + window ORDER BY.
+            let mut key: Vec<vibesql_ast::OrderByItem> = Vec::new();
+            if let Some(partition_by) = &spec.partition_by {
+                for expr in partition_by {
+                    key.push(vibesql_ast::OrderByItem {
+                        expr: expr.clone(),
+                        direction: vibesql_ast::OrderDirection::Asc,
+                        nulls_order: None,
+                    });
+                }
+            }
+            if let Some(order_by) = &spec.order_by {
+                key.extend(order_by.iter().cloned());
+            }
+
+            // OVER () — no partitioning or ordering — needs no sort pass.
+            if key.is_empty() {
+                continue;
+            }
+
+            if !distinct_keys.contains(&key) {
+                distinct_keys.push(key);
+            }
+        }
+
+        distinct_keys
+            .iter()
+            .filter(|key| {
+                Self::needs_temp_btree_for_order_by(
+                    stmt.from.as_ref(),
+                    stmt.where_clause.as_ref(),
+                    key,
+                    database,
+                )
+            })
+            .count()
     }
 
     /// Check if ORDER BY requires a temp B-tree (sorting pass) for EQP rendering.

--- a/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
@@ -671,7 +671,15 @@ pub(crate) fn needs_temp_btree_for_order_by_eqp(
             continue;
         }
         let pinned_columns = count_pinned_index_columns(where_clause, &index_metadata.columns);
-        if pinned_columns == 0 {
+        // With a WHERE clause and no leading pinned column, the planner may
+        // choose a different (filtering) index, so the EQP exception only
+        // applies when leading columns are pinned. Without a WHERE clause
+        // there is no competing access path: a structural prefix match alone
+        // means the index's natural traversal yields the requested order
+        // (e.g. window1.test 23.1: index t5ab(a, b) serves key (a, b) with
+        // no predicate), so SQLite's EQP shows no temp B-tree even when the
+        // columns are nullable and a runtime stabilization sort still runs.
+        if pinned_columns == 0 && where_clause.is_some() {
             continue; // No leading pin → no EQP exception applies.
         }
 

--- a/crates/vibesql-executor/src/select/window/mod.rs
+++ b/crates/vibesql-executor/src/select/window/mod.rs
@@ -22,6 +22,22 @@ use vibesql_storage::Row;
 
 use crate::{errors::ExecutorError, evaluator::CombinedExpressionEvaluator};
 
+/// Collect the resolved window specs for all window functions in the SELECT list.
+///
+/// Named window references (`WINDOW w AS (...)` + `OVER w`) are resolved to
+/// their full specifications, including inheritance chains. Used by EXPLAIN
+/// QUERY PLAN to derive window sort keys statically without hooking the
+/// runtime evaluation path.
+pub(crate) fn collect_resolved_window_specs(
+    select_list: &[SelectItem],
+    window_definitions: Option<&Vec<WindowDefinition>>,
+) -> Result<Vec<vibesql_ast::WindowSpec>, ExecutorError> {
+    Ok(collection::collect_window_functions(select_list, window_definitions)?
+        .into_iter()
+        .map(|info| info.window_spec)
+        .collect())
+}
+
 /// Evaluate window functions and add results to rows
 ///
 /// This processes all window functions in the SELECT list and adds computed values

--- a/crates/vibesql-executor/tests/explain_window_sort_tests.rs
+++ b/crates/vibesql-executor/tests/explain_window_sort_tests.rs
@@ -1,0 +1,199 @@
+//! Tests for EXPLAIN QUERY PLAN window-sort entries
+//!
+//! SQLite's `do_ordercount_test` (window1.test section 23) counts `ORDER`
+//! occurrences in EXPLAIN QUERY PLAN output. Each window function sorting
+//! pass that is not satisfied by an index contributes one
+//! `USE TEMP B-TREE FOR ORDER BY` entry. Semantics:
+//!
+//! - The sort key is PARTITION BY exprs (as ASC) + the window ORDER BY items
+//! - Distinct keys are deduplicated structurally
+//! - Frame clauses are ignored
+//! - Keys satisfied by an index emit no entry
+
+use vibesql_ast::Statement;
+use vibesql_executor::ExplainExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+/// Create the window1.test section-23 schema:
+/// CREATE TABLE t5(a, b, c); CREATE INDEX t5ab ON t5(a, b);
+fn setup_db() -> Database {
+    let mut db = Database::new();
+
+    let create = Parser::parse_sql("CREATE TABLE t5 (a INTEGER, b INTEGER, c INTEGER)").unwrap();
+    if let Statement::CreateTable(stmt) = create {
+        vibesql_executor::CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+    } else {
+        panic!("Expected CREATE TABLE statement");
+    }
+
+    let create_index = Parser::parse_sql("CREATE INDEX t5ab ON t5(a, b)").unwrap();
+    if let Statement::CreateIndex(stmt) = create_index {
+        vibesql_executor::CreateIndexExecutor::execute(&stmt, &mut db).unwrap();
+    } else {
+        panic!("Expected CREATE INDEX statement");
+    }
+
+    db
+}
+
+/// Run EXPLAIN QUERY PLAN and count occurrences of "ORDER" in the output,
+/// mirroring `do_ordercount_test` from window1.test.
+fn order_count(db: &Database, sql: &str) -> usize {
+    let explain_sql = format!("EXPLAIN QUERY PLAN {}", sql);
+    let stmt = Parser::parse_sql(&explain_sql).expect("Failed to parse SQL");
+
+    if let Statement::Explain(explain_stmt) = stmt {
+        let result = ExplainExecutor::execute(&explain_stmt, db).expect("EXPLAIN failed");
+        result.to_sqlite_eqp().matches("ORDER").count()
+    } else {
+        panic!("Expected EXPLAIN statement");
+    }
+}
+
+// window1.test 23.1: both windows have combined key (a, b), which is
+// satisfied by index t5ab(a, b) — no sort entries.
+#[test]
+fn test_index_satisfied_window_sort_emits_no_entry() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (ORDER BY a, b),
+            sum(c) OVER (PARTITION BY a ORDER BY b)
+         FROM t5",
+    );
+    assert_eq!(count, 0);
+}
+
+// window1.test 23.2: both windows have combined key (b, a) — dedup to 1 sort.
+#[test]
+fn test_duplicate_window_keys_dedup_to_one_entry() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (ORDER BY b, a),
+            sum(c) OVER (PARTITION BY b ORDER BY a)
+         FROM t5",
+    );
+    assert_eq!(count, 1);
+}
+
+// window1.test 23.3: keys (b, a) and (c, b) are distinct — 2 sorts.
+#[test]
+fn test_distinct_window_keys_emit_separate_entries() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (ORDER BY b, a),
+            sum(c) OVER (ORDER BY c, b)
+         FROM t5",
+    );
+    assert_eq!(count, 2);
+}
+
+// window1.test 23.4: same ORDER BY key with three different frame clauses —
+// frames are ignored, 1 sort.
+#[test]
+fn test_frame_clauses_ignored_for_dedup() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (ORDER BY b ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+            sum(c) OVER (ORDER BY b RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+            sum(c) OVER (ORDER BY b GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+         FROM t5",
+    );
+    assert_eq!(count, 1);
+}
+
+// window1.test 23.5: same expression key (b+1) across three windows — 1 sort.
+#[test]
+fn test_same_expression_key_dedups() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (ORDER BY b+1 ROWS UNBOUNDED PRECEDING),
+            sum(c) OVER (ORDER BY b+1 RANGE UNBOUNDED PRECEDING),
+            sum(c) OVER (ORDER BY b+1 GROUPS UNBOUNDED PRECEDING)
+         FROM t5",
+    );
+    assert_eq!(count, 1);
+}
+
+// window1.test 23.6: distinct expression keys b+1, b+2, b+3 — 3 sorts.
+#[test]
+fn test_distinct_expression_keys_emit_separate_entries() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (ORDER BY b+1 ROWS UNBOUNDED PRECEDING),
+            sum(c) OVER (ORDER BY b+2 RANGE UNBOUNDED PRECEDING),
+            sum(c) OVER (ORDER BY b+3 GROUPS UNBOUNDED PRECEDING)
+         FROM t5",
+    );
+    assert_eq!(count, 3);
+}
+
+// window1.test 24.1/24.2: OVER () has no partition or order key — no sort.
+#[test]
+fn test_empty_over_clause_emits_no_entry() {
+    let db = setup_db();
+    let count = order_count(&db, "SELECT sum(c) OVER () FROM t5");
+    assert_eq!(count, 0);
+}
+
+// A window sort and a statement-level ORDER BY are separate sorting passes —
+// both are counted (no cross-dedup).
+#[test]
+fn test_window_sort_and_statement_order_by_both_counted() {
+    let db = setup_db();
+    let count = order_count(&db, "SELECT sum(c) OVER (ORDER BY c) FROM t5 ORDER BY b");
+    assert_eq!(count, 2);
+}
+
+// Named windows (WINDOW w AS (...)) are resolved before key extraction.
+#[test]
+fn test_named_window_resolved_for_key() {
+    let db = setup_db();
+
+    // Named window with key (c) — not satisfied by index t5ab — 1 sort,
+    // deduped against an inline window with the same key.
+    let count = order_count(
+        &db,
+        "SELECT sum(c) OVER w, sum(b) OVER (ORDER BY c) FROM t5 WINDOW w AS (ORDER BY c)",
+    );
+    assert_eq!(count, 1);
+
+    // Named window whose key (a, b) is satisfied by the index — 0 sorts.
+    let count =
+        order_count(&db, "SELECT sum(c) OVER w FROM t5 WINDOW w AS (PARTITION BY a ORDER BY b)");
+    assert_eq!(count, 0);
+}
+
+// Window functions nested inside arithmetic expressions are still collected.
+#[test]
+fn test_window_function_nested_in_arithmetic() {
+    let db = setup_db();
+    let count = order_count(&db, "SELECT 1 + sum(c) OVER (ORDER BY c) FROM t5");
+    assert_eq!(count, 1);
+}
+
+// DESC vs ASC on the same column are different keys — no dedup.
+#[test]
+fn test_direction_distinguishes_keys() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (ORDER BY c ASC),
+            sum(c) OVER (ORDER BY c DESC)
+         FROM t5",
+    );
+    assert_eq!(count, 2);
+}


### PR DESCRIPTION
## Summary

EXPLAIN QUERY PLAN never emitted sort entries for window `OVER (...)` sorting passes — it only modeled the statement-level ORDER BY. SQLite's `do_ordercount_test` (window1.test section 23) counts `ORDER` occurrences in EQP output, so the count was always 0 and tests 23.2-23.6 failed.

This implements the curator's Option A (real EQP fix, no shim intercept): derive window sort keys statically from the SELECT list and emit one `USE TEMP B-TREE FOR ORDER BY` entry per distinct key not satisfied by an index.

## Changes

- `crates/vibesql-executor/src/explain.rs`: new `count_window_sorts` — builds each window's combined sort key (PARTITION BY exprs as ASC + window ORDER BY items, frames ignored), dedups by exact structural equality, and counts keys needing a sort via the existing EQP index check. New `PlanNode.window_sort_count` field; `collect_eqp_entries` emits that many `USE TEMP B-TREE FOR ORDER BY` lines before the statement-level entry (no cross-dedup — separate passes).
- `crates/vibesql-executor/src/select/window/mod.rs`: new `pub(crate) collect_resolved_window_specs` wrapper around the existing `collect_window_functions` (handles named windows, inheritance chains, and nested expressions — no second expression walker).
- `crates/vibesql-executor/src/select/scan/index_scan/selection.rs`: `needs_temp_btree_for_order_by_eqp` now applies the structural index-prefix check when there is no WHERE clause (previously required a pinned leading column). Needed for window1-23.1: index `t5ab(a,b)` serves key `(a,b)` with no predicate, so SQLite shows no temp B-tree even though the columns are nullable.
- `crates/vibesql-executor/tests/explain_window_sort_tests.rs`: NEW — 11 tests covering the six 23.x count scenarios plus `OVER ()`, window+statement ORDER BY coexistence, named windows, nested window functions, and ASC/DESC key distinction.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 23.2-23.6 pass | ✅ | `./scripts/tcltest test window1.test`: all five now pass; file failures 17 → 12 with no new failures |
| 23.1 still expects 0 ORDER entries | ✅ | 23.1 passes; CLI spot-check shows plan with only `SCAN t5` (0 ORDER entries) |

## Test Plan

- `./scripts/tcltest test window1.test`: 254 → 259 passed (17 → 12 failed); failure delta is exactly 23.2-23.6
- New integration tests: `cargo test -p vibesql-executor --test explain_window_sort_tests` — 11/11 pass
- Full `cargo test -p vibesql-executor` — all 60 test targets pass, 0 failures
- Regression A/B for the `selection.rs` EQP extension: ran every Priority-1 TCL file that asserts `B-TREE FOR ORDER BY` (where3, where7, whereH, whereL, wherelimit3, orderby1, orderby2) against pre-change and post-change release binaries — identical pass/fail counts
- `cargo check` / `cargo clippy` clean for the changed hunks (remaining warnings pre-exist on main)

Closes #5230