### PR TITLE
fix(executor): evaluate window functions mixed with aggregates in one SELECT

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs
@@ -343,7 +343,19 @@ impl CombinedExpressionEvaluator<'_> {
         // Pass CTE context for queries referencing CTEs from outer scope (#3044)
         let select_executor =
             if let (Some(ref schema), Some(ref outer_row)) = (&merged_schema, &merged_row) {
-                if let Some(cte_ctx) = self.cte_context {
+                if let Some(outer_rows) = self.outer_rows {
+                    // Pass outer_rows for outer-correlated aggregates inside the
+                    // IN-subquery (issues #4930 / #5232).
+                    if let Some(cte_ctx) = self.cte_context {
+                        crate::select::SelectExecutor::new_with_outer_rows_and_cte_and_depth(
+                            database, outer_row, schema, outer_rows, cte_ctx, self.depth,
+                        )
+                    } else {
+                        crate::select::SelectExecutor::new_with_outer_rows_and_depth(
+                            database, outer_row, schema, outer_rows, self.depth,
+                        )
+                    }
+                } else if let Some(cte_ctx) = self.cte_context {
                     crate::select::SelectExecutor::new_with_outer_and_cte_and_depth(
                         database, outer_row, schema, cte_ctx, self.depth,
                     )
@@ -412,12 +424,8 @@ impl CombinedExpressionEvaluator<'_> {
 
         // Evaluate all elements of the left row value
         let mut expr_values = Vec::with_capacity(expected_columns);
-        let mut has_null_element = false;
         for elem_expr in expr_elements {
             let val = self.eval(elem_expr, row)?;
-            if matches!(val, SqlValue::Null) {
-                has_null_element = true;
-            }
             expr_values.push(val);
         }
 
@@ -438,7 +446,21 @@ impl CombinedExpressionEvaluator<'_> {
 
         let select_executor =
             if let (Some(ref schema), Some(ref outer_row)) = (&merged_schema, &merged_row) {
-                if let Some(cte_ctx) = self.cte_context {
+                if let Some(outer_rows) = self.outer_rows {
+                    // Pass outer_rows for outer-correlated aggregates inside the
+                    // IN-subquery (issues #4930 / #5232 — e.g.
+                    // `(0,0) IN (SELECT MIN(c0), NTILE(1) OVER())` where MIN(c0)
+                    // aggregates over all outer rows).
+                    if let Some(cte_ctx) = self.cte_context {
+                        crate::select::SelectExecutor::new_with_outer_rows_and_cte_and_depth(
+                            database, outer_row, schema, outer_rows, cte_ctx, self.depth,
+                        )
+                    } else {
+                        crate::select::SelectExecutor::new_with_outer_rows_and_depth(
+                            database, outer_row, schema, outer_rows, self.depth,
+                        )
+                    }
+                } else if let Some(cte_ctx) = self.cte_context {
                     crate::select::SelectExecutor::new_with_outer_and_cte_and_depth(
                         database, outer_row, schema, cte_ctx, self.depth,
                     )
@@ -475,7 +497,14 @@ impl CombinedExpressionEvaluator<'_> {
         }
 
         let sql_mode = database.sql_mode();
-        let mut found_null_in_subquery = false;
+        // Whether any row compared as UNKNOWN (all non-NULL elements equal,
+        // but at least one element comparison involved NULL). Rows that are
+        // definitively FALSE (some element definitively unequal) do NOT make
+        // the overall result UNKNOWN — SQL three-valued AND semantics:
+        // (0,0) IN (SELECT NULL, 1) is FALSE (0=1 is false), while
+        // (0,0) IN (SELECT NULL, 0) is NULL (0=NULL is unknown). (#5232,
+        // window1.test 44.3.2)
+        let mut found_unknown_row = false;
 
         // Compare with each row from the subquery using element-wise equality
         for subquery_row in &rows {
@@ -490,9 +519,6 @@ impl CombinedExpressionEvaluator<'_> {
                 // NULL on either side propagates as UNKNOWN for this element
                 if matches!(expr_val, SqlValue::Null) || matches!(subquery_val, SqlValue::Null) {
                     has_null_comparison = true;
-                    if matches!(subquery_val, SqlValue::Null) {
-                        found_null_in_subquery = true;
-                    }
                     continue;
                 }
 
@@ -508,7 +534,7 @@ impl CombinedExpressionEvaluator<'_> {
                         // Equal at this position - continue
                     }
                     SqlValue::Boolean(false) => {
-                        // Not equal - this row can't match
+                        // Not equal - this row is definitively FALSE
                         all_equal = false;
                         break;
                     }
@@ -524,15 +550,19 @@ impl CombinedExpressionEvaluator<'_> {
                 }
             }
 
-            if all_equal && !has_null_comparison {
-                // Found an exact match
-                return Ok(SqlValue::Boolean(!negated));
+            if all_equal {
+                if !has_null_comparison {
+                    // Found an exact match
+                    return Ok(SqlValue::Boolean(!negated));
+                }
+                // No element definitively unequal, but some comparison was
+                // UNKNOWN — this row's match is UNKNOWN.
+                found_unknown_row = true;
             }
         }
 
         // No exact match found
-        if has_null_element || found_null_in_subquery {
-            // Any NULL involvement makes the result UNKNOWN
+        if found_unknown_row {
             Ok(SqlValue::Null)
         } else {
             Ok(SqlValue::Boolean(negated))

--- a/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
@@ -22,37 +22,7 @@ fn expression_contains_outer_aggregate_collapse(
     use vibesql_ast::Expression;
 
     match expr {
-        Expression::ScalarSubquery(stmt) => {
-            // Bare (FROM-less) subquery: an aggregate in the projection that
-            // references a column is necessarily outer-correlated (no inner
-            // tables) → triggers collapse.
-            if stmt.from.is_none() {
-                for item in &stmt.select_list {
-                    if let vibesql_ast::SelectItem::Expression { expr: inner, .. } = item {
-                        if expr_has_column_referencing_aggregate(inner) {
-                            return true;
-                        }
-                        // Recurse: nested scalar subqueries.
-                        if expression_contains_outer_aggregate_collapse(inner, database) {
-                            return true;
-                        }
-                    }
-                }
-                return false;
-            }
-
-            // FROM-bearing subquery: walk the SELECT list, FROM, WHERE,
-            // HAVING, and ORDER BY of the inner query, tracking the chain
-            // of inner FROM scopes. If we find an aggregate whose column
-            // reference does not resolve to any inner scope along the chain,
-            // it is outer-correlated to the surrounding query → triggers
-            // collapse. (#5135 / window1.test 57.3.)
-            //
-            // The scope chain is initialized with this subquery's own FROM
-            // scope; nested subqueries extend the chain with their own FROM
-            // scopes when descending.
-            scope_chain_contains_outer_correlated_aggregate(stmt, &[], database)
-        }
+        Expression::ScalarSubquery(stmt) => subquery_stmt_triggers_collapse(stmt, database),
         // Recurse into compound expressions.
         Expression::BinaryOp { left, right, .. } => {
             expression_contains_outer_aggregate_collapse(left, database)
@@ -80,7 +50,16 @@ fn expression_contains_outer_aggregate_collapse(
             expression_contains_outer_aggregate_collapse(expr, database)
                 || values.iter().any(|v| expression_contains_outer_aggregate_collapse(v, database))
         }
-        Expression::In { expr, .. } => expression_contains_outer_aggregate_collapse(expr, database),
+        // IN with subquery: the collapse trigger can hide in the LHS *or* in
+        // the IN-subquery itself (window1.test 44.x:
+        // `SELECT (0,0) IN (SELECT MIN(c0), NTILE(1) OVER()) FROM t0`).
+        // The FROM-less IN subquery's MIN(c0) references an outer column, so
+        // the outer query collapses to a single-row implicit aggregate.
+        // (#5232)
+        Expression::In { expr, subquery, .. } => {
+            expression_contains_outer_aggregate_collapse(expr, database)
+                || subquery_stmt_triggers_collapse(subquery, database)
+        }
         Expression::Case { operand, when_clauses, else_result } => {
             operand
                 .as_ref()
@@ -151,6 +130,43 @@ fn expression_contains_outer_aggregate_collapse(
         // Other leaf expressions can't contain a scalar subquery.
         _ => false,
     }
+}
+
+/// Check whether a subquery (scalar or IN) triggers SQLite's
+/// implicit-outer-aggregate-collapse semantics.
+///
+/// Bare (FROM-less) subquery: an aggregate in the projection that references
+/// a column is necessarily outer-correlated (no inner tables) → triggers
+/// collapse.
+///
+/// FROM-bearing subquery: walk the SELECT list, FROM, WHERE, HAVING, and
+/// ORDER BY of the inner query, tracking the chain of inner FROM scopes. If
+/// we find an aggregate whose column reference does not resolve to any inner
+/// scope along the chain, it is outer-correlated to the surrounding query →
+/// triggers collapse. (#5135 / window1.test 57.3.)
+fn subquery_stmt_triggers_collapse(
+    stmt: &vibesql_ast::SelectStmt,
+    database: &vibesql_storage::Database,
+) -> bool {
+    if stmt.from.is_none() {
+        for item in &stmt.select_list {
+            if let vibesql_ast::SelectItem::Expression { expr: inner, .. } = item {
+                if expr_has_column_referencing_aggregate(inner) {
+                    return true;
+                }
+                // Recurse: nested scalar subqueries.
+                if expression_contains_outer_aggregate_collapse(inner, database) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // The scope chain is initialized with this subquery's own FROM scope;
+    // nested subqueries extend the chain with their own FROM scopes when
+    // descending.
+    scope_chain_contains_outer_correlated_aggregate(stmt, &[], database)
 }
 
 // ------------------------------------------------------------------------
@@ -736,8 +752,52 @@ fn expr_has_column_referencing_aggregate(expr: &vibesql_ast::Expression) -> bool
                 })
                 || else_result.as_ref().is_some_and(|e| expr_has_column_referencing_aggregate(e))
         }
-        // Don't descend into inner subqueries / window functions — they have
-        // their own scope. Stop here.
+        // Window function: the collapse trigger can hide inside the window's
+        // args or its OVER (PARTITION BY / ORDER BY / frame) expressions,
+        // e.g. `SELECT (SELECT count(a) OVER (ORDER BY sum(a))) FROM t1`
+        // (window1.test 61.4.2). Only *plain* AggregateFunction nodes found
+        // by the recursion trigger collapse — the window function itself
+        // (e.g. `total(a) OVER()`, a `WindowFunctionSpec::Aggregate`) must
+        // NOT trigger (window1.test 61.3.1). (#5232)
+        Expression::WindowFunction { function, over } => {
+            let args = match function {
+                vibesql_ast::WindowFunctionSpec::Aggregate { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args,
+            };
+            if args.iter().any(expr_has_column_referencing_aggregate) {
+                return true;
+            }
+            if over.partition_by.as_ref().is_some_and(|exprs| {
+                exprs.iter().any(expr_has_column_referencing_aggregate)
+            }) {
+                return true;
+            }
+            if over.order_by.as_ref().is_some_and(|items| {
+                items.iter().any(|i| expr_has_column_referencing_aggregate(&i.expr))
+            }) {
+                return true;
+            }
+            if let Some(frame) = &over.frame {
+                if let vibesql_ast::FrameBound::Preceding(e)
+                | vibesql_ast::FrameBound::Following(e) = &frame.start
+                {
+                    if expr_has_column_referencing_aggregate(e) {
+                        return true;
+                    }
+                }
+                if let Some(vibesql_ast::FrameBound::Preceding(e))
+                | Some(vibesql_ast::FrameBound::Following(e)) = &frame.end
+                {
+                    if expr_has_column_referencing_aggregate(e) {
+                        return true;
+                    }
+                }
+            }
+            false
+        }
+        // Don't descend into inner subqueries — they have their own scope.
+        // Stop here.
         _ => false,
     }
 }
@@ -883,14 +943,26 @@ impl SelectExecutor<'_> {
             }
             // Window functions may contain nested aggregates in their arguments
             // e.g., min(sum(a)) OVER () — the sum(a) is an aggregate that must be
-            // evaluated in the aggregation path before the window function is applied
-            vibesql_ast::Expression::WindowFunction { function, .. } => {
+            // evaluated in the aggregation path before the window function is applied.
+            // Aggregates can also hide in the OVER clause's PARTITION BY / ORDER BY,
+            // e.g. `count(a) OVER (ORDER BY sum(a))` — per SQLite this makes the
+            // query an aggregate query (one row per group). (#5232 / window1.test
+            // 61.4.2.) Note: ScalarSubquery is not descended into anywhere in this
+            // function, so `OVER (ORDER BY (SELECT sum(y) FROM t2))` does NOT make
+            // the outer query an aggregate (window1.test 61.3.1).
+            vibesql_ast::Expression::WindowFunction { function, over } => {
                 let args = match function {
                     vibesql_ast::WindowFunctionSpec::Aggregate { args, .. } => args,
                     vibesql_ast::WindowFunctionSpec::Ranking { args, .. } => args,
                     vibesql_ast::WindowFunctionSpec::Value { args, .. } => args,
                 };
                 args.iter().any(|arg| self.expression_has_aggregate(arg))
+                    || over.partition_by.as_ref().is_some_and(|exprs| {
+                        exprs.iter().any(|e| self.expression_has_aggregate(e))
+                    })
+                    || over.order_by.as_ref().is_some_and(|items| {
+                        items.iter().any(|i| self.expression_has_aggregate(&i.expr))
+                    })
             }
             // DuplicateKeyValue references a column from INSERT VALUES
             vibesql_ast::Expression::DuplicateKeyValue { .. } => false,
@@ -1203,6 +1275,131 @@ mod tests {
             "An aggregate referencing both an outer column (a from t1) and an \
              inner column (x from t2) must NOT trigger collapse — it's a normal \
              correlated aggregate evaluated per outer row"
+        );
+    }
+
+    /// Build a window-function expression `name(args) OVER (ORDER BY order_by_expr)`.
+    fn window_fn(
+        function: vibesql_ast::WindowFunctionSpec,
+        order_by_expr: Option<Expression>,
+    ) -> Expression {
+        Expression::WindowFunction {
+            function,
+            over: vibesql_ast::WindowSpec {
+                base_window_name: None,
+                partition_by: None,
+                order_by: order_by_expr.map(|e| {
+                    vec![vibesql_ast::OrderByItem {
+                        expr: e,
+                        direction: vibesql_ast::OrderDirection::Asc,
+                        nulls_order: None,
+                    }]
+                }),
+                frame: None,
+            },
+        }
+    }
+
+    /// Gap 2 (#5232, window1.test 44.x): the collapse trigger must be
+    /// detected through an IN subquery:
+    /// `SELECT (0, 0) IN (SELECT MIN(c0), NTILE(1) OVER()) FROM t0`.
+    #[test]
+    fn collapse_detected_through_in_subquery() {
+        let db = setup_db_t1_t2();
+
+        // Inner (FROM-less): SELECT MIN(a), NTILE(1) OVER()
+        let mut inner = empty_select_stmt();
+        inner.select_list.push(SelectItem::Expression {
+            expr: agg("min", col("a")),
+            alias: None,
+            source_text: None,
+        });
+        inner.select_list.push(SelectItem::Expression {
+            expr: window_fn(
+                vibesql_ast::WindowFunctionSpec::Ranking {
+                    name: FunctionIdentifier::new("ntile"),
+                    args: vec![Expression::Literal(vibesql_types::SqlValue::Integer(1))],
+                },
+                None,
+            ),
+            alias: None,
+            source_text: None,
+        });
+
+        let in_expr = Expression::In {
+            expr: Box::new(Expression::RowValueConstructor(vec![
+                Expression::Literal(vibesql_types::SqlValue::Integer(0)),
+                Expression::Literal(vibesql_types::SqlValue::Integer(0)),
+            ])),
+            subquery: Box::new(inner),
+            negated: false,
+        };
+
+        assert!(
+            expression_contains_outer_aggregate_collapse(&in_expr, &db),
+            "(0,0) IN (SELECT MIN(a), NTILE(1) OVER()) must trigger collapse — \
+             the FROM-less IN subquery aggregates over an outer column"
+        );
+    }
+
+    /// Gap 3 (#5232, window1.test 61.4.2): the collapse trigger must be
+    /// detected when the aggregate hides inside a window function's
+    /// OVER (ORDER BY ...): `SELECT (SELECT count(a) OVER (ORDER BY sum(a))) FROM t1`.
+    #[test]
+    fn collapse_detected_for_aggregate_inside_over_order_by() {
+        let db = setup_db_t1_t2();
+
+        let mut inner = empty_select_stmt();
+        inner.select_list.push(SelectItem::Expression {
+            expr: window_fn(
+                vibesql_ast::WindowFunctionSpec::Aggregate {
+                    name: FunctionIdentifier::new("count"),
+                    args: vec![col("a")],
+                    filter: None,
+                },
+                Some(agg("sum", col("a"))),
+            ),
+            alias: None,
+            source_text: None,
+        });
+
+        let outer_subq = Expression::ScalarSubquery(Box::new(inner));
+
+        assert!(
+            expression_contains_outer_aggregate_collapse(&outer_subq, &db),
+            "(SELECT count(a) OVER (ORDER BY sum(a))) must trigger collapse — \
+             sum(a) inside the OVER ORDER BY is an outer-correlated aggregate"
+        );
+    }
+
+    /// Guard (#5232, window1.test 61.3.1): a window-aggregate like
+    /// `total(a) OVER()` is a `WindowFunctionSpec::Aggregate`, NOT a plain
+    /// `AggregateFunction`, and must NOT trigger collapse —
+    /// `SELECT (SELECT total(a) OVER()) FROM t1` returns 0 rows on empty t1.
+    #[test]
+    fn no_collapse_for_window_aggregate_spec() {
+        let db = setup_db_t1_t2();
+
+        let mut inner = empty_select_stmt();
+        inner.select_list.push(SelectItem::Expression {
+            expr: window_fn(
+                vibesql_ast::WindowFunctionSpec::Aggregate {
+                    name: FunctionIdentifier::new("total"),
+                    args: vec![col("a")],
+                    filter: None,
+                },
+                None,
+            ),
+            alias: None,
+            source_text: None,
+        });
+
+        let outer_subq = Expression::ScalarSubquery(Box::new(inner));
+
+        assert!(
+            !expression_contains_outer_aggregate_collapse(&outer_subq, &db),
+            "(SELECT total(a) OVER()) must NOT trigger collapse — the window \
+             aggregate has its own scope and is not a plain aggregate"
         );
     }
 }

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/subquery.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/subquery.rs
@@ -49,6 +49,20 @@ pub(super) fn evaluate_scalar(
             return overridden.eval(expr, row);
         }
         evaluator.eval(expr, row)
+    } else if scalar_subquery_needs_outer_rows(expr) {
+        // Issue #5232 (window1.test 61.4.2): empty group, but the subquery
+        // triggers implicit-outer-aggregate-collapse — the aggregation still
+        // produces exactly one row, with the inner aggregate computed over
+        // zero outer rows. Evaluate against an all-NULL stand-in row so
+        // outer column references resolve to NULL while the inner aggregate
+        // iterates the (empty) outer_rows.
+        let mut overridden = evaluator.clone_for_new_expression();
+        overridden.set_outer_rows(group_rows);
+        let null_row = vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Null;
+            evaluator.get_schema().total_columns
+        ]);
+        overridden.eval(expr, &null_row)
     } else {
         Ok(vibesql_types::SqlValue::Null)
     }
@@ -144,9 +158,45 @@ fn bare_subquery_inner_has_outer_aggregate(expr: &vibesql_ast::Expression) -> bo
                 })
                 || else_result.as_ref().is_some_and(|e| bare_subquery_inner_has_outer_aggregate(e))
         }
