### PR TITLE
feat(insert): expression/partial-index conflict targets (upsert1-200/201/320)

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -641,10 +641,20 @@ impl<'a, 'arena> Converter<'a, 'arena> {
         clause: &arena_dml::OnConflictClause<'arena>,
     ) -> crate::OnConflictClause {
         crate::OnConflictClause {
-            conflict_target: clause
-                .conflict_target
-                .as_ref()
-                .map(|cols| cols.iter().map(|s| self.resolve(*s)).collect()),
+            conflict_target: clause.conflict_target.as_ref().map(|items| {
+                items
+                    .iter()
+                    .map(|item| match item {
+                        arena_dml::ConflictTargetItem::Column(s) => {
+                            crate::ConflictTargetItem::Column(self.resolve(*s))
+                        }
+                        arena_dml::ConflictTargetItem::Expression(e) => {
+                            crate::ConflictTargetItem::Expression(self.convert_expression(e))
+                        }
+                    })
+                    .collect()
+            }),
+            target_where: clause.target_where.as_ref().map(|e| self.convert_expression(e)),
             target_inexact: clause.target_inexact,
             action: match &clause.action {
                 arena_dml::OnConflictAction::DoNothing => crate::OnConflictAction::DoNothing,

--- a/crates/vibesql-ast/src/arena/dml.rs
+++ b/crates/vibesql-ast/src/arena/dml.rs
@@ -73,6 +73,16 @@ pub enum OnConflictAction<'arena> {
     },
 }
 
+/// One entry of an `ON CONFLICT (...)` conflict target.
+/// Arena mirror of the owned-AST `ConflictTargetItem`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConflictTargetItem<'arena> {
+    /// Plain column name with the default BINARY collation.
+    Column(Symbol),
+    /// Expression entry (e.g. `ON CONFLICT(a+b)`).
+    Expression(Expression<'arena>),
+}
+
 /// ON CONFLICT clause for INSERT statements (SQLite upsert)
 ///
 /// Syntax:
@@ -86,12 +96,14 @@ pub enum OnConflictAction<'arena> {
 /// See: <https://www.sqlite.org/lang_upsert.html>
 #[derive(Debug, Clone, PartialEq)]
 pub struct OnConflictClause<'arena> {
-    /// Optional list of indexed columns to match for conflict detection.
-    /// When None, matches any unique constraint violation.
-    pub conflict_target: Option<BumpVec<'arena, Symbol>>,
-    /// True when the conflict target contains components that a plain
-    /// column-name list cannot represent exactly (expressions, non-BINARY
-    /// COLLATE, or a target WHERE predicate). See the owned-AST
+    /// Optional list of indexed columns/expressions to match for conflict
+    /// detection. When None, matches any unique constraint violation.
+    pub conflict_target: Option<BumpVec<'arena, ConflictTargetItem<'arena>>>,
+    /// Optional target-level WHERE predicate (partial-index upsert). See the
+    /// owned-AST `OnConflictClause::target_where`.
+    pub target_where: Option<Expression<'arena>>,
+    /// True when the conflict target contains components the AST cannot
+    /// represent exactly (currently non-BINARY COLLATE). See the owned-AST
     /// `OnConflictClause::target_inexact` for details (issue #5269).
     pub target_inexact: bool,
     /// The action to take when a conflict occurs.

--- a/crates/vibesql-ast/src/dml.rs
+++ b/crates/vibesql-ast/src/dml.rs
@@ -78,6 +78,21 @@ pub enum OnConflictAction {
     },
 }
 
+/// One entry of an `ON CONFLICT (...)` conflict target.
+///
+/// SQLite allows each entry to be an arbitrary indexed expression: a plain
+/// column name matches simple-column indexes/constraints, while an
+/// expression entry (`ON CONFLICT(a+b)`) matches expression indexes with a
+/// structurally identical component (upsert1-200).
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConflictTargetItem {
+    /// Plain column name with the default BINARY collation.
+    Column(String),
+    /// Expression entry (e.g. `ON CONFLICT(a+b)`); matched structurally
+    /// against expression-index components.
+    Expression(Expression),
+}
+
 /// ON CONFLICT clause for INSERT statements (SQLite upsert)
 ///
 /// Syntax:
