### PR TITLE
fix(executor): columnar Blob/Boolean comparison parity + NULL-aware SIMD IN lists

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/filter/comparison.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/comparison.rs
@@ -221,6 +221,23 @@ pub(super) fn compare_values(a: &SqlValue, b: &SqlValue) -> CompareResult {
                 return CompareResult::Ordering(Ordering::Greater);
             }
 
+            // SQLite storage-class ordering (issue #5340): numeric < TEXT <
+            // BLOB. BLOB compares greater than every non-BLOB storage class,
+            // mirroring the expression evaluator
+            // (evaluator/operators/comparison/mod.rs). Without these arms,
+            // Blob-vs-string and Blob-vs-numeric pairs fell through to
+            // Incomparable and excluded every row, while the evaluator orders
+            // them (e.g. `blob_col >= 'abc'` is true for every non-NULL
+            // blob).
+            let a_is_blob = matches!(a, SqlValue::Blob(_));
+            let b_is_blob = matches!(b, SqlValue::Blob(_));
+            if a_is_blob && (is_string(b) || is_numeric(b)) {
+                return CompareResult::Ordering(Ordering::Greater);
+            }
+            if b_is_blob && (is_string(a) || is_numeric(a)) {
+                return CompareResult::Ordering(Ordering::Less);
+            }
+
             // Non-comparable types: no defined ordering in this comparator.
             // Issue #5335: this used to return Ordering::Equal, which made
             // every equality/range predicate on such pairs a tautology or a
@@ -485,6 +502,46 @@ mod tests {
             compare_values(&SqlValue::Blob(vec![0x61, 0x62]), &SqlValue::Blob(vec![0x61, 0x63])),
             CompareResult::Ordering(Ordering::Less)
         );
+    }
+
+    /// Issue #5340: Blob vs string/numeric uses SQLite storage-class ordering
+    /// (numeric < TEXT < BLOB), mirroring the expression evaluator. Before
+    /// this fix these pairs hit the Incomparable catch-all and excluded every
+    /// row (e.g. `blob_col >= 'abc'` matched nothing instead of everything).
+    #[test]
+    fn test_blob_vs_string_and_numeric_type_ordering() {
+        use std::cmp::Ordering;
+        let blob = SqlValue::Blob(vec![0x61, 0x62]); // x'6162' = "ab" bytes
+
+        // BLOB > TEXT, even when the bytes equal the string's bytes
+        assert_eq!(
+            compare_values(&blob, &varchar("ab")),
+            CompareResult::Ordering(Ordering::Greater),
+            "BLOB must compare greater than TEXT (never equal)"
+        );
+        assert_eq!(
+            compare_values(&varchar("zzz"), &blob),
+            CompareResult::Ordering(Ordering::Less),
+            "TEXT must compare less than BLOB"
+        );
+
+        // BLOB > numeric
+        assert_eq!(
+            compare_values(&blob, &SqlValue::Integer(5)),
+            CompareResult::Ordering(Ordering::Greater)
+        );
+        assert_eq!(
+            compare_values(&SqlValue::Double(1e9), &blob),
+            CompareResult::Ordering(Ordering::Less)
+        );
+
+        // NULL still wins over type ordering
+        assert_eq!(compare_values(&blob, &SqlValue::Null), CompareResult::Unknown);
+
+        // Boolean vs Blob has no evaluator ordering (TypeMismatch there);
+        // stays Incomparable here and pushdown is declined in predicates.rs.
+        assert_eq!(compare_values(&SqlValue::Boolean(true), &blob), CompareResult::Incomparable);
+        assert_eq!(compare_values(&blob, &SqlValue::Boolean(false)), CompareResult::Incomparable);
     }
 
     /// Test evaluate_predicate with text vs integer

--- a/crates/vibesql-executor/src/select/columnar/filter/evaluation.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/evaluation.rs
@@ -294,6 +294,13 @@ pub fn evaluate_predicate(predicate: &ColumnPredicate, value: &SqlValue) -> bool
             use std::cmp::Ordering;
             use vibesql_types::SqlValue;
 
+            // A NULL column value is UNKNOWN for both IN and NOT IN (issue
+            // #5341): excluded in WHERE context. Without this check the
+            // negated branch below returned TRUE for NULL values.
+            if matches!(value, SqlValue::Null) {
+                return false;
+            }
+
             // Check if value matches any in the list
             let matches = list_values.iter().any(|list_val| {
                 // Handle NULL in list

--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -328,6 +328,26 @@ fn is_string_type(t: &DataType) -> bool {
     )
 }
 
+/// Whether a column's declared type is the binary (BLOB) type
+fn is_blob_type(t: &DataType) -> bool {
+    matches!(t, DataType::BinaryLargeObject)
+}
+
+/// Whether a literal value is one of the numeric types the columnar
+/// comparator (`compare_values`) has faithful arms for.
+fn is_numeric_value(v: &SqlValue) -> bool {
+    matches!(
+        v,
+        SqlValue::Integer(_)
+            | SqlValue::Bigint(_)
+            | SqlValue::Smallint(_)
+            | SqlValue::Float(_)
+            | SqlValue::Double(_)
+            | SqlValue::Real(_)
+            | SqlValue::Numeric(_)
+    )
+}
+
 /// Whether a string would be coerced to a number by the expression
 /// evaluator's NUMERIC-affinity rules (`try_coerce_string_to_numeric`).
 /// Temporal columns have NUMERIC affinity, so numeric-parseable string
@@ -372,17 +392,40 @@ fn value_supported_for_column(col_type: Option<&DataType>, value: &SqlValue) -> 
             SqlValue::Varchar(s) | SqlValue::Character(s) => !string_coerces_to_numeric(s),
             _ => false,
         },
