### PR TITLE
fix(window): honor NULLS FIRST/LAST and collation in sort and RANGE frames

### DIFF
--- a/crates/vibesql-executor/src/evaluator/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/mod.rs
@@ -34,5 +34,7 @@ pub(crate) use core::values_are_equal;
 pub use arena::ArenaExpressionEvaluator;
 // Re-export cache clearing function for benchmarks
 pub use combined::clear_in_subquery_cache;
+// Re-export subquery column counting for prepare-time IN validation (#5191)
+pub(crate) use combined::subqueries::schema_utils::compute_select_list_column_count;
 // Re-export eval_unary_op for use in other modules
 pub(crate) use expressions::operators::eval_unary_op;

--- a/crates/vibesql-executor/src/evaluator/window/frames.rs
+++ b/crates/vibesql-executor/src/evaluator/window/frames.rs
@@ -7,14 +7,15 @@ use std::cmp::Ordering;
 use std::ops::Range;
 
 use vibesql_ast::{
-    Expression, FrameBound, FrameExclude, FrameUnit, OrderByItem, UnaryOperator, WindowFrame,
+    Expression, FrameBound, FrameExclude, FrameUnit, NullsOrder, OrderByItem, OrderDirection,
+    UnaryOperator, WindowFrame,
 };
 use vibesql_types::SqlValue;
 
 use vibesql_storage::Row;
 
 use super::partitioning::Partition;
-use super::sorting::compare_values;
+use super::sorting::{compare_values, compare_values_with_collation};
 
 /// Validate a window frame specification, returning an error if invalid.
 ///
@@ -56,13 +57,11 @@ pub fn validate_range_order_by(
     }
 
     // Check if either bound uses a numeric offset (N PRECEDING or N FOLLOWING)
-    let has_offset_bound = matches!(
-        frame.start,
-        FrameBound::Preceding(_) | FrameBound::Following(_)
-    ) || frame
-        .end
-        .as_ref()
-        .is_some_and(|end| matches!(end, FrameBound::Preceding(_) | FrameBound::Following(_)));
+    let has_offset_bound =
+        matches!(frame.start, FrameBound::Preceding(_) | FrameBound::Following(_))
+            || frame.end.as_ref().is_some_and(|end| {
+                matches!(end, FrameBound::Preceding(_) | FrameBound::Following(_))
+            });
 
     if !has_offset_bound {
         return Ok(());
@@ -72,7 +71,7 @@ pub fn validate_range_order_by(
     let order_by_count = order_by.as_ref().map_or(0, |items| items.len());
     if order_by_count != 1 {
         return Err(
-            "RANGE with offset PRECEDING/FOLLOWING requires one ORDER BY expression".to_string(),
+            "RANGE with offset PRECEDING/FOLLOWING requires one ORDER BY expression".to_string()
         );
     }
 
@@ -362,6 +361,9 @@ where
 
             // For DESC order, PRECEDING means larger values (add offset)
             // For ASC order, PRECEDING means smaller values (subtract offset)
+            // For non-numeric values (text/blob/NULL) the arithmetic is a no-op,
+            // so the target collapses to the current key (SQLite: the frame
+            // degenerates to the current row's peer group).
             let target_value = if is_desc {
                 add_to_value(current_value, offset)
             } else {
@@ -369,23 +371,13 @@ where
             };
 
             if is_start {
-                // For DESC: find first row where value <= target (target is larger, comes first)
-                // For ASC: find first row where value >= target (target is smaller, comes first)
-                if is_desc {
-                    find_first_row_le_desc(partition, order_items, &target_value, eval_fn)
-                } else {
-                    find_first_row_ge(partition, order_items, &target_value, eval_fn)
-                }
+                // First row at-or-after the target in window order
+                find_first_row_at_or_after(partition, order_items, &target_value, eval_fn)
             } else {
-                // Find the boundary row and return exclusive end
+                // Last row at-or-before the target in window order (exclusive end).
                 // If no matching row exists, return 0 (empty frame end)
-                if is_desc {
-                    find_last_row_ge_desc(partition, order_items, &target_value, eval_fn)
-                        .map_or(0, |i| i + 1)
-                } else {
-                    find_last_row_le(partition, order_items, &target_value, eval_fn)
-                        .map_or(0, |i| i + 1)
-                }
+                find_last_row_at_or_before(partition, order_items, &target_value, eval_fn)
+                    .map_or(0, |i| i + 1)
             }
         }
 
@@ -401,23 +393,69 @@ where
             };
 
             if is_start {
-                // For DESC: find first row where value <= target (target is smaller, comes later)
-                // For ASC: find first row where value >= target (target is larger, comes later)
-                if is_desc {
-                    find_first_row_le_desc(partition, order_items, &target_value, eval_fn)
-                } else {
-                    find_first_row_ge(partition, order_items, &target_value, eval_fn)
-                }
+                find_first_row_at_or_after(partition, order_items, &target_value, eval_fn)
             } else {
-                // Find the boundary row and return exclusive end
-                // If no matching row exists, return 0 (empty frame end)
-                if is_desc {
-                    find_last_row_ge_desc(partition, order_items, &target_value, eval_fn)
-                        .map_or(0, |i| i + 1)
-                } else {
-                    find_last_row_le(partition, order_items, &target_value, eval_fn)
-                        .map_or(0, |i| i + 1)
-                }
+                find_last_row_at_or_before(partition, order_items, &target_value, eval_fn)
+                    .map_or(0, |i| i + 1)
+            }
+        }
+    }
+}
+
+/// Whether NULL ORDER BY keys sort before non-NULL keys in the sorted partition.
+///
+/// Honors an explicit NULLS FIRST/LAST modifier; otherwise uses SQLite's
+/// defaults (NULLS FIRST for ASC, NULLS LAST for DESC).
+fn nulls_sort_first(item: &OrderByItem) -> bool {
+    match item.nulls_order {
+        Some(NullsOrder::First) => true,
+        Some(NullsOrder::Last) => false,
+        None => matches!(item.direction, OrderDirection::Asc),
+    }
+}
+
+/// Extract an explicit COLLATE from an ORDER BY expression
+/// (e.g. `ORDER BY a COLLATE nocase`).
+fn explicit_collation(expr: &Expression) -> Option<&str> {
+    match expr {
+        Expression::Collate { collation, .. } => Some(collation),
+        _ => None,
+    }
+}
+
+/// Compare two ORDER BY key values in *window order* — the order in which rows
+/// appear in the sorted partition. Accounts for sort direction, NULLS
+/// FIRST/LAST placement, and explicit collation, so boundary searches stay
+/// consistent with the partition sort (see `sort_partition_with_collations`).
+fn compare_keys_window_order(
+    a: &SqlValue,
+    b: &SqlValue,
+    item: &OrderByItem,
+    collation: Option<&str>,
+) -> Ordering {
+    let a_null = matches!(a, SqlValue::Null);
+    let b_null = matches!(b, SqlValue::Null);
+    match (a_null, b_null) {
+        (true, true) => Ordering::Equal,
+        (true, false) => {
+            if nulls_sort_first(item) {
+                Ordering::Less
+            } else {
+                Ordering::Greater
+            }
+        }
+        (false, true) => {
+            if nulls_sort_first(item) {
+                Ordering::Greater
+            } else {
+                Ordering::Less
+            }
+        }
+        (false, false) => {
+            let cmp = compare_values_with_collation(a, b, collation);
+            match item.direction {
+                OrderDirection::Asc => cmp,
+                OrderDirection::Desc => cmp.reverse(),
             }
         }
     }
@@ -677,8 +715,11 @@ where
     partition.len() - 1
 }
 
