### PR TITLE
fix(executor): thread CTE-name scope into nested INDEXED BY validation scopes

### DIFF
--- a/crates/vibesql-executor/src/select/executor/validation/index_hints.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/index_hints.rs
@@ -30,14 +30,34 @@ pub fn validate_index_hints(
     stmt: &SelectStmt,
     database: &vibesql_storage::Database,
 ) -> Result<(), ExecutorError> {
+    validate_select(stmt, &[], database)
+}
+
+/// Validate a SELECT scope with the CTE names inherited from enclosing scopes.
+///
+/// The CTE-name scope is purely additive across nested scopes: an outer CTE
+/// remains visible inside derived-table subqueries, set-operation arms, and
+/// later CTE bodies, and an inner WITH can only add names. So a simple
+/// extended `Vec` threaded down the recursion is sufficient — no
+/// shadowing/removal logic is needed.
+fn validate_select(
+    stmt: &SelectStmt,
+    outer_cte_names: &[String],
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
     // CTE names visible to this statement's FROM clause: a table reference
     // that resolves to a CTE can never carry a valid INDEXED BY hint.
-    let mut cte_names: Vec<String> = Vec::new();
+    let mut cte_names: Vec<String> = outer_cte_names.to_vec();
     if let Some(ctes) = &stmt.with_clause {
         for cte in ctes {
-            // Validate hints inside the CTE body itself
-            validate_index_hints(&cte.query, database)?;
+            // Push the CTE's own name before validating its body so a
+            // self-reference (`WITH x AS (... FROM x INDEXED BY i)`) errors
+            // rather than passing; SQLite errors on self-reference too
+            // (`circular reference` / `no query solution` — exact message
+            // parity is out of scope). Earlier CTEs in the same WITH clause
+            // plus the outer scope are also visible to the body.
             cte_names.push(cte.name.to_lowercase());
+            validate_select(&cte.query, &cte_names, database)?;
         }
     }
 
@@ -47,7 +67,7 @@ pub fn validate_index_hints(
 
     // Set-operation arms (UNION / INTERSECT / EXCEPT)
     if let Some(set_op) = &stmt.set_operation {
-        validate_index_hints(&set_op.right, database)?;
+        validate_select(&set_op.right, &cte_names, database)?;
     }
 
     Ok(())
@@ -70,7 +90,7 @@ fn validate_from_clause(
             validate_from_clause(left, cte_names, database)?;
             validate_from_clause(right, cte_names, database)
         }
-        FromClause::Subquery { query, .. } => validate_index_hints(query, database),
+        FromClause::Subquery { query, .. } => validate_select(query, cte_names, database),
         FromClause::Values { .. } => Ok(()),
     }
 }

--- a/crates/vibesql-executor/src/tests/index_hint_validation.rs
+++ b/crates/vibesql-executor/src/tests/index_hint_validation.rs
@@ -197,3 +197,94 @@ fn test_indexed_by_in_from_subquery_errors() {
         "missing_idx",
     );
 }
