### PR TITLE
fix(executor): implement temporal semantics in columnar full-scan comparators

### DIFF
--- a/crates/vibesql-executor/src/evaluator/compiled.rs
+++ b/crates/vibesql-executor/src/evaluator/compiled.rs
@@ -201,6 +201,9 @@ impl CompiledPredicate {
         if let (Expression::ColumnRef(col_id), Expression::Literal(value)) = (left, right) {
             let col_idx =
                 schema.get_column_index(col_id.table_canonical(), col_id.column_canonical())?;
+            if !Self::literal_supported_for_column(schema, col_idx, value) {
+                return None;
+            }
             return Self::compile_comparison_with_idx(col_idx, op, value.clone(), false);
         }
 
@@ -208,10 +211,74 @@ impl CompiledPredicate {
         if let (Expression::Literal(value), Expression::ColumnRef(col_id)) = (left, right) {
             let col_idx =
                 schema.get_column_index(col_id.table_canonical(), col_id.column_canonical())?;
+            if !Self::literal_supported_for_column(schema, col_idx, value) {
+                return None;
+            }
             return Self::compile_comparison_with_idx(col_idx, op, value.clone(), true);
         }
 
         None
+    }
+
+    /// Issue #5335: decide whether `values_equal` / `compare_range` can
+    /// evaluate this column/literal pairing with the same semantics as the
+    /// full expression evaluator. Returns false to decline compilation (the
+    /// predicate becomes `Complex` and the full evaluator runs instead).
+    fn literal_supported_for_column(
+        schema: &CombinedSchema,
+        col_idx: usize,
+        value: &SqlValue,
+    ) -> bool {
+        use std::str::FromStr;
+
+        use vibesql_types::DataType;
+
+        let col_type = schema.get_column_type_by_index(col_idx);
+        let is_string_col = |t: &DataType| {
+            matches!(
+                t,
+                DataType::Character { .. }
+                    | DataType::Varchar { .. }
+                    | DataType::CharacterLargeObject
+                    | DataType::Name
+            )
+        };
+
+        match value {
+            // Strings against a DATE column compare parse-first; an
+            // unparseable string must raise the evaluator's type-mismatch
+            // error, which the compiled fast path cannot do (its evaluate()
+            // has no error channel and callers treat None as exclude).
+            // Strings against TIMESTAMP/TIME columns compare TEXT renderings
+            // (#5329) - but numeric-parseable strings are coerced to numbers
+            // by the evaluator's NUMERIC-affinity rules first (temporal vs
+            // numeric is then always false), so decline those for parity.
+            SqlValue::Varchar(s) | SqlValue::Character(s) => match col_type {
+                Some(DataType::Date) => vibesql_types::Date::from_str(s).is_ok(),
+                Some(DataType::Timestamp { .. }) | Some(DataType::Time { .. }) => {
+                    let trimmed = s.trim();
+                    trimmed.parse::<i64>().is_err() && trimmed.parse::<f64>().is_err()
+                }
+                _ => true,
+            },
+            // Temporal literals are supported against the matching temporal
+            // column type and against string columns (TEXT-rendering /
+            // parse-first arms). Other known column types have no compiled
+            // arm with evaluator-equivalent semantics.
+            SqlValue::Timestamp(_) => match col_type {
+                Some(DataType::Timestamp { .. }) | None => true,
+                Some(t) => is_string_col(t),
+            },
+            SqlValue::Time(_) => match col_type {
+                Some(DataType::Time { .. }) | None => true,
+                Some(t) => is_string_col(t),
+            },
+            SqlValue::Date(_) => match col_type {
+                Some(DataType::Date) | None => true,
+                Some(t) => is_string_col(t),
+            },
+            _ => true,
+        }
     }
 
     /// Compile a comparison with a known column index
@@ -535,6 +602,33 @@ impl CompiledPredicate {
                 s.trim().parse::<f64>().map(|x| x == *y).unwrap_or(false)
             }
 
+            // Timestamp/Time <-> String: TEXT-rendering equality, matching
+            // the expression evaluator's #5329 semantics (issue #5335: the
+            // PartialEq fallback was always false, so `ts = '<rendering>'`
+            // missed rows and `ts != 'junk'` matched nothing)
+            (SqlValue::Timestamp(x), SqlValue::Varchar(s))
+            | (SqlValue::Timestamp(x), SqlValue::Character(s)) => x.to_string() == s.as_str(),
+            (SqlValue::Varchar(s), SqlValue::Timestamp(y))
+            | (SqlValue::Character(s), SqlValue::Timestamp(y)) => y.to_string() == s.as_str(),
+            (SqlValue::Time(x), SqlValue::Varchar(s))
+            | (SqlValue::Time(x), SqlValue::Character(s)) => x.to_string() == s.as_str(),
+            (SqlValue::Varchar(s), SqlValue::Time(y))
+            | (SqlValue::Character(s), SqlValue::Time(y)) => y.to_string() == s.as_str(),
+
+            // Date <-> String: parse-first (#5329). Unparseable strings are
+            // declined at compile time (the evaluator raises a type-mismatch
+            // error); defensively report not-equal if one slips through.
+            (SqlValue::Date(x), SqlValue::Varchar(s))
+            | (SqlValue::Date(x), SqlValue::Character(s)) => {
+                use std::str::FromStr;
+                vibesql_types::Date::from_str(s).map(|d| *x == d).unwrap_or(false)
+            }
+            (SqlValue::Varchar(s), SqlValue::Date(y))
+            | (SqlValue::Character(s), SqlValue::Date(y)) => {
+                use std::str::FromStr;
+                vibesql_types::Date::from_str(s).map(|d| d == *y).unwrap_or(false)
+            }
+
             // Fallback to PartialEq
             _ => a == b,
         }
@@ -740,6 +834,48 @@ impl CompiledPredicate {
             (SqlValue::Varchar(s), SqlValue::Real(y))
             | (SqlValue::Character(s), SqlValue::Real(y)) => {
                 s.trim().parse::<f64>().map(|x| Self::apply_range_op(x, op, *y)).ok()
+            }
+
+            // Same-type temporal comparisons (issue #5335: previously fell
+            // through to the None fallback, which callers treat as exclude)
+            (SqlValue::Date(x), SqlValue::Date(y)) => Some(Self::apply_range_op(x, op, y)),
+            (SqlValue::Time(x), SqlValue::Time(y)) => Some(Self::apply_range_op(x, op, y)),
+            (SqlValue::Timestamp(x), SqlValue::Timestamp(y)) => {
+                Some(Self::apply_range_op(x, op, y))
+            }
+
+            // Timestamp/Time <-> String: compare TEXT renderings
+            // lexicographically, matching the expression evaluator's #5329
+            // semantics (e.g. `ts < 'hello'` is true for every timestamp
+            // because renderings start with a digit)
+            (SqlValue::Timestamp(x), SqlValue::Varchar(s))
+            | (SqlValue::Timestamp(x), SqlValue::Character(s)) => {
+                Some(Self::apply_range_op(x.to_string().as_str(), op, s.as_str()))
+            }
+            (SqlValue::Varchar(s), SqlValue::Timestamp(y))
+            | (SqlValue::Character(s), SqlValue::Timestamp(y)) => {
+                Some(Self::apply_range_op(s.as_str(), op, y.to_string().as_str()))
+            }
+            (SqlValue::Time(x), SqlValue::Varchar(s))
+            | (SqlValue::Time(x), SqlValue::Character(s)) => {
+                Some(Self::apply_range_op(x.to_string().as_str(), op, s.as_str()))
+            }
+            (SqlValue::Varchar(s), SqlValue::Time(y))
+            | (SqlValue::Character(s), SqlValue::Time(y)) => {
+                Some(Self::apply_range_op(s.as_str(), op, y.to_string().as_str()))
+            }
+
+            // Date <-> String: parse-first (#5329). Unparseable strings are
+            // declined at compile time; None (exclude) if one slips through.
+            (SqlValue::Date(x), SqlValue::Varchar(s))
+            | (SqlValue::Date(x), SqlValue::Character(s)) => {
+                use std::str::FromStr;
+                vibesql_types::Date::from_str(s).ok().map(|d| Self::apply_range_op(*x, op, d))
+            }
+            (SqlValue::Varchar(s), SqlValue::Date(y))
+            | (SqlValue::Character(s), SqlValue::Date(y)) => {
+                use std::str::FromStr;
+                vibesql_types::Date::from_str(s).ok().map(|d| Self::apply_range_op(d, op, *y))
             }
 
             // BLOB vs BLOB - bytewise comparison (SQLite memcmp semantics)
@@ -966,14 +1102,8 @@ mod tests {
             CompiledPredicate::compare_range(&abc, RangeOp::GreaterThanOrEqual, &ab),
             Some(true)
         );
-        assert_eq!(
-            CompiledPredicate::compare_range(&ab, RangeOp::LessThan, &abc),
-            Some(true)
-        );
-        assert_eq!(
-            CompiledPredicate::compare_range(&abc, RangeOp::LessThan, &ab),
-            Some(false)
-        );
+        assert_eq!(CompiledPredicate::compare_range(&ab, RangeOp::LessThan, &abc), Some(true));
+        assert_eq!(CompiledPredicate::compare_range(&abc, RangeOp::LessThan, &ab), Some(false));
     }
 
     #[test]
@@ -992,15 +1122,9 @@ mod tests {
             CompiledPredicate::compare_range(&blob, RangeOp::GreaterThanOrEqual, &text),
             Some(true)
         );
-        assert_eq!(
-            CompiledPredicate::compare_range(&blob, RangeOp::LessThan, &text),
-            Some(false)
-        );
+        assert_eq!(CompiledPredicate::compare_range(&blob, RangeOp::LessThan, &text), Some(false));
         // TEXT < BLOB