-        // Don't descend into nested subqueries / window functions (own scope).
+        // Window function: the outer aggregate can hide inside the window's
+        // args or its OVER (PARTITION BY / ORDER BY / frame), e.g.
+        // `(SELECT count(a) OVER (ORDER BY sum(a)))` (window1.test 61.4.2).
+        // Only *plain* aggregates found by the recursion count — the window
+        // function itself (e.g. `total(a) OVER()`) does not. (#5232)
+        Expression::WindowFunction { function, over, .. } => {
+            let args = match function {
+                vibesql_ast::WindowFunctionSpec::Aggregate { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args,
+            };
+            args.iter().any(bare_subquery_inner_has_outer_aggregate)
+                || over.partition_by.as_ref().is_some_and(|exprs| {
+                    exprs.iter().any(bare_subquery_inner_has_outer_aggregate)
+                })
+                || over.order_by.as_ref().is_some_and(|items| {
+                    items.iter().any(|i| bare_subquery_inner_has_outer_aggregate(&i.expr))
+                })
+        }
+        // Don't descend into nested subqueries (own scope).
         _ => false,
     }
+}
+
+/// Check whether an IN-subquery triggers SQLite's
+/// implicit-outer-aggregate-collapse semantics (#5232, window1.test 44.x):
+/// a bare (FROM-less) subquery whose SELECT list contains an aggregate
+/// referencing an outer column, e.g.
+/// `(0, 0) IN (SELECT MIN(c0), NTILE(1) OVER())`.
+fn in_subquery_needs_outer_rows(subquery: &vibesql_ast::SelectStmt) -> bool {
+    if subquery.from.is_some() {
+        return false;
+    }
+    subquery.select_list.iter().any(|item| match item {
+        vibesql_ast::SelectItem::Expression { expr: inner, .. } => {
+            bare_subquery_inner_has_outer_aggregate(inner)
+        }
+        _ => false,
+    })
 }
 
 /// Recursively check whether `expr` contains any column reference. Used inside
