### PR TITLE
feat(consensus): ADR 0004 + ConsensusBackend trait scaffolding (Raft Phase A1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     "crates/vibesql-sqllogictest",
     "crates/vibesql-l10n",
     "crates/vibesql-bench-common",
+    "crates/vibesql-consensus",
 ]
 # Exclude Python bindings from default build (requires Python development environment)
 default-members = [
@@ -77,6 +78,7 @@ default-members = [
     "crates/vibesql-wasm-bindings",
     "crates/vibesql-sqllogictest",
     "crates/vibesql-l10n",
+    "crates/vibesql-consensus",
 ]
 resolver = "2"
 

--- a/crates/vibesql-consensus/Cargo.toml
+++ b/crates/vibesql-consensus/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "vibesql-consensus"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Consensus adapter layer for VibeSQL WAN replication (see ADR-0004)"
+keywords = ["sql", "database", "consensus", "raft", "replication"]
+categories = ["database"]
+
+# NOTE: `openraft` is deliberately NOT a dependency yet. ADR-0004 selects it,
+# but wiring it in is Raft Phase A2/A3 work. This crate is scaffolding only:
+# the engine-agnostic `ConsensusBackend` trait plus a single-node loopback
+# implementation for dev/test.
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "2.0"
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["rt", "macros"] }

--- a/crates/vibesql-consensus/src/backend.rs
+++ b/crates/vibesql-consensus/src/backend.rs
@@ -1,0 +1,99 @@
+//! The engine-agnostic [`ConsensusBackend`] adapter trait and its companion
+//! types. See ADR-0004 for the full design rationale.
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+/// Index of an entry in the replicated log.
+///
+/// Indices are **1-based**, following the Raft convention where index `0`
+/// means "no entry" (the state before anything has been committed).
+pub type LogIndex = u64;
+
+/// Raft-style role of the local node within the consensus group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Role {
+    /// This node sequences writes; proposals are accepted here.
+    Leader,
+    /// This node replicates the leader's log.
+    Follower,
+    /// This node is campaigning for leadership.
+    Candidate,
+}
+
+/// An opaque snapshot of the replicated state machine.
+///
+/// The byte encoding of `data` is backend-specific and intentionally not
+/// part of this contract; real snapshot encoding is decided when WAL wiring
+/// lands (later Raft phases).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Snapshot {
+    /// The last log index whose effects are included in this snapshot.
+    /// Entries at or below this index may be truncated from the log.
+    pub last_included_index: LogIndex,
+    /// Backend-specific serialized state.
+    pub data: Vec<u8>,
+}
+
+/// Errors surfaced by a [`ConsensusBackend`].
+#[derive(Debug, thiserror::Error)]
+pub enum ConsensusError {
+    /// The local node is not the leader; proposals must be retried against
+    /// the leader (hint is the backend's best guess at its node id, if any).
+    #[error("not the leader of the consensus group (leader hint: {leader_hint:?})")]
+    NotLeader {
+        /// Best-effort identifier of the current leader, if known.
+        leader_hint: Option<u64>,
+    },
+    /// The requested log index has not been committed (or never existed).
+    #[error("log index {0} is not committed")]
+    NotCommitted(LogIndex),
+    /// Snapshot serialization or deserialization failed.
+    #[error("snapshot encode/decode failed: {0}")]
+    SnapshotCodec(String),
+    /// Catch-all for backend-internal failures.
+    #[error("consensus backend error: {0}")]
+    Backend(String),
+}
+
+/// Convenience alias used throughout this crate.
+pub type Result<T> = std::result::Result<T, ConsensusError>;
+
+/// Engine-agnostic consensus adapter.
+///
+/// Consumers (replication, server) depend on this trait, never on the
+/// underlying consensus library, so the engine — `openraft` per ADR-0004 —
+/// or even the replication topology can be swapped without rewriting them.
+///
+/// Native `async fn` in traits is used deliberately (stable since Rust
+/// 1.75). The `async_fn_in_trait` lint is allowed because this is Phase A1
+/// scaffolding: `Send` bounds on the returned futures and dyn-compatibility
+/// will be revisited in Phase A2 when the first real backend lands; if dyn
+/// dispatch is needed then, this will switch to explicit
+/// `impl Future + Send` returns or boxed futures.
+#[allow(async_fn_in_trait)]
+pub trait ConsensusBackend: Send + Sync {
+    /// The log entry type replicated through consensus (e.g. a serialized
+    /// transaction or write batch).
+    type Entry: Serialize + DeserializeOwned + Send;
+
+    /// Propose an entry for replication. Resolves with the entry's log
+    /// index once the entry is **committed** (durable on a quorum).
+    ///
+    /// Returns [`ConsensusError::NotLeader`] if this node cannot sequence
+    /// writes.
+    async fn propose(&self, entry: Self::Entry) -> Result<LogIndex>;
+
+    /// Read back a committed entry by log index.
+    ///
+    /// Returns [`ConsensusError::NotCommitted`] if `idx` is `0`, beyond the
+    /// committed prefix, or otherwise unavailable.
+    async fn read_committed(&self, idx: LogIndex) -> Result<Self::Entry>;
+
+    /// Capture a snapshot of the committed state, suitable for log
+    /// truncation and follower catch-up.
+    async fn snapshot(&self) -> Result<Snapshot>;
+
+    /// The current role of this node in the consensus group.
+    fn role(&self) -> Role;
+}

