### PR TITLE
feat(executor): add floor/ceiling modifiers, zero-arg datetime(), temporal-vs-string comparison, printf-style format()

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/datetime/current.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/datetime/current.rs
@@ -176,17 +176,15 @@ fn format_time_with_precision(time: chrono::NaiveTime, precision: u32) -> String
 /// Modifiers supported:
 /// - Time shifts: +N days, -N hours, +N minutes, +N seconds, +N months, +N years
 /// - Special: 'start of month', 'start of year', 'start of day', 'weekday N'
+/// - Overflow: 'floor', 'ceiling' (day-of-month overflow handling)
 /// - Timezone: 'localtime', 'utc'
 /// - Unix: 'unixepoch' (interprets numeric input as Unix timestamp)
 ///
+/// An omitted time-value defaults to 'now' (SQLite: `datetime()` is the
+/// current date and time).
+///
 /// SQLite Reference: https://www.sqlite.org/lang_datefunc.html
 pub fn datetime(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
-    if args.is_empty() {
-        return Err(ExecutorError::UnsupportedFeature(
-            "DATETIME requires at least 1 argument".to_string(),
-        ));
-    }
-
     // Resolve the time value (base + modifiers); None means SQL NULL
     let dt = match resolve_time_value(args, "DATETIME")? {
         Some(dt) => dt,
@@ -195,6 +193,47 @@ pub fn datetime(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
 
     // Convert NaiveDateTime to SqlValue::Timestamp
     naive_datetime_to_timestamp(dt)
+}
+
+/// A resolved datetime plus the day-of-month overflow count needed by the
+/// 'floor'/'ceiling' modifiers (SQLite date.c `nFloor`).
+///
+/// `n_floor` is the number of days the *nominal* Y-M-D overflowed past the end
+/// of its month before rolling into the following month (rolling is the
+/// default / 'ceiling' behavior). It is (re)computed at exactly three sites,
+/// matching SQLite's `computeFloor` call sites: the base `YYYY-MM-DD` parse,
+/// the `±N months`/`±N years` shifts, and the `±YYYY-MM-DD[ HH:MM:SS]`
+/// date-offset modifier. The 'floor' modifier subtracts it; 'ceiling' clears
+/// it; pure-duration shifts leave it untouched.
+#[derive(Clone, Copy)]
+struct ResolvedDateTime {
+    dt: NaiveDateTime,
+    n_floor: i64,
+}
+
+impl ResolvedDateTime {
+    /// Wrap a datetime whose nominal Y-M-D did not overflow (n_floor = 0)
+    fn exact(dt: NaiveDateTime) -> Self {
+        ResolvedDateTime { dt, n_floor: 0 }
+    }
+}
+
+/// Compute the day-of-month overflow count for a *nominal* (pre-roll) Y/M/D,
+/// mirroring SQLite date.c `computeFloor`:
+/// - `D <= 28` -> 0
+/// - months with 31 days (Jan/Mar/May/Jul/Aug/Oct/Dec) -> 0
+/// - non-February months -> 1 if `D == 31`, else 0
+/// - February -> `D - 28` (non-leap year) or `D - 29` (leap year)
+fn compute_floor(year: i32, month: u32, day: i64) -> i64 {
+    if day <= 28 || matches!(month, 1 | 3 | 5 | 7 | 8 | 10 | 12) {
+        0
+    } else if month != 2 {
+        i64::from(day == 31)
+    } else if year % 4 != 0 || (year % 100 == 0 && year % 400 != 0) {
+        day - 28
+    } else {
+        day - 29
+    }
 }
 
 /// Resolve a SQLite time-value argument list (timestring + modifiers) to a `NaiveDateTime`.
@@ -238,8 +277,8 @@ pub(super) fn resolve_time_value(
     };
 
     // If base value is NULL, return NULL
-    let mut dt = match base_result {
-        Some(dt) => dt,
+    let mut rdt = match base_result {
+        Some(rdt) => rdt,
         None => return Ok(None),
     };
 
@@ -272,8 +311,8 @@ pub(super) fn resolve_time_value(
         }
 
         // Apply the modifier
-        match apply_datetime_modifier(dt, modifier_str) {
-            Some(new_dt) => dt = new_dt,
+        match apply_datetime_modifier(rdt, modifier_str) {
+            Some(new_rdt) => rdt = new_rdt,
             None => return Ok(None), // Invalid modifier returns NULL
         }
     }
@@ -281,34 +320,35 @@ pub(super) fn resolve_time_value(
     // SQLite validates the final result against the valid Julian Day range
     // (`isDate` -> `validJulianDay`): modifiers that push the date outside
     // -4713-11-24 12:00:00 .. 9999-12-31 23:59:59.999 yield NULL.
-    if !(0..=MAX_IJD_MS).contains(&naive_to_ijd_ms(&dt)) {
+    if !(0..=MAX_IJD_MS).contains(&naive_to_ijd_ms(&rdt.dt)) {
         return Ok(None);
     }
 
-    Ok(Some(dt))
+    Ok(Some(rdt.dt))
 }
 
 /// Parse the base datetime value (first argument to DATETIME/STRFTIME's time value)
 fn parse_base_datetime(
     value: &SqlValue,
     func_name: &str,
-) -> Result<Option<NaiveDateTime>, ExecutorError> {
+) -> Result<Option<ResolvedDateTime>, ExecutorError> {
     match value {
         SqlValue::Null => Ok(None),
         SqlValue::Varchar(s) | SqlValue::Character(s) => {
             // Handle 'now' special case
             if s.eq_ignore_ascii_case("now") {
                 let now = Local::now();
-                Ok(Some(now.naive_local()))
+                Ok(Some(ResolvedDateTime::exact(now.naive_local())))
             } else {
-                // Parse the timestring
+                // Parse the timestring (the only base form whose nominal
+                // day-of-month can overflow, e.g. '2000-02-31')
                 Ok(parse_datetime_string_to_naive(s))
             }
         }
         SqlValue::Date(d) => {
             // Convert Date to NaiveDateTime with time 00:00:00
             let naive_date = chrono::NaiveDate::from_ymd_opt(d.year, d.month as u32, d.day as u32);
-            Ok(naive_date.map(|date| date.and_hms_opt(0, 0, 0).unwrap()))
+            Ok(naive_date.map(|date| ResolvedDateTime::exact(date.and_hms_opt(0, 0, 0).unwrap())))
         }
         SqlValue::Timestamp(ts) => {
             // Convert Timestamp to NaiveDateTime
@@ -323,17 +363,19 @@ fn parse_base_datetime(
                 ts.time.second as u32,
             );
             match (naive_date, naive_time) {
-                (Some(date), Some(time)) => Ok(Some(NaiveDateTime::new(date, time))),
+                (Some(date), Some(time)) => {
+                    Ok(Some(ResolvedDateTime::exact(NaiveDateTime::new(date, time))))
+                }
                 _ => Ok(None),
             }
         }
         // Integer or float: treat as Julian Day number by default
-        SqlValue::Integer(n) => Ok(julian_day_to_naive(*n as f64)),
-        SqlValue::Bigint(n) => Ok(julian_day_to_naive(*n as f64)),
-        SqlValue::Smallint(n) => Ok(julian_day_to_naive(*n as f64)),
-        SqlValue::Float(n) => Ok(julian_day_to_naive(*n as f64)),
+        SqlValue::Integer(n) => Ok(julian_day_to_naive(*n as f64).map(ResolvedDateTime::exact)),
+        SqlValue::Bigint(n) => Ok(julian_day_to_naive(*n as f64).map(ResolvedDateTime::exact)),
+        SqlValue::Smallint(n) => Ok(julian_day_to_naive(*n as f64).map(ResolvedDateTime::exact)),
+        SqlValue::Float(n) => Ok(julian_day_to_naive(*n as f64).map(ResolvedDateTime::exact)),
         SqlValue::Double(n) | SqlValue::Real(n) | SqlValue::Numeric(n) => {
-            Ok(julian_day_to_naive(*n))
+            Ok(julian_day_to_naive(*n).map(ResolvedDateTime::exact))
         }
         _ => Err(ExecutorError::UnsupportedFeature(format!(
             "{} requires string, date, timestamp, or numeric argument, got {:?}",
@@ -347,37 +389,40 @@ fn parse_base_datetime(
 fn parse_base_datetime_for_unixepoch(
     value: &SqlValue,
     func_name: &str,
-) -> Result<Option<NaiveDateTime>, ExecutorError> {
-    match value {
-        SqlValue::Null => Ok(None),
+) -> Result<Option<ResolvedDateTime>, ExecutorError> {
+    let dt = match value {
+        SqlValue::Null => None,
         SqlValue::Varchar(s) | SqlValue::Character(s) => {
             // Try to parse string as number for unixepoch
             if let Ok(n) = s.trim().parse::<i64>() {
-                Ok(unix_epoch_to_datetime(n))
+                unix_epoch_to_datetime(n)
             } else if let Ok(n) = s.trim().parse::<f64>() {
-                Ok(unix_epoch_seconds_f64_to_datetime(n))
+                unix_epoch_seconds_f64_to_datetime(n)
             } else {
                 // String that's not a valid number + unixepoch = NULL
-                Ok(None)
+                None
             }
         }
         SqlValue::Date(_) | SqlValue::Timestamp(_) => {
             // Date/Timestamp with unixepoch doesn't make sense - return NULL
-            Ok(None)
+            None
         }
         // Integer or float: treat as Unix timestamp (floats keep ms precision)
-        SqlValue::Integer(n) => Ok(unix_epoch_to_datetime(*n as i64)),
-        SqlValue::Bigint(n) => Ok(unix_epoch_to_datetime(*n)),
-        SqlValue::Smallint(n) => Ok(unix_epoch_to_datetime(*n as i64)),
-        SqlValue::Float(n) => Ok(unix_epoch_seconds_f64_to_datetime(*n as f64)),
+        SqlValue::Integer(n) => unix_epoch_to_datetime(*n as i64),
+        SqlValue::Bigint(n) => unix_epoch_to_datetime(*n),
+        SqlValue::Smallint(n) => unix_epoch_to_datetime(*n as i64),
+        SqlValue::Float(n) => unix_epoch_seconds_f64_to_datetime(*n as f64),
         SqlValue::Double(n) | SqlValue::Real(n) | SqlValue::Numeric(n) => {
-            Ok(unix_epoch_seconds_f64_to_datetime(*n))
+            unix_epoch_seconds_f64_to_datetime(*n)
         }
-        _ => Err(ExecutorError::UnsupportedFeature(format!(
-            "{} requires string, date, timestamp, or numeric argument, got {:?}",
-            func_name, value
-        ))),
-    }
+        _ => {
+            return Err(ExecutorError::UnsupportedFeature(format!(
+                "{} requires string, date, timestamp, or numeric argument, got {:?}",
+                func_name, value
+            )))
+        }
+    };
+    Ok(dt.map(ResolvedDateTime::exact))
 }
 
 /// Extract the numeric interpretation of a time value, if it has one.
@@ -406,14 +451,16 @@ fn numeric_time_value(value: &SqlValue) -> Option<f64> {
 fn parse_base_datetime_auto(
     value: &SqlValue,
     func_name: &str,
-) -> Result<Option<NaiveDateTime>, ExecutorError> {
+) -> Result<Option<ResolvedDateTime>, ExecutorError> {
     if matches!(value, SqlValue::Null) {
         return Ok(None);
     }
     match numeric_time_value(value) {
-        Some(n) if (0.0..5_373_484.5).contains(&n) => Ok(julian_day_to_naive(n)),
+        Some(n) if (0.0..5_373_484.5).contains(&n) => {
+            Ok(julian_day_to_naive(n).map(ResolvedDateTime::exact))
+        }
         Some(n) if (-210_866_760_000.0..=253_402_300_799.0).contains(&n) => {
-            Ok(unix_epoch_seconds_f64_to_datetime(n))
+            Ok(unix_epoch_seconds_f64_to_datetime(n).map(ResolvedDateTime::exact))
         }
         Some(_) => Ok(None), // Out of range for both interpretations
         None => parse_base_datetime(value, func_name), // No-op for text values
@@ -424,37 +471,49 @@ fn parse_base_datetime_auto(
 ///
 /// SQLite semantics: only valid when the time value is numeric (the DDDDDDDDDD
 /// format) and within the valid Julian Day range; all other uses return NULL.
-fn parse_base_datetime_julianday(value: &SqlValue) -> Option<NaiveDateTime> {
+fn parse_base_datetime_julianday(value: &SqlValue) -> Option<ResolvedDateTime> {
     match numeric_time_value(value) {
-        Some(n) if (0.0..5_373_484.5).contains(&n) => julian_day_to_naive(n),
+        Some(n) if (0.0..5_373_484.5).contains(&n) => {
+            julian_day_to_naive(n).map(ResolvedDateTime::exact)
+        }
         _ => None,
     }
 }
 
-/// Apply a single modifier to a NaiveDateTime
+/// Apply a single modifier to a resolved datetime
 /// Returns None if the modifier is invalid (SQLite returns NULL for invalid modifiers)
-fn apply_datetime_modifier(dt: NaiveDateTime, modifier: &str) -> Option<NaiveDateTime> {
+fn apply_datetime_modifier(rdt: ResolvedDateTime, modifier: &str) -> Option<ResolvedDateTime> {
     let modifier = modifier.trim();
     let lower = modifier.to_lowercase();
+    let dt = rdt.dt;
+
+    // Handle 'floor' / 'ceiling' (SQLite 3.46+): resolve a pending
+    // day-of-month overflow. Rolling forward is the default, so 'ceiling'
+    // just clears the pending count; 'floor' rolls back to the last day of
+    // the nominal month by subtracting the overflow days.
+    if lower == "floor" {
+        return Some(ResolvedDateTime::exact(dt - Duration::days(rdt.n_floor)));
+    }
+    if lower == "ceiling" {
+        return Some(ResolvedDateTime::exact(dt));
+    }
 
     // Handle "start of" modifiers
     if lower.starts_with("start of ") {
         let unit = &lower[9..].trim();
-        return match *unit {
+        let new_dt = match *unit {
             "month" => {
                 let date = chrono::NaiveDate::from_ymd_opt(dt.year(), dt.month(), 1)?;
-                Some(date.and_hms_opt(0, 0, 0)?)
+                date.and_hms_opt(0, 0, 0)?
             }
             "year" => {
                 let date = chrono::NaiveDate::from_ymd_opt(dt.year(), 1, 1)?;
-                Some(date.and_hms_opt(0, 0, 0)?)
+                date.and_hms_opt(0, 0, 0)?
             }
-            "day" => {
-                let date = dt.date();
-                Some(date.and_hms_opt(0, 0, 0)?)
-            }
-            _ => None, // Invalid "start of" unit
+            "day" => dt.date().and_hms_opt(0, 0, 0)?,
+            _ => return None, // Invalid "start of" unit
         };
+        return Some(ResolvedDateTime { dt: new_dt, n_floor: rdt.n_floor });
     }
 
     // Handle incomplete "start of" (returns NULL)
@@ -469,7 +528,8 @@ fn apply_datetime_modifier(dt: NaiveDateTime, modifier: &str) -> Option<NaiveDat
         if rest.len() == 1 {
             if let Ok(weekday_num) = rest.parse::<u32>() {
                 if weekday_num <= 6 {
-                    return apply_weekday_modifier(dt, weekday_num);
+                    return apply_weekday_modifier(dt, weekday_num)
+                        .map(|new_dt| ResolvedDateTime { dt: new_dt, n_floor: rdt.n_floor });
                 }
             }
         }
@@ -480,23 +540,25 @@ fn apply_datetime_modifier(dt: NaiveDateTime, modifier: &str) -> Option<NaiveDat
     if lower == "localtime" || lower == "utc" {
         // For now, these are no-ops since we work with naive datetimes
         // A full implementation would need timezone-aware handling
-        return Some(dt);
+        return Some(rdt);
     }
 
     // Handle (+|-)YYYY-MM-DD[ HH:MM[:SS[.FFF]]] modifiers (the inverse of
     // timediff(); SQLite 3.43+). Must be checked before generic time shifts.
+    // This is one of the sites that recomputes n_floor.
     if let Some(result) = try_apply_date_offset_modifier(dt, modifier) {
         return result;
     }
 
     // Handle (+|-)HH:MM[:SS[.FFF]] modifiers (no sign means plus). Must be
-    // checked before generic time shifts.
+    // checked before generic time shifts. Pure-duration shift: n_floor is
+    // preserved.
     if let Some(result) = try_apply_hh_mm_modifier(dt, modifier) {
-        return result;
+        return result.map(|new_dt| ResolvedDateTime { dt: new_dt, n_floor: rdt.n_floor });
     }
 
     // Handle time shift modifiers: +N unit, -N unit, N unit
-    parse_and_apply_time_shift(dt, modifier)
+    parse_and_apply_time_shift(rdt, modifier)
 }
 
 /// Detect and apply a `[+-]HH:MM[:SS[.FFF]]` modifier (SQLite date.c
@@ -537,7 +599,7 @@ fn try_apply_hh_mm_modifier(dt: NaiveDateTime, modifier: &str) -> Option<Option<
 fn try_apply_date_offset_modifier(
     dt: NaiveDateTime,
     modifier: &str,
-) -> Option<Option<NaiveDateTime>> {
+) -> Option<Option<ResolvedDateTime>> {
     let sign: i64 = match modifier.as_bytes().first() {
         Some(b'+') => 1,
         Some(b'-') => -1,
@@ -554,12 +616,16 @@ fn try_apply_date_offset_modifier(
 
 /// Apply a validated-prefix `YYYY-MM-DD[ HH:MM[:SS[.FFF]]]` offset to `dt`.
 /// Any malformation makes the whole modifier invalid (returns None -> NULL).
+///
+/// Recomputes `n_floor` from the nominal year/month/day after the year+month
+/// shift but before the day/time offsets are added (matching SQLite's
+/// `computeFloor` call in the date-offset modifier).
 fn apply_date_offset_modifier(
     dt: NaiveDateTime,
     sign: i64,
     rest: &str,
     year_digits: usize,
-) -> Option<NaiveDateTime> {
+) -> Option<ResolvedDateTime> {
     let years: i64 = rest[..year_digits].parse().ok()?;
     let after = &rest[year_digits + 1..];
     let ab = after.as_bytes();
@@ -597,10 +663,14 @@ fn apply_date_offset_modifier(
         dt.year() as i64 * 12 + (dt.month() as i64 - 1) + sign * (years * 12 + months);
     let new_year = i32::try_from(total_months.div_euclid(12)).ok()?;
     let new_month = total_months.rem_euclid(12) as u32 + 1;
+    let n_floor = compute_floor(new_year, new_month, dt.day() as i64);
     let base = chrono::NaiveDate::from_ymd_opt(new_year, new_month, 1)?.and_time(dt.time())
         + Duration::days(dt.day() as i64 - 1);
 
-    Some(base + Duration::days(sign * days) + Duration::milliseconds(sign * time_offset_ms))
+    Some(ResolvedDateTime {
+        dt: base + Duration::days(sign * days) + Duration::milliseconds(sign * time_offset_ms),
+        n_floor,
+    })
 }
 
 /// Apply weekday modifier - advances to the next occurrence of the specified weekday
@@ -643,8 +713,13 @@ fn weekday_to_num(wd: Weekday) -> u32 {
 }
 
 /// Parse and apply a time shift modifier like "+1 day", "-2 hours", "3 months"
-fn parse_and_apply_time_shift(dt: NaiveDateTime, modifier: &str) -> Option<NaiveDateTime> {
+///
+/// Pure-duration shifts (days/hours/minutes/seconds) preserve the incoming
+/// `n_floor`; month/year shifts recompute it (SQLite's `computeFloor` call in
+/// the month/year transform cases).
+fn parse_and_apply_time_shift(rdt: ResolvedDateTime, modifier: &str) -> Option<ResolvedDateTime> {
     let modifier = modifier.trim();
+    let dt = rdt.dt;
 
     // Parse the amount and unit
     // Format: [+/-]N[.N] unit[s]
@@ -663,24 +738,34 @@ fn parse_and_apply_time_shift(dt: NaiveDateTime, modifier: &str) -> Option<Naive
         (value + rounder) as i64
     };
 
+    let duration_shift = |ms: i64| -> Option<ResolvedDateTime> {
+        Some(ResolvedDateTime { dt: dt + Duration::milliseconds(ms), n_floor: rdt.n_floor })
+    };
+
     match unit_normalized {
-        "day" => Some(dt + Duration::milliseconds(to_ms(amount * 86_400_000.0))),
-        "hour" => Some(dt + Duration::milliseconds(to_ms(amount * 3_600_000.0))),
-        "minute" => Some(dt + Duration::milliseconds(to_ms(amount * 60_000.0))),
-        "second" => Some(dt + Duration::milliseconds(to_ms(amount * 1000.0))),
+        "day" => duration_shift(to_ms(amount * 86_400_000.0)),
+        "hour" => duration_shift(to_ms(amount * 3_600_000.0)),
+        "minute" => duration_shift(to_ms(amount * 60_000.0)),
+        "second" => duration_shift(to_ms(amount * 1000.0)),
         "month" => {
             // Whole months shift the calendar; the fractional residue is added
             // as 30-day months in milliseconds (SQLite aXformType rXform)
             let whole_months = amount.trunc() as i32;
-            let new_dt = add_months(dt, whole_months)?;
-            Some(new_dt + Duration::milliseconds(to_ms(amount.fract() * 2_592_000_000.0)))
+            let new_rdt = add_months(dt, whole_months)?;
+            Some(ResolvedDateTime {
+                dt: new_rdt.dt + Duration::milliseconds(to_ms(amount.fract() * 2_592_000_000.0)),
+                n_floor: new_rdt.n_floor,
+            })
         }
         "year" => {
             // Whole years shift the calendar; the fractional residue is added
             // as 365-day years in milliseconds (SQLite aXformType rXform)
             let whole_years = amount.trunc() as i32;
-            let new_dt = add_months(dt, whole_years * 12)?;
-            Some(new_dt + Duration::milliseconds(to_ms(amount.fract() * 31_536_000_000.0)))
+            let new_rdt = add_months(dt, whole_years * 12)?;
+            Some(ResolvedDateTime {
+                dt: new_rdt.dt + Duration::milliseconds(to_ms(amount.fract() * 31_536_000_000.0)),
+                n_floor: new_rdt.n_floor,
+            })
         }
         _ => None, // Unknown unit
     }
@@ -721,16 +806,19 @@ fn split_amount_and_unit(s: &str) -> Option<(&str, &str)> {
 ///
 /// Matches SQLite's `computeJD` normalization: when the day-of-month overflows
 /// the target month (e.g. Jan 31 + 1 month), the date rolls into the following
-/// month (2000-01-31 '+1 month' -> 2000-03-02) rather than clamping.
-fn add_months(dt: NaiveDateTime, months: i32) -> Option<NaiveDateTime> {
+/// month (2000-01-31 '+1 month' -> 2000-03-02) rather than clamping. The
+/// overflow-day count is recorded in `n_floor` so a subsequent 'floor'
+/// modifier can clamp to the last day of the nominal month instead.
+fn add_months(dt: NaiveDateTime, months: i32) -> Option<ResolvedDateTime> {
     let total_months = dt.year() as i64 * 12 + dt.month() as i64 - 1 + months as i64;
     let new_year = i32::try_from(total_months.div_euclid(12)).ok()?;
     let new_month = total_months.rem_euclid(12) as u32 + 1;
+    let n_floor = compute_floor(new_year, new_month, dt.day() as i64);
 
     // Day-of-month overflow rolls into the next month (SQLite normalization)
     let new_date = chrono::NaiveDate::from_ymd_opt(new_year, new_month, 1)?
         + Duration::days(dt.day() as i64 - 1);
-    Some(NaiveDateTime::new(new_date, dt.time()))
+    Some(ResolvedDateTime { dt: NaiveDateTime::new(new_date, dt.time()), n_floor })
 }
 
 /// Convert Unix epoch timestamp to NaiveDateTime
@@ -788,31 +876,34 @@ fn naive_datetime_to_timestamp(dt: NaiveDateTime) -> Result<SqlValue, ExecutorEr
 /// `HH:MM[:SS[.FFF...]]` defaults the date to 2000-01-01 (SQLite
 /// `parseTimeOnly`). A plain numeric string is interpreted as a Julian Day
 /// number.
-fn parse_datetime_string_to_naive(s: &str) -> Option<NaiveDateTime> {
+fn parse_datetime_string_to_naive(s: &str) -> Option<ResolvedDateTime> {
     let s = s.trim();
 
-    if let Some(dt) = parse_yyyy_mm_dd(s) {
-        return Some(dt);
+    if let Some(rdt) = parse_yyyy_mm_dd(s) {
+        return Some(rdt);
     }
 
     // SQLite: time-only values `HH:MM[:SS[.FFF...]]` default the date to
     // 2000-01-01 (parseTimeOnly in date.c)
     if let Some(time_ms) = parse_hh_mm_ss_tz_ms(s) {
         let midnight = chrono::NaiveDate::from_ymd_opt(2000, 1, 1)?.and_hms_opt(0, 0, 0)?;
-        return Some(midnight + Duration::milliseconds(time_ms));
+        return Some(ResolvedDateTime::exact(midnight + Duration::milliseconds(time_ms)));
     }
 
     // SQLite: a string that is a plain numeric literal is interpreted as a
     // Julian Day number, e.g. datetime('2451545.0') = '2000-01-01 12:00:00'
     if let Ok(jd) = s.parse::<f64>() {
-        return julian_day_to_naive(jd);
+        return julian_day_to_naive(jd).map(ResolvedDateTime::exact);
     }
 
     None
 }
 
 /// Strict `[-]YYYY-MM-DD[<sep>HH:MM[:SS[.FFF...]]]` parser (SQLite parseYyyyMmDd).
-fn parse_yyyy_mm_dd(s: &str) -> Option<NaiveDateTime> {
+///
+/// Records the day-of-month overflow count in `n_floor` (e.g. '2000-02-31'
+/// rolls to 2000-03-02 with `n_floor` = 2) for the 'floor'/'ceiling' modifiers.
+fn parse_yyyy_mm_dd(s: &str) -> Option<ResolvedDateTime> {
     // Optional leading '-' for negative (astronomical) years
     let (negative_year, rest) = match s.strip_prefix('-') {
         Some(r) => (true, r),
@@ -840,18 +931,23 @@ fn parse_yyyy_mm_dd(s: &str) -> Option<NaiveDateTime> {
         return None;
     }
     // Day-of-month overflow rolls into the next month (SQLite computeJD
-    // normalization, e.g. 2003-02-31 -> 2003-03-03)
+    // normalization, e.g. 2003-02-31 -> 2003-03-03); the overflow count is
+    // tracked so the 'floor' modifier can clamp instead
+    let n_floor = compute_floor(year, month, day);
     let date = chrono::NaiveDate::from_ymd_opt(year, month, 1)? + Duration::days(day - 1);
 
     // Optional time part. SQLite skips any run of whitespace and/or 'T'
     // characters between the date and the time (including none at all).
     let tail = rest[10..].trim_start_matches(|c: char| c.is_ascii_whitespace() || c == 'T');
     if tail.is_empty() {
-        return date.and_hms_opt(0, 0, 0);
+        return Some(ResolvedDateTime { dt: date.and_hms_opt(0, 0, 0)?, n_floor });
     }
 
     let time_ms = parse_hh_mm_ss_tz_ms(tail)?;
-    Some(date.and_hms_opt(0, 0, 0)? + Duration::milliseconds(time_ms))
+    Some(ResolvedDateTime {
+        dt: date.and_hms_opt(0, 0, 0)? + Duration::milliseconds(time_ms),
+        n_floor,
+    })
 }
 
 /// Strict `HH:MM[:SS[.FFF...]]` parser returning milliseconds since midnight

--- a/crates/vibesql-executor/src/evaluator/functions/datetime/current.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/datetime/current.rs
@@ -714,9 +714,11 @@ fn weekday_to_num(wd: Weekday) -> u32 {
 
 /// Parse and apply a time shift modifier like "+1 day", "-2 hours", "3 months"
 ///
-/// Pure-duration shifts (days/hours/minutes/seconds) preserve the incoming
-/// `n_floor`; month/year shifts recompute it (SQLite's `computeFloor` call in
-/// the month/year transform cases).
+/// SQLite's `parseModifier` executes `p->nFloor = 0;` before the `aXformType`
+/// loop, so every `±N unit` shift first clears the pending day-of-month
+/// overflow; month/year shifts then recompute it (the `computeFloor` call in
+/// the month/year transform cases). Day/hour/minute/second shifts therefore
+/// leave `n_floor` at 0.
 fn parse_and_apply_time_shift(rdt: ResolvedDateTime, modifier: &str) -> Option<ResolvedDateTime> {
     let modifier = modifier.trim();
     let dt = rdt.dt;
@@ -739,7 +741,9 @@ fn parse_and_apply_time_shift(rdt: ResolvedDateTime, modifier: &str) -> Option<R
     };
 
     let duration_shift = |ms: i64| -> Option<ResolvedDateTime> {
-        Some(ResolvedDateTime { dt: dt + Duration::milliseconds(ms), n_floor: rdt.n_floor })
+        // date.c line 1045: nFloor is reset before the aXformType loop, so a
+        // pure-duration shift clears any pending day-of-month overflow.
+        Some(ResolvedDateTime { dt: dt + Duration::milliseconds(ms), n_floor: 0 })
     };
 
     match unit_normalized {

--- a/crates/vibesql-executor/src/evaluator/functions/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/mod.rs
@@ -97,7 +97,19 @@ pub(super) fn eval_scalar_function(
         // These return NULL if any argument is NULL, unlike LEAST/GREATEST
         "MIN" => numeric::scalar_min(args),
         "MAX" => numeric::scalar_max(args),
-        "FORMAT" => numeric::format(args),
+        // FORMAT is overloaded: SQLite's format() is an alias for printf()
+        // (format-string first argument), while MySQL's FORMAT(number,
+        // decimals) formats a number with thousand separators. Route by the
+        // type of the first argument: strings (and NULL, which printf
+        // propagates) go to printf, numerics keep the MySQL behavior.
+        "FORMAT" => match args.first() {
+            Some(
+                vibesql_types::SqlValue::Varchar(_)
+                | vibesql_types::SqlValue::Character(_)
+                | vibesql_types::SqlValue::Null,
+            ) => sqlite_compat::printf(args),
+            _ => numeric::format(args),
+        },
 
         // Vector functions
         "COSINE_DISTANCE" => vector::cosine_distance(args),

--- a/crates/vibesql-executor/src/evaluator/operators/comparison/equality.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/comparison/equality.rs
@@ -272,4 +272,49 @@ mod tests {
         assert_eq!(equal(&a, &c).unwrap(), SqlValue::Boolean(false));
         assert_eq!(not_equal(&a, &c).unwrap(), SqlValue::Boolean(true));
     }
+
+    fn ts(s: &str) -> SqlValue {
+        use std::str::FromStr;
+        SqlValue::Timestamp(vibesql_types::Timestamp::from_str(s).unwrap())
+    }
+
+    #[test]
+    fn test_timestamp_vs_string_equality() {
+        // SQLite date3.test 2.40: datetime(x,'auto') == '<text>' must evaluate
+        // to a boolean, not raise a type mismatch (SQLite's datetime() returns
+        // TEXT, so the comparison is valid there)
+        let timestamp = ts("2022-01-27 13:15:44");
+        let matching = SqlValue::Varchar(arcstr::ArcStr::from("2022-01-27 13:15:44"));
+        let differing = SqlValue::Varchar(arcstr::ArcStr::from("2022-01-27 13:15:45"));
+
+        assert_eq!(equal(&timestamp, &matching).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(equal(&matching, &timestamp).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(equal(&timestamp, &differing).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(not_equal(&timestamp, &differing).unwrap(), SqlValue::Boolean(true));
+
+        // Character storage class behaves like Varchar
+        let matching_char = SqlValue::Character(arcstr::ArcStr::from("2022-01-27 13:15:44"));
+        assert_eq!(equal(&timestamp, &matching_char).unwrap(), SqlValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_timestamp_vs_unparseable_string_is_false_not_error() {
+        // SQLite: SELECT datetime('2022-01-27') == 'hello' → 0 (text
+        // comparison of the renderings), never an error
+        let timestamp = ts("2022-01-27 00:00:00");
+        let junk = SqlValue::Varchar(arcstr::ArcStr::from("hello"));
+        assert_eq!(equal(&timestamp, &junk).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(equal(&junk, &timestamp).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(not_equal(&timestamp, &junk).unwrap(), SqlValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_time_vs_string_equality() {
+        let time = SqlValue::Time(vibesql_types::Time::new(13, 15, 44, 0).unwrap());
+        let matching = SqlValue::Varchar(arcstr::ArcStr::from("13:15:44"));
+        let differing = SqlValue::Varchar(arcstr::ArcStr::from("13:15:45"));
+        assert_eq!(equal(&time, &matching).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(equal(&matching, &time).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(equal(&time, &differing).unwrap(), SqlValue::Boolean(false));
+    }
 }

--- a/crates/vibesql-executor/src/evaluator/operators/comparison/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/comparison/mod.rs
@@ -194,6 +194,40 @@ where
             }
         },
 
+        // Timestamp compared to string - parse the string as a timestamp when
+        // possible; otherwise compare the TEXT renderings. SQLite's datetime()
+        // returns TEXT, so expressions like `datetime(x,'auto') == '2022-01-27
+        // 13:15:44'` are plain text comparisons there (date3.test 2.40); the
+        // Display rendering of Timestamp matches SQLite's 'YYYY-MM-DD
+        // HH:MM:SS' format, and an unparseable string (e.g. 'hello') compares
+        // as text instead of raising a type mismatch, like SQLite.
+        (Timestamp(ts), Varchar(s)) | (Timestamp(ts), Character(s)) => {
+            return Ok(Boolean(predicate(match vibesql_types::Timestamp::from_str(s) {
+                Ok(parsed) => ts.cmp(&parsed),
+                Err(_) => ts.to_string().as_str().cmp(s.as_str()),
+            })));
+        }
+        (Varchar(s), Timestamp(ts)) | (Character(s), Timestamp(ts)) => {
+            return Ok(Boolean(predicate(match vibesql_types::Timestamp::from_str(s) {
+                Ok(parsed) => parsed.cmp(ts),
+                Err(_) => s.as_str().cmp(ts.to_string().as_str()),
+            })));
+        }
+
+        // Time compared to string - same approach as Timestamp
+        (Time(t), Varchar(s)) | (Time(t), Character(s)) => {
+            return Ok(Boolean(predicate(match vibesql_types::Time::from_str(s) {
+                Ok(parsed) => t.cmp(&parsed),
+                Err(_) => t.to_string().as_str().cmp(s.as_str()),
+            })));
+        }
+        (Varchar(s), Time(t)) | (Character(s), Time(t)) => {
+            return Ok(Boolean(predicate(match vibesql_types::Time::from_str(s) {
+                Ok(parsed) => parsed.cmp(t),
+                Err(_) => s.as_str().cmp(t.to_string().as_str()),
+            })));
+        }
+
         _ => {} // Fall through to regular comparison logic
     }
 

--- a/crates/vibesql-executor/src/evaluator/operators/comparison/ordering.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/comparison/ordering.rs
@@ -60,6 +60,20 @@ mod tests {
     }
 
     #[test]
+    fn test_timestamp_vs_string_ordering() {
+        // Timestamp-vs-string ordering parses the string as a timestamp
+        // (date-only strings get midnight, matching Timestamp::from_str)
+        let timestamp = SqlValue::Timestamp("2022-01-27 13:15:44".parse().unwrap());
+        let later = SqlValue::Varchar(arcstr::ArcStr::from("2022-01-27 13:15:45"));
+        let earlier = SqlValue::Varchar(arcstr::ArcStr::from("2022-01-27"));
+
+        assert_eq!(less_than(&timestamp, &later).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(greater_than(&timestamp, &earlier).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(less_than(&earlier, &timestamp).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(greater_than_or_equal(&later, &timestamp).unwrap(), SqlValue::Boolean(true));
+    }
+
+    #[test]
     fn test_boolean_less_than_integer() {
         // FALSE (0) < 5 = true
         assert_eq!(

--- a/crates/vibesql-executor/tests/date_time_function_tests/current_datetime.rs
+++ b/crates/vibesql-executor/tests/date_time_function_tests/current_datetime.rs
@@ -241,14 +241,19 @@ fn test_datetime_with_timestamp_value() {
 }
 
 #[test]
-fn test_datetime_no_arguments_error() {
+fn test_datetime_no_arguments_is_now() {
+    // SQLite: an omitted time-value defaults to 'now', so datetime() is the
+    // current date and time (date.test 2.40)
     let (evaluator, row) = setup_test();
 
     let expr = create_datetime_function("DATETIME", vec![]);
-    let result = evaluator.eval(&expr, &row);
+    let result = evaluator.eval(&expr, &row).unwrap();
 
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("requires at least 1 argument"));
+    assert!(
+        matches!(result, vibesql_types::SqlValue::Timestamp(_)),
+        "datetime() should return the current timestamp, got {:?}",
+        result
+    );
 }
 
 #[test]

--- a/crates/vibesql-executor/tests/date_time_function_tests/date_time.rs
+++ b/crates/vibesql-executor/tests/date_time_function_tests/date_time.rs
@@ -67,6 +67,74 @@ fn test_month_overflow_normalizes_like_sqlite() {
 }
 
 #[test]
+fn test_floor_ceiling_modifiers_base_parse() {
+    // SQLite date.test 19.1-19.32: 'floor' clamps a day-of-month overflow to
+    // the last day of the nominal month; 'ceiling' (the default) rolls forward
+    assert_renders("date('2000-01-31','floor')", "2000-01-31"); // 19.1: no overflow
+    assert_renders("date('2000-02-31','floor')", "2000-02-29"); // 19.2a: leap year
+    assert_renders("date('1999-02-31','floor')", "1999-02-28"); // 19.2b
+    assert_renders("date('1900-02-31','floor')", "1900-02-28"); // 19.2c: century non-leap
+    assert_renders("date('2000-04-31','floor')", "2000-04-30"); // 19.4
+    assert_renders("date('2000-01-31','ceiling')", "2000-01-31"); // 19.21
+    assert_renders("date('2000-02-31','ceiling')", "2000-03-02"); // 19.22a
+    assert_renders("date('1999-02-31','ceiling')", "1999-03-03"); // 19.22b
+    assert_renders("date('1900-02-31','ceiling')", "1900-03-03"); // 19.22c
+    assert_renders("date('2000-04-31','ceiling')", "2000-05-01"); // 19.24
+}
+
+#[test]
+fn test_floor_ceiling_modifiers_month_year_shift() {
+    // SQLite date.test 19.40-19.47: ±N months/years recompute the overflow count
+    assert_renders("date('2024-01-31','+1 month','ceiling')", "2024-03-02"); // 19.40
+    assert_renders("date('2024-01-31','+1 month','floor')", "2024-02-29"); // 19.41
+    assert_renders("date('2023-01-31','+1 month','ceiling')", "2023-03-03"); // 19.42
+    assert_renders("date('2023-01-31','+1 month','floor')", "2023-02-28"); // 19.43
+    assert_renders("date('2024-02-29','+1 year','ceiling')", "2025-03-01"); // 19.44
+    assert_renders("date('2024-02-29','+1 year','floor')", "2025-02-28"); // 19.45
+    assert_renders("date('2024-02-29','-110 years','ceiling')", "1914-03-01"); // 19.46
+    assert_renders("date('2024-02-29','-110 years','floor')", "1914-02-28"); // 19.47
+}
+
+#[test]
+fn test_floor_ceiling_modifiers_date_offset() {
+    // SQLite date.test 19.48-19.53: ±YYYY-MM-DD offsets recompute the overflow count
+    assert_renders("date('2024-02-29','-0110-00-00','floor')", "1914-02-28"); // 19.48
+    assert_renders("date('2024-02-29','-0110-00-00','ceiling')", "1914-03-01"); // 19.49
+    assert_renders("date('2000-08-31','+0023-06-00','floor')", "2024-02-29"); // 19.50
+    assert_renders("date('2000-08-31','+0022-06-00','floor')", "2023-02-28"); // 19.51
+    assert_renders("date('2000-08-31','+0023-06-00','ceiling')", "2024-03-02"); // 19.52
+    assert_renders("date('2000-08-31','+0022-06-00','ceiling')", "2023-03-03"); // 19.53
+}
+
+#[test]
+fn test_floor_is_consumed_by_subsequent_modifiers() {
+    // 'floor' resolves the pending overflow; later duration shifts apply to
+    // the clamped date (verified against SQLite 3.51:
+    // date('2000-01-31','floor','+1 day') -> 2000-02-01)
+    assert_renders("date('2000-01-31','floor','+1 day')", "2000-02-01");
+    assert_renders("date('2000-02-31','floor','+1 day')", "2000-03-01");
+    // A pure-duration shift does not disturb the pending overflow count
+    assert_renders("datetime('2000-02-31','+1 hour','floor')", "2000-02-29 01:00:00");
+}
+
+#[test]
+fn test_zero_argument_datetime_is_now() {
+    // SQLite date.test 2.40: datetime() with no arguments means 'now'.
+    // The harness cannot pin the clock, so just assert a non-NULL current
+    // timestamp that matches datetime('now') to minute precision.
+    let value = eval_scalar("datetime()");
+    assert!(
+        matches!(value, SqlValue::Timestamp(_)),
+        "datetime() should return a timestamp, got {:?}",
+        value
+    );
+    let in_range = eval_scalar(
+        "datetime() BETWEEN datetime('now','-1 minute') AND datetime('now','+1 minute')",
+    );
+    assert_eq!(in_range, SqlValue::Boolean(true), "datetime() should be the current datetime");
+}
+
+#[test]
 fn test_timezone_offset_suffix() {
     // SQLite date.test 5.x: TZ-offset/Z suffix converts the timestamp to UTC
     assert_renders("datetime('1994-04-16 14:00:00 +05:00')", "1994-04-16 09:00:00");

--- a/crates/vibesql-executor/tests/date_time_function_tests/date_time.rs
+++ b/crates/vibesql-executor/tests/date_time_function_tests/date_time.rs
@@ -113,8 +113,24 @@ fn test_floor_is_consumed_by_subsequent_modifiers() {
     // date('2000-01-31','floor','+1 day') -> 2000-02-01)
     assert_renders("date('2000-01-31','floor','+1 day')", "2000-02-01");
     assert_renders("date('2000-02-31','floor','+1 day')", "2000-03-01");
-    // A pure-duration shift does not disturb the pending overflow count
-    assert_renders("datetime('2000-02-31','+1 hour','floor')", "2000-02-29 01:00:00");
+    // A pure-duration shift CLEARS the pending overflow count (date.c resets
+    // nFloor before the aXformType loop), so a later 'floor' is a no-op
+    assert_renders("datetime('2000-02-31','+1 hour','floor')", "2000-03-02 01:00:00");
+}
+
+#[test]
+fn test_duration_shift_resets_pending_floor() {
+    // SQLite's parseModifier executes `p->nFloor = 0;` before the aXformType
+    // loop, so every '±N unit' shift clears the pending day-of-month overflow
+    // (month/year shifts then recompute it via computeFloor). Verified against
+    // sqlite3 3.51.0.
+    assert_renders("datetime('2000-02-31','+1 hour','floor')", "2000-03-02 01:00:00");
+    assert_renders("date('2024-01-31','+1 month','+0 seconds','floor')", "2024-03-02");
+    assert_renders("date('2024-01-31','+1 month','+1 day','floor')", "2024-03-03");
+    // Contrast: the colon-form ±HH:MM modifier does NOT touch nFloor ...
+    assert_renders("datetime('2024-01-31','+1 month','+02:00','floor')", "2024-02-29 02:00:00");
+    // ... and neither does 'start of X'
+    assert_renders("date('2024-01-31','+1 month','start of month','floor')", "2024-02-28");
 }
 
 #[test]

--- a/crates/vibesql-executor/tests/utility_function_tests.rs
+++ b/crates/vibesql-executor/tests/utility_function_tests.rs
@@ -227,6 +227,41 @@ fn test_format_negative() {
     assert_eq!(result, vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("-1,234,567.89")));
 }
 
+#[test]
+fn test_format_string_first_arg_routes_to_printf() {
+    // SQLite's format() is an alias for printf(): a string first argument is
+    // a format string (date3.test 5.0 uses format('%+d days', x))
+    let (evaluator, row) = create_test_evaluator();
+    let expr = vibesql_ast::Expression::Function {
+        name: vibesql_ast::FunctionIdentifier::new("FORMAT"),
+        args: vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("%+d days"),
+            )),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(5)),
+        ],
+        character_unit: None,
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("+5 days")));
+}
+
+#[test]
+fn test_format_null_first_arg_returns_null() {
+    // SQLite: format(NULL, ...) is NULL (printf propagates a NULL format)
+    let (evaluator, row) = create_test_evaluator();
+    let expr = vibesql_ast::Expression::Function {
+        name: vibesql_ast::FunctionIdentifier::new("FORMAT"),
+        args: vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(2)),
+        ],
+        character_unit: None,
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, vibesql_types::SqlValue::Null);
+}
+
 // ============================================================================
 // VERSION Tests
 // ============================================================================

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3263,7 +3263,7 @@ array set vibesql_skip_tests {
 
     triggerupfrom-2.3 "Cascades from auto-skipped test 2.2. CREATE TEMP TRIGGER now parses (#5218), but 2.2 references aux.t3 and is auto-skipped by the ATTACH/aux regex (VibeSQL has no ATTACH/multi-database support), so the rows 2.2 inserts (10 y {}, 20 y {}) never exist and 2.3's expected output cannot match. The UPDATE…FROM trigger logic in 2.3 itself works correctly when run in isolation (verified during #5192 builder pass)."
 
-    date-2.40 "zero-argument datetime() rejected by the parser (#5317); also needs the sqlite_current_time fake-clock hook the harness cannot honor"
+    date-2.40 "needs the sqlite_current_time fake-clock hook the harness cannot honor ('now' uses real clock; zero-argument datetime() itself is supported as of #5317)"
     date-4.1 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
     date-8.1 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
     date-8.2 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
@@ -3307,8 +3307,6 @@ array set vibesql_skip_tests {
     date2-610 "non-deterministic use of date/time functions in CHECK constraints is not rejected"
     date2-612 "non-deterministic use of date/time functions in CHECK constraints is not rejected"
     date3-620 "non-deterministic use of date/time functions in CHECK constraints is not rejected (test lives in date2.test)"
-    date3-2.40 "datetime() returns a Timestamp value, not TEXT, so datetime(x,'auto') == '...' string comparison raises a type mismatch (#5317)"
-    date3-5.0 "format('%+d days',x) string formatting not supported by format() (#5317)"
 }
 
 # Pattern-based skip list for tests with many numbered variants
@@ -3371,7 +3369,6 @@ variable vibesql_skip_patterns {
     {windowfault- "SQLite fault injection testing"}
 
     {date-6. "localtime/utc DST boundary tests require the SQLITE_TESTCTRL_LOCALTIME_FAULT harness localtime_r override (harness limitation)"}
-    {date-19. "the 'ceiling'/'floor' modifiers are not supported and return NULL (#5317)"}
     {date4- "compares VibeSQL strftime against the C library strftime; shim only stubs the TCL strftime command via clock format, so expected values are computed by the stub rather than libc (harness limitation)"}
 }
 
@@ -4146,12 +4143,12 @@ proc check_single_capability {cap} {
     # Capabilities we don't support (unsupported_caps means NOT supported)
     # NOTE: datetime/datetime_time/datetime_funcs were removed from this list
     # (#5294) — VibeSQL implements date(), time(), datetime(), strftime().
-    # Remaining gaps are pattern-skipped: see #5317 ('ceiling'/'floor'
-    # modifiers, zero-arg datetime(), TEXT return-type comparisons).
     # date()/time() function calls were implemented in #5307;
     # julianday()/unixepoch()/timediff() in #5308; fractional unixepoch,
     # TZ offsets, +/-HH:MM:SS modifiers, strftime specifiers, 'auto'/
-    # 'julianday' modifiers, and Julian Day range bounds in #5309.
+    # 'julianday' modifiers, and Julian Day range bounds in #5309;
+    # 'ceiling'/'floor' modifiers, zero-arg datetime(), Timestamp-vs-TEXT
+    # comparisons, and printf-style format() in #5317.
     set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 trigger conflict hiddencolumns}
 
     # Handle negated capability (e.g., !autovacuum)


### PR DESCRIPTION
## Summary

Closes the four remaining datetime conformance gaps tracked in #5317. Per the curator's sizing note, items 3 and 4 turned out to be surgical (one comparison-arm block + one dispatch reroute, ~50 LOC combined), so this PR covers all four items rather than splitting: the comparison and FORMAT changes are small, independently testable, and were regression-checked against the comparison-sensitive TCL files.

## Changes

- **'ceiling'/'floor' modifiers** (`datetime/current.rs`): threads SQLite's `nFloor` day-of-month overflow count through the modifier pipeline via an internal `ResolvedDateTime { dt, n_floor }` struct. `compute_floor` mirrors date.c `computeFloor` and is invoked at the same three sites (base `YYYY-MM-DD` parse, `±N months/years` shifts, `±YYYY-MM-DD` date offsets). `'floor'` subtracts the pending overflow; `'ceiling'` clears it (rolling forward was already the default). `resolve_time_value`'s public signature is unchanged.
- **Zero-arg `datetime()`**: deleted the 5-line arity guard; `resolve_time_value` already treats empty args as `'now'` (matching `date()`/`time()`).
- **Timestamp/Time-vs-string comparison** (`operators/comparison/mod.rs`): new arms parse the string as a temporal value when possible (consistent with the existing Date-vs-string arms) and fall back to comparing the TEXT renderings otherwise — so `datetime(x,'auto') == '<text>'` evaluates to a boolean and `ts == 'hello'` is false rather than a TypeMismatch, matching SQLite. The compiled fast path (`compiled.rs` `compare_range`) needed no change: unmatched type pairs already fall back to full interpreted evaluation.
- **`format()` routing** (`functions/mod.rs`): string (or NULL) first argument routes to the existing `sqlite_compat::printf` (which supports `%+d`); numeric first argument keeps the MySQL `FORMAT(number, decimals)` behavior.
- **TCL shim** (`scripts/tester_vibesql.tcl`): removed the `date-19.` pattern skip and the `date3-2.40`/`date3-5.0` entries; re-worded `date-2.40` to cite only the `sqlite_current_time` fake-clock harness limitation; updated the capability-notes comment.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `date('2000-02-31','floor')` → 2000-02-29; `'ceiling'` → 2000-03-02; date-19.1–19.53 pass; pattern skip removed | ✅ | CLI probes match sqlite3 3.51; date.test run below (+42 assertions) |
| `SELECT datetime()` returns current datetime; date-2.40 skip re-worded | ✅ | CLI probe + `test_zero_argument_datetime_is_now`; skip entry re-worded |
| `datetime(x,'auto') == '<text>'` evaluates to boolean; date3-2.40 skip removed | ✅ | CLI probe → 1; date3.test now passes 2.40 |
| `format('%+d days', 5)` → `'+5 days'`; `FORMAT(12345.678, 2)` → `'12,345.68'`; date3-5.0 skip removed | ✅ | CLI probes; new unit tests; date3.test now passes 5.0 |
| date.test / date3.test pass with zero new failures | ✅ | Results below |

## Test Plan

- `sqlite3` 3.51 used as the reference for every probe before implementation
- New unit tests: floor/ceiling matrices for all three n_floor sites + floor-then-shift interactions (`date_time.rs`), zero-arg datetime (`date_time.rs`, `current_datetime.rs` — replaced the test that asserted the old arity error), Timestamp/Time-vs-string equality/ordering (`equality.rs`, `ordering.rs`), printf-routing + NULL format (`utility_function_tests.rs`)
- Full `cargo test -p vibesql-executor` (lib 2571 + all integration suites): green
- `cargo clippy` clean for changed files (merged the one warning my code introduced); `cargo fmt` applied

### TCL conformance deltas (vs. baseline run on main workspace binary)

| File | Result | Delta |
|------|--------|-------|
| date.test | 1372 passed / 0 failed / 54 skipped | +42 newly passing (date-19.1–19.53); skips 98→54 |
| date2.test | 7 passed / 0 failed / 22 skipped | unchanged |
| date3.test | 126 passed / 0 failed / 0 skipped | +2 newly passing (2.40, 5.0); skips 2→0 |
| whereB.test | 63 passed / 0 failed | 0 new failures |
| expr.test | 638 passed / 0 failed / 22 skipped | 0 new failures |
| where.test | 148 passed / 20 failed / 139 skipped | failure set byte-identical to main baseline (pre-existing) |
| in.test | 113 passed / 1 failed (in-23.0) / 9 skipped | identical to main baseline (pre-existing) |

Closes #5317