### PR TITLE
fix(update): RETURNING clause + INSTEAD OF UPDATE trigger fire semantics

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -691,6 +691,10 @@ impl<'a, 'arena> Converter<'a, 'arena> {
                 .map(|froms| froms.iter().map(|f| self.convert_from_clause(f)).collect()),
             where_clause: stmt.where_clause.as_ref().map(|wc| self.convert_where_clause(wc)),
             conflict_clause: stmt.conflict_clause.map(ConflictClause::from),
+            returning: stmt
+                .returning
+                .as_ref()
+                .map(|items| items.iter().map(|item| self.convert_select_item(item)).collect()),
         }
     }
 

--- a/crates/vibesql-ast/src/arena/dml.rs
+++ b/crates/vibesql-ast/src/arena/dml.rs
@@ -7,7 +7,7 @@ use bumpalo::collections::Vec as BumpVec;
 use super::{
     expression::{Expression, OrderByItem},
     interner::Symbol,
-    select::{CommonTableExpr, FromClause, SelectStmt},
+    select::{CommonTableExpr, FromClause, SelectItem, SelectStmt},
 };
 
 // ============================================================================
@@ -154,6 +154,10 @@ pub struct UpdateStmt<'arena> {
     /// Optional conflict resolution clause (SQLite extension)
     /// Syntax: UPDATE OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL table SET ...
     pub conflict_clause: Option<ConflictClause>,
+    /// Optional RETURNING clause (SQLite 3.35.0+)
+    /// Syntax: UPDATE table SET ... [WHERE ...] RETURNING expr [, expr ...]
+    /// Returns the NEW row values (after assignments) for each updated row.
+    pub returning: Option<BumpVec<'arena, SelectItem<'arena>>>,
 }
 
 /// Column assignment (column = value)

--- a/crates/vibesql-ast/src/dml.rs
+++ b/crates/vibesql-ast/src/dml.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains INSERT, UPDATE, and DELETE statement types.
 
-use crate::{CommonTableExpr, Expression, FromClause, OrderByItem, SelectStmt};
+use crate::{CommonTableExpr, Expression, FromClause, OrderByItem, SelectItem, SelectStmt};
 
 // ============================================================================
 // INSERT Statement
@@ -159,6 +159,10 @@ pub struct UpdateStmt {
     /// Optional conflict resolution clause (SQLite extension)
     /// Syntax: UPDATE OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL table SET ...
     pub conflict_clause: Option<ConflictClause>,
+    /// Optional RETURNING clause (SQLite 3.35.0+)
+    /// Syntax: UPDATE table SET ... [WHERE ...] RETURNING expr [, expr ...]
+    /// Returns the NEW row values (after assignments) for each updated row.
+    pub returning: Option<Vec<SelectItem>>,
 }
 
 /// Column assignment (column = value)

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1070,7 +1070,21 @@ fn walk_update<V: ExpressionVisitor>(visitor: &mut V, stmt: &UpdateStmt) {
         }
     }
     if let Some(WhereClause::Condition(expr)) = &stmt.where_clause {
-        walk_expression(visitor, expr);
+        let result = walk_expression(visitor, expr);
+        if result.should_stop() {
+            return;
+        }
+    }
+    // Walk RETURNING expressions
+    if let Some(items) = &stmt.returning {
+        for item in items {
+            if let SelectItem::Expression { expr, .. } = item {
+                let result = walk_expression(visitor, expr);
+                if result.should_stop() {
+                    return;
+                }
+            }
+        }
     }
 }
 
@@ -1368,6 +1382,19 @@ pub fn transform_update<V: ExpressionMutVisitor>(visitor: &mut V, stmt: UpdateSt
             other => other,
         }),
         conflict_clause: stmt.conflict_clause,
+        returning: stmt.returning.map(|items| {
+            items
+                .into_iter()
+                .map(|item| match item {
+                    SelectItem::Expression { expr, alias, source_text } => SelectItem::Expression {
+                        expr: transform_expression(visitor, expr),
+                        alias,
+                        source_text,
+                    },
+                    other => other,
+                })
+                .collect()
+        }),
     }
 }
 