@@ -232,6 +282,40 @@ pub(super) fn evaluate_in(
         }
         _ => unreachable!("evaluate_in called with non-IN expression"),
     };
+
+    // Issue #5232 (window1.test 44.x): when the IN-subquery is a bare
+    // (FROM-less) subquery whose body has an aggregate referencing an outer
+    // column, SQLite's implicit-outer-aggregate-collapse applies: the inner
+    // aggregate is computed over the current group's rows. Delegate the
+    // whole IN expression to the combined evaluator (which supports
+    // row-value LHS and propagates outer context to the subquery) with
+    // `outer_rows` overridden to the group rows — mirroring the scalar
+    // subquery path above.
+    if in_subquery_needs_outer_rows(subquery) {
+        let mut overridden = evaluator.clone_for_new_expression();
+        overridden.set_outer_rows(group_rows);
+
+        let representative_row = if let Some(idx) = executor.get_aggregate_representative_row() {
+            group_rows.get(idx)
+        } else {
+            group_rows.first()
+        };
+
+        return match representative_row {
+            Some(row) => overridden.eval(expr, row),
+            None => {
+                // Empty group: the collapsed aggregation still produces one
+                // row; evaluate against an all-NULL stand-in row so outer
+                // column references resolve to NULL while inner aggregates
+                // iterate the (empty) outer_rows.
+                let null_row = vibesql_storage::Row::new(vec![
+                    vibesql_types::SqlValue::Null;
+                    evaluator.get_schema().total_columns
+                ]);
+                overridden.eval(expr, &null_row)
+            }
+        };
+    }
 
     // Evaluate left-hand expression (which may be an aggregate)
     let left_val =