-        assert_eq!(
-            CompiledPredicate::compare_range(&text, RangeOp::LessThan, &blob),
-            Some(true)
-        );
+        assert_eq!(CompiledPredicate::compare_range(&text, RangeOp::LessThan, &blob), Some(true));
         assert_eq!(
             CompiledPredicate::compare_range(&text, RangeOp::GreaterThanOrEqual, &blob),
             Some(false)

--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -589,6 +589,27 @@ impl CombinedSchema {
         None
     }
 
+    /// Get the declared data type for a column by its combined (absolute) index
+    ///
+    /// Returns `None` if the index does not fall inside any table at this
+    /// schema level (e.g. it resolves into an outer scope, or belongs to an
+    /// alias table). Used by columnar predicate extraction to decide whether
+    /// a predicate can be pushed down to the columnar comparators (issue
+    /// #5335: temporal columns need type-aware pushdown decisions).
+    pub fn get_column_type_by_index(&self, idx: usize) -> Option<&vibesql_types::DataType> {
+        for (table_id, (start_index, schema)) in &self.table_schemas {
+            // Alias tables share start_index 0 with non-contiguous columns;
+            // skip them so we only match real, contiguous column ranges.
+            if self.alias_tables.contains(table_id) {
+                continue;
+            }
+            if idx >= *start_index && idx < start_index + schema.columns.len() {
+                return Some(&schema.columns[idx - start_index].data_type);
+            }
+        }
+        None
+    }
+
     /// Get the type affinity for a column by name
     ///
     /// Returns the SQLite type affinity for the column, which determines how

--- a/crates/vibesql-executor/src/select/columnar/batch/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/batch/mod.rs
@@ -27,4 +27,5 @@ mod storage;
 mod types;
 
 // Re-export public types
+pub(crate) use operations::microseconds_to_timestamp;
 pub use types::{ColumnArray, ColumnarBatch};

--- a/crates/vibesql-executor/src/select/columnar/batch/operations.rs
+++ b/crates/vibesql-executor/src/select/columnar/batch/operations.rs
@@ -670,7 +670,11 @@ fn days_since_epoch_to_date(days: i32) -> Date {
 }
 
 /// Convert microseconds since Unix epoch to Timestamp
-fn microseconds_to_timestamp(micros: i64) -> Timestamp {
+///
+/// `pub(crate)` so the SIMD filter kernels can render Timestamp column values
+/// (stored as i64 microseconds) back to `Timestamp` for TEXT-rendering string
+/// comparisons (issue #5335).
+pub(crate) fn microseconds_to_timestamp(micros: i64) -> Timestamp {
     let days = (micros / 86_400_000_000) as i32;
     let remaining_micros = micros % 86_400_000_000;
 

--- a/crates/vibesql-executor/src/select/columnar/filter/comparison.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/comparison.rs
@@ -7,24 +7,35 @@ pub(super) enum CompareResult {
     Ordering(std::cmp::Ordering),
     /// At least one value is NULL - comparison is UNKNOWN
     Unknown,
+    /// The two values have no defined ordering in this comparator (issue
+    /// #5335). The old behavior returned `Ordering::Equal` here, which turned
+    /// `=`, `<=`, `>=`, and BETWEEN into tautologies (every row passed) and
+    /// `<`, `>`, `!=` into contradictions. Incomparable pairs now
+    /// conservatively fail every predicate instead of lying about equality.
+    /// Predicate extraction (`predicates.rs`) declines columnar pushdown for
+    /// the type combinations known to land here, so the expression evaluator
+    /// (with its full coercion/error semantics) handles them instead.
+    Incomparable,
 }
 
 impl CompareResult {
     /// Check if comparison result equals a specific ordering
     /// Returns false for Unknown (NULL comparisons always fail in WHERE)
+    /// and for Incomparable (no defined ordering - conservatively exclude)
     pub fn equals(&self, expected: std::cmp::Ordering) -> bool {
         match self {
             CompareResult::Ordering(ord) => *ord == expected,
-            CompareResult::Unknown => false,
+            CompareResult::Unknown | CompareResult::Incomparable => false,
         }
     }
 
     /// Check if comparison result matches any of the given orderings
     /// Returns false for Unknown (NULL comparisons always fail in WHERE)
+    /// and for Incomparable (no defined ordering - conservatively exclude)
     pub fn matches(&self, orderings: &[std::cmp::Ordering]) -> bool {
         match self {
             CompareResult::Ordering(ord) => orderings.contains(ord),
-            CompareResult::Unknown => false,
+            CompareResult::Unknown | CompareResult::Incomparable => false,
         }
     }
 }
@@ -47,10 +58,13 @@ pub(super) fn compare_values(a: &SqlValue, b: &SqlValue) -> CompareResult {
             SqlValue::Integer(n) => Some(*n as f64),
             SqlValue::Bigint(n) => Some(*n as f64),
             SqlValue::Smallint(n) => Some(*n as f64),
+            SqlValue::Unsigned(n) => Some(*n as f64),
             SqlValue::Float(n) => Some(*n as f64),
             SqlValue::Double(n) => Some(*n),
             SqlValue::Numeric(n) => n.to_string().parse().ok(),
             SqlValue::Real(n) => Some(*n as f64),
+            // Booleans are integers (0/1) in SQLite storage semantics
+            SqlValue::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
             _ => None,
         }
     }
@@ -124,6 +138,40 @@ pub(super) fn compare_values(a: &SqlValue, b: &SqlValue) -> CompareResult {
             }
         }
 
+        // Same-type temporal comparisons (issue #5335: these previously fell
+        // through to the incomparable-types catch-all, which reported Equal
+        // for every pair and made e.g. `ts = TIMESTAMP '...'` match all rows)
+        (SqlValue::Timestamp(a), SqlValue::Timestamp(b)) => a.cmp(b),
+        (SqlValue::Time(a), SqlValue::Time(b)) => a.cmp(b),
+
+        // Timestamp vs string: compare the TEXT renderings lexicographically,
+        // matching the expression evaluator semantics from #5329
+        // (evaluator/operators/comparison/mod.rs). The Display rendering is
+        // 'YYYY-MM-DD HH:MM:SS[.fff]', so for full canonical timestamp
+        // strings lexicographic ordering equals temporal ordering; date-only
+        // strings compare as text prefixes ('2017-07-08 00:00:00' >
+        // '2017-07-08'); unparseable strings compare as text instead of
+        // raising a type mismatch, like SQLite.
+        (SqlValue::Timestamp(ts), SqlValue::Varchar(s))
+        | (SqlValue::Timestamp(ts), SqlValue::Character(s)) => {
+            ts.to_string().as_str().cmp(s.as_str())
+        }
+        (SqlValue::Varchar(s), SqlValue::Timestamp(ts))
+        | (SqlValue::Character(s), SqlValue::Timestamp(ts)) => {
+            s.as_str().cmp(ts.to_string().as_str())
+        }
+
+        // Time vs string: same TEXT-rendering approach as Timestamp
+        (SqlValue::Time(t), SqlValue::Varchar(s)) | (SqlValue::Time(t), SqlValue::Character(s)) => {
+            t.to_string().as_str().cmp(s.as_str())
+        }
+        (SqlValue::Varchar(s), SqlValue::Time(t)) | (SqlValue::Character(s), SqlValue::Time(t)) => {
+            s.as_str().cmp(t.to_string().as_str())
+        }
+
+        // Blob vs Blob: bytewise comparison (SQLite memcmp semantics)
+        (SqlValue::Blob(a), SqlValue::Blob(b)) => a.cmp(b),
+
         // Mixed numeric types: coerce to f64 with epsilon comparison for floats
         _ => {
             // First try direct numeric comparison
@@ -173,9 +221,13 @@ pub(super) fn compare_values(a: &SqlValue, b: &SqlValue) -> CompareResult {
                 return CompareResult::Ordering(Ordering::Greater);
             }
 
-            // Non-comparable types: use SQLite type ordering (INTEGER < REAL < TEXT < BLOB)
-            // For equality checks, this will correctly fail (different types)
-            Ordering::Equal
+            // Non-comparable types: no defined ordering in this comparator.
+            // Issue #5335: this used to return Ordering::Equal, which made
+            // every equality/range predicate on such pairs a tautology or a
+            // contradiction. Report Incomparable so all predicates
+            // conservatively fail; predicate extraction declines pushdown for
+            // these combinations so the expression evaluator handles them.
+            return CompareResult::Incomparable;
         }
     })
 }
@@ -333,6 +385,105 @@ mod tests {
             result_abc,
             CompareResult::Ordering(std::cmp::Ordering::Greater),
             "'abc' (TEXT) should be > Integer in SQLite type ordering"
+        );
+    }
+
+    fn ts(s: &str) -> SqlValue {
+        use std::str::FromStr;
+        SqlValue::Timestamp(vibesql_types::Timestamp::from_str(s).unwrap())
+    }
+
+    fn varchar(s: &str) -> SqlValue {
+        SqlValue::Varchar(arcstr::ArcStr::from(s))
+    }
+
+    /// Issue #5335: Timestamp vs Timestamp must compare temporally, not fall
+    /// through to the catch-all (which used to report Equal for every pair).
+    #[test]
+    fn test_timestamp_vs_timestamp_comparison() {
+        use std::cmp::Ordering;
+        let a = ts("2017-07-20 15:30:00");
+        let b = ts("2017-07-22 08:00:00");
+
+        assert_eq!(compare_values(&a, &b), CompareResult::Ordering(Ordering::Less));
+        assert_eq!(compare_values(&b, &a), CompareResult::Ordering(Ordering::Greater));
+        assert_eq!(compare_values(&a, &a), CompareResult::Ordering(Ordering::Equal));
+    }
+
+    /// Issue #5335: Timestamp vs string uses TEXT-rendering lexicographic
+    /// comparison (#5329 semantics), never the catch-all.
+    #[test]
+    fn test_timestamp_vs_string_text_rendering() {
+        use std::cmp::Ordering;
+        let a = ts("2017-07-20 15:30:00");
+
+        // Canonical full rendering: equality
+        assert_eq!(
+            compare_values(&a, &varchar("2017-07-20 15:30:00")),
+            CompareResult::Ordering(Ordering::Equal)
+        );
+        // Unparseable string: text ordering ('2...' < 'zzz')
+        assert_eq!(compare_values(&a, &varchar("zzz")), CompareResult::Ordering(Ordering::Less));
+        assert_eq!(compare_values(&varchar("zzz"), &a), CompareResult::Ordering(Ordering::Greater));
+        // Date-only string: rendering is longer with equal prefix, so greater
+        assert_eq!(
+            compare_values(&a, &varchar("2017-07-20")),
+            CompareResult::Ordering(Ordering::Greater)
+        );
+        // Later date-only string: rendering sorts below it
+        assert_eq!(
+            compare_values(&a, &varchar("2017-07-21")),
+            CompareResult::Ordering(Ordering::Less)
+        );
+    }
+
+    /// Issue #5335: Time vs Time and Time vs string semantics.
+    #[test]
+    fn test_time_comparisons() {
+        use std::{cmp::Ordering, str::FromStr};
+        let t1 = SqlValue::Time(vibesql_types::Time::from_str("08:00:00").unwrap());
+        let t2 = SqlValue::Time(vibesql_types::Time::from_str("15:30:00").unwrap());
+
+        assert_eq!(compare_values(&t1, &t2), CompareResult::Ordering(Ordering::Less));
+        assert_eq!(
+            compare_values(&t1, &varchar("08:00:00")),
+            CompareResult::Ordering(Ordering::Equal)
+        );
+        assert_eq!(compare_values(&t1, &varchar("zzz")), CompareResult::Ordering(Ordering::Less));
+    }
+
+    /// Issue #5335: the catch-all must no longer report incomparable pairs as
+    /// Equal (which made `=`/`<=`/`>=`/BETWEEN tautologies).
+    #[test]
+    fn test_incomparable_types_not_equal() {
+        use std::cmp::Ordering;
+        let a = ts("2017-07-20 15:30:00");
+        let date = SqlValue::Date(vibesql_types::Date::new(2017, 7, 20).unwrap());
+
+        // Timestamp vs Date has no defined ordering in this comparator
+        let result = compare_values(&a, &date);
+        assert_eq!(result, CompareResult::Incomparable);
+        assert!(!result.equals(Ordering::Equal));
+        assert!(!result.matches(&[Ordering::Less, Ordering::Greater]));
+        assert!(!result.matches(&[Ordering::Less, Ordering::Equal]));
+    }
+
+    /// Issue #5335: Boolean and Blob same-type pairs used to hit the Equal
+    /// catch-all too; verify they now compare properly.
+    #[test]
+    fn test_boolean_and_blob_comparisons() {
+        use std::cmp::Ordering;
+        assert_eq!(
+            compare_values(&SqlValue::Boolean(false), &SqlValue::Boolean(true)),
+            CompareResult::Ordering(Ordering::Less)
+        );
+        assert_eq!(
+            compare_values(&SqlValue::Boolean(true), &SqlValue::Boolean(true)),
+            CompareResult::Ordering(Ordering::Equal)
+        );
+        assert_eq!(
+            compare_values(&SqlValue::Blob(vec![0x61, 0x62]), &SqlValue::Blob(vec![0x61, 0x63])),
+            CompareResult::Ordering(Ordering::Less)
         );
     }
 

