### PR TITLE
fix(executor): coerce Boolean literals to 0/1 in SIMD numeric filter kernels

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/simd_filter/conversion.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/conversion.rs
@@ -34,6 +34,10 @@ pub fn value_to_f64(value: &SqlValue) -> Option<f64> {
         // without lossy string round-trip (fixes #2857)
         SqlValue::Numeric(n) => Some(*n),
         SqlValue::Real(n) => Some(*n as f64),
+        // Booleans are integers (0/1) in SQLite storage semantics, matching
+        // the scalar columnar comparator (`filter/comparison.rs::to_f64`) and
+        // the expression evaluator's boolean coercion (issue #5345).
+        SqlValue::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
         _ => None,
     }
 }

--- a/crates/vibesql-executor/tests/columnar_filter_type_pairs_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_filter_type_pairs_tests.rs
@@ -266,6 +266,89 @@ fn boolean_column_supported_pairs_still_filter() {
 }
 
 // ---------------------------------------------------------------------------
+// Issue #5345: Boolean literal vs numeric column on the SIMD kernels.
+// Booleans are integers (0/1) in SQLite storage semantics, so `v = TRUE`
+// matches rows where v = 1. The SIMD path's `value_to_f64` had no Boolean
+// arm and raised ColumnarTypeMismatch at/above SIMD_COLUMNAR_THRESHOLD while
+// the scalar path (below threshold) filtered correctly.
+// ---------------------------------------------------------------------------
+
+/// Integer + double columns; `v` = id % 2 (the issue's repro shape) and
+/// `f` = v as a float, so TRUE/FALSE literals partition the rows in half.
+fn numeric_db(rows: usize) -> Database {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        "CREATE TABLE ti (id INTEGER PRIMARY KEY, v INTEGER, f DOUBLE PRECISION)",
+    );
+    let mut inserts = String::new();
+    for id in 1..=rows {
+        let v = id % 2;
+        inserts.push_str(&format!("INSERT INTO ti VALUES ({id}, {v}, {v}.0);"));
+        if id % 100 == 0 {
+            execute_sql(&mut db, &inserts);
+            inserts.clear();
+        }
+    }
+    execute_sql(&mut db, &inserts);
+    db
+}
+
+/// Boolean literals against INTEGER and DOUBLE columns must coerce to 0/1
+/// on both sides of SIMD_COLUMNAR_THRESHOLD. sqlite3-verified: `v = TRUE`
+/// returns the v = 1 rows, `v != FALSE` the v <> 0 rows, etc.
+#[test]
+fn boolean_literal_vs_numeric_column_across_threshold() {
+    for rows in [2usize, 600] {
+        let db = numeric_db(rows);
+        let odd: Vec<i64> = (1..=rows as i64).filter(|id| id % 2 == 1).collect();
+        let even: Vec<i64> = (1..=rows as i64).filter(|id| id % 2 == 0).collect();
+        let all: Vec<i64> = (1..=rows as i64).collect();
+
+        // Equal / NotEqual kernels (the issue's repro)
+        let cases: Vec<(&str, &Vec<i64>)> = vec![
+            ("v = TRUE", &odd),
+            ("v = FALSE", &even),
+            ("v != FALSE", &odd),
+            ("v != TRUE", &even),
+            // LessThan / GreaterThan / Less-or-eq / Greater-or-eq kernels
+            ("v > FALSE", &odd),
+            ("v < TRUE", &even),
+            ("v >= TRUE", &odd),
+            ("v <= FALSE", &even),
+            ("v >= FALSE", &all),
+            // f64 kernels (same value_to_f64 conversion)
+            ("f = TRUE", &odd),
+            ("f != FALSE", &odd),
+            ("f < TRUE", &even),
+        ];
+        for (pred, expected) in cases {
+            let ids = assert_where_matches_projection(&db, "ti", pred);
+            assert_eq!(
+                &ids, expected,
+                "wrong rows for boolean-literal predicate ({rows} rows): {pred}"
+            );
+        }
+    }
+}
+
+/// NULL numeric values stay excluded when compared against Boolean literals.
+#[test]
+fn boolean_literal_vs_numeric_column_null_rows_excluded() {
+    for rows in [2usize, 600] {
+        let mut db = numeric_db(rows);
+        execute_sql(&mut db, "INSERT INTO ti VALUES (100001, NULL, NULL)");
+        for pred in ["v = TRUE", "v != FALSE", "f != TRUE"] {
+            let ids = assert_where_matches_projection(&db, "ti", pred);
+            assert!(
+                !ids.contains(&100001),
+                "NULL row must not match boolean-literal predicate ({rows} rows): {pred}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Issue #5341: IN / NOT IN with NULL list elements (three-valued logic)
 // `x NOT IN (a, NULL)` is never TRUE; `x IN (a, NULL)` is TRUE only on match.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #5345: `WHERE int_col = TRUE` errored with `ColumnarTypeMismatch` ("Incompatible types for comparison: Int64 vs Boolean(true)") at/above `SIMD_COLUMNAR_THRESHOLD` (500 rows) while working correctly below it.
- Root cause: `value_to_f64` in `crates/vibesql-executor/src/select/columnar/simd_filter/conversion.rs` had no `SqlValue::Boolean` arm, so every numeric SIMD kernel (i64/i32/f64) raised the error on Boolean literals that the #5344 pushdown fence intentionally admits against numeric columns.
- Fix (issue's option 1): add `SqlValue::Boolean(b) => Some(if *b { 1.0 } else { 0.0 })`, mirroring the scalar comparator's `to_f64` and the expression evaluator's boolean coercion (SQLite storage semantics: TRUE=1, FALSE=0). This keeps the fast path and matches sqlite3.

### Sibling check (no further gaps)

- `value_to_timestamp_i64` / `value_to_date_i32`: only reached for Date/Timestamp/Time columns, where `value_supported_for_column` (predicates.rs) already declines Boolean literals (`_ => false`), so no Boolean arm is needed there.
- Boolean against an i64 column falls through `value_to_timestamp_i64` (None) into the fixed `value_to_f64` — correct.

## Tests

Added to `crates/vibesql-executor/tests/columnar_filter_type_pairs_tests.rs` (the #5344 parity-test file), run at 2 rows (scalar path) and 600 rows (SIMD path):

- `boolean_literal_vs_numeric_column_across_threshold`: `v = TRUE`, `v != FALSE`, `v > FALSE`, `v < TRUE`, `v >= TRUE`, `v <= FALSE`, `v >= FALSE` against INTEGER plus `f = TRUE`, `f != FALSE`, `f < TRUE` against DOUBLE — all sqlite3-verified and cross-checked against per-row projections (expression evaluator).
- `boolean_literal_vs_numeric_column_null_rows_excluded`: NULL rows never match.
- `bool_col = 1` parity was already covered by the existing `boolean_column_supported_pairs_still_filter` test (Boolean columns dispatch to the scalar fallback) and stays green.
- Confirmed the new tests reproduce the exact `ColumnarTypeMismatch` error with the fix reverted.

## Verification

- `cargo test -p vibesql-executor --test columnar_filter_type_pairs_tests`: 10 passed
- `cargo test -p vibesql-executor --lib`: 2627 passed
- Columnar/SIMD suites (`columnar_storage_tests`, `mvcc_simd_columnar_visibility_tests`, `tpch_columnar_q1`, `tpch_columnar_q6`): all green

Note: `cargo clippy -p vibesql-executor --tests` fails with a pre-existing `approx_constant` error in `src/evaluator/expressions/operators.rs:339` (`-3.14` in a test assertion), untouched by this PR.

Closes #5345

🤖 Generated with [Claude Code](https://claude.com/claude-code)