### PR TITLE
feat(insert): INSERT ... RETURNING clause (SQLite 3.35.0+)

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -629,6 +629,10 @@ impl<'a, 'arena> Converter<'a, 'arena> {
             on_duplicate_key_update: stmt.on_duplicate_key_update.as_ref().map(|assignments| {
                 assignments.iter().map(|a| self.convert_assignment(a)).collect()
             }),
+            returning: stmt
+                .returning
+                .as_ref()
+                .map(|items| items.iter().map(|item| self.convert_select_item(item)).collect()),
         }
     }
 

--- a/crates/vibesql-ast/src/arena/dml.rs
+++ b/crates/vibesql-ast/src/arena/dml.rs
@@ -118,6 +118,10 @@ pub struct InsertStmt<'arena> {
     pub on_conflict: Option<OnConflictClause<'arena>>,
     /// ON DUPLICATE KEY UPDATE clause (MySQL-style upsert)
     pub on_duplicate_key_update: Option<BumpVec<'arena, Assignment<'arena>>>,
+    /// Optional RETURNING clause (SQLite 3.35.0+)
+    /// Syntax: INSERT INTO table ... [ON CONFLICT ...] RETURNING expr [, expr ...]
+    /// Returns the NEW row values (as actually inserted) for each inserted row.
+    pub returning: Option<BumpVec<'arena, SelectItem<'arena>>>,
 }
 
 // ============================================================================

--- a/crates/vibesql-ast/src/dml.rs
+++ b/crates/vibesql-ast/src/dml.rs
@@ -123,6 +123,10 @@ pub struct InsertStmt {
     pub on_conflict: Option<OnConflictClause>,
     /// ON DUPLICATE KEY UPDATE clause (MySQL-style upsert)
     pub on_duplicate_key_update: Option<Vec<Assignment>>,
+    /// Optional RETURNING clause (SQLite 3.35.0+)
+    /// Syntax: INSERT INTO table ... [ON CONFLICT ...] RETURNING expr [, expr ...]
+    /// Returns the NEW row values (as actually inserted) for each inserted row.
+    pub returning: Option<Vec<SelectItem>>,
 }
 
 // ============================================================================

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1053,6 +1053,18 @@ fn walk_insert<V: ExpressionVisitor>(visitor: &mut V, stmt: &InsertStmt) {
             }
         }
     }
+
+    // Walk RETURNING expressions
+    if let Some(items) = &stmt.returning {
+        for item in items {
+            if let SelectItem::Expression { expr, .. } = item {
+                let result = walk_expression(visitor, expr);
+                if result.should_stop() {
+                    return;
+                }
+            }
+        }
+    }
 }
 
 /// Walk an UPDATE statement
@@ -1355,6 +1367,19 @@ pub fn transform_insert<V: ExpressionMutVisitor>(visitor: &mut V, stmt: InsertSt
                 .map(|a| Assignment {
                     column: a.column,
                     value: transform_expression(visitor, a.value),
+                })
+                .collect()
+        }),
+        returning: stmt.returning.map(|items| {
+            items
+                .into_iter()
+                .map(|item| match item {
+                    SelectItem::Expression { expr, alias, source_text } => SelectItem::Expression {
+                        expr: transform_expression(visitor, expr),
+                        alias,
+                        source_text,
+                    },
+                    other => other,
                 })
                 .collect()
         }),

