### PR TITLE
refactor(executor): consolidate duplicated extract_table_names in subquery_rewrite

### DIFF
--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
@@ -161,6 +161,12 @@ fn has_exists_subqueries(stmt: &SelectStmt) -> bool {
 }
 
 /// Extract table names from a FROM clause
+///
+/// Shared by this module and `scalar_decorrelation`. Each unaliased table
+/// contributes exactly one entry; an aliased table contributes two (alias
+/// then original name). Callers that count entries to detect multi-relation
+/// FROM clauses (e.g., `rewrite_expression_with_context`) rely on these
+/// dedup semantics — do not reintroduce duplicate pushes.
 fn extract_table_names(from: &Option<vibesql_ast::FromClause>) -> Vec<String> {
     fn collect_tables(from: &vibesql_ast::FromClause, tables: &mut Vec<String>) {
         match from {
@@ -231,6 +237,40 @@ mod tests {
             set_operation: None,
             values: None,
         }
+    }
+
+    #[test]
+    fn test_extract_table_names_unaliased_table_single_entry() {
+        // Unaliased tables must contribute exactly one entry:
+        // rewrite_expression_with_context uses the entry count to detect
+        // multi-relation FROM clauses (outer_tables.len() <= 1).
+        let stmt = simple_select("orders", "order_id");
+        assert_eq!(extract_table_names(&stmt.from), vec!["orders".to_string()]);
+    }
+
+    #[test]
+    fn test_extract_table_names_aliased_table_includes_alias_and_name() {
+        let mut stmt = simple_select("orders", "order_id");
+        if let Some(vibesql_ast::FromClause::Table { alias, .. }) = &mut stmt.from {
+            *alias = Some("o".to_string());
+        }
+        assert_eq!(extract_table_names(&stmt.from), vec!["o".to_string(), "orders".to_string()]);
+    }
+
+    #[test]
+    fn test_extract_table_names_join_collects_both_sides() {
+        let left = simple_select("orders", "order_id").from.unwrap();
+        let right = simple_select("customers", "customer_id").from.unwrap();
+        let from = Some(vibesql_ast::FromClause::Join {
+            join_type: vibesql_ast::JoinType::Inner,
+            left: Box::new(left),
+            right: Box::new(right),
+            condition: None,
+            using_columns: None,
+            natural: false,
+            alias: None,
+        });
+        assert_eq!(extract_table_names(&from), vec!["orders".to_string(), "customers".to_string()]);
     }
 
     #[test]

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/scalar_decorrelation.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/scalar_decorrelation.rs
@@ -51,6 +51,8 @@ use vibesql_ast::{
     GroupByClause, JoinType, SelectItem, SelectStmt,
 };
 
+use super::extract_table_names;
+
 /// Global counter for generating unique CTE aliases
 static CTE_COUNTER: AtomicU32 = AtomicU32::new(0);
 
@@ -613,34 +615,6 @@ fn extract_scalar_subquery_with_multiplier(
     }
 }
 
-/// Extract table names from a FROM clause
-fn extract_table_names(from: &Option<FromClause>) -> Vec<String> {
-    fn collect_tables(from: &FromClause, tables: &mut Vec<String>) {
-        match from {
-            FromClause::Table { name, alias, .. } => {
-                tables.push(alias.clone().unwrap_or_else(|| name.clone()));
-                tables.push(name.clone());
-            }
-            FromClause::Join { left, right, .. } => {
-                collect_tables(left, tables);
-                collect_tables(right, tables);
-            }
-            FromClause::Subquery { alias, .. } => {
-                tables.push(alias.clone());
-            }
-            FromClause::Values { alias, .. } => {
-                tables.push(alias.clone());
-            }
-        }
-    }
-
-    let mut tables = Vec::new();
-    if let Some(from_clause) = from {
-        collect_tables(from_clause, &mut tables);
-    }
-    tables
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -650,5 +624,99 @@ mod tests {
         assert!(is_constant(&Expression::Literal(vibesql_types::SqlValue::Integer(42))));
         assert!(is_constant(&Expression::Literal(vibesql_types::SqlValue::Float(1.2))));
         assert!(!is_constant(&Expression::ColumnRef(ColumnIdentifier::simple("x", false))));
+    }
+
+    /// Helper to create a bare SELECT statement for testing
+    fn select_stmt(from: Option<FromClause>) -> SelectStmt {
+        SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Expression {
+                expr: Expression::ColumnRef(ColumnIdentifier::simple("total", false)),
+                alias: None,
+                source_text: None,
+            }],
+            into_table: None,
+            into_variables: None,
+            from,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            window_definitions: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        }
+    }
+
+    /// SELECT AVG(l.amount) FROM lineitem AS l WHERE l.order_id = orders.order_id
+    fn correlated_avg_subquery() -> SelectStmt {
+        let mut subq = select_stmt(Some(FromClause::Table {
+            index_hint: None,
+            name: "lineitem".to_string(),
+            alias: Some("l".to_string()),
+            column_aliases: None,
+            quoted: false,
+        }));
+        subq.select_list = vec![SelectItem::Expression {
+            expr: Expression::AggregateFunction {
+                name: vibesql_ast::FunctionIdentifier::new("AVG"),
+                distinct: false,
+                args: vec![Expression::ColumnRef(ColumnIdentifier::qualified(
+                    "l", false, "amount", false,
+                ))],
+                order_by: None,
+                filter: None,
+            },
+            alias: None,
+            source_text: None,
+        }];
+        subq.where_clause = Some(Expression::BinaryOp {
+            op: BinaryOperator::Equal,
+            left: Box::new(Expression::ColumnRef(ColumnIdentifier::qualified(
+                "l", false, "order_id", false,
+            ))),
+            right: Box::new(Expression::ColumnRef(ColumnIdentifier::qualified(
+                "orders", false, "order_id", false,
+            ))),
+        });
+        subq
+    }
+
+    /// Regression test for the consolidated `extract_table_names` helper:
+    /// with the shared (dedup) semantics an unaliased outer table produces a
+    /// single entry ("orders") instead of the old duplicated pair. The
+    /// membership-based correlation detection in this module must still
+    /// decorrelate correctly.
+    #[test]
+    fn test_decorrelation_with_unaliased_outer_table() {
+        // SELECT total FROM orders
+        // WHERE orders.total > (SELECT AVG(l.amount) FROM lineitem l
+        //                       WHERE l.order_id = orders.order_id)
+        let mut stmt = select_stmt(Some(FromClause::Table {
+            index_hint: None,
+            name: "orders".to_string(),
+            alias: None,
+            column_aliases: None,
+            quoted: false,
+        }));
+        stmt.where_clause = Some(Expression::BinaryOp {
+            op: BinaryOperator::GreaterThan,
+            left: Box::new(Expression::ColumnRef(ColumnIdentifier::qualified(
+                "orders", false, "total", false,
+            ))),
+            right: Box::new(Expression::ScalarSubquery(Box::new(correlated_avg_subquery()))),
+        });
+
+        let result = apply_scalar_decorrelation(&stmt);
+
+        let ctes = result.with_clause.as_ref().expect("decorrelation should add a CTE");
+        assert_eq!(ctes.len(), 1, "expected exactly one decorrelation CTE");
+        assert!(
+            matches!(result.from, Some(FromClause::Join { .. })),
+            "decorrelation should rewrite FROM into a JOIN with the CTE"
+        );
     }
 }


