### PR TITLE
fix(window): propagate PARTITION BY evaluation errors instead of NULL-keying

### DIFF
--- a/crates/vibesql-executor/src/evaluator/window/partitioning.rs
+++ b/crates/vibesql-executor/src/evaluator/window/partitioning.rs
@@ -61,11 +61,14 @@ impl Partition {
 ///
 /// Partitions are ordered by their key values (using BTreeMap with SqlValue keys
 /// for proper numeric/string ordering), matching SQLite's behavior.
+///
+/// Returns an error if evaluating any PARTITION BY expression fails. Expressions
+/// that legitimately evaluate to NULL still group together under the NULL key.
 pub fn partition_rows<F>(
     rows: Vec<Row>,
     partition_by: &Option<Vec<Expression>>,
     eval_fn: F,
-) -> Vec<Partition>
+) -> Result<Vec<Partition>, String>
 where
     F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
 {
@@ -76,22 +79,25 @@ where
 ///
 /// `collations` maps each PARTITION BY expression index to its resolved collation.
 /// For NOCASE collation, partition keys are compared case-insensitively.
+///
+/// Returns an error if evaluating any PARTITION BY expression fails. Expressions
+/// that legitimately evaluate to NULL still group together under the NULL key.
 pub fn partition_rows_with_collations<F>(
     rows: Vec<Row>,
     partition_by: &Option<Vec<Expression>>,
     collations: &[Option<String>],
     eval_fn: F,
-) -> Vec<Partition>
+) -> Result<Vec<Partition>, String>
 where
     F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
 {
     // If no PARTITION BY, return all rows in single partition
     let Some(partition_exprs) = partition_by else {
-        return vec![Partition::new(rows)];
+        return Ok(vec![Partition::new(rows)]);
     };
 
     if partition_exprs.is_empty() {
-        return vec![Partition::new(rows)];
+        return Ok(vec![Partition::new(rows)]);
     }
 
     // Group rows by partition key values
@@ -105,7 +111,10 @@ where
         let mut partition_key = Vec::new();
 
         for (i, expr) in partition_exprs.iter().enumerate() {
-            let value = eval_fn(expr, &row).unwrap_or(SqlValue::Null);
+            // Propagate evaluation errors instead of collapsing them into a NULL
+            // partition key, which would silently merge all affected rows into
+            // one partition and produce wrong window results.
+            let value = eval_fn(expr, &row)?;
             // Apply collation to partition key for case-insensitive grouping
             let collation = collations.get(i).and_then(|c| c.as_deref());
             if let Some(coll) = collation {
@@ -130,11 +139,11 @@ where
     }
 
     // Convert BTreeMap to Vec<Partition>, preserving sorted partition key order
-    partitions_map
+    Ok(partitions_map
         .into_values()
         .map(|rows_with_indices| {
             let (indices, rows): (Vec<_>, Vec<_>) = rows_with_indices.into_iter().unzip();
             Partition::with_indices(rows, indices)
         })
-        .collect()
+        .collect())
 }

--- a/crates/vibesql-executor/src/evaluator/window/tests/partitions.rs
+++ b/crates/vibesql-executor/src/evaluator/window/tests/partitions.rs
@@ -10,7 +10,7 @@ fn make_test_rows(values: Vec<i64>) -> Vec<Row> {
 #[test]
 fn test_partition_rows_no_partition_by() {
     let rows = make_test_rows(vec![1, 2, 3]);
-    let partitions = partition_rows(rows, &None, evaluate_expression);
+    let partitions = partition_rows(rows, &None, evaluate_expression).unwrap();
 
     assert_eq!(partitions.len(), 1);
     assert_eq!(partitions[0].len(), 3);
@@ -19,10 +19,59 @@ fn test_partition_rows_no_partition_by() {
 #[test]
 fn test_partition_rows_empty_partition_by() {
     let rows = make_test_rows(vec![1, 2, 3]);
-    let partitions = partition_rows(rows, &Some(vec![]), evaluate_expression);
+    let partitions = partition_rows(rows, &Some(vec![]), evaluate_expression).unwrap();
 
     assert_eq!(partitions.len(), 1);
     assert_eq!(partitions[0].len(), 3);
+}
+
+// ===== Error propagation from PARTITION BY evaluation (#5301) =====
+
+fn partition_by_column(index: &str) -> Option<Vec<vibesql_ast::Expression>> {
+    Some(vec![vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+        index, false,
+    ))])
+}
+
+/// An evaluation error in a PARTITION BY expression must surface as Err,
+/// not silently become a NULL partition key (which would collapse all
+/// affected rows into one partition and produce wrong window results).
+#[test]
+fn test_partition_rows_propagates_eval_errors() {
+    let rows = make_test_rows(vec![1, 2, 3]);
+    let failing_eval = |_expr: &vibesql_ast::Expression, row: &Row| -> Result<SqlValue, String> {
+        match row.values[0] {
+            SqlValue::Integer(2) => Err("ColumnNotFound: simulated failure".to_string()),
+            ref v => Ok(v.clone()),
+        }
+    };
+
+    let result = partition_rows(rows, &partition_by_column("0"), failing_eval);
+
+    let err = result.expect_err("evaluation error must propagate, not become a NULL key");
+    assert!(err.contains("ColumnNotFound"), "error message should be preserved, got: {err}");
+}
+
+/// Partition expressions that legitimately evaluate to NULL (Ok(Null), not Err)
+/// must keep their previous behavior: all NULL-keyed rows group together.
+#[test]
+fn test_partition_rows_null_keys_still_group_together() {
+    let rows = vec![
+        Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(10)]),
+        Row::new(vec![SqlValue::Integer(2), SqlValue::Null]),
+        Row::new(vec![SqlValue::Integer(3), SqlValue::Integer(10)]),
+        Row::new(vec![SqlValue::Integer(4), SqlValue::Null]),
+    ];
+
+    let partitions = partition_rows(rows, &partition_by_column("1"), evaluate_expression).unwrap();
+
+    assert_eq!(partitions.len(), 2, "expected one NULL partition and one Integer(10) partition");
+    for partition in &partitions {
+        assert_eq!(partition.len(), 2);
+        // All rows within a partition share the same key value
+        let first_key = partition.rows[0].values[1].clone();
+        assert!(partition.rows.iter().all(|r| r.values[1] == first_key));
+    }
 }
 
 // ===== ORDER BY NULLS FIRST/LAST in partition sort (#5191) =====

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -590,7 +590,8 @@ pub(super) fn apply_window_functions_to_aggregates(
             evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
         };
 