+        // Issue #5340: the expression evaluator raises a type-mismatch error
+        // for Boolean vs string/BLOB/temporal operands, and the columnar
+        // comparator has no error channel, so decline those. Boolean vs
+        // Boolean and Boolean vs numeric compare faithfully in both paths
+        // (booleans coerce to 0/1).
+        Some(DataType::Boolean) => matches!(value, SqlValue::Boolean(_)) || is_numeric_value(value),
         Some(other) => match value {
             // Temporal literal against a non-temporal column: only string
             // columns have comparator support (parse-first for Date, TEXT
             // rendering for Timestamp/Time).
             SqlValue::Date(_) | SqlValue::Timestamp(_) | SqlValue::Time(_) => is_string_type(other),
+            // Issue #5340: Blob literals are only supported against BLOB
+            // columns (bytewise comparison). Against numeric/string columns
+            // the evaluator applies storage-class ordering (numeric < TEXT <
+            // BLOB), but the numeric/string SIMD kernels have no blob arm
+            // (they raise ColumnarTypeMismatch), so decline and let the
+            // evaluator handle it.
+            SqlValue::Blob(_) => is_blob_type(other),
+            // Issue #5340: Boolean literal vs string/BLOB column raises a
+            // type-mismatch error in the evaluator; decline (no error
+            // channel in the columnar path).
+            SqlValue::Boolean(_) => !is_string_type(other) && !is_blob_type(other),
+            // Everything else (including string/numeric literals against
+            // BLOB columns, which compare_values orders via the #5340
+            // storage-class arms) keeps existing comparator behavior.
             _ => true,
         },
         // Unknown column type (e.g. outer-scope reference): allow existing
-        // behavior except for temporal literals, where we cannot prove the
-        // comparators have a faithful arm.
-        None => !matches!(value, SqlValue::Date(_) | SqlValue::Timestamp(_) | SqlValue::Time(_)),
+        // behavior except for temporal and Blob literals, where we cannot
+        // prove the comparators have a faithful arm.
+        None => !matches!(
+            value,
+            SqlValue::Date(_) | SqlValue::Timestamp(_) | SqlValue::Time(_) | SqlValue::Blob(_)
+        ),
     }
 }
 
