### PR TITLE
fix(explain): restrict window-sort index suppression to the innermost pass

### DIFF
--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -901,8 +901,13 @@ impl ExplainExecutor {
     ///   direction and COLLATE); frame clauses are ignored entirely.
     /// - Windows with neither PARTITION BY nor ORDER BY (`OVER ()`) need no
     ///   sorting pass.
-    /// - A key satisfied by an index scan order is suppressed (e.g. key
-    ///   `(a, b)` with index `t5ab(a, b)`).
+    /// - Only the INNERMOST sorting pass scans the base table and can be
+    ///   satisfied by an index (e.g. key `(a, b)` with index `t5ab(a, b)`).
+    ///   SQLite's nested co-routine rewrite emits passes in reverse
+    ///   SELECT-list order, so the innermost pass corresponds to the LAST
+    ///   distinct key (by first occurrence). All outer passes read
+    ///   co-routine output and always need a temp B-tree, even if their key
+    ///   matches an index.
     fn count_window_sorts(stmt: &SelectStmt, database: &Database) -> usize {
         let Ok(specs) = crate::select::window::collect_resolved_window_specs(
             &stmt.select_list,
@@ -927,15 +932,21 @@ impl ExplainExecutor {
             }
         }
 
+        // Only the innermost pass — the last distinct key — scans the base
+        // table; it alone is eligible for index suppression. Outer passes
+        // read co-routine output, so their keys always count.
+        let last_index = distinct_keys.len().wrapping_sub(1);
         distinct_keys
             .iter()
-            .filter(|key| {
-                Self::needs_temp_btree_for_order_by(
-                    stmt.from.as_ref(),
-                    stmt.where_clause.as_ref(),
-                    key,
-                    database,
-                )
+            .enumerate()
+            .filter(|(i, key)| {
+                *i != last_index
+                    || Self::needs_temp_btree_for_order_by(
+                        stmt.from.as_ref(),
+                        stmt.where_clause.as_ref(),
+                        key,
+                        database,
+                    )
             })
             .count()
     }

--- a/crates/vibesql-executor/tests/explain_window_sort_tests.rs
+++ b/crates/vibesql-executor/tests/explain_window_sort_tests.rs
@@ -15,12 +15,15 @@ use vibesql_executor::ExplainExecutor;
 use vibesql_parser::Parser;
 use vibesql_storage::Database;
 
-/// Create the window1.test section-23 schema:
-/// CREATE TABLE t5(a, b, c); CREATE INDEX t5ab ON t5(a, b);
+/// Create the window1.test section-23 schema (extended with a `d` column
+/// for the multi-window index-position tests; sqlite3 verification used
+/// t5(a,b,c,d) and the EQP output for the original cases is unchanged):
+/// CREATE TABLE t5(a, b, c, d); CREATE INDEX t5ab ON t5(a, b);
 fn setup_db() -> Database {
     let mut db = Database::new();
 
-    let create = Parser::parse_sql("CREATE TABLE t5 (a INTEGER, b INTEGER, c INTEGER)").unwrap();
+    let create =
+        Parser::parse_sql("CREATE TABLE t5 (a INTEGER, b INTEGER, c INTEGER, d INTEGER)").unwrap();
     if let Statement::CreateTable(stmt) = create {
         vibesql_executor::CreateTableExecutor::execute(&stmt, &mut db).unwrap();
     } else {
@@ -342,4 +345,125 @@ fn test_suppression_follows_window_order_in_select_list() {
          FROM t5 ORDER BY b",
     );
     assert_eq!(count, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-window index suppression (issue #5248)
+//
+// SQLite's nested co-routine rewrite emits window sorting passes in reverse
+// SELECT-list order: the LAST distinct window key (by first occurrence) is
+// the INNERMOST pass — the only one that scans the base table and can use an
+// index. All outer passes read co-routine output and always need a temp
+// B-tree, even when their key matches an index. Expected counts below
+// verified against sqlite3 3.51.0 with schema t5(a,b,c,d), index t5ab(a,b).
+// ---------------------------------------------------------------------------
+
+// Two windows, index-matching key (a, b) FIRST: its pass is outermost and
+// reads a co-routine, so the index is NOT usable — both keys count.
+#[test]
+fn test_index_key_first_of_two_windows_not_suppressed() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (ORDER BY a, b),
+            sum(a) OVER (ORDER BY c)
+         FROM t5",
+    );
+    assert_eq!(count, 2);
+}
+
+// Two windows, index-matching key (a, b) LAST: its pass is innermost, scans
+// t5 via index t5ab, and is suppressed — only key (c) counts.
+#[test]
+fn test_index_key_last_of_two_windows_suppressed() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(a) OVER (ORDER BY c),
+            sum(c) OVER (ORDER BY a, b)
+         FROM t5",
+    );
+    assert_eq!(count, 1);
+}
+
+// Three windows, index-matching key (a, b) FIRST: outermost pass — all
+// three keys count.
+#[test]
+fn test_index_key_first_of_three_windows_not_suppressed() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(d) OVER (ORDER BY a, b),
+            sum(d) OVER (ORDER BY c),
+            sum(d) OVER (ORDER BY d)
+         FROM t5",
+    );
+    assert_eq!(count, 3);
+}
+
+// Three windows, index-matching key (a, b) in the MIDDLE: still an outer
+// pass — all three keys count.
+#[test]
+fn test_index_key_middle_of_three_windows_not_suppressed() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(d) OVER (ORDER BY c),
+            sum(d) OVER (ORDER BY a, b),
+            sum(d) OVER (ORDER BY d)
+         FROM t5",
+    );
+    assert_eq!(count, 3);
+}
+
+// Three windows, index-matching key (a, b) LAST: innermost pass uses the
+// index — only the two outer keys count.
+#[test]
+fn test_index_key_last_of_three_windows_suppressed() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(d) OVER (ORDER BY c),
+            sum(d) OVER (ORDER BY d),
+            sum(d) OVER (ORDER BY a, b)
+         FROM t5",
+    );
+    assert_eq!(count, 2);
+}
+
+// Dedup keeps FIRST-occurrence position: (a,b), (c), (a,b) dedups to
+// [(a,b), (c)] — innermost key is (c), index NOT used, both keys count.
+#[test]
+fn test_repeated_index_key_keeps_first_position_not_suppressed() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(c) OVER (ORDER BY a, b),
+            sum(a) OVER (ORDER BY c),
+            sum(b) OVER (ORDER BY a, b)
+         FROM t5",
+    );
+    assert_eq!(count, 2);
+}
+
+// Dedup control: (c), (a,b), (c) dedups to [(c), (a,b)] — innermost key is
+// (a,b), index used — only key (c) counts.
+#[test]
+fn test_repeated_outer_key_leaves_index_key_innermost_suppressed() {
+    let db = setup_db();
+    let count = order_count(
+        &db,
+        "SELECT
+            sum(a) OVER (ORDER BY c),
+            sum(c) OVER (ORDER BY a, b),
+            sum(b) OVER (ORDER BY c)
+         FROM t5",
+    );
+    assert_eq!(count, 1);
 }


