### PR TITLE
feat(cli): implement PRAGMA count_changes and SQLite ?NNN placeholders

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -15,6 +15,10 @@ mod tests;
 pub struct SqlExecutor {
     db: Database,
     timing_enabled: bool,
+    /// PRAGMA count_changes session flag (SQLite-compatible, default OFF).
+    /// When ON, INSERT/UPDATE/DELETE statements return a one-row, one-column
+    /// result containing the change count.
+    count_changes: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -163,7 +167,7 @@ impl SqlExecutor {
             Database::new()
         };
 
-        Ok(SqlExecutor { db, timing_enabled: false })
+        Ok(SqlExecutor { db, timing_enabled: false, count_changes: false })
     }
 
     /// Returns true if the current session is inside an active transaction.
@@ -222,7 +226,8 @@ impl SqlExecutor {
                     &mut self.db,
                     &insert_stmt,
                 ) {
-                    Ok((affected_rows, returning)) => {
+                    Ok(outcome) => {
+                        let affected_rows = outcome.affected_rows;
                         // Track changes count for changes() and total_changes() functions
                         self.db.set_last_changes_count(affected_rows);
                         self.db.increment_total_changes_count(affected_rows);
@@ -230,7 +235,7 @@ impl SqlExecutor {
 
                         // RETURNING clause: render the projected NEW rows like
                         // a SELECT result (SQLite 3.35.0+ semantics).
-                        if let Some(returning_result) = returning {
+                        if let Some(returning_result) = outcome.returning {
                             result.row_count = returning_result.rows.len();
                             result.columns = returning_result.columns;
                             for row in returning_result.rows {
@@ -247,6 +252,16 @@ impl SqlExecutor {
                                         .collect();
                                 result.rows.push(row_strs);
                             }
+                        } else if self.count_changes {
+                            // PRAGMA count_changes=ON (SQLite parity): emit a
+                            // one-row result with the DIRECT insert count.
+                            // Rows taken through the upsert DO UPDATE arm are
+                            // excluded here even though changes() includes
+                            // them (verified against sqlite3; upsert1-400).
+                            let count = affected_rows - outcome.upsert_updated_rows;
+                            result.columns = vec!["rows inserted".to_string()];
+                            result.rows = vec![vec![Some(count.to_string())]];
+                            result.row_count = 1;
                         }
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
@@ -282,6 +297,12 @@ impl SqlExecutor {
                                         .collect();
                                 result.rows.push(row_strs);
                             }
+                        } else if self.count_changes {
+                            // PRAGMA count_changes=ON (SQLite parity): emit a
+                            // one-row result with the number of updated rows.
+                            result.columns = vec!["rows updated".to_string()];
+                            result.rows = vec![vec![Some(affected_rows.to_string())]];
+                            result.row_count = 1;
                         }
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
@@ -317,6 +338,12 @@ impl SqlExecutor {
                                         .collect();
                                 result.rows.push(row_strs);
                             }
+                        } else if self.count_changes {
+                            // PRAGMA count_changes=ON (SQLite parity): emit a
+                            // one-row result with the number of deleted rows.
+                            result.columns = vec!["rows deleted".to_string()];
+                            result.rows = vec![vec![Some(affected_rows.to_string())]];
+                            result.row_count = 1;
                         }
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
@@ -979,6 +1006,19 @@ impl SqlExecutor {
                         message: None,
                     })
                 }
+                "COUNT_CHANGES" => {
+                    // SQLite-compatible PRAGMA count_changes: when ON, each
+                    // INSERT/UPDATE/DELETE returns a one-row result with the
+                    // change count (issue #5283). Session-scoped, default OFF.
+                    self.count_changes = bool_value;
+                    Ok(QueryResult {
+                        rows: Vec::new(),
+                        columns: Vec::new(),
+                        row_count: 0,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
                 "REVERSE_UNORDERED_SELECTS" => {
                     self.db.set_reverse_unordered_selects(bool_value);
                     Ok(QueryResult {
@@ -1051,6 +1091,16 @@ impl SqlExecutor {
                     let value = if self.db.case_sensitive_like() { "1" } else { "0" };
                     Ok(QueryResult {
                         columns: vec!["case_sensitive_like".to_string()],
+                        rows: vec![vec![Some(value.to_string())]],
+                        row_count: 1,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "COUNT_CHANGES" => {
+                    let value = if self.count_changes { "1" } else { "0" };
+                    Ok(QueryResult {
+                        columns: vec!["count_changes".to_string()],
                         rows: vec![vec![Some(value.to_string())]],
                         row_count: 1,
                         execution_time_ms: None,

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -446,3 +446,123 @@ fn test_savepoint() {
 
     executor.execute("COMMIT").unwrap();
 }
+
+// ============================================================================
+// PRAGMA count_changes tests (issue #5283)
+// ============================================================================
+
+#[test]
+fn test_count_changes_default_off() {
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t(a INT)").unwrap();
+
+    // Default OFF: DML returns no result rows
+    let result = executor.execute("INSERT INTO t VALUES(1),(2)").unwrap();
+    assert!(result.rows.is_empty());
+    assert_eq!(result.row_count, 2);
+
+    // Query form reports 0
+    let result = executor.execute("PRAGMA count_changes").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("0".to_string())]]);
+}
+
+#[test]
+fn test_count_changes_insert_update_delete() {
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t(a INT)").unwrap();
+    executor.execute("PRAGMA count_changes=ON").unwrap();
+
+    // Query form reports 1 while ON
+    let result = executor.execute("PRAGMA count_changes").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("1".to_string())]]);
+
+    let result = executor.execute("INSERT INTO t VALUES(1),(2),(3)").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("3".to_string())]]);
+
+    let result = executor.execute("UPDATE t SET a=a+10 WHERE a<3").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("2".to_string())]]);
+
+    let result = executor.execute("DELETE FROM t WHERE a=3").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("1".to_string())]]);
+
+    // SELECT output is unaffected by the pragma
+    let result = executor.execute("SELECT count(*) FROM t").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("2".to_string())]]);
+
+    // OFF restores current behavior
+    executor.execute("PRAGMA count_changes=OFF").unwrap();
+    let result = executor.execute("INSERT INTO t VALUES(9)").unwrap();
+    assert!(result.rows.is_empty());
+}
+
+#[test]
+fn test_count_changes_upsert_counts_direct_inserts_only() {
+    // upsert1-400 semantics (verified against sqlite3): the count row for an
+    // upsert INSERT reports only directly inserted rows, while changes()
+    // includes rows taken through the DO UPDATE arm.
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t2(a TEXT UNIQUE, b INT DEFAULT 1)").unwrap();
+    executor.execute("INSERT INTO t2(a) VALUES('one'),('two'),('three')").unwrap();
+    executor.execute("PRAGMA count_changes=ON").unwrap();
+
+    let result = executor
+        .execute(
+            "INSERT INTO t2(a) VALUES('one'),('one'),('three'),('four') \
+             ON CONFLICT(a) DO UPDATE SET b=b+1",
+        )
+        .unwrap();
+    // Count row: 1 direct insert ('four'); the 3 DO UPDATE-arm rows excluded
+    assert_eq!(result.rows, vec![vec![Some("1".to_string())]]);
+
+    executor.execute("PRAGMA count_changes=OFF").unwrap();
+
+    // changes() still reports all 4 affected rows (SQLite parity)
+    let result = executor.execute("SELECT changes()").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("4".to_string())]]);
+
+    // upsert1-410: the DO UPDATE arm really ran (one hit twice, three once)
+    let result = executor.execute("SELECT a, b FROM t2 ORDER BY a").unwrap();
+    assert_eq!(
+        result.rows,
+        vec![
+            vec![Some("four".to_string()), Some("1".to_string())],
+            vec![Some("one".to_string()), Some("3".to_string())],
+            vec![Some("three".to_string()), Some("2".to_string())],
+            vec![Some("two".to_string()), Some("1".to_string())],
+        ]
+    );
+}
+
+#[test]
+fn test_count_changes_does_not_replace_returning() {
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t(a INT)").unwrap();
+    executor.execute("PRAGMA count_changes=ON").unwrap();
+
+    // RETURNING output takes precedence over the count row
+    let result = executor.execute("INSERT INTO t VALUES(7) RETURNING a").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("7".to_string())]]);
+    assert_eq!(result.columns, vec!["a".to_string()]);
+}
+
+// ============================================================================
+// ?NNN numbered placeholder tests (issue #5283)
+// ============================================================================
+
+#[test]
+fn test_question_numbered_placeholder_upsert_inexact_target() {
+    // upsert1-1210: once `b+?1` lexes, the inexact-conflict-target path must
+    // yield SQLite's canonical error (not a syntax error near "1")
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t1(a INT, b INT)").unwrap();
+    executor.execute("CREATE UNIQUE INDEX t1x ON t1(b+3)").unwrap();
+
+    let err = executor
+        .execute("INSERT INTO t1(a,b) VALUES(1,2) ON CONFLICT(b+?1) DO NOTHING")
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint"),
+        "unexpected error: {msg}"
+    );
+}

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -7,29 +7,44 @@ use crate::{
     sqlite_schema::is_sqlite_schema_table, sqlite_stat::is_sqlite_stat1_table,
 };
 
