### PR TITLE
fix(temporal): pad fractional-seconds Display to 3 digits; coerce disk-backed temporal index probes

### DIFF
--- a/crates/vibesql-executor/src/select/scan/index_scan/predicate/temporal_coercion.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/predicate/temporal_coercion.rs
@@ -34,10 +34,13 @@
 //!   to exclusive. Equality probes arrive as `start == end` ranges, so the
 //!   two rules compose to the half-open empty range `[T, T)` automatically.
 //!   Anything that doesn't round-trip and isn't a strict rendering prefix
-//!   (junk strings, `T`-separated ISO forms, trailing-zero fractions, ...) is
-//!   *declined*: the caller drops the index predicate and the row set is
-//!   computed by the full-index-scan + WHERE-filter path, which evaluates
-//!   with executor semantics.
+//!   (junk strings, `T`-separated ISO forms, ...) is *declined*: the caller
+//!   drops the index predicate and the row set is computed by the
+//!   full-index-scan + WHERE-filter path, which evaluates with executor
+//!   semantics. (Since #5332 fractions render padded to a minimum of 3
+//!   digits, so trailing-zero strings like `'...44.500'` round-trip exactly
+//!   and shorter ones like `'...44.5'` fall under the prefix rule — both
+//!   stay on the index path.)
 //!
 //! The invariant being preserved: **index probe results == full-scan + WHERE
 //! results under VibeSQL's own comparison semantics.**
