### PR TITLE
fix(executor): coerce string index-probe bounds to stored temporal key type

### DIFF
--- a/crates/vibesql-executor/src/optimizer/predicate_implication.rs
+++ b/crates/vibesql-executor/src/optimizer/predicate_implication.rs
@@ -20,11 +20,12 @@
 //! SELECT id FROM orders WHERE status = 1 AND sku = 300;
 //! ```
 //!
-//! v1 additionally restricts selection to NON-EXPRESSION partial indexes:
-//! partial indexes with expression columns (e.g. the date2-330/331 index
-//! `CREATE INDEX t3b1 ON t3(datetime(b)) WHERE typeof(b)='real'`) are excluded
-//! until the expression-index equality/BETWEEN probe bug (#5333) is fixed —
-//! see [`partial_index_usable`].
+//! Partial EXPRESSION indexes (e.g. the date2-330/331 index
+//! `CREATE INDEX t3b1 ON t3(datetime(b)) WHERE typeof(b)='real'`) are selected
+//! under the same implication rule. They were temporarily excluded while the
+//! temporal probe-bound bug existed; #5333 fixed the probes by coercing string
+//! bounds to the stored temporal key type (see
+//! `select::scan::index_scan::predicate::temporal_coercion`).
 //!
 //! Correctness:
 //! - **Extra rows are harmless** — the full WHERE clause is always re-applied
