### PR TITLE
feat(executor): close datetime conformance gaps (TZ offsets, ±HH:MM:SS modifiers, strftime specifiers, auto/julianday, JD bounds)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/datetime/current.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/datetime/current.rs
@@ -218,16 +218,23 @@ pub(super) fn resolve_time_value(
         return Ok(Some(Local::now().naive_local()));
     }
 
-    // Check if 'unixepoch' is the first modifier - affects how we parse the base value
-    let has_unixepoch_first = args.len() > 1
-        && matches!(&args[1], SqlValue::Varchar(s) | SqlValue::Character(s) if s.eq_ignore_ascii_case("unixepoch"));
+    // The first modifier may change how the base value is interpreted:
+    // 'unixepoch' (Unix timestamp), 'julianday' (forced Julian Day number),
+    // 'auto' (Julian Day or Unix timestamp depending on magnitude).
+    let first_modifier = match args.get(1) {
+        Some(SqlValue::Varchar(s)) | Some(SqlValue::Character(s)) => Some(s.as_str()),
+        _ => None,
+    };
 
     // Parse the base datetime value
-    let base_result = if has_unixepoch_first {
-        // For unixepoch, parse numeric values as Unix timestamps instead of Julian Days
-        parse_base_datetime_for_unixepoch(&args[0], func_name)?
-    } else {
-        parse_base_datetime(&args[0], func_name)?
+    let base_result = match first_modifier {
+        Some(m) if m.eq_ignore_ascii_case("unixepoch") => {
+            // For unixepoch, parse numeric values as Unix timestamps instead of Julian Days
+            parse_base_datetime_for_unixepoch(&args[0], func_name)?
+        }
+        Some(m) if m.eq_ignore_ascii_case("auto") => parse_base_datetime_auto(&args[0], func_name)?,
+        Some(m) if m.eq_ignore_ascii_case("julianday") => parse_base_datetime_julianday(&args[0]),
+        _ => parse_base_datetime(&args[0], func_name)?,
     };
 
     // If base value is NULL, return NULL
@@ -249,11 +256,15 @@ pub(super) fn resolve_time_value(
             }
         };
 
-        // Special case: 'unixepoch' must be the first modifier
-        // We've already handled it above by parsing as unix timestamp
-        if modifier_str.eq_ignore_ascii_case("unixepoch") {
+        // Special case: 'unixepoch', 'auto', and 'julianday' must immediately
+        // follow the time value (i.e. be the first modifier). They were already
+        // handled above when parsing the base value.
+        if modifier_str.eq_ignore_ascii_case("unixepoch")
+            || modifier_str.eq_ignore_ascii_case("auto")
+            || modifier_str.eq_ignore_ascii_case("julianday")
+        {
             if idx != 1 {
-                // unixepoch only valid as first modifier
+                // Only valid as the first modifier (SQLite returns NULL otherwise)
                 return Ok(None);
             }
             // Already handled during parsing, just continue
@@ -265,6 +276,13 @@ pub(super) fn resolve_time_value(
             Some(new_dt) => dt = new_dt,
             None => return Ok(None), // Invalid modifier returns NULL
         }
+    }
+
+    // SQLite validates the final result against the valid Julian Day range
+    // (`isDate` -> `validJulianDay`): modifiers that push the date outside
+    // -4713-11-24 12:00:00 .. 9999-12-31 23:59:59.999 yield NULL.
+    if !(0..=MAX_IJD_MS).contains(&naive_to_ijd_ms(&dt)) {
+        return Ok(None);
     }
 
     Ok(Some(dt))
@@ -362,6 +380,57 @@ fn parse_base_datetime_for_unixepoch(
     }
 }
 
