### PR TITLE
fix(cte): dedup NATURAL/USING join columns in static wildcard schema expansion

### DIFF
--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -243,11 +243,27 @@ fn legacy_cte_schema(
     vibesql_catalog::TableSchema::new(cte.name.clone(), columns)
 }
 
+/// A column of a FROM-clause source resolved for wildcard expansion.
+///
+/// `hidden_for_star` marks right-side NATURAL/USING join columns that are
+/// deduplicated out of plain-`*` expansion. Qualified wildcards (`t.*`) keep
+/// ALL of the source's columns, including hidden ones, matching SQLite
+/// (`SELECT b.* FROM a NATURAL JOIN b` returns the join column too).
+struct WildcardColumn {
+    name: String,
+    hidden_for_star: bool,
+}
+
 /// A FROM-clause source resolved for wildcard expansion: the effective
 /// qualifier (alias if present, else table name) and its column names.
 struct WildcardSource {
     qualifier: String,
-    columns: Vec<String>,
+    columns: Vec<WildcardColumn>,
+}
+
+/// Wrap plain column names as star-visible wildcard columns.
+fn visible_columns(names: Vec<String>) -> Vec<WildcardColumn> {
+    names.into_iter().map(|name| WildcardColumn { name, hidden_for_star: false }).collect()
 }
 
 /// Expand a wildcard SELECT item (`*` or `qualifier.*`) into column names
@@ -268,7 +284,14 @@ fn expand_wildcard_names(
                 return Some(alias_names.clone());
             }
             let sources = collect_from_sources(stmt.from.as_ref()?, database, prior_ctes)?;
-            Some(sources.into_iter().flat_map(|s| s.columns).collect())
+            Some(
+                sources
+                    .into_iter()
+                    .flat_map(|s| s.columns)
+                    .filter(|c| !c.hidden_for_star)
+                    .map(|c| c.name)
+                    .collect(),
+            )
         }
         vibesql_ast::SelectItem::QualifiedWildcard { qualifier, alias } => {
             if let Some(alias_names) = alias {
@@ -278,7 +301,9 @@ fn expand_wildcard_names(
             sources
                 .into_iter()
                 .find(|s| s.qualifier.eq_ignore_ascii_case(qualifier))
-                .map(|s| s.columns)
+                // Qualified wildcards keep ALL of the source's columns,
+                // including NATURAL/USING join columns hidden from plain `*`
+                .map(|s| s.columns.into_iter().map(|c| c.name).collect())
         }
         vibesql_ast::SelectItem::Expression { .. } => None,
     }
@@ -320,17 +345,61 @@ fn collect_from_sources(
             };
 
             let qualifier = alias.clone().unwrap_or_else(|| name.clone());
-            Some(vec![WildcardSource { qualifier, columns }])
+            Some(vec![WildcardSource { qualifier, columns: visible_columns(columns) }])
         }
