### PR TITLE
fix(cte): expand wildcard SELECT items when deriving CTE schemas

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -296,7 +296,7 @@ impl DeleteExecutor {
 
         // Execute CTEs if present (WITH clause support)
         let cte_results = if let Some(ref cte_list) = stmt.with_clause {
-            Some(crate::select::cte::execute_ctes(cte_list, |cte_query, prior_ctes| {
+            Some(crate::select::cte::execute_ctes(cte_list, database, |cte_query, prior_ctes| {
                 let cte_executor = crate::SelectExecutor::new_with_cte(database, prior_ctes);
                 cte_executor.execute(cte_query)
             })?)

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -219,7 +219,7 @@ fn execute_insert_internal(
             let select_result = if let Some(ref cte_list) = stmt.with_clause {
                 // Execute CTEs first
                 let cte_results =
-                    crate::select::cte::execute_ctes(cte_list, |cte_query, prior_ctes| {
+                    crate::select::cte::execute_ctes(cte_list, db, |cte_query, prior_ctes| {
                         let cte_executor = crate::SelectExecutor::new_with_cte(db, prior_ctes);
                         cte_executor
                             .execute_with_columns(cte_query)

--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -19,8 +19,13 @@ pub type CteResult = (vibesql_catalog::TableSchema, Arc<Vec<vibesql_storage::Row
 /// Execute all CTEs and return their results
 ///
 /// CTEs are executed in order, allowing later CTEs to reference earlier ones.
+///
+/// The `database` reference is used to statically expand wildcard SELECT items
+/// (`SELECT * FROM t`) into the underlying table's column names when deriving
+/// each CTE's schema (#5293).
 pub fn execute_ctes<F>(
     ctes: &[vibesql_ast::CommonTableExpr],
+    database: &vibesql_storage::Database,
     executor: F,
 ) -> Result<HashMap<String, CteResult>, ExecutorError>
 where
@@ -30,7 +35,7 @@ where
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError>,
 {
     // Use the memory-tracking version with a no-op memory check
-    execute_ctes_with_memory_check(ctes, executor, |_| Ok(()))
+    execute_ctes_with_memory_check(ctes, database, executor, |_| Ok(()))
 }
 
 /// Execute all CTEs with memory tracking
@@ -40,6 +45,7 @@ where
 /// the estimated size of the CTE result to enforce memory limits.
 pub(super) fn execute_ctes_with_memory_check<F, M>(
     ctes: &[vibesql_ast::CommonTableExpr],
+    database: &vibesql_storage::Database,
     executor: F,
     memory_check: M,
 ) -> Result<HashMap<String, CteResult>, ExecutorError>
@@ -61,7 +67,7 @@ where
         let is_recursive = cte.recursive || is_cte_self_referential(cte);
         let rows = if is_recursive {
             // Recursive CTE: execute base term, then iteratively execute recursive term
-            execute_recursive_cte(cte, &cte_results, &executor, &memory_check)?
+            execute_recursive_cte(cte, &cte_results, database, &executor, &memory_check)?
         } else {
             // Non-recursive CTE: execute query directly
             executor(&cte.query, &cte_results)?
@@ -72,7 +78,7 @@ where
         memory_check(estimated_size)?;
 
         //  Determine the schema for this CTE
-        let schema = derive_cte_schema(cte, &rows)?;
+        let schema = derive_cte_schema(cte, &rows, database, &cte_results)?;
 
         // Store the CTE result wrapped in Arc for efficient sharing
         cte_results.insert(cte.name.clone(), (schema, Arc::new(rows)));
@@ -82,9 +88,16 @@ where
 }
 
 /// Derive the schema for a CTE from its query and results
+///
+/// `database` and `prior_ctes` are used to statically expand wildcard SELECT
+/// items (`*` / `t.*`) into the column names of the underlying FROM sources
+/// (#5293). Without expansion, `WITH cte AS (SELECT * FROM t)` would
+/// materialize a single `col{i}` column, silently dropping columns.
 pub(super) fn derive_cte_schema(
     cte: &vibesql_ast::CommonTableExpr,
     rows: &[vibesql_storage::Row],
+    database: &vibesql_storage::Database,
+    prior_ctes: &HashMap<String, CteResult>,
 ) -> Result<vibesql_catalog::TableSchema, ExecutorError> {
     // If column names are explicitly specified, use those
     if let Some(column_names) = &cte.columns {
@@ -126,47 +139,257 @@ pub(super) fn derive_cte_schema(
             Ok(vibesql_catalog::TableSchema::new(cte.name.clone(), columns))
         }
     } else {
-        // No explicit column names - infer from query SELECT list
-        // Extract column names from SELECT items
-        let columns = cte
-            .query
-            .select_list
-            .iter()
-            .enumerate()
-            .map(|(i, item)| {
-                // Infer data type from first row if available, otherwise use default
-                let data_type = if let Some(first_row) = rows.first() {
-                    infer_type_from_value(&first_row.values[i])
-                } else {
-                    // No rows - use default type (VARCHAR)
-                    vibesql_types::DataType::Varchar { max_length: Some(255) }
-                };
+        // No explicit column names - infer from query SELECT list.
+        // Wildcard items are statically expanded into the column names of the
+        // underlying FROM sources (#5293). A running value offset tracks the
+        // position of each output column in the materialized rows so that
+        // type inference stays aligned after expansion (e.g. `SELECT *, expr`
+        // from a 2-column table puts `expr` at value index 2, not 1).
+        let mut columns: Vec<vibesql_catalog::ColumnSchema> = Vec::new();
+        let mut value_idx = 0usize;
 
-                // Extract column name from SELECT item
-                let col_name = match item {
-                    vibesql_ast::SelectItem::Wildcard { .. }
-                    | vibesql_ast::SelectItem::QualifiedWildcard { .. } => format!("col{}", i),
-                    vibesql_ast::SelectItem::Expression { expr, alias, .. } => {
-                        if let Some(a) = alias {
-                            a.clone()
-                        } else {
-                            // Try to extract name from expression
-                            match expr {
-                                vibesql_ast::Expression::ColumnRef(col_id) => {
-                                    col_id.column_canonical().to_string()
-                                }
-                                _ => format!("col{}", i),
+        for (i, item) in cte.query.select_list.iter().enumerate() {
+            // Determine the output column name(s) for this SELECT item
+            let names: Vec<String> = match item {
+                vibesql_ast::SelectItem::Wildcard { .. }
+                | vibesql_ast::SelectItem::QualifiedWildcard { .. } => {
+                    expand_wildcard_names(item, &cte.query, database, prior_ctes)
+                        // Unresolvable FROM source (e.g. a view): fall back to
+                        // the legacy positional name for this item
+                        .unwrap_or_else(|| vec![format!("col{}", i)])
+                }
+                vibesql_ast::SelectItem::Expression { expr, alias, .. } => {
+                    vec![if let Some(a) = alias {
+                        a.clone()
+                    } else {
+                        // Try to extract name from expression
+                        match expr {
+                            vibesql_ast::Expression::ColumnRef(col_id) => {
+                                col_id.column_canonical().to_string()
                             }
+                            _ => format!("col{}", i),
                         }
-                    }
-                };
+                    }]
+                }
+            };
 
-                vibesql_catalog::ColumnSchema::new(col_name, data_type, true) // nullable
-            })
-            .collect();
+            for name in names {
+                // Infer data type from first row if available, otherwise use default
+                let data_type = rows
+                    .first()
+                    .and_then(|first_row| first_row.values.get(value_idx))
+                    .map(infer_type_from_value)
+                    .unwrap_or(vibesql_types::DataType::Varchar { max_length: Some(255) });
+
+                columns.push(vibesql_catalog::ColumnSchema::new(name, data_type, true)); // nullable
+                value_idx += 1;
+            }
+        }
+
+        // Sanity check: if static expansion disagrees with the actual row
+        // width, the resolution was wrong (e.g. an exotic FROM source).
+        // Fall back to the legacy one-column-per-item naming rather than
+        // exposing a schema that misattributes columns.
+        if let Some(first_row) = rows.first() {
+            if columns.len() != first_row.values.len() {
+                return Ok(legacy_cte_schema(cte, rows));
+            }
+        }
 
         Ok(vibesql_catalog::TableSchema::new(cte.name.clone(), columns))
     }
+}
+
+/// Legacy schema derivation: one column per SELECT item, wildcards named
+/// `col{i}`. Used only as a fallback when static wildcard expansion cannot
+/// resolve the FROM sources or disagrees with the materialized row width.
+fn legacy_cte_schema(
+    cte: &vibesql_ast::CommonTableExpr,
+    rows: &[vibesql_storage::Row],
+) -> vibesql_catalog::TableSchema {
+    let columns = cte
+        .query
+        .select_list
+        .iter()
+        .enumerate()
+        .map(|(i, item)| {
+            let data_type = rows
+                .first()
+                .and_then(|first_row| first_row.values.get(i))
+                .map(infer_type_from_value)
+                .unwrap_or(vibesql_types::DataType::Varchar { max_length: Some(255) });
+
+            let col_name = match item {
+                vibesql_ast::SelectItem::Wildcard { .. }
+                | vibesql_ast::SelectItem::QualifiedWildcard { .. } => format!("col{}", i),
+                vibesql_ast::SelectItem::Expression { expr, alias, .. } => {
+                    if let Some(a) = alias {
+                        a.clone()
+                    } else {
+                        match expr {
+                            vibesql_ast::Expression::ColumnRef(col_id) => {
+                                col_id.column_canonical().to_string()
+                            }
+                            _ => format!("col{}", i),
+                        }
+                    }
+                }
+            };
+
+            vibesql_catalog::ColumnSchema::new(col_name, data_type, true) // nullable
+        })
+        .collect();
+
+    vibesql_catalog::TableSchema::new(cte.name.clone(), columns)
+}
+
+/// A FROM-clause source resolved for wildcard expansion: the effective
+/// qualifier (alias if present, else table name) and its column names.
+struct WildcardSource {
+    qualifier: String,
+    columns: Vec<String>,
+}
+
+/// Expand a wildcard SELECT item (`*` or `qualifier.*`) into column names
+/// using the statement's FROM clause.
+///
+/// Returns `None` if any FROM source cannot be resolved statically (e.g. a
+/// view); callers fall back to legacy `col{i}` naming.
+fn expand_wildcard_names(
+    item: &vibesql_ast::SelectItem,
+    stmt: &vibesql_ast::SelectStmt,
+    database: &vibesql_storage::Database,
+    prior_ctes: &HashMap<String, CteResult>,
+) -> Option<Vec<String>> {
+    match item {
+        vibesql_ast::SelectItem::Wildcard { alias } => {
+            // SQL:1999 E051-07 derived column list: SELECT * AS (a, b, ...)
+            if let Some(alias_names) = alias {
+                return Some(alias_names.clone());
+            }
+            let sources = collect_from_sources(stmt.from.as_ref()?, database, prior_ctes)?;
+            Some(sources.into_iter().flat_map(|s| s.columns).collect())
+        }
+        vibesql_ast::SelectItem::QualifiedWildcard { qualifier, alias } => {
+            if let Some(alias_names) = alias {
+                return Some(alias_names.clone());
+            }
+            let sources = collect_from_sources(stmt.from.as_ref()?, database, prior_ctes)?;
+            sources
+                .into_iter()
+                .find(|s| s.qualifier.eq_ignore_ascii_case(qualifier))
+                .map(|s| s.columns)
+        }
+        vibesql_ast::SelectItem::Expression { .. } => None,
+    }
+}
+
+/// Resolve the sources of a FROM clause to their column names for wildcard
+/// expansion. Mirrors the traversal in
+/// `evaluator::combined::subqueries::schema_utils::count_columns_in_from_clause`
+/// but collects names instead of counts.
+///
+/// Returns `None` when a source cannot be resolved statically; callers fall
+/// back to legacy naming rather than erroring.
+fn collect_from_sources(
+    from: &vibesql_ast::FromClause,
+    database: &vibesql_storage::Database,
+    prior_ctes: &HashMap<String, CteResult>,
+) -> Option<Vec<WildcardSource>> {
+    match from {
+        vibesql_ast::FromClause::Table { name, alias, column_aliases, .. } => {
+            // Check prior CTEs first (case-insensitive, matching the
+            // resolution convention used elsewhere), then database tables
+            let base_columns: Vec<String> = if let Some((schema, _)) =
+                prior_ctes.get(name).or_else(|| {
+                    prior_ctes.iter().find(|(k, _)| k.eq_ignore_ascii_case(name)).map(|(_, v)| v)
+                }) {
+                schema.columns.iter().map(|c| c.name.clone()).collect()
+            } else if let Some(table) = database.get_table(name) {
+                table.schema.columns.iter().map(|c| c.name.clone()).collect()
+            } else {
+                // Unknown source (e.g. a view) - cannot resolve statically
+                return None;
+            };
+
+            // SQL:1999 E051-09: FROM t AS a(x, y) renames the columns
+            let columns = match column_aliases {
+                Some(aliases) if aliases.len() == base_columns.len() => aliases.clone(),
+                Some(_) => return None, // mismatched rename list - bail out
+                None => base_columns,
+            };
+
+            let qualifier = alias.clone().unwrap_or_else(|| name.clone());
+            Some(vec![WildcardSource { qualifier, columns }])
+        }
+        vibesql_ast::FromClause::Join { left, right, natural, using_columns, .. } => {
+            // NATURAL and USING joins deduplicate common columns during
+            // wildcard expansion; a simple concatenation would produce wrong
+            // names, so fall back to legacy naming for those
+            if *natural || using_columns.is_some() {
+                return None;
+            }
+            let mut sources = collect_from_sources(left, database, prior_ctes)?;
+            sources.extend(collect_from_sources(right, database, prior_ctes)?);
+            Some(sources)
+        }
+        vibesql_ast::FromClause::Subquery { query, alias, column_aliases } => {
+            let columns = if let Some(aliases) = column_aliases {
+                aliases.clone()
+            } else {
+                collect_select_list_columns(query, database, prior_ctes)?
+            };
+            Some(vec![WildcardSource { qualifier: alias.clone(), columns }])
+        }
+        vibesql_ast::FromClause::Values { rows, alias, column_aliases } => {
+            let columns = if let Some(aliases) = column_aliases {
+                aliases.clone()
+            } else {
+                let first_row = rows.first()?;
+                (0..first_row.len()).map(|i| format!("col{}", i)).collect()
+            };
+            Some(vec![WildcardSource { qualifier: alias.clone(), columns }])
+        }
+    }
+}
+
+/// Compute the output column names of a SELECT statement, expanding any
+/// wildcard items. Used to resolve subqueries appearing in a FROM clause.
+///
+/// Returns `None` if names cannot be determined statically.
+fn collect_select_list_columns(
+    stmt: &vibesql_ast::SelectStmt,
+    database: &vibesql_storage::Database,
+    prior_ctes: &HashMap<String, CteResult>,
+) -> Option<Vec<String>> {
+    // VALUES statement: names come from the first row's width
+    if let Some(values_rows) = &stmt.values {
+        let first_row = values_rows.first()?;
+        return Some((0..first_row.len()).map(|i| format!("col{}", i)).collect());
+    }
+
+    let mut names = Vec::new();
+    for (i, item) in stmt.select_list.iter().enumerate() {
+        match item {
+            vibesql_ast::SelectItem::Wildcard { .. }
+            | vibesql_ast::SelectItem::QualifiedWildcard { .. } => {
+                names.extend(expand_wildcard_names(item, stmt, database, prior_ctes)?);
+            }
+            vibesql_ast::SelectItem::Expression { expr, alias, .. } => {
+                names.push(if let Some(a) = alias {
+                    a.clone()
+                } else {
+                    match expr {
+                        vibesql_ast::Expression::ColumnRef(col_id) => {
+                            col_id.column_canonical().to_string()
+                        }
+                        _ => format!("col{}", i),
+                    }
+                });
+            }
+        }
+    }
+    Some(names)
 }
 
 /// Execute a recursive CTE using iterative evaluation
@@ -191,6 +414,7 @@ pub(super) fn derive_cte_schema(
 fn execute_recursive_cte<F, M>(
     cte: &vibesql_ast::CommonTableExpr,
     cte_results: &HashMap<String, CteResult>,
+    database: &vibesql_storage::Database,
     executor: &F,
     memory_check: &M,
 ) -> Result<Vec<vibesql_storage::Row>, ExecutorError>
@@ -272,7 +496,9 @@ where
     let mut working_table = all_rows.clone();
 
     // Derive schema from base term result
-    let schema = derive_cte_schema(cte, &all_rows)?;
+    // Wildcards in the base term are expanded against database tables and
+    // prior CTEs (#5293)
+    let schema = derive_cte_schema(cte, &all_rows, database, cte_results)?;
 
     // Track seen rows for UNION (deduplication)
     // For UNION ALL, we skip tracking to preserve all rows

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -214,6 +214,7 @@ impl SelectExecutor<'_> {
             // This query has its own CTEs - execute them with memory tracking
             execute_ctes_with_memory_check(
                 with_clause,
+                self.database,
                 |query, cte_ctx| self.execute_with_ctes(query, cte_ctx),
                 |size| self.track_memory_allocation(size),
             )?
@@ -422,7 +423,9 @@ impl SelectExecutor<'_> {
         // First, get the FROM result to access the schema
         let from_result = if let Some(from_clause) = &stmt.from {
             let mut cte_results = if let Some(with_clause) = &stmt.with_clause {
-                execute_ctes(with_clause, |query, cte_ctx| self.execute_with_ctes(query, cte_ctx))?
+                execute_ctes(with_clause, self.database, |query, cte_ctx| {
+                    self.execute_with_ctes(query, cte_ctx)
+                })?
             } else {
                 HashMap::new()
             };
@@ -518,7 +521,9 @@ impl SelectExecutor<'_> {
         // Execute the FROM clause to get combined schema
         let from_result = if let Some(from_clause) = &stmt.from {
             let mut cte_results = if let Some(with_clause) = &stmt.with_clause {
-                execute_ctes(with_clause, |query, cte_ctx| self.execute_with_ctes(query, cte_ctx))?
+                execute_ctes(with_clause, self.database, |query, cte_ctx| {
+                    self.execute_with_ctes(query, cte_ctx)
+                })?
             } else {
                 HashMap::new()
             };

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -141,7 +141,7 @@ pub(super) fn execute_internal(
 
     // Execute CTEs if present (WITH clause support)
     let cte_results = if let Some(ref cte_list) = stmt.with_clause {
-        Some(crate::select::cte::execute_ctes(cte_list, |cte_query, prior_ctes| {
+        Some(crate::select::cte::execute_ctes(cte_list, database, |cte_query, prior_ctes| {
             let cte_executor = crate::SelectExecutor::new_with_cte(database, prior_ctes);
             cte_executor.execute(cte_query)
         })?)

--- a/crates/vibesql-executor/tests/cte_wildcard_schema_tests.rs
+++ b/crates/vibesql-executor/tests/cte_wildcard_schema_tests.rs
@@ -1,0 +1,184 @@
+//! Regression tests for issue #5293 (window8.test 8.3)
+//!
+//! `WITH cte AS (SELECT * FROM t)` used to materialize a schema with a single
+//! `col{i}` column instead of expanding the wildcard to the underlying
+//! table's columns. This caused:
+//!
+//! - `SELECT t FROM cte` to fail with "Column 't' not found"
+//! - `SELECT * FROM cte` to silently DROP all but the first column
+//! - correlated subqueries against the CTE to fail (and, in window
+//!   PARTITION BY position, to silently collapse into one partition because
+//!   the evaluation error was swallowed as NULL)
+//!
+//! The fix statically expands wildcard SELECT items in `derive_cte_schema`
+//! using the database catalog and prior CTE schemas.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+fn query(db: &vibesql_storage::Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e))
+            .into_iter()
+            .map(|row| row.values.to_vec())
+            .collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+/// Setup from the issue body (window8.test 8.x)
+fn setup_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE tx(a INTEGER PRIMARY KEY)");
+    run_stmt(&mut db, "INSERT INTO tx VALUES(1),(2),(3),(4),(5),(6)");
+    run_stmt(&mut db, "CREATE TABLE map(v INTEGER PRIMARY KEY, t TEXT)");
+    run_stmt(
+        &mut db,
+        "INSERT INTO map VALUES (1,'odd'),(2,'even'),(3,'odd'),(4,'even'),(5,'odd'),(6,'even')",
+    );
+    db
+}
+
+fn odd_even(v: i64) -> SqlValue {
+    SqlValue::Varchar(arcstr::ArcStr::from(if v % 2 == 0 { "even" } else { "odd" }))
+}
+
+#[test]
+fn test_select_column_by_name_from_wildcard_cte() {
+    // Previously: Error: Column 't' not found ... Available columns: col0
+    let db = setup_db();
+    let rows = query(&db, "WITH map2 AS (SELECT * FROM map) SELECT t FROM map2 ORDER BY t");
+    assert_eq!(rows.len(), 6);
+    assert_eq!(rows[0], vec![odd_even(2)]);
+    assert_eq!(rows[5], vec![odd_even(1)]);
+}
+
+#[test]
+fn test_select_star_from_wildcard_cte_returns_all_columns() {
+    // Previously returned a single col0 column (silent data loss)
+    let db = setup_db();
+    let rows = query(&db, "WITH map2 AS (SELECT * FROM map) SELECT * FROM map2 ORDER BY v");
+    assert_eq!(rows.len(), 6);
+    for (i, row) in rows.iter().enumerate() {
+        let v = (i + 1) as i64;
+        assert_eq!(row.len(), 2, "expected both v and t columns, got {:?}", row);
+        assert_eq!(row[0], SqlValue::Integer(v));
+        assert_eq!(row[1], odd_even(v));
+    }
+}
+
+#[test]
+fn test_qualified_wildcard_cte() {
+    // Previously: same failure via SELECT map.* (qualified wildcard)
+    let db = setup_db();
+    let rows = query(&db, "WITH map2 AS (SELECT map.* FROM map) SELECT t FROM map2 WHERE v = 2");
+    assert_eq!(rows, vec![vec![odd_even(2)]]);
+}
+
+#[test]
+fn test_correlated_subquery_against_wildcard_cte() {
+    // Issue reproducer: correlated scalar subquery in the SELECT list
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH map2 AS (SELECT * FROM map) \
+         SELECT a, (SELECT t FROM map2 WHERE v=a) FROM tx ORDER BY a",
+    );
+    assert_eq!(rows.len(), 6);
+    for (i, row) in rows.iter().enumerate() {
+        let a = (i + 1) as i64;
+        assert_eq!(row[0], SqlValue::Integer(a));
+        assert_eq!(row[1], odd_even(a), "wrong subquery result for a={}", a);
+    }
+}
+
+#[test]
+fn test_window_partition_by_correlated_subquery_against_wildcard_cte() {
+    // window8.test 8.3: the partition key used to silently evaluate to NULL
+    // for every row, collapsing the window into one partition
+    // (got 1 3 6 10 15 21 instead of per-parity running sums)
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH map2 AS (SELECT * FROM map) \
+         SELECT sum(a) OVER (PARTITION BY (SELECT t FROM map2 WHERE v=a) ORDER BY a) \
+         FROM tx ORDER BY a",
+    );
+    // odd partition: 1, 1+3=4, 1+3+5=9; even partition: 2, 2+4=6, 2+4+6=12
+    let expected: Vec<Vec<SqlValue>> = vec![
+        vec![SqlValue::Integer(1)],
+        vec![SqlValue::Integer(2)],
+        vec![SqlValue::Integer(4)],
+        vec![SqlValue::Integer(6)],
+        vec![SqlValue::Integer(9)],
+        vec![SqlValue::Integer(12)],
+    ];
+    assert_eq!(rows, expected);
+}
+
+#[test]
+fn test_wildcard_cte_referencing_prior_wildcard_cte() {
+    // Later CTEs must expand wildcards against prior CTE schemas
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH c1 AS (SELECT * FROM map), c2 AS (SELECT * FROM c1) \
+         SELECT t FROM c2 WHERE v = 3",
+    );
+    assert_eq!(rows, vec![vec![odd_even(3)]]);
+}
+
+#[test]
+fn test_mixed_wildcard_and_expression_type_alignment() {
+    // `SELECT *, expr` from a 2-column table puts expr at value index 2;
+    // the schema's running value offset must track wildcard expansion
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH c AS (SELECT *, v + 100 AS vplus FROM map) \
+         SELECT v, t, vplus FROM c WHERE v = 4",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(4), odd_even(4), SqlValue::Integer(104)]]);
+}
+
+#[test]
+fn test_empty_result_wildcard_cte_still_exposes_column_names() {
+    // With no rows, types cannot be inferred, but names must still expand
+    let db = setup_db();
+    let rows = query(&db, "WITH c AS (SELECT * FROM map WHERE v > 100) SELECT t FROM c");
+    assert!(rows.is_empty(), "expected empty result, got {:?}", rows);
+}
+
+#[test]
+fn test_table_alias_qualified_wildcard_cte() {
+    // Qualified wildcard must match the FROM alias, not just the table name
+    let db = setup_db();
+    let rows = query(&db, "WITH c AS (SELECT mp.* FROM map mp) SELECT t FROM c WHERE v = 5");
+    assert_eq!(rows, vec![vec![odd_even(5)]]);
+}
+
+#[test]
+fn test_explicit_column_list_still_works() {
+    // Explicit CTE column lists take precedence over expansion
+    let db = setup_db();
+    let rows = query(&db, "WITH c(x, y) AS (SELECT * FROM map) SELECT y FROM c WHERE x = 6");
+    assert_eq!(rows, vec![vec![odd_even(6)]]);
+}


### PR DESCRIPTION
## Summary

`WITH cte AS (SELECT * FROM t)` materialized a CTE schema with a single `col{i}` column per SELECT item instead of expanding the wildcard. This caused silent data loss in `SELECT * FROM cte`, hard `Column not found` errors for by-name references, and the window8.test 8.3 silent-NULL partition collapse (the resolution error was swallowed by `unwrap_or(Null)` in window partition-key evaluation).

This implements the curator's recommended Option A: static wildcard expansion in `derive_cte_schema` using the database catalog and prior-CTE schemas.

## Changes

- `derive_cte_schema` now expands `*` and `qualifier.*` SELECT items against the FROM clause: database tables (with alias/`AS a(x,y)` column renames), prior CTEs (case-insensitive, CTEs shadow tables), joins (concatenated; NATURAL/USING joins fall back since they deduplicate columns), FROM-subqueries (column aliases or recursive select-list resolution), and VALUES sources
- Type inference tracks a running value offset so mixed lists like `SELECT *, expr` map `expr` to the correct value index
- Safety fallback: if a FROM source cannot be resolved statically (e.g. views) or the expansion disagrees with the materialized row width, the legacy `col{i}` naming is preserved (no behavior change for exotic cases)
- Threaded `database` through `execute_ctes` / `execute_ctes_with_memory_check` / `execute_recursive_cte`; updated all 6 call sites (select x3, insert, update, delete)
- New regression suite `crates/vibesql-executor/tests/cte_wildcard_schema_tests.rs` (10 tests): bare/qualified/alias-qualified wildcards, `SELECT *` completeness, correlated subqueries, the window8 8.3 reproducer, prior-CTE chaining, mixed `*, expr` type alignment, empty-result CTEs, explicit column lists

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `WITH map2 AS (SELECT * FROM map) SELECT a, (SELECT t FROM map2 WHERE v=a) FROM tx;` works | PASS | Release CLI returns odd/even per row; regression test `test_correlated_subquery_against_wildcard_cte` |
| window8.test 8.3 passes | PASS | `make test-tcl-file FILE=window8.test`: 181 passed / 0 failed (baseline at branch point: 180 / 1); CLI returns `2 6 12 1 4 9` |
| No regression in with1/with2/window8 TCL files | PASS | with2: 37 passed / 31 failed vs baseline 34 / 34 (3 newly passing, none newly failing by count); with3/with4/with5/window9 identical to baseline; window1-7 all 0 failures; with1/with6 report 0/0 in both |

## Test Plan

- `cargo test -p vibesql-executor` — full suite green (including 10 new regression tests)
- `cargo check` / `cargo clippy` — no new warnings (remaining cte.rs lints are pre-existing `map_or` style in untouched code)
- TCL conformance run with the fixed release binary vs a baseline binary built at the branch point (87c3d56a3): window8 1→0 failures, with2 34→31 failures, with3/with4/with5/window9 unchanged
- Manual CLI verification of all four curator reproducers (by-name select, `SELECT *` completeness, qualified wildcard, correlated subquery, window partition)

Follow-up (per curator guidance, kept out of this PR): window partition-key evaluation swallows errors via `unwrap_or(SqlValue::Null)` at `evaluator/window/partitioning.rs:108` — filed as a separate issue.

Closes #5293