### PR TITLE
fix(executor): propagate outer CTE context into expression subqueries

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined_core.rs
+++ b/crates/vibesql-executor/src/evaluator/combined_core.rs
@@ -367,6 +367,21 @@ impl<'a> CombinedExpressionEvaluator<'a> {
         }
     }
 
+    /// Attach an outer CTE context to this evaluator (builder style).
+    ///
+    /// Used by execution paths whose constructor combination has no
+    /// dedicated `*_and_cte` variant (e.g. outer context + window mapping),
+    /// so that subqueries evaluated in expression position resolve names
+    /// bound by an enclosing WITH clause before falling back to catalog
+    /// tables/views (issue #5350).
+    pub(crate) fn with_cte_context(
+        mut self,
+        cte_context: &'a HashMap<String, crate::select::cte::CteResult>,
+    ) -> Self {
+        self.cte_context = Some(cte_context);
+        self
+    }
+
     /// Clear the CSE cache
     /// Should be called before evaluating expressions for a new row in multi-row contexts
     pub(crate) fn clear_cse_cache(&self) {

--- a/crates/vibesql-executor/src/evaluator/single.rs
+++ b/crates/vibesql-executor/src/evaluator/single.rs
@@ -212,6 +212,19 @@ impl<'a> ExpressionEvaluator<'a> {
         }
     }
 
+    /// Attach an outer CTE context to this evaluator (builder style).
+    ///
+    /// Ensures subqueries evaluated in expression position resolve names
+    /// bound by an enclosing WITH clause before falling back to catalog
+    /// tables/views (issue #5350).
+    pub fn with_cte_context(
+        mut self,
+        cte_context: &'a std::collections::HashMap<String, crate::select::cte::CteResult>,
+    ) -> Self {
+        self.cte_context = Some(cte_context);
+        self
+    }
+
     /// Set the row index for ROWID pseudo-column support
     ///
     /// When set, references to ROWID, _rowid_, or oid columns will return

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -871,17 +871,25 @@ impl SelectExecutor<'_> {
                             set_operation: None,
                             values: None,
                         };
-                        let row_results = self.execute_select_without_from(&temp_stmt)?;
+                        let row_results =
+                            self.execute_select_without_from(&temp_stmt, cte_results)?;
                         all_rows.extend(row_results);
                     } else {
                         // No window functions - evaluate normally
                         let schema = crate::schema::CombinedSchema::empty();
                         let empty_row = vibesql_storage::Row::new(vec![]);
-                        let evaluator =
+                        let mut evaluator =
                             crate::evaluator::CombinedExpressionEvaluator::with_database(
                                 &schema,
                                 self.database,
                             );
+                        // Thread CTE context so subqueries in VALUES rows can
+                        // reference names bound by an enclosing WITH (#5350)
+                        if !cte_results.is_empty() {
+                            evaluator = evaluator.with_cte_context(cte_results);
+                        } else if let Some(cte_ctx) = self.cte_context {
+                            evaluator = evaluator.with_cte_context(cte_ctx);
+                        }
                         let mut values = Vec::with_capacity(row_exprs.len());
                         for expr in row_exprs {
                             let value = evaluator.eval(expr, &empty_row)?;
@@ -935,7 +943,7 @@ impl SelectExecutor<'_> {
             self.execute_with_aggregation(stmt, cte_results)
         } else {
             // Simple expression evaluation (e.g., SELECT 1 + 1)
-            self.execute_select_without_from(stmt)
+            self.execute_select_without_from(stmt, cte_results)
         }
     }
 
@@ -1397,7 +1405,7 @@ impl SelectExecutor<'_> {
             self.execute_without_aggregation(stmt, from_result, cte_results)
         } else {
             // SELECT without FROM - evaluate expressions as a single row
-            self.execute_select_without_from(stmt)
+            self.execute_select_without_from(stmt, cte_results)
         }
     }
 

