### PR TITLE
fix(parser): accept contextual keywords as qualified-wildcard qualifiers

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -392,8 +392,21 @@ impl<'arena> ArenaParser<'arena> {
         // The expression parser would parse "table.*" as Expression::Wildcard, losing the table
         // name.
         let saved_position = self.position;
-        if let Token::Identifier(qualifier) | Token::DelimitedIdentifier(qualifier) = self.peek() {
-            let qualifier = qualifier.clone();
+        let qualifier = match self.peek() {
+            Token::Identifier(qualifier) | Token::DelimitedIdentifier(qualifier) => {
+                Some(qualifier.clone())
+            }
+            // Allow contextual keywords (M, YEAR, WINDOW, ...) as wildcard qualifiers,
+            // matching the keyword-as-identifier handling in expression parsing. Without
+            // this, `m.*` would fall through to parse_expression and silently degrade to a
+            // bare Wildcard, losing the qualifier.
+            // SQL:1999 normalizes unquoted identifiers to lowercase.
+            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                Some(format!("{}", kw).to_lowercase())
+            }
+            _ => None,
+        };
+        if let Some(qualifier) = qualifier {
             self.advance();
 
             if matches!(self.peek(), Token::Symbol('.')) {

--- a/crates/vibesql-parser/src/parser/select/list.rs
+++ b/crates/vibesql-parser/src/parser/select/list.rs
@@ -69,12 +69,17 @@ impl Parser {
     pub(crate) fn parse_select_item(&mut self) -> Result<vibesql_ast::SelectItem, ParseError> {
         // Check for qualified wildcard (table.* or alias.*)
         let saved_position = self.position;
-        let qualifier = if let Token::Identifier(ref qualifier)
-        | Token::DelimitedIdentifier(ref qualifier) = self.peek()
-        {
-            Some(qualifier.clone())
-        } else {
-            None
+        let qualifier = match self.peek() {
+            Token::Identifier(ref qualifier) | Token::DelimitedIdentifier(ref qualifier) => {
+                Some(qualifier.clone())
+            }
+            // Allow contextual keywords (M, YEAR, WINDOW, ...) as wildcard qualifiers,
+            // matching the keyword-as-identifier handling in parse_identifier_expression.
+            // SQL:1999 normalizes unquoted identifiers to lowercase.
+            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                Some(format!("{}", kw).to_lowercase())
+            }
+            _ => None,
         };
 
         if let Some(qualifier) = qualifier {

--- a/crates/vibesql-parser/src/tests/select/basic_expressions.rs
+++ b/crates/vibesql-parser/src/tests/select/basic_expressions.rs
@@ -292,3 +292,133 @@ fn test_parse_select_qualified_wildcard_alias() {
         _ => panic!("Expected SELECT statement"),
     }
 }
+
+// ============================================================================
+// Regression tests for issue #5302: contextual keywords (M, YEAR, WINDOW, ...)
+// were rejected (classic parser) or silently dropped (arena parser) when used
+// as qualified-wildcard qualifiers, e.g. `SELECT m.* FROM map AS m`.
+// ============================================================================
+
+/// Assert the classic parser yields a QualifiedWildcard with the expected qualifier.
+fn assert_classic_qualified_wildcard(sql: &str, expected_qualifier: &str) {
+    let stmt =
+        Parser::parse_sql(sql).unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match &select.select_list[0] {
+            vibesql_ast::SelectItem::QualifiedWildcard { qualifier, .. } => {
+                assert_eq!(qualifier, expected_qualifier, "wrong qualifier for {:?}", sql);
+            }
+            other => panic!("Expected QualifiedWildcard for {:?}, got {:?}", sql, other),
+        },
+        _ => panic!("Expected SELECT statement for {:?}", sql),
+    }
+}
+
+/// Assert the arena parser yields a QualifiedWildcard with the expected qualifier
+/// (i.e. the qualifier is NOT silently dropped to a bare Wildcard).
+fn assert_arena_qualified_wildcard(sql: &str, expected_qualifier: &str) {
+    let arena = bumpalo::Bump::new();
+    let (stmt, interner) =
+        crate::arena_parser::ArenaParser::parse_select_with_interner(sql, &arena)
+            .unwrap_or_else(|e| panic!("Failed to arena-parse {:?}: {:?}", sql, e));
+    match &stmt.select_list[0] {
+        vibesql_ast::arena::SelectItem::QualifiedWildcard { qualifier, .. } => {
+            assert_eq!(
+                interner.resolve(*qualifier),
+                expected_qualifier,
+                "wrong qualifier for {:?}",
+                sql
+            );
+        }
+        other => panic!("Expected QualifiedWildcard for {:?}, got {:?}", sql, other),
+    }
+}
+
+#[test]
+fn test_parse_select_qualified_wildcard_all_single_letter_aliases() {
+    // Every single letter (a-z, A-Z) must work as a wildcard qualifier.
+    // `m`/`M` lex as the contextual HNSW keyword Keyword::M and are normalized
+    // to lowercase (SQL:1999 unquoted-identifier folding, matching
+    // parse_identifier_expression); plain identifiers preserve source case.
+    for c in ('a'..='z').chain('A'..='Z') {
+        let sql = format!("SELECT {c}.* FROM map AS {c};");
+        let expected = if c.eq_ignore_ascii_case(&'m') { "m".to_string() } else { c.to_string() };
+        assert_classic_qualified_wildcard(&sql, &expected);
+        assert_arena_qualified_wildcard(&sql, &expected);
+    }
+}
+
+#[test]
+fn test_parse_select_qualified_wildcard_keyword_qualifiers() {
+    // Any can_be_identifier() keyword must be usable as a wildcard qualifier.
+    for kw in ["year", "month", "out", "window", "range", "rowid", "temp", "filter"] {
+        let sql = format!("SELECT {kw}.* FROM some_table AS {kw};");
+        assert_classic_qualified_wildcard(&sql, kw);
+        assert_arena_qualified_wildcard(&sql, kw);
+    }
+}
+
+#[test]
+fn test_parse_select_qualified_wildcard_m_in_join_not_degraded() {
+    // Arena parser previously degraded `m.*` to a bare Wildcard, which in a
+    // join would expand ALL tables' columns instead of just m's.
+    let sql = "SELECT m.*, t.x FROM map AS m JOIN t ON m.id = t.id";
+
+    // Classic parser
+    let stmt =
+        Parser::parse_sql(sql).unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            assert_eq!(select.select_list.len(), 2);
+            match &select.select_list[0] {
+                vibesql_ast::SelectItem::QualifiedWildcard { qualifier, .. } => {
+                    assert_eq!(qualifier, "m");
+                }
+                other => panic!("Expected QualifiedWildcard, got {:?}", other),
+            }
+            assert!(matches!(&select.select_list[1], vibesql_ast::SelectItem::Expression { .. }));
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+
+    // Arena parser: qualifier must be preserved, not dropped to bare Wildcard
+    let arena = bumpalo::Bump::new();
+    let (stmt, interner) =
+        crate::arena_parser::ArenaParser::parse_select_with_interner(sql, &arena)
+            .unwrap_or_else(|e| panic!("Failed to arena-parse {:?}: {:?}", sql, e));
+    assert_eq!(stmt.select_list.len(), 2);
+    match &stmt.select_list[0] {
+        vibesql_ast::arena::SelectItem::QualifiedWildcard { qualifier, .. } => {
+            assert_eq!(interner.resolve(*qualifier), "m");
+        }
+        other => {
+            panic!("Expected QualifiedWildcard (qualifier must not be dropped), got {:?}", other)
+        }
+    }
+}
+
+#[test]
+fn test_parse_select_qualified_wildcard_keyword_case_variants() {
+    // Uppercase keyword qualifier and case-mismatched alias both normalize to
+    // lowercase; executor table lookup is case-insensitive.
+    assert_classic_qualified_wildcard("SELECT M.* FROM map AS m;", "m");
+    assert_arena_qualified_wildcard("SELECT M.* FROM map AS m;", "m");
+    assert_arena_qualified_wildcard("SELECT m.* FROM map AS M;", "m");
+    // Implicit alias without AS: the classic parser accepts keyword implicit
+    // aliases (`FROM map m`); the arena parser does not (pre-existing
+    // limitation — it errors and the caller falls back to the classic parser),
+    // so only the classic parser is asserted for this variant.
+    assert_classic_qualified_wildcard("SELECT m.* FROM map m;", "m");
+}
+
+#[test]
+fn test_hnsw_index_with_m_parameter_still_parses() {
+    // Keyword::M's legitimate use: HNSW index parameters must keep working.
+    for sql in [
+        "CREATE INDEX idx ON t USING HNSW (v) WITH (M = 16, EF_CONSTRUCTION = 64);",
+        "CREATE INDEX idx ON t USING HNSW (v) WITH (m = 16, ef_construction = 64);",
+    ] {
+        let result = Parser::parse_sql(sql);
+        assert!(result.is_ok(), "Failed to parse {:?}: {:?}", sql, result.err());
+    }
+}


### PR DESCRIPTION
## Summary

`SELECT m.* FROM map AS m` failed to parse because `m`/`M` lex as the contextual HNSW keyword `Keyword::M`, and qualified-wildcard parsing in both parsers only accepted `Identifier`/`DelimitedIdentifier` tokens as the qualifier. The classic parser errored with "Expected identifier after '.'", while the arena parser silently degraded `m.*` to a bare `Wildcard` — losing the qualifier and expanding ALL tables' columns in joins (a silent correctness bug). The same bug affected every `can_be_identifier()` keyword (`year.*`, `out.*`, `window.*`, ...).

## Changes

- `crates/vibesql-parser/src/parser/select/list.rs` — extend the qualifier match in `parse_select_item` to accept `can_be_identifier()` keywords, lowercased per SQL:1999 unquoted-identifier folding (same pattern as `parse_identifier_expression`)
- `crates/vibesql-parser/src/arena_parser/select.rs` — identical fix in the arena `parse_select_item`, eliminating the silent qualifier drop
- `crates/vibesql-parser/src/tests/select/basic_expressions.rs` — regression tests: all 52 single-letter aliases (classic + arena), keyword qualifiers (`year`, `month`, `out`, `window`, `range`, `rowid`, `temp`, `filter`), join case asserting the arena qualifier is preserved (not degraded to bare `Wildcard`), case variants (`M.*` with alias `m`, `m.*` with alias `M`, implicit alias without `AS`), and HNSW `WITH (M = 16)` / `WITH (m = 16)` still parsing

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SELECT m.* FROM map AS m` parses as `QualifiedWildcard { qualifier: "m" }` in both parsers | ✅ | `test_parse_select_qualified_wildcard_all_single_letter_aliases` asserts both `Parser::parse_sql` and `ArenaParser` ASTs |
| Arena parser no longer degrades `m.*` to bare `Wildcard`; join expands only `m`'s columns | ✅ | `test_parse_select_qualified_wildcard_m_in_join_not_degraded`; CLI run: `SELECT m.*, t.x FROM map AS m JOIN t ON m.id = t.id` returns only `id, name, x` |
| All 52 single letters (a-z, A-Z) as alias + `.*` parse as qualified wildcards | ✅ | Regression test loops `('a'..='z').chain('A'..='Z')` over both parsers |
| Representative `can_be_identifier()` keywords work as qualifiers (`year.*`, `out.*`, `window.*`, `rowid.*`, `temp.*`) | ✅ | `test_parse_select_qualified_wildcard_keyword_qualifiers` covers 8 keywords in both parsers; verified end-to-end via CLI |
| HNSW `CREATE INDEX ... WITH (M = 16, EF_CONSTRUCTION = 64)` still parses (upper and lower case) | ✅ | `test_hnsw_index_with_m_parameter_still_parses` |
| Qualifier resolves against FROM alias regardless of case (`AS m` / `AS M`) | ✅ | Qualifier lowercased per SQL:1999 folding; executor `schema.get_table` lookup is case-insensitive (verified at `columns.rs`, `projection.rs`, `arena_execution.rs`); `test_parse_select_qualified_wildcard_keyword_case_variants` + CLI check of `SELECT M.* FROM map AS m` |

Note on the `SELECT m.* FROM map m` (implicit alias, no `AS`) edge case: the classic parser handles it (asserted in tests). The arena parser has never accepted keyword implicit table aliases — it errors and the caller falls back to the classic parser, so end-to-end behavior is correct. Extending arena implicit-alias parsing is a pre-existing limitation left out of scope.

## Test Plan

- `cargo test -p vibesql-parser --lib` — 1355 passed, 0 failed
- `cargo test -p vibesql-executor --lib` — 2525 passed, 0 failed
- `cargo check` / `cargo clippy -p vibesql-parser` — no new warnings (the two clippy warnings present are pre-existing on main: `from_clause.rs:240` collapsible-match and one in `vibesql-ast`)
- TCL spot-check: `make test-tcl-file FILE=select1.test` and `FILE=join.test` — failures (`select1-18.1`, `join-2.4`, `join-2.5`, `join-7.1`) are pre-existing: verified identical failure set with the parser reverted to `origin/main` and rebuilt; none involve qualified wildcards
- Manual CLI verification: `m.*`, `M.*`, `year.*`, `window.*` qualifiers all expand only the qualified table's columns, including in a two-table join

Closes #5302