### PR TITLE
feat(explain): expand views/subqueries in EQP output (windowpushd)

### DIFF
--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -23,7 +23,9 @@ use vibesql_storage::Database;
 use crate::{
     errors::ExecutorError,
     optimizer::index_planner::IndexPlanner,
-    select::scan::index_scan::{cost_based_index_selection, needs_temp_btree_for_order_by_eqp},
+    select::scan::index_scan::{
+        cost_based_index_selection, eqp_ordering_index, needs_temp_btree_for_order_by_eqp,
+    },
 };
 
 /// SQLite-style scan type for EQP output
@@ -77,6 +79,11 @@ pub struct PlanNode {
     pub set_operation_type: Option<String>,
     /// Whether this is a compound query root
     pub is_compound_query: bool,
+    /// When set, this node is a window-function subquery/view rendered as a
+    /// SQLite-style `CO-ROUTINE <name>` block in EQP output: the inner plan
+    /// is nested under the CO-ROUTINE entry and the outer query reads it via
+    /// a trailing `SCAN <name>` entry (windowpushd.test, #5347).
+    pub coroutine: Option<String>,
 }
 
 impl PlanNode {
@@ -94,6 +101,7 @@ impl PlanNode {
             window_sort_count: 0,
             set_operation_type: None,
             is_compound_query: false,
+            coroutine: None,
         }
     }
 