--- a/crates/vibesql-ast/tests/statements.rs
+++ b/crates/vibesql-ast/tests/statements.rs
@@ -68,6 +68,7 @@ fn test_create_update_statement() {
         from_clause: None,
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     });
 
     match stmt {

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -229,12 +229,36 @@ impl SqlExecutor {
                 }
             }
             vibesql_ast::Statement::Update(update_stmt) => {
-                match vibesql_executor::UpdateExecutor::execute(&update_stmt, &mut self.db) {
-                    Ok(affected_rows) => {
+                match vibesql_executor::UpdateExecutor::execute_returning(
+                    &update_stmt,
+                    &mut self.db,
+                ) {
+                    Ok((affected_rows, returning)) => {
                         // Track changes count for changes() and total_changes() functions
                         self.db.set_last_changes_count(affected_rows);
                         self.db.increment_total_changes_count(affected_rows);
                         result.row_count = affected_rows;
+
+                        // RETURNING clause: render the projected NEW rows like
+                        // a SELECT result (SQLite 3.35.0+ semantics).
+                        if let Some(returning_result) = returning {
+                            result.row_count = returning_result.rows.len();
+                            result.columns = returning_result.columns;
+                            for row in returning_result.rows {
+                                let row_strs: Vec<Option<String>> = row
+                                    .values
+                                    .iter()
+                                    .map(|v| {
+                                        if v.is_null() {
+                                            None
+                                        } else {
+                                            Some(format_sql_value(v))
+                                        }
+                                    })
+                                    .collect();
+                                result.rows.push(row_strs);
+                            }
+                        }
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }

--- a/crates/vibesql-executor/benches/sysbench_benchmark.rs
+++ b/crates/vibesql-executor/benches/sysbench_benchmark.rs
@@ -202,6 +202,7 @@ fn bind_update(stmt: &UpdateStmt, params: &[SqlValue]) -> UpdateStmt {
         from_clause: stmt.from_clause.clone(), // UPDATE FROM not used in sysbench
         where_clause: bind_where_clause(&stmt.where_clause, params),
         conflict_clause: stmt.conflict_clause.clone(),
+        returning: None,
     }
 }
 

--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -1032,31 +1032,8 @@ fn build_view_schema(
 
 /// Check if a SqlValue is truthy using SQLite truthiness rules.
 ///
-/// SQLite rules:
-/// - `Boolean(true)` → true
-/// - `Boolean(false)` → false
-/// - `Null` → false (NULL is not truthy for WHERE clause purposes)
-/// - `0` and `0.0` → false
-/// - Any other numeric value → true
-/// - Strings → parse leading numeric, non-zero is true, 0 or non-numeric is false
+/// Delegates to the shared helper in `crate::evaluator::operators` so DELETE
+/// and UPDATE-on-view row selection use identical truthiness semantics.
 fn is_truthy(value: &SqlValue) -> bool {
-    use SqlValue::*;
-    match value {
-        Boolean(b) => *b,
-        Null => false, // NULL is not truthy for row selection
-        // Integer types: 0 is false, non-zero is true
-        Integer(n) => *n != 0,
-        Smallint(n) => *n != 0,
-        Bigint(n) => *n != 0,
-        Unsigned(n) => *n != 0,
-        // Floating point types: 0.0 is false, non-zero is true
-        Float(f) => *f != 0.0,
-        Real(f) => *f != 0.0,
-        Double(f) => *f != 0.0,
-        Numeric(f) => *f != 0.0,
-        // String types: SQLite parses leading numeric portion
-        Varchar(s) | Character(s) => crate::evaluator::operators::is_truthy_string(s),
-        // Other types are not truthy (conservative default)
-        _ => false,
-    }
+    crate::evaluator::operators::is_truthy(value)
 }

--- a/crates/vibesql-executor/src/evaluator/operators/logical.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/logical.rs
@@ -29,6 +29,41 @@ pub fn is_truthy_string(s: &str) -> bool {
     parse_leading_numeric(s) != 0.0
 }
 
+/// Check if a SqlValue is truthy using SQLite truthiness rules.
+///
+/// SQLite rules:
+/// - `Boolean(true)` → true
+/// - `Boolean(false)` → false
+/// - `Null` → false (NULL is not truthy for WHERE clause purposes)
+/// - `0` and `0.0` → false
+/// - Any other numeric value → true
+/// - Strings → parse leading numeric, non-zero is true, 0 or non-numeric is false
+///
+/// Shared by row-selection paths (DELETE, UPDATE-on-view) so comparison
+/// results that surface as `Integer(1)`/`Integer(0)` (SQLite-style) are
+/// treated identically to `Boolean(true)`/`Boolean(false)`.
+pub fn is_truthy(value: &SqlValue) -> bool {
+    use SqlValue::*;
+    match value {
+        Boolean(b) => *b,
+        Null => false, // NULL is not truthy for row selection
+        // Integer types: 0 is false, non-zero is true
+        Integer(n) => *n != 0,
+        Smallint(n) => *n != 0,
+        Bigint(n) => *n != 0,
+        Unsigned(n) => *n != 0,
+        // Floating point types: 0.0 is false, non-zero is true
+        Float(f) => *f != 0.0,
+        Real(f) => *f != 0.0,
+        Double(f) => *f != 0.0,
+        Numeric(f) => *f != 0.0,
+        // String types: SQLite parses leading numeric portion
+        Varchar(s) | Character(s) => is_truthy_string(s),
+        // Other types are not truthy (conservative default)
+        _ => false,
+    }
+}
+
 fn parse_leading_numeric(s: &str) -> f64 {
     let s = s.trim_start();
     if s.is_empty() {

--- a/crates/vibesql-executor/src/evaluator/operators/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/mod.rs
@@ -19,8 +19,8 @@ use logical::LogicalOps;
 use string::StringOps;
 use vector::VectorOps;
 
-// Re-export string truthiness helper for use in CASE evaluation
-pub use logical::is_truthy_string;
+// Re-export truthiness helpers for use in CASE evaluation and row selection
+pub use logical::{is_truthy, is_truthy_string};
 use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -129,6 +129,7 @@ mod triggers;
 mod truncate_cascade_tests;
 mod truncate_table_tests;
 mod unique_index_tests;
+mod update_returning;
 mod vector_distance_operators;
 mod view_tests;
 mod window1_quick_wins;

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -78,6 +78,7 @@ fn test_after_update_trigger_fires() {
             },
         )),
         conflict_clause: None,
+        returning: None,
     };
     UpdateExecutor::execute(&update, &mut db).expect("Failed to update");
 
@@ -151,6 +152,7 @@ fn test_before_update_trigger_fires() {
             },
         )),
         conflict_clause: None,
+        returning: None,
     };
     UpdateExecutor::execute(&update, &mut db).expect("Failed to update");
 
@@ -306,9 +308,7 @@ fn test_update_from_on_view_zero_matches() {
         table_name: "V1".to_string(),
         granularity: TriggerGranularity::Row,
         when_condition: None,
-        triggered_action: TriggerAction::RawSql(
-            "INSERT INTO log VALUES('fired')".to_string(),
-        ),
+        triggered_action: TriggerAction::RawSql("INSERT INTO log VALUES('fired')".to_string()),
     };
     advanced_objects::execute_create_trigger(&trigger_stmt, &mut db)
         .expect("Failed to create INSTEAD OF trigger");