--- a/crates/vibesql-ast/tests/statements.rs
+++ b/crates/vibesql-ast/tests/statements.rs
@@ -46,6 +46,7 @@ fn test_create_insert_statement() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     });
 
     match stmt {

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -218,12 +218,36 @@ impl SqlExecutor {
                 }
             }
             vibesql_ast::Statement::Insert(insert_stmt) => {
-                match vibesql_executor::InsertExecutor::execute(&mut self.db, &insert_stmt) {
-                    Ok(affected_rows) => {
+                match vibesql_executor::InsertExecutor::execute_returning(
+                    &mut self.db,
+                    &insert_stmt,
+                ) {
+                    Ok((affected_rows, returning)) => {
                         // Track changes count for changes() and total_changes() functions
                         self.db.set_last_changes_count(affected_rows);
                         self.db.increment_total_changes_count(affected_rows);
                         result.row_count = affected_rows;
+
+                        // RETURNING clause: render the projected NEW rows like
+                        // a SELECT result (SQLite 3.35.0+ semantics).
+                        if let Some(returning_result) = returning {
+                            result.row_count = returning_result.rows.len();
+                            result.columns = returning_result.columns;
+                            for row in returning_result.rows {
+                                let row_strs: Vec<Option<String>> =
+                                    row.values
+                                        .iter()
+                                        .map(|v| {
+                                            if v.is_null() {
+                                                None
+                                            } else {
+                                                Some(format_sql_value(v))
+                                            }
+                                        })
+                                        .collect();
+                                result.rows.push(row_strs);
+                            }
+                        }
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
@@ -245,17 +269,17 @@ impl SqlExecutor {
                             result.row_count = returning_result.rows.len();
                             result.columns = returning_result.columns;
                             for row in returning_result.rows {
-                                let row_strs: Vec<Option<String>> = row
-                                    .values
-                                    .iter()
-                                    .map(|v| {
-                                        if v.is_null() {
-                                            None
-                                        } else {
-                                            Some(format_sql_value(v))
-                                        }
-                                    })
-                                    .collect();
+                                let row_strs: Vec<Option<String>> =
+                                    row.values
+                                        .iter()
+                                        .map(|v| {
+                                            if v.is_null() {
+                                                None
+                                            } else {
+                                                Some(format_sql_value(v))
+                                            }
+                                        })
+                                        .collect();
                                 result.rows.push(row_strs);
                             }
                         }
@@ -280,17 +304,17 @@ impl SqlExecutor {
                             result.row_count = returning_result.rows.len();
                             result.columns = returning_result.columns;
                             for row in returning_result.rows {
-                                let row_strs: Vec<Option<String>> = row
-                                    .values
-                                    .iter()
-                                    .map(|v| {
-                                        if v.is_null() {
-                                            None
-                                        } else {
-                                            Some(format_sql_value(v))
-                                        }
-                                    })
-                                    .collect();
+                                let row_strs: Vec<Option<String>> =
+                                    row.values
+                                        .iter()
+                                        .map(|v| {
+                                            if v.is_null() {
+                                                None
+                                            } else {
+                                                Some(format_sql_value(v))
+                                            }
+                                        })
+                                        .collect();
                                 result.rows.push(row_strs);
                             }
                         }
@@ -1089,8 +1113,7 @@ impl SqlExecutor {
                     //
                     // See SQLite's DBSTATUS_DEFERRED_FKS:
                     //   https://www.sqlite.org/c3ref/c_dbstatus_options.html
-                    let count =
-                        vibesql_executor::live_deferred_fk_violation_count(&self.db) as i64;
+                    let count = vibesql_executor::live_deferred_fk_violation_count(&self.db) as i64;
                     Ok(QueryResult {
                         columns: vec!["deferred_fk_count".to_string()],
                         rows: vec![vec![Some(count.to_string())]],
@@ -1156,11 +1179,8 @@ impl SqlExecutor {
         let mut rows = Vec::new();
         if let Some(schema) = self.db.catalog.get_table(&table_name) {
             for (fk_id, fk) in schema.foreign_keys.iter().enumerate() {
-                for (seq, (col_name, parent_col_name)) in fk
-                    .column_names
-                    .iter()
-                    .zip(fk.parent_column_names.iter())
-                    .enumerate()
+                for (seq, (col_name, parent_col_name)) in
+                    fk.column_names.iter().zip(fk.parent_column_names.iter()).enumerate()
                 {
                     let on_update = match &fk.on_update {
                         vibesql_catalog::ReferentialAction::NoAction => "NO ACTION",
@@ -1214,8 +1234,8 @@ impl SqlExecutor {
         // "main" and the current schema both refer to the only available schema.
         let current_schema = self.db.catalog.get_current_schema().to_string();
         if let Some(ref schema) = stmt.database {
-            let is_current = schema.eq_ignore_ascii_case(&current_schema)
-                || schema.eq_ignore_ascii_case("main");
+            let is_current =
+                schema.eq_ignore_ascii_case(&current_schema) || schema.eq_ignore_ascii_case("main");
             if !is_current {
                 let table_part = match &stmt.value {
                     Some(vibesql_ast::PragmaValue::Identifier(name)) => Some(name.clone()),
@@ -1254,11 +1274,7 @@ impl SqlExecutor {
         for tbl_name in &tables_to_check {
             let (fk_constraints, rowid_alias_idx, without_rowid) =
                 if let Some(schema) = self.db.catalog.get_table(tbl_name) {
-                    (
-                        schema.foreign_keys.clone(),
-                        schema.rowid_alias_column,
-                        schema.without_rowid,
-                    )
+                    (schema.foreign_keys.clone(), schema.rowid_alias_column, schema.without_rowid)
                 } else {
                     continue;
                 };
@@ -1269,11 +1285,7 @@ impl SqlExecutor {
 
             // Get all rows from the child table
             // Note: tables are stored with qualified names (schema.table)
-            let qualified_name = format!(
-                "{}.{}",
-                self.db.catalog.get_current_schema(),
-                tbl_name
-            );
+            let qualified_name = format!("{}.{}", self.db.catalog.get_current_schema(), tbl_name);
             let child_rows: Vec<_> = if let Some(table) = self.db.tables.get(&qualified_name) {
                 table.scan_live().map(|(id, row)| (id, row.clone())).collect()
             } else if let Some(table) = self.db.tables.get(tbl_name.as_str()) {
@@ -1292,9 +1304,7 @@ impl SqlExecutor {
                     if without_rowid {
                         return (None, row);
                     }
-                    let rowid = match rowid_alias_idx
-                        .and_then(|idx| row.values.get(idx))
-                    {
+                    let rowid = match rowid_alias_idx.and_then(|idx| row.values.get(idx)) {
                         Some(vibesql_types::SqlValue::Integer(v)) => *v,
                         _ => (*phys_idx as i64) + 1,
                     };
@@ -1308,11 +1318,7 @@ impl SqlExecutor {
                 // covering the FK columns, raise the SQLite-compatible error.
                 // Matches `do_catchsql_test 11.1` in fkey5.test.
                 if let Some((child, parent)) =
-                    vibesql_executor::foreign_key_check::detect_fk_mismatch(
-                        &self.db,
-                        tbl_name,
-                        fk,
-                    )
+                    vibesql_executor::foreign_key_check::detect_fk_mismatch(&self.db, tbl_name, fk)
                 {
                     anyhow::bail!(
                         "foreign key mismatch - \"{}\" referencing \"{}\"",
@@ -1326,33 +1332,20 @@ impl SqlExecutor {
                 // Use the shared resolver so post-reload placeholder indices
                 // do not skew which parent columns we read from.
                 let parent_column_collations: Vec<Option<String>> =
-                    vibesql_executor::foreign_key_check::parent_collations_for_fk(
-                        &self.db, fk,
-                    );
+                    vibesql_executor::foreign_key_check::parent_collations_for_fk(&self.db, fk);
                 let resolved_parent_indices =
                     vibesql_executor::foreign_key_check::resolved_parent_indices_for_fk(
                         &self.db, fk,
                     );
 
                 // Get parent table data
-                let parent_qualified = format!(
-                    "{}.{}",
-                    self.db.catalog.get_current_schema(),
-                    &fk.parent_table
-                );
+                let parent_qualified =
+                    format!("{}.{}", self.db.catalog.get_current_schema(), &fk.parent_table);
                 let parent_rows: Vec<_> =
                     if let Some(parent_table) = self.db.tables.get(&parent_qualified) {
-                        parent_table
-                            .scan_live()
-                            .map(|(_, row)| row.clone())
-                            .collect()
-                    } else if let Some(parent_table) =
-                        self.db.tables.get(&fk.parent_table)
-                    {
-                        parent_table
-                            .scan_live()
-                            .map(|(_, row)| row.clone())
-                            .collect()
+                        parent_table.scan_live().map(|(_, row)| row.clone()).collect()
+                    } else if let Some(parent_table) = self.db.tables.get(&fk.parent_table) {
+                        parent_table.scan_live().map(|(_, row)| row.clone()).collect()
                     } else {
                         // Parent table doesn't exist - every row whose FK columns are all
                         // non-NULL is a violation. NULL FK values never violate (matches SQLite).
@@ -1366,12 +1359,7 @@ impl SqlExecutor {
                             if any_null {
                                 continue;
                             }
-                            rows.push((
-                                tbl_name.clone(),
-                                *rowid,
-                                fk.parent_table.clone(),
-                                fk_id,
-                            ));
+                            rows.push((tbl_name.clone(), *rowid, fk.parent_table.clone(), fk_id));
                         }
                         continue;
                     };
@@ -1391,62 +1379,41 @@ impl SqlExecutor {
                         .collect();
 
                     // Skip if any FK value is NULL (NULL doesn't violate FK)
-                    if child_values
-                        .iter()
-                        .any(|v| matches!(v, vibesql_types::SqlValue::Null))
-                    {
+                    if child_values.iter().any(|v| matches!(v, vibesql_types::SqlValue::Null)) {
                         continue;
                     }
 
                     // Check if matching parent row exists
                     let found = parent_rows.iter().any(|parent_row| {
-                        resolved_parent_indices
-                            .iter()
-                            .zip(child_values.iter())
-                            .enumerate()
-                            .all(|(i, (&parent_idx, child_val))| {
+                        resolved_parent_indices.iter().zip(child_values.iter()).enumerate().all(
+                            |(i, (&parent_idx, child_val))| {
                                 if parent_idx < parent_row.values.len() {
                                     vibesql_executor::foreign_key_check::fk_values_equal(
                                         child_val,
                                         &parent_row.values[parent_idx],
-                                        parent_column_collations
-                                            .get(i)
-                                            .and_then(|c| c.as_deref()),
+                                        parent_column_collations.get(i).and_then(|c| c.as_deref()),
                                     )
                                 } else {
                                     false
                                 }
-                            })
+                            },
+                        )
                     });
 
                     if !found {
-                        rows.push((
-                            tbl_name.clone(),
-                            *rowid,
-                            fk.parent_table.clone(),
-                            fk_id,
-                        ));
+                        rows.push((tbl_name.clone(), *rowid, fk.parent_table.clone(), fk_id));
                     }
                 }
             }
         }
 
         // Sort violations by (table, rowid, fk_id) so output matches SQLite's btree order.
-        rows.sort_by(|a, b| {
-            a.0.cmp(&b.0)
-                .then(a.1.cmp(&b.1))
-                .then(a.3.cmp(&b.3))
-        });
+        rows.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)).then(a.3.cmp(&b.3)));
 
         let final_rows: Vec<Vec<Option<String>>> = rows
             .into_iter()
             .map(|(t, rid, p, fk)| {
-                vec![
-                    Some(t),
-                    rid.map(|v| v.to_string()),
-                    Some(p),
-                    Some(fk.to_string()),
-                ]
+                vec![Some(t), rid.map(|v| v.to_string()), Some(p), Some(fk.to_string())]
             })
             .collect();
 
@@ -1504,8 +1471,8 @@ impl SqlExecutor {
         // (SQLite returns no rows for a missing table in table_info, no error).
         let current_schema = self.db.catalog.get_current_schema().to_string();
         if let Some(ref schema) = stmt.database {
-            let is_current = schema.eq_ignore_ascii_case(&current_schema)
-                || schema.eq_ignore_ascii_case("main");
+            let is_current =
+                schema.eq_ignore_ascii_case(&current_schema) || schema.eq_ignore_ascii_case("main");
             if !is_current {
                 return Ok(QueryResult {
                     columns,
@@ -1536,11 +1503,9 @@ impl SqlExecutor {
         // the declared primary-key column list.
         let pk_positions: std::collections::HashMap<String, usize> =
             match schema.primary_key.as_ref() {
-                Some(pk_cols) => pk_cols
-                    .iter()
-                    .enumerate()
-                    .map(|(i, name)| (name.clone(), i + 1))
-                    .collect(),
+                Some(pk_cols) => {
+                    pk_cols.iter().enumerate().map(|(i, name)| (name.clone(), i + 1)).collect()
+                }
                 None => std::collections::HashMap::new(),
             };
 
@@ -1562,10 +1527,7 @@ impl SqlExecutor {
             });
 
             // pk: 1-based position within the primary key, or 0 if not PK.
-            let pk = pk_positions
-                .get(&column.name)
-                .copied()
-                .unwrap_or(0);
+            let pk = pk_positions.get(&column.name).copied().unwrap_or(0);
 
             rows.push(vec![
                 Some(cid.to_string()),

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -13,6 +13,23 @@ pub fn execute_insert(
     db: &mut vibesql_storage::Database,
     stmt: &vibesql_ast::InsertStmt,
 ) -> Result<usize, ExecutorError> {
+    execute_insert_internal(db, stmt, None, None).map(|(count, _)| count)
+}
+
+/// Execute an INSERT statement, capturing RETURNING rows (SQLite 3.35.0+)
+///
+/// Returns the number of inserted rows plus, when the statement carries a
+/// RETURNING clause, the projected NEW rows (values as actually inserted,
+/// including defaults, generated columns, and auto INTEGER PRIMARY KEY) —
+/// one per inserted row, in insertion order. Rows skipped by `OR IGNORE` /
+/// `ON CONFLICT DO NOTHING` do not appear. For `ON DUPLICATE KEY UPDATE`,
+/// the post-UPDATE row is returned.
+///
+/// When the statement has no RETURNING clause the second element is `None`.
+pub fn execute_insert_returning(
+    db: &mut vibesql_storage::Database,
+    stmt: &vibesql_ast::InsertStmt,
+) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
     execute_insert_internal(db, stmt, None, None)
 }
 
@@ -23,7 +40,7 @@ pub fn execute_insert_with_procedural_context(
     stmt: &vibesql_ast::InsertStmt,
     procedural_context: &crate::procedural::ExecutionContext,
 ) -> Result<usize, ExecutorError> {
-    execute_insert_internal(db, stmt, Some(procedural_context), None)
+    execute_insert_internal(db, stmt, Some(procedural_context), None).map(|(count, _)| count)
 }
 
 /// Execute an INSERT statement with trigger context
@@ -34,7 +51,7 @@ pub fn execute_insert_with_trigger_context(
     stmt: &vibesql_ast::InsertStmt,
     trigger_context: &crate::trigger_execution::TriggerContext,
 ) -> Result<usize, ExecutorError> {
-    execute_insert_internal(db, stmt, None, Some(trigger_context))
+    execute_insert_internal(db, stmt, None, Some(trigger_context)).map(|(count, _)| count)
 }
 
 /// Internal implementation of INSERT execution
@@ -43,7 +60,7 @@ fn execute_insert_internal(
     stmt: &vibesql_ast::InsertStmt,
     procedural_context: Option<&crate::procedural::ExecutionContext>,
     trigger_context: Option<&crate::trigger_execution::TriggerContext>,
-) -> Result<usize, ExecutorError> {
+) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
     // Build full table name for error messages and privilege checks
     let full_table_name = match &stmt.schema_name {
         Some(schema) => format!("{}.{}", schema, stmt.table_name),
@@ -59,8 +76,9 @@ fn execute_insert_internal(
     }
 
     // Check if target is sqlite_stat1 (special writable statistics table)
+    // RETURNING is not supported on this virtual statistics table.
     if is_sqlite_stat1_table(&stmt.table_name) {
-        return execute_insert_sqlite_stat1(db, stmt);
+        return execute_insert_sqlite_stat1(db, stmt).map(|count| (count, None));
     }
 
     // Check INSERT privilege on the table
@@ -123,14 +141,16 @@ fn execute_insert_internal(
         vibesql_ast::InsertSource::Select(select_stmt) => {
             // Try bulk transfer optimization first (Phase 1-3)
             // This provides 10-50x performance improvement for compatible schemas
-            // Note: bulk transfer doesn't support CTEs, so skip if with_clause is present
-            if stmt.columns.is_empty() && stmt.with_clause.is_none() {
+            // Note: bulk transfer doesn't support CTEs, so skip if with_clause is present.
+            // RETURNING also gates this fast path: it returns early with only a
+            // count, but RETURNING must project the actually-inserted NEW rows.
+            if stmt.columns.is_empty() && stmt.with_clause.is_none() && stmt.returning.is_none() {
                 // Only attempt bulk transfer for INSERT INTO table SELECT (no column list)
                 if let Some(count) =
                     super::bulk_transfer::try_bulk_transfer(db, table_name, select_stmt)?
                 {
                     // Fast path succeeded, return early
-                    return Ok(count);
+                    return Ok((count, None));
                 }
             }
 
@@ -664,6 +684,13 @@ fn execute_insert_internal(
 
     let mut rows_inserted = 0;
 
+    // RETURNING (SQLite 3.35.0+): collect the rows as ACTUALLY inserted (or
+    // updated by ON DUPLICATE KEY UPDATE). The slow path can rewrite the
+    // IPK/rowid after validation (REPLACE reserved-rowid interplay), so rows
+    // are captured at the insert_row call sites, not from validated_rows.
+    let mut returned_rows: Vec<vibesql_storage::Row> = Vec::new();
+    let capture_returning = stmt.returning.is_some();
+
     // Check if any assertions exist - needed for rollback support
     let has_assertions = db.catalog.get_all_assertions().next().is_some();
 
@@ -728,6 +755,10 @@ fn execute_insert_internal(
                         ExecutorError::UnsupportedExpression(format!("Storage error: {}", e))
                     })?;
 
+                if capture_returning {
+                    returned_rows.extend(rows.iter().cloned());
+                }
+
                 // Maintain expression indexes for each inserted row
                 for (i, row) in rows.iter().enumerate() {
                     expression_index_maintenance::maintain_expression_indexes_for_insert(
@@ -766,6 +797,10 @@ fn execute_insert_internal(
                     ExecutorError::UnsupportedExpression(format!("Storage error: {}", e))
                 })?;
 
+            if capture_returning {
+                returned_rows.extend(rows.iter().cloned());
+            }
+
             // Maintain expression indexes for each inserted row
             for (i, row) in rows.iter().enumerate() {
                 expression_index_maintenance::maintain_expression_indexes_for_insert(
@@ -796,9 +831,20 @@ fn execute_insert_internal(
                     assignments,
                 )?;
 
-                if update_result.is_some() {
+                if let Some(updated_row_id) = update_result {
                     // Row was updated, count it
                     rows_inserted += 1;
+
+                    // RETURNING: SQLite/MySQL return the post-UPDATE row for
+                    // upserts that take the update arm.
+                    if capture_returning {
+                        if let Some(updated_row) = db
+                            .get_table(table_name)
+                            .and_then(|table| table.scan().get(updated_row_id))
+                        {
+                            returned_rows.push(updated_row.clone());
+                        }
+                    }
                     continue;
                 }
                 // No conflict, fall through to insert
@@ -967,6 +1013,12 @@ fn execute_insert_internal(
                 ExecutorError::UnsupportedExpression(format!("Storage error: {}", e))
             })?;
 
+            // RETURNING: capture the row exactly as inserted (after any
+            // REPLACE reserved-rowid / IPK rewrites above).
+            if capture_returning {
+                returned_rows.push(row.clone());
+            }
+
             // Maintain expression indexes for this insert
             expression_index_maintenance::maintain_expression_indexes_for_insert(
                 db,
@@ -1080,7 +1132,17 @@ fn execute_insert_internal(
         return Err(assertion_error);
     }
 
-    Ok(rows_inserted)
+    // Project the RETURNING clause against the rows actually inserted/updated
+    // (one result row per affected row, in insertion order). Zero affected
+    // rows still yield an empty result with the derived column headers.
+    let returning_result = if let Some(items) = &stmt.returning {
+        let row_refs: Vec<&vibesql_storage::Row> = returned_rows.iter().collect();
+        Some(crate::dml_returning::project_returning(items, &schema, db, None, &row_refs)?)
+    } else {
+        None
+    };
+
+    Ok((rows_inserted, returning_result))
 }
 
 /// Check if inserting a row would violate any constraints (for IGNORE conflict resolution)
@@ -1239,7 +1301,7 @@ fn execute_insert_on_view(
     view_def: &vibesql_catalog::ViewDefinition,
     procedural_context: Option<&crate::procedural::ExecutionContext>,
     trigger_context: Option<&crate::trigger_execution::TriggerContext>,
-) -> Result<usize, ExecutorError> {
+) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
     use vibesql_ast::TriggerTiming;
 
     // Find INSTEAD OF INSERT triggers for this view
@@ -1351,6 +1413,16 @@ fn execute_insert_on_view(
         collected_rows
     }; // evaluator dropped here
 
+    // RETURNING: project the NEW view rows (one per INSTEAD OF trigger fire),
+    // mirroring the UPDATE/DELETE view semantics. Projected before the
+    // triggers run since the database must be borrowed mutably below.
+    let returning_result = if let Some(items) = &stmt.returning {
+        let row_refs: Vec<&vibesql_storage::Row> = new_rows.iter().collect();
+        Some(crate::dml_returning::project_returning(items, &view_schema, db, None, &row_refs)?)
+    } else {
+        None
+    };
+
     // Now fire triggers (database can be mutably borrowed)
     let rows_processed = new_rows.len();
     for row in new_rows {
@@ -1359,7 +1431,7 @@ fn execute_insert_on_view(
         }
     }
 
-    Ok(rows_processed)
+    Ok((rows_processed, returning_result))
 }
 
 /// Build a pseudo TableSchema from a view definition

--- a/crates/vibesql-executor/src/insert/mod.rs
+++ b/crates/vibesql-executor/src/insert/mod.rs
@@ -23,6 +23,22 @@ impl InsertExecutor {
         execution::execute_insert(db, stmt)
     }
 
+    /// Execute an INSERT statement, capturing RETURNING rows (SQLite 3.35.0+)
+    ///
+    /// Returns the number of inserted rows plus, when the statement carries a
+    /// RETURNING clause, the projected NEW rows (values as actually inserted,
+    /// including defaults, generated columns, and auto INTEGER PRIMARY KEY).
+    /// Rows skipped by `OR IGNORE` / `ON CONFLICT DO NOTHING` are omitted;
+    /// `ON DUPLICATE KEY UPDATE` contributes the post-UPDATE row.
+    ///
+    /// When the statement has no RETURNING clause the second element is `None`.
+    pub fn execute_returning(
+        db: &mut vibesql_storage::Database,
+        stmt: &vibesql_ast::InsertStmt,
+    ) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
+        execution::execute_insert_returning(db, stmt)
+    }
+
     /// Execute an INSERT statement with procedural context
     /// Supports procedural variables in VALUES clause
     /// Returns number of rows inserted

--- a/crates/vibesql-executor/src/tests/auto_increment_tests.rs
+++ b/crates/vibesql-executor/src/tests/auto_increment_tests.rs
@@ -69,6 +69,7 @@ fn test_auto_increment_basic_inserts() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     let result = InsertExecutor::execute(&mut db, &insert1);
     assert!(result.is_ok(), "Failed to insert alice: {:?}", result.err());
@@ -87,6 +88,7 @@ fn test_auto_increment_basic_inserts() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     let result = InsertExecutor::execute(&mut db, &insert2);
     assert!(result.is_ok(), "Failed to insert bob: {:?}", result.err());
@@ -216,6 +218,7 @@ fn test_last_insert_rowid_basic() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     let result = InsertExecutor::execute(&mut db, &insert1);
     assert!(result.is_ok(), "Failed to insert alice: {:?}", result.err());
@@ -237,6 +240,7 @@ fn test_last_insert_rowid_basic() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     let result = InsertExecutor::execute(&mut db, &insert2);
     assert!(result.is_ok(), "Failed to insert bob: {:?}", result.err());
@@ -314,6 +318,7 @@ fn test_last_insert_rowid_multi_row_insert() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     let result = InsertExecutor::execute(&mut db, &multi_insert);
     assert!(result.is_ok(), "Failed to multi-row insert: {:?}", result.err());
@@ -389,6 +394,7 @@ fn test_last_insert_rowid_no_auto_increment() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     let result = InsertExecutor::execute(&mut db, &insert1);
     assert!(result.is_ok(), "Failed to insert: {:?}", result.err());
@@ -462,6 +468,7 @@ fn test_last_insert_rowid_via_select() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     let result = InsertExecutor::execute(&mut db, &insert1);
     assert!(result.is_ok(), "Failed to insert: {:?}", result.err());

--- a/crates/vibesql-executor/src/tests/insert_returning.rs
+++ b/crates/vibesql-executor/src/tests/insert_returning.rs
@@ -1,0 +1,294 @@
+//! Regression tests for issue #5263: INSERT ... RETURNING (SQLite 3.35.0+).
+//!
+//! SQLite semantics: RETURNING yields one result row per inserted row,
+//! evaluated against the NEW row values as ACTUALLY inserted (defaults,
+//! generated columns, and auto INTEGER PRIMARY KEY materialized; REPLACE
+//! rowid rewrites included). Rows skipped by `OR IGNORE` / `ON CONFLICT DO
+//! NOTHING` are omitted; `ON DUPLICATE KEY UPDATE` contributes the
+//! post-UPDATE row. The bulk-transfer fast path for `INSERT INTO t SELECT`
+//! is gated when a RETURNING clause is present.
+//!
+//! Modeled on `delete_returning.rs` (#5262) / `update_returning.rs` (#5260).
+
+use vibesql_ast::Statement;
+use vibesql_parser::Parser;
+use vibesql_types::SqlValue;
+
+use super::super::*;
+
+fn execute_sql(db: &mut vibesql_storage::Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let stmt =
+        Parser::parse_sql(sql).unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            vec![]
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+            vec![]
+        }
+        Statement::Select(s) => SelectExecutor::new(db).execute(&s).expect("SELECT failed"),
+        other => panic!("Unsupported statement in test helper: {:?}", other),
+    }
+}
+
+/// Run an INSERT and return (count, RETURNING result).
+fn execute_insert_returning(
+    db: &mut vibesql_storage::Database,
+    sql: &str,
+) -> (usize, Option<crate::select::SelectResult>) {
+    let stmt =
+        Parser::parse_sql(sql).unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    match stmt {
+        Statement::Insert(s) => InsertExecutor::execute_returning(db, &s).expect("INSERT failed"),
+        other => panic!("Expected INSERT, got {:?}", other),
+    }
+}
+
+fn int_rows(result: &crate::select::SelectResult) -> Vec<Vec<i64>> {
+    result
+        .rows
+        .iter()
+        .map(|row| {
+            row.values
+                .iter()
+                .map(|v| match v {
+                    SqlValue::Integer(n) => *n,
+                    SqlValue::Bigint(n) => *n,
+                    SqlValue::Smallint(n) => *n as i64,
+                    other => panic!("Expected integer value, got {:?}", other),
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn string_value(v: &SqlValue) -> String {
+    match v {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+        other => panic!("Expected string value, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_insert_returning_new_values() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT, b INT)");
+
+    let (count, returning) =
+        execute_insert_returning(&mut db, "INSERT INTO t1 VALUES (1, 10) RETURNING *, a + 1");
+    assert_eq!(count, 1);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(returning.columns, vec!["a".to_string(), "b".to_string(), "a+1".to_string()]);
+    assert_eq!(int_rows(&returning), vec![vec![1, 10, 2]]);
+
+    // The row is actually inserted.
+    let rows = execute_sql(&mut db, "SELECT a FROM t1");
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn test_insert_returning_multi_row_values_in_order() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT, b INT)");
+
+    // Multi-row VALUES takes the batch insert path; one result row per
+    // inserted row, in insertion order.
+    let (count, returning) = execute_insert_returning(
+        &mut db,
+        "INSERT INTO t1 VALUES (1, 10), (2, 20), (3, 30) RETURNING b",
+    );
+    assert_eq!(count, 3);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(returning.columns, vec!["b".to_string()]);
+    assert_eq!(int_rows(&returning), vec![vec![10], vec![20], vec![30]]);
+}
+
+#[test]
+fn test_insert_returning_auto_ipk_and_defaults() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT, c INT DEFAULT 7)");
+
+    // SQLite: RETURNING projects the NEW row with the auto-assigned INTEGER
+    // PRIMARY KEY and DEFAULT values materialized.
+    let (count, returning) =
+        execute_insert_returning(&mut db, "INSERT INTO t1(b) VALUES ('x') RETURNING a, b, c");
+    assert_eq!(count, 1);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(returning.columns, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+    assert_eq!(returning.rows.len(), 1);
+    assert_eq!(returning.rows[0].values[0], SqlValue::Integer(1));
+    assert_eq!(string_value(&returning.rows[0].values[1]), "x");
+    assert_eq!(returning.rows[0].values[2], SqlValue::Integer(7));
+
+    // Second insert auto-assigns the next IPK.
+    let (_, returning) =
+        execute_insert_returning(&mut db, "INSERT INTO t1(b) VALUES ('y') RETURNING a");
+    let returning = returning.unwrap();
+    assert_eq!(int_rows(&returning), vec![vec![2]]);
+}
+
+#[test]
+fn test_insert_returning_default_values() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT DEFAULT 5, b INT DEFAULT 6)");
+
+    let (count, returning) =
+        execute_insert_returning(&mut db, "INSERT INTO t1 DEFAULT VALUES RETURNING *");
+    assert_eq!(count, 1);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(int_rows(&returning), vec![vec![5, 6]]);
+}
+
+#[test]
+fn test_insert_select_returning_gates_bulk_transfer() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE src(a INT, b INT)");
+    execute_sql(&mut db, "CREATE TABLE dst(a INT, b INT)");
+    execute_sql(&mut db, "INSERT INTO src VALUES (1, 10), (2, 20)");
+
+    // INSERT INTO dst SELECT (no column list) is bulk-transfer eligible;
+    // the fast path must be gated so the NEW rows can be projected.
+    let (count, returning) =
+        execute_insert_returning(&mut db, "INSERT INTO dst SELECT * FROM src RETURNING a, b");
+    assert_eq!(count, 2);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(int_rows(&returning), vec![vec![1, 10], vec![2, 20]]);
+
+    let rows = execute_sql(&mut db, "SELECT a FROM dst");
+    assert_eq!(rows.len(), 2, "rows must still be inserted");
+}
+
+#[test]
+fn test_insert_or_ignore_returning_skips_conflicting_rows() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b INT)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES (1, 10)");
+
+    // SQLite: rows skipped by OR IGNORE do not appear in RETURNING output.
+    let (count, returning) = execute_insert_returning(
+        &mut db,
+        "INSERT OR IGNORE INTO t1 VALUES (1, 99), (2, 20), (3, 30) RETURNING a",
+    );
+    assert_eq!(count, 2, "conflicting row must be skipped");
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(int_rows(&returning), vec![vec![2], vec![3]]);
+}
+
+#[test]
+fn test_insert_or_ignore_returning_all_skipped_is_empty_with_headers() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b INT)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES (1, 10)");
+
+    let (count, returning) =
+        execute_insert_returning(&mut db, "INSERT OR IGNORE INTO t1 VALUES (1, 99) RETURNING a, b");
+    assert_eq!(count, 0);
+    let returning = returning.expect("RETURNING clause should still produce a (empty) result");
+    assert_eq!(returning.columns, vec!["a".to_string(), "b".to_string()]);
+    assert!(returning.rows.is_empty(), "no rows inserted, no rows returned");
+}
+
+#[test]
+fn test_insert_on_conflict_do_nothing_returning_empty() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b INT)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES (1, 10)");
+
+    // ON CONFLICT DO NOTHING: the conflicting row returns nothing.
+    let (count, returning) = execute_insert_returning(
+        &mut db,
+        "INSERT INTO t1 VALUES (1, 99) ON CONFLICT(a) DO NOTHING RETURNING *",
+    );
+    assert_eq!(count, 0);
+    let returning = returning.expect("RETURNING clause should still produce a (empty) result");
+    assert!(returning.rows.is_empty());
+}
+
+#[test]
+fn test_insert_on_duplicate_key_update_returning_post_update_row() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b INT)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES (1, 10)");
+
+    // MySQL-style upsert: the update arm fires for the conflicting row and
+    // RETURNING projects the post-UPDATE row.
+    let (count, returning) = execute_insert_returning(
+        &mut db,
+        "INSERT INTO t1 VALUES (1, 99) ON DUPLICATE KEY UPDATE b = 42 RETURNING a, b",
+    );
+    assert_eq!(count, 1);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(int_rows(&returning), vec![vec![1, 42]]);
+}
+
+#[test]
+fn test_replace_into_returning_new_row() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b INT)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES (1, 10)");
+
+    // SQLite: REPLACE returns the newly inserted row.
+    let (count, returning) =
+        execute_insert_returning(&mut db, "REPLACE INTO t1 VALUES (1, 99) RETURNING a, b");
+    assert_eq!(count, 1);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(int_rows(&returning), vec![vec![1, 99]]);
+
+    // Old row is gone, new row in place.
+    let rows = execute_sql(&mut db, "SELECT b FROM t1");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0], SqlValue::Integer(99));
+}
+
+#[test]
+fn test_insert_or_replace_returning_new_row() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b INT)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES (1, 10)");
+
+    let (count, returning) =
+        execute_insert_returning(&mut db, "INSERT OR REPLACE INTO t1 VALUES (1, 77) RETURNING b");
+    assert_eq!(count, 1);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(int_rows(&returning), vec![vec![77]]);
+}
+
+#[test]
+fn test_insert_returning_expression_with_alias() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT, b INT)");
+
+    let (count, returning) = execute_insert_returning(
+        &mut db,
+        "INSERT INTO t1 VALUES (3, 4) RETURNING a + b AS total, a * b product",
+    );
+    assert_eq!(count, 1);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(returning.columns, vec!["total".to_string(), "product".to_string()]);
+    assert_eq!(int_rows(&returning), vec![vec![7, 12]]);
+}
+
+#[test]
+fn test_insert_without_returning_yields_none() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT)");
+
+    let (count, returning) = execute_insert_returning(&mut db, "INSERT INTO t1 VALUES (1)");
+    assert_eq!(count, 1);
+    assert!(returning.is_none(), "no RETURNING clause, no result expected");
+}
+
+#[test]
+fn test_insert_returning_count_reflects_affected_rows_not_projection() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT)");
+
+    // The affected-row count (used for changes()) is independent of the
+    // RETURNING projection.
+    let (count, returning) =
+        execute_insert_returning(&mut db, "INSERT INTO t1 VALUES (1), (2) RETURNING a");
+    assert_eq!(count, 2);
+    assert_eq!(returning.unwrap().rows.len(), 2);
+}

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -86,6 +86,7 @@ mod function_tests;
 mod index_hint_validation;
 mod index_optimization;
 mod index_scan_tests;
+mod insert_returning;
 mod issue_938_integer_type_preservation;
 mod join_aggregation;
 mod lazy_evaluation_tests;

--- a/crates/vibesql-executor/src/tests/transaction_tests.rs
+++ b/crates/vibesql-executor/src/tests/transaction_tests.rs
@@ -132,6 +132,7 @@ fn test_transaction_insert_commit() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     let rows = InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
     assert_eq!(rows, 1);
@@ -172,6 +173,7 @@ fn test_transaction_insert_rollback() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     let rows = InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
     assert_eq!(rows, 1);
@@ -208,6 +210,7 @@ fn test_transaction_multiple_operations_commit() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt1).unwrap();
 
@@ -230,6 +233,7 @@ fn test_transaction_multiple_operations_commit() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt2).unwrap();
 
@@ -265,6 +269,7 @@ fn test_transaction_multiple_operations_rollback() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt1).unwrap();
 
@@ -287,6 +292,7 @@ fn test_transaction_multiple_operations_rollback() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt2).unwrap();
 
@@ -330,6 +336,7 @@ fn test_transaction_isolation() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db1, &insert_stmt).unwrap();
 
@@ -376,6 +383,7 @@ fn test_transaction_nested_operations() {
             conflict_clause: None,
             on_conflict: None,
             on_duplicate_key_update: None,
+            returning: None,
         };
         InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
     }
@@ -412,6 +420,7 @@ fn test_transaction_empty_rollback() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
 
@@ -449,6 +458,7 @@ fn test_multiple_transactions() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt1).unwrap();
     CommitExecutor::execute(&CommitStmt, &mut db).unwrap();
@@ -470,6 +480,7 @@ fn test_multiple_transactions() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt2).unwrap();
     RollbackExecutor::execute(&RollbackStmt, &mut db).unwrap();

--- a/crates/vibesql-executor/src/tests/triggers/conditions.rs
+++ b/crates/vibesql-executor/src/tests/triggers/conditions.rs
@@ -87,6 +87,7 @@ fn test_when_clause_filters_firing() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert1).expect("Failed to insert");
 
@@ -108,6 +109,7 @@ fn test_when_clause_filters_firing() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert2).expect("Failed to insert");
 

--- a/crates/vibesql-executor/src/tests/triggers/coordination.rs
+++ b/crates/vibesql-executor/src/tests/triggers/coordination.rs
@@ -61,6 +61,7 @@ fn test_multiple_triggers_fire_in_order() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
 
@@ -107,6 +108,7 @@ fn test_trigger_with_multiple_statements() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
 
@@ -156,6 +158,7 @@ fn test_before_trigger_executes_first() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &init_insert).expect("Failed to initialize counter");
 
@@ -189,6 +192,7 @@ fn test_before_trigger_executes_first() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
 

--- a/crates/vibesql-executor/src/tests/triggers/delete.rs
+++ b/crates/vibesql-executor/src/tests/triggers/delete.rs
@@ -31,6 +31,7 @@ fn test_after_delete_trigger_fires() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
 
@@ -100,6 +101,7 @@ fn test_before_delete_trigger_fires() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
 

--- a/crates/vibesql-executor/src/tests/triggers/error_handling.rs
+++ b/crates/vibesql-executor/src/tests/triggers/error_handling.rs
@@ -45,6 +45,7 @@ fn test_trigger_failure_causes_rollback() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     let result = InsertExecutor::execute(&mut db, &insert);
 
@@ -119,6 +120,7 @@ fn test_recursion_prevention() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     let result = InsertExecutor::execute(&mut db, &insert);
 

--- a/crates/vibesql-executor/src/tests/triggers/insert.rs
+++ b/crates/vibesql-executor/src/tests/triggers/insert.rs
@@ -46,6 +46,7 @@ fn test_after_insert_trigger_fires() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
 
@@ -105,6 +106,7 @@ fn test_after_insert_trigger_fires_for_each_row() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
 
@@ -150,6 +152,7 @@ fn test_before_insert_trigger_fires() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
 

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -35,6 +35,7 @@ fn test_after_update_trigger_fires() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
 
@@ -109,6 +110,7 @@ fn test_before_update_trigger_fires() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
 

--- a/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
@@ -136,6 +136,7 @@ fn insert_row(db: &mut Database, table_name: &str, values: Vec<SqlValue>) {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(db, &stmt).unwrap();
 }

--- a/crates/vibesql-executor/src/tests/truncate_table_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_table_tests.rs
@@ -412,6 +412,7 @@ fn test_truncate_resets_auto_increment() {
             conflict_clause: None,
             on_conflict: None,
             on_duplicate_key_update: None,
+            returning: None,
         };
         InsertExecutor::execute(&mut db, &insert).unwrap();
     }
@@ -445,6 +446,7 @@ fn test_truncate_resets_auto_increment() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert).unwrap();
 