@@ -1042,9 +1085,8 @@ mod tests {
         use std::str::FromStr;
         let schema = create_temporal_schema();
 
-        let ts_literal = SqlValue::Timestamp(
-            vibesql_types::Timestamp::from_str("2017-07-20 15:30:00").unwrap(),
-        );
+        let ts_literal =
+            SqlValue::Timestamp(vibesql_types::Timestamp::from_str("2017-07-20 15:30:00").unwrap());
         for value in [ts_literal, SqlValue::Varchar(arcstr::ArcStr::from("2017-07-21"))] {
             let expr = comparison_expr("ts", BinaryOperator::GreaterThanOrEqual, value.clone());
             assert!(
@@ -1116,6 +1158,89 @@ mod tests {
         );
         assert!(extract_column_predicates(&expr, &schema, false).is_some());
         assert!(extract_predicate_tree(&expr, &schema, false).is_some());
+    }
+
+    fn create_blob_bool_schema() -> CombinedSchema {
+        let schema = TableSchema::new(
+            "t".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new("b".to_string(), DataType::BinaryLargeObject, true),
+                ColumnSchema::new("flag".to_string(), DataType::Boolean, true),
+                ColumnSchema::new("s".to_string(), DataType::Varchar { max_length: None }, true),
+            ],
+        );
+        CombinedSchema::from_table("t".to_string(), schema)
+    }
+
+    /// Issue #5340: Blob columns vs string/numeric literals stay on the
+    /// columnar path (compare_values now implements the storage-class
+    /// ordering numeric < TEXT < BLOB), and Blob vs Blob is bytewise.
+    #[test]
+    fn test_blob_column_supported_literals_extracted() {
+        let schema = create_blob_bool_schema();
+        for value in [
+            SqlValue::Varchar(arcstr::ArcStr::from("abc")),
+            SqlValue::Integer(5),
+            SqlValue::Blob(vec![0x61, 0x62]),
+        ] {
+            let expr = comparison_expr("b", BinaryOperator::GreaterThanOrEqual, value.clone());
+            assert!(
+                extract_column_predicates(&expr, &schema, false).is_some(),
+                "expected pushdown for b >= {value:?}"
+            );
+            assert!(extract_predicate_tree(&expr, &schema, false).is_some());
+        }
+    }
+
+    /// Issue #5340: combinations where the evaluator raises a type-mismatch
+    /// error (no columnar error channel) or the SIMD kernels have no blob arm
+    /// must decline pushdown so the expression evaluator handles them.
+    #[test]
+    fn test_blob_boolean_unsupported_pairs_decline_extraction() {
+        let schema = create_blob_bool_schema();
+
+        // Boolean column vs string literal: evaluator raises TypeMismatch
+        let expr = comparison_expr(
+            "flag",
+            BinaryOperator::Equal,
+            SqlValue::Varchar(arcstr::ArcStr::from("true")),
+        );
+        assert!(extract_column_predicates(&expr, &schema, false).is_none());
+        assert!(extract_predicate_tree(&expr, &schema, false).is_none());
+
+        // Boolean column vs Blob literal: evaluator raises TypeMismatch
+        let expr = comparison_expr("flag", BinaryOperator::Equal, SqlValue::Blob(vec![0x01]));
+        assert!(extract_column_predicates(&expr, &schema, false).is_none());
+
+        // Blob column vs Boolean literal: evaluator raises TypeMismatch
+        let expr = comparison_expr("b", BinaryOperator::Equal, SqlValue::Boolean(true));
+        assert!(extract_column_predicates(&expr, &schema, false).is_none());
+
+        // String column vs Boolean literal: evaluator raises TypeMismatch
+        let expr = comparison_expr("s", BinaryOperator::Equal, SqlValue::Boolean(true));
+        assert!(extract_column_predicates(&expr, &schema, false).is_none());
+
+        // Numeric/string column vs Blob literal: the numeric/string SIMD
+        // kernels have no blob arm, so decline (evaluator orders these)
+        let expr = comparison_expr("id", BinaryOperator::LessThan, SqlValue::Blob(vec![0x01]));
+        assert!(extract_column_predicates(&expr, &schema, false).is_none());
+        let expr = comparison_expr("s", BinaryOperator::LessThan, SqlValue::Blob(vec![0x01]));
+        assert!(extract_column_predicates(&expr, &schema, false).is_none());
+    }
+
+    /// Issue #5340: Boolean columns keep pushdown for the pairs both paths
+    /// evaluate faithfully (Boolean and numeric operands coerce to 0/1).
+    #[test]
+    fn test_boolean_column_supported_literals_extracted() {
+        let schema = create_blob_bool_schema();
+        for value in [SqlValue::Boolean(true), SqlValue::Integer(1)] {
+            let expr = comparison_expr("flag", BinaryOperator::Equal, value.clone());
+            assert!(
+                extract_column_predicates(&expr, &schema, false).is_some(),
+                "expected pushdown for flag = {value:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/comparison.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/comparison.rs
@@ -246,6 +246,12 @@ pub fn evaluate_predicate_i64_simd(
         }
 
         ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // SQL three-valued logic (issue #5341): a NULL list element never
+            // matches, but it poisons NOT IN — when no element matches the
+            // result is UNKNOWN, so `x NOT IN (..., NULL)` is never TRUE.
+            if *negated && list_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+                return Ok(vec![false; values.len()]);
+            }
             // For i64 columns, check if value is in the list
             let mut result = vec![false; values.len()];
             for i64_val in list_values {
@@ -407,6 +413,12 @@ pub fn evaluate_predicate_timestamp_simd(
             low_mask.iter().zip(high_mask.iter()).map(|(&l, &h)| l && h).collect()
         }
         ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // SQL three-valued logic (issue #5341): a NULL list element never
+            // matches, but it poisons NOT IN — when no element matches the
+            // result is UNKNOWN, so `x NOT IN (..., NULL)` is never TRUE.
+            if *negated && list_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+                return Ok(vec![false; values.len()]);
+            }
             let mut result = vec![false; values.len()];
             for list_val in list_values {
                 // NULL list elements match nothing
@@ -561,6 +573,12 @@ pub fn evaluate_predicate_i32_simd(
         }
 
         ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // SQL three-valued logic (issue #5341): a NULL list element never
+            // matches, but it poisons NOT IN — when no element matches the
+            // result is UNKNOWN, so `x NOT IN (..., NULL)` is never TRUE.
+            if *negated && list_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+                return Ok(vec![false; values.len()]);
+            }
             // For date (i32) columns, check if value is in the list
             let mut result = vec![false; values.len()];
             for date_val in list_values {
@@ -753,6 +771,12 @@ pub fn evaluate_predicate_f64_simd(
         }
 
         ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // SQL three-valued logic (issue #5341): a NULL list element never
+            // matches, but it poisons NOT IN — when no element matches the
+            // result is UNKNOWN, so `x NOT IN (..., NULL)` is never TRUE.
+            if *negated && list_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+                return Ok(vec![false; values.len()]);
+            }
             // For f64 columns, check if value is in the list
             let mut result = vec![false; values.len()];
             for f_val in list_values {
@@ -1039,6 +1063,12 @@ pub fn evaluate_predicate_i64_packed(
         }
 
         ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // SQL three-valued logic (issue #5341): a NULL list element never
+            // matches, but it poisons NOT IN — when no element matches the
+            // result is UNKNOWN, so `x NOT IN (..., NULL)` is never TRUE.
+            if *negated && list_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+                return Ok(PackedMask::new_all_clear(values.len()));
+            }
             // For i64 columns with packed mask
             let mut result = PackedMask::new_all_clear(values.len());
             for i64_val in list_values {
@@ -1183,6 +1213,12 @@ pub fn evaluate_predicate_i32_packed(
         }
 
         ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // SQL three-valued logic (issue #5341): a NULL list element never
+            // matches, but it poisons NOT IN — when no element matches the
+            // result is UNKNOWN, so `x NOT IN (..., NULL)` is never TRUE.
+            if *negated && list_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+                return Ok(PackedMask::new_all_clear(values.len()));
+            }
             // For date (i32) columns with packed mask
             let mut result = PackedMask::new_all_clear(values.len());
             for date_val in list_values {
@@ -1373,6 +1409,12 @@ pub fn evaluate_predicate_f64_packed(
         }
 
         ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // SQL three-valued logic (issue #5341): a NULL list element never
+            // matches, but it poisons NOT IN — when no element matches the
+            // result is UNKNOWN, so `x NOT IN (..., NULL)` is never TRUE.
+            if *negated && list_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+                return Ok(PackedMask::new_all_clear(values.len()));
+            }
             // For f64 columns with packed mask
             let mut result = PackedMask::new_all_clear(values.len());
             for f_val in list_values {

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/mod.rs
@@ -53,10 +53,12 @@ fn predicate_contains_null(predicate: &ColumnPredicate) -> bool {
         }
         // LIKE patterns don't have NULL values in the pattern itself
         ColumnPredicate::Like { .. } => false,
-        // IN list may contain NULL values
-        ColumnPredicate::InList { values, .. } => {
-            values.iter().any(|v| matches!(v, SqlValue::Null))
-        }
+        // IN/NOT IN implement SQL three-valued logic for NULL list elements
+        // in the kernels themselves (issue #5341): a NULL element never
+        // matches for IN, and poisons NOT IN (the result is never TRUE).
+        // Don't short-circuit to all-false here — doing so excluded
+        // genuinely matching rows for `x IN (a, NULL)`.
+        ColumnPredicate::InList { .. } => false,
         // Column-to-column comparisons don't have literal NULLs
         // (NULL columns are handled during evaluation)
         ColumnPredicate::ColumnCompare { .. } => false,

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/string.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/string.rs
@@ -266,17 +266,15 @@ pub fn evaluate_predicate_string_batch(
         }
 
         ColumnPredicate::InList { values: list_values, negated, .. } => {
+            // SQL three-valued logic (issue #5341): a NULL list element never
+            // matches, but it poisons NOT IN — when no element matches the
+            // result is UNKNOWN, so `x NOT IN (..., NULL)` is never TRUE.
+            if *negated && list_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+                return Ok(vec![false; values.len()]);
+            }
+
             // For string columns, check if value is in the list
             let mut result = vec![false; values.len()];
-
-            // Apply null mask first
-            if let Some(null_mask) = nulls {
-                for (i, &is_null) in null_mask.iter().enumerate() {
-                    if is_null {
-                        result[i] = false;
-                    }
-                }
-            }
 
             // Check each list value
             for list_val in list_values {
@@ -291,7 +289,18 @@ pub fn evaluate_predicate_string_batch(
             }
 
             if *negated {
-                result.iter_mut().for_each(|v| *v = !*v);
+                // Invert only non-NULL rows: a NULL column value is UNKNOWN
+                // for NOT IN, not TRUE (issue #5341 — the unconditional
+                // inversion used to resurrect NULL rows)
+                if let Some(null_mask) = nulls {
+                    for (i, v) in result.iter_mut().enumerate() {
+                        if !null_mask[i] {
+                            *v = !*v;
+                        }
+                    }
+                } else {
+                    result.iter_mut().for_each(|v| *v = !*v);
+                }
             }
             result
         }

--- a/crates/vibesql-executor/tests/columnar_filter_type_pairs_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_filter_type_pairs_tests.rs
@@ -1,0 +1,389 @@
+//! Regression tests for full-scan WHERE filtering on Blob/Boolean type pairs
+//! (issue #5340) and IN/NOT IN lists containing NULL (issue #5341).
+//!
+//! Issue #5340: the columnar full-scan comparator
+//! (`select/columnar/filter/comparison.rs`) reported
+//! `CompareResult::Incomparable` for Blob-vs-string and Blob-vs-numeric
+//! pairs, conservatively excluding every row, while the expression evaluator
+//! orders them with SQLite's storage-class ordering (numeric < TEXT < BLOB) —
+//! so `blob_col >= 'abc'` is true for every non-NULL blob. Boolean-vs-string
+//! raises a type-mismatch error in the evaluator, which the columnar path
+//! cannot (no error channel), so pushdown is declined for that pair.
+//!
+//! Issue #5341: the SIMD InList kernels skipped NULL list elements and then
+//! blindly negated the match mask, so `x NOT IN ('x', NULL)` *included*
+//! non-matching rows above SIMD_COLUMNAR_THRESHOLD (500 rows). SQL
+//! three-valued logic: a NULL element poisons NOT IN — if no element matches
+//! the result is UNKNOWN, so `x NOT IN (..., NULL)` is never TRUE. The
+//! dispatch-level guard that previously masked this also excluded genuinely
+//! matching rows for positive `x IN (a, NULL)`.
+//!
+//! Every WHERE result is cross-checked against a per-row projection of the
+//! same predicate (`SELECT id, <pred>`), which exercises the expression
+//! evaluator — the canonical semantics. The matrix runs at two table sizes:
+//! 2 rows (scalar columnar path, below SIMD_COLUMNAR_THRESHOLD = 500) and
+//! 600 rows (SIMD / cached-columnar path) so the paths must agree across the
+//! threshold. All literal expectations were verified against sqlite3.
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Execute one or more non-SELECT SQL statements separated by ';'.
+fn execute_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            }
+            vibesql_ast::Statement::Insert(s) => {
+                InsertExecutor::execute(db, &s).expect("INSERT failed");
+            }
+            other => panic!("Unsupported statement type: {:?}", other),
+        }
+    }
+}
+
+/// Execute a SELECT and return the resulting rows.
+fn select_rows(db: &Database, sql: &str) -> Result<Vec<vibesql_storage::Row>, String> {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = vibesql_executor::SelectExecutor::new(db);
+        executor.execute(&select_stmt).map_err(|e| e.to_string())
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+/// Execute a SELECT and return the first column of each row as sorted i64s.
+fn select_ints(db: &Database, sql: &str) -> Result<Vec<i64>, String> {
+    let rows = select_rows(db, sql)?;
+    let mut out: Vec<i64> = rows
+        .iter()
+        .map(|row| match &row.values[0] {
+            SqlValue::Integer(i) => *i,
+            other => panic!("expected integer, got {:?}", other),
+        })
+        .collect();
+    out.sort_unstable();
+    Ok(out)
+}
+
+/// True if a projected predicate value is SQL true.
+fn is_sql_true(v: &SqlValue) -> bool {
+    match v {
+        SqlValue::Boolean(b) => *b,
+        SqlValue::Integer(i) => *i != 0,
+        SqlValue::Null => false,
+        other => panic!("expected boolean-ish predicate value, got {:?}", other),
+    }
+}
+
+/// Assert that `WHERE <pred>` returns exactly the rows for which the per-row
+/// projection `SELECT id, <pred>` (expression evaluator, canonical
+/// semantics) is true. Returns the WHERE result so callers can also pin
+/// literal expected values.
+fn assert_where_matches_projection(db: &Database, table: &str, pred: &str) -> Vec<i64> {
+    let where_sql = format!("SELECT id FROM {table} WHERE {pred}");
+    let where_ids = select_ints(db, &where_sql)
+        .unwrap_or_else(|e| panic!("WHERE query failed: {e}\n  sql: {where_sql}"));
+
+    let proj_sql = format!("SELECT id, {pred} FROM {table}");
+    let proj_rows = select_rows(db, &proj_sql)
+        .unwrap_or_else(|e| panic!("projection query failed: {e}\n  sql: {proj_sql}"));
+    let mut proj_ids: Vec<i64> = proj_rows
+        .iter()
+        .filter(|row| is_sql_true(&row.values[1]))
+        .map(|row| match &row.values[0] {
+            SqlValue::Integer(i) => *i,
+            other => panic!("expected integer id, got {:?}", other),
+        })
+        .collect();
+    proj_ids.sort_unstable();
+
+    assert_eq!(
+        where_ids, proj_ids,
+        "WHERE filtering diverged from per-row projection for predicate: {pred}\n  WHERE:      {where_ids:?}\n  projection: {proj_ids:?}"
+    );
+    where_ids
+}
+
+// ---------------------------------------------------------------------------
+// Issue #5340: Blob column vs string/numeric literals
+// (SQLite storage-class ordering: numeric < TEXT < BLOB)
+// ---------------------------------------------------------------------------
+
+/// Blob table with `rows` rows. ids 1 and 2 hold x'6162' ("ab" bytes) and
+/// x'7a7a' ("zz" bytes); ids 3.. hold varying two-byte blobs.
+fn blob_db(rows: usize) -> Database {
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE tb (id INTEGER PRIMARY KEY, b BLOB)");
+    execute_sql(
+        &mut db,
+        "INSERT INTO tb VALUES (1, x'6162');
+         INSERT INTO tb VALUES (2, x'7a7a')",
+    );
+    if rows > 2 {
+        let mut inserts = String::new();
+        for id in 3..=rows {
+            inserts.push_str(&format!(
+                "INSERT INTO tb VALUES ({id}, x'{:02x}{:02x}');",
+                id % 256,
+                (id / 256) % 256
+            ));
+        }
+        execute_sql(&mut db, &inserts);
+    }
+    db
+}
+
+/// (predicate, expected ids for the 2-row table) — sqlite3-verified:
+/// every BLOB orders greater than every TEXT and every numeric.
+fn blob_matrix() -> Vec<(&'static str, Vec<i64>)> {
+    vec![
+        // BLOB vs string: BLOB > TEXT for every row, regardless of bytes
+        ("b >= 'abc'", vec![1, 2]),
+        ("b > 'zzz'", vec![1, 2]),
+        // even when the blob's bytes equal the string's bytes (x'6162' = 'ab')
+        ("b = 'ab'", vec![]),
+        ("b != 'abc'", vec![1, 2]),
+        ("b < 'zzz'", vec![]),
+        ("b <= 'ab'", vec![]),
+        // BLOB vs numeric: BLOB > numeric for every row
+        ("b > 5", vec![1, 2]),
+        ("b >= 1000000", vec![1, 2]),
+        ("b <= 5", vec![]),
+        ("b = 5", vec![]),
+        ("b != 5", vec![1, 2]),
+        // BLOB vs BLOB: bytewise (sanity, pre-existing arm)
+        ("b = x'6162'", vec![1]),
+        ("b != x'6162'", vec![2]),
+        ("b < x'7a7a'", vec![1]),
+    ]
+}
+
+#[test]
+fn blob_column_scalar_path_matrix() {
+    let db = blob_db(2);
+    for (pred, expected) in blob_matrix() {
+        let ids = assert_where_matches_projection(&db, "tb", pred);
+        assert_eq!(ids, expected, "wrong rows for blob predicate: {pred}");
+    }
+}
+
+#[test]
+fn blob_column_simd_path_matrix() {
+    let db = blob_db(600);
+    for (pred, expected) in blob_matrix() {
+        let ids = assert_where_matches_projection(&db, "tb", pred);
+        let prefix: Vec<i64> = ids.iter().copied().filter(|&id| id <= 2).collect();
+        assert_eq!(prefix, expected, "wrong (prefix) rows for blob predicate: {pred}");
+    }
+
+    // Predicates true for *every* blob must sweep in all 600 rows
+    let ids = assert_where_matches_projection(&db, "tb", "b >= 'abc'");
+    assert_eq!(ids.len(), 600, "BLOB > TEXT must hold for every row");
+    let ids = assert_where_matches_projection(&db, "tb", "b > 5");
+    assert_eq!(ids.len(), 600, "BLOB > numeric must hold for every row");
+}
+
+#[test]
+fn null_blobs_excluded_from_all_predicates() {
+    for rows in [2usize, 600] {
+        let mut db = blob_db(rows);
+        execute_sql(&mut db, "INSERT INTO tb VALUES (100001, NULL)");
+        for pred in ["b >= 'abc'", "b != 'abc'", "b > 5", "b != x'6162'"] {
+            let ids = assert_where_matches_projection(&db, "tb", pred);
+            assert!(
+                !ids.contains(&100001),
+                "NULL blob row must not match predicate ({rows} rows): {pred}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Issue #5340: Boolean column vs string literal raises the evaluator's
+// type-mismatch error (pushdown declined; no columnar error channel)
+// ---------------------------------------------------------------------------
+
+fn boolean_db(rows: usize) -> Database {
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE tf (id INTEGER PRIMARY KEY, flag BOOLEAN)");
+    execute_sql(
+        &mut db,
+        "INSERT INTO tf VALUES (1, TRUE);
+         INSERT INTO tf VALUES (2, FALSE)",
+    );
+    if rows > 2 {
+        let mut inserts = String::new();
+        for id in 3..=rows {
+            let v = if id % 2 == 0 { "FALSE" } else { "TRUE" };
+            inserts.push_str(&format!("INSERT INTO tf VALUES ({id}, {v});"));
+        }
+        execute_sql(&mut db, &inserts);
+    }
+    db
+}
+
+#[test]
+fn boolean_column_vs_string_raises_type_mismatch() {
+    for rows in [2usize, 600] {
+        let db = boolean_db(rows);
+        // The expression evaluator raises a type-mismatch error for Boolean
+        // vs string; the full-scan WHERE path must match instead of silently
+        // excluding every row.
+        for pred in ["flag = 'true'", "flag != 'x'", "flag < 'zzz'"] {
+            let result = select_ints(&db, &format!("SELECT id FROM tf WHERE {pred}"));
+            assert!(
+                result.is_err(),
+                "Boolean vs string must raise the evaluator's type-mismatch error \
+                 ({rows} rows) for {pred}, got: {result:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn boolean_column_supported_pairs_still_filter() {
+    for rows in [2usize, 600] {
+        let db = boolean_db(rows);
+        // Boolean vs Boolean and Boolean vs numeric (0/1 coercion) keep
+        // working on both sides of the threshold.
+        let ids = assert_where_matches_projection(&db, "tf", "flag = TRUE");
+        assert!(ids.contains(&1) && !ids.contains(&2), "flag = TRUE wrong at {rows} rows");
+        let ids = assert_where_matches_projection(&db, "tf", "flag = 1");
+        assert!(ids.contains(&1) && !ids.contains(&2), "flag = 1 wrong at {rows} rows");
+        let ids = assert_where_matches_projection(&db, "tf", "flag = 0");
+        assert!(ids.contains(&2) && !ids.contains(&1), "flag = 0 wrong at {rows} rows");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Issue #5341: IN / NOT IN with NULL list elements (three-valued logic)
+// `x NOT IN (a, NULL)` is never TRUE; `x IN (a, NULL)` is TRUE only on match.
+// ---------------------------------------------------------------------------
+
+/// Table with integer, float, string, date, and timestamp value columns.
+/// `v` cycles 0..10, `f` = v + 0.5, `s` cycles 'a'..'e', dates/timestamps
+/// cycle across five days in July 2017. id 100001 (when `with_nulls`) holds
+/// NULL in every value column.
+fn inlist_db(rows: usize, with_nulls: bool) -> Database {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        "CREATE TABLE tn (id INTEGER PRIMARY KEY, v INTEGER, f DOUBLE PRECISION, \
+         s VARCHAR(10), d DATE, ts TIMESTAMP)",
+    );
+    let mut inserts = String::new();
+    for id in 1..=rows {
+        let v = id % 10;
+        let letter = (b'a' + (id % 5) as u8) as char;
+        let day = 20 + (id % 5);
+        inserts.push_str(&format!(
+            "INSERT INTO tn VALUES ({id}, {v}, {v}.5, '{letter}', DATE '2017-07-{day}', \
+             TIMESTAMP '2017-07-{day} 12:00:00');"
+        ));
+        if id % 100 == 0 {
+            execute_sql(&mut db, &inserts);
+            inserts.clear();
+        }
+    }
+    execute_sql(&mut db, &inserts);
+    if with_nulls {
+        execute_sql(&mut db, "INSERT INTO tn VALUES (100001, NULL, NULL, NULL, NULL, NULL)");
+    }
+    db
+}
+
+/// NOT IN lists containing NULL match no rows; IN lists containing NULL
+/// match only genuine matches. Exercises the i64, f64, string, date, and
+/// timestamp kernels (600 rows) and the scalar columnar path (2 rows).
+#[test]
+fn in_list_with_null_three_valued_logic() {
+    for rows in [2usize, 600] {
+        let db = inlist_db(rows, false);
+
+        // NOT IN with NULL in the list: never TRUE, for every kernel type
+        for pred in [
+            "v NOT IN (1, NULL)",
+            "f NOT IN (1.5, NULL)",
+            "s NOT IN ('a', NULL)",
+            "d NOT IN (DATE '2017-07-21', NULL)",
+            "ts NOT IN (TIMESTAMP '2017-07-21 12:00:00', NULL)",
+            "v NOT IN (NULL)",
+        ] {
+            let ids = assert_where_matches_projection(&db, "tn", pred);
+            assert_eq!(
+                ids,
+                Vec::<i64>::new(),
+                "NOT IN with NULL must match no rows ({rows} rows): {pred}"
+            );
+        }
+
+        // Positive IN with NULL in the list: matches only genuine matches
+        // (the old dispatch guard excluded these too)
+        let ids = assert_where_matches_projection(&db, "tn", "v IN (1, NULL)");
+        let expected: Vec<i64> = (1..=rows as i64).filter(|id| id % 10 == 1).collect();
+        assert_eq!(ids, expected, "IN with NULL must still match v = 1 ({rows} rows)");
+
+        let ids = assert_where_matches_projection(&db, "tn", "s IN ('a', NULL)");
+        let expected: Vec<i64> = (1..=rows as i64).filter(|id| id % 5 == 0).collect();
+        assert_eq!(ids, expected, "IN with NULL must still match s = 'a' ({rows} rows)");
+
+        // Sanity: NOT IN without NULL still filters normally
+        let ids = assert_where_matches_projection(&db, "tn", "v NOT IN (1, 2)");
+        let expected: Vec<i64> =
+            (1..=rows as i64).filter(|id| id % 10 != 1 && id % 10 != 2).collect();
+        assert_eq!(ids, expected, "plain NOT IN broken ({rows} rows)");
+    }
+}
+
+/// NULL column values are UNKNOWN for both IN and NOT IN — excluded in WHERE
+/// context (the string kernel's blind negation used to resurrect them, and
+/// the scalar columnar evaluator returned TRUE for negated lists).
+#[test]
+fn null_column_values_excluded_from_in_and_not_in() {
+    for rows in [2usize, 600] {
+        let db = inlist_db(rows, true);
+        for pred in [
+            "v NOT IN (1, 2)",
+            "s NOT IN ('a', 'b')",
+            "f NOT IN (1.5)",
+            "d NOT IN (DATE '2017-07-21')",
+            "ts NOT IN (TIMESTAMP '2017-07-21 12:00:00')",
+            "v IN (1, 2)",
+            "s IN ('a', 'b')",
+        ] {
+            let ids = assert_where_matches_projection(&db, "tn", pred);
+            assert!(
+                !ids.contains(&100001),
+                "NULL row must not match IN/NOT IN predicate ({rows} rows): {pred}"
+            );
+        }
+    }
+}
+
+/// count(*) goes through the fused filter+aggregate path (packed masks).
+#[test]
+fn in_list_with_null_packed_mask_counts() {
+    let db = inlist_db(600, false);
+
+    let count = select_ints(&db, "SELECT count(*) FROM tn WHERE v NOT IN (1, NULL)")
+        .expect("count query failed");
+    assert_eq!(count, vec![0], "NOT IN with NULL must count 0 rows");
+
+    let count = select_ints(&db, "SELECT count(*) FROM tn WHERE v IN (1, NULL)")
+        .expect("count query failed");
+    assert_eq!(count, vec![60], "IN with NULL must count the 60 rows where v = 1");
+
+    let count = select_ints(&db, "SELECT count(*) FROM tn WHERE v NOT IN (1, 2)")
+        .expect("count query failed");
+    assert_eq!(count, vec![480], "plain NOT IN must count rows where v NOT IN (1,2)");
+}


### PR DESCRIPTION
Closes #5340
Closes #5341

## Summary

Two related columnar-filter parity fixes (both filed by #5339's judge, same code area):

### #5340 — Blob/Boolean-vs-string pairs (residual from #5335)
- `select/columnar/filter/comparison.rs`: add SQLite storage-class ordering arms (numeric < TEXT < BLOB) to `compare_values`, mirroring `evaluator/operators/comparison/mod.rs`. `blob_col >= 'abc'` now matches every non-NULL blob on the columnar path instead of excluding everything via `Incomparable`.
- `select/columnar/filter/predicates.rs`: extend the #5339 pushdown fence to decline pairs the evaluator raises `TypeMismatch` for (Boolean column vs string/BLOB/temporal literal, string/BLOB column vs Boolean literal) and Blob literals against non-BLOB columns (the numeric/string SIMD kernels have no blob arm and would raise `ColumnarTypeMismatch`). Declined predicates fall back to the expression evaluator — correct over fast.

### #5341 — SIMD InList kernels vs NULL list elements (pre-existing, all kernels)
- Every SIMD `InList` arm (i64/f64/date/timestamp simd + i64/i32/f64 packed + string batch) now implements three-valued logic: a NULL list element never matches, and poisons NOT IN (`x NOT IN (..., NULL)` is never TRUE → all-false mask).
- The dispatch-level `predicate_contains_null` guard previously short-circuited *all* InList predicates containing NULL to all-false — accidentally correct for NOT IN, but it wrongly excluded genuinely matching rows for positive `x IN (a, NULL)`. InList now defers to the kernels.
- Two adjacent NULL bugs in the same family: the string kernel's blind mask negation resurrected NULL column rows under NOT IN, and the scalar columnar evaluator (`filter/evaluation.rs`) returned TRUE for a NULL column value under negated lists.

## Testing
- New `tests/columnar_filter_type_pairs_tests.rs`: 8 tests at 2 and 600 rows (across `SIMD_COLUMNAR_THRESHOLD = 500`), every WHERE result cross-checked against a per-row projection (expression evaluator = canonical), literal expectations verified against sqlite3. 7 of 8 fail without the source fixes.
- New unit tests: `compare_values` blob ordering; pushdown fence accept/decline matrices for Blob/Boolean columns.
- `cargo test -p vibesql-executor --lib`: 2627 passed.
- Columnar/SIMD integration suites (`columnar_storage`, `mvcc_simd_columnar_visibility`, `tpch_columnar_q1/q6`, `timestamp_fullscan_filter`): all green.
- TCL baselines unchanged: `where.test` 148 passed / 20 failed (identical pre-existing failure list verified against unmodified source), `expr.test` 638 passed / 0 failed.
- clippy/fmt: no new warnings; touched files formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)