@@ -91,18 +106,20 @@ pub enum OnConflictAction {
 /// See: <https://www.sqlite.org/lang_upsert.html>
 #[derive(Debug, Clone, PartialEq)]
 pub struct OnConflictClause {
-    /// Optional list of indexed columns to match for conflict detection.
-    /// When None, matches any unique constraint violation.
-    pub conflict_target: Option<Vec<String>>,
-    /// True when the conflict target contains components that a plain
-    /// column-name list cannot represent exactly: expression components
-    /// (`ON CONFLICT(a+b)`), an explicit non-BINARY COLLATE
-    /// (`ON CONFLICT(b COLLATE nocase)`), or a target-level WHERE predicate
-    /// (`ON CONFLICT(b) WHERE b>10`, partial-index upsert).
+    /// Optional list of indexed columns/expressions to match for conflict
+    /// detection. When None, matches any unique constraint violation.
+    pub conflict_target: Option<Vec<ConflictTargetItem>>,
+    /// Optional target-level WHERE predicate (`ON CONFLICT(b) WHERE b>10`),
+    /// matched structurally against a partial unique index's predicate
+    /// (upsert1-320).
+    pub target_where: Option<Expression>,
+    /// True when the conflict target contains components that the AST cannot
+    /// represent exactly: currently an explicit non-BINARY COLLATE
+    /// (`ON CONFLICT(b COLLATE nocase)`).
     ///
     /// The executor conservatively reports inexact targets with SQLite's
     /// canonical "ON CONFLICT clause does not match any PRIMARY KEY or
-    /// UNIQUE constraint" error (v1 limitation, issue #5269).
+    /// UNIQUE constraint" error (upsert1-130; issue #5269).
     pub target_inexact: bool,
     /// The action to take when a conflict occurs.
     pub action: OnConflictAction,

--- a/crates/vibesql-ast/src/lib.rs
+++ b/crates/vibesql-ast/src/lib.rs
@@ -181,8 +181,8 @@ pub use ddl::{
     VariableScope, VectorDistanceMetric,
 };
 pub use dml::{
-    Assignment, ConflictClause, DeleteStmt, InsertSource, InsertStmt, OnConflictAction,
-    OnConflictClause, UpdateStmt, WhereClause,
+    Assignment, ConflictClause, ConflictTargetItem, DeleteStmt, InsertSource, InsertStmt,
+    OnConflictAction, OnConflictClause, UpdateStmt, WhereClause,
 };
 pub use expression::{
     CaseWhen, CharacterUnit, Expression, FrameBound, FrameExclude, FrameUnit, FulltextMode,

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1344,7 +1344,22 @@ pub fn transform_insert<V: ExpressionMutVisitor>(visitor: &mut V, stmt: InsertSt
         },
         conflict_clause: stmt.conflict_clause,
         on_conflict: stmt.on_conflict.map(|clause| crate::OnConflictClause {
-            conflict_target: clause.conflict_target,
+            conflict_target: clause.conflict_target.map(|items| {
+                items
+                    .into_iter()
+                    .map(|item| match item {
+                        crate::ConflictTargetItem::Column(name) => {
+                            crate::ConflictTargetItem::Column(name)
+                        }
+                        crate::ConflictTargetItem::Expression(expr) => {
+                            crate::ConflictTargetItem::Expression(transform_expression(
+                                visitor, expr,
+                            ))
+                        }
+                    })
+                    .collect()
+            }),
+            target_where: clause.target_where.map(|e| transform_expression(visitor, e)),
             target_inexact: clause.target_inexact,
             action: match clause.action {
                 crate::OnConflictAction::DoNothing => crate::OnConflictAction::DoNothing,

--- a/crates/vibesql-executor/src/insert/constraints.rs
+++ b/crates/vibesql-executor/src/insert/constraints.rs
@@ -250,12 +250,32 @@ pub fn enforce_unique_indexes(
                 continue;
             }
 
-            // Skip expression indexes: this check builds keys from plain
-            // column values and expect_column_name() panics on expression
-            // components (observed via upsert1-800 with a UNIQUE expression
-            // index). Expression indexes are maintained separately by
-            // expression_index_maintenance.
+            // Partial index: a row that doesn't satisfy the predicate never
+            // enters the index, so it cannot violate its uniqueness.
+            if let Some(predicate) = index_metadata.where_clause.as_deref() {
+                let candidate_row = vibesql_storage::Row::new(row_values.to_vec());
+                let evaluator = crate::evaluator::ExpressionEvaluator::new(schema);
+                let satisfied = evaluator
+                    .eval(predicate, &candidate_row)
+                    .map(|v| crate::partial_index_maintenance::is_predicate_truthy(&v))
+                    .unwrap_or(false);
+                if !satisfied {
+                    continue;
+                }
+            }
+
+            // Expression indexes need their key built by evaluating the
+            // index expressions; they get a dedicated enforcement path that
+            // scans live rows (index data can be stale after upsert-arm
+            // updates) and SQLite's index-name error format (upsert1-201).
             if index_metadata.columns.iter().any(|col| col.is_expression()) {
+                enforce_unique_expression_index(
+                    schema,
+                    index_metadata,
+                    row_values,
+                    table,
+                    &snapshot,
+                )?;
                 continue;
             }
 
@@ -318,4 +338,87 @@ pub fn enforce_unique_indexes(
     }
 
     Ok(())
+}
+
+/// Enforce a UNIQUE *expression* index (e.g. `CREATE UNIQUE INDEX t1x1 ON
+/// t1(a+b)`) against a candidate row.
+///
+/// The key is built by evaluating each index component (expression or plain
+/// column) against the candidate row, then compared against every
+/// MVCC-visible live row — the maintained index data is not used because it
+/// can be stale after upsert-arm updates (known limitation, issue #5269).
+///
+/// SQLite reports violations of expression indexes with the index-name
+/// format: `UNIQUE constraint failed: index 't1x1'` (upsert1-201).
+fn enforce_unique_expression_index(
+    schema: &vibesql_catalog::TableSchema,
+    index_metadata: &vibesql_storage::database::indexes::IndexMetadata,
+    row_values: &[vibesql_types::SqlValue],
+    table: Option<&vibesql_storage::Table>,
+    snapshot: &vibesql_storage::TxnSnapshot,
+) -> Result<(), ExecutorError> {
+    let Some(table) = table else {
+        return Ok(());
+    };
+
+    let evaluator = crate::evaluator::ExpressionEvaluator::new(schema);
+    let candidate_row = vibesql_storage::Row::new(row_values.to_vec());
+
+    // Build the candidate key. Evaluation failures become NULL (matching
+    // expression-index maintenance), and NULL keys never conflict.
+    let Some(new_key) =
+        eval_expression_index_key(&evaluator, schema, index_metadata, &candidate_row)
+    else {
+        return Ok(());
+    };
+
+    for (_idx, existing_row) in table.scan_visible(snapshot) {
+        // Partial expression indexes: rows outside the predicate are not in
+        // the index. (The caller already verified the candidate row.)
+        if let Some(predicate) = index_metadata.where_clause.as_deref() {
+            let in_index = evaluator
+                .eval(predicate, existing_row)
+                .map(|v| crate::partial_index_maintenance::is_predicate_truthy(&v))
+                .unwrap_or(false);
+            if !in_index {
+                continue;
+            }
+        }
+        if eval_expression_index_key(&evaluator, schema, index_metadata, existing_row).as_deref()
+            == Some(&new_key[..])
+        {
+            // SQLite format for expression indexes: index name, not columns.
+            return Err(ExecutorError::SqliteCompatError(format!(
+                "UNIQUE constraint failed: index '{}'",
+                index_metadata.index_name
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Evaluate an expression index's key for a row. Returns `None` when any
+/// component is NULL (NULL keys never conflict) or fails to evaluate.
+fn eval_expression_index_key(
+    evaluator: &crate::evaluator::ExpressionEvaluator,
+    schema: &vibesql_catalog::TableSchema,
+    index_metadata: &vibesql_storage::database::indexes::IndexMetadata,
+    row: &vibesql_storage::Row,
+) -> Option<Vec<vibesql_types::SqlValue>> {
+    let mut key = Vec::with_capacity(index_metadata.columns.len());
+    for col in &index_metadata.columns {
+        let value = if let Some(expr) = col.get_expression() {
+            evaluator.eval(expr, row).unwrap_or(vibesql_types::SqlValue::Null)
+        } else if let Some(name) = col.column_name() {
+            row.values.get(schema.get_column_index(name)?)?.clone()
+        } else {
+            vibesql_types::SqlValue::Null
+        };
+        if matches!(value, vibesql_types::SqlValue::Null) {
+            return None;
+        }
+        key.push(value);
+    }
+    Some(key)
 }

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -130,9 +130,8 @@ fn execute_insert_internal(
     // PRIMARY KEY / UNIQUE constraint / unique index raise the canonical
     // "ON CONFLICT clause does not match..." error (upsert1-110/120/300).
     if let Some(ref on_conflict) = stmt.on_conflict {
-        // Targets the parser could not represent as a plain column list
-        // (expressions, non-BINARY COLLATE, target WHERE) never match in v1
-        // (upsert1-130/210/310/1210; see issue #5269).
+        // Targets the AST cannot represent exactly (currently non-BINARY
+        // COLLATE) never match (upsert1-130; see issue #5269).
         if on_conflict.target_inexact {
             return Err(ExecutorError::SqliteCompatError(
                 "ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint"
@@ -140,7 +139,13 @@ fn execute_insert_internal(
             ));
         }
         if let Some(ref target) = on_conflict.conflict_target {
-            super::on_conflict_update::validate_conflict_target(db, table_name, &schema, target)?;
+            super::on_conflict_update::validate_conflict_target(
+                db,
+                table_name,
+                &schema,
+                target,
+                on_conflict.target_where.as_ref(),
+            )?;
         }
     }
 
@@ -284,7 +289,8 @@ fn execute_insert_internal(
 
     // Check if IGNORE conflict clause is set - if so, skip rows with constraint violations
     // Also treat ON CONFLICT ... DO NOTHING as equivalent to IGNORE
-    let use_ignore = matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Ignore))
+    let or_ignore = matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Ignore));
+    let use_ignore = or_ignore
         || matches!(
             &stmt.on_conflict,
             Some(vibesql_ast::OnConflictClause {
@@ -292,6 +298,24 @@ fn execute_insert_internal(
                 ..
             })
         );
+
+    // `ON CONFLICT (cols) [WHERE ...] DO NOTHING` with an explicit target
+    // (and without INSERT OR IGNORE) only suppresses conflicts on the
+    // *targeted* constraint; conflicts on other constraints surface as
+    // normal UNIQUE errors (upsert1-201). Untargeted DO NOTHING and
+    // INSERT OR IGNORE keep the suppress-everything behavior.
+    let do_nothing_target: Option<(
+        &[vibesql_ast::ConflictTargetItem],
+        Option<&vibesql_ast::Expression>,
+    )> = match &stmt.on_conflict {
+        Some(vibesql_ast::OnConflictClause {
+            conflict_target: Some(items),
+            target_where,
+            action: vibesql_ast::OnConflictAction::DoNothing,
+            ..
+        }) if !or_ignore => Some((items.as_slice(), target_where.as_ref())),
+        _ => None,
+    };
 
     // Track the first auto-generated ID for LAST_INSERT_ROWID() support
     // Per MySQL semantics, for multi-row inserts, LAST_INSERT_ID() returns
@@ -624,11 +648,17 @@ fn execute_insert_internal(
         // Skip PK/UNIQUE duplicate checks if using REPLACE conflict clause, ON DUPLICATE KEY
         // UPDATE, or ON CONFLICT clause. Also skip for IGNORE since we'll handle violations
         // by skipping the row.
+        //
+        // Exception: a *targeted* DO NOTHING (without OR IGNORE) must NOT
+        // skip duplicate checks — rows that conflict on the targeted
+        // constraint are skipped before validation (below), so any remaining
+        // duplicate is on a non-targeted constraint and must raise a normal
+        // UNIQUE error (SQLite semantics, upsert1-201).
         let skip_duplicate_checks =
             matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Replace))
                 || matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Ignore))
                 || stmt.on_duplicate_key_update.is_some()
-                || stmt.on_conflict.is_some();
+                || (stmt.on_conflict.is_some() && do_nothing_target.is_none());
         let validator = super::row_validator::RowValidator::new(
             db,
             &schema,
@@ -642,15 +672,31 @@ fn execute_insert_internal(
         // For IGNORE, we need to check for constraint violations before adding to validated_rows
         // If there's a violation, skip this row instead of returning an error
         if use_ignore {
-            // Check if this row would violate any constraints
-            let would_violate = check_would_violate_constraints(
-                db,
-                &schema,
-                &storage_table_name,
-                &full_row_values,
-                &primary_key_values,
-                &unique_constraint_values,
-            );
+            let would_violate = if let Some((target, target_where)) = do_nothing_target {
+                // Targeted DO NOTHING: only conflicts on the targeted
+                // constraint are suppressed (expression- and partial-index
+                // aware; checks earlier batch rows too — upsert1-320).
+                super::on_conflict_update::row_conflicts_on_target(
+                    db,
+                    table_name,
+                    &schema,
+                    &full_row_values,
+                    target,
+                    target_where,
+                    &batch_full_rows,
+                )?
+            } else {
+                // OR IGNORE / untargeted DO NOTHING: skip the row on any
+                // constraint violation.
+                check_would_violate_constraints(
+                    db,
+                    &schema,
+                    &storage_table_name,
+                    &full_row_values,
+                    &primary_key_values,
+                    &unique_constraint_values,
+                )
+            };
             if would_violate {
                 // Skip this row - don't add to validated_rows
                 continue;
@@ -875,7 +921,9 @@ fn execute_insert_internal(
                 // No conflict, fall through to insert
             } else if let Some(vibesql_ast::OnConflictClause {
                 ref conflict_target,
-                action: vibesql_ast::OnConflictAction::DoUpdate { ref assignments, ref where_clause },
+                ref target_where,
+                action:
+                    vibesql_ast::OnConflictAction::DoUpdate { ref assignments, ref where_clause },
                 ..
             }) = stmt.on_conflict
             {
@@ -885,7 +933,8 @@ fn execute_insert_internal(
                     table_name,
                     &schema,
                     &full_row_values,
-                    conflict_target.as_ref(),
+                    conflict_target.as_deref(),
+                    target_where.as_ref(),
                     assignments,
                     where_clause.as_ref(),
                 )? {
@@ -1284,17 +1333,45 @@ fn check_would_violate_constraints(
 
     // Check user-defined UNIQUE indexes
     if let Some(table) = db.get_table(table_name) {
+        // Lazily-built evaluator context for expression-index components and
+        // partial-index predicates (issue #5278: expect_column_name() on an
+        // expression component used to panic here).
+        let candidate_row = vibesql_storage::Row::new(row_values.to_vec());
+        let evaluator = crate::evaluator::ExpressionEvaluator::new(schema);
+
         for index_name in db.list_indexes_for_table(table_name) {
             if let Some(index_metadata) = db.get_index(&index_name) {
                 if !index_metadata.unique {
                     continue;
                 }
 
-                // Build key values for this index
+                // Partial index: a row that doesn't satisfy the predicate is
+                // never added to the index, so it cannot conflict through it.
+                if let Some(predicate) = index_metadata.where_clause.as_deref() {
+                    let satisfied = evaluator
+                        .eval(predicate, &candidate_row)
+                        .map(|v| crate::partial_index_maintenance::is_predicate_truthy(&v))
+                        .unwrap_or(false);
+                    if !satisfied {
+                        continue;
+                    }
+                }
+
+                // Build key values for this index (evaluating expression
+                // components against the candidate row; evaluation failures
+                // become NULL, matching expression-index maintenance).
                 let mut key_values = Vec::new();
                 for index_col in &index_metadata.columns {
-                    if let Some(col_idx) = schema.get_column_index(index_col.expect_column_name()) {
-                        key_values.push(row_values[col_idx].clone());
+                    if let Some(name) = index_col.column_name() {
+                        if let Some(col_idx) = schema.get_column_index(name) {
+                            key_values.push(row_values[col_idx].clone());
+                        }
+                    } else if let Some(expr) = index_col.get_expression() {
+                        key_values.push(
+                            evaluator
+                                .eval(expr, &candidate_row)
+                                .unwrap_or(vibesql_types::SqlValue::Null),
+                        );
                     }
                 }
 

--- a/crates/vibesql-executor/src/insert/on_conflict_update.rs
+++ b/crates/vibesql-executor/src/insert/on_conflict_update.rs
@@ -17,10 +17,17 @@
 //! - When the `DO UPDATE ... WHERE` predicate is false or NULL the candidate
 //!   row is silently dropped (neither inserted nor updated).
 //!
-//! Known limitations (v1, issue #5269):
-//! - Expression-index conflict targets (`ON CONFLICT(a+b)`) and partial-index
-//!   targets (`ON CONFLICT(b) WHERE ...`) are not matched; they raise the
-//!   canonical "does not match" error like a non-unique target.
+//! Conflict targets match the PRIMARY KEY, table-level UNIQUE constraints,
+//! and unique indexes — including expression indexes (`ON CONFLICT(a+b)`
+//! matches `CREATE UNIQUE INDEX ... ON t(a+b)`, upsert1-200) and partial
+//! indexes (`ON CONFLICT(b) WHERE b>10` matches
+//! `CREATE UNIQUE INDEX ... ON t(b) WHERE b>10`, upsert1-320). Expression
+//! components are compared structurally (`a+(+b)` does NOT match `a+b`,
+//! upsert1-210) and a target WHERE must structurally equal the index
+//! predicate (upsert1-300/310).
+//!
+//! Known limitations (issue #5269):
+//! - Non-BINARY `COLLATE` in the target is never matched (upsert1-130).
 //! - UPDATE triggers do not fire on the upsert update arm (parity with the
 //!   MySQL-style `ON DUPLICATE KEY UPDATE` path).
 //!
@@ -32,9 +39,12 @@
 use crate::errors::ExecutorError;
 use vibesql_ast::{
     visitor::{transform_expression, ExpressionMutVisitor, VisitResult},
-    Assignment, Expression, FromClause, SelectStmt,
+    Assignment, ConflictTargetItem, Expression, FromClause, SelectStmt,
 };
 use vibesql_types::SqlValue;
+
+use crate::partial_index_maintenance::is_predicate_truthy;
+use crate::select::grouping::expressions_equal;
 
 /// Outcome of attempting the DO UPDATE arm for one candidate row.
 pub enum UpsertAction {
@@ -47,83 +57,186 @@ pub enum UpsertAction {
     NoConflict,
 }
 
-/// Collect every unique column set that can act as an upsert conflict target:
-/// the PRIMARY KEY, table-level UNIQUE constraints, and unique non-partial,
-/// simple-column indexes created via `CREATE UNIQUE INDEX`.
-///
-/// Partial indexes (`CREATE UNIQUE INDEX ... WHERE ...`) and expression
-/// indexes are intentionally excluded: a plain column-list conflict target
-/// cannot match them in SQLite either (upsert1-300).
-fn collect_unique_column_sets(
+/// One key component of a unique constraint/index candidate.
+enum KeyPart {
+    /// Plain column, resolved to a schema column index.
+    Column(usize),
+    /// Expression component of an expression index.
+    Expr(Expression),
+}
+
+/// A unique constraint or index that can act as an upsert conflict target:
+/// the PRIMARY KEY, a table-level UNIQUE constraint, or a unique index
+/// created via `CREATE UNIQUE INDEX` (including expression and partial
+/// indexes).
+struct UniqueCandidate {
+    /// Key components (column references or index expressions).
+    parts: Vec<KeyPart>,
+    /// Partial-index WHERE predicate; None for full indexes/constraints.
+    predicate: Option<Expression>,
+}
+
+/// Collect every unique constraint/index that can act as an upsert conflict
+/// target.
+fn collect_unique_candidates(
     db: &vibesql_storage::Database,
     table_name: &str,
     schema: &vibesql_catalog::TableSchema,
-) -> Vec<Vec<usize>> {
-    let mut sets: Vec<Vec<usize>> = Vec::new();
+) -> Vec<UniqueCandidate> {
+    let mut candidates: Vec<UniqueCandidate> = Vec::new();
 
     if let Some(pk) = schema.get_primary_key_indices() {
         if !pk.is_empty() {
-            sets.push(pk);
+            candidates.push(UniqueCandidate {
+                parts: pk.into_iter().map(KeyPart::Column).collect(),
+                predicate: None,
+            });
         }
     }
 
     for unique in schema.get_unique_constraint_indices() {
         if !unique.is_empty() {
-            sets.push(unique);
+            candidates.push(UniqueCandidate {
+                parts: unique.into_iter().map(KeyPart::Column).collect(),
+                predicate: None,
+            });
         }
     }
 
     for index_name in db.list_indexes_for_table(table_name) {
         let Some(meta) = db.get_index(&index_name) else { continue };
-        if !meta.unique || meta.is_partial() {
+        if !meta.unique {
             continue;
         }
-        let mut cols = Vec::with_capacity(meta.columns.len());
-        let mut simple = true;
+        let mut parts = Vec::with_capacity(meta.columns.len());
+        let mut representable = true;
         for index_col in &meta.columns {
-            match index_col.column_name().and_then(|name| schema.get_column_index(name)) {
-                Some(idx) => cols.push(idx),
-                None => {
-                    // Expression index component (or unknown column): the
-                    // whole index cannot be matched by a column-list target.
-                    simple = false;
-                    break;
+            if let Some(name) = index_col.column_name() {
+                match schema.get_column_index(name) {
+                    Some(idx) => parts.push(KeyPart::Column(idx)),
+                    None => {
+                        // Unknown column: the index cannot be matched.
+                        representable = false;
+                        break;
+                    }
                 }
+            } else if let Some(expr) = index_col.get_expression() {
+                // Normalize bare column-ref expressions to plain columns so
+                // a column-name target can match them.
+                match bare_column_index(schema, expr) {
+                    Some(idx) => parts.push(KeyPart::Column(idx)),
+                    None => parts.push(KeyPart::Expr(expr.clone())),
+                }
+            } else {
+                representable = false;
+                break;
             }
         }
-        if simple && !cols.is_empty() {
-            sets.push(cols);
+        if representable && !parts.is_empty() {
+            candidates
+                .push(UniqueCandidate { parts, predicate: meta.where_clause.as_deref().cloned() });
         }
     }
 
-    sets
+    candidates
 }
 
-/// Resolve conflict-target column names to schema column indices.
-/// Errors with SQLite's "no such column" message for unknown names.
-fn resolve_target_indices(
+/// If `expr` is a bare (unqualified) column reference naming a schema
+/// column, return that column's index.
+fn bare_column_index(schema: &vibesql_catalog::TableSchema, expr: &Expression) -> Option<usize> {
+    match expr {
+        Expression::ColumnRef(id) if id.table_canonical().is_none() => {
+            schema.get_column_index(id.column_canonical())
+        }
+        _ => None,
+    }
+}
+
+/// A conflict-target item resolved against the table schema.
+enum ResolvedTargetItem<'a> {
+    Column(usize),
+    Expr(&'a Expression),
+}
+
+/// Resolve conflict-target items against the schema. Plain column names that
+/// don't exist raise SQLite's "no such column" error (upsert1-110).
+fn resolve_target_items<'a>(
     schema: &vibesql_catalog::TableSchema,
-    target: &[String],
-) -> Result<Vec<usize>, ExecutorError> {
+    target: &'a [ConflictTargetItem],
+) -> Result<Vec<ResolvedTargetItem<'a>>, ExecutorError> {
     target
         .iter()
-        .map(|col| {
-            schema.get_column_index(col).ok_or_else(|| {
-                ExecutorError::SqliteCompatError(format!("no such column: {}", col))
-            })
+        .map(|item| match item {
+            ConflictTargetItem::Column(name) => {
+                schema.get_column_index(name).map(ResolvedTargetItem::Column).ok_or_else(|| {
+                    ExecutorError::SqliteCompatError(format!("no such column: {}", name))
+                })
+            }
+            ConflictTargetItem::Expression(expr) => match bare_column_index(schema, expr) {
+                Some(idx) => Ok(ResolvedTargetItem::Column(idx)),
+                None => Ok(ResolvedTargetItem::Expr(expr)),
+            },
         })
         .collect()
 }
 
-/// Normalize a column index set for order-insensitive comparison.
-fn normalized(mut indices: Vec<usize>) -> Vec<usize> {
-    indices.sort_unstable();
-    indices.dedup();
-    indices
+/// Does this candidate match the resolved conflict target?
+///
+/// The target must cover the candidate's key components exactly
+/// (order-insensitive). Column items match resolved column indices;
+/// expression items match expression components structurally
+/// (`expressions_equal`, so `a+(+b)` does NOT match `a+b` — upsert1-210).
+/// The target-level WHERE must structurally equal the index predicate:
+/// a bare target never matches a partial index (upsert1-300) and a
+/// mismatched predicate never matches (upsert1-310).
+fn candidate_matches_target(
+    candidate: &UniqueCandidate,
+    target: &[ResolvedTargetItem<'_>],
+    target_where: Option<&Expression>,
+) -> bool {
+    // Partial-index predicate must match structurally.
+    match (target_where, candidate.predicate.as_ref()) {
+        (None, None) => {}
+        (Some(tw), Some(pred)) => {
+            if !expressions_equal(tw, pred) {
+                return false;
+            }
+        }
+        _ => return false,
+    }
+
+    if candidate.parts.len() != target.len() {
+        return false;
+    }
+
+    // Order-insensitive multiset match between target items and key parts.
+    let mut used = vec![false; candidate.parts.len()];
+    for item in target {
+        let mut matched = false;
+        for (i, part) in candidate.parts.iter().enumerate() {
+            if used[i] {
+                continue;
+            }
+            let matches = match (item, part) {
+                (ResolvedTargetItem::Column(t), KeyPart::Column(c)) => t == c,
+                (ResolvedTargetItem::Expr(t), KeyPart::Expr(c)) => expressions_equal(t, c),
+                _ => false,
+            };
+            if matches {
+                used[i] = true;
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            return false;
+        }
+    }
+    true
 }
 
-/// Validate an explicit `ON CONFLICT (cols)` target against the table's
-/// PRIMARY KEY, UNIQUE constraints, and unique indexes.
+/// Validate an explicit `ON CONFLICT (cols) [WHERE ...]` target against the
+/// table's PRIMARY KEY, UNIQUE constraints, and unique indexes.
 ///
 /// SQLite validates the conflict target at prepare time, even when no row
 /// actually conflicts (upsert1-110/120). Unknown columns raise
@@ -133,12 +246,13 @@ pub fn validate_conflict_target(
     db: &vibesql_storage::Database,
     table_name: &str,
     schema: &vibesql_catalog::TableSchema,
-    target: &[String],
+    target: &[ConflictTargetItem],
+    target_where: Option<&Expression>,
 ) -> Result<(), ExecutorError> {
-    let target_set = normalized(resolve_target_indices(schema, target)?);
-    let matched = collect_unique_column_sets(db, table_name, schema)
-        .into_iter()
-        .any(|set| normalized(set) == target_set);
+    let resolved = resolve_target_items(schema, target)?;
+    let matched = collect_unique_candidates(db, table_name, schema)
+        .iter()
+        .any(|candidate| candidate_matches_target(candidate, &resolved, target_where));
 
     if matched {
         Ok(())
@@ -147,6 +261,129 @@ pub fn validate_conflict_target(
             "ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint".to_string(),
         ))
     }
+}
+
+/// Evaluate a candidate's key for a row. Returns `None` when any component
+/// is NULL (NULL keys never conflict under UNIQUE semantics) or when an
+/// expression component fails to evaluate (treated as NULL, matching
+/// expression-index maintenance).
+fn eval_candidate_key(
+    evaluator: &crate::evaluator::ExpressionEvaluator,
+    candidate: &UniqueCandidate,
+    row: &vibesql_storage::Row,
+) -> Option<Vec<SqlValue>> {
+    let mut key = Vec::with_capacity(candidate.parts.len());
+    for part in &candidate.parts {
+        let value = match part {
+            KeyPart::Column(idx) => row.values.get(*idx)?.clone(),
+            KeyPart::Expr(expr) => evaluator.eval(expr, row).unwrap_or(SqlValue::Null),
+        };
+        if matches!(value, SqlValue::Null) {
+            return None;
+        }
+        key.push(value);
+    }
+    Some(key)
+}
+
+/// Does the row satisfy the candidate's partial-index predicate (or is the
+/// candidate a full index/constraint)? Rows outside a partial index can
+/// never conflict through it.
+fn row_in_candidate(
+    evaluator: &crate::evaluator::ExpressionEvaluator,
+    candidate: &UniqueCandidate,
+    row: &vibesql_storage::Row,
+) -> bool {
+    match &candidate.predicate {
+        None => true,
+        Some(pred) => evaluator.eval(pred, row).map(|v| is_predicate_truthy(&v)).unwrap_or(false),
+    }
+}
+
+/// Find a live row that conflicts with `row_values` on one of the candidate
+/// constraints. Candidates are tested in order (SQLite tests the targeted
+/// constraint first — upsert1-700 series).
+fn find_conflicting_live_row(
+    db: &vibesql_storage::Database,
+    table_name: &str,
+    schema: &vibesql_catalog::TableSchema,
+    candidates: &[UniqueCandidate],
+    row_values: &[SqlValue],
+) -> Result<Option<usize>, ExecutorError> {
+    let table = db
+        .get_table(table_name)
+        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+    let evaluator = crate::evaluator::ExpressionEvaluator::new(schema);
+    let candidate_row = vibesql_storage::Row::new(row_values.to_vec());
+
+    for candidate in candidates {
+        let Some(new_key) = eval_candidate_key(&evaluator, candidate, &candidate_row) else {
+            continue;
+        };
+        if !row_in_candidate(&evaluator, candidate, &candidate_row) {
+            continue;
+        }
+        for (row_id, row) in table.scan_live() {
+            if !row_in_candidate(&evaluator, candidate, row) {
+                continue;
+            }
+            if eval_candidate_key(&evaluator, candidate, row).as_deref() == Some(&new_key[..]) {
+                return Ok(Some(row_id));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Would inserting `row_values` conflict on the explicit DO NOTHING conflict
+/// target? Used by the targeted `ON CONFLICT (cols) [WHERE ...] DO NOTHING`
+/// path: only conflicts on the *targeted* constraint are suppressed —
+/// conflicts on other constraints surface as normal UNIQUE errors
+/// (upsert1-201).
+///
+/// `batch_rows` carries earlier rows from the same multi-row INSERT that
+/// have been validated but not yet inserted, so later rows in a VALUES list
+/// can conflict with earlier ones (upsert1-320).
+pub fn row_conflicts_on_target(
+    db: &vibesql_storage::Database,
+    table_name: &str,
+    schema: &vibesql_catalog::TableSchema,
+    row_values: &[SqlValue],
+    target: &[ConflictTargetItem],
+    target_where: Option<&Expression>,
+    batch_rows: &[Vec<SqlValue>],
+) -> Result<bool, ExecutorError> {
+    let resolved = resolve_target_items(schema, target)?;
+    let candidates: Vec<UniqueCandidate> = collect_unique_candidates(db, table_name, schema)
+        .into_iter()
+        .filter(|candidate| candidate_matches_target(candidate, &resolved, target_where))
+        .collect();
+
+    if find_conflicting_live_row(db, table_name, schema, &candidates, row_values)?.is_some() {
+        return Ok(true);
+    }
+
+    // Conflicts with earlier (not-yet-inserted) rows from the same batch.
+    let evaluator = crate::evaluator::ExpressionEvaluator::new(schema);
+    let candidate_row = vibesql_storage::Row::new(row_values.to_vec());
+    for candidate in &candidates {
+        let Some(new_key) = eval_candidate_key(&evaluator, candidate, &candidate_row) else {
+            continue;
+        };
+        if !row_in_candidate(&evaluator, candidate, &candidate_row) {
+            continue;
+        }
+        for batch_row in batch_rows {
+            let row = vibesql_storage::Row::new(batch_row.clone());
+            if !row_in_candidate(&evaluator, candidate, &row) {
+                continue;
+            }
+            if eval_candidate_key(&evaluator, candidate, &row).as_deref() == Some(&new_key[..]) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
 }
 
 /// Handle the `ON CONFLICT [(cols)] DO UPDATE SET ... [WHERE ...]` arm for a
@@ -160,46 +397,34 @@ pub fn validate_conflict_target(
 ///   caller should proceed with a normal insert (which may still raise
 ///   UNIQUE errors for constraints other than the named target — SQLite
 ///   semantics, upsert1-201).
+#[allow(clippy::too_many_arguments)]
 pub fn handle_on_conflict_update(
     db: &mut vibesql_storage::Database,
     table_name: &str,
     schema: &vibesql_catalog::TableSchema,
     row_values: &[SqlValue],
-    conflict_target: Option<&Vec<String>>,
+    conflict_target: Option<&[ConflictTargetItem]>,
+    target_where: Option<&Expression>,
     assignments: &[Assignment],
     where_clause: Option<&Expression>,
 ) -> Result<UpsertAction, ExecutorError> {
-    // Determine which unique column sets the update arm applies to.
+    // Determine which unique constraints/indexes the update arm applies to.
     // SQLite tests the targeted constraint first (upsert1-700 series).
-    let all_sets = collect_unique_column_sets(db, table_name, schema);
-    let candidate_sets: Vec<Vec<usize>> = match conflict_target {
+    let all_candidates = collect_unique_candidates(db, table_name, schema);
+    let candidates: Vec<UniqueCandidate> = match conflict_target {
         Some(target) => {
-            let target_set = normalized(resolve_target_indices(schema, target)?);
-            all_sets.into_iter().filter(|set| normalized(set.clone()) == target_set).collect()
+            let resolved = resolve_target_items(schema, target)?;
+            all_candidates
+                .into_iter()
+                .filter(|candidate| candidate_matches_target(candidate, &resolved, target_where))
+                .collect()
         }
-        None => all_sets,
+        None => all_candidates,
     };
 
     // Find a live row that conflicts on one of the candidate constraints.
-    let conflicting_row_id = {
-        let table = db
-            .get_table(table_name)
-            .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
-        let mut found = None;
-        'outer: for set in &candidate_sets {
-            // NULLs never conflict under UNIQUE semantics.
-            if set.iter().any(|&i| matches!(row_values[i], SqlValue::Null)) {
-                continue;
-            }
-            for (row_id, row) in table.scan_live() {
-                if set.iter().all(|&i| row.values[i] == row_values[i]) {
-                    found = Some(row_id);
-                    break 'outer;
-                }
-            }
-        }
-        found
-    };
+    let conflicting_row_id =
+        find_conflicting_live_row(db, table_name, schema, &candidates, row_values)?;
 
     let Some(row_id) = conflicting_row_id else {
         return Ok(UpsertAction::NoConflict);

--- a/crates/vibesql-executor/tests/conflict_resolution_tests.rs
+++ b/crates/vibesql-executor/tests/conflict_resolution_tests.rs
@@ -579,7 +579,8 @@ fn test_insert_on_conflict_do_nothing_primary_key() {
         ]]),
         conflict_clause: None,
         on_conflict: Some(OnConflictClause {
-            conflict_target: Some(vec!["id".to_string()]),
+            conflict_target: Some(vec![vibesql_ast::ConflictTargetItem::Column("id".to_string())]),
+            target_where: None,
             target_inexact: false,
             action: OnConflictAction::DoNothing,
         }),
@@ -624,6 +625,7 @@ fn test_insert_on_conflict_do_nothing_without_target() {
         conflict_clause: None,
         on_conflict: Some(OnConflictClause {
             conflict_target: None, // No specific conflict target
+            target_where: None,
             target_inexact: false,
             action: OnConflictAction::DoNothing,
         }),
@@ -661,7 +663,8 @@ fn test_insert_on_conflict_do_nothing_no_conflict() {
         ]]),
         conflict_clause: None,
         on_conflict: Some(OnConflictClause {
-            conflict_target: Some(vec!["id".to_string()]),
+            conflict_target: Some(vec![vibesql_ast::ConflictTargetItem::Column("id".to_string())]),
+            target_where: None,
             target_inexact: false,
             action: OnConflictAction::DoNothing,
         }),

--- a/crates/vibesql-executor/tests/insert_on_conflict_update_tests.rs
+++ b/crates/vibesql-executor/tests/insert_on_conflict_update_tests.rs
@@ -490,3 +490,180 @@ fn test_do_update_in_subquery_in_set() {
     .unwrap();
     assert_eq!(rows(&db, "t"), vec![vec![int(1), int(77)]]);
 }
+
+// ============================================================================
+// Expression-index and partial-index conflict targets (issue #5278,
+// upsert1-200/201/210/300/310/320)
+// ============================================================================
+
+#[test]
+fn test_expression_index_target_do_nothing() {
+    // upsert1-200: ON CONFLICT(a+b) matches CREATE UNIQUE INDEX t1x1 ON t1(a+b)
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT, c DEFAULT 0)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1x1 ON t1(a+b)").unwrap();
+    let n = exec(&mut db, "INSERT INTO t1(a,b) VALUES(7,8) ON CONFLICT(a+b) DO NOTHING").unwrap();
+    assert_eq!(n, 1);
+    // Both rows conflict on a+b=15 with the existing (7,8) row.
+    let n =
+        exec(&mut db, "INSERT INTO t1(a,b) VALUES(8,7),(9,6) ON CONFLICT(a+b) DO NOTHING").unwrap();
+    assert_eq!(n, 0, "conflicting rows must be silently skipped");
+    assert_eq!(rows(&db, "t1"), vec![vec![int(7), int(8), int(0)]]);
+}
+
+#[test]
+fn test_expression_index_violation_error_format() {
+    // upsert1-201: a conflict on a NON-targeted unique expression index must
+    // raise SQLite's index-name error format, not be silently skipped.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT, c DEFAULT 0)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1x1 ON t1(a+b)").unwrap();
+    exec(&mut db, "INSERT INTO t1(a,b) VALUES(7,8)").unwrap();
+    let err = exec(&mut db, "INSERT INTO t1(a,b) VALUES(8,7),(9,6) ON CONFLICT(a) DO NOTHING")
+        .expect_err("conflict on non-targeted expression index must error");
+    assert!(format!("{err:?}").contains("UNIQUE constraint failed: index 't1x1'"), "got: {err:?}");
+}
+
+#[test]
+fn test_insert_or_ignore_with_unique_expression_index_no_panic() {
+    // Regression test for the pre-existing panic: check_would_violate_constraints
+    // called expect_column_name() on expression-index components
+    // ("Expression indexes are not supported in this context").
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT, c DEFAULT 0)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1x1 ON t1(a+b)").unwrap();
+    exec(&mut db, "INSERT INTO t1(a,b) VALUES(7,8)").unwrap();
+    let stmt =
+        vibesql_parser::Parser::parse_sql("INSERT OR IGNORE INTO t1(a,b) VALUES(8,7)").unwrap();
+    let vibesql_ast::Statement::Insert(insert) = stmt else { panic!("expected INSERT") };
+    let n = InsertExecutor::execute(&mut db, &insert).expect("OR IGNORE must not panic or error");
+    assert_eq!(n, 0, "conflicting row must be ignored");
+    assert_eq!(rows(&db, "t1"), vec![vec![int(7), int(8), int(0)]]);
+}
+
+#[test]
+fn test_plain_insert_unique_expression_index_enforced() {
+    // A plain INSERT violating a unique expression index must error with
+    // SQLite's index-name format (previously the violation was not enforced).
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1x1 ON t1(a+b)").unwrap();
+    exec(&mut db, "INSERT INTO t1(a,b) VALUES(7,8)").unwrap();
+    let err = exec(&mut db, "INSERT INTO t1(a,b) VALUES(8,7)")
+        .expect_err("duplicate expression-index key must error");
+    assert!(format!("{err:?}").contains("UNIQUE constraint failed: index 't1x1'"), "got: {err:?}");
+}
+
+#[test]
+fn test_null_expression_index_key_never_conflicts() {
+    // NULL expression keys never conflict under UNIQUE semantics.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1x1 ON t1(a+b)").unwrap();
+    exec(&mut db, "INSERT INTO t1(a,b) VALUES(1,NULL)").unwrap();
+    let n = exec(&mut db, "INSERT INTO t1(a,b) VALUES(2,NULL)").unwrap();
+    assert_eq!(n, 1, "NULL keys must not conflict");
+    assert_eq!(rows(&db, "t1").len(), 2);
+}
+
+#[test]
+fn test_expression_target_structural_mismatch_errors() {
+    // upsert1-210: a+(+b) must NOT match the index on a+b.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1x1 ON t1(a+b)").unwrap();
+    let err = exec(&mut db, "INSERT INTO t1(a,b) VALUES(9,10) ON CONFLICT(a+(+b)) DO NOTHING")
+        .expect_err("structurally different expression target must not match");
+    assert!(
+        format!("{err:?}")
+            .contains("ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint"),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn test_partial_index_target_do_nothing() {
+    // upsert1-320: ON CONFLICT(b) WHERE b>10 matches the partial unique
+    // index, including conflicts with earlier rows of the same batch.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT, c DEFAULT 0)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1x1 ON t1(b) WHERE b>10").unwrap();
+    let n = exec(
+        &mut db,
+        "INSERT INTO t1(a,b) VALUES(1,2),(3,2),(4,20),(5,20) \
+         ON CONFLICT(b) WHERE b>10 DO NOTHING",
+    )
+    .unwrap();
+    // (5,20) conflicts with (4,20) through the partial index; the duplicate
+    // b=2 rows are outside the index and both insert.
+    assert_eq!(n, 3);
+    assert_eq!(
+        rows(&db, "t1"),
+        vec![
+            vec![int(1), int(2), int(0)],
+            vec![int(3), int(2), int(0)],
+            vec![int(4), int(20), int(0)],
+        ]
+    );
+}
+
+#[test]
+fn test_bare_column_target_does_not_match_partial_index() {
+    // upsert1-300: ON CONFLICT(b) without WHERE must not match a partial index.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1x1 ON t1(b) WHERE b>10").unwrap();
+    let err = exec(&mut db, "INSERT INTO t1(a,b) VALUES(1,2),(3,2) ON CONFLICT(b) DO NOTHING")
+        .expect_err("bare column target must not match a partial index");
+    assert!(
+        format!("{err:?}")
+            .contains("ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint"),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn test_mismatched_target_where_does_not_match_partial_index() {
+    // upsert1-310: WHERE b!=10 must not match the index predicate WHERE b>10.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1x1 ON t1(b) WHERE b>10").unwrap();
+    let err = exec(
+        &mut db,
+        "INSERT INTO t1(a,b) VALUES(1,2),(3,2) ON CONFLICT(b) WHERE b!=10 DO NOTHING",
+    )
+    .expect_err("mismatched target WHERE must not match the index predicate");
+    assert!(
+        format!("{err:?}")
+            .contains("ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint"),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn test_expression_index_target_do_update() {
+    // The DO UPDATE arm must also match expression-index targets.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT, c DEFAULT 0)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1x1 ON t1(a+b)").unwrap();
+    exec(&mut db, "INSERT INTO t1(a,b) VALUES(7,8)").unwrap();
+    let n = exec(
+        &mut db,
+        "INSERT INTO t1(a,b) VALUES(8,7) ON CONFLICT(a+b) DO UPDATE SET c=excluded.a",
+    )
+    .unwrap();
+    assert_eq!(n, 1, "update arm counts toward affected rows");
+    assert_eq!(rows(&db, "t1"), vec![vec![int(7), int(8), int(8)]]);
+}
+
+#[test]
+fn test_targeted_do_nothing_other_plain_constraint_still_errors() {
+    // A targeted DO NOTHING must not suppress conflicts on other plain
+    // unique constraints (SQLite semantics; companion to upsert1-201).
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT UNIQUE)").unwrap();
+    exec(&mut db, "INSERT INTO t1(a,b) VALUES(1,5)").unwrap();
+    let err = exec(&mut db, "INSERT INTO t1(a,b) VALUES(2,5) ON CONFLICT(a) DO NOTHING")
+        .expect_err("conflict on the non-targeted UNIQUE column must error");
+    assert!(format!("{err:?}").contains("UNIQUE constraint failed"), "got: {err:?}");
+}

--- a/crates/vibesql-parser/src/arena_parser/insert.rs
+++ b/crates/vibesql-parser/src/arena_parser/insert.rs
@@ -267,11 +267,20 @@ impl<'arena> ArenaParser<'arena> {
         if self.try_consume_keyword(Keyword::Conflict) {
             // SQLite/PostgreSQL: ON CONFLICT [(cols)] DO {NOTHING | UPDATE SET ...}
 
-            // Parse optional conflict target (column list)
+            // Parse optional conflict target (column list).
+            //
+            // The arena parser only supports plain column-name targets;
+            // expression targets, COLLATE, and target-level WHERE predicates
+            // fail here and fall back to the standard parser (which retains
+            // them — see parser/insert.rs).
             let conflict_target = if self.try_consume(&Token::LParen) {
                 let cols = self.parse_identifier_list()?;
                 self.expect_token(Token::RParen)?;
-                Some(cols)
+                let mut items = BumpVec::new_in(self.arena);
+                for col in cols {
+                    items.push(vibesql_ast::arena::ConflictTargetItem::Column(col));
+                }
+                Some(items)
             } else {
                 None
             };
@@ -300,7 +309,15 @@ impl<'arena> ArenaParser<'arena> {
                 });
             };
 
-            Ok((Some(OnConflictClause { conflict_target, target_inexact: false, action }), None))
+            Ok((
+                Some(OnConflictClause {
+                    conflict_target,
+                    target_where: None,
+                    target_inexact: false,
+                    action,
+                }),
+                None,
+            ))
         } else if self.try_consume_keyword(Keyword::Duplicate) {
             // MySQL: ON DUPLICATE KEY UPDATE ...
             self.consume_keyword(Keyword::Key)?;

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -420,12 +420,14 @@ impl Parser {
             // We mirror that behavior so nulls1.test 3.1.11 / 3.1.12 see the
             // expected error message.
             //
-            // v1 (issue #5269) matches plain column names with the default
-            // BINARY collation only. Expression components, non-BINARY
-            // COLLATE, and target WHERE predicates parse successfully but
-            // mark the target "inexact" so the executor reports SQLite's
-            // canonical "ON CONFLICT clause does not match any PRIMARY KEY
-            // or UNIQUE constraint" error (upsert1-130/210/310/1210).
+            // Plain column names (default BINARY collation) become
+            // `ConflictTargetItem::Column`; everything else is retained as a
+            // `ConflictTargetItem::Expression` for structural matching
+            // against expression indexes (upsert1-200/210). An explicit
+            // non-BINARY COLLATE still marks the target "inexact" so the
+            // executor reports SQLite's canonical "ON CONFLICT clause does
+            // not match any PRIMARY KEY or UNIQUE constraint" error
+            // (upsert1-130; issue #5269).
             let mut target_inexact = false;
             let conflict_target = if matches!(self.peek(), Token::LParen) {
                 self.advance(); // consume (
@@ -445,46 +447,46 @@ impl Parser {
                     p.reject_nulls_in_index_position()?;
 
                     // Peel an optional COLLATE wrapper.
-                    let (base, collation) = match &expr {
+                    let (base, collation) = match expr {
                         vibesql_ast::Expression::Collate { expr: inner, collation } => {
-                            (inner.as_ref(), Some(collation.as_str()))
+                            (*inner, Some(collation))
                         }
                         other => (other, None),
                     };
 
-                    match base {
+                    // A non-default (non-BINARY) collation cannot be matched
+                    // against an index in v1 (upsert1-130).
+                    let inexact = collation
+                        .as_deref()
+                        .map(|c| !c.eq_ignore_ascii_case("binary"))
+                        .unwrap_or(false);
+
+                    let item = match &base {
                         vibesql_ast::Expression::ColumnRef(id)
                             if id.table_canonical().is_none() =>
                         {
-                            // Plain column: exact unless a non-default
-                            // (non-BINARY) collation was requested.
-                            let inexact = collation
-                                .map(|c| !c.eq_ignore_ascii_case("binary"))
-                                .unwrap_or(false);
-                            Ok((id.column_display().to_string(), inexact))
+                            vibesql_ast::ConflictTargetItem::Column(id.column_display().to_string())
                         }
-                        _ => {
-                            // Expression component: cannot match a plain
-                            // column-list constraint in v1.
-                            Ok((String::new(), true))
-                        }
-                    }
+                        _ => vibesql_ast::ConflictTargetItem::Expression(base),
+                    };
+                    Ok((item, inexact))
                 })?;
                 self.expect_token(Token::RParen)?;
                 target_inexact = entries.iter().any(|(_, inexact)| *inexact);
-                Some(entries.into_iter().map(|(name, _)| name).collect())
+                Some(entries.into_iter().map(|(item, _)| item).collect())
             } else {
                 None
             };
 
-            // Optional target-level WHERE predicate (partial-index upsert).
-            // Parsed but not matched in v1: marks the target inexact
-            // (upsert1-310).
-            if conflict_target.is_some() && self.peek_keyword(Keyword::Where) {
+            // Optional target-level WHERE predicate (partial-index upsert,
+            // upsert1-310/320). Retained for structural matching against a
+            // partial unique index's predicate.
+            let target_where = if conflict_target.is_some() && self.peek_keyword(Keyword::Where) {
                 self.advance(); // consume WHERE
-                let _predicate = self.parse_expression()?;
-                target_inexact = true;
-            }
+                Some(self.parse_expression()?)
+            } else {
+                None
+            };
 
             self.expect_keyword(Keyword::Do)?;
 
@@ -514,7 +516,12 @@ impl Parser {
             };
 
             Ok((
-                Some(vibesql_ast::OnConflictClause { conflict_target, target_inexact, action }),
+                Some(vibesql_ast::OnConflictClause {
+                    conflict_target,
+                    target_where,
+                    target_inexact,
+                    action,
+                }),
                 None,
             ))
         } else if self.peek_keyword(Keyword::Duplicate) {


### PR DESCRIPTION
Closes #5278

## Summary

Implements the upsert engine follow-ups from #5278: expression-index and partial-index conflict targets, unique expression-index enforcement, and the pre-existing `expect_column_name()` panic fix.

- **upsert1-200**: `ON CONFLICT(a+b) DO NOTHING` now matches `CREATE UNIQUE INDEX t1x1 ON t1(a+b)`. The AST gains `ConflictTargetItem` (`Column | Expression`) so the parser retains expression target entries instead of flattening them to an "inexact" flag; the executor matches them structurally against expression-index components.
- **upsert1-201**: unique expression indexes are now enforced — violations raise SQLite's index-name format `UNIQUE constraint failed: index 't1x1'`. A targeted `DO NOTHING` only suppresses conflicts on the *targeted* constraint; conflicts on other constraints surface as normal UNIQUE errors.
- **upsert1-320**: partial-index targets (`ON CONFLICT(b) WHERE b>10`) match a partial unique index whose predicate is structurally equal; conflict detection only considers rows satisfying the predicate, including earlier rows of the same multi-row VALUES batch.
- **Panic fix** (pre-existing, not a #5277 regression): `check_would_violate_constraints` (`insert/execution.rs`) called `expect_column_name()` on expression-index components, so plain `INSERT OR IGNORE` into a table with a unique expression index panicked ("Expression indexes are not supported in this context"). It now evaluates expression components and respects partial-index predicates. Regression test included.

Negative-match semantics are preserved: `a+(+b)` does NOT match `a+b` (upsert1-210), a bare `ON CONFLICT(b)` does NOT match a partial index (upsert1-300), a mismatched target WHERE does NOT match (upsert1-310), and non-BINARY COLLATE targets still raise the canonical "does not match" error (upsert1-130).

`target_inexact` now covers only the genuinely unsupported case (non-BINARY COLLATE). The arena parser keeps plain-column-only targets and falls back to the standard parser for expression/WHERE targets.

## Results

- `./scripts/tcltest test upsert1.test`: **27 → 30 passed** (failures remaining: 400, 1210 — CLI/lexer items split out to #5283)
- All three issue reproducers verified against the CLI (200 skips silently, 201 errors with `UNIQUE constraint failed: index 't1x1'` instead of panicking, 320 yields `{1 2 0, 3 2 0, 4 20 0}`)
- `cargo test -p vibesql-ast -p vibesql-parser -p vibesql-executor`: all green (89 executor suites)
- New tests in `insert_on_conflict_update_tests.rs` cover expression targets, partial targets, enforcement error format, the OR IGNORE panic regression, batch-internal conflicts, and the negative cases

## Test plan

- [x] upsert1-200/201/320 pass; 130/210/300/310 stay passing (no regressions among the 27 baseline passes)
- [x] `INSERT OR IGNORE` + unique expression index no longer panics (regression test)
- [x] Full `vibesql-executor`, `vibesql-parser`, `vibesql-ast` test suites green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)