### PR TITLE
fix(explain): suppress statement ORDER BY temp-B-tree entry when covered by first window sort key

### DIFF
--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -766,14 +766,29 @@ impl ExplainExecutor {
         // clause is passed through so the planner can pin leading index columns
         // and accept trailing ORDER BY columns that would otherwise be rejected
         // due to nullability.
+        //
+        // The entry is also suppressed when the statement-level ORDER BY is a
+        // structural prefix of (or equal to) the FIRST SELECT-list window's
+        // combined sort key. SQLite's window co-routine rewrite places the
+        // first window's sorting pass outermost, so its key is the final
+        // output order and the outer sort is satisfied without a second temp
+        // B-tree (verified against sqlite3 3.51.0). An empty key (`OVER ()`)
+        // never suppresses; extensions, direction/COLLATE mismatches, and
+        // matches against later windows do not suppress.
         if let Some(ref order_by) = stmt.order_by {
-            let needs_temp = Self::needs_temp_btree_for_order_by(
-                stmt.from.as_ref(),
-                stmt.where_clause.as_ref(),
-                order_by,
-                database,
-            );
-            root.needs_temp_btree_for_order_by = needs_temp;
+            let satisfied_by_window_sort =
+                Self::first_window_combined_key(stmt).is_some_and(|key| {
+                    !key.is_empty()
+                        && order_by.len() <= key.len()
+                        && key[..order_by.len()] == order_by[..]
+                });
+            root.needs_temp_btree_for_order_by = !satisfied_by_window_sort
+                && Self::needs_temp_btree_for_order_by(
+                    stmt.from.as_ref(),
+                    stmt.where_clause.as_ref(),
+                    order_by,
+                    database,
+                );
         }
 
         // Count window-function sorting passes for EQP output. SQLite emits
@@ -900,20 +915,7 @@ impl ExplainExecutor {
 
         let mut distinct_keys: Vec<Vec<vibesql_ast::OrderByItem>> = Vec::new();
         for spec in &specs {
-            // Combined sort key: PARTITION BY exprs (ASC) + window ORDER BY.
-            let mut key: Vec<vibesql_ast::OrderByItem> = Vec::new();
-            if let Some(partition_by) = &spec.partition_by {
-                for expr in partition_by {
-                    key.push(vibesql_ast::OrderByItem {
-                        expr: expr.clone(),
-                        direction: vibesql_ast::OrderDirection::Asc,
-                        nulls_order: None,
-                    });
-                }
-            }
-            if let Some(order_by) = &spec.order_by {
-                key.extend(order_by.iter().cloned());
-            }
+            let key = Self::window_combined_key(spec);
 
             // OVER () — no partitioning or ordering — needs no sort pass.
             if key.is_empty() {
@@ -936,6 +938,40 @@ impl ExplainExecutor {
                 )
             })
             .count()
+    }
+
+    /// Build the combined sort key for a window spec: PARTITION BY
+    /// expressions (treated as ASC with default null ordering) followed by
+    /// the window's ORDER BY items. `OVER ()` yields an empty key.
+    fn window_combined_key(spec: &vibesql_ast::WindowSpec) -> Vec<vibesql_ast::OrderByItem> {
+        let mut key: Vec<vibesql_ast::OrderByItem> = Vec::new();
+        if let Some(partition_by) = &spec.partition_by {
+            for expr in partition_by {
+                key.push(vibesql_ast::OrderByItem {
+                    expr: expr.clone(),
+                    direction: vibesql_ast::OrderDirection::Asc,
+                    nulls_order: None,
+                });
+            }
+        }
+        if let Some(order_by) = &spec.order_by {
+            key.extend(order_by.iter().cloned());
+        }
+        key
+    }
+
+    /// Combined sort key of the FIRST window function in the SELECT list, if
+    /// any. SELECT-list order is preserved by
+    /// `collect_resolved_window_specs`, and SQLite's co-routine rewrite makes
+    /// the first window's sorting pass the outermost one — its key is the
+    /// order of the final output.
+    fn first_window_combined_key(stmt: &SelectStmt) -> Option<Vec<vibesql_ast::OrderByItem>> {
+        let specs = crate::select::window::collect_resolved_window_specs(
+            &stmt.select_list,
+            stmt.window_definitions.as_ref(),
+        )
+        .ok()?;
+        specs.first().map(Self::window_combined_key)
     }
 
     /// Check if ORDER BY requires a temp B-tree (sorting pass) for EQP rendering.

--- a/crates/vibesql-executor/tests/explain_window_sort_tests.rs
+++ b/crates/vibesql-executor/tests/explain_window_sort_tests.rs
@@ -197,3 +197,149 @@ fn test_direction_distinguishes_keys() {
     );
     assert_eq!(count, 2);
 }