@@ -199,7 +202,10 @@ fn coerce_rendered(
 /// semantics (correct, just slower; only hit for unusual string bounds).
 ///
 /// Non-temporal indexes, non-string bounds, and indexes whose key type cannot
-/// be sampled (empty, all-NULL, disk-backed) are passed through unchanged.
+/// be sampled (empty/all-NULL in-memory, vector indexes) are passed through
+/// unchanged. Disk-backed indexes report their key type from the persisted
+/// `key_schema` (page-0 metadata, no I/O), so they are coerced like in-memory
+/// ones — even when empty (issue #5337).
 pub(crate) fn coerce_index_predicate_for_temporal_keys(
     predicate: Option<IndexPredicate>,
     index_data: &IndexData,
@@ -556,5 +562,145 @@ mod tests {
             coerce_equality_key(&date("2017-07-05"), &varchar("junk")),
             EqualityKeyCoercion::Unusable
         ));
+    }
+
+    #[test]
+    fn trailing_zero_fraction_string_round_trips_after_5332() {
+        // Since #5332 fractions render padded to >= 3 digits, so a
+        // trailing-zero string like '.500' round-trips exactly and keeps its
+        // original inclusivity instead of declining.
+        let index = index_with_keys(vec![ts("2024-01-01 13:15:44.5")]);
+        let pred = range(Some(varchar("2024-01-01 13:15:44.500")), None, false, false);
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::Range(r) => {
+                assert_eq!(r.start, Some(ts("2024-01-01 13:15:44.500")));
+                assert!(!r.inclusive_start, "exact round-trip keeps original inclusivity");
+            }
+            other => panic!("expected Range, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn short_fraction_string_takes_prefix_rule_after_5332() {
+        // '...44.5' renders as '...44.500' — a strict rendering prefix, so
+        // lower bounds become inclusive and upper bounds exclusive.
+        let index = index_with_keys(vec![ts("2024-01-01 13:15:44.5")]);
+        let pred = range(
+            Some(varchar("2024-01-01 13:15:44.5")),
+            Some(varchar("2024-01-01 13:15:44.5")),
+            true,
+            true,
+        );
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::Range(r) => {
+                assert_eq!(r.start, Some(ts("2024-01-01 13:15:44.5")));
+                assert!(r.inclusive_start);
+                assert_eq!(r.end, Some(ts("2024-01-01 13:15:44.5")));
+                assert!(!r.inclusive_end);
+            }
+            other => panic!("expected Range, got {:?}", other),
+        }
+    }
+
+    /// Build a disk-backed `IndexData` over the given single-column keys
+    /// with the given key schema. Returns the TempDir so the backing file
+    /// outlives the assertions.
+    fn disk_backed_index_with_keys(
+        key_schema: Vec<vibesql_types::DataType>,
+        keys: Vec<SqlValue>,
+    ) -> (IndexData, tempfile::TempDir) {
+        use std::sync::Arc;
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = Arc::new(vibesql_storage::NativeStorage::new(temp_dir.path()).unwrap());
+        let page_manager =
+            Arc::new(vibesql_storage::page::PageManager::new("test_index.idx", storage).unwrap());
+
+        let mut sorted_entries: Vec<(Vec<SqlValue>, usize)> =
+            keys.into_iter().enumerate().map(|(i, key)| (vec![key], i)).collect();
+        sorted_entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let btree = vibesql_storage::btree::BTreeIndex::bulk_load(
+            sorted_entries,
+            key_schema,
+            page_manager.clone(),
+        )
+        .unwrap();
+        let index =
+            IndexData::DiskBacked { btree: Arc::new(parking_lot::Mutex::new(btree)), page_manager };
+        (index, temp_dir)
+    }
+
+    #[test]
+    fn disk_backed_timestamp_index_coerces_string_bounds() {
+        // Issue #5337: disk-backed indexes report their key type from the
+        // persisted key_schema, so string probe bounds are coerced exactly
+        // like for in-memory indexes.
+        let (index, _dir) = disk_backed_index_with_keys(
+            vec![vibesql_types::DataType::Timestamp { with_timezone: false }],
+            vec![ts("2017-07-05 00:00:00"), ts("2017-07-20 15:30:00")],
+        );
+        let pred = range(Some(varchar("2017-07-04")), Some(varchar("2017-07-08")), true, true);
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::Range(r) => {
+                assert_eq!(r.start, Some(ts("2017-07-04 00:00:00")));
+                assert!(r.inclusive_start);
+                assert_eq!(r.end, Some(ts("2017-07-08 00:00:00")));
+                assert!(!r.inclusive_end);
+            }
+            other => panic!("expected Range, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn empty_disk_backed_temporal_index_still_coerces() {
+        // The schema-based key type works even for empty indexes, which the
+        // in-memory sampling approach cannot handle.
+        let (index, _dir) = disk_backed_index_with_keys(
+            vec![vibesql_types::DataType::Timestamp { with_timezone: false }],
+            vec![],
+        );
+        let pred = range(Some(varchar("2017-07-20 15:30:00")), None, true, false);
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::Range(r) => {
+                assert_eq!(r.start, Some(ts("2017-07-20 15:30:00")));
+            }
+            other => panic!("expected Range, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn disk_backed_non_temporal_index_passes_through() {
+        let (index, _dir) = disk_backed_index_with_keys(
+            vec![vibesql_types::DataType::Integer],
+            vec![SqlValue::Integer(1), SqlValue::Integer(2)],
+        );
+        let pred = range(Some(varchar("2017-07-20")), None, true, false);
+        let coerced = coerce_index_predicate_for_temporal_keys(pred, &index).unwrap();
+        match coerced {
+            IndexPredicate::Range(r) => {
+                assert_eq!(r.start, Some(varchar("2017-07-20")), "no coercion expected");
+            }
+            other => panic!("expected Range, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn disk_backed_equality_lookup_key_coerces_via_sample() {
+        // Fast-path point lookups sample per column; the disk-backed sample
+        // must drive the same equality coercion as in-memory samples.
+        let (index, _dir) = disk_backed_index_with_keys(
+            vec![vibesql_types::DataType::Timestamp { with_timezone: false }],
+            vec![ts("2017-07-20 15:30:00")],
+        );
+        let sample = index.first_key_value_sample(0).expect("schema-based sample");
+        match coerce_equality_key(&sample, &varchar("2017-07-20 15:30:00")) {
+            EqualityKeyCoercion::Coerced(v) => assert_eq!(v, ts("2017-07-20 15:30:00")),
+            _ => panic!("expected Coerced"),
+        }
     }
 }

--- a/crates/vibesql-executor/tests/temporal_index_probe_tests.rs
+++ b/crates/vibesql-executor/tests/temporal_index_probe_tests.rs
@@ -387,3 +387,67 @@ fn column_index_timestamp_null_keys_excluded_from_ranges() {
     check_t4(&db, "SELECT id FROM t4 WHERE ts < '2017-07-23'", &[1, 2]);
     check_t4(&db, "SELECT id FROM t4 WHERE ts >= '2017-07-21'", &[2, 3]);
 }
+
+// ---------------------------------------------------------------------------
+// Fractional seconds (issue #5332): Display pads fractions to a minimum of 3
+// digits (`.5` → `.500`, matching SQLite's subsec rendering) while keeping
+// sub-millisecond digits (`.123456` unchanged). Under TEXT-rendering
+// comparison semantics (#5329) this makes trailing-zero-fraction string
+// bounds round-trip (coercible) and short fractions like `.5` strict
+// rendering prefixes. Same literal-expected style as the t4 section (#5335).
+// ---------------------------------------------------------------------------
+
+fn fractional_timestamp_db() -> Database {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        "CREATE TABLE t5 (id INTEGER PRIMARY KEY, ts TIMESTAMP);
+         INSERT INTO t5 VALUES (1, TIMESTAMP '2024-01-01 12:00:00');
+         INSERT INTO t5 VALUES (2, TIMESTAMP '2024-01-01 12:00:00.5');
+         INSERT INTO t5 VALUES (3, TIMESTAMP '2024-01-01 12:00:00.123456');
+         CREATE INDEX t5ts ON t5(ts)",
+    );
+    db
+}
+
+fn check_t5(db: &Database, sql: &str, expected: &[i64]) {
+    let rows = select_ints(db, sql).unwrap_or_else(|e| panic!("query failed: {e}\n  sql: {sql}"));
+    assert_eq!(rows, expected, "wrong rows for indexed query: {sql}");
+}
+
+#[test]
+fn column_index_timestamp_fractional_equality_padded_string() {
+    // '.500' is the canonical rendering after #5332: the bound round-trips
+    // and the equality probe stays on the index path. Before #5332 the
+    // stored value rendered '.5' so this string declined coercion (and the
+    // equality was false under TEXT semantics).
+    let db = fractional_timestamp_db();
+    check_t5(&db, "SELECT id FROM t5 WHERE ts = '2024-01-01 12:00:00.500'", &[2]);
+    // Sub-millisecond renderings are preserved verbatim.
+    check_t5(&db, "SELECT id FROM t5 WHERE ts = '2024-01-01 12:00:00.123456'", &[3]);
+}
+
+#[test]
+fn column_index_timestamp_fractional_equality_short_string_is_empty() {
+    // '.5' is now a strict rendering *prefix* of '.500': no rendering equals
+    // it, so equality matches nothing — via the index and the full scan.
+    let db = fractional_timestamp_db();
+    check_t5(&db, "SELECT id FROM t5 WHERE ts = '2024-01-01 12:00:00.5'", &[]);
+}
+
+#[test]
+fn column_index_timestamp_fractional_ranges() {
+    let db = fractional_timestamp_db();
+    // Renderings: row1 '…12:00:00' < row3 '…12:00:00.123456' < row2 '…12:00:00.500'.
+    check_t5(&db, "SELECT id FROM t5 WHERE ts >= '2024-01-01 12:00:00.500'", &[2]);
+    check_t5(&db, "SELECT id FROM t5 WHERE ts < '2024-01-01 12:00:00.500'", &[1, 3]);
+    // Prefix-rule bound: every fractional rendering with prefix '.5' sorts
+    // strictly above the bound, so >= and > agree.
+    check_t5(&db, "SELECT id FROM t5 WHERE ts >= '2024-01-01 12:00:00.5'", &[2]);
+    check_t5(&db, "SELECT id FROM t5 WHERE ts > '2024-01-01 12:00:00.5'", &[2]);
+    check_t5(
+        &db,
+        "SELECT id FROM t5 WHERE ts BETWEEN '2024-01-01 12:00:00.123456' AND '2024-01-01 12:00:00.500'",
+        &[2, 3],
+    );
+}

--- a/crates/vibesql-storage/src/btree/node/btree_index/mod.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/mod.rs
@@ -73,6 +73,16 @@ pub struct BTreeIndex {
 }
 
 impl BTreeIndex {
+    /// The data types of this index's key columns.
+    ///
+    /// Persisted in page-0 metadata at build time and restored by
+    /// [`BTreeIndex::load`], so it is authoritative even for empty indexes.
+    /// Used by the executor to determine the stored key type for probe-bound
+    /// coercion (issue #5337) without any disk I/O.
+    pub fn key_schema(&self) -> &[DataType] {
+        &self.key_schema
+    }
+
     /// Create a new B+ tree index
     ///
     /// Creates a new disk-backed B+ tree index that supports both unique and

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -474,6 +474,14 @@ impl IndexManager {
                     SqlValue::Character(_) | SqlValue::Varchar(_) => {
                         DataType::Varchar { max_length: None }
                     }
+                    // Temporal keys must keep their temporal type: the
+                    // persisted key_schema is what `first_key_value_sample`
+                    // reports for disk-backed indexes, and a mis-typed
+                    // (Integer) schema would silently disable temporal
+                    // probe-bound coercion for spilled indexes (issue #5337).
+                    SqlValue::Date(_) => DataType::Date,
+                    SqlValue::Timestamp(_) => DataType::Timestamp { with_timezone: false },
+                    SqlValue::Time(_) => DataType::Time { with_timezone: false },
                     _ => DataType::Integer, // Fallback for other types
                 })
                 .collect()
@@ -514,5 +522,127 @@ impl IndexManager {
 impl Default for IndexManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use std::{collections::BTreeMap, str::FromStr};
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// Regression test for issue #5337 (caveat 1): `spill_index_to_disk`
+    /// inferred the persisted key schema from the first key's `SqlValue`
+    /// with an `_ => Integer` fallback, mis-typing temporal keys. A spilled
+    /// temporal index would then report no temporal key type via
+    /// `first_key_value_sample`, silently disabling probe-bound coercion.
+    #[test]
+    fn spill_preserves_temporal_key_schema() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = IndexManager::new();
+        manager.set_database_path(temp_dir.path().to_path_buf());
+
+        let index_name = "idx_ts";
+        let ts = |s: &str| SqlValue::Timestamp(vibesql_types::Timestamp::from_str(s).unwrap());
+
+        let mut data: BTreeMap<Vec<SqlValue>, Vec<usize>> = BTreeMap::new();
+        data.insert(vec![ts("2024-01-01 12:00:00.5")], vec![0]);
+        data.insert(vec![ts("2024-06-15 08:30:00")], vec![1]);
+
+        manager.indexes.insert(
+            index_name.to_string(),
+            IndexMetadata {
+                index_name: index_name.to_string(),
+                table_name: "events".to_string(),
+                unique: false,
+                columns: vec![vibesql_ast::IndexColumn::new_column(
+                    "created_at".to_string(),
+                    vibesql_ast::OrderDirection::Asc,
+                )],
+                where_clause: None,
+            },
+        );
+        manager.index_data.insert(
+            index_name.to_string(),
+            IndexData::InMemory { data, pending_deletions: vec![] },
+        );
+
+        manager.spill_index_to_disk(index_name).unwrap();
+
+        let spilled = manager.index_data.get(index_name).unwrap();
+        match spilled {
+            IndexData::DiskBacked { btree, .. } => {
+                let guard = acquire_btree_lock(btree).unwrap();
+                assert_eq!(
+                    guard.key_schema(),
+                    &[DataType::Timestamp { with_timezone: false }],
+                    "spilled temporal index must persist a temporal key schema"
+                );
+            }
+            other => panic!("expected DiskBacked after spill, got {:?}", other),
+        }
+
+        // The key type must remain detectable for probe-bound coercion.
+        assert!(matches!(spilled.first_key_value_sample(0), Some(SqlValue::Timestamp(_))));
+    }
+
+    #[test]
+    fn spill_preserves_date_and_time_key_schema() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = IndexManager::new();
+        manager.set_database_path(temp_dir.path().to_path_buf());
+
+        let cases: Vec<(&str, Vec<SqlValue>, DataType)> = vec![
+            (
+                "idx_date",
+                vec![SqlValue::Date(vibesql_types::Date::from_str("2024-01-01").unwrap())],
+                DataType::Date,
+            ),
+            (
+                "idx_time",
+                vec![SqlValue::Time(vibesql_types::Time::from_str("12:00:00").unwrap())],
+                DataType::Time { with_timezone: false },
+            ),
+        ];
+
+        for (index_name, key, expected_type) in cases {
+            let mut data: BTreeMap<Vec<SqlValue>, Vec<usize>> = BTreeMap::new();
+            data.insert(key, vec![0]);
+
+            manager.indexes.insert(
+                index_name.to_string(),
+                IndexMetadata {
+                    index_name: index_name.to_string(),
+                    table_name: "events".to_string(),
+                    unique: false,
+                    columns: vec![vibesql_ast::IndexColumn::new_column(
+                        "c".to_string(),
+                        vibesql_ast::OrderDirection::Asc,
+                    )],
+                    where_clause: None,
+                },
+            );
+            manager.index_data.insert(
+                index_name.to_string(),
+                IndexData::InMemory { data, pending_deletions: vec![] },
+            );
+
+            manager.spill_index_to_disk(index_name).unwrap();
+
+            match manager.index_data.get(index_name).unwrap() {
+                IndexData::DiskBacked { btree, .. } => {
+                    let guard = acquire_btree_lock(btree).unwrap();
+                    assert_eq!(
+                        guard.key_schema(),
+                        std::slice::from_ref(&expected_type),
+                        "{}",
+                        index_name
+                    );
+                }
+                other => panic!("expected DiskBacked after spill, got {:?}", other),
+            }
+        }
     }
 }