--- a/crates/vibesql-executor/src/select/executor/nonagg/without_from.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/without_from.rs
@@ -3,10 +3,13 @@
 //! This module handles the special case of SELECT statements without a FROM clause,
 //! which evaluates expressions without any table context.
 
+use std::collections::HashMap;
+
 use super::builder::SelectExecutor;
 use crate::{
     errors::ExecutorError,
     evaluator::{CombinedExpressionEvaluator, ExpressionEvaluator},
+    select::cte::CteResult,
     select::helpers::{apply_limit_offset, evaluate_limit, evaluate_offset},
     select::window::{evaluate_window_functions, has_window_functions},
 };
@@ -23,9 +26,15 @@ impl SelectExecutor<'_> {
     /// column references can be resolved from the outer scope. This enables queries like:
     /// `SELECT * FROM t2 WHERE x IN (SELECT x)` where the inner `SELECT x` has no FROM
     /// but `x` is resolved from the outer `t2`.
+    ///
+    /// Fix for #5350: `cte_results` carries the enclosing statement's CTE bindings
+    /// (already merged with any outer CTE context by `execute()`), so subqueries in
+    /// expression position (scalar, EXISTS, IN) resolve CTE names before falling
+    /// back to same-named catalog tables/views, matching SQLite precedence.
     pub(in crate::select::executor) fn execute_select_without_from(
         &self,
         stmt: &vibesql_ast::SelectStmt,
+        cte_results: &HashMap<String, CteResult>,
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
         // Validate ORDER BY column positions early (SQLite compatibility)
         if let Some(order_by) = &stmt.order_by {
@@ -61,6 +70,12 @@ impl SelectExecutor<'_> {
             }
         }
 
+        // CTE context for expression-position subqueries (#5350).
+        // `cte_results` already merges local CTEs over the executor's outer CTE
+        // context (see execute()); fall back to the executor's context when the
+        // merged map is empty (same pattern as the materialized/iterator paths).
+        let cte_ctx = if !cte_results.is_empty() { Some(cte_results) } else { self.cte_context };
+
         // Check if we have outer context (for correlated subqueries)
         let has_outer_context = self.outer_row.is_some() && self.outer_schema.is_some();
 
@@ -74,7 +89,7 @@ impl SelectExecutor<'_> {
                 && !has_window_functions(&stmt.select_list)
                 && self.expression_references_column(where_clause)
             {
-                return self.execute_select_without_from_alias_where(stmt, where_clause);
+                return self.execute_select_without_from_alias_where(stmt, where_clause, cte_ctx);
             }
         }
 
@@ -85,16 +100,23 @@ impl SelectExecutor<'_> {
                 let outer_row = self.outer_row.unwrap();
                 let outer_schema = self.outer_schema.unwrap();
                 let empty_combined_schema = crate::schema::CombinedSchema::empty();
-                let evaluator = CombinedExpressionEvaluator::with_database_and_outer_context(
+                let mut evaluator = CombinedExpressionEvaluator::with_database_and_outer_context(
                     &empty_combined_schema,
                     self.database,
                     outer_row,
                     outer_schema,
                 );
+                if let Some(cte) = cte_ctx {
+                    evaluator = evaluator.with_cte_context(cte);
+                }
                 evaluator.eval(where_clause, outer_row)?
             } else {
                 let empty_schema = vibesql_catalog::TableSchema::new("".to_string(), vec![]);
-                let evaluator = ExpressionEvaluator::with_database(&empty_schema, self.database);
+                let mut evaluator =
+                    ExpressionEvaluator::with_database(&empty_schema, self.database);
+                if let Some(cte) = cte_ctx {
+                    evaluator = evaluator.with_cte_context(cte);
+                }
                 let empty_row = vibesql_storage::Row::new(vec![]);
                 evaluator.eval(where_clause, &empty_row)?
             };
