### PR TITLE
feat(parser,executor): support date() and time() as scalar function calls

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/datetime/current.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/datetime/current.rs
@@ -704,12 +704,21 @@ fn naive_datetime_to_timestamp(dt: NaiveDateTime) -> Result<SqlValue, ExecutorEr
 /// `[-]YYYY-MM-DD[<space|T>HH:MM[:SS[.FFF...]]]` where every field is exactly
 /// the documented number of digits. An out-of-range day-of-month (e.g.
 /// `2003-02-31`) normalizes into the following month, matching SQLite's
-/// `computeJD`. A plain numeric string is interpreted as a Julian Day number.
+/// `computeJD`. A time-only value `HH:MM[:SS[.FFF...]]` defaults the date to
+/// 2000-01-01 (SQLite `parseTimeOnly`). A plain numeric string is interpreted
+/// as a Julian Day number.
 fn parse_datetime_string_to_naive(s: &str) -> Option<NaiveDateTime> {
     let s = s.trim();
 
     if let Some(dt) = parse_yyyy_mm_dd(s) {
         return Some(dt);
+    }
+
+    // SQLite: time-only values `HH:MM[:SS[.FFF...]]` default the date to
+    // 2000-01-01 (parseTimeOnly in date.c)
+    if let Some(time_ms) = parse_hh_mm_ss_ms(s) {
+        let midnight = chrono::NaiveDate::from_ymd_opt(2000, 1, 1)?.and_hms_opt(0, 0, 0)?;
+        return Some(midnight + Duration::milliseconds(time_ms));
     }
 
     // SQLite: a string that is a plain numeric literal is interpreted as a

--- a/crates/vibesql-executor/src/evaluator/functions/datetime/date_time.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/datetime/date_time.rs
@@ -1,0 +1,53 @@
+//! SQLite-compatible DATE and TIME scalar functions
+//!
+//! `date(time-value, modifier, ...)` and `time(time-value, modifier, ...)`
+//! share the SQLite time-value + modifiers model implemented by
+//! `current::resolve_time_value` (the same machinery behind `datetime()`,
+//! `strftime()`, `julianday()`, and `unixepoch()`).
+//!
+//! - `date()` returns the date component (SQLite renders `YYYY-MM-DD`)
+//! - `time()` returns the time component truncated to whole seconds (SQLite's
+//!   `time('12:34:56.43')` is `12:34:56`)
+//!
+//! Both return NULL for NULL/unparseable input or invalid modifiers, and treat
+//! an omitted time-value as 'now' (matching SQLite).
+//!
+//! SQLite Reference: https://www.sqlite.org/lang_datefunc.html
+
+use chrono::{Datelike, Timelike};
+use vibesql_types::SqlValue;
+
+use super::current::resolve_time_value;
+use crate::errors::ExecutorError;
+
+/// DATE - Return the date component of a time value
+///
+/// `date(time-value, modifier, modifier, ...)`
+pub fn date(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    let dt = match resolve_time_value(args, "DATE")? {
+        Some(dt) => dt,
+        None => return Ok(SqlValue::Null),
+    };
+
+    let date = vibesql_types::Date::new(dt.year(), dt.month() as u8, dt.day() as u8)
+        .map_err(|e| ExecutorError::UnsupportedFeature(format!("Invalid date: {}", e)))?;
+    Ok(SqlValue::Date(date))
+}
+
+/// TIME - Return the time-of-day component of a time value
+///
+/// `time(time-value, modifier, modifier, ...)`
+///
+/// Truncates to whole seconds: SQLite's `time()` renders `HH:MM:SS` without a
+/// fractional part, while `vibesql_types::Time` Display prints fractional
+/// seconds when nonzero - so nanoseconds must not be carried through.
+pub fn time(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    let dt = match resolve_time_value(args, "TIME")? {
+        Some(dt) => dt,
+        None => return Ok(SqlValue::Null),
+    };
+
+    let time = vibesql_types::Time::new(dt.hour() as u8, dt.minute() as u8, dt.second() as u8, 0)
+        .map_err(|e| ExecutorError::UnsupportedFeature(format!("Invalid time: {}", e)))?;
+    Ok(SqlValue::Time(time))
+}

--- a/crates/vibesql-executor/src/evaluator/functions/datetime/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/datetime/mod.rs
@@ -20,6 +20,7 @@
 
 mod arithmetic;
 mod current;
+mod date_time;
 mod extract;
 mod sqlite_datefuncs;
 mod strftime;
@@ -29,6 +30,7 @@ mod strftime;
 pub(crate) use arithmetic::date_add_subtract;
 pub(super) use arithmetic::{age, date_add, date_sub, datediff, extract};
 pub(super) use current::{current_date, current_time, current_timestamp, datetime};
+pub(super) use date_time::{date, time};
 pub(super) use extract::{day, hour, minute, month, second, year};
 pub(super) use sqlite_datefuncs::{julianday, timediff, unixepoch};
 pub(super) use strftime::strftime;

--- a/crates/vibesql-executor/src/evaluator/functions/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/mod.rs
@@ -111,6 +111,8 @@ pub(super) fn eval_scalar_function(
         "CURRENT_TIME" | "CURTIME" => datetime::current_time(args),
         "CURRENT_TIMESTAMP" | "NOW" => datetime::current_timestamp(args),
         "DATETIME" => datetime::datetime(args),
+        "DATE" => datetime::date(args),
+        "TIME" => datetime::time(args),
         "STRFTIME" => datetime::strftime(args),
         "JULIANDAY" => datetime::julianday(args),
         "UNIXEPOCH" => datetime::unixepoch(args),

--- a/crates/vibesql-executor/tests/date_time_function_tests.rs
+++ b/crates/vibesql-executor/tests/date_time_function_tests.rs
@@ -11,6 +11,7 @@
 //! - **extraction**: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND extraction
 //! - **nested_operations**: Nested and combined datetime operations
 //! - **strftime**: SQLite-compatible STRFTIME formatting
+//! - **date_time**: SQLite-compatible date() and time() scalar functions
 
 mod common;
 
@@ -32,3 +33,6 @@ mod nested_operations;
 
 #[path = "date_time_function_tests/strftime.rs"]
 mod strftime;
+
+#[path = "date_time_function_tests/date_time.rs"]
+mod date_time;

--- a/crates/vibesql-executor/tests/date_time_function_tests/date_time.rs
+++ b/crates/vibesql-executor/tests/date_time_function_tests/date_time.rs
@@ -1,0 +1,198 @@
+//! Integration tests for the SQLite-compatible DATE and TIME scalar functions
+//!
+//! `date()` and `time()` share the time-value + modifiers machinery behind
+//! `datetime()` and `strftime()`. Conformance values are taken from SQLite's
+//! date.test (docs/reference/sqlite/test/date.test).
+
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn execute_query(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor.execute(&select_stmt).unwrap()
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+/// Execute `SELECT <expr>` and return the single result value
+fn eval_scalar(sql_expr: &str) -> SqlValue {
+    let db = Database::new();
+    let rows = execute_query(&db, &format!("SELECT {}", sql_expr));
+    assert_eq!(rows.len(), 1, "expected a single row for {}", sql_expr);
+    rows[0].values[0].clone()
+}
+
+/// Assert the textual rendering of an expression result
+fn assert_renders(sql_expr: &str, expected: &str) {
+    let value = eval_scalar(sql_expr);
+    assert_eq!(value.to_string(), expected, "for {}", sql_expr);
+}
+
+fn assert_null(sql_expr: &str) {
+    let value = eval_scalar(sql_expr);
+    assert!(matches!(value, SqlValue::Null), "{} should be NULL, got {:?}", sql_expr, value);
+}
+
+// ==================== date() ====================
+
+#[test]
+fn test_date_basic() {
+    assert_renders("date('2024-01-01')", "2024-01-01");
+    assert_renders("date('2003-10-22 12:34:00')", "2003-10-22");
+}
+
+#[test]
+fn test_date_with_modifiers() {
+    assert_renders("date('2024-01-01', '+1 day')", "2024-01-02");
+    assert_renders("date('2024-03-15', 'start of month')", "2024-03-01");
+    assert_renders("date('2024-01-15', '+1 month')", "2024-02-15");
+    // NOTE: SQLite month-overflow rollover (2024-01-31 '+1 month' -> 2024-03-02)
+    // is a known divergence tracked in #5309; not asserted here.
+    assert_renders("date('2024-01-01', '-1 day')", "2023-12-31");
+}
+
+#[test]
+fn test_date_julian_day_input() {
+    // SQLite date.test date5/jd cases: numeric input is a Julian Day number
+    assert_renders("date(2451545.0)", "2000-01-01");
+    assert_renders("date('2451545.0')", "2000-01-01");
+    assert_renders("date(2440587.5)", "1970-01-01");
+}
+
+#[test]
+fn test_date_now_returns_a_date() {
+    match eval_scalar("date('now')") {
+        SqlValue::Date(_) => {}
+        other => panic!("date('now') should return a Date, got {:?}", other),
+    }
+    // Omitted time-value defaults to 'now' in SQLite
+    match eval_scalar("date()") {
+        SqlValue::Date(_) => {}
+        other => panic!("date() should return a Date, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_date_null_and_invalid_input() {
+    assert_null("date(NULL)");
+    assert_null("date('bogus')");
+    assert_null("date('2024-01-01', 'bogus modifier')");
+}
+
+// ==================== time() ====================
+
+#[test]
+fn test_time_basic() {
+    assert_renders("time('12:00:00')", "12:00:00");
+    assert_renders("time('2003-10-22 12:34:56')", "12:34:56");
+}
+
+#[test]
+fn test_time_truncates_fractional_seconds() {
+    // SQLite: time('12:34:56.43') is '12:34:56' (no fractional part)
+    assert_renders("time('12:34:56.43')", "12:34:56");
+    assert_renders("time('2003-10-31 12:34:56.432')", "12:34:56");
+}
+
+#[test]
+fn test_time_with_modifiers() {
+    assert_renders("time('12:00:00', '+1 hour')", "13:00:00");
+    assert_renders("time('2024-01-01 23:30:00', '+45 minutes')", "00:15:00");
+    assert_renders("time('2024-01-01 12:34:56', 'start of day')", "00:00:00");
+}
+
+#[test]
+fn test_time_now_returns_a_time() {
+    match eval_scalar("time('now')") {
+        SqlValue::Time(_) => {}
+        other => panic!("time('now') should return a Time, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_time_null_and_invalid_input() {
+    assert_null("time(NULL)");
+    assert_null("time('bogus')");
+}
+
+// ==================== typed literals & column refs still work ====================
+
+#[test]
+fn test_typed_literals_still_parse() {
+    assert_renders("DATE '2024-01-01'", "2024-01-01");
+    assert_renders("TIME '12:00:00'", "12:00:00");
+}
+
+#[test]
+fn test_date_time_as_column_names_still_resolve() {
+    use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+
+    let mut db = Database::new();
+
+    let create = Parser::parse_sql("CREATE TABLE t (date VARCHAR(20), time VARCHAR(20))").unwrap();
+    if let vibesql_ast::Statement::CreateTable(stmt) = create {
+        CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+    } else {
+        panic!("Expected CREATE TABLE");
+    }
+
+    let insert = Parser::parse_sql("INSERT INTO t VALUES ('d-value', 't-value')").unwrap();
+    if let vibesql_ast::Statement::Insert(stmt) = insert {
+        InsertExecutor::execute(&mut db, &stmt).unwrap();
+    } else {
+        panic!("Expected INSERT");
+    }
+
+    let rows = execute_query(&db, "SELECT date, time FROM t");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0], SqlValue::Varchar("d-value".into()));
+    assert_eq!(rows[0].values[1], SqlValue::Varchar("t-value".into()));
+}
+
+// ==================== both parser paths ====================
+
+#[test]
+fn test_date_function_via_insert_recursive_descent_parser() {
+    use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+
+    let mut db = Database::new();
+
+    let create = Parser::parse_sql("CREATE TABLE t2 (d DATE)").unwrap();
+    if let vibesql_ast::Statement::CreateTable(stmt) = create {
+        CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+    } else {
+        panic!("Expected CREATE TABLE");
+    }
+
+    // INSERT goes through the recursive-descent parser
+    let insert = Parser::parse_sql("INSERT INTO t2 VALUES (date('2024-01-01', '+1 day'))").unwrap();
+    if let vibesql_ast::Statement::Insert(stmt) = insert {
+        InsertExecutor::execute(&mut db, &stmt).unwrap();
+    } else {
+        panic!("Expected INSERT");
+    }
+
+    let rows = execute_query(&db, "SELECT d FROM t2");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0].to_string(), "2024-01-02");
+}
+
+#[test]
+fn test_date_function_via_arena_parser() {
+    // parse_with_arena_fallback routes SELECT through the arena parser first
+    let stmt = vibesql_parser::parse_with_arena_fallback("SELECT date('2024-01-01', '+1 day')")
+        .expect("arena path should parse date() call");
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let db = Database::new();
+        let executor = SelectExecutor::new(&db);
+        let rows = executor.execute(&select_stmt).unwrap();
+        assert_eq!(rows[0].values[0].to_string(), "2024-01-02");
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -755,6 +755,12 @@ impl<'arena> ArenaParser<'arena> {
             // Typed literals: DATE 'string', TIME 'string', TIMESTAMP 'string'
             // If not followed by a string literal, treat as column name (SQLite compatibility)
             Token::Keyword { keyword: Keyword::Date, .. } => {
+                // date(...) is a function call, not a typed literal - don't consume
+                // the keyword; the identifier path routes it to parse_function_call
+                // via can_be_identifier() (issue #5307)
+                if matches!(self.peek_next(), Token::LParen) {
+                    return Ok(None);
+                }
                 self.advance();
                 match self.peek() {
                     Token::String(s) => {
@@ -783,6 +789,12 @@ impl<'arena> ArenaParser<'arena> {
                 }
             }
             Token::Keyword { keyword: Keyword::Time, .. } => {
+                // time(...) is a function call, not a typed literal - don't consume
+                // the keyword; the identifier path routes it to parse_function_call
+                // via can_be_identifier() (issue #5307)
+                if matches!(self.peek_next(), Token::LParen) {
+                    return Ok(None);
+                }
                 self.advance();
                 match self.peek() {
                     Token::String(s) => {

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -29,8 +29,9 @@ impl Parser {
                 }
                 name
             }
-            // Allow LEFT, RIGHT, REPLACE, SCHEMA, GROUPING, GROUPING_ID, GLOB, LIKE, and MATCH keywords
-            // as function names. These are reserved keywords but can also be functions.
+            // Allow LEFT, RIGHT, REPLACE, SCHEMA, GROUPING, GROUPING_ID, GLOB, LIKE, MATCH,
+            // DATE, and TIME keywords as function names. These are reserved keywords but
+            // can also be functions (DATE/TIME: SQLite date('now')/time('now'), #5307).
             Token::Keyword { keyword: Keyword::Left, .. }
             | Token::Keyword { keyword: Keyword::Right, .. }
             | Token::Keyword { keyword: Keyword::Replace, .. }
@@ -39,7 +40,9 @@ impl Parser {
             | Token::Keyword { keyword: Keyword::GroupingId, .. }
             | Token::Keyword { keyword: Keyword::Glob, .. }
             | Token::Keyword { keyword: Keyword::Like, .. }
-            | Token::Keyword { keyword: Keyword::Match, .. } => {
+            | Token::Keyword { keyword: Keyword::Match, .. }
+            | Token::Keyword { keyword: Keyword::Date, .. }
+            | Token::Keyword { keyword: Keyword::Time, .. } => {
                 // Peek ahead to see if this is followed by '('
                 // Don't consume the keyword unless we're sure it's a function
                 // SQL:1999 normalizes unquoted identifiers (including function names) to lowercase
@@ -53,6 +56,8 @@ impl Parser {
                     Token::Keyword { keyword: Keyword::Glob, .. } => "glob",
                     Token::Keyword { keyword: Keyword::Like, .. } => "like",
                     Token::Keyword { keyword: Keyword::Match, .. } => "match",
+                    Token::Keyword { keyword: Keyword::Date, .. } => "date",
+                    Token::Keyword { keyword: Keyword::Time, .. } => "time",
                     _ => unreachable!(),
                 };
 

--- a/crates/vibesql-parser/src/parser/expressions/literals.rs
+++ b/crates/vibesql-parser/src/parser/expressions/literals.rs
@@ -50,6 +50,11 @@ impl Parser {
             // Typed literals: DATE 'string', TIME 'string', TIMESTAMP 'string'
             // If not followed by a string literal, treat as column name (SQLite compatibility)
             Token::Keyword { keyword: Keyword::Date, .. } => {
+                // date(...) is a function call, not a typed literal - don't consume
+                // the keyword; let parse_function_call handle it (issue #5307)
+                if matches!(self.peek_next(), Token::LParen) {
+                    return Ok(None);
+                }
                 self.advance();
                 match self.peek() {
                     Token::String(s) => {
@@ -75,6 +80,11 @@ impl Parser {
                 }
             }
             Token::Keyword { keyword: Keyword::Time, .. } => {
+                // time(...) is a function call, not a typed literal - don't consume
+                // the keyword; let parse_function_call handle it (issue #5307)
+                if matches!(self.peek_next(), Token::LParen) {
+                    return Ok(None);
+                }
                 self.advance();
                 match self.peek() {
                     Token::String(s) => {

--- a/crates/vibesql-parser/src/tests/literals.rs
+++ b/crates/vibesql-parser/src/tests/literals.rs
@@ -516,3 +516,140 @@ fn test_parse_large_positive_as_numeric() {
         _ => panic!("Expected SELECT statement"),
     }
 }
+
+// ========================================================================
+// DATE/TIME as Function Calls (issue #5307)
+//
+// SQLite supports date('now', ...) and time('now', ...) as scalar
+// functions. The DATE/TIME keywords must only be treated as typed-literal
+// introducers when followed by a string literal, not by '('.
+// ========================================================================
+
+/// Extract the expression of the first select item.
+fn first_select_expr(stmt: &vibesql_ast::Statement) -> &vibesql_ast::Expression {
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match &select.select_list[0] {
+            vibesql_ast::SelectItem::Expression { expr, .. } => expr,
+            other => panic!("Expected expression select item, got {:?}", other),
+        },
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_parse_date_function_call() {
+    // Recursive-descent parser path
+    let result = Parser::parse_sql("SELECT date('now');");
+    assert!(result.is_ok(), "date('now') should parse as a function call: {:?}", result);
+
+    match first_select_expr(&result.unwrap()) {
+        vibesql_ast::Expression::Function { name, args, .. } => {
+            assert_eq!(name, "date");
+            assert_eq!(args.len(), 1);
+        }
+        other => panic!("Expected function call, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_time_function_call() {
+    // Recursive-descent parser path
+    let result = Parser::parse_sql("SELECT time('12:00:00');");
+    assert!(result.is_ok(), "time('12:00:00') should parse as a function call: {:?}", result);
+
+    match first_select_expr(&result.unwrap()) {
+        vibesql_ast::Expression::Function { name, args, .. } => {
+            assert_eq!(name, "time");
+            assert_eq!(args.len(), 1);
+        }
+        other => panic!("Expected function call, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_date_function_call_with_modifiers() {
+    let result = Parser::parse_sql("SELECT date('2024-01-01', '+1 day');");
+    assert!(result.is_ok(), "date() with modifiers should parse: {:?}", result);
+
+    match first_select_expr(&result.unwrap()) {
+        vibesql_ast::Expression::Function { name, args, .. } => {
+            assert_eq!(name, "date");
+            assert_eq!(args.len(), 2);
+        }
+        other => panic!("Expected function call, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_date_time_function_call_arena() {
+    // Arena parser path (no silent fallback to the recursive-descent parser)
+    let result = crate::arena_parser::parse_select_to_owned(
+        "SELECT date('now', 'start of month'), time('now', '+1 hour')",
+    );
+    assert!(result.is_ok(), "arena parser should accept date()/time() calls: {:?}", result);
+
+    let select = result.unwrap();
+    assert_eq!(select.select_list.len(), 2);
+    for (item, expected) in select.select_list.iter().zip(["date", "time"]) {
+        match item {
+            vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                vibesql_ast::Expression::Function { name, args, .. } => {
+                    assert_eq!(name, expected);
+                    assert_eq!(args.len(), 2);
+                }
+                other => panic!("Expected {} function call, got {:?}", expected, other),
+            },
+            other => panic!("Expected expression select item, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn test_parse_typed_literals_arena() {
+    // Regression: typed literals must still parse in the arena parser
+    let result =
+        crate::arena_parser::parse_select_to_owned("SELECT DATE '2024-01-01', TIME '12:00:00'");
+    assert!(result.is_ok(), "arena parser should accept typed literals: {:?}", result);
+
+    let select = result.unwrap();
+    match &select.select_list[0] {
+        vibesql_ast::SelectItem::Expression { expr, .. } => {
+            assert!(
+                matches!(expr, vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Date(_))),
+                "Expected DATE literal, got {:?}",
+                expr
+            );
+        }
+        other => panic!("Expected expression select item, got {:?}", other),
+    }
+    match &select.select_list[1] {
+        vibesql_ast::SelectItem::Expression { expr, .. } => {
+            assert!(
+                matches!(expr, vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Time(_))),
+                "Expected TIME literal, got {:?}",
+                expr
+            );
+        }
+        other => panic!("Expected expression select item, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_date_time_function_call_in_insert_and_update() {
+    // INSERT/UPDATE always use the recursive-descent parser
+    let insert = Parser::parse_sql("INSERT INTO t VALUES (date('now'), time('now'));");
+    assert!(insert.is_ok(), "date()/time() should parse inside INSERT: {:?}", insert);
+
+    let update = Parser::parse_sql("UPDATE t SET x = date('now', '+1 day');");
+    assert!(update.is_ok(), "date() should parse inside UPDATE: {:?}", update);
+}
+
+#[test]
+fn test_parse_date_time_as_bare_identifiers() {
+    // Regression: bare DATE/TIME (no '(' and no string) remain column references
+    let result = Parser::parse_sql("SELECT date, time FROM t;");
+    assert!(result.is_ok(), "bare date/time should parse as column refs: {:?}", result);
+
+    let result = crate::arena_parser::parse_select_to_owned("SELECT date, time FROM t");
+    assert!(result.is_ok(), "arena: bare date/time should parse as column refs: {:?}", result);
+}

--- a/crates/vibesql-types/src/temporal/date.rs
+++ b/crates/vibesql-types/src/temporal/date.rs
@@ -46,7 +46,14 @@ impl FromStr for Date {
 
 impl fmt::Display for Date {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:04}-{:02}-{:02}", self.year, self.month, self.day)
+        // Zero-pad the year to 4 digits excluding the sign: SQLite renders
+        // negative (astronomical) years as e.g. '-0900-02-28', but Rust's
+        // `{:04}` counts the '-' toward the width (giving '-900').
+        if self.year < 0 {
+            write!(f, "-{:04}-{:02}-{:02}", -self.year, self.month, self.day)
+        } else {
+            write!(f, "{:04}-{:02}-{:02}", self.year, self.month, self.day)
+        }
     }
 }
 

--- a/crates/vibesql-types/tests/type_display_tests.rs
+++ b/crates/vibesql-types/tests/type_display_tests.rs
@@ -104,6 +104,18 @@ fn test_date_display() {
 }
 
 #[test]
+fn test_negative_year_date_display() {
+    // SQLite zero-pads negative (astronomical) years to 4 digits after the
+    // sign, e.g. date(1392399.5) renders '-0900-02-28'
+    let date = Date::new(-900, 2, 28).unwrap();
+    let value = SqlValue::Date(date);
+    assert_eq!(format!("{}", value), "-0900-02-28");
+
+    let date = Date::new(900, 2, 28).unwrap();
+    assert_eq!(format!("{}", SqlValue::Date(date)), "0900-02-28");
+}
+
+#[test]
 fn test_time_display() {
     let time = "12:30:00".parse::<Time>().unwrap();
     let value = SqlValue::Time(time);

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3263,26 +3263,8 @@ array set vibesql_skip_tests {
 
     triggerupfrom-2.3 "Cascades from auto-skipped test 2.2. CREATE TEMP TRIGGER now parses (#5218), but 2.2 references aux.t3 and is auto-skipped by the ATTACH/aux regex (VibeSQL has no ATTACH/multi-database support), so the rows 2.2 inserts (10 y {}, 20 y {}) never exist and 2.3's expected output cannot match. The UPDATE…FROM trigger logic in 2.3 itself works correctly when run in isolation (verified during #5192 builder pass)."
 
-    expr-8.4 "time('now') parsed as TIME typed-literal keyword, not a function call (#5307)"
-    expr-8.5 "date('now') parsed as DATE typed-literal keyword, not a function call (#5307)"
-
-    date-2.3 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.4 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.5 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.6 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.7 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.8 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.9 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.10 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.11 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.16 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
     date-2.40 "zero-argument datetime() rejected (SQLite treats it as 'now') (#5309)"
     date-2.60 "invalid-date rollover normalization (2023-02-31 -> 2023-03-03) differs (#5309)"
-    date-2.4a "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.4b "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.4c "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.4d "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-2.4e "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
     date-3.11.99 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
     date-3.20 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
     date-3.21 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
@@ -3302,7 +3284,7 @@ array set vibesql_skip_tests {
     date-3.35 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
     date-3.36 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
     date-3.37 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-4.1 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
+    date-4.1 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
     date-5.1 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
     date-5.2 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
     date-5.3 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
@@ -3313,12 +3295,6 @@ array set vibesql_skip_tests {
     date-5.10 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
     date-5.11 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
     date-5.12 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
-    date-7.4 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-7.5 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-7.6 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-7.7 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-7.8 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-7.9 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
     date-8.1 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
     date-8.2 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
     date-8.3 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
@@ -3347,16 +3323,7 @@ array set vibesql_skip_tests {
     date-11.7 "+/-HH:MM:SS modifiers return NULL (#5309)"
     date-11.8 "+/-HH:MM:SS modifiers return NULL (#5309)"
     date-11.9 "+/-HH:MM:SS modifiers return NULL (#5309)"
-    date-13.30 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-13.31 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-13.32 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-13.33 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-13.34 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-13.35 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-13.36 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
-    date-13.37 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
     date-15.2 "sleeper TCL UDF registered via db func is not visible to the VibeSQL CLI subprocess (harness limitation)"
-    date-16.1 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
     date-16.3 "julian-day range bounds not enforced for extreme date values (#5309)"
     date-16.7 "julian-day range bounds not enforced for extreme date values (#5309)"
     date-16.9 "julian-day range bounds not enforced for extreme date values (#5309)"
@@ -3374,13 +3341,10 @@ array set vibesql_skip_tests {
     date-16.28 "julian-day range bounds not enforced for extreme date values (#5309)"
     date-16.30 "julian-day range bounds not enforced for extreme date values (#5309)"
     date-17.6 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-1.5 "time-only input (HH:MM:SS) should default the date to 2000-01-01 (#5309)"
-    date2-100 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
     date2-110 "non-deterministic use of date/time functions in CHECK constraints is not rejected"
     date2-120 "non-deterministic use of date/time functions in CHECK constraints is not rejected"
     date2-130 "non-deterministic use of date/time functions in CHECK constraints is not rejected"
     date2-140 "non-deterministic use of date/time functions in generated columns is not rejected"
-    date2-200 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
     date2-210 "non-deterministic use of date/time functions in indexes is not rejected"
     date2-220 "non-deterministic use of date/time functions in indexes is not rejected"
     date2-310 "non-deterministic use of date/time functions in indexes is not rejected"
@@ -3408,7 +3372,7 @@ array set vibesql_skip_tests {
     date3-2.11 "'auto' modifier not supported (#5309)"
     date3-2.12 "'auto' modifier not supported (#5309)"
     date3-2.13 "'auto' modifier not supported (#5309)"
-    date3-2.30 "date()/time() parsed as DATE/TIME typed-literal keyword, not a function call (#5307)"
+    date3-2.30 "'auto' modifier not supported (#5309)"
     date3-2.40 "'auto' modifier not supported (#5309)"
     date3-4.1 "'julianday' modifier not supported (#5309)"
     date3-5.0 "'auto' modifier not supported (#5309)"
@@ -3492,10 +3456,8 @@ variable vibesql_skip_patterns {
     {date-2.2c-8 "strftime('%f') with numeric 'unixepoch' input drops fractional seconds (#5309)"}
     {date-2.2c-9 "strftime('%f') with numeric 'unixepoch' input drops fractional seconds (#5309)"}
     {date-6. "localtime/utc DST boundary tests require the SQLITE_TESTCTRL_LOCALTIME_FAULT harness localtime_r override (#5309)"}
-    {date-10. "time-only input (HH:MM:SS) should default the date to 2000-01-01 (#5309); date() typed-literal parse (#5307)"}
-    {date-19. "date() parsed as DATE typed-literal keyword - ceiling/floor modifier tests cannot parse (#5307)"}
+    {date-19. "date() now parses (#5307) but the 'ceiling'/'floor' modifiers are not supported and return NULL (#5309)"}
     {date4- "compares VibeSQL strftime against the C library strftime; shim only stubs the TCL strftime command via clock format, and strftime specifier gaps remain (#5309)"}
-    {date5-jd "date() parsed as DATE typed-literal keyword, not a function call (#5307); the julianday() halves (date5-cal/*) pass"}
 }
 
 # Check if a test should be skipped based on VibeSQL-specific exclusions
@@ -4269,9 +4231,9 @@ proc check_single_capability {cap} {
     # Capabilities we don't support (unsupported_caps means NOT supported)
     # NOTE: datetime/datetime_time/datetime_funcs were removed from this list
     # (#5294) — VibeSQL implements date(), time(), datetime(), strftime().
-    # Remaining gaps are pattern-skipped: see #5307 (DATE/TIME typed-literal
-    # parse), #5309 (strftime %f/%W/%j, TZ offsets, HH:MM:SS modifiers).
-    # julianday()/unixepoch()/timediff() were implemented in #5308.
+    # Remaining gaps are pattern-skipped: see #5309 (strftime %f/%W/%j,
+    # TZ offsets, HH:MM:SS modifiers). date()/time() function calls were
+    # implemented in #5307; julianday()/unixepoch()/timediff() in #5308.
     set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 trigger conflict hiddencolumns}
 
     # Handle negated capability (e.g., !autovacuum)


### PR DESCRIPTION
## Summary

`SELECT date('2024-01-01','+1 day')` and `SELECT time('12:00:00')` previously failed with `Parse error: near "(": syntax error` because both parsers consumed the DATE/TIME keywords as typed-literal introducers before the function-call path could see them. This PR disambiguates with a one-token lookahead (keyword followed by `(` is a function call; followed by a string it remains a typed literal) and implements the `date()`/`time()` scalar functions as thin wrappers over the shared `resolve_time_value()` time-value + modifiers machinery.

## Changes

- **Recursive-descent parser** (`parser/expressions/literals.rs`): Date/Time arms of `parse_literal()` return `None` without consuming when the next token is `(`; added `Date`/`Time` to the keyword-as-function-name allowlist in `parser/expressions/functions/mod.rs`
- **Arena parser** (`arena_parser/expression.rs`): same lookahead; the existing `can_be_identifier()` identifier path then routes to `parse_function_call` with no further change
- **Executor** (`evaluator/functions/datetime/date_time.rs`, new): `date()` returns the date component; `time()` returns the time component truncated to whole seconds (SQLite's `time('12:34:56.43')` is `12:34:56`); dispatch arms added in `evaluator/functions/mod.rs`. `TIMESTAMP(...)` left untouched (no such SQLite function); MySQL `DATE_ADD`/`DATEDIFF` dispatch unchanged
- **Time-only inputs** (`datetime/current.rs`): `resolve_time_value` now accepts `HH:MM[:SS[.FFF...]]` with the date defaulting to 2000-01-01 (SQLite `parseTimeOnly`) — required for the issue's `time('12:34:56.43')` acceptance criterion; benefits `datetime()`/`strftime()`/`julianday()`/`unixepoch()` equally
- **Negative-year display** (`vibesql-types/temporal/date.rs`): zero-pad years to 4 digits excluding the sign (`-0900-02-28`, matching SQLite) — required for the date5-jd julian-day cases; Rust's `{:04}` counts the `-` toward the width
- **TCL shim** (`scripts/tester_vibesql.tcl`): removed the 36 named `#5307` skips plus the `date-10.`/`date5-jd` patterns and `date-1.5` (all pass now); `date-4.1` re-added as a fake-clock harness skip (it uses `sqlite_current_time`, same as date-8.*); `date-19.` pattern retagged to #5309 (parses now, but `ceiling`/`floor` modifiers return NULL); `date3-2.30` retagged to #5309 (`'auto'` modifier)
- **Tests**: 8 new parser tests (both parsers, typed-literal and bare-identifier regression guards) and a new `date_time.rs` executor integration module (15 tests)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `date('2024-01-01','+1 day')` returns `2024-01-02` | OK | CLI smoke test + `test_date_with_modifiers` |
| `time('12:34:56.43')` returns `12:34:56` | OK | CLI smoke test + `test_time_truncates_fractional_seconds` |
| `date('now')` / `time('now')` work | OK | `test_date_now_returns_a_date`, `test_time_now_returns_a_time`, expr-8.4/8.5 pass |
| Typed literals `DATE '2024-01-01'` still parse | OK | existing parser tests + `test_parse_typed_literals_arena`, `test_typed_literals_still_parse` |
| Both parsers covered (SELECT + INSERT/UPDATE) | OK | `test_parse_date_time_function_call_arena`, `test_parse_date_time_function_call_in_insert_and_update`, `test_date_function_via_insert_recursive_descent_parser` |
| `SELECT date FROM t` still column ref | OK | `test_parse_date_time_as_bare_identifiers`, `test_date_time_as_column_names_still_resolve` |
| Modifier chain passthrough | OK | `test_date_with_modifiers`, `test_time_with_modifiers` |
| `date(NULL)` / `date('bogus')` return NULL | OK | `test_date_null_and_invalid_input`, `test_time_null_and_invalid_input` |
| Skip entries removed, zero new TCL failures | OK | see deltas below |

## TCL Test Deltas (vs main baseline)

| File | Before (main) | After | Delta |
|------|---------------|-------|-------|
| date.test | 236 pass / 40 skipped for #5307-related reasons | 275 pass / 0 fail | +39 newly passing |
| date2.test | 5 pass | 7 pass / 0 fail | +2 (date2-100, date2-200) |
| date3.test | 112 pass | 113 pass / 0 fail | +1 run path; date3-2.30 retagged #5309 ('auto' still unsupported) |
| date5.test | ~437 run (date5-jd pattern skipped) | 874 pass / 0 fail / 0 skipped | entire file green |
| expr.test | 636 pass | 638 pass / 0 fail | +2 (expr-8.4, expr-8.5) |
| select1/insert.test | unchanged | unchanged | select1-18.1 failure is pre-existing on main (verified with pre-change binary) |

## Test Plan

- `cargo test -p vibesql-parser` — 1362 + 8 doc tests pass
- `cargo test -p vibesql-executor -p vibesql-storage -p vibesql-types` — all green (re-run after the Display change)
- `cargo check` / `cargo clippy` — no new warnings (remaining warnings pre-existing on main)
- TCL: date.test, date2.test, date3.test, date5.test, expr.test, insert.test all 0 failures

Closes #5307