--- a/crates/vibesql-storage/src/database/indexes/index_metadata.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_metadata.rs
@@ -175,10 +175,15 @@ impl IndexData {
 
     /// Sample the stored key value at a given column position.
     ///
-    /// Returns the first non-NULL `SqlValue` found at position `col_idx`
-    /// across the index's stored keys, or `None` if the index is empty, all
-    /// keys are NULL at that position, or the backend does not support cheap
-    /// key sampling (disk-backed / vector indexes).
+    /// For in-memory indexes, returns the first non-NULL `SqlValue` found at
+    /// position `col_idx` across the index's stored keys. For disk-backed B+
+    /// trees, synthesizes a representative value from the persisted
+    /// `key_schema` (page-0 metadata, in memory after load — no I/O), which
+    /// works even for empty or all-NULL indexes (issue #5337); only temporal
+    /// schema types yield a sample, preserving current caller behavior for
+    /// non-temporal keys. Returns `None` if the key type cannot be
+    /// determined (empty/all-NULL in-memory index, non-temporal disk-backed
+    /// schema, vector indexes).
     ///
     /// This is used by the executor to determine the stored key *type* so
     /// that string probe bounds can be coerced to match temporal keys
@@ -190,9 +195,28 @@ impl IndexData {
                 .filter_map(|key| key.get(col_idx))
                 .find(|v| !matches!(v, SqlValue::Null))
                 .cloned(),
-            // Disk-backed B+ trees don't expose cheap key iteration; vector
-            // indexes don't store comparable scalar keys. Callers treat None
-            // as "unknown key type" and skip coercion.
+            IndexData::DiskBacked { btree, .. } => {
+                use vibesql_types::DataType;
+
+                let guard = acquire_btree_lock(btree).ok()?;
+                // Synthesize a representative value of the declared key type;
+                // only the type is meaningful per this method's contract.
+                let min_date = vibesql_types::Date { year: 1, month: 1, day: 1 };
+                let midnight = vibesql_types::Time { hour: 0, minute: 0, second: 0, nanosecond: 0 };
+                match guard.key_schema().get(col_idx)? {
+                    DataType::Date => Some(SqlValue::Date(min_date)),
+                    DataType::Timestamp { .. } => {
+                        Some(SqlValue::Timestamp(vibesql_types::Timestamp::new(min_date, midnight)))
+                    }
+                    DataType::Time { .. } => Some(SqlValue::Time(midnight)),
+                    // Non-temporal schema types: callers treat None as
+                    // "unknown key type" and skip coercion (no behavior
+                    // change for non-temporal disk-backed indexes).
+                    _ => None,
+                }
+            }
+            // Vector indexes don't store comparable scalar keys. Callers
+            // treat None as "unknown key type" and skip coercion.
             _ => None,
         }
     }