@@ -123,7 +145,7 @@ impl SelectExecutor<'_> {
         // Window functions without FROM clause operate on a single implicit row (Issue #4747)
         // Example: SELECT min(1) OVER() returns 1 (the min of a single implicit row)
         if has_window_functions(&stmt.select_list) {
-            return self.execute_select_without_from_with_windows(stmt, has_outer_context);
+            return self.execute_select_without_from_with_windows(stmt, has_outer_context, cte_ctx);
         }
 
         // Evaluate each item in the SELECT list
@@ -154,20 +176,26 @@ impl SelectExecutor<'_> {
                         // Create an empty CombinedSchema for current level (no FROM clause)
                         let empty_combined_schema = crate::schema::CombinedSchema::empty();
                         // Create evaluator that can resolve columns from outer schema
-                        let evaluator =
+                        let mut evaluator =
                             CombinedExpressionEvaluator::with_database_and_outer_context(
                                 &empty_combined_schema,
                                 self.database,
                                 outer_row,
                                 outer_schema,
                             );
+                        if let Some(cte) = cte_ctx {
+                            evaluator = evaluator.with_cte_context(cte);
+                        }
                         evaluator.eval(expr, outer_row)?
                     } else {
                         // No outer context - use simple evaluation
                         let empty_schema =
                             vibesql_catalog::TableSchema::new("".to_string(), vec![]);
-                        let evaluator =
+                        let mut evaluator =
                             ExpressionEvaluator::with_database(&empty_schema, self.database);
+                        if let Some(cte) = cte_ctx {
+                            evaluator = evaluator.with_cte_context(cte);
+                        }
                         let empty_row = vibesql_storage::Row::new(vec![]);
                         evaluator.eval(expr, &empty_row)?
                     };
@@ -196,9 +224,13 @@ impl SelectExecutor<'_> {
         &self,
         stmt: &vibesql_ast::SelectStmt,
         where_clause: &vibesql_ast::Expression,
+        cte_ctx: Option<&HashMap<String, CteResult>>,
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
         let empty_schema = vibesql_catalog::TableSchema::new("".to_string(), vec![]);
-        let evaluator = ExpressionEvaluator::with_database(&empty_schema, self.database);
+        let mut evaluator = ExpressionEvaluator::with_database(&empty_schema, self.database);
+        if let Some(cte) = cte_ctx {
+            evaluator = evaluator.with_cte_context(cte);
+        }
         let empty_row = vibesql_storage::Row::new(vec![]);
 
         // Evaluate the select list and collect alias bindings
@@ -233,7 +265,10 @@ impl SelectExecutor<'_> {
 
         // Evaluate WHERE with the aliases bound as columns of a single row
         let alias_schema = vibesql_catalog::TableSchema::new("".to_string(), alias_columns);
-        let where_evaluator = ExpressionEvaluator::with_database(&alias_schema, self.database);
+        let mut where_evaluator = ExpressionEvaluator::with_database(&alias_schema, self.database);
+        if let Some(cte) = cte_ctx {
+            where_evaluator = where_evaluator.with_cte_context(cte);
+        }
         let result_row = vibesql_storage::Row::new(values);
         let where_result = where_evaluator.eval(where_clause, &result_row)?;
 
@@ -277,6 +312,7 @@ impl SelectExecutor<'_> {
         &self,
         stmt: &vibesql_ast::SelectStmt,
         has_outer_context: bool,
+        cte_ctx: Option<&HashMap<String, CteResult>>,
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
         // Create an implicit single empty row for window function processing
         // This represents the single implicit row that exists for SELECT without FROM
@@ -285,7 +321,7 @@ impl SelectExecutor<'_> {
 
         // Create evaluator for window function processing
         let empty_combined_schema = crate::schema::CombinedSchema::empty();