--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -382,6 +382,28 @@ impl SelectExecutor<'_> {
         let expanded_select_list =
             self.expand_wildcards_for_aggregation(&stmt.select_list, &schema)?;
 
+        // Get GROUP BY base expressions (appended as hidden columns after the
+        // SELECT items; also used later for ORDER BY resolution).
+        let group_by_exprs: Vec<vibesql_ast::Expression> = if let Some(group_by) = &stmt.group_by {
+            get_base_expressions(group_by)
+        } else {
+            Vec::new()
+        };
+
+        // Plan decomposition of SELECT items that embed window functions inside
+        // larger expressions (e.g. `lead(2) OVER() + sum(c)`). Each embedded
+        // window and each maximal window-free subexpression becomes a hidden
+        // component column; the post-aggregation window pass computes the
+        // window values and re-evaluates the residual expression. See #5232.
+        let embedded_window_hidden_base = expanded_select_list.len()
+            + group_by_exprs.len()
+            + order_by_aggregates.len()
+            + window_aggregates.len();
+        let embedded_window_plan = window::plan_embedded_window_rewrites(
+            &expanded_select_list,
+            embedded_window_hidden_base,
+        );
+
         // Detect and set up pivot aggregate optimization (#3136)
         // This detects patterns like: SUM(CASE WHEN col='A' THEN val END), SUM(CASE WHEN col='B'
         // THEN val END)... and batches them into a single pass over the data
@@ -572,6 +594,21 @@ impl SelectExecutor<'_> {
                             row_values.push(agg_value);
                         }
 
+                        // Compute embedded-window components and append them to
+                        // row values. Window components evaluate to their
+                        // placeholder (overwritten by the window pass); window-free
+                        // components evaluate to their per-group value. See #5232.
+                        for component in &embedded_window_plan.components {
+                            let value = self.evaluate_with_aggregates_and_grouping(
+                                &component.expr,
+                                &group_rows,
+                                &group_key,
+                                &evaluator,
+                                &grouping_context,
+                            )?;
+                            row_values.push(value);
+                        }
+
                         let row = vibesql_storage::Row::new(row_values);
 
                         // Track memory for aggregation result row
@@ -670,10 +707,23 @@ impl SelectExecutor<'_> {
                 };
 
                 if include_group {
-                    // No GROUP BY columns and no ORDER BY aggregates in this path,
-                    // but we still need to append window-function aggregates so the
-                    // window evaluator can reference them. See issue #5106.
+                    // No GROUP BY columns in this path, but we still need to append
+                    // ORDER BY aggregates and window-function aggregates so the row
+                    // layout matches the schema the window pass builds (SELECT items,
+                    // GROUP BY columns, ORDER BY aggregates, window aggregates,
+                    // embedded window components). See issues #5106 and #5232.
                     let mut row_values = aggregate_results;
+
+                    for order_agg_expr in &order_by_aggregates {
+                        let agg_value = self.evaluate_with_aggregates_and_grouping(
+                            order_agg_expr,
+                            &group_rows,
+                            &group_key,
+                            &evaluator,
+                            &grouping_context,
+                        )?;
+                        row_values.push(agg_value);
+                    }
 
                     for win_agg_expr in &window_aggregates {
                         let agg_value = self.evaluate_with_aggregates_and_grouping(
@@ -684,6 +734,19 @@ impl SelectExecutor<'_> {
                             &grouping_context,
                         )?;
                         row_values.push(agg_value);
+                    }
+
+                    // Embedded-window components: placeholders for window nodes,
+                    // per-group values for window-free subexpressions. See #5232.
+                    for component in &embedded_window_plan.components {
+                        let value = self.evaluate_with_aggregates_and_grouping(
+                            &component.expr,
+                            &group_rows,
+                            &group_key,
+                            &evaluator,
+                            &grouping_context,
+                        )?;
+                        row_values.push(value);
                     }
 
                     let row = vibesql_storage::Row::new(row_values);
@@ -698,19 +761,16 @@ impl SelectExecutor<'_> {
             }
         }
 
-        // Get GROUP BY expressions for ORDER BY resolution
-        let group_by_exprs: Vec<vibesql_ast::Expression> = if let Some(group_by) = &stmt.group_by {
-            get_base_expressions(group_by)
-        } else {
-            Vec::new()
-        };
-
         // Apply window functions that wrap aggregates (e.g., AVG(SUM(x)) OVER (...))
         // This must happen after GROUP BY but before ORDER BY
         // Pass GROUP BY expressions so window ORDER BY/PARTITION BY can reference them.
         // Pass window_aggregates and order_by_aggregates count so window evaluator can
         // map references to the pre-computed hidden columns. See issue #5106.