--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -1,6 +1,7 @@
 use vibesql_ast::{BinaryOperator, Expression, UnaryOperator};
-use vibesql_types::{SqlMode, SqlValue, TypeAffinity};
+use vibesql_types::{DataType, SqlMode, SqlValue, TypeAffinity};
 
+use super::comparison::parse_date_string;
 use crate::{evaluator::ExpressionEvaluator, schema::CombinedSchema};
 
 /// Comparison operator for column-to-column predicates
@@ -247,7 +248,169 @@ pub fn extract_predicate_tree(
     schema: &CombinedSchema,
     case_sensitive_like: bool,
 ) -> Option<PredicateTree> {
-    extract_tree_recursive(expr, schema, case_sensitive_like)
+    let tree = extract_tree_recursive(expr, schema, case_sensitive_like)?;
+    // Issue #5335: decline pushdown entirely when any extracted predicate
+    // pairs a column with a literal the columnar comparators cannot evaluate
+    // faithfully (e.g. DATE vs unparseable string must raise the evaluator's
+    // type-mismatch error; temporal vs numeric has no columnar ordering).
+    // Declining must be all-or-nothing: callers mark the WHERE clause as
+    // consumed after columnar filtering, so a silently skipped predicate
+    // would over-return rows.
+    if !tree_supported_by_columnar(&tree, schema) {
+        return None;
+    }
+    Some(tree)
+}
+
+/// Check whether every leaf of a predicate tree can be evaluated faithfully
+/// by the columnar comparators (see `predicate_supported_by_columnar`).
+fn tree_supported_by_columnar(tree: &PredicateTree, schema: &CombinedSchema) -> bool {
+    match tree {
+        PredicateTree::And(children) | PredicateTree::Or(children) => {
+            children.iter().all(|child| tree_supported_by_columnar(child, schema))
+        }
+        PredicateTree::Leaf(predicate) => predicate_supported_by_columnar(predicate, schema),
+    }
+}
+
+/// Check whether a single column predicate can be evaluated faithfully by the
+/// columnar comparators (`filter::comparison::compare_values` and the SIMD
+/// kernels), given the column's declared data type.
+///
+/// Issue #5335: the columnar comparators implement the #5329 semantics for
+/// temporal columns versus matching temporal literals and strings, but they
+/// have no error channel (DATE vs unparseable string must raise a
+/// type-mismatch error in the expression evaluator) and no defined ordering
+/// for mixed temporal/non-temporal pairs. Those combinations must fall back
+/// to the full expression evaluator, so extraction declines them here.
+fn predicate_supported_by_columnar(predicate: &ColumnPredicate, schema: &CombinedSchema) -> bool {
+    match predicate {
+        ColumnPredicate::LessThan { column_idx, value }
+        | ColumnPredicate::GreaterThan { column_idx, value }
+        | ColumnPredicate::GreaterThanOrEqual { column_idx, value }
+        | ColumnPredicate::LessThanOrEqual { column_idx, value }
+        | ColumnPredicate::Equal { column_idx, value }
+        | ColumnPredicate::NotEqual { column_idx, value } => {
+            value_supported_for_column(schema.get_column_type_by_index(*column_idx), value)
+        }
+        ColumnPredicate::Between { column_idx, low, high } => {
+            let col_type = schema.get_column_type_by_index(*column_idx);
+            value_supported_for_column(col_type, low) && value_supported_for_column(col_type, high)
+        }
+        ColumnPredicate::InList { column_idx, values, .. } => {
+            let col_type = schema.get_column_type_by_index(*column_idx);
+            values.iter().all(|v| value_supported_for_column(col_type, v))
+        }
+        // LIKE patterns are strings; existing comparator behavior applies
+        ColumnPredicate::Like { .. } => true,
+        ColumnPredicate::ColumnCompare { left_column_idx, right_column_idx, .. } => {
+            column_compare_supported(
+                schema.get_column_type_by_index(*left_column_idx),
+                schema.get_column_type_by_index(*right_column_idx),
+            )
+        }
+    }
+}
+
+/// Whether a column's declared type is a temporal type
+fn is_temporal_type(t: &DataType) -> bool {
+    matches!(t, DataType::Date | DataType::Time { .. } | DataType::Timestamp { .. })
+}
+
+/// Whether a column's declared type is a character string type
+fn is_string_type(t: &DataType) -> bool {
+    matches!(
+        t,
+        DataType::Character { .. }
+            | DataType::Varchar { .. }
+            | DataType::CharacterLargeObject
+            | DataType::Name
+    )
+}
+
+/// Whether a string would be coerced to a number by the expression
+/// evaluator's NUMERIC-affinity rules (`try_coerce_string_to_numeric`).
+/// Temporal columns have NUMERIC affinity, so numeric-parseable string
+/// literals against them become Timestamp/Date/Time-vs-number comparisons in
+/// the evaluator (which yield false), not TEXT-rendering comparisons.
+fn string_coerces_to_numeric(s: &str) -> bool {
+    let trimmed = s.trim();
+    trimmed.parse::<i64>().is_ok() || trimmed.parse::<f64>().is_ok()
+}
+
+/// Check whether a literal operand can be compared faithfully against a
+/// column of the given declared type by the columnar comparators.
+fn value_supported_for_column(col_type: Option<&DataType>, value: &SqlValue) -> bool {
+    // NULL literals are handled uniformly (comparison is UNKNOWN)
+    if matches!(value, SqlValue::Null) {
+        return true;
+    }
+
+    match col_type {
+        Some(DataType::Date) => match value {
+            SqlValue::Date(_) => true,
+            // Date vs parseable string compares parse-first (hot path for
+            // TPC-H date range predicates); unparseable strings must raise
+            // the evaluator's type-mismatch error, so decline pushdown.
+            // (Numeric-looking strings fail YYYY-MM-DD parsing and are
+            // declined too, matching the evaluator's affinity coercion.)
+            SqlValue::Varchar(s) | SqlValue::Character(s) => parse_date_string(s).is_some(),
+            _ => false,
+        },
+        Some(DataType::Timestamp { .. }) => match value {
+            // Timestamp vs Timestamp compares temporally; Timestamp vs a
+            // non-numeric string compares TEXT renderings (#5329).
+            // Numeric-parseable strings are coerced to numbers by the
+            // evaluator's NUMERIC-affinity rules first (temporal vs numeric
+            // is then always false), so decline those to preserve parity.
+            SqlValue::Timestamp(_) => true,
+            SqlValue::Varchar(s) | SqlValue::Character(s) => !string_coerces_to_numeric(s),
+            _ => false,
+        },
+        Some(DataType::Time { .. }) => match value {
+            SqlValue::Time(_) => true,
+            SqlValue::Varchar(s) | SqlValue::Character(s) => !string_coerces_to_numeric(s),
+            _ => false,
+        },
+        Some(other) => match value {
+            // Temporal literal against a non-temporal column: only string
+            // columns have comparator support (parse-first for Date, TEXT
+            // rendering for Timestamp/Time).
+            SqlValue::Date(_) | SqlValue::Timestamp(_) | SqlValue::Time(_) => is_string_type(other),
+            _ => true,
+        },
+        // Unknown column type (e.g. outer-scope reference): allow existing
+        // behavior except for temporal literals, where we cannot prove the
+        // comparators have a faithful arm.
+        None => !matches!(value, SqlValue::Date(_) | SqlValue::Timestamp(_) | SqlValue::Time(_)),
+    }
+}
+
+/// Check whether a column-to-column comparison is supported by the columnar
+/// comparators given both columns' declared types.
+fn column_compare_supported(left: Option<&DataType>, right: Option<&DataType>) -> bool {
+    match (left, right) {
+        (Some(l), Some(r)) => {
+            let l_temporal = is_temporal_type(l);
+            let r_temporal = is_temporal_type(r);
+            if l_temporal && r_temporal {
+                // Same temporal kind compares natively; mixed kinds (e.g.
+                // Date vs Timestamp) have no columnar ordering.
+                std::mem::discriminant(l) == std::mem::discriminant(r)
+            } else if l_temporal || r_temporal {
+                // Temporal vs non-temporal column: the evaluator applies
+                // per-row affinity coercion (numeric-looking strings in a
+                // TEXT column coerce to numbers against a NUMERIC-affinity
+                // temporal column), which the columnar comparator cannot
+                // replicate. Decline so the evaluator runs.
+                false
+            } else {
+                true
+            }
+        }
+        // Unknown types: keep existing behavior
+        _ => true,
+    }
 }
 
 /// Extract simple column predicates from a WHERE clause expression (legacy)
@@ -279,10 +442,17 @@ pub fn extract_column_predicates(
     // Return None if no predicates were extracted (all were cross-table or unsupported)
     // This allows fallback to generic predicate evaluation
     if predicates.is_empty() {
-        None
-    } else {
-        Some(predicates)
+        return None;
     }
+    // Issue #5335: decline pushdown entirely when any extracted predicate
+    // pairs a column with a literal the columnar comparators cannot evaluate
+    // faithfully. Must be all-or-nothing: callers mark the WHERE clause as
+    // consumed after columnar filtering, so skipping one predicate here
+    // would over-return rows.
+    if !predicates.iter().all(|p| predicate_supported_by_columnar(p, schema)) {
+        return None;
+    }
+    Some(predicates)
 }
 
 /// Try to fold a constant expression to a literal value
@@ -836,6 +1006,116 @@ mod tests {
             ],
         );
         CombinedSchema::from_table("test".to_string(), schema)
