### PR TITLE
fix(parser): accept non-ASCII chars in placeholder/variable names

### DIFF
--- a/crates/vibesql-parser/src/lexer/mod.rs
+++ b/crates/vibesql-parser/src/lexer/mod.rs
@@ -200,8 +200,15 @@ impl<'a> Lexer<'a> {
                 if next.map(|b| b.is_ascii_digit()).unwrap_or(false) {
                     // PostgreSQL-style numbered placeholder ($1, $2, etc.)
                     self.tokenize_numbered_placeholder()
-                } else if next.map(|b| b.is_ascii_alphabetic() || b == b'_').unwrap_or(false) {
-                    // SQLite/TCL-style named placeholder ($name, $x1, etc.)
+                } else if next
+                    .map(|b| b.is_ascii_alphabetic() || b == b'_' || !b.is_ascii())
+                    .unwrap_or(false)
+                {
+                    // SQLite/TCL-style named placeholder ($name, $x1, etc.).
+                    // SQLite's IdChar macro treats any byte >= 0x80 as an
+                    // identifier char, so non-ASCII starts a named variable
+                    // (e.g. `$Ց`). The first byte of a multi-byte UTF-8 char
+                    // is always >= 0x80, so the byte-level check is correct.
                     self.tokenize_dollar_named_placeholder()
                 } else if next == Some(b':') {
                     // TCL global variable syntax ($::name) - treat as named placeholder
@@ -217,8 +224,13 @@ impl<'a> Lexer<'a> {
                 }
             }
             ':' => {
-                // Check if followed by alphabetic character or underscore for named placeholder
-                if self.peek_byte(1).map(|b| b.is_ascii_alphabetic() || b == b'_').unwrap_or(false)
+                // Check if followed by alphabetic character, underscore, or a
+                // non-ASCII byte (SQLite's IdChar accepts bytes >= 0x80) for a
+                // named placeholder (e.g. `:name`, `:Ց`)
+                if self
+                    .peek_byte(1)
+                    .map(|b| b.is_ascii_alphabetic() || b == b'_' || !b.is_ascii())
+                    .unwrap_or(false)
                 {
                     self.tokenize_named_placeholder()
                 } else {
@@ -381,7 +393,10 @@ impl<'a> Lexer<'a> {
 
         let start = self.byte_pos;
 
-        // Read the variable name (which may include scope prefix like 'global' or 'session')
+        // Read the variable name (which may include scope prefix like 'global'
+        // or 'session'). Deliberately ASCII-only: `@@` is a MySQL extension
+        // (SQLite rejects it entirely) and MySQL system variable names are
+        // ASCII, so SQLite's IdChar non-ASCII rule does not apply here.
         while !self.is_eof() {
             let ch = self.current_char();
             if ch.is_ascii_alphanumeric() || ch == '_' || ch == '.' {
@@ -409,10 +424,11 @@ impl<'a> Lexer<'a> {
 
         let start = self.byte_pos;
 
-        // Read the variable name
+        // Read the variable name. Like SQLite's IdChar, any non-ASCII char is
+        // part of the name (e.g. `@tՑ`).
         while !self.is_eof() {
             let ch = self.current_char();
-            if ch.is_ascii_alphanumeric() || ch == '_' {
+            if ch.is_ascii_alphanumeric() || ch == '_' || !ch.is_ascii() {
                 self.advance();
             } else {
                 break;
@@ -482,10 +498,11 @@ impl<'a> Lexer<'a> {
 
         let mut name = String::new();
 
-        // Read the identifier (alphanumeric or underscore)
+        // Read the identifier (alphanumeric, underscore, or non-ASCII —
+        // SQLite's IdChar accepts any byte >= 0x80, e.g. `:tՑ`)
         while !self.is_eof() {
             let ch = self.current_char();
-            if ch.is_ascii_alphanumeric() || ch == '_' {
+            if ch.is_ascii_alphanumeric() || ch == '_' || !ch.is_ascii() {
                 name.push(ch);
                 self.advance();
             } else {
@@ -511,10 +528,11 @@ impl<'a> Lexer<'a> {
 
         let mut name = String::new();
 
-        // Read the identifier (alphanumeric or underscore)
+        // Read the identifier (alphanumeric, underscore, or non-ASCII —
+        // SQLite's IdChar accepts any byte >= 0x80, e.g. `$tՑ`)
         while !self.is_eof() {
             let ch = self.current_char();
-            if ch.is_ascii_alphanumeric() || ch == '_' {
+            if ch.is_ascii_alphanumeric() || ch == '_' || !ch.is_ascii() {
                 name.push(ch);
                 self.advance();
             } else {
@@ -541,10 +559,12 @@ impl<'a> Lexer<'a> {
 
         let mut name = String::new();
 
-        // Consume the :: prefix and any subsequent ::namespace:: parts
+        // Consume the :: prefix and any subsequent ::namespace:: parts.
+        // Non-ASCII chars are part of the name (SQLite's IdChar accepts any
+        // byte >= 0x80, e.g. `$::Ց`).
         while !self.is_eof() {
             let ch = self.current_char();
-            if ch == ':' || ch.is_ascii_alphanumeric() || ch == '_' {
+            if ch == ':' || ch.is_ascii_alphanumeric() || ch == '_' || !ch.is_ascii() {
                 name.push(ch);
                 self.advance();
             } else {

--- a/crates/vibesql-parser/src/tests/lexer/errors.rs
+++ b/crates/vibesql-parser/src/tests/lexer/errors.rs
@@ -13,12 +13,12 @@ fn test_tokenize_invalid_character() {
 
 #[test]
 fn test_error_token_with_multibyte_char_does_not_panic() {
-    // `$` followed by a non-placeholder char takes the extract_error_token
-    // path; a multi-byte char right after the `$` must not cause a
-    // non-char-boundary slice panic (issue #5236)
+    // Historically (issue #5236) `SELECT $Ց` hit the extract_error_token path
+    // and could panic on a non-char-boundary slice. Since issue #5240,
+    // non-ASCII chars after `$` start a named variable (SQLite IdChar), so
+    // this input must lex cleanly as a single placeholder — and must still
+    // never panic.
     let mut lexer = Lexer::new("SELECT $Ց");
-    let result = lexer.tokenize();
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert_eq!(err.near_token.as_deref(), Some("$"));
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::NamedPlaceholder("Ց".to_string()));
 }

--- a/crates/vibesql-parser/src/tests/lexer/identifiers.rs
+++ b/crates/vibesql-parser/src/tests/lexer/identifiers.rs
@@ -149,6 +149,119 @@ fn test_keyword_matching_unchanged_for_ascii() {
 }
 
 // ============================================================================
+// Multi-byte UTF-8 Placeholder/Variable Tests (issue #5240)
+//
+// SQLite applies its IdChar rule (any byte >= 0x80 is an identifier char) to
+// variable/placeholder names too: `$tՑ`, `:tՑ`, `@tՑ`, `$Ց`, `:Ց`, `@Ց`,
+// and `$::Ց` are each a single variable token.
+// ============================================================================
+
+#[test]
+fn test_tokenize_dollar_placeholder_multibyte_middle() {
+    // SQLite: one variable `$tՑ` — must not split into `$t` + identifier `Ց`
+    let mut lexer = Lexer::new("SELECT $tՑ");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::NamedPlaceholder("tՑ".to_string()));
+    assert_eq!(tokens[2], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_dollar_placeholder_multibyte_leading() {
+    // SQLite: one variable `$Ց` — previously a lexer error in VibeSQL
+    let mut lexer = Lexer::new("SELECT $Ց");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::NamedPlaceholder("Ց".to_string()));
+    assert_eq!(tokens[2], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_dollar_placeholder_4byte_utf8() {
+    // 4-byte UTF-8 sequence (U+1F600) inside a placeholder name
+    let mut lexer = Lexer::new("SELECT $t😀");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::NamedPlaceholder("t😀".to_string()));
+    assert_eq!(tokens[2], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_colon_placeholder_multibyte_middle() {
+    // SQLite: one variable `:tՑ`; also covers non-ASCII at end of input
+    // with no trailing whitespace/semicolon
+    let mut lexer = Lexer::new("SELECT :tՑ");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::NamedPlaceholder("tՑ".to_string()));
+    assert_eq!(tokens[2], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_colon_placeholder_multibyte_leading() {
+    // SQLite: one variable `:Ց` — previously Symbol(':') + identifier
+    let mut lexer = Lexer::new("SELECT :Ց");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::NamedPlaceholder("Ց".to_string()));
+    assert_eq!(tokens[2], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_user_variable_multibyte_middle() {
+    // SQLite: one variable `@tՑ` — must not split into `@t` + identifier `Ց`
+    let mut lexer = Lexer::new("SELECT @tՑ");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::UserVariable("tՑ".to_string()));
+    assert_eq!(tokens[2], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_user_variable_multibyte_leading() {
+    // SQLite: one variable `@Ց` — previously "empty variable name" error
+    let mut lexer = Lexer::new("SELECT @Ց");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::UserVariable("Ց".to_string()));
+    assert_eq!(tokens[2], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_tcl_global_placeholder_multibyte() {
+    // SQLite: one variable `$::Ց` (TCL global namespace syntax)
+    let mut lexer = Lexer::new("SELECT $::Ց");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::NamedPlaceholder("::Ց".to_string()));
+    assert_eq!(tokens[2], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_tcl_global_placeholder_multibyte_namespaced() {
+    // Mixed namespace path with a non-ASCII trailing component
+    let mut lexer = Lexer::new("SELECT $::ns::Ց");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::NamedPlaceholder("::ns::Ց".to_string()));
+    assert_eq!(tokens[2], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_question_placeholder_not_extended_by_multibyte() {
+    // SQLite: `?Ց` is the anonymous `?` placeholder followed by identifier
+    // `Ց` (implicit alias) — `?` names are numeric-only, so no change here
+    let mut lexer = Lexer::new("SELECT ?Ց");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::Placeholder);
+    assert_eq!(tokens[2], Token::Identifier("Ց".to_string()));
+    assert_eq!(tokens[3], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_ascii_placeholders_unchanged() {
+    // ASCII placeholder lexing must be unaffected
+    let mut lexer = Lexer::new("SELECT $name, :name, @name, $1, ?");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::NamedPlaceholder("name".to_string()));
+    assert_eq!(tokens[3], Token::NamedPlaceholder("name".to_string()));
+    assert_eq!(tokens[5], Token::UserVariable("name".to_string()));
+    assert_eq!(tokens[7], Token::NumberedPlaceholder(1));
+    assert_eq!(tokens[9], Token::Placeholder);
+}
+
+// ============================================================================
 // Delimited Identifier Tests
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Aligns placeholder/variable name lexing with SQLite's `IdChar` rule (any byte >= 0x80 is an identifier char): `$tՑ`, `$Ց`, `:tՑ`, `:Ց`, `@tՑ`, `@Ց`, and `$::Ց` now each lex as a single variable token instead of splitting at the non-ASCII char (or erroring).
- Mirrors the PR #5239 pattern: `|| !b.is_ascii()` on the `$`/`:` dispatch predicates in `next_token()` and `|| !ch.is_ascii()` on the continuation loops of `tokenize_user_variable`, `tokenize_named_placeholder`, `tokenize_dollar_named_placeholder`, and `tokenize_tcl_global_placeholder`.
- The MySQL-only `@@` session-variable path (`tokenize_session_variable`) is deliberately left ASCII-only — SQLite rejects `@@` entirely and MySQL system variable names are ASCII; documented with a code comment per the curator's note.
- `?Ց` behavior intentionally unchanged: `?` placeholder followed by identifier `Ց` (matches SQLite, covered by a regression test).
- Updates the now-obsolete `test_error_token_with_multibyte_char_does_not_panic` expectation: `SELECT $Ց` must now lex cleanly as `NamedPlaceholder("Ց")` (still asserts the no-panic property from #5236/#5239).

Out of scope (pre-existing documented divergences, untouched): `$1a`, `:123`, TCL array suffix `$name(index)`.

Closes #5240

## Test plan

- [x] New tests in `crates/vibesql-parser/src/tests/lexer/identifiers.rs`: `$tՑ`, `$Ց`, `$t😀` (4-byte UTF-8), `:tՑ` (also covers non-ASCII at end of input), `:Ց`, `@tՑ`, `@Ց`, `$::Ց`, `$::ns::Ց`, the `?Ց` non-case, and an ASCII-placeholders-unchanged regression test
- [x] Updated obsolete error expectation in `crates/vibesql-parser/src/tests/lexer/errors.rs`
- [x] `cargo test -p vibesql-parser --lib` — 1297 passed, 0 failed
- [x] `cargo clippy -p vibesql-parser` — no new warnings (remaining warnings pre-exist in unrelated files)
- [x] `cargo fmt` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)