### PR TITLE
feat(explain): flatten plain views in EQP output

### DIFF
--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -551,6 +551,22 @@ fn append_scan_entries(node: &PlanNode, entries: &mut Vec<EqpEntry>) {
     }
 }
 
+/// True when any node in `node`'s subtree needs a temp B-tree for ORDER BY.
+///
+/// Used by the view-flattening branch to hoist a body's sort flag onto the
+/// `Subquery` node it nests under, since [`collect_eqp_entries`] only checks
+/// a node and its DIRECT children. Co-routine subtrees are skipped: their
+/// inner entries (including temp B-tree lines) are re-collected inside the
+/// `CO-ROUTINE` block by [`append_scan_entries`], so counting them here
+/// would emit the line twice.
+fn subtree_needs_order_by_temp_btree(node: &PlanNode) -> bool {
+    if node.coroutine.is_some() {
+        return false;
+    }
+    node.needs_temp_btree_for_order_by
+        || node.children.iter().any(subtree_needs_order_by_temp_btree)
+}
+
 /// Collect all EQP entries from the plan tree, including TEMP B-TREE entries
 fn collect_eqp_entries(node: &PlanNode) -> Vec<EqpEntry> {
     let mut entries = Vec::new();
@@ -1269,6 +1285,18 @@ impl ExplainExecutor {
                             let child = Self::explain_select(&view.query, database, ctes)?;
                             let mut view_node = PlanNode::new("Subquery");
                             view_node.object = Some(format!("AS {}", source));
+                            // The body's ORDER BY genuinely sorts at runtime
+                            // (views are materialized), and SQLite's
+                            // flattened plan keeps the body's `USE TEMP
+                            // B-TREE FOR ORDER BY` line. collect_eqp_entries
+                            // only checks the root's DIRECT children for the
+                            // flag, but the body root sits one level deeper
+                            // (root -> Subquery -> body) — and deeper still
+                            // for nested ORDER BY views — so hoist the
+                            // subtree's flag onto this node to keep the line
+                            // rendered (verified against sqlite3 3.51.0).
+                            view_node.needs_temp_btree_for_order_by =
+                                subtree_needs_order_by_temp_btree(&child);
                             view_node.add_child(child);
                             return Ok(view_node);
                         }

--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -1190,6 +1190,33 @@ impl ExplainExecutor {
         .unwrap_or(false)
     }
 
+    /// True when a plain (window-free) view body is simple enough for its
+    /// plan to be inlined into the outer EQP output (#5355).
+    ///
+    /// Mirrors SQLite's query-flattener blocking conditions conservatively:
+    /// aggregates, GROUP BY/HAVING, DISTINCT, LIMIT/OFFSET, compound bodies,
+    /// VALUES, and WITH clauses all keep the pre-existing opaque
+    /// `SCAN <view>` rendering (SQLite materializes/co-routines these;
+    /// VibeSQL keeps the conservative opaque line rather than guessing —
+    /// follow-on work can add CO-ROUTINE blocks case by case). Window
+    /// functions are handled separately by the CO-ROUTINE path (#5347).
+    fn view_body_is_flattenable(stmt: &SelectStmt) -> bool {
+        let select_list_has_aggregate = stmt.select_list.iter().any(|item| match item {
+            SelectItem::Expression { expr, .. } => contains_aggregate_function(expr),
+            SelectItem::Wildcard { .. } | SelectItem::QualifiedWildcard { .. } => false,
+        });
+
+        stmt.set_operation.is_none()
+            && !stmt.distinct
+            && stmt.group_by.is_none()
+            && stmt.having.is_none()
+            && stmt.limit.is_none()
+            && stmt.offset.is_none()
+            && stmt.values.is_none()
+            && stmt.with_clause.is_none()
+            && !select_list_has_aggregate
+    }
+
     /// Generate plan node for FROM clause
     ///
     /// `order_from_window` is true when `order_by` is a window sort key
@@ -1206,13 +1233,25 @@ impl ExplainExecutor {
     ) -> Result<PlanNode, ExecutorError> {
         match from {
             vibesql_ast::FromClause::Table { name, alias, .. } => {
-                // Expand window-function views (#5347): SQLite's EQP shows
-                // the view body's plan as a CO-ROUTINE block instead of an
-                // opaque `SCAN <view>` (windowpushd.test 2.1.3.6). Only
-                // window views are expanded — plain views keep the existing
-                // opaque rendering (flattening them faithfully would also
-                // require pushing the outer WHERE; follow-on work). CTE
-                // names shadow same-named views and are never expanded.
+                // Expand views in EQP output instead of showing an opaque
+                // `SCAN <view>`. CTE names shadow same-named views and are
+                // never expanded.
+                //
+                // - Window-function views (#5347): SQLite cannot flatten
+                //   them, so the body's plan renders as a CO-ROUTINE block
+                //   plus a trailing `SCAN <name>` (windowpushd.test 2.1.3.6).
+                // - Plain flattenable views (#5355): SQLite inlines the body
+                //   into the outer query and shows the underlying table
+                //   access with no mention of the view. VibeSQL's runtime
+                //   MATERIALIZES views (select/scan/table.rs executes the
+                //   full body, then post-filters the outer WHERE), so the
+                //   inner scans shown here are the truthful access path; we
+                //   deliberately do NOT fabricate SQLite's outer-WHERE
+                //   push-down (`SEARCH <table> (x=?)`) because no index
+                //   probe happens at runtime. Where no index applies the
+                //   output matches SQLite exactly (`SCAN <table>`).
+                // - Blocked bodies (aggregate/GROUP BY/DISTINCT/LIMIT/
+                //   compound/...) keep the opaque rendering.
                 if !ctes.contains(&name.to_ascii_lowercase()) {
                     if let Some(view) = database.catalog.get_view(name) {
                         if Self::select_has_window_functions(&view.query) {
@@ -1221,6 +1260,15 @@ impl ExplainExecutor {
                             let mut view_node = PlanNode::new("Subquery");
                             view_node.object = Some(format!("AS {}", source));
                             view_node.coroutine = Some(source.to_string());
+                            view_node.add_child(child);
+                            return Ok(view_node);
+                        }
+
+                        if Self::view_body_is_flattenable(&view.query) {
+                            let source = alias.as_deref().unwrap_or(name.as_str());
+                            let child = Self::explain_select(&view.query, database, ctes)?;
+                            let mut view_node = PlanNode::new("Subquery");
+                            view_node.object = Some(format!("AS {}", source));
                             view_node.add_child(child);
                             return Ok(view_node);
                         }
@@ -1471,10 +1519,8 @@ impl ExplainExecutor {
             }
 
             idx_node
-        } else if let Some(ordering_index) = order_by
-            .as_deref()
-            .filter(|_| order_from_window)
-            .and_then(|items| {
+        } else if let Some(ordering_index) =
+            order_by.as_deref().filter(|_| order_from_window).and_then(|items| {
                 eqp_ordering_index(table_name, where_clause.as_ref(), items, database, true)
             })
         {
@@ -1532,6 +1578,47 @@ impl ExplainExecutor {
         }
 
         false
+    }
+}
+
+/// Recursively check if an expression contains aggregate functions.
+///
+/// Used by the EQP view-flattening gate (#5355): a view body whose SELECT
+/// list aggregates cannot be flattened. Subqueries are conservatively treated
+/// as containing aggregates (blocking flattening keeps the safe opaque
+/// rendering).
+fn contains_aggregate_function(expr: &Expression) -> bool {
+    match expr {
+        Expression::AggregateFunction { .. } => true,
+        Expression::Function { args, .. } => args.iter().any(contains_aggregate_function),
+        Expression::BinaryOp { left, right, .. } => {
+            contains_aggregate_function(left) || contains_aggregate_function(right)
+        }
+        Expression::UnaryOp { expr, .. } => contains_aggregate_function(expr),
+        Expression::IsNull { expr, .. } => contains_aggregate_function(expr),
+        Expression::Cast { expr, .. } => contains_aggregate_function(expr),
+        Expression::Conjunction(exprs) | Expression::Disjunction(exprs) => {
+            exprs.iter().any(contains_aggregate_function)
+        }
+        Expression::Case { operand, when_clauses, else_result, .. } => {
+            operand.as_ref().is_some_and(|e| contains_aggregate_function(e))
+                || when_clauses.iter().any(|clause| {
+                    clause.conditions.iter().any(contains_aggregate_function)
+                        || contains_aggregate_function(&clause.result)
+                })
+                || else_result.as_ref().is_some_and(|e| contains_aggregate_function(e))
+        }
+        Expression::InList { expr, values, .. } => {
+            contains_aggregate_function(expr) || values.iter().any(contains_aggregate_function)
+        }
+        Expression::Between { expr, low, high, .. } => {
+            contains_aggregate_function(expr)
+                || contains_aggregate_function(low)
+                || contains_aggregate_function(high)
+        }
+        // Conservative: subqueries may contain anything; block flattening.
+        Expression::ScalarSubquery(_) | Expression::In { .. } | Expression::Exists { .. } => true,
+        _ => false,
     }
 }
 

--- a/crates/vibesql-executor/tests/explain_view_expansion_tests.rs
+++ b/crates/vibesql-executor/tests/explain_view_expansion_tests.rs
@@ -1,5 +1,5 @@
-//! Tests for EXPLAIN QUERY PLAN expansion of window-function views and
-//! subqueries (#5347, windowpushd.test)
+//! Tests for EXPLAIN QUERY PLAN expansion of views and subqueries
+//! (#5347/#5355, windowpushd.test)
 //!
 //! SQLite renders a view/subquery containing window functions as a
 //! `CO-ROUTINE <name>` block whose inner plan shows the real table access
@@ -8,6 +8,13 @@
 //! PARTITION BY order. Expected shapes below verified against sqlite3
 //! (modulo SQLite's extra nested `(subquery-N)` co-routine layers, which
 //! VibeSQL flattens into a single block).
+//!
+//! Plain (window-free) flattenable views inline their body's plan into the
+//! outer output with no mention of the view name (#5355), matching SQLite's
+//! flattener. One documented divergence: SQLite pushes the OUTER WHERE into
+//! the flattened body (`SEARCH t USING INDEX ... (x=?)`); VibeSQL's runtime
+//! materializes views and post-filters, so EQP truthfully shows the body's
+//! own plan (`SCAN t`) without fabricating an index probe.
 
 use vibesql_ast::Statement;
 use vibesql_executor::ExplainExecutor;
@@ -133,11 +140,7 @@ fn test_view_expansion_index_for_partition_order_without_push() {
     let output = eqp(&db, "SELECT * FROM v3 WHERE d < 0.55");
 
     assert!(output.contains("CO-ROUTINE v3"), "missing CO-ROUTINE block:\n{}", output);
-    assert!(
-        output.contains("SCAN t2 USING INDEX i2b"),
-        "missing ordering index scan:\n{}",
-        output
-    );
+    assert!(output.contains("SCAN t2 USING INDEX i2b"), "missing ordering index scan:\n{}", output);
     assert!(
         !output.contains("SEARCH t2"),
         "no predicate was pushed; inner scan must not be a SEARCH:\n{}",
@@ -169,21 +172,166 @@ fn test_window_subquery_renders_coroutine_with_pushed_predicate() {
 }
 
 // ---------------------------------------------------------------------------
-// No expansion
+// Plain-view flattening (#5355)
 // ---------------------------------------------------------------------------
 
-// Plain (window-free) views keep the existing opaque rendering — general
-// view flattening is follow-on work.
-#[test]
-fn test_plain_view_not_expanded() {
+/// Schema for plain-view flattening tests: base table, index, and a set of
+/// flattenable and non-flattenable (blocked) views.
+fn setup_plain_view_db() -> Database {
     let mut db = Database::new();
     run_ddl(&mut db, "CREATE TABLE t3(x INTEGER, y INTEGER)");
+    run_ddl(&mut db, "CREATE INDEX i3x ON t3(x)");
     run_ddl(&mut db, "CREATE VIEW pv AS SELECT x, y FROM t3");
+    run_ddl(&mut db, "CREATE VIEW fv AS SELECT x, y FROM t3 WHERE x = 5");
+    run_ddl(&mut db, "CREATE VIEW av AS SELECT x, count(*) AS c FROM t3 GROUP BY x");
+    run_ddl(&mut db, "CREATE VIEW sv AS SELECT count(*) AS c FROM t3");
+    run_ddl(&mut db, "CREATE VIEW lv AS SELECT x FROM t3 LIMIT 5");
+    run_ddl(&mut db, "CREATE VIEW dv AS SELECT DISTINCT x FROM t3");
+    run_ddl(&mut db, "CREATE VIEW cv AS SELECT x FROM t3 UNION SELECT y FROM t3");
+    run_ddl(&mut db, "CREATE VIEW pv2 AS SELECT x FROM pv");
+    db
+}
+
+// A plain view's body is inlined: the underlying table scan appears with no
+// mention of the view. SQLite (no usable outer predicate): `SCAN t3` —
+// identical shape.
+#[test]
+fn test_plain_view_flattened() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM pv");
+
+    assert!(!output.contains("CO-ROUTINE"), "plain view must not co-routine:\n{}", output);
+    assert!(!output.contains("pv"), "view name must not appear:\n{}", output);
+    assert!(output.contains("SCAN t3"), "expected flattened inner scan:\n{}", output);
+}
+
+// Outer WHERE on a flattened view: SQLite pushes the predicate into the
+// flattened body (`SEARCH t3 USING INDEX i3x (x=?)`). VibeSQL's runtime
+// materializes the view and post-filters, so EQP truthfully shows the body's
+// own access path (`SCAN t3`) — documented divergence (#5355).
+#[test]
+fn test_plain_view_flattened_outer_where_not_fabricated() {
+    let db = setup_plain_view_db();
     let output = eqp(&db, "SELECT * FROM pv WHERE x = 1");
 
-    assert!(!output.contains("CO-ROUTINE"), "plain view must not expand:\n{}", output);
-    assert!(output.contains("SCAN pv"), "expected opaque view scan:\n{}", output);
+    assert!(!output.contains("CO-ROUTINE"), "plain view must not co-routine:\n{}", output);
+    assert!(!output.contains("SCAN pv"), "view name must not appear:\n{}", output);
+    assert!(output.contains("SCAN t3"), "expected truthful inner scan:\n{}", output);
+    assert!(
+        !output.contains("SEARCH t3"),
+        "runtime does not push the outer WHERE into the view; no index probe:\n{}",
+        output
+    );
 }
+
+// A view body with its OWN indexed WHERE shows the real index probe.
+// SQLite: `SEARCH t3 USING INDEX i3x (x=?)` — identical shape (the probe is
+// part of the body, which the runtime genuinely executes).
+#[test]
+fn test_plain_view_flattened_body_where_uses_index() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM fv");
+
+    assert!(
+        output.contains("SEARCH t3 USING COVERING INDEX i3x (x=?)")
+            || output.contains("SEARCH t3 USING INDEX i3x (x=?)"),
+        "expected inner index probe from the view body's own WHERE:\n{}",
+        output
+    );
+    assert!(!output.contains("SCAN fv"), "view name must not appear:\n{}", output);
+}
+
+// Nested plain view-on-view flattens all the way down to the base table.
+// SQLite: `SCAN t3` — identical shape.
+#[test]
+fn test_nested_plain_view_flattened() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM pv2");
+
+    assert!(output.contains("SCAN t3"), "expected base-table scan:\n{}", output);
+    assert!(!output.contains("pv"), "no view name may appear:\n{}", output);
+}
+
+// A view over a join flattens to the join's scans. SQLite shows both base
+// tables (modulo automatic-index/bloom-filter lines).
+#[test]
+fn test_plain_join_view_flattened() {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE t3(x INTEGER, y INTEGER)");
+    run_ddl(&mut db, "CREATE TABLE t4(a INTEGER, b INTEGER)");
+    run_ddl(&mut db, "CREATE VIEW jv AS SELECT t3.x, t4.b FROM t3, t4 WHERE t3.y = t4.a");
+    let output = eqp(&db, "SELECT * FROM jv");
+
+    assert!(!output.contains("SCAN jv"), "view name must not appear:\n{}", output);
+    assert!(output.contains("t3"), "expected left base table:\n{}", output);
+    assert!(output.contains("t4"), "expected right base table:\n{}", output);
+}
+
+// ---------------------------------------------------------------------------
+// Blocked view bodies keep the opaque rendering (#5355)
+// ---------------------------------------------------------------------------
+// SQLite renders all of these as `CO-ROUTINE <view>` blocks; VibeSQL
+// conservatively keeps the pre-existing opaque `SCAN <view>` line rather
+// than guessing (follow-on work can add the CO-ROUTINE shape per case).
+
+#[test]
+fn test_aggregate_group_by_view_not_flattened() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM av WHERE x = 1");
+
+    assert!(output.contains("SCAN av"), "expected opaque view scan:\n{}", output);
+    assert!(!output.contains("SCAN t3"), "blocked body must not inline:\n{}", output);
+}
+
+#[test]
+fn test_scalar_aggregate_view_not_flattened() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM sv");
+
+    assert!(output.contains("SCAN sv"), "expected opaque view scan:\n{}", output);
+    assert!(!output.contains("SCAN t3"), "blocked body must not inline:\n{}", output);
+}
+
+#[test]
+fn test_limit_view_not_flattened() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM lv WHERE x = 1");
+
+    assert!(output.contains("SCAN lv"), "expected opaque view scan:\n{}", output);
+    assert!(!output.contains("SCAN t3"), "blocked body must not inline:\n{}", output);
+}
+
+#[test]
+fn test_distinct_view_not_flattened() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM dv WHERE x = 1");
+
+    assert!(output.contains("SCAN dv"), "expected opaque view scan:\n{}", output);
+    assert!(!output.contains("SCAN t3"), "blocked body must not inline:\n{}", output);
+}
+
+#[test]
+fn test_compound_view_not_flattened() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM cv WHERE x = 1");
+
+    assert!(output.contains("SCAN cv"), "expected opaque view scan:\n{}", output);
+    assert!(!output.contains("SCAN t3"), "blocked body must not inline:\n{}", output);
+}
+
+// A WITH-clause CTE shadows a same-named plain view: the view body must NOT
+// be inlined (CTE precedence, same gate as the window-view path).
+#[test]
+fn test_cte_shadowing_plain_view_not_flattened() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "WITH pv AS (SELECT 1 AS x, 2 AS y) SELECT * FROM pv WHERE x = 1");
+
+    assert!(!output.contains("SCAN t3"), "view body must not be planned:\n{}", output);
+}
+
+// ---------------------------------------------------------------------------
+// No expansion
+// ---------------------------------------------------------------------------
 
 // Plain derived tables keep the existing flat rendering (SQLite flattens
 // them — no CO-ROUTINE, no SCAN of the alias).