+/// Outcome of an INSERT statement execution.
+#[derive(Debug)]
+pub struct InsertOutcome {
+    /// Total affected rows: direct inserts plus rows taken through the
+    /// `ON CONFLICT DO UPDATE` arm. Matches SQLite's `changes()`.
+    pub affected_rows: usize,
+    /// Rows handled via the `ON CONFLICT DO UPDATE` arm (subset of
+    /// `affected_rows`). SQLite's `PRAGMA count_changes` reports
+    /// `affected_rows - upsert_updated_rows` for INSERT (direct inserts
+    /// only), while `changes()` includes the update-arm rows.
+    pub upsert_updated_rows: usize,
+    /// Projected RETURNING rows when the statement carries a RETURNING
+    /// clause; `None` otherwise.
+    pub returning: Option<crate::select::SelectResult>,
+}
+
 /// Execute an INSERT statement
 /// Returns number of rows inserted
 pub fn execute_insert(
     db: &mut vibesql_storage::Database,
     stmt: &vibesql_ast::InsertStmt,
 ) -> Result<usize, ExecutorError> {
-    execute_insert_internal(db, stmt, None, None).map(|(count, _)| count)
+    execute_insert_internal(db, stmt, None, None).map(|outcome| outcome.affected_rows)
 }
 
 /// Execute an INSERT statement, capturing RETURNING rows (SQLite 3.35.0+)
 ///
