### PR TITLE
fix(executor): FROM-less row-value IN returns FALSE for definitively-unequal rows

### DIFF
--- a/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
@@ -453,13 +453,8 @@ impl ExpressionEvaluator<'_> {
 
         // Evaluate all elements of the left row value
         let mut expr_values = Vec::with_capacity(expected_columns);
-        let mut has_null_element = false;
-
         for elem_expr in expr_elements {
             let val = self.eval(elem_expr, row)?;
-            if matches!(val, SqlValue::Null) {
-                has_null_element = true;
-            }
             expr_values.push(val);
         }
 
@@ -528,11 +523,14 @@ impl ExpressionEvaluator<'_> {
             return Ok(SqlValue::Boolean(negated));
         }
 
-        // If the row value has a NULL element, handle specially
-        // NULL IN (empty set) → FALSE, but we already handled empty set above
-        // NULL IN (non-empty set) → depends on matches
-
-        let mut found_null_in_subquery = false;
+        // Whether any row compared as UNKNOWN (all non-NULL elements equal,
+        // but at least one element comparison involved NULL). Rows that are
+        // definitively FALSE (some element definitively unequal) do NOT make
+        // the overall result UNKNOWN — SQL three-valued AND semantics:
+        // (0,0) IN (SELECT NULL, 1) is FALSE (0=1 is false), while
+        // (0,0) IN (SELECT NULL, 0) is NULL (0=NULL is unknown). (#5268,
+        // mirrors the combined-evaluator fix from #5265)
+        let mut found_unknown_row = false;
 
         // Compare with each row from subquery
         for subquery_row in &rows {
@@ -545,12 +543,9 @@ impl ExpressionEvaluator<'_> {
                     .get(i)
                     .ok_or(ExecutorError::ColumnIndexOutOfBounds { index: i })?;
 
-                // Check for NULL
+                // NULL on either side propagates as UNKNOWN for this element
                 if matches!(expr_val, SqlValue::Null) || matches!(subquery_val, SqlValue::Null) {
                     has_null_comparison = true;
-                    if matches!(subquery_val, SqlValue::Null) {
-                        found_null_in_subquery = true;
-                    }
                     // Can't determine equality with NULL - continue to check other elements
                     continue;
                 }
@@ -584,18 +579,21 @@ impl ExpressionEvaluator<'_> {
                 }
             }
 
-            if all_equal && !has_null_comparison {
-                // Found a match!
-                return Ok(SqlValue::Boolean(!negated));
+            if all_equal {
+                if !has_null_comparison {
+                    // Found an exact match
+                    return Ok(SqlValue::Boolean(!negated));
+                }
+                // No element definitively unequal, but some comparison was
+                // UNKNOWN — this row's match is UNKNOWN.
+                found_unknown_row = true;
             }
         }
 
         // No exact match found
-        if has_null_element || found_null_in_subquery {
-            // NULL in either side means result is NULL (unless we found an exact match above)
+        if found_unknown_row {
             Ok(SqlValue::Null)
         } else {
-            // No match found
             Ok(SqlValue::Boolean(negated))
         }
     }