+
+// ---------------------------------------------------------------------------
+// Statement-level ORDER BY suppression (issue #5246)
+//
+// SQLite suppresses the statement-level USE TEMP B-TREE FOR ORDER BY entry
+// when the statement ORDER BY is a structural prefix of (or equal to) the
+// combined sort key of the FIRST window in the SELECT list: the co-routine
+// rewrite places the first window's sorting pass outermost, so its key is
+// the final output order. Expected counts below verified against
+// sqlite3 3.51.0 with the same schema.
+// ---------------------------------------------------------------------------
+
+// Case 1: statement ORDER BY identical to the window sort key — suppressed.
+#[test]
+fn test_statement_order_by_identical_to_window_key_suppressed() {
+    let db = setup_db();
+    let count = order_count(&db, "SELECT sum(c) OVER (ORDER BY c) FROM t5 ORDER BY c");
+    assert_eq!(count, 1);
+}
+
+// Case 2: statement ORDER BY extends the window key — NOT suppressed.
+#[test]
+fn test_statement_order_by_extending_window_key_not_suppressed() {
+    let db = setup_db();
+    let count = order_count(&db, "SELECT sum(c) OVER (ORDER BY c) FROM t5 ORDER BY c, b");
+    assert_eq!(count, 2);
+}
+
+// Case 3: statement ORDER BY is a prefix of the window key — suppressed.
+#[test]
+fn test_statement_order_by_prefix_of_window_key_suppressed() {
+    let db = setup_db();
+    let count = order_count(&db, "SELECT sum(c) OVER (ORDER BY c, b) FROM t5 ORDER BY c");
+    assert_eq!(count, 1);
+}
+
+// Case 4: direction mismatch (window ASC, statement DESC) — NOT suppressed.
+#[test]
+fn test_statement_order_by_direction_mismatch_not_suppressed() {
+    let db = setup_db();
+    let count = order_count(&db, "SELECT sum(c) OVER (ORDER BY c) FROM t5 ORDER BY c DESC");
+    assert_eq!(count, 2);
+}
+
+// Case 5: DESC exact match — suppressed.
+#[test]
+fn test_statement_order_by_desc_exact_match_suppressed() {
+    let db = setup_db();
+    let count = order_count(&db, "SELECT sum(c) OVER (ORDER BY c DESC) FROM t5 ORDER BY c DESC");
+    assert_eq!(count, 1);
+}
+
+// Case 6: DESC prefix match — suppressed.
+#[test]
+fn test_statement_order_by_desc_prefix_suppressed() {
+    let db = setup_db();
+    let count = order_count(&db, "SELECT sum(c) OVER (ORDER BY c DESC, b) FROM t5 ORDER BY c DESC");
+    assert_eq!(count, 1);
+}
+
+// Case 7: statement ORDER BY matches the window PARTITION BY key — suppressed.
+#[test]
+fn test_statement_order_by_matching_partition_key_suppressed() {
+    let db = setup_db();
+    let count = order_count(&db, "SELECT sum(c) OVER (PARTITION BY c) FROM t5 ORDER BY c");
+    assert_eq!(count, 1);
+}
+
+// Case 8: statement ORDER BY is a prefix via the PARTITION BY portion of the
+// combined key (PARTITION BY c ORDER BY b => key (c, b)) — suppressed.
+#[test]
+fn test_statement_order_by_partition_prefix_suppressed() {
+    let db = setup_db();
+    let count =
+        order_count(&db, "SELECT sum(c) OVER (PARTITION BY c ORDER BY b) FROM t5 ORDER BY c");
+    assert_eq!(count, 1);
+}
+
+// Case 9: COLLATE mismatch — NOT suppressed.
+#[test]
+fn test_statement_order_by_collate_mismatch_not_suppressed() {
+    let db = setup_db();
+    let count =
+        order_count(&db, "SELECT sum(c) OVER (ORDER BY c) FROM t5 ORDER BY c COLLATE NOCASE");
+    assert_eq!(count, 2);
+}
+
+// Case 10: multiple windows — statement ORDER BY matching the FIRST window's
+// key is suppressed.
+#[test]
+fn test_statement_order_by_matching_first_window_suppressed() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (ORDER BY c),
+            sum(c) OVER (ORDER BY b)
+         FROM t5 ORDER BY c",
+    );
+    assert_eq!(count, 2);
+}
+
+// Case 11: multiple windows — statement ORDER BY matching only the SECOND
+// window's key is NOT suppressed (only the first window's key governs).
+#[test]
+fn test_statement_order_by_matching_second_window_not_suppressed() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (ORDER BY c),
+            sum(c) OVER (ORDER BY b)
+         FROM t5 ORDER BY b",
+    );
+    assert_eq!(count, 3);
+}
+
+// Case 12: first window has an empty key (OVER ()) — never suppresses, even
+// if a later window's key matches the statement ORDER BY.
+#[test]
+fn test_empty_first_window_key_never_suppresses() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (),
+            sum(c) OVER (ORDER BY c)
+         FROM t5 ORDER BY c",
+    );
+    assert_eq!(count, 2);
+}
+
+// Reversed-window-order control for cases 10/11: with the windows swapped,
+// suppression follows the new first window's key.
+#[test]
+fn test_suppression_follows_window_order_in_select_list() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (ORDER BY b),
+            sum(c) OVER (ORDER BY c)
+         FROM t5 ORDER BY b",
+    );
+    assert_eq!(count, 2);
+}


