### PR TITLE
fix(executor): compare Timestamp/Time vs string as TEXT renderings (date2-331)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/operators/comparison/equality.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/comparison/equality.rs
@@ -281,8 +281,9 @@ mod tests {
     #[test]
     fn test_timestamp_vs_string_equality() {
         // SQLite date3.test 2.40: datetime(x,'auto') == '<text>' must evaluate
-        // to a boolean, not raise a type mismatch (SQLite's datetime() returns
-        // TEXT, so the comparison is valid there)
+        // to a boolean, not raise a type mismatch. SQLite's datetime() returns
+        // TEXT, so this is a plain text comparison of the renderings there;
+        // Timestamp's Display matches SQLite's 'YYYY-MM-DD HH:MM:SS' output.
         let timestamp = ts("2022-01-27 13:15:44");
         let matching = SqlValue::Varchar(arcstr::ArcStr::from("2022-01-27 13:15:44"));
         let differing = SqlValue::Varchar(arcstr::ArcStr::from("2022-01-27 13:15:45"));
@@ -306,6 +307,19 @@ mod tests {
         assert_eq!(equal(&timestamp, &junk).unwrap(), SqlValue::Boolean(false));
         assert_eq!(equal(&junk, &timestamp).unwrap(), SqlValue::Boolean(false));
         assert_eq!(not_equal(&timestamp, &junk).unwrap(), SqlValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_timestamp_vs_date_only_string_is_not_equal() {
+        // SQLite date2-331 regression: a midnight timestamp is NOT equal to
+        // its date-only string. SQLite compares the TEXT renderings:
+        // '2017-07-08 00:00:00' != '2017-07-08'. (The old parse-first
+        // behavior treated the string as midnight and returned true.)
+        let midnight = ts("2017-07-08 00:00:00");
+        let date_only = SqlValue::Varchar(arcstr::ArcStr::from("2017-07-08"));
+        assert_eq!(equal(&midnight, &date_only).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(equal(&date_only, &midnight).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(not_equal(&midnight, &date_only).unwrap(), SqlValue::Boolean(true));
     }
 
     #[test]

--- a/crates/vibesql-executor/src/evaluator/operators/comparison/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/comparison/mod.rs
@@ -194,38 +194,32 @@ where
             }
         },
 
-        // Timestamp compared to string - parse the string as a timestamp when
-        // possible; otherwise compare the TEXT renderings. SQLite's datetime()
-        // returns TEXT, so expressions like `datetime(x,'auto') == '2022-01-27
-        // 13:15:44'` are plain text comparisons there (date3.test 2.40); the
-        // Display rendering of Timestamp matches SQLite's 'YYYY-MM-DD
-        // HH:MM:SS' format, and an unparseable string (e.g. 'hello') compares
-        // as text instead of raising a type mismatch, like SQLite.
+        // Timestamp compared to string - always compare the TEXT renderings
+        // lexicographically. SQLite's datetime() returns TEXT, so expressions
+        // like `datetime(x,'auto') == '2022-01-27 13:15:44'` (date3.test 2.40)
+        // and `datetime(b) BETWEEN '2017-07-04' AND '2017-07-08'` (date2-331)
+        // are plain text comparisons there. The Display rendering of Timestamp
+        // matches SQLite's 'YYYY-MM-DD HH:MM:SS' format, so for full canonical
+        // timestamp strings lexicographic ordering equals semantic ordering
+        // (ISO-8601); behavior only diverges for date-only strings, where
+        // SQLite is lexicographic: '2017-07-08 00:00:00' > '2017-07-08'
+        // (longer string with equal prefix). Unparseable strings (e.g.
+        // 'hello') also compare as text instead of raising a type mismatch,
+        // like SQLite.
         (Timestamp(ts), Varchar(s)) | (Timestamp(ts), Character(s)) => {
-            return Ok(Boolean(predicate(match vibesql_types::Timestamp::from_str(s) {
-                Ok(parsed) => ts.cmp(&parsed),
-                Err(_) => ts.to_string().as_str().cmp(s.as_str()),
-            })));
+            return Ok(Boolean(predicate(ts.to_string().as_str().cmp(s.as_str()))));
         }
         (Varchar(s), Timestamp(ts)) | (Character(s), Timestamp(ts)) => {
-            return Ok(Boolean(predicate(match vibesql_types::Timestamp::from_str(s) {
-                Ok(parsed) => parsed.cmp(ts),
-                Err(_) => s.as_str().cmp(ts.to_string().as_str()),
-            })));
+            return Ok(Boolean(predicate(s.as_str().cmp(ts.to_string().as_str()))));
         }
 
-        // Time compared to string - same approach as Timestamp
+        // Time compared to string - same TEXT-rendering approach as Timestamp
+        // (Time's Display matches SQLite's time() 'HH:MM:SS' output)
         (Time(t), Varchar(s)) | (Time(t), Character(s)) => {
-            return Ok(Boolean(predicate(match vibesql_types::Time::from_str(s) {
-                Ok(parsed) => t.cmp(&parsed),
-                Err(_) => t.to_string().as_str().cmp(s.as_str()),
-            })));
+            return Ok(Boolean(predicate(t.to_string().as_str().cmp(s.as_str()))));
         }
         (Varchar(s), Time(t)) | (Character(s), Time(t)) => {
-            return Ok(Boolean(predicate(match vibesql_types::Time::from_str(s) {
-                Ok(parsed) => parsed.cmp(t),
-                Err(_) => s.as_str().cmp(t.to_string().as_str()),
-            })));
+            return Ok(Boolean(predicate(s.as_str().cmp(t.to_string().as_str()))));
         }
 
         _ => {} // Fall through to regular comparison logic

--- a/crates/vibesql-executor/src/evaluator/operators/comparison/ordering.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/comparison/ordering.rs
@@ -61,8 +61,11 @@ mod tests {
 
     #[test]
     fn test_timestamp_vs_string_ordering() {
-        // Timestamp-vs-string ordering parses the string as a timestamp
-        // (date-only strings get midnight, matching Timestamp::from_str)
+        // Timestamp-vs-string ordering compares TEXT renderings
+        // lexicographically (SQLite's datetime() returns TEXT, so these are
+        // plain text comparisons there). For full canonical timestamp strings
+        // lexicographic ordering equals semantic ordering; a date-only string
+        // sorts before the rendered timestamp by the prefix rule.
         let timestamp = SqlValue::Timestamp("2022-01-27 13:15:44".parse().unwrap());
         let later = SqlValue::Varchar(arcstr::ArcStr::from("2022-01-27 13:15:45"));
         let earlier = SqlValue::Varchar(arcstr::ArcStr::from("2022-01-27"));
@@ -71,6 +74,30 @@ mod tests {
         assert_eq!(greater_than(&timestamp, &earlier).unwrap(), SqlValue::Boolean(true));
         assert_eq!(less_than(&earlier, &timestamp).unwrap(), SqlValue::Boolean(true));
         assert_eq!(greater_than_or_equal(&later, &timestamp).unwrap(), SqlValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_timestamp_vs_date_only_string_is_lexicographic() {
+        // SQLite date2-331 regression: datetime(b) BETWEEN '2017-07-04' AND
+        // '2017-07-08' must EXCLUDE midnight of the upper bound, because
+        // SQLite compares TEXT lexicographically:
+        // '2017-07-08 00:00:00' > '2017-07-08' (longer string, equal prefix).
+        let midnight = SqlValue::Timestamp("2017-07-08 00:00:00".parse().unwrap());
+        let date_only = SqlValue::Varchar(arcstr::ArcStr::from("2017-07-08"));
+
+        assert_eq!(greater_than(&midnight, &date_only).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(less_than_or_equal(&midnight, &date_only).unwrap(), SqlValue::Boolean(false));
+        // Symmetric arm: string < timestamp
+        assert_eq!(less_than(&date_only, &midnight).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(greater_than_or_equal(&date_only, &midnight).unwrap(), SqlValue::Boolean(false));
+        // Character storage class behaves like Varchar
+        let date_only_char = SqlValue::Character(arcstr::ArcStr::from("2017-07-08"));
+        assert_eq!(greater_than(&midnight, &date_only_char).unwrap(), SqlValue::Boolean(true));
+        // T-separator strings are also plain text in SQLite's model:
+        // '2022-01-27 ...' < '2022-01-27T...' because ' ' < 'T'
+        let t_separated = SqlValue::Varchar(arcstr::ArcStr::from("2022-01-27T13:15:44"));
+        let ts = SqlValue::Timestamp("2022-01-27 13:15:44".parse().unwrap());
+        assert_eq!(less_than(&ts, &t_separated).unwrap(), SqlValue::Boolean(true));
     }
 
     #[test]

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3286,7 +3286,6 @@ array set vibesql_skip_tests {
     date-8.19 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
     date-15.2 "sleeper TCL UDF registered via db func is not visible to the VibeSQL CLI subprocess (harness limitation)"
     date2-330 "planner does not select partial expression indexes (EXPLAIN QUERY PLAN expects USING INDEX t3b1); index rejection itself works (date2-310/320 pass)"
-    date2-331 "datetime() returns a temporal value instead of TEXT, so BETWEEN against '2017-07-08' compares semantically (includes midnight) instead of lexicographically"
 }
 
 # Pattern-based skip list for tests with many numbered variants


### PR DESCRIPTION
## Summary

SQLite's `datetime()`/`time()` return TEXT, so comparing them against string literals is lexicographic there. VibeSQL's parse-first Timestamp/Time-vs-string comparison arms (from #5320) parsed date-only strings as midnight timestamps, so `datetime(b) BETWEEN '2017-07-04' AND '2017-07-08'` included midnight of the upper bound (`'2017-07-08 00:00:00' > '2017-07-08'` lexicographically in SQLite — excluded there). This PR makes those arms always compare the TEXT renderings, matching SQLite (Curator-recommended Option 1).

## Changes

- `crates/vibesql-executor/src/evaluator/operators/comparison/mod.rs` — the four Timestamp/Time-vs-string arms now compare `to_string()` renderings lexicographically (parse-first branch dropped); comments updated. Date-vs-string arms (TPC-H critical) untouched.
- `crates/vibesql-executor/src/evaluator/operators/comparison/ordering.rs` — updated stale parse-first comment; new regression test `test_timestamp_vs_date_only_string_is_lexicographic` (midnight > date-only string, symmetric arm, Character class, T-separator string).
- `crates/vibesql-executor/src/evaluator/operators/comparison/equality.rs` — new test `test_timestamp_vs_date_only_string_is_not_equal` (flips from prior parse-first behavior); comment updated.
- `scripts/tester_vibesql.tcl` — removed the date2-331 skip entry (date2-330 planner skip stays).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| date2-331 passes, skip removed | ✅ | `make test-tcl-file FILE=date2.test`: 28/28 passed, 1 skipped (date2-330 only) |
| No regression in date.test | ✅ | 1372 passed, 0 failed (matches baseline) |
| No regression in date3.test (incl. 2.40) | ✅ | 126/126 passed |
| No regression in timediff1.test | ✅ | 1520/1520 passed |

## Test Plan

- `cargo test -p vibesql-executor` — 2582 lib tests + all integration suites green; all #5320 comparison tests still pass unchanged
- New unit regression tests for the date2-331 boundary (ordering + equality, both operand orders, Character class, T-separator)
- CLI smoke: `datetime('2017-07-08') BETWEEN '2017-07-04' AND '2017-07-08'` → 0; `datetime('2017-07-06') BETWEEN ...` → 1; `datetime(ts) = '<canonical>'` → 1 (all match SQLite)
- TPC-H Date-arm smoke: `l_shipdate <= '1998-09-02'` includes the boundary row (semantic Date compare unchanged)
- Verified columnar/SIMD filter path has no separate Timestamp-vs-string kernel (`value_to_timestamp_i64` returns None for strings; scalar `compare_values` has no Timestamp-string arm), so no divergent kernel exists
- `cargo check` / `cargo clippy -p vibesql-executor` — no new warnings (remaining warnings pre-exist in unrelated files)

Closes #5326