-        let mut partitions = partition_rows(rows.clone(), &partition_exprs, eval_fn);
+        let mut partitions = partition_rows(rows.clone(), &partition_exprs, eval_fn)
+            .map_err(ExecutorError::SqliteCompatError)?;
 
         // Sort each partition
         let order_by_items: Option<Vec<vibesql_ast::OrderByItem>> =

--- a/crates/vibesql-executor/src/select/window/evaluation.rs
+++ b/crates/vibesql-executor/src/select/window/evaluation.rs
@@ -91,7 +91,8 @@ pub(super) fn evaluate_single_window_function(
         &win_func.window_spec.partition_by,
         &partition_collations,
         eval_fn,
-    );
+    )
+    .map_err(ExecutorError::SqliteCompatError)?;
 
     // Build column name map for frame calculations (RANGE/GROUPS need to resolve named columns)
     let column_map = evaluator.get_schema().build_column_name_map();


### PR DESCRIPTION
## Summary

`partition_rows` / `partition_rows_with_collations` silently converted any error raised while evaluating a window PARTITION BY expression into a NULL partition key (`unwrap_or(SqlValue::Null)` at `evaluator/window/partitioning.rs:108`). This collapsed all affected rows into a single partition and produced silently wrong window results instead of surfacing the error (concrete precedent: window8.test 8.3 under the pre-#5300 CTE wildcard bug returned `1 3 6 10 15 21` instead of an error).

This PR propagates the evaluation error to the caller. Legitimate NULL partition values (`Ok(SqlValue::Null)`) are unaffected and still group together under the NULL key.

## Changes

- `crates/vibesql-executor/src/evaluator/window/partitioning.rs`: `partition_rows` and `partition_rows_with_collations` now return `Result<Vec<Partition>, String>`; the `unwrap_or(SqlValue::Null)` at the key-evaluation site is replaced with `?`
- `crates/vibesql-executor/src/select/window/evaluation.rs`: call site propagates via `.map_err(ExecutorError::SqliteCompatError)?` (same pattern as `validate_frame` above it)
- `crates/vibesql-executor/src/select/executor/aggregation/window.rs`: same propagation at the post-aggregation window call site
- `crates/vibesql-executor/src/evaluator/window/tests/partitions.rs`: two existing tests updated with `.unwrap()`; two new regression tests added (error propagation; NULL-key grouping preserved)

These are exactly the 4 files the curator's prototype identified; no other callers exist. The same swallow pattern in sorting.rs/ranking.rs/frames.rs comparators is deliberately out of scope (flagged in the issue as follow-up territory).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Errors evaluating PARTITION BY expressions surface to the caller instead of becoming NULL keys | Done | New unit test `test_partition_rows_propagates_eval_errors`: an `eval_fn` returning `Err` for one row makes `partition_rows` return `Err` with the message preserved |
| Legitimate NULL partition values still group together | Done | New unit test `test_partition_rows_null_keys_still_group_together`: rows with `Ok(SqlValue::Null)` keys form one 2-row partition alongside the `Integer(10)` partition |
| No regressions in window TCL files (window1-window9, windowA-E) | Done | Ran all 14 files patched vs baseline (stash + rebuild) on this branch: byte-identical results, including window9's 2 pre-existing failures (window1: 271/0, window2: 63/0, window3: 1462/0, window4: 216/0, window7: 10/0, window8: 181/0, window9: 36/2, windowA: 1/0, windowB: 34/0, windowC: 41/0, windowD: 13/0, windowE: 5/0) |
| `cargo test -p vibesql-executor` passes | Done | Full suite: all test binaries pass, 0 failures (exit 0) |

## Test Plan

- `cargo check` / `cargo clippy -p vibesql-executor`: clean (only pre-existing warnings on untouched lines)
- `cargo test -p vibesql-executor`: all binaries pass
- Window unit tests: 54 passed including 2 new regression tests
- TCL window1-window9 + windowA-windowE: identical pass/fail counts patched vs baseline

Closes #5301