### PR TITLE
fix(window): match SQLite last-pass row order and sort GROUP BY output by key

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/aggregate/group_by.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/group_by.rs
@@ -688,7 +688,31 @@ pub fn columnar_group_by(
         }
     }
 
+    // Sort by group key for deterministic ordering (SQLite compatibility).
+    // AHashMap iteration order is randomized per process; the row-based path
+    // (select/grouping/hash.rs) already sorts by the GROUP BY columns, so the
+    // columnar path must match (issue #5291, windowpushd.test 2.x.4.1).
+    sort_rows_by_group_key_prefix(&mut result_rows, group_cols.len());
+
     Ok(result_rows)
+}
+
+/// Sort GROUP BY result rows by their leading group-key columns.
+///
+/// SQLite returns GROUP BY results sorted by the GROUP BY columns (in the
+/// absence of an explicit ORDER BY). Result rows are laid out as
+/// (group_key_cols..., aggregate_cols...), so comparing the first
+/// `group_key_len` values matches the comparator used by the row-based
+/// grouping path in `select/grouping/hash.rs`.
+fn sort_rows_by_group_key_prefix(rows: &mut [Row], group_key_len: usize) {
+    if group_key_len == 0 {
+        return;
+    }
+    rows.sort_by(|a, b| {
+        let a_key = &a.values[..group_key_len.min(a.values.len())];
+        let b_key = &b.values[..group_key_len.min(b.values.len())];
+        a_key.cmp(b_key)
+    });
 }
 
 /// Compute aggregates with GROUP BY using SIMD-accelerated columnar execution
@@ -770,6 +794,10 @@ pub fn columnar_group_by_batch(
 
         result_rows.push(Row::new(result_values));
     }
+
+    // Sort by group key for deterministic ordering (SQLite compatibility).
+    // See sort_rows_by_group_key_prefix and issue #5291.
+    sort_rows_by_group_key_prefix(&mut result_rows, group_cols.len());
 
     Ok(result_rows)
 }
