### PR TITLE
fix(web-demo): restore expectedRows/expectedCount payloads for example validation

### DIFF
--- a/web-demo/src/data/examples-metadata.ts
+++ b/web-demo/src/data/examples-metadata.ts
@@ -22,6 +22,9 @@ export interface QueryExample {
   executionTimeMs?: number
   relatedExamples?: string[] // IDs of related examples
   tags?: string[] // Searchable tags
+  // Expected results (regenerated from the engine; see ExamplePayload in examples/types.ts)
+  expectedRows?: string[][] // Expected result rows (excluding header)
+  expectedCount?: number // Expected number of rows
 }
 
 export interface ExampleCategory {

--- a/web-demo/src/data/examples/basic.json
+++ b/web-demo/src/data/examples/basic.json
@@ -13,7 +13,15 @@
       "sqlFeatures": [
         "SELECT",
         "LIMIT"
-      ]
+      ],
+      "expectedRows": [
+        ["1", "Chai", "1", "18"],
+        ["2", "Chang", "1", "19"],
+        ["3", "Aniseed Syrup", "2", "10"],
+        ["4", "Chef Antons Cajun Seasoning", "2", "22"],
+        ["5", "Chef Antons Gumbo Mix", "2", "21.35"]
+      ],
+      "expectedCount": 5
     },
     "basic-2": {
       "title": "WHERE clause filtering",
@@ -24,7 +32,8 @@
         "SELECT",
         "WHERE",
         "ORDER BY"
-      ]
+      ],
+      "expectedCount": 14
     },
     "basic-3": {
       "title": "Column aliases",
@@ -35,7 +44,20 @@
         "SELECT",
         "AS",
         "Expressions"
-      ]
+      ],
+      "expectedRows": [
+        ["Chai", "18", "21.6"],
+        ["Chang", "19", "22.8"],
+        ["Aniseed Syrup", "10", "12.0"],
+        ["Chef Antons Cajun Seasoning", "22", "26.4"],
+        ["Chef Antons Gumbo Mix", "21.35", "25.62"],
+        ["Grandmas Boysenberry Spread", "25", "30.0"],
+        ["Uncle Bobs Organic Dried Pears", "30", "36.0"],
+        ["Northwoods Cranberry Sauce", "40", "48.0"],
+        ["Mishi Kobe Niku", "97", "116.4"],
+        ["Ikura", "31", "37.2"]
+      ],
+      "expectedCount": 10
     },
     "basic-4": {
       "title": "DISTINCT values",
@@ -46,7 +68,18 @@
         "SELECT",
         "DISTINCT",
         "ORDER BY"
-      ]
+      ],
+      "expectedRows": [
+        ["1"],
+        ["2"],
+        ["3"],
+        ["4"],
+        ["5"],
+        ["6"],
+        ["7"],
+        ["8"]
+      ],
+      "expectedCount": 8
     }
   }
 }

--- a/web-demo/src/data/examples/loader.ts
+++ b/web-demo/src/data/examples/loader.ts
@@ -51,6 +51,8 @@ interface CategoryJSON {
       executionTimeMs?: number
       relatedExamples?: string[]
       tags?: string[]
+      expectedRows?: string[][]
+      expectedCount?: number
     }
   }
 }
@@ -101,6 +103,8 @@ export function loadAllCategories(): ExampleCategory[] {
       executionTimeMs: example.executionTimeMs,
       relatedExamples: example.relatedExamples,
       tags: example.tags,
+      expectedRows: example.expectedRows,
+      expectedCount: example.expectedCount,
     }))
 
     return {

--- a/web-demo/src/data/examples/string.json
+++ b/web-demo/src/data/examples/string.json
@@ -23,7 +23,18 @@
       "sqlFeatures": [
         "SUBSTRING",
         "LENGTH"
-      ]
+      ],
+      "expectedRows": [
+        ["Sarah", "Chen", "S", "4"],
+        ["Michael", "Rodriguez", "M", "9"],
+        ["Emily", "Johnson", "E", "7"],
+        ["David", "Kim", "D", "3"],
+        ["Jennifer", "Martinez", "J", "8"],
+        ["Robert", "Taylor", "R", "6"],
+        ["Lisa", "Anderson", "L", "8"],
+        ["James", "Wilson", "J", "6"]
+      ],
+      "expectedCount": 8
     },
     "string-3": {
       "title": "Text Trimming",


### PR DESCRIPTION
## Summary

Restores the `expectedRows`/`expectedCount` payloads that the `b29c7686` externalization refactor dropped from `basic-1`..`basic-4` (northwind) and `string-2` (employees), with values regenerated from the current engine against the current seed data (the historical values were schema-stale — `products` now has 4 columns, not 6). Also fixes the structural half of the regression: the JSON loader explicitly mapped fields and silently stripped `expectedRows`/`expectedCount`, so restoring the JSON alone was not sufficient.

This un-breaks the 3 existence assertions in `examples-execution.test.ts` that were masked for ~7 months until #5257 made the test file importable again.

## Changes

- `web-demo/src/data/examples/basic.json` — add regenerated `expectedRows` + `expectedCount` to `basic-1`, `basic-3`, `basic-4`; `expectedCount: 14` only for `basic-2` (its `ORDER BY unit_price DESC` has a tie at `unit_price = 21` — Queso Cabrales / Gustafs Knäckebröd — making row order non-deterministic, and changing the example SQL is out of scope per the issue)
- `web-demo/src/data/examples/string.json` — add regenerated `expectedRows` + `expectedCount` to `string-2`
- `web-demo/src/data/examples/loader.ts` — pass `expectedRows`/`expectedCount` through `loadAllCategories()` (the refactor's loader dropped them even when present in JSON)
- `web-demo/src/data/examples-metadata.ts` — add the optional fields to `QueryExample` so the pass-through type-checks

All values were generated by piping each example's SQL through `target/release/vibesql` after loading `web-demo/examples/northwind.sql` / `employees.sql`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `pnpm vitest run src/__tests__/examples-execution.test.ts` passes with more tests as per-example validations activate | ✅ | 165 passed / 0 failed (was 157/3; 5 new per-example structural validations now run) |
| Restored `expectedRows` match actual engine output against current seeds (string cells, rows-of-arrays) | ✅ | Ran each example's SQL via `target/release/vibesql` against the current seed files and transcribed the output verbatim (including `12.0`-style decimal formatting in basic-3) |
| `expectedCount` matches `expectedRows.length` for each example | ✅ | basic-1: 5/5, basic-3: 10/10, basic-4: 8/8, string-2: 8/8; asserted by test line 55 (all pass) |
| No changes to example `sql` payloads | ✅ | Diff touches only `expectedRows`/`expectedCount` keys in the JSON files; basic-2 tie handled via count-only expectation instead of an ORDER BY tiebreaker |

## Test Plan

- `cd web-demo && pnpm vitest run src/__tests__/examples-execution.test.ts` → 165/165 pass
- `cd web-demo && pnpm vitest run` → 221/221 runnable tests pass; the 2 failing files (`persistence.test.ts`, `sqllogictest-database.test.ts`) are the pre-existing missing-WASM-artifact failures tracked by #5253, unrelated to this change
- `pnpm lint` → 0 errors (10 pre-existing `no-console` warnings in unrelated files)
- `pnpm format:check` → clean

Closes #5258