### PR TITLE
fix(executor): window IN-subqueries and ordinal ORDER BY through wildcards

### DIFF
--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
@@ -66,6 +66,18 @@ pub(super) fn try_convert_in_to_join(
         _ => return None,
     };
 
+    // Skip if the subquery's SELECT expression contains a window function (issue #5231).
+    // Window functions are computed over the subquery's entire result set, so hoisting
+    // them into a per-row join ON condition is semantically invalid:
+    //   x IN (SELECT row_number() OVER (ORDER BY ...) FROM t)
+    // cannot become `... SEMI JOIN t ON x = row_number() OVER (...)`.
+    // Falling back to row-by-row IN evaluation (eval_in_subquery) handles both
+    // correlated and uncorrelated forms correctly. This guard also covers the
+    // NOT IN → ANTI join path and the aggregate (GROUP BY/HAVING) path below.
+    if crate::select::window::expression_has_window_function(&subquery_column) {
+        return None;
+    }
+
     // Skip if subquery has LIMIT, OFFSET, or set operations (can't safely convert)
     if subquery.limit.is_some() || subquery.offset.is_some() || subquery.set_operation.is_some() {
         return None;

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/tests.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/tests.rs
@@ -949,3 +949,122 @@ fn test_conjunction_multiple_subqueries_iterative() {
     // Remaining WHERE should have just the one predicate
     assert!(transformed.where_clause.is_some(), "Simple predicate should remain in WHERE clause");
 }
+
+// =============================================================================
+// Window function guard tests (issue #5231)
+//
+// Window functions in an IN-subquery's SELECT list are computed over the
+// subquery's entire result set, so they cannot be hoisted into a per-row
+// join ON condition. The transform must be skipped so evaluation falls back
+// to row-by-row IN evaluation (eval_in_subquery), which handles both
+// correlated and uncorrelated forms correctly.
+// =============================================================================
+
+fn row_number_over(order_by_column: &str) -> Expression {
+    Expression::WindowFunction {
+        function: vibesql_ast::WindowFunctionSpec::Ranking {
+            name: vibesql_ast::FunctionIdentifier::new("row_number"),
+            args: vec![],
+        },
+        over: vibesql_ast::WindowSpec {
+            base_window_name: None,
+            partition_by: None,
+            order_by: Some(vec![vibesql_ast::OrderByItem {
+                expr: column_ref(order_by_column),
+                direction: vibesql_ast::OrderDirection::Asc,
+                nulls_order: None,
+            }]),
+            frame: None,
+        },
+    }
+}
+
+/// Build a single-item SELECT over `table` whose select expression is `expr`
+fn select_with_expr(table: &str, expr: Expression) -> SelectStmt {
+    let mut stmt = simple_select(table, "placeholder");
+    stmt.select_list =
+        vec![SelectItem::Expression { expr, alias: None, source_text: None }];
+    stmt
+}
+
+#[test]
+fn test_in_subquery_with_window_function_not_transformed() {
+    // SELECT t1_id FROM t1 WHERE t1_id IN (SELECT row_number() OVER (ORDER BY t3_id) FROM t3)
+    let mut stmt = simple_select("t1", "t1_id");
+    let subquery = select_with_expr("t3", row_number_over("t3_id"));
+
+    stmt.where_clause = Some(Expression::In {
+        expr: Box::new(column_ref("t1_id")),
+        subquery: Box::new(subquery),
+        negated: false,
+    });
+
+    let transformed = transform_subqueries_to_joins(&stmt);
+
+    // The transform must be skipped: WHERE clause keeps the IN subquery and
+    // the FROM clause stays a plain table scan.
+    assert!(
+        matches!(transformed.where_clause, Some(Expression::In { .. })),
+        "IN subquery with window function must not be transformed"
+    );
+    assert!(
+        matches!(transformed.from, Some(FromClause::Table { .. })),
+        "FROM clause must remain a plain table (no semi-join)"
+    );
+}
+
+#[test]
+fn test_in_subquery_with_nested_window_function_not_transformed() {
+    // SELECT t1_id FROM t1 WHERE t1_id IN
+    //   (SELECT t1_id + row_number() OVER (ORDER BY t1_id) FROM t3)
+    // The window function is nested inside a binary expression and the
+    // ORDER BY references a correlated outer column.
+    let mut stmt = simple_select("t1", "t1_id");
+    let nested = Expression::BinaryOp {
+        op: BinaryOperator::Plus,
+        left: Box::new(column_ref("t1_id")),
+        right: Box::new(row_number_over("t1_id")),
+    };
+    let subquery = select_with_expr("t3", nested);
+
+    stmt.where_clause = Some(Expression::In {
+        expr: Box::new(column_ref("t1_id")),
+        subquery: Box::new(subquery),
+        negated: false,
+    });
+
+    let transformed = transform_subqueries_to_joins(&stmt);
+
+    assert!(
+        matches!(transformed.where_clause, Some(Expression::In { .. })),
+        "IN subquery with nested window function must not be transformed"
+    );
+    assert!(
+        matches!(transformed.from, Some(FromClause::Table { .. })),
+        "FROM clause must remain a plain table (no semi-join)"
+    );
+}
+
+#[test]
+fn test_not_in_subquery_with_window_function_not_transformed() {
+    // NOT IN goes through the same code path (ANTI join) and must share the guard.
+    let mut stmt = simple_select("t1", "t1_id");
+    let subquery = select_with_expr("t3", row_number_over("t3_id"));
+
+    stmt.where_clause = Some(Expression::In {
+        expr: Box::new(column_ref("t1_id")),
+        subquery: Box::new(subquery),
+        negated: true,
+    });
+
+    let transformed = transform_subqueries_to_joins(&stmt);
+
+    assert!(
+        matches!(transformed.where_clause, Some(Expression::In { negated: true, .. })),
+        "NOT IN subquery with window function must not be transformed"
+    );
+    assert!(
+        matches!(transformed.from, Some(FromClause::Table { .. })),
+        "FROM clause must remain a plain table (no anti-join)"
+    );
+}

--- a/crates/vibesql-executor/src/select/order/position.rs
+++ b/crates/vibesql-executor/src/select/order/position.rs
@@ -97,8 +97,19 @@ pub(crate) fn resolve_position_to_column_name(
 pub(crate) enum ResolvedPosition<'a> {
     /// The expression at the position (for regular SELECT items)
     Expression(&'a vibesql_ast::Expression),
-    /// A column name resolved from a wildcard expansion
-    ColumnName(String),
+    /// A column resolved from a wildcard expansion.
+    ///
+    /// The column is qualified with the canonical name of the table it came
+    /// from (when known) so downstream name resolution does not trip the
+    /// ambiguity check when the same column name exists in multiple tables
+    /// (issue #5231: `SELECT * FROM b, (SELECT x FROM a) ORDER BY 1` must not
+    /// fail with "ambiguous column name: x").
+    ColumnName {
+        /// Canonical table name the column belongs to, if known
+        table: Option<String>,
+        /// The column name
+        column: String,
+    },
     /// Position not found (shouldn't happen if validation passed)
     NotFound,
 }
@@ -128,19 +139,24 @@ pub(crate) fn resolve_position_with_wildcards<'a>(
                     // The position is within this wildcard's expanded columns
                     if let Some(s) = schema {
                         let offset_in_wildcard = target_col - current_col;
-                        // Collect all columns from all tables in schema order
-                        let mut all_columns: Vec<(usize, String)> = Vec::new();
-                        for (start_idx, table_schema) in s.table_schemas.values() {
+                        // Collect all columns from all tables in schema order,
+                        // tracking which table each column belongs to so the
+                        // result can be table-qualified (issue #5231)
+                        let mut all_columns: Vec<(usize, String, String)> = Vec::new();
+                        for (table_id, (start_idx, table_schema)) in &s.table_schemas {
                             for (i, col) in table_schema.columns.iter().enumerate() {
-                                all_columns.push((start_idx + i, col.name.clone()));
+                                all_columns.push((
+                                    start_idx + i,
+                                    table_id.table_canonical().to_string(),
+                                    col.name.clone(),
+                                ));
                             }
                         }
-                        all_columns.sort_by_key(|(idx, _)| *idx);
+                        all_columns.sort_by_key(|(idx, _, _)| *idx);
 
                         if offset_in_wildcard < all_columns.len() {
-                            return ResolvedPosition::ColumnName(
-                                all_columns[offset_in_wildcard].1.clone(),
-                            );
+                            let (_, table, column) = all_columns[offset_in_wildcard].clone();
+                            return ResolvedPosition::ColumnName { table: Some(table), column };
                         }
                     }
                     return ResolvedPosition::NotFound;
@@ -161,9 +177,14 @@ pub(crate) fn resolve_position_with_wildcards<'a>(
                         if let Some((_, table_schema)) = s.get_table(qualifier) {
                             let offset = target_col - current_col;
                             if offset < table_schema.columns.len() {
-                                return ResolvedPosition::ColumnName(
-                                    table_schema.columns[offset].name.clone(),
-                                );
+                                // Qualify with the (canonicalized) qualifier so
+                                // downstream resolution is unambiguous (#5231).
+                                // get_table resolves via TableIdentifier::unquoted,
+                                // so lowercase folding matches its lookup.
+                                return ResolvedPosition::ColumnName {
+                                    table: Some(qualifier.to_ascii_lowercase()),
+                                    column: table_schema.columns[offset].name.clone(),
+                                };
                             }
                         }
                     }

--- a/crates/vibesql-executor/src/select/order/resolution.rs
+++ b/crates/vibesql-executor/src/select/order/resolution.rs
@@ -346,10 +346,22 @@ pub(crate) fn resolve_order_by_alias<'a>(
                 ResolvedPosition::Expression(expr) => {
                     return Ok(Cow::Borrowed(expr));
                 }
-                ResolvedPosition::ColumnName(col_name) => {
-                    return Ok(Cow::Owned(vibesql_ast::Expression::ColumnRef(
-                        vibesql_ast::ColumnIdentifier::simple(&col_name, false),
-                    )));
+                ResolvedPosition::ColumnName { table, column } => {
+                    // Build a table-qualified reference when the source table is
+                    // known so the ambiguity check is not tripped when multiple
+                    // tables expose the same column name (issue #5231).
+                    // quoted=true preserves the canonical table/column names
+                    // exactly as stored in the schema.
+                    let col_id = match table {
+                        Some(table_name) => vibesql_ast::ColumnIdentifier::qualified(
+                            &table_name,
+                            true,
+                            &column,
+                            true,
+                        ),
+                        None => vibesql_ast::ColumnIdentifier::simple(&column, false),
+                    };
+                    return Ok(Cow::Owned(vibesql_ast::Expression::ColumnRef(col_id)));
                 }
                 ResolvedPosition::NotFound => {
                     // Fallback: shouldn't reach here if validation passed

--- a/crates/vibesql-executor/src/select/window/detection.rs
+++ b/crates/vibesql-executor/src/select/window/detection.rs
@@ -23,7 +23,7 @@ pub(in crate::select) fn has_window_functions(select_list: &[SelectItem]) -> boo
 /// `QuantifiedComparison`) are intentionally treated as leaves: a window
 /// inside a subquery belongs to the subquery's own scope, not the outer
 /// SELECT's.
-pub(in crate::select) fn expression_has_window_function(expr: &Expression) -> bool {
+pub(crate) fn expression_has_window_function(expr: &Expression) -> bool {
     match expr {
         Expression::WindowFunction { .. } => true,
         Expression::BinaryOp { left, right, .. } => {

--- a/crates/vibesql-executor/src/select/window/mod.rs
+++ b/crates/vibesql-executor/src/select/window/mod.rs
@@ -11,8 +11,10 @@ mod types;
 
 use std::collections::HashMap;
 
-// Re-export detection helpers for use by select module
-pub(super) use detection::{expression_has_window_function, has_window_functions};
+// Re-export detection helpers for use by the select module and the
+// subquery-to-join optimizer (issue #5231)
+pub(crate) use detection::expression_has_window_function;
+pub(super) use detection::has_window_functions;
 // Re-export ORDER BY support functions
 pub(super) use order_by::{collect_order_by_window_functions, evaluate_order_by_window_functions};
 // Re-export public types

--- a/crates/vibesql-executor/tests/window_subquery_and_ordinal_tests.rs
+++ b/crates/vibesql-executor/tests/window_subquery_and_ordinal_tests.rs
@@ -1,0 +1,169 @@
+//! Regression tests for issue #5231 (window1.test 6.2, 25.1, 25.2)
+//!
+//! Covers two independent fixes:
+//!
+//! 1. IN/NOT IN subqueries whose SELECT list contains a window function must
+//!    NOT be converted to semi/anti joins (the window function is computed
+//!    over the subquery's whole result set and cannot be hoisted into a
+//!    per-row join condition). They fall back to row-by-row IN evaluation.
+//!
+//! 2. Ordinal ORDER BY terms that land inside a `SELECT *` wildcard expansion
+//!    must resolve to a table-qualified column reference so the ambiguity
+//!    check is not tripped when multiple tables expose the same column name.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+fn query(db: &vibesql_storage::Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e))
+            .into_iter()
+            .map(|row| row.values.to_vec())
+            .collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+/// Setup matching the curator's minimal reproducers for 25.1 / 25.2
+fn setup_in_subquery_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1(t1_id INTEGER PRIMARY KEY)");
+    run_stmt(&mut db, "CREATE TABLE t3(t3_id INTEGER PRIMARY KEY)");
+    run_stmt(&mut db, "INSERT INTO t1 VALUES(1),(3),(5)");
+    run_stmt(&mut db, "INSERT INTO t3 VALUES(10),(11),(12)");
+    db
+}
+
+#[test]
+fn test_in_subquery_with_uncorrelated_window_function() {
+    // window1.test 25.2 reproducer: row_number() over t3 yields {1, 2, 3},
+    // so t1 ids 1 and 3 match. Previously errored with
+    // "misuse of window function row_number()".
+    let db = setup_in_subquery_db();
+    let rows = query(
+        &db,
+        "SELECT * FROM t1 WHERE t1_id IN (SELECT row_number() OVER (ORDER BY t3_id) FROM t3) \
+         ORDER BY t1_id",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1)], vec![SqlValue::Integer(3)]]);
+}
+
+#[test]
+fn test_in_subquery_with_correlated_window_function() {
+    // window1.test 25.1 reproducer: for each outer row the subquery yields
+    // {t1_id+1, t1_id+2, t1_id+3}, which never contains t1_id, so the result
+    // is empty. Previously errored with "Column 't1_id' not found".
+    let db = setup_in_subquery_db();
+    let rows = query(
+        &db,
+        "SELECT * FROM t1 WHERE t1_id IN \
+         (SELECT t1_id + row_number() OVER (ORDER BY t1_id) FROM t3)",
+    );
+    assert!(rows.is_empty(), "Expected empty result, got {:?}", rows);
+}
+
+#[test]
+fn test_not_in_subquery_with_window_function() {
+    // The ANTI-join path shares the same guard: row_number() over t3 yields
+    // {1, 2, 3}, so only t1_id = 5 survives NOT IN.
+    let db = setup_in_subquery_db();
+    let rows = query(
+        &db,
+        "SELECT * FROM t1 WHERE t1_id NOT IN \
+         (SELECT row_number() OVER (ORDER BY t3_id) FROM t3)",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(5)]]);
+}
+
+/// Setup matching the curator's minimal reproducer for 6.2
+fn setup_ordinal_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE a(x INTEGER)");
+    run_stmt(&mut db, "CREATE TABLE b(x INTEGER)");
+    run_stmt(&mut db, "INSERT INTO a VALUES(2),(1)");
+    run_stmt(&mut db, "INSERT INTO b VALUES(20),(10)");
+    db
+}
+
+#[test]
+fn test_order_by_ordinal_through_wildcard_with_duplicate_column_names() {
+    // window1.test 6.2 reproducer (window-free): ordinal ORDER BY through
+    // SELECT * must not be re-resolved as a bare column name. Previously
+    // errored with "ambiguous column name: x" because both b and the derived
+    // table expose column x.
+    let db = setup_ordinal_db();
+    let rows = query(&db, "SELECT * FROM b, (SELECT x FROM a) ORDER BY 1, 2");
+    assert_eq!(
+        rows,
+        vec![
+            vec![SqlValue::Integer(10), SqlValue::Integer(1)],
+            vec![SqlValue::Integer(10), SqlValue::Integer(2)],
+            vec![SqlValue::Integer(20), SqlValue::Integer(1)],
+            vec![SqlValue::Integer(20), SqlValue::Integer(2)],
+        ]
+    );
+}
+
+#[test]
+fn test_order_by_ordinal_through_qualified_wildcard() {
+    // Same defect through the table.* arm: the qualified wildcard must also
+    // emit a table-qualified reference.
+    let db = setup_ordinal_db();
+    let rows = query(&db, "SELECT b.x, sub.x FROM b, (SELECT x FROM a) AS sub ORDER BY 1, 2");
+    assert_eq!(
+        rows,
+        vec![
+            vec![SqlValue::Integer(10), SqlValue::Integer(1)],
+            vec![SqlValue::Integer(10), SqlValue::Integer(2)],
+            vec![SqlValue::Integer(20), SqlValue::Integer(1)],
+            vec![SqlValue::Integer(20), SqlValue::Integer(2)],
+        ]
+    );
+
+    let rows = query(&db, "SELECT b.*, sub.* FROM b, (SELECT x FROM a) AS sub ORDER BY 1, 2");
+    assert_eq!(
+        rows,
+        vec![
+            vec![SqlValue::Integer(10), SqlValue::Integer(1)],
+            vec![SqlValue::Integer(10), SqlValue::Integer(2)],
+            vec![SqlValue::Integer(20), SqlValue::Integer(1)],
+            vec![SqlValue::Integer(20), SqlValue::Integer(2)],
+        ]
+    );
+}
+
+#[test]
+fn test_order_by_ordinal_wildcard_with_window_in_derived_table() {
+    // Full shape of window1.test 6.2: the derived table contains a window
+    // function and the second ordinal lands on its (unnamed) output column.
+    let db = setup_ordinal_db();
+    let rows =
+        query(&db, "SELECT * FROM b, (SELECT x, count(*) OVER (ORDER BY x) FROM a) ORDER BY 1, 2");
+    assert_eq!(rows.len(), 4);
+    // First column (b.x) must be the primary sort key
+    assert_eq!(rows[0][0], SqlValue::Integer(10));
+    assert_eq!(rows[1][0], SqlValue::Integer(10));
+    assert_eq!(rows[2][0], SqlValue::Integer(20));
+    assert_eq!(rows[3][0], SqlValue::Integer(20));
+    // Second column (derived x) must be the secondary sort key
+    assert_eq!(rows[0][1], SqlValue::Integer(1));
+    assert_eq!(rows[1][1], SqlValue::Integer(2));
+}


### PR DESCRIPTION
Closes #5231

## Summary

Two independent fixes for the window1.test failures 6.2, 25.1, 25.2, following the curator's root-cause analysis:

1. **25.1 / 25.2 — IN→semi-join transform hoisted window functions into join conditions** (`crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs`): `try_convert_in_to_join` now bails out (`return None`) when the subquery's SELECT expression contains a window function, using the existing `expression_has_window_function` helper (visibility widened to `pub(crate)`). Window functions are computed over the subquery's entire result set and cannot be expressed as a per-joined-row condition. Evaluation falls back to row-by-row `eval_in_subquery`, which handles both correlated (`OVER (ORDER BY outer_col)`) and uncorrelated forms correctly. The guard also covers the NOT IN → ANTI join path.

2. **6.2 — ordinal ORDER BY through `SELECT *` re-resolved by bare column name** (`crates/vibesql-executor/src/select/order/position.rs`, `resolution.rs`): `resolve_position_with_wildcards` now returns a table-qualified column (canonical table name) from both the `Wildcard` and `QualifiedWildcard` arms, and `resolve_order_by_alias` builds a qualified `ColumnIdentifier` from it. This stops the ambiguity check from rejecting legal queries like `SELECT * FROM b, (SELECT x FROM a) ORDER BY 1, 2` where duplicate output column names span a cross join.

## Testing

- `./scripts/tcltest test window1.test`: baseline 12 failures → 9 failures; **6.2, 25.1, 25.2 now pass**, remaining 9 identical to baseline
- window2.test (0 failed), window3.test (0 failed), window8.test (5 failed — verified pre-existing NULLS FIRST/LAST frame semantics + CTE-in-PARTITION-BY issues, unrelated to these code paths)
- Manual CLI verification of the curator's minimal reproducers: `{1,3}`, `{}` (empty), NOT IN → `{5}`, and correctly ordered cross-join rows — all matching SQLite
- New unit tests in `optimizer/subquery_to_join/tests.rs`: transform skipped for top-level, nested (`col + row_number() OVER (...)`), and NOT IN window subqueries
- New integration tests in `tests/window_subquery_and_ordinal_tests.rs` covering all curator reproducers end-to-end, including the qualified-wildcard arm and the window-in-derived-table shape of 6.2
- Full `cargo test -p vibesql-executor`: all 86 test binaries green, including `tpch_subquery_tests` (Q18 aggregate IN→semi-join path intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)