### PR TITLE
feat(tcl): add do_not_use_codec and nonzero_reserved_bytes stubs to TCL shim

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -4819,6 +4819,18 @@ proc sqlite3_key {args} {
     return
 }
 
+proc do_not_use_codec {} {
+    # SQLite codec (SEE encryption) testing - not applicable to VibeSQL.
+    # Matches SQLite tester.tcl semantics: mark run codec-incompatible, reset db.
+    set ::do_not_use_codec 1
+    reset_db
+}
+
+proc nonzero_reserved_bytes {} {
+    # True only in codec builds (non-zero reserved bytes). VibeSQL has no codec.
+    return 0
+}
+
 proc sqlite_register_test_function {args} {
     # SQLite test function registration - not supported
     # This is used to register custom test functions at the C level


### PR DESCRIPTION
## Summary

The TCL shim (`scripts/tester_vibesql.tcl`) did not define SQLite's codec-test helpers `do_not_use_codec` and `nonzero_reserved_bytes`. Any test file calling them aborted instantly with an unknown-command error under native tclsh mode, blocking 52 SQLite .test files from running at all. This PR adds faithful no-codec stubs next to the existing `sqlite3_key`/`sqlite3_rekey` codec stubs.

## Changes

- Add `do_not_use_codec` proc matching SQLite `tester.tcl:323-327` semantics: `set ::do_not_use_codec 1; reset_db` (the shim's existing `reset_db` is reused)
- Add `nonzero_reserved_bytes` proc returning `0` (VibeSQL has no codec, so reserved bytes are always zero) — referenced by 29 files with the same abort class

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `do_not_use_codec` added matching SQLite semantics | ✅ | Stub sets `::do_not_use_codec 1` and calls `reset_db`, placed with the other codec stubs |
| `nonzero_reserved_bytes` stub returning 0 | ✅ | Added in same location |
| `make test-tcl-file FILE=date.test` exits cleanly, no `invalid command name` error | ✅ | Loads cleanly, 0 tests run / 0 failed (datetime capability gate still short-circuits — tracked in #5294) |
| `make test-tcl-file FILE=minmax3.test` runs 47 tests (≥19 pass) | ✅ | 47 tests: 19 pass / 28 fail — exactly matches curator's measured baseline |
| `make test-tcl` (Priority 1) unchanged | ✅ | Change is a 12-line pure addition of two procs; none of the Priority 1/2 files reference them (verified via grep). Spot checks: select1.test 187/188 pass, insert.test 51 pass / 0 fail / 19 skip, update.test 124 pass / 0 fail / 10 skip |

## Test Plan

- `make test-tcl-file FILE=minmax3.test` — 47 tests, 19 pass (was: abort, 0 tests)
- `make test-tcl-file FILE=tkt4018.test` — 7 tests, 3 pass (was: abort, 0 tests)
- `make test-tcl-file FILE=descidx1.test` — 51 tests, 9 pass (was: abort, 0 tests)
- `make test-tcl-file FILE=date.test` — clean 0-test exit, no unknown-command error (follow-up #5294 covers the datetime gate)
- Priority 1 spot checks (select1, insert, update) pass with 0 failures attributable to this change

New failures in the activated files are pre-existing conformance gaps (e.g. missing `hexio_read`, `sqlite3_test_control_pending_byte` helpers), not regressions; none of the 52 activated files match the Priority 1/2 CI glob patterns.

Closes #5289