+    }
+
+    fn create_temporal_schema() -> CombinedSchema {
+        let schema = TableSchema::new(
+            "t".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "ts".to_string(),
+                    DataType::Timestamp { with_timezone: false },
+                    true,
+                ),
+                ColumnSchema::new("d".to_string(), DataType::Date, true),
+            ],
+        );
+        CombinedSchema::from_table("t".to_string(), schema)
+    }
+
+    fn comparison_expr(column: &str, op: BinaryOperator, value: SqlValue) -> Expression {
+        Expression::BinaryOp {
+            left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                column, false,
+            ))),
+            op,
+            right: Box::new(Expression::Literal(value)),
+        }
+    }
+
+    /// Issue #5335: extraction supports Timestamp columns vs Timestamp
+    /// literals and non-numeric strings (the comparators implement #5329
+    /// semantics for those).
+    #[test]
+    fn test_timestamp_column_supported_literals_extracted() {
+        use std::str::FromStr;
+        let schema = create_temporal_schema();
+
+        let ts_literal = SqlValue::Timestamp(
+            vibesql_types::Timestamp::from_str("2017-07-20 15:30:00").unwrap(),
+        );
+        for value in [ts_literal, SqlValue::Varchar(arcstr::ArcStr::from("2017-07-21"))] {
+            let expr = comparison_expr("ts", BinaryOperator::GreaterThanOrEqual, value.clone());
+            assert!(
+                extract_column_predicates(&expr, &schema, false).is_some(),
+                "expected pushdown for ts >= {value:?}"
+            );
+            assert!(extract_predicate_tree(&expr, &schema, false).is_some());
+        }
+    }
+
+    /// Issue #5335: extraction declines combinations the columnar comparators
+    /// cannot evaluate faithfully (must be all-or-nothing so the WHERE clause
+    /// is not marked consumed with predicates silently dropped).
+    #[test]
+    fn test_unsupported_temporal_literals_decline_extraction() {
+        let schema = create_temporal_schema();
+
+        // Numeric-parseable string vs Timestamp column: the evaluator's
+        // NUMERIC-affinity rules coerce it to a number first.
+        let expr = comparison_expr(
+            "ts",
+            BinaryOperator::LessThan,
+            SqlValue::Varchar(arcstr::ArcStr::from("1999")),
+        );
+        assert!(extract_column_predicates(&expr, &schema, false).is_none());
+        assert!(extract_predicate_tree(&expr, &schema, false).is_none());
+
+        // Numeric literal vs Timestamp column: no columnar ordering.
+        let expr = comparison_expr("ts", BinaryOperator::Equal, SqlValue::Integer(1999));
+        assert!(extract_column_predicates(&expr, &schema, false).is_none());
+
+        // Unparseable string vs Date column: the evaluator raises a
+        // type-mismatch error, which the comparators cannot.
+        let expr = comparison_expr(
+            "d",
+            BinaryOperator::Equal,
+            SqlValue::Varchar(arcstr::ArcStr::from("not-a-date")),
+        );
+        assert!(extract_column_predicates(&expr, &schema, false).is_none());
+        assert!(extract_predicate_tree(&expr, &schema, false).is_none());
+
+        // AND with one unsupported predicate declines the whole extraction.
+        let expr = Expression::BinaryOp {
+            left: Box::new(comparison_expr(
+                "id",
+                BinaryOperator::GreaterThan,
+                SqlValue::Integer(0),
+            )),
+            op: BinaryOperator::And,
+            right: Box::new(comparison_expr(
+                "ts",
+                BinaryOperator::LessThan,
+                SqlValue::Varchar(arcstr::ArcStr::from("1999")),
+            )),
+        };
+        assert!(extract_column_predicates(&expr, &schema, false).is_none());
+        assert!(extract_predicate_tree(&expr, &schema, false).is_none());
+    }
+
+    /// Issue #5335 perf guard: Date columns vs parseable strings stay on the
+    /// columnar fast path (TPC-H date range predicates).
+    #[test]
+    fn test_date_column_parseable_string_still_extracted() {
+        let schema = create_temporal_schema();
+        let expr = comparison_expr(
+            "d",
+            BinaryOperator::GreaterThanOrEqual,
+            SqlValue::Varchar(arcstr::ArcStr::from("1994-01-01")),
+        );
+        assert!(extract_column_predicates(&expr, &schema, false).is_some());
+        assert!(extract_predicate_tree(&expr, &schema, false).is_some());
     }
 
     #[test]

--- a/crates/vibesql-executor/src/select/columnar/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/mod.rs
@@ -373,252 +373,39 @@ pub fn fast_aggregate_on_rows(
 }
 
 /// Evaluate a column predicate against a row