--- a/crates/vibesql-executor/src/tests/update_returning.rs
+++ b/crates/vibesql-executor/src/tests/update_returning.rs
@@ -1,0 +1,218 @@
+//! Regression tests for issue #5233 (window1.test 73.2/73.4):
+//!
+//! - INSTEAD OF UPDATE view WHERE truthiness: comparison expressions return
+//!   SQLite-style `Integer(1)`, which previously failed the Boolean-only
+//!   match arm and fired the trigger 0 times.
+//! - UPDATE ... FROM on a view fires the INSTEAD OF trigger once per join
+//!   match (SQLite semantics) — the previous per-view-row dedup is gone.
+//! - UPDATE ... RETURNING returns the NEW rows (after SET assignments), for
+//!   base tables and for views routed through INSTEAD OF UPDATE triggers.
+
+use vibesql_ast::Statement;
+use vibesql_parser::Parser;
+use vibesql_types::SqlValue;
+
+use super::super::*;
+
+fn execute_sql(db: &mut vibesql_storage::Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let stmt =
+        Parser::parse_sql(sql).unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            vec![]
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+            vec![]
+        }
+        Statement::CreateView(s) => {
+            crate::advanced_objects::execute_create_view(&s, db).expect("CREATE VIEW failed");
+            vec![]
+        }
+        Statement::CreateTrigger(s) => {
+            crate::advanced_objects::execute_create_trigger(&s, db).expect("CREATE TRIGGER failed");
+            vec![]
+        }
+        Statement::Select(s) => SelectExecutor::new(db).execute(&s).expect("SELECT failed"),
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).expect("UPDATE failed");
+            vec![]
+        }
+        other => panic!("Unsupported statement in test helper: {:?}", other),
+    }
+}
+
+/// Run an UPDATE and return (count, RETURNING result).
+fn execute_update_returning(
+    db: &mut vibesql_storage::Database,
+    sql: &str,
+) -> (usize, Option<crate::select::SelectResult>) {
+    let stmt =
+        Parser::parse_sql(sql).unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    match stmt {
+        Statement::Update(s) => UpdateExecutor::execute_returning(&s, db).expect("UPDATE failed"),
+        other => panic!("Expected UPDATE, got {:?}", other),
+    }
+}
+
+fn int_rows(result: &crate::select::SelectResult) -> Vec<Vec<i64>> {
+    result
+        .rows
+        .iter()
+        .map(|row| {
+            row.values
+                .iter()
+                .map(|v| match v {
+                    SqlValue::Integer(n) => *n,
+                    SqlValue::Bigint(n) => *n,
+                    SqlValue::Smallint(n) => *n as i64,
+                    other => panic!("Expected integer value, got {:?}", other),
+                })
+                .collect()
+        })
+        .collect()
+}
+
+// ------------------------------------------------------------------------
+// Root cause 1: WHERE truthiness on the no-FROM view path (73.2 fire count)
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_instead_of_update_view_where_comparison_fires() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES (1), (2), (4)");
+    execute_sql(&mut db, "CREATE TABLE log(x INT)");
+    execute_sql(&mut db, "CREATE VIEW v3 AS SELECT a AS b FROM t1");
+    execute_sql(
+        &mut db,
+        "CREATE TRIGGER y1 INSTEAD OF UPDATE ON v3 BEGIN INSERT INTO log VALUES(1); END",
+    );
+
+    // Comparison results surface as Integer(1) in this evaluator context;
+    // before the fix the trigger fired 0 times (Boolean-only match arm).
+    let (count, _) = execute_update_returning(&mut db, "UPDATE v3 SET b=9 WHERE b=4");
+    assert_eq!(count, 1, "exactly one view row matches b=4");
+
+    let log = execute_sql(&mut db, "SELECT x FROM log");
+    assert_eq!(log.len(), 1, "INSTEAD OF trigger should fire once for WHERE b=4");
+}
+
+// ------------------------------------------------------------------------
+// Root cause 2: UPDATE...FROM view path fires once per join match (73.4)
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_instead_of_update_view_from_fires_per_join_match() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE base(b INT, c INT)");
+    execute_sql(&mut db, "INSERT INTO base VALUES (4, 10)");
+    execute_sql(&mut db, "CREATE TABLE m(k INT)");
+    execute_sql(&mut db, "INSERT INTO m VALUES (1), (2), (3)");
+    execute_sql(&mut db, "CREATE TABLE log(x INT)");
+    execute_sql(&mut db, "CREATE VIEW v2 AS SELECT b, c FROM base");
+    execute_sql(
+        &mut db,
+        "CREATE TRIGGER y2 INSTEAD OF UPDATE ON v2 BEGIN INSERT INTO log VALUES(1); END",
+    );
+
+    // One view row, three FROM rows, no join condition restricting them:
+    // SQLite fires the INSTEAD OF trigger once per join match (3 times).
+    // The previous implementation deduped to one fire per view row.
+    let (count, _) = execute_update_returning(&mut db, "UPDATE v2 SET c=99 FROM m WHERE b=4");
+    assert_eq!(count, 3, "one view row x three FROM rows = 3 trigger fires");
+
+    let log = execute_sql(&mut db, "SELECT x FROM log");
+    assert_eq!(log.len(), 3, "INSTEAD OF trigger should fire once per join match");
+}
+
+// ------------------------------------------------------------------------
+// Root cause 3: UPDATE ... RETURNING
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_update_returning_base_table_new_values() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES (1), (2), (4)");
+
+    // SQLite: RETURNING evaluates against the NEW row (5|6), not the old one.
+    let (count, returning) =
+        execute_update_returning(&mut db, "UPDATE t1 SET a=5 WHERE a=4 RETURNING *, a+1");
+    assert_eq!(count, 1);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(returning.columns.len(), 2);
+    assert_eq!(int_rows(&returning), vec![vec![5, 6]]);
+}
+
+#[test]
+fn test_update_returning_zero_matched_rows_is_empty_not_error() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES (1)");
+
+    let (count, returning) =
+        execute_update_returning(&mut db, "UPDATE t1 SET a=5 WHERE a=100 RETURNING *");
+    assert_eq!(count, 0);
+    let returning = returning.expect("RETURNING clause should produce a (empty) result");
+    assert_eq!(returning.rows.len(), 0);
+    assert_eq!(returning.columns, vec!["a".to_string()]);
+}
+
+#[test]
+fn test_update_without_returning_yields_none() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES (4)");
+
+    let (count, returning) = execute_update_returning(&mut db, "UPDATE t1 SET a=5 WHERE a=4");
+    assert_eq!(count, 1);
+    assert!(returning.is_none());
+}
+
+/// window1.test 73.2 shape: RETURNING through an INSTEAD OF UPDATE trigger
+/// returns the NEW view rows (old row with SET applied), one per fire,
+/// regardless of what the trigger body does.
+#[test]
+fn test_update_returning_through_instead_of_trigger() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE base(b INT, c INT)");
+    execute_sql(&mut db, "INSERT INTO base VALUES (4, 8), (4, 9), (4, 10), (5, 11)");
+    execute_sql(&mut db, "CREATE TABLE log(x INT)");
+    execute_sql(&mut db, "CREATE VIEW t2 AS SELECT b, c FROM base");
+    execute_sql(
+        &mut db,
+        "CREATE TRIGGER t2_tr INSTEAD OF UPDATE ON t2 BEGIN INSERT INTO log VALUES(1); END",
+    );
+
+    let (count, returning) =
+        execute_update_returning(&mut db, "UPDATE t2 SET c=99 WHERE b=4 RETURNING *");
+    assert_eq!(count, 3);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(returning.columns, vec!["b".to_string(), "c".to_string()]);
+    assert_eq!(int_rows(&returning), vec![vec![4, 99], vec![4, 99], vec![4, 99]]);
+}
+
+/// window1.test 73.4 shape: UPDATE ... FROM ... RETURNING on a view fires
+/// (and returns a row) once per join match — 1 view row x 3 FROM rows here.
+#[test]
+fn test_update_returning_through_instead_of_trigger_with_from() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE base(b INT, c INT)");
+    execute_sql(&mut db, "INSERT INTO base VALUES (4, 10)");
+    execute_sql(&mut db, "CREATE TABLE m(k INT)");
+    execute_sql(&mut db, "INSERT INTO m VALUES (1), (2), (3)");
+    execute_sql(&mut db, "CREATE VIEW t2 AS SELECT b, c FROM base");
+    execute_sql(&mut db, "CREATE TABLE log(x INT)");
+    execute_sql(
+        &mut db,
+        "CREATE TRIGGER t2_tr INSTEAD OF UPDATE ON t2 BEGIN INSERT INTO log VALUES(1); END",
+    );
+
+    let (count, returning) =
+        execute_update_returning(&mut db, "UPDATE t2 SET c=15 FROM m WHERE b=4 RETURNING *");
+    assert_eq!(count, 3);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(int_rows(&returning), vec![vec![4, 15], vec![4, 15], vec![4, 15]]);
+}

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -34,13 +34,16 @@ use super::{
 
 /// Internal implementation supporting both schema caching, procedural context, and trigger
 /// context
+///
+/// Returns the number of updated rows plus, when the statement carries a
+/// RETURNING clause, the projected NEW rows (SQLite 3.35.0+ semantics).
 pub(super) fn execute_internal(
     stmt: &UpdateStmt,
     database: &mut Database,
     schema: Option<&vibesql_catalog::TableSchema>,
     procedural_context: Option<&crate::procedural::ExecutionContext>,
     trigger_context: Option<&crate::trigger_execution::TriggerContext>,
-) -> Result<usize, ExecutorError> {
+) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
     // Check if target is sqlite_master/sqlite_schema (read-only system table)
     if is_sqlite_schema_table(&stmt.table_name) {
         return Err(ExecutorError::SqliteSystemTableReadOnly {
@@ -107,13 +110,15 @@ pub(super) fn execute_internal(
         && trigger_context.is_none()
         && !has_assertions
         && !has_expression_indexes
+        // RETURNING needs the two-phase path so NEW rows can be captured
+        && stmt.returning.is_none()
     {
         if let Some(result) = fast_path::try_fast_path_update(stmt, database, schema)? {
             // Invalidate columnar cache after fast path update
             if result > 0 {
                 database.invalidate_columnar_cache(table_name);
             }
-            return Ok(result);
+            return Ok((result, None));
         }
     }
 
@@ -661,7 +666,21 @@ pub(super) fn execute_internal(
         return Err(assertion_error);
     }
 
-    Ok(update_count)
+    // Project RETURNING items against the NEW rows (SQLite 3.35.0+).
+    let returning = if let Some(items) = &stmt.returning {
+        let new_rows: Vec<&Row> = updates.iter().map(|u| &u.new_row).collect();
+        Some(super::returning::project_returning(
+            items,
+            schema,
+            database,
+            stmt.alias.as_deref(),
+            &new_rows,
+        )?)
+    } else {
+        None
+    };
+
+    Ok((update_count, returning))
 }
 
 /// Validate only NOT NULL and CHECK constraints (for REPLACE conflict resolution)
@@ -1167,7 +1186,7 @@ fn execute_update_from(
     has_triggers: bool,
     pk_indices: &Option<Vec<usize>>,
     trigger_context: Option<&crate::trigger_execution::TriggerContext<'_>>,
-) -> Result<usize, ExecutorError> {
+) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
     // Execute the join and get matched rows with computed SET values
     // Issue #5082: pass trigger_context so the synthetic SELECT can resolve
     // OLD/NEW pseudo-variables when this UPDATE runs inside a trigger body.
@@ -1203,7 +1222,7 @@ fn execute_update_from(
                 vibesql_ast::TriggerEvent::Update(None),
             )?;
         }
-        return Ok(0);
+        return Ok((0, empty_returning(stmt, schema, database)?));
     }
 
     // Validate constraints for each update.
@@ -1439,7 +1458,7 @@ fn execute_update_from(
                 vibesql_ast::TriggerEvent::Update(None),
             )?;
         }
-        return Ok(0);
+        return Ok((0, empty_returning(stmt, schema, database)?));
     }
 
     // Cross-update uniqueness validation: catches multiple updates landing on the
