### PR TITLE
fix(executor): thread WITH-clause CTE context into INSERT execution

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -598,7 +598,12 @@ impl DeleteExecutor {
             let old_rows: Vec<&vibesql_storage::Row> =
                 rows_and_indices_to_delete.iter().map(|(_, row)| row).collect();
             Some(crate::dml_returning::project_returning(
-                items, &schema, database, None, &old_rows,
+                items,
+                &schema,
+                database,
+                None,
+                &old_rows,
+                cte_results.as_ref(),
             )?)
         } else {
             None
@@ -1050,6 +1055,7 @@ fn execute_delete_on_view(
             database,
             None,
             &old_rows,
+            None,
         )?)
     } else {
         None

--- a/crates/vibesql-executor/src/dml_returning.rs
+++ b/crates/vibesql-executor/src/dml_returning.rs
@@ -22,14 +22,22 @@ use crate::{errors::ExecutorError, evaluator::ExpressionEvaluator, select::Selec
 /// affected row / trigger fire). Returns a `SelectResult` whose columns are
 /// derived from the RETURNING items (aliases win, then original source
 /// text, then the expression's column name).
+///
+/// `cte_results` carries the enclosing statement's WITH-clause CTEs (if any)
+/// so subqueries in RETURNING expressions can reference CTE names, matching
+/// SQLite (issue #5359).
 pub(crate) fn project_returning(
     items: &[SelectItem],
     schema: &TableSchema,
     database: &Database,
     table_alias: Option<&str>,
     rows: &[&Row],
+    cte_results: Option<&std::collections::HashMap<String, crate::select::cte::CteResult>>,
 ) -> Result<SelectResult, ExecutorError> {
     let mut evaluator = ExpressionEvaluator::with_database(schema, database);
+    if let Some(ctes) = cte_results {
+        evaluator = evaluator.with_cte_context(ctes);
+    }
     if let Some(alias) = table_alias {
         evaluator.set_table_alias(alias.to_string());
     }

--- a/crates/vibesql-executor/src/insert/defaults.rs
+++ b/crates/vibesql-executor/src/insert/defaults.rs
@@ -8,17 +8,29 @@ pub fn evaluate_insert_expression(
     column: &vibesql_catalog::ColumnSchema,
     procedural_context: Option<&crate::procedural::ExecutionContext>,
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
-    evaluate_insert_expression_with_trigger_context(expr, column, procedural_context, None, None)
+    evaluate_insert_expression_with_trigger_context(
+        expr,
+        column,
+        procedural_context,
+        None,
+        None,
+        None,
+    )
 }
 
 /// Evaluate an INSERT expression with trigger context support
 /// This is used when executing INSERT statements inside trigger bodies
+///
+/// `cte_results` carries the enclosing INSERT statement's WITH-clause CTEs
+/// (if any) so subqueries in VALUES rows can reference CTE names, matching
+/// SQLite (issue #5359).
 pub fn evaluate_insert_expression_with_trigger_context(
     expr: &vibesql_ast::Expression,
     column: &vibesql_catalog::ColumnSchema,
     procedural_context: Option<&crate::procedural::ExecutionContext>,
     trigger_context: Option<&crate::trigger_execution::TriggerContext>,
     database: Option<&vibesql_storage::Database>,
+    cte_results: Option<&std::collections::HashMap<String, crate::select::cte::CteResult>>,
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
     match expr {
         vibesql_ast::Expression::Literal(lit) => Ok(lit.clone()),
@@ -69,8 +81,11 @@ pub fn evaluate_insert_expression_with_trigger_context(
             if let (Some(ctx), Some(db)) = (trigger_context, database) {
                 // Create a dummy row for evaluation (trigger context available)
                 let dummy_row = vibesql_storage::Row::new(vec![]);
-                let evaluator =
+                let mut evaluator =
                     crate::ExpressionEvaluator::with_trigger_context(ctx.table_schema, db, ctx);
+                if let Some(ctes) = cte_results {
+                    evaluator = evaluator.with_cte_context(ctes);
+                }
                 evaluator.eval(expr, &dummy_row)
             } else if let Some(db) = database {
                 // No trigger context, but we have database access - evaluate the expression
@@ -79,7 +94,10 @@ pub fn evaluate_insert_expression_with_trigger_context(
                 let dummy_schema =
                     vibesql_catalog::TableSchema::new("__insert_expr__".to_string(), vec![]);
                 let dummy_row = vibesql_storage::Row::new(vec![]);
-                let evaluator = crate::ExpressionEvaluator::with_database(&dummy_schema, db);
+                let mut evaluator = crate::ExpressionEvaluator::with_database(&dummy_schema, db);
+                if let Some(ctes) = cte_results {
+                    evaluator = evaluator.with_cte_context(ctes);
+                }
                 evaluator.eval(expr, &dummy_row)
             } else {
                 Err(ExecutorError::UnsupportedExpression(

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -105,6 +105,23 @@ fn execute_insert_internal(
     // Check INSERT privilege on the table
     PrivilegeChecker::check_insert(db, &full_table_name)?;
 
+    // Materialize statement-level WITH-clause CTEs once, up front, so they
+    // are visible to subqueries in VALUES rows, the INSERT ... SELECT
+    // source, the upsert DO UPDATE arm, and RETURNING expressions —
+    // matching SQLite semantics (issue #5359). CTE names shadow same-named
+    // catalog tables/views and resolve ASCII case-insensitively (#5350).
+    let cte_results: Option<std::collections::HashMap<String, crate::select::cte::CteResult>> =
+        if let Some(ref cte_list) = stmt.with_clause {
+            Some(crate::select::cte::execute_ctes(cte_list, db, |cte_query, prior_ctes| {
+                let cte_executor = crate::SelectExecutor::new_with_cte(db, prior_ctes);
+                cte_executor
+                    .execute_with_columns(cte_query)
+                    .map(|result| result.rows.into_iter().collect())
+            })?)
+        } else {
+            None
+        };
+
     // Check if target is a VIEW with INSTEAD OF triggers
     if let Some(view_def) = db.catalog.get_view(&stmt.table_name).cloned() {
         // SQLite: the upsert syntax cannot target a view, even when INSTEAD
@@ -112,12 +129,19 @@ fn execute_insert_internal(
         if stmt.on_conflict.is_some() {
             return Err(ExecutorError::SqliteCompatError("cannot UPSERT a view".to_string()));
         }
-        return execute_insert_on_view(db, stmt, &view_def, procedural_context, trigger_context)
-            .map(|(count, returning)| InsertOutcome {
-                affected_rows: count,
-                upsert_updated_rows: 0,
-                returning,
-            });
+        return execute_insert_on_view(
+            db,
+            stmt,
+            &view_def,
+            procedural_context,
+            trigger_context,
+            cte_results.as_ref(),
+        )
+        .map(|(count, returning)| InsertOutcome {
+            affected_rows: count,
+            upsert_updated_rows: 0,
+            returning,
+        });
     }
 
     // Get table schema from catalog (clone to avoid borrow issues)
@@ -215,19 +239,10 @@ fn execute_insert_internal(
             }
 
             // Fall back to normal path: execute SELECT and convert to expressions
-            // If we have a with_clause (CTEs), execute them first and pass to SelectExecutor
-            let select_result = if let Some(ref cte_list) = stmt.with_clause {
-                // Execute CTEs first
-                let cte_results =
-                    crate::select::cte::execute_ctes(cte_list, db, |cte_query, prior_ctes| {
-                        let cte_executor = crate::SelectExecutor::new_with_cte(db, prior_ctes);
-                        cte_executor
-                            .execute_with_columns(cte_query)
-                            .map(|result| result.rows.into_iter().collect())
-                    })?;
-
+            // If we have a with_clause (CTEs), reuse the results materialized above
+            let select_result = if let Some(ref ctes) = cte_results {
                 // Create executor with CTE results
-                let select_executor = crate::SelectExecutor::new_with_cte(db, &cte_results);
+                let select_executor = crate::SelectExecutor::new_with_cte(db, ctes);
                 select_executor.execute_with_columns(select_stmt)?
             } else {
                 let select_executor = crate::SelectExecutor::new(db);
@@ -537,7 +552,11 @@ fn execute_insert_internal(
                     let dummy_schema =
                         vibesql_catalog::TableSchema::new("__rowid_expr__".to_string(), vec![]);
                     let dummy_row = vibesql_storage::Row::new(vec![]);
-                    let evaluator = crate::ExpressionEvaluator::with_database(&dummy_schema, db);
+                    let mut evaluator =
+                        crate::ExpressionEvaluator::with_database(&dummy_schema, db);
+                    if let Some(ref ctes) = cte_results {
+                        evaluator = evaluator.with_cte_context(ctes);
+                    }
                     let val = evaluator.eval(rowid_expr, &dummy_row)?;
 
                     match val {
@@ -617,6 +636,7 @@ fn execute_insert_internal(
                 procedural_context,
                 trigger_context,
                 Some(db),
+                cte_results.as_ref(),
             )?;
 
             // Type check and coerce: ensure value matches column type
@@ -972,6 +992,7 @@ fn execute_insert_internal(
                     target_where.as_ref(),
                     assignments,
                     where_clause.as_ref(),
+                    cte_results.as_ref(),
                 )? {
                     super::on_conflict_update::UpsertAction::Updated(updated_row_id) => {
                         // Row was updated, count it toward affected rows
@@ -1290,7 +1311,14 @@ fn execute_insert_internal(
     // rows still yield an empty result with the derived column headers.
     let returning_result = if let Some(items) = &stmt.returning {
         let row_refs: Vec<&vibesql_storage::Row> = returned_rows.iter().collect();
-        Some(crate::dml_returning::project_returning(items, &schema, db, None, &row_refs)?)
+        Some(crate::dml_returning::project_returning(
+            items,
+            &schema,
+            db,
+            None,
+            &row_refs,
+            cte_results.as_ref(),
+        )?)
     } else {
         None
     };
@@ -1486,6 +1514,7 @@ fn execute_insert_on_view(
     view_def: &vibesql_catalog::ViewDefinition,
     procedural_context: Option<&crate::procedural::ExecutionContext>,
     trigger_context: Option<&crate::trigger_execution::TriggerContext>,
+    cte_results: Option<&std::collections::HashMap<String, crate::select::cte::CteResult>>,
 ) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
     use vibesql_ast::TriggerTiming;
 
@@ -1522,9 +1551,13 @@ fn execute_insert_on_view(
             vec![default_row]
         }
         vibesql_ast::InsertSource::Select(select_stmt) => {
-            // Execute SELECT and convert to expressions
-            let select_executor = crate::SelectExecutor::new(db);
-            let select_result = select_executor.execute_with_columns(select_stmt)?;
+            // Execute SELECT and convert to expressions, with the enclosing
+            // statement's CTEs (if any) visible to the source query.
+            let select_result = if let Some(ctes) = cte_results {
+                crate::SelectExecutor::new_with_cte(db, ctes).execute_with_columns(select_stmt)?
+            } else {
+                crate::SelectExecutor::new(db).execute_with_columns(select_stmt)?
+            };
             select_result
                 .rows
                 .into_iter()
@@ -1564,13 +1597,16 @@ fn execute_insert_on_view(
     // This avoids borrow conflicts with the evaluator
     let new_rows: Vec<vibesql_storage::Row> = {
         let dummy_row = vibesql_storage::Row::new(vec![]);
-        let evaluator = if let Some(ctx) = trigger_context {
+        let mut evaluator = if let Some(ctx) = trigger_context {
             crate::evaluator::ExpressionEvaluator::with_trigger_context(&view_schema, db, ctx)
         } else if let Some(ctx) = procedural_context {
             crate::evaluator::ExpressionEvaluator::with_procedural_context(&view_schema, db, ctx)
         } else {
             crate::evaluator::ExpressionEvaluator::with_database(&view_schema, db)
         };
+        if let Some(ctes) = cte_results {
+            evaluator = evaluator.with_cte_context(ctes);
+        }
 
         let mut collected_rows = Vec::new();
         for value_exprs in &rows_to_insert {
@@ -1603,7 +1639,14 @@ fn execute_insert_on_view(
     // triggers run since the database must be borrowed mutably below.
     let returning_result = if let Some(items) = &stmt.returning {
         let row_refs: Vec<&vibesql_storage::Row> = new_rows.iter().collect();
-        Some(crate::dml_returning::project_returning(items, &view_schema, db, None, &row_refs)?)
+        Some(crate::dml_returning::project_returning(
+            items,
+            &view_schema,
+            db,
+            None,
+            &row_refs,
+            cte_results,
+        )?)
     } else {
         None
     };

--- a/crates/vibesql-executor/src/insert/on_conflict_update.rs
+++ b/crates/vibesql-executor/src/insert/on_conflict_update.rs
@@ -407,6 +407,7 @@ pub fn handle_on_conflict_update(
     target_where: Option<&Expression>,
     assignments: &[Assignment],
     where_clause: Option<&Expression>,
+    cte_results: Option<&std::collections::HashMap<String, crate::select::cte::CteResult>>,
 ) -> Result<UpsertAction, ExecutorError> {
     // Determine which unique constraints/indexes the update arm applies to.
     // SQLite tests the targeted constraint first (upsert1-700 series).
@@ -456,7 +457,12 @@ pub fn handle_on_conflict_update(
     // first — SQLite semantics). Only `excluded.` references need rewriting,
     // since `excluded` is not a real table.
     let new_values = {
-        let evaluator = crate::evaluator::ExpressionEvaluator::with_database(schema, db);
+        let mut evaluator = crate::evaluator::ExpressionEvaluator::with_database(schema, db);
+        // Make the enclosing INSERT statement's WITH-clause CTEs visible to
+        // subqueries in the DO UPDATE SET/WHERE expressions (issue #5359).
+        if let Some(ctes) = cte_results {
+            evaluator = evaluator.with_cte_context(ctes);
+        }
 
         // DO UPDATE ... WHERE: when false or NULL, drop the row silently.
         if let Some(where_expr) = where_clause {

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -710,7 +710,9 @@ pub(super) fn execute_internal(
         return Err(assertion_error);
     }
 
-    // Project RETURNING items against the NEW rows (SQLite 3.35.0+).
+    // Project RETURNING items against the NEW rows (SQLite 3.35.0+), with
+    // the statement's WITH-clause CTEs (if any) visible to subqueries in
+    // RETURNING expressions (issue #5359).
     let returning = if let Some(items) = &stmt.returning {
         let new_rows: Vec<&Row> = updates.iter().map(|u| &u.new_row).collect();
         Some(crate::dml_returning::project_returning(
@@ -719,6 +721,7 @@ pub(super) fn execute_internal(
             database,
             stmt.alias.as_deref(),
             &new_rows,
+            cte_results.as_ref(),
         )?)
     } else {
         None
@@ -1689,6 +1692,8 @@ fn execute_update_from(
     let _ = pk_indices;
 
     // Project RETURNING items against the NEW rows (SQLite 3.35.0+).
+    // UPDATE ... FROM does not currently thread WITH-clause CTEs into this
+    // path, so no CTE context is available here.
     let returning = if let Some(items) = &stmt.returning {
         let new_rows: Vec<&Row> = updates.iter().map(|u| &u.new_row).collect();
         Some(crate::dml_returning::project_returning(
@@ -1697,6 +1702,7 @@ fn execute_update_from(
             database,
             stmt.alias.as_deref(),
             &new_rows,
+            None,
         )?)
     } else {
         None
@@ -1722,6 +1728,7 @@ fn empty_returning(
                 database,
                 stmt.alias.as_deref(),
                 &[],
+                None,
             )
         })
         .transpose()

--- a/crates/vibesql-executor/src/update/triggers.rs
+++ b/crates/vibesql-executor/src/update/triggers.rs
@@ -109,6 +109,7 @@ pub(super) fn execute_update_on_view(
             database,
             stmt.alias.as_deref(),
             &new_rows,
+            None,
         )?)
     } else {
         None

--- a/crates/vibesql-executor/tests/with_insert_cte_tests.rs
+++ b/crates/vibesql-executor/tests/with_insert_cte_tests.rs
@@ -1,0 +1,263 @@
+//! Regression tests for issue #5359
+//!
+//! SQLite allows a `WITH` clause on INSERT (and UPDATE/DELETE), with CTE
+//! names visible to subqueries in the VALUES rows, the `INSERT ... SELECT`
+//! source, the upsert `ON CONFLICT DO UPDATE` arm, and RETURNING
+//! expressions. VibeSQL parsed `WITH ... INSERT` but the INSERT executor
+//! dropped the statement's `with_clause` on the floor, so subqueries inside
+//! VALUES rows failed with "Table not found".
+//!
+//! Repro from the issue:
+//!
+//! ```sql
+//! CREATE TABLE t(a INTEGER);
+//! WITH c AS (SELECT 8) INSERT INTO t VALUES((SELECT * FROM c));
+//! -- sqlite3 3.51.0: inserts 8
+//! -- VibeSQL used to fail: Table 'c' not found
+//! ```
+//!
+//! CTE precedence matches #5350/#5352 semantics: CTE names shadow same-named
+//! catalog tables/views and resolve ASCII case-insensitively.
+//!
+//! All expected values below were verified against sqlite3 3.51.0.
+
+use vibesql_executor::{DeleteExecutor, InsertExecutor, SelectExecutor, UpdateExecutor};
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            InsertExecutor::execute(db, &insert)
+                .unwrap_or_else(|e| panic!("Insert failed: {} -- {:?}", sql, e));
+        }
+        vibesql_ast::Statement::Update(update) => {
+            UpdateExecutor::execute(&update, db)
+                .unwrap_or_else(|e| panic!("Update failed: {} -- {:?}", sql, e));
+        }
+        vibesql_ast::Statement::Delete(delete) => {
+            DeleteExecutor::execute(&delete, db)
+                .unwrap_or_else(|e| panic!("Delete failed: {} -- {:?}", sql, e));
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+fn query(db: &vibesql_storage::Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e))
+            .into_iter()
+            .map(|row| row.values.to_vec())
+            .collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+/// The exact repro from issue #5359 (sqlite3: inserts 8).
+#[test]
+fn test_with_insert_values_scalar_subquery() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER)");
+    run_stmt(&mut db, "WITH c AS (SELECT 8) INSERT INTO t VALUES((SELECT * FROM c))");
+    assert_eq!(query(&db, "SELECT a FROM t"), vec![vec![SqlValue::Integer(8)]]);
+}
+
+/// Multiple VALUES rows, each with a CTE-referencing subquery (sqlite3: 5, 6).
+#[test]
+fn test_with_insert_values_multi_row() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER)");
+    run_stmt(
+        &mut db,
+        "WITH c AS (SELECT 5 AS v) \
+         INSERT INTO t VALUES((SELECT v FROM c)), ((SELECT v+1 FROM c))",
+    );
+    assert_eq!(
+        query(&db, "SELECT a FROM t ORDER BY a"),
+        vec![vec![SqlValue::Integer(5)], vec![SqlValue::Integer(6)]]
+    );
+}
+
+/// `WITH ... INSERT INTO t SELECT ... FROM cte` (sqlite3: 8).
+#[test]
+fn test_with_insert_select_from_cte() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER)");
+    run_stmt(&mut db, "WITH c AS (SELECT 8 AS v) INSERT INTO t SELECT v FROM c");
+    assert_eq!(query(&db, "SELECT a FROM t"), vec![vec![SqlValue::Integer(8)]]);
+}
+
+/// CTE referenced from the WHERE clause of an INSERT ... SELECT
+/// (sqlite3: inserts 20, 30).
+#[test]
+fn test_with_insert_select_cte_in_where() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE src(x INTEGER)");
+    run_stmt(&mut db, "INSERT INTO src VALUES(10),(20),(30)");
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER)");
+    run_stmt(
+        &mut db,
+        "WITH c AS (SELECT 15 AS lim) \
+         INSERT INTO t SELECT x FROM src WHERE x > (SELECT lim FROM c)",
+    );
+    assert_eq!(
+        query(&db, "SELECT a FROM t ORDER BY a"),
+        vec![vec![SqlValue::Integer(20)], vec![SqlValue::Integer(30)]]
+    );
+}
+
+/// A CTE shadows a same-named catalog table, both as the INSERT ... SELECT
+/// source and inside a VALUES subquery (sqlite3: 8, then 9).
+#[test]
+fn test_with_insert_cte_shadows_catalog_table() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE c(v INTEGER)");
+    run_stmt(&mut db, "INSERT INTO c VALUES(111)");
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER)");
+
+    // CTE shadows table `c` as the SELECT source.
+    run_stmt(&mut db, "WITH c AS (SELECT 8 AS v) INSERT INTO t SELECT v FROM c");
+    assert_eq!(query(&db, "SELECT a FROM t"), vec![vec![SqlValue::Integer(8)]]);
+
+    // CTE shadows table `c` inside a VALUES subquery.
+    run_stmt(&mut db, "DELETE FROM t");
+    run_stmt(&mut db, "WITH c AS (SELECT 9 AS v) INSERT INTO t VALUES((SELECT v FROM c))");
+    assert_eq!(query(&db, "SELECT a FROM t"), vec![vec![SqlValue::Integer(9)]]);
+
+    // The catalog table is untouched.
+    assert_eq!(query(&db, "SELECT v FROM c"), vec![vec![SqlValue::Integer(111)]]);
+}
+
+/// CTE names resolve ASCII case-insensitively (sqlite3: inserts 20, 30).
+#[test]
+fn test_with_insert_cte_case_insensitive() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE src(x INTEGER)");
+    run_stmt(&mut db, "INSERT INTO src VALUES(10),(20),(30)");
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER)");
+    run_stmt(
+        &mut db,
+        "WITH Costs AS (SELECT 15 AS lim) \
+         INSERT INTO t SELECT x FROM src WHERE x > (SELECT lim FROM cOSTS)",
+    );
+    assert_eq!(
+        query(&db, "SELECT a FROM t ORDER BY a"),
+        vec![vec![SqlValue::Integer(20)], vec![SqlValue::Integer(30)]]
+    );
+
+    // Case-insensitive in a VALUES subquery too.
+    run_stmt(&mut db, "DELETE FROM t");
+    run_stmt(&mut db, "WITH C AS (SELECT 9 AS v) INSERT INTO t VALUES((SELECT v FROM c))");
+    assert_eq!(query(&db, "SELECT a FROM t"), vec![vec![SqlValue::Integer(9)]]);
+}
+
+/// DEFAULT VALUES with a WITH clause is a no-op for CTE visibility but must
+/// still execute (sqlite3: inserts the default).
+#[test]
+fn test_with_insert_default_values() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER DEFAULT 7)");
+    run_stmt(&mut db, "WITH c AS (SELECT 8) INSERT INTO t DEFAULT VALUES");
+    assert_eq!(query(&db, "SELECT a FROM t"), vec![vec![SqlValue::Integer(7)]]);
+}
+
+/// Upsert: CTE visible in the ON CONFLICT DO UPDATE SET expression
+/// (sqlite3: a=1, b=8 after the upsert takes the update arm).
+#[test]
+fn test_with_insert_on_conflict_do_update_cte() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b INTEGER)");
+    run_stmt(&mut db, "INSERT INTO t VALUES(1, 0)");
+    run_stmt(
+        &mut db,
+        "WITH c AS (SELECT 8 AS v) INSERT INTO t VALUES(1, 99) \
+         ON CONFLICT(a) DO UPDATE SET b=(SELECT v FROM c)",
+    );
+    assert_eq!(
+        query(&db, "SELECT a, b FROM t"),
+        vec![vec![SqlValue::Integer(1), SqlValue::Integer(8)]]
+    );
+}
+
+/// RETURNING with a CTE-referencing subquery (sqlite3: returns 8).
+#[test]
+fn test_with_insert_returning_cte_subquery() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER)");
+
+    let sql = "WITH c AS (SELECT 8 AS v) INSERT INTO t VALUES(1) RETURNING (SELECT v FROM c)";
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    let vibesql_ast::Statement::Insert(insert) = stmt else {
+        panic!("Expected INSERT statement");
+    };
+    let outcome = InsertExecutor::execute_returning(&mut db, &insert).unwrap();
+    assert_eq!(outcome.affected_rows, 1);
+    let returning = outcome.returning.expect("RETURNING result expected");
+    assert_eq!(returning.rows.len(), 1);
+    assert_eq!(returning.rows[0].values.to_vec(), vec![SqlValue::Integer(8)]);
+}
+
+/// UPDATE with WITH: CTE visible in SET and WHERE subqueries
+/// (sqlite3: rows 2, 10 after `a*10` where a matches the CTE key).
+#[test]
+fn test_with_update_cte_in_set_and_where() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER)");
+    run_stmt(&mut db, "INSERT INTO t VALUES(1),(2)");
+    run_stmt(&mut db, "WITH c AS (SELECT 1 AS k) UPDATE t SET a = a*10 WHERE a = (SELECT k FROM c)");
+    assert_eq!(
+        query(&db, "SELECT a FROM t ORDER BY a"),
+        vec![vec![SqlValue::Integer(2)], vec![SqlValue::Integer(10)]]
+    );
+}
+
+/// UPDATE ... RETURNING with a CTE-referencing subquery (sqlite3: returns 8).
+#[test]
+fn test_with_update_returning_cte_subquery() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER)");
+    run_stmt(&mut db, "INSERT INTO t VALUES(1)");
+
+    let sql = "WITH c AS (SELECT 8 AS v) UPDATE t SET a=2 RETURNING (SELECT v FROM c)";
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    let vibesql_ast::Statement::Update(update) = stmt else {
+        panic!("Expected UPDATE statement");
+    };
+    let (count, returning) = UpdateExecutor::execute_returning(&update, &mut db).unwrap();
+    assert_eq!(count, 1);
+    let returning = returning.expect("RETURNING result expected");
+    assert_eq!(returning.rows.len(), 1);
+    assert_eq!(returning.rows[0].values.to_vec(), vec![SqlValue::Integer(8)]);
+}
+
+/// DELETE with WITH: CTE visible in the WHERE subquery (sqlite3: only row 10
+/// remains), and DELETE ... RETURNING sees the CTE too (sqlite3: returns 9).
+#[test]
+fn test_with_delete_cte_in_where_and_returning() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER)");
+    run_stmt(&mut db, "INSERT INTO t VALUES(2),(10)");
+    run_stmt(&mut db, "WITH c AS (SELECT 2 AS k) DELETE FROM t WHERE a = (SELECT k FROM c)");
+    assert_eq!(query(&db, "SELECT a FROM t"), vec![vec![SqlValue::Integer(10)]]);
+
+    let sql = "WITH c AS (SELECT 9 AS v) DELETE FROM t RETURNING (SELECT v FROM c)";
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    let vibesql_ast::Statement::Delete(delete) = stmt else {
+        panic!("Expected DELETE statement");
+    };
+    let (count, returning) = DeleteExecutor::execute_returning(&delete, &mut db).unwrap();
+    assert_eq!(count, 1);
+    let returning = returning.expect("RETURNING result expected");
+    assert_eq!(returning.rows.len(), 1);
+    assert_eq!(returning.rows[0].values.to_vec(), vec![SqlValue::Integer(9)]);
+}


### PR DESCRIPTION
Closes #5359

## Root cause

`WITH c AS (SELECT 8) INSERT INTO t VALUES((SELECT * FROM c))` parsed fine (the WITH→INSERT dispatch exists) but failed at execution with `Table 'c' not found`: `execute_insert_internal()` only materialized the statement's CTEs inside the `InsertSource::Select` branch. Every other evaluation site — VALUES row expressions, complex rowid expressions, the upsert `ON CONFLICT DO UPDATE` arm, RETURNING projection, and the view INSTEAD OF path — built evaluators without CTE context, dropping `stmt.with_clause` on the floor.

## Fix

- `insert/execution.rs`: materialize WITH-clause CTEs once, up front (via `select::cte::execute_ctes`), reuse them for the `INSERT ... SELECT` source (no double materialization), and thread them into:
  - VALUES row evaluation (`insert/defaults.rs::evaluate_insert_expression_with_trigger_context`, new `cte_results` param → `with_cte_context`)
  - complex rowid expressions
  - the view INSTEAD OF INSERT path (row expressions, SELECT source, RETURNING)
  - the upsert arm (`insert/on_conflict_update.rs::handle_on_conflict_update`, new param → DO UPDATE SET/WHERE evaluator)
  - RETURNING projection
- `dml_returning.rs::project_returning`: new optional CTE-context param; INSERT, UPDATE, and DELETE statement paths now pass their materialized CTEs so `RETURNING (SELECT ... FROM cte)` works (SQLite allows this; UPDATE/DELETE RETURNING had the same gap even though their SET/WHERE threading already existed). View-trigger and UPDATE...FROM RETURNING paths pass `None` (UPDATE...FROM does not thread CTEs at all today — pre-existing, out of scope).

UPDATE and DELETE SET/WHERE threading already existed (`with_database_and_cte`) and is unchanged; only their RETURNING projection gained CTE visibility.

Precedence matches #5350/#5352 semantics: CTE names shadow same-named catalog tables/views and resolve ASCII case-insensitively. Every test expectation was verified side by side with sqlite3 3.51.0.

## Tests

New integration file `crates/vibesql-executor/tests/with_insert_cte_tests.rs` (12 tests, conventions follow `with_values_tests.rs`):
- the issue repro (VALUES scalar subquery), multi-row VALUES
- `INSERT ... SELECT FROM cte`, CTE in WHERE of `INSERT ... SELECT`
- CTE shadowing a same-named catalog table (as SELECT source and in VALUES subquery)
- case-insensitive CTE resolution
- `WITH ... INSERT ... DEFAULT VALUES` (no-op for visibility, still executes)
- upsert `ON CONFLICT DO UPDATE SET x=(SELECT ... FROM cte)`
- INSERT/UPDATE/DELETE `RETURNING (SELECT ... FROM cte)`
- UPDATE SET/WHERE and DELETE WHERE with CTE subqueries (regression coverage)

## Test evidence

- `cargo test -p vibesql-executor`: 40 suites, 0 failures (573 tests passed)
- New file: 12/12 pass; `with_values_tests` 10/10, `cte_expression_subquery_tests` 13/13 unchanged
- TCL `with1/with2/with3`: per-test results byte-identical to a main-baseline build (with2 40/68, with3 3/12 — failures are pre-existing recursive-CTE ordering/limit issues; with1 aborts mid-file on a pre-existing TCL shim error in both runs). Zero new failures, zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)