+
+// --- CTE-name scope threaded into nested validation scopes (issue #5243) ---
+//
+// A CTE shadows any same-named real table, so `INDEXED BY` on a CTE
+// reference must error even when the reference appears in a nested scope
+// (derived-table subquery, set-operation arm, or a later CTE body). All SQL
+// below was verified against sqlite3.
+
+#[test]
+fn test_indexed_by_on_outer_cte_inside_subquery_errors() {
+    let db = create_test_db();
+    // The inner t1 resolves to the CTE, which can't carry an index hint.
+    // SQLite: no such index: t1x
+    assert_no_such_index(
+        &db,
+        "WITH t1 AS (SELECT 1 AS x) SELECT * FROM (SELECT * FROM t1 INDEXED BY t1x) sub",
+        "t1x",
+    );
+}
+
+#[test]
+fn test_indexed_by_on_outer_cte_in_union_arm_errors() {
+    let db = create_test_db();
+    // SQLite: no such index: t1x
+    assert_no_such_index(
+        &db,
+        "WITH t1 AS (SELECT 1 AS x) SELECT * FROM t1 UNION SELECT * FROM t1 INDEXED BY t1x",
+        "t1x",
+    );
+}
+
+#[test]
+fn test_indexed_by_on_earlier_cte_in_later_cte_body_errors() {
+    let db = create_test_db();
+    // SQLite: no such index: t1x
+    assert_no_such_index(
+        &db,
+        "WITH t1 AS (SELECT 1 AS x), b AS (SELECT * FROM t1 INDEXED BY t1x) SELECT * FROM b",
+        "t1x",
+    );
+}
+
+#[test]
+fn test_indexed_by_on_outer_cte_in_join_inside_subquery_errors() {
+    let db = create_test_db();
+    // CTE scope must thread through Join arms inside the subquery.
+    // SQLite: no such index: t1x
+    assert_no_such_index(
+        &db,
+        "WITH t1 AS (SELECT 1 AS x) SELECT * FROM (SELECT * FROM t2 JOIN t1 INDEXED BY t1x ON 1=1) sub",
+        "t1x",
+    );
+}
+
+#[test]
+fn test_indexed_by_self_reference_in_cte_body_errors() {
+    let db = create_test_db();
+    // SQLite errors with "circular reference: t1"; any error beats silently
+    // succeeding, so VibeSQL reports NoSuchIndex (message parity out of scope).
+    assert_no_such_index(
+        &db,
+        "WITH t1 AS (SELECT * FROM t1 INDEXED BY t1x) SELECT * FROM t1",
+        "t1x",
+    );
+}
+
+#[test]
+fn test_indexed_by_real_table_in_subquery_with_unrelated_cte_succeeds() {
+    let db = create_test_db();
+    // Negative control: an unrelated CTE in scope must not poison a valid
+    // hint on a real table inside a nested scope. SQLite: succeeds.
+    let rows = run_select(
+        &db,
+        "WITH q AS (SELECT 1 AS z) SELECT * FROM (SELECT * FROM t2 INDEXED BY t2a) sub",
+    )
+    .unwrap();
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn test_indexed_by_real_table_with_inner_with_in_subquery_succeeds() {
+    let db = create_test_db();
+    // Negative control: an inner WITH inside a derived table doesn't poison
+    // real-table hints. SQLite: succeeds.
+    let rows = run_select(
+        &db,
+        "SELECT * FROM (WITH q AS (SELECT 1 AS z) SELECT * FROM t1 INDEXED BY t1x)",
+    )
+    .unwrap();
+    assert_eq!(rows.len(), 2);
+}


### PR DESCRIPTION
## Summary

`validate_index_hints` correctly rejected `INDEXED BY` on a CTE reference in the statement's own FROM clause, but restarted with an empty CTE scope when recursing into nested scopes. If a real table shared a CTE's name and owned the hinted index, validation passed where SQLite errors with `no such index`. This PR threads an additive `cte_names` scope through the recursion (per the curator's sqlite3-verified guidance on #5243).

## Changes

- Added a private `validate_select(stmt, outer_cte_names, database)` worker in `crates/vibesql-executor/src/select/executor/validation/index_hints.rs`; the public `validate_index_hints(stmt, database)` entry point is unchanged and delegates with an empty scope
- Fixed all three scope-drop sites: CTE bodies, set-operation arms, and `FromClause::Subquery` now receive the inherited CTE-name scope
- Each CTE's own name is pushed into scope **before** validating its body, so self-references (`WITH t1 AS (SELECT * FROM t1 INDEXED BY t1x) ...`) now error instead of silently passing (SQLite errors with `circular reference`; exact message parity is out of scope)
- Added 7 regression tests in `crates/vibesql-executor/src/tests/index_hint_validation.rs` (all SQL verified against sqlite3 per the curator's test plan)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `INDEXED BY` on a CTE reference errors inside derived-table subqueries, set-op arms, and later CTE bodies | Pass | `test_indexed_by_on_outer_cte_inside_subquery_errors`, `test_indexed_by_on_outer_cte_in_union_arm_errors`, `test_indexed_by_on_earlier_cte_in_later_cte_body_errors`, `test_indexed_by_on_outer_cte_in_join_inside_subquery_errors` |
| Self-reference inside a CTE body errors rather than passing | Pass | `test_indexed_by_self_reference_in_cte_body_errors` |
| Valid hints on real tables inside nested scopes still succeed with an unrelated CTE in scope | Pass | `test_indexed_by_real_table_in_subquery_with_unrelated_cte_succeeds`, `test_indexed_by_real_table_with_inner_with_in_subquery_succeeds` |
| Public `validate_index_hints(stmt, database)` signature unchanged | Pass | Entry point delegates to private worker; caller in `execute.rs` untouched |
| All existing tests in `index_hint_validation.rs` still pass | Pass | All 21 tests in the file pass |

## Test Plan

- `cargo test -p vibesql-executor index_hint --lib` — 21 passed (14 existing + 7 new)
- `cargo test -p vibesql-executor --lib` — full suite: 2425 passed, 0 failed, 2 ignored

Closes #5243