### PR DESCRIPTION
Closes #5248

## Summary

- `count_window_sorts` in `crates/vibesql-executor/src/explain.rs` applied the index-satisfaction check (`needs_temp_btree_for_order_by`) to every distinct window sort key, under-counting `USE TEMP B-TREE FOR ORDER BY` entries in EXPLAIN QUERY PLAN for multi-window queries.
- In SQLite's nested co-routine rewrite, only the **innermost** pass — the last distinct window key by first-occurrence SELECT-list order — scans the base table and can use an index. All outer passes read co-routine output and always need a temp B-tree, even if their key matches an index.
- Fix: apply the index check only to `distinct_keys.last()`; count all earlier keys unconditionally. Since dedup already preserves first-occurrence order, `.last()` is exactly the innermost key — no reordering needed.
- Complementary to #5246 / PR #5249: statement-ORDER-BY suppression keys off the FIRST distinct key (outermost pass = final output order); this keys off the LAST (innermost pass = base-table scan). No interaction.

## Tests

Added 7 cases to `crates/vibesql-executor/tests/explain_window_sort_tests.rs` (all expectations verified against sqlite3 3.51.0 in the issue's curator comment); extended `setup_db` with a `d` column for the 3-key matrix (sqlite3 verification used `t5(a,b,c,d)`; EQP output for existing cases unchanged):

- 2 windows, index key `(a,b)` first → 2 entries (was 1 — the bug); last → 1
- 3 windows, index key first/middle/last → 3 / 3 / 2
- Dedup keeps first-occurrence position: `(a,b),(c),(a,b)` → 2; `(c),(a,b),(c)` → 1

## Test plan

- [x] `cargo test -p vibesql-executor --test explain_window_sort_tests` — 31 passed (24 existing + 7 new)
- [x] `cargo test -p vibesql-executor --lib` — 2425 passed
- [x] `make test-tcl-file FILE=window1.test` — all section 23 ordercount tests pass; 12 remaining failures (6.2, 25.x, 44.x, 53.0, 61.x, 71.0, 73.x) are pre-existing on the baseline (which fails those plus 12 more)
- [x] `cargo fmt --check` and `cargo clippy -p vibesql-executor --tests` — clean for changed files (remaining warnings pre-exist in other crates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)