### PR TITLE
fix(executor): window1.test residuals — nested scope binding, UNION-arm misuse, text coercion

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
@@ -37,6 +37,27 @@ use crate::{errors::ExecutorError, select::cte::CteResult};
 /// 2. Follow outer_schema chain to Level 1 [t2, t1] - FOUND in t2!
 ///
 /// No HashMap collision because each level keeps its own tables!
+///
+/// # Index alignment with the merged row (window1.test 61.1)
+///
+/// [`build_merged_outer_row`] lays the row out as `current.values ++
+/// outer.values` — the current level's values form the *prefix* and the
+/// outer chain's values the *suffix*. This matches
+/// [`CombinedSchema::get_column_index`](crate::schema::CombinedSchema::get_column_index)'s
+/// index space: current-level tables keep their 0-based `start_index`
+/// values (so the merged schema also stays aligned with *raw* current-level
+/// rows, as used by the outer-correlated aggregate path over `outer_rows`,
+/// issue #4930 / window1.test 53.0), while lookups that resolve in the
+/// outer chain are offset by the current level's `total_columns` (and so
+/// land in the outer suffix; by induction the outer row is itself merged
+/// with this same convention at the previous nesting level).
+///
+/// Before this convention was made consistent, the merged row put the
+/// outer values first while the schema kept current-level indices 0-based,
+/// so a correlated reference that should resolve to the nearest enclosing
+/// scope read the outermost scope's value instead — e.g.
+/// `SELECT (SELECT sum(a IN (SELECT sum(a) OVER() FROM (SELECT 1 AS x))) FROM t1) FROM t1`
+/// bound the inner `a` to the outermost t1 row (window1.test 61.1).
 pub(super) fn build_merged_outer_schema<'a>(
     current_schema: &'a crate::schema::CombinedSchema,
     outer_schema: Option<&'a crate::schema::CombinedSchema>,
@@ -58,6 +79,13 @@ pub(super) fn build_merged_outer_schema<'a>(
 /// When we merge schemas from multiple levels, we must also merge the corresponding
 /// rows so that column indices align correctly.
 ///
+/// Layout: `current.values ++ outer.values`. The current level's values form
+/// the prefix (aligned with the merged schema's 0-based current-level
+/// `start_index` values); the outer chain's values form the suffix (reached
+/// via the `total_columns` offset applied by
+/// [`CombinedSchema::get_column_index`](crate::schema::CombinedSchema::get_column_index)
+/// when delegating to the outer chain). See [`build_merged_outer_schema`].
+///
 /// # Arguments
 /// * `current_row` - Row from the current level
 /// * `outer_row` - Optional row from outer level(s)