### PR DESCRIPTION
## Summary
PR #5321 gave the `extract_table_names` helper in `optimizer/subquery_rewrite/mod.rs` dedup semantics (unaliased tables contribute one entry, because `rewrite_expression_with_context` uses the entry count to detect multi-relation FROM clauses). A private copy of the same helper in `scalar_decorrelation.rs` still double-pushed, leaving two helpers with intentionally different semantics under the same name — a maintenance hazard for anyone adding a count-sensitive check on the scalar decorrelation path.

This PR consolidates to the single mod.rs helper and deletes the private copy.

## Changes
- Delete the private `extract_table_names` copy in `scalar_decorrelation.rs`; import the shared helper via `use super::extract_table_names;` (child modules can access the parent's private items, so no visibility widening is needed)
- Document the dedup contract on the shared helper in `mod.rs` (unaliased table = one entry; aliased table = alias then name; count-sensitive callers rely on this)
- Add unit tests pinning the helper semantics: unaliased single entry, aliased pair, join collection
- Add a regression test in `scalar_decorrelation.rs` proving decorrelation still fires for an unaliased outer table under the shared (dedup) semantics

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Single shared helper, private copy deleted | ✅ | `grep -rn "fn extract_table_names" crates/vibesql-executor/src/optimizer/subquery_rewrite/` shows only the mod.rs definition |
| Verified scalar_decorrelation does not depend on old non-dedup semantics | ✅ | Audited all `outer_tables` consumers in `scalar_decorrelation.rs`: only `is_empty()` (line 416) and case-insensitive membership via `iter().any(...)` in `is_from_outer` — neither is count-sensitive, so dedup is behavior-preserving |
| Semantics pinned with tests | ✅ | 3 new helper-semantics tests in mod.rs + 1 decorrelation regression test with unaliased outer table |

## Test Plan
- `cargo test -p vibesql-executor --lib subquery_rewrite`: 18 passed (4 new)
- `cargo test -p vibesql-executor --lib optimizer`: 152 passed
- Integration suites: `scalar_comparison_decorrelation_tests` (6 passed), `tpch_subquery_tests` (10 passed, includes Q20 nested-IN and Q20 scalar-comparison NULL semantics), `having_subquery_tests` (12 passed), `issue_2998_correlated_subquery` (2 passed)
- TPC-H Q20 spot check via `tpch_profiling` harness (SF 0.01): **1 row** returned, matching expected output
- `cargo check -p vibesql-executor` clean; clippy warnings in the touched file are pre-existing (`clone` on `Copy` `BinaryOperator`, untouched lines)

Closes #5322