### PR TITLE
fix(executor): enforce datetime determinism in UPDATE OR IGNORE / OR REPLACE

### DIFF
--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -314,17 +314,38 @@ pub(super) fn execute_internal(
         let constraint_validator = ConstraintValidator::new(schema);
 
         if use_ignore {
+            // Non-deterministic date/time uses in index expressions /
+            // partial-index predicates abort the statement even under
+            // OR IGNORE — SQLite raises a runtime SQL function error, not a
+            // constraint conflict, so conflict resolution does not apply
+            // (issue #5324). Runs pre-application so no mutation occurs and
+            // the lenient index-maintenance paths never see the row.
+            crate::insert::constraints::enforce_index_expression_determinism(
+                database,
+                schema,
+                table_name,
+                &new_row.values,
+            )?;
+
             // For IGNORE: try validation and skip row on any constraint violation
             let validation_result =
                 constraint_validator.validate_row(table, table_name, row_index, &new_row, &row);
-            if validation_result.is_err() {
+            if let Err(e) = validation_result {
+                // Non-deterministic date/time use in a CHECK constraint is a
+                // statement-level error, not an ignorable conflict (issue #5324).
+                if e.is_non_deterministic_use() {
+                    return Err(e);
+                }
                 continue; // Skip this row
             }
 
             // Validate user-defined UNIQUE indexes
             let unique_index_result =
                 constraint_validator.validate_unique_indexes(database, table_name, &new_row, &row);
-            if unique_index_result.is_err() {
+            if let Err(e) = unique_index_result {
+                if e.is_non_deterministic_use() {
+                    return Err(e);
+                }
                 continue; // Skip this row
             }
 
@@ -343,6 +364,18 @@ pub(super) fn execute_internal(
             // For REPLACE: validate NOT NULL and CHECK constraints, but skip PK/UNIQUE
             // since conflicting rows will be deleted
             validate_non_uniqueness_constraints(schema, table_name, &new_row)?;
+
+            // Non-deterministic date/time uses in index expressions /
+            // partial-index predicates abort the statement even under
+            // OR REPLACE — runtime SQL function error, not a resolvable
+            // conflict (issue #5324). Runs before any conflicting rows are
+            // deleted, so the statement aborts with no mutation.
+            crate::insert::constraints::enforce_index_expression_determinism(
+                database,
+                schema,
+                table_name,
+                &new_row.values,
+            )?;
 
             // Validate foreign key constraints
             if !schema.foreign_keys.is_empty() {
@@ -1273,6 +1306,18 @@ fn execute_update_from(
         let mut kept_updates: Vec<PendingUpdate> = Vec::with_capacity(updates.len());
 
         for u in updates.drain(..) {
+            // Non-deterministic date/time uses in index expressions /
+            // partial-index predicates abort the statement even under
+            // OR IGNORE — SQLite raises a runtime SQL function error, not a
+            // constraint conflict, so conflict resolution does not apply
+            // (issue #5324).
+            crate::insert::constraints::enforce_index_expression_determinism(
+                database,
+                schema,
+                table_name,
+                &u.new_row.values,
+            )?;
+
             // Per-row: try full validation including PK/UNIQUE; skip on violation.
             let validation_result = constraint_validator.validate_row(
                 table,
@@ -1281,14 +1326,22 @@ fn execute_update_from(
                 &u.new_row,
                 &u.old_row,
             );
-            if validation_result.is_err() {
+            if let Err(e) = validation_result {
+                // Non-deterministic date/time use in a CHECK constraint is a
+                // statement-level error, not an ignorable conflict (issue #5324).
+                if e.is_non_deterministic_use() {
+                    return Err(e);
+                }
                 continue;
             }
 
             // Validate user-defined UNIQUE indexes
             let unique_index_result = constraint_validator
                 .validate_unique_indexes(database, table_name, &u.new_row, &u.old_row);
-            if unique_index_result.is_err() {
+            if let Err(e) = unique_index_result {
+                if e.is_non_deterministic_use() {
+                    return Err(e);
+                }
                 continue;
             }
 
@@ -1336,6 +1389,18 @@ fn execute_update_from(
                 // NOT NULL + CHECK only (no PK/UNIQUE — those collisions get
                 // resolved by deletion).
                 validate_non_uniqueness_constraints(schema, table_name, &u.new_row)?;
+
+                // Non-deterministic date/time uses in index expressions /
+                // partial-index predicates abort the statement even under
+                // OR REPLACE — runtime SQL function error, not a resolvable
+                // conflict (issue #5324). Runs before any conflicting rows
+                // are deleted, so the statement aborts with no mutation.
+                crate::insert::constraints::enforce_index_expression_determinism(
+                    database,
+                    schema,
+                    table_name,
+                    &u.new_row.values,
+                )?;
 
                 // Foreign key constraints still apply.
                 if !schema.foreign_keys.is_empty() {

--- a/crates/vibesql-executor/tests/non_deterministic_datetime_tests.rs
+++ b/crates/vibesql-executor/tests/non_deterministic_datetime_tests.rs
@@ -334,6 +334,138 @@ fn create_partial_index_fails_when_predicate_hits_now_row() {
 }
 
 // ============================================================================
+// UPDATE OR IGNORE / OR REPLACE conflict clauses (issue #5324)
+//
+// SQLite aborts the statement even under OR IGNORE / OR REPLACE: the
+// non-deterministic error is a runtime SQL function error, not a constraint
+// conflict, so conflict resolution does not apply. Verified with sqlite3
+// 3.51.0:
+//
+//     CREATE TABLE t2(a INT, b TEXT);
+//     CREATE INDEX i2 ON t2(date(b));
+//     INSERT INTO t2 VALUES(1,'2024-01-01');
+//     UPDATE OR IGNORE t2 SET b='now';
+//     -- Runtime error: non-deterministic use of date() in an index
+//     -- row remains b='2024-01-01'
+// ============================================================================
+
+/// Fetch column `col` of every live row in `table` as display strings.
+fn column_values(db: &Database, table: &str, col: usize) -> Vec<String> {
+    db.get_table(table)
+        .expect("table not found")
+        .scan_live()
+        .map(|(_, row)| format!("{}", row.values[col]))
+        .collect()
+}
+
+fn setup_expression_index_table(db: &mut Database) {
+    run_sql(
+        db,
+        "CREATE TABLE t2(a INT, b TEXT);
+         INSERT INTO t2 VALUES(1, '2024-01-01');
+         CREATE INDEX i2 ON t2(date(b))",
+    );
+}
+
+#[test]
+fn update_or_ignore_expression_index_now_value_rejected() {
+    let mut db = Database::new();
+    setup_expression_index_table(&mut db);
+    assert_sql_error(
+        &mut db,
+        "UPDATE OR IGNORE t2 SET b='now'",
+        "non-deterministic use of date() in an index",
+    );
+    // The statement must abort with no mutation: the row keeps its old value
+    assert_eq!(column_values(&db, "t2", 1), vec!["2024-01-01"]);
+}
+
+#[test]
+fn update_or_replace_expression_index_now_value_rejected() {
+    let mut db = Database::new();
+    setup_expression_index_table(&mut db);
+    assert_sql_error(
+        &mut db,
+        "UPDATE OR REPLACE t2 SET b='now'",
+        "non-deterministic use of date() in an index",
+    );
+    assert_eq!(column_values(&db, "t2", 1), vec!["2024-01-01"]);
+}
+
+#[test]
+fn update_or_ignore_and_or_replace_deterministic_values_still_work() {
+    let mut db = Database::new();
+    setup_expression_index_table(&mut db);
+    run_sql(&mut db, "UPDATE OR IGNORE t2 SET b='2024-02-02'");
+    assert_eq!(column_values(&db, "t2", 1), vec!["2024-02-02"]);
+    run_sql(&mut db, "UPDATE OR REPLACE t2 SET b='2024-03-03'");
+    assert_eq!(column_values(&db, "t2", 1), vec!["2024-03-03"]);
+}
+
+#[test]
+fn update_or_ignore_partial_index_predicate_now_value_rejected() {
+    // The partial-index WHERE predicate counts as an index expression
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE t6(a INT, b TEXT);
+         INSERT INTO t6 VALUES(1, '2024-01-01');
+         CREATE INDEX i6 ON t6(b) WHERE date(b) > '2020-01-01'",
+    );
+    assert_sql_error(
+        &mut db,
+        "UPDATE OR IGNORE t6 SET b='now'",
+        "non-deterministic use of date() in an index",
+    );
+    assert_eq!(column_values(&db, "t6", 1), vec!["2024-01-01"]);
+}
+
+#[test]
+fn update_or_ignore_check_constraint_now_value_aborts() {
+    // A non-deterministic use inside a CHECK constraint is a statement-level
+    // error under OR IGNORE, not an ignorable conflict (SQLite aborts).
+    let mut db = Database::new();
+    run_sql(
+        &mut db,
+        "CREATE TABLE t7(x, CHECK( date(x) BETWEEN '2017-07-01' AND '2017-07-31' ));
+         INSERT INTO t7(x) VALUES('2017-07-20')",
+    );
+    assert_sql_error(
+        &mut db,
+        "UPDATE OR IGNORE t7 SET x='now'",
+        "non-deterministic use of date() in a CHECK constraint",
+    );
+    assert_eq!(column_values(&db, "t7", 0), vec!["2017-07-20"]);
+}
+
+#[test]
+fn update_from_or_ignore_expression_index_now_value_rejected() {
+    // The UPDATE ... FROM dispatch path has its own IGNORE/REPLACE branches
+    let mut db = Database::new();
+    setup_expression_index_table(&mut db);
+    run_sql(&mut db, "CREATE TABLE src(a INT, v TEXT); INSERT INTO src VALUES(1, 'now')");
+    assert_sql_error(
+        &mut db,
+        "UPDATE OR IGNORE t2 SET b=src.v FROM src WHERE t2.a=src.a",
+        "non-deterministic use of date() in an index",
+    );
+    assert_eq!(column_values(&db, "t2", 1), vec!["2024-01-01"]);
+}
+
+#[test]
+fn update_from_or_replace_expression_index_now_value_rejected() {
+    let mut db = Database::new();
+    setup_expression_index_table(&mut db);
+    run_sql(&mut db, "CREATE TABLE src(a INT, v TEXT); INSERT INTO src VALUES(1, 'now')");
+    assert_sql_error(
+        &mut db,
+        "UPDATE OR REPLACE t2 SET b=src.v FROM src WHERE t2.a=src.a",
+        "non-deterministic use of date() in an index",
+    );
+    assert_eq!(column_values(&db, "t2", 1), vec!["2024-01-01"]);
+}
+
+// ============================================================================
 // 'localtime' / 'utc' modifiers from row data (date2-500..520)
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Closes #5324

PR #5323 added evaluation-time rejection of non-deterministic date/time functions in schema-attached expressions, but the pre-mutation `enforce_index_expression_determinism` check was only called from the **default** branch of the UPDATE executor. The `use_ignore` / `use_replace` branches — in both the plain UPDATE path (`execute_internal`) and the UPDATE ... FROM path (`execute_update_from`) — skipped it, so `UPDATE OR IGNORE t2 SET y='now'` wrote the row and the lenient post-mutation index maintenance stored a time-dependent index key.

SQLite (verified 3.51.0 in the issue) aborts the statement even under OR IGNORE / OR REPLACE: the non-deterministic error is a runtime SQL function error, not a constraint conflict, so conflict resolution does not apply.

### Changes

- `crates/vibesql-executor/src/update/executor.rs`: call `enforce_index_expression_determinism` (with `?` propagation) in all four IGNORE/REPLACE branches, mirroring the default branch. The check runs before any mutation (REPLACE conflict deletions happen later), so the statement aborts cleanly.
- In the IGNORE branches, propagate `is_non_deterministic_use()` errors from `validate_row` / `validate_unique_indexes` instead of `continue`-ing — this fixes the lesser variant where a non-deterministic call in a CHECK constraint silently skipped the row instead of aborting.
- 7 new integration tests in `non_deterministic_datetime_tests.rs`: OR IGNORE / OR REPLACE with `'now'` under an expression index (error + row unchanged), partial-index predicate variant, CHECK-constraint variant, UPDATE ... FROM variants, and a no-regression test that deterministic values still update under both clauses.

### Testing

- `cargo test -p vibesql-executor --test non_deterministic_datetime_tests`: 22 passed (15 pre-existing from #5323 + 7 new)
- `cargo test -p vibesql-executor --lib`: 2576 passed
- `conflict_resolution_tests`, `update_basic_tests`, `update_constraint_tests`, `update_deferred_uniqueness_tests`: 57 passed
- `make test-tcl-file FILE=date2.test`: 27/27 passed (2 skipped, pre-existing)
- clippy: no new warnings in changed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)