-        vibesql_ast::FromClause::Join { left, right, natural, using_columns, .. } => {
-            // NATURAL and USING joins deduplicate common columns during
-            // wildcard expansion; a simple concatenation would produce wrong
-            // names, so fall back to legacy naming for those
-            if *natural || using_columns.is_some() {
+        vibesql_ast::FromClause::Join { left, right, natural, using_columns, alias, .. } => {
+            // Non-goal: aliased parenthesized NATURAL/USING joins
+            // (`(a JOIN b USING(k)) AS j`) hoist the USING columns to the
+            // front under SQLite semantics (#4916). Static expansion does not
+            // model that reordering, so fall back to legacy naming.
+            if alias.is_some() && (*natural || using_columns.is_some()) {
                 return None;
             }
+
             let mut sources = collect_from_sources(left, database, prior_ctes)?;
-            sources.extend(collect_from_sources(right, database, prior_ctes)?);
+            let mut right_sources = collect_from_sources(right, database, prior_ctes)?;
+
+            // NATURAL/USING joins deduplicate the shared columns out of
+            // plain-`*` expansion: ALL left columns stay in declaration order
+            // (join columns are NOT hoisted to the front), then the right
+            // columns minus the shared ones. This mirrors the runtime
+            // expansion in `select/projection.rs` (issue #4916 ordering).
+            if *natural || using_columns.is_some() {
+                let shared: Vec<String> = if let Some(using) = using_columns {
+                    using.clone()
+                } else {
+                    // NATURAL: case-insensitive intersection of the left
+                    // operand's star-visible names with the right operand's
+                    // star-visible names. Using star-visible (already
+                    // deduplicated) names makes chained NATURAL joins compute
+                    // each join's shared set against the accumulated output.
+                    let left_visible: Vec<&str> = sources
+                        .iter()
+                        .flat_map(|s| s.columns.iter())
+                        .filter(|c| !c.hidden_for_star)
+                        .map(|c| c.name.as_str())
+                        .collect();
+                    right_sources
+                        .iter()
+                        .flat_map(|s| s.columns.iter())
+                        .filter(|c| !c.hidden_for_star)
+                        .filter(|c| left_visible.iter().any(|l| l.eq_ignore_ascii_case(&c.name)))
+                        .map(|c| c.name.clone())
+                        .collect()
+                };
+
+                // Hide the shared columns on the right side only; they remain
+                // resolvable through qualified wildcards (`b.*`).
+                for source in &mut right_sources {
+                    for col in &mut source.columns {
+                        if shared.iter().any(|s| s.eq_ignore_ascii_case(&col.name)) {
+                            col.hidden_for_star = true;
+                        }
+                    }
+                }
+            }
+
+            sources.extend(right_sources);
             Some(sources)
         }
         vibesql_ast::FromClause::Subquery { query, alias, column_aliases } => {
@@ -339,7 +408,10 @@ fn collect_from_sources(
             } else {
                 collect_select_list_columns(query, database, prior_ctes)?
             };
-            Some(vec![WildcardSource { qualifier: alias.clone(), columns }])
+            Some(vec![WildcardSource {
+                qualifier: alias.clone(),
+                columns: visible_columns(columns),
+            }])
         }
         vibesql_ast::FromClause::Values { rows, alias, column_aliases } => {
             let columns = if let Some(aliases) = column_aliases {
@@ -348,7 +420,10 @@ fn collect_from_sources(
                 let first_row = rows.first()?;
                 (0..first_row.len()).map(|i| format!("col{}", i)).collect()
             };
-            Some(vec![WildcardSource { qualifier: alias.clone(), columns }])
+            Some(vec![WildcardSource {
+                qualifier: alias.clone(),
+                columns: visible_columns(columns),
+            }])
         }
     }
 }

--- a/crates/vibesql-executor/tests/cte_wildcard_schema_tests.rs
+++ b/crates/vibesql-executor/tests/cte_wildcard_schema_tests.rs
@@ -182,3 +182,218 @@ fn test_explicit_column_list_still_works() {
     let rows = query(&db, "WITH c(x, y) AS (SELECT * FROM map) SELECT y FROM c WHERE x = 6");
     assert_eq!(rows, vec![vec![odd_even(6)]]);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #5303: NATURAL/USING join wildcard CTE schema expansion
+//
+// `WITH c AS (SELECT * FROM t1 NATURAL JOIN t2)` used to fall back to the
+// legacy one-column-per-SELECT-item naming (a single `col0`), silently
+// dropping the remaining columns. The static expansion now deduplicates the
+// shared columns exactly like the runtime: ALL left columns in declaration
+// order (join columns are NOT hoisted), then right columns minus shared.
+// All expected outputs below verified against sqlite3.
+// ---------------------------------------------------------------------------
+
+fn s(v: &str) -> SqlValue {
+    SqlValue::Varchar(arcstr::ArcStr::from(v))
+}
+
+/// Tables from the issue reproduction plus ordering/chaining fixtures
+fn setup_join_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1(id INTEGER, v1 TEXT)");
+    run_stmt(&mut db, "CREATE TABLE t2(id INTEGER, v2 TEXT)");
+    run_stmt(&mut db, "INSERT INTO t1 VALUES (1,'a'),(2,'c')");
+    run_stmt(&mut db, "INSERT INTO t2 VALUES (1,'b')");
+    // Ordering fixture: join column `k` is NOT first in the left table
+    run_stmt(&mut db, "CREATE TABLE ta(x INTEGER, k INTEGER, y TEXT)");
+    run_stmt(&mut db, "CREATE TABLE tb(k INTEGER, z TEXT, w INTEGER)");
+    run_stmt(&mut db, "CREATE TABLE tc(z TEXT, q INTEGER)");
+    run_stmt(&mut db, "INSERT INTO ta VALUES (10, 1, 'ay')");
+    run_stmt(&mut db, "INSERT INTO tb VALUES (1, 'bz', 20)");
+    run_stmt(&mut db, "INSERT INTO tc VALUES ('bz', 30)");
+    db
+}
+
+#[test]
+fn test_natural_join_cte_star_returns_all_columns() {
+    // Issue reproduction: previously returned a single col0 column
+    let db = setup_join_db();
+    let rows = query(&db, "WITH c AS (SELECT * FROM t1 NATURAL JOIN t2) SELECT * FROM c");
+    // sqlite3: id, v1, v2 -> 1, a, b
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1), s("a"), s("b")]]);
+}
+
+#[test]
+fn test_natural_join_cte_named_column_select() {
+    // Previously: Error: Column 'v2' not found ... Available columns: col0
+    let db = setup_join_db();
+    let rows = query(&db, "WITH c AS (SELECT * FROM t1 NATURAL JOIN t2) SELECT v2, id FROM c");
+    assert_eq!(rows, vec![vec![s("b"), SqlValue::Integer(1)]]);
+}
+
+#[test]
+fn test_using_join_cte() {
+    let db = setup_join_db();
+    let rows = query(&db, "WITH c AS (SELECT * FROM t1 JOIN t2 USING (id)) SELECT * FROM c");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1), s("a"), s("b")]]);
+    let rows = query(&db, "WITH c AS (SELECT * FROM t1 JOIN t2 USING (id)) SELECT v2, id FROM c");
+    assert_eq!(rows, vec![vec![s("b"), SqlValue::Integer(1)]]);
+}
+
+#[test]
+fn test_natural_left_join_cte() {
+    // Naming/ordering is join-type agnostic; unmatched right side is NULL
+    let db = setup_join_db();
+    let rows = query(
+        &db,
+        "WITH c AS (SELECT * FROM t1 NATURAL LEFT JOIN t2) \
+         SELECT id, v1, v2 FROM c ORDER BY id",
+    );
+    assert_eq!(
+        rows,
+        vec![
+            vec![SqlValue::Integer(1), s("a"), s("b")],
+            vec![SqlValue::Integer(2), s("c"), SqlValue::Null],
+        ]
+    );
+}
+
+#[test]
+fn test_natural_join_cte_column_ordering_no_hoisting() {
+    // sqlite3-verified: a(x,k,y) NATURAL JOIN b(k,z,w) -> x, k, y, z, w.
+    // The join column stays at its left-table position (NOT hoisted front).
+    let db = setup_join_db();
+    let rows = query(&db, "WITH c AS (SELECT * FROM ta NATURAL JOIN tb) SELECT * FROM c");
+    assert_eq!(
+        rows,
+        vec![vec![
+            SqlValue::Integer(10),
+            SqlValue::Integer(1),
+            s("ay"),
+            s("bz"),
+            SqlValue::Integer(20),
+        ]]
+    );
+    // Names map to the right positions
+    let rows = query(&db, "WITH c AS (SELECT * FROM ta NATURAL JOIN tb) SELECT w, x, k FROM c");
+    assert_eq!(
+        rows,
+        vec![vec![SqlValue::Integer(20), SqlValue::Integer(10), SqlValue::Integer(1)]]
+    );
+}
+
+#[test]
+fn test_qualified_wildcard_over_natural_join_in_cte() {
+    // sqlite3-verified: SELECT tb.* keeps ALL of tb's columns including the
+    // join column (dedup applies only to plain `*`)
+    let db = setup_join_db();
+    let rows = query(&db, "WITH c AS (SELECT tb.* FROM ta NATURAL JOIN tb) SELECT * FROM c");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1), s("bz"), SqlValue::Integer(20)]]);
+    let rows = query(&db, "WITH c AS (SELECT tb.* FROM ta NATURAL JOIN tb) SELECT z, k FROM c");
+    assert_eq!(rows, vec![vec![s("bz"), SqlValue::Integer(1)]]);
+}
+
+#[test]
+fn test_multi_column_using_join_cte() {
+    let mut db = setup_join_db();
+    run_stmt(&mut db, "CREATE TABLE tm1(k1 INTEGER, k2 INTEGER, p TEXT)");
+    run_stmt(&mut db, "CREATE TABLE tm2(k1 INTEGER, k2 INTEGER, q TEXT)");
+    run_stmt(&mut db, "INSERT INTO tm1 VALUES (1,2,'p1')");
+    run_stmt(&mut db, "INSERT INTO tm2 VALUES (1,2,'q1')");
+    let rows = query(&db, "WITH c AS (SELECT * FROM tm1 JOIN tm2 USING (k1, k2)) SELECT * FROM c");
+    // sqlite3: k1, k2, p, q
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1), SqlValue::Integer(2), s("p1"), s("q1")]]);
+    let rows =
+        query(&db, "WITH c AS (SELECT * FROM tm1 JOIN tm2 USING (k1, k2)) SELECT q, k2 FROM c");
+    assert_eq!(rows, vec![vec![s("q1"), SqlValue::Integer(2)]]);
+}
+
+#[test]
+fn test_chained_natural_joins_cte() {
+    // sqlite3-verified: ta NATURAL JOIN tb NATURAL JOIN tc -> x, k, y, z, w, q.
+    // The second join's shared set (z) is computed against the accumulated
+    // already-deduplicated visible columns of the first join.
+    let db = setup_join_db();
+    let rows =
+        query(&db, "WITH c AS (SELECT * FROM ta NATURAL JOIN tb NATURAL JOIN tc) SELECT * FROM c");
+    assert_eq!(
+        rows,
+        vec![vec![
+            SqlValue::Integer(10),
+            SqlValue::Integer(1),
+            s("ay"),
+            s("bz"),
+            SqlValue::Integer(20),
+            SqlValue::Integer(30),
+        ]]
+    );
+    let rows = query(
+        &db,
+        "WITH c AS (SELECT * FROM ta NATURAL JOIN tb NATURAL JOIN tc) SELECT q, z FROM c",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(30), s("bz")]]);
+}
+
+#[test]
+fn test_empty_result_natural_join_cte_exposes_names() {
+    // With no rows the width sanity check is skipped; the statically expanded
+    // names are the only source and must still resolve
+    let db = setup_join_db();
+    let rows =
+        query(&db, "WITH c AS (SELECT * FROM t1 NATURAL JOIN t2 WHERE id > 100) SELECT v2 FROM c");
+    assert!(rows.is_empty(), "expected empty result, got {:?}", rows);
+}
+
+#[test]
+fn test_subquery_in_cte_over_natural_join() {
+    // NATURAL join nested inside a derived table within a CTE body
+    let db = setup_join_db();
+    let rows = query(
+        &db,
+        "WITH c AS (SELECT * FROM (SELECT * FROM t1 NATURAL JOIN t2) s) \
+         SELECT v2, id FROM c",
+    );
+    assert_eq!(rows, vec![vec![s("b"), SqlValue::Integer(1)]]);
+}
+
+#[test]
+fn test_case_insensitive_natural_join_cte() {
+    // NATURAL join matching is case-insensitive (ID vs id)
+    let mut db = setup_join_db();
+    run_stmt(&mut db, "CREATE TABLE tu(ID INTEGER, p TEXT)");
+    run_stmt(&mut db, "CREATE TABLE tl(id INTEGER, q TEXT)");
+    run_stmt(&mut db, "INSERT INTO tu VALUES (7,'pu')");
+    run_stmt(&mut db, "INSERT INTO tl VALUES (7,'ql')");
+    let rows = query(&db, "WITH c AS (SELECT * FROM tu NATURAL JOIN tl) SELECT * FROM c");
+    // sqlite3: ID, p, q -> 7, pu, ql
+    assert_eq!(rows, vec![vec![SqlValue::Integer(7), s("pu"), s("ql")]]);
+    let rows = query(&db, "WITH c AS (SELECT * FROM tu NATURAL JOIN tl) SELECT q, p FROM c");
+    assert_eq!(rows, vec![vec![s("ql"), s("pu")]]);
+}
+
+#[test]
+fn test_explicit_column_list_over_natural_join_cte() {
+    // Explicit column list: the width check at the top of derive_cte_schema
+    // must pass with the deduplicated 3-value rows
+    let db = setup_join_db();
+    let rows = query(
+        &db,
+        "WITH c(a1, b1, c1) AS (SELECT * FROM t1 NATURAL JOIN t2) \
+         SELECT b1, c1 FROM c WHERE a1 = 1",
+    );
+    assert_eq!(rows, vec![vec![s("a"), s("b")]]);
+}
+
+#[test]
+fn test_aliased_parenthesized_using_join_cte_falls_back() {
+    // Documented non-goal (#4916): aliased parenthesized NATURAL/USING joins
+    // may hoist USING columns first, so static expansion bails to the legacy
+    // fallback. The query must still execute without error.
+    let db = setup_join_db();
+    let rows = query(&db, "WITH c AS (SELECT * FROM (t1 JOIN t2 USING (id)) AS j) SELECT * FROM c");
+    assert_eq!(rows.len(), 1, "expected one row, got {:?}", rows);
+    // Legacy fallback exposes at least the first column; do not assert the
+    // (known-lossy) column count here
+    assert_eq!(rows[0][0], SqlValue::Integer(1));
+}