@@ -889,5 +917,136 @@ mod batch_tests {
 
         let result = columnar_group_by_batch(&batch, &group_cols, &agg_cols).unwrap();
         assert_eq!(result.len(), 0);
+    }
+
+    /// Rows with enough distinct group keys to expose hash-iteration-order
+    /// nondeterminism (issue #5291). Keys inserted in non-sorted order.
+    fn make_unsorted_key_rows() -> Vec<Row> {
+        let keys = ["W", "Z", "Q", "A", "M", "X", "B", "Y", "K", "C"];
+        let mut rows = Vec::new();
+        for (i, key) in keys.iter().enumerate() {
+            // Two rows per group
+            rows.push(Row::new(vec![
+                SqlValue::Varchar(arcstr::ArcStr::from(*key)),
+                SqlValue::Integer(i as i64),
+            ]));
+            rows.push(Row::new(vec![
+                SqlValue::Varchar(arcstr::ArcStr::from(*key)),
+                SqlValue::Integer((i * 10) as i64),
+            ]));
+        }
+        rows
+    }
+
+    fn assert_sorted_by_first_col(result: &[Row]) {
+        for pair in result.windows(2) {
+            assert!(
+                pair[0].values[0] <= pair[1].values[0],
+                "result not sorted by group key: {:?} > {:?}",
+                pair[0].values[0],
+                pair[1].values[0]
+            );
+        }
+    }
+
+    /// Issue #5291: columnar_group_by must emit rows sorted by group key,
+    /// deterministically across repeated invocations (AHashMap iteration
+    /// order is randomized per map instance).
+    #[test]
+    fn test_columnar_group_by_deterministic_key_order() {
+        let rows = make_unsorted_key_rows();
+        let group_cols = vec![0];
+        let agg_cols = vec![(1, AggregateOp::Sum)];
+
+        let first = columnar_group_by(&rows, &group_cols, &agg_cols, None).unwrap();
+        assert_eq!(first.len(), 10);
+        assert_sorted_by_first_col(&first);
+
+        for run in 0..10 {
+            let again = columnar_group_by(&rows, &group_cols, &agg_cols, None).unwrap();
+            assert_eq!(
+                again.iter().map(|r| r.values.to_vec()).collect::<Vec<_>>(),
+                first.iter().map(|r| r.values.to_vec()).collect::<Vec<_>>(),
+                "run {} produced different row order",
+                run
+            );
+        }
+    }
+
+    /// Issue #5291: same determinism guarantee for the SIMD batch path.
+    #[test]
+    fn test_columnar_group_by_batch_deterministic_key_order() {
+        let rows = make_unsorted_key_rows();
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+        let group_cols = vec![0];
+        let agg_cols = vec![(1, AggregateOp::Sum)];
+
+        let first = columnar_group_by_batch(&batch, &group_cols, &agg_cols).unwrap();
+        assert_eq!(first.len(), 10);
+        assert_sorted_by_first_col(&first);
+
+        for run in 0..10 {
+            let again = columnar_group_by_batch(&batch, &group_cols, &agg_cols).unwrap();
+            assert_eq!(
+                again.iter().map(|r| r.values.to_vec()).collect::<Vec<_>>(),
+                first.iter().map(|r| r.values.to_vec()).collect::<Vec<_>>(),
+                "run {} produced different row order",
+                run
+            );
+        }
+    }
+
+    /// Multi-column group keys sort lexicographically by the full key prefix.
+    #[test]
+    fn test_columnar_group_by_multi_key_order() {
+        let rows = vec![
+            Row::new(vec![
+                SqlValue::Varchar(arcstr::ArcStr::from("B")),
+                SqlValue::Integer(2),
+                SqlValue::Integer(1),
+            ]),
+            Row::new(vec![
+                SqlValue::Varchar(arcstr::ArcStr::from("A")),
+                SqlValue::Integer(2),
+                SqlValue::Integer(2),
+            ]),
+            Row::new(vec![
+                SqlValue::Varchar(arcstr::ArcStr::from("B")),
+                SqlValue::Integer(1),
+                SqlValue::Integer(3),
+            ]),
+            Row::new(vec![
+                SqlValue::Varchar(arcstr::ArcStr::from("A")),
+                SqlValue::Integer(1),
+                SqlValue::Integer(4),
+            ]),
+        ];
+        let group_cols = vec![0, 1];
+        let agg_cols = vec![(2, AggregateOp::Sum)];
+
+        let result = columnar_group_by(&rows, &group_cols, &agg_cols, None).unwrap();
+        let keys: Vec<(String, i64)> = result
+            .iter()
+            .map(|r| {
+                let s = match &r.values[0] {
+                    SqlValue::Varchar(s) => s.to_string(),
+                    other => panic!("unexpected key type: {:?}", other),
+                };
+                let n = match &r.values[1] {
+                    SqlValue::Integer(n) => *n,
+                    other => panic!("unexpected key type: {:?}", other),
+                };
+                (s, n)
+            })
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                ("A".to_string(), 1),
+                ("A".to_string(), 2),
+                ("B".to_string(), 1),
+                ("B".to_string(), 2),
+            ]
+        );
     }
 }

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -558,6 +558,14 @@ pub(super) fn apply_window_functions_to_aggregates(
     );
     let evaluator = CombinedExpressionEvaluator::with_database(&result_schema, database);
 
