### PR TITLE
fix(parser): reject trailing garbage after UPDATE/DELETE/INSERT statements

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/delete.rs
+++ b/crates/vibesql-parser/src/arena_parser/delete.rs
@@ -107,8 +107,8 @@ impl<'arena> ArenaParser<'arena> {
             None
         };
 
-        // Consume optional semicolon
-        self.try_consume(&Token::Semicolon);
+        // Require end of statement: trailing tokens are a syntax error (issue #5261)
+        self.expect_statement_end()?;
 
         let stmt = DeleteStmt {
             with_clause: None,

--- a/crates/vibesql-parser/src/arena_parser/insert.rs
+++ b/crates/vibesql-parser/src/arena_parser/insert.rs
@@ -145,8 +145,8 @@ impl<'arena> ArenaParser<'arena> {
             None
         };
 
-        // Consume optional semicolon
-        self.try_consume(&Token::Semicolon);
+        // Require end of statement: trailing tokens are a syntax error (issue #5261)
+        self.expect_statement_end()?;
 
         let stmt = InsertStmt {
             with_clause: None,
@@ -212,8 +212,8 @@ impl<'arena> ArenaParser<'arena> {
             None
         };
 
-        // Consume optional semicolon
-        self.try_consume(&Token::Semicolon);
+        // Require end of statement: trailing tokens are a syntax error (issue #5261)
+        self.expect_statement_end()?;
 
         let stmt = InsertStmt {
             with_clause: None,

--- a/crates/vibesql-parser/src/arena_parser/mod.rs
+++ b/crates/vibesql-parser/src/arena_parser/mod.rs
@@ -596,6 +596,23 @@ impl<'arena> ArenaParser<'arena> {
         }
     }
 
+    /// Require end of statement after the final clause of a statement.
+    ///
+    /// Consumes a trailing semicolon if present. Any token other than `;` or
+    /// EOF is a syntax error matching SQLite's `near "X": syntax error`
+    /// (issue #5261: trailing garbage after UPDATE/DELETE/INSERT was
+    /// previously ignored silently).
+    pub(crate) fn expect_statement_end(&mut self) -> Result<(), ParseError> {
+        match self.peek() {
+            Token::Semicolon => {
+                self.advance();
+                Ok(())
+            }
+            Token::Eof => Ok(()),
+            token => Err(ParseError { message: token.syntax_error() }),
+        }
+    }
+
     /// Get the next placeholder index.
     pub(crate) fn next_placeholder(&mut self) -> usize {
         let index = self.placeholder_count;

--- a/crates/vibesql-parser/src/arena_parser/update.rs
+++ b/crates/vibesql-parser/src/arena_parser/update.rs
@@ -130,8 +130,8 @@ impl<'arena> ArenaParser<'arena> {
             None
         };
 
-        // Consume optional semicolon
-        self.try_consume(&Token::Semicolon);
+        // Require end of statement: trailing tokens are a syntax error (issue #5261)
+        self.expect_statement_end()?;
 
         let stmt = UpdateStmt {
             with_clause: None,

--- a/crates/vibesql-parser/src/parser/delete.rs
+++ b/crates/vibesql-parser/src/parser/delete.rs
@@ -126,10 +126,8 @@ impl Parser {
             None
         };
 
-        // Expect semicolon or EOF
-        if matches!(self.peek(), Token::Semicolon) {
-            self.advance();
-        }
+        // Require end of statement: trailing tokens are a syntax error (issue #5261)
+        self.expect_statement_end()?;
 
         Ok(vibesql_ast::DeleteStmt {
             with_clause: None,
@@ -269,10 +267,8 @@ impl Parser {
             None
         };
 
-        // Expect semicolon or EOF
-        if matches!(self.peek(), Token::Semicolon) {
-            self.advance();
-        }
+        // Require end of statement: trailing tokens are a syntax error (issue #5261)
+        self.expect_statement_end()?;
 
         Ok(vibesql_ast::DeleteStmt {
             with_clause: Some(with_clause),

--- a/crates/vibesql-parser/src/parser/helpers.rs
+++ b/crates/vibesql-parser/src/parser/helpers.rs
@@ -100,6 +100,23 @@ impl Parser {
         }
     }
 
+    /// Require end of statement after the final clause of a statement.
+    ///
+    /// Consumes a trailing semicolon if present. Any token other than `;` or
+    /// EOF is a syntax error matching SQLite's `near "X": syntax error`
+    /// (issue #5261: trailing garbage after UPDATE/DELETE/INSERT was
+    /// previously ignored silently).
+    pub(super) fn expect_statement_end(&mut self) -> Result<(), ParseError> {
+        match self.peek() {
+            Token::Semicolon => {
+                self.advance();
+                Ok(())
+            }
+            Token::Eof => Ok(()),
+            token => Err(ParseError { message: token.syntax_error() }),
+        }
+    }
+
     /// Parse an identifier token (regular or delimited).
     pub(super) fn parse_identifier(&mut self) -> Result<String, ParseError> {
         match self.peek() {

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -123,10 +123,8 @@ impl Parser {
             None
         };
 
-        // Expect semicolon or EOF
-        if matches!(self.peek(), Token::Semicolon) {
-            self.advance();
-        }
+        // Require end of statement: trailing tokens are a syntax error (issue #5261)
+        self.expect_statement_end()?;
 
         Ok(vibesql_ast::InsertStmt {
             with_clause: None,
@@ -263,10 +261,8 @@ impl Parser {
             None
         };
 
-        // Expect semicolon or EOF
-        if matches!(self.peek(), Token::Semicolon) {
-            self.advance();
-        }
+        // Require end of statement: trailing tokens are a syntax error (issue #5261)
+        self.expect_statement_end()?;
 
         Ok(vibesql_ast::InsertStmt {
             with_clause: Some(with_clause),
@@ -372,10 +368,8 @@ impl Parser {
             None
         };
 
-        // Expect semicolon or EOF
-        if matches!(self.peek(), Token::Semicolon) {
-            self.advance();
-        }
+        // Require end of statement: trailing tokens are a syntax error (issue #5261)
+        self.expect_statement_end()?;
 
         Ok(vibesql_ast::InsertStmt {
             with_clause: None,

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -148,10 +148,8 @@ impl Parser {
             None
         };
 
-        // Expect semicolon or EOF
-        if matches!(self.peek(), Token::Semicolon) {
-            self.advance();
-        }
+        // Require end of statement: trailing tokens are a syntax error (issue #5261)
+        self.expect_statement_end()?;
 
         Ok(vibesql_ast::UpdateStmt {
             with_clause: None,
@@ -304,10 +302,8 @@ impl Parser {
             None
         };
 
-        // Expect semicolon or EOF
-        if matches!(self.peek(), Token::Semicolon) {
-            self.advance();
-        }
+        // Require end of statement: trailing tokens are a syntax error (issue #5261)
+        self.expect_statement_end()?;
 
         Ok(vibesql_ast::UpdateStmt {
             with_clause: Some(with_clause),

--- a/crates/vibesql-parser/src/tests/errors.rs
+++ b/crates/vibesql-parser/src/tests/errors.rs
@@ -556,3 +556,163 @@ fn test_issue_5271_bare_select_returning_arena_fallback_is_error() {
     let result = crate::parse_with_arena_fallback("SELECT 1 RETURNING a");
     assert!(result.is_err(), "bare SELECT ... RETURNING should be a syntax error in both parsers");
 }
+
+// ========================================================================
+// Issue #5261: trailing garbage tokens after the last clause of
+// UPDATE/DELETE/INSERT must be a syntax error (SQLite: near "X": syntax
+// error). Previously the parser stopped consuming after the last clause
+// and silently ignored the rest of the input.
+// ========================================================================
+
+#[test]
+fn test_issue_5261_update_trailing_garbage_is_error() {
+    let result = Parser::parse_sql("UPDATE t SET a=1 WHERE b=2 XYZZY");
+    assert!(result.is_err(), "UPDATE with trailing garbage should be a syntax error");
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("near \"XYZZY\": syntax error"), "unexpected error message: {}", msg);
+}
+
+#[test]
+fn test_issue_5261_update_trailing_garbage_multiple_tokens_is_error() {
+    let result = Parser::parse_sql("UPDATE t SET a=8 WHERE a=7 GARBAGE TOKENS");
+    assert!(result.is_err(), "UPDATE with trailing garbage should be a syntax error");
+}
+
+#[test]
+fn test_issue_5261_update_returning_trailing_garbage_is_error() {
+    // Note: `RETURNING a XYZZY` is valid SQLite (XYZZY is an implicit column
+    // alias), so use a reserved keyword that cannot be an alias instead.
+    let result = Parser::parse_sql("UPDATE t SET a=1 RETURNING a WHERE b=2");
+    assert!(result.is_err(), "UPDATE ... RETURNING with trailing clause should be a syntax error");
+}
+
+#[test]
+fn test_issue_5261_update_with_cte_trailing_garbage_is_error() {
+    let result = Parser::parse_sql("WITH c AS (SELECT 1) UPDATE t SET a=1 WHERE b=2 XYZZY");
+    assert!(result.is_err(), "WITH ... UPDATE with trailing garbage should be a syntax error");
+}
+
+#[test]
+fn test_issue_5261_delete_trailing_garbage_is_error() {
+    let result = Parser::parse_sql("DELETE FROM t WHERE a=1 XYZZY");
+    assert!(result.is_err(), "DELETE with trailing garbage should be a syntax error");
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("near \"XYZZY\": syntax error"), "unexpected error message: {}", msg);
+}
+
+#[test]
+fn test_issue_5261_delete_limit_trailing_garbage_is_error() {
+    let result = Parser::parse_sql("DELETE FROM t WHERE a=1 ORDER BY a LIMIT 1 XYZZY");
+    assert!(result.is_err(), "DELETE ... LIMIT with trailing garbage should be a syntax error");
+}
+
+#[test]
+fn test_issue_5261_delete_with_cte_trailing_garbage_is_error() {
+    let result = Parser::parse_sql("WITH c AS (SELECT 1) DELETE FROM t WHERE a=1 XYZZY");
+    assert!(result.is_err(), "WITH ... DELETE with trailing garbage should be a syntax error");
+}
+
+#[test]
+fn test_issue_5261_insert_trailing_garbage_is_error() {
+    let result = Parser::parse_sql("INSERT INTO t VALUES (1) XYZZY");
+    assert!(result.is_err(), "INSERT with trailing garbage should be a syntax error");
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("near \"XYZZY\": syntax error"), "unexpected error message: {}", msg);
+}
+
+#[test]
+fn test_issue_5261_insert_returning_trailing_garbage_is_error() {
+    // Note: `RETURNING a XYZZY` is valid SQLite (implicit alias); a numeric
+    // literal cannot be an alias, matching SQLite's near "123" error.
+    let result = Parser::parse_sql("INSERT INTO t VALUES (1) RETURNING a 123");
+    assert!(result.is_err(), "INSERT ... RETURNING with trailing garbage should be a syntax error");
+}
+
+#[test]
+fn test_issue_5261_insert_on_conflict_trailing_garbage_is_error() {
+    let result = Parser::parse_sql("INSERT INTO t VALUES (1) ON CONFLICT DO NOTHING XYZZY");
+    assert!(
+        result.is_err(),
+        "INSERT ... ON CONFLICT with trailing garbage should be a syntax error"
+    );
+}
+
+#[test]
+fn test_issue_5261_insert_with_cte_trailing_garbage_is_error() {
+    // Note: `FROM c XYZZY` is valid SQLite (implicit table alias), so use a
+    // dangling GROUP keyword that cannot be an alias instead.
+    let result =
+        Parser::parse_sql("WITH c AS (SELECT 1) INSERT INTO t SELECT * FROM c WHERE 1 GROUP");
+    assert!(result.is_err(), "WITH ... INSERT with trailing garbage should be a syntax error");
+}
+
+#[test]
+fn test_issue_5261_replace_trailing_garbage_is_error() {
+    let result = Parser::parse_sql("REPLACE INTO t VALUES (1) XYZZY");
+    assert!(result.is_err(), "REPLACE with trailing garbage should be a syntax error");
+}
+
+#[test]
+fn test_issue_5261_garbage_after_semicolon_keyword_token() {
+    // Keyword garbage (not just identifiers) must also be rejected
+    let result = Parser::parse_sql("UPDATE t SET a=1 WHERE b=2 SELECT");
+    assert!(result.is_err(), "UPDATE with trailing keyword should be a syntax error");
+}
+
+#[test]
+fn test_issue_5261_arena_update_trailing_garbage_is_error() {
+    let result = crate::arena_parser::parse_update_to_owned("UPDATE t SET a=1 WHERE b=2 XYZZY");
+    assert!(result.is_err(), "arena UPDATE with trailing garbage should be a syntax error");
+}
+
+#[test]
+fn test_issue_5261_arena_delete_trailing_garbage_is_error() {
+    let result = crate::arena_parser::parse_delete_to_owned("DELETE FROM t WHERE a=1 XYZZY");
+    assert!(result.is_err(), "arena DELETE with trailing garbage should be a syntax error");
+}
+
+#[test]
+fn test_issue_5261_arena_insert_trailing_garbage_is_error() {
+    let result = crate::arena_parser::parse_insert_to_owned("INSERT INTO t VALUES (1) XYZZY");
+    assert!(result.is_err(), "arena INSERT with trailing garbage should be a syntax error");
+}
+
+// Valid statements must be unaffected by the end-of-statement check.
+
+#[test]
+fn test_issue_5261_valid_dml_statements_still_parse() {
+    let valid = [
+        "UPDATE t SET a=1 WHERE b=2",
+        "UPDATE t SET a=1 WHERE b=2;",
+        "UPDATE t SET a=1 RETURNING a, b",
+        "UPDATE t SET a=1 FROM u WHERE t.id=u.id RETURNING *;",
+        "DELETE FROM t WHERE a=1",
+        "DELETE FROM t WHERE a=1;",
+        "DELETE FROM t WHERE a=1 ORDER BY a LIMIT 1 OFFSET 2",
+        "DELETE FROM t RETURNING *",
+        "INSERT INTO t VALUES (1)",
+        "INSERT INTO t VALUES (1);",
+        "INSERT INTO t VALUES (1) RETURNING rowid",
+        "INSERT INTO t VALUES (1) ON CONFLICT DO NOTHING",
+        "INSERT INTO t VALUES (1) ON CONFLICT(a) DO UPDATE SET b=2 RETURNING a",
+        "INSERT INTO t SELECT * FROM u",
+        "REPLACE INTO t VALUES (1)",
+        "WITH c AS (SELECT 1) UPDATE t SET a=1 WHERE b IN (SELECT * FROM c)",
+        "WITH c AS (SELECT 1) DELETE FROM t WHERE a IN (SELECT * FROM c)",
+        "WITH c AS (SELECT 1) INSERT INTO t SELECT * FROM c",
+    ];
+    for sql in valid {
+        let result = Parser::parse_sql(sql);
+        assert!(result.is_ok(), "valid statement should parse: {} -> {:?}", sql, result.err());
+    }
+}
+
+#[test]
+fn test_issue_5261_valid_arena_dml_statements_still_parse() {
+    assert!(crate::arena_parser::parse_update_to_owned("UPDATE t SET a=1 WHERE b=2;").is_ok());
+    assert!(crate::arena_parser::parse_delete_to_owned("DELETE FROM t WHERE a=1;").is_ok());
+    assert!(crate::arena_parser::parse_insert_to_owned(
+        "INSERT INTO t VALUES (1) ON CONFLICT DO NOTHING RETURNING a;"
+    )
+    .is_ok());
+}

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/rwalters/GitHub/vibesql/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/rwalters/GitHub/vibesql/node_modules


### PR DESCRIPTION
## Summary

Both the standard parser and the arena parser stopped consuming tokens after the last clause of UPDATE/DELETE/INSERT/REPLACE, so input like `UPDATE t SET a=8 WHERE a=7 GARBAGE TOKENS` parsed and executed silently. This adds an `expect_statement_end()` helper to both parsers that requires end-of-statement (`;` or EOF) after the final clause (which, after PRs #5260/#5266/#5270, is the optional RETURNING clause) and errors with SQLite's `near "X": syntax error` otherwise.

## Changes

- `parser/helpers.rs` / `arena_parser/mod.rs`: new `expect_statement_end()` helper (consumes optional `;`, errors on any other token via `Token::syntax_error()`)
- Standard parser: applied at all 7 DML statement tails — `parse_update_statement[_with_cte]`, `parse_delete_statement[_with_cte]`, `parse_insert_statement[_with_cte]`, `parse_replace_statement`
- Arena parser: applied at all 4 active DML tails — `update.rs`, `delete.rs`, `insert.rs` (INSERT + REPLACE)
- 18 new tests in `tests/errors.rs`: garbage rejection for each statement form (incl. CTE variants, RETURNING/ON CONFLICT tails, arena parser entry points) plus a valid-statement matrix confirming `;`, RETURNING, ON CONFLICT, UPDATE...FROM, ORDER BY/LIMIT/OFFSET tails are unaffected

Contexts that embed these parsers (EXPLAIN, PREPARE, WITH dispatch) all end at the statement tail, so the check is safe there. Trigger bodies collect raw tokens and are unaffected. `arena_parser/dml.rs` is not declared in `mod.rs` (dead code) and was left untouched.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `UPDATE t SET a=1 WHERE b=2 XYZZY` → parse error (`near "XYZZY": syntax error`) | ✅ | `test_issue_5261_update_trailing_garbage_is_error` asserts exact message; verified via release CLI |
| Same check for DELETE and INSERT statement tails | ✅ | Tests for DELETE/INSERT/REPLACE incl. CTE + arena variants; CLI smoke tests |
| Existing parser/TCL suites triaged for surfaced latent failures | ✅ | See triage notes below |

## Test Plan

- `cargo test -p vibesql-parser`: 1350 passed, 0 failed
- `cargo test -p vibesql-executor`: all 89 test binaries pass (exit 0)
- Workspace crates (`--no-fail-fast`, excluding parser/executor already run): 81 binaries ok, 1 pre-existing failure (see below)
- TCL: `update.test` 124/124, `delete.test` 44/44, `delete2-4.test` all pass, `insert.test` 51/51, `insert2.test` 16/16, `insert3.test` 3/3 (update2/insert4/insert5 extract 0 tests under the shim — pre-existing runner behavior)
- Release CLI smoke tests: garbage UPDATE/DELETE/INSERT all rejected with `near "X": syntax error`; valid `ON CONFLICT DO NOTHING RETURNING` unaffected

### Latent-failure triage

1. **Initial test drafts surfaced SQLite implicit-alias semantics, not parser gaps**: `RETURNING a XYZZY` and `FROM c XYZZY` are *valid* SQLite (implicit aliases) — verified against real sqlite3 and the tests use truly-invalid tails (`RETURNING a WHERE`, `RETURNING a 123`, dangling `GROUP`) instead.
2. **`tests/issue_2998_correlated_subquery.rs` fails on current main** (wrong results: 1 row instead of 2 from a correlated-subquery SELECT). Verified unrelated to this change by reverting `crates/vibesql-parser` to `origin/main` and reproducing the identical failure. Filed as #5288.

No test in the repo relied on trailing garbage being ignored.

Closes #5261