### PR TITLE
fix(executor): exclude legacy COUNT(*) wildcard from outer-column detection in collapse analysis

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
@@ -571,6 +571,18 @@ fn expression_has_column_outside_scopes(
 
     match expr {
         Expression::ColumnRef(col) => {
+            // The legacy parser represents COUNT(*) as ColumnRef { column: "*" }
+            // (the arena parser uses Expression::Wildcard). The "*" wildcard
+            // references no specific column — it counts rows of its own query
+            // scope — so it can never be an outer column reference. Without
+            // this guard, "*" is absent from every inner scope and would be
+            // misclassified as outer, incorrectly triggering collapse (#5288).
+            if col.schema_canonical().is_none()
+                && col.table_canonical().is_none()
+                && col.column_canonical() == "*"
+            {
+                return false;
+            }
             let name = col.column_canonical().to_ascii_lowercase();
             // If the column is qualified by a table name, we still check by
             // column name only — qualifying doesn't change whether the
@@ -645,6 +657,16 @@ fn expression_has_column_inside_scopes(
 
     match expr {
         Expression::ColumnRef(col) => {
+            // Legacy-parser COUNT(*) wildcard (ColumnRef { column: "*" }) is
+            // not a column reference. "*" can never appear in a scope set, so
+            // this guard is a no-op behaviorally, but it documents intent and
+            // mirrors expression_has_column_outside_scopes (#5288).
+            if col.schema_canonical().is_none()
+                && col.table_canonical().is_none()
+                && col.column_canonical() == "*"
+            {
+                return false;
+            }
             let name = col.column_canonical().to_ascii_lowercase();
             inner_scopes.iter().any(|s| s.contains(&name))
         }
@@ -808,7 +830,14 @@ fn expression_contains_column_ref_simple(expr: &vibesql_ast::Expression) -> bool
     use vibesql_ast::Expression;
 
     match expr {
-        Expression::ColumnRef(_) => true,
+        Expression::ColumnRef(col) => {
+            // Exclude the legacy-parser COUNT(*) representation
+            // (ColumnRef { column: "*" }) — "*" references no specific column,
+            // so it is never an outer column reference (#5288).
+            !(col.schema_canonical().is_none()
+                && col.table_canonical().is_none()
+                && col.column_canonical() == "*")
+        }
         Expression::BinaryOp { left, right, .. } => {
             expression_contains_column_ref_simple(left)
                 || expression_contains_column_ref_simple(right)

--- a/tests/issue_2998_correlated_subquery.rs
+++ b/tests/issue_2998_correlated_subquery.rs
@@ -61,3 +61,28 @@ fn test_correlated_subquery_outer_table_reference() {
         }
     }
 }
+
+/// Regression test for issue #5288: the legacy parser represents COUNT(*) as
+/// ColumnRef { column: "*" }, which the implicit-outer-aggregate-collapse
+/// detection misclassified as an outer column reference. A bare (FROM-less)
+/// scalar subquery `(SELECT count(*))` must NOT collapse the outer query to a
+/// single row. sqlite3 returns one row per outer row, each with count 1.
+#[test]
+fn test_bare_count_star_subquery_does_not_collapse_outer_query() {
+    let mut db = Database::new();
+
+    execute_sql(&mut db, "CREATE TABLE t1(a INTEGER, b INTEGER, c INTEGER, d INTEGER, e INTEGER)")
+        .expect("Failed to create table");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(1,2,3,4,5)").expect("Failed to insert row 1");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(2,3,4,5,6)").expect("Failed to insert row 2");
+
+    let rows =
+        execute_sql(&mut db, "SELECT a, (SELECT count(*)) FROM t1").expect("Query should succeed");
+
+    for row in &rows {
+        println!("{:?}", row);
+    }
+    // sqlite3: 1|1 and 2|1 — one row per outer row, count(*) of a FROM-less
+    // subquery is always 1.
+    assert_eq!(rows.len(), 2, "outer query must not collapse to a single row");
+}


### PR DESCRIPTION
## Summary

The legacy parser (`Parser::parse_sql`) represents `COUNT(*)` as `ColumnRef { column: "*" }` (the arena parser uses `Expression::Wildcard`). The implicit-outer-aggregate-collapse detection introduced in #5104/#5139 classified any `ColumnRef` whose name is absent from all inner scopes as an outer column reference — and `"*"` is never a real column name, so legacy-parsed `count(*)` was misclassified as outer-correlated. This incorrectly triggered the collapse, turning the outer query into a single-row implicit aggregate and dropping all but one outer row (`SELECT a, (SELECT count(*) FROM t1 AS x WHERE x.b < t1.b) FROM t1` returned 1 row instead of 2).

`COUNT(*)` references no specific column — it counts rows of its own query scope — so it can never be outer-correlated via its argument. Excluding `"*"` from outer/inner column classification is semantically correct.

## Changes

- `crates/vibesql-executor/src/select/executor/aggregation/detection.rs`:
  - `expression_has_column_outside_scopes`: return `false` for the legacy `"*"` wildcard ColumnRef (schema/table `None` && column == `"*"`, matching the `is_simple_count_star` precedent in this file) — fixes the FROM-bearing subquery path
  - `expression_contains_column_ref_simple`: exclude the `"*"` wildcard from `ColumnRef(_) => true` — fixes the FROM-less subquery path (`SELECT a, (SELECT count(*)) FROM t1`)
  - `expression_has_column_inside_scopes`: explicit `"*"` guard (behavioral no-op since `"*"` is never in a scope set; documents intent and mirrors the outside-scopes walker)
- `tests/issue_2998_correlated_subquery.rs`: added `test_bare_count_star_subquery_does_not_collapse_outer_query` covering the FROM-less variant (2 rows, each with count 1, verified against sqlite3)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cargo test -p vibesql --test issue_2998_correlated_subquery` passes (2 rows: `(1,0)`, `(2,1)`) | ✅ | `test result: ok. 2 passed; 0 failed` |
| Bare-subquery case `SELECT a, (SELECT count(*)) FROM t1` returns one row per outer row with value 1 | ✅ | New regression test passes; CLI smoke check returns `1|1`, `2|1` matching sqlite3 |
| Genuine collapse cases still work (`SELECT (SELECT avg(a)) FROM t1`, #5135 nested-FROM case) | ✅ | CLI returns 1 collapsed row for `SELECT (SELECT avg(a)) FROM t1`; window1.test 271/271 (collapse feature's motivating tests) |
| No regressions in `cargo test -p vibesql-executor` | ✅ | All 19 test binaries pass, 0 failures |

## Test Plan

- `cargo test -p vibesql --test issue_2998_correlated_subquery` — 2 passed (previously failing test now green, plus new FROM-less variant test)
- `cargo test -p vibesql-executor` — all green
- `make test-tcl-file FILE=window1.test` — 271 passed / 0 failed (no regression in #5104/#5135 collapse behavior)
- CLI smoke check (`./target/release/vibesql`): repro query returns 2 rows (`1|0`, `2|1`); bare case returns 2 rows (`1|1`, `2|1`); genuine collapse `SELECT (SELECT avg(a)) FROM t1` still returns 1 row — all matching sqlite3
- `cargo check` / `cargo clippy -p vibesql-executor` — no new warnings

Closes #5288