@@ -524,6 +526,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
             conflict_clause: None,
             on_conflict: None,
             on_duplicate_key_update: None,
+            returning: None,
         };
         InsertExecutor::execute(&mut db, &insert).unwrap();
     }
@@ -553,6 +556,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert).unwrap();
 

--- a/crates/vibesql-executor/tests/alter_table_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/alter_table_columnar_cache_tests.rs
@@ -46,6 +46,7 @@ fn insert_row(db: &mut Database, id: i64, name: &str, value: i64) {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(db, &stmt).unwrap();
 }
@@ -363,6 +364,7 @@ fn test_alter_column_drop_not_null_invalidates_cache() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &stmt).unwrap();
 
@@ -456,6 +458,7 @@ fn test_alter_column_drop_default_invalidates_cache() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &stmt).unwrap();
 

--- a/crates/vibesql-executor/tests/common/insert_constraint_fixtures.rs
+++ b/crates/vibesql-executor/tests/common/insert_constraint_fixtures.rs
@@ -311,6 +311,7 @@ pub fn build_insert_values(
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     }
 }
 
@@ -335,6 +336,7 @@ pub fn build_insert_columns(
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     }
 }
 

--- a/crates/vibesql-executor/tests/conflict_resolution_tests.rs
+++ b/crates/vibesql-executor/tests/conflict_resolution_tests.rs
@@ -48,6 +48,7 @@ fn insert_user(db: &mut Database, id: i64, email: &str, name: &str) {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(db, &stmt).unwrap();
 }
