### PR TITLE
fix(wasm): enable wasm_js feature on getrandom 0.3 pulled in via ahash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,26 @@ jobs:
           df -h
 
   # ============================================================================
+  # WASM build check - catches wasm32-only breakage (e.g., getrandom backend
+  # feature regressions from dependency bumps) that native builds never see.
+  # See issue #5253 for the regression that motivated this job.
+  # ============================================================================
+  wasm-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          targets: wasm32-unknown-unknown
+          cache-key-suffix: wasm
+
+      - name: Check wasm32 build
+        run: cargo check -p vibesql-wasm-bindings --lib --target wasm32-unknown-unknown
+
+  # ============================================================================
   # Extended validation tests (TPC-DS, SQLLogicTest, PostgreSQL, TCL) have been
   # moved to ci-extended.yml for manual dispatch. Run before merging significant
   # PRs with: gh workflow run ci-extended.yml

--- a/crates/vibesql-wasm-bindings/Cargo.toml
+++ b/crates/vibesql-wasm-bindings/Cargo.toml
@@ -28,8 +28,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 serde_json = "1.0"
 
-# Enable wasm_js backend for getrandom 0.3.x (required by rand, uuid, ahash, etc.)
+# Enable wasm_js backend on BOTH getrandom major versions in the tree:
+# 0.4.x is used by rand 0.10; 0.3.x is pulled by ahash 0.8.12 (via arrow 58)
 getrandom = { version = "0.4", features = ["wasm_js"] }
+getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
 
 # Optional i18n support
 vibesql-l10n = { version = "0.1.4", path = "../vibesql-l10n", optional = true }


### PR DESCRIPTION
## Summary

`make build-wasm` broke on main: getrandom 0.3.4 hits its `compile_error!` on wasm32-unknown-unknown because no crate enables its `wasm_js` feature. Dependabot bump #5031 moved the direct getrandom dep from 0.3 to 0.4 — but cargo features are per-major-version, so `wasm_js` was only enabled on the 0.4.2 copy, while ahash 0.8.12 (via arrow 58.1.0) still pulls getrandom 0.3.4 with no backend selected.

This PR adds a renamed `getrandom_03` dependency to enable `wasm_js` on the 0.3 copy as well (the curator-validated one-line fix), and adds a `wasm-check` CI job so wasm32-only breakage like this can no longer ship silently — no CI previously built the wasm32 target.

## Changes

- `crates/vibesql-wasm-bindings/Cargo.toml`: add `getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }`; fix the stale "0.3.x" comment on the existing 0.4 line
- `.github/workflows/ci.yml`: add `wasm-check` job running `cargo check -p vibesql-wasm-bindings --lib --target wasm32-unknown-unknown` (uses the existing `setup-rust` composite action's `targets` input)

No RUSTFLAGS / `.cargo/config.toml` / `build-wasm.sh` changes — the feature alone selects the backend in getrandom 0.3.4 (verified by curator against `src/backends.rs`; the "feature flag alone is insufficient" error text is stale upstream wording).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cargo check -p vibesql-wasm-bindings --lib --target wasm32-unknown-unknown` passes | PASS | Fails with the exact reported `compile_error!` with the fix stashed; passes (`Finished dev profile`) with the fix applied (Homebrew LLVM CC/AR per `scripts/build-wasm.sh`) |
| `make build-wasm` completes and regenerates `web-demo/public/pkg/vibesql_wasm.js` | PASS | Full release wasm-pack build completed in 5m24s; `vibesql_wasm.js` and `vibesql_wasm_bg.wasm` regenerated |
| `cd web-demo && pnpm build` passes | PASS | `tsc --noEmit && vite build` succeeded; tsc resolves `../../public/pkg/vibesql_wasm.js` (note: had to install with `--no-frozen-lockfile` due to pre-existing lockfile drift tracked in #5251; lockfile change not committed) |
| 3 blocked vitest files pass | PARTIAL | The artifact import now succeeds (the failure mode reported in the issue is gone). The tests themselves still fail for a pre-existing, unrelated environment reason: wasm-bindgen `instantiateStreaming` rejects happy-dom's `Response` object, and vitest's happy-dom default URL (`localhost:3000`) has no server. This cannot pass in the current vitest setup regardless of the wasm artifact — out of scope; see follow-up note below |
| Native build unaffected | PASS | `cargo check -p vibesql-wasm-bindings` (host target) passes; the change only adds a feature on a dep already in the graph, no-op off-wasm |
| Stale "0.3.x" comment corrected | PASS | Comment now documents both majors and why each is present |

## Test Plan

- Reproduced the failure on the unmodified branch (`compile_error!` in getrandom 0.3.4), then confirmed `cargo check --target wasm32-unknown-unknown` passes with the fix
- Ran `./scripts/build-wasm.sh` end-to-end (release, wasm-opt) — success
- Ran `cd web-demo && pnpm build` — success against the regenerated artifact
- Validated `ci.yml` YAML parses; the new job reuses the existing `setup-rust` composite action which already supports a `targets` input

## Notes for reviewer

- The web-demo vitest wasm tests (`persistence.test.ts`, `sqllogictest-database.test.ts`, `examples-execution.test.ts`) have a pre-existing environment incompatibility (happy-dom Response vs `WebAssembly.instantiateStreaming`) independent of this fix — they appear to be browser-only in practice. Can file a follow-up issue if desired.
- `Cargo.lock` is untracked in this repo, so no lockfile commit is involved.

Closes #5253