+    // Track row reordering from the last window function with PARTITION BY/ORDER BY.
+    // SQLite leaves rows in the order of the last window sort pass when there is
+    // no statement-level ORDER BY; mirror the non-aggregate path in
+    // select/window/mod.rs (issue #5291, windowpushd.test 2.x.4.1).
+    // Indices refer to positions in `rows`, which stay stable across the loop
+    // below (values are updated in place; rows are never reordered mid-loop).
+    let mut row_reordering: Option<Vec<usize>> = None;
+
     // Process each window function
     for win_func in &window_funcs {
         // Validate frame specification (checks for non-negative offsets, etc.)
@@ -626,6 +634,18 @@ pub(super) fn apply_window_functions_to_aggregates(
                 evaluator.eval(expr, row).map_err(|e| format!("{:?}", e))
             };
             sort_partition(partition, &order_by_ref, sort_eval_fn);
+        }
+
+        // Capture the window order (partition order, then ORDER BY within each
+        // partition) of the last window function that has PARTITION BY or
+        // ORDER BY. `partition_rows` orders partitions by key (BTreeMap), so
+        // concatenating original_indices yields SQLite's last-pass row order.
+        let has_partition_by =
+            win_func.window_spec.partition_by.as_ref().is_some_and(|p| !p.is_empty());
+        let has_order_by = win_func.window_spec.order_by.as_ref().is_some_and(|o| !o.is_empty());
+        if has_partition_by || has_order_by {
+            row_reordering =
+                Some(partitions.iter().flat_map(|p| p.original_indices.iter().copied()).collect());
         }
 
         // Compute window function values for each partition
@@ -993,6 +1013,13 @@ pub(super) fn apply_window_functions_to_aggregates(
             let value = evaluator.eval(&rewrite.residual, row)?;
             row.values[rewrite.select_index] = value;
         }
+    }
+
+    // Reorder output rows into the last window pass's order (see comment at
+    // `row_reordering` above). A statement-level ORDER BY, if present, is
+    // applied downstream and overrides this order.
+    if let Some(order) = row_reordering {
+        rows = order.into_iter().map(|idx| rows[idx].clone()).collect();
     }
 
     Ok(rows)