@@ -80,6 +81,7 @@ fn test_insert_or_ignore_primary_key_conflict() {
         conflict_clause: Some(ConflictClause::Ignore),
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows_inserted = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -117,6 +119,7 @@ fn test_insert_or_ignore_unique_constraint_conflict() {
         conflict_clause: Some(ConflictClause::Ignore),
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows_inserted = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -168,6 +171,7 @@ fn test_insert_or_ignore_multi_row() {
         conflict_clause: Some(ConflictClause::Ignore),
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows_inserted = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -199,6 +203,7 @@ fn test_insert_or_ignore_no_conflict() {
         conflict_clause: Some(ConflictClause::Ignore),
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows_inserted = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -497,6 +502,7 @@ fn test_insert_or_ignore_not_null_violation() {
         conflict_clause: Some(ConflictClause::Ignore),
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows_inserted = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -577,6 +583,7 @@ fn test_insert_on_conflict_do_nothing_primary_key() {
             action: OnConflictAction::DoNothing,
         }),
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows_inserted = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -619,6 +626,7 @@ fn test_insert_on_conflict_do_nothing_without_target() {
             action: OnConflictAction::DoNothing,
         }),
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows_inserted = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -655,6 +663,7 @@ fn test_insert_on_conflict_do_nothing_no_conflict() {
             action: OnConflictAction::DoNothing,
         }),
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows_inserted = InsertExecutor::execute(&mut db, &stmt).unwrap();

--- a/crates/vibesql-executor/tests/duplicate_key_update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/duplicate_key_update_columnar_cache_tests.rs
@@ -42,6 +42,7 @@ fn insert_product(db: &mut Database, id: i64, name: &str, stock: i64) {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(db, &stmt).unwrap();
 }
@@ -72,6 +73,7 @@ fn upsert_product(db: &mut Database, id: i64, name: &str, stock: i64) {
                 value: vibesql_ast::Expression::DuplicateKeyValue { column: "stock".to_string() },
             },
         ]),