### PR DESCRIPTION
## Summary

`WITH c AS (SELECT * FROM t1 NATURAL JOIN t2) SELECT * FROM c` previously exposed a single `col0` column and silently dropped the remaining columns, because the static wildcard expansion added in #5300 bailed out to legacy naming for NATURAL/USING joins. This PR implements NATURAL/USING-aware dedup in `collect_from_sources`, mirroring the runtime expansion semantics in `select/projection.rs` (all expectations verified against sqlite3).

## Changes

- Extended `WildcardSource` with per-column star visibility (`WildcardColumn { name, hidden_for_star }`): right-side NATURAL/USING join columns are marked hidden rather than dropped, so qualified wildcards (`b.*`) still see ALL of the source's columns including the join column.
- `FromClause::Join` arm: computes the shared set (USING list, or case-insensitive intersection of star-visible names for NATURAL) and hides matching right-side columns. Left columns stay untouched in declaration order — join columns are NOT hoisted to the front (`a(x,k,y) NATURAL JOIN b(k,z,w)` → `x,k,y,z,w`).
- Chained NATURAL joins recurse naturally: each join's shared set is computed against the left operand's already-deduplicated star-visible columns.
- Aliased parenthesized NATURAL/USING joins (`(...) AS j`) keep the legacy `None` fallback, documented as a non-goal, since SQLite hoists USING columns first for that shape (#4916).
- Plain-`*` expansion in `expand_wildcard_names` now filters out `hidden_for_star` columns; qualified-wildcard resolution keeps the complete column list.
- Added 13 tests to `cte_wildcard_schema_tests.rs` covering all acceptance criteria.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `WITH c AS (SELECT * FROM t1 NATURAL JOIN t2) SELECT * FROM c` returns 3 named columns | ✅ | `test_natural_join_cte_star_returns_all_columns` + CLI repro returns `id, v1, v2` = `1, a, b` |
| Same for `JOIN ... USING (id)` and `NATURAL LEFT JOIN` | ✅ | `test_using_join_cte`, `test_natural_left_join_cte` |
| `SELECT v2, id FROM c` works | ✅ | `test_natural_join_cte_named_column_select` + CLI repro |
| `a(x,k,y) NATURAL JOIN b(k,z,w)` yields exactly `x, k, y, z, w` | ✅ | `test_natural_join_cte_column_ordering_no_hoisting` (sqlite3-verified values) |
| Qualified wildcard `b.*` yields `k, z, w` | ✅ | `test_qualified_wildcard_over_natural_join_in_cte` |
| Multi-column `USING (k1, k2)` dedups both | ✅ | `test_multi_column_using_join_cte` |
| Chained NATURAL joins dedup against accumulated visible columns | ✅ | `test_chained_natural_joins_cte` (`x,k,y,z,w,q`, sqlite3-verified) |
| Empty-result CTE still exposes expanded names | ✅ | `test_empty_result_natural_join_cte_exposes_names` |
| Aliased parenthesized join falls back to legacy naming (non-goal) | ✅ | `test_aliased_parenthesized_using_join_cte_falls_back` |
| Case-insensitive matching (`ID` vs `id`) | ✅ | `test_case_insensitive_natural_join_cte` |
| Explicit column list `WITH c(a,b,c) AS (...)` width check passes | ✅ | `test_explicit_column_list_over_natural_join_cte` |
| Existing wildcard tests pass; no TCL regression | ✅ | All 23 tests in `cte_wildcard_schema_tests.rs` pass; with2/3/4/5 + window8 TCL results identical to origin/main baseline (rebuilt main's `cte.rs` and diffed summaries) |

## Test Plan

- `cargo test -p vibesql-executor --test cte_wildcard_schema_tests`: 23/23 pass (10 existing + 13 new)
- `cargo test -p vibesql-executor --lib`: 2525 pass, 0 fail
- `cargo check` / `cargo clippy -p vibesql-executor`: clean (only pre-existing warnings in unrelated files)
- Manual CLI verification of the issue repro, diffed against `sqlite3`
- TCL regression: with2/3/4/5 + window8 pass/fail counts identical to origin/main baseline (failures there are pre-existing recursive-CTE gaps, untouched by this change; window8: 0 failed)

Closes #5303