-        let evaluator = if has_outer_context {
+        let mut evaluator = if has_outer_context {
             let outer_row = self.outer_row.unwrap();
             let outer_schema = self.outer_schema.unwrap();
             CombinedExpressionEvaluator::with_database_and_outer_context(
@@ -297,6 +333,9 @@ impl SelectExecutor<'_> {
         } else {
             CombinedExpressionEvaluator::with_database(&empty_combined_schema, self.database)
         };
+        if let Some(cte) = cte_ctx {
+            evaluator = evaluator.with_cte_context(cte);
+        }
 
         // Process window functions - this adds computed values to each row
         // and returns a mapping from WindowFunctionKey to column index
@@ -321,7 +360,7 @@ impl SelectExecutor<'_> {
                 }
                 vibesql_ast::SelectItem::Expression { expr, .. } => {
                     // Create evaluator with window mapping for this expression
-                    let eval_with_windows = if has_outer_context {
+                    let mut eval_with_windows = if has_outer_context {
                         let outer_row = self.outer_row.unwrap();
                         let outer_schema = self.outer_schema.unwrap();
                         CombinedExpressionEvaluator::with_database_outer_and_windows(
@@ -338,6 +377,9 @@ impl SelectExecutor<'_> {
                             &window_mapping,
                         )
                     };
+                    if let Some(cte) = cte_ctx {
+                        eval_with_windows = eval_with_windows.with_cte_context(cte);
+                    }
                     // Use the row with window values appended
                     let row = &rows[0];
                     let value = eval_with_windows.eval(expr, row)?;

--- a/crates/vibesql-executor/src/select/executor/set_operations.rs
+++ b/crates/vibesql-executor/src/select/executor/set_operations.rs
@@ -201,7 +201,7 @@ impl SelectExecutor<'_> {
             )?;
             from_result.into_rows()
         } else {
-            self.execute_select_without_from(right_stmt)?
+            self.execute_select_without_from(right_stmt, cte_results)?
         };
 
         // Track memory for right result before set operation

--- a/crates/vibesql-executor/tests/cte_expression_subquery_tests.rs
+++ b/crates/vibesql-executor/tests/cte_expression_subquery_tests.rs
@@ -1,0 +1,193 @@
+//! Regression tests for issue #5350
+//!
+//! Subqueries in expression position (scalar subqueries, EXISTS, IN) inside a
+//! FROM-less SELECT did not inherit the enclosing statement's CTE bindings, so
+//! a name bound by an outer `WITH` clause resolved to a same-named catalog
+//! object (view/table) instead of the CTE. SQLite gives the CTE precedence.
+//!
+//! Repro from the issue:
+//!
+//! ```sql
+//! CREATE TABLE t1(id INTEGER PRIMARY KEY, grp_id INTEGER);
+//! INSERT INTO t1 VALUES (1,2),(2,3),(3,2);
+//! CREATE VIEW lll AS
+//!   SELECT row_number() OVER (PARTITION BY grp_id) AS rn, grp_id, id FROM t1;
+//!
+//! WITH lll AS (SELECT 99 AS rn, 2 AS grp_id, 100 AS id)
+//! SELECT (SELECT max(id) FROM lll WHERE grp_id = 2);
+//! -- sqlite3: 100 (CTE row); VibeSQL used to return 3 (view rows)
+//! ```
+//!
+//! All expected values below were verified against sqlite3.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        vibesql_ast::Statement::CreateView(create_view) => {
+            vibesql_executor::ViewExecutor::execute_create_view(&create_view, db).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+fn query(db: &vibesql_storage::Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e))
+            .into_iter()
+            .map(|row| row.values.to_vec())
+            .collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+/// Setup from the issue body: a view `lll` over `t1`, shadowed by a CTE.
+fn setup_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, grp_id INTEGER)");
+    run_stmt(&mut db, "INSERT INTO t1 VALUES (1,2),(2,3),(3,2)");
+    run_stmt(
+        &mut db,
+        "CREATE VIEW lll AS \
+         SELECT row_number() OVER (PARTITION BY grp_id) AS rn, grp_id, id FROM t1",
+    );
+    db
+}
+
+/// The exact repro from issue #5350: sqlite3 returns 100 (CTE shadows view).
+#[test]
+fn test_scalar_subquery_sees_outer_cte() {
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH lll AS (SELECT 99 AS rn, 2 AS grp_id, 100 AS id) \
+         SELECT (SELECT max(id) FROM lll WHERE grp_id = 2)",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(100)]]);
+}
+
+/// EXISTS in expression position must also see the CTE (sqlite3: 1).
+#[test]
+fn test_exists_subquery_sees_outer_cte() {
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH lll AS (SELECT 99 AS rn, 2 AS grp_id, 100 AS id) \
+         SELECT EXISTS(SELECT 1 FROM lll WHERE id = 100)",
+    );
+    // VibeSQL represents EXISTS results as Boolean (rendered as 1 by the CLI)
+    assert_eq!(rows, vec![vec![SqlValue::Boolean(true)]]);
+}
+
+/// IN (SELECT ...) in expression position must also see the CTE (sqlite3: 1).
+#[test]
+fn test_in_subquery_sees_outer_cte() {
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH lll AS (SELECT 99 AS rn, 2 AS grp_id, 100 AS id) \
+         SELECT 100 IN (SELECT id FROM lll)",
+    );
+    // VibeSQL represents IN results as Boolean (rendered as 1 by the CLI)
+    assert_eq!(rows, vec![vec![SqlValue::Boolean(true)]]);
+}
+
+/// Scalar subquery in the WHERE clause of a FROM-less SELECT (sqlite3: 5).
+#[test]
+fn test_where_clause_subquery_sees_outer_cte() {
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH lll AS (SELECT 99 AS rn, 2 AS grp_id, 100 AS id) \
+         SELECT 5 WHERE (SELECT max(id) FROM lll) = 100",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(5)]]);
+}
+
+/// CTE names are ASCII case-insensitive, like catalog names (sqlite3: 100).
+#[test]
+fn test_case_insensitive_cte_reference() {
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH lll AS (SELECT 99 AS rn, 2 AS grp_id, 100 AS id) \
+         SELECT (SELECT max(id) FROM LLL)",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(100)]]);
+}
+
+/// A WITH clause inside the subquery shadows the outer CTE (sqlite3: 200).
+#[test]
+fn test_inner_with_shadows_outer_cte() {
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH lll AS (SELECT 100 AS id) \
+         SELECT (WITH lll AS (SELECT 200 AS id) SELECT max(id) FROM lll)",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(200)]]);
+}
+
+/// Control: without a CTE the same name still resolves to the catalog view
+/// (sqlite3: 3 = max(id) over the view rows).
+#[test]
+fn test_no_cte_still_resolves_catalog_view() {
+    let db = setup_db();
+    let rows = query(&db, "SELECT (SELECT max(id) FROM lll WHERE grp_id = 2)");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(3)]]);
+}
+
+/// CTE context must compose with correlation bindings, not replace them
+/// (sqlite3: 11, 12, 13).
+#[test]
+fn test_cte_composes_with_correlated_subquery() {
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH c AS (SELECT 10 AS v) \
+         SELECT (SELECT t1.id + (SELECT v FROM c)) FROM t1 ORDER BY id",
+    );
+    assert_eq!(
+        rows,
+        vec![vec![SqlValue::Integer(11)], vec![SqlValue::Integer(12)], vec![SqlValue::Integer(13)],]
+    );
+}
+
+/// Subqueries on the right side of a set operation see the CTE (sqlite3: 1, 100).
+#[test]
+fn test_union_branch_subquery_sees_outer_cte() {
+    let db = setup_db();
+    let mut rows = query(
+        &db,
+        "WITH lll AS (SELECT 100 AS id) \
+         SELECT 1 UNION SELECT (SELECT max(id) FROM lll)",
+    );
+    rows.sort();
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1)], vec![SqlValue::Integer(100)]]);
+}
+
+/// FROM-less SELECT with a window function alongside a CTE-referencing
+/// scalar subquery (sqlite3: 100|1).
+#[test]
+fn test_window_path_subquery_sees_outer_cte() {
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH lll AS (SELECT 100 AS id) \
+         SELECT (SELECT max(id) FROM lll), min(1) OVER ()",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(100), SqlValue::Integer(1)]]);
+}