+///
+/// Delegates to the canonical comparator in `filter::evaluation`. Issue
+/// #5335: this module previously carried a near-duplicate `compare_values`
+/// whose incomparable-types catch-all returned `Ordering::Equal`, turning
+/// equality/range predicates on temporal columns into tautologies or
+/// contradictions. Routing through the filter module keeps a single source
+/// of truth for predicate comparison semantics.
 fn evaluate_predicate(row: &Row, predicate: &ColumnPredicate) -> bool {
-    match predicate {
-        ColumnPredicate::LessThan { column_idx, value } => row
-            .get(*column_idx)
-            .map(|v| compare_values(v, value) == std::cmp::Ordering::Less)
-            .unwrap_or(false),
-        ColumnPredicate::LessThanOrEqual { column_idx, value } => row
-            .get(*column_idx)
-            .map(|v| compare_values(v, value) != std::cmp::Ordering::Greater)
-            .unwrap_or(false),
-        ColumnPredicate::GreaterThan { column_idx, value } => row
-            .get(*column_idx)
-            .map(|v| compare_values(v, value) == std::cmp::Ordering::Greater)
-            .unwrap_or(false),
-        ColumnPredicate::GreaterThanOrEqual { column_idx, value } => row
-            .get(*column_idx)
-            .map(|v| compare_values(v, value) != std::cmp::Ordering::Less)
-            .unwrap_or(false),
-        ColumnPredicate::Equal { column_idx, value } => row
-            .get(*column_idx)
-            .map(|v| compare_values(v, value) == std::cmp::Ordering::Equal)
-            .unwrap_or(false),
-        ColumnPredicate::NotEqual { column_idx, value } => row
-            .get(*column_idx)
-            .map(|v| compare_values(v, value) != std::cmp::Ordering::Equal)
-            .unwrap_or(false),
-        ColumnPredicate::Between { column_idx, low, high } => row
-            .get(*column_idx)
-            .map(|v| {
-                compare_values(v, low) != std::cmp::Ordering::Less
-                    && compare_values(v, high) != std::cmp::Ordering::Greater
-            })
-            .unwrap_or(false),
-        ColumnPredicate::Like { column_idx, pattern, negated, case_sensitive, escape } => {
-            // LIKE pattern matching using the proper evaluator
-            let matches = row
-                .get(*column_idx)
-                .map(|v| {
-                    let text: std::borrow::Cow<str> = match v {
-                        SqlValue::Varchar(s) | SqlValue::Character(s) => {
-                            std::borrow::Cow::Borrowed(s.as_str())
-                        }
-                        SqlValue::Integer(i) => std::borrow::Cow::Owned(i.to_string()),
-                        SqlValue::Bigint(i) => std::borrow::Cow::Owned(i.to_string()),
-                        SqlValue::Float(f) => std::borrow::Cow::Owned(f.to_string()),
-                        SqlValue::Double(f) => std::borrow::Cow::Owned(f.to_string()),
-                        SqlValue::Real(f) => std::borrow::Cow::Owned(f.to_string()),
-                        SqlValue::Blob(b) => String::from_utf8_lossy(b),
-                        _ => return false,
-                    };
-                    crate::evaluator::pattern::like_match(
-                        &text,
-                        pattern,
-                        *case_sensitive,
-                        *escape,
-                    )
-                })
-                .unwrap_or(false);
-            if *negated {
-                !matches
-            } else {
-                matches
-            }
-        }
-        ColumnPredicate::InList { column_idx, values, negated, use_strict_type_ordering } => {
-            // Check if column value matches any value in the list
-            let matches = row
-                .get(*column_idx)
-                .map(|v| {
-                    values.iter().any(|list_val| {
-                        if *use_strict_type_ordering {
-                            // Use strict type ordering - no coercion
-                            strict_type_equal(v, list_val)
-                        } else {
-                            compare_values(v, list_val) == std::cmp::Ordering::Equal
-                        }
-                    })
-                })
-                .unwrap_or(false);
-            if *negated {
-                !matches
-            } else {
-                matches
-            }
-        }
-        ColumnPredicate::ColumnCompare { left_column_idx, op, right_column_idx } => {
-            // Column-to-column comparison
-            let left_val = row.get(*left_column_idx);
-            let right_val = row.get(*right_column_idx);
-            match (left_val, right_val) {
-                (Some(l), Some(r)) => {
-                    use std::cmp::Ordering;
-                    let cmp = compare_values(l, r);
-                    match op {
-                        filter::CompareOp::LessThan => cmp == Ordering::Less,
-                        filter::CompareOp::GreaterThan => cmp == Ordering::Greater,
-                        filter::CompareOp::LessThanOrEqual => cmp != Ordering::Greater,
-                        filter::CompareOp::GreaterThanOrEqual => cmp != Ordering::Less,
-                        filter::CompareOp::Equal => cmp == Ordering::Equal,
-                        filter::CompareOp::NotEqual => cmp != Ordering::Equal,
-                    }
-                }
-                _ => false, // NULL comparison returns false
-            }
-        }
-    }
-}
-
-/// Compare two SqlValues
-fn compare_values(a: &SqlValue, b: &SqlValue) -> std::cmp::Ordering {
-    use std::cmp::Ordering;
-
-    match (a, b) {
-        (SqlValue::Integer(a), SqlValue::Integer(b)) => a.cmp(b),
-        (SqlValue::Bigint(a), SqlValue::Bigint(b)) => a.cmp(b),
-        (SqlValue::Double(a), SqlValue::Double(b)) => a.partial_cmp(b).unwrap_or(Ordering::Equal),
-        (SqlValue::Float(a), SqlValue::Float(b)) => a.partial_cmp(b).unwrap_or(Ordering::Equal),
-        // Cross-type comparisons
-        (SqlValue::Integer(a), SqlValue::Double(b)) => {
-            (*a as f64).partial_cmp(b).unwrap_or(Ordering::Equal)
-        }
-        (SqlValue::Double(a), SqlValue::Integer(b)) => {
-            a.partial_cmp(&(*b as f64)).unwrap_or(Ordering::Equal)
-        }
-        (SqlValue::Integer(a), SqlValue::Bigint(b)) => (*a).cmp(b),
-        (SqlValue::Bigint(a), SqlValue::Integer(b)) => a.cmp(&{ *b }),
-        // String comparisons
-        (SqlValue::Varchar(a), SqlValue::Varchar(b)) => a.cmp(b),
-        // Date comparisons
-        (SqlValue::Date(a), SqlValue::Date(b)) => {
-            // Compare year, month, day
-            match a.year.cmp(&b.year) {
-                Ordering::Equal => match a.month.cmp(&b.month) {
-                    Ordering::Equal => a.day.cmp(&b.day),
-                    other => other,
-                },
-                other => other,
-            }
-        }
-        // NULL handling
-        (SqlValue::Null, _) | (_, SqlValue::Null) => Ordering::Equal, /* NULL comparisons are */
-        // undefined
-        _ => Ordering::Equal, // Incompatible types
-    }
-}
-
-/// Strict equality comparison without string-to-number coercion
-///
-/// Returns true if both values can be considered equal WITHOUT coercing
-/// string values to numbers. This is used for columns with NONE or INTEGER
-/// affinity in IN expressions, where string values should NOT be coerced.
-///
-/// Numeric types (Integer, Float, Real, Double, etc.) can still be compared
-/// with each other since they're all in the same storage class.
-fn strict_type_equal(a: &SqlValue, b: &SqlValue) -> bool {
-    // NULL never equals anything
-    if matches!(a, SqlValue::Null) || matches!(b, SqlValue::Null) {
-        return false;
+    // Column-to-column comparison needs two values
+    if let ColumnPredicate::ColumnCompare { left_column_idx, op, right_column_idx } = predicate {
+        return filter::evaluate_column_compare(
+            *op,
+            row.get(*left_column_idx),
+            row.get(*right_column_idx),
+        );
     }
 
-    // Helper to check if a value is a string type
-    let is_string = |v: &SqlValue| matches!(v, SqlValue::Varchar(_) | SqlValue::Character(_));
-
-    // Helper to check if a value is a numeric type
-    let is_numeric = |v: &SqlValue| {
-        matches!(
-            v,
-            SqlValue::Integer(_)
-                | SqlValue::Bigint(_)
-                | SqlValue::Smallint(_)
-                | SqlValue::Float(_)
-                | SqlValue::Real(_)
-                | SqlValue::Double(_)
-                | SqlValue::Numeric(_)
-        )
+    let column_idx = match predicate {
+        ColumnPredicate::LessThan { column_idx, .. }
+        | ColumnPredicate::GreaterThan { column_idx, .. }
+        | ColumnPredicate::GreaterThanOrEqual { column_idx, .. }
+        | ColumnPredicate::LessThanOrEqual { column_idx, .. }
+        | ColumnPredicate::Equal { column_idx, .. }
+        | ColumnPredicate::NotEqual { column_idx, .. }
+        | ColumnPredicate::Between { column_idx, .. }
+        | ColumnPredicate::Like { column_idx, .. }
+        | ColumnPredicate::InList { column_idx, .. } => *column_idx,
+        ColumnPredicate::ColumnCompare { .. } => unreachable!(), // Handled above
     };
 
-    // Different storage classes (string vs numeric) - NOT equal without coercion
-    if (is_string(a) && is_numeric(b)) || (is_numeric(a) && is_string(b)) {
-        return false;
-    }
-
-    // Same storage class - use normal comparison
-    match (a, b) {
-        // Same integer types
-        (SqlValue::Integer(x), SqlValue::Integer(y)) => x == y,
-        (SqlValue::Bigint(x), SqlValue::Bigint(y)) => x == y,
-        (SqlValue::Smallint(x), SqlValue::Smallint(y)) => x == y,
-
-        // Same string types (VARCHAR and CHAR are compatible)
-        (SqlValue::Varchar(x), SqlValue::Varchar(y))
-        | (SqlValue::Character(x), SqlValue::Character(y)) => x == y,
-        (SqlValue::Varchar(x), SqlValue::Character(y))
-        | (SqlValue::Character(x), SqlValue::Varchar(y)) => x == y,
-
-        // Same float types
-        (SqlValue::Float(x), SqlValue::Float(y)) => (x - y).abs() < f32::EPSILON,
-        (SqlValue::Double(x), SqlValue::Double(y)) => (x - y).abs() < f64::EPSILON,
-        (SqlValue::Real(x), SqlValue::Real(y)) => (x - y).abs() < f64::EPSILON,
-
-        // Cross-type numeric comparisons (all numeric types are comparable)
-        (SqlValue::Integer(x), SqlValue::Bigint(y))
-        | (SqlValue::Bigint(y), SqlValue::Integer(x)) => *x as i64 == *y,
-
-        // Float types with integer
-        (SqlValue::Float(x), SqlValue::Integer(y)) | (SqlValue::Integer(y), SqlValue::Float(x)) => {
-            (*x as f64 - *y as f64).abs() < f64::EPSILON
-        }
-        (SqlValue::Double(x), SqlValue::Integer(y))
-        | (SqlValue::Integer(y), SqlValue::Double(x)) => (*x - *y as f64).abs() < f64::EPSILON,
-        (SqlValue::Real(x), SqlValue::Integer(y)) | (SqlValue::Integer(y), SqlValue::Real(x)) => {
-            (*x - *y as f64).abs() < f64::EPSILON
-        }
-
-        // Mixed float types
-        (SqlValue::Float(x), SqlValue::Double(y)) | (SqlValue::Double(y), SqlValue::Float(x)) => {
-            (*x as f64 - *y).abs() < f64::EPSILON
-        }
-        (SqlValue::Float(x), SqlValue::Real(y)) | (SqlValue::Real(y), SqlValue::Float(x)) => {
-            (*x as f64 - *y).abs() < f64::EPSILON
-        }
-        (SqlValue::Double(x), SqlValue::Real(y)) | (SqlValue::Real(y), SqlValue::Double(x)) => {
-            (*x - *y).abs() < f64::EPSILON
-        }
-
-        // Numeric type (f64) with integer types
-        (SqlValue::Numeric(x), SqlValue::Integer(y))
-        | (SqlValue::Integer(y), SqlValue::Numeric(x)) => (*x - *y as f64).abs() < f64::EPSILON,
-        (SqlValue::Numeric(x), SqlValue::Bigint(y))
-        | (SqlValue::Bigint(y), SqlValue::Numeric(x)) => (*x - *y as f64).abs() < f64::EPSILON,
-        (SqlValue::Numeric(x), SqlValue::Smallint(y))
-        | (SqlValue::Smallint(y), SqlValue::Numeric(x)) => (*x - *y as f64).abs() < f64::EPSILON,
-
-        // Numeric with float types
-        (SqlValue::Numeric(x), SqlValue::Float(y)) | (SqlValue::Float(y), SqlValue::Numeric(x)) => {
-            (*x - *y as f64).abs() < f64::EPSILON
-        }
-        (SqlValue::Numeric(x), SqlValue::Double(y))
-        | (SqlValue::Double(y), SqlValue::Numeric(x)) => (*x - *y).abs() < f64::EPSILON,
-        (SqlValue::Numeric(x), SqlValue::Real(y)) | (SqlValue::Real(y), SqlValue::Numeric(x)) => {
-            (*x - *y).abs() < f64::EPSILON
-        }
-        (SqlValue::Numeric(x), SqlValue::Numeric(y)) => (*x - *y).abs() < f64::EPSILON,
-
-        // Different storage classes not handled above - NOT equal
-        _ => false,
+    match row.get(column_idx) {
+        Some(value) => filter::evaluate_predicate(predicate, value),
+        None => false,
     }
 }
 

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/comparison.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/comparison.rs
@@ -7,6 +7,7 @@ use vibesql_types::SqlValue;
 
 use super::{
     super::{
+        batch::microseconds_to_timestamp,
         filter::ColumnPredicate,
         simd_ops::{self, PackedMask},
     },
@@ -47,8 +48,6 @@ pub fn evaluate_predicate_i64_simd(
                 simd_ops::lt_i64(values, *threshold)
             } else if let SqlValue::Bigint(threshold) = value {
                 simd_ops::lt_i64(values, *threshold)
-            } else if let Some(threshold) = value_to_timestamp_i64(value) {
-                simd_ops::lt_i64(values, threshold)
             } else {
                 let threshold =
                     value_to_f64(value).ok_or_else(|| ExecutorError::ColumnarTypeMismatch {
@@ -301,6 +300,173 @@ pub fn evaluate_predicate_i64_simd(
     }
 
     Ok(result)
+}
+
+/// Comparison operator for the Timestamp kernel
+#[derive(Clone, Copy)]
+enum TimestampCmpOp {
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Eq,
+    Ne,
+}
+
+/// Build a boolean mask comparing a Timestamp column (i64 microseconds since
+/// epoch) against a single literal operand.
+///
+/// Issue #5335 semantics (matching the scalar comparator and the expression
+/// evaluator's #5329 rules):
+/// - `SqlValue::Timestamp` literal: ordinary temporal comparison via the
+///   microsecond encoding (SIMD i64 fast path)
+/// - string literal: compare the TEXT rendering of each timestamp against
+///   the string lexicographically (per-row scalar; strings on timestamp
+///   columns are rare and correctness across the scalar/SIMD threshold is
+///   required)
+/// - anything else: type mismatch error (predicate extraction declines these
+///   combinations, so this is defense in depth)
+fn timestamp_cmp_mask(
+    values: &[i64],
+    value: &SqlValue,
+    op: TimestampCmpOp,
+) -> Result<Vec<bool>, ExecutorError> {
+    use std::cmp::Ordering;
+
+    if let Some(threshold) = value_to_timestamp_i64(value) {
+        return Ok(match op {
+            TimestampCmpOp::Lt => simd_ops::lt_i64(values, threshold),
+            TimestampCmpOp::Le => simd_ops::le_i64(values, threshold),
+            TimestampCmpOp::Gt => simd_ops::gt_i64(values, threshold),
+            TimestampCmpOp::Ge => simd_ops::ge_i64(values, threshold),
+            TimestampCmpOp::Eq => simd_ops::eq_i64(values, threshold),
+            TimestampCmpOp::Ne => simd_ops::ne_i64(values, threshold),
+        });
+    }
+
+    if let SqlValue::Varchar(s) | SqlValue::Character(s) = value {
+        let s = s.as_str();
+        return Ok(values
+            .iter()
+            .map(|&v| {
+                let rendering = microseconds_to_timestamp(v).to_string();
+                let cmp = rendering.as_str().cmp(s);
+                match op {
+                    TimestampCmpOp::Lt => cmp == Ordering::Less,
+                    TimestampCmpOp::Le => cmp != Ordering::Greater,
+                    TimestampCmpOp::Gt => cmp == Ordering::Greater,
+                    TimestampCmpOp::Ge => cmp != Ordering::Less,
+                    TimestampCmpOp::Eq => cmp == Ordering::Equal,
+                    TimestampCmpOp::Ne => cmp != Ordering::Equal,
+                }
+            })
+            .collect());
+    }
+
+    Err(ExecutorError::ColumnarTypeMismatch {
+        operation: "comparison".to_string(),
+        left_type: "Timestamp".to_string(),
+        right_type: Some(format!("{:?}", value)),
+    })
+}
+
+/// Evaluate predicate on a Timestamp column (i64 microseconds since epoch)
+///
+/// Issue #5335: Timestamp columns previously dispatched to
+/// `evaluate_predicate_i64_simd`, which applies INTEGER-affinity semantics to
+/// string operands (parsing them as numbers and comparing against raw
+/// microseconds) and only handled genuine Timestamp literals for `<`. This
+/// kernel implements the #5329 temporal semantics for every operator.
+pub fn evaluate_predicate_timestamp_simd(
+    predicate: &ColumnPredicate,
+    values: &[i64],
+    nulls: Option<&[bool]>,
+) -> Result<Vec<bool>, ExecutorError> {
+    let mut result = match predicate {
+        ColumnPredicate::LessThan { value, .. } => {
+            timestamp_cmp_mask(values, value, TimestampCmpOp::Lt)?
+        }
+        ColumnPredicate::LessThanOrEqual { value, .. } => {
+            timestamp_cmp_mask(values, value, TimestampCmpOp::Le)?
+        }
+        ColumnPredicate::GreaterThan { value, .. } => {
+            timestamp_cmp_mask(values, value, TimestampCmpOp::Gt)?
+        }
+        ColumnPredicate::GreaterThanOrEqual { value, .. } => {
+            timestamp_cmp_mask(values, value, TimestampCmpOp::Ge)?
+        }
+        ColumnPredicate::Equal { value, .. } => {
+            timestamp_cmp_mask(values, value, TimestampCmpOp::Eq)?
+        }
+        ColumnPredicate::NotEqual { value, .. } => {
+            timestamp_cmp_mask(values, value, TimestampCmpOp::Ne)?
+        }
+        ColumnPredicate::Between { low, high, .. } => {
+            let low_mask = timestamp_cmp_mask(values, low, TimestampCmpOp::Ge)?;
+            let high_mask = timestamp_cmp_mask(values, high, TimestampCmpOp::Le)?;
+            low_mask.iter().zip(high_mask.iter()).map(|(&l, &h)| l && h).collect()
+        }
+        ColumnPredicate::InList { values: list_values, negated, .. } => {
+            let mut result = vec![false; values.len()];
+            for list_val in list_values {
+                // NULL list elements match nothing
+                if matches!(list_val, SqlValue::Null) {
+                    continue;
+                }
+                // Non-temporal, non-string list elements match nothing
+                // (consistent with the scalar comparator's Incomparable)
+                if value_to_timestamp_i64(list_val).is_none() && !is_string_value(list_val) {
+                    continue;
+                }
+                let matches = timestamp_cmp_mask(values, list_val, TimestampCmpOp::Eq)?;
+                for (i, &m) in matches.iter().enumerate() {
+                    result[i] = result[i] || m;
+                }
+            }
+            if *negated {
+                result.iter_mut().for_each(|v| *v = !*v);
+            }
+            result
+        }
+        ColumnPredicate::Like { .. } => {
+            return Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "LIKE".to_string(),
+                left_type: "Timestamp".to_string(),
+                right_type: Some("String pattern".to_string()),
+            });
+        }
+        // ColumnCompare is handled at higher level in simd_filter/mod.rs
+        ColumnPredicate::ColumnCompare { .. } => {
+            return Err(ExecutorError::ColumnarTypeMismatch {
+                operation: "column-to-column comparison".to_string(),
+                left_type: "Timestamp".to_string(),
+                right_type: Some("Should be handled in simd_filter/mod.rs".to_string()),
+            });
+        }
+    };
+
+    // Apply NULL mask: NULLs always fail predicates
+    if let Some(null_mask) = nulls {
+        for (i, is_null) in null_mask.iter().enumerate() {
+            if *is_null {
+                result[i] = false;
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Evaluate predicate on a Timestamp column returning a packed mask
+///
+/// Packed-mask counterpart of `evaluate_predicate_timestamp_simd`.
+pub fn evaluate_predicate_timestamp_packed(
+    predicate: &ColumnPredicate,
+    values: &[i64],
+    nulls: Option<&[bool]>,
+) -> Result<PackedMask, ExecutorError> {
+    let bool_mask = evaluate_predicate_timestamp_simd(predicate, values, nulls)?;
+    Ok(PackedMask::from_bool_slice(&bool_mask))
 }
 
 /// Evaluate predicate on i32 column using SIMD (for dates)
@@ -677,8 +843,6 @@ pub fn evaluate_predicate_i64_packed(
                 simd_ops::lt_i64_packed(values, *threshold)
             } else if let SqlValue::Bigint(threshold) = value {
                 simd_ops::lt_i64_packed(values, *threshold)
-            } else if let Some(threshold) = value_to_timestamp_i64(value) {
-                simd_ops::lt_i64_packed(values, threshold)
             } else {
                 let threshold =
                     value_to_f64(value).ok_or_else(|| ExecutorError::ColumnarTypeMismatch {

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/mod.rs
@@ -396,7 +396,9 @@ fn evaluate_predicate_for_range(
         ColumnArray::Timestamp(values, nulls) => {
             let values_slice = &values[start..end];
             let nulls_slice = nulls.as_ref().map(|n| &n[start..end] as &[bool]);
-            comparison::evaluate_predicate_i64_simd(predicate, values_slice, nulls_slice)
+            // Issue #5335: Timestamp columns need temporal semantics, not the
+            // INTEGER-affinity semantics of the i64 kernel
+            comparison::evaluate_predicate_timestamp_simd(predicate, values_slice, nulls_slice)
         }
         ColumnArray::String(values, nulls) => {
             let values_slice = &values[start..end];
@@ -654,10 +656,13 @@ fn evaluate_predicate_simd_packed(
             evaluate_predicate_i32_packed(predicate, values, nulls.as_ref().map(|n| n.as_slice()))
         }
 
-        // Packed path for Timestamp columns (i64)
-        ColumnArray::Timestamp(values, nulls) => {
-            evaluate_predicate_i64_packed(predicate, values, nulls.as_ref().map(|n| n.as_slice()))
-        }
+        // Packed path for Timestamp columns (i64 microseconds; issue #5335:
+        // temporal semantics, not the INTEGER-affinity i64 kernel)
+        ColumnArray::Timestamp(values, nulls) => comparison::evaluate_predicate_timestamp_packed(
+            predicate,
+            values,
+            nulls.as_ref().map(|n| n.as_slice()),
+        ),
 
         // For other types, fall back to Vec<bool> and convert
         _ => {
@@ -717,10 +722,13 @@ fn evaluate_predicate_simd(
             evaluate_predicate_i32_simd(predicate, values, nulls.as_ref().map(|n| n.as_slice()))
         }
 
-        // SIMD path for Timestamp columns (i64 - microseconds since epoch)
-        ColumnArray::Timestamp(values, nulls) => {
-            evaluate_predicate_i64_simd(predicate, values, nulls.as_ref().map(|n| n.as_slice()))
-        }
+        // SIMD path for Timestamp columns (i64 microseconds; issue #5335:
+        // temporal semantics, not the INTEGER-affinity i64 kernel)
+        ColumnArray::Timestamp(values, nulls) => comparison::evaluate_predicate_timestamp_simd(
+            predicate,
+            values,
+            nulls.as_ref().map(|n| n.as_slice()),
+        ),
 
         // Batch string operations for String columns
         ColumnArray::String(values, nulls) => {

--- a/crates/vibesql-executor/tests/temporal_index_probe_tests.rs
+++ b/crates/vibesql-executor/tests/temporal_index_probe_tests.rs
@@ -301,14 +301,14 @@ fn expression_index_date_unparseable_bound_matches_full_scan_error() {
 // ---------------------------------------------------------------------------
 // Plain TIMESTAMP column index (t4 repro from the issue)
 //
-// NOTE: these assert literal expected values (executor semantics) for the
-// INDEXED queries instead of diffing against DROP INDEX, because the
-// full-scan WHERE path has its own pre-existing temporal-vs-string bug (the
-// columnar SIMD filter and CompiledPredicate lack the #5329 semantics and
-// over-return — `WHERE ts = 'zzz'` returns every row via a full scan). That
-// is tracked separately in issue #5335; once fixed, these can be upgraded to
-// indexed-vs-full-scan comparisons like the expression-index tests above.
+// Issue #5335 fixed the full-scan WHERE path (the columnar comparators and
+// CompiledPredicate now implement the #5329 temporal semantics), so these
+// tests assert the same indexed-vs-DROP-INDEX invariant as the
+// expression-index tests above, in addition to the literal expected values.
 // ---------------------------------------------------------------------------
+
+const T4_CREATE_INDEX: &str = "CREATE INDEX t4ts ON t4(ts)";
+const T4_DROP_INDEX: &str = "DROP INDEX t4ts";
 
 fn timestamp_column_db() -> Database {
     let mut db = Database::new();
@@ -317,24 +317,23 @@ fn timestamp_column_db() -> Database {
         "CREATE TABLE t4 (id INTEGER PRIMARY KEY, ts TIMESTAMP);
          INSERT INTO t4 VALUES (1, TIMESTAMP '2017-07-20 15:30:00');
          INSERT INTO t4 VALUES (2, TIMESTAMP '2017-07-22 08:00:00');
-         INSERT INTO t4 VALUES (3, TIMESTAMP '2017-07-25 23:59:59');
-         CREATE INDEX t4ts ON t4(ts)",
+         INSERT INTO t4 VALUES (3, TIMESTAMP '2017-07-25 23:59:59')",
     );
+    execute_sql(&mut db, T4_CREATE_INDEX);
     db
 }
 
-fn check_t4(db: &Database, sql: &str, expected: &[i64]) {
-    let rows = select_ints(db, sql).unwrap_or_else(|e| panic!("query failed: {e}\n  sql: {sql}"));
-    assert_eq!(rows, expected, "wrong rows for indexed query: {sql}");
+fn check_t4(db: &mut Database, sql: &str, expected: &[i64]) {
+    assert_index_matches_full_scan(db, T4_CREATE_INDEX, T4_DROP_INDEX, sql, expected);
 }
 
 #[test]
 fn column_index_timestamp_equality_string() {
     // Was 0 rows before the fix (row loss).
-    let db = timestamp_column_db();
-    check_t4(&db, "SELECT id FROM t4 WHERE ts = '2017-07-20 15:30:00'", &[1]);
+    let mut db = timestamp_column_db();
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts = '2017-07-20 15:30:00'", &[1]);
     // TEXT-rendering semantics: a date-only string equals no timestamp.
-    check_t4(&db, "SELECT id FROM t4 WHERE ts = '2017-07-20'", &[]);
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts = '2017-07-20'", &[]);
 }
 
 #[test]
@@ -342,40 +341,44 @@ fn column_index_timestamp_no_over_return_on_lower_bound() {
     // The t4 repro: `ts >= '2017-07-21'` returned the 2017-07-20 row before
     // the fix because the probe over-returned and the planner skipped the
     // residual filter.
-    let db = timestamp_column_db();
-    check_t4(&db, "SELECT id FROM t4 WHERE ts >= '2017-07-21'", &[2, 3]);
-    check_t4(&db, "SELECT id FROM t4 WHERE ts > '2017-07-21'", &[2, 3]);
+    let mut db = timestamp_column_db();
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts >= '2017-07-21'", &[2, 3]);
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts > '2017-07-21'", &[2, 3]);
 }
 
 #[test]
 fn column_index_timestamp_between_and_upper_bounds() {
-    let db = timestamp_column_db();
-    check_t4(&db, "SELECT id FROM t4 WHERE ts BETWEEN '2017-07-21' AND '2017-07-23'", &[2]);
-    check_t4(&db, "SELECT id FROM t4 WHERE ts < '2017-07-22'", &[1]);
-    check_t4(&db, "SELECT id FROM t4 WHERE ts <= '2017-07-22 08:00:00'", &[1, 2]);
-    check_t4(&db, "SELECT id FROM t4 WHERE ts < '2017-07-22 08:00:00'", &[1]);
+    let mut db = timestamp_column_db();
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts BETWEEN '2017-07-21' AND '2017-07-23'", &[2]);
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts < '2017-07-22'", &[1]);
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts <= '2017-07-22 08:00:00'", &[1, 2]);
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts < '2017-07-22 08:00:00'", &[1]);
 }
 
 #[test]
 fn column_index_timestamp_in_list_and_typed_literals() {
-    let db = timestamp_column_db();
+    let mut db = timestamp_column_db();
     check_t4(
-        &db,
+        &mut db,
         "SELECT id FROM t4 WHERE ts IN ('2017-07-20 15:30:00', '2017-07-25 23:59:59')",
         &[1, 3],
     );
-    // Typed literals were already correct; pin that they stay correct.
-    check_t4(&db, "SELECT id FROM t4 WHERE ts = TIMESTAMP '2017-07-22 08:00:00'", &[2]);
-    check_t4(&db, "SELECT id FROM t4 WHERE ts >= TIMESTAMP '2017-07-22 08:00:00'", &[2, 3]);
+    // Typed literals: previously correct via the index but tautological on a
+    // full scan (issue #5335); both paths must agree now.
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts = TIMESTAMP '2017-07-22 08:00:00'", &[2]);
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts >= TIMESTAMP '2017-07-22 08:00:00'", &[2, 3]);
 }
 
 #[test]
 fn column_index_timestamp_unparseable_equality_is_empty() {
     // Junk strings never equal a timestamp rendering — no panic, no rows.
-    // (Range operators with junk bounds are governed by the residual-filter
-    // semantics tracked in #5335 and are not asserted here.)
-    let db = timestamp_column_db();
-    check_t4(&db, "SELECT id FROM t4 WHERE ts = 'hello'", &[]);
+    let mut db = timestamp_column_db();
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts = 'hello'", &[]);
+    // Junk-string range bounds follow TEXT-rendering semantics on both paths
+    // (every timestamp rendering starts with a digit, so ts < 'hello' is
+    // always true).
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts < 'hello'", &[1, 2, 3]);
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts > 'hello'", &[]);
 }
 
 #[test]
@@ -384,6 +387,6 @@ fn column_index_timestamp_null_keys_excluded_from_ranges() {
     // (SQL semantics: NULL < x is NULL, not true).
     let mut db = timestamp_column_db();
     execute_sql(&mut db, "INSERT INTO t4 VALUES (4, NULL)");
-    check_t4(&db, "SELECT id FROM t4 WHERE ts < '2017-07-23'", &[1, 2]);
-    check_t4(&db, "SELECT id FROM t4 WHERE ts >= '2017-07-21'", &[2, 3]);
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts < '2017-07-23'", &[1, 2]);
+    check_t4(&mut db, "SELECT id FROM t4 WHERE ts >= '2017-07-21'", &[2, 3]);
 }

--- a/crates/vibesql-executor/tests/timestamp_fullscan_filter_tests.rs
+++ b/crates/vibesql-executor/tests/timestamp_fullscan_filter_tests.rs
@@ -1,0 +1,385 @@
+//! Regression tests for full-scan WHERE filtering on temporal columns
+//! (issue #5335).
+//!
+//! The columnar full-scan comparators (`select/columnar/filter/comparison.rs`
+//! and the SIMD kernels) previously had **no match arms for Timestamp/Time at
+//! all** — both Timestamp-vs-string and Timestamp-vs-Timestamp comparisons
+//! fell through to a catch-all that returned `Ordering::Equal`, turning `=`,
+//! `<=`, `>=`, and BETWEEN into tautologies (all rows returned) and `<`, `>`,
+//! `!=` into contradictions (0 rows). Because `execute_table_scan` marks the
+//! WHERE clause as consumed after columnar filtering, the (correct)
+//! expression evaluator never re-checked the rows.
+//!
+//! These tests assert the #5329 semantics on full scans (no index):
+//! - Timestamp/Time vs string: compare TEXT renderings lexicographically
+//! - Timestamp vs Timestamp: ordinary temporal comparison
+//! - Date vs parseable string: parse-first; unparseable string: type-mismatch
+//!   error (same as the expression evaluator)
+//!
+//! Every WHERE result is also cross-checked against a per-row projection of
+//! the same predicate (`SELECT id, <pred> FROM t`), which exercises the
+//! expression evaluator — the canonical semantics. The matrix runs at two
+//! table sizes: 2 rows (scalar columnar path, below SIMD_COLUMNAR_THRESHOLD
+//! = 500) and 600 rows (SIMD / cached-columnar path) so the paths must agree
+//! across the threshold.
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Execute one or more non-SELECT SQL statements separated by ';'.
+fn execute_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            }
+            vibesql_ast::Statement::Insert(s) => {
+                InsertExecutor::execute(db, &s).expect("INSERT failed");
+            }
+            other => panic!("Unsupported statement type: {:?}", other),
+        }
+    }
+}
+
+/// Execute a SELECT and return the resulting rows.
+fn select_rows(db: &Database, sql: &str) -> Result<Vec<vibesql_storage::Row>, String> {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = vibesql_executor::SelectExecutor::new(db);
+        executor.execute(&select_stmt).map_err(|e| e.to_string())
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+/// Execute a SELECT and return the first column of each row as sorted i64s.
+fn select_ints(db: &Database, sql: &str) -> Result<Vec<i64>, String> {
+    let rows = select_rows(db, sql)?;
+    let mut out: Vec<i64> = rows
+        .iter()
+        .map(|row| match &row.values[0] {
+            SqlValue::Integer(i) => *i,
+            other => panic!("expected integer, got {:?}", other),
+        })
+        .collect();
+    out.sort_unstable();
+    Ok(out)
+}
+
+/// True if a projected predicate value is SQL true.
+fn is_sql_true(v: &SqlValue) -> bool {
+    match v {
+        SqlValue::Boolean(b) => *b,
+        SqlValue::Integer(i) => *i != 0,
+        SqlValue::Null => false,
+        other => panic!("expected boolean-ish predicate value, got {:?}", other),
+    }
+}
+
+/// Assert that `WHERE <pred>` returns exactly the rows for which the per-row
+/// projection `SELECT id, <pred>` (expression evaluator, canonical #5329
+/// semantics) is true. Returns the WHERE result so callers can also pin
+/// literal expected values.
+fn assert_where_matches_projection(db: &Database, table: &str, pred: &str) -> Vec<i64> {
+    let where_sql = format!("SELECT id FROM {table} WHERE {pred}");
+    let where_ids = select_ints(db, &where_sql)
+        .unwrap_or_else(|e| panic!("WHERE query failed: {e}\n  sql: {where_sql}"));
+
+    let proj_sql = format!("SELECT id, {pred} FROM {table}");
+    let proj_rows = select_rows(db, &proj_sql)
+        .unwrap_or_else(|e| panic!("projection query failed: {e}\n  sql: {proj_sql}"));
+    let mut proj_ids: Vec<i64> = proj_rows
+        .iter()
+        .filter(|row| is_sql_true(&row.values[1]))
+        .map(|row| match &row.values[0] {
+            SqlValue::Integer(i) => *i,
+            other => panic!("expected integer id, got {:?}", other),
+        })
+        .collect();
+    proj_ids.sort_unstable();
+
+    assert_eq!(
+        where_ids, proj_ids,
+        "WHERE filtering diverged from per-row projection for predicate: {pred}\n  WHERE:      {where_ids:?}\n  projection: {proj_ids:?}"
+    );
+    where_ids
+}
+
+/// The full operator matrix from the issue's verified failure table.
+/// Each entry: (predicate, expected ids for the 2-row table).
+fn small_table_matrix() -> Vec<(&'static str, Vec<i64>)> {
+    vec![
+        // Timestamp vs unparseable string (TEXT-rendering semantics)
+        ("ts = 'zzz'", vec![]),
+        ("ts != 'zzz'", vec![1, 2]),
+        ("ts < 'zzz'", vec![1, 2]),
+        ("ts <= 'zzz'", vec![1, 2]),
+        ("ts > 'zzz'", vec![]),
+        ("ts >= 'zzz'", vec![]),
+        // Timestamp vs canonical full rendering
+        ("ts = '2017-07-20 15:30:00'", vec![1]),
+        ("ts != '2017-07-20 15:30:00'", vec![2]),
+        ("ts <= '2017-07-20 15:30:00'", vec![1]),
+        ("ts > '2017-07-20 15:30:00'", vec![2]),
+        // Timestamp vs date-only string (lexicographic prefix semantics)
+        ("ts >= '2017-07-21'", vec![2]),
+        ("ts < '2017-07-21'", vec![1]),
+        ("ts BETWEEN '2017-07-19' AND '2017-07-21'", vec![1]),
+        // BETWEEN with mixed parseable/unparseable bounds
+        ("ts BETWEEN '2017-07-19' AND 'zzz'", vec![1, 2]),
+        // Numeric-looking string: the expression evaluator's NUMERIC-affinity
+        // rules coerce '1999' to a number first, and temporal-vs-numeric is
+        // always false (evaluator/operators/comparison/mod.rs). The WHERE
+        // path must match the evaluator - in particular it must NOT compare
+        // raw microseconds against 1999.0 (the old SIMD i64 kernel did).
+        ("ts < '1999'", vec![]),
+        ("ts > '1999'", vec![]),
+        ("ts = '1999'", vec![]),
+        // Timestamp literals (new defect: tautology/contradiction on full scan)
+        ("ts = TIMESTAMP '2017-07-20 15:30:00'", vec![1]),
+        ("ts != TIMESTAMP '2017-07-20 15:30:00'", vec![2]),
+        ("ts < TIMESTAMP '2017-07-22 08:00:00'", vec![1]),
+        ("ts <= TIMESTAMP '2017-07-22 08:00:00'", vec![1, 2]),
+        ("ts > TIMESTAMP '2017-07-20 15:30:00'", vec![2]),
+        ("ts >= TIMESTAMP '2017-07-22 08:00:00'", vec![2]),
+        ("ts BETWEEN TIMESTAMP '2017-07-19 00:00:00' AND TIMESTAMP '2017-07-21 00:00:00'", vec![1]),
+        // IN list mixing strings and junk
+        ("ts IN ('2017-07-20 15:30:00', 'zzz')", vec![1]),
+        ("ts IN (TIMESTAMP '2017-07-22 08:00:00', 'zzz')", vec![2]),
+    ]
+}
+
+fn small_timestamp_db() -> Database {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        "CREATE TABLE t4 (id INTEGER PRIMARY KEY, ts TIMESTAMP);
+         INSERT INTO t4 VALUES (1, TIMESTAMP '2017-07-20 15:30:00');
+         INSERT INTO t4 VALUES (2, TIMESTAMP '2017-07-22 08:00:00')",
+    );
+    db
+}
+
+/// 600-row table (above SIMD_COLUMNAR_THRESHOLD = 500) exercising the SIMD /
+/// cached-columnar filter path. ids 1 and 2 carry the same timestamps as the
+/// small table; ids 3..=600 are hourly timestamps starting 2017-08-01 so the
+/// small-table expectations carry over for predicates bounded before August.
+fn large_timestamp_db() -> Database {
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t5 (id INTEGER PRIMARY KEY, ts TIMESTAMP)");
+    execute_sql(
+        &mut db,
+        "INSERT INTO t5 VALUES (1, TIMESTAMP '2017-07-20 15:30:00');
+         INSERT INTO t5 VALUES (2, TIMESTAMP '2017-07-22 08:00:00')",
+    );
+    let mut inserts = String::new();
+    for id in 3..=600i64 {
+        let offset_hours = id - 3;
+        let day = 1 + (offset_hours / 24);
+        let hour = offset_hours % 24;
+        // 598 rows spread across 2017-08-01 .. 2017-08-25
+        inserts.push_str(&format!(
+            "INSERT INTO t5 VALUES ({id}, TIMESTAMP '2017-08-{day:02} {hour:02}:00:00');"
+        ));
+    }
+    execute_sql(&mut db, &inserts);
+    db
+}
+
+#[test]
+fn small_table_scalar_path_matrix() {
+    let db = small_timestamp_db();
+    for (pred, expected) in small_table_matrix() {
+        let ids = assert_where_matches_projection(&db, "t4", pred);
+        assert_eq!(ids, expected, "wrong rows for small-table predicate: {pred}");
+    }
+}
+
+#[test]
+fn large_table_simd_path_matrix() {
+    let db = large_timestamp_db();
+    for (pred, expected) in small_table_matrix() {
+        let ids = assert_where_matches_projection(&db, "t5", pred);
+        // Predicates without an upper bound also sweep in the August rows;
+        // only check the prefix ids that exist in the small table.
+        let prefix: Vec<i64> = ids.iter().copied().filter(|&id| id <= 2).collect();
+        assert_eq!(prefix, expected, "wrong (prefix) rows for large-table predicate: {pred}");
+    }
+}
+
+#[test]
+fn large_table_simd_counts() {
+    let db = large_timestamp_db();
+
+    // count(*) goes through the fused filter+aggregate path
+    let count =
+        select_ints(&db, "SELECT count(*) FROM t5 WHERE ts = 'zzz'").expect("count query failed");
+    assert_eq!(count, vec![0], "count(*) with junk string must be 0");
+
+    let count =
+        select_ints(&db, "SELECT count(*) FROM t5 WHERE ts != 'zzz'").expect("count query failed");
+    assert_eq!(count, vec![600], "count(*) != junk string must match every row");
+
+    // Timestamp literal range on a full scan (previously returned 0)
+    let count =
+        select_ints(&db, "SELECT count(*) FROM t5 WHERE ts < TIMESTAMP '2017-08-01 00:00:00'")
+            .expect("count query failed");
+    assert_eq!(count, vec![2], "only ids 1,2 predate August");
+
+    let count =
+        select_ints(&db, "SELECT count(*) FROM t5 WHERE ts >= TIMESTAMP '2017-08-01 00:00:00'")
+            .expect("count query failed");
+    assert_eq!(count, vec![598]);
+
+    // String bound spanning the August rows (TEXT-rendering semantics)
+    let count = select_ints(&db, "SELECT count(*) FROM t5 WHERE ts < '2017-08-02'")
+        .expect("count query failed");
+    // ids 1, 2 plus the 24 hourly rows on 2017-08-01
+    assert_eq!(count, vec![26]);
+}
+
+#[test]
+fn null_timestamps_excluded_from_all_predicates() {
+    let mut db = small_timestamp_db();
+    execute_sql(&mut db, "INSERT INTO t4 VALUES (3, NULL)");
+
+    for pred in
+        ["ts < 'zzz'", "ts != 'zzz'", "ts <= TIMESTAMP '2017-07-22 08:00:00'", "ts >= '2017-07-01'"]
+    {
+        let ids = assert_where_matches_projection(&db, "t4", pred);
+        assert!(!ids.contains(&3), "NULL timestamp row must not match predicate: {pred}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TIME columns: same TEXT-rendering fallback semantics as Timestamp (#5329)
+// ---------------------------------------------------------------------------
+
+fn time_db(rows: usize) -> Database {
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE tt (id INTEGER PRIMARY KEY, t TIME)");
+    execute_sql(
+        &mut db,
+        "INSERT INTO tt VALUES (1, TIME '08:00:00');
+         INSERT INTO tt VALUES (2, TIME '15:30:00')",
+    );
+    if rows > 2 {
+        let mut inserts = String::new();
+        for id in 3..=rows {
+            let minute = (id - 3) % 60;
+            let second = (id - 3) / 60;
+            inserts.push_str(&format!(
+                "INSERT INTO tt VALUES ({id}, TIME '20:{minute:02}:{second:02}');"
+            ));
+        }
+        execute_sql(&mut db, &inserts);
+    }
+    db
+}
+
+fn time_matrix() -> Vec<(&'static str, Vec<i64>)> {
+    vec![
+        ("t = '08:00:00'", vec![1]),
+        ("t = 'zzz'", vec![]),
+        ("t != 'zzz'", vec![1, 2]),
+        ("t < 'zzz'", vec![1, 2]),
+        ("t > 'zzz'", vec![]),
+        ("t >= '09:00'", vec![2]),
+        ("t = TIME '15:30:00'", vec![2]),
+        ("t < TIME '15:30:00'", vec![1]),
+        ("t >= TIME '08:00:00'", vec![1, 2]),
+    ]
+}
+
+#[test]
+fn time_column_scalar_path_matrix() {
+    let db = time_db(2);
+    for (pred, expected) in time_matrix() {
+        let ids = assert_where_matches_projection(&db, "tt", pred);
+        assert_eq!(ids, expected, "wrong rows for TIME predicate: {pred}");
+    }
+}
+
+#[test]
+fn time_column_simd_path_matrix() {
+    // 600 rows: ids 3.. all have times in the 20:xx:xx range
+    let db = time_db(600);
+    for (pred, expected) in time_matrix() {
+        let ids = assert_where_matches_projection(&db, "tt", pred);
+        let prefix: Vec<i64> = ids.iter().copied().filter(|&id| id <= 2).collect();
+        assert_eq!(prefix, expected, "wrong (prefix) rows for TIME predicate: {pred}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DATE columns: parse-first for parseable strings; unparseable strings raise
+// the expression evaluator's type-mismatch error (#5329)
+// ---------------------------------------------------------------------------
+
+fn date_db(rows: usize) -> Database {
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE td (id INTEGER PRIMARY KEY, d DATE)");
+    execute_sql(
+        &mut db,
+        "INSERT INTO td VALUES (1, DATE '2017-07-20');
+         INSERT INTO td VALUES (2, DATE '2017-07-22')",
+    );
+    if rows > 2 {
+        let mut inserts = String::new();
+        for id in 3..=rows {
+            let day = 1 + ((id - 3) % 28);
+            let month = 8 + ((id - 3) / 28) % 4;
+            inserts.push_str(&format!(
+                "INSERT INTO td VALUES ({id}, DATE '2017-{month:02}-{day:02}');"
+            ));
+        }
+        execute_sql(&mut db, &inserts);
+    }
+    db
+}
+
+#[test]
+fn date_column_parseable_strings_parse_first() {
+    for rows in [2usize, 600] {
+        let db = date_db(rows);
+        let ids = assert_where_matches_projection(&db, "td", "d >= '2017-07-21'");
+        let prefix: Vec<i64> = ids.iter().copied().filter(|&id| id <= 2).collect();
+        assert_eq!(prefix, vec![2], "date range failed at {rows} rows");
+
+        let ids = assert_where_matches_projection(&db, "td", "d = '2017-07-20'");
+        assert_eq!(
+            ids.iter().copied().filter(|&id| id <= 2).collect::<Vec<_>>(),
+            vec![1],
+            "date equality failed at {rows} rows"
+        );
+    }
+}
+
+#[test]
+fn date_column_unparseable_string_raises_type_mismatch() {
+    for rows in [2usize, 600] {
+        let db = date_db(rows);
+        // The expression evaluator raises a type-mismatch error for DATE vs
+        // unparseable string; the full-scan WHERE path must match instead of
+        // silently filtering.
+        let result = select_ints(&db, "SELECT id FROM td WHERE d = 'not-a-date'");
+        assert!(
+            result.is_err(),
+            "DATE vs unparseable string must raise the evaluator's type-mismatch error \
+             ({rows} rows), got: {result:?}"
+        );
+        let result = select_ints(&db, "SELECT id FROM td WHERE d < 'zzz'");
+        assert!(
+            result.is_err(),
+            "DATE vs unparseable string must raise the evaluator's type-mismatch error \
+             ({rows} rows), got: {result:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the wrong-results bug where full-scan WHERE filtering on TIMESTAMP columns returned all rows for `=`/`<=`/`>=`/BETWEEN and 0 rows for `<`/`>`/`!=` — for both string operands AND genuine `TIMESTAMP` literals. The columnar comparators (`filter/comparison.rs` and a near-duplicate in `columnar/mod.rs`) had no Timestamp/Time arms at all; incomparable pairs fell into a catch-all returning `Ordering::Equal`, and `execute_table_scan` marks the WHERE clause consumed after columnar filtering so the (correct) expression evaluator never re-checked.

## Changes

- **Scalar comparator** (`select/columnar/filter/comparison.rs`): added Timestamp/Time same-type arms (temporal compare), Timestamp/Time-vs-string arms (TEXT-rendering lexicographic, #5329), plus Boolean/Blob arms that previously also hit the Equal catch-all. The catch-all now returns a new `CompareResult::Incomparable` that conservatively fails every predicate instead of reporting equality.
- **Duplicate comparator removed** (`select/columnar/mod.rs`): `fast_aggregate_on_rows`'s private `compare_values`/`strict_type_equal`/`evaluate_predicate` (same catch-all bug, plus NULL-compares-Equal) deleted; now delegates to the canonical `filter::evaluation` comparator.
- **Type-aware pushdown decline** (`select/columnar/filter/predicates.rs` + new `CombinedSchema::get_column_type_by_index`): extraction declines pushdown — all-or-nothing, since callers mark the WHERE consumed — for combinations the comparators cannot evaluate faithfully:
  - DATE vs unparseable string (the evaluator raises a type-mismatch error, which the comparators have no channel for)
  - numeric-parseable strings vs Timestamp/Time columns (the evaluator's NUMERIC-affinity rules coerce these to numbers first; temporal-vs-numeric is then `false`, not a TEXT comparison)
  - temporal columns vs non-temporal/mismatched-temporal literals, and mixed temporal column-to-column compares
  - DATE vs **parseable** string stays on the fast path (TPC-H date-range predicates), verified by a unit test.
- **SIMD kernels** (`simd_filter/comparison.rs` + dispatch in `simd_filter/mod.rs`): Timestamp columns no longer share the INTEGER-affinity i64 kernel. New `evaluate_predicate_timestamp_simd`/`_packed` handle `SqlValue::Timestamp` literals for every operator via i64 microsecond SIMD, and string operands via per-row TEXT-rendering comparison (exact parity with the scalar path across the 500-row threshold). The LessThan-only Timestamp-literal asymmetry in the i64 kernels was removed.
- **CompiledPredicate** (`evaluator/compiled.rs`): `values_equal`/`compare_range` gained temporal same-type and vs-string arms (previously cross-type `PartialEq`/`None`, i.e. always-false / exclude on index-scan residual filters); compilation declines for Date-vs-unparseable-string and mismatched temporal pairings so the full evaluator runs.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Issue repro queries return 0 / {1} / {2} / 0 | PASS | `small_table_scalar_path_matrix` + `large_table_simd_counts` in new `timestamp_fullscan_filter_tests.rs` |
| `ts < 'hello'` (junk string) returns all rows, matching per-row `SELECT ts < 'hello'` | PASS | every matrix entry is cross-checked against the per-row projection (expression evaluator) |
| DATE variants: parseable parse-first; unparseable raises type-mismatch error | PASS | `date_column_parseable_strings_parse_first`, `date_column_unparseable_string_raises_type_mismatch` (both at 2 and 600 rows) |
| `temporal_index_probe_tests.rs` t4 section upgraded to indexed-vs-DROP-INDEX parity | PASS | `check_t4` now uses `assert_index_matches_full_scan`; all 18 tests pass |
| `ts = TIMESTAMP '...'` / `ts < TIMESTAMP '...'` correct on full scan | PASS | matrix entries + `large_table_simd_counts` (598/2 split at the August boundary) |
| Results identical across the SIMD_COLUMNAR_THRESHOLD (500) | PASS | identical matrix asserted at 2 rows and 600 rows |
| catch-all no longer reports incomparable pairs as Equal (both copies) | PASS | `test_incomparable_types_not_equal` unit test; second copy deleted outright |

## Test Plan

- New `tests/timestamp_fullscan_filter_tests.rs`: full operator matrix (`=`, `!=`, `<`, `<=`, `>`, `>=`, BETWEEN, IN) for TIMESTAMP columns vs unparseable strings, canonical renderings, date-only strings, numeric-looking strings, and Timestamp literals — at 2 rows (scalar columnar path) and 600 rows (SIMD/cached-columnar path), each cross-checked against per-row `SELECT <pred>` projections; `count(*)` fused-aggregate variants; NULL exclusion; TIME and DATE column variants.
- Unit tests for `compare_values` arms and `Incomparable`, and for the extraction fence (decline + TPC-H fast-path guard).
- Full `vibesql-executor` suite: 96 binaries, 0 failures (2614 lib + integration tests).
- TCL conformance: `expr.test` (638 passed/0 failed) and `date.test` (1372 passed/0 failed) clean; `where.test` failures (where-5.102/103, where-24.5-24.9) verified byte-identical against the pre-change baseline binary — pre-existing, unrelated.
- TPC-H date pushdown guard: `test_date_column_parseable_string_still_extracted` pins Date-vs-parseable-string predicates to the columnar fast path; `tpch_strftime_sqlite_parity` passes.

### Note on numeric-looking strings

During implementation the per-row projection baseline revealed that the expression evaluator coerces numeric-parseable string literals (e.g. `'1999'`) to numbers via NUMERIC affinity before comparing, and temporal-vs-numeric yields `false` for every operator (`evaluator/operators/comparison/mod.rs`). The WHERE path now matches that exactly (parity is the issue's stated goal). Whether that evaluator rule itself should follow SQLite (`ts > '1999'` is true there via TEXT > NUMERIC type ordering) is a pre-existing question outside this PR's scope.

Closes #5335