### PR TITLE
ci: raise test job timeout from 25 to 35 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
   # ============================================================================
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Recent successful runs take 18-23 min (growing with the test suite); 25 min
+    # left too little headroom and caused timeout-kill flakes (see issue #5342).
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
The `test` job in `.github/workflows/ci.yml` has been brushing against its 25-minute `timeout-minutes` cap. PR #5339's first CI run was killed at 25m18s mid-way through integration tests, and recent successful runs took 20m10s-23m10s, leaving under 2-5 minutes of headroom. This raises the cap to 35 minutes to eliminate spurious timeout-kill flakes while the suite continues to grow.

## Changes
- Raise `timeout-minutes` for the `test` job from 25 to 35
- Add a comment documenting typical run durations (18-23 min) and the rationale

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `timeout-minutes` raised for the `test` job | ✅ | `.github/workflows/ci.yml` line 56: `timeout-minutes: 35` |
| Workflow YAML remains valid | ✅ | `python3 -c "import yaml; yaml.safe_load(...)"` parses cleanly |
| Other jobs' timeouts untouched | ✅ | `git diff` shows only the `test` job changed (3 insertions, 1 deletion) |

## Test Plan
- Validated YAML syntax with `yaml.safe_load`
- CI on this PR will exercise the workflow directly

## Merge Note
**This PR touches `.github/workflows/`, which the `gh` token cannot merge (no `workflow` scope — see PR #5255's history). Merge must be done via git push by the orchestrator.**

The issue's other suggested directions (avoiding the mid-job `cargo clean`, splitting integration tests into a matrix) are larger structural changes and intentionally out of scope here; they can be tracked separately if the suite keeps growing.

Closes #5342