-        let result_rows = if window::has_aggregate_window_functions(&expanded_select_list) {
+        // Embedded window functions inside larger SELECT expressions are handled
+        // via the decomposition plan. See #5232.
+        let result_rows = if window::has_aggregate_window_functions(&expanded_select_list)
+            || !embedded_window_plan.is_empty()
+        {
             window::apply_window_functions_to_aggregates(
                 result_rows,
                 &expanded_select_list,
@@ -719,14 +779,18 @@ impl SelectExecutor<'_> {
                 &group_by_exprs,
                 order_by_aggregates.len(),
                 &window_aggregates,
+                &embedded_window_plan,
             )?
         } else {
             result_rows
         };
 
-        // Calculate count of hidden columns (GROUP BY + ORDER BY aggregates + window aggregates)
-        let hidden_col_count =
-            group_by_exprs.len() + order_by_aggregates.len() + window_aggregates.len();
+        // Calculate count of hidden columns (GROUP BY + ORDER BY aggregates +
+        // window aggregates + embedded window components)
+        let hidden_col_count = group_by_exprs.len()
+            + order_by_aggregates.len()
+            + window_aggregates.len()
+            + embedded_window_plan.components.len();
 
         // Apply ORDER BY if present
         // Note: For scalar aggregates (no GROUP BY), ORDER BY is skipped because:

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -72,6 +72,300 @@ fn is_window_function(expr: &Expression) -> bool {
     matches!(expr, Expression::WindowFunction { .. })
 }
 
+// ------------------------------------------------------------------------
+// Embedded window functions in aggregate SELECT items (#5232)
+// ------------------------------------------------------------------------
+//
+// A window function can appear *inside* a larger expression in an aggregate
+// SELECT, e.g. `SELECT lead(2) OVER() + sum(c) FROM a`. During the GROUP BY
+// pass, `evaluate_with_aggregates` evaluates the WindowFunction node to a
+// placeholder (its first argument), expecting the post-aggregation window
+// pass to fix it up — but that pass historically handled only *top-level*
+// window SELECT items. The machinery below decomposes such expressions:
+//
+// 1. Each maximal window-free subexpression becomes a hidden "component"
+//    column, evaluated per group during aggregation (e.g. `sum(c)` → 4).
+// 2. Each embedded WindowFunction node becomes a hidden component column
+//    holding its placeholder, which the window pass later overwrites with
+//    the real window value (same contract as top-level windows).
+// 3. The original expression is rewritten into a "residual" expression that
+//    references the hidden columns; it is re-evaluated per row after the
+//    window pass and stored into the SELECT slot.
+
+/// One hidden component column backing an embedded-window rewrite.
+pub(in crate::select::executor) struct EmbeddedWindowComponent {
+    /// The original subexpression. Evaluated per group via
+    /// `evaluate_with_aggregates` (for window components this naturally
+    /// yields the placeholder value — the window's first argument).
+    pub expr: Expression,
+    /// True when this component is a WindowFunction node whose hidden column
+    /// must be overwritten by the post-aggregation window pass.
+    pub is_window: bool,
+}
+
+/// A SELECT item whose expression embeds window functions.
+pub(in crate::select::executor) struct EmbeddedWindowRewrite {
+    /// Index of the SELECT item to overwrite with the residual's value.
+    pub select_index: usize,
+    /// The original expression with components replaced by hidden-column
+    /// references into the synthetic post-aggregation result schema.
+    pub residual: Expression,
+}
+
+/// Decomposition plan for all embedded-window SELECT items.
+#[derive(Default)]
+pub(in crate::select::executor) struct EmbeddedWindowPlan {
+    pub rewrites: Vec<EmbeddedWindowRewrite>,
+    pub components: Vec<EmbeddedWindowComponent>,
+}
+
+impl EmbeddedWindowPlan {
+    pub fn is_empty(&self) -> bool {
+        self.rewrites.is_empty()
+    }
+}
+
+/// Check whether an expression contains a window function anywhere within it,
+/// WITHOUT descending into subqueries (which have their own scope).
+pub(in crate::select::executor) fn expression_contains_window_function(
+    expr: &Expression,
+) -> bool {
+    match expr {
+        Expression::WindowFunction { .. } => true,
+        Expression::BinaryOp { left, right, .. } => {
+            expression_contains_window_function(left)
+                || expression_contains_window_function(right)
+        }
+        Expression::UnaryOp { expr, .. }
+        | Expression::Cast { expr, .. }
+        | Expression::IsNull { expr, .. }
+        | Expression::IsTruthValue { expr, .. }
+        | Expression::Collate { expr, .. } => expression_contains_window_function(expr),
+        Expression::IsDistinctFrom { left, right, .. } => {
+            expression_contains_window_function(left)
+                || expression_contains_window_function(right)
+        }
+        Expression::Function { args, .. } => {
+            args.iter().any(expression_contains_window_function)
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            operand.as_ref().is_some_and(|e| expression_contains_window_function(e))
+                || when_clauses.iter().any(|w| {
+                    w.conditions.iter().any(expression_contains_window_function)
+                        || expression_contains_window_function(&w.result)
+                })
+                || else_result
+                    .as_ref()
+                    .is_some_and(|e| expression_contains_window_function(e))
+        }
+        Expression::Between { expr, low, high, .. } => {
+            expression_contains_window_function(expr)
+                || expression_contains_window_function(low)
+                || expression_contains_window_function(high)
+        }
+        Expression::InList { expr, values, .. } => {
+            expression_contains_window_function(expr)
+                || values.iter().any(expression_contains_window_function)
+        }
+        Expression::Like { expr, pattern, .. } | Expression::Glob { expr, pattern, .. } => {
+            expression_contains_window_function(expr)
+                || expression_contains_window_function(pattern)
+        }
+        Expression::Conjunction(exprs)
+        | Expression::Disjunction(exprs)
+        | Expression::RowValueConstructor(exprs) => {
+            exprs.iter().any(expression_contains_window_function)
+        }
+        // IN / quantified comparison: only the LHS shares this scope.
+        Expression::In { expr, .. } | Expression::QuantifiedComparison { expr, .. } => {
+            expression_contains_window_function(expr)
+        }
+        // Aggregate args cannot legally contain window functions (SQLite
+        // rejects them at parse/resolve time) — don't descend.
+        // Subqueries (ScalarSubquery / Exists) have their own scope.
+        _ => false,
+    }
+}
+
+/// Build the decomposition plan for SELECT items that embed window functions
+/// inside larger expressions. `hidden_base` is the absolute column index in
+/// the post-aggregation row layout where the embedded component columns
+/// start (after SELECT items, GROUP BY columns, ORDER BY aggregates, and
+/// window aggregates).
+pub(in crate::select::executor) fn plan_embedded_window_rewrites(
+    select_list: &[SelectItem],
+    hidden_base: usize,
+) -> EmbeddedWindowPlan {
+    let mut plan = EmbeddedWindowPlan::default();
+
+    for (idx, item) in select_list.iter().enumerate() {
+        if let SelectItem::Expression { expr, .. } = item {
+            // Top-level window functions are handled by the existing
+            // select-slot placeholder machinery.
+            if is_window_function(expr) {
+                continue;
+            }
+            if !expression_contains_window_function(expr) {
+                continue;
+            }
+            let residual = rewrite_embedded_expression(expr, hidden_base, &mut plan.components);
+            plan.rewrites.push(EmbeddedWindowRewrite { select_index: idx, residual });
+        }
+    }
+
+    plan
+}
+
+/// Create a column reference into the synthetic post-aggregation result schema.
+fn embedded_col_ref(idx: usize) -> Expression {
+    Expression::ColumnRef(vibesql_ast::ColumnIdentifier::qualified(
+        "result",
+        false,
+        &format!("col{}", idx),
+        false,
+    ))
+}
+
+/// Rewrite an expression containing embedded window functions: WindowFunction
+/// nodes and maximal window-free subexpressions are replaced with hidden
+/// column references, registering each as a component to be computed per
+/// group during aggregation.
+fn rewrite_embedded_expression(
+    expr: &Expression,
+    hidden_base: usize,
+    components: &mut Vec<EmbeddedWindowComponent>,
+) -> Expression {
+    // Window function: becomes a hidden placeholder column that the window
+    // pass overwrites with the computed window value.
+    if is_window_function(expr) {
+        let idx = hidden_base + components.len();
+        components.push(EmbeddedWindowComponent { expr: expr.clone(), is_window: true });
+        return embedded_col_ref(idx);
+    }
+
+    // Maximal window-free subexpression: computed per group during
+    // aggregation (may contain aggregates, subqueries, literals, ...).
+    if !expression_contains_window_function(expr) {
+        let idx = hidden_base + components.len();
+        components.push(EmbeddedWindowComponent { expr: expr.clone(), is_window: false });
+        return embedded_col_ref(idx);
+    }
+
+    // Otherwise recurse structurally (the expression contains a window
+    // function somewhere below).
+    match expr {
+        Expression::BinaryOp { left, op, right } => Expression::BinaryOp {
+            left: Box::new(rewrite_embedded_expression(left, hidden_base, components)),
+            op: op.clone(),
+            right: Box::new(rewrite_embedded_expression(right, hidden_base, components)),
+        },
+        Expression::UnaryOp { op, expr } => Expression::UnaryOp {
+            op: op.clone(),
+            expr: Box::new(rewrite_embedded_expression(expr, hidden_base, components)),
+        },
+        Expression::Cast { expr, data_type } => Expression::Cast {
+            expr: Box::new(rewrite_embedded_expression(expr, hidden_base, components)),
+            data_type: data_type.clone(),
+        },
+        Expression::Collate { expr, collation } => Expression::Collate {
+            expr: Box::new(rewrite_embedded_expression(expr, hidden_base, components)),
+            collation: collation.clone(),
+        },
+        Expression::IsNull { expr, negated } => Expression::IsNull {
+            expr: Box::new(rewrite_embedded_expression(expr, hidden_base, components)),
+            negated: *negated,
+        },
+        Expression::IsDistinctFrom { left, right, negated } => Expression::IsDistinctFrom {
+            left: Box::new(rewrite_embedded_expression(left, hidden_base, components)),
+            right: Box::new(rewrite_embedded_expression(right, hidden_base, components)),
+            negated: *negated,
+        },
+        Expression::IsTruthValue { expr, truth_value, negated } => Expression::IsTruthValue {
+            expr: Box::new(rewrite_embedded_expression(expr, hidden_base, components)),
+            truth_value: truth_value.clone(),
+            negated: *negated,
+        },
+        Expression::Function { name, args, character_unit } => Expression::Function {
+            name: name.clone(),
+            args: args
+                .iter()
+                .map(|a| rewrite_embedded_expression(a, hidden_base, components))
+                .collect(),
+            character_unit: character_unit.clone(),
+        },
+        Expression::Case { operand, when_clauses, else_result } => Expression::Case {
+            operand: operand
+                .as_ref()
+                .map(|e| Box::new(rewrite_embedded_expression(e, hidden_base, components))),
+            when_clauses: when_clauses
+                .iter()
+                .map(|w| vibesql_ast::CaseWhen {
+                    conditions: w
+                        .conditions
+                        .iter()
+                        .map(|c| rewrite_embedded_expression(c, hidden_base, components))
+                        .collect(),
+                    result: rewrite_embedded_expression(&w.result, hidden_base, components),
+                })
+                .collect(),
+            else_result: else_result
+                .as_ref()
+                .map(|e| Box::new(rewrite_embedded_expression(e, hidden_base, components))),
+        },
+        Expression::Between { expr, low, high, negated, symmetric } => Expression::Between {
+            expr: Box::new(rewrite_embedded_expression(expr, hidden_base, components)),
+            low: Box::new(rewrite_embedded_expression(low, hidden_base, components)),
+            high: Box::new(rewrite_embedded_expression(high, hidden_base, components)),
+            negated: *negated,
+            symmetric: *symmetric,
+        },
+        Expression::InList { expr, values, negated } => Expression::InList {
+            expr: Box::new(rewrite_embedded_expression(expr, hidden_base, components)),
+            values: values
+                .iter()
+                .map(|v| rewrite_embedded_expression(v, hidden_base, components))
+                .collect(),
+            negated: *negated,
+        },
+        Expression::Like { expr, pattern, negated, escape } => Expression::Like {
+            expr: Box::new(rewrite_embedded_expression(expr, hidden_base, components)),
+            pattern: Box::new(rewrite_embedded_expression(pattern, hidden_base, components)),
+            negated: *negated,
+            escape: escape.clone(),
+        },
+        Expression::Conjunction(exprs) => Expression::Conjunction(
+            exprs
+                .iter()
+                .map(|e| rewrite_embedded_expression(e, hidden_base, components))
+                .collect(),
+        ),
+        Expression::Disjunction(exprs) => Expression::Disjunction(
+            exprs
+                .iter()
+                .map(|e| rewrite_embedded_expression(e, hidden_base, components))
+                .collect(),
+        ),
+        Expression::RowValueConstructor(exprs) => Expression::RowValueConstructor(
+            exprs
+                .iter()
+                .map(|e| rewrite_embedded_expression(e, hidden_base, components))
+                .collect(),
+        ),
+        Expression::In { expr, subquery, negated } => Expression::In {
+            expr: Box::new(rewrite_embedded_expression(expr, hidden_base, components)),
+            subquery: subquery.clone(),
+            negated: *negated,
+        },
+        // Fallback: treat as an opaque window-free component (preserves the
+        // pre-#5232 placeholder behavior for exotic shapes).
+        other => {
+            let idx = hidden_base + components.len();
+            components.push(EmbeddedWindowComponent { expr: other.clone(), is_window: false });
+            embedded_col_ref(idx)
+        }
+    }
+}
+
 /// Build a map of window names to their resolved definitions
 /// This handles window inheritance (e.g., WINDOW win AS (...), win2 AS (win ORDER BY x))
 fn build_window_map(
@@ -142,10 +436,46 @@ fn resolve_window_spec(
     }
 }
 
-/// Collect all window functions from the SELECT list, resolving named window references
+/// Build a `PostAggregateWindowFunction` for a WindowFunction expression
+/// whose placeholder value lives at `target_index` in the result rows.
+fn make_post_aggregate_window_fn(
+    function: &WindowFunctionSpec,
+    over: &WindowSpec,
+    target_index: usize,
+    window_map: &HashMap<String, WindowSpec>,
+) -> Result<PostAggregateWindowFunction, ExecutorError> {
+    let (func_name, func_type, args) = match function {
+        WindowFunctionSpec::Aggregate { name, args, .. } => {
+            (name.to_string(), WindowFunctionType::Aggregate, args.clone())
+        }
+        WindowFunctionSpec::Ranking { name, args } => {
+            (name.to_string(), WindowFunctionType::Ranking, args.clone())
+        }
+        WindowFunctionSpec::Value { name, args } => {
+            (name.to_string(), WindowFunctionType::Value, args.clone())
+        }
+    };
+
+    // Resolve named window references
+    let resolved_spec = resolve_window_spec(over, window_map)?;
+
+    Ok(PostAggregateWindowFunction {
+        select_index: target_index,
+        func_name,
+        func_type,
+        args,
+        window_spec: resolved_spec,
+    })
+}
+
+/// Collect all window functions from the SELECT list, resolving named window
+/// references. Includes embedded window functions from the decomposition plan
+/// (#5232), whose placeholder/result slot is their hidden component column.
 fn collect_window_functions(
     select_list: &[SelectItem],
     window_definitions: Option<&Vec<WindowDefinition>>,
+    embedded_plan: &EmbeddedWindowPlan,
+    embedded_hidden_base: usize,
 ) -> Result<Vec<PostAggregateWindowFunction>, ExecutorError> {
     let window_map = build_window_map(window_definitions)?;
     let mut result = Vec::new();
@@ -155,28 +485,23 @@ fn collect_window_functions(
             expr: Expression::WindowFunction { function, over }, ..
         } = item
         {
-            let (func_name, func_type, args) = match function {
-                WindowFunctionSpec::Aggregate { name, args, .. } => {
-                    (name.to_string(), WindowFunctionType::Aggregate, args.clone())
-                }
-                WindowFunctionSpec::Ranking { name, args } => {
-                    (name.to_string(), WindowFunctionType::Ranking, args.clone())
-                }
-                WindowFunctionSpec::Value { name, args } => {
-                    (name.to_string(), WindowFunctionType::Value, args.clone())
-                }
-            };
+            result.push(make_post_aggregate_window_fn(function, over, idx, &window_map)?);
+        }
+    }
 
-            // Resolve named window references
-            let resolved_spec = resolve_window_spec(over, &window_map)?;
-
-            result.push(PostAggregateWindowFunction {
-                select_index: idx,
-                func_name,
-                func_type,
-                args,
-                window_spec: resolved_spec,
-            });
+    // Embedded window functions (#5232): their placeholder lives in a hidden
+    // component column, which the window pass overwrites in place.
+    for (i, comp) in embedded_plan.components.iter().enumerate() {
+        if !comp.is_window {
+            continue;
+        }
+        if let Expression::WindowFunction { function, over } = &comp.expr {
+            result.push(make_post_aggregate_window_fn(
+                function,
+                over,
+                embedded_hidden_base + i,
+                &window_map,
+            )?);
         }
     }
 
@@ -204,21 +529,32 @@ pub(super) fn apply_window_functions_to_aggregates(
     group_by_exprs: &[Expression],
     order_by_aggregates_count: usize,
     window_aggregates: &[Expression],
+    embedded_plan: &EmbeddedWindowPlan,
 ) -> Result<Vec<Row>, ExecutorError> {
-    let window_funcs = collect_window_functions(select_list, window_definitions)?;
+    let embedded_hidden_base = select_list.len()
+        + group_by_exprs.len()
+        + order_by_aggregates_count
+        + window_aggregates.len();
+    let window_funcs = collect_window_functions(
+        select_list,
+        window_definitions,
+        embedded_plan,
+        embedded_hidden_base,
+    )?;
 
-    if window_funcs.is_empty() {
+    if window_funcs.is_empty() && embedded_plan.is_empty() {
         return Ok(rows);
     }
 
     // Build a schema for the aggregate result rows
-    // Each column corresponds to a SELECT list item, plus hidden GROUP BY columns
-    // and window-aggregate columns.
+    // Each column corresponds to a SELECT list item, plus hidden GROUP BY columns,
+    // window-aggregate columns, and embedded-window component columns (#5232).
     let result_schema = build_aggregate_result_schema(
         select_list,
         group_by_exprs,
         order_by_aggregates_count,
         window_aggregates,
+        embedded_plan.components.len(),
     );
     let evaluator = CombinedExpressionEvaluator::with_database(&result_schema, database);
 
@@ -456,8 +792,12 @@ pub(super) fn apply_window_functions_to_aggregates(
                                 } else {
                                     1
                                 };
+                                // SqliteCompatError keeps the bare SQLite message
+                                // (e.g. "argument of ntile must be a positive
+                                // integer") — mirrors the non-aggregate path in
+                                // select/window/evaluation.rs. (window1.test 44.2.2)
                                 evaluate_ntile(partition, n_val)
-                                    .map_err(ExecutorError::UnsupportedExpression)?
+                                    .map_err(ExecutorError::SqliteCompatError)?
                             }
                         }
                         other => {
@@ -641,6 +981,19 @@ pub(super) fn apply_window_functions_to_aggregates(
         }
     }
 
+    // Re-evaluate residual expressions for SELECT items with embedded window
+    // functions (#5232). At this point the hidden component columns hold the
+    // computed window values (for window components) and the per-group values
+    // (for window-free components), so the residual evaluates to the final
+    // SELECT value.
+    for rewrite in &embedded_plan.rewrites {
+        for row in rows.iter_mut() {
+            evaluator.clear_cse_cache();
+            let value = evaluator.eval(&rewrite.residual, row)?;
+            row.values[rewrite.select_index] = value;
+        }
+    }
+
     Ok(rows)
 }
 