--- a/crates/vibesql-executor/tests/row_value_in_three_valued_tests.rs
+++ b/crates/vibesql-executor/tests/row_value_in_three_valued_tests.rs
@@ -1,0 +1,176 @@
+//! Regression tests for issue #5268 (and #5232 / PR #5265)
+//!
+//! Row-value IN/NOT IN must follow SQL three-valued logic:
+//!
+//! - Per candidate row, the element-wise comparison is TRUE only if all
+//!   pairs are non-NULL and equal; FALSE if ANY pair is non-NULL and
+//!   unequal (three-valued AND short-circuits on FALSE); UNKNOWN otherwise.
+//! - IN is then a three-valued OR over rows: TRUE if any row is TRUE;
+//!   UNKNOWN if no row is TRUE but some row is UNKNOWN; FALSE otherwise.
+//!
+//! PR #5265 fixed this in the combined evaluator (table-backed queries),
+//! but FROM-less constant queries route through the simple
+//! `ExpressionEvaluator`, which retained the old behavior of forcing NULL
+//! whenever a NULL appeared on either side — even for rows that are
+//! definitively unequal. Issue #5268 ports the fix to that path.
+//!
+//! Expected values below were verified against sqlite3.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+/// Run a SELECT that yields a single scalar value and return it,
+/// normalizing Boolean to Integer (SQLite has no boolean storage class;
+/// IN results display as 0/1).
+fn query_scalar(db: &vibesql_storage::Database, sql: &str) -> SqlValue {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        let rows = executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e));
+        assert_eq!(rows.len(), 1, "Expected exactly one row for: {}", sql);
+        assert_eq!(rows[0].values.len(), 1, "Expected exactly one column for: {}", sql);
+        match &rows[0].values[0] {
+            SqlValue::Boolean(b) => SqlValue::Integer(*b as i64),
+            other => other.clone(),
+        }
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+fn assert_query(db: &vibesql_storage::Database, sql: &str, expected: SqlValue) {
+    let actual = query_scalar(db, sql);
+    assert_eq!(actual, expected, "Query: {} -- expected {:?}, got {:?}", sql, expected, actual);
+}
+
+/// Database with a single-row table so the same predicates can be run
+/// through the combined evaluator (table-backed path).
+fn db_with_t0() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t0(c0 INTEGER)");
+    run_stmt(&mut db, "INSERT INTO t0 VALUES(0)");
+    db
+}
+
+// ---------------------------------------------------------------------------
+// FROM-less constant queries (simple evaluator path) — issue #5268
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fromless_definitively_unequal_row_is_false() {
+    // (NULL, 1) vs (0, 0): 0=1 is definitively FALSE, so the row is FALSE
+    // regardless of the NULL element. SQLite: 0.
+    let db = vibesql_storage::Database::new();
+    assert_query(&db, "SELECT (0,0) IN (SELECT NULL, 1)", SqlValue::Integer(0));
+}
+
+#[test]
+fn fromless_not_in_definitively_unequal_row_is_true() {
+    // NOT IN negation of a definitive FALSE. SQLite: 1.
+    let db = vibesql_storage::Database::new();
+    assert_query(&db, "SELECT (0,0) NOT IN (SELECT NULL, 1)", SqlValue::Integer(1));
+}
+
+#[test]
+fn fromless_lhs_null_with_unequal_element_is_false() {
+    // LHS has a NULL element, but 0=1 is definitively FALSE, so the row is
+    // FALSE — the LHS NULL must not force UNKNOWN. SQLite: 0.
+    let db = vibesql_storage::Database::new();
+    assert_query(&db, "SELECT (NULL,0) IN (SELECT 1, 1)", SqlValue::Integer(0));
+}
+
+#[test]
+fn fromless_lhs_null_with_unequal_element_not_in_is_true() {
+    let db = vibesql_storage::Database::new();
+    assert_query(&db, "SELECT (NULL,0) NOT IN (SELECT 1, 1)", SqlValue::Integer(1));
+}
+
+#[test]
+fn fromless_unknown_rows_stay_null() {
+    // All non-NULL element pairs are equal, but a NULL comparison makes the
+    // row UNKNOWN — the IN result is NULL. SQLite: NULL for all three.
+    let db = vibesql_storage::Database::new();
+    assert_query(&db, "SELECT (0,0) IN (SELECT NULL, 0)", SqlValue::Null);
+    assert_query(&db, "SELECT (0,0) IN (SELECT 0, NULL)", SqlValue::Null);
+    assert_query(&db, "SELECT (NULL,0) IN (SELECT 1, 0)", SqlValue::Null);
+}
+
+#[test]
+fn fromless_not_in_unknown_rows_stay_null() {
+    // NOT IN negation of UNKNOWN is still UNKNOWN. SQLite: NULL.
+    let db = vibesql_storage::Database::new();
+    assert_query(&db, "SELECT (0,0) NOT IN (SELECT NULL, 0)", SqlValue::Null);
+    assert_query(&db, "SELECT (0,0) NOT IN (SELECT 0, NULL)", SqlValue::Null);
+    assert_query(&db, "SELECT (NULL,0) NOT IN (SELECT 1, 0)", SqlValue::Null);
+}
+
+#[test]
+fn fromless_empty_subquery_is_false() {
+    // IN over an empty set is FALSE (even with NULLs on the left);
+    // NOT IN is TRUE. SQLite: 0 / 1.
+    let db = vibesql_storage::Database::new();
+    assert_query(&db, "SELECT (0,0) IN (SELECT NULL, 1 WHERE 0)", SqlValue::Integer(0));
+    assert_query(&db, "SELECT (0,0) NOT IN (SELECT NULL, 1 WHERE 0)", SqlValue::Integer(1));
+}
+
+#[test]
+fn fromless_mixed_false_and_unknown_rows_is_null() {
+    // One row definitively FALSE, one row UNKNOWN: three-valued OR over
+    // {FALSE, UNKNOWN} is UNKNOWN. SQLite: NULL.
+    let db = vibesql_storage::Database::new();
+    assert_query(&db, "SELECT (0,0) IN (SELECT NULL, 1 UNION ALL SELECT NULL, 0)", SqlValue::Null);
+    assert_query(
+        &db,
+        "SELECT (0,0) NOT IN (SELECT NULL, 1 UNION ALL SELECT NULL, 0)",
+        SqlValue::Null,
+    );
+}
+
+#[test]
+fn fromless_true_row_wins_over_unknown_rows() {
+    // A definitive match makes IN TRUE even when other rows are UNKNOWN.
+    // SQLite: 1.
+    let db = vibesql_storage::Database::new();
+    assert_query(
+        &db,
+        "SELECT (0,0) IN (SELECT 0, 0 UNION ALL SELECT NULL, 0)",
+        SqlValue::Integer(1),
+    );
+    assert_query(&db, "SELECT (0,0) IN (SELECT 0, 0)", SqlValue::Integer(1));
+}
+
+// ---------------------------------------------------------------------------
+// Table-backed parity (combined evaluator path) — fixed by PR #5265,
+// must keep matching the FROM-less results above.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn table_backed_definitively_unequal_row_is_false() {
+    let db = db_with_t0();
+    assert_query(&db, "SELECT (0,0) IN (SELECT NULL, 1) FROM t0", SqlValue::Integer(0));
+    assert_query(&db, "SELECT (0,0) NOT IN (SELECT NULL, 1) FROM t0", SqlValue::Integer(1));
+    assert_query(&db, "SELECT (NULL,0) IN (SELECT 1, 1) FROM t0", SqlValue::Integer(0));
+}
+
+#[test]
+fn table_backed_unknown_rows_stay_null() {
+    let db = db_with_t0();
+    assert_query(&db, "SELECT (0,0) IN (SELECT NULL, 0) FROM t0", SqlValue::Null);
+    assert_query(&db, "SELECT (0,0) IN (SELECT 0, NULL) FROM t0", SqlValue::Null);
+    assert_query(&db, "SELECT (NULL,0) IN (SELECT 1, 0) FROM t0", SqlValue::Null);
+}