+        returning: None,
     };
     InsertExecutor::execute(db, &stmt).unwrap();
 }
@@ -227,6 +229,7 @@ fn test_on_duplicate_key_update_unique_constraint_invalidates_cache() {
             conflict_clause: None,
             on_conflict: None,
             on_duplicate_key_update: None,
+            returning: None,
         };
         InsertExecutor::execute(db, &stmt).unwrap();
     };
@@ -256,6 +259,7 @@ fn test_on_duplicate_key_update_unique_constraint_invalidates_cache() {
             column: "score".to_string(),
             value: vibesql_ast::Expression::DuplicateKeyValue { column: "score".to_string() },
         }]),
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &upsert_stmt).unwrap();
 
@@ -350,6 +354,7 @@ fn test_on_duplicate_key_update_arithmetic_invalidates_cache() {
                 }),
             },
         }]),
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &upsert_stmt).unwrap();
 

--- a/crates/vibesql-executor/tests/index_ordering_tests.rs
+++ b/crates/vibesql-executor/tests/index_ordering_tests.rs
@@ -74,6 +74,7 @@ fn test_index_ordering() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     vibesql_executor::InsertExecutor::execute(&mut db, &insert_stmt).unwrap();

--- a/crates/vibesql-executor/tests/insert_basic_tests.rs
+++ b/crates/vibesql-executor/tests/insert_basic_tests.rs
@@ -25,6 +25,7 @@ fn test_basic_insert() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -65,6 +66,7 @@ fn test_multi_row_insert() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -96,6 +98,7 @@ fn test_insert_with_column_list() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -143,6 +146,7 @@ fn test_insert_null_value() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -178,6 +182,7 @@ fn test_insert_sqlite_type_affinity() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     // SQLite affinity: this should succeed
@@ -205,6 +210,7 @@ fn test_insert_column_count_mismatch() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let result = InsertExecutor::execute(&mut db, &stmt);
@@ -232,6 +238,7 @@ fn test_insert_table_not_found() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let result = InsertExecutor::execute(&mut db, &stmt);
@@ -261,6 +268,7 @@ fn test_insert_column_not_found() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let result = InsertExecutor::execute(&mut db, &stmt);
@@ -292,6 +300,7 @@ fn test_insert_not_null_constraint_violation() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let result = InsertExecutor::execute(&mut db, &stmt);

