### PR TITLE
feat(consensus): in-process channel network + multi-node test cluster (phase A3, PR 1/2)

### DIFF
--- a/crates/vibesql-consensus/Cargo.toml
+++ b/crates/vibesql-consensus/Cargo.toml
@@ -25,4 +25,7 @@ tokio = { version = "1.0", features = ["sync"] }
 
 [dev-dependencies]
 tempfile = "3.19"
-tokio = { version = "1.0", features = ["rt", "macros"] }
+# `rt` also unlocks `tokio::spawn` for the in-process channel network's
+# per-node server loops (Phase A3, PR 1); `time` provides the bounded waits
+# in the multi-node cluster tests.
+tokio = { version = "1.0", features = ["rt", "macros", "time"] }

--- a/crates/vibesql-consensus/src/cluster.rs
+++ b/crates/vibesql-consensus/src/cluster.rs
@@ -1,0 +1,388 @@
+//! In-process multi-node cluster harness and deterministic replication
+//! tests (Raft Phase A3, PR 1 of issue #5197).
+//!
+//! [`TestCluster`] boots N `OpenraftBackend` voters in one process, routing
+//! their Raft RPCs through the channel transport in [`crate::network`], and
+//! exposes the failure-injection primitives the A3 acceptance scenarios
+//! need: `kill`, `restore`, `wait_for_leader`, `wait_for_apply`. All waits
+//! are bounded polls with explicit timeouts — no bare sleeps as
+//! synchronization — so the tests are CI-deterministic.
+//!
+//! Storage comes in both flavors:
+//!
+//! - **In-memory** ([`InMemoryLogStore`]): the harness keeps a handle to
+//!   each node's store, so a killed node's log and vote survive until
+//!   `restore` reboots a node on the same store — modeling a process that
+//!   lost its volatile state machine but kept its Raft log.
+//! - **Durable** ([`DurableLogStore`]): each node gets a tempdir; `restore`
+//!   reopens `raft.log` from disk, exercising the real recovery path from
+//!   Phase A2 inside a cluster.
+//!
+//! Deliberately out of scope here (matching the issue): snapshot-based
+//! catch-up (Phase A4, #5198 — these tests stay far below any log-purge
+//! threshold so catch-up always happens via plain AppendEntries backfill),
+//! TCP transport and process-level clusters (PR 2), and dynamic membership.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use openraft::BasicNode;
+use tempfile::TempDir;
+
+use crate::durable::DurableLogStore;
+use crate::network::ChannelRouter;
+use crate::openraft_backend::{Bootstrap, InMemoryLogStore};
+use crate::{ConsensusBackend, ConsensusError, LogIndex, OpenraftBackend, Role};
+
+/// Upper bound for any single cluster-level wait (election, catch-up).
+/// Generous next to the 200–400ms election timeouts so CI machines under
+/// load do not flake, but every wait still fails loudly instead of hanging.
+const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Poll interval inside bounded waits.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Where a node keeps its Raft log + vote between `kill` and `restore`.
+enum NodeStorage {
+    /// Shared handle to the killed node's in-memory store.
+    InMemory(InMemoryLogStore),
+    /// Data directory whose `raft.log` is reopened on restore.
+    Durable(TempDir),
+}
+
+struct TestNode {
+    /// `None` while the node is killed.
+    backend: Option<OpenraftBackend<String>>,
+    storage: NodeStorage,
+}
+
+/// An in-process Raft cluster of [`OpenraftBackend`] voters wired together
+/// by the channel transport.
+struct TestCluster {
+    router: ChannelRouter,
+    /// The static membership every node was initialized with.
+    members: BTreeMap<u64, BasicNode>,
+    nodes: BTreeMap<u64, TestNode>,
+}
+
+impl TestCluster {
+    /// Boot `n` voters (ids `1..=n`) with in-memory Raft logs and initialize
+    /// the n-voter membership.
+    async fn new(n: u64) -> Self {
+        Self::build(n, false).await
+    }
+
+    /// Like [`new`](Self::new), but every node persists its Raft log + vote
+    /// in its own temporary data directory.
+    async fn new_durable(n: u64) -> Self {
+        Self::build(n, true).await
+    }
+
+    async fn build(n: u64, durable: bool) -> Self {
+        let router = ChannelRouter::default();
+        let members: BTreeMap<u64, BasicNode> =
+            (1..=n).map(|id| (id, BasicNode::default())).collect();
+
+        let mut nodes = BTreeMap::new();
+        for id in 1..=n {
+            let node = if durable {
+                let dir = TempDir::new().expect("create tempdir for durable raft log");
+                let store = DurableLogStore::open(dir.path()).expect("open durable raft log");
+                let backend = OpenraftBackend::join_channel_cluster(
+                    id,
+                    &members,
+                    &router,
+                    store,
+                    Bootstrap::Initialize,
+                )
+                .await
+                .expect("boot durable cluster node");
+                TestNode { backend: Some(backend), storage: NodeStorage::Durable(dir) }
+            } else {
+                let store = InMemoryLogStore::default();
+                let backend = OpenraftBackend::join_channel_cluster(
+                    id,
+                    &members,
+                    &router,
+                    store.clone(),
+                    Bootstrap::Initialize,
+                )
+                .await
+                .expect("boot cluster node");
+                TestNode { backend: Some(backend), storage: NodeStorage::InMemory(store) }
+            };
+            nodes.insert(id, node);
+        }
+
+        Self { router, members, nodes }
+    }
+
+    /// The backend of a live node. Panics if `id` is killed or unknown.
+    fn node(&self, id: u64) -> &OpenraftBackend<String> {
+        self.nodes
+            .get(&id)
+            .and_then(|n| n.backend.as_ref())
+            .unwrap_or_else(|| panic!("node {id} is killed or unknown"))
+    }
+
+    /// Ids of nodes that are currently alive.
+    fn live_ids(&self) -> Vec<u64> {
+        self.nodes.iter().filter(|(_, n)| n.backend.is_some()).map(|(id, _)| *id).collect()
+    }
+
+    /// "Crash" a node: cut it off from the network (peers see
+    /// `Unreachable`, like a dead socket) and stop its Raft core. Its log
+    /// and vote remain in [`NodeStorage`] so it can be [`restore`]d.
+    ///
+    /// [`restore`]: Self::restore
+    async fn kill(&mut self, id: u64) {
+        // Deregister first so peers stop reaching a half-shut-down core.
+        self.router.deregister(id);
+        let backend = self
+            .nodes
+            .get_mut(&id)
+            .and_then(|n| n.backend.take())
+            .unwrap_or_else(|| panic!("node {id} is already killed or unknown"));
+        backend.shutdown().await.expect("shut down killed node's raft core");
+    }
+
+    /// Restart a killed node from its retained storage. The node rejoins
+    /// with its pre-kill log and vote and catches up via log replication;
+    /// callers await convergence with [`wait_for_apply`](Self::wait_for_apply).
+    async fn restore(&mut self, id: u64) {
+        let node = self.nodes.get_mut(&id).expect("unknown node");
+        assert!(node.backend.is_none(), "node {id} is not killed");
+
+        // The reopened log already contains the membership entry (and the
+        // node's vote), so this is a recovery boot: re-running `initialize`
+        // would be rejected. `last_log_index: None` because a cluster member
+        // does not need to finish local replay before returning — the test
+        // awaits cluster-level convergence instead.
+        let bootstrap = Bootstrap::Recover { last_log_index: None };
+        let backend = match &node.storage {
+            NodeStorage::InMemory(store) => {
+                OpenraftBackend::join_channel_cluster(
+                    id,
+                    &self.members,
+                    &self.router,
+                    store.clone(),
+                    bootstrap,
+                )
+                .await
+            }
+            NodeStorage::Durable(dir) => {
+                let store = DurableLogStore::open(dir.path()).expect("reopen durable raft log");
+                OpenraftBackend::join_channel_cluster(
+                    id,
+                    &self.members,
+                    &self.router,
+                    store,
+                    bootstrap,
+                )
+                .await
+            }
+        };
+        node.backend = Some(backend.expect("restore killed node"));
+    }
+
+    /// Wait (bounded) until some live node reports itself leader; returns
+    /// its id.
+    async fn wait_for_leader(&self) -> u64 {
+        self.wait_until("a leader to be elected", || {
+            self.live_ids().into_iter().find(|id| self.node(*id).role() == Role::Leader)
+        })
+        .await
+    }
+
+    /// Wait (bounded) until node `id` has applied the application log entry
+    /// at `idx` (i.e. `last_index() >= idx`).
+    async fn wait_for_apply(&self, id: u64, idx: LogIndex) {
+        self.wait_until(&format!("node {id} to apply log index {idx}"), || {
+            (self.node(id).last_index() >= idx).then_some(())
+        })
+        .await;
+    }
+
+    /// Poll `probe` until it yields a value, panicking after
+    /// [`WAIT_TIMEOUT`]. The single bounded-wait primitive every
+    /// cluster-level synchronization goes through.
+    async fn wait_until<T>(&self, what: &str, mut probe: impl FnMut() -> Option<T>) -> T {
+        let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        loop {
+            if let Some(value) = probe() {
+                return value;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out after {WAIT_TIMEOUT:?} waiting for {what}"
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+/// Pick a live node that is not `leader`.
+fn follower_of(cluster: &TestCluster, leader: u64) -> u64 {
+    cluster
+        .live_ids()
+        .into_iter()
+        .find(|id| *id != leader)
+        .expect("cluster has at least one follower")
+}
+
+// ---------------------------------------------------------------------------
+// A3 acceptance scenarios (in-process / PR 1)
+// ---------------------------------------------------------------------------
+
+/// Cold start: three voters elect exactly one leader, a proposal on the
+/// leader commits, and all three state machines apply it identically.
+#[tokio::test]
+async fn boot_elects_leader_and_replicates_to_all() {
+    let cluster = TestCluster::new(3).await;
+    let leader = cluster.wait_for_leader().await;
+
+    let idx = cluster.node(leader).propose("write-1".to_string()).await.unwrap();
+    assert_eq!(idx, 1, "first application entry gets the first dense index");
+
+    for id in 1..=3 {
+        cluster.wait_for_apply(id, idx).await;
+        assert_eq!(
+            cluster.node(id).read_committed(idx).await.unwrap(),
+            "write-1",
+            "node {id} applied a different value"
+        );
+    }
+
+    // With replication settled and heartbeats healthy, leadership is
+    // unique: exactly the elected node reports `Role::Leader`.
+    let leaders: Vec<u64> = (1..=3).filter(|id| cluster.node(*id).role() == Role::Leader).collect();
+    assert_eq!(leaders, vec![leader]);
+}
+
+/// Kill the leader: the two survivors elect a new leader and writes resume,
+/// committing on the remaining majority.
+#[tokio::test]
+async fn killing_the_leader_elects_a_new_one_and_writes_resume() {
+    let mut cluster = TestCluster::new(3).await;
+    let leader = cluster.wait_for_leader().await;
+
+    let idx = cluster.node(leader).propose("before-failover".to_string()).await.unwrap();
+    for id in cluster.live_ids() {
+        cluster.wait_for_apply(id, idx).await;
+    }
+
+    cluster.kill(leader).await;
+
+    let new_leader = cluster.wait_for_leader().await;
+    assert_ne!(new_leader, leader, "the killed node cannot be the new leader");
+
+    let idx2 = cluster.node(new_leader).propose("after-failover".to_string()).await.unwrap();
+    assert_eq!(idx2, 2, "application indices stay dense across the failover");
+
+    for id in cluster.live_ids() {
+        cluster.wait_for_apply(id, idx2).await;
+        assert_eq!(cluster.node(id).read_committed(idx2).await.unwrap(), "after-failover");
+    }
+}
+
+/// A killed follower misses writes, then catches up via AppendEntries
+/// backfill after being restored, converging on the full history. (The
+/// entry count stays far below any snapshot/purge threshold on purpose:
+/// snapshot-based catch-up is Phase A4, #5198.)
+#[tokio::test]
+async fn restored_follower_catches_up_via_log_replication() {
+    let mut cluster = TestCluster::new(3).await;
+    let leader = cluster.wait_for_leader().await;
+
+    for i in 1..=5u64 {
+        let idx = cluster.node(leader).propose(format!("entry-{i}")).await.unwrap();
+        assert_eq!(idx, i);
+    }
+    let follower = follower_of(&cluster, leader);
+    cluster.wait_for_apply(follower, 5).await;
+
+    cluster.kill(follower).await;
+
+    // The two survivors are still a majority: writes keep committing.
+    for i in 6..=10u64 {
+        let idx = cluster.node(leader).propose(format!("entry-{i}")).await.unwrap();
+        assert_eq!(idx, i);
+    }
+
+    cluster.restore(follower).await;
+    cluster.wait_for_apply(follower, 10).await;
+
+    for i in 1..=10u64 {
+        assert_eq!(
+            cluster.node(follower).read_committed(i).await.unwrap(),
+            format!("entry-{i}"),
+            "restored follower diverged at index {i}"
+        );
+    }
+}
+
+/// Proposing on a follower surfaces as a **typed error** —
+/// [`ConsensusError::NotLeader`] with the follower's best guess at the
+/// leader id — rather than auto-forwarding to the leader.
+///
+/// Decision (A3 scope question): no transparent forwarding. The typed error
+/// keeps the adapter thin and the failure mode explicit; the caller (or the
+/// SQL layer above it) retries against `leader_hint`. Leader-aware routing
+/// and read semantics are revisited in B2 (#5200).
+#[tokio::test]
+async fn propose_on_follower_surfaces_not_leader_with_hint() {
+    let cluster = TestCluster::new(3).await;
+    let leader = cluster.wait_for_leader().await;
+    let follower = follower_of(&cluster, leader);
+
+    // Wait until the follower has heard from the leader, so the hint it
+    // attaches is deterministic rather than `None`.
+    cluster
+        .wait_until("the follower to learn who leads", || {
+            (cluster.node(follower).current_leader() == Some(leader)).then_some(())
+        })
+        .await;
+
+    let err = cluster.node(follower).propose("not here".to_string()).await.unwrap_err();
+    match err {
+        ConsensusError::NotLeader { leader_hint } => assert_eq!(leader_hint, Some(leader)),
+        other => panic!("expected NotLeader with a hint, got: {other:?}"),
+    }
+}
+
+/// Durable variant of kill/restore: a node persisting its Raft log on disk
+/// is killed, recovers its pre-kill log + vote from `raft.log` on restart,
+/// and rejoins the cluster to catch up on the writes it missed.
+#[tokio::test]
+async fn durable_node_recovers_from_disk_and_rejoins() {
+    let mut cluster = TestCluster::new_durable(3).await;
+    let leader = cluster.wait_for_leader().await;
+
+    for i in 1..=3u64 {
+        let idx = cluster.node(leader).propose(format!("entry-{i}")).await.unwrap();
+        assert_eq!(idx, i);
+    }
+    let follower = follower_of(&cluster, leader);
+    cluster.wait_for_apply(follower, 3).await;
+
+    cluster.kill(follower).await;
+
+    for i in 4..=5u64 {
+        let idx = cluster.node(leader).propose(format!("entry-{i}")).await.unwrap();
+        assert_eq!(idx, i);
+    }
+
+    // Restore reopens the node's raft.log from its data directory: entries
+    // 1..=3 (and the vote) come back from disk, 4..=5 arrive via
+    // replication.
+    cluster.restore(follower).await;
+    cluster.wait_for_apply(follower, 5).await;
+
+    for i in 1..=5u64 {
+        assert_eq!(
+            cluster.node(follower).read_committed(i).await.unwrap(),
+            format!("entry-{i}"),
+            "durable node diverged at index {i}"
+        );
+    }
+}

--- a/crates/vibesql-consensus/src/lib.rs
+++ b/crates/vibesql-consensus/src/lib.rs
@@ -26,16 +26,28 @@
 //! (the `conformance` test module), so consumers written against the trait
 //! behave identically on any of them.
 //!
-//! Deliberately **not** here yet (later Raft phases): multi-node replication
-//! and RPC/network code (Phase A3), snapshot/truncation *policy* (Phase A4;
-//! the storage-level truncate/purge hooks exist), and membership changes.
+//! Phase A3 (PR 1 of #5197) adds **in-process multi-node replication for
+//! tests**: a channel-based implementation of openraft's network traits
+//! (the `network` module) plus a cluster harness with kill/restore failure
+//! injection (the `cluster` module). Both are test-only; nothing about them
+//! is public API.
+//!
+//! Deliberately **not** here yet (later Raft phases): a real TCP transport
+//! and process-level clusters (Phase A3, PR 2), snapshot transfer and
+//! truncation *policy* (Phase A4; the storage-level truncate/purge hooks
+//! exist), applying entries to VibeSQL storage (Phase B1), and membership
+//! changes.
 //!
 //! [ADR-0004]: https://github.com/rjwalters/vibesql/blob/main/docs/decisions/0004-consensus-library.md
 
 mod backend;
 #[cfg(test)]
+mod cluster;
+#[cfg(test)]
 mod conformance;
 mod durable;
+#[cfg(test)]
+mod network;
 mod openraft_backend;
 mod single_node;
 

--- a/crates/vibesql-consensus/src/network.rs
+++ b/crates/vibesql-consensus/src/network.rs
@@ -1,0 +1,219 @@
+//! In-process channel transport for multi-node openraft clusters
+//! (Raft Phase A3, PR 1 of issue #5197).
+//!
+//! This module implements openraft 0.9's pluggable network layer —
+//! [`RaftNetwork`] / [`RaftNetworkFactory`] — over tokio channels, so several
+//! `Raft` instances can form a real cluster inside one process. That makes
+//! leader-election, failover, and catch-up tests fast and deterministic
+//! enough for CI, independent of sockets (the curator re-scope on #5197).
+//! The TCP transport that implements the same traits over real connections
+//! is PR 2.
+//!
+//! ## Topology
+//!
+//! A [`ChannelRouter`] is the shared "switchboard": it maps node ids to the
+//! sending half of a per-node mpsc queue. Each node, once its `Raft` handle
+//! exists, [registers](ChannelRouter::register) with the router, which spawns
+//! a server loop draining that node's queue and feeding each RPC into the
+//! local `Raft` (`Raft::append_entries` / `Raft::vote` /
+//! `Raft::install_snapshot` — exactly what a socket listener will do in
+//! PR 2). On the client side, [`ChannelNetwork`] resolves the target's queue
+//! through the router *per RPC*, so connectivity changes take effect
+//! immediately.
+//!
+//! ## Failure injection
+//!
+//! "Killing" a node is [`ChannelRouter::deregister`]: subsequent RPCs to it
+//! fail with [`Unreachable`], which openraft treats like a dead socket
+//! (replication backs off and retries). Restoring a node is registering a
+//! freshly booted `Raft` under the same id. The cluster harness in
+//! `crate::cluster` builds `kill`/`restore` on these primitives.
+//!
+//! ## Ordering
+//!
+//! openraft expects RPCs between a (source, target) pair to arrive in send
+//! order. Each replication stream sends one RPC at a time and the server
+//! loop handles requests sequentially, so the per-pair order is preserved —
+//! same guarantee a TCP connection gives.
+
+use tokio::sync::{mpsc, oneshot};
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use openraft::error::{InstallSnapshotError, RPCError, RaftError, RemoteError, Unreachable};
+use openraft::network::RPCOption;
+use openraft::raft::{
+    AppendEntriesRequest, AppendEntriesResponse, InstallSnapshotRequest, InstallSnapshotResponse,
+    VoteRequest, VoteResponse,
+};
+use openraft::{BasicNode, Raft, RaftNetwork, RaftNetworkFactory};
+
+use crate::openraft_backend::TypeConfig;
+
+/// One Raft RPC traveling from a peer to a node's server loop, paired with
+/// the oneshot on which the (local-`Raft`-produced) response travels back.
+enum RaftRequest {
+    AppendEntries(
+        AppendEntriesRequest<TypeConfig>,
+        oneshot::Sender<Result<AppendEntriesResponse<u64>, RaftError<u64>>>,
+    ),
+    Vote(VoteRequest<u64>, oneshot::Sender<Result<VoteResponse<u64>, RaftError<u64>>>),
+    InstallSnapshot(
+        InstallSnapshotRequest<TypeConfig>,
+        oneshot::Sender<Result<InstallSnapshotResponse<u64>, RaftError<u64, InstallSnapshotError>>>,
+    ),
+}
+
+/// Shared switchboard mapping node ids to their inbound RPC queues.
+///
+/// Cloning shares the switchboard (it is a handle); every node of one test
+/// cluster holds a clone of the same router.
+#[derive(Clone, Default)]
+pub(crate) struct ChannelRouter {
+    inner: Arc<Mutex<HashMap<u64, mpsc::UnboundedSender<RaftRequest>>>>,
+}
+
+impl ChannelRouter {
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<u64, mpsc::UnboundedSender<RaftRequest>>> {
+        self.inner.lock().expect("channel router mutex poisoned")
+    }
+
+    /// Make `raft` reachable as `node_id`: spawns the server loop that feeds
+    /// this node's inbound RPCs into it.
+    ///
+    /// Must be called before peers need to reach the node (i.e. before the
+    /// cluster is initialized). Registering an id twice replaces the previous
+    /// registration, which also ends the superseded server loop.
+    pub(crate) fn register(&self, node_id: u64, raft: Raft<TypeConfig>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.lock().insert(node_id, tx);
+        // The loop ends (recv -> None) once this node is deregistered and
+        // any in-flight sender clones are dropped, so no JoinHandle to keep.
+        tokio::spawn(serve(raft, rx));
+    }
+
+    /// Cut a node off: peers' RPCs to `node_id` now fail with
+    /// [`Unreachable`], and its server loop winds down.
+    pub(crate) fn deregister(&self, node_id: u64) {
+        self.lock().remove(&node_id);
+    }
+
+    fn sender(&self, node_id: u64) -> Option<mpsc::UnboundedSender<RaftRequest>> {
+        self.lock().get(&node_id).cloned()
+    }
+}
+
+/// Server loop: drain a node's inbound queue, dispatching each RPC to the
+/// local `Raft` exactly as a socket listener would.
+async fn serve(raft: Raft<TypeConfig>, mut rx: mpsc::UnboundedReceiver<RaftRequest>) {
+    while let Some(request) = rx.recv().await {
+        // A dropped response receiver just means the caller gave up
+        // (e.g. its node was killed mid-RPC); nothing to do.
+        match request {
+            RaftRequest::AppendEntries(rpc, tx) => {
+                let _ = tx.send(raft.append_entries(rpc).await);
+            }
+            RaftRequest::Vote(rpc, tx) => {
+                let _ = tx.send(raft.vote(rpc).await);
+            }
+            RaftRequest::InstallSnapshot(rpc, tx) => {
+                let _ = tx.send(raft.install_snapshot(rpc).await);
+            }
+        }
+    }
+}
+
+/// Factory handed to `Raft::new`; produces one [`ChannelNetwork`] per
+/// (source, target) replication stream.
+pub(crate) struct ChannelNetworkFactory {
+    router: ChannelRouter,
+}
+
+impl ChannelNetworkFactory {
+    pub(crate) fn new(router: ChannelRouter) -> Self {
+        Self { router }
+    }
+}
+
+impl RaftNetworkFactory<TypeConfig> for ChannelNetworkFactory {
+    type Network = ChannelNetwork;
+
+    async fn new_client(&mut self, target: u64, _node: &BasicNode) -> Self::Network {
+        ChannelNetwork { target, router: self.router.clone() }
+    }
+}
+
+/// Client side of the channel transport: sends RPCs to one target node.
+pub(crate) struct ChannelNetwork {
+    target: u64,
+    router: ChannelRouter,
+}
+
+/// The error a client sees when the target is deregistered (killed) or its
+/// server loop dropped the request/response mid-flight.
+fn unreachable<E: std::error::Error>(target: u64) -> RPCError<u64, BasicNode, E> {
+    RPCError::Unreachable(Unreachable::new(&std::io::Error::other(format!(
+        "node {target} is not reachable (killed or not yet registered)"
+    ))))
+}
+
+impl ChannelNetwork {
+    /// Send one request and await its response. `make` wraps the rpc and the
+    /// response oneshot into the right [`RaftRequest`] variant.
+    async fn call<R, E>(
+        &self,
+        make: impl FnOnce(oneshot::Sender<Result<R, E>>) -> RaftRequest,
+    ) -> Result<R, RPCError<u64, BasicNode, E>>
+    where
+        E: std::error::Error,
+    {
+        let Some(tx) = self.router.sender(self.target) else {
+            return Err(unreachable(self.target));
+        };
+        let (response_tx, response_rx) = oneshot::channel();
+        if tx.send(make(response_tx)).is_err() {
+            // Deregistered between lookup and send.
+            return Err(unreachable(self.target));
+        }
+        match response_rx.await {
+            Ok(Ok(response)) => Ok(response),
+            // The remote Raft rejected/failed the RPC; report it as the
+            // remote's error, as a socket transport would.
+            Ok(Err(raft_error)) => {
+                Err(RPCError::RemoteError(RemoteError::new(self.target, raft_error)))
+            }
+            // Server loop dropped the oneshot (node killed mid-RPC).
+            Err(_) => Err(unreachable(self.target)),
+        }
+    }
+}
+
+impl RaftNetwork<TypeConfig> for ChannelNetwork {
+    async fn append_entries(
+        &mut self,
+        rpc: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<AppendEntriesResponse<u64>, RPCError<u64, BasicNode, RaftError<u64>>> {
+        self.call(|tx| RaftRequest::AppendEntries(rpc, tx)).await
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        rpc: InstallSnapshotRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<
+        InstallSnapshotResponse<u64>,
+        RPCError<u64, BasicNode, RaftError<u64, InstallSnapshotError>>,
+    > {
+        self.call(|tx| RaftRequest::InstallSnapshot(rpc, tx)).await
+    }
+
+    async fn vote(
+        &mut self,
+        rpc: VoteRequest<u64>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<u64>, RPCError<u64, BasicNode, RaftError<u64>>> {
+        self.call(|tx| RaftRequest::Vote(rpc, tx)).await
+    }
+}

--- a/crates/vibesql-consensus/src/openraft_backend.rs
+++ b/crates/vibesql-consensus/src/openraft_backend.rs
@@ -6,8 +6,13 @@
 //! [`OpenraftBackend::with_data_dir`] persists the log and vote on disk via
 //! [`DurableLogStore`] and recovers them on restart (PR 2). The state machine
 //! is in-memory in both — applying entries to VibeSQL storage is Phase B1.
-//! Multi-node networking is Phase A3 — the network factory here is a no-op
-//! that is never exercised because a single-voter cluster sends no RPCs.
+//!
+//! Raft Phase A3 (PR 1 of #5197) adds `join_channel_cluster` (test-only):
+//! the same backend booted as one voter of an in-process multi-node cluster
+//! whose RPCs travel over the channel transport in `crate::network`. The
+//! TCP transport is PR 2. The single-node constructors keep the no-op
+//! network factory, which is never exercised because a single-voter cluster
+//! sends no RPCs.
 //!
 //! ## Log index mapping
 //!
@@ -83,12 +88,15 @@ struct LogStoreInner {
     vote: Option<Vote<u64>>,
 }
 
-/// In-memory [`RaftLogStorage`] for the single-node Phase A2 configuration.
+/// In-memory [`RaftLogStorage`] for the single-node Phase A2 configuration
+/// (and, via the shared handle, for the in-process cluster tests of Phase
+/// A3: a "restarted" node reopens the same store, which is how it keeps its
+/// log and vote across the restart).
 ///
 /// Cloning shares the underlying store (it is a handle), which is what
 /// openraft expects from `get_log_reader`.
 #[derive(Debug, Clone, Default)]
-struct InMemoryLogStore {
+pub(crate) struct InMemoryLogStore {
     inner: Arc<Mutex<LogStoreInner>>,
 }
 
@@ -330,8 +338,9 @@ impl RaftStateMachine<TypeConfig> for InMemoryStateMachine {
 ///
 /// A single-voter cluster never replicates to peers, so these methods are
 /// unreachable in practice; they return [`Unreachable`] (rather than
-/// panicking) for defense in depth. Phase A3 replaces this with a real
-/// transport.
+/// panicking) for defense in depth. Multi-node configurations use a real
+/// transport instead: the in-process channel network in `crate::network`
+/// (Phase A3, PR 1; test-only), with TCP following in PR 2.
 #[derive(Debug, Default)]
 struct NoopNetwork;
 
@@ -386,17 +395,20 @@ impl openraft::RaftNetworkFactory<TypeConfig> for NoopNetworkFactory {
 // The backend
 // ---------------------------------------------------------------------------
 
-/// How a starting backend obtains its single-voter membership.
+/// How a starting backend obtains its membership.
 #[derive(Debug, Clone, Copy)]
-enum Bootstrap {
-    /// Fresh log: form the cluster by writing the single-voter membership
-    /// entry ([`Raft::initialize`]).
+pub(crate) enum Bootstrap {
+    /// Fresh log: form the cluster by writing the membership entry
+    /// ([`Raft::initialize`]).
     Initialize,
-    /// Prior Raft state was recovered from disk: the membership entry (and
+    /// Prior Raft state was recovered (from disk, or from a kept-alive
+    /// [`InMemoryLogStore`] in cluster tests): the membership entry (and
     /// vote) are already in the log, so re-running `initialize` would be
     /// rejected by openraft. `last_log_index` is the raw index of the last
-    /// recovered entry; startup waits until the state machine has re-applied
-    /// up to it so reads reflect pre-restart state.
+    /// recovered entry; single-node startup waits until the state machine
+    /// has re-applied up to it so reads reflect pre-restart state (cluster
+    /// restarts pass `None` and let the test harness await convergence
+    /// instead).
     Recover { last_log_index: Option<u64> },
 }
 
@@ -509,16 +521,28 @@ impl<E> OpenraftBackend<E> {
         Self::start(log_store, restore.unwrap_or_default(), bootstrap).await
     }
 
-    async fn start<LS>(log_store: LS, entries: Vec<Vec<u8>>, bootstrap: Bootstrap) -> Result<Self>
+    /// Spawn the Raft core: storage + state machine + network, no membership
+    /// yet. Shared by the single-node constructors and the in-process
+    /// cluster constructor; the caller decides how membership is established
+    /// (initialize vs. recovered log) and what to wait for.
+    async fn boot<LS, NF>(
+        node_id: u64,
+        network: NF,
+        log_store: LS,
+        entries: Vec<Vec<u8>>,
+    ) -> Result<Self>
     where
         LS: RaftLogStorage<TypeConfig>,
+        NF: openraft::RaftNetworkFactory<TypeConfig>,
     {
-        // Short election timeouts keep single-node startup snappy; with one
-        // voter there is no contention to back off from.
+        // Short timeouts keep single-node startup and test elections snappy;
+        // the 4x gap between heartbeat and the minimum election timeout
+        // keeps healthy multi-node clusters from triggering spurious
+        // elections.
         let config = Config {
-            heartbeat_interval: 100,
-            election_timeout_min: 150,
-            election_timeout_max: 300,
+            heartbeat_interval: 50,
+            election_timeout_min: 200,
+            election_timeout_max: 400,
             ..Default::default()
         };
         let config =
@@ -530,14 +554,24 @@ impl<E> OpenraftBackend<E> {
         // continue numbering after them.
         state_machine.lock().entries = entries;
 
-        let raft = Raft::new(NODE_ID, config, NoopNetworkFactory, log_store, state_machine.clone())
+        let raft = Raft::new(node_id, config, network, log_store, state_machine.clone())
             .await
             .map_err(|e| ConsensusError::Backend(format!("failed to start raft core: {e}")))?;
+
+        let metrics = raft.metrics();
+        Ok(Self { raft, state_machine, metrics, _entry: PhantomData })
+    }
+
+    async fn start<LS>(log_store: LS, entries: Vec<Vec<u8>>, bootstrap: Bootstrap) -> Result<Self>
+    where
+        LS: RaftLogStorage<TypeConfig>,
+    {
+        let backend = Self::boot(NODE_ID, NoopNetworkFactory, log_store, entries).await?;
 
         if matches!(bootstrap, Bootstrap::Initialize) {
             let mut members = BTreeMap::new();
             members.insert(NODE_ID, BasicNode::default());
-            raft.initialize(members).await.map_err(|e| {
+            backend.raft.initialize(members).await.map_err(|e| {
                 ConsensusError::Backend(format!("failed to initialize cluster: {e}"))
             })?;
         }
@@ -548,7 +582,9 @@ impl<E> OpenraftBackend<E> {
 
         // A single voter elects itself; wait for leadership so `propose`
         // never races the initial election.
-        raft.wait(Some(Duration::from_secs(10)))
+        backend
+            .raft
+            .wait(Some(Duration::from_secs(10)))
             .state(ServerState::Leader, "single-node leader election")
             .await
             .map_err(|e| ConsensusError::Backend(format!("leader election did not settle: {e}")))?;
@@ -558,7 +594,9 @@ impl<E> OpenraftBackend<E> {
             // starts empty on every boot; wait for the recovered log to be
             // re-applied so `read_committed` and `last_index` reflect
             // pre-restart state before the constructor returns.
-            raft.wait(Some(Duration::from_secs(10)))
+            backend
+                .raft
+                .wait(Some(Duration::from_secs(10)))
                 .metrics(
                     move |m| m.last_applied.map_or(0, |id| id.index) >= last,
                     "recovered log entries re-applied",
@@ -569,8 +607,65 @@ impl<E> OpenraftBackend<E> {
                 })?;
         }
 
-        let metrics = raft.metrics();
-        Ok(Self { raft, state_machine, metrics, _entry: PhantomData })
+        Ok(backend)
+    }
+}
+
+#[cfg(test)]
+impl<E> OpenraftBackend<E> {
+    /// Boot one member of an **in-process multi-node cluster** whose RPCs
+    /// are routed through `router` (Raft Phase A3, PR 1 of #5197).
+    ///
+    /// `members` is the full static membership of the cluster (every node
+    /// passes the same map; dynamic add/remove is a later issue). With
+    /// [`Bootstrap::Initialize`] the node writes that membership into its
+    /// fresh log; with [`Bootstrap::Recover`] the membership is already in
+    /// the (kept-alive or on-disk) log being reopened.
+    ///
+    /// Unlike the single-node constructors this does **not** wait for an
+    /// election or for log replay: which node wins, and when a restarted
+    /// node has caught up, are cluster-level outcomes the test harness
+    /// awaits explicitly (with bounded timeouts).
+    pub(crate) async fn join_channel_cluster<LS>(
+        node_id: u64,
+        members: &BTreeMap<u64, BasicNode>,
+        router: &crate::network::ChannelRouter,
+        log_store: LS,
+        bootstrap: Bootstrap,
+    ) -> Result<Self>
+    where
+        LS: RaftLogStorage<TypeConfig>,
+    {
+        let network = crate::network::ChannelNetworkFactory::new(router.clone());
+        let backend = Self::boot(node_id, network, log_store, Vec::new()).await?;
+
+        // Register the inbound RPC loop *before* initializing, so peers that
+        // initialized first can already send this node vote/append RPCs.
+        router.register(node_id, backend.raft.clone());
+
+        if matches!(bootstrap, Bootstrap::Initialize) {
+            match backend.raft.initialize(members.clone()).await {
+                Ok(()) => {}
+                // openraft documents that multiple nodes initializing with
+                // the *same* membership is safe; a node that already voted
+                // for (or received the membership entry from) a faster peer
+                // rejects its own initialize with `NotAllowed`. Both paths
+                // converge on the same membership, so tolerate it.
+                Err(RaftError::APIError(openraft::error::InitializeError::NotAllowed(_))) => {}
+                Err(e) => {
+                    return Err(ConsensusError::Backend(format!(
+                        "failed to initialize cluster: {e}"
+                    )))
+                }
+            }
+        }
+
+        Ok(backend)
+    }
+
+    /// The node this backend currently believes is leader, per its metrics.
+    pub(crate) fn current_leader(&self) -> Option<u64> {
+        self.metrics.borrow().current_leader
     }
 }
 


### PR DESCRIPTION
Part of #5197 (Raft Phase A3 — curator re-scope, PR 1 of 2; PR 2 adds the TCP transport, cluster.toml, and `make test-cluster`).

## Summary

- **Channel transport** (`crates/vibesql-consensus/src/network.rs`, test-only): implements openraft 0.9.24's pluggable network layer — `RaftNetwork` + `RaftNetworkFactory` (the v1 trait names; `storage-v2` does not change the network traits in 0.9.x) — over tokio mpsc/oneshot. A shared `ChannelRouter` maps node ids to per-node inbound queues; each node's server loop feeds RPCs into its local `Raft` (`append_entries` / `vote` / `install_snapshot`), exactly what PR 2's socket listener will do. Killing a node = deregistering it; peers then see `Unreachable`, which openraft treats like a dead socket.
- **Multi-voter boot** (`openraft_backend.rs`): the single-node `start` is refactored into a generic `boot` (node id + network factory) reused by a new test-only `join_channel_cluster` constructor that initializes static N-voter membership (every node passes the same map; openraft documents concurrent same-config `initialize` as safe, and a node beaten to it by a peer tolerates `InitializeError::NotAllowed`). No dynamic membership.
- **`TestCluster` harness + A3 acceptance tests** (`cluster.rs`, test-only): boots N voters (in-memory or durable storage), with `kill(node)`, `restore(node)`, `wait_for_leader()`, `wait_for_apply(node, idx)`. All synchronization is bounded polling with explicit 10s timeouts — no bare sleeps.

## Deterministic multi-node tests

1. `boot_elects_leader_and_replicates_to_all` — 3-node cold start elects exactly one leader; a proposal on the leader applies on all 3 and `read_committed` agrees.
2. `killing_the_leader_elects_a_new_one_and_writes_resume` — survivors elect a new leader; writes commit on the remaining majority.
3. `restored_follower_catches_up_via_log_replication` — a killed follower misses 5 writes, then converges via AppendEntries backfill after restore (entry counts stay far below any purge threshold; snapshot transfer is #5198).
4. `propose_on_follower_surfaces_not_leader_with_hint` — **decision**: proposing on a follower surfaces a *typed error*, `ConsensusError::NotLeader { leader_hint }`, rather than auto-forwarding. This keeps the adapter thin and the failure mode explicit; callers retry against the hint. Leader-aware routing/read semantics are revisited in B2 (#5200).
5. `durable_node_recovers_from_disk_and_rejoins` — a durable-storage follower is killed, recovers its log + vote from `raft.log` on disk, rejoins, and catches up.

Shared Raft config now uses heartbeat 50ms / election 200–400ms (4x margin so healthy clusters don't trigger spurious elections; single-node behavior unchanged).

## Verification

- `cargo test -p vibesql-consensus`: 46 passed (41 pre-existing incl. full conformance suite + 5 new), ~2s; cluster tests stable across 5 repeated runs.
- `cargo clippy -p vibesql-consensus --all-targets`: clean.
- `cargo build --workspace`: green.

## Out of scope (per curator plan)

- TCP transport, ports, `cluster.toml`, `make test-cluster` (PR 2)
- Snapshot transfer / log-purge catch-up (#5198)
- Dynamic membership changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)