### PR TITLE
feat(parser): support WITH clause before VALUES statement

### DIFF
--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -900,11 +900,17 @@ impl SelectExecutor<'_> {
                 }
                 all_rows
             } else {
+                // Thread CTE context so subqueries in VALUES rows can reference
+                // names bound by an enclosing WITH clause (#5353); fall back to
+                // the outer context when no local CTEs were materialized.
+                let cte_ctx =
+                    if !cte_results.is_empty() { Some(cte_results) } else { self.cte_context };
                 let from_result = crate::select::scan::values::execute_values(
                     values_rows,
                     "_values_",
                     None,
                     Some(self.database),
+                    cte_ctx,
                 )?;
                 from_result.into_rows()
             };

--- a/crates/vibesql-executor/src/select/executor/set_operations.rs
+++ b/crates/vibesql-executor/src/select/executor/set_operations.rs
@@ -193,11 +193,17 @@ impl SelectExecutor<'_> {
             self.execute_without_aggregation(right_stmt, from_result, cte_results)?
         } else if let Some(values_rows) = &right_stmt.values {
             // Handle standalone VALUES in set operation right side (Issue #4546)
+            // Thread CTE context so subqueries in VALUES rows can reference
+            // names bound by an enclosing WITH clause (#5353); fall back to
+            // the outer context when no local CTEs were materialized.
+            let cte_ctx =
+                if !cte_results.is_empty() { Some(cte_results) } else { self.cte_context };
             let from_result = crate::select::scan::values::execute_values(
                 values_rows,
                 "_values_",
                 None,
                 Some(self.database),
+                cte_ctx,
             )?;
             from_result.into_rows()
         } else {

--- a/crates/vibesql-executor/src/select/scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/mod.rs
@@ -181,8 +181,12 @@ where
         vibesql_ast::FromClause::Subquery { query, alias, column_aliases } => {
             derived::execute_derived_table(query, alias, column_aliases.as_ref(), execute_subquery)
         }
-        vibesql_ast::FromClause::Values { rows, alias, column_aliases } => {
-            values::execute_values(rows, alias, column_aliases.as_ref(), Some(database))
-        }
+        vibesql_ast::FromClause::Values { rows, alias, column_aliases } => values::execute_values(
+            rows,
+            alias,
+            column_aliases.as_ref(),
+            Some(database),
+            Some(cte_results),
+        ),
     }
 }