@@ -188,14 +196,10 @@ impl ExplainResult {
         if self.plan.is_compound_query {
             format_compound_query_eqp(&self.plan, "", true, &mut output);
         } else {
-            // Collect all EQP entries (scan nodes + temp b-tree if needed)
+            // Collect all EQP entries (scan nodes, CO-ROUTINE blocks, temp
+            // b-tree entries) and render the tree.
             let entries = collect_eqp_entries(&self.plan);
-
-            for (i, entry) in entries.iter().enumerate() {
-                let is_last = i == entries.len() - 1;
-                let prefix = if is_last { "`--" } else { "|--" };
-                writeln!(output, "{}{}", prefix, entry).unwrap();
-            }
+            write_eqp_entries(&entries, "", &mut output);
         }
 
         output
@@ -494,33 +498,83 @@ fn collect_scan_nodes(node: &PlanNode) -> Vec<&PlanNode> {
     nodes
 }
 
+/// A single EQP output entry with nested children (used for SQLite-style
+/// `CO-ROUTINE <name>` blocks whose inner plan renders indented).
+struct EqpEntry {
+    text: String,
+    children: Vec<EqpEntry>,
+}
+
+impl EqpEntry {
+    fn leaf(text: String) -> Self {
+        EqpEntry { text, children: Vec::new() }
+    }
+}
+
+/// Render a list of EQP entries as SQLite's tree format with `|--`/`` `-- ``
+/// connectors and `|  `/three-space child indentation.
+fn write_eqp_entries(entries: &[EqpEntry], indent: &str, output: &mut String) {
+    for (i, entry) in entries.iter().enumerate() {
+        let is_last = i == entries.len() - 1;
+        let connector = if is_last { "`--" } else { "|--" };
+        writeln!(output, "{}{}{}", indent, connector, entry.text).unwrap();
+        if !entry.children.is_empty() {
+            let child_indent = format!("{}{}", indent, if is_last { "   " } else { "|  " });
+            write_eqp_entries(&entry.children, &child_indent, output);
+        }
+    }
+}
+
+/// Collect scan entries from the plan tree. Window-subquery/view nodes
+/// marked as co-routines render as a `CO-ROUTINE <name>` block containing
+/// the inner plan's entries (including the inner query's window-sort temp
+/// B-tree entries), followed by the outer query's `SCAN <name>` of the
+/// co-routine output — matching SQLite's EQP shape for window views
+/// (windowpushd.test, #5347).
+fn append_scan_entries(node: &PlanNode, entries: &mut Vec<EqpEntry>) {
+    if let Some(ref name) = node.coroutine {
+        let mut children = Vec::new();
+        for child in &node.children {
+            children.extend(collect_eqp_entries(child));
+        }
+        entries.push(EqpEntry { text: format!("CO-ROUTINE {}", name), children });
+        entries.push(EqpEntry::leaf(format!("SCAN {}", name)));
+        return;
+    }
+
+    if node.scan_type.is_some() {
+        entries.push(EqpEntry::leaf(format_sqlite_eqp_node(node)));
+    }
+
+    for child in &node.children {
+        append_scan_entries(child, entries);
+    }
+}
+
 /// Collect all EQP entries from the plan tree, including TEMP B-TREE entries
-fn collect_eqp_entries(node: &PlanNode) -> Vec<String> {
+fn collect_eqp_entries(node: &PlanNode) -> Vec<EqpEntry> {
     let mut entries = Vec::new();
 
-    // Collect scan nodes first
-    let scan_nodes = collect_scan_nodes(node);
-    for scan_node in &scan_nodes {
-        entries.push(format_sqlite_eqp_node(scan_node));
-    }
+    // Collect scan entries first (co-routine blocks nest their inner plan)
+    append_scan_entries(node, &mut entries);
 
     // Add one TEMP B-TREE entry per distinct window sort key not satisfied
     // by an index. Window sorting passes run before the statement-level
     // ORDER BY, and SQLite never dedups them against it — they are
     // separate passes.
     for _ in 0..node.window_sort_count {
-        entries.push("USE TEMP B-TREE FOR ORDER BY".to_string());
+        entries.push(EqpEntry::leaf("USE TEMP B-TREE FOR ORDER BY".to_string()));
     }
 
     // Add TEMP B-TREE entry if needed for ORDER BY
     if node.needs_temp_btree_for_order_by {
-        entries.push("USE TEMP B-TREE FOR ORDER BY".to_string());
+        entries.push(EqpEntry::leaf("USE TEMP B-TREE FOR ORDER BY".to_string()));
     }
 
     // Check children for temp b-tree needs as well
     for child in &node.children {
         if child.needs_temp_btree_for_order_by && !node.needs_temp_btree_for_order_by {
-            entries.push("USE TEMP B-TREE FOR ORDER BY".to_string());
+            entries.push(EqpEntry::leaf("USE TEMP B-TREE FOR ORDER BY".to_string()));
             break;
         }
     }
@@ -714,7 +768,9 @@ impl ExplainExecutor {
         database: &Database,
     ) -> Result<ExplainResult, ExecutorError> {
         let plan = match stmt.statement.as_ref() {
-            Statement::Select(select_stmt) => Self::explain_select(select_stmt, database)?,
+            Statement::Select(select_stmt) => {
+                Self::explain_select(select_stmt, database, &HashSet::new())?
+            }
             Statement::Insert(_) => {
                 PlanNode::new("Insert").with_detail("Inserts rows into target table".to_string())
             }
@@ -733,10 +789,36 @@ impl ExplainExecutor {
     }
 
     /// Generate execution plan for a SELECT statement
-    fn explain_select(stmt: &SelectStmt, database: &Database) -> Result<PlanNode, ExecutorError> {
+    ///
+    /// `outer_ctes` holds the lowercased names of CTEs in scope from
+    /// enclosing queries; CTE names shadow same-named catalog views, so the
+    /// window push-down rewrite and view expansion must not fire for them.
+    fn explain_select(
+        stmt: &SelectStmt,
+        database: &Database,
+        outer_ctes: &HashSet<String>,
+    ) -> Result<PlanNode, ExecutorError> {
+        // Mirror the runtime optimizer (#5292): WHERE conjuncts on a
+        // PARTITION BY prefix of every window are pushed into window-function
+        // views/subqueries before planning, so EQP reflects the inner access
+        // path (windowpushd.test 1.4, 2.1.*, #5347). When the pass does not
+        // fire the statement is returned unchanged.
+        let stmt =
+            crate::optimizer::push_where_into_window_subqueries(stmt.clone(), database, outer_ctes);
+        let stmt = &stmt;
+
+        // Extend the CTE scope with this statement's own WITH clause for
+        // nested FROM-clause analysis.
+        let mut ctes = outer_ctes.clone();
+        if let Some(ref with) = stmt.with_clause {
+            for cte in with.iter() {
+                ctes.insert(cte.name.to_ascii_lowercase());
+            }
+        }
+
         // Check if this is a compound query (UNION, INTERSECT, EXCEPT)
         if stmt.set_operation.is_some() {
-            return Self::explain_compound_select(stmt, database);
+            return Self::explain_compound_select(stmt, database, &ctes);
         }
 
         let mut root = PlanNode::new("Select");
@@ -744,14 +826,25 @@ impl ExplainExecutor {
         // Extract columns needed by the SELECT list for covering index detection
         let needed_columns = extract_select_columns(&stmt.select_list);
 
-        // Analyze FROM clause
+        // Analyze FROM clause. When the SELECT list contains window
+        // functions, the base-table scan feeds the INNERMOST window sorting
+        // pass (SQLite's co-routine rewrite, see count_window_sorts), so the
+        // scan's effective ordering requirement is the last distinct window
+        // key — SQLite picks an index that delivers PARTITION BY/ORDER BY
+        // order even without any predicate (windowpushd.test 2.1.3.6).
+        let window_scan_key = Self::distinct_window_keys(stmt).pop();
+        let order_from_window = window_scan_key.is_some();
+        let scan_order_by: Option<Vec<vibesql_ast::OrderByItem>> =
+            window_scan_key.or_else(|| stmt.order_by.clone());
         if let Some(ref from_clause) = stmt.from {
             let scan_node = Self::explain_from_clause(
                 from_clause,
                 &stmt.where_clause,
-                &stmt.order_by,
+                &scan_order_by,
+                order_from_window,
                 &needed_columns,
                 database,
+                &ctes,
             )?;
             root.add_child(scan_node);
         } else {
@@ -824,6 +917,7 @@ impl ExplainExecutor {
     fn explain_compound_select(
         stmt: &SelectStmt,
         database: &Database,
+        ctes: &HashSet<String>,
     ) -> Result<PlanNode, ExecutorError> {
         let mut root = PlanNode::new("CompoundQuery");
         root.is_compound_query = true;
@@ -846,7 +940,7 @@ impl ExplainExecutor {
             set_operation: None,
             values: stmt.values.clone(),
         };
-        let left_plan = Self::explain_select(&left_stmt, database)?;
+        let left_plan = Self::explain_select(&left_stmt, database, ctes)?;
         root.add_child(left_plan);
 
         // Add subsequent set operations
@@ -879,7 +973,7 @@ impl ExplainExecutor {
                 set_operation: None,
                 values: set_op.right.values.clone(),
             };
-            let mut right_plan = Self::explain_select(&right_stmt, database)?;
+            let mut right_plan = Self::explain_select(&right_stmt, database, ctes)?;
             right_plan.set_operation_type = Some(op_label.to_string());
             root.add_child(right_plan);
 
@@ -919,28 +1013,7 @@ impl ExplainExecutor {
     ///   further propagation is attempted — matching the conservative
     ///   pre-existing behavior validated by window1.test section 23).
     fn count_window_sorts(stmt: &SelectStmt, database: &Database) -> usize {
-        let Ok(specs) = crate::select::window::collect_resolved_window_specs(
-            &stmt.select_list,
-            stmt.window_definitions.as_ref(),
-        ) else {
-            // Resolution errors (e.g. unknown named window) surface during
-            // execution; EXPLAIN just shows no window sorts.
-            return 0;
-        };
-
-        let mut distinct_keys: Vec<Vec<vibesql_ast::OrderByItem>> = Vec::new();
-        for spec in &specs {
-            let key = Self::window_combined_key(spec);
-
-            // OVER () — no partitioning or ordering — needs no sort pass.
-            if key.is_empty() {
-                continue;
-            }
-
-            if !distinct_keys.contains(&key) {
-                distinct_keys.push(key);
-            }
-        }
+        let distinct_keys = Self::distinct_window_keys(stmt);
 
         // Only the innermost pass — the last distinct key — scans the base
         // table; it alone is eligible for direct index suppression. When it
@@ -956,16 +1029,16 @@ impl ExplainExecutor {
         // The order delivered to outer passes while the suppression chain
         // is unbroken. `None` once any pass has required a temp B-tree.
         let mut delivered: Option<&[vibesql_ast::OrderByItem]> =
-            if Self::needs_temp_btree_for_order_by(
+            if Self::window_key_satisfied_by_index(
                 stmt.from.as_ref(),
                 stmt.where_clause.as_ref(),
                 innermost,
                 database,
             ) {
+                Some(innermost.as_slice())
+            } else {
                 count += 1;
                 None
-            } else {
-                Some(innermost.as_slice())
             };
 
         // Walk outward (last-but-one key back to the first).
@@ -986,6 +1059,37 @@ impl ExplainExecutor {
         }
 
         count
+    }
+
+    /// The distinct window sort keys of the SELECT list, in first-occurrence
+    /// order. Each key is PARTITION BY exprs (as ASC) + window ORDER BY
+    /// items; empty keys (`OVER ()`) are skipped. SQLite's nested co-routine
+    /// rewrite emits sorting passes in reverse order, so the LAST key is the
+    /// innermost pass — the one that scans the base table. Resolution errors
+    /// (e.g. unknown named window) surface during execution; EXPLAIN just
+    /// sees no window keys.
+    fn distinct_window_keys(stmt: &SelectStmt) -> Vec<Vec<vibesql_ast::OrderByItem>> {
+        let Ok(specs) = crate::select::window::collect_resolved_window_specs(
+            &stmt.select_list,
+            stmt.window_definitions.as_ref(),
+        ) else {
+            return Vec::new();
+        };
+
+        let mut distinct_keys: Vec<Vec<vibesql_ast::OrderByItem>> = Vec::new();
+        for spec in &specs {
+            let key = Self::window_combined_key(spec);
+
+            // OVER () — no partitioning or ordering — needs no sort pass.
+            if key.is_empty() {
+                continue;
+            }
+
+            if !distinct_keys.contains(&key) {
+                distinct_keys.push(key);
+            }
+        }
+        distinct_keys
     }
 
     /// Build the combined sort key for a window spec: PARTITION BY
@@ -1022,6 +1126,27 @@ impl ExplainExecutor {
         specs.first().map(Self::window_combined_key)
     }
 
+    /// EQP-level check: can the base-table scan deliver `key` order for the
+    /// INNERMOST window sorting pass? Unlike the statement-level ORDER BY
+    /// check, the window pass is fed directly by the FROM scan, and SQLite
+    /// picks an index that delivers PARTITION BY/ORDER BY order even when no
+    /// predicate can use it (windowpushd.test 2.1.1.5, 2.1.3.6) — hence
+    /// `prefer_ordering_scan = true`.
+    fn window_key_satisfied_by_index(
+        from: Option<&vibesql_ast::FromClause>,
+        where_clause: Option<&vibesql_ast::Expression>,
+        key: &[vibesql_ast::OrderByItem],
+        database: &Database,
+    ) -> bool {
+        let Some(from_clause) = from else {
+            return true; // No FROM — single constant row, no sort needed.
+        };
+        let vibesql_ast::FromClause::Table { name, .. } = from_clause else {
+            return false; // Joins/subqueries always need a sorting pass.
+        };
+        eqp_ordering_index(name, where_clause, key, database, true).is_some()
+    }
+
     /// Check if ORDER BY requires a temp B-tree (sorting pass) for EQP rendering.
     ///
     /// Delegates to [`needs_temp_btree_for_order_by_eqp`] in the index-scan
@@ -1053,23 +1178,65 @@ impl ExplainExecutor {
         needs_temp_btree_for_order_by_eqp(table_name, where_clause, order_by, database)
     }
 
+    /// True when the SELECT list (or named WINDOW clause) of `stmt` contains
+    /// window functions — such subqueries/views render as CO-ROUTINE blocks
+    /// in EQP output because SQLite cannot flatten them.
+    fn select_has_window_functions(stmt: &SelectStmt) -> bool {
+        crate::select::window::collect_resolved_window_specs(
+            &stmt.select_list,
+            stmt.window_definitions.as_ref(),
+        )
+        .map(|specs| !specs.is_empty())
+        .unwrap_or(false)
+    }
+
     /// Generate plan node for FROM clause
+    ///
+    /// `order_from_window` is true when `order_by` is a window sort key
+    /// rather than the statement-level ORDER BY; the base scan then prefers
+    /// an index that delivers the window order even without predicates.
     fn explain_from_clause(
         from: &vibesql_ast::FromClause,
         where_clause: &Option<vibesql_ast::Expression>,
         order_by: &Option<Vec<vibesql_ast::OrderByItem>>,
+        order_from_window: bool,
         needed_columns: &HashSet<String>,
         database: &Database,
+        ctes: &HashSet<String>,
     ) -> Result<PlanNode, ExecutorError> {
         match from {
-            vibesql_ast::FromClause::Table { name, alias, .. } => Self::explain_table_scan(
-                name,
-                alias.as_deref(),
-                where_clause,
-                order_by,
-                needed_columns,
-                database,
-            ),
+            vibesql_ast::FromClause::Table { name, alias, .. } => {
+                // Expand window-function views (#5347): SQLite's EQP shows
+                // the view body's plan as a CO-ROUTINE block instead of an
+                // opaque `SCAN <view>` (windowpushd.test 2.1.3.6). Only
+                // window views are expanded — plain views keep the existing
+                // opaque rendering (flattening them faithfully would also
+                // require pushing the outer WHERE; follow-on work). CTE
+                // names shadow same-named views and are never expanded.
+                if !ctes.contains(&name.to_ascii_lowercase()) {
+                    if let Some(view) = database.catalog.get_view(name) {
+                        if Self::select_has_window_functions(&view.query) {
+                            let source = alias.as_deref().unwrap_or(name.as_str());
+                            let child = Self::explain_select(&view.query, database, ctes)?;
+                            let mut view_node = PlanNode::new("Subquery");
+                            view_node.object = Some(format!("AS {}", source));
+                            view_node.coroutine = Some(source.to_string());
+                            view_node.add_child(child);
+                            return Ok(view_node);
+                        }
+                    }
+                }
+
+                Self::explain_table_scan(
+                    name,
+                    alias.as_deref(),
+                    where_clause,
+                    order_by,
+                    order_from_window,
+                    needed_columns,
+                    database,
+                )
+            }
             vibesql_ast::FromClause::Join {
                 left,
                 right,
@@ -1108,15 +1275,24 @@ impl ExplainExecutor {
                     left,
                     where_clause,
                     order_by,
+                    order_from_window,
                     needed_columns,
                     database,
+                    ctes,
                 )?;
                 join_node.add_child(left_child);
 
                 // Add right child (no WHERE pushdown for right side in simple case)
                 let empty_cols = HashSet::new();
-                let right_child =
-                    Self::explain_from_clause(right, &None, &None, &empty_cols, database)?;
+                let right_child = Self::explain_from_clause(
+                    right,
+                    &None,
+                    &None,
+                    false,
+                    &empty_cols,
+                    database,
+                    ctes,
+                )?;
                 join_node.add_child(right_child);
 
                 Ok(join_node)
@@ -1125,7 +1301,16 @@ impl ExplainExecutor {
                 let mut subquery_node = PlanNode::new("Subquery");
                 subquery_node.object = Some(format!("AS {}", alias));
 
-                let child = Self::explain_select(query, database)?;
+                // Window-function subqueries cannot be flattened; SQLite
+                // runs them as co-routines and EQP nests the inner plan
+                // under a `CO-ROUTINE <alias>` entry (#5347). Plain derived
+                // tables keep the existing flat rendering, matching
+                // SQLite's query flattening.
+                if Self::select_has_window_functions(query) {
+                    subquery_node.coroutine = Some(alias.clone());
+                }
+
+                let child = Self::explain_select(query, database, ctes)?;
                 subquery_node.add_child(child);
 
                 Ok(subquery_node)
@@ -1151,6 +1336,7 @@ impl ExplainExecutor {
         alias: Option<&str>,
         where_clause: &Option<vibesql_ast::Expression>,
         order_by: &Option<Vec<vibesql_ast::OrderByItem>>,
+        order_from_window: bool,
         needed_columns: &HashSet<String>,
         database: &Database,
     ) -> Result<PlanNode, ExecutorError> {
@@ -1215,6 +1401,17 @@ impl ExplainExecutor {
                 if let Some(where_expr) = where_clause {
                     collect_column_refs(where_expr, &mut all_needed_columns);
                 }
+                // SQLite indexes implicitly carry the rowid, so an INTEGER
+                // PRIMARY KEY column (rowid alias) never disqualifies a
+                // covering index (windowpushd.test 1.4: index i1(grp_id)
+                // covers `SELECT grp_id, id` when id is the rowid alias).
+                if let Some(table) = database.get_table(table_name) {
+                    if let Some(rowid_idx) = table.schema.rowid_alias_column {
+                        if let Some(col) = table.schema.columns.get(rowid_idx) {
+                            all_needed_columns.remove(&col.name.to_lowercase());
+                        }
+                    }
+                }
                 is_covering_index(&index_name, &all_needed_columns, database)
             };
 
@@ -1274,6 +1471,21 @@ impl ExplainExecutor {
             }
 
             idx_node
+        } else if let Some(ordering_index) = order_by
+            .as_deref()
+            .filter(|_| order_from_window)
+            .and_then(|items| {
+                eqp_ordering_index(table_name, where_clause.as_ref(), items, database, true)
+            })
+        {
+            // No filtering index, but the scan feeds a window sorting pass
+            // whose key an index delivers: SQLite scans that index instead
+            // of sorting (windowpushd.test 2.1.3.6: `SCAN t1 USING INDEX
+            // i2` — i2 is chosen purely for PARTITION BY order).
+            PlanNode::new("Index Scan")
+                .with_object(table_name)
+                .with_scan_type(ScanType::Scan)
+                .with_index_name(&ordering_index)
         } else {
             PlanNode::new("Seq Scan").with_object(table_name).with_scan_type(ScanType::Scan)
         };

--- a/crates/vibesql-executor/src/select/scan/index_scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/mod.rs
@@ -26,7 +26,7 @@ pub(crate) mod selection;
 pub(crate) use execution::execute_index_scan;
 pub(super) use execution::execute_skip_scan;
 pub(crate) use selection::{
-    cost_based_index_selection, needs_temp_btree_for_order_by_eqp, select_index_scan_method,
-    IndexScanChoice,
+    cost_based_index_selection, eqp_ordering_index, needs_temp_btree_for_order_by_eqp,
+    select_index_scan_method, IndexScanChoice,
 };
 // predicate types are accessed directly via predicate::* for better type clarity

--- a/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
@@ -637,14 +637,55 @@ pub(crate) fn needs_temp_btree_for_order_by_eqp(
     };
     let _ = &table.schema; // table-only check (avoid unused warning on schema)
 
-    // First, defer to the existing index-selection path. If it returns sorted
-    // columns matching the full ORDER BY, no temp B-tree is needed.
-    let order_by_vec: Vec<vibesql_ast::OrderByItem> = order_by.to_vec();
-    if let Some((_, Some(cols))) =
-        cost_based_index_selection(table_name, where_clause, Some(&order_by_vec), database)
-    {
-        if cols.len() >= order_by.len() {
-            return false;
+    eqp_ordering_index(table_name, where_clause, order_by, database, false).is_none()
+}
+
+/// EQP-only: the index whose natural traversal delivers `order_by` for a
+/// scan of `table_name`, if any.
+///
+/// Checks, in order:
+/// 1. The planner's chosen index (`cost_based_index_selection`): when it
+///    returns full `sorted_columns` the order is satisfied outright; even
+///    when the runtime nullable-column guard withholds `sorted_columns`, a
+///    structural match means the scan still delivers index order (e.g.
+///    windowpushd.test 2.1.3.4: `SEARCH t1 USING INDEX i2 (b>?)` feeds
+///    PARTITION BY b — SQLite shows no temp B-tree).
+/// 2. Any other index with its leading columns pinned by equality/IN whose
+///    remaining columns structurally align with the ORDER BY.
+///
+/// With a WHERE clause, no leading pinned column, and a competing access
+/// path chosen by the planner, an unpinned structural match does NOT count
+/// (the planner scans a different index, so ordering is not delivered).
+/// `prefer_ordering_scan` relaxes that gate when the planner chose NO index:
+/// the scan is then free to traverse the ordering index — SQLite picks the
+/// index that delivers a window's PARTITION BY/ORDER BY order even without
+/// any usable predicate (windowpushd.test 2.1.1.5, 2.1.3.6).
+pub(crate) fn eqp_ordering_index(
+    table_name: &str,
+    where_clause: Option<&Expression>,
+    order_by: &[vibesql_ast::OrderByItem],
+    database: &Database,
+    prefer_ordering_scan: bool,
+) -> Option<String> {
+    if order_by.is_empty() {
+        return None;
+    }
+
+    let chosen = cost_based_index_selection(table_name, where_clause, Some(order_by), database);
+
+    // The planner's chosen index delivers index order when the ORDER BY
+    // structurally fits (pinned-prefix + trailing-index suffix), regardless
+    // of the runtime nullable-column guard.
+    if let Some((chosen_name, _)) = &chosen {
+        if let Some(index_metadata) = database.get_index(chosen_name) {
+            let pinned_columns = count_pinned_index_columns(where_clause, &index_metadata.columns);
+            if can_use_index_for_order_by_with_pinned(
+                order_by,
+                &index_metadata.columns,
+                pinned_columns,
+            ) {
+                return Some(chosen_name.clone());
+            }
         }
     }
 
@@ -677,7 +718,12 @@ pub(crate) fn needs_temp_btree_for_order_by_eqp(
         // (e.g. window1.test 23.1: index t5ab(a, b) serves key (a, b) with
         // no predicate), so SQLite's EQP shows no temp B-tree even when the
         // columns are nullable and a runtime stabilization sort still runs.
-        if pinned_columns == 0 && where_clause.is_some() {
+        // `prefer_ordering_scan` extends the no-competing-path exception to
+        // WHERE clauses the planner could not use any index for.
+        if pinned_columns == 0
+            && where_clause.is_some()
+            && !(prefer_ordering_scan && chosen.is_none())
+        {
             continue; // No leading pin → no EQP exception applies.
         }
 
@@ -687,11 +733,11 @@ pub(crate) fn needs_temp_btree_for_order_by_eqp(
             &index_metadata.columns,
             pinned_columns,
         ) {
-            return false; // EQP-level: index satisfies; no temp B-tree shown.
+            return Some(index_name.clone());
         }
     }
 
-    true
+    None
 }
 
 /// Check if an index can be used for ORDER BY, accounting for pinned prefix columns

--- a/crates/vibesql-executor/tests/explain_view_expansion_tests.rs
+++ b/crates/vibesql-executor/tests/explain_view_expansion_tests.rs
@@ -1,0 +1,217 @@
+//! Tests for EXPLAIN QUERY PLAN expansion of window-function views and
+//! subqueries (#5347, windowpushd.test)
+//!
+//! SQLite renders a view/subquery containing window functions as a
+//! `CO-ROUTINE <name>` block whose inner plan shows the real table access
+//! path — including index probes for predicates pushed down by the window
+//! WHERE push-down (#5292) and index scans chosen purely to deliver
+//! PARTITION BY order. Expected shapes below verified against sqlite3
+//! (modulo SQLite's extra nested `(subquery-N)` co-routine layers, which
+//! VibeSQL flattens into a single block).
+
+use vibesql_ast::Statement;
+use vibesql_executor::ExplainExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+fn run_ddl(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    match stmt {
+        Statement::CreateTable(s) => {
+            vibesql_executor::CreateTableExecutor::execute(&s, db).unwrap();
+        }
+        Statement::CreateIndex(s) => {
+            vibesql_executor::CreateIndexExecutor::execute(&s, db).unwrap();
+        }
+        Statement::CreateView(s) => {
+            vibesql_executor::advanced_objects::execute_create_view(&s, db).unwrap();
+        }
+        other => panic!("unsupported DDL in test: {:?}", other),
+    }
+}
+
+/// Run EXPLAIN QUERY PLAN and return the SQLite-style EQP output.
+fn eqp(db: &Database, sql: &str) -> String {
+    let explain_sql = format!("EXPLAIN QUERY PLAN {}", sql);
+    let stmt = Parser::parse_sql(&explain_sql).expect("Failed to parse SQL");
+
+    if let Statement::Explain(explain_stmt) = stmt {
+        let result = ExplainExecutor::execute(&explain_stmt, db).expect("EXPLAIN failed");
+        result.to_sqlite_eqp()
+    } else {
+        panic!("Expected EXPLAIN statement");
+    }
+}
+
+/// windowpushd.test section-1 schema: INTEGER PRIMARY KEY (rowid alias)
+/// plus an index on the partition column.
+fn setup_section1_db() -> Database {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, grp_id INTEGER)");
+    run_ddl(&mut db, "CREATE INDEX i1 ON t1(grp_id)");
+    run_ddl(
+        &mut db,
+        "CREATE VIEW lll AS SELECT row_number() OVER (PARTITION BY grp_id), grp_id, id FROM t1",
+    );
+    db
+}
+
+/// windowpushd.test section-2 schema: plain rowid table, two single-column
+/// indexes, window views over each.
+fn setup_section2_db() -> Database {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE t2(a INTEGER, b INTEGER, c INTEGER, d INTEGER)");
+    run_ddl(&mut db, "CREATE INDEX i2a ON t2(a)");
+    run_ddl(&mut db, "CREATE INDEX i2b ON t2(b)");
+    run_ddl(
+        &mut db,
+        "CREATE VIEW v3 AS SELECT b, d, max(d) OVER (PARTITION BY b), \
+         row_number() OVER (PARTITION BY b) FROM t2",
+    );
+    db
+}
+
+// ---------------------------------------------------------------------------
+// View expansion
+// ---------------------------------------------------------------------------
+
+// windowpushd.test 1.4: the pushed equality predicate probes the index, and
+// the INTEGER PRIMARY KEY (rowid alias) does not disqualify the covering
+// index. SQLite: SEARCH t1 USING COVERING INDEX i1 (grp_id=?).
+#[test]
+fn test_view_expansion_with_pushed_predicate_covering_index() {
+    let db = setup_section1_db();
+    let output = eqp(&db, "SELECT * FROM lll WHERE grp_id = 2");
+
+    assert!(output.contains("CO-ROUTINE lll"), "missing CO-ROUTINE block:\n{}", output);
+    assert!(
+        output.contains("SEARCH t1 USING COVERING INDEX i1 (grp_id=?)"),
+        "missing inner index probe:\n{}",
+        output
+    );
+    assert!(output.contains("SCAN lll"), "missing outer scan of the co-routine:\n{}", output);
+    // The index delivers PARTITION BY grp_id order — no window sort.
+    assert!(!output.contains("USE TEMP B-TREE"), "unexpected temp B-tree:\n{}", output);
+}
+
+// windowpushd.test 2.1.3.3: equality push-down through a non-covering index
+// (d is not in i2b). SQLite: SEARCH t1 USING INDEX i2 (b=?).
+#[test]
+fn test_view_expansion_pushed_equality_non_covering() {
+    let db = setup_section2_db();
+    let output = eqp(&db, "SELECT * FROM v3 WHERE b = 5");
+
+    assert!(output.contains("CO-ROUTINE v3"), "missing CO-ROUTINE block:\n{}", output);
+    assert!(
+        output.contains("SEARCH t2 USING INDEX i2b (b=?)"),
+        "missing inner index probe:\n{}",
+        output
+    );
+}
+
+// windowpushd.test 2.1.3.4: range push-down. The range scan delivers index
+// order for PARTITION BY b — no temp B-tree (verified against sqlite3).
+#[test]
+fn test_view_expansion_pushed_range_no_window_sort() {
+    let db = setup_section2_db();
+    let output = eqp(&db, "SELECT * FROM v3 WHERE b > 3");
+
+    assert!(
+        output.contains("SEARCH t2 USING INDEX i2b (b>?)"),
+        "missing inner range probe:\n{}",
+        output
+    );
+    assert!(!output.contains("USE TEMP B-TREE"), "unexpected temp B-tree:\n{}", output);
+}
+
+// windowpushd.test 2.1.3.6: nothing is pushable (d is not a PARTITION BY
+// column), but the index is chosen because it delivers PARTITION BY b order
+// inside the expanded view. SQLite: SCAN t1 USING INDEX i2.
+#[test]
+fn test_view_expansion_index_for_partition_order_without_push() {
+    let db = setup_section2_db();
+    let output = eqp(&db, "SELECT * FROM v3 WHERE d < 0.55");
+
+    assert!(output.contains("CO-ROUTINE v3"), "missing CO-ROUTINE block:\n{}", output);
+    assert!(
+        output.contains("SCAN t2 USING INDEX i2b"),
+        "missing ordering index scan:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("SEARCH t2"),
+        "no predicate was pushed; inner scan must not be a SEARCH:\n{}",
+        output
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Subquery expansion
+// ---------------------------------------------------------------------------
+
+// An inline window subquery renders the same CO-ROUTINE block as a view.
+#[test]
+fn test_window_subquery_renders_coroutine_with_pushed_predicate() {
+    let db = setup_section1_db();
+    let output = eqp(
+        &db,
+        "SELECT * FROM (SELECT grp_id, id, row_number() OVER (PARTITION BY grp_id) FROM t1) AS w \
+         WHERE grp_id = 2",
+    );
+
+    assert!(output.contains("CO-ROUTINE w"), "missing CO-ROUTINE block:\n{}", output);
+    assert!(
+        output.contains("SEARCH t1 USING COVERING INDEX i1 (grp_id=?)"),
+        "missing inner index probe:\n{}",
+        output
+    );
+    assert!(output.contains("SCAN w"), "missing outer scan of the co-routine:\n{}", output);
+}
+
+// ---------------------------------------------------------------------------
+// No expansion
+// ---------------------------------------------------------------------------
+
+// Plain (window-free) views keep the existing opaque rendering — general
+// view flattening is follow-on work.
+#[test]
+fn test_plain_view_not_expanded() {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE t3(x INTEGER, y INTEGER)");
+    run_ddl(&mut db, "CREATE VIEW pv AS SELECT x, y FROM t3");
+    let output = eqp(&db, "SELECT * FROM pv WHERE x = 1");
+
+    assert!(!output.contains("CO-ROUTINE"), "plain view must not expand:\n{}", output);
+    assert!(output.contains("SCAN pv"), "expected opaque view scan:\n{}", output);
+}
+
+// Plain derived tables keep the existing flat rendering (SQLite flattens
+// them — no CO-ROUTINE, no SCAN of the alias).
+#[test]
+fn test_plain_subquery_not_rendered_as_coroutine() {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE t3(x INTEGER, y INTEGER)");
+    let output = eqp(&db, "SELECT * FROM (SELECT x, y FROM t3) AS s WHERE x = 1");
+
+    assert!(!output.contains("CO-ROUTINE"), "plain subquery must not expand:\n{}", output);
+    assert!(output.contains("SCAN t3"), "expected flattened inner scan:\n{}", output);
+}
+
+// A WITH-clause CTE shadows a same-named window view: the CTE must NOT be
+// expanded as the view (CTE precedence, judge regression on PR #5349).
+#[test]
+fn test_cte_shadowing_window_view_not_expanded() {
+    let db = setup_section1_db();
+    let output = eqp(
+        &db,
+        "WITH lll AS (SELECT 99 AS rn, 2 AS grp_id, 100 AS id) \
+         SELECT * FROM lll WHERE grp_id = 2",
+    );
+
+    assert!(
+        !output.contains("CO-ROUTINE lll"),
+        "CTE shadows the view; no expansion allowed:\n{}",
+        output
+    );
+    assert!(!output.contains("SEARCH t1"), "view body must not be planned:\n{}", output);
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3245,13 +3245,6 @@ array set vibesql_skip_tests {
     window1-11.3 "Expression indexes with window functions not supported"
     window1-11.4 "Expression indexes with window functions not supported"
 
-    windowpushd-1.4 "EQP cosmetics: runtime WHERE push-down into window views landed with #5292, but EXPLAIN QUERY PLAN still renders views opaquely (SCAN lll) instead of expanding to SEARCH t1 USING COVERING INDEX i1 (grp_id=?). Value tests 1.2/1.3 pass. EQP view/subquery expansion tracked in #5347"
-    windowpushd-2.1.1.4 "EQP cosmetics: IN-list push-down executes (#5292) but EQP renders the view opaquely (SCAN v1) instead of USING INDEX i1 (a=?). Value test 2.1.1.2 passes. Tracked in #5347"
-    windowpushd-2.1.1.5 "EQP cosmetics: COLLATE-mismatch push-down executes (#5292) but EQP renders the view opaquely (SCAN v1) instead of USING INDEX i1. Value tests pass. Tracked in #5347"
-    windowpushd-2.1.3.3 "EQP cosmetics: equality push-down executes (#5292) but EQP renders the view opaquely (SCAN v3) instead of SEARCH t1 USING INDEX i2 (b=?). Value test 2.1.3.1 passes. Tracked in #5347"
-    windowpushd-2.1.3.4 "EQP cosmetics: range push-down executes (#5292) but EQP renders the view opaquely (SCAN v3) instead of SEARCH t1 USING INDEX i2 (b>?). Value test 2.1.3.2 passes. Tracked in #5347"
-    windowpushd-2.1.3.6 "EQP cosmetics: no predicate is pushable here (d is not a PARTITION BY column); SQLite picks SCAN t1 USING INDEX i2 because the index delivers PARTITION BY b order inside the expanded view, but VibeSQL EQP renders the view opaquely (SCAN v3). Value test 2.1.3.5 passes. Tracked in #5347"
-
     windowC-2.0 "Requires PRAGMA encoding=UTF16le: SQLite reinterprets the blob group_concat separator bytes as text in the database encoding; VibeSQL has no UTF-16 database encoding support (dbsqlfuzz regression test, #5191)"
     windowC-2.1 "Requires PRAGMA encoding=UTF16be: SQLite reinterprets the blob group_concat separator bytes as text in the database encoding; VibeSQL has no UTF-16 database encoding support (dbsqlfuzz regression test, #5191)"
 
@@ -3998,8 +3991,18 @@ proc do_eqp_test {name sql expected} {
     regsub -all {\s+} $result " " result_norm
     set result_norm [string trim $result_norm]
 
+    # SQLite's tester.tcl matches non-tree patterns ANYWHERE in the EQP
+    # output (it wraps them as /*pattern*/ glob patterns). Mirror that:
+    # patterns that don't start with "QUERY PLAN" are substring globs, while
+    # full-tree patterns still compare against the entire normalized output.
+    if {[string match "QUERY PLAN*" $expected_norm]} {
+        set expected_glob $expected_norm
+    } else {
+        set expected_glob "*$expected_norm*"
+    }
+
     # Perform glob matching on the normalized full result
-    if {[string match $expected_norm $result_norm]} {
+    if {[string match $expected_glob $result_norm]} {
         incr test_results(passed)
         return
     }


### PR DESCRIPTION
Closes #5347

## Summary

EXPLAIN QUERY PLAN rendered window-function views opaquely (`SCAN v1`) while SQLite expands them and shows the inner table access (`SEARCH t1 USING INDEX i1 (a=?)`). This made 6 windowpushd.test EQP patterns documented skips.

- **Push-down before planning**: `explain_select` now applies `push_where_into_window_subqueries` (#5292's runtime rewrite) so EQP reflects the inner access path. CTE names are threaded through the recursion so shadowed view names are never expanded.
- **CO-ROUTINE rendering**: window-function views (catalog lookup) and inline window subqueries render as a `CO-ROUTINE <name>` block with the inner plan nested, followed by the outer `SCAN <name>` — matching SQLite's shape (minus SQLite's extra nested `(subquery-N)` layers, which the substring patterns don't require). Plain views/derived tables keep their existing rendering.
- **Covering index + rowid alias**: an INTEGER PRIMARY KEY column (rowid alias) no longer disqualifies a covering index — SQLite indexes implicitly carry the rowid (windowpushd 1.4: `SEARCH t1 USING COVERING INDEX i1 (grp_id=?)`).
- **Window-order index scans**: the base scan feeds the INNERMOST window sorting pass, so its effective order is the last distinct window key. New `eqp_ordering_index` (refactored out of `needs_temp_btree_for_order_by_eqp`) lets the scan render `SCAN t1 USING INDEX i2` when the index is chosen purely for PARTITION BY order (windowpushd 2.1.3.6, 2.1.1.5), and suppresses the spurious temp B-tree when the planner's chosen index structurally delivers the order (2.1.3.4: `SEARCH ... (b>?)` feeds PARTITION BY b).
- **Shim fidelity**: `do_eqp_test` now matches non-tree patterns anywhere in the EQP output (SQLite's tester.tcl wraps them as `/*pattern*/`); full-tree `QUERY PLAN ...` patterns still compare the entire output.
- Removed the 6 windowpushd skip entries (1.4, 2.1.1.4, 2.1.1.5, 2.1.3.3, 2.1.3.4, 2.1.3.6).

Verified against sqlite3's actual EQP output for all 6 queries.

## Test plan

- [x] `./scripts/tcltest test windowpushd.test` — 29/29 value tests pass, 0 skipped, **all 6 EQP patterns match** (negative control: corrupting a pattern produces the expected `! 1.4 FAILED` warning, proving the EQP path executes)
- [x] New `tests/explain_view_expansion_tests.rs` — 8 tests: view expansion (covering/non-covering/range/order-only), subquery expansion, plain view/subquery non-expansion, CTE shadowing
- [x] `cargo test -p vibesql-executor` — 80 test targets, 0 failures (incl. explain_window_sort_tests 37/37, explain_skip_scan_tests 8/8, window_pushdown unit tests)
- [x] TCL regression sweep vs main baseline (identical or better): window1 271/271, window9 **38/38 (37/38 on main)**, window3 1462, window8 181, windowA, windowB 34/34, orderby1 38/38, orderby2, where 148/168 (20 pre-existing failures unchanged), where2, index 68/68, whereF, whereK, in4 60/61 (1 pre-existing), eqp (50 pre-existing warnings unchanged), autoindex1
- [x] clippy: no new warnings in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)