@@ -69,9 +97,9 @@ pub(super) fn build_merged_outer_row<'a>(
     outer_row: Option<&'a vibesql_storage::Row>,
 ) -> std::borrow::Cow<'a, vibesql_storage::Row> {
     if let Some(outer) = outer_row {
-        // Merge: outer row values + current row values
-        let mut merged_values = outer.values.clone();
-        merged_values.extend(current_row.values.iter().cloned());
+        // Merge: current row values + outer row values (current is the prefix)
+        let mut merged_values = current_row.values.clone();
+        merged_values.extend(outer.values.iter().cloned());
 
         std::borrow::Cow::Owned(vibesql_storage::Row::new(merged_values))
     } else {

--- a/crates/vibesql-executor/src/evaluator/operators/bitwise.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/bitwise.rs
@@ -6,26 +6,46 @@
 
 use vibesql_types::SqlValue;
 
-use crate::{errors::ExecutorError, evaluator::casting::to_i64};
+use crate::{
+    errors::ExecutorError,
+    evaluator::casting::{string_to_number, to_i64},
+};
 
 /// Bitwise operations (SQLite compatible)
 pub(crate) struct BitwiseOps;
+
+/// Convert an operand to i64 with SQLite bitwise-operator semantics.
+///
+/// SQLite coerces text/blob operands with string-to-number conversion
+/// (`SELECT 'seventeen' & 5` → 0, `SELECT '5' | 0` → 5) instead of
+/// erroring, so bitwise operands get a lenient conversion rather than
+/// the strict numeric `to_i64`.
+fn to_i64_bitwise(value: &SqlValue) -> Result<i64, ExecutorError> {
+    match value {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => Ok(string_to_number(s).0),
+        SqlValue::Blob(bytes) => {
+            let text = std::str::from_utf8(bytes).unwrap_or("");
+            Ok(string_to_number(text).0)
+        }
+        _ => to_i64(value),
+    }
+}
 
 impl BitwiseOps {
     /// Bitwise OR operator (|)
     #[inline]
     pub fn or(left: &SqlValue, right: &SqlValue) -> Result<SqlValue, ExecutorError> {
         // NULL propagation is handled at the registry level
-        let left_i64 = to_i64(left)?;
-        let right_i64 = to_i64(right)?;
+        let left_i64 = to_i64_bitwise(left)?;
+        let right_i64 = to_i64_bitwise(right)?;
         Ok(SqlValue::Integer(left_i64 | right_i64))
     }
 
     /// Bitwise AND operator (&)
     #[inline]
     pub fn and(left: &SqlValue, right: &SqlValue) -> Result<SqlValue, ExecutorError> {
-        let left_i64 = to_i64(left)?;
-        let right_i64 = to_i64(right)?;
+        let left_i64 = to_i64_bitwise(left)?;
+        let right_i64 = to_i64_bitwise(right)?;
         Ok(SqlValue::Integer(left_i64 & right_i64))
     }
 
@@ -34,15 +54,15 @@ impl BitwiseOps {
     #[inline]
     #[allow(dead_code)] // Provided for completeness; will be used when unary ~ is implemented
     pub fn not(value: &SqlValue) -> Result<SqlValue, ExecutorError> {
-        let val_i64 = to_i64(value)?;
+        let val_i64 = to_i64_bitwise(value)?;
         Ok(SqlValue::Integer(!val_i64))
     }
 
     /// Left shift operator (<<)
     #[inline]
     pub fn left_shift(left: &SqlValue, right: &SqlValue) -> Result<SqlValue, ExecutorError> {
-        let left_i64 = to_i64(left)?;
-        let right_i64 = to_i64(right)?;
+        let left_i64 = to_i64_bitwise(left)?;
+        let right_i64 = to_i64_bitwise(right)?;
 
         // Handle i64::MIN specially - shifting by this extreme amount returns 0
         if right_i64 == i64::MIN {
@@ -84,8 +104,8 @@ impl BitwiseOps {
     /// SQLite uses arithmetic (signed) right shift
     #[inline]
     pub fn right_shift(left: &SqlValue, right: &SqlValue) -> Result<SqlValue, ExecutorError> {
-        let left_i64 = to_i64(left)?;
-        let right_i64 = to_i64(right)?;
+        let left_i64 = to_i64_bitwise(left)?;
+        let right_i64 = to_i64_bitwise(right)?;
 
         // Handle i64::MIN specially - shifting by this extreme amount returns 0
         // (or -1 for negative left values in left_shift direction)

--- a/crates/vibesql-executor/src/evaluator/window/aggregates.rs
+++ b/crates/vibesql-executor/src/evaluator/window/aggregates.rs
@@ -11,6 +11,27 @@ use vibesql_storage::Row;
 use vibesql_types::SqlValue;
 
 use super::{partitioning::Partition, sorting::compare_values};
+use crate::evaluator::casting::string_to_number;
+
+/// SQLite numeric coercion for text arguments of sum/total/avg.
+///
+/// SQLite forces text aggregate inputs to a number instead of skipping them:
+/// - text that is entirely a valid integer → INTEGER (`sum('5') OVER()` → 5)
+/// - anything else → REAL from the parsed numeric prefix
+///   (`sum('seventeen') OVER()` → 0.0, `sum('5xyz') OVER()` → 5.0)
+///
+/// Returns `(value, is_real)` where `is_real` indicates the REAL storage
+/// class was used (so sum() yields a real result).
+fn coerce_text_to_number(s: &str) -> (f64, bool) {
+    let trimmed = s.trim();
+    if !trimmed.is_empty() {
+        if let Ok(n) = trimmed.parse::<i64>() {
+            return (n as f64, false);
+        }
+    }
+    let (_, float_val, _) = string_to_number(s);
+    (float_val, true)
+}
 
 /// Helper function to check if a row passes the FILTER condition
 /// Returns true if there's no filter, or if the filter evaluates to TRUE
@@ -178,6 +199,26 @@ where
                     has_value = true;
                     saw_real = true;
                 }
+                // SQLite coerces text/blob inputs to a number instead of
+                // skipping them: sum('5') OVER() → 5, sum('seventeen')
+                // OVER() → 0.0 (window1.test 61.1 chain).
+                SqlValue::Varchar(ref s) | SqlValue::Character(ref s) => {
+                    let (v, is_real) = coerce_text_to_number(s);
+                    sum += v;
+                    has_value = true;
+                    if is_real {
+                        saw_real = true;
+                    }
+                }
+                // SQLite: blob operands always coerce to REAL
+                // (sum(x'35') OVER() → 5.0, typeof real).
+                SqlValue::Blob(ref bytes) => {
+                    let text = std::str::from_utf8(bytes).unwrap_or("");
+                    let (v, _) = coerce_text_to_number(text);
+                    sum += v;
+                    has_value = true;
+                    saw_real = true;
+                }
                 SqlValue::Null => {} // Ignore NULL
                 _ => {}              // Ignore non-numeric values
             }
@@ -250,6 +291,15 @@ where
                 }
                 SqlValue::Double(n) => {
                     sum += n;
+                }
+                // SQLite coerces text/blob inputs to a number instead of
+                // skipping them (total('seventeen') OVER() → 0.0).
+                SqlValue::Varchar(ref s) | SqlValue::Character(ref s) => {
+                    sum += coerce_text_to_number(s).0;
+                }
+                SqlValue::Blob(ref bytes) => {
+                    let text = std::str::from_utf8(bytes).unwrap_or("");
+                    sum += coerce_text_to_number(text).0;
                 }
                 SqlValue::Null => {} // Ignore NULL
                 _ => {}              // Ignore non-numeric values
@@ -324,6 +374,17 @@ where
                 }
                 SqlValue::Double(n) => {
                     sum += n;
+                    count += 1;
+                }
+                // SQLite coerces text/blob inputs to a number instead of
+                // skipping them (avg('seventeen') OVER() → 0.0).
+                SqlValue::Varchar(ref s) | SqlValue::Character(ref s) => {
+                    sum += coerce_text_to_number(s).0;
+                    count += 1;
+                }
+                SqlValue::Blob(ref bytes) => {
+                    let text = std::str::from_utf8(bytes).unwrap_or("");
+                    sum += coerce_text_to_number(text).0;
                     count += 1;
                 }
                 SqlValue::Null => {} // Ignore NULL

--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -572,8 +572,17 @@ impl CombinedSchema {
         // Not found at current level - search outer scopes via chain
         // This enables nested correlated subqueries to reference columns
         // from multiple enclosing scopes (issue #4493)
+        //
+        // Index convention (window1.test 61.1): the row paired with a chained
+        // schema is laid out as `current.values ++ outer.values` (see
+        // `build_merged_outer_row`), so indices resolved in the outer chain
+        // must be offset by this level's column span. This keeps the current
+        // level's 0-based indices valid both against the merged row (current
+        // values form the prefix) and against raw current-level rows (as used
+        // by the outer-correlated aggregate path over `outer_rows`, #4930 /
+        // window1.test 53.0).
         if let Some(outer) = &self.outer_schema {
-            return outer.get_column_index(table, column);
+            return outer.get_column_index(table, column).map(|idx| self.total_columns + idx);
         }
 
         // Not found anywhere in the chain

--- a/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
@@ -1526,52 +1526,65 @@ pub fn validate_subquery_context_misuse(
 ) -> Result<(), ExecutorError> {
     match expr {
         Expression::ScalarSubquery(stmt) => {
-            // Only "bare" subqueries (no FROM) re-borrow the outer context.
-            if stmt.from.is_none() {
-                // Check for row value misuse (sole projection is a row value
-                // constructor with multiple elements). This is an error in
-                // any context.
-                if stmt.select_list.len() == 1 {
-                    if let SelectItem::Expression {
-                        expr: Expression::RowValueConstructor(items),
-                        ..
-                    } = &stmt.select_list[0]
-                    {
-                        if items.len() > 1 {
-                            return Err(ExecutorError::RowValueMisused);
-                        }
-                    }
-                }
-
-                // Check each projection for an aggregate function. We only
-                // flag aggregates whose body references something outside the
-                // bare subquery's own scope (i.e., references a column — the
-                // bare subquery has no tables, so any column is an outer ref).
-                //
-                // In SELECT-list context, this is *not* a misuse; it triggers
-                // implicit-outer-aggregate-collapse instead (#5104). Skip the
-                // rejection so the executor's collapse path can handle it.
-                if context == SubqueryContext::WhereOrEqual {
-                    for item in &stmt.select_list {
-                        if let SelectItem::Expression { expr: inner, .. } = item {
-                            if let Some(name) = find_outer_referencing_aggregate(inner) {
-                                return Err(ExecutorError::MisuseOfAggregateContext {
-                                    function_name: name,
-                                });
+            // Walk the full compound chain: the head SELECT plus every
+            // set-operation arm (UNION/INTERSECT/EXCEPT). Each arm carries
+            // its own FROM clause, and SQLite flags misuse in *any* FROM-less
+            // arm — e.g. `(SELECT 2,2 UNION SELECT sum(b),... )` errors even
+            // though the head arm is clean (window1.test 71.0).
+            let mut arm: &vibesql_ast::SelectStmt = stmt;
+            loop {
+                // Only "bare" arms (no FROM) re-borrow the outer context.
+                if arm.from.is_none() {
+                    // Check for row value misuse (sole projection is a row value
+                    // constructor with multiple elements). This is an error in
+                    // any context.
+                    if arm.select_list.len() == 1 {
+                        if let SelectItem::Expression {
+                            expr: Expression::RowValueConstructor(items),
+                            ..
+                        } = &arm.select_list[0]
+                        {
+                            if items.len() > 1 {
+                                return Err(ExecutorError::RowValueMisused);
                             }
                         }
                     }
+
+                    // Check each projection for an aggregate function. We only
+                    // flag aggregates whose body references something outside the
+                    // bare subquery's own scope (i.e., references a column — the
+                    // bare subquery has no tables, so any column is an outer ref).
+                    //
+                    // In SELECT-list context, this is *not* a misuse; it triggers
+                    // implicit-outer-aggregate-collapse instead (#5104). Skip the
+                    // rejection so the executor's collapse path can handle it.
+                    if context == SubqueryContext::WhereOrEqual {
+                        for item in &arm.select_list {
+                            if let SelectItem::Expression { expr: inner, .. } = item {
+                                if let Some(name) = find_outer_referencing_aggregate(inner) {
+                                    return Err(ExecutorError::MisuseOfAggregateContext {
+                                        function_name: name,
+                                    });
+                                }
+                            }
+                        }
+                    }
+
+                    // Recurse into nested expressions inside the bare arm's
+                    // SELECT list as well — e.g. (SELECT (SELECT sum(x))).
+                    // Inner subqueries inherit the same context: nested bare
+                    // subqueries in a SELECT-list context still treat their own
+                    // SELECT-list position as SELECT-list.
+                    for item in &arm.select_list {
+                        if let SelectItem::Expression { expr: inner, .. } = item {
+                            validate_subquery_context_misuse(inner, context)?;
+                        }
+                    }
                 }
 
-                // Recurse into nested expressions inside the bare subquery's
-                // SELECT list as well — e.g. (SELECT (SELECT sum(x))).
-                // Inner subqueries inherit the same context: nested bare
-                // subqueries in a SELECT-list context still treat their own
-                // SELECT-list position as SELECT-list.
-                for item in &stmt.select_list {
-                    if let SelectItem::Expression { expr: inner, .. } = item {
-                        validate_subquery_context_misuse(inner, context)?;
-                    }
+                match arm.set_operation.as_ref() {
+                    Some(set_op) => arm = &set_op.right,
+                    None => break,
                 }
             }
             Ok(())

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -134,3 +134,4 @@ mod update_returning;
 mod vector_distance_operators;
 mod view_tests;
 mod window1_quick_wins;
+mod window1_residuals;

--- a/crates/vibesql-executor/src/tests/window1_residuals.rs
+++ b/crates/vibesql-executor/src/tests/window1_residuals.rs
@@ -1,0 +1,217 @@
+//! Regression tests for the window1.test residual fixes (issue #5264)
+//!
+//! Covers:
+//! - 61.1-A: `CAST(x AS )` (empty type name) gets NUMERIC affinity
+//! - 61.1-B: bitwise operators coerce text operands SQLite-style
+//! - 61.1-B: window sum/total/avg coerce text arguments instead of skipping
+//! - 61.1-B: nested correlated references bind to the nearest enclosing
+//!   scope (merged outer schema/row alignment)
+//! - 71.0: outer-correlated aggregate misuse detected in UNION arms of a
+//!   scalar subquery
+
+use vibesql_ast::Statement;
+use vibesql_parser::Parser;
+use vibesql_types::SqlValue;
+
+use super::super::*;
+
+fn execute_sql(
+    db: &mut vibesql_storage::Database,
+    sql: &str,
+) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| ExecutorError::ParseError(format!("{:?}", e)))?;
+    match stmt {
+        Statement::CreateTable(create_stmt) => {
+            CreateTableExecutor::execute(&create_stmt, db)?;
+            Ok(vec![])
+        }
+        Statement::Insert(insert_stmt) => {
+            InsertExecutor::execute(db, &insert_stmt)?;
+            Ok(vec![])
+        }
+        Statement::Select(select_stmt) => Ok(SelectExecutor::new(db).execute(&select_stmt)?),
+        other => {
+            Err(ExecutorError::UnsupportedFeature(format!("Unsupported statement: {:?}", other)))
+        }
+    }
+}
+
+fn single_value(db: &mut vibesql_storage::Database, sql: &str) -> SqlValue {
+    let rows = execute_sql(db, sql).unwrap();
+    assert_eq!(rows.len(), 1, "expected one row from {sql}");
+    rows[0].values[0].clone()
+}
+
+// ------------------------------------------------------------------------
+// 61.1-A — empty CAST type name gets NUMERIC affinity
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_cast_empty_typename_numeric_affinity_text() {
+    let mut db = vibesql_storage::Database::new();
+    // SQLite 3.51: CAST('seventeen' AS ) → 0 (typeof integer)
+    assert_eq!(single_value(&mut db, "SELECT CAST('seventeen' AS )"), SqlValue::Integer(0));
+}
+
+#[test]
+fn test_cast_empty_typename_numeric_affinity_real_text() {
+    let mut db = vibesql_storage::Database::new();
+    // SQLite 3.51: CAST('5.5' AS ) → 5.5 (typeof real)
+    assert_eq!(single_value(&mut db, "SELECT CAST('5.5' AS )"), SqlValue::Numeric(5.5));
+}
+
+#[test]
+fn test_cast_empty_typename_sum_over_mixed_column() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a)").unwrap();
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(5),(NULL),('seventeen')").unwrap();
+    // window1.test 61.1 L0 layer: 'seventeen' → 0, NULL skipped → 5
+    assert_eq!(single_value(&mut db, "SELECT sum(CAST(a AS )) FROM t1"), SqlValue::Integer(5));
+}
+
+// ------------------------------------------------------------------------
+// 61.1-B — bitwise operators coerce text SQLite-style
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_bitwise_and_coerces_text() {
+    let mut db = vibesql_storage::Database::new();
+    // SQLite: SELECT 'seventeen' & 5 → 0
+    assert_eq!(single_value(&mut db, "SELECT 'seventeen' & 5"), SqlValue::Integer(0));
+    // Numeric text prefix coerces: '5' | 2 → 7
+    assert_eq!(single_value(&mut db, "SELECT '5' | 2"), SqlValue::Integer(7));
+}
+
+// ------------------------------------------------------------------------
+// 61.1-B — window sum/total/avg coerce text arguments
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_window_sum_text_coercion() {
+    let mut db = vibesql_storage::Database::new();
+    // SQLite: sum('seventeen') OVER() → 0.0 (real)
+    assert_eq!(single_value(&mut db, "SELECT sum('seventeen') OVER()"), SqlValue::Numeric(0.0));
+    // SQLite: sum('5') OVER() → 5 (integer — fully-integer text stays integer)
+    assert_eq!(single_value(&mut db, "SELECT sum('5') OVER()"), SqlValue::Integer(5));
+    // SQLite: sum('5.0') OVER() → 5.0 (real)
+    assert_eq!(single_value(&mut db, "SELECT sum('5.0') OVER()"), SqlValue::Numeric(5.0));
+}
+
+#[test]
+fn test_window_total_and_avg_text_coercion() {
+    let mut db = vibesql_storage::Database::new();
+    assert_eq!(single_value(&mut db, "SELECT total('seventeen') OVER()"), SqlValue::Numeric(0.0));
+    assert_eq!(single_value(&mut db, "SELECT avg('seventeen') OVER()"), SqlValue::Numeric(0.0));
+}
+
+// ------------------------------------------------------------------------
+// 61.1-B — nearest-enclosing-scope binding for nested correlated refs
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_nested_correlated_ref_binds_to_nearest_scope() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a)").unwrap();
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(5),(NULL),(17)").unwrap();
+
+    // The inner `sum(a) OVER()` must bind `a` to the *middle* t1 scope (the
+    // scalar subquery's own FROM), not the outermost t1 row. SQLite: 2 2 2.
+    let rows = execute_sql(
+        &mut db,
+        "SELECT (SELECT sum(a IN(SELECT sum(a) OVER() FROM (SELECT 1 AS x))) FROM t1) FROM t1",
+    )
+    .unwrap();
+    assert_eq!(rows.len(), 3);
+    for row in &rows {
+        assert_eq!(
+            row.values[0],
+            SqlValue::Integer(2),
+            "inner correlated `a` bound to the wrong scope"
+        );
+    }
+}
+
+#[test]
+fn test_in_subquery_null_three_valued_logic_guard() {
+    let mut db = vibesql_storage::Database::new();
+    // Regression guard: 5 IN (SELECT NULL) → NULL
+    assert_eq!(single_value(&mut db, "SELECT 5 IN (SELECT NULL)"), SqlValue::Null);
+}
+
+// ------------------------------------------------------------------------
+// 71.0 — misuse of aggregate detected in UNION arms
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_misuse_of_aggregate_in_union_arm() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t0(a)").unwrap();
+
+    // Misuse lives in the *second* UNION arm; must error even with an empty table.
+    let err = execute_sql(
+        &mut db,
+        "SELECT a FROM t0 WHERE (a,1)=(SELECT 2,2 UNION SELECT sum(a),1)",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("misuse of aggregate"),
+        "expected misuse-of-aggregate error, got: {err}"
+    );
+}
+
+#[test]
+fn test_misuse_of_aggregate_in_third_compound_arm() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t0(a)").unwrap();
+
+    let err = execute_sql(
+        &mut db,
+        "SELECT a FROM t0 WHERE (a,1)=(SELECT 2,2 UNION SELECT 3,3 UNION SELECT sum(a),1)",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("misuse of aggregate"),
+        "expected misuse-of-aggregate error, got: {err}"
+    );
+}
+
+#[test]
+fn test_window1_71_0_full_query_errors() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t0(a)").unwrap();
+
+    // window1.test 71.0: expects *any* prepare-time error.
+    let result = execute_sql(
+        &mut db,
+        "SELECT a FROM t0, (SELECT a AS b FROM t0) \
+         WHERE (a,1)=(SELECT 2,2 UNION SELECT sum(b),max(b) OVER(ORDER BY b) ORDER BY 2) \
+           AND b=4 \
+         ORDER BY b",
+    );
+    assert!(result.is_err(), "window1.test 71.0 must produce an error, got {result:?}");
+}
+
+#[test]
+fn test_from_bearing_union_arm_with_aggregate_not_flagged() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t0(a)").unwrap();
+    execute_sql(&mut db, "INSERT INTO t0 VALUES(2)").unwrap();
+
+    // The aggregate in the second arm has its own FROM — NOT a misuse.
+    let rows = execute_sql(
+        &mut db,
+        "SELECT a FROM t0 WHERE a=(SELECT 2 UNION SELECT sum(a) FROM t0)",
+    );
+    assert!(rows.is_ok(), "FROM-bearing UNION arm must not be flagged: {rows:?}");
+}
+
+#[test]
+fn test_non_correlated_aggregate_in_union_arm_not_flagged() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t0(a)").unwrap();
+
+    // sum(5) doesn't reference an outer column — stays accepted (matches SQLite).
+    let rows =
+        execute_sql(&mut db, "SELECT a FROM t0 WHERE (a,1)=(SELECT 2,2 UNION SELECT sum(5),1)");
+    assert!(rows.is_ok(), "non-correlated aggregate in UNION arm must not be flagged: {rows:?}");
+}

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -986,10 +986,11 @@ impl<'arena> ArenaParser<'arena> {
         let expr_ref = self.arena.alloc(expr);
 
         self.consume_keyword(Keyword::As)?;
-        // SQLite tolerates a missing type name: CAST(x AS ) parses with
-        // no affinity (treated like CAST(x AS ANY) — value passes through).
+        // SQLite tolerates a missing type name: CAST(x AS ) gets NUMERIC
+        // affinity, same as an unrecognized type name
+        // (sqlite3AffinityType("") falls through to NUMERIC).
         let data_type = if matches!(self.peek(), Token::RParen) {
-            vibesql_types::DataType::BinaryLargeObject
+            vibesql_types::DataType::Numeric { precision: 38, scale: 0 }
         } else {
             self.parse_data_type()?
         };

--- a/crates/vibesql-parser/src/parser/expressions/special_forms.rs
+++ b/crates/vibesql-parser/src/parser/expressions/special_forms.rs
@@ -156,10 +156,13 @@ impl Parser {
                 self.expect_keyword(Keyword::As)?;
 
                 // Parse the target data type.
-                // SQLite tolerates a missing type name: CAST(x AS ) parses with
-                // no affinity (treated like CAST(x AS ANY) — value passes through).
+                // SQLite tolerates a missing type name: CAST(x AS ) gets
+                // NUMERIC affinity, same as an unrecognized type name
+                // (sqlite3AffinityType("") falls through to NUMERIC).
+                // Verified against SQLite 3.51: CAST('seventeen' AS ) → 0
+                // (typeof integer), CAST('5.5' AS ) → 5.5 (typeof real).
                 let data_type = if matches!(self.peek(), Token::RParen) {
-                    vibesql_types::DataType::BinaryLargeObject
+                    vibesql_types::DataType::Numeric { precision: 38, scale: 0 }
                 } else {
                     self.parse_data_type()?
                 };

--- a/crates/vibesql-parser/src/tests/cast.rs
+++ b/crates/vibesql-parser/src/tests/cast.rs
@@ -281,8 +281,10 @@ fn test_parse_cast_signed_cross_join_subquery() {
 
 #[test]
 fn test_parse_cast_empty_typename() {
-    // SQLite tolerates a missing type name: CAST(x AS ) parses with no
-    // affinity (treated like CAST(x AS ANY)). From window1.test 61.1.
+    // SQLite tolerates a missing type name: CAST(x AS ) gets NUMERIC
+    // affinity, same as an unrecognized type name (sqlite3AffinityType("")
+    // falls through to NUMERIC). From window1.test 61.1; verified against
+    // SQLite 3.51: CAST('seventeen' AS ) → 0 (typeof integer).
     let result = Parser::parse_sql("SELECT CAST(a AS ) FROM t1;");
     assert!(result.is_ok(), "CAST with empty type name should parse: {:?}", result);
 
@@ -293,8 +295,8 @@ fn test_parse_cast_empty_typename() {
                 vibesql_ast::Expression::Cast { data_type, .. } => {
                     assert_eq!(
                         data_type,
-                        &vibesql_types::DataType::BinaryLargeObject,
-                        "empty type name should map to no-affinity (BLOB) cast"
+                        &vibesql_types::DataType::Numeric { precision: 38, scale: 0 },
+                        "empty type name should map to NUMERIC affinity"
                     );
                 }
                 _ => panic!("Expected CAST expression, got {:?}", expr),


### PR DESCRIPTION
## Summary

Fixes the two remaining window1.test failures (61.1 and 71.0), bringing the file to **271 passed / 0 failed** (baseline: 269/2). Implements the curator's full bisection from #5264.

## Changes

**71.0 — misuse of aggregate in compound arms** (`select/executor/validation/aggregates.rs`)
- `validate_subquery_context_misuse` now walks the full compound chain (head + every `set_operation.right` arm), applying the existing FROM-less checks per arm. `(SELECT 2,2 UNION SELECT sum(b),...)` with an outer-correlated `sum(b)` now errors at prepare time with `misuse of aggregate: sum()`.

**61.1-A — empty CAST type name gets NUMERIC affinity** (`parser/expressions/special_forms.rs`, `arena_parser/expression.rs`)
- `CAST(x AS )` previously mapped to BLOB (pass-through, per #5234's "no-affinity" reading). Verified against SQLite 3.51: `CAST('seventeen' AS )` → `0|integer`, `CAST('5.5' AS )` → `5.5|real` — i.e. NUMERIC affinity, the same fall-through as an unrecognized type name (`sqlite3AffinityType("")`). Both parsers now map it to `Numeric { 38, 0 }`, matching the existing unknown-type-name convention.

**61.1-B — text coercion gaps**
- `evaluator/operators/bitwise.rs`: bitwise ops (`| & ~ << >>`) coerce text/blob operands with string-to-number semantics (`'seventeen' & 5` → 0) instead of erroring through strict `to_i64`.
- `evaluator/window/aggregates.rs`: window `sum`/`total`/`avg` coerce text/blob arguments instead of silently skipping them. Matches SQLite typing: `sum('5') OVER()` → 5 (integer), `sum('seventeen') OVER()` → 0.0 (real), blobs always coerce to REAL.

**61.1-B — merged outer schema/row alignment** (`schema_utils.rs`, `schema.rs`) — the root cause of the wrong `x`
- The merged outer row was laid out `outer ++ current` while the merged schema kept current-level indices 0-based, so a correlated reference resolving to the *nearest* enclosing scope read the *outermost* row's value. Minimal repro (SQLite: `2 2 2`, VibeSQL before: `1 1 1`):
  ```sql
  SELECT (SELECT sum(a IN(SELECT sum(a) OVER() FROM (SELECT 1 AS x))) FROM t1) FROM t1;
  ```
- New consistent convention: merged row = `current ++ outer`; `CombinedSchema::get_column_index` offsets outer-chain hits by the current level's `total_columns`. This keeps current-level indices 0-based, which also keeps the *raw* `outer_rows` used by the outer-correlated-aggregate collapse path (#4930, window1.test 53.0) aligned — the first attempt (shifting the base level instead) fixed 61.1 but regressed 53.0; this convention fixes both.

**Note on the curator's cache/retry suspects**: the `in_subquery.rs` cache key and `ColumnNotFound` retry turned out to be innocent — the mis-binding was in the merged-context alignment they feed into. No changes needed there. The error-swallowing in window aggregate evaluation (`if let Ok(val) = eval_fn(...)`) was not needed for 61.1 once coercion was fixed; left as-is to avoid a behavior-risky signature change (worth a follow-up issue).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 61.1 returns three NULLs | ✅ | Full fuzzer query returns `NULL NULL NULL`; `./scripts/tcltest test window1.test` 61.1 passes |
| 71.0 produces an error (any message) | ✅ | `misuse of aggregate: sum()` at prepare time; 71.0 passes |
| No window1.test regressions | ✅ | 271 passed / 0 failed (baseline 269/2) |
| Minimal repros match SQLite 3.51 | ✅ | `CAST('seventeen' AS )` → `0|integer`; `'seventeen' & 5` → 0; `sum('seventeen') OVER()` → 0.0; `sum('5') OVER()` → 5 (integer); UNION-arm misuse errors with empty table |
| Regression guards | ✅ | `5 IN (SELECT NULL)` → NULL; `(SELECT sum(5),1)` UNION forms stay accepted; FROM-bearing UNION arm with aggregate not flagged; misuse in 3rd compound arm caught (all unit-tested) |
| No regressions in sibling TCL files | ✅ | window2 (63/0), window3 (1462/0), window4 (216/0), cast (122/0), in3 (18/0), subquery2 (18/0); window8 (5), window9 (5), in (1), in4 (1), select1 (1) failures are **identical** to a baseline binary built from the branch point (8c492d09) — all pre-existing |
| Lib tests green | ✅ | `cargo test -p vibesql-executor -p vibesql-parser --lib`: 2447 + 1310 passed, 0 failed (plus 13 new tests in `tests/window1_residuals.rs`) |

## Test Plan

- `./scripts/tcltest test window1.test` → 271/271
- 13 new unit tests in `crates/vibesql-executor/src/tests/window1_residuals.rs` covering each root cause and edge case
- Parser test `test_parse_cast_empty_typename` updated to assert NUMERIC affinity
- Engine-vs-engine baseline comparison for all TCL files with failures (identical lists ⇒ pre-existing)
- `cargo clippy` introduces no new warnings in touched files

Closes #5264