--- a/crates/vibesql-consensus/src/lib.rs
+++ b/crates/vibesql-consensus/src/lib.rs
@@ -1,0 +1,28 @@
+//! Consensus adapter layer for VibeSQL WAN replication.
+//!
+//! This crate is the stable seam between VibeSQL and whatever consensus
+//! engine drives replication. [ADR-0004] selects `openraft` running as a
+//! **single Raft group replicating the whole database** (the
+//! rqlite/dqlite/Turso model), but consumers of this crate depend only on
+//! the [`ConsensusBackend`] trait — never on the underlying library — so the
+//! engine (or topology) can change without rewriting them.
+//!
+//! Phase A1 scaffolding (this crate, today):
+//!
+//! - [`ConsensusBackend`]: the engine-agnostic adapter trait
+//!   (propose / read_committed / snapshot / role).
+//! - [`SingleNodeBackend`]: an in-memory loopback implementation that
+//!   commits every proposal immediately, so dev and unit tests can exercise
+//!   the trait without standing up a multi-node cluster.
+//!
+//! Deliberately **not** here yet (later Raft phases): the `openraft`
+//! dependency, multi-node replication, log persistence wired to the WAL,
+//! membership changes, and any RPC/network code.
+//!
+//! [ADR-0004]: https://github.com/rjwalters/vibesql/blob/main/docs/decisions/0004-consensus-library.md
+
+mod backend;
+mod single_node;
+
+pub use backend::{ConsensusBackend, ConsensusError, LogIndex, Result, Role, Snapshot};
+pub use single_node::SingleNodeBackend;