@@ -1581,5 +1600,35 @@ fn execute_update_from(
     // Mark pk_indices as used (it's available for future enhancements)
     let _ = pk_indices;
 
-    Ok(update_count)
+    // Project RETURNING items against the NEW rows (SQLite 3.35.0+).
+    let returning = if let Some(items) = &stmt.returning {
+        let new_rows: Vec<&Row> = updates.iter().map(|u| &u.new_row).collect();
+        Some(super::returning::project_returning(
+            items,
+            schema,
+            database,
+            stmt.alias.as_deref(),
+            &new_rows,
+        )?)
+    } else {
+        None
+    };
+
+    Ok((update_count, returning))
+}
+
+/// Build an empty RETURNING result (column names only) for statements whose
+/// RETURNING clause matched zero rows. Returns `None` when the statement has
+/// no RETURNING clause.
+fn empty_returning(
+    stmt: &UpdateStmt,
+    schema: &vibesql_catalog::TableSchema,
+    database: &Database,
+) -> Result<Option<crate::select::SelectResult>, ExecutorError> {
+    stmt.returning
+        .as_ref()
+        .map(|items| {
+            super::returning::project_returning(items, schema, database, stmt.alias.as_deref(), &[])
+        })
+        .transpose()
 }

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -29,6 +29,7 @@ mod fast_path;
 mod foreign_keys;
 mod from_clause;
 mod index_sync;
+mod returning;
 mod row_selector;
 mod triggers;
 mod value_updater;
@@ -129,12 +130,27 @@ impl UpdateExecutor {
     ///     from_clause: None,
     ///     where_clause: None,
     ///     conflict_clause: None,
+    ///     returning: None,
     /// };
     ///
     /// let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
     /// assert_eq!(count, 1);
     /// ```
     pub fn execute(stmt: &UpdateStmt, database: &mut Database) -> Result<usize, ExecutorError> {
+        executor::execute_internal(stmt, database, None, None, None).map(|(count, _)| count)
+    }
+
+    /// Execute an UPDATE statement, capturing RETURNING rows (SQLite 3.35.0+)
+    ///
+    /// Returns the number of updated rows plus, when the statement carries a
+    /// RETURNING clause, the projected NEW rows (after SET assignments) — one
+    /// per updated row, or one per INSTEAD OF trigger fire for views.
+    ///
+    /// When the statement has no RETURNING clause the second element is `None`.
+    pub fn execute_returning(
+        stmt: &UpdateStmt,
+        database: &mut Database,
+    ) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
         executor::execute_internal(stmt, database, None, None, None)
     }
 
@@ -146,6 +162,7 @@ impl UpdateExecutor {
         procedural_context: &crate::procedural::ExecutionContext,
     ) -> Result<usize, ExecutorError> {
         executor::execute_internal(stmt, database, None, Some(procedural_context), None)
+            .map(|(count, _)| count)
     }
 
     /// Execute an UPDATE statement with trigger context
@@ -156,6 +173,7 @@ impl UpdateExecutor {
         trigger_context: &crate::trigger_execution::TriggerContext,
     ) -> Result<usize, ExecutorError> {
         executor::execute_internal(stmt, database, None, None, Some(trigger_context))
+            .map(|(count, _)| count)
     }
 
     /// Execute an UPDATE statement with optional pre-fetched schema
@@ -177,6 +195,6 @@ impl UpdateExecutor {
         database: &mut Database,
         schema: Option<&vibesql_catalog::TableSchema>,
     ) -> Result<usize, ExecutorError> {
-        executor::execute_internal(stmt, database, schema, None, None)
+        executor::execute_internal(stmt, database, schema, None, None).map(|(count, _)| count)
     }
 }

