### PR TITLE
fix(views): limit 'error in view' prefix to ORDER-BY-term errors

### DIFF
--- a/crates/vibesql-executor/src/advanced_objects/views.rs
+++ b/crates/vibesql-executor/src/advanced_objects/views.rs
@@ -23,13 +23,22 @@ pub fn execute_create_view(stmt: &CreateViewStmt, db: &mut Database) -> Result<(
     // Use simple column names (without table prefix) for view schema compatibility
     let columns = if stmt.columns.is_none() {
         // Execute the query once to derive column names.
-        // SQLite-compatible: errors surfaced while compiling a view's query are
-        // prefixed with the view name (e.g. "error in view a: 1st ORDER BY term
-        // does not match any column in the result set").
+        //
+        // SQLite-compatible error prefixing: in SQLite the "error in view <name>: "
+        // prefix is exclusively an ALTER-time schema-reparse phenomenon (alter.c);
+        // query-time view expansion errors are bare. VibeSQL compiles views eagerly,
+        // so both error classes surface here at CREATE VIEW time. We allow-list the
+        // prefix to OrderByTermNotInResultSet only — the sole class the TCL suite
+        // expects prefixed (window1.test 32.10, altertab.test). All other variants
+        // (notably SetOperationColumnMismatch, see select7.test 8.2) pass through
+        // bare, matching SQLite's query-time messages.
         use crate::select::SelectExecutor;
         let executor = SelectExecutor::new(db);
-        let result = executor.execute_with_simple_columns(&stmt.query).map_err(|e| {
-            ExecutorError::SqliteCompatError(format!("error in view {}: {}", stmt.view_name, e))
+        let result = executor.execute_with_simple_columns(&stmt.query).map_err(|e| match e {
+            e @ ExecutorError::OrderByTermNotInResultSet { .. } => {
+                ExecutorError::SqliteCompatError(format!("error in view {}: {}", stmt.view_name, e))
+            }
+            other => other,
         })?;
         Some(result.columns)
     } else {

--- a/crates/vibesql-executor/src/tests/window1_quick_wins.rs
+++ b/crates/vibesql-executor/src/tests/window1_quick_wins.rs
@@ -147,6 +147,41 @@ fn test_create_view_error_is_prefixed_with_view_name() {
     );
 }
 
+#[test]
+fn test_create_view_set_operation_mismatch_is_not_prefixed() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t01(x INTEGER, y INTEGER)").unwrap();
+    execute_sql(&mut db, "CREATE TABLE t02(x INTEGER)").unwrap();
+
+    // select7.test 8.2 shape: SQLite surfaces set-operation arity mismatches at
+    // query time with NO "error in view" prefix; VibeSQL compiles views eagerly,
+    // so the bare message must surface at CREATE VIEW time.
+    let err =
+        execute_sql(&mut db, "CREATE VIEW v0 AS SELECT x, y FROM t01 UNION SELECT x FROM t02")
+            .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "SELECTs to the left and right of UNION do not have the same number of result columns"
+    );
+}
+
+#[test]
+fn test_create_view_intersect_mismatch_is_not_prefixed() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t01(x INTEGER, y INTEGER)").unwrap();
+    execute_sql(&mut db, "CREATE TABLE t02(x INTEGER)").unwrap();
+
+    let err =
+        execute_sql(&mut db, "CREATE VIEW v1 AS SELECT x, y FROM t01 INTERSECT SELECT x FROM t02")
+            .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        !msg.starts_with("error in view"),
+        "INTERSECT arity mismatch must not carry the view prefix, got: {msg}"
+    );
+    assert!(msg.contains("INTERSECT"), "expected INTERSECT in message, got: {msg}");
+}
+
 // ------------------------------------------------------------------------
 // 61.1 — CAST to unknown type names (SQLite affinity rules)
 // ------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
PR #5234 added an unconditional `error in view <name>: ` prefix to every error surfaced while eagerly compiling a view's query at CREATE VIEW time. In SQLite that prefix is exclusively an ALTER-time schema-reparse phenomenon (alter.c); query-time view expansion errors are bare. This broke select7.test 8.2, where SQLite reports the UNION arity mismatch with no prefix.

This change allow-lists the prefix to `ExecutorError::OrderByTermNotInResultSet` only — the sole error class the TCL suite expects prefixed (window1.test 32.10, altertab.test) — and passes all other variants (notably `SetOperationColumnMismatch`) through bare.

## Changes
- `crates/vibesql-executor/src/advanced_objects/views.rs`: replace the unconditional `map_err` prefix with a match that prefixes only `OrderByTermNotInResultSet`; all other errors pass through unchanged
- `crates/vibesql-executor/src/tests/window1_quick_wins.rs`: add `test_create_view_set_operation_mismatch_is_not_prefixed` (select7-8.2 shape, exact bare message) and `test_create_view_intersect_mismatch_is_not_prefixed` (INTERSECT edge case); existing prefix regression test `test_create_view_error_is_prefixed_with_view_name` unchanged and passing

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| select7.test 8.2 passes | ✅ | `./scripts/tcltest test select7.test` → 24/24 passed, 0 failed (was 23/24) |
| window1.test 32.10 still passes (271/271 overall) | ✅ | `./scripts/tcltest test window1.test` → 271/271 passed, 0 failed, 76 skipped |

## Test Plan
- `./scripts/tcltest test select7.test` → 24 passed / 0 failed / 2 skipped (fresh release build)
- `./scripts/tcltest test window1.test` → 271 passed / 0 failed / 76 skipped
- `cargo test -p vibesql-executor --lib` → 2525 passed / 0 failed
- New unit tests assert the exact bare UNION message and the INTERSECT edge case; the existing `error in view a: ` prefix test still passes

Closes #5298