@@ -227,5 +251,99 @@ impl IndexData {
             // Clear pending deletions after applying
             pending_deletions.clear();
         }
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use std::str::FromStr;
+
+    use tempfile::TempDir;
+    use vibesql_types::DataType;
+
+    use super::*;
+    use crate::NativeStorage;
+
+    /// Build a disk-backed `IndexData` with the given key schema and keys.
+    /// Returns the TempDir so the backing file outlives the assertions.
+    fn disk_backed_index(
+        key_schema: Vec<DataType>,
+        keys: Vec<Vec<SqlValue>>,
+    ) -> (IndexData, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Arc::new(NativeStorage::new(temp_dir.path()).unwrap());
+        let page_manager = Arc::new(PageManager::new("test_index.idx", storage).unwrap());
+
+        let mut sorted_entries: Vec<(Vec<SqlValue>, usize)> =
+            keys.into_iter().enumerate().map(|(i, key)| (key, i)).collect();
+        sorted_entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let btree =
+            BTreeIndex::bulk_load(sorted_entries, key_schema, page_manager.clone()).unwrap();
+        let index = IndexData::DiskBacked { btree: Arc::new(Mutex::new(btree)), page_manager };
+        (index, temp_dir)
+    }
+
+    fn ts(s: &str) -> SqlValue {
+        SqlValue::Timestamp(vibesql_types::Timestamp::from_str(s).unwrap())
+    }
+
+    #[test]
+    fn disk_backed_sample_reports_timestamp_from_schema() {
+        let (index, _dir) = disk_backed_index(
+            vec![DataType::Timestamp { with_timezone: false }],
+            vec![vec![ts("2024-01-01 12:00:00")]],
+        );
+        assert!(matches!(index.first_key_value_sample(0), Some(SqlValue::Timestamp(_))));
+    }
+
+    #[test]
+    fn disk_backed_sample_reports_date_from_schema() {
+        let (index, _dir) = disk_backed_index(
+            vec![DataType::Date],
+            vec![vec![SqlValue::Date(vibesql_types::Date::from_str("2024-01-01").unwrap())]],
+        );
+        assert!(matches!(index.first_key_value_sample(0), Some(SqlValue::Date(_))));
+    }
+
+    #[test]
+    fn disk_backed_sample_reports_time_from_schema() {
+        let (index, _dir) = disk_backed_index(
+            vec![DataType::Time { with_timezone: false }],
+            vec![vec![SqlValue::Time(vibesql_types::Time::from_str("12:00:00").unwrap())]],
+        );
+        assert!(matches!(index.first_key_value_sample(0), Some(SqlValue::Time(_))));
+    }
+
+    #[test]
+    fn disk_backed_sample_returns_none_for_non_temporal_schema() {
+        // Non-temporal disk-backed indexes keep the pre-#5337 behavior:
+        // callers treat None as "unknown key type" and skip coercion.
+        let (index, _dir) =
+            disk_backed_index(vec![DataType::Integer], vec![vec![SqlValue::Integer(42)]]);
+        assert_eq!(index.first_key_value_sample(0), None);
+    }
+
+    #[test]
+    fn disk_backed_sample_works_for_empty_index() {
+        // The schema-based sample comes from page-0 metadata, so it works
+        // even when the index holds no keys (impossible for the in-memory
+        // sampling approach).
+        let (index, _dir) =
+            disk_backed_index(vec![DataType::Timestamp { with_timezone: false }], vec![]);
+        assert!(matches!(index.first_key_value_sample(0), Some(SqlValue::Timestamp(_))));
+    }
+
+    #[test]
+    fn disk_backed_sample_uses_per_column_schema() {
+        // Multi-column index with the temporal column at position 1: the
+        // fast-path point lookup samples each column index separately.
+        let (index, _dir) = disk_backed_index(
+            vec![DataType::Integer, DataType::Timestamp { with_timezone: false }],
+            vec![vec![SqlValue::Integer(1), ts("2024-01-01 12:00:00")]],
+        );
+        assert_eq!(index.first_key_value_sample(0), None);
+        assert!(matches!(index.first_key_value_sample(1), Some(SqlValue::Timestamp(_))));
+        assert_eq!(index.first_key_value_sample(2), None);
     }
 }