+/// Extract the numeric interpretation of a time value, if it has one.
+///
+/// Mirrors SQLite's "raw number" classification (`setRawDateNumber` /
+/// `sqlite3AtoF` fallback in `parseDateOrTime`): SQL numerics and strings that
+/// are plain numeric literals qualify; everything else does not.
+fn numeric_time_value(value: &SqlValue) -> Option<f64> {
+    match value {
+        SqlValue::Integer(n) => Some(*n as f64),
+        SqlValue::Bigint(n) => Some(*n as f64),
+        SqlValue::Smallint(n) => Some(*n as f64),
+        SqlValue::Float(n) => Some(*n as f64),
+        SqlValue::Double(n) | SqlValue::Real(n) | SqlValue::Numeric(n) => Some(*n),
+        SqlValue::Varchar(s) | SqlValue::Character(s) => s.trim().parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+/// Parse the base datetime value when 'auto' is the first modifier.
+///
+/// SQLite semantics (date.c, 'auto' case): numeric values in `[0.0, 5373484.5)`
+/// are Julian Day numbers; other numerics within `[-210866760000, 253402300799]`
+/// are Unix timestamps; numerics outside both ranges yield NULL. 'auto' is a
+/// no-op for text (non-numeric) time values.
+fn parse_base_datetime_auto(
+    value: &SqlValue,
+    func_name: &str,
+) -> Result<Option<NaiveDateTime>, ExecutorError> {
+    if matches!(value, SqlValue::Null) {
+        return Ok(None);
+    }
+    match numeric_time_value(value) {
+        Some(n) if (0.0..5_373_484.5).contains(&n) => Ok(julian_day_to_naive(n)),
+        Some(n) if (-210_866_760_000.0..=253_402_300_799.0).contains(&n) => {
+            Ok(unix_epoch_seconds_f64_to_datetime(n))
+        }
+        Some(_) => Ok(None), // Out of range for both interpretations
+        None => parse_base_datetime(value, func_name), // No-op for text values
+    }
+}
+
+/// Parse the base datetime value when 'julianday' is the first modifier.
+///
+/// SQLite semantics: only valid when the time value is numeric (the DDDDDDDDDD
+/// format) and within the valid Julian Day range; all other uses return NULL.
+fn parse_base_datetime_julianday(value: &SqlValue) -> Option<NaiveDateTime> {
+    match numeric_time_value(value) {
+        Some(n) if (0.0..5_373_484.5).contains(&n) => julian_day_to_naive(n),
+        _ => None,
+    }
+}
+
 /// Apply a single modifier to a NaiveDateTime
 /// Returns None if the modifier is invalid (SQLite returns NULL for invalid modifiers)
 fn apply_datetime_modifier(dt: NaiveDateTime, modifier: &str) -> Option<NaiveDateTime> {
@@ -420,8 +489,37 @@ fn apply_datetime_modifier(dt: NaiveDateTime, modifier: &str) -> Option<NaiveDat
         return result;
     }
 
+    // Handle (+|-)HH:MM[:SS[.FFF]] modifiers (no sign means plus). Must be
+    // checked before generic time shifts.
+    if let Some(result) = try_apply_hh_mm_modifier(dt, modifier) {
+        return result;
+    }
+
     // Handle time shift modifiers: +N unit, -N unit, N unit
     parse_and_apply_time_shift(dt, modifier)
+}
+
+/// Detect and apply a `[+-]HH:MM[:SS[.FFF]]` modifier (SQLite date.c
+/// `parseModifier`, '+'/'-'/digit case with a ':' after the leading number).
+/// A missing sign means plus (e.g. `'12:30'` adds 12 hours 30 minutes).
+///
+/// Returns:
+/// - `None` if the modifier is not of this form (caller should fall through)
+/// - `Some(None)` if it is of this form but invalid (SQLite returns NULL,
+///   e.g. `'12:60'`)
+/// - `Some(Some(dt))` on success
+fn try_apply_hh_mm_modifier(dt: NaiveDateTime, modifier: &str) -> Option<Option<NaiveDateTime>> {
+    let (sign, rest) = match modifier.as_bytes().first() {
+        Some(b'+') => (1i64, &modifier[1..]),
+        Some(b'-') => (-1i64, &modifier[1..]),
+        Some(b) if b.is_ascii_digit() => (1i64, modifier),
+        _ => return None,
+    };
+    let b = rest.as_bytes();
+    if !(b.len() >= 5 && b[0].is_ascii_digit() && b[1].is_ascii_digit() && b[2] == b':') {
+        return None; // Not the HH:MM form; fall through to other modifiers
+    }
+    Some(parse_hh_mm_ss_ms(rest).map(|ms| dt + Duration::milliseconds(sign * ms)))
 }
 
 /// Detect and apply a `(+|-)YYYY-MM-DD[ HH:MM[:SS[.FFF]]]` modifier.
@@ -619,39 +717,20 @@ fn split_amount_and_unit(s: &str) -> Option<(&str, &str)> {
     Some((amount, unit))
 }
 
-/// Add months to a NaiveDateTime, handling edge cases like Jan 31 + 1 month
+/// Add months to a NaiveDateTime.
+///
+/// Matches SQLite's `computeJD` normalization: when the day-of-month overflows
+/// the target month (e.g. Jan 31 + 1 month), the date rolls into the following
+/// month (2000-01-31 '+1 month' -> 2000-03-02) rather than clamping.
 fn add_months(dt: NaiveDateTime, months: i32) -> Option<NaiveDateTime> {
     let total_months = dt.year() as i64 * 12 + dt.month() as i64 - 1 + months as i64;
-    let new_year = (total_months / 12) as i32;
-    let new_month = (total_months % 12 + 1) as u32;
+    let new_year = i32::try_from(total_months.div_euclid(12)).ok()?;
+    let new_month = total_months.rem_euclid(12) as u32 + 1;
 
-    // Handle month overflow for the day (e.g., Jan 31 -> Feb 28)
-    let max_day = days_in_month(new_year, new_month);
-    let new_day = dt.day().min(max_day);
-
-    let new_date = chrono::NaiveDate::from_ymd_opt(new_year, new_month, new_day)?;
+    // Day-of-month overflow rolls into the next month (SQLite normalization)
+    let new_date = chrono::NaiveDate::from_ymd_opt(new_year, new_month, 1)?
+        + Duration::days(dt.day() as i64 - 1);
     Some(NaiveDateTime::new(new_date, dt.time()))
-}
-
-/// Get the number of days in a month
-fn days_in_month(year: i32, month: u32) -> u32 {
-    match month {
-        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
-        4 | 6 | 9 | 11 => 30,
-        2 => {
-            if is_leap_year(year) {
-                29
-            } else {
-                28
-            }
-        }
-        _ => 30,
-    }
-}
-
-/// Check if a year is a leap year
-fn is_leap_year(year: i32) -> bool {
-    (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
 }
 
 /// Convert Unix epoch timestamp to NaiveDateTime
@@ -701,12 +780,14 @@ fn naive_datetime_to_timestamp(dt: NaiveDateTime) -> Result<SqlValue, ExecutorEr
 /// Helper to parse SQLite datetime strings to NaiveDateTime
 ///
 /// Follows SQLite's `parseYyyyMmDd` grammar strictly:
-/// `[-]YYYY-MM-DD[<space|T>HH:MM[:SS[.FFF...]]]` where every field is exactly
-/// the documented number of digits. An out-of-range day-of-month (e.g.
-/// `2003-02-31`) normalizes into the following month, matching SQLite's
-/// `computeJD`. A time-only value `HH:MM[:SS[.FFF...]]` defaults the date to
-/// 2000-01-01 (SQLite `parseTimeOnly`). A plain numeric string is interpreted
-/// as a Julian Day number.
+/// `[-]YYYY-MM-DD[<space|T>HH:MM[:SS[.FFF...]][TZ]]` where every field is
+/// exactly the documented number of digits and `TZ` is an optional timezone
+/// suffix (`Z`/`z` or `[+-]HH:MM`) that converts the timestamp to UTC. An
+/// out-of-range day-of-month (e.g. `2003-02-31`) normalizes into the following
+/// month, matching SQLite's `computeJD`. A time-only value
+/// `HH:MM[:SS[.FFF...]]` defaults the date to 2000-01-01 (SQLite
+/// `parseTimeOnly`). A plain numeric string is interpreted as a Julian Day
+/// number.
 fn parse_datetime_string_to_naive(s: &str) -> Option<NaiveDateTime> {
     let s = s.trim();
 
@@ -716,7 +797,7 @@ fn parse_datetime_string_to_naive(s: &str) -> Option<NaiveDateTime> {
 
     // SQLite: time-only values `HH:MM[:SS[.FFF...]]` default the date to
     // 2000-01-01 (parseTimeOnly in date.c)
-    if let Some(time_ms) = parse_hh_mm_ss_ms(s) {
+    if let Some(time_ms) = parse_hh_mm_ss_tz_ms(s) {
         let midnight = chrono::NaiveDate::from_ymd_opt(2000, 1, 1)?.and_hms_opt(0, 0, 0)?;
         return Some(midnight + Duration::milliseconds(time_ms));
     }
@@ -769,16 +850,15 @@ fn parse_yyyy_mm_dd(s: &str) -> Option<NaiveDateTime> {
         return date.and_hms_opt(0, 0, 0);
     }
 
-    let time_ms = parse_hh_mm_ss_ms(tail)?;
+    let time_ms = parse_hh_mm_ss_tz_ms(tail)?;
     Some(date.and_hms_opt(0, 0, 0)? + Duration::milliseconds(time_ms))
 }
 
-/// Strict `HH:MM[:SS[.FFF...]]` parser returning milliseconds since midnight.
-/// Mirrors SQLite's parseHhMmSs limits: HH <= 24, MM/SS <= 59, the fraction
-/// needs at least one digit, sub-millisecond fractions round like SQLite.
-/// Trailing content other than whitespace is an error (timezone suffixes are
-/// not supported and yield NULL).
-fn parse_hh_mm_ss_ms(t: &str) -> Option<i64> {
+/// Strict `HH:MM[:SS[.FFF...]]` parser returning milliseconds since midnight
+/// plus the unconsumed tail. Mirrors SQLite's parseHhMmSs limits: HH <= 24,
+/// MM/SS <= 59, the fraction needs at least one digit, sub-millisecond
+/// fractions round like SQLite.
+fn parse_hh_mm_ss_core(t: &str) -> Option<(i64, &str)> {
     let b = t.as_bytes();
     if b.len() < 5
         || !b[0].is_ascii_digit()
@@ -821,9 +901,68 @@ fn parse_hh_mm_ss_ms(t: &str) -> Option<i64> {
         }
     }
 
+    Some((total_ms, rest))
+}
+
+/// Strict `HH:MM[:SS[.FFF...]]` parser returning milliseconds since midnight.
+/// Used for modifiers, where a timezone suffix is not allowed: trailing
+/// content other than whitespace is an error.
+fn parse_hh_mm_ss_ms(t: &str) -> Option<i64> {
+    let (total_ms, rest) = parse_hh_mm_ss_core(t)?;
     // Only trailing whitespace is allowed
     if rest.chars().all(|c| c.is_ascii_whitespace()) {
         Some(total_ms)
+    } else {
+        None
+    }
+}
+
+/// `HH:MM[:SS[.FFF...]]` parser for timestrings, with an optional timezone
+/// suffix (`Z`/`z` or `[+-]HH:MM`, SQLite date.c `parseTimezone`). Returns the
+/// UTC-adjusted milliseconds offset from midnight (the timezone offset is
+/// subtracted, converting the timestamp to UTC).
+fn parse_hh_mm_ss_tz_ms(t: &str) -> Option<i64> {
+    let (total_ms, rest) = parse_hh_mm_ss_core(t)?;
+    let tz_minutes = parse_timezone_suffix(rest)?;
+    Some(total_ms - tz_minutes * 60_000)
+}
+
+/// Parse an optional timezone suffix following the time component, mirroring
+/// SQLite's `parseTimezone`: optional whitespace, then either `Z`/`z` or
+/// `[+-]HH:MM` (HH <= 14, MM <= 59), then optional trailing whitespace.
+/// Returns the offset in minutes (0 for Zulu or no suffix); `None` for
+/// malformed suffixes or trailing junk.
+fn parse_timezone_suffix(s: &str) -> Option<i64> {
+    let s = s.trim_start_matches(|c: char| c.is_ascii_whitespace());
+    if s.is_empty() {
+        return Some(0);
+    }
+    let (offset_minutes, rest) = match s.as_bytes()[0] {
+        b'Z' | b'z' => (0, &s[1..]),
+        sign @ (b'+' | b'-') => {
+            let b = s.as_bytes();
+            if b.len() < 6
+                || !b[1].is_ascii_digit()
+                || !b[2].is_ascii_digit()
+                || b[3] != b':'
+                || !b[4].is_ascii_digit()
+                || !b[5].is_ascii_digit()
+            {
+                return None;
+            }
+            let hours: i64 = s[1..3].parse().ok()?;
+            let minutes: i64 = s[4..6].parse().ok()?;
+            if hours > 14 || minutes > 59 {
+                return None;
+            }
+            let total = hours * 60 + minutes;
+            (if sign == b'-' { -total } else { total }, &s[6..])
+        }
+        _ => return None,
+    };
+    // Only trailing whitespace is allowed after the timezone
+    if rest.chars().all(|c| c.is_ascii_whitespace()) {
+        Some(offset_minutes)
     } else {
         None
     }

--- a/crates/vibesql-executor/src/evaluator/functions/datetime/strftime.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/datetime/strftime.rs
@@ -5,28 +5,42 @@
 //! `datetime()` (see `current::resolve_time_value`), then the resolved instant
 //! is rendered through the format string.
 //!
-//! Supported format specifiers (the classic SQLite set):
+//! Supported format specifiers (the classic SQLite set plus the 3.44+
+//! additions):
 //!
 //! | Specifier | Meaning                                  | Example (`2003-10-31 12:34:56.432`) |
 //! |-----------|------------------------------------------|--------------------------------------|
 //! | `%d`      | day of month, zero-padded (01-31)        | `31`                                 |
+//! | `%e`      | day of month, space-padded ( 1-31)       | `31`                                 |
 //! | `%f`      | fractional seconds `SS.SSS`              | `56.432`                             |
+//! | `%F`      | ISO 8601 date, same as `%Y-%m-%d`        | `2003-10-31`                         |
+//! | `%G`      | ISO 8601 week-based year                 | `2003`                               |
+//! | `%g`      | ISO 8601 week-based year, 2 digits       | `03`                                 |
 //! | `%H`      | hour, zero-padded (00-23)                | `12`                                 |
+//! | `%I`      | 12-hour clock hour, zero-padded (01-12)  | `12`                                 |
 //! | `%j`      | day of year, zero-padded (001-366)       | `304`                                |
 //! | `%J`      | fractional Julian Day number             | `2452944.024264259`                  |
+//! | `%k`      | hour, space-padded ( 0-23)               | `12`                                 |
+//! | `%l`      | 12-hour clock hour, space-padded ( 1-12) | `12`                                 |
 //! | `%m`      | month, zero-padded (01-12)               | `10`                                 |
 //! | `%M`      | minute, zero-padded (00-59)              | `34`                                 |
+//! | `%p`      | `AM` or `PM`                             | `PM`                                 |
+//! | `%P`      | `am` or `pm`                             | `pm`                                 |
+//! | `%R`      | same as `%H:%M`                          | `12:34`                              |
 //! | `%s`      | seconds since Unix epoch (integer)       | `1067603696`                         |
 //! | `%S`      | seconds, zero-padded (00-59)             | `56`                                 |
+//! | `%T`      | same as `%H:%M:%S`                       | `12:34:56`                           |
+//! | `%u`      | ISO day of week (1-7, Monday=1)          | `5`                                  |
+//! | `%U`      | week of year (00-53, Sunday-based)       | `43`                                 |
+//! | `%V`      | ISO 8601 week of year (01-53)            | `44`                                 |
 //! | `%w`      | day of week (0-6, Sunday=0)              | `5`                                  |
 //! | `%W`      | week of year (00-53, Monday-based)       | `43`                                 |
 //! | `%Y`      | year, zero-padded to 4 digits            | `2003`                               |
 //! | `%%`      | literal `%`                              | `%`                                  |
 //!
-//! Out of scope for v1 (returns NULL like older SQLite versions):
-//! - SQLite 3.44+ additions: `%e %F %G %g %I %k %l %p %P %R %T %u %U %V`
+//! Out of scope (returns NULL like SQLite does for unknown specifiers):
 //! - Modifiers beyond what `datetime()` supports (`subsec`, real timezone
-//!   conversion for `localtime`/`utc`, `±HH:MM` offsets, `auto`, `julianday`)
+//!   conversion for `localtime`/`utc`)
 //!
 //! SQLite Reference: https://www.sqlite.org/lang_datefunc.html
 
@@ -93,19 +107,42 @@ fn format_datetime(format: &str, dt: NaiveDateTime) -> Option<String> {
         let spec = chars.next()?; // trailing '%' is an error -> NULL
         match spec {
             'd' => write!(out, "{:02}", dt.day()).ok()?,
+            'e' => write!(out, "{:2}", dt.day()).ok()?,
             'f' => {
                 // Seconds with milliseconds, "%06.3f" in SQLite (e.g. 56.432, 06.400).
                 // Truncate (not round) sub-millisecond precision; clamp leap seconds.
                 let millis = (dt.nanosecond() / 1_000_000).min(999);
                 write!(out, "{:02}.{:03}", dt.second(), millis).ok()?
             }
+            'F' => write!(out, "{:04}-{:02}-{:02}", dt.year(), dt.month(), dt.day()).ok()?,
+            'G' => write!(out, "{:04}", dt.iso_week().year()).ok()?,
+            'g' => write!(out, "{:02}", dt.iso_week().year().rem_euclid(100)).ok()?,
             'H' => write!(out, "{:02}", dt.hour()).ok()?,
+            'I' => write!(out, "{:02}", hour_12(&dt)).ok()?,
             'j' => write!(out, "{:03}", dt.ordinal()).ok()?,
             'J' => out.push_str(&format_julian_day(dt)),
+            'k' => write!(out, "{:2}", dt.hour()).ok()?,
+            'l' => write!(out, "{:2}", hour_12(&dt)).ok()?,
             'm' => write!(out, "{:02}", dt.month()).ok()?,
             'M' => write!(out, "{:02}", dt.minute()).ok()?,
+            'p' => out.push_str(if dt.hour() >= 12 { "PM" } else { "AM" }),
+            'P' => out.push_str(if dt.hour() >= 12 { "pm" } else { "am" }),
+            'R' => write!(out, "{:02}:{:02}", dt.hour(), dt.minute()).ok()?,
             's' => write!(out, "{}", dt.and_utc().timestamp()).ok()?,
             'S' => write!(out, "{:02}", dt.second()).ok()?,
+            'T' => write!(out, "{:02}:{:02}:{:02}", dt.hour(), dt.minute(), dt.second()).ok()?,
+            'u' => {
+                // ISO day of week: Monday=1 .. Sunday=7
+                write!(out, "{}", dt.weekday().num_days_from_monday() + 1).ok()?
+            }
+            'U' => {
+                // Week 01 starts on the first Sunday of the year; days before
+                // that are week 00 (Sunday-based analog of %W).
+                let n_day = dt.ordinal0();
+                let wd = dt.weekday().num_days_from_sunday();
+                write!(out, "{:02}", (n_day + 7 - wd) / 7).ok()?
+            }
+            'V' => write!(out, "{:02}", dt.iso_week().week()).ok()?,
             'w' => write!(out, "{}", dt.weekday().num_days_from_sunday()).ok()?,
             'W' => {
                 // SQLite: week 01 starts on the first Monday of the year; days
@@ -123,6 +160,16 @@ fn format_datetime(format: &str, dt: NaiveDateTime) -> Option<String> {
     }
 
     Some(out)
+}
+
+/// 12-hour clock hour for `%I`/`%l`: 00:xx is 12, 13:xx is 1.
+fn hour_12(dt: &NaiveDateTime) -> u32 {
+    let h = dt.hour() % 12;
+    if h == 0 {
+        12
+    } else {
+        h
+    }
 }
 
 /// Format the fractional Julian Day number for `%J`.
@@ -307,17 +354,61 @@ mod tests {
     fn test_unknown_specifier_returns_null() {
         // date.test 3.14: %_ -> NULL
         assert_eq!(sf(&[text("%_"), text("2003-10-31 12:34:56.432")]), SqlValue::Null);
-        // 3.44+ specifiers are out of scope for v1 -> NULL
-        for spec in ["%e", "%F", "%I", "%k", "%p", "%P", "%R", "%T", "%u", "%G", "%g", "%U", "%V"] {
+        // date.test 3.18: genuinely unknown specifiers -> NULL
+        for c in [
+            'a', 'b', 'c', 'h', 'i', 'n', 'o', 'q', 'r', 't', 'v', 'x', 'y', 'z', 'A', 'B', 'C',
+            'D', 'E', 'K', 'L', 'N', 'O', 'Q', 'Z', '0', '1', '9', '_',
+        ] {
             assert_eq!(
-                sf(&[text(spec), text("2003-10-31")]),
+                sf(&[text(&format!("%{}", c)), text("2003-10-31")]),
                 SqlValue::Null,
-                "{} should return NULL",
-                spec
+                "%{} should return NULL",
+                c
             );
         }
         // Trailing bare '%' -> NULL
         assert_eq!(sf(&[text("abc%"), text("2003-10-31")]), SqlValue::Null);
+    }
+
+    #[test]
+    fn test_extended_specifiers() {
+        // date.test 3.20-3.30 (SQLite 3.44+ additions)
+        assert_strftime("%e", "2023-08-09", " 9");
+        assert_strftime("%e", "2023-08-19", "19");
+        assert_strftime("%F %T", "2023-08-09 01:23", "2023-08-09 01:23:00");
+        assert_strftime("%k", "2023-08-09 04:59:59", " 4");
+        assert_strftime("%I%P", "2023-08-09 11:59:59", "11am");
+        assert_strftime("%I%p", "2023-08-09 12:00:00", "12PM");
+        assert_strftime("%I%P", "2023-08-09 12:59:59.9", "12pm");
+        assert_strftime("%I%p", "2023-08-09 13:00:00", "01PM");
+        assert_strftime("%I%P", "2023-08-09 23:59:59", "11pm");
+        assert_strftime("%I%p", "2023-08-09 00:00:00", "12AM");
+        assert_strftime("%l:%M%P", "2023-08-09 13:00:00", " 1:00pm");
+        assert_strftime("%F %R", "2023-08-09 12:34:56", "2023-08-09 12:34");
+    }
+
+    #[test]
+    fn test_iso_weekday() {
+        // date.test 3.31-3.37: %u is 1-7 with Monday=1, Sunday=7
+        assert_strftime("%w %u", "2023-01-01", "0 7");
+        assert_strftime("%w %u", "2023-01-02", "1 1");
+        assert_strftime("%w %u", "2023-01-03", "2 2");
+        assert_strftime("%w %u", "2023-01-07", "6 6");
+    }
+
+    #[test]
+    fn test_iso_week_specifiers() {
+        // %V/%G/%g: ISO 8601 week numbering (2023-01-01 is week 52 of 2022)
+        assert_strftime("%V", "2023-01-01", "52");
+        assert_strftime("%G", "2023-01-01", "2022");
+        assert_strftime("%g", "2023-01-01", "22");
+        assert_strftime("%V", "2023-01-02", "01");
+        assert_strftime("%G", "2023-01-02", "2023");
+        // %U: Sunday-based week of year (week 01 starts on the first Sunday)
+        assert_strftime("%U", "2023-01-01", "01");
+        assert_strftime("%U", "2022-12-31", "52");
+        assert_strftime("%U", "2004-01-03", "00");
+        assert_strftime("%U", "2004-01-04", "01");
     }
 
     #[test]

--- a/crates/vibesql-executor/tests/date_time_function_tests/date_time.rs
+++ b/crates/vibesql-executor/tests/date_time_function_tests/date_time.rs
@@ -51,9 +51,95 @@ fn test_date_with_modifiers() {
     assert_renders("date('2024-01-01', '+1 day')", "2024-01-02");
     assert_renders("date('2024-03-15', 'start of month')", "2024-03-01");
     assert_renders("date('2024-01-15', '+1 month')", "2024-02-15");
-    // NOTE: SQLite month-overflow rollover (2024-01-31 '+1 month' -> 2024-03-02)
-    // is a known divergence tracked in #5309; not asserted here.
     assert_renders("date('2024-01-01', '-1 day')", "2023-12-31");
+}
+
+#[test]
+fn test_month_overflow_normalizes_like_sqlite() {
+    // SQLite timediff1.test 1.x/2.x: day-of-month overflow rolls into the
+    // following month rather than clamping (date.c computeJD normalization)
+    assert_renders("datetime('2000-01-31','+1 month')", "2000-03-02 00:00:00");
+    assert_renders("datetime('2004-01-29','+1 month')", "2004-02-29 00:00:00");
+    assert_renders("datetime('2000-03-31','-1 month')", "2000-03-02 00:00:00");
+    assert_renders("datetime('2000-02-29','+1 year')", "2001-03-01 00:00:00");
+    assert_renders("datetime('2001-01-31','+1 month')", "2001-03-03 00:00:00");
+    assert_renders("datetime('2001-03-31','-1 month')", "2001-03-03 00:00:00");
+}
+
+#[test]
+fn test_timezone_offset_suffix() {
+    // SQLite date.test 5.x: TZ-offset/Z suffix converts the timestamp to UTC
+    assert_renders("datetime('1994-04-16 14:00:00 +05:00')", "1994-04-16 09:00:00");
+    assert_renders("datetime('1994-04-16 14:00:00 -05:15')", "1994-04-16 19:15:00");
+    assert_renders("datetime('1994-04-16 05:00:00 +08:30')", "1994-04-15 20:30:00");
+    assert_renders("datetime('1994-04-16 14:00:00 -11:55')", "1994-04-17 01:55:00");
+    assert_renders("datetime('1994-04-16 14:00:00 -11:55  ')", "1994-04-17 01:55:00");
+    assert_renders("datetime('1994-04-16T14:00:00Z')", "1994-04-16 14:00:00");
+    assert_renders("datetime('1994-04-16 14:00:00z')", "1994-04-16 14:00:00");
+    assert_renders("datetime('1994-04-16 14:00:00 Z')", "1994-04-16 14:00:00");
+    assert_renders("datetime('1994-04-16 14:00:00z    ')", "1994-04-16 14:00:00");
+    // Invalid offsets / trailing junk / combined Z+offset -> NULL
+    assert_null("datetime('1994-04-16 14:00:00 -11:60')");
+    assert_null("datetime('1994-04-16 14:00:00 -11:55 x')");
+    assert_null("datetime('1994-04-16 14:00:00Zulu')");
+    assert_null("datetime('1994-04-16 14:00:00Z +05:00')");
+    assert_null("datetime('1994-04-16 14:00:00 +05:00 Z')");
+}
+
+#[test]
+fn test_hh_mm_ss_modifiers() {
+    // SQLite date.test 11.x: ±HH:MM[:SS] modifiers; no sign means plus
+    assert_renders("datetime('2004-02-28 20:00:00', '-01:20:30')", "2004-02-28 18:39:30");
+    assert_renders("datetime('2004-02-28 20:00:00', '+12:30:00')", "2004-02-29 08:30:00");
+    assert_renders("datetime('2004-02-28 20:00:00', '+12:30')", "2004-02-29 08:30:00");
+    assert_renders("datetime('2004-02-28 20:00:00', '12:30')", "2004-02-29 08:30:00");
+    assert_renders("datetime('2004-02-28 20:00:00', '-12:00')", "2004-02-28 08:00:00");
+    assert_renders("datetime('2004-02-28 20:00:00', '-12:01')", "2004-02-28 07:59:00");
+    assert_renders("datetime('2004-02-28 20:00:00', '12:01')", "2004-02-29 08:01:00");
+    // Out-of-range minutes -> NULL
+    assert_null("datetime('2004-02-28 20:00:00', '12:60')");
+}
+
+#[test]
+fn test_auto_modifier() {
+    // SQLite date3.test 2.x: numeric values in the julian-day range are
+    // julian days; other in-range numerics are unix timestamps
+    assert_renders("datetime(2440587.5, 'auto')", "1970-01-01 00:00:00");
+    assert_renders("datetime(2440615.7475463, 'auto')", "1970-01-29 05:56:28");
+    assert_renders("datetime(-1, 'auto')", "1969-12-31 23:59:59");
+    assert_renders("datetime(5373485, 'auto')", "1970-03-04 04:38:05");
+    assert_renders("datetime(253402300799, 'auto')", "9999-12-31 23:59:59");
+    // Out of range for both interpretations -> NULL
+    assert_null("datetime(-210866760001, 'auto')");
+    assert_null("datetime(253402300800, 'auto')");
+    // No-op for text values
+    assert_renders("date('2022-01-29', 'auto')", "2022-01-29");
+    // Only valid as the first modifier
+    assert_null("datetime(2459607.05, '+1 hour', 'auto')");
+}
+
+#[test]
+fn test_julianday_modifier() {
+    // SQLite date3.test 4.x: 'julianday' forces julian-day interpretation
+    // and is only valid immediately after a numeric time value
+    assert_renders("datetime(2459607, 'julianday')", "2022-01-27 12:00:00");
+    assert_renders("datetime('2459607', 'julianday')", "2022-01-27 12:00:00");
+    assert_null("datetime(2459607, '+1 hour', 'julianday')");
+    assert_null("datetime('2022-01-27', 'julianday')");
+}
+
+#[test]
+fn test_julian_day_range_bounds() {
+    // SQLite date.test 16.x/17.x: modifiers that push the result outside the
+    // valid julian-day range yield NULL
+    assert_renders("datetime(0, '+464269060799 seconds')", "9999-12-31 23:59:59");
+    assert_null("datetime(0, '+464269060800 seconds')");
+    assert_null("datetime(0, '+5373485 days')");
+    assert_null("datetime(0, '+176546 months')");
+    assert_null("datetime(0, '+14713 years')");
+    assert_null("datetime(5373484, '-5373485 days')");
+    assert_null("datetime(37, 'start of year')");
+    assert_renders("datetime(38, 'start of year')", "-4712-01-01 00:00:00");
 }
 
 #[test]

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3263,38 +3263,8 @@ array set vibesql_skip_tests {
 
     triggerupfrom-2.3 "Cascades from auto-skipped test 2.2. CREATE TEMP TRIGGER now parses (#5218), but 2.2 references aux.t3 and is auto-skipped by the ATTACH/aux regex (VibeSQL has no ATTACH/multi-database support), so the rows 2.2 inserts (10 y {}, 20 y {}) never exist and 2.3's expected output cannot match. The UPDATE…FROM trigger logic in 2.3 itself works correctly when run in isolation (verified during #5192 builder pass)."
 
-    date-2.40 "zero-argument datetime() rejected (SQLite treats it as 'now') (#5309)"
-    date-2.60 "invalid-date rollover normalization (2023-02-31 -> 2023-03-03) differs (#5309)"
-    date-3.11.99 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.20 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.21 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.22 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.23 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.24 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.25 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.26 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.27 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.28 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.29 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.30 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.31 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.32 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.33 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.34 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.35 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.36 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
-    date-3.37 "strftime specifier gaps (%e/%F/%T/%k/%P/%U/%V/%G/%g, string julian-day input) (#5309)"
+    date-2.40 "zero-argument datetime() rejected by the parser (#5317); also needs the sqlite_current_time fake-clock hook the harness cannot honor"
     date-4.1 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
-    date-5.1 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
-    date-5.2 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
-    date-5.3 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
-    date-5.4 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
-    date-5.6 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
-    date-5.8 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
-    date-5.9 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
-    date-5.10 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
-    date-5.11 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
-    date-5.12 "TZ-offset/Z suffix in datetime input strings returns NULL (#5309)"
     date-8.1 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
     date-8.2 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
     date-8.3 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
@@ -3314,33 +3284,7 @@ array set vibesql_skip_tests {
     date-8.17 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
     date-8.18 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
     date-8.19 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
-    date-11.1 "+/-HH:MM:SS modifiers return NULL (#5309)"
-    date-11.2 "+/-HH:MM:SS modifiers return NULL (#5309)"
-    date-11.3 "+/-HH:MM:SS modifiers return NULL (#5309)"
-    date-11.4 "+/-HH:MM:SS modifiers return NULL (#5309)"
-    date-11.5 "+/-HH:MM:SS modifiers return NULL (#5309)"
-    date-11.6 "+/-HH:MM:SS modifiers return NULL (#5309)"
-    date-11.7 "+/-HH:MM:SS modifiers return NULL (#5309)"
-    date-11.8 "+/-HH:MM:SS modifiers return NULL (#5309)"
-    date-11.9 "+/-HH:MM:SS modifiers return NULL (#5309)"
     date-15.2 "sleeper TCL UDF registered via db func is not visible to the VibeSQL CLI subprocess (harness limitation)"
-    date-16.3 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.7 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.9 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.11 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.13 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.15 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.17 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.20 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.21 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.22 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.23 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.24 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.25 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.27 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.28 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-16.30 "julian-day range bounds not enforced for extreme date values (#5309)"
-    date-17.6 "julian-day range bounds not enforced for extreme date values (#5309)"
     date2-110 "non-deterministic use of date/time functions in CHECK constraints is not rejected"
     date2-120 "non-deterministic use of date/time functions in CHECK constraints is not rejected"
     date2-130 "non-deterministic use of date/time functions in CHECK constraints is not rejected"
@@ -3363,28 +3307,8 @@ array set vibesql_skip_tests {
     date2-610 "non-deterministic use of date/time functions in CHECK constraints is not rejected"
     date2-612 "non-deterministic use of date/time functions in CHECK constraints is not rejected"
     date3-620 "non-deterministic use of date/time functions in CHECK constraints is not rejected (test lives in date2.test)"
-    date3-2.1 "'auto' modifier not supported (#5309)"
-    date3-2.2 "'auto' modifier not supported (#5309)"
-    date3-2.3 "'auto' modifier not supported (#5309)"
-    date3-2.4 "'auto' modifier not supported (#5309)"
-    date3-2.5 "'auto' modifier not supported (#5309)"
-    date3-2.10 "'auto' modifier not supported (#5309)"
-    date3-2.11 "'auto' modifier not supported (#5309)"
-    date3-2.12 "'auto' modifier not supported (#5309)"
-    date3-2.13 "'auto' modifier not supported (#5309)"
-    date3-2.30 "'auto' modifier not supported (#5309)"
-    date3-2.40 "'auto' modifier not supported (#5309)"
-    date3-4.1 "'julianday' modifier not supported (#5309)"
-    date3-5.0 "'auto' modifier not supported (#5309)"
-    timediff-1.1 "month-overflow date normalization (e.g. 2000-01-31 '+1 month' -> 2000-03-02) differs (#5309)"
-    timediff-1.4 "month-overflow date normalization (e.g. 2000-01-31 '+1 month' -> 2000-03-02) differs (#5309)"
-    timediff-1.5 "month-overflow date normalization (e.g. 2000-01-31 '+1 month' -> 2000-03-02) differs (#5309)"
-    timediff-1.8 "month-overflow date normalization (e.g. 2000-01-31 '+1 month' -> 2000-03-02) differs (#5309)"
-    timediff-2.1 "month-overflow date normalization (e.g. 2000-01-31 '+1 month' -> 2000-03-02) differs (#5309)"
-    timediff-2.2 "month-overflow date normalization (e.g. 2000-01-31 '+1 month' -> 2000-03-02) differs (#5309)"
-    timediff-2.4 "month-overflow date normalization (e.g. 2000-01-31 '+1 month' -> 2000-03-02) differs (#5309)"
-    timediff-2.5 "month-overflow date normalization (e.g. 2000-01-31 '+1 month' -> 2000-03-02) differs (#5309)"
-    timediff-2.6 "month-overflow date normalization (e.g. 2000-01-31 '+1 month' -> 2000-03-02) differs (#5309)"
+    date3-2.40 "datetime() returns a Timestamp value, not TEXT, so datetime(x,'auto') == '...' string comparison raises a type mismatch (#5317)"
+    date3-5.0 "format('%+d days',x) string formatting not supported by format() (#5317)"
 }
 
 # Pattern-based skip list for tests with many numbered variants
@@ -3446,18 +3370,9 @@ variable vibesql_skip_patterns {
     {window2-66. "json_group_array/json_group_object as window function not implemented"}
     {windowfault- "SQLite fault injection testing"}
 
-    {date-2.2c-1 "strftime('%f') with numeric 'unixepoch' input drops fractional seconds (#5309); date-2.2c-0 (.000) passes and is not skipped"}
-    {date-2.2c-2 "strftime('%f') with numeric 'unixepoch' input drops fractional seconds (#5309)"}
-    {date-2.2c-3 "strftime('%f') with numeric 'unixepoch' input drops fractional seconds (#5309)"}
-    {date-2.2c-4 "strftime('%f') with numeric 'unixepoch' input drops fractional seconds (#5309)"}
-    {date-2.2c-5 "strftime('%f') with numeric 'unixepoch' input drops fractional seconds (#5309)"}
-    {date-2.2c-6 "strftime('%f') with numeric 'unixepoch' input drops fractional seconds (#5309)"}
-    {date-2.2c-7 "strftime('%f') with numeric 'unixepoch' input drops fractional seconds (#5309)"}
-    {date-2.2c-8 "strftime('%f') with numeric 'unixepoch' input drops fractional seconds (#5309)"}
-    {date-2.2c-9 "strftime('%f') with numeric 'unixepoch' input drops fractional seconds (#5309)"}
-    {date-6. "localtime/utc DST boundary tests require the SQLITE_TESTCTRL_LOCALTIME_FAULT harness localtime_r override (#5309)"}
-    {date-19. "date() now parses (#5307) but the 'ceiling'/'floor' modifiers are not supported and return NULL (#5309)"}
-    {date4- "compares VibeSQL strftime against the C library strftime; shim only stubs the TCL strftime command via clock format, and strftime specifier gaps remain (#5309)"}
+    {date-6. "localtime/utc DST boundary tests require the SQLITE_TESTCTRL_LOCALTIME_FAULT harness localtime_r override (harness limitation)"}
+    {date-19. "the 'ceiling'/'floor' modifiers are not supported and return NULL (#5317)"}
+    {date4- "compares VibeSQL strftime against the C library strftime; shim only stubs the TCL strftime command via clock format, so expected values are computed by the stub rather than libc (harness limitation)"}
 }
 
 # Check if a test should be skipped based on VibeSQL-specific exclusions
@@ -4231,9 +4146,12 @@ proc check_single_capability {cap} {
     # Capabilities we don't support (unsupported_caps means NOT supported)
     # NOTE: datetime/datetime_time/datetime_funcs were removed from this list
     # (#5294) — VibeSQL implements date(), time(), datetime(), strftime().
-    # Remaining gaps are pattern-skipped: see #5309 (strftime %f/%W/%j,
-    # TZ offsets, HH:MM:SS modifiers). date()/time() function calls were
-    # implemented in #5307; julianday()/unixepoch()/timediff() in #5308.
+    # Remaining gaps are pattern-skipped: see #5317 ('ceiling'/'floor'
+    # modifiers, zero-arg datetime(), TEXT return-type comparisons).
+    # date()/time() function calls were implemented in #5307;
+    # julianday()/unixepoch()/timediff() in #5308; fractional unixepoch,
+    # TZ offsets, +/-HH:MM:SS modifiers, strftime specifiers, 'auto'/
+    # 'julianday' modifiers, and Julian Day range bounds in #5309.
     set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 trigger conflict hiddencolumns}
 
     # Handle negated capability (e.g., !autovacuum)
@@ -4981,9 +4899,10 @@ proc strftime {format seconds} {
     # strftime). date4.test calls it at file level to compute expected
     # values, which aborts the whole file under plain tclsh (#5294).
     # Implemented via [clock format] in UTC; close enough to keep the file
-    # loading. The date4- tests themselves are pattern-skipped (#5309)
-    # because VibeSQL's strftime does not yet cover all C-library
-    # specifiers, so this stub's output is never compared against results.
+    # loading. The date4- tests themselves are pattern-skipped (harness
+    # limitation) because the stub computes expected values via [clock
+    # format] rather than the C library strftime the tests assume, so this
+    # stub's output is never compared against results.
     return [clock format [expr {int($seconds)}] -format $format -gmt 1]
 }
 


### PR DESCRIPTION
## Summary

Implements the remaining buckets of #5309 (re-baselined on current main — the fractional-unixepoch bucket, numeric-string julian-day input, time-only defaulting, and `±YYYY-MM-DD` modifiers had already landed via #5312/#5316; their skip entries are removed here after verification):

- **TZ-offset / Z suffix in timestrings** (date-5.x): `[+-]HH:MM` and `Z`/`z` after the time component convert to UTC, with SQLite `parseTimezone` validation (HH≤14, MM≤59; trailing junk, `Z`+offset combos, and `-11:60` yield NULL)
- **`±HH:MM[:SS[.FFF]]` modifiers** (date-11.x): no sign means plus; `'12:60'` → NULL
- **strftime specifiers** `%e %F %G %g %I %k %l %p %P %R %T %u %U %V` (date-3.20–3.37): the SQLite 3.44+ set, including the 12-hour clock edge cases (00:00 → `12AM`, 12:59 → `12pm`)
- **`'auto'` / `'julianday'` modifiers** (date3-2.x/4.x): first-modifier-only; `'auto'` dispatches numerics between julian day (`[0, 5373484.5)`) and unix timestamp (`[-210866760000, 253402300799]`), NULL outside both; no-op for text
- **Month-overflow normalization** (timediff-1.x/2.x): `'+1 month'` on Jan 31 now rolls into Mar 02/03 like SQLite `computeJD`, instead of clamping; `add_months` also handles pre-zero years via euclidean division
- **Julian Day range bounds** (date-16.x, date-17.6): the final resolved value is validated against `[0, 464269060799999]` iJD ms (SQLite `isDate`/`validJulianDay`), so modifiers pushing past 9999-12-31 23:59:59.999 or before -4713-11-24 12:00:00 return NULL

Removes all 85 now-passing `#5309` skip entries from `scripts/tester_vibesql.tcl` (including the date-2.2c fractional-unixepoch patterns and date-2.60, which already pass on main) and retargets the remaining rationales (ceiling/floor modifiers, zero-arg `datetime()`, Timestamp-vs-TEXT comparisons, string `format()`) to follow-up #5317.

## Conformance deltas

Measured with the same binary, before/after shim skip removal:

| File | Passing before | Passing after | Delta | Failures |
|------|---------------|---------------|-------|----------|
| date.test | 275 | 1,330 | **+1,055** | 0 |
| date3.test | 113 | 124 | **+11** | 0 |
| timediff1.test | 1,511 | 1,520 | **+9** | 0 |

Remaining date.test skips (96) are fake-clock/localtime harness limitations, date-19 ceiling/floor (#5317), and date-2.40 (#5317).

## Test plan

- [x] `cargo test -p vibesql-executor --lib` — 2,567 passed, 0 failed (includes new in-module strftime specifier tests)
- [x] `cargo test -p vibesql-executor --test date_time_function_tests` — 92 passed (new integration tests for TZ suffixes, ±HH:MM:SS modifiers, auto/julianday, month overflow, JD bounds)
- [x] `make test-tcl-file FILE=date.test` / `date3.test` / `timediff1.test` — 0 failures
- [x] `make test-tcl-file FILE=date2.test` / `date4.test` — unchanged, 0 failures
- [x] clippy: no new warnings in changed files

Closes #5309

🤖 Generated with [Claude Code](https://claude.com/claude-code)