### PR TITLE
fix(parser): bare SELECT/VALUES + RETURNING is a syntax error; view INSERT RETURNING test

### DIFF
--- a/crates/vibesql-executor/src/tests/insert_returning.rs
+++ b/crates/vibesql-executor/src/tests/insert_returning.rs
@@ -28,6 +28,14 @@ fn execute_sql(db: &mut vibesql_storage::Database, sql: &str) -> Vec<vibesql_sto
             InsertExecutor::execute(db, &s).expect("INSERT failed");
             vec![]
         }
+        Statement::CreateView(s) => {
+            crate::advanced_objects::execute_create_view(&s, db).expect("CREATE VIEW failed");
+            vec![]
+        }
+        Statement::CreateTrigger(s) => {
+            crate::advanced_objects::execute_create_trigger(&s, db).expect("CREATE TRIGGER failed");
+            vec![]
+        }
         Statement::Select(s) => SelectExecutor::new(db).execute(&s).expect("SELECT failed"),
         other => panic!("Unsupported statement in test helper: {:?}", other),
     }
@@ -278,6 +286,38 @@ fn test_insert_without_returning_yields_none() {
     let (count, returning) = execute_insert_returning(&mut db, "INSERT INTO t1 VALUES (1)");
     assert_eq!(count, 1);
     assert!(returning.is_none(), "no RETURNING clause, no result expected");
+}
+
+#[test]
+fn test_insert_returning_through_instead_of_trigger() {
+    // Issue #5272: view path parity with delete_returning.rs. INSERT into a
+    // view with an INSTEAD OF INSERT trigger projects RETURNING against the
+    // NEW view rows, one result row per trigger fire.
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE base(a INT, b TEXT)");
+    execute_sql(&mut db, "CREATE VIEW v1 AS SELECT a, b FROM base");
+    execute_sql(
+        &mut db,
+        "CREATE TRIGGER v1_tr INSTEAD OF INSERT ON v1 \
+         BEGIN INSERT INTO base VALUES(NEW.a, NEW.b); END",
+    );
+
+    let (count, returning) = execute_insert_returning(
+        &mut db,
+        "INSERT INTO v1 VALUES (1, 'x'), (2, 'y') RETURNING a, b",
+    );
+    assert_eq!(count, 2);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(returning.columns, vec!["a".to_string(), "b".to_string()]);
+    assert_eq!(returning.rows.len(), 2, "one RETURNING row per INSTEAD OF trigger fire");
+    assert_eq!(returning.rows[0].values[0], SqlValue::Integer(1));
+    assert_eq!(string_value(&returning.rows[0].values[1]), "x");
+    assert_eq!(returning.rows[1].values[0], SqlValue::Integer(2));
+    assert_eq!(string_value(&returning.rows[1].values[1]), "y");
+
+    // The trigger actually inserted both rows into the base table.
+    let rows = execute_sql(&mut db, "SELECT a FROM base");
+    assert_eq!(rows.len(), 2, "INSTEAD OF trigger should fire once per inserted view row");
 }
 
 #[test]

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -83,7 +83,7 @@ impl Parser {
             // Parse VALUES using the full statement parser to handle compound operators
             // allow_order_limit=false: INSERT VALUES doesn't support ORDER BY/LIMIT
             // validate_end_tokens=false: INSERT has additional tokens after VALUES
-            let values_stmt = self.parse_values_statement_internal(false, false)?;
+            let values_stmt = self.parse_values_statement_internal(false, false, true)?;
 
             // If there's a set operation (UNION/INTERSECT/EXCEPT), use Select source
             // Otherwise, extract the values directly for the Values source
@@ -103,7 +103,7 @@ impl Parser {
             }
         } else if self.peek_keyword(Keyword::Select) || self.peek_keyword(Keyword::With) {
             // Parse SELECT
-            let select_stmt = self.parse_select_statement()?;
+            let select_stmt = self.parse_dml_source_select_statement()?;
             vibesql_ast::InsertSource::Select(Box::new(select_stmt))
         } else {
             return Err(ParseError {
@@ -226,7 +226,7 @@ impl Parser {
             vibesql_ast::InsertSource::DefaultValues
         } else if self.peek_keyword(Keyword::Values) {
             // Parse VALUES using the full statement parser to handle compound operators
-            let values_stmt = self.parse_values_statement_internal(false, false)?;
+            let values_stmt = self.parse_values_statement_internal(false, false, true)?;
 
             // If there's a set operation (UNION/INTERSECT/EXCEPT), use Select source
             if values_stmt.set_operation.is_some() {
@@ -243,7 +243,7 @@ impl Parser {
             }
         } else if self.peek_keyword(Keyword::Select) {
             // Parse SELECT without consuming WITH (already parsed)
-            let select_stmt = self.parse_select_statement()?;
+            let select_stmt = self.parse_dml_source_select_statement()?;
             vibesql_ast::InsertSource::Select(Box::new(select_stmt))
         } else {
             return Err(ParseError {
@@ -336,7 +336,7 @@ impl Parser {
             vibesql_ast::InsertSource::DefaultValues
         } else if self.peek_keyword(Keyword::Values) {
             // Parse VALUES using the full statement parser to handle compound operators
-            let values_stmt = self.parse_values_statement_internal(false, false)?;
+            let values_stmt = self.parse_values_statement_internal(false, false, true)?;
 
             // If there's a set operation (UNION/INTERSECT/EXCEPT), use Select source
             if values_stmt.set_operation.is_some() {
@@ -352,7 +352,7 @@ impl Parser {
                 }
             }
         } else if self.peek_keyword(Keyword::Select) || self.peek_keyword(Keyword::With) {
-            let select_stmt = self.parse_select_statement()?;
+            let select_stmt = self.parse_dml_source_select_statement()?;
             vibesql_ast::InsertSource::Select(Box::new(select_stmt))
         } else {
             return Err(ParseError {

--- a/crates/vibesql-parser/src/parser/select/statement.rs
+++ b/crates/vibesql-parser/src/parser/select/statement.rs
@@ -3,7 +3,20 @@ use super::*;
 impl Parser {
     /// Parse SELECT statement (public entry point)
     pub(crate) fn parse_select_statement(&mut self) -> Result<vibesql_ast::SelectStmt, ParseError> {
-        self.parse_select_statement_internal(true, true)
+        self.parse_select_statement_internal(true, true, false)
+    }
+
+    /// Parse a SELECT statement used as the source of a DML statement
+    /// (e.g., INSERT INTO t SELECT ... RETURNING ...).
+    ///
+    /// Unlike `parse_select_statement`, a trailing RETURNING keyword is accepted
+    /// as a valid end token because the clause belongs to the outer DML statement
+    /// (issue #5263). Bare SELECT statements must NOT use this entry point, since
+    /// SQLite rejects RETURNING outside DML (issue #5271).
+    pub(crate) fn parse_dml_source_select_statement(
+        &mut self,
+    ) -> Result<vibesql_ast::SelectStmt, ParseError> {
+        self.parse_select_statement_internal(true, true, true)
     }
 
     /// Parse SELECT or VALUES statement when embedded in another statement (cursor, view, etc.)
@@ -17,9 +30,9 @@ impl Parser {
     ) -> Result<vibesql_ast::SelectStmt, ParseError> {
         if self.peek_keyword(Keyword::Values) {
             // Handle VALUES clause as view source (e.g., CREATE VIEW dual(dummy) AS VALUES('x'))
-            self.parse_values_statement_internal(true, false)
+            self.parse_values_statement_internal(true, false, false)
         } else {
-            self.parse_select_statement_internal(true, false)
+            self.parse_select_statement_internal(true, false, false)
         }
     }
 
@@ -33,10 +46,17 @@ impl Parser {
     /// unexpected tokens follow the SELECT statement. This is set to false when parsing
     /// SELECT as part of another statement (cursor, view, etc.) where additional tokens
     /// belong to the outer statement.
+    ///
+    /// The `allow_returning` parameter controls whether a trailing RETURNING keyword
+    /// is accepted as a valid end token. This is true only when the SELECT/VALUES is
+    /// the source of a DML statement (INSERT INTO t SELECT ... RETURNING ..., issue
+    /// #5263). For bare SELECT statements it must be false so that SQLite-incompatible
+    /// input like `SELECT 1 RETURNING a` is rejected (issue #5271).
     fn parse_select_statement_internal(
         &mut self,
         allow_order_limit: bool,
         validate_end_tokens: bool,
+        allow_returning: bool,
     ) -> Result<vibesql_ast::SelectStmt, ParseError> {
         // Parse optional WITH clause (CTEs)
         let with_clause = if self.peek_keyword(Keyword::With) {
@@ -183,9 +203,9 @@ impl Parser {
             let right = if matches!(self.peek(), Token::LParen) {
                 self.advance(); // consume '('
                 let stmt = if self.peek_keyword(Keyword::Values) {
-                    self.parse_values_statement_internal(false, true)?
+                    self.parse_values_statement_internal(false, true, false)?
                 } else {
-                    self.parse_select_statement_internal(false, true)?
+                    self.parse_select_statement_internal(false, true, false)?
                 };
                 if !matches!(self.peek(), Token::RParen) {
                     return Err(ParseError {
@@ -196,9 +216,9 @@ impl Parser {
                 self.advance(); // consume ')'
                 Box::new(stmt)
             } else if self.peek_keyword(Keyword::Values) {
-                Box::new(self.parse_values_statement_internal(false, true)?)
+                Box::new(self.parse_values_statement_internal(false, true, allow_returning)?)
             } else {
-                Box::new(self.parse_select_statement_internal(false, true)?)
+                Box::new(self.parse_select_statement_internal(false, true, allow_returning)?)
             };
 
             Some(vibesql_ast::SetOperation { op, all, right })
@@ -379,16 +399,16 @@ impl Parser {
         if validate_end_tokens {
             if allow_order_limit {
                 // Top-level: only allow semicolon, EOF, or ) (for subqueries/CTEs).
-                // RETURNING is allowed because the SELECT may be the source of
+                // RETURNING is allowed only when the SELECT is the source of
                 // INSERT INTO t SELECT ... RETURNING ... (the clause belongs to
-                // the outer INSERT, issue #5263).
-                if !matches!(
-                    self.peek(),
-                    Token::Semicolon
-                        | Token::Eof
-                        | Token::RParen
-                        | Token::Keyword { keyword: Keyword::Returning, .. }
-                ) {
+                // the outer INSERT, issue #5263). For a bare SELECT, a trailing
+                // RETURNING is a syntax error, matching SQLite (issue #5271).
+                let valid_end_token = match self.peek() {
+                    Token::Semicolon | Token::Eof | Token::RParen => true,
+                    Token::Keyword { keyword: Keyword::Returning, .. } if allow_returning => true,
+                    _ => false,
+                };
+                if !valid_end_token {
                     return Err(ParseError { message: self.peek().syntax_error() });
                 }
             } else {
@@ -398,6 +418,10 @@ impl Parser {
                     Token::Keyword { keyword: Keyword::Order, .. }
                     | Token::Keyword { keyword: Keyword::Limit, .. }
                     | Token::Keyword { keyword: Keyword::Offset, .. } => {}
+                    // RETURNING belongs to an outer DML statement when this SELECT
+                    // is the right side of a set operation in its source, e.g.
+                    // INSERT INTO t SELECT 1 UNION SELECT 2 RETURNING a (issue #5263)
+                    Token::Keyword { keyword: Keyword::Returning, .. } if allow_returning => {}
                     _ => return Err(ParseError { message: self.peek().syntax_error() }),
                 }
             }
@@ -554,7 +578,7 @@ impl Parser {
     /// - VALUES(1),(2),(3);
     /// - VALUES(1) UNION VALUES(2);
     pub(crate) fn parse_values_statement(&mut self) -> Result<vibesql_ast::SelectStmt, ParseError> {
-        self.parse_values_statement_internal(true, true)
+        self.parse_values_statement_internal(true, true, false)
     }
 
     /// Internal VALUES parser with control over ORDER BY/LIMIT parsing
@@ -562,12 +586,18 @@ impl Parser {
     /// The `validate_end_tokens` parameter controls whether to validate that no
     /// unexpected tokens follow the statement.
     ///
+    /// The `allow_returning` parameter controls whether a trailing RETURNING keyword
+    /// is accepted as a valid end token (only when the VALUES is the source of a DML
+    /// statement, issue #5263). For bare VALUES statements it must be false (issue
+    /// #5271).
+    ///
     /// This is used by INSERT parser to handle compound VALUES statements like:
     /// `INSERT INTO t VALUES(1) UNION VALUES(2)`
     pub(crate) fn parse_values_statement_internal(
         &mut self,
         allow_order_limit: bool,
         validate_end_tokens: bool,
+        allow_returning: bool,
     ) -> Result<vibesql_ast::SelectStmt, ParseError> {
         // Parse the VALUES rows
         let rows = self.parse_values_rows()?;
@@ -602,9 +632,9 @@ impl Parser {
             let right = if matches!(self.peek(), Token::LParen) {
                 self.advance(); // consume '('
                 let stmt = if self.peek_keyword(Keyword::Values) {
-                    self.parse_values_statement_internal(false, true)?
+                    self.parse_values_statement_internal(false, true, false)?
                 } else {
-                    self.parse_select_statement_internal(false, true)?
+                    self.parse_select_statement_internal(false, true, false)?
                 };
                 if !matches!(self.peek(), Token::RParen) {
                     return Err(ParseError {
@@ -615,9 +645,9 @@ impl Parser {
                 self.advance(); // consume ')'
                 Box::new(stmt)
             } else if self.peek_keyword(Keyword::Values) {
-                Box::new(self.parse_values_statement_internal(false, true)?)
+                Box::new(self.parse_values_statement_internal(false, true, allow_returning)?)
             } else {
-                Box::new(self.parse_select_statement_internal(false, true)?)
+                Box::new(self.parse_select_statement_internal(false, true, allow_returning)?)
             };
 
             Some(vibesql_ast::SetOperation { op, all, right })
@@ -730,8 +760,10 @@ impl Parser {
             let valid_end_token = match self.peek() {
                 Token::Semicolon | Token::Eof | Token::RParen => true,
                 // RETURNING belongs to an outer INSERT (INSERT INTO t VALUES
-                // ... RETURNING ..., issue #5263).
-                Token::Keyword { keyword: Keyword::Returning, .. } => true,
+                // ... RETURNING ..., issue #5263). For a bare VALUES statement a
+                // trailing RETURNING is a syntax error, matching SQLite (issue
+                // #5271).
+                Token::Keyword { keyword: Keyword::Returning, .. } if allow_returning => true,
                 // When nested, allow ORDER BY/LIMIT/OFFSET for outer statement
                 Token::Keyword { keyword: Keyword::Order, .. }
                 | Token::Keyword { keyword: Keyword::Limit, .. }

--- a/crates/vibesql-parser/src/tests/errors.rs
+++ b/crates/vibesql-parser/src/tests/errors.rs
@@ -518,3 +518,41 @@ fn test_issue_4467_mixed_case_keyword_error() {
         error_msg
     );
 }
+
+// ========================================================================
+// Issue #5271: bare SELECT/VALUES with a trailing RETURNING clause must be
+// a syntax error (SQLite: Parse error: near "RETURNING": syntax error).
+// RETURNING is only valid as part of a DML statement (INSERT/UPDATE/DELETE).
+// ========================================================================
+
+#[test]
+fn test_issue_5271_bare_select_returning_is_error() {
+    let result = Parser::parse_sql("SELECT 1 RETURNING a;");
+    assert!(result.is_err(), "bare SELECT ... RETURNING should be a syntax error");
+}
+
+#[test]
+fn test_issue_5271_bare_select_from_returning_is_error() {
+    let result = Parser::parse_sql("SELECT * FROM t RETURNING;");
+    assert!(result.is_err(), "bare SELECT ... RETURNING should be a syntax error");
+}
+
+#[test]
+fn test_issue_5271_bare_values_returning_is_error() {
+    let result = Parser::parse_sql("VALUES(1) RETURNING a;");
+    assert!(result.is_err(), "bare VALUES ... RETURNING should be a syntax error");
+}
+
+#[test]
+fn test_issue_5271_bare_compound_select_returning_is_error() {
+    let result = Parser::parse_sql("SELECT 1 UNION SELECT 2 RETURNING a;");
+    assert!(result.is_err(), "bare compound SELECT ... RETURNING should be a syntax error");
+}
+
+#[test]
+fn test_issue_5271_bare_select_returning_arena_fallback_is_error() {
+    // The CLI path goes through parse_with_arena_fallback; the arena parser
+    // rejects this on its own, but the owned-parser fallback must reject it too.
+    let result = crate::parse_with_arena_fallback("SELECT 1 RETURNING a");
+    assert!(result.is_err(), "bare SELECT ... RETURNING should be a syntax error in both parsers");
+}

--- a/crates/vibesql-parser/src/tests/insert.rs
+++ b/crates/vibesql-parser/src/tests/insert.rs
@@ -362,3 +362,49 @@ fn test_parse_insert_without_returning_is_none() {
         _ => panic!("Expected INSERT statement"),
     }
 }
+
+#[test]
+fn test_parse_insert_select_returning() {
+    // The RETURNING keyword terminates the embedded SELECT source and belongs
+    // to the outer INSERT (issue #5263); this must keep working after the
+    // bare-SELECT RETURNING fix (issue #5271).
+    let result = Parser::parse_sql("INSERT INTO t1 SELECT a FROM t2 RETURNING a;");
+    assert!(result.is_ok(), "INSERT ... SELECT ... RETURNING should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => {
+            assert!(matches!(insert.source, vibesql_ast::InsertSource::Select(_)));
+            let returning = insert.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 1);
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_parse_insert_compound_select_returning() {
+    // RETURNING after a compound SELECT source: the keyword follows the right
+    // side of the set operation, so the allow_returning flag must propagate
+    // through nested set-operation parsing (issue #5271).
+    let result = Parser::parse_sql("INSERT INTO t1 SELECT 1 UNION SELECT 2 RETURNING a;");
+    assert!(result.is_ok(), "compound SELECT source + RETURNING should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => {
+            let returning = insert.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 1);
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}
+
+#[test]
+fn test_parse_insert_compound_values_returning() {
+    let result = Parser::parse_sql("INSERT INTO t1 VALUES (1) UNION VALUES (2) RETURNING a;");
+    assert!(result.is_ok(), "compound VALUES source + RETURNING should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => {
+            let returning = insert.returning.expect("returning clause should be captured");
+            assert_eq!(returning.len(), 1);
+        }
+        _ => panic!("Expected INSERT statement"),
+    }
+}


### PR DESCRIPTION
Closes #5271
Closes #5272

Both issues are small follow-ups from the judge review of PR #5270 (INSERT ... RETURNING). Neither carried the `loom:issue` label (they came straight from review); both were labeled `loom:building` when claimed.

## Summary

**#5271 — bare SELECT silently accepted a trailing RETURNING clause**
- PR #5270 unconditionally added `Keyword::Returning` to the SELECT/VALUES end-token checks in the owned parser, so `SELECT 1 RETURNING a;` parsed and silently dropped the clause (SQLite: syntax error).
- Fix: thread an `allow_returning` flag through `parse_select_statement_internal` / `parse_values_statement_internal`. RETURNING is accepted as an end token only when the query is parsed as the source of an INSERT (new `parse_dml_source_select_statement` entry point used by `parser/insert.rs`).
- The flag propagates through set-operation right sides, which also fixes a gap: `INSERT INTO t SELECT 1 UNION SELECT 2 RETURNING a` now parses (the nested end-token arm previously rejected it).
- Arena parser needs no change: it already rejected bare `SELECT ... RETURNING`, and `INSERT ... SELECT ... RETURNING` reaches the owned parser via the arena fallback (verified by `test_issue_5271_bare_select_returning_arena_fallback_is_error`).

**#5272 — test parity for the view INSTEAD OF INSERT RETURNING path**
- Added `test_insert_returning_through_instead_of_trigger` to `crates/vibesql-executor/src/tests/insert_returning.rs`, mirroring the DELETE counterpart in `delete_returning.rs` (CreateView/CreateTrigger arms copied into the `execute_sql` helper).

## Testing

- New parser error tests (`tests/errors.rs`): `SELECT 1 RETURNING a`, `SELECT * FROM t RETURNING`, `VALUES(1) RETURNING a`, compound bare SELECT, and the arena-fallback path all error.
- New parser positive tests (`tests/insert.rs`): `INSERT ... SELECT ... RETURNING`, compound SELECT source + RETURNING, compound VALUES source + RETURNING.
- `cargo test -p vibesql-parser`: 1327 passed, 0 failed.
- `cargo test -p vibesql-executor --lib`: 2475 passed, 0 failed (includes the new INSTEAD OF INSERT test).
- TCL `returning1.test`: 46 passed / 33 failed / 4 skipped — identical to the main baseline (no regression; failures are pre-existing UPDATE-RETURNING/trigger gaps).
- Pre-existing clippy warnings (`collapsible_match` in `from_clause.rs`, executor lib warnings) are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)