--- a/crates/vibesql-types/src/temporal/time.rs
+++ b/crates/vibesql-types/src/temporal/time.rs
@@ -76,9 +76,22 @@ impl fmt::Display for Time {
         if self.nanosecond == 0 {
             write!(f, "{:02}:{:02}:{:02}", self.hour, self.minute, self.second)
         } else {
-            // Display fractional seconds, trimming trailing zeros for readability
-            let frac = format!("{:09}", self.nanosecond).trim_end_matches('0').to_string();
-            write!(f, "{:02}:{:02}:{:02}.{}", self.hour, self.minute, self.second, frac)
+            // Display fractional seconds, trimming trailing zeros but never
+            // below 3 digits. SQLite's subsec rendering is always exactly 3
+            // digits (`HH:MM:SS.SSS`); padding to a minimum of 3 keeps
+            // `.5` → `.500` aligned with SQLite while preserving stored
+            // sub-millisecond precision (e.g. `.123456`) so Display → parse
+            // round-trips hold (issue #5332).
+            let frac = format!("{:09}", self.nanosecond);
+            let trimmed_len = frac.trim_end_matches('0').len().max(3);
+            write!(
+                f,
+                "{:02}:{:02}:{:02}.{}",
+                self.hour,
+                self.minute,
+                self.second,
+                &frac[..trimmed_len]
+            )
         }
     }
 }