--- a/crates/vibesql-executor/src/update/returning.rs
+++ b/crates/vibesql-executor/src/update/returning.rs
@@ -1,0 +1,112 @@
+//! RETURNING clause projection for UPDATE statements (SQLite 3.35.0+)
+//!
+//! SQLite semantics: RETURNING yields one result row per updated row,
+//! evaluated against the NEW row values (after SET assignments). For
+//! UPDATEs on views routed through INSTEAD OF triggers, the NEW view row
+//! is returned once per trigger fire, regardless of what the trigger body
+//! actually does.
+
+use vibesql_ast::{Expression, SelectItem};
+use vibesql_catalog::TableSchema;
+use vibesql_storage::{Database, Row};
+
+use crate::{errors::ExecutorError, evaluator::ExpressionEvaluator, select::SelectResult};
+
+/// Project RETURNING select items against a set of NEW rows.
+///
+/// `rows` must contain values in `schema` column order (one entry per
+/// updated row / trigger fire). Returns a `SelectResult` whose columns are
+/// derived from the RETURNING items (aliases win, then original source
+/// text, then the expression's column name).
+pub(super) fn project_returning(
+    items: &[SelectItem],
+    schema: &TableSchema,
+    database: &Database,
+    table_alias: Option<&str>,
+    rows: &[&Row],
+) -> Result<SelectResult, ExecutorError> {
+    let mut evaluator = ExpressionEvaluator::with_database(schema, database);
+    if let Some(alias) = table_alias {
+        evaluator.set_table_alias(alias.to_string());
+    }
+
+    // Indices of columns expanded by `*` (hidden `__hidden__*` view columns
+    // are excluded, matching SQLite's hidden-column convention).
+    let visible_columns: Vec<usize> = schema
+        .columns
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| !c.name.starts_with("__hidden__"))
+        .map(|(i, _)| i)
+        .collect();
+
+    // Derive result column names (computable even with zero updated rows).
+    let mut columns: Vec<String> = Vec::new();
+    for item in items {
+        match item {
+            SelectItem::Wildcard { .. } => {
+                columns.extend(visible_columns.iter().map(|&i| schema.columns[i].name.clone()));
+            }
+            SelectItem::QualifiedWildcard { qualifier, .. } => {
+                validate_wildcard_qualifier(qualifier, schema, table_alias)?;
+                columns.extend(visible_columns.iter().map(|&i| schema.columns[i].name.clone()));
+            }
+            SelectItem::Expression { expr, alias, source_text } => {
+                let name = if let Some(alias) = alias {
+                    alias.clone()
+                } else if let Expression::ColumnRef(col_id) = expr {
+                    col_id.column_canonical().to_string()
+                } else if let Some(text) = source_text {
+                    text.clone()
+                } else {
+                    format!("{:?}", expr)
+                };
+                columns.push(name);
+            }
+        }
+    }
+
+    // Evaluate each item against each NEW row.
+    let mut result_rows: Vec<Row> = Vec::with_capacity(rows.len());
+    for row in rows {
+        // Clear the CSE cache so expression results from the previous row
+        // are not replayed for this one.
+        evaluator.clear_cse_cache();
+        let mut values = Vec::with_capacity(columns.len());
+        for item in items {
+            match item {
+                SelectItem::Wildcard { .. } | SelectItem::QualifiedWildcard { .. } => {
+                    for &i in &visible_columns {
+                        values.push(
+                            row.values
+                                .get(i)
+                                .cloned()
+                                .ok_or(ExecutorError::ColumnIndexOutOfBounds { index: i })?,
+                        );
+                    }
+                }
+                SelectItem::Expression { expr, .. } => {
+                    values.push(evaluator.eval(expr, row)?);
+                }
+            }
+        }
+        result_rows.push(Row::new(values));
+    }
+
+    Ok(SelectResult { columns, rows: result_rows })
+}
+
+/// Validate that a qualified wildcard (`t.*`) refers to the updated table.
+fn validate_wildcard_qualifier(
+    qualifier: &str,
+    schema: &TableSchema,
+    table_alias: Option<&str>,
+) -> Result<(), ExecutorError> {
+    let matches_table = qualifier.eq_ignore_ascii_case(&schema.name)
+        || table_alias.is_some_and(|a| qualifier.eq_ignore_ascii_case(a));
+    if matches_table {
+        Ok(())
+    } else {
+        Err(ExecutorError::TableNotFound(qualifier.to_string()))
+    }
+}

--- a/crates/vibesql-executor/src/update/triggers.rs
+++ b/crates/vibesql-executor/src/update/triggers.rs
@@ -31,13 +31,17 @@ pub fn execute_update_with_trigger_context(
 /// When updating a view, we need to fire INSTEAD OF UPDATE triggers
 /// instead of actually updating data. The triggers typically update
 /// the underlying tables.
+///
+/// When the statement has a RETURNING clause, the projected NEW view rows
+/// (old row with SET assignments applied) are returned — one per trigger
+/// fire, regardless of what the trigger body does (SQLite semantics).
 pub(super) fn execute_update_on_view(
     database: &mut Database,
     stmt: &UpdateStmt,
     view_def: &ViewDefinition,
     procedural_context: Option<&crate::procedural::ExecutionContext>,
     trigger_context: Option<&crate::trigger_execution::TriggerContext>,
-) -> Result<usize, ExecutorError> {
+) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
     // Find INSTEAD OF UPDATE triggers for this view
     let triggers = crate::TriggerFirer::find_triggers(
         database,
@@ -89,18 +93,28 @@ pub(super) fn execute_update_on_view(
 
     // Now fire triggers (database can be mutably borrowed)
     let rows_processed = updates.len();
-    for (old_row, new_row) in updates {
+    for (old_row, new_row) in &updates {
         for trigger in &triggers {
-            crate::TriggerFirer::execute_trigger(
-                database,
-                trigger,
-                Some(&old_row),
-                Some(&new_row),
-            )?;
+            crate::TriggerFirer::execute_trigger(database, trigger, Some(old_row), Some(new_row))?;
         }
     }
 
-    Ok(rows_processed)
+    // Project RETURNING items against the NEW view rows (SQLite returns the
+    // updated view row per trigger fire, not whatever the trigger body did).
+    let returning = if let Some(items) = &stmt.returning {
+        let new_rows: Vec<&Row> = updates.iter().map(|(_, new_row)| new_row).collect();
+        Some(super::returning::project_returning(
+            items,
+            &view_schema,
+            database,
+            stmt.alias.as_deref(),
+            &new_rows,
+        )?)
+    } else {
+        None
+    };
+
+    Ok((rows_processed, returning))
 }
 
 /// Build (old_row, new_row) update pairs for an UPDATE on a view WITHOUT a FROM
@@ -130,12 +144,20 @@ fn collect_view_updates_no_from(
     // Select rows matching WHERE clause and build updates
     let mut collected_updates = Vec::new();
     for row in &all_rows.rows {
+        // Clear the CSE cache before evaluating this row: cached expression
+        // results (e.g. the WHERE comparison itself) from a previous row
+        // would otherwise be replayed for every subsequent row, making the
+        // first row's WHERE verdict apply to the whole view (issue #5233 —
+        // `UPDATE v SET ... WHERE b=4` fired the trigger 0 times).
+        evaluator.clear_cse_cache();
+
         let matches = match &stmt.where_clause {
-            Some(WhereClause::Condition(expr)) => match evaluator.eval(expr, row)? {
-                SqlValue::Boolean(b) => b,
-                SqlValue::Null => false,
-                _ => false,
-            },
+            // Use SQLite truthiness rather than a Boolean-only match so
+            // SQLite-style Integer(1)/Integer(0) comparison results count
+            // as matches too (issue #5233).
+            Some(WhereClause::Condition(expr)) => {
+                crate::evaluator::operators::is_truthy(&evaluator.eval(expr, row)?)
+            }
             None => true, // No WHERE clause - update all rows
             Some(WhereClause::CurrentOf(_)) => {
                 return Err(ExecutorError::UnsupportedExpression(
@@ -301,12 +323,11 @@ fn collect_view_updates_with_from(
     // Reconstruct (old_row, new_row) pairs from the joined output.
     //
     // The synthetic SELECT's WHERE has already filtered the rows, so every
-    // result row corresponds to one matched view row. If a single view row
-    // matches multiple FROM-side rows, SQLite picks one arbitrary join row
-    // for the trigger fire (the first match in physical order). We mirror
-    // that by deduplicating on the projected view columns — the first
-    // occurrence wins.
-    let mut seen_old: Vec<Row> = Vec::new();
+    // result row corresponds to one join match. SQLite fires the INSTEAD OF
+    // trigger once per join match — if a single view row matches multiple
+    // FROM-side rows, the trigger fires once per match (verified against
+    // sqlite3 3.51.0 for window1.test 73.4, which expects 9 fires for
+    // 3 view rows x 3 subquery rows). No deduplication is performed.
     let mut collected_updates: Vec<(Row, Row)> = Vec::new();
 
     for row in rows {
@@ -323,12 +344,6 @@ fn collect_view_updates_with_from(
         // First view_col_count values are the old row's column values.
         let old_values: Vec<SqlValue> = row.values[..view_col_count].to_vec();
         let old_row = Row::new(old_values);
-
-        // SQLite semantics: at most one trigger fire per matched view row.
-        // Dedup on the old row's contents (we don't have a rowid for views).
-        if seen_old.iter().any(|existing| existing.values == old_row.values) {
-            continue;
-        }
 
         // Build NEW row: copy old, then overwrite assigned columns with
         // the corresponding __set_<i>__ values.
@@ -348,7 +363,6 @@ fn collect_view_updates_with_from(
         }
         let new_row = Row::new(new_row_values);
 
-        seen_old.push(old_row.clone());
         collected_updates.push((old_row, new_row));
     }
 
@@ -401,10 +415,16 @@ pub(super) fn build_view_schema(
     let column_names: Vec<String> =
         if let Some(ref cols) = view_def.columns { cols.clone() } else { result.columns.clone() };
 
-    // Build columns with a generic data type (we just need names for trigger binding)
+    // Build columns with NONE affinity (DataType::Null). The pseudo-schema
+    // mainly provides column names for trigger binding, but its data types
+    // feed SQLite affinity rules during WHERE evaluation: declaring the
+    // columns as Varchar gave them TEXT affinity, which converted numeric
+    // literals to text and made comparisons like `WHERE b=4` never match
+    // (issue #5233). NONE affinity compares values by their actual types,
+    // matching bare (undeclared) columns in SQLite.
     let columns: Vec<ColumnSchema> = column_names
         .into_iter()
-        .map(|name| ColumnSchema::new(name, DataType::Varchar { max_length: None }, true))
+        .map(|name| ColumnSchema::new(name, DataType::Null, true))
         .collect();
 
     Ok(TableSchema::new(view_def.name.clone(), columns))

--- a/crates/vibesql-executor/tests/conflict_resolution_tests.rs
+++ b/crates/vibesql-executor/tests/conflict_resolution_tests.rs
@@ -240,6 +240,7 @@ fn test_update_or_ignore_primary_key_conflict() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: Some(ConflictClause::Ignore),
+        returning: None,
     };
 
     let rows_updated = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -287,6 +288,7 @@ fn test_update_or_ignore_unique_constraint_conflict() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: Some(ConflictClause::Ignore),
+        returning: None,
     };
 
     let rows_updated = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -324,6 +326,7 @@ fn test_update_or_ignore_no_conflict() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: Some(ConflictClause::Ignore),
+        returning: None,
     };
 
     let rows_updated = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -369,6 +372,7 @@ fn test_update_or_replace_primary_key_conflict() {
             )))),
         })),
         conflict_clause: Some(ConflictClause::Replace),
+        returning: None,
     };
 
     let rows_updated = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -411,6 +415,7 @@ fn test_update_or_replace_unique_constraint_conflict() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: Some(ConflictClause::Replace),
+        returning: None,
     };
 
     let rows_updated = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -456,6 +461,7 @@ fn test_update_or_replace_no_conflict() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: Some(ConflictClause::Replace),
+        returning: None,
     };
 
     let rows_updated = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -526,6 +532,7 @@ fn test_update_or_ignore_not_null_violation() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: Some(ConflictClause::Ignore),