--- a/crates/vibesql-executor/src/select/window/mod.rs
+++ b/crates/vibesql-executor/src/select/window/mod.rs
@@ -83,15 +83,26 @@ pub(super) fn evaluate_window_functions(
     // Track the column index where window function results start
     let base_column_count = if rows.is_empty() { 0 } else { rows[0].values.len() };
 
-    // Track row reordering from the first window function with PARTITION BY
+    // Track row reordering from the last window function with PARTITION BY/ORDER BY.
+    //
+    // SQLite rewrites multi-window queries into nested sorting passes; when there
+    // is no statement-level ORDER BY, rows are left in the order produced by the
+    // *last* window's sort pass. We mirror that by overwriting the captured order
+    // for each window function that has one (issue #5291, window9.test 1.4).
+    //
+    // Known limitation: each pass's order is computed from the *original* input
+    // order, whereas SQLite's chained passes stable-sort over the previous pass's
+    // output. These differ only when the last window's (PARTITION BY, ORDER BY)
+    // keys have ties. If a future test demands exact tie behavior, reorder `rows`
+    // (plus previously computed window columns) sequentially after each pass.
     let mut row_reordering: Option<Vec<usize>> = None;
 
     for (idx, win_func) in window_functions.iter().enumerate() {
         let result = evaluation::evaluate_single_window_function(&rows, win_func, evaluator)?;
         window_results.push(result.values);
 
-        // Capture row reordering from the first window function that has PARTITION BY
-        if row_reordering.is_none() {
+        // Capture row reordering from the last window function that has one
+        if result.partition_order.is_some() {
             row_reordering = result.partition_order;
         }
 

--- a/crates/vibesql-executor/tests/window_pass_order_tests.rs
+++ b/crates/vibesql-executor/tests/window_pass_order_tests.rs
@@ -1,0 +1,207 @@
+//! Regression tests for issue #5291 (window9.test 1.4, windowpushd.test 2.x.4.1)
+//!
+//! SQLite rewrites multi-window queries into nested sorting passes; when there
+//! is no statement-level ORDER BY, output rows are left in the order produced
+//! by the *last* window's sort pass. Plain GROUP BY output (without ORDER BY)
+//! is emitted in group-key order.
+//!
+//! Covers three fixes:
+//!
+//! 1. `select/window/mod.rs`: capture row reordering from the *last* window function with PARTITION
+//!    BY/ORDER BY, not the first (window9 1.4).
+//! 2. `select/executor/aggregation/window.rs`: the window-over-GROUP-BY path reorders output rows
+//!    into the last window pass's partition order (windowpushd 2.x.4.1, windowed instance).
+//! 3. `select/columnar/aggregate/group_by.rs`: columnar GROUP BY output is sorted by group key
+//!    instead of AHashMap iteration order (windowpushd 2.x.4.1, plain instance — previously
+//!    nondeterministic per process).
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+/// Run a SELECT and return each row as a vector of display strings
+/// (SQLite-style formatting), making assertions independent of the exact
+/// numeric SqlValue variant.
+fn query_strings(db: &vibesql_storage::Database, sql: &str) -> Vec<Vec<String>> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e))
+            .into_iter()
+            .map(|row| row.values.iter().map(|v: &SqlValue| v.to_string()).collect())
+            .collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+fn rows(expected: &[&[&str]]) -> Vec<Vec<String>> {
+    expected.iter().map(|r| r.iter().map(|s| s.to_string()).collect()).collect()
+}
+
+/// window9.test 1.0/1.1 fixture
+fn setup_fruits_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE fruits(name TEXT COLLATE NOCASE, color TEXT COLLATE NOCASE)");
+    run_stmt(&mut db, "INSERT INTO fruits (name, color) VALUES ('apple', 'RED')");
+    run_stmt(&mut db, "INSERT INTO fruits (name, color) VALUES ('APPLE', 'yellow')");
+    run_stmt(&mut db, "INSERT INTO fruits (name, color) VALUES ('pear', 'YELLOW')");
+    run_stmt(&mut db, "INSERT INTO fruits (name, color) VALUES ('PEAR', 'green')");
+    db
+}
+
+/// windowpushd.test 2.0 t2 fixture
+fn setup_t2_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t2(x, y, z)");
+    run_stmt(
+        &mut db,
+        "INSERT INTO t2 VALUES('W', 3, 1), ('W', 2, 2), ('X', 1, 4), ('X', 5, 7), \
+         ('Y', 1, 9), ('Y', 4, 2), ('Z', 3, 3), ('Z', 3, 4)",
+    );
+    db
+}
+
+#[test]
+fn test_multi_window_rows_left_in_last_pass_order() {
+    // window9.test 1.4: with two windows and no statement-level ORDER BY,
+    // rows come out in the LAST window's sort pass order
+    // (PARTITION BY name ORDER BY color, both NOCASE).
+    let db = setup_fruits_db();
+    let result = query_strings(
+        &db,
+        "SELECT name, color, \
+           dense_rank() OVER (ORDER BY name), \
+           dense_rank() OVER (PARTITION BY name ORDER BY color) \
+         FROM fruits",
+    );
+    assert_eq!(
+        result,
+        rows(&[
+            &["apple", "RED", "1", "1"],
+            &["APPLE", "yellow", "1", "2"],
+            &["PEAR", "green", "2", "1"],
+            &["pear", "YELLOW", "2", "2"],
+        ])
+    );
+}
+
+#[test]
+fn test_statement_order_by_overrides_window_pass_order() {
+    // window9.test 1.5: an explicit statement-level ORDER BY still wins.
+    let db = setup_fruits_db();
+    let result = query_strings(
+        &db,
+        "SELECT name, color, \
+           dense_rank() OVER (ORDER BY name), \
+           dense_rank() OVER (PARTITION BY name ORDER BY color) \
+         FROM fruits ORDER BY color",
+    );
+    assert_eq!(
+        result,
+        rows(&[
+            &["PEAR", "green", "2", "1"],
+            &["apple", "RED", "1", "1"],
+            &["APPLE", "yellow", "1", "2"],
+            &["pear", "YELLOW", "2", "2"],
+        ])
+    );
+}
+
+#[test]
+fn test_single_window_order_unchanged() {
+    // window9.test 1.3: single-window behavior is unchanged by the
+    // last-pass capture (it is both the first and last pass).
+    let db = setup_fruits_db();
+    let result = query_strings(
+        &db,
+        "SELECT name, color, dense_rank() OVER (PARTITION BY name ORDER BY color) FROM fruits",
+    );
+    assert_eq!(
+        result,
+        rows(&[
+            &["apple", "RED", "1"],
+            &["APPLE", "yellow", "2"],
+            &["PEAR", "green", "1"],
+            &["pear", "YELLOW", "2"],
+        ])
+    );
+}
+
+#[test]
+fn test_plain_group_by_emits_group_key_order() {
+    // windowpushd.test 2.x.4.1 (plain instance): GROUP BY output without
+    // ORDER BY comes out sorted by the group key. Run several times to catch
+    // hash-iteration-order nondeterminism (AHashMap seeds vary per instance).
+    let db = setup_t2_db();
+    let expected = rows(&[&["W", "5", "2"], &["X", "6", "7"], &["Y", "5", "9"], &["Z", "6", "4"]]);
+    for run in 0..5 {
+        let result = query_strings(
+            &db,
+            "SELECT * FROM (SELECT x, sum(y) AS s, max(z) AS m FROM t2 GROUP BY x)",
+        );
+        assert_eq!(result, expected, "run {} produced wrong order", run);
+    }
+}
+
+#[test]
+fn test_window_over_group_by_rows_left_in_window_pass_order() {
+    // windowpushd.test 2.x.4.1 (windowed instance): the window pass over the
+    // GROUP BY result leaves rows in partition order (PARTITION BY sum(y):
+    // 5 -> [W, Y], 6 -> [X, Z]).
+    let db = setup_t2_db();
+    let expected = rows(&[
+        &["W", "5", "2", "9"],
+        &["Y", "5", "9", "9"],
+        &["X", "6", "7", "7"],
+        &["Z", "6", "4", "7"],
+    ]);
+    for run in 0..5 {
+        let result = query_strings(
+            &db,
+            "SELECT * FROM (\
+               SELECT x, sum(y) AS s, max(z) AS m, \
+                 max( max(z) ) OVER (PARTITION BY sum(y) \
+                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) \
+               FROM t2 GROUP BY x)",
+        );
+        assert_eq!(result, expected, "run {} produced wrong order", run);
+    }
+}
+
+#[test]
+fn test_window_over_group_by_with_order_by_overrides() {
+    // windowpushd.test 2.x.4.2-style: statement-level ORDER BY overrides the
+    // window pass order on the aggregation path too.
+    let db = setup_t2_db();
+    let result = query_strings(
+        &db,
+        "SELECT x, sum(y) AS s, max(z) AS m, \
+           max( max(z) ) OVER (PARTITION BY sum(y) \
+             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) \
+         FROM t2 GROUP BY x ORDER BY x",
+    );
+    assert_eq!(
+        result,
+        rows(&[
+            &["W", "5", "2", "9"],
+            &["X", "6", "7", "7"],
+            &["Y", "5", "9", "9"],
+            &["Z", "6", "4", "7"],
+        ])
+    );
+}