@@ -655,6 +1008,7 @@ fn build_aggregate_result_schema(
     group_by_exprs: &[Expression],
     order_by_aggregates_count: usize,
     window_aggregates: &[Expression],
+    embedded_component_count: usize,
 ) -> CombinedSchema {
     let mut columns = Vec::new();
 
@@ -695,6 +1049,19 @@ fn build_aggregate_result_schema(
     let window_offset = order_by_offset + order_by_aggregates_count;
     for i in 0..window_aggregates.len() {
         let column_name = format!("col{}", window_offset + i);
+        columns.push(ColumnSchema::new(
+            column_name,
+            DataType::Varchar { max_length: Some(255) },
+            true,
+        ));
+    }
+
+    // Hidden embedded-window component columns (#5232): placeholders for
+    // embedded window functions and per-group values for window-free
+    // subexpressions of SELECT items that mix windows with aggregates.
+    let embedded_offset = window_offset + window_aggregates.len();
+    for i in 0..embedded_component_count {
+        let column_name = format!("col{}", embedded_offset + i);
         columns.push(ColumnSchema::new(
             column_name,
             DataType::Varchar { max_length: Some(255) },

--- a/crates/vibesql-executor/src/select/order/resolution.rs
+++ b/crates/vibesql-executor/src/select/order/resolution.rs
@@ -1370,24 +1370,43 @@ pub(crate) fn extract_order_by_aggregates(
 pub(crate) fn extract_window_aggregates(
     select_list: &[vibesql_ast::SelectItem],
 ) -> Vec<vibesql_ast::Expression> {
-    use vibesql_ast::{Expression, SelectItem};
+    use vibesql_ast::SelectItem;
 
     let mut aggregates = Vec::new();
 
     for item in select_list {
-        if let SelectItem::Expression { expr: Expression::WindowFunction { over, .. }, .. } =
-            item
-        {
+        if let SelectItem::Expression { expr, .. } = item {
+            // Window functions can be top-level SELECT items or embedded inside
+            // larger expressions (e.g. `count(a) OVER (ORDER BY sum(a)) + total(a)
+            // OVER()`, #5232) — walk the expression to find all of them.
+            collect_window_over_aggregates_from_expr(expr, &mut aggregates);
+        }
+    }
+
+    aggregates
+}
+
+/// Walk an expression tree (without descending into subqueries) and, for every
+/// window function found, collect the aggregate expressions appearing in its
+/// OVER clause (PARTITION BY, ORDER BY, frame offsets).
+fn collect_window_over_aggregates_from_expr(
+    expr: &vibesql_ast::Expression,
+    aggregates: &mut Vec<vibesql_ast::Expression>,
+) {
+    use vibesql_ast::Expression;
+
+    match expr {
+        Expression::WindowFunction { over, .. } => {
             // PARTITION BY expressions
             if let Some(partition_by) = &over.partition_by {
                 for p_expr in partition_by {
-                    collect_aggregates_from_expr(p_expr, &mut aggregates);
+                    collect_aggregates_from_expr(p_expr, aggregates);
                 }
             }
             // ORDER BY expressions
             if let Some(order_by) = &over.order_by {
                 for ob_item in order_by {
-                    collect_aggregates_from_expr(&ob_item.expr, &mut aggregates);
+                    collect_aggregates_from_expr(&ob_item.expr, aggregates);
                 }
             }
             // Frame offset expressions (e.g., `ROWS BETWEEN sum(x) PRECEDING ...`)
@@ -1395,20 +1414,81 @@ pub(crate) fn extract_window_aggregates(
                 if let vibesql_ast::FrameBound::Preceding(e)
                 | vibesql_ast::FrameBound::Following(e) = &frame.start
                 {
-                    collect_aggregates_from_expr(e, &mut aggregates);
+                    collect_aggregates_from_expr(e, aggregates);
                 }
                 if let Some(end) = &frame.end {
                     if let vibesql_ast::FrameBound::Preceding(e)
                     | vibesql_ast::FrameBound::Following(e) = end
                     {
-                        collect_aggregates_from_expr(e, &mut aggregates);
+                        collect_aggregates_from_expr(e, aggregates);
                     }
                 }
             }
         }
+        // Recurse into compound expressions to find embedded window functions.
+        Expression::BinaryOp { left, right, .. } => {
+            collect_window_over_aggregates_from_expr(left, aggregates);
+            collect_window_over_aggregates_from_expr(right, aggregates);
+        }
+        Expression::UnaryOp { expr: inner, .. }
+        | Expression::Cast { expr: inner, .. }
+        | Expression::IsNull { expr: inner, .. }
+        | Expression::IsTruthValue { expr: inner, .. }
+        | Expression::Collate { expr: inner, .. } => {
+            collect_window_over_aggregates_from_expr(inner, aggregates);
+        }
+        Expression::IsDistinctFrom { left, right, .. } => {
+            collect_window_over_aggregates_from_expr(left, aggregates);
+            collect_window_over_aggregates_from_expr(right, aggregates);
+        }
+        Expression::Function { args, .. } => {
+            for arg in args {
+                collect_window_over_aggregates_from_expr(arg, aggregates);
+            }
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                collect_window_over_aggregates_from_expr(op, aggregates);
+            }
+            for when_clause in when_clauses {
+                for cond in &when_clause.conditions {
+                    collect_window_over_aggregates_from_expr(cond, aggregates);
+                }
+                collect_window_over_aggregates_from_expr(&when_clause.result, aggregates);
+            }
+            if let Some(else_expr) = else_result {
+                collect_window_over_aggregates_from_expr(else_expr, aggregates);
+            }
+        }
+        Expression::Between { expr, low, high, .. } => {
+            collect_window_over_aggregates_from_expr(expr, aggregates);
+            collect_window_over_aggregates_from_expr(low, aggregates);
+            collect_window_over_aggregates_from_expr(high, aggregates);
+        }
+        Expression::InList { expr, values, .. } => {
+            collect_window_over_aggregates_from_expr(expr, aggregates);
+            for item in values {
+                collect_window_over_aggregates_from_expr(item, aggregates);
+            }
+        }
+        Expression::Like { expr, pattern, .. } | Expression::Glob { expr, pattern, .. } => {
+            collect_window_over_aggregates_from_expr(expr, aggregates);
+            collect_window_over_aggregates_from_expr(pattern, aggregates);
+        }
+        Expression::Conjunction(exprs)
+        | Expression::Disjunction(exprs)
+        | Expression::RowValueConstructor(exprs) => {
+            for e in exprs {
+                collect_window_over_aggregates_from_expr(e, aggregates);
+            }
+        }
+        // IN / quantified comparison: only the LHS shares this scope.
+        Expression::In { expr, .. } | Expression::QuantifiedComparison { expr, .. } => {
+            collect_window_over_aggregates_from_expr(expr, aggregates);
+        }
+        // Subqueries have their own scope; other leaves can't contain windows.
+        _ => {}
     }
-
-    aggregates
 }
 
 /// Recursively collect aggregate function expressions from an expression tree.


### PR DESCRIPTION
## Summary

Fixes the three root causes behind the remaining window1.test failures around mixed aggregate + window SELECTs (curator analysis in #5232): embedded windows in aggregate SELECT items were left as placeholders, implicit-outer-aggregate-collapse was not detected through IN subqueries, and the collapse walker skipped window-function internals.

## Changes

- **Gap 1 — embedded windows in aggregate SELECTs** (`aggregation/window.rs`, `aggregation/mod.rs`): SELECT items that embed window functions inside larger expressions (e.g. `lead(2) OVER() + sum(c)`) are decomposed into hidden component columns — window placeholders plus per-group values of the maximal window-free subexpressions — and a residual expression that is re-evaluated after the post-aggregation window pass and stored into the SELECT slot. The window pass now also processes embedded windows (target slot = hidden column), and the no-GROUP-BY row layout now includes ORDER BY aggregate columns so it matches the schema the window pass builds.
- **Gap 2 — collapse through IN subqueries** (`aggregation/detection.rs`, `aggregation/evaluation/subquery.rs`, `evaluator/combined/subqueries/in_subquery.rs`): `Expression::In` detection now inspects the IN-subquery (factored `subquery_stmt_triggers_collapse`); aggregate-context IN evaluation delegates collapse-triggering subqueries to the combined evaluator with `outer_rows` bound to the group rows (row-value LHS support, empty-group handling via an all-NULL stand-in row); the evaluator's IN-subquery executors propagate `outer_rows`. Also fixes row-value IN three-valued logic: a candidate row with a definitively unequal element is FALSE, not UNKNOWN — `(0,0) IN (SELECT NULL, 1)` is now 0, matching SQLite.
- **Gap 3 — collapse triggers inside OVER clauses** (`aggregation/detection.rs`, `aggregation/evaluation/subquery.rs`, `select/order/resolution.rs`): the bare-subquery collapse walkers and `expression_has_aggregate` now descend into window-function args and OVER (PARTITION BY / ORDER BY / frame) expressions looking for plain aggregates; `extract_window_aggregates` finds OVER-clause aggregates of embedded windows too. Window-aggregate specs like `total(a) OVER()` still do NOT trigger collapse (61.3.1 guard).
- ntile errors in the post-aggregation window pass now use `SqliteCompatError` so the bare SQLite message surfaces (44.2.2).
- New unit tests in `detection.rs`: collapse through IN subquery, collapse via aggregate inside OVER ORDER BY, and the `total(a) OVER()` no-collapse guard.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 44.2.2, 44.3.2, 44.4.2, 53.0, 61.4.2 pass | PASS | `./scripts/tcltest test window1.test` → 269/271, all five pass |
| 61.1 / 71.0 best-effort | Deferred | Re-checked after Gap 1: 61.1 still `0.0 0.0 0.0` (root cause in nested CAST/sum chain), 71.0 still succeeds; follow-up filed as #5264 |
| No window1.test regressions | PASS | 264 → 269 passing, 0 new failures |
| `SELECT (SELECT total(a) OVER()) FROM t1` still 0 rows | PASS | Verified manually + new unit test `no_collapse_for_window_aggregate_spec` |

## Test Plan

- Manual reproducers vs sqlite3: `lead(2) OVER() + sum(c)` → NULL, `coalesce(lead(2) OVER(),0) + sum(c)` → 4, 44.x row-value IN (0 / 1 / ntile error), 61.4.2 → 0.0, 53.0 → `4 4 4 4`
- `./scripts/tcltest test window1.test`: 7 failures → 2 (61.1, 71.0 only)
- Regression sweep with stash-based baseline comparison: window2 (0 failures), window3 (0), window8 (5, identical pre-existing), window9 (5, identical pre-existing), aggerror/aggnested/aggorderby/aggfault (identical pre-existing failures)
- `cargo test -p vibesql-executor --release`: all green (2438 lib tests + integration suites)
- `cargo clippy` clean (only pre-existing warnings in unrelated files)
- TPC-H spot check: full 22-query benchmark vs SQLite completes with no errors

Closes #5232

🤖 Generated with [Claude Code](https://claude.com/claude-code)