--- a/crates/vibesql-consensus/src/single_node.rs
+++ b/crates/vibesql-consensus/src/single_node.rs
@@ -1,0 +1,201 @@
+//! [`SingleNodeBackend`]: an in-process loopback implementation of
+//! [`ConsensusBackend`] that commits every proposal immediately.
+//!
+//! This exists so dev and unit tests can exercise the adapter trait without
+//! standing up a multi-node cluster (see ADR-0004, "Single-Node Loopback
+//! Plan"). It is **not** a replication mechanism: there is exactly one node,
+//! it is always the leader, and the log lives in memory.
+
+use std::sync::Mutex;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::backend::{ConsensusBackend, ConsensusError, LogIndex, Result, Role, Snapshot};
+
+/// Single-node, in-memory [`ConsensusBackend`].
+///
+/// Proposals are appended to a `Vec`-backed log under a mutex and are
+/// considered committed as soon as `propose` returns. [`Role::Leader`] is
+/// always reported.
+///
+/// Snapshots encode the entire log as JSON. This is a stand-in format for
+/// tests only; real snapshot encoding is decided when WAL wiring lands.
+#[derive(Debug)]
+pub struct SingleNodeBackend<E> {
+    /// Committed log entries; entry `i` of the vec holds log index `i + 1`
+    /// (log indices are 1-based per Raft convention).
+    log: Mutex<Vec<E>>,
+}
+
+impl<E> SingleNodeBackend<E> {
+    /// Create a backend with an empty log.
+    pub fn new() -> Self {
+        Self { log: Mutex::new(Vec::new()) }
+    }
+
+    /// The index of the most recently committed entry (`0` if the log is
+    /// empty).
+    pub fn last_index(&self) -> LogIndex {
+        self.log.lock().expect("consensus log mutex poisoned").len() as LogIndex
+    }
+}
+
+impl<E: DeserializeOwned> SingleNodeBackend<E> {
+    /// Rebuild a backend from a snapshot previously produced by
+    /// [`ConsensusBackend::snapshot`] on a `SingleNodeBackend`.
+    ///
+    /// This is an inherent method rather than part of the trait: snapshot
+    /// *installation* hooks belong to later Raft phases, but the loopback
+    /// backend needs a way to prove snapshot roundtrips in unit tests.
+    pub fn from_snapshot(snapshot: &Snapshot) -> Result<Self> {
+        let log: Vec<E> = serde_json::from_slice(&snapshot.data)
+            .map_err(|e| ConsensusError::SnapshotCodec(e.to_string()))?;
+        if log.len() as LogIndex != snapshot.last_included_index {
+            return Err(ConsensusError::SnapshotCodec(format!(
+                "snapshot claims last_included_index {} but contains {} entries",
+                snapshot.last_included_index,
+                log.len()
+            )));
+        }
+        Ok(Self { log: Mutex::new(log) })
+    }
+}
+
+impl<E> Default for SingleNodeBackend<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E> ConsensusBackend for SingleNodeBackend<E>
+where
+    E: Serialize + DeserializeOwned + Clone + Send,
+{
+    type Entry = E;
+
+    async fn propose(&self, entry: E) -> Result<LogIndex> {
+        let mut log = self.log.lock().expect("consensus log mutex poisoned");
+        log.push(entry);
+        Ok(log.len() as LogIndex)
+    }
+
+    async fn read_committed(&self, idx: LogIndex) -> Result<E> {
+        let log = self.log.lock().expect("consensus log mutex poisoned");
+        if idx == 0 || idx > log.len() as LogIndex {
+            return Err(ConsensusError::NotCommitted(idx));
+        }
+        Ok(log[(idx - 1) as usize].clone())
+    }
+
+    async fn snapshot(&self) -> Result<Snapshot> {
+        let log = self.log.lock().expect("consensus log mutex poisoned");
+        let data =
+            serde_json::to_vec(&*log).map_err(|e| ConsensusError::SnapshotCodec(e.to_string()))?;
+        Ok(Snapshot { last_included_index: log.len() as LogIndex, data })
+    }
+
+    fn role(&self) -> Role {
+        Role::Leader
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::*;
+
+    /// Stand-in for a replicated write (a serialized transaction or batch).
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct TestEntry {
+        txn_id: u64,
+        payload: String,
+    }
+
+    fn entry(txn_id: u64, payload: &str) -> TestEntry {
+        TestEntry { txn_id, payload: payload.to_string() }
+    }
+
+    #[tokio::test]
+    async fn propose_read_committed_roundtrip() {
+        let backend = SingleNodeBackend::new();
+
+        let first = entry(1, "INSERT INTO t VALUES (1)");
+        let second = entry(2, "UPDATE t SET x = 2");
+
+        let idx1 = backend.propose(first.clone()).await.unwrap();
+        let idx2 = backend.propose(second.clone()).await.unwrap();
+
+        // Log indices are 1-based and monotonically increasing.
+        assert_eq!(idx1, 1);
+        assert_eq!(idx2, 2);
+        assert_eq!(backend.last_index(), 2);
+
+        assert_eq!(backend.read_committed(idx1).await.unwrap(), first);
+        assert_eq!(backend.read_committed(idx2).await.unwrap(), second);
+    }
+
+    #[tokio::test]
+    async fn read_uncommitted_index_is_an_error() {
+        let backend = SingleNodeBackend::<TestEntry>::new();
+
+        // Index 0 means "no entry" and is never readable.
+        assert!(matches!(backend.read_committed(0).await, Err(ConsensusError::NotCommitted(0))));
+
+        // Nothing proposed yet, so index 1 is not committed either.
+        assert!(matches!(backend.read_committed(1).await, Err(ConsensusError::NotCommitted(1))));
+    }
+
+    #[tokio::test]
+    async fn single_node_is_always_leader() {
+        let backend = SingleNodeBackend::<TestEntry>::new();
+        assert_eq!(backend.role(), Role::Leader);
+    }
+
+    #[tokio::test]
+    async fn snapshot_roundtrip_restores_the_log() {
+        let backend = SingleNodeBackend::new();
+        for i in 1..=3 {
+            backend.propose(entry(i, "write")).await.unwrap();
+        }
+
+        let snapshot = backend.snapshot().await.unwrap();
+        assert_eq!(snapshot.last_included_index, 3);
+
+        let restored = SingleNodeBackend::<TestEntry>::from_snapshot(&snapshot).unwrap();
+        assert_eq!(restored.last_index(), 3);
+        for i in 1..=3u64 {
+            assert_eq!(restored.read_committed(i).await.unwrap(), entry(i, "write"));
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_of_empty_log_is_valid() {
+        let backend = SingleNodeBackend::<TestEntry>::new();
+        let snapshot = backend.snapshot().await.unwrap();
+        assert_eq!(snapshot.last_included_index, 0);
+
+        let restored = SingleNodeBackend::<TestEntry>::from_snapshot(&snapshot).unwrap();
+        assert_eq!(restored.last_index(), 0);
+    }
+
+    #[tokio::test]
+    async fn corrupt_snapshot_is_rejected() {
+        let bogus = Snapshot { last_included_index: 5, data: b"not json".to_vec() };
+        assert!(matches!(
+            SingleNodeBackend::<TestEntry>::from_snapshot(&bogus),
+            Err(ConsensusError::SnapshotCodec(_))
+        ));
+
+        // Valid JSON but inconsistent index claim.
+        let inconsistent = Snapshot {
+            last_included_index: 5,
+            data: serde_json::to_vec(&vec![entry(1, "only one")]).unwrap(),
+        };
+        assert!(matches!(
+            SingleNodeBackend::<TestEntry>::from_snapshot(&inconsistent),
+            Err(ConsensusError::SnapshotCodec(_))
+        ));
+    }
+}

--- a/docs/decisions/0004-consensus-library.md
+++ b/docs/decisions/0004-consensus-library.md
@@ -1,0 +1,315 @@
+# ADR-0004: Consensus Library and Replication Topology
+
+**Status**: Accepted
+
+**Date**: 2026-06-11
+
+**Deciders**: Claude Code + rwalters
+
+**Related**:
+- Issue [#4460](https://github.com/rjwalters/vibesql/issues/4460) - WAN replication architectural decomposition (parent)
+- Issue [#5195](https://github.com/rjwalters/vibesql/issues/5195) - Raft Phase A1: this decision + adapter scaffolding
+- Issue [#5200](https://github.com/rjwalters/vibesql/issues/5200) - Phase B2: leader leases + bounded-staleness follower reads
+- Issue [#5201](https://github.com/rjwalters/vibesql/issues/5201) - Phase C1: distributed multi-shard transactions (deferred)
+- Issue [#5202](https://github.com/rjwalters/vibesql/issues/5202) - Phase A0: range sharding / per-range Raft groups (deferred)
+- [ADR-0001](0001-language-choice.md) - Rust implementation language
+
+## Context and Problem Statement
+
+VibeSQL's WAN replication track (#4460) needs a consensus layer so that a
+cluster of nodes can agree on a single ordered log of writes. Two decisions
+must be made before any replication code can land:
+
+1. **Which consensus implementation do we build on?** A mature Rust library,
+   or a hand-rolled protocol?
+2. **What replication topology do we target?** One Raft group replicating the
+   whole database (rqlite/dqlite/Turso model), or many Raft groups each owning
+   a key range (CockroachDB/TiKV model, as originally sketched in #4460)?
+
+This ADR records both decisions and lands a thin, engine-agnostic adapter
+trait (`ConsensusBackend`) in a new `vibesql-consensus` crate so the rest of
+the Raft track can proceed against a stable interface even if the underlying
+engine (or topology) changes later.
+
+**Constraints**:
+- VibeSQL is async on **tokio** (server crate); the consensus layer must fit
+  that runtime without thread-bridging hacks.
+- Sole-developer project: anything that requires hand-maintaining a consensus
+  protocol implementation is a long-term liability.
+- This phase is **decision + scaffolding only** — no multi-node replication,
+  no log-to-WAL wiring, no membership changes, no RPC code.
+
+## Decision Drivers
+
+* **Correctness risk** - Consensus bugs are subtle, rare-event bugs; we want
+  an implementation hardened by production use, not a first draft.
+* **Async-runtime fit** - Must compose naturally with tokio.
+* **Maintenance status** - Actively maintained, responsive upstream.
+* **Hooks exposed** - Snapshots, log truncation, and membership changes must
+  be pluggable, because VibeSQL will eventually wire these to its own WAL and
+  storage engine.
+* **Fit with existing MVCC work** - The MVCC Phase 1 machinery (xmin/xmax
+  stamping) should compose with replication without redesign.
+* **Licensing** - Must be compatible with MIT OR Apache-2.0.
+* **Reversibility** - The choice should be swappable behind an adapter trait.
+
+## Considered Options
+
+### Option 1: `openraft` (chosen)
+
+**Description**: Async-native Raft implementation, MIT/Apache-2.0 dual
+licensed, used in production by Databend.
+
+**Pros**:
+* ✅ **tokio-native async/await API** - no callback-to-future shims needed
+* ✅ **Actively maintained** - frequent releases, responsive maintainers
+* ✅ **Production-proven** - Databend runs it as its meta-service consensus
+* ✅ **Exposes the hooks we need** - pluggable `RaftLogStorage` /
+  `RaftStateMachine` traits cover log persistence, snapshot build/install,
+  log truncation/purge, and membership changes
+* ✅ **Licensing fits** - MIT OR Apache-2.0, same as VibeSQL
+
+**Cons**:
+* ❌ Generic-heavy API; type-config boilerplate to learn
+* ❌ Younger than `raft-rs`; API has historically evolved between minor versions
+  - **Mitigation**: the `ConsensusBackend` adapter trait isolates consumers
+    from openraft's types entirely
+
+### Option 2: `raft-rs` (TiKV)
+
+**Description**: TiKV's Raft core, extremely battle-tested at scale.
+
+**Pros**:
+* ✅ The most production-hardened Raft in the Rust ecosystem (TiKV)
+* ✅ Stable, well-understood API
+
+**Cons**:
+* ❌ **Older callback/tick-driven API style** - it is a state-machine library
+  you must drive yourself (ready/advance loop); not async-native
+* ❌ Significant integration glue required to host it on tokio: we would
+  hand-write the driver loop, message plumbing, and storage glue that
+  openraft already provides as async traits
+* ❌ Log persistence, snapshot transport, and network layer are all
+  bring-your-own
+
+**Verdict**: Rejected. The battle-testing is attractive, but the integration
+surface we would have to write and maintain is exactly the code most likely
+to harbor bugs — and openraft gives us that layer pre-built and proven.
+
+### Option 3: Viewstamped Replication (VR/VSR), hand-rolled
+
+**Description**: VSR (raised by @ansarizafar on #4460; used by TigerBeetle)
+is arguably a cleaner protocol than Raft, but **no mature Rust crate exists**
+— choosing it means hand-rolling consensus.
+
+**Pros**:
+* ✅ Cleaner protocol design; no separate snapshot/log-compaction sub-protocol
+* ✅ TigerBeetle demonstrates it works extremely well in production
+
+**Cons**:
+* ❌ **No mature Rust implementation to build on** - we would write the
+  protocol from scratch
+* ❌ **Hand-rolling consensus without deterministic-simulation test
+  infrastructure is an unacceptable risk for a sole-developer project.**
+  TigerBeetle's VSR is trustworthy because they built deterministic
+  simulation testing (the VOPR) *first* and run their entire cluster inside
+  it; VibeSQL has no equivalent harness, and building one is a larger project
+  than the replication feature itself.
+
+**Verdict**: Rejected (deferred indefinitely). Documented here per the
+discussion on #4460.
+
+### Option 4: Hand-rolled Raft
+
+**Description**: Implement Raft ourselves.
+
+**Verdict**: Rejected — strictly worse than the alternatives. It carries the
+same "consensus without deterministic-simulation testing" objection as
+Option 3, *and* unlike VSR there are mature Rust libraries available, so
+hand-rolling buys nothing.
+
+## Topology Decision: Single Raft Group, Whole Database
+
+Independent of library choice, #4460 originally sketched a
+CockroachDB-style design: ranges, per-range Raft groups, HLC timestamps, and
+distributed transactions. **We are explicitly not building that shape.**
+
+**Chosen topology**: a **single Raft group replicating the whole database**
+— the rqlite / dqlite / Turso model. Every committed log entry is a
+transaction (or batch) applied to the full database state machine.
+
+**Rationale**:
+
+1. **Commit order = log order.** With one group there is a single total order
+   of commits, which composes directly with VibeSQL's existing MVCC Phase 1
+   machinery (xmin/xmax stamping): the Raft apply index maps onto the commit
+   timestamp. No hybrid logical clocks, no cross-shard ordering questions.
+2. **No sharding metadata, no distributed transactions.** Range descriptors,
+   range splits/merges, intent resolution, and two-phase commit records all
+   evaporate. The replication layer stays small enough for one person to own.
+3. **Sharding solves a capacity problem VibeSQL doesn't have.** VibeSQL is
+   in-memory-leaning and single-process; the working set fits one machine by
+   design. Per-range groups exist to scale data and write throughput across
+   machines — that is not this project's bottleneck.
+
+**Known tradeoff (stated honestly)**: a single group caps write throughput at
+what one leader on one machine can sequence. Multi-region **write** scaling
+would require revisiting the sharded design (#5202 keeps that door open).
+Multi-region **read** scaling remains in scope via leader leases +
+bounded-staleness follower reads (#5200, Phase B2).
+
+## Decision Outcome
+
+**Chosen**: **`openraft`**, in a **single Raft group replicating the whole
+database**, consumed exclusively through the engine-agnostic
+`ConsensusBackend` adapter trait below.
+
+`openraft` is the only candidate that is simultaneously async/tokio-native,
+actively maintained, production-proven (Databend), and exposes the
+snapshot / log-truncation / membership hooks VibeSQL needs. The adapter trait
+keeps the decision reversible: consumers never see openraft types, so the
+library — or even the topology — can change later without rewriting them.
+
+**Note**: `openraft` is **not** added as a dependency in this phase. Phase A1
+is decision + scaffolding; wiring openraft into the adapter is Phase A2/A3
+work. This keeps the current PR purely additive.
+
+## Adapter Trait Sketch
+
+Landed in the new `vibesql-consensus` crate (this PR):
+
+```rust
+/// Index of an entry in the replicated log (1-based, Raft convention).
+pub type LogIndex = u64;
+
+/// Raft-style role of the local node.
+pub enum Role { Leader, Follower, Candidate }
+
+/// Opaque state-machine snapshot plus the last log index it covers.
+pub struct Snapshot {
+    pub last_included_index: LogIndex,
+    pub data: Vec<u8>,
+}
+
+/// Engine-agnostic consensus adapter. Consumers depend on this trait,
+/// never on the underlying library (openraft in Phase A2+).
+pub trait ConsensusBackend: Send + Sync {
+    type Entry: Serialize + DeserializeOwned + Send;
+
+    /// Propose an entry; resolves once the entry is committed.
+    async fn propose(&self, entry: Self::Entry) -> Result<LogIndex>;
+    /// Read back a committed entry by index.
+    async fn read_committed(&self, idx: LogIndex) -> Result<Self::Entry>;
+    /// Capture a snapshot of committed state (for log truncation / catch-up).
+    async fn snapshot(&self) -> Result<Snapshot>;
+    /// Current role of this node.
+    fn role(&self) -> Role;
+}
+```
+
+What VibeSQL plugs in behind this trait in later phases: the database state
+machine (apply committed entries), log persistence (WAL wiring), snapshot
+build/install, and membership-change hooks — all of which openraft exposes
+via its `RaftLogStorage` / `RaftStateMachine` traits.
+
+**Async style**: the trait uses native `async fn` in traits (stable since
+Rust 1.75; the workspace toolchain is far newer, so no MSRV impact). The
+`async_fn_in_trait` lint is explicitly allowed at the trait definition: the
+auto-trait (`Send`) bounds on returned futures and dyn-compatibility will be
+revisited in Phase A2 when the first real (openraft) backend lands; if dyn
+dispatch or stricter bounds are needed then, we will switch to explicit
+`impl Future + Send` returns or boxed futures.
+
+## Single-Node Loopback Plan
+
+`vibesql-consensus` ships `SingleNodeBackend`, an in-memory implementation
+that commits every proposal immediately (a `Vec`-backed log behind a mutex)
+and always reports `Role::Leader`. Purpose:
+
+- Dev and unit tests exercise the `ConsensusBackend` interface without
+  standing up a multi-node cluster.
+- Consumers of the trait (Phase B work) can be written and tested against it
+  before the openraft backend exists.
+- Its snapshot format (serde_json of the log, with an inherent
+  `from_snapshot` constructor) is a stand-in only; real snapshot encoding is
+  decided when WAL wiring lands.
+
+## Deferred Non-Goals
+
+Explicitly out of scope for the chosen design (not just this PR):
+
+| Deferred item | Tracking | Why deferred |
+|---------------|----------|--------------|
+| Range sharding / per-range Raft groups | #5202 (Phase A0) | Solves a capacity problem VibeSQL doesn't have; revisit only if multi-region write scaling becomes a requirement |
+| Distributed multi-shard transactions (intents + commit records) | #5201 (Phase C1) | Only needed with sharding; single group makes every transaction single-group |
+| HLC (hybrid logical clock) timestamping | — | Single total log order makes commit ordering trivial; apply index maps onto commit timestamp |
+
+Also out of scope for this PR specifically (next issues in the Raft track):
+actual multi-node replication, log-persistence wiring to the WAL, membership
+changes, and any Raft RPC / network code.
+
+## Consequences
+
+### Positive
+
+* ✅ Consensus correctness outsourced to a production-proven library
+* ✅ Replication layer composes with existing MVCC Phase 1 without redesign
+* ✅ Adapter trait keeps both the library and the topology swappable
+* ✅ `SingleNodeBackend` lets downstream work start immediately, testable
+  without clusters
+* ✅ Purely additive scaffolding — zero risk to existing crates
+
+### Negative
+
+* ❌ Write throughput capped at one leader / one machine
+  - **Mitigation**: acceptable for VibeSQL's in-memory, single-process
+    positioning; #5202 preserves the sharded option if that changes
+* ❌ openraft API churn between minor versions
+  - **Mitigation**: only `vibesql-consensus` internals touch openraft types
+* ❌ Whole-database snapshots can be large
+  - **Mitigation**: snapshot encoding/transport is deliberately deferred to
+    the WAL-wiring phase, where incremental options can be evaluated
+
+### Neutral
+
+* The trait is intentionally minimal (4 methods); membership-change and
+  log-truncation surface will be added when a real backend needs them
+
+## Validation
+
+Success criteria for this decision:
+
+1. ✅ `ConsensusBackend` compiles in `vibesql-consensus` (this PR)
+2. ✅ `SingleNodeBackend` passes propose/read roundtrip, role, and snapshot
+   roundtrip unit tests (this PR)
+3. ⏳ Phase A2: openraft backend implements the same trait with no consumer
+   changes
+4. ⏳ Phase B: replication consumers are written against the trait and pass
+   against both backends
+
+## References
+
+* **openraft**: https://github.com/databendlabs/openraft
+* **raft-rs**: https://github.com/tikv/raft-rs
+* **Databend** (openraft in production): https://github.com/databendlabs/databend
+* **rqlite** (single-group whole-DB Raft over SQLite): https://github.com/rqlite/rqlite
+* **dqlite**: https://dqlite.io/
+* **TigerBeetle VOPR** (deterministic simulation testing built before/with VSR): https://docs.tigerbeetle.com/about/vopr/
+* **Viewstamped Replication Revisited** (Liskov & Cowling, 2012)
+* **Raft paper**: Ongaro & Ousterhout, "In Search of an Understandable Consensus Algorithm" (2014)
+
+### Related Decisions
+
+* ADR-0001: Language Choice (Rust) — ecosystem availability of openraft is a
+  direct consequence
+
+---
+
+**Status**: ACCEPTED ✅
+
+**Date Accepted**: 2026-06-11
+
+**Next Steps**:
+1. Phase A2/A3: add `openraft` dependency and implement `ConsensusBackend` over it
+2. Wire log persistence to the WAL (separate issue)
+3. Phase B2: leader leases + bounded-staleness follower reads (#5200)

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -22,12 +22,16 @@ See `docs/templates/ADR_TEMPLATE.md` for the full template.
 |----|-------|--------|------|---------|
 | 0001 | **Language Choice: Rust** | ✅ **Accepted** | 2025-10-25 | **Rust chosen** for type safety, pattern matching, compiler feedback, and correctness focus |
 | 0002 | **Parser Strategy: Hand-Written** | ✅ **Accepted** | 2025-10-25 | **Hand-written recursive descent + Pratt parser** chosen for full control, TDD alignment, and SQL:1999 flexibility |
+| 0004 | **Consensus Library: openraft** | ✅ **Accepted** | 2026-06-11 | **openraft, single Raft group replicating the whole database** behind an engine-agnostic `ConsensusBackend` trait; sharding/HLC/distributed txns explicitly deferred |
 
 ## Decisions by Category
 
 ### Core Technology Stack
 - [ADR-0001](docs/decisions/0001-language-choice.md) - **Language Choice: Rust** ✅ (Accepted 2025-10-25)
 - [ADR-0002](docs/decisions/0002-parser-strategy.md) - **Parser Strategy: Hand-Written** ✅ (Accepted 2025-10-25)
+
+### Replication and Distribution
+- [ADR-0004](docs/decisions/0004-consensus-library.md) - **Consensus Library: openraft (single-group topology)** ✅ (Accepted 2026-06-11)
 
 ## Decision Process
 
@@ -58,6 +62,7 @@ Create an ADR when:
 ## Quick Reference
 
 ### Recently Accepted
+- **ADR-0004**: Consensus Library - openraft, single Raft group (2026-06-11)
 - **ADR-0001**: Language Choice - Rust (2025-10-25)
 - **ADR-0002**: Parser Strategy - Hand-Written Recursive Descent (2025-10-25)
 
@@ -85,6 +90,6 @@ When making architectural decisions:
 
 ---
 
-**Last Updated**: 2025-10-26
-**Total ADRs**: 2 accepted, 0 pending
-**Status**: Foundation established - language and parser strategy implemented!
+**Last Updated**: 2026-06-11
+**Total ADRs**: 3 accepted, 0 pending
+**Status**: Foundation established; consensus library selected for the WAN replication track (Raft Phase A1)


### PR DESCRIPTION
Closes #5195

## Summary

Raft Phase A1 of the WAN replication track (#4460): decision + scaffolding only, purely additive.

- **ADR-0004** (`docs/decisions/0004-consensus-library.md`): selects **openraft** (tokio-native, actively maintained, production-proven in Databend, exposes snapshot/log-truncation/membership hooks) over `raft-rs` (callback-style, not async-native), hand-rolled VSR (no mature Rust crate; hand-rolling consensus without deterministic-simulation testing — cf. TigerBeetle's VOPR — is unacceptable risk for a sole-developer project), and hand-rolled Raft (strictly worse). Also records the **topology decision**: a single Raft group replicating the whole database (rqlite/dqlite/Turso model), not the #4460 range-sharding shape — commit order = log order, composing directly with MVCC Phase 1 xmin/xmax stamping; no HLC, sharding metadata, or distributed transactions. Deferred non-goals are listed explicitly (#5202 sharding, #5201 distributed txns, HLC), including the honest tradeoff that a single group caps write throughput at one leader; multi-region read scaling stays in scope via leader leases + follower reads (#5200).
- **New `vibesql-consensus` crate** (added to workspace members): engine-agnostic `ConsensusBackend` trait (`propose` / `read_committed` / `snapshot` / `role`, native `async fn` in traits) plus a `SingleNodeBackend` in-memory loopback that commits immediately, so consumers and tests never depend on the underlying library.
- **`openraft` is deliberately NOT a dependency yet** — wiring it in is Phase A2/A3. No changes to existing storage/executor crates; diff touches only the new crate, `docs/decisions/`, and the root `Cargo.toml` members lists.
- `DECISION_LOG.md` index updated.

## Test evidence

- `cargo build --workspace` — green (pre-existing `vibesql-executor` warnings only)
- `cargo test -p vibesql-consensus` — 6/6 pass: propose/read_committed roundtrip, uncommitted-index error, role() == Leader, snapshot roundtrip, empty-log snapshot, corrupt-snapshot rejection
- `cargo clippy -p vibesql-consensus --all-targets` — clean
- New files formatted with the repo rustfmt config (no repo-wide fmt run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)