### PR DESCRIPTION
## Summary

Fixes three distinct row-ordering defects identified by the curator on #5291 (window9.test 1.4, windowpushd.test 2.x.4.1):

1. **Multi-window last-pass order** (`select/window/mod.rs`): row reordering was captured from the *first* window function with PARTITION BY; SQLite leaves rows in the order of the *last* window sort pass when there is no statement-level ORDER BY. The captured order is now overwritten per pass.
2. **Window-over-GROUP-BY never reordered** (`select/executor/aggregation/window.rs`): the post-aggregation window path wrote values in place and left rows in group order. It now captures the last window pass's partition order (concatenated `original_indices` of the BTreeMap-ordered, sorted partitions) and reorders the output rows before returning. Statement-level ORDER BY is applied downstream and still overrides.
3. **Nondeterministic columnar GROUP BY** (`select/columnar/aggregate/group_by.rs`): `columnar_group_by` and `columnar_group_by_batch` emitted rows in AHashMap iteration order (randomized per map instance — output order varied across runs of the same query). Both now sort by the group-key prefix, matching the row-based path's comparator in `select/grouping/hash.rs`.

Known limitation (documented in code, per curator decision): the last-pass order is computed from the original input order rather than chaining stable sorts over the previous pass's output; these differ only when the last window's (PARTITION BY, ORDER BY) keys have ties. window9 5.1.1 and windowpushd 2.1.1.x EQP tests are pre-existing failures out of scope (#5292's territory).

## Changes

- `crates/vibesql-executor/src/select/window/mod.rs` — capture last (not first) window pass's `partition_order`
- `crates/vibesql-executor/src/select/executor/aggregation/window.rs` — reorder aggregate-window output rows into last window pass order
- `crates/vibesql-executor/src/select/columnar/aggregate/group_by.rs` — sort columnar GROUP BY output by group-key prefix (both scalar and SIMD batch paths) + determinism unit tests
- `crates/vibesql-executor/tests/window_pass_order_tests.rs` — new regression tests (window9 1.3/1.4/1.5 and windowpushd 2.x.4.1 reproducers, plus ORDER-BY-override cases)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| window9 1.4 passes | PASS | `./scripts/tcltest test window9.test`: 37 passed, only pre-existing 5.1.1 (EQP, out of scope) fails |
| windowpushd 2.0.4.1 / 2.1.4.1 pass deterministically | PASS | `./scripts/tcltest test windowpushd.test` run 3x consecutively: 29/29 each run |
| No regression window1-9, windowA-E | PASS | window1-8 + windowA-E all 0 failures (window5/6 have no applicable tests) |
| No regression in Priority 1 sweep | PASS | Full P1 sweep run on this branch AND on an origin/main baseline binary built in the same worktree: both 23064 passed / 150 failed, and the per-test failure sets are **byte-identical** (`diff` of extracted (file, test) pairs is empty). The 150 baseline failures (select3 env issue, join9, where, etc.) are pre-existing |
| Unit tests for last-pass ordering and deterministic columnar GROUP BY | PASS | 6 new integration tests in `window_pass_order_tests.rs`; 3 new unit tests in `group_by.rs::batch_tests` including repeated-invocation determinism checks (10 runs each) |
| `cargo test -p vibesql-executor` passes | PASS | lib: 2530 passed / 0 failed; all integration test binaries (69 suites): 0 failures |
| Edge cases: single window unchanged; statement ORDER BY overrides (window9 1.5) | PASS | Covered by `test_single_window_order_unchanged`, `test_statement_order_by_overrides_window_pass_order`, `test_window_over_group_by_with_order_by_overrides` |

## Test Plan

- New regression tests: `cargo test -p vibesql-executor --test window_pass_order_tests` (6/6)
- New determinism unit tests: `cargo test -p vibesql-executor --lib group_by::batch_tests` (8/8)
- TCL conformance: window9 (1.4 newly passing), windowpushd (29/29 x3), window1-8/A-E (0 failures), aggorderby/aggerror/aggnested failures verified as pre-existing parser/UDF/multi-connection-shim limitations unrelated to ordering
- P1 sweep regression check via baseline-vs-branch binary diff (identical failure sets)
- Note: the added GROUP BY output sort is O(G log G) over output groups only (TPC-H Q1: 6 groups), so benchmark impact should be negligible; `make benchmark-quick` was not run as part of this PR

Closes #5291