+        returning: None,
     };
 
     let rows_updated = UpdateExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/update_basic_tests.rs
+++ b/crates/vibesql-executor/tests/update_basic_tests.rs
@@ -23,6 +23,7 @@ fn test_update_all_rows() {
         }],
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -61,6 +62,7 @@ fn test_update_with_where_clause() {
             )))),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -107,6 +109,7 @@ fn test_update_multiple_columns() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -147,6 +150,7 @@ fn test_update_with_expression() {
         }],
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -174,6 +178,7 @@ fn test_update_table_not_found() {
         assignments: vec![],
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);
@@ -198,6 +203,7 @@ fn test_update_column_not_found() {
         }],
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);
@@ -228,6 +234,7 @@ fn test_update_no_matching_rows() {
             right: Box::new(Expression::Literal(SqlValue::Integer(999))),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
@@ -69,6 +69,7 @@ fn test_update_invalidates_columnar_cache() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: None,
+        returning: None,
     };
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(count, 1, "Should update 1 row");
@@ -140,6 +141,7 @@ fn test_update_invalidates_prewarmed_cache() {
             right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Bob")))),
         })),
         conflict_clause: None,
+        returning: None,
     };
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(count, 1, "Should update 1 row");
@@ -179,6 +181,7 @@ fn test_update_all_rows_invalidates_cache() {
         }],
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     };
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(count, 3, "Should update 3 rows");
@@ -222,6 +225,7 @@ fn test_update_no_match_does_not_invalidate_cache() {
             right: Box::new(Expression::Literal(SqlValue::Integer(999))), // No such id
         })),
         conflict_clause: None,
+        returning: None,
     };
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(count, 0, "Should update 0 rows");
@@ -266,6 +270,7 @@ fn test_multiple_updates_invalidate_cache() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: None,
+        returning: None,
     };
     UpdateExecutor::execute(&stmt1, &mut db).unwrap();
 
@@ -296,6 +301,7 @@ fn test_multiple_updates_invalidate_cache() {
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
         conflict_clause: None,
+        returning: None,
     };
     UpdateExecutor::execute(&stmt2, &mut db).unwrap();
 
@@ -348,6 +354,7 @@ fn test_update_multiple_columns_invalidates_cache() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: None,
+        returning: None,
     };
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
     assert_eq!(count, 1, "Should update 1 row");

--- a/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
@@ -29,6 +29,7 @@ fn test_update_check_constraint_passes() {
         }],
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -56,6 +57,7 @@ fn test_update_check_constraint_violation() {
         }],
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);
@@ -91,6 +93,7 @@ fn test_update_check_constraint_with_null() {
         }],
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -122,6 +125,7 @@ fn test_update_check_constraint_with_expression() {
         }],
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     };
     let count = UpdateExecutor::execute(&stmt1, &mut db).unwrap();
     assert_eq!(count, 1);
@@ -139,6 +143,7 @@ fn test_update_check_constraint_with_expression() {
         }],
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     };
 
     let result = UpdateExecutor::execute(&stmt2, &mut db);

--- a/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
@@ -192,5 +192,6 @@ pub fn create_update_with_id_clause(
             right: Box::new(Expression::Literal(SqlValue::Integer(id))),
         })),
         conflict_clause: None,
+        returning: None,
     }
 }