--- a/crates/vibesql-executor/tests/insert_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/insert_columnar_cache_tests.rs
@@ -42,6 +42,7 @@ fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(db, &stmt).unwrap();
 }
@@ -191,6 +192,7 @@ fn test_multi_row_insert_invalidates_cache() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &stmt).unwrap();
 
@@ -256,6 +258,7 @@ fn test_insert_select_invalidates_cache() {
             conflict_clause: None,
             on_conflict: None,
             on_duplicate_key_update: None,
+            returning: None,
         };
         InsertExecutor::execute(db, &stmt).unwrap();
     };
@@ -303,6 +306,7 @@ fn test_insert_select_invalidates_cache() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
 

--- a/crates/vibesql-executor/tests/insert_default_tests.rs
+++ b/crates/vibesql-executor/tests/insert_default_tests.rs
@@ -41,6 +41,7 @@ fn test_character_varying_column_with_length() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -90,6 +91,7 @@ fn test_character_varying_column_without_length() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -143,6 +145,7 @@ fn test_insert_with_default_value() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -194,6 +197,7 @@ fn test_insert_default_no_default_value_defined() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -258,6 +262,7 @@ fn test_insert_default_values_syntax() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -316,6 +321,7 @@ fn test_insert_default_values_with_integer_primary_key() {
             conflict_clause: None,
             on_conflict: None,
             on_duplicate_key_update: None,
+            returning: None,
         };
         InsertExecutor::execute(&mut db, &stmt).unwrap();
     }
@@ -376,6 +382,7 @@ fn test_integer_primary_key_null_autogen_empty_table() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -429,6 +436,7 @@ fn test_integer_primary_key_null_autogen_sequential() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &stmt1).unwrap();
 
@@ -449,6 +457,7 @@ fn test_integer_primary_key_null_autogen_sequential() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &stmt2).unwrap();
 
@@ -500,6 +509,7 @@ fn test_integer_primary_key_null_autogen_after_explicit() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &stmt1).unwrap();
 
@@ -520,6 +530,7 @@ fn test_integer_primary_key_null_autogen_after_explicit() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &stmt2).unwrap();
 
@@ -576,6 +587,7 @@ fn test_bigint_primary_key_no_autogen() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &stmt).unwrap();
 
@@ -640,6 +652,7 @@ fn test_integer_primary_key_null_autogen_multirow() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -706,6 +719,7 @@ fn test_composite_primary_key_no_autogen() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &stmt).unwrap();
 

--- a/crates/vibesql-executor/tests/insert_duplicate_key_update_tests.rs
+++ b/crates/vibesql-executor/tests/insert_duplicate_key_update_tests.rs
@@ -50,6 +50,7 @@ fn test_on_duplicate_key_update_basic() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &initial_stmt).unwrap();
@@ -77,6 +78,7 @@ fn test_on_duplicate_key_update_basic() {
             column: "stock".to_string(),
             value: vibesql_ast::Expression::DuplicateKeyValue { column: "stock".to_string() },
         }]),
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &upsert_stmt).unwrap();
@@ -116,6 +118,7 @@ fn test_on_duplicate_key_update_with_arithmetic() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     InsertExecutor::execute(&mut db, &initial_stmt).unwrap();
@@ -149,6 +152,7 @@ fn test_on_duplicate_key_update_with_arithmetic() {
                 }),
             },
         }]),
+        returning: None,
     };
 
     InsertExecutor::execute(&mut db, &upsert_stmt).unwrap();
@@ -188,6 +192,7 @@ fn test_on_duplicate_key_update_no_conflict() {
             column: "stock".to_string(),
             value: vibesql_ast::Expression::DuplicateKeyValue { column: "stock".to_string() },
         }]),
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &upsert_stmt).unwrap();

--- a/crates/vibesql-executor/tests/insert_multi_row_tests.rs
+++ b/crates/vibesql-executor/tests/insert_multi_row_tests.rs
@@ -40,6 +40,7 @@ fn test_multi_row_insert_atomic_success() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -86,6 +87,7 @@ fn test_multi_row_insert_atomic_failure() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let result = InsertExecutor::execute(&mut db, &stmt);
@@ -127,6 +129,7 @@ fn test_multi_row_insert_with_column_list() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -172,6 +175,7 @@ fn test_multi_row_insert_sqlite_type_affinity() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     // SQLite affinity: both rows should be inserted successfully
@@ -254,6 +258,7 @@ fn test_multi_row_insert_various_data_types() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -312,6 +317,7 @@ fn test_multi_row_insert_primary_key_violation() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let result = InsertExecutor::execute(&mut db, &stmt);
@@ -351,6 +357,7 @@ fn test_single_row_insert_no_transaction() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &stmt).unwrap();

--- a/crates/vibesql-executor/tests/insert_select_tests.rs
+++ b/crates/vibesql-executor/tests/insert_select_tests.rs
@@ -25,6 +25,7 @@ fn test_insert_from_select_basic() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
 
@@ -82,6 +83,7 @@ fn test_insert_from_select_basic() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &insert_select_stmt).unwrap();
@@ -121,6 +123,7 @@ fn test_insert_from_select_with_where() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
 
@@ -184,6 +187,7 @@ fn test_insert_from_select_with_where() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let rows = InsertExecutor::execute(&mut db, &insert_select_stmt).unwrap();
@@ -215,6 +219,7 @@ fn test_insert_from_select_column_mismatch() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
 
@@ -277,6 +282,7 @@ fn test_insert_from_select_column_mismatch() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     let result = InsertExecutor::execute(&mut db, &insert_select_stmt);
@@ -327,6 +333,7 @@ fn test_insert_from_select_with_aggregates() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
 
@@ -405,6 +412,7 @@ fn test_insert_from_select_with_aggregates() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     let rows = InsertExecutor::execute(&mut db, &insert_select_stmt).unwrap();
     assert_eq!(rows, 1);

--- a/crates/vibesql-executor/tests/replace_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/replace_columnar_cache_tests.rs
@@ -42,6 +42,7 @@ fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(db, &stmt).unwrap();
 }
@@ -63,6 +64,7 @@ fn replace_product(db: &mut Database, id: i64, name: &str, price: i64) {
         conflict_clause: Some(vibesql_ast::ConflictClause::Replace),
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(db, &stmt).unwrap();
 }
@@ -216,6 +218,7 @@ fn test_replace_unique_constraint_invalidates_cache() {
             conflict_clause: None,
             on_conflict: None,
             on_duplicate_key_update: None,
+            returning: None,
         };
         InsertExecutor::execute(db, &stmt).unwrap();
     };
@@ -242,6 +245,7 @@ fn test_replace_unique_constraint_invalidates_cache() {
         conflict_clause: Some(vibesql_ast::ConflictClause::Replace),
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &replace_stmt).unwrap();
 

--- a/crates/vibesql-executor/tests/transaction_tests.rs
+++ b/crates/vibesql-executor/tests/transaction_tests.rs
@@ -40,6 +40,7 @@ fn test_basic_savepoint() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     vibesql_executor::InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
 
@@ -62,6 +63,7 @@ fn test_basic_savepoint() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     vibesql_executor::InsertExecutor::execute(&mut db, &insert_stmt2).unwrap();
 