### PR DESCRIPTION
Closes #5350

## Summary

A FROM-less SELECT dropped the enclosing statement's CTE bindings: `execute()` merges local CTEs over the outer CTE context into `cte_results`, but `execute_select_without_from()` never received that map, so subqueries in expression position (scalar, `EXISTS`, `IN (SELECT ...)`) constructed evaluators with `cte_context: None` and resolved CTE names to same-named catalog views/tables. SQLite gives the CTE precedence.

The with-FROM paths (materialized/iterator pipelines) and the aggregation path already threaded `cte_context` correctly — only the no-FROM family was affected.

### Root cause
`crates/vibesql-executor/src/select/executor/nonagg/without_from.rs`: `execute_select_without_from()` and its alias-WHERE / window-function helpers built `ExpressionEvaluator` / `CombinedExpressionEvaluator` instances without a CTE context.

### Sites fixed
- `execute_select_without_from()` — select-list and WHERE-clause evaluators (with and without outer correlation context)
- `execute_select_without_from_alias_where()` — select-list and alias-bound WHERE evaluators
- `execute_select_without_from_with_windows()` — window-arg and per-expression evaluators
- `execute_expression_only()` — VALUES rows evaluated through the window-aware path
- `execute_set_operations()` — FROM-less right-hand sides of UNION/INTERSECT/EXCEPT
- Added `with_cte_context()` builder setters on `ExpressionEvaluator` and `CombinedExpressionEvaluator` for constructor combinations lacking a dedicated `*_and_cte` variant (e.g. outer context + window mapping)