--- a/crates/vibesql-executor/tests/explain_view_expansion_tests.rs
+++ b/crates/vibesql-executor/tests/explain_view_expansion_tests.rs
@@ -189,6 +189,9 @@ fn setup_plain_view_db() -> Database {
     run_ddl(&mut db, "CREATE VIEW dv AS SELECT DISTINCT x FROM t3");
     run_ddl(&mut db, "CREATE VIEW cv AS SELECT x FROM t3 UNION SELECT y FROM t3");
     run_ddl(&mut db, "CREATE VIEW pv2 AS SELECT x FROM pv");
+    run_ddl(&mut db, "CREATE VIEW ov AS SELECT x, y FROM t3 ORDER BY y");
+    run_ddl(&mut db, "CREATE VIEW ovx AS SELECT x, y FROM t3 ORDER BY x");
+    run_ddl(&mut db, "CREATE VIEW ov2 AS SELECT x, y FROM ov");
     db
 }
 
@@ -265,6 +268,75 @@ fn test_plain_join_view_flattened() {
     assert!(!output.contains("SCAN jv"), "view name must not appear:\n{}", output);
     assert!(output.contains("t3"), "expected left base table:\n{}", output);
     assert!(output.contains("t4"), "expected right base table:\n{}", output);
+}
+
+// An ORDER BY view body still flattens, and the body's sorting pass keeps
+// its temp B-tree line (the runtime genuinely sorts: views are
+// materialized). SQLite: `SCAN t3` + `USE TEMP B-TREE FOR ORDER BY` —
+// identical shape (verified against sqlite3 3.51.0).
+#[test]
+fn test_order_by_view_flattened_keeps_temp_btree() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM ov");
+
+    assert!(!output.contains("SCAN ov"), "view name must not appear:\n{}", output);
+    assert!(output.contains("SCAN t3"), "expected flattened inner scan:\n{}", output);
+    assert!(
+        output.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "body ORDER BY sorts at runtime; temp B-tree line must render:\n{}",
+        output
+    );
+}
+
+// An ORDER BY view whose sort is satisfied by an index flattens with NO
+// temp B-tree, and the flattened plan is identical to the bare body's plan.
+// SQLite annotates the ordering index (`SCAN t3 USING INDEX i3x`); VibeSQL's
+// pre-existing base-scan rendering shows `SCAN t3` for pure ordering indexes
+// (same for the bare body — unrelated to view flattening).
+#[test]
+fn test_order_by_view_flattened_index_satisfied_no_temp_btree() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM ovx");
+    let bare = eqp(&db, "SELECT x, y FROM t3 ORDER BY x");
+
+    assert!(!output.contains("SCAN ovx"), "view name must not appear:\n{}", output);
+    assert!(output.contains("SCAN t3"), "expected flattened inner scan:\n{}", output);
+    assert!(!output.contains("USE TEMP B-TREE"), "index satisfies the sort:\n{}", output);
+    assert_eq!(output, bare, "flattened plan must match the bare body's plan");
+}
+
+// A nested plain view over an ORDER BY view: the inner body's sort flag must
+// survive the extra Subquery nesting level. SQLite: `SCAN t3` +
+// `USE TEMP B-TREE FOR ORDER BY` — identical shape.
+#[test]
+fn test_nested_order_by_view_flattened_keeps_temp_btree() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM ov2");
+
+    assert!(!output.contains("SCAN ov"), "no view name may appear:\n{}", output);
+    assert!(output.contains("SCAN t3"), "expected flattened inner scan:\n{}", output);
+    assert!(
+        output.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "inner body ORDER BY sorts at runtime; temp B-tree line must render:\n{}",
+        output
+    );
+}
+
+// Outer-query ORDER BY over a flattened plain view (no ORDER BY in the
+// body): the outer sort's temp B-tree line renders. SQLite: `SCAN t3` +
+// `USE TEMP B-TREE FOR ORDER BY` — identical shape.
+#[test]
+fn test_outer_order_by_over_flattened_view_keeps_temp_btree() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM pv ORDER BY y");
+
+    assert!(!output.contains("SCAN pv"), "view name must not appear:\n{}", output);
+    assert!(output.contains("SCAN t3"), "expected flattened inner scan:\n{}", output);
+    assert!(
+        output.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "outer ORDER BY needs a sorting pass:\n{}",
+        output
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #5355

## Summary

EXPLAIN QUERY PLAN now inlines the body of plain (window-free, flattenable) views into the outer plan instead of rendering an opaque `SCAN <view>`, matching SQLite's flattener for simple views. Follow-on to #5354 (window views as `CO-ROUTINE` blocks), reusing the same `explain_from_clause` view-lookup and CTE-shadowing gate.

- **Flattened**: plain view bodies (including bodies with their own WHERE — real index probes show through — joins, ORDER BY, and nested view-on-view) inline their plan; the view name no longer appears.
- **Blocked (kept opaque `SCAN <view>`)**: bodies with aggregates, GROUP BY/HAVING, DISTINCT, LIMIT/OFFSET, compound operators, VALUES, or WITH clauses. SQLite renders these as `CO-ROUTINE` blocks; per the issue's conservative guidance we keep the pre-existing opaque line rather than guessing (follow-on candidate).
- **CTE shadowing**: a WITH-clause CTE bound to the view's name still suppresses expansion, identical to the #5354 gate.
- Display-only: no runtime planning/execution change.

## Execution-truthfulness finding

The runtime does **not** flatten plain views: `crates/vibesql-executor/src/select/scan/table.rs` materializes the full view body via `SelectExecutor::execute_with_columns(&view.query)` and applies the outer WHERE as a post-filter on the materialized rows. Therefore this PR renders the **truthful expansion** — the view body's genuine plan — and deliberately does NOT fabricate SQLite's outer-WHERE push-down:

- `CREATE VIEW pv AS SELECT x, y FROM t3` + index `i3x(x)`; `SELECT * FROM pv WHERE x=1`
  - SQLite: `SEARCH t3 USING INDEX i3x (x=?)` (predicate pushed through the flattened view)
  - VibeSQL: `SCAN t3` (truthful: full body scan + post-filter) — documented divergence
- Whenever no outer predicate would use an index (the common TCL shapes), output matches sqlite3 exactly: `SCAN t3` for plain/ORDER-BY/nested views, `SEARCH t3 USING INDEX i3x (x=?)` when the *body's own* WHERE uses the index.

All expected shapes in the new tests were verified against sqlite3 `.eqp on` for the same schema/queries; agreements and the one divergence are noted per test.

## Test evidence

- `cargo test -p vibesql-executor`: **3399 passed, 0 failed** (50 test binaries)
- `tests/explain_view_expansion_tests.rs`: 18 tests (7 pre-existing #5354 tests unchanged + 11 new: flattened plain view, outer-WHERE-not-fabricated, body-WHERE index probe, nested view-on-view, join view, aggregate/scalar-aggregate/LIMIT/DISTINCT/compound blocked, CTE-shadowed plain view)
- TCL (`windowpushd`, `window9`, `eqp`, `whereF`, `autoindex1`, `view`): identical pass/fail/skip counts vs baseline (origin/main source, same harness) — **0 failures on both**:
  - windowpushd 29/29, window9 38 pass/4 skip, eqp 5 pass/1 skip, whereF 11 pass/12 skip, autoindex1 0 extracted, view 24 pass/93 skip
- `scripts/tester_vibesql.tcl`: no skip entries cite #5355 (or view flattening); nothing to remove.

Pre-existing, unrelated: `cargo clippy -p vibesql-executor --tests` fails on `src/evaluator/expressions/operators.rs:339` (`clippy::approx_constant`, `-3.14` literal) — present on origin/main, untouched here.

## Follow-ons

- Render blocked view bodies (aggregate/LIMIT/DISTINCT/compound) as `CO-ROUTINE <view>` blocks to fully match SQLite, case by case.
- If/when the runtime learns to flatten plain views (or push outer WHERE into them), upgrade the display to SQLite's `SEARCH <table> (col=?)` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)