@@ -96,5 +109,58 @@ impl Ord for Time {
             .then_with(|| self.minute.cmp(&other.minute))
             .then_with(|| self.second.cmp(&other.second))
             .then_with(|| self.nanosecond.cmp(&other.nanosecond))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn time_with_ns(nanosecond: u32) -> Time {
+        Time::new(13, 15, 44, nanosecond).unwrap()
+    }
+
+    #[test]
+    fn display_no_fraction_when_nanosecond_zero() {
+        assert_eq!(time_with_ns(0).to_string(), "13:15:44");
+    }
+
+    #[test]
+    fn display_pads_fraction_to_minimum_three_digits() {
+        // SQLite renders subsec with exactly 3 digits: `.5` must become `.500`.
+        assert_eq!(time_with_ns(500_000_000).to_string(), "13:15:44.500");
+        assert_eq!(time_with_ns(120_000_000).to_string(), "13:15:44.120");
+        assert_eq!(time_with_ns(1_000_000).to_string(), "13:15:44.001");
+    }
+
+    #[test]
+    fn display_keeps_three_digit_fractions_unchanged() {
+        assert_eq!(time_with_ns(123_000_000).to_string(), "13:15:44.123");
+    }
+
+    #[test]
+    fn display_preserves_sub_millisecond_digits() {
+        // No hard truncation: stored sub-ms precision must stay visible.
+        assert_eq!(time_with_ns(123_456_000).to_string(), "13:15:44.123456");
+        assert_eq!(time_with_ns(123_456_789).to_string(), "13:15:44.123456789");
+    }
+
+    #[test]
+    fn display_parse_round_trip_preserves_nanoseconds() {
+        for ns in [
+            0u32,
+            500_000_000,
+            123_000_000,
+            120_000_000,
+            123_456_000,
+            1_000_000,
+            123_456_789,
+            999_999_999,
+            1, // renders as .000000001
+        ] {
+            let t = time_with_ns(ns);
+            let parsed = Time::from_str(&t.to_string()).unwrap();
+            assert_eq!(parsed, t, "round-trip failed for ns={} (rendered '{}')", ns, t);
+        }
     }
 }