-/// Returns the number of inserted rows plus, when the statement carries a
-/// RETURNING clause, the projected NEW rows (values as actually inserted,
-/// including defaults, generated columns, and auto INTEGER PRIMARY KEY) —
-/// one per inserted row, in insertion order. Rows skipped by `OR IGNORE` /
-/// `ON CONFLICT DO NOTHING` do not appear. For `ON DUPLICATE KEY UPDATE`,
-/// the post-UPDATE row is returned.
-///
-/// When the statement has no RETURNING clause the second element is `None`.
+/// Returns an [`InsertOutcome`] carrying the number of affected rows, the
+/// number of rows handled via the upsert `DO UPDATE` arm, and, when the
+/// statement carries a RETURNING clause, the projected NEW rows (values as
+/// actually inserted, including defaults, generated columns, and auto
+/// INTEGER PRIMARY KEY) — one per affected row, in insertion order. Rows
+/// skipped by `OR IGNORE` / `ON CONFLICT DO NOTHING` do not appear. For
+/// `ON DUPLICATE KEY UPDATE`, the post-UPDATE row is returned.
 pub fn execute_insert_returning(
     db: &mut vibesql_storage::Database,
     stmt: &vibesql_ast::InsertStmt,
-) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
+) -> Result<InsertOutcome, ExecutorError> {
     execute_insert_internal(db, stmt, None, None)
 }
 
@@ -40,7 +55,8 @@ pub fn execute_insert_with_procedural_context(
     stmt: &vibesql_ast::InsertStmt,
     procedural_context: &crate::procedural::ExecutionContext,
 ) -> Result<usize, ExecutorError> {
-    execute_insert_internal(db, stmt, Some(procedural_context), None).map(|(count, _)| count)
+    execute_insert_internal(db, stmt, Some(procedural_context), None)
+        .map(|outcome| outcome.affected_rows)
 }
 
 /// Execute an INSERT statement with trigger context