-/// Find the first row where ORDER BY value >= target
-fn find_first_row_ge<F>(
+/// Find the first row whose ORDER BY key sorts at-or-after `target` in window order
+///
+/// Window order accounts for direction (ASC/DESC), NULLS FIRST/LAST placement,
+/// and explicit collation, so this works for any sorted partition layout.
+fn find_first_row_at_or_after<F>(
     partition: &Partition,
     order_items: &[OrderByItem],
     target: &SqlValue,
@@ -687,17 +728,19 @@ fn find_first_row_ge<F>(
 where
     F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
 {
+    let item = &order_items[0];
+    let collation = explicit_collation(&item.expr);
     for (i, row) in partition.rows.iter().enumerate() {
-        let val = eval_fn(&order_items[0].expr, row).unwrap_or(SqlValue::Null);
-        if compare_values(&val, target) != Ordering::Less {
+        let val = eval_fn(&item.expr, row).unwrap_or(SqlValue::Null);
+        if compare_keys_window_order(&val, target, item, collation) != Ordering::Less {
             return i;
         }
     }
     partition.len()
 }
 
-/// Find the last row where ORDER BY value <= target
-fn find_last_row_le<F>(
+/// Find the last row whose ORDER BY key sorts at-or-before `target` in window order
+fn find_last_row_at_or_before<F>(
     partition: &Partition,
     order_items: &[OrderByItem],
     target: &SqlValue,
@@ -706,53 +749,11 @@ fn find_last_row_le<F>(
 where
     F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
 {
+    let item = &order_items[0];
+    let collation = explicit_collation(&item.expr);
     for i in (0..partition.len()).rev() {
-        let val = eval_fn(&order_items[0].expr, &partition.rows[i]).unwrap_or(SqlValue::Null);
-        if compare_values(&val, target) != Ordering::Greater {
-            return Some(i);
-        }
-    }
-    None
-}
-
-/// Find the first row where ORDER BY value <= target (for DESC sorted partitions)
-///
-/// In a DESC-sorted partition, values decrease as we go through the rows.
-/// This finds the first row (smallest index) where value <= target.
-fn find_first_row_le_desc<F>(
-    partition: &Partition,
-    order_items: &[OrderByItem],
-    target: &SqlValue,
-    eval_fn: &F,
-) -> usize
-where
-    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
-{
-    for (i, row) in partition.rows.iter().enumerate() {
-        let val = eval_fn(&order_items[0].expr, row).unwrap_or(SqlValue::Null);
-        if compare_values(&val, target) != Ordering::Greater {
-            return i;
-        }
-    }
-    partition.len()
-}
-
-/// Find the last row where ORDER BY value >= target (for DESC sorted partitions)
-///
-/// In a DESC-sorted partition, values decrease as we go through the rows.
-/// This finds the last row (largest index) where value >= target.
-fn find_last_row_ge_desc<F>(
-    partition: &Partition,
-    order_items: &[OrderByItem],
-    target: &SqlValue,
-    eval_fn: &F,
-) -> Option<usize>
-where
-    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
-{
-    for i in (0..partition.len()).rev() {
-        let val = eval_fn(&order_items[0].expr, &partition.rows[i]).unwrap_or(SqlValue::Null);
-        if compare_values(&val, target) != Ordering::Less {
+        let val = eval_fn(&item.expr, &partition.rows[i]).unwrap_or(SqlValue::Null);
+        if compare_keys_window_order(&val, target, item, collation) != Ordering::Greater {
             return Some(i);
         }
     }

--- a/crates/vibesql-executor/src/evaluator/window/sorting.rs
+++ b/crates/vibesql-executor/src/evaluator/window/sorting.rs
@@ -4,7 +4,7 @@
 
 use std::cmp::Ordering;
 
-use vibesql_ast::{Expression, OrderByItem, OrderDirection};
+use vibesql_ast::{Expression, NullsOrder, OrderByItem, OrderDirection};
 use vibesql_storage::Row;
 use vibesql_types::SqlValue;
 
@@ -57,11 +57,33 @@ pub fn sort_partition_with_collations<F>(
             let val_b = eval_fn(&order_item.expr, &rows[b]).unwrap_or(SqlValue::Null);
 
             let collation = collations.get(i).and_then(|c| c.as_deref());
-            let cmp = compare_values_with_collation(&val_a, &val_b, collation);
 
-            let cmp = match order_item.direction {
-                OrderDirection::Asc => cmp,
-                OrderDirection::Desc => cmp.reverse(),
+            // Explicit NULLS FIRST/LAST overrides the default NULL placement.
+            // The placement is absolute (not affected by ASC/DESC), so it must
+            // bypass the direction reversal below. The default behavior
+            // (NULL-sorts-first + direction reversal) matches SQLite's
+            // defaults: NULLS FIRST for ASC, NULLS LAST for DESC.
+            let a_null = matches!(val_a, SqlValue::Null);
+            let b_null = matches!(val_b, SqlValue::Null);
+            let cmp = if a_null != b_null {
+                if let Some(nulls_order) = order_item.nulls_order {
+                    match (nulls_order, a_null) {
+                        (NullsOrder::First, true) | (NullsOrder::Last, false) => Ordering::Less,
+                        (NullsOrder::First, false) | (NullsOrder::Last, true) => Ordering::Greater,
+                    }
+                } else {
+                    let cmp = compare_values(&val_a, &val_b);
+                    match order_item.direction {
+                        OrderDirection::Asc => cmp,
+                        OrderDirection::Desc => cmp.reverse(),
+                    }
+                }
+            } else {
+                let cmp = compare_values_with_collation(&val_a, &val_b, collation);
+                match order_item.direction {
+                    OrderDirection::Asc => cmp,
+                    OrderDirection::Desc => cmp.reverse(),
+                }
             };
 
             if cmp != Ordering::Equal {

--- a/crates/vibesql-executor/src/evaluator/window/tests/frames.rs
+++ b/crates/vibesql-executor/src/evaluator/window/tests/frames.rs
@@ -1,4 +1,6 @@
-use vibesql_ast::{Expression, FrameBound, FrameUnit, WindowFrame};
+use vibesql_ast::{
+    Expression, FrameBound, FrameUnit, NullsOrder, OrderByItem, OrderDirection, WindowFrame,
+};
 use vibesql_storage::Row;
 use vibesql_types::SqlValue;
 
@@ -88,4 +90,128 @@ fn test_calculate_frame_unbounded_following() {
 
     // Current row 2 to end: rows 2, 3, 4
     assert_eq!(frame, 2..5);
+}
+
+// ===== RANGE frames with NULLS FIRST/LAST and non-numeric keys (#5191) =====
+
+fn make_value_rows(values: Vec<SqlValue>) -> Vec<Row> {
+    values.into_iter().map(|v| Row::new(vec![v])).collect()
+}
+
+fn order_by_first_col(
+    direction: OrderDirection,
+    nulls_order: Option<NullsOrder>,
+) -> Option<Vec<OrderByItem>> {
+    Some(vec![OrderByItem {
+        expr: Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("0", false)),
+        direction,
+        nulls_order,
+    }])
+}
+
+#[test]
+fn test_range_frame_asc_nulls_last() {
+    // window8.test 4.3.2: ORDER BY a NULLS LAST
+    // Partition sorted ASC NULLS LAST: 10, 10, NULL, NULL, NULL
+    let partition = Partition::new(make_value_rows(vec![
+        SqlValue::Integer(10),
+        SqlValue::Integer(10),
+        SqlValue::Null,
+        SqlValue::Null,
+        SqlValue::Null,
+    ]));
+    let order_by = order_by_first_col(OrderDirection::Asc, Some(NullsOrder::Last));
+
+    let frame_spec = WindowFrame {
+        unit: FrameUnit::Range,
+        start: FrameBound::UnboundedPreceding,
+        end: Some(FrameBound::Following(Box::new(Expression::Literal(SqlValue::Integer(10))))),
+        exclude: None,
+    };
+
+    // Non-NULL rows: 10 FOLLOWING reaches value 20; the NULL suffix sorts
+    // after all values and is out of range of the offset
+    let frame = calculate_frame(&partition, 0, &order_by, &Some(frame_spec.clone()), &test_eval_fn);
+    assert_eq!(frame, 0..2);
+
+    // NULL rows: offset bounds collapse to the NULL peer group, which runs
+    // to the end of the partition
+    let frame = calculate_frame(&partition, 2, &order_by, &Some(frame_spec), &test_eval_fn);
+    assert_eq!(frame, 0..5);
+}
+
+#[test]
+fn test_range_frame_desc_nulls_first() {
+    // window8.test 4.5.2: ORDER BY a DESC NULLS FIRST
+    // Partition sorted DESC NULLS FIRST: NULL, NULL, NULL, 10, 10
+    let partition = Partition::new(make_value_rows(vec![
+        SqlValue::Null,
+        SqlValue::Null,
+        SqlValue::Null,
+        SqlValue::Integer(10),
+        SqlValue::Integer(10),
+    ]));
+    let order_by = order_by_first_col(OrderDirection::Desc, Some(NullsOrder::First));
+
+    let frame_spec = WindowFrame {
+        unit: FrameUnit::Range,
+        start: FrameBound::UnboundedPreceding,
+        end: Some(FrameBound::Following(Box::new(Expression::Literal(SqlValue::Integer(10))))),
+        exclude: None,
+    };
+
+    // NULL rows: offset bounds collapse to the NULL peer group (prefix)
+    let frame = calculate_frame(&partition, 0, &order_by, &Some(frame_spec.clone()), &test_eval_fn);
+    assert_eq!(frame, 0..3);
+
+    // Non-NULL rows (DESC): 10 FOLLOWING reaches value 0, which covers both
+    // 10s; the NULL prefix is included positionally via UNBOUNDED PRECEDING
+    let frame = calculate_frame(&partition, 3, &order_by, &Some(frame_spec), &test_eval_fn);
+    assert_eq!(frame, 0..5);
+}
+
+#[test]
+fn test_range_frame_text_keys_collate_nocase() {
+    // windowB.test 8.1: ORDER BY a COLLATE nocase RANGE BETWEEN
+    // 10.0 PRECEDING AND 5.0 PRECEDING over text keys.
+    // Numeric offset arithmetic is a no-op on text, so the frame collapses
+    // to the current row's peer group. Boundary comparisons must honor the
+    // explicit collation (binary comparison would order 'BB' before 'aa').
+    let partition = Partition::new(make_value_rows(vec![
+        SqlValue::Varchar(arcstr::ArcStr::from("aa")),
+        SqlValue::Varchar(arcstr::ArcStr::from("BB")),
+        SqlValue::Varchar(arcstr::ArcStr::from("CC")),
+        SqlValue::Varchar(arcstr::ArcStr::from("dd")),
+    ]));
+    let order_by = Some(vec![OrderByItem {
+        expr: Expression::Collate {
+            expr: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "0", false,
+            ))),
+            collation: "nocase".to_string(),
+        },
+        direction: OrderDirection::Asc,
+        nulls_order: None,
+    }]);
+
+    // Test eval that peels COLLATE before resolving the column
+    fn collate_eval_fn(expr: &Expression, row: &Row) -> Result<SqlValue, String> {
+        match expr {
+            Expression::Collate { expr, .. } => collate_eval_fn(expr, row),
+            _ => test_eval_fn(expr, row),
+        }
+    }
+
+    let frame_spec = WindowFrame {
+        unit: FrameUnit::Range,
+        start: FrameBound::Preceding(Box::new(Expression::Literal(SqlValue::Real(10.0)))),
+        end: Some(FrameBound::Preceding(Box::new(Expression::Literal(SqlValue::Real(5.0))))),
+        exclude: None,
+    };
+
+    for i in 0..4 {
+        let frame =
+            calculate_frame(&partition, i, &order_by, &Some(frame_spec.clone()), &collate_eval_fn);
+        assert_eq!(frame, i..i + 1, "frame for row {} should be its own peer group", i);
+    }
 }

--- a/crates/vibesql-executor/src/evaluator/window/tests/partitions.rs
+++ b/crates/vibesql-executor/src/evaluator/window/tests/partitions.rs
@@ -24,3 +24,76 @@ fn test_partition_rows_empty_partition_by() {
     assert_eq!(partitions.len(), 1);
     assert_eq!(partitions[0].len(), 3);
 }
+
+// ===== ORDER BY NULLS FIRST/LAST in partition sort (#5191) =====
+
+/// Extract the first-column values of a partition's rows
+fn first_col_values(partition: &Partition) -> Vec<SqlValue> {
+    partition.rows.iter().map(|r| r.values[0].clone()).collect()
+}
+
+fn sort_test_partition() -> Partition {
+    Partition::new(vec![
+        Row::new(vec![SqlValue::Integer(10)]),
+        Row::new(vec![SqlValue::Null]),
+        Row::new(vec![SqlValue::Integer(5)]),
+        Row::new(vec![SqlValue::Null]),
+    ])
+}
+
+fn nulls_order_by(
+    direction: vibesql_ast::OrderDirection,
+    nulls_order: Option<vibesql_ast::NullsOrder>,
+) -> Option<Vec<vibesql_ast::OrderByItem>> {
+    Some(vec![vibesql_ast::OrderByItem {
+        expr: vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("0", false)),
+        direction,
+        nulls_order,
+    }])
+}
+
+#[test]
+fn test_sort_partition_asc_nulls_last() {
+    let mut partition = sort_test_partition();
+    let order_by =
+        nulls_order_by(vibesql_ast::OrderDirection::Asc, Some(vibesql_ast::NullsOrder::Last));
+    sort_partition(&mut partition, &order_by, evaluate_expression);
+
+    assert_eq!(
+        first_col_values(&partition),
+        vec![SqlValue::Integer(5), SqlValue::Integer(10), SqlValue::Null, SqlValue::Null]
+    );
+}
+
+#[test]
+fn test_sort_partition_desc_nulls_first() {
+    let mut partition = sort_test_partition();
+    let order_by =
+        nulls_order_by(vibesql_ast::OrderDirection::Desc, Some(vibesql_ast::NullsOrder::First));
+    sort_partition(&mut partition, &order_by, evaluate_expression);
+
+    assert_eq!(
+        first_col_values(&partition),
+        vec![SqlValue::Null, SqlValue::Null, SqlValue::Integer(10), SqlValue::Integer(5)]
+    );
+}
+
+#[test]
+fn test_sort_partition_default_null_placement() {
+    // Defaults (no NULLS modifier): NULLS FIRST for ASC, NULLS LAST for DESC
+    let mut partition = sort_test_partition();
+    let order_by = nulls_order_by(vibesql_ast::OrderDirection::Asc, None);
+    sort_partition(&mut partition, &order_by, evaluate_expression);
+    assert_eq!(
+        first_col_values(&partition),
+        vec![SqlValue::Null, SqlValue::Null, SqlValue::Integer(5), SqlValue::Integer(10)]
+    );
+
+    let mut partition = sort_test_partition();
+    let order_by = nulls_order_by(vibesql_ast::OrderDirection::Desc, None);
+    sort_partition(&mut partition, &order_by, evaluate_expression);
+    assert_eq!(
+        first_col_values(&partition),
+        vec![SqlValue::Integer(10), SqlValue::Integer(5), SqlValue::Null, SqlValue::Null]
+    );
+}

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -58,6 +58,13 @@ impl SelectExecutor<'_> {
         // This catches queries like SELECT * FROM t, t, t, ... (65+ times)
         super::validation::validate_join_table_limit(stmt)?;
 
+        // Validate IN (SELECT ...) subquery column counts (issue #5191)
+        // SQLite raises "sub-select returns N columns - expected 1" at
+        // prepare time; the runtime check in the expression evaluator only
+        // fires when a row is actually evaluated, so it misses the
+        // empty-table case (window9.test 3.4).
+        super::validation::validate_in_subquery_column_counts(stmt, self.database)?;
+
         // Validate SQLite index hints (issue #5235)
         // INDEXED BY must name an index that exists on that table; SQLite
         // reports "no such index: X" at prepare time. The hint is otherwise

--- a/crates/vibesql-executor/src/select/executor/validation/in_subquery_columns.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/in_subquery_columns.rs
@@ -1,0 +1,185 @@
+//! Prepare-time validation of `IN (SELECT ...)` subquery column counts
+//!
+//! SQLite validates at prepare time that the subquery on the right-hand side
+//! of an IN operator returns exactly as many columns as the left-hand side
+//! expects (1 for a scalar LHS, N for a row-value LHS), producing
+//! `sub-select returns N columns - expected M`.
+//!
+//! VibeSQL's expression evaluator performs the same check, but only when the
+//! IN expression is actually evaluated against a row. When the outer table is
+//! empty the expression is never evaluated and the malformed query silently
+//! succeeds (window9.test 3.4). This module walks the statement's expressions
+//! up front so the error is raised regardless of row count, like SQLite's
+//! prepare step.
+
+use vibesql_ast::{Expression, SelectItem, SelectStmt};
+
+use crate::errors::ExecutorError;
+
+/// Validate the column counts of all `IN (SELECT ...)` subqueries appearing in
+/// this statement's SELECT list, WHERE, HAVING, and ORDER BY clauses.
+///
+/// Nested subquery *statements* (derived tables, scalar subqueries, the IN
+/// subqueries themselves) are validated when they execute through
+/// `SelectExecutor::execute`, so this walk only needs to cover the current
+/// statement's own expression trees (plus set-operation arms, which do not
+/// re-enter `execute`).
+///
+/// If the subquery's column count cannot be computed statically (e.g. a
+/// wildcard over a CTE that has not been materialized yet), validation is
+/// skipped and deferred to the runtime check in the expression evaluator.
+pub fn validate_in_subquery_column_counts(
+    stmt: &SelectStmt,
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    for item in &stmt.select_list {
+        if let SelectItem::Expression { expr, .. } = item {
+            validate_expr(expr, database)?;
+        }
+    }
+    if let Some(where_clause) = &stmt.where_clause {
+        validate_expr(where_clause, database)?;
+    }
+    if let Some(having) = &stmt.having {
+        validate_expr(having, database)?;
+    }
+    if let Some(order_by) = stmt.order_by.as_deref() {
+        for item in order_by {
+            validate_expr(&item.expr, database)?;
+        }
+    }
+
+    // Set-operation arms share this prepare step (they are executed as part of
+    // this statement, not through a separate SelectExecutor::execute call).
+    if let Some(set_op) = &stmt.set_operation {
+        validate_in_subquery_column_counts(&set_op.right, database)?;
+    }
+
+    Ok(())
+}
+
+/// Recursively walk an expression tree looking for `Expression::In` nodes.
+fn validate_expr(
+    expr: &Expression,
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    match expr {
+        Expression::In { expr: lhs, subquery, .. } => {
+            // Row-value LHS expects one subquery column per LHS element;
+            // any other LHS is scalar and expects exactly one column.
+            let expected = match lhs.as_ref() {
+                Expression::RowValueConstructor(items) => items.len(),
+                _ => 1,
+            };
+
+            // Compute the subquery's column count. If it cannot be determined
+            // statically (e.g. wildcard over a not-yet-materialized CTE),
+            // defer to the runtime check instead of failing the query.
+            if let Ok(actual) =
+                crate::evaluator::compute_select_list_column_count(subquery, database, None)
+            {
+                if actual != expected {
+                    return Err(ExecutorError::SubqueryColumnCountMismatch { expected, actual });
+                }
+            }
+
+            validate_expr(lhs, database)
+        }
+
+        Expression::BinaryOp { left, right, .. } => {
+            validate_expr(left, database)?;
+            validate_expr(right, database)
+        }
+        Expression::UnaryOp { expr: inner, .. }
+        | Expression::Cast { expr: inner, .. }
+        | Expression::Collate { expr: inner, .. }
+        | Expression::IsNull { expr: inner, .. }
+        | Expression::IsTruthValue { expr: inner, .. }
+        | Expression::Extract { expr: inner, .. } => validate_expr(inner, database),
+        Expression::IsDistinctFrom { left, right, .. } => {
+            validate_expr(left, database)?;
+            validate_expr(right, database)
+        }
+        Expression::Function { args, .. } => {
+            for arg in args {
+                validate_expr(arg, database)?;
+            }
+            Ok(())
+        }
+        Expression::AggregateFunction { args, filter, .. } => {
+            for arg in args {
+                validate_expr(arg, database)?;
+            }
+            if let Some(f) = filter {
+                validate_expr(f, database)?;
+            }
+            Ok(())
+        }
+        Expression::WindowFunction { function, over } => {
+            let args = match function {
+                vibesql_ast::WindowFunctionSpec::Aggregate { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args,
+            };
+            for arg in args {
+                validate_expr(arg, database)?;
+            }
+            if let Some(partition_by) = &over.partition_by {
+                for p in partition_by {
+                    validate_expr(p, database)?;
+                }
+            }
+            if let Some(order_by) = &over.order_by {
+                for item in order_by {
+                    validate_expr(&item.expr, database)?;
+                }
+            }
+            Ok(())
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                validate_expr(op, database)?;
+            }
+            for clause in when_clauses {
+                for cond in &clause.conditions {
+                    validate_expr(cond, database)?;
+                }
+                validate_expr(&clause.result, database)?;
+            }
+            if let Some(e) = else_result {
+                validate_expr(e, database)?;
+            }
+            Ok(())
+        }
+        Expression::Between { expr: inner, low, high, .. } => {
+            validate_expr(inner, database)?;
+            validate_expr(low, database)?;
+            validate_expr(high, database)
+        }
+        Expression::InList { expr: inner, values, .. } => {
+            validate_expr(inner, database)?;
+            for v in values {
+                validate_expr(v, database)?;
+            }
+            Ok(())
+        }
+        Expression::Like { expr: inner, pattern, .. }
+        | Expression::Glob { expr: inner, pattern, .. } => {
+            validate_expr(inner, database)?;
+            validate_expr(pattern, database)
+        }
+        Expression::Conjunction(children)
+        | Expression::Disjunction(children)
+        | Expression::RowValueConstructor(children) => {
+            for c in children {
+                validate_expr(c, database)?;
+            }
+            Ok(())
+        }
+        Expression::QuantifiedComparison { expr: inner, .. } => validate_expr(inner, database),
+
+        // Leaf expressions and subquery statements (validated on their own
+        // execution): nothing to do.
+        _ => Ok(()),
+    }
+}

--- a/crates/vibesql-executor/src/select/executor/validation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/mod.rs
@@ -14,6 +14,7 @@
 
 mod aggregates;
 mod column_refs;
+mod in_subquery_columns;
 mod index_hints;
 mod join_limits;
 mod schema;
@@ -29,6 +30,7 @@ pub use aggregates::{
     validate_window_query_order_by_aggregates, SubqueryContext,
 };
 pub use column_refs::{extract_column_refs, validate_column_ref};
+pub use in_subquery_columns::validate_in_subquery_column_counts;
 pub use index_hints::validate_index_hints;
 pub use join_limits::validate_join_table_limit;
 pub use schema::validate_aggregate_subquery_outer_refs;

--- a/crates/vibesql-executor/src/select/order/resolution.rs
+++ b/crates/vibesql-executor/src/select/order/resolution.rs
@@ -580,6 +580,110 @@ fn resolve_aliases_in_expression(
             }
         }
 
+        // Handle IS / IS NOT (parsed as IsDistinctFrom), e.g. ORDER BY (z IS y)
+        // where z is a SELECT alias (window9.test 7.2/7.3)
+        vibesql_ast::Expression::IsDistinctFrom { left, right, negated } => {
+            let resolved_left = resolve_alias_or_clone(left, select_list);
+            let resolved_right = resolve_alias_or_clone(right, select_list);
+
+            if resolved_left.is_some() || resolved_right.is_some() {
+                Some(vibesql_ast::Expression::IsDistinctFrom {
+                    left: Box::new(resolved_left.unwrap_or_else(|| left.as_ref().clone())),
+                    right: Box::new(resolved_right.unwrap_or_else(|| right.as_ref().clone())),
+                    negated: *negated,
+                })
+            } else {
+                None
+            }
+        }
+
+        // Handle IS NULL / IS NOT NULL (e.g. ORDER BY x IS NULL where x is an alias)
+        vibesql_ast::Expression::IsNull { expr: inner, negated } => {
+            resolve_alias_or_clone(inner, select_list).map(|resolved_inner| {
+                vibesql_ast::Expression::IsNull {
+                    expr: Box::new(resolved_inner),
+                    negated: *negated,
+                }
+            })
+        }
+
+        // Handle IS TRUE / IS FALSE / IS UNKNOWN
+        vibesql_ast::Expression::IsTruthValue { expr: inner, truth_value, negated } => {
+            resolve_alias_or_clone(inner, select_list).map(|resolved_inner| {
+                vibesql_ast::Expression::IsTruthValue {
+                    expr: Box::new(resolved_inner),
+                    truth_value: *truth_value,
+                    negated: *negated,
+                }
+            })
+        }
+
+        // Handle CAST(x AS type)
+        vibesql_ast::Expression::Cast { expr: inner, data_type } => {
+            resolve_alias_or_clone(inner, select_list).map(|resolved_inner| {
+                vibesql_ast::Expression::Cast {
+                    expr: Box::new(resolved_inner),
+                    data_type: data_type.clone(),
+                }
+            })
+        }
+
+        // Handle x COLLATE name
+        vibesql_ast::Expression::Collate { expr: inner, collation } => {
+            resolve_alias_or_clone(inner, select_list).map(|resolved_inner| {
+                vibesql_ast::Expression::Collate {
+                    expr: Box::new(resolved_inner),
+                    collation: collation.clone(),
+                }
+            })
+        }
+
+        // Handle x BETWEEN low AND high
+        vibesql_ast::Expression::Between { expr: inner, low, high, negated, symmetric } => {
+            let resolved_inner = resolve_alias_or_clone(inner, select_list);
+            let resolved_low = resolve_alias_or_clone(low, select_list);
+            let resolved_high = resolve_alias_or_clone(high, select_list);
+
+            if resolved_inner.is_some() || resolved_low.is_some() || resolved_high.is_some() {
+                Some(vibesql_ast::Expression::Between {
+                    expr: Box::new(resolved_inner.unwrap_or_else(|| inner.as_ref().clone())),
+                    low: Box::new(resolved_low.unwrap_or_else(|| low.as_ref().clone())),
+                    high: Box::new(resolved_high.unwrap_or_else(|| high.as_ref().clone())),
+                    negated: *negated,
+                    symmetric: *symmetric,
+                })
+            } else {
+                None
+            }
+        }
+
+        // Handle x IN (a, b, c)
+        vibesql_ast::Expression::InList { expr: inner, values, negated } => {
+            let resolved_inner = resolve_alias_or_clone(inner, select_list);
+            let mut any_resolved = resolved_inner.is_some();
+            let resolved_values: Vec<_> = values
+                .iter()
+                .map(|v| {
+                    if let Some(resolved) = resolve_alias_or_clone(v, select_list) {
+                        any_resolved = true;
+                        resolved
+                    } else {
+                        v.clone()
+                    }
+                })
+                .collect();
+
+            if any_resolved {
+                Some(vibesql_ast::Expression::InList {
+                    expr: Box::new(resolved_inner.unwrap_or_else(|| inner.as_ref().clone())),
+                    values: resolved_values,
+                    negated: *negated,
+                })
+            } else {
+                None
+            }
+        }
+
         // For other expression types, no resolution needed
         _ => None,
     }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3245,6 +3245,9 @@ array set vibesql_skip_tests {
     window1-11.3 "Expression indexes with window functions not supported"
     window1-11.4 "Expression indexes with window functions not supported"
 
+    windowC-2.0 "Requires PRAGMA encoding=UTF16le: SQLite reinterprets the blob group_concat separator bytes as text in the database encoding; VibeSQL has no UTF-16 database encoding support (dbsqlfuzz regression test, #5191)"
+    windowC-2.1 "Requires PRAGMA encoding=UTF16be: SQLite reinterprets the blob group_concat separator bytes as text in the database encoding; VibeSQL has no UTF-16 database encoding support (dbsqlfuzz regression test, #5191)"
+
     fkey1-3.5 "Uses sqlite3_db_status internal API"
     fkey1-8.3 "Tests SQLite-internal B-tree corruption via PRAGMA writable_schema + REINDEX (not portable to VibeSQL)"
     fkey6-1.3 "Uses sqlite3_db_status internal API"


### PR DESCRIPTION
## Summary

Fixes the high-value engine buckets from the curator's analysis of the window8/window9/windowB/windowC/windowpushd TCL failures (buckets A, C, D, G + the F skips). Window test deltas: **17 failures → 6**, with the remaining 6 covered by follow-up issues #5291 (output ordering), #5292 (EQP/push-down optimizer), and #5293 (CTE column names in correlated subqueries).

## Changes

- **Bucket A — NULLS FIRST/LAST in window ORDER BY** (`evaluator/window/sorting.rs`): the partition-sort comparator now honors `OrderByItem.nulls_order`. Explicit NULL placement is absolute, so it bypasses the ASC/DESC reversal; the default path (NULL-first + reversal) already matched SQLite's defaults. Fixes window8 4.3.2/4.4.2/4.5.1/4.5.2.
- **Buckets A+G — window-order-aware RANGE boundaries** (`evaluator/window/frames.rs`): replaced the four direction-specific boundary scans (`find_first_row_ge`, `find_last_row_le`, `*_desc`) with two unified searches over "window order" — a comparison that accounts for direction, NULLS FIRST/LAST placement, and explicit `COLLATE`. This fixes RANGE frames over NULLS-modified keys and RANGE-over-text frames (windowB 8.1, where offset arithmetic no-ops on text and the frame degenerates to the current row's peer group — previously computed with binary collation against a NOCASE-sorted partition).
- **Bucket C — alias resolution inside ORDER BY expressions** (`select/order/resolution.rs`): `resolve_aliases_in_expression` now recurses into `IsDistinctFrom` (the parse of `x IS y`), `IsNull`, `IsTruthValue`, `Cast`, `Collate`, `Between`, and `InList`. Fixes window9 7.2/7.3 (`ORDER BY (z IS y)` → "no such column: z").
- **Bucket D — prepare-time IN subquery column-count validation** (new `select/executor/validation/in_subquery_columns.rs`): SQLite validates `expr IN (SELECT a,b,c)` at prepare time; VibeSQL only checked per-row, so empty outer tables silently succeeded. Fixes window9 3.4 with SQLite's exact message (`sub-select returns 3 columns - expected 1`). Skips validation when the count can't be computed statically (defers to the existing runtime check), and respects row-value LHS arity.
- **Bucket F — documented skips** (`scripts/tester_vibesql.tcl`): windowC 2.0/2.1 require `PRAGMA encoding=UTF16le/be` blob-separator reinterpretation, which VibeSQL does not implement (dbsqlfuzz regression tests).
- Unit tests: NULLS-modified RANGE frames, RANGE-over-text-with-COLLATE frames (`evaluator/window/tests/frames.rs`), and NULLS FIRST/LAST partition-sort placement incl. defaults (`evaluator/window/tests/partitions.rs`).

## Test deltas (this branch vs origin/main)

| File | Before | After |
|------|--------|-------|
| window8.test | 5 failures | 1 (8.3 → #5293) |
| window9.test | 5 failures | 2 (1.4 → #5291, 5.1.1 → #5292) |
| windowB.test | 1 failure | 0 |
| windowC.test | 2 failures | 0 (documented skips) |
| windowpushd.test | 4 failures | 3 (2.x.4.1 → #5291; EQP warnings → #5292) |

No regressions: window1/2/3/4/7/A/D/E/err all pass (window3: 1462/1462).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Each remaining failure fixed or documented skip | ✅ | 9 fixed; windowC 2.0/2.1 skipped with rationale in tester_vibesql.tcl; remaining 6 tracked in follow-ups #5291/#5292/#5293 filed per curator's PR-split guidance |
| No P1 regression | ✅ | Full P1 run on this branch: 23,066 passed / 148 failed (99.4%) — every failing file (select1/2/3/7, selectB, where, where3, where9, join, join2, join5, join7, join9, in, in4, in6, orderby9) re-run standalone against an origin/main build with **identical** failure sets; suite-mode-only extras (whereG etc.) reproduce as 0 failures standalone on both binaries (load-induced flakiness, not regressions) |
| Unit tests added per bucket | ✅ | 3 frame tests + 3 sort tests in `evaluator/window/tests/` |
| window8 4.3.2/4.4.2/4.5.1/4.5.2 pass | ✅ | `./scripts/tcltest test window8.test` — only 8.3 remains (#5293) |
| window9 1.4/3.4/7.2/7.3 pass | ✅ partially | 3.4/7.2/7.3 pass; 1.4 is Bucket B (#5291), 5.1.1 is Bucket E (#5292) per curation |
| windowB 8.1 passes | ✅ | 34 passed / 0 failed |
| windowC 2.0/2.1 pass or skip | ✅ | Documented skips (UTF-16 database encoding unsupported) |
| windowpushd 2.x.4.1 / EQP follow-up | ✅ | #5291 (value tests) and #5292 (EQP/push-down optimizer) filed |

## Test Plan

- `cargo test -p vibesql-executor --lib` — 2499 passed, 0 failed
- `cargo check` / `cargo clippy` — no new warnings in changed files
- TCL: window1–window9, windowA–E, windowerr, windowpushd run before/after (deltas above)
- Perf sanity: DELETE + IN-subquery timing identical to origin/main build (prepare-time walk is allocation-free)

## Follow-ups filed

- #5291 — last-window-pass output ordering + GROUP BY key order (window9 1.4, windowpushd 2.x.4.1)
- #5292 — WHERE push-down into window subqueries + covering-index window sorts (EQP bucket, window9 5.1.1)
- #5293 — CTE columns lose names in correlated subqueries (window8 8.3, root cause is not window-specific)

Closes #5191