### PR TITLE
feat(functions): implement SQLite-compatible strftime() scalar function

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/datetime/current.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/datetime/current.rs
@@ -173,6 +173,37 @@ pub fn datetime(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         ));
     }
 
+    // Resolve the time value (base + modifiers); None means SQL NULL
+    let dt = match resolve_time_value(args, "DATETIME")? {
+        Some(dt) => dt,
+        None => return Ok(SqlValue::Null),
+    };
+
+    // Convert NaiveDateTime to SqlValue::Timestamp
+    naive_datetime_to_timestamp(dt)
+}
+
+/// Resolve a SQLite time-value argument list (timestring + modifiers) to a `NaiveDateTime`.
+///
+/// `args[0]` is the base time value; `args[1..]` are modifiers applied in sequence.
+/// If `args` is empty, the current local time is used (SQLite treats an omitted
+/// time-value as 'now').
+///
+/// Returns:
+/// - `Ok(None)` for NULL input, unparseable timestrings, or invalid modifiers
+///   (SQLite returns NULL in these cases)
+/// - `Err(...)` for argument types that are not supported at all
+///
+/// Shared by `datetime()` and `strftime()`; `func_name` is used in error messages.
+pub(super) fn resolve_time_value(
+    args: &[SqlValue],
+    func_name: &str,
+) -> Result<Option<NaiveDateTime>, ExecutorError> {
+    if args.is_empty() {
+        // SQLite: omitted time-value defaults to 'now'
+        return Ok(Some(Local::now().naive_local()));
+    }
+
     // Check if 'unixepoch' is the first modifier - affects how we parse the base value
     let has_unixepoch_first = args.len() > 1
         && matches!(&args[1], SqlValue::Varchar(s) | SqlValue::Character(s) if s.eq_ignore_ascii_case("unixepoch"));
@@ -180,26 +211,26 @@ pub fn datetime(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     // Parse the base datetime value
     let base_result = if has_unixepoch_first {
         // For unixepoch, parse numeric values as Unix timestamps instead of Julian Days
-        parse_base_datetime_for_unixepoch(&args[0])?
+        parse_base_datetime_for_unixepoch(&args[0], func_name)?
     } else {
-        parse_base_datetime(&args[0])?
+        parse_base_datetime(&args[0], func_name)?
     };
 
     // If base value is NULL, return NULL
     let mut dt = match base_result {
         Some(dt) => dt,
-        None => return Ok(SqlValue::Null),
+        None => return Ok(None),
     };
 
     // Apply each modifier in sequence
     for (idx, modifier_arg) in args.iter().enumerate().skip(1) {
         let modifier_str = match modifier_arg {
             SqlValue::Varchar(s) | SqlValue::Character(s) => s.as_str(),
-            SqlValue::Null => return Ok(SqlValue::Null),
+            SqlValue::Null => return Ok(None),
             _ => {
                 return Err(ExecutorError::UnsupportedFeature(format!(
-                    "DATETIME modifier must be a string, got {:?}",
-                    modifier_arg
+                    "{} modifier must be a string, got {:?}",
+                    func_name, modifier_arg
                 )))
             }
         };
@@ -209,7 +240,7 @@ pub fn datetime(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         if modifier_str.eq_ignore_ascii_case("unixepoch") {
             if idx != 1 {
                 // unixepoch only valid as first modifier
-                return Ok(SqlValue::Null);
+                return Ok(None);
             }
             // Already handled during parsing, just continue
             continue;
@@ -218,16 +249,18 @@ pub fn datetime(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         // Apply the modifier
         match apply_datetime_modifier(dt, modifier_str) {
             Some(new_dt) => dt = new_dt,
-            None => return Ok(SqlValue::Null), // Invalid modifier returns NULL
+            None => return Ok(None), // Invalid modifier returns NULL
         }
     }
 
-    // Convert NaiveDateTime to SqlValue::Timestamp
-    naive_datetime_to_timestamp(dt)
+    Ok(Some(dt))
 }
 
-/// Parse the base datetime value (first argument to DATETIME)
-fn parse_base_datetime(value: &SqlValue) -> Result<Option<NaiveDateTime>, ExecutorError> {
+/// Parse the base datetime value (first argument to DATETIME/STRFTIME's time value)
+fn parse_base_datetime(
+    value: &SqlValue,
+    func_name: &str,
+) -> Result<Option<NaiveDateTime>, ExecutorError> {
     match value {
         SqlValue::Null => Ok(None),
         SqlValue::Varchar(s) | SqlValue::Character(s) => {
@@ -271,8 +304,8 @@ fn parse_base_datetime(value: &SqlValue) -> Result<Option<NaiveDateTime>, Execut
             Ok(julian_day_to_naive(*n))
         }
         _ => Err(ExecutorError::UnsupportedFeature(format!(
-            "DATETIME requires string, date, timestamp, or numeric argument, got {:?}",
-            value
+            "{} requires string, date, timestamp, or numeric argument, got {:?}",
+            func_name, value
         ))),
     }
 }
@@ -281,6 +314,7 @@ fn parse_base_datetime(value: &SqlValue) -> Result<Option<NaiveDateTime>, Execut
 /// Numeric values are interpreted as Unix timestamps instead of Julian Days
 fn parse_base_datetime_for_unixepoch(
     value: &SqlValue,
+    func_name: &str,
 ) -> Result<Option<NaiveDateTime>, ExecutorError> {
     match value {
         SqlValue::Null => Ok(None),
@@ -306,8 +340,8 @@ fn parse_base_datetime_for_unixepoch(
             Ok(unix_epoch_to_datetime(*n as i64))
         }
         _ => Err(ExecutorError::UnsupportedFeature(format!(
-            "DATETIME requires string, date, timestamp, or numeric argument, got {:?}",
-            value
+            "{} requires string, date, timestamp, or numeric argument, got {:?}",
+            func_name, value
         ))),
     }
 }

--- a/crates/vibesql-executor/src/evaluator/functions/datetime/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/datetime/mod.rs
@@ -16,10 +16,12 @@
 //!   DATETIME)
 //! - `extract` - Field extraction (YEAR, MONTH, DAY, HOUR, MINUTE, SECOND)
 //! - `arithmetic` - Date/time arithmetic (DATEDIFF, DATE_ADD, DATE_SUB, AGE, EXTRACT)
+//! - `strftime` - SQLite-compatible STRFTIME formatting
 
 mod arithmetic;
 mod current;
 mod extract;
+mod strftime;
 
 // Re-export all public functions
 // Re-export helper for use by arithmetic operators
@@ -27,3 +29,4 @@ pub(crate) use arithmetic::date_add_subtract;
 pub(super) use arithmetic::{age, date_add, date_sub, datediff, extract};
 pub(super) use current::{current_date, current_time, current_timestamp, datetime};
 pub(super) use extract::{day, hour, minute, month, second, year};
+pub(super) use strftime::strftime;

--- a/crates/vibesql-executor/src/evaluator/functions/datetime/strftime.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/datetime/strftime.rs
@@ -1,0 +1,403 @@
+//! STRFTIME - SQLite-compatible date/time formatting function
+//!
+//! Implements `strftime(format, timevalue, modifier, modifier, ...)` following
+//! SQLite semantics: the time value and modifiers are resolved exactly like
+//! `datetime()` (see `current::resolve_time_value`), then the resolved instant
+//! is rendered through the format string.
+//!
+//! Supported format specifiers (the classic SQLite set):
+//!
+//! | Specifier | Meaning                                  | Example (`2003-10-31 12:34:56.432`) |
+//! |-----------|------------------------------------------|--------------------------------------|
+//! | `%d`      | day of month, zero-padded (01-31)        | `31`                                 |
+//! | `%f`      | fractional seconds `SS.SSS`              | `56.432`                             |
+//! | `%H`      | hour, zero-padded (00-23)                | `12`                                 |
+//! | `%j`      | day of year, zero-padded (001-366)       | `304`                                |
+//! | `%J`      | fractional Julian Day number             | `2452944.024264259`                  |
+//! | `%m`      | month, zero-padded (01-12)               | `10`                                 |
+//! | `%M`      | minute, zero-padded (00-59)              | `34`                                 |
+//! | `%s`      | seconds since Unix epoch (integer)       | `1067603696`                         |
+//! | `%S`      | seconds, zero-padded (00-59)             | `56`                                 |
+//! | `%w`      | day of week (0-6, Sunday=0)              | `5`                                  |
+//! | `%W`      | week of year (00-53, Monday-based)       | `43`                                 |
+//! | `%Y`      | year, zero-padded to 4 digits            | `2003`                               |
+//! | `%%`      | literal `%`                              | `%`                                  |
+//!
+//! Out of scope for v1 (returns NULL like older SQLite versions):
+//! - SQLite 3.44+ additions: `%e %F %G %g %I %k %l %p %P %R %T %u %U %V`
+//! - Modifiers beyond what `datetime()` supports (`subsec`, real timezone
+//!   conversion for `localtime`/`utc`, `±HH:MM` offsets, `auto`, `julianday`)
+//!
+//! SQLite Reference: https://www.sqlite.org/lang_datefunc.html
+
+use chrono::{Datelike, NaiveDateTime, Timelike};
+use vibesql_types::SqlValue;
+
+use super::current::resolve_time_value;
+use crate::errors::ExecutorError;
+
+/// Milliseconds between the start of the Julian Day epoch (-4714-11-24 12:00:00)
+/// and the Unix epoch (1970-01-01 00:00:00). Matches SQLite's internal iJD origin.
+const JULIAN_EPOCH_OFFSET_MS: i64 = 210_866_760_000_000;
+
+/// STRFTIME - Format a time value according to a format string
+///
+/// `strftime(format, timevalue, modifier, modifier, ...)`
+///
+/// Returns TEXT (SQLite semantics). Returns NULL when:
+/// - the format or time value is NULL
+/// - the time value cannot be parsed
+/// - a modifier is invalid
+/// - the format contains an unsupported `%x` specifier
+pub fn strftime(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    if args.is_empty() {
+        return Err(ExecutorError::UnsupportedFeature(
+            "STRFTIME requires at least 1 argument".to_string(),
+        ));
+    }
+
+    // First argument is the format string
+    let format = match &args[0] {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => s.as_str(),
+        SqlValue::Null => return Ok(SqlValue::Null),
+        other => {
+            return Err(ExecutorError::UnsupportedFeature(format!(
+                "STRFTIME format must be a string, got {:?}",
+                other
+            )))
+        }
+    };
+
+    // Remaining arguments are the time value + modifiers (an empty list means 'now')
+    let dt = match resolve_time_value(&args[1..], "STRFTIME")? {
+        Some(dt) => dt,
+        None => return Ok(SqlValue::Null),
+    };
+
+    match format_datetime(format, dt) {
+        Some(s) => Ok(SqlValue::Varchar(s.into())),
+        None => Ok(SqlValue::Null), // Unknown specifier returns NULL (SQLite behavior)
+    }
+}
+
+/// Render `dt` through the strftime format string.
+/// Returns None for unsupported/unknown specifiers (including a trailing `%`).
+fn format_datetime(format: &str, dt: NaiveDateTime) -> Option<String> {
+    use std::fmt::Write;
+
+    let mut out = String::with_capacity(format.len() + 16);
+    let mut chars = format.chars();
+
+    while let Some(c) = chars.next() {
+        if c != '%' {
+            out.push(c);
+            continue;
+        }
+
+        let spec = chars.next()?; // trailing '%' is an error -> NULL
+        match spec {
+            'd' => write!(out, "{:02}", dt.day()).ok()?,
+            'f' => {
+                // Seconds with milliseconds, "%06.3f" in SQLite (e.g. 56.432, 06.400).
+                // Truncate (not round) sub-millisecond precision; clamp leap seconds.
+                let millis = (dt.nanosecond() / 1_000_000).min(999);
+                write!(out, "{:02}.{:03}", dt.second(), millis).ok()?
+            }
+            'H' => write!(out, "{:02}", dt.hour()).ok()?,
+            'j' => write!(out, "{:03}", dt.ordinal()).ok()?,
+            'J' => out.push_str(&format_julian_day(dt)),
+            'm' => write!(out, "{:02}", dt.month()).ok()?,
+            'M' => write!(out, "{:02}", dt.minute()).ok()?,
+            's' => write!(out, "{}", dt.and_utc().timestamp()).ok()?,
+            'S' => write!(out, "{:02}", dt.second()).ok()?,
+            'w' => write!(out, "{}", dt.weekday().num_days_from_sunday()).ok()?,
+            'W' => {
+                // SQLite: week 01 starts on the first Monday of the year; days
+                // before that are week 00. Computed as (nDay + 7 - wd) / 7 where
+                // nDay is the 0-based day of year and wd is the Monday-based
+                // day of week (0=Monday).
+                let n_day = dt.ordinal0();
+                let wd = dt.weekday().num_days_from_monday();
+                write!(out, "{:02}", (n_day + 7 - wd) / 7).ok()?
+            }
+            'Y' => write!(out, "{:04}", dt.year()).ok()?,
+            '%' => out.push('%'),
+            _ => return None, // Unsupported specifier -> NULL (matches SQLite)
+        }
+    }
+
+    Some(out)
+}
+
+/// Format the fractional Julian Day number for `%J`.
+///
+/// SQLite computes `iJD / 86400000.0` (iJD = milliseconds since the Julian Day
+/// origin) and prints it with `"%.16g"`. We reproduce both the arithmetic and
+/// the 16-significant-digit rendering so output matches SQLite byte-for-byte.
+fn format_julian_day(dt: NaiveDateTime) -> String {
+    let epoch_ms = dt.and_utc().timestamp_millis();
+    let jd = (epoch_ms + JULIAN_EPOCH_OFFSET_MS) as f64 / 86_400_000.0;
+    format_g16(jd)
+}
+
+/// Emulate C's `"%.16g"` (16 significant digits, trailing zeros trimmed) for
+/// the magnitude range Julian Day numbers occupy (0 .. ~5.4 million). Values in
+/// this range never use scientific notation under `%g`.
+fn format_g16(v: f64) -> String {
+    if v == 0.0 {
+        return "0".to_string();
+    }
+    // Number of digits before the decimal point
+    let int_digits = if v.abs() < 1.0 { 1 } else { v.abs().log10().floor() as i32 + 1 };
+    let decimals = (16 - int_digits).clamp(0, 17) as usize;
+    let s = format!("{:.*}", decimals, v);
+    if s.contains('.') {
+        s.trim_end_matches('0').trim_end_matches('.').to_string()
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sf(args: &[SqlValue]) -> SqlValue {
+        strftime(args).expect("strftime should not error")
+    }
+
+    fn text(s: &str) -> SqlValue {
+        SqlValue::Varchar(s.into())
+    }
+
+    fn assert_strftime(format: &str, timevalue: &str, expected: &str) {
+        let result = sf(&[text(format), text(timevalue)]);
+        assert_eq!(
+            result,
+            text(expected),
+            "strftime('{}', '{}') should be '{}'",
+            format,
+            timevalue,
+            expected
+        );
+    }
+
+    // Ground truth: SQLite date.test section 3 ('2003-10-31 12:34:56.432')
+
+    #[test]
+    fn test_day_of_month() {
+        assert_strftime("%d", "2003-10-31 12:34:56.432", "31");
+        assert_strftime("%d", "2004-01-02", "02");
+    }
+
+    #[test]
+    fn test_fractional_seconds() {
+        // date.test 3.2.1
+        assert_strftime("pre%fpost", "2003-10-31 12:34:56.432", "pre56.432post");
+        // date.test 3.2.2: truncation, not rounding
+        assert_strftime("%f", "2003-10-31 12:34:59.9999999", "59.999");
+        // Zero-padding on both sides
+        assert_strftime("%f", "2003-10-31 12:34:06.4", "06.400");
+        assert_strftime("%f", "2003-10-31 12:34:56", "56.000");
+    }
+
+    #[test]
+    fn test_hour() {
+        assert_strftime("%H", "2003-10-31 12:34:56.432", "12");
+        assert_strftime("%H", "2003-10-31 04:34:56", "04");
+        assert_strftime("%H", "2003-10-31 00:00:00", "00");
+    }
+
+    #[test]
+    fn test_day_of_year() {
+        assert_strftime("%j", "2003-10-31 12:34:56.432", "304");
+        assert_strftime("%j", "2004-01-01", "001");
+        assert_strftime("%j", "2004-12-31", "366"); // leap year
+    }
+
+    #[test]
+    fn test_julian_day() {
+        // date.test 3.5
+        assert_strftime("%J", "2003-10-31 12:34:56.432", "2452944.024264259");
+        // Noon on the Unix epoch is an exact Julian Day boundary
+        assert_strftime("%J", "1970-01-01 12:00:00", "2440588");
+        assert_strftime("%J", "1970-01-01 00:00:00", "2440587.5");
+    }
+
+    #[test]
+    fn test_month() {
+        assert_strftime("%m", "2003-10-31 12:34:56.432", "10");
+        assert_strftime("%m", "2003-01-31", "01");
+    }
+
+    #[test]
+    fn test_minute() {
+        assert_strftime("%M", "2003-10-31 12:34:56.432", "34");
+        assert_strftime("%M", "2003-10-31 12:04:56", "04");
+    }
+
+    #[test]
+    fn test_unix_epoch_seconds() {
+        // date.test 3.8.x
+        assert_strftime("%s", "2003-10-31 12:34:56.432", "1067603696");
+        assert_strftime("%s", "2038-01-19 03:14:07", "2147483647");
+        assert_strftime("%s", "2038-01-19 03:14:08", "2147483648");
+        assert_strftime("%s", "2201-04-09 12:00:00", "7298164800");
+        assert_strftime("%s", "9999-12-31 23:59:59", "253402300799");
+        assert_strftime("%s", "1969-12-31 23:59:59", "-1");
+        assert_strftime("%s", "1901-12-13 20:45:52", "-2147483648");
+        assert_strftime("%s", "1901-12-13 20:45:51", "-2147483649");
+        assert_strftime("%s", "1776-07-04 00:00:00", "-6106060800");
+    }
+
+    #[test]
+    fn test_seconds() {
+        assert_strftime("%S", "2003-10-31 12:34:56.432", "56");
+        assert_strftime("%S", "2003-10-31 12:34:06", "06");
+    }
+
+    #[test]
+    fn test_day_of_week() {
+        // 2003-10-31 was a Friday (Sunday=0 -> 5)
+        assert_strftime("%w", "2003-10-31 12:34:56.432", "5");
+        // 2004-01-04 was a Sunday
+        assert_strftime("%w", "2004-01-04", "0");
+        // 2004-01-03 was a Saturday
+        assert_strftime("%w", "2004-01-03", "6");
+    }
+
+    #[test]
+    fn test_week_of_year() {
+        // date.test 3.11.x
+        assert_strftime("%W", "2003-10-31 12:34:56.432", "43");
+        assert_strftime("%W", "2004-01-01", "00");
+        assert_strftime("%W", "2004-01-02", "00");
+        assert_strftime("%W", "2004-01-03", "00");
+        assert_strftime("abc%Wxyz", "2004-01-04", "abc00xyz");
+        assert_strftime("%W", "2004-01-05", "01");
+        assert_strftime("%W", "2004-01-06", "01");
+        assert_strftime("%W", "2004-07-18", "28");
+        assert_strftime("%W", "2004-12-31", "52");
+        assert_strftime("%W", "2007-12-31", "53");
+        assert_strftime("%W", "2007-01-01", "01");
+    }
+
+    #[test]
+    fn test_year() {
+        assert_strftime("%Y", "2003-10-31 12:34:56.432", "2003");
+        assert_strftime("%Y", "0100-01-01", "0100");
+    }
+
+    #[test]
+    fn test_percent_literal() {
+        assert_strftime("%%", "2003-10-31 12:34:56.432", "%");
+        assert_strftime("100%%", "2003-10-31", "100%");
+    }
+
+    #[test]
+    fn test_multi_specifier_format() {
+        assert_strftime("%Y-%m-%d", "2003-10-31", "2003-10-31");
+        assert_strftime("%Y-%m-%d %H:%M:%S", "2003-10-31 12:34:56", "2003-10-31 12:34:56");
+        assert_strftime("%d/%m/%Y", "1995-03-15", "15/03/1995");
+    }
+
+    #[test]
+    fn test_plain_text_passthrough() {
+        assert_strftime("no specifiers here", "2003-10-31", "no specifiers here");
+        assert_strftime("", "2003-10-31", "");
+    }
+
+    #[test]
+    fn test_unknown_specifier_returns_null() {
+        // date.test 3.14: %_ -> NULL
+        assert_eq!(sf(&[text("%_"), text("2003-10-31 12:34:56.432")]), SqlValue::Null);
+        // 3.44+ specifiers are out of scope for v1 -> NULL
+        for spec in ["%e", "%F", "%I", "%k", "%p", "%P", "%R", "%T", "%u", "%G", "%g", "%U", "%V"] {
+            assert_eq!(
+                sf(&[text(spec), text("2003-10-31")]),
+                SqlValue::Null,
+                "{} should return NULL",
+                spec
+            );
+        }
+        // Trailing bare '%' -> NULL
+        assert_eq!(sf(&[text("abc%"), text("2003-10-31")]), SqlValue::Null);
+    }
+
+    #[test]
+    fn test_null_arguments() {
+        assert_eq!(sf(&[SqlValue::Null, text("2003-10-31")]), SqlValue::Null);
+        assert_eq!(sf(&[text("%Y"), SqlValue::Null]), SqlValue::Null);
+        assert_eq!(sf(&[text("%Y"), text("2003-10-31"), SqlValue::Null]), SqlValue::Null);
+    }
+
+    #[test]
+    fn test_invalid_timestring_returns_null() {
+        assert_eq!(sf(&[text("%Y"), text("not-a-date")]), SqlValue::Null);
+        assert_eq!(sf(&[text("%Y"), text("")]), SqlValue::Null);
+    }
+
+    #[test]
+    fn test_modifiers_flow_through() {
+        let result = sf(&[text("%Y"), text("1995-03-15"), text("+1 year")]);
+        assert_eq!(result, text("1996"));
+
+        let result = sf(&[text("%Y-%m-%d"), text("2003-10-31"), text("start of month")]);
+        assert_eq!(result, text("2003-10-01"));
+
+        let result = sf(&[text("%Y-%m-%d"), text("2003-10-31"), text("+2 days")]);
+        assert_eq!(result, text("2003-11-02"));
+
+        // Invalid modifier -> NULL
+        assert_eq!(sf(&[text("%Y"), text("2003-10-31"), text("not a modifier")]), SqlValue::Null);
+    }
+
+    #[test]
+    fn test_unixepoch_modifier() {
+        let result =
+            sf(&[text("%Y-%m-%d %H:%M:%S"), SqlValue::Integer(1067603696), text("unixepoch")]);
+        assert_eq!(result, text("2003-10-31 12:34:56"));
+    }
+
+    #[test]
+    fn test_date_and_timestamp_values() {
+        let date = SqlValue::Date(vibesql_types::Date::new(1995, 3, 15).unwrap());
+        assert_eq!(sf(&[text("%Y"), date]), text("1995"));
+
+        let ts = SqlValue::Timestamp(vibesql_types::Timestamp::new(
+            vibesql_types::Date::new(2003, 10, 31).unwrap(),
+            vibesql_types::Time::new(12, 34, 56, 0).unwrap(),
+        ));
+        assert_eq!(sf(&[text("%Y-%m-%d %H:%M:%S"), ts]), text("2003-10-31 12:34:56"));
+    }
+
+    #[test]
+    fn test_returns_text_type() {
+        // SQLite's strftime returns TEXT, never a numeric type — this matters
+        // for GROUP BY/ORDER BY semantics in TPC-H Q7/Q8/Q9
+        let result = sf(&[text("%Y"), text("1995-03-15")]);
+        assert!(matches!(result, SqlValue::Varchar(_)), "strftime must return TEXT");
+    }
+
+    #[test]
+    fn test_now_default_timevalue() {
+        // strftime('%Y') uses the current time (SQLite behavior)
+        let result = sf(&[text("%Y")]);
+        match result {
+            SqlValue::Varchar(s) => {
+                let year: i32 = s.parse().expect("year should be numeric");
+                assert!((2020..=2200).contains(&year), "unexpected year {}", year);
+            }
+            other => panic!("expected TEXT, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_format_g16() {
+        assert_eq!(format_g16(2452944.0242642593), "2452944.024264259");
+        assert_eq!(format_g16(2440588.0), "2440588");
+        assert_eq!(format_g16(2440587.5), "2440587.5");
+        assert_eq!(format_g16(0.5), "0.5");
+        assert_eq!(format_g16(0.0), "0");
+    }
+}

--- a/crates/vibesql-executor/src/evaluator/functions/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/mod.rs
@@ -111,6 +111,7 @@ pub(super) fn eval_scalar_function(
         "CURRENT_TIME" | "CURTIME" => datetime::current_time(args),
         "CURRENT_TIMESTAMP" | "NOW" => datetime::current_timestamp(args),
         "DATETIME" => datetime::datetime(args),
+        "STRFTIME" => datetime::strftime(args),
         "YEAR" => datetime::year(args),
         "MONTH" => datetime::month(args),
         "DAY" => datetime::day(args),

--- a/crates/vibesql-executor/tests/date_time_function_tests.rs
+++ b/crates/vibesql-executor/tests/date_time_function_tests.rs
@@ -10,6 +10,7 @@
 //! - **precision**: Precision arguments for fractional seconds
 //! - **extraction**: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND extraction
 //! - **nested_operations**: Nested and combined datetime operations
+//! - **strftime**: SQLite-compatible STRFTIME formatting
 
 mod common;
 
@@ -28,3 +29,6 @@ mod extraction;
 
 #[path = "date_time_function_tests/nested_operations.rs"]
 mod nested_operations;
+
+#[path = "date_time_function_tests/strftime.rs"]
+mod strftime;

--- a/crates/vibesql-executor/tests/date_time_function_tests/strftime.rs
+++ b/crates/vibesql-executor/tests/date_time_function_tests/strftime.rs
@@ -1,0 +1,158 @@
+//! Integration tests for the SQLite-compatible STRFTIME function
+//!
+//! Conformance values are taken from SQLite's date.test section 3
+//! (docs/reference/sqlite/test/date.test), which uses the reference value
+//! '2003-10-31 12:34:56.432'.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn execute_query(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor.execute(&select_stmt).unwrap()
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+/// Execute `SELECT <expr>` and return the single result value
+fn eval_scalar(sql_expr: &str) -> SqlValue {
+    let db = Database::new();
+    let rows = execute_query(&db, &format!("SELECT {}", sql_expr));
+    assert_eq!(rows.len(), 1, "expected a single row for {}", sql_expr);
+    rows[0].values[0].clone()
+}
+
+fn assert_text(sql_expr: &str, expected: &str) {
+    match eval_scalar(sql_expr) {
+        SqlValue::Varchar(s) => assert_eq!(s.as_str(), expected, "for {}", sql_expr),
+        other => panic!("{} should return TEXT '{}', got {:?}", sql_expr, expected, other),
+    }
+}
+
+// ==================== SQLite date.test section 3 conformance ====================
+
+#[test]
+fn test_strftime_sqlite_date_test_section_3() {
+    let reference = "'2003-10-31 12:34:56.432'";
+    let cases = [
+        ("%d", "31"),                   // 3.1
+        ("pre%fpost", "pre56.432post"), // 3.2.1
+        ("%H", "12"),                   // 3.3
+        ("%j", "304"),                  // 3.4
+        ("%J", "2452944.024264259"),    // 3.5
+        ("%m", "10"),                   // 3.6
+        ("%M", "34"),                   // 3.7
+        ("%s", "1067603696"),           // 3.8.1
+        ("%S", "56"),                   // 3.9
+        ("%w", "5"),                    // 3.10
+        ("%W", "43"),                   // 3.11.1
+        ("%Y", "2003"),                 // 3.12
+        ("%%", "%"),                    // 3.13
+    ];
+    for (format, expected) in cases {
+        assert_text(&format!("strftime('{}', {})", format, reference), expected);
+    }
+
+    // 3.2.2: fractional seconds truncate, not round
+    assert_text("strftime('%f', '2003-10-31 12:34:59.9999999')", "59.999");
+    // 3.14: unknown specifier returns NULL
+    assert_eq!(eval_scalar("strftime('%_', '2003-10-31 12:34:56.432')"), SqlValue::Null);
+    // 3.15: multi-specifier format
+    assert_text("strftime('%Y-%m-%d', '2003-10-31')", "2003-10-31");
+}
+
+#[test]
+fn test_strftime_returns_text_type() {
+    // SQLite's strftime returns TEXT (matters for cross-engine comparison: '1995' vs 1995)
+    assert_text("strftime('%Y', '1995-03-15')", "1995");
+    assert_text("typeof(strftime('%Y', '1995-03-15'))", "text");
+}
+
+#[test]
+fn test_strftime_with_modifiers() {
+    assert_text("strftime('%Y', '1995-03-15', '+1 year')", "1996");
+    assert_text("strftime('%Y-%m-%d', '2003-10-31', 'start of month')", "2003-10-01");
+    assert_text("strftime('%Y-%m-%d', '2003-10-31', '+2 days')", "2003-11-02");
+    assert_text("strftime('%Y-%m-%d %H:%M:%S', 1067603696, 'unixepoch')", "2003-10-31 12:34:56");
+}
+
+#[test]
+fn test_strftime_null_and_invalid_inputs() {
+    assert_eq!(eval_scalar("strftime(NULL, '2003-10-31')"), SqlValue::Null);
+    assert_eq!(eval_scalar("strftime('%Y', NULL)"), SqlValue::Null);
+    assert_eq!(eval_scalar("strftime('%Y', 'not-a-date')"), SqlValue::Null);
+    assert_eq!(eval_scalar("strftime('%Y', '2003-10-31', 'bogus modifier')"), SqlValue::Null);
+}
+
+// ==================== Use with table columns (TPC-H Q7/Q8/Q9 pattern) ====================
+
+fn setup_orders_db() -> Database {
+    let mut db = Database::new();
+
+    let create = Parser::parse_sql("CREATE TABLE orders (id INTEGER, o_orderdate DATE)").unwrap();
+    if let vibesql_ast::Statement::CreateTable(stmt) = create {
+        vibesql_executor::CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+    }
+
+    let inserts = [
+        "INSERT INTO orders VALUES (1, '1995-03-15')",
+        "INSERT INTO orders VALUES (2, '1995-11-30')",
+        "INSERT INTO orders VALUES (3, '1996-01-02')",
+        "INSERT INTO orders VALUES (4, '1996-12-01')",
+    ];
+    for sql in inserts {
+        let stmt = Parser::parse_sql(sql).unwrap();
+        if let vibesql_ast::Statement::Insert(insert_stmt) = stmt {
+            vibesql_executor::InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
+        }
+    }
+
+    db
+}
+
+#[test]
+fn test_strftime_on_date_column() {
+    let db = setup_orders_db();
+    let rows = execute_query(&db, "SELECT strftime('%Y', o_orderdate) FROM orders ORDER BY id");
+    let years: Vec<String> = rows
+        .iter()
+        .map(|r| match &r.values[0] {
+            SqlValue::Varchar(s) => s.to_string(),
+            other => panic!("expected TEXT, got {:?}", other),
+        })
+        .collect();
+    assert_eq!(years, vec!["1995", "1995", "1996", "1996"]);
+}
+
+#[test]
+fn test_strftime_in_group_by() {
+    // The TPC-H Q7/Q8/Q9 pattern: GROUP BY strftime('%Y', date_col)
+    let db = setup_orders_db();
+    let rows = execute_query(
+        &db,
+        "SELECT strftime('%Y', o_orderdate) AS o_year, COUNT(*) \
+         FROM orders GROUP BY o_year ORDER BY o_year",
+    );
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].values[0], SqlValue::Varchar("1995".into()));
+    assert_eq!(rows[0].values[1], SqlValue::Integer(2));
+    assert_eq!(rows[1].values[0], SqlValue::Varchar("1996".into()));
+    assert_eq!(rows[1].values[1], SqlValue::Integer(2));
+}
+
+#[test]
+fn test_strftime_in_where_clause() {
+    let db = setup_orders_db();
+    let rows = execute_query(
+        &db,
+        "SELECT id FROM orders WHERE strftime('%Y', o_orderdate) = '1995' ORDER BY id",
+    );
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].values[0], SqlValue::Integer(1));
+    assert_eq!(rows[1].values[0], SqlValue::Integer(2));
+}

--- a/crates/vibesql-executor/tests/tpch_strftime_sqlite_parity.rs
+++ b/crates/vibesql-executor/tests/tpch_strftime_sqlite_parity.rs
@@ -1,0 +1,155 @@
+//! TPC-H Q7/Q8/Q9 SQLite-parity verification (strftime-dependent queries)
+//!
+//! The SQLite-flavored TPC-H query text in `vibesql-bench-common` uses
+//! `strftime('%Y', date_col)` in place of `EXTRACT(YEAR FROM date_col)`
+//! (see `crates/vibesql-bench-common/src/tpch/queries.rs`). This test runs
+//! those queries against both VibeSQL and SQLite on identical SF 0.01 data
+//! and asserts the results match, which is the acceptance criterion for
+//! issue #5282 (Q8/Q9 previously failed with `no such function: strftime`).
+//!
+//! Requires the `sqlite` feature:
+//!
+//! ```sh
+//! cargo test -p vibesql-executor --release --features sqlite \
+//!     --test tpch_strftime_sqlite_parity
+//! ```
+//!
+//! Note: run with `--release`; TPC-H joins are impractically slow in debug
+//! builds even at SF 0.01.
+#![cfg(feature = "sqlite")]
+
+use vibesql_bench_common::tpch::queries::{TPCH_Q7_SQLITE, TPCH_Q8_SQLITE, TPCH_Q9_SQLITE};
+use vibesql_bench_common::tpch::schema::{load_sqlite, load_vibesql};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_types::SqlValue;
+
+const SCALE_FACTOR: f64 = 0.01;
+
+fn vibesql_rows(db: &vibesql_storage::Database, sql: &str) -> Vec<Vec<String>> {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    let select = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        _ => panic!("expected SELECT"),
+    };
+    let executor = SelectExecutor::new(db);
+    let rows = executor.execute(&select).unwrap();
+    rows.iter().map(|r| r.values.iter().map(normalize_vibesql).collect()).collect()
+}
+
+/// Normalize values to tagged strings so TEXT-vs-numeric mismatches are
+/// detected (SQLite's strftime returns TEXT; VibeSQL must match).
+fn normalize_vibesql(v: &SqlValue) -> String {
+    match v {
+        SqlValue::Null => "NULL".to_string(),
+        SqlValue::Varchar(s) | SqlValue::Character(s) => format!("T:{}", s),
+        SqlValue::Integer(n) => format!("N:{:.6}", *n as f64),
+        SqlValue::Bigint(n) => format!("N:{:.6}", *n as f64),
+        SqlValue::Smallint(n) => format!("N:{:.6}", *n as f64),
+        SqlValue::Float(n) => format!("N:{:.6}", *n as f64),
+        SqlValue::Double(n) | SqlValue::Real(n) | SqlValue::Numeric(n) => format!("N:{:.6}", n),
+        other => format!("O:{:?}", other),
+    }
+}
+
+fn sqlite_rows(conn: &rusqlite::Connection, sql: &str) -> Vec<Vec<String>> {
+    let mut stmt = conn.prepare(sql).unwrap();
+    let ncols = stmt.column_count();
+    let rows = stmt
+        .query_map([], |row| {
+            let mut out = Vec::with_capacity(ncols);
+            for i in 0..ncols {
+                let val = match row.get_ref(i).unwrap() {
+                    rusqlite::types::ValueRef::Null => "NULL".to_string(),
+                    rusqlite::types::ValueRef::Integer(n) => format!("N:{:.6}", n as f64),
+                    rusqlite::types::ValueRef::Real(f) => format!("N:{:.6}", f),
+                    rusqlite::types::ValueRef::Text(t) => {
+                        format!("T:{}", String::from_utf8_lossy(t))
+                    }
+                    rusqlite::types::ValueRef::Blob(_) => "BLOB".to_string(),
+                };
+                out.push(val);
+            }
+            Ok(out)
+        })
+        .unwrap();
+    rows.map(|r| r.unwrap()).collect()
+}
+
+fn values_match(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    // Numeric comparison with relative tolerance (float summation order differs)
+    if let (Some(x), Some(y)) = (
+        a.strip_prefix("N:").and_then(|s| s.parse::<f64>().ok()),
+        b.strip_prefix("N:").and_then(|s| s.parse::<f64>().ok()),
+    ) {
+        let denom = x.abs().max(y.abs()).max(1.0);
+        return ((x - y) / denom).abs() < 1e-6;
+    }
+    false
+}
+
+#[test]
+fn tpch_q7_q8_q9_match_sqlite() {
+    let vdb = load_vibesql(SCALE_FACTOR);
+    let sconn = load_sqlite(SCALE_FACTOR);
+
+    // At SF 0.01 the official Q7/Q8 filters are so selective that both engines
+    // return 0 rows, which makes the parity check vacuous for those queries.
+    // Relaxed variants keep the exact query shape (strftime in SELECT and
+    // GROUP BY) while widening one data filter so rows flow through. The
+    // widened filters stay bounded — do NOT relax Q7 to `n1 <> n2` (600 nation
+    // pairs), which makes the join intermediate explode.
+    let q7_relaxed = TPCH_Q7_SQLITE.replace(
+        "((n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')\n         OR (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE'))",
+        "n1.n_name IN ('FRANCE', 'GERMANY', 'RUSSIA', 'ROMANIA', 'UNITED KINGDOM')\n         AND n2.n_name IN ('FRANCE', 'GERMANY', 'RUSSIA', 'ROMANIA', 'UNITED KINGDOM')",
+    );
+    assert_ne!(q7_relaxed, TPCH_Q7_SQLITE, "Q7 filter text changed; update the replacement");
+    let q8_relaxed =
+        TPCH_Q8_SQLITE.replace("AND p_type = 'ECONOMY ANODIZED STEEL'", "AND p_type LIKE '%STEEL%'");
+    assert_ne!(q8_relaxed, TPCH_Q8_SQLITE, "Q8 filter text changed; update the replacement");
+
+    let mut nonempty = 0;
+    for (name, sql) in [
+        ("Q7", TPCH_Q7_SQLITE),
+        ("Q8", TPCH_Q8_SQLITE),
+        ("Q9", TPCH_Q9_SQLITE),
+        ("Q7-relaxed", q7_relaxed.as_str()),
+        ("Q8-relaxed", q8_relaxed.as_str()),
+    ] {
+        let v = vibesql_rows(&vdb, sql);
+        let s = sqlite_rows(&sconn, sql);
+        assert_eq!(
+            v.len(),
+            s.len(),
+            "{}: row count mismatch (vibesql={}, sqlite={})",
+            name,
+            v.len(),
+            s.len()
+        );
+        for (i, (vr, sr)) in v.iter().zip(s.iter()).enumerate() {
+            assert_eq!(vr.len(), sr.len(), "{} row {}: column count mismatch", name, i);
+            for (j, (va, sa)) in vr.iter().zip(sr.iter()).enumerate() {
+                assert!(
+                    values_match(va, sa),
+                    "{} row {} col {}: vibesql={} sqlite={}",
+                    name,
+                    i,
+                    j,
+                    va,
+                    sa
+                );
+            }
+        }
+        if !v.is_empty() {
+            nonempty += 1;
+        }
+        println!("{}: {} rows match SQLite", name, v.len());
+    }
+
+    // Guard against a vacuous pass: Q9 and the relaxed Q7/Q8 variants must
+    // produce rows through the strftime GROUP BY at SF 0.01.
+    assert!(nonempty >= 3, "expected >= 3 non-empty result sets, got {}", nonempty);
+}


### PR DESCRIPTION
Closes #5282

## Summary

- Implements `strftime(format, timevalue, modifiers...)` with the classic SQLite specifier set (`%d %f %H %j %J %m %M %s %S %w %W %Y %%`), returning TEXT (SQLite semantics — matters for `GROUP BY`/`ORDER BY` and cross-engine comparison of `'1995'` vs `1995`).
- Time-value resolution (ISO-8601 strings, `'now'`, Julian Day numbers, `unixepoch`, and the full modifier chain) is shared with `datetime()` via a new `resolve_time_value()` helper extracted from `current.rs` — no duplicated parsing logic.
- Hand-rolled format scanner (no chrono `format()` passthrough): unknown specifiers, trailing `%`, NULL args, and unparseable timestrings all return NULL per SQLite. `%J` reproduces SQLite's `iJD/86400000.0` arithmetic with `%.16g` rendering for byte-exact output (`2452944.024264259`).
- Single dispatch arm added in `eval_scalar_function()`, covering all evaluator paths (row, arena, compiled).
- New feature-gated parity test (`--features sqlite`) runs the SQLite-flavored TPC-H Q7/Q8/Q9 (which `GROUP BY strftime('%Y', ...)`) against both VibeSQL and SQLite on identical SF 0.01 data and asserts identical results, including bounded relaxed-filter variants so the grouping path is exercised with non-empty result sets.

Out of scope for v1 (documented in module comments): SQLite 3.44+ specifiers (`%e %F %G %g %I %k %l %p %P %R %T %u %U %V`), `subsec`, real timezone conversion, and the sibling missing scalars `date()`/`time()`/`julianday()`/`unixepoch()`.

## Verification

- Unit tests: 24 in `strftime.rs` covering every v1 specifier with SQLite `date.test` section 3 ground-truth values (`'2003-10-31 12:34:56.432'`), `%f` truncation, `%s` epoch boundaries, `%W` week edge cases, modifier flow-through, NULL/invalid handling.
- Integration tests: 7 in `date_time_function_tests/strftime.rs` including `typeof(...) = 'text'`, date columns, `GROUP BY`/`WHERE` usage.
- TPC-H SQLite parity at SF 0.01 (`cargo test -p vibesql-executor --release --features sqlite --test tpch_strftime_sqlite_parity`):
  - Q9: 175 rows match SQLite exactly
  - Q7-relaxed: 10 rows match; Q8-relaxed: 2 rows match
  - Official Q7/Q8 execute without error and agree with SQLite (both 0 rows at SF 0.01 due to selective filters)
- `cargo test -p vibesql-executor` lib suite: 2517 passed, 0 failed; `date_time_function_tests`: 72 passed.
- Note: `make test-tcl-file FILE=date.test` cannot run — the TCL shim lacks `do_not_use_codec` (pre-existing infrastructure gap, unrelated).

## Test plan

- [ ] CI green
- [ ] `cargo test -p vibesql-executor --release --features sqlite --test tpch_strftime_sqlite_parity` (manual; requires release build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)