--- a/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
@@ -183,6 +183,7 @@ fn test_update_unique_constraint_composite() {
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);

--- a/crates/vibesql-executor/tests/update_default_tests.rs
+++ b/crates/vibesql-executor/tests/update_default_tests.rs
@@ -43,6 +43,7 @@ fn test_update_with_default_value() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -95,6 +96,7 @@ fn test_update_default_no_default_value_defined() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/update_onepass_tests.rs
+++ b/crates/vibesql-executor/tests/update_onepass_tests.rs
@@ -128,6 +128,7 @@ fn test_onepass_multiple_literal_assignments() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -170,6 +171,7 @@ fn test_onepass_single_literal_assignment() {
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -204,6 +206,7 @@ fn test_onepass_pk_not_found_returns_zero() {
             right: Box::new(Expression::Literal(SqlValue::Integer(999))),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -247,6 +250,7 @@ fn test_onepass_not_null_constraint_enforced() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);
@@ -292,6 +296,7 @@ fn test_composite_pk_update_both_columns_specified() {
             }),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -343,6 +348,7 @@ fn test_composite_pk_update_reversed_order() {
             }),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -379,6 +385,7 @@ fn test_composite_pk_partial_match_uses_scan() {
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -426,6 +433,7 @@ fn test_composite_pk_not_found_returns_zero() {
             }),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -472,6 +480,7 @@ fn test_composite_pk_multiple_columns_updated() {
             }),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
@@ -77,6 +77,7 @@ fn test_update_with_subquery_multiple_rows_uses_first() {
         }],
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);
@@ -173,6 +174,7 @@ fn test_update_with_subquery_multiple_columns_error() {
         }],
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     };
 
     let result = UpdateExecutor::execute(&stmt, &mut db);

--- a/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
@@ -137,6 +137,7 @@ fn create_update_stmt(
         from_clause: None,
         where_clause,
         conflict_clause: None,
+        returning: None,
     }
 }
 