### PR DESCRIPTION
## Summary

FROM-less constant queries route row-value IN through the simple `ExpressionEvaluator`, which still had the pre-#5265 NULL-tracking logic: any NULL on either side of the comparison forced the IN result to NULL, even when a candidate row was definitively unequal. This ports the `found_unknown_row` logic from PR #5265 (combined evaluator, `evaluator/combined/subqueries/in_subquery.rs`) into `evaluator/expressions/subqueries.rs::eval_row_value_in_subquery` (curator Option A, minimal port).

Per SQL three-valued semantics, a candidate row with any non-NULL unequal element pair is FALSE (three-valued AND short-circuits); only rows where all non-NULL pairs are equal but some comparison involved NULL are UNKNOWN. IN is then a three-valued OR over rows.

## Changes

- `crates/vibesql-executor/src/evaluator/expressions/subqueries.rs`: removed the `has_null_element` (LHS NULL) and `found_null_in_subquery` (RHS NULL) flags; added per-row `found_unknown_row` tracking mirroring the combined-evaluator fix from #5265 (including the explanatory comment block)
- `crates/vibesql-executor/tests/row_value_in_three_valued_tests.rs` (new): 11 integration tests covering the full SQLite-verified truth table for the FROM-less path, NOT IN negation of both FALSE and UNKNOWN, empty subqueries, multi-row subqueries mixing FALSE/UNKNOWN/TRUE rows, and table-backed parity through the combined evaluator

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SELECT (0,0) IN (SELECT NULL, 1);` returns `0` | ✅ | CLI manual check + `fromless_definitively_unequal_row_is_false` |
| `SELECT (0,0) NOT IN (SELECT NULL, 1);` returns `1` | ✅ | CLI manual check + `fromless_not_in_definitively_unequal_row_is_true` |
| `SELECT (NULL,0) IN (SELECT 1, 1);` returns `0` | ✅ | CLI manual check + `fromless_lhs_null_with_unequal_element_is_false` |
| UNKNOWN cases still return NULL (all 3) | ✅ | CLI manual check + `fromless_unknown_rows_stay_null` / `fromless_not_in_unknown_rows_stay_null` |
| Table-backed equivalents unchanged | ✅ | `table_backed_*` tests + CLI manual check with `FROM t0` |
| No regressions in existing executor tests | ✅ | `cargo test -p vibesql-executor`: 40 test binaries, all green |

## Test Plan

- Manual CLI verification of all six truth-table rows plus NOT IN variants against the sqlite3 values in the curator comment — all match
- Edge cases verified: empty subquery (`WHERE 0`) → 0/1, mixed FALSE+UNKNOWN rows → NULL, TRUE row wins over UNKNOWN rows → 1
- `cargo test -p vibesql-executor` — all green (includes new test file, 11/11 pass)
- `cargo clippy` / `rustfmt` — clean for changed files
- TCL regression: `window1.test` (the #5265 fix territory) 271 passed / 0 failed; `in3.test` 0 failed; `in.test` (in-23.0) and `in4.test` (in4-4.4) each have one failure **verified pre-existing on main** by rebuilding without this change (scalar-IN collation cases, unrelated to row-value IN)

Out of scope per curator: `(0,0) IN (VALUES(NULL,1))` parse error (separate parser gap).

Closes #5268