CTE precedence follows the existing pattern from the materialized/iterator paths: the merged `cte_results` (local CTEs shadow outer CTEs) when non-empty, else the executor's own `cte_context`; catalog fallback is unchanged, and lookups remain ASCII case-insensitive.

## Test evidence

Repro from the issue (verified side by side with sqlite3 3.x):

```
WITH lll AS (SELECT 99 AS rn, 2 AS grp_id, 100 AS id)
SELECT (SELECT max(id) FROM lll WHERE grp_id = 2);
-- sqlite3: 100; VibeSQL before: 3; VibeSQL after: 100
```

- New `crates/vibesql-executor/tests/cte_expression_subquery_tests.rs` (10 tests, all values cross-checked against sqlite3): the repro, EXISTS + IN variants, WHERE-position scalar subquery, case-insensitive CTE reference (`FROM LLL`), inner WITH shadowing outer CTE, control without CTE (catalog view still used, returns 3), correlated subquery composing with CTE bindings, UNION right-hand branch, and FROM-less window-function path.
- `cargo test -p vibesql-executor`: green (no failures).
- TCL conformance (main vs branch, same machine):
  - `with2.test`: 37 → 40 passed (fixes 1.2, 1.3, 1.9; zero new failures)
  - `with1.test`: 0 tests extracted on both (pre-existing runner limitation)
  - `with3/4/5/6.test`: unchanged
  - `select1.test`: 188/188 both; `select6.test`: 86 passed / 0 failed both
- `scripts/tester_vibesql.tcl` has no skip entries citing this bug.

## Notes / follow-ons

- `WITH ... VALUES (...)` is rejected at parse time ("Expected SELECT, INSERT, UPDATE, or DELETE after WITH clause") — pre-existing parser gap, unrelated to this fix; filing a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)