@@ -98,22 +99,16 @@ pub(crate) fn query_implies_index_predicate(
 /// clause, considering partial-index predicates.
 ///
 /// - Non-partial indexes are always usable (returns `true`).
-/// - Partial indexes containing **expression columns** are never usable (v1
-///   exclusion, see below).
-/// - Other partial indexes are usable only when `query_where` structurally
-///   implies the index predicate (see [`query_implies_index_predicate`]).
+/// - Partial indexes (expression or not) are usable only when `query_where`
+///   structurally implies the index predicate (see
+///   [`query_implies_index_predicate`]).
 /// - A partial index with no query WHERE clause is never usable.
 ///
-/// v1 exclusion of partial EXPRESSION indexes (issue #5333): the
-/// expression-index probe machinery compares `Timestamp` keys against string
-/// bounds incorrectly for equality and BETWEEN probes (both return 0 rows;
-/// one-sided ranges are fine). Selecting a partial expression index such as
-/// `CREATE INDEX t3b1 ON t3(datetime(b)) WHERE typeof(b)='real'` (date2-331)
-/// therefore silently loses rows — an empty probe result can only be narrowed
-/// by the WHERE post-filter, never widened. Until #5333 fixes the probes,
-/// partial expression indexes stay excluded from planner selection, matching
-/// the pre-#5331 behavior for them. (Non-partial expression indexes keep
-/// their existing selection behavior — also tracked by #5333.)
+/// Partial EXPRESSION indexes were excluded here (v1) while the temporal
+/// probe-bound bug existed: probes compared `Timestamp` keys against raw
+/// string bounds with type-tag ordering and silently lost rows. Issue #5333
+/// fixed the probes by coercing string bounds to the stored temporal key type
+/// at probe time, so the exclusion is no longer needed.
 ///
 /// The partial predicate lives on the catalog-side `IndexMetadata`
 /// (`where_clause`); the storage-side metadata does not yet carry it.
@@ -131,12 +126,6 @@ pub(crate) fn partial_index_usable(
         // Not a partial index: no predicate gate.
         return true;
     };
-
-    // v1: partial expression indexes are excluded until the expression-index
-    // equality/BETWEEN probe bug (#5333) is fixed.
-    if metadata.has_expression_columns() {
-        return false;
-    }
 
     match query_where {
         Some(query_where) => query_implies_index_predicate(query_where, index_where),
@@ -323,12 +312,10 @@ mod tests {
     }
 
     #[test]
-    fn partial_expression_index_excluded_even_when_implied() {
-        // v1 exclusion (#5333): the expression-index equality/BETWEEN probe
-        // machinery loses rows (Timestamp keys vs string bounds), so a
-        // partial EXPRESSION index must never be planner-usable — even when
-        // the query WHERE implies the index predicate verbatim (date2-331
-        // shape). Remove this exclusion when #5333 is fixed.
+    fn partial_expression_index_usable_when_implied() {
+        // #5333 fixed the temporal probe-bound bug, so partial EXPRESSION
+        // indexes follow the same implication rule as non-expression ones
+        // (date2-330/331 shape).
         use vibesql_storage::Database;
 
         let mut db = Database::new();
@@ -345,10 +332,14 @@ mod tests {
             crate::CreateIndexExecutor::execute(&stmt, &mut db).unwrap();
         }
 
-        // Even a verbatim-implying WHERE clause must not make it usable.
+        // Verbatim-implying WHERE clause makes it usable.
         let implying =
             parse_where("typeof(b)='real' AND datetime(b) BETWEEN '2017-07-04' AND '2017-07-08'");
-        assert!(!partial_index_usable(&db, "t3b1", Some(&implying)));
+        assert!(partial_index_usable(&db, "t3b1", Some(&implying)));
+
+        // Non-implying / absent WHERE clause: still unusable.
+        let non_implying = parse_where("datetime(b) > '2017-07-04'");
+        assert!(!partial_index_usable(&db, "t3b1", Some(&non_implying)));
         assert!(!partial_index_usable(&db, "t3b1", None));
     }
 

--- a/crates/vibesql-executor/src/select/executor/fast_path/index_lookup.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path/index_lookup.rs
@@ -170,6 +170,14 @@ impl SelectExecutor<'_> {
                 None => continue,
             };
 
+            // Issue #5333: coerce string equality keys to the stored temporal
+            // key type; skip this index when no faithful coercion exists
+            // (slower paths evaluate with executor semantics).
+            let mut prefix_key = prefix_key;
+            if !coerce_temporal_lookup_keys(index_data, &mut prefix_key) {
+                continue;
+            }
+
             // Perform the optimized prefix scan
             let row_indices = if is_desc {
                 // Use reverse prefix scan for DESC ORDER BY
@@ -360,6 +368,15 @@ impl SelectExecutor<'_> {
                 None => continue,
             };
 
+            // Issue #5333: coerce string equality keys to the stored temporal
+            // key type (e.g. `ts_col = '2017-07-20 15:30:00'` against
+            // Timestamp keys); skip this index when no faithful coercion
+            // exists (slower paths evaluate with executor semantics).
+            let mut key_values = key_values;
+            if !coerce_temporal_lookup_keys(index_data, &mut key_values) {
+                continue;
+            }
+
             let row_indices = if key_values.len() == index_columns.len() {
                 // Full key match - use exact lookup
                 match index_data.get(&key_values) {
@@ -544,4 +561,42 @@ impl SelectExecutor<'_> {
         // No suitable covering index found
         Ok(None)
     }
+}
+
+/// Coerce string equality lookup keys to the stored temporal key type
+/// (issue #5333).
+///
+/// Index keys are compared with `SqlValue`'s total order, where cross-type
+/// pairs (e.g. `Varchar` vs `Timestamp`) are never equal. A point lookup
+/// built from a raw string literal therefore silently returns 0 rows against
+/// temporal keys. This mirrors the executor's comparison semantics:
+/// `Date` keys parse the string (parse-first); `Timestamp`/`Time` keys
+/// require an exact parse → Display round-trip (TEXT-rendering equality).
+///
+/// Returns `false` when the index cannot be probed faithfully with these
+/// keys — the caller should skip the index and let a slower path compute the
+/// result with executor semantics.
+fn coerce_temporal_lookup_keys(
+    index_data: &vibesql_storage::database::indexes::IndexData,
+    key_values: &mut [SqlValue],
+) -> bool {
+    use crate::select::scan::index_scan::predicate::{coerce_equality_key, EqualityKeyCoercion};
+
+    // Fast exit: nothing to do unless some key component is a string.
+    if !key_values.iter().any(|v| matches!(v, SqlValue::Varchar(_) | SqlValue::Character(_))) {
+        return true;
+    }
+
+    for (col_idx, value) in key_values.iter_mut().enumerate() {
+        let Some(sample) = index_data.first_key_value_sample(col_idx) else {
+            continue;
+        };
+        match coerce_equality_key(&sample, value) {
+            EqualityKeyCoercion::Unchanged => {}
+            EqualityKeyCoercion::Coerced(coerced) => *value = coerced,
+            EqualityKeyCoercion::Unusable => return false,
+        }
+    }
+
+    true
 }

--- a/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
@@ -8,11 +8,12 @@ use vibesql_ast::Expression;
 use vibesql_storage::{Database, Row};
 
 use super::predicate::{
-    build_residual_where_clause, extract_composite_predicates_with_in,
-    extract_index_predicate_for_indexed_column, extract_prefix_equality_predicates,
-    extract_prefix_with_trailing_range, generate_composite_keys,
-    where_clause_fully_satisfied_by_composite_key, where_clause_fully_satisfied_by_indexed_column,
-    CompositePredicateType, IndexPredicate, PrefixPredicateResult, PrefixWithRangeResult,
+    build_residual_where_clause, coerce_index_predicate_for_temporal_keys,
+    extract_composite_predicates_with_in, extract_index_predicate_for_indexed_column,
+    extract_prefix_equality_predicates, extract_prefix_with_trailing_range,
+    generate_composite_keys, where_clause_fully_satisfied_by_composite_key,
+    where_clause_fully_satisfied_by_indexed_column, CompositePredicateType, IndexPredicate,
+    PrefixPredicateResult, PrefixWithRangeResult,
 };
 use crate::{
     errors::ExecutorError, optimizer::PredicatePlan, schema::CombinedSchema, select::cte::CteResult,
@@ -144,6 +145,16 @@ pub(crate) fn execute_index_scan(
             where_clause.and_then(|expr| extract_index_predicate_for_indexed_column(expr, idx_col))
         })
     };
+
+    // Issue #5333: when the index stores temporal keys (e.g. an expression
+    // index on date()/datetime(), or a plain TIMESTAMP column index) but the
+    // WHERE clause supplies string bounds, coerce the bounds to the stored
+    // key type so the probe matches executor comparison semantics. Without
+    // this, type-tag ordering makes equality/upper-bounded probes silently
+    // lose rows and lower-bounded probes over-return. If no faithful
+    // coercion exists the predicate is dropped, falling back to the
+    // full-index-scan + WHERE-filter path below (correct, just slower).
+    let index_predicate = coerce_index_predicate_for_temporal_keys(index_predicate, index_data);
 
     // Build residual WHERE clause for prefix lookups
     // This contains only the predicates NOT covered by the index prefix

--- a/crates/vibesql-executor/src/select/scan/index_scan/predicate/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/predicate/mod.rs
@@ -24,6 +24,7 @@ mod composite;
 mod expression_index;
 mod in_list;
 pub(super) mod range;
+mod temporal_coercion;
 
 // Re-export types
 pub(crate) use composite::{CompositePredicateType, PrefixPredicateResult, PrefixWithRangeResult};
@@ -68,6 +69,11 @@ pub(crate) use expression_index::{
 
 // Re-export main extraction function
 pub(crate) use in_list::{extract_index_predicate, where_clause_fully_satisfied_by_index};
+
+// Re-export temporal probe-bound coercion (issue #5333)
+pub(crate) use temporal_coercion::{
+    coerce_equality_key, coerce_index_predicate_for_temporal_keys, EqualityKeyCoercion,
+};
 
 #[cfg(test)]
 #[path = "tests.rs"]

--- a/crates/vibesql-executor/src/select/scan/index_scan/predicate/temporal_coercion.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/predicate/temporal_coercion.rs
@@ -1,0 +1,560 @@
+//! Temporal probe-bound coercion (issue #5333)
+//!
+//! Index probes are evaluated with `SqlValue`'s total order, which falls back
+//! to type-tag ordering for cross-type pairs (`Varchar`=10 < `Date`=12 <
+//! `Timestamp`=14, cross-type `PartialEq` = false). When an index stores
+//! temporal keys (e.g. an expression index on `date(y)` / `datetime(b)`, or a
+//! plain `TIMESTAMP` column index) and the WHERE clause supplies *string*
+//! bounds, raw probes are wrong in both directions:
+//!
+//! - equality / upper-bounded probes return 0 rows (silent row loss), because
+//!   every temporal key sorts *above* every string key;
+//! - lower-bounded probes return every temporal key (over-return), which
+//!   surfaces as wrong rows whenever the planner decides the WHERE clause is
+//!   fully satisfied by the index and skips the residual filter.
+//!
+//! The fix is to coerce string probe bounds into the stored temporal key type
+//! *before* probing, mirroring the executor's comparison semantics exactly
+//! (see `crate::evaluator::operators::comparison`, established by #5329):
+//!
+//! - `Date` vs string: parse-first via `Date::from_str`; unparseable strings
+//!   raise a type mismatch in the executor, so we *decline* the probe and let
+//!   the fallback path surface the identical error.
+//! - `Timestamp` / `Time` vs string: the executor compares the TEXT
+//!   *renderings* lexicographically (SQLite's `datetime()` returns TEXT). For
+//!   strings that round-trip through parse → Display the coerced bound is
+//!   exactly equivalent. For date-only strings (`'2017-07-04'` against
+//!   `Timestamp` keys) the rendering of any timestamp on that date is a
+//!   longer string with the bound as prefix, so it compares strictly
+//!   *greater* than the bound. That makes the text-true set:
+//!   - `>= s` and `> s`  ⇔  `key >= parse(s)` (midnight included in both),
+//!   - `<= s` and `< s`  ⇔  `key <  parse(s)` (midnight excluded from both),
+//!   - `= s`             ⇔  empty (no rendering equals a date-only string),
+//!   which we encode by coercing lower bounds to inclusive and upper bounds
+//!   to exclusive. Equality probes arrive as `start == end` ranges, so the
+//!   two rules compose to the half-open empty range `[T, T)` automatically.
+//!   Anything that doesn't round-trip and isn't a strict rendering prefix
+//!   (junk strings, `T`-separated ISO forms, trailing-zero fractions, ...) is
+//!   *declined*: the caller drops the index predicate and the row set is
+//!   computed by the full-index-scan + WHERE-filter path, which evaluates
+//!   with executor semantics.
+//!
+//! The invariant being preserved: **index probe results == full-scan + WHERE
+//! results under VibeSQL's own comparison semantics.**
+
+use std::str::FromStr;
+
+use vibesql_storage::database::indexes::IndexData;
+use vibesql_types::SqlValue;
+
+use super::IndexPredicate;
+
+/// The temporal type of a stored index key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TemporalKeyType {
+    Date,
+    Timestamp,
+    Time,
+}
+
+/// Which side of a range a bound sits on (determines inclusivity adjustment
+/// for prefix-matching strings under TEXT-rendering semantics).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BoundSide {
+    Lower,
+    Upper,
+}
+
+/// Result of coercing a single probe bound.
+enum CoercedBound {
+    /// Bound is not affected (not a string, or key type not temporal).
+    Unchanged,
+    /// Bound replaced with a temporal value; inclusivity may have changed.
+    Coerced { value: SqlValue, inclusive: bool },
+    /// No faithful coercion exists; the caller must drop the index predicate
+    /// and fall back to the filtered full-index-scan path.
+    Decline,
+}
+
+/// Result of coercing an equality lookup key component (fast-path point
+/// lookups build composite keys directly rather than range predicates).
+pub(crate) enum EqualityKeyCoercion {
+    /// Key component unaffected.
+    Unchanged,
+    /// Key component replaced with the coerced temporal value.
+    Coerced(SqlValue),
+    /// The index cannot be probed faithfully with this key (unparseable or
+    /// non-round-tripping string); the caller should skip this index and let
+    /// a slower path compute the result with executor semantics.
+    Unusable,
+}
+
+fn temporal_key_type(sample: &SqlValue) -> Option<TemporalKeyType> {
+    match sample {
+        SqlValue::Date(_) => Some(TemporalKeyType::Date),
+        SqlValue::Timestamp(_) => Some(TemporalKeyType::Timestamp),
+        SqlValue::Time(_) => Some(TemporalKeyType::Time),
+        _ => None,
+    }
+}
+
+fn is_string(value: &SqlValue) -> bool {
+    matches!(value, SqlValue::Varchar(_) | SqlValue::Character(_))
+}
+
+fn as_str(value: &SqlValue) -> Option<&str> {
+    match value {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+/// The minimal value of a temporal key type, used to pin an inclusive lower
+/// bound on otherwise lower-unbounded coerced ranges. This keeps NULL keys
+/// (and any other lower-sorting type tags) out of the probe range, matching
+/// SQL semantics where `NULL < x` is NULL (not true). The column-index path
+/// has a separate NULL row filter, but expression indexes cannot identify a
+/// column to filter, so the probe range itself must exclude NULL keys.
+fn temporal_min_value(key_type: TemporalKeyType) -> SqlValue {
+    let min_date = vibesql_types::Date { year: i32::MIN, month: 1, day: 1 };
+    let midnight = vibesql_types::Time { hour: 0, minute: 0, second: 0, nanosecond: 0 };
+    match key_type {
+        TemporalKeyType::Date => SqlValue::Date(min_date),
+        TemporalKeyType::Timestamp => {
+            SqlValue::Timestamp(vibesql_types::Timestamp::new(min_date, midnight))
+        }
+        TemporalKeyType::Time => SqlValue::Time(midnight),
+    }
+}
+
+/// Coerce one string bound against a temporal key type.
+///
+/// `inclusive` is the bound's current inclusivity; the returned
+/// [`CoercedBound::Coerced`] carries the (possibly adjusted) inclusivity.
+fn coerce_string_bound(
+    key_type: TemporalKeyType,
+    bound: &SqlValue,
+    inclusive: bool,
+    side: BoundSide,
+) -> CoercedBound {
+    let Some(s) = as_str(bound) else {
+        return CoercedBound::Unchanged;
+    };
+
+    match key_type {
+        // Date vs string is parse-first in the executor (type-mismatch error
+        // on unparseable strings), so plain coercion is exactly equivalent.
+        TemporalKeyType::Date => match vibesql_types::Date::from_str(s) {
+            Ok(d) => CoercedBound::Coerced { value: SqlValue::Date(d), inclusive },
+            Err(_) => CoercedBound::Decline,
+        },
+        // Timestamp/Time vs string compares TEXT renderings in the executor.
+        TemporalKeyType::Timestamp => match vibesql_types::Timestamp::from_str(s) {
+            Ok(t) => coerce_rendered(t.to_string(), SqlValue::Timestamp(t), s, inclusive, side),
+            Err(_) => CoercedBound::Decline,
+        },
+        TemporalKeyType::Time => match vibesql_types::Time::from_str(s) {
+            Ok(t) => coerce_rendered(t.to_string(), SqlValue::Time(t), s, inclusive, side),
+            Err(_) => CoercedBound::Decline,
+        },
+    }
+}
+
+/// Shared TEXT-rendering coercion for `Timestamp` / `Time` keys.
+///
+/// * exact round-trip (`render(parse(s)) == s`): the coerced bound is
+///   equivalent under all operators — keep the original inclusivity.
+/// * strict rendering prefix (`render(parse(s))` starts with `s`, e.g. a
+///   date-only string against `Timestamp` keys): every key `>= parse(s)`
+///   renders strictly greater than `s` and every key `< parse(s)` renders
+///   strictly less, with no key rendering equal — so lower bounds become
+///   inclusive and upper bounds exclusive regardless of the original
+///   operator's inclusivity.
+/// * anything else: no faithful interval exists — decline.
+fn coerce_rendered(
+    rendered: String,
+    value: SqlValue,
+    s: &str,
+    inclusive: bool,
+    side: BoundSide,
+) -> CoercedBound {
+    if rendered == s {
+        CoercedBound::Coerced { value, inclusive }
+    } else if rendered.starts_with(s) {
+        match side {
+            BoundSide::Lower => CoercedBound::Coerced { value, inclusive: true },
+            BoundSide::Upper => CoercedBound::Coerced { value, inclusive: false },
+        }
+    } else {
+        CoercedBound::Decline
+    }
+}
+
+/// Coerce string probe bounds in an [`IndexPredicate`] to the stored temporal
+/// key type of the index's first column (issue #5333).
+///
+/// Returns the (possibly rewritten) predicate. Returns `None` when no
+/// faithful coercion exists — the caller then executes a full index scan with
+/// the WHERE clause applied as a filter, which evaluates with executor
+/// semantics (correct, just slower; only hit for unusual string bounds).
+///
+/// Non-temporal indexes, non-string bounds, and indexes whose key type cannot
+/// be sampled (empty, all-NULL, disk-backed) are passed through unchanged.
+pub(crate) fn coerce_index_predicate_for_temporal_keys(
+    predicate: Option<IndexPredicate>,
+    index_data: &IndexData,
+) -> Option<IndexPredicate> {
+    let predicate = predicate?;
+
+    // Fast exit: nothing to coerce unless some bound is a string.
+    let has_string_bound = match &predicate {
+        IndexPredicate::Range(range) => {
+            range.start.as_ref().is_some_and(is_string) || range.end.as_ref().is_some_and(is_string)
+        }
+        IndexPredicate::In(values) => values.iter().any(is_string),
+    };
+    if !has_string_bound {
+        return Some(predicate);
+    }
+
+    // Determine the stored key type from the first column's stored values.
+    let Some(key_type) = index_data.first_key_value_sample(0).as_ref().and_then(temporal_key_type)
+    else {
+        return Some(predicate);
+    };
+
+    match predicate {
+        IndexPredicate::Range(mut range) => {
+            if let Some(start) = &range.start {
+                match coerce_string_bound(key_type, start, range.inclusive_start, BoundSide::Lower)
+                {
+                    CoercedBound::Unchanged => {}
+                    CoercedBound::Coerced { value, inclusive } => {
+                        range.start = Some(value);
+                        range.inclusive_start = inclusive;
+                    }
+                    CoercedBound::Decline => return None,
+                }
+            }
+            if let Some(end) = &range.end {
+                match coerce_string_bound(key_type, end, range.inclusive_end, BoundSide::Upper) {
+                    CoercedBound::Unchanged => {}
+                    CoercedBound::Coerced { value, inclusive } => {
+                        range.end = Some(value);
+                        range.inclusive_end = inclusive;
+                    }
+                    CoercedBound::Decline => return None,
+                }
+            }
+
+            // Upper-bounded-only coerced ranges would otherwise sweep up NULL
+            // keys (and any lower-sorting type tags) via type-tag ordering.
+            // Pin the scan to the temporal key space with an inclusive
+            // minimal lower bound. (`exclude_nulls` is set for all inequality
+            // predicates; equality predicates carry both bounds already.)
+            if range.start.is_none() && range.end.is_some() && range.exclude_nulls {
+                range.start = Some(temporal_min_value(key_type));
+                range.inclusive_start = true;
+            }
+
+            Some(IndexPredicate::Range(range))
+        }
+        IndexPredicate::In(values) => {
+            let mut coerced = Vec::with_capacity(values.len());
+            for value in values {
+                if !is_string(&value) {
+                    coerced.push(value);
+                    continue;
+                }
+                match coerce_equality_key_for_sample_type(key_type, &value) {
+                    EqualityKeyCoercion::Unchanged => coerced.push(value),
+                    EqualityKeyCoercion::Coerced(v) => coerced.push(v),
+                    EqualityKeyCoercion::Unusable => match key_type {
+                        // Date vs unparseable string raises a type mismatch
+                        // in the executor — decline so the fallback raises
+                        // the identical error instead of silently dropping.
+                        TemporalKeyType::Date => return None,
+                        // Timestamp/Time TEXT-rendering equality with a
+                        // non-round-tripping string is false for every key:
+                        // drop the element from the lookup list.
+                        TemporalKeyType::Timestamp | TemporalKeyType::Time => {}
+                    },
+                }
+            }
+            Some(IndexPredicate::In(coerced))
+        }
+    }
+}
+
+/// Coerce a single *equality* lookup key component against a stored key
+/// sample. Used by fast-path point lookups that build composite keys
+/// directly (`crate::select::executor::fast_path::index_lookup`).
+///
+/// [`EqualityKeyCoercion::Unusable`] means the index cannot be probed
+/// faithfully for this key — callers should skip the index entirely and let
+/// a slower path compute the result with executor semantics.
+pub(crate) fn coerce_equality_key(sample: &SqlValue, value: &SqlValue) -> EqualityKeyCoercion {
+    let Some(key_type) = temporal_key_type(sample) else {
+        return EqualityKeyCoercion::Unchanged;
+    };
+    if !is_string(value) {
+        return EqualityKeyCoercion::Unchanged;
+    }
+    coerce_equality_key_for_sample_type(key_type, value)
+}
+
+fn coerce_equality_key_for_sample_type(
+    key_type: TemporalKeyType,
+    value: &SqlValue,
+) -> EqualityKeyCoercion {
+    let Some(s) = as_str(value) else {
+        return EqualityKeyCoercion::Unchanged;
+    };
+    match key_type {
+        TemporalKeyType::Date => match vibesql_types::Date::from_str(s) {
+            Ok(d) => EqualityKeyCoercion::Coerced(SqlValue::Date(d)),
+            Err(_) => EqualityKeyCoercion::Unusable,
+        },
+        // Equality under TEXT-rendering semantics only ever matches strings
+        // that round-trip exactly through parse → Display.
+        TemporalKeyType::Timestamp => match vibesql_types::Timestamp::from_str(s) {
+            Ok(t) if t.to_string() == s => EqualityKeyCoercion::Coerced(SqlValue::Timestamp(t)),
+            _ => EqualityKeyCoercion::Unusable,
+        },
+        TemporalKeyType::Time => match vibesql_types::Time::from_str(s) {
+            Ok(t) if t.to_string() == s => EqualityKeyCoercion::Coerced(SqlValue::Time(t)),
+            _ => EqualityKeyCoercion::Unusable,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::RangePredicate;
+    use super::*;
+
+    fn varchar(s: &str) -> SqlValue {
+        SqlValue::Varchar(arcstr::ArcStr::from(s))
+    }
+
+    fn ts(s: &str) -> SqlValue {
+        SqlValue::Timestamp(vibesql_types::Timestamp::from_str(s).unwrap())
+    }
+
+    fn date(s: &str) -> SqlValue {
+        SqlValue::Date(vibesql_types::Date::from_str(s).unwrap())
+    }
+
+    /// Build an in-memory IndexData with the given single-column keys.
+    fn index_with_keys(keys: Vec<SqlValue>) -> IndexData {
+        let mut data = std::collections::BTreeMap::new();
+        for (i, key) in keys.into_iter().enumerate() {
+            data.insert(vec![key], vec![i]);
+        }
+        IndexData::InMemory { data, pending_deletions: vec![] }
+    }
+
+    fn range(
+        start: Option<SqlValue>,
+        end: Option<SqlValue>,
+        inclusive_start: bool,
+        inclusive_end: bool,
+    ) -> Option<IndexPredicate> {
+        Some(IndexPredicate::Range(RangePredicate {
+            start,
+            end,
+            inclusive_start,
+            inclusive_end,
+            exclude_nulls: true,
+        }))
+    }
+
+    #[test]
+    fn equality_roundtrip_string_coerces_to_timestamp() {
+        let index = index_with_keys(vec![ts("2017-07-20 15:30:00")]);
+        let pred = Some(IndexPredicate::Range(RangePredicate {
+            start: Some(varchar("2017-07-20 15:30:00")),
+            end: Some(varchar("2017-07-20 15:30:00")),
+            inclusive_start: true,
+            inclusive_end: true,
+            exclude_nulls: false,
+        }));
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::Range(r) => {
+                assert_eq!(r.start, Some(ts("2017-07-20 15:30:00")));
+                assert_eq!(r.end, Some(ts("2017-07-20 15:30:00")));
+                assert!(r.inclusive_start && r.inclusive_end);
+            }
+            other => panic!("expected Range, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn equality_date_only_string_vs_timestamp_keys_becomes_empty_range() {
+        // TEXT-rendering semantics: no timestamp renders equal to a
+        // date-only string, so the equality probe must match nothing.
+        let index = index_with_keys(vec![ts("2017-07-05 00:00:00")]);
+        let pred = Some(IndexPredicate::Range(RangePredicate {
+            start: Some(varchar("2017-07-05")),
+            end: Some(varchar("2017-07-05")),
+            inclusive_start: true,
+            inclusive_end: true,
+            exclude_nulls: false,
+        }));
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::Range(r) => {
+                // [T, T) — half-open empty range.
+                assert_eq!(r.start, Some(ts("2017-07-05 00:00:00")));
+                assert_eq!(r.end, Some(ts("2017-07-05 00:00:00")));
+                assert!(r.inclusive_start);
+                assert!(!r.inclusive_end);
+            }
+            other => panic!("expected Range, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn between_date_only_strings_vs_timestamp_keys() {
+        // BETWEEN '2017-07-04' AND '2017-07-08' against Timestamp keys:
+        // lower midnight included, upper midnight excluded (date2-331).
+        let index = index_with_keys(vec![ts("2017-07-05 00:00:00")]);
+        let pred = range(Some(varchar("2017-07-04")), Some(varchar("2017-07-08")), true, true);
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::Range(r) => {
+                assert_eq!(r.start, Some(ts("2017-07-04 00:00:00")));
+                assert!(r.inclusive_start);
+                assert_eq!(r.end, Some(ts("2017-07-08 00:00:00")));
+                assert!(!r.inclusive_end);
+            }
+            other => panic!("expected Range, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn upper_only_range_gains_minimal_lower_bound() {
+        // `< '2017-07-08'` must not sweep NULL keys into the probe range.
+        let index = index_with_keys(vec![ts("2017-07-05 00:00:00"), SqlValue::Null]);
+        let pred = range(None, Some(varchar("2017-07-08")), false, false);
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::Range(r) => {
+                assert!(r.start.is_some(), "expected pinned minimal lower bound");
+                assert!(matches!(r.start, Some(SqlValue::Timestamp(_))));
+                assert!(r.inclusive_start);
+            }
+            other => panic!("expected Range, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn date_keys_parse_first_any_parseable_format() {
+        let index = index_with_keys(vec![date("2017-07-20")]);
+        let pred = range(Some(varchar("2017-07-20")), None, false, false);
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::Range(r) => {
+                assert_eq!(r.start, Some(date("2017-07-20")));
+                // Date is parse-first: original (exclusive) inclusivity kept.
+                assert!(!r.inclusive_start);
+            }
+            other => panic!("expected Range, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unparseable_string_declines() {
+        let index = index_with_keys(vec![ts("2017-07-05 00:00:00")]);
+        let pred = range(Some(varchar("hello")), None, true, false);
+        assert!(coerce_index_predicate_for_temporal_keys(pred, &index).is_none());
+
+        let date_index = index_with_keys(vec![date("2017-07-05")]);
+        let pred = range(None, Some(varchar("junk")), false, true);
+        assert!(coerce_index_predicate_for_temporal_keys(pred, &date_index).is_none());
+    }
+
+    #[test]
+    fn non_prefix_parseable_forms_decline_for_timestamp_keys() {
+        let index = index_with_keys(vec![ts("2017-07-05 00:00:00")]);
+        // ISO 'T' separator parses but renders differently — decline.
+        let pred = range(Some(varchar("2017-07-05T00:00:00")), None, true, false);
+        assert!(coerce_index_predicate_for_temporal_keys(pred, &index).is_none());
+    }
+
+    #[test]
+    fn in_list_drops_non_roundtrip_strings_for_timestamp_keys() {
+        let index = index_with_keys(vec![ts("2017-07-05 00:00:00")]);
+        let pred = Some(IndexPredicate::In(vec![
+            varchar("2017-07-05 00:00:00"), // round-trips → coerced
+            varchar("2017-07-06"),          // date-only → matches nothing → dropped
+            varchar("hello"),               // junk → matches nothing → dropped
+        ]));
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::In(values) => {
+                assert_eq!(values, vec![ts("2017-07-05 00:00:00")]);
+            }
+            other => panic!("expected In, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn in_list_with_unparseable_string_vs_date_keys_declines() {
+        let index = index_with_keys(vec![date("2017-07-05")]);
+        let pred = Some(IndexPredicate::In(vec![varchar("2017-07-05"), varchar("junk")]));
+        assert!(coerce_index_predicate_for_temporal_keys(pred, &index).is_none());
+    }
+
+    #[test]
+    fn non_temporal_keys_pass_through_unchanged() {
+        let index = index_with_keys(vec![varchar("apple"), varchar("pear")]);
+        let pred = range(Some(varchar("banana")), None, true, false);
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::Range(r) => assert_eq!(r.start, Some(varchar("banana"))),
+            other => panic!("expected Range, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn numeric_bounds_pass_through_unchanged() {
+        let index = index_with_keys(vec![ts("2017-07-05 00:00:00")]);
+        let pred = range(Some(SqlValue::Double(5.0)), None, true, false);
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::Range(r) => assert_eq!(r.start, Some(SqlValue::Double(5.0))),
+            other => panic!("expected Range, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn coerce_equality_key_semantics() {
+        let ts_sample = ts("2017-07-05 00:00:00");
+        // Round-trip string coerces.
+        match coerce_equality_key(&ts_sample, &varchar("2017-07-20 15:30:00")) {
+            EqualityKeyCoercion::Coerced(v) => assert_eq!(v, ts("2017-07-20 15:30:00")),
+            _ => panic!("expected Coerced"),
+        }
+        // Date-only string never equals a timestamp rendering.
+        assert!(matches!(
+            coerce_equality_key(&ts_sample, &varchar("2017-07-20")),
+            EqualityKeyCoercion::Unusable
+        ));
+        // Non-string keys pass through.
+        assert!(matches!(
+            coerce_equality_key(&ts_sample, &SqlValue::Integer(5)),
+            EqualityKeyCoercion::Unchanged
+        ));
+        // Date keys are parse-first.
+        match coerce_equality_key(&date("2017-07-05"), &varchar("2017-07-20")) {
+            EqualityKeyCoercion::Coerced(v) => assert_eq!(v, date("2017-07-20")),
+            _ => panic!("expected Coerced"),
+        }
+        assert!(matches!(
+            coerce_equality_key(&date("2017-07-05"), &varchar("junk")),
+            EqualityKeyCoercion::Unusable
+        ));
+    }
+}

--- a/crates/vibesql-executor/tests/partial_index_tests.rs
+++ b/crates/vibesql-executor/tests/partial_index_tests.rs
@@ -517,8 +517,8 @@ fn partial_index_body_empty_after_compaction_removes_all_truthy_rows() {
 
 // ---------------------------------------------------------------------------
 // Planner selection of partial indexes via structural predicate implication
-// (issue #5325; v1 covers non-expression partial indexes only — expression
-// ones are excluded until the probe bug #5333 is fixed)
+// (issue #5325; expression partial indexes included since #5333 fixed the
+// temporal probe-bound bug)
 // ---------------------------------------------------------------------------
 
 /// Run EXPLAIN QUERY PLAN and return the text output.
@@ -551,18 +551,15 @@ fn select_first_column_ints(db: &Database, sql: &str) -> Vec<i64> {
     }
 }
 
-/// date2-330/331 shape: partial EXPRESSION indexes are excluded from planner
-/// selection (v1, issue #5333) even when the query WHERE contains the index
-/// predicate verbatim as a conjunct. The expression-index equality/BETWEEN
-/// probe machinery compares Timestamp keys against string bounds incorrectly
-/// and returns 0 rows — with `t3b1` selected this exact query returns `{}`
-/// instead of `{1, 2}` (silent row loss; the WHERE post-filter can only
-/// narrow an empty probe result, never widen it). So the plan must be a full
-/// scan AND the rows must be correct. When #5333 fixes the probes, flip the
-/// plan assertion back to expecting `USING INDEX t3b1` and keep the row
-/// assertion — the rows are the real guard.
+/// date2-330/331 shape: partial EXPRESSION indexes are selected when the
+/// query WHERE contains the index predicate verbatim as a conjunct. Before
+/// #5333 fixed the temporal probe bounds (Timestamp keys vs string bounds
+/// compared by type-tag order), selecting `t3b1` for this exact query
+/// returned `{}` instead of `{1, 2}` (silent row loss; the WHERE post-filter
+/// can only narrow an empty probe result, never widen it). The plan must use
+/// the index AND the rows must be correct — the rows are the real guard.
 #[test]
-fn planner_excludes_partial_expression_index_from_selection() {
+fn planner_selects_partial_expression_index_when_predicate_implied() {
     let mut db = Database::new();
     execute_sql(
         &mut db,
@@ -580,8 +577,8 @@ fn planner_excludes_partial_expression_index_from_selection() {
 
     let plan = explain_query_plan(&db, sql);
     assert!(
-        !plan.contains("t3b1"),
-        "partial expression index must be excluded from selection until #5333, got:\n{}",
+        plan.contains("t3b1"),
+        "partial expression index must be selected when the predicate is implied (#5333), got:\n{}",
         plan
     );
 
@@ -589,7 +586,7 @@ fn planner_excludes_partial_expression_index_from_selection() {
     // 2017-07-06 (in range); 2457950.5 = 2017-07-16 (out of range).
     let mut rows = select_first_column_ints(&db, sql);
     rows.sort_unstable();
-    assert_eq!(rows, vec![1, 2], "query must return correct rows via full scan");
+    assert_eq!(rows, vec![1, 2], "query must return correct rows via the index probe");
 }
 
 /// Without the typeof(b)='real' conjunct the implication fails and the

--- a/crates/vibesql-executor/tests/temporal_index_probe_tests.rs
+++ b/crates/vibesql-executor/tests/temporal_index_probe_tests.rs
@@ -1,0 +1,389 @@
+//! Regression tests for temporal index probes with string bounds (issue #5333).
+//!
+//! Index keys produced by `date()` / `datetime()` expression indexes — and by
+//! plain `DATE`/`TIMESTAMP` column indexes — are temporal `SqlValue`s, while
+//! WHERE-clause string literals stay `Varchar`. `SqlValue`'s total order
+//! falls back to type-tag ordering for cross-type pairs (`Varchar`=10 <
+//! `Date`=12 < `Timestamp`=14, cross-type equality = false), so before the
+//! fix:
+//!
+//! - equality / BETWEEN / `<` / `<=` probes silently returned 0 rows, and
+//! - `>` / `>=` probes over-returned (every temporal key sorts above every
+//!   string), returning rows below the bound whenever the planner skipped the
+//!   residual WHERE filter.
+//!
+//! The fix coerces string probe bounds to the stored temporal key type at
+//! probe time, mirroring the executor comparison semantics from #5329:
+//! `Date` vs string is parse-first; `Timestamp`/`Time` vs string compares the
+//! TEXT renderings. The invariant under test: **every indexed query returns
+//! exactly the same rows as the identical query after `DROP INDEX`.**
+
+use vibesql_executor::{
+    CreateIndexExecutor, CreateTableExecutor, DropIndexExecutor, InsertExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Execute one or more non-SELECT SQL statements separated by ';'.
+fn execute_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            }
+            vibesql_ast::Statement::CreateIndex(s) => {
+                CreateIndexExecutor::execute(&s, db).expect("CREATE INDEX failed");
+            }
+            vibesql_ast::Statement::DropIndex(s) => {
+                DropIndexExecutor::execute(&s, db).expect("DROP INDEX failed");
+            }
+            vibesql_ast::Statement::Insert(s) => {
+                InsertExecutor::execute(db, &s).expect("INSERT failed");
+            }
+            other => panic!("Unsupported statement type: {:?}", other),
+        }
+    }
+}
+
+/// Execute a SELECT and return the first column of each row as sorted i64s.
+fn select_ints(db: &Database, sql: &str) -> Result<Vec<i64>, String> {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = vibesql_executor::SelectExecutor::new(db);
+        let rows = executor.execute(&select_stmt).map_err(|e| e.to_string())?;
+        let mut out: Vec<i64> = rows
+            .iter()
+            .map(|row| match &row.values[0] {
+                SqlValue::Integer(i) => *i,
+                other => panic!("expected integer, got {:?}", other),
+            })
+            .collect();
+        out.sort_unstable();
+        Ok(out)
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+/// Assert that `sql` returns the same rows with the index present as after
+/// dropping it (index probe == full scan invariant), and that both match
+/// `expected`. Recreates the index afterwards so the caller can chain checks.
+fn assert_index_matches_full_scan(
+    db: &mut Database,
+    create_index_sql: &str,
+    drop_index_sql: &str,
+    sql: &str,
+    expected: &[i64],
+) {
+    let indexed =
+        select_ints(db, sql).unwrap_or_else(|e| panic!("indexed query failed: {e}\n  sql: {sql}"));
+    execute_sql(db, drop_index_sql);
+    let full_scan = select_ints(db, sql)
+        .unwrap_or_else(|e| panic!("full-scan query failed: {e}\n  sql: {sql}"));
+    execute_sql(db, create_index_sql);
+
+    assert_eq!(
+        indexed, full_scan,
+        "index probe diverged from full scan for: {sql}\n  indexed:   {indexed:?}\n  full scan: {full_scan:?}"
+    );
+    assert_eq!(indexed, expected, "wrong rows for: {sql}");
+}
+
+// ---------------------------------------------------------------------------
+// Expression index on datetime(b) — Timestamp keys (TEXT-rendering semantics)
+// ---------------------------------------------------------------------------
+
+const T1_CREATE_INDEX: &str = "CREATE INDEX t1dt ON t1(datetime(b))";
+const T1_DROP_INDEX: &str = "DROP INDEX t1dt";
+
+/// Rows: julianday-style REALs; datetime(b) yields midnight timestamps
+/// 2017-07-02 .. 2017-07-11 for x = 1..10 (2457936.5 = 2017-07-02 00:00:00).
+fn timestamp_expression_db() -> Database {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        "CREATE TABLE t1 (x INTEGER PRIMARY KEY, b REAL);
+         INSERT INTO t1 VALUES (1, 2457936.5);
+         INSERT INTO t1 VALUES (2, 2457937.5);
+         INSERT INTO t1 VALUES (3, 2457938.5);
+         INSERT INTO t1 VALUES (4, 2457939.5);
+         INSERT INTO t1 VALUES (5, 2457940.5);
+         INSERT INTO t1 VALUES (6, 2457941.5);
+         INSERT INTO t1 VALUES (7, 2457942.5);
+         INSERT INTO t1 VALUES (8, 2457943.5);
+         INSERT INTO t1 VALUES (9, 2457944.5);
+         INSERT INTO t1 VALUES (10, 2457945.5)",
+    );
+    execute_sql(&mut db, T1_CREATE_INDEX);
+    db
+}
+
+fn check_t1(db: &mut Database, sql: &str, expected: &[i64]) {
+    assert_index_matches_full_scan(db, T1_CREATE_INDEX, T1_DROP_INDEX, sql, expected);
+}
+
+#[test]
+fn expression_index_timestamp_equality_full_string() {
+    let mut db = timestamp_expression_db();
+    // Round-tripping canonical string: matches the midnight timestamp.
+    check_t1(&mut db, "SELECT x FROM t1 WHERE datetime(b) = '2017-07-05 00:00:00'", &[4]);
+}
+
+#[test]
+fn expression_index_timestamp_equality_date_only_string_is_empty() {
+    let mut db = timestamp_expression_db();
+    // TEXT-rendering semantics (#5329): a midnight timestamp renders
+    // '2017-07-05 00:00:00' which is NOT equal to the date-only string, so
+    // equality matches nothing — both via the index and via the full scan.
+    check_t1(&mut db, "SELECT x FROM t1 WHERE datetime(b) = '2017-07-05'", &[]);
+}
+
+#[test]
+fn expression_index_timestamp_between_date_only_strings() {
+    let mut db = timestamp_expression_db();
+    // date2-331 shape: '2017-07-04' midnight included (renders greater than
+    // the date-only lower bound), '2017-07-08' midnight excluded (renders
+    // greater than the upper bound too). x: 07-04→3 .. 07-07→6.
+    check_t1(
+        &mut db,
+        "SELECT x FROM t1 WHERE datetime(b) BETWEEN '2017-07-04' AND '2017-07-08'",
+        &[3, 4, 5, 6],
+    );
+}
+
+#[test]
+fn expression_index_timestamp_one_sided_ranges_date_only_strings() {
+    let mut db = timestamp_expression_db();
+    // Under TEXT semantics every timestamp on 2017-07-08 renders strictly
+    // greater than '2017-07-08', so > and >= are the same set (midnight of
+    // 07-08 = x 7 included in both), and < and <= are the same set.
+    check_t1(&mut db, "SELECT x FROM t1 WHERE datetime(b) >= '2017-07-08'", &[7, 8, 9, 10]);
+    check_t1(&mut db, "SELECT x FROM t1 WHERE datetime(b) > '2017-07-08'", &[7, 8, 9, 10]);
+    check_t1(&mut db, "SELECT x FROM t1 WHERE datetime(b) <= '2017-07-04'", &[1, 2]);
+    check_t1(&mut db, "SELECT x FROM t1 WHERE datetime(b) < '2017-07-04'", &[1, 2]);
+}
+
+#[test]
+fn expression_index_timestamp_one_sided_ranges_full_strings() {
+    let mut db = timestamp_expression_db();
+    // Round-tripping canonical strings: exact bounds.
+    check_t1(
+        &mut db,
+        "SELECT x FROM t1 WHERE datetime(b) >= '2017-07-08 00:00:00'",
+        &[7, 8, 9, 10],
+    );
+    check_t1(&mut db, "SELECT x FROM t1 WHERE datetime(b) > '2017-07-08 00:00:00'", &[8, 9, 10]);
+    check_t1(&mut db, "SELECT x FROM t1 WHERE datetime(b) <= '2017-07-04 00:00:00'", &[1, 2, 3]);
+    check_t1(&mut db, "SELECT x FROM t1 WHERE datetime(b) < '2017-07-04 00:00:00'", &[1, 2]);
+}
+
+#[test]
+fn expression_index_timestamp_no_over_return_on_lower_bound() {
+    let mut db = timestamp_expression_db();
+    // Over-return guard: rows strictly below the bound must NOT be returned.
+    // Before the fix, lower-bounded probes returned every temporal key.
+    let rows = select_ints(&db, "SELECT x FROM t1 WHERE datetime(b) >= '2017-07-10'").unwrap();
+    assert_eq!(rows, vec![9, 10], "rows below the lower bound must not be returned");
+    drop(db);
+}
+
+#[test]
+fn expression_index_timestamp_in_list() {
+    let mut db = timestamp_expression_db();
+    check_t1(
+        &mut db,
+        "SELECT x FROM t1 WHERE datetime(b) IN ('2017-07-03 00:00:00', '2017-07-09 00:00:00')",
+        &[2, 8],
+    );
+    // Date-only / junk elements match nothing under TEXT-rendering equality.
+    check_t1(
+        &mut db,
+        "SELECT x FROM t1 WHERE datetime(b) IN ('2017-07-03', 'junk', '2017-07-09 00:00:00')",
+        &[8],
+    );
+}
+
+#[test]
+fn expression_index_timestamp_unparseable_bound_matches_full_scan() {
+    let mut db = timestamp_expression_db();
+    // Junk strings compare as text in the executor (never an error for
+    // Timestamp): every rendering starts with a digit < 'h', so all rows
+    // sort below 'hello'.
+    check_t1(&mut db, "SELECT x FROM t1 WHERE datetime(b) = 'hello'", &[]);
+    check_t1(
+        &mut db,
+        "SELECT x FROM t1 WHERE datetime(b) < 'hello'",
+        &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    );
+    check_t1(&mut db, "SELECT x FROM t1 WHERE datetime(b) > 'hello'", &[]);
+}
+
+// ---------------------------------------------------------------------------
+// Expression index on date(y) — Date keys (parse-first semantics)
+// ---------------------------------------------------------------------------
+
+const T2_CREATE_INDEX: &str = "CREATE INDEX t2y ON t2(date(y))";
+const T2_DROP_INDEX: &str = "DROP INDEX t2y";
+
+fn date_expression_db() -> Database {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        "CREATE TABLE t2 (x INTEGER PRIMARY KEY, y TEXT);
+         INSERT INTO t2 VALUES (1, '2017-07-20 15:30:00');
+         INSERT INTO t2 VALUES (2, '2017-07-22 08:00:00');
+         INSERT INTO t2 VALUES (3, '2017-07-25 23:59:59')",
+    );
+    execute_sql(&mut db, T2_CREATE_INDEX);
+    db
+}
+
+fn check_t2(db: &mut Database, sql: &str, expected: &[i64]) {
+    assert_index_matches_full_scan(db, T2_CREATE_INDEX, T2_DROP_INDEX, sql, expected);
+}
+
+#[test]
+fn expression_index_date_equality() {
+    // Issue-body repro: was 0 rows via the index probe before the fix.
+    let mut db = date_expression_db();
+    check_t2(&mut db, "SELECT x FROM t2 WHERE date(y) = '2017-07-20'", &[1]);
+}
+
+#[test]
+fn expression_index_date_between_and_one_sided() {
+    let mut db = date_expression_db();
+    check_t2(
+        &mut db,
+        "SELECT x FROM t2 WHERE date(y) BETWEEN '2017-07-20' AND '2017-07-22'",
+        &[1, 2],
+    );
+    check_t2(&mut db, "SELECT x FROM t2 WHERE date(y) > '2017-07-20'", &[2, 3]);
+    check_t2(&mut db, "SELECT x FROM t2 WHERE date(y) >= '2017-07-22'", &[2, 3]);
+    check_t2(&mut db, "SELECT x FROM t2 WHERE date(y) < '2017-07-22'", &[1]);
+    check_t2(&mut db, "SELECT x FROM t2 WHERE date(y) <= '2017-07-22'", &[1, 2]);
+}
+
+#[test]
+fn expression_index_date_in_list() {
+    let mut db = date_expression_db();
+    check_t2(&mut db, "SELECT x FROM t2 WHERE date(y) IN ('2017-07-20', '2017-07-25')", &[1, 3]);
+}
+
+#[test]
+fn expression_index_date_unparseable_bound_matches_full_scan_error() {
+    // Date vs unparseable string is a type-mismatch error in the executor
+    // (parse-first semantics). The indexed path must not silently return
+    // 0 rows — it must surface the same outcome as the full scan.
+    let db = date_expression_db();
+    let indexed = select_ints(&db, "SELECT x FROM t2 WHERE date(y) = 'junk'");
+
+    let mut db2 = date_expression_db();
+    execute_sql(&mut db2, T2_DROP_INDEX);
+    let full_scan = select_ints(&db2, "SELECT x FROM t2 WHERE date(y) = 'junk'");
+
+    assert_eq!(
+        indexed.is_err(),
+        full_scan.is_err(),
+        "indexed and full-scan outcomes must agree for unparseable Date bound: \
+         indexed={indexed:?}, full_scan={full_scan:?}"
+    );
+    if let (Ok(a), Ok(b)) = (&indexed, &full_scan) {
+        assert_eq!(a, b);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plain TIMESTAMP column index (t4 repro from the issue)
+//
+// NOTE: these assert literal expected values (executor semantics) for the
+// INDEXED queries instead of diffing against DROP INDEX, because the
+// full-scan WHERE path has its own pre-existing temporal-vs-string bug (the
+// columnar SIMD filter and CompiledPredicate lack the #5329 semantics and
+// over-return — `WHERE ts = 'zzz'` returns every row via a full scan). That
+// is tracked separately in issue #5335; once fixed, these can be upgraded to
+// indexed-vs-full-scan comparisons like the expression-index tests above.
+// ---------------------------------------------------------------------------
+
+fn timestamp_column_db() -> Database {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        "CREATE TABLE t4 (id INTEGER PRIMARY KEY, ts TIMESTAMP);
+         INSERT INTO t4 VALUES (1, TIMESTAMP '2017-07-20 15:30:00');
+         INSERT INTO t4 VALUES (2, TIMESTAMP '2017-07-22 08:00:00');
+         INSERT INTO t4 VALUES (3, TIMESTAMP '2017-07-25 23:59:59');
+         CREATE INDEX t4ts ON t4(ts)",
+    );
+    db
+}
+
+fn check_t4(db: &Database, sql: &str, expected: &[i64]) {
+    let rows = select_ints(db, sql).unwrap_or_else(|e| panic!("query failed: {e}\n  sql: {sql}"));
+    assert_eq!(rows, expected, "wrong rows for indexed query: {sql}");
+}
+
+#[test]
+fn column_index_timestamp_equality_string() {
+    // Was 0 rows before the fix (row loss).
+    let db = timestamp_column_db();
+    check_t4(&db, "SELECT id FROM t4 WHERE ts = '2017-07-20 15:30:00'", &[1]);
+    // TEXT-rendering semantics: a date-only string equals no timestamp.
+    check_t4(&db, "SELECT id FROM t4 WHERE ts = '2017-07-20'", &[]);
+}
+
+#[test]
+fn column_index_timestamp_no_over_return_on_lower_bound() {
+    // The t4 repro: `ts >= '2017-07-21'` returned the 2017-07-20 row before
+    // the fix because the probe over-returned and the planner skipped the
+    // residual filter.
+    let db = timestamp_column_db();
+    check_t4(&db, "SELECT id FROM t4 WHERE ts >= '2017-07-21'", &[2, 3]);
+    check_t4(&db, "SELECT id FROM t4 WHERE ts > '2017-07-21'", &[2, 3]);
+}
+
+#[test]
+fn column_index_timestamp_between_and_upper_bounds() {
+    let db = timestamp_column_db();
+    check_t4(&db, "SELECT id FROM t4 WHERE ts BETWEEN '2017-07-21' AND '2017-07-23'", &[2]);
+    check_t4(&db, "SELECT id FROM t4 WHERE ts < '2017-07-22'", &[1]);
+    check_t4(&db, "SELECT id FROM t4 WHERE ts <= '2017-07-22 08:00:00'", &[1, 2]);
+    check_t4(&db, "SELECT id FROM t4 WHERE ts < '2017-07-22 08:00:00'", &[1]);
+}
+
+#[test]
+fn column_index_timestamp_in_list_and_typed_literals() {
+    let db = timestamp_column_db();
+    check_t4(
+        &db,
+        "SELECT id FROM t4 WHERE ts IN ('2017-07-20 15:30:00', '2017-07-25 23:59:59')",
+        &[1, 3],
+    );
+    // Typed literals were already correct; pin that they stay correct.
+    check_t4(&db, "SELECT id FROM t4 WHERE ts = TIMESTAMP '2017-07-22 08:00:00'", &[2]);
+    check_t4(&db, "SELECT id FROM t4 WHERE ts >= TIMESTAMP '2017-07-22 08:00:00'", &[2, 3]);
+}
+
+#[test]
+fn column_index_timestamp_unparseable_equality_is_empty() {
+    // Junk strings never equal a timestamp rendering — no panic, no rows.
+    // (Range operators with junk bounds are governed by the residual-filter
+    // semantics tracked in #5335 and are not asserted here.)
+    let db = timestamp_column_db();
+    check_t4(&db, "SELECT id FROM t4 WHERE ts = 'hello'", &[]);
+}
+
+#[test]
+fn column_index_timestamp_null_keys_excluded_from_ranges() {
+    // NULL keys must not be swept into coerced upper-bounded ranges
+    // (SQL semantics: NULL < x is NULL, not true).
+    let mut db = timestamp_column_db();
+    execute_sql(&mut db, "INSERT INTO t4 VALUES (4, NULL)");
+    check_t4(&db, "SELECT id FROM t4 WHERE ts < '2017-07-23'", &[1, 2]);
+    check_t4(&db, "SELECT id FROM t4 WHERE ts >= '2017-07-21'", &[2, 3]);
+}

--- a/crates/vibesql-storage/src/database/indexes/index_metadata.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_metadata.rs
@@ -173,6 +173,30 @@ impl IndexData {
         }
     }
 
+    /// Sample the stored key value at a given column position.
+    ///
+    /// Returns the first non-NULL `SqlValue` found at position `col_idx`
+    /// across the index's stored keys, or `None` if the index is empty, all
+    /// keys are NULL at that position, or the backend does not support cheap
+    /// key sampling (disk-backed / vector indexes).
+    ///
+    /// This is used by the executor to determine the stored key *type* so
+    /// that string probe bounds can be coerced to match temporal keys
+    /// (issue #5333). Only the type of the returned value is meaningful.
+    pub fn first_key_value_sample(&self, col_idx: usize) -> Option<SqlValue> {
+        match self {
+            IndexData::InMemory { data, .. } => data
+                .keys()
+                .filter_map(|key| key.get(col_idx))
+                .find(|v| !matches!(v, SqlValue::Null))
+                .cloned(),
+            // Disk-backed B+ trees don't expose cheap key iteration; vector
+            // indexes don't store comparable scalar keys. Callers treat None
+            // as "unknown key type" and skip coercion.
+            _ => None,
+        }
+    }
+
     /// Check if the pending deletions need compaction.
     #[inline]
     pub fn needs_compaction(&self) -> bool {

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3285,7 +3285,6 @@ array set vibesql_skip_tests {
     date-8.18 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
     date-8.19 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"
     date-15.2 "sleeper TCL UDF registered via db func is not visible to the VibeSQL CLI subprocess (harness limitation)"
-    date2-330 "EXPLAIN QUERY PLAN expects USING INDEX t3b1, but partial EXPRESSION indexes are excluded from planner selection until the expression-index equality/BETWEEN probe bug is fixed (#5333: Timestamp keys vs string bounds return 0 rows, silently losing rows). date2-331 verifies the query returns correct rows via full scan."
 }
 
 # Pattern-based skip list for tests with many numbered variants


### PR DESCRIPTION
Closes #5333

## Summary

Temporal index probes (expression indexes on `date()`/`datetime()`, plain `TIMESTAMP` column indexes) compared stored temporal keys against raw string bounds using `SqlValue`'s type-tag total order (`Varchar`=10 < `Date`=12 < `Timestamp`=14, cross-type equality = false):

- **Row loss**: equality, `BETWEEN`, `<`, `<=` probes returned 0 rows (every temporal key sorts above every string; cross-type `==` is false). Post-filtering can never widen an empty probe.
- **Over-return**: `>`, `>=` probes returned *every* temporal key, surfacing as wrong rows whenever the planner decided the WHERE was fully satisfied by the index and skipped the residual filter (`ts >= '2017-07-21'` returned a `2017-07-20` row).

## Fix

New module `select/scan/index_scan/predicate/temporal_coercion.rs`: coerce string probe bounds to the stored temporal key type (sampled via a new `IndexData::first_key_value_sample`) before probing, mirroring the **actual** #5329 executor semantics:

- `Date` vs string: **parse-first** (`Date::from_str`); unparseable → decline the probe so the fallback path raises the identical type-mismatch error.
- `Timestamp`/`Time` vs string: the executor compares **TEXT renderings** lexicographically (note: the issue/curator notes describe this as parse-first, but `evaluator/operators/comparison/mod.rs` lines 197–223 and its #5329 regression tests pin TEXT-rendering — e.g. `datetime(b) = '2017-07-08'` is *false* for a midnight timestamp). Coercion rules derived from that:
  - exact parse→Display round-trip → coerce, keep inclusivity (equivalent under all operators);
  - rendering-prefix strings (date-only bounds) → coerce with lower bounds inclusive / upper bounds exclusive (equality `[T,T]` composes to the empty `[T,T)` automatically — correct, since no rendering equals a date-only string);
  - anything else (junk, ISO `T` forms, trailing-zero fractions) → **decline**: predicate dropped, falls back to full-index-scan + WHERE filter.
- `IN` lists: per-element equality coercion (`multi_lookup` had the same cross-type `PartialEq` failure); non-round-tripping elements vs Timestamp/Time keys are provably-no-match and dropped.
- Coerced upper-bound-only ranges get a pinned minimal temporal lower bound so NULL keys aren't swept in via type-tag ordering (expression indexes have no column to NULL-filter).

Applied in `execute_index_scan` (Range + In; upstream of the streaming path) and in the fast-path point lookups (`fast_path/index_lookup.rs`), which build composite keys directly.

## Re-enable checklist (from the issue)

- Removed the v1 `has_expression_columns()` exclusion in `partial_index_usable` (`optimizer/predicate_implication.rs`); updated its unit test to assert the index is now usable when implied.
- Flipped `planner_excludes_partial_expression_index_from_selection` → `planner_selects_partial_expression_index_when_predicate_implied` (`tests/partial_index_tests.rs`), now asserting `USING INDEX t3b1` + correct rows.
- Removed the `date2-330` skip in `scripts/tester_vibesql.tcl`.

## Out of scope / follow-up

The **full-scan** WHERE path for plain temporal columns has its own pre-existing temporal-vs-string bug (`WHERE ts = 'zzz'` returns every row on main, no index involved): the columnar SIMD filter and `CompiledPredicate` never got #5329 semantics. Filed as #5335 with repro and root cause. The plain-column tests here therefore pin indexed results to literal expected values; the expression-index tests use full indexed-vs-`DROP INDEX` parity (that path is correct).

Composite/prefix multi-column probe key construction is also untouched (same scoping as the issue; #5330 covers adjacent direct-probe sites).

## Test plan

- [x] New `tests/temporal_index_probe_tests.rs`: full matrix (`=`, `BETWEEN`, `<`, `<=`, `>`, `>=`, `IN`, unparseable bounds, midnight boundary, NULL keys, typed literals) for `datetime()` expression indexes (Timestamp keys), `date()` expression indexes (Date keys), and a plain `TIMESTAMP` column index — 18/18 pass. Expression-index cases assert indexed == full-scan == expected.
- [x] 12 unit tests in `temporal_coercion.rs` (round-trip, prefix-inclusivity, declines, IN handling, NULL pinning).
- [x] `make test-tcl-file FILE=date2.test` → **29/29, zero skips** (date2-330 `USING INDEX t3b1` and date2-331 `{3 4 5 6}` both pass).
- [x] `date3.test` 126/126; `date.test` 0 failures; `index.test` 0 failures; `fkey1.test` 0 failures.
- [x] `where.test`: 20 failures — byte-identical to the main baseline (where-5.102/103 mixed-direction ORDER BY, where-24.x `Placeholder` unsupported); pre-existing, unrelated.
- [x] `cargo test -p vibesql-executor --lib` 2609 passed; `cargo test -p vibesql-storage` 684 passed; `partial_index_tests` 15/15; `predicate_implication` 15/15.
- [x] Manual CLI verification of the issue's t4 acceptance queries: `ts >= '2017-07-21'` → {2,3}, `ts = '2017-07-20 15:30:00'` → {1}, EXPLAIN shows `USING INDEX t4ts`.

Pre-existing failures noted (not introduced here): clippy `E0599 random_range` in `benches/tpcds/data.rs` (rand API churn) and stable-vs-nightly rustfmt diffs across untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)