@@ -115,6 +117,7 @@ fn test_nested_savepoints() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     vibesql_executor::InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
 
@@ -137,6 +140,7 @@ fn test_nested_savepoints() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     vibesql_executor::InsertExecutor::execute(&mut db, &insert_stmt2).unwrap();
 
@@ -159,6 +163,7 @@ fn test_nested_savepoints() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     vibesql_executor::InsertExecutor::execute(&mut db, &insert_stmt3).unwrap();
 

--- a/crates/vibesql-executor/tests/truncate_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/truncate_columnar_cache_tests.rs
@@ -43,6 +43,7 @@ fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(db, &stmt).unwrap();
 }
@@ -271,6 +272,7 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &parent_stmt).unwrap();
 
@@ -290,6 +292,7 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &child_stmt1).unwrap();
 
@@ -308,6 +311,7 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
     InsertExecutor::execute(&mut db, &child_stmt2).unwrap();
 

--- a/crates/vibesql-parser/src/arena_parser/insert.rs
+++ b/crates/vibesql-parser/src/arena_parser/insert.rs
@@ -137,6 +137,14 @@ impl<'arena> ArenaParser<'arena> {
         // Parse optional ON CONFLICT or ON DUPLICATE KEY UPDATE clause
         let (on_conflict, on_duplicate_key_update) = self.parse_on_clause_for_insert()?;
 
+        // Parse optional RETURNING clause (SQLite 3.35.0+)
+        // Syntax: INSERT INTO ... [ON CONFLICT ...] RETURNING expr [, expr ...]
+        let returning = if self.try_consume_keyword(Keyword::Returning) {
+            Some(self.parse_select_list()?)
+        } else {
+            None
+        };
+
         // Consume optional semicolon
         self.try_consume(&Token::Semicolon);
 
@@ -151,6 +159,7 @@ impl<'arena> ArenaParser<'arena> {
             conflict_clause,
             on_conflict,
             on_duplicate_key_update,
+            returning,
         };
 
         Ok(self.arena.alloc(stmt))
@@ -195,6 +204,14 @@ impl<'arena> ArenaParser<'arena> {
         // Parse optional ON CONFLICT or ON DUPLICATE KEY UPDATE clause
         let (on_conflict, on_duplicate_key_update) = self.parse_on_clause_for_insert()?;
 
+        // Parse optional RETURNING clause (SQLite 3.35.0+)
+        // Syntax: INSERT INTO ... [ON CONFLICT ...] RETURNING expr [, expr ...]
+        let returning = if self.try_consume_keyword(Keyword::Returning) {
+            Some(self.parse_select_list()?)
+        } else {
+            None
+        };
+
         // Consume optional semicolon
         self.try_consume(&Token::Semicolon);
 
@@ -209,6 +226,7 @@ impl<'arena> ArenaParser<'arena> {
             conflict_clause: Some(ConflictClause::Replace),
             on_conflict,
             on_duplicate_key_update,
+            returning,
         };
 
         Ok(self.arena.alloc(stmt))

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -114,6 +114,15 @@ impl Parser {
         // Parse optional ON CONFLICT or ON DUPLICATE KEY UPDATE clause
         let (on_conflict, on_duplicate_key_update) = self.parse_on_clause_for_insert()?;
 
+        // Parse optional RETURNING clause (SQLite 3.35.0+)
+        // Syntax: INSERT INTO ... [ON CONFLICT ...] RETURNING expr [, expr ...]
+        let returning = if self.peek_keyword(Keyword::Returning) {
+            self.consume_keyword(Keyword::Returning)?;
+            Some(self.parse_select_list()?)
+        } else {
+            None
+        };
+
         // Expect semicolon or EOF
         if matches!(self.peek(), Token::Semicolon) {
             self.advance();
@@ -130,6 +139,7 @@ impl Parser {
             conflict_clause,
             on_conflict,
             on_duplicate_key_update,
+            returning,
         })
     }
 
@@ -244,6 +254,15 @@ impl Parser {
         // Parse optional ON CONFLICT or ON DUPLICATE KEY UPDATE clause
         let (on_conflict, on_duplicate_key_update) = self.parse_on_clause_for_insert()?;
 
+        // Parse optional RETURNING clause (SQLite 3.35.0+)
+        // Syntax: INSERT INTO ... [ON CONFLICT ...] RETURNING expr [, expr ...]
+        let returning = if self.peek_keyword(Keyword::Returning) {
+            self.consume_keyword(Keyword::Returning)?;
+            Some(self.parse_select_list()?)
+        } else {
+            None
+        };
+
         // Expect semicolon or EOF
         if matches!(self.peek(), Token::Semicolon) {
             self.advance();
@@ -260,6 +279,7 @@ impl Parser {
             conflict_clause,
             on_conflict,
             on_duplicate_key_update,
+            returning,
         })
     }
 
@@ -343,6 +363,15 @@ impl Parser {
         // Parse optional ON CONFLICT or ON DUPLICATE KEY UPDATE clause
         let (on_conflict, on_duplicate_key_update) = self.parse_on_clause_for_insert()?;
 
+        // Parse optional RETURNING clause (SQLite 3.35.0+)
+        // Syntax: INSERT INTO ... [ON CONFLICT ...] RETURNING expr [, expr ...]
+        let returning = if self.peek_keyword(Keyword::Returning) {
+            self.consume_keyword(Keyword::Returning)?;
+            Some(self.parse_select_list()?)
+        } else {
+            None
+        };
+
         // Expect semicolon or EOF
         if matches!(self.peek(), Token::Semicolon) {
             self.advance();
@@ -359,6 +388,7 @@ impl Parser {
             conflict_clause: Some(vibesql_ast::ConflictClause::Replace),
             on_conflict,
             on_duplicate_key_update,
+            returning,
         })
     }
 

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -518,6 +518,10 @@ impl Parser {
                 | Token::Keyword { keyword: Keyword::Except, .. }
                 | Token::Keyword { keyword: Keyword::Using, .. }
                 | Token::Keyword { keyword: Keyword::For, .. }
+                // RETURNING terminates the SELECT embedded in INSERT ... SELECT
+                // ... RETURNING; SQLite likewise refuses RETURNING as an
+                // implicit (AS-less) table alias.
+                | Token::Keyword { keyword: Keyword::Returning, .. }
         )
     }
 

--- a/crates/vibesql-parser/src/parser/select/statement.rs
+++ b/crates/vibesql-parser/src/parser/select/statement.rs
@@ -378,8 +378,17 @@ impl Parser {
         // - Parenthesized subexpressions
         if validate_end_tokens {
             if allow_order_limit {
-                // Top-level: only allow semicolon, EOF, or ) (for subqueries/CTEs)
-                if !matches!(self.peek(), Token::Semicolon | Token::Eof | Token::RParen) {
+                // Top-level: only allow semicolon, EOF, or ) (for subqueries/CTEs).
+                // RETURNING is allowed because the SELECT may be the source of
+                // INSERT INTO t SELECT ... RETURNING ... (the clause belongs to
+                // the outer INSERT, issue #5263).
+                if !matches!(
+                    self.peek(),
+                    Token::Semicolon
+                        | Token::Eof
+                        | Token::RParen
+                        | Token::Keyword { keyword: Keyword::Returning, .. }
+                ) {
                     return Err(ParseError { message: self.peek().syntax_error() });
                 }
             } else {
@@ -720,6 +729,9 @@ impl Parser {
             //       ORDER/LIMIT/OFFSET may follow and belong to the outer statement
             let valid_end_token = match self.peek() {
                 Token::Semicolon | Token::Eof | Token::RParen => true,
+                // RETURNING belongs to an outer INSERT (INSERT INTO t VALUES
+                // ... RETURNING ..., issue #5263).
+                Token::Keyword { keyword: Keyword::Returning, .. } => true,
                 // When nested, allow ORDER BY/LIMIT/OFFSET for outer statement
                 Token::Keyword { keyword: Keyword::Order, .. }
                 | Token::Keyword { keyword: Keyword::Limit, .. }

--- a/crates/vibesql-parser/src/tests/insert.rs
+++ b/crates/vibesql-parser/src/tests/insert.rs
@@ -215,3 +215,150 @@ fn test_parse_replace_with_rowid_column() {
         _ => panic!("Expected INSERT statement"),
     }
 }
+
+// ========================================================================
+// RETURNING Clause Tests (SQLite 3.35.0+, issue #5263)
+// ========================================================================
+
+#[test]
+fn test_parse_insert_returning_star() {
+    let result = Parser::parse_sql("INSERT INTO t1(b) VALUES ('x') RETURNING *;");
+    assert!(result.is_ok(), "RETURNING * should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => {
+            let returning = insert.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 1);
+            assert!(matches!(returning[0], vibesql_ast::SelectItem::Wildcard { .. }));
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_parse_insert_returning_expression_list() {
+    let result = Parser::parse_sql("INSERT INTO t1 VALUES (1, 2) RETURNING a, b + 1;");
+    assert!(result.is_ok(), "RETURNING expr list should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => {
+            let returning = insert.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 2);
+            assert!(matches!(returning[0], vibesql_ast::SelectItem::Expression { .. }));
+            assert!(matches!(returning[1], vibesql_ast::SelectItem::Expression { .. }));
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_parse_insert_returning_with_alias() {
+    let result =
+        Parser::parse_sql("INSERT INTO t1 VALUES (1) RETURNING a AS new_a, a + 1 incremented;");
+    assert!(result.is_ok(), "RETURNING aliases should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => {
+            let returning = insert.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 2);
+            match &returning[0] {
+                vibesql_ast::SelectItem::Expression { alias, .. } => {
+                    assert_eq!(alias.as_deref(), Some("new_a"));
+                }
+                other => panic!("Expected expression item, got {:?}", other),
+            }
+            match &returning[1] {
+                vibesql_ast::SelectItem::Expression { alias, .. } => {
+                    assert_eq!(alias.as_deref(), Some("incremented"));
+                }
+                other => panic!("Expected expression item, got {:?}", other),
+            }
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_parse_insert_returning_after_on_conflict() {
+    let result = Parser::parse_sql(
+        "INSERT INTO t1(a, b) VALUES (1, 2) ON CONFLICT(a) DO UPDATE SET b = 3 RETURNING *;",
+    );
+    assert!(result.is_ok(), "RETURNING after ON CONFLICT should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => {
+            assert!(insert.on_conflict.is_some());
+            let returning = insert.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 1);
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_parse_insert_returning_with_cte() {
+    let result = Parser::parse_sql(
+        "WITH src AS (SELECT 1 AS x) INSERT INTO t1 SELECT x FROM src RETURNING *;",
+    );
+    assert!(result.is_ok(), "RETURNING with CTE should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => {
+            assert!(insert.with_clause.is_some());
+            let returning = insert.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 1);
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_parse_replace_into_returning() {
+    let result = Parser::parse_sql("REPLACE INTO t1(a, b) VALUES (1, 'x') RETURNING a, b;");
+    assert!(result.is_ok(), "REPLACE INTO RETURNING should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => {
+            assert_eq!(
+                insert.conflict_clause,
+                Some(vibesql_ast::ConflictClause::Replace),
+                "REPLACE INTO should set the Replace conflict clause"
+            );
+            let returning = insert.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 2);
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_parse_insert_returning_arena_parser() {
+    // The CLI path goes through parse_with_arena_fallback; make sure the
+    // arena parser captures RETURNING too.
+    let result = crate::parse_with_arena_fallback("INSERT INTO t1(b) VALUES ('x') RETURNING a, b");
+    assert!(result.is_ok(), "arena parser should handle RETURNING: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => {
+            let returning = insert.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 2);
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_parse_replace_returning_arena_parser() {
+    let result =
+        crate::parse_with_arena_fallback("REPLACE INTO t1(a, b) VALUES (1, 'x') RETURNING *");
+    assert!(result.is_ok(), "arena parser should handle REPLACE RETURNING: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => {
+            let returning = insert.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 1);
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_parse_insert_without_returning_is_none() {
+    let result = Parser::parse_sql("INSERT INTO t1 VALUES (1);");
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => assert!(insert.returning.is_none()),
+        _ => panic!("Expected INSERT statement"),
+    }
+}

--- a/tests/storage/insert_constraint_performance.rs
+++ b/tests/storage/insert_constraint_performance.rs
@@ -55,6 +55,7 @@ fn test_insert_with_merged_constraint_validation() {
             conflict_clause: None,
             on_conflict: None,
             on_duplicate_key_update: None,
+            returning: None,
         };
 
         InsertExecutor::execute(&mut db, &stmt).unwrap();
@@ -122,6 +123,7 @@ fn test_insert_multi_row_with_constraints() {
         conflict_clause: None,
         on_conflict: None,
         on_duplicate_key_update: None,
+        returning: None,
     };
 
     InsertExecutor::execute(&mut db, &stmt).unwrap();


### PR DESCRIPTION
## Summary

INSERT (including `REPLACE INTO`) silently dropped a RETURNING clause — the statement executed but returned no result rows. This PR implements `INSERT ... RETURNING` end-to-end, completing the second half of #5262 (DELETE half landed via #5266) by reusing the shared `dml_returning::project_returning` module that PR promoted.

Per the #5266 builder's caution, RETURNING rows are captured at the actual `insert_row` / `insert_rows_batch` call sites — not from pre-loop `validated_rows` — so REPLACE reserved-rowid / IPK rewrites are reflected in the output.

## Changes

- **AST**: `InsertStmt.returning: Option<Vec<SelectItem>>` (owned + arena), arena→owned conversion in `convert_insert`, visitor `walk_insert` / `transform_insert` coverage. Includes the deferred-from-#5266 mechanical sweep: 119 `returning: None` fills across ~28 files (mostly tests).
- **Parser** (owned, 3 sites: `parse_insert_statement`, `parse_insert_statement_with_cte`, `parse_replace_statement`; arena, 2 sites: `parse_insert_statement`, `parse_replace_statement`): parse `RETURNING expr [, ...]` after the ON CONFLICT / ON DUPLICATE KEY UPDATE clause, copying the DELETE pattern. Two supporting parser fixes so the INSERT-embedded source doesn't swallow the clause:
  - `select/statement.rs`: `RETURNING` accepted as a SELECT/VALUES end token (it belongs to the outer INSERT), enabling `INSERT INTO t SELECT ... RETURNING` and `VALUES ... RETURNING`.
  - `select/from_clause.rs`: `RETURNING` excluded from implicit (AS-less) table aliases — SQLite has the same restriction.
- **Executor** (`insert/execution.rs`): `execute_insert_internal` returns `(usize, Option<SelectResult>)`; new `execute_insert_returning` / `InsertExecutor::execute_returning`; count-only wrappers unchanged in behavior.
  - Batch path: collects the exact `Row`s passed to `insert_rows_batch` (both chunked and single-batch arms).
  - Slow path: collects `row` as passed to `insert_row` (captures REPLACE reserved-rowid/IPK rewrites); `ON DUPLICATE KEY UPDATE` arm fetches and contributes the post-UPDATE row.
  - `bulk_transfer::try_bulk_transfer` fast path gated on `stmt.returning.is_none()` (it returns early with only a count).
  - View INSTEAD OF INSERT path returns the NEW view rows, one per trigger fire, mirroring the UPDATE/DELETE view semantics.
  - `sqlite_stat1` virtual-table inserts return no RETURNING rows (documented).
- **CLI**: Insert arm switches to `execute_returning` and renders RETURNING rows like a SELECT result (copied verbatim from the Update/Delete arms); `set_last_changes_count` still uses affected rows.
- **Tests**: new `crates/vibesql-executor/src/tests/insert_returning.rs` (14 tests, modeled on `delete_returning.rs`); 9 parser tests in `crates/vibesql-parser/src/tests/insert.rs` (owned + arena, REPLACE INTO, ON CONFLICT, CTE variants).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `INSERT ... VALUES` (single + multi-row) returns NEW rows incl. defaults and auto IPK | ✅ | `test_insert_returning_new_values`, `test_insert_returning_multi_row_values_in_order`, `test_insert_returning_auto_ipk_and_defaults` |
| `INSERT ... SELECT` + `DEFAULT VALUES` work, bulk transfer gated | ✅ | `test_insert_select_returning_gates_bulk_transfer` (bulk-eligible shape, RETURNING still projects), `test_insert_returning_default_values` |
| `REPLACE INTO ... RETURNING` returns the newly inserted row | ✅ | `test_replace_into_returning_new_row`, `test_insert_or_replace_returning_new_row` |
| `OR IGNORE` omits skipped rows; all-skipped → empty result with headers | ✅ | `test_insert_or_ignore_returning_skips_conflicting_rows`, `test_insert_or_ignore_returning_all_skipped_is_empty_with_headers` |
| `ON CONFLICT DO NOTHING` returns no row; DO UPDATE returns updated row or documented deferral | ✅ | DO NOTHING: `test_insert_on_conflict_do_nothing_returning_empty`. DO UPDATE: **deferred** — the upsert update arm itself is not executed by the engine (fails with UNIQUE constraint error on main too); filed #5269 with analysis. The MySQL-style `ON DUPLICATE KEY UPDATE` arm DOES return the post-UPDATE row: `test_insert_on_duplicate_key_update_returning_post_update_row` |
| `changes()` reflects affected rows, not RETURNING row count | ✅ | CLI keeps `set_last_changes_count(affected_rows)`; release-binary smoke test shows `changes() = 2` after 2-row RETURNING insert |
| No regression for INSERTs without RETURNING | ✅ | All fast paths keyed on `returning.is_none()`; executor lib (2461 tests) + all 85 integration test binaries pass; TCL `insert.test` 51/51, `insert2.test` 16/16 |

## Test Plan

- `cargo test -p vibesql-executor --lib` — 2461 passed
- `cargo test -p vibesql-executor --tests` — 85 binaries, all pass
- `cargo test -p vibesql-parser` / `-p vibesql-ast` / `-p vibesql-cli` — all pass
- TCL `returning1.test`: **32 → 46 passing** of 79 (47 → 33 failures; baseline measured against main's binary at 8c492d09). Remaining failures are orthogonal: ON CONFLICT DO UPDATE execution (#5269), NEW/OLD error-message wording, bare `RETURNING rowid` resolution on non-IPK tables (same limitation as UPDATE/DELETE RETURNING), subqueries in RETURNING expressions, `sqlite_temp_schema`
- TCL `insert.test`, `insert2.test`: 100%; `upsert1.test`: 6/32 unchanged from main (pre-existing, #5269)
- Pre-existing failures not addressed (verified identical on main with the local toolchain): `cargo check --benches` rand-API drift in `benches/tpcds/data.rs`; clippy `large_enum_variant` on `Statement`/`OnConflictAction`

Closes #5263

🤖 Generated with [Claude Code](https://claude.com/claude-code)