--- a/crates/vibesql-types/src/temporal/timestamp.rs
+++ b/crates/vibesql-types/src/temporal/timestamp.rs
@@ -150,3 +150,37 @@ impl Ord for Timestamp {
         self.date.cmp(&other.date).then_with(|| self.time.cmp(&other.time))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_pads_fraction_to_minimum_three_digits() {
+        // Timestamp delegates fractional rendering to Time (issue #5332):
+        // `.5` must render as `.500` to match SQLite's subsec output.
+        let ts = Timestamp::from_str("2024-01-01 12:00:00.5").unwrap();
+        assert_eq!(ts.to_string(), "2024-01-01 12:00:00.500");
+    }
+
+    #[test]
+    fn display_preserves_sub_millisecond_digits() {
+        let ts = Timestamp::from_str("2024-01-01 14:30:00.123456").unwrap();
+        assert_eq!(ts.to_string(), "2024-01-01 14:30:00.123456");
+    }
+
+    #[test]
+    fn display_parse_round_trip_preserves_value() {
+        for s in [
+            "2024-01-01 12:00:00",
+            "2024-01-01 12:00:00.5",
+            "2024-01-01 12:00:00.500",
+            "2024-01-01 14:30:00.123456",
+            "2024-01-01 14:30:00.123456789",
+        ] {
+            let ts = Timestamp::from_str(s).unwrap();
+            let reparsed = Timestamp::from_str(&ts.to_string()).unwrap();
+            assert_eq!(reparsed, ts, "round-trip failed for '{}' (rendered '{}')", s, ts);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements two related curated temporal issues in one PR:

### #5332 — fractional-seconds Display (`.5` → `.500`)
- `Time`'s Display (the single trimming site; `Timestamp` delegates) now trims trailing zeros **but never below 3 digits**, matching SQLite's subsec rendering (`sqlite3: datetime('2024-01-01 12:00:00.5','subsec')` → `2024-01-01 12:00:00.500`).
- No hard truncation: sub-millisecond digits are preserved (`.123456` unchanged — the `parser/tests/literals.rs:163` pin passes), so Display → parse round-trips hold.
- Updated the now-stale "trailing-zero fractions decline" doc comments in `temporal_coercion.rs`: `'...44.500'` now round-trips (coercible), `'...44.5'` falls under the existing prefix rule — both stay on the index path.

### #5337 — disk-backed temporal probe coercion
- New public `BTreeIndex::key_schema()` accessor (key types already persisted in page-0 metadata).
- `IndexData::first_key_value_sample` gains a `DiskBacked` arm: synthesizes a representative temporal `SqlValue` from the persisted key schema — no I/O, works for empty/all-NULL indexes; returns `None` for non-temporal schemas to preserve current caller behavior. Both consumers (range probes in `temporal_coercion.rs`, fast-path point lookups in `index_lookup.rs`) go through this method, so no executor-side changes were needed.
- **Caveat 1 fix**: `spill_index_to_disk`'s schema inference mapped temporal `SqlValue`s to `DataType::Integer` via its fallback arm; added `Date`/`Timestamp`/`Time` mappings so spilled temporal indexes keep a temporal key schema (with regression tests).

## Testing
- New Display/round-trip unit tests in `time.rs` / `timestamp.rs` (`.500`, `.120`, `.001`, `.123456`, `.123456789`, nine-case round-trip).
- New storage unit tests: disk-backed `first_key_value_sample` for Timestamp/Date/Time/non-temporal/empty/multi-column; spill regression tests asserting persisted temporal key schema.
- New executor unit tests: disk-backed index probe coercion (range, empty index, non-temporal pass-through, equality-key path); trailing-zero round-trip + short-fraction prefix-rule cases.
- New integration tests in `temporal_index_probe_tests.rs`: fractional-seconds equality/ranges/BETWEEN on an indexed TIMESTAMP column (21/21 pass).
- Full suites green: `vibesql-types` (1362), `vibesql-parser` (incl. both literal pins), `vibesql-storage`, `vibesql-executor` (all 0 failed).
- TCL conformance: `date2.test` 29/29 holds.
- Manual CLI check: `SELECT TIMESTAMP '2024-01-01 12:00:00.5'` renders `2024-01-01 12:00:00.500`; `TIME '13:15:44.5'` renders `13:15:44.500` (matches sqlite3 subsec).

Closes #5337
Closes #5332

🤖 Generated with [Claude Code](https://claude.com/claude-code)