### PR DESCRIPTION
## Summary

EQP fidelity fix: when a query has window functions and a statement-level ORDER BY, VibeSQL emitted a `USE TEMP B-TREE FOR ORDER BY` entry for the outer sort even when the first window's sorting pass already produces rows in that order. SQLite suppresses the entry in that case (its co-routine rewrite places the first SELECT-list window's sorting pass outermost). This PR implements the exact dedup rule verified against sqlite3 3.51.0 in the issue's curator comment.

Display-layer change only — the executor still re-sorts in `apply_sorting`, which is documented out of scope (results are identical; sort reuse is optional future perf work).

## Changes

- `crates/vibesql-executor/src/explain.rs`
  - Gate `needs_temp_btree_for_order_by` in `explain_select`: suppressed iff the statement ORDER BY items are a structural prefix of (or equal to) the first window's combined sort key (expr + direction + COLLATE via `OrderByItem` equality); an empty `OVER ()` key never suppresses
  - Extract the combined-key construction (PARTITION BY exprs as ASC + window ORDER BY) from `count_window_sorts` into `window_combined_key`, shared with new `first_window_combined_key`
  - `count_window_sorts` behavior is unchanged
- `crates/vibesql-executor/tests/explain_window_sort_tests.rs`: 13 new `order_count` tests — the 12 evidence-table cases plus the reversed-window-order control

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `EXPLAIN QUERY PLAN SELECT sum(c) OVER (ORDER BY c) FROM t5 ORDER BY c` emits exactly 1 temp-B-tree entry | Pass | `test_statement_order_by_identical_to_window_key_suppressed` asserts count 1 |
| All 12 evidence-table cases match sqlite3 counts (1, 2, 1, 2, 1, 1, 1, 1, 2, 2, 3, 2) | Pass | One test per case in `explain_window_sort_tests.rs`, all green |
| Existing `explain_window_sort_tests` from #5244 pass unchanged | Pass | All 11 pre-existing tests untouched and passing (24/24 total) |
| No executor/runtime behavior change (EQP display only) | Pass | Diff touches only `explain.rs` EQP gating + tests; `cargo test -p vibesql-executor --lib`: 2418 passed, 0 failed |

## Test Plan

- `cargo test -p vibesql-executor --test explain_window_sort_tests`: 24 passed (11 existing + 13 new)
- `cargo test -p vibesql-executor --lib`: 2418 passed, 0 failed
- `make test-tcl-file FILE=window1.test`: 259/347 passed with this change — identical to baseline run on unmodified main (same 12 pre-existing failures, none in section 23)
- Edge cases covered: empty first-window key (`OVER ()`), DESC prefix, COLLATE mismatch, multi-window first-governs and second-window non-match, reversed window order
- Pre-existing and untouched: clippy `approx_constant` error in `src/evaluator/expressions/operators.rs:339` (lib test, exists on main); related multi-window index-suppression gap is tracked separately in #5248 and deliberately not addressed here

Closes #5246