@@ -156,6 +157,7 @@ fn create_multi_column_update_stmt(
         from_clause: None,
         where_clause: None,
         conflict_clause: None,
+        returning: None,
     }
 }
 

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
@@ -79,6 +79,7 @@ fn test_update_where_scalar_subquery_equal() {
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -170,6 +171,7 @@ fn test_update_where_scalar_subquery_less_than() {
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -253,6 +255,7 @@ fn test_update_where_subquery_returns_null() {
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -348,6 +351,7 @@ fn test_update_where_subquery_with_aggregate() {
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -480,6 +484,7 @@ fn test_update_where_and_set_both_use_subqueries() {
             negated: false,
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
@@ -94,6 +94,7 @@ fn test_update_where_in_subquery() {
             negated: false,
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -189,6 +190,7 @@ fn test_update_where_not_in_subquery() {
             negated: true,
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -277,6 +279,7 @@ fn test_update_where_subquery_empty_result() {
             negated: false,
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -382,6 +385,7 @@ fn test_update_where_complex_subquery_condition() {
             negated: false,
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
@@ -481,6 +485,7 @@ fn test_update_where_multiple_rows_in_subquery() {
             negated: false,
         })),
         conflict_clause: None,
+        returning: None,
     };
 
     let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -361,7 +361,10 @@ impl<'arena> ArenaParser<'arena> {
     }
 
     /// Parse select list.
-    fn parse_select_list(&mut self) -> Result<BumpVec<'arena, SelectItem<'arena>>, ParseError> {
+    /// Also used for RETURNING clauses on DML statements (same item grammar).
+    pub(crate) fn parse_select_list(
+        &mut self,
+    ) -> Result<BumpVec<'arena, SelectItem<'arena>>, ParseError> {
         let mut items = BumpVec::new_in(self.arena);
 
         loop {

--- a/crates/vibesql-parser/src/arena_parser/update.rs
+++ b/crates/vibesql-parser/src/arena_parser/update.rs
@@ -122,6 +122,14 @@ impl<'arena> ArenaParser<'arena> {
             None
         };
 
+        // Parse optional RETURNING clause (SQLite 3.35.0+)
+        // Syntax: UPDATE ... [WHERE ...] RETURNING expr [, expr ...]
+        let returning = if self.try_consume_keyword(Keyword::Returning) {
+            Some(self.parse_select_list()?)
+        } else {
+            None
+        };
+
         // Consume optional semicolon
         self.try_consume(&Token::Semicolon);
 
@@ -134,6 +142,7 @@ impl<'arena> ArenaParser<'arena> {
             from_clause,
             where_clause,
             conflict_clause,
+            returning,
         };
 
         Ok(self.arena.alloc(stmt))

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -129,6 +129,8 @@ pub enum Keyword {
     Rename,
     Modify,
     Change,
+    /// RETURNING clause on DML statements (SQLite 3.35.0+)
+    Returning,
     // SAVEPOINT keywords
     Savepoint,
     Release,
@@ -405,7 +407,11 @@ impl Keyword {
             Keyword::Current | Keyword::Exclude | Keyword::Filter | Keyword::Following |
             Keyword::Groups | Keyword::No | Keyword::Others | Keyword::Over |
             Keyword::Partition | Keyword::Preceding | Keyword::Range | Keyword::Ties |
-            Keyword::Unbounded | Keyword::Window | Keyword::First | Keyword::Last
+            Keyword::Unbounded | Keyword::Window | Keyword::First | Keyword::Last |
+            // RETURNING is a "fallback" keyword in SQLite (3.35.0+): it is only
+            // meaningful at the end of a DML statement and remains usable as an
+            // ordinary identifier elsewhere.
+            Keyword::Returning
         )
     }
 }
@@ -526,6 +532,7 @@ impl fmt::Display for Keyword {
             Keyword::Constraint => "CONSTRAINT",
             Keyword::Default => "DEFAULT",
             Keyword::Rename => "RENAME",
+            Keyword::Returning => "RETURNING",
             Keyword::Modify => "MODIFY",
             Keyword::Change => "CHANGE",
             Keyword::Savepoint => "SAVEPOINT",

--- a/crates/vibesql-parser/src/lexer/keywords.rs
+++ b/crates/vibesql-parser/src/lexer/keywords.rs
@@ -114,6 +114,7 @@ static KEYWORDS: phf::Map<&'static str, Keyword> = phf_map! {
     "COMMIT" => Keyword::Commit,
     "CONSTRAINT" => Keyword::Constraint,
     "RENAME" => Keyword::Rename,
+    "RETURNING" => Keyword::Returning,
     "MODIFY" => Keyword::Modify,
     "CHANGE" => Keyword::Change,
     "ROLLBACK" => Keyword::Rollback,

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -139,6 +139,15 @@ impl Parser {
             None
         };
 
+        // Parse optional RETURNING clause (SQLite 3.35.0+)
+        // Syntax: UPDATE ... [WHERE ...] RETURNING expr [, expr ...]
+        let returning = if self.peek_keyword(Keyword::Returning) {
+            self.consume_keyword(Keyword::Returning)?;
+            Some(self.parse_select_list()?)
+        } else {
+            None
+        };
+
         // Expect semicolon or EOF
         if matches!(self.peek(), Token::Semicolon) {
             self.advance();
@@ -153,6 +162,7 @@ impl Parser {
             from_clause,
             where_clause,
             conflict_clause,
+            returning,
         })
     }
 
@@ -285,6 +295,15 @@ impl Parser {
             None
         };
 
+        // Parse optional RETURNING clause (SQLite 3.35.0+)
+        // Syntax: UPDATE ... [WHERE ...] RETURNING expr [, expr ...]
+        let returning = if self.peek_keyword(Keyword::Returning) {
+            self.consume_keyword(Keyword::Returning)?;
+            Some(self.parse_select_list()?)
+        } else {
+            None
+        };
+
         // Expect semicolon or EOF
         if matches!(self.peek(), Token::Semicolon) {
             self.advance();
@@ -299,6 +318,7 @@ impl Parser {
             from_clause,
             where_clause,
             conflict_clause,
+            returning,
         })
     }
 }

--- a/crates/vibesql-parser/src/tests/update.rs
+++ b/crates/vibesql-parser/src/tests/update.rs
@@ -167,3 +167,100 @@ fn test_parse_update_without_conflict_clause() {
         _ => panic!("Expected UPDATE statement"),
     }
 }
+
+// ========================================================================
+// RETURNING Clause Tests (SQLite 3.35.0+, issue #5233)
+// ========================================================================
+
+#[test]
+fn test_parse_update_returning_star() {
+    let result = Parser::parse_sql("UPDATE t1 SET a = 5 WHERE a = 4 RETURNING *;");
+    assert!(result.is_ok(), "RETURNING * should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            let returning = update.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 1);
+            assert!(matches!(returning[0], vibesql_ast::SelectItem::Wildcard { .. }));
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_returning_expression_list() {
+    let result = Parser::parse_sql("UPDATE t1 SET a = 5 WHERE a = 4 RETURNING *, a + 1;");
+    assert!(result.is_ok(), "RETURNING expr list should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            let returning = update.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 2);
+            assert!(matches!(returning[0], vibesql_ast::SelectItem::Wildcard { .. }));
+            assert!(matches!(returning[1], vibesql_ast::SelectItem::Expression { .. }));
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_returning_with_alias() {
+    let result = Parser::parse_sql("UPDATE t1 SET a = 5 RETURNING a AS new_a, a + 1 incremented;");
+    assert!(result.is_ok(), "RETURNING aliases should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            let returning = update.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 2);
+            match &returning[0] {
+                vibesql_ast::SelectItem::Expression { alias, .. } => {
+                    assert_eq!(alias.as_deref(), Some("new_a"));
+                }
+                other => panic!("Expected expression item, got {:?}", other),
+            }
+            match &returning[1] {
+                vibesql_ast::SelectItem::Expression { alias, .. } => {
+                    assert_eq!(alias.as_deref(), Some("incremented"));
+                }
+                other => panic!("Expected expression item, got {:?}", other),
+            }
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_returning_arena_parser() {
+    // The CLI path goes through parse_with_arena_fallback; make sure the
+    // arena parser captures RETURNING too.
+    let result =
+        crate::parse_with_arena_fallback("UPDATE t1 SET a = 5 WHERE a = 4 RETURNING *, a + 1");
+    assert!(result.is_ok(), "arena parser should handle RETURNING: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            let returning = update.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 2);
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_without_returning_is_none() {
+    let result = Parser::parse_sql("UPDATE t1 SET a = 5 WHERE a = 4;");
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => assert!(update.returning.is_none()),
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_returning_still_usable_as_identifier() {
+    // RETURNING is a fallback keyword in SQLite: it must remain usable as a
+    // column name outside the DML RETURNING position.
+    let result = Parser::parse_sql("UPDATE t1 SET returning = 5 WHERE returning = 4;");
+    assert!(result.is_ok(), "'returning' as column name should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            assert_eq!(update.assignments[0].column, "returning");
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}

--- a/tests/storage/update_pk_performance.rs
+++ b/tests/storage/update_pk_performance.rs
@@ -69,6 +69,7 @@ fn test_update_with_pk_index_performance() {
             })),
             quoted: false,
             conflict_clause: None,
+            returning: None,
         };
 
         UpdateExecutor::execute(&stmt, &mut db).unwrap();


### PR DESCRIPTION
Closes #5233

## Summary

Fixes window1.test 73.2/73.4 by addressing all three root causes identified by the curator:

1. **WHERE truthiness on the no-FROM view path** (`crates/vibesql-executor/src/update/triggers.rs`): comparison expressions in this evaluator context return SQLite-style `Integer(1)`/`Integer(0)`, which the Boolean-only match arm swallowed — the INSTEAD OF trigger fired 0 times for `WHERE b=4`. Extracted the private `is_truthy` from `delete/executor.rs` into `evaluator::operators` and shared it. Two supporting fixes were needed for the same path: clear the CSE cache per row (cached WHERE verdicts were replayed across rows) and give the view pseudo-schema NONE affinity (`DataType::Null`) instead of TEXT so numeric comparisons match.

2. **UPDATE...FROM view path dedup removed**: SQLite fires the INSTEAD OF trigger once per join match (verified against sqlite3 3.51.0 — 9 fires for 3 view rows x 3 subquery rows in 73.4). `triggerupfrom.test` still passes (8 passed, 0 failed, unchanged).

3. **UPDATE ... RETURNING implemented end to end**: `Returning` fallback keyword (still usable as an identifier), RETURNING select-item parsing in both owned and arena parsers, `UpdateStmt.returning` through AST/visitor/arena conversion, new `UpdateExecutor::execute_returning` entry point projecting NEW rows (base-table, UPDATE...FROM, and INSTEAD OF view paths; existing `execute` callers unchanged), and CLI rendering of RETURNING rows as a result set.

## Test results

- `window1.test`: **264 passed / 7 failed** vs 259/12 baseline on main — 73.2 and 73.4 now pass, no regressions (remaining 7 failures are pre-existing and unrelated)
- `triggerupfrom.test`: 8 passed / 0 failed (unchanged)
- `cargo test -p vibesql-executor` (lib + 84 integration test binaries): all green
- `cargo test -p vibesql-parser -p vibesql-ast -p vibesql-cli`: all green
- Manual CLI verification: `UPDATE t2 SET c=99 WHERE b=4 RETURNING *` through an INSTEAD OF trigger returns the NEW view rows; base-table `UPDATE t1 SET b=5 WHERE a=4 RETURNING *, a+1` returns NEW values
- New regression tests: `crates/vibesql-executor/src/tests/update_returning.rs` (6 tests covering all three root causes) and RETURNING parser tests in `crates/vibesql-parser/src/tests/update.rs`

## Pre-existing failures (not caused by this PR)

- `tests/issue_2998_correlated_subquery.rs` fails identically on clean main (verified by stash/run)
- Workspace `cargo fmt --check` fails on main (2989 lines); this PR avoids adding formatting churn

## Out of scope (per curator)

- `INSERT ... RETURNING` / `DELETE ... RETURNING`
- Parser accepting arbitrary trailing tokens after UPDATE's WHERE clause (the latent bug that masked RETURNING)

🤖 Generated with [Claude Code](https://claude.com/claude-code)