@@ -51,7 +67,8 @@ pub fn execute_insert_with_trigger_context(
     stmt: &vibesql_ast::InsertStmt,
     trigger_context: &crate::trigger_execution::TriggerContext,
 ) -> Result<usize, ExecutorError> {
-    execute_insert_internal(db, stmt, None, Some(trigger_context)).map(|(count, _)| count)
+    execute_insert_internal(db, stmt, None, Some(trigger_context))
+        .map(|outcome| outcome.affected_rows)
 }
 
 /// Internal implementation of INSERT execution
@@ -60,7 +77,7 @@ fn execute_insert_internal(
     stmt: &vibesql_ast::InsertStmt,
     procedural_context: Option<&crate::procedural::ExecutionContext>,
     trigger_context: Option<&crate::trigger_execution::TriggerContext>,
-) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
+) -> Result<InsertOutcome, ExecutorError> {
     // Build full table name for error messages and privilege checks
     let full_table_name = match &stmt.schema_name {
         Some(schema) => format!("{}.{}", schema, stmt.table_name),
@@ -78,7 +95,11 @@ fn execute_insert_internal(
     // Check if target is sqlite_stat1 (special writable statistics table)
     // RETURNING is not supported on this virtual statistics table.
     if is_sqlite_stat1_table(&stmt.table_name) {
-        return execute_insert_sqlite_stat1(db, stmt).map(|count| (count, None));
+        return execute_insert_sqlite_stat1(db, stmt).map(|count| InsertOutcome {
+            affected_rows: count,
+            upsert_updated_rows: 0,
+            returning: None,
+        });
     }
 
     // Check INSERT privilege on the table
@@ -91,7 +112,12 @@ fn execute_insert_internal(
         if stmt.on_conflict.is_some() {
             return Err(ExecutorError::SqliteCompatError("cannot UPSERT a view".to_string()));
         }
-        return execute_insert_on_view(db, stmt, &view_def, procedural_context, trigger_context);
+        return execute_insert_on_view(db, stmt, &view_def, procedural_context, trigger_context)
+            .map(|(count, returning)| InsertOutcome {
+                affected_rows: count,
+                upsert_updated_rows: 0,
+                returning,
+            });
     }
 
     // Get table schema from catalog (clone to avoid borrow issues)
@@ -175,7 +201,11 @@ fn execute_insert_internal(
                     super::bulk_transfer::try_bulk_transfer(db, table_name, select_stmt)?
                 {
                     // Fast path succeeded, return early
-                    return Ok((count, None));
+                    return Ok(InsertOutcome {
+                        affected_rows: count,
+                        upsert_updated_rows: 0,
+                        returning: None,
+                    });
                 }
             }
 
@@ -709,6 +739,11 @@ fn execute_insert_internal(
 
     let mut rows_inserted = 0;
 
+    // Rows taken through the upsert ON CONFLICT DO UPDATE arm. These count
+    // toward changes() (rows_inserted) but are excluded from the direct-insert
+    // count that PRAGMA count_changes reports for INSERT (issue #5283).
+    let mut upsert_updated_rows = 0;
+
     // RETURNING (SQLite 3.35.0+): collect the rows as ACTUALLY inserted (or
     // updated by ON DUPLICATE KEY UPDATE). The slow path can rewrite the
     // IPK/rowid after validation (REPLACE reserved-rowid interplay), so rows
@@ -892,6 +927,7 @@ fn execute_insert_internal(
                     super::on_conflict_update::UpsertAction::Updated(updated_row_id) => {
                         // Row was updated, count it toward affected rows
                         rows_inserted += 1;
+                        upsert_updated_rows += 1;
 
                         // RETURNING: SQLite returns the post-UPDATE row for
                         // upserts that take the update arm.
@@ -1210,7 +1246,11 @@ fn execute_insert_internal(
         None
     };
 
-    Ok((rows_inserted, returning_result))
+    Ok(InsertOutcome {
+        affected_rows: rows_inserted,
+        upsert_updated_rows,
+        returning: returning_result,
+    })
 }
 
 /// Check if inserting a row would violate any constraints (for IGNORE conflict resolution)

--- a/crates/vibesql-executor/src/insert/mod.rs
+++ b/crates/vibesql-executor/src/insert/mod.rs
@@ -11,6 +11,8 @@ pub mod validation;
 
 use crate::errors::ExecutorError;
 
+pub use execution::InsertOutcome;
+
 /// Executor for INSERT statements
 pub struct InsertExecutor;
 
@@ -26,17 +28,19 @@ impl InsertExecutor {
 
     /// Execute an INSERT statement, capturing RETURNING rows (SQLite 3.35.0+)
     ///
-    /// Returns the number of inserted rows plus, when the statement carries a
-    /// RETURNING clause, the projected NEW rows (values as actually inserted,
-    /// including defaults, generated columns, and auto INTEGER PRIMARY KEY).
-    /// Rows skipped by `OR IGNORE` / `ON CONFLICT DO NOTHING` are omitted;
-    /// `ON DUPLICATE KEY UPDATE` contributes the post-UPDATE row.
+    /// Returns an [`InsertOutcome`] carrying the number of affected rows, the
+    /// number of rows handled via the upsert `ON CONFLICT DO UPDATE` arm, and,
+    /// when the statement carries a RETURNING clause, the projected NEW rows
+    /// (values as actually inserted, including defaults, generated columns,
+    /// and auto INTEGER PRIMARY KEY). Rows skipped by `OR IGNORE` /
+    /// `ON CONFLICT DO NOTHING` are omitted; `ON DUPLICATE KEY UPDATE`
+    /// contributes the post-UPDATE row.
     ///
-    /// When the statement has no RETURNING clause the second element is `None`.
+    /// When the statement has no RETURNING clause `returning` is `None`.
     pub fn execute_returning(
         db: &mut vibesql_storage::Database,
         stmt: &vibesql_ast::InsertStmt,
-    ) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
+    ) -> Result<InsertOutcome, ExecutorError> {
         execution::execute_insert_returning(db, stmt)
     }
 

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -81,7 +81,7 @@ pub use grant::GrantExecutor;
 pub use index_ddl::{
     AnalyzeExecutor, CreateIndexExecutor, DropIndexExecutor, IndexExecutor, ReindexExecutor,
 };
-pub use insert::InsertExecutor;
+pub use insert::{InsertExecutor, InsertOutcome};
 pub use introspection::IntrospectionExecutor;
 pub use memory::QueryArena;
 pub use persistence::load_sql_dump;

--- a/crates/vibesql-executor/src/tests/insert_returning.rs
+++ b/crates/vibesql-executor/src/tests/insert_returning.rs
@@ -49,7 +49,10 @@ fn execute_insert_returning(
     let stmt =
         Parser::parse_sql(sql).unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
     match stmt {
-        Statement::Insert(s) => InsertExecutor::execute_returning(db, &s).expect("INSERT failed"),
+        Statement::Insert(s) => {
+            let outcome = InsertExecutor::execute_returning(db, &s).expect("INSERT failed");
+            (outcome.affected_rows, outcome.returning)
+        }
         other => panic!("Expected INSERT, got {:?}", other),
     }
 }

--- a/crates/vibesql-executor/tests/insert_on_conflict_update_tests.rs
+++ b/crates/vibesql-executor/tests/insert_on_conflict_update_tests.rs
@@ -276,9 +276,11 @@ fn test_returning_post_update_row() {
         vibesql_ast::Statement::Insert(insert) => insert,
         other => panic!("expected INSERT, got {other:?}"),
     };
-    let (count, result) = InsertExecutor::execute_returning(&mut db, &insert).unwrap();
-    assert_eq!(count, 1);
-    let result = result.expect("RETURNING must produce a result set");
+    let outcome = InsertExecutor::execute_returning(&mut db, &insert).unwrap();
+    assert_eq!(outcome.affected_rows, 1);
+    // The single affected row was handled via the DO UPDATE arm
+    assert_eq!(outcome.upsert_updated_rows, 1);
+    let result = outcome.returning.expect("RETURNING must produce a result set");
     assert_eq!(result.rows.len(), 1);
     assert_eq!(result.rows[0].values.to_vec(), vec![int(1), int(15)]);
 }

--- a/crates/vibesql-parser/src/lexer/mod.rs
+++ b/crates/vibesql-parser/src/lexer/mod.rs
@@ -191,8 +191,14 @@ impl<'a> Lexer<'a> {
                 self.tokenize_identifier_or_keyword()
             }
             '?' => {
-                self.advance();
-                Ok(Token::Placeholder)
+                // SQLite-style numbered placeholder (?1, ?2, ...) when digits
+                // follow; otherwise the anonymous `?` placeholder.
+                if self.peek_byte(1).map(|b| b.is_ascii_digit()).unwrap_or(false) {
+                    self.tokenize_question_numbered_placeholder()
+                } else {
+                    self.advance();
+                    Ok(Token::Placeholder)
+                }
             }
             '$' => {
                 // Check what follows the $
@@ -486,6 +492,44 @@ impl<'a> Lexer<'a> {
                 message: "Numbered placeholder must be $1 or higher (no $0)".to_string(),
                 position: start_pos,
                 near_token: Some("$0".to_string()),
+            });
+        }
+
+        Ok(Token::NumberedPlaceholder(index))
+    }
+
+    /// Tokenize a SQLite-style numbered placeholder (?1, ?2, etc.).
+    /// 1-indexed like `$N`; `?0` is rejected (SQLite: "variable number must
+    /// be between ?1 and ?NNN"). Only called when a digit follows the `?`.
+    fn tokenize_question_numbered_placeholder(&mut self) -> Result<Token, LexerError> {
+        self.advance(); // consume '?'
+
+        let start_pos = self.position();
+        let mut num_str = String::new();
+
+        // Read all digits
+        while !self.is_eof() {
+            let ch = self.current_char();
+            if ch.is_ascii_digit() {
+                num_str.push(ch);
+                self.advance();
+            } else {
+                break;
+            }
+        }
+
+        let index: usize = num_str.parse().map_err(|_| LexerError {
+            message: format!("Invalid numbered placeholder: ?{}", num_str),
+            position: start_pos,
+            near_token: Some(format!("?{}", num_str)),
+        })?;
+
+        // SQLite requires ?1 or higher (no ?0)
+        if index == 0 {
+            return Err(LexerError {
+                message: "variable number must be between ?1 and ?NNN".to_string(),
+                position: start_pos,
+                near_token: Some(format!("?{}", num_str)),
             });
         }
 

--- a/crates/vibesql-parser/src/tests/lexer/identifiers.rs
+++ b/crates/vibesql-parser/src/tests/lexer/identifiers.rs
@@ -262,6 +262,55 @@ fn test_tokenize_ascii_placeholders_unchanged() {
 }
 
 // ============================================================================
+// SQLite ?NNN Numbered Placeholder Tests (issue #5283)
+// ============================================================================
+
+#[test]
+fn test_tokenize_question_numbered_placeholder_single_digit() {
+    // SQLite ?NNN syntax: `?1` is a numbered placeholder, not `?` followed by 1
+    let mut lexer = Lexer::new("SELECT ?1");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::NumberedPlaceholder(1));
+    assert_eq!(tokens[2], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_question_numbered_placeholder_multi_digit() {
+    let mut lexer = Lexer::new("SELECT ?23");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::NumberedPlaceholder(23));
+    assert_eq!(tokens[2], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_question_numbered_placeholder_in_expression() {
+    // upsert1-1210: `b+?1` must lex as Identifier, '+', NumberedPlaceholder(1)
+    let mut lexer = Lexer::new("b+?1");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::Identifier("b".to_string()));
+    assert_eq!(tokens[1], Token::Symbol('+'));
+    assert_eq!(tokens[2], Token::NumberedPlaceholder(1));
+    assert_eq!(tokens[3], Token::Eof);
+}
+
+#[test]
+fn test_tokenize_question_zero_rejected() {
+    // SQLite rejects ?0: "variable number must be between ?1 and ?NNN"
+    let mut lexer = Lexer::new("SELECT ?0");
+    let err = lexer.tokenize().unwrap_err();
+    assert!(err.message.contains("?1"), "expected ?0 rejection message, got: {}", err.message);
+}
+
+#[test]
+fn test_tokenize_bare_question_placeholder_unchanged() {
+    // Bare `?` (no trailing digits) still lexes as the anonymous placeholder
+    let mut lexer = Lexer::new("SELECT ?, ? + 1");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::Placeholder);
+    assert_eq!(tokens[3], Token::Placeholder);
+}
+
+// ============================================================================
 // Delimited Identifier Tests
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Fixes two upsert1.test conformance gaps (upsert1-400, upsert1-1210) that are CLI/lexer-level rather than upsert-engine work:

- **`?NNN` numbered placeholders** (lexer-only): `?` followed by digits now tokenizes as `Token::NumberedPlaceholder` (SQLite `?NNN` syntax). Both expression parsers and executor binding already handle the token (it was previously produced only for PostgreSQL-style `$1`). `?0` is rejected, mirroring the existing `$0` rejection. Once `b+?1` parses, the existing inexact-conflict-target path yields SQLite's canonical "ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint" error (upsert1-1210).
- **`PRAGMA count_changes`** (session flag in the CLI executor): when ON, INSERT/UPDATE/DELETE return a one-row, one-column result with the change count; OFF (default) restores current behavior. SELECT output is unaffected, and RETURNING takes precedence over the count row.

Per sqlite3-verified semantics, the count row for an upsert INSERT reports **direct inserts only** (rows taken through the DO UPDATE arm are excluded) while `changes()` still includes them. Since `affected_rows` couldn't express both, `InsertExecutor::execute_returning` now returns an `InsertOutcome` struct (`affected_rows`, `upsert_updated_rows`, `returning`); `changes()`/`total_changes()` plumbing is unchanged.

## Changes

- `crates/vibesql-parser/src/lexer/mod.rs`: `?` arm consumes trailing digits into `Token::NumberedPlaceholder`; new `tokenize_question_numbered_placeholder` helper rejects `?0`
- `crates/vibesql-executor/src/insert/{execution.rs,mod.rs}` + `lib.rs`: new `InsertOutcome` return type for `execute_returning`; tracks `upsert_updated_rows` in the ON CONFLICT DO UPDATE arm
- `crates/vibesql-cli/src/executor/mod.rs`: `count_changes` session flag, PRAGMA set/query arms, count-row emission in the INSERT/UPDATE/DELETE dispatch (INSERT emits `affected - upsert_updated`)
- Tests: 5 lexer unit tests (`?1`, `?23`, `b+?1`, `?0` rejected, bare `?` unchanged), 5 CLI tests (count_changes ON/OFF, upsert direct-insert count + `changes()`=4 parity, RETURNING precedence, `?1` inexact-target error), updated 2 existing callers of `execute_returning`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| upsert1-400 and upsert1-1210 pass (29+ passed) | ✅ | `./scripts/tcltest test upsert1.test`: 29 passed / 3 failed / 3 skipped (baseline 27/5/3; remaining failures 200/201/320 are #5278 scope) |
| count_changes makes INSERT/UPDATE/DELETE return a count row; OFF restores behavior | ✅ | `test_count_changes_insert_update_delete`, `test_count_changes_default_off` |
| Upsert INSERT count excludes DO UPDATE-arm rows ({1} in upsert1-400) | ✅ | `test_count_changes_upsert_counts_direct_inserts_only` + upsert1-400 passing |
| `?1` parses anywhere an expression is accepted, behaves like `$1` | ✅ | Lexer emits the same `NumberedPlaceholder` token `$1` produces; parser/binding paths pre-existing; lexer tests |
| No regressions in upsert1.test or pragma/placeholder unit tests | ✅ | 29 passed ≥ 27 baseline; parser 1332, executor 2493 (+20 integration), CLI 119 tests all green |
| `changes()`/`total_changes()` unchanged (4 after upsert1-400 INSERT) | ✅ | Asserted in `test_count_changes_upsert_counts_direct_inserts_only` |
| count_changes does not add rows to SELECT results | ✅ | Asserted in `test_count_changes_insert_update_delete` |
| `?0` rejected (parity with `$0`) | ✅ | `test_tokenize_question_zero_rejected` |

## Test Plan

- `./scripts/tcltest test upsert1.test` — 29 passed (was 27), 400 and 1210 now pass, no new failures
- Regression sweep (`delete.test update.test insert2.test conflict.test conflict2.test fkey2.test where7.test without_rowid3.test`) — identical pass/fail/skip counts to the pre-change baseline captured on the same commit
- `cargo test -p vibesql-parser --lib` (1332), `-p vibesql-executor --lib` (2493) + `insert_on_conflict_update_tests` (20), `-p vibesql-cli --bin vibesql` (119) — all green
- Rebased onto current main (includes #5284) with all of the above re-verified

Closes #5283