--- a/crates/vibesql-executor/src/select/scan/values.rs
+++ b/crates/vibesql-executor/src/select/scan/values.rs
@@ -21,11 +21,14 @@ use crate::{
 /// * `column_aliases` - Optional column name overrides
 /// * `database` - Optional database reference for expression evaluation (enables
 ///   function calls, subqueries, etc.)
+/// * `cte_results` - Optional CTE context so subqueries inside VALUES rows can
+///   reference names bound by an enclosing WITH clause (issue #5353)
 pub(crate) fn execute_values(
     rows: &[Vec<vibesql_ast::Expression>],
     alias: &str,
     column_aliases: Option<&Vec<String>>,
     database: Option<&vibesql_storage::Database>,
+    cte_results: Option<&std::collections::HashMap<String, crate::select::cte::CteResult>>,
 ) -> Result<super::FromResult, ExecutorError> {
     // Handle empty VALUES - return empty result with appropriate schema
     if rows.is_empty() {
@@ -48,11 +51,19 @@ pub(crate) fn execute_values(
     let empty_row = vibesql_storage::Row::new(vec![]);
 
     // Create evaluator - use database if available for function calls, subqueries, etc.
-    let evaluator = if let Some(db) = database {
+    let mut evaluator = if let Some(db) = database {
         CombinedExpressionEvaluator::with_database(&empty_schema, db)
     } else {
         CombinedExpressionEvaluator::new(&empty_schema)
     };
+
+    // Thread CTE context so subqueries in VALUES rows can reference names
+    // bound by an enclosing WITH clause (issue #5353)
+    if let Some(ctes) = cte_results {
+        if !ctes.is_empty() {
+            evaluator = evaluator.with_cte_context(ctes);
+        }
+    }
 
     // Evaluate all rows and collect results
     let mut result_rows = Vec::with_capacity(rows.len());

--- a/crates/vibesql-executor/tests/with_values_tests.rs
+++ b/crates/vibesql-executor/tests/with_values_tests.rs
@@ -1,0 +1,207 @@
+//! Regression tests for issue #5353
+//!
+//! SQLite allows a `WITH` clause to precede a standalone `VALUES` statement
+//! (a standalone VALUES is treated as a SELECT form), but VibeSQL rejected it
+//! at parse time. Additionally, the standalone-VALUES execution path
+//! (`execute_values()`) did not receive the enclosing statement's CTE context,
+//! so subqueries inside VALUES rows could not reference CTE names — including
+//! in compound positions like `SELECT 1 UNION VALUES((SELECT ... FROM cte))`.
+//!
+//! Repro from the issue:
+//!
+//! ```sql
+//! WITH lll AS (SELECT 100 AS id) VALUES((SELECT max(id) FROM lll));
+//! -- sqlite3 3.51.0: 100
+//! -- VibeSQL used to fail: Parse error: Expected SELECT, INSERT, UPDATE, or
+//! -- DELETE after WITH clause, found near "VALUES": syntax error
+//! ```
+//!
+//! All expected values below were verified against sqlite3 3.51.0.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        vibesql_ast::Statement::CreateView(create_view) => {
+            vibesql_executor::ViewExecutor::execute_create_view(&create_view, db).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+fn query(db: &vibesql_storage::Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e))
+            .into_iter()
+            .map(|row| row.values.to_vec())
+            .collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+/// Setup matching issue #5350: a view `lll` over `t1`, shadowed by a CTE.
+fn setup_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, grp_id INTEGER)");
+    run_stmt(&mut db, "INSERT INTO t1 VALUES (1,2),(2,3),(3,2)");
+    run_stmt(
+        &mut db,
+        "CREATE VIEW lll AS \
+         SELECT row_number() OVER (PARTITION BY grp_id) AS rn, grp_id, id FROM t1",
+    );
+    db
+}
+
+/// The exact repro from issue #5353 (sqlite3: 100).
+#[test]
+fn test_with_values_scalar_subquery() {
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH lll AS (SELECT 99 AS rn, 2 AS grp_id, 100 AS id) \
+         VALUES((SELECT max(id) FROM lll WHERE grp_id = 2))",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(100)]]);
+}
+
+/// Minimal form (sqlite3: 1).
+#[test]
+fn test_with_values_minimal() {
+    let db = vibesql_storage::Database::new();
+    let rows = query(&db, "WITH c AS (SELECT 1) VALUES((SELECT * FROM c))");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1)]]);
+}
+
+/// Multi-row VALUES with a CTE-referencing subquery (sqlite3: 1, 2, 5).
+#[test]
+fn test_with_values_multi_row() {
+    let db = vibesql_storage::Database::new();
+    let rows = query(&db, "WITH x AS (SELECT 5) VALUES(1),(2),((SELECT * FROM x))");
+    assert_eq!(
+        rows,
+        vec![vec![SqlValue::Integer(1)], vec![SqlValue::Integer(2)], vec![SqlValue::Integer(5)]]
+    );
+}
+
+/// Multiple rows each referencing the CTE (sqlite3: 10, 11).
+#[test]
+fn test_with_values_cte_referenced_in_each_row() {
+    let db = vibesql_storage::Database::new();
+    let rows =
+        query(&db, "WITH c AS (SELECT 10 AS v) VALUES((SELECT v FROM c)),((SELECT v+1 FROM c))");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(10)], vec![SqlValue::Integer(11)]]);
+}
+
+/// Judge-confirmed gap from #5352: VALUES on the right side of a compound
+/// must see the enclosing WITH (sqlite3: 1, 100).
+#[test]
+fn test_union_values_subquery_sees_outer_cte() {
+    let db = setup_db();
+    let mut rows = query(
+        &db,
+        "WITH lll AS (SELECT 100 AS id) SELECT 1 UNION VALUES((SELECT max(id) FROM lll))",
+    );
+    rows.sort();
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1)], vec![SqlValue::Integer(100)]]);
+}
+
+/// VALUES on both sides of a compound under a WITH (sqlite3: 2, 9).
+#[test]
+fn test_with_values_union_values() {
+    let db = vibesql_storage::Database::new();
+    let mut rows = query(&db, "WITH c AS (SELECT 9) VALUES((SELECT * FROM c)) UNION VALUES(2)");
+    rows.sort();
+    assert_eq!(rows, vec![vec![SqlValue::Integer(2)], vec![SqlValue::Integer(9)]]);
+}
+
+/// CTE names are ASCII case-insensitive (sqlite3: 1).
+#[test]
+fn test_with_values_case_insensitive_cte_reference() {
+    let db = vibesql_storage::Database::new();
+    let rows = query(&db, "WITH c AS (SELECT 1) VALUES((SELECT * FROM C))");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1)]]);
+}
+
+/// The CTE shadows a same-named catalog view, like in #5350 (sqlite3: 100),
+/// while a bare VALUES without the CTE still resolves the view (sqlite3: 3).
+#[test]
+fn test_with_values_cte_shadows_catalog_view() {
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH lll AS (SELECT 99 AS rn, 2 AS grp_id, 100 AS id) \
+         VALUES((SELECT max(id) FROM lll WHERE grp_id = 2))",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(100)]]);
+
+    // Control: no CTE, the subquery resolves to the catalog view.
+    let rows = query(&db, "VALUES((SELECT max(id) FROM lll WHERE grp_id = 2))");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(3)]]);
+}
+
+/// Multiple chained CTEs before VALUES (sqlite3: 1).
+#[test]
+fn test_with_multiple_ctes_then_values() {
+    let db = vibesql_storage::Database::new();
+    let rows = query(&db, "WITH a AS (SELECT 1), b AS (SELECT * FROM a) VALUES((SELECT * FROM b))");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1)]]);
+}
+
+/// WITH RECURSIVE before VALUES (sqlite3: 3).
+#[test]
+fn test_with_recursive_then_values() {
+    let db = vibesql_storage::Database::new();
+    let rows = query(
+        &db,
+        "WITH RECURSIVE cnt(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM cnt WHERE x<3) \
+         VALUES((SELECT max(x) FROM cnt))",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(3)]]);
+}
+
+/// EXISTS inside a VALUES row sees the CTE (sqlite3: 1).
+#[test]
+fn test_with_values_exists_subquery() {
+    let db = setup_db();
+    let rows = query(
+        &db,
+        "WITH lll AS (SELECT 100 AS id) \
+         VALUES((SELECT EXISTS(SELECT 1 FROM lll WHERE id = 100)))",
+    );
+    // VibeSQL represents EXISTS results as Boolean (rendered as 1 by the CLI)
+    assert_eq!(rows, vec![vec![SqlValue::Boolean(true)]]);
+}
+
+/// IN (SELECT ...) inside a VALUES row sees the CTE (sqlite3: 1).
+#[test]
+fn test_with_values_in_subquery() {
+    let db = setup_db();
+    let rows =
+        query(&db, "WITH lll AS (SELECT 100 AS id) VALUES((SELECT 100 IN (SELECT id FROM lll)))");
+    // VibeSQL represents IN results as Boolean (rendered as 1 by the CLI)
+    assert_eq!(rows, vec![vec![SqlValue::Boolean(true)]]);
+}
+
+/// VALUES in FROM position with a CTE-referencing subquery (sqlite3: 11,
+/// verified with `AS v`; the `v(x)` column alias is a VibeSQL extension).
+#[test]
+fn test_from_values_subquery_sees_cte() {
+    let db = vibesql_storage::Database::new();
+    let rows =
+        query(&db, "WITH c AS (SELECT 11) SELECT * FROM (VALUES((SELECT * FROM c))) AS v(x)");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(11)]]);
+}

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -729,7 +729,7 @@ impl Parser {
 
     /// Parse statement starting with WITH clause (CTEs)
     ///
-    /// WITH can precede SELECT, INSERT, UPDATE, or DELETE statements.
+    /// WITH can precede SELECT, VALUES, INSERT, UPDATE, or DELETE statements.
     /// This method parses the CTE list first, then dispatches to the appropriate
     /// statement parser based on the following keyword.
     fn parse_with_statement(&mut self) -> Result<vibesql_ast::Statement, ParseError> {
@@ -756,6 +756,15 @@ impl Parser {
                 select_stmt.with_clause = Some(cte_list);
                 Ok(vibesql_ast::Statement::Select(Box::new(select_stmt)))
             }
+            Token::Keyword { keyword: Keyword::Values, .. } => {
+                // SQLite treats a standalone VALUES as a SELECT form, so a WITH
+                // clause may precede a bare VALUES statement (issue #5353).
+                // parse_values_statement already returns a SelectStmt with the
+                // `values` body set; attach the CTEs to it.
+                let mut select_stmt = self.parse_values_statement()?;
+                select_stmt.with_clause = Some(cte_list);
+                Ok(vibesql_ast::Statement::Select(Box::new(select_stmt)))
+            }
             Token::Keyword { keyword: Keyword::Insert, .. } => {
                 // Parse INSERT with pre-parsed CTEs
                 let insert_stmt = self.parse_insert_statement_with_cte(cte_list)?;
@@ -773,7 +782,7 @@ impl Parser {
             }
             _ => Err(ParseError {
                 message: format!(
-                    "Expected SELECT, INSERT, UPDATE, or DELETE after WITH clause, found {}",
+                    "Expected SELECT, VALUES, INSERT, UPDATE, or DELETE after WITH clause, found {}",
                     self.peek().syntax_error()
                 ),
             }),

--- a/crates/vibesql-parser/src/tests/cte.rs
+++ b/crates/vibesql-parser/src/tests/cte.rs
@@ -297,3 +297,86 @@ fn test_parse_cte_materialized_with_column_list() {
     let result = Parser::parse_sql("WITH t(a, b) AS MATERIALIZED (SELECT 1, 2) SELECT * FROM t;");
     assert!(result.is_ok(), "CTE with column list and MATERIALIZED should parse: {:?}", result);
 }
+
+// ========================================================================
+// WITH ... VALUES Tests (issue #5353)
+//
+// SQLite treats a standalone VALUES as a SELECT form, so a WITH clause may
+// precede a bare VALUES statement.
+// ========================================================================
+
+#[test]
+fn test_parse_with_values_basic() {
+    let stmt = Parser::parse_sql("WITH c AS (SELECT 1) VALUES((SELECT * FROM c));").unwrap();
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            assert!(select.with_clause.is_some(), "WITH clause should be attached");
+            assert_eq!(select.with_clause.as_ref().unwrap()[0].name, "c");
+            let values = select.values.as_ref().expect("VALUES body should be set");
+            assert_eq!(values.len(), 1);
+            assert_eq!(values[0].len(), 1);
+            assert!(select.select_list.is_empty(), "VALUES form has no select list");
+        }
+        other => panic!("Expected SELECT statement with VALUES body, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_with_values_multi_row() {
+    let stmt =
+        Parser::parse_sql("WITH x AS (SELECT 5) VALUES(1),(2),((SELECT * FROM x));").unwrap();
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            assert!(select.with_clause.is_some());
+            assert_eq!(select.values.as_ref().unwrap().len(), 3);
+        }
+        other => panic!("Expected SELECT statement with VALUES body, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_with_recursive_values() {
+    let result = Parser::parse_sql(
+        "WITH RECURSIVE cnt(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM cnt WHERE x<3) \
+         VALUES((SELECT max(x) FROM cnt));",
+    );
+    assert!(result.is_ok(), "WITH RECURSIVE before VALUES should parse: {:?}", result);
+}
+
+#[test]
+fn test_parse_with_values_union() {
+    let stmt = Parser::parse_sql("WITH c AS (SELECT 9) VALUES((SELECT * FROM c)) UNION VALUES(2);")
+        .unwrap();
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            assert!(select.with_clause.is_some());
+            assert!(select.values.is_some());
+            assert!(select.set_operation.is_some(), "UNION should be attached");
+        }
+        other => panic!("Expected SELECT statement with VALUES body, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_with_multiple_ctes_then_values() {
+    let result = Parser::parse_sql(
+        "WITH a AS (SELECT 1), b AS (SELECT * FROM a) VALUES((SELECT * FROM b));",
+    );
+    assert!(result.is_ok(), "WITH multiple CTEs before VALUES should parse: {:?}", result);
+}
+
+#[test]
+fn test_parse_with_followed_by_invalid_statement_still_errors() {
+    // WITH may only precede SELECT, VALUES, INSERT, UPDATE, or DELETE
+    let result = Parser::parse_sql("WITH c AS (SELECT 1) CREATE TABLE t(a INTEGER);");
+    assert!(result.is_err(), "WITH before CREATE should not parse");
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("after WITH clause"), "Unexpected error message: {}", msg);
+}
+
+#[test]
+fn test_parse_with_values_missing_rows_errors() {
+    // VALUES keyword with no row list is still invalid
+    let result = Parser::parse_sql("WITH c AS (SELECT 1) VALUES;");
+    assert!(result.is_err(), "WITH ... VALUES without rows should not parse");
+}


### PR DESCRIPTION
## Summary

Closes #5353

SQLite allows a `WITH` clause to precede a standalone `VALUES` statement (a bare VALUES is a SELECT form), but VibeSQL rejected it at parse time:

```sql
WITH lll AS (SELECT 100 AS id) VALUES((SELECT max(id) FROM lll));
-- sqlite3 3.51.0: 100
-- VibeSQL (before): Parse error: Expected SELECT, INSERT, UPDATE, or DELETE after WITH clause
-- VibeSQL (after): 100
```

### Parser

`parse_with_statement()` (crates/vibesql-parser/src/parser/mod.rs) gains a `Keyword::Values` dispatch arm: it calls the existing `parse_values_statement()` — producing the same `SelectStmt` with a `values` body that a bare `VALUES (...)` produces (including compound set operations) — and attaches the parsed CTE list as `with_clause`. The error message now mentions VALUES.

### Executor

`execute_values()` (crates/vibesql-executor/src/select/scan/values.rs) now takes an optional CTE context and attaches it to the row evaluator via the `with_cte_context` builder from #5352, so subqueries inside VALUES rows resolve names bound by an enclosing WITH (CTE precedence over same-named catalog objects, ASCII case-insensitive). All three call sites thread it:

- `execute_expression_only()` (execute.rs) — non-window standalone VALUES path; uses the merged `cte_results`, falling back to `self.cte_context` (same precedence pattern as #5352)
- `execute_set_operations()` (set_operations.rs) — fixes the judge-confirmed pre-existing gap from #5352: `WITH c AS (...) SELECT 1 UNION VALUES((SELECT ... FROM c))` returned "Table 'c' not found"
- `execute_from_clause()` (scan/mod.rs) — FROM-position VALUES: `WITH c AS (SELECT 11) SELECT * FROM (VALUES((SELECT * FROM c))) AS v(x)`

## Test evidence

All expected values verified against sqlite3 3.51.0 side by side.

- **Parser unit tests** (`crates/vibesql-parser/src/tests/cte.rs`, 7 new): WITH+VALUES basic/multi-row/UNION/RECURSIVE/multiple CTEs parse with the right AST shape; `WITH ... CREATE` and `WITH ... VALUES;` (no rows) still rejected.
- **Executor integration tests** (`crates/vibesql-executor/tests/with_values_tests.rs`, 13 new): issue repro, minimal/multi-row VALUES, CTE referenced in each row, `UNION VALUES` both directions, case-insensitive CTE names, CTE shadowing a catalog view (+ control without CTE), chained CTEs, WITH RECURSIVE, EXISTS/IN subqueries, FROM-position VALUES. All pass.
- **`cargo test -p vibesql-parser -p vibesql-executor`**: green (exit 0; 1369 parser tests + full executor suites).
- **TCL** `with1.test` / `with2.test` / `with3.test`: failure sets are byte-identical to an origin/main baseline run (with1: 0 tests under harness; with2: 40/68; with3: 3/12 on both). Zero new failures; remaining failures are pre-existing (recursive CTE iteration limit, "must use UNION ALL", cascading missing tables).

## Out of scope / follow-on

- `WITH c AS (...) INSERT INTO t VALUES((SELECT * FROM c))` (sqlite3: inserts 8) still fails with "Table 'c' not found" — the INSERT executor has no CTE threading at all (`crates/vibesql-executor/src/insert/` never receives a CTE context). Pre-existing on main and separable; follow-on issue filed.
- The arena parser (`crates/vibesql-parser/src/arena_parser/`) has never supported standalone VALUES statements at top level (prepared-statement SELECT fast path; errors fall back to the regular parser). Unchanged.
- SQLite 3.51 rejects `ORDER BY`/`LIMIT` directly after a bare top-level VALUES; VibeSQL has long accepted them as an extension. WITH+VALUES inherits the existing VibeSQL behavior (same code path as bare VALUES).

🤖 Generated with [Claude Code](https://claude.com/claude-code)