### PR TITLE
fix(executor): thread CTE context into UPDATE ... FROM RETURNING

### DIFF
--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -191,6 +191,7 @@ pub(super) fn execute_internal(
             has_triggers,
             &pk_indices,
             trigger_context,
+            cte_results.as_ref(),
         );
     }
 
@@ -1236,6 +1237,7 @@ fn execute_update_from(
     has_triggers: bool,
     pk_indices: &Option<Vec<usize>>,
     trigger_context: Option<&crate::trigger_execution::TriggerContext<'_>>,
+    cte_results: Option<&std::collections::HashMap<String, crate::select::cte::CteResult>>,
 ) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
     // Execute the join and get matched rows with computed SET values
     // Issue #5082: pass trigger_context so the synthetic SELECT can resolve
@@ -1272,7 +1274,7 @@ fn execute_update_from(
                 vibesql_ast::TriggerEvent::Update(None),
             )?;
         }
-        return Ok((0, empty_returning(stmt, schema, database)?));
+        return Ok((0, empty_returning(stmt, schema, database, cte_results)?));
     }
 
     // Validate constraints for each update.
@@ -1549,7 +1551,7 @@ fn execute_update_from(
                 vibesql_ast::TriggerEvent::Update(None),
             )?;
         }
-        return Ok((0, empty_returning(stmt, schema, database)?));
+        return Ok((0, empty_returning(stmt, schema, database, cte_results)?));
     }
 
     // Cross-update uniqueness validation: catches multiple updates landing on the
@@ -1691,9 +1693,9 @@ fn execute_update_from(
     // Mark pk_indices as used (it's available for future enhancements)
     let _ = pk_indices;
 
-    // Project RETURNING items against the NEW rows (SQLite 3.35.0+).
-    // UPDATE ... FROM does not currently thread WITH-clause CTEs into this
-    // path, so no CTE context is available here.
+    // Project RETURNING items against the NEW rows (SQLite 3.35.0+), with
+    // the statement's WITH-clause CTEs (if any) visible to subqueries in
+    // RETURNING expressions (issue #5363).
     let returning = if let Some(items) = &stmt.returning {
         let new_rows: Vec<&Row> = updates.iter().map(|u| &u.new_row).collect();
         Some(crate::dml_returning::project_returning(
@@ -1702,7 +1704,7 @@ fn execute_update_from(
             database,
             stmt.alias.as_deref(),
             &new_rows,
-            None,
+            cte_results,
         )?)
     } else {
         None
@@ -1718,6 +1720,7 @@ fn empty_returning(
     stmt: &UpdateStmt,
     schema: &vibesql_catalog::TableSchema,
     database: &Database,
+    cte_results: Option<&std::collections::HashMap<String, crate::select::cte::CteResult>>,
 ) -> Result<Option<crate::select::SelectResult>, ExecutorError> {
     stmt.returning
         .as_ref()
@@ -1728,7 +1731,7 @@ fn empty_returning(
                 database,
                 stmt.alias.as_deref(),
                 &[],
-                None,
+                cte_results,
             )
         })
         .transpose()

--- a/crates/vibesql-executor/tests/with_update_from_cte_tests.rs
+++ b/crates/vibesql-executor/tests/with_update_from_cte_tests.rs
@@ -1,0 +1,250 @@
+//! Regression tests for issue #5363
+//!
+//! `UPDATE ... FROM` (the multi-table UPDATE extension) takes a separate
+//! execution path (`execute_update_from`) from plain UPDATE. After #5362
+//! threaded WITH-clause CTE context into plain UPDATE/DELETE RETURNING,
+//! the UPDATE ... FROM path still passed `None` to
+//! `dml_returning::project_returning`, so a CTE-referencing subquery in
+//! RETURNING failed with "Table not found" even though the same CTE was
+//! already visible to SET and WHERE subqueries (those run inside a
+//! synthetic SELECT that carries the statement's `with_clause`).
+//!
+//! Repro from the issue:
+//!
+//! ```sql
+//! CREATE TABLE t(a INTEGER, b INTEGER);
+//! INSERT INTO t VALUES(1, 0);
+//! CREATE TABLE s(a INTEGER, v INTEGER);
+//! INSERT INTO s VALUES(1, 7);
+//! WITH c AS (SELECT 100 AS bonus)
+//! UPDATE t SET b = s.v FROM s WHERE t.a = s.a
+//! RETURNING b, (SELECT bonus FROM c);
+//! -- sqlite3 3.51.0: returns 7|100
+//! -- VibeSQL used to fail: Table 'c' not found
+//! ```
+//!
+//! CTE precedence matches #5350/#5352 semantics: CTE names shadow same-named
+//! catalog tables/views and resolve ASCII case-insensitively.
+//!
+//! All expected values below were verified against sqlite3 3.51.0.
+
+use vibesql_executor::{SelectExecutor, UpdateExecutor};
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert)
+                .unwrap_or_else(|e| panic!("Insert failed: {} -- {:?}", sql, e));
+        }
+        vibesql_ast::Statement::Update(update) => {
+            UpdateExecutor::execute(&update, db)
+                .unwrap_or_else(|e| panic!("Update failed: {} -- {:?}", sql, e));
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+fn query(db: &vibesql_storage::Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e))
+            .into_iter()
+            .map(|row| row.values.to_vec())
+            .collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+/// Run an UPDATE and return (affected_count, RETURNING rows).
+fn run_update_returning(
+    db: &mut vibesql_storage::Database,
+    sql: &str,
+) -> (usize, Vec<Vec<SqlValue>>) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    let vibesql_ast::Statement::Update(update) = stmt else {
+        panic!("Expected UPDATE statement: {}", sql);
+    };
+    let (count, returning) = UpdateExecutor::execute_returning(&update, db)
+        .unwrap_or_else(|e| panic!("Update failed: {} -- {:?}", sql, e));
+    let rows = returning
+        .expect("RETURNING result expected")
+        .rows
+        .into_iter()
+        .map(|row| row.values.to_vec())
+        .collect();
+    (count, rows)
+}
+
+/// Standard two-table fixture: t(a, b) = (1, 0); s(a, v) = (1, 7).
+fn setup_t_and_s(db: &mut vibesql_storage::Database) {
+    run_stmt(db, "CREATE TABLE t(a INTEGER, b INTEGER)");
+    run_stmt(db, "INSERT INTO t VALUES(1, 0)");
+    run_stmt(db, "CREATE TABLE s(a INTEGER, v INTEGER)");
+    run_stmt(db, "INSERT INTO s VALUES(1, 7)");
+}
+
+/// The exact repro from issue #5363 (sqlite3: returns 7|100).
+#[test]
+fn test_update_from_returning_cte_subquery() {
+    let mut db = vibesql_storage::Database::new();
+    setup_t_and_s(&mut db);
+
+    let (count, rows) = run_update_returning(
+        &mut db,
+        "WITH c AS (SELECT 100 AS bonus) \
+         UPDATE t SET b = s.v FROM s WHERE t.a = s.a \
+         RETURNING b, (SELECT bonus FROM c)",
+    );
+    assert_eq!(count, 1);
+    assert_eq!(rows, vec![vec![SqlValue::Integer(7), SqlValue::Integer(100)]]);
+    assert_eq!(query(&db, "SELECT b FROM t"), vec![vec![SqlValue::Integer(7)]]);
+}
+
+/// CTE referenced from both a SET subquery and a RETURNING subquery in the
+/// same UPDATE ... FROM statement (sqlite3: returns 107|101).
+#[test]
+fn test_update_from_cte_in_set_and_returning() {
+    let mut db = vibesql_storage::Database::new();
+    setup_t_and_s(&mut db);
+
+    let (count, rows) = run_update_returning(
+        &mut db,
+        "WITH c AS (SELECT 100 AS bonus) \
+         UPDATE t SET b = s.v + (SELECT bonus FROM c) FROM s WHERE t.a = s.a \
+         RETURNING b, (SELECT bonus FROM c) + 1",
+    );
+    assert_eq!(count, 1);
+    assert_eq!(rows, vec![vec![SqlValue::Integer(107), SqlValue::Integer(101)]]);
+}
+
+/// The CTE itself is the FROM source of UPDATE ... FROM, and RETURNING also
+/// references it (sqlite3: 1|50|60 and 2|60|60).
+#[test]
+fn test_update_from_cte_as_from_source() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER, b INTEGER)");
+    run_stmt(&mut db, "INSERT INTO t VALUES(1, 0)");
+    run_stmt(&mut db, "INSERT INTO t VALUES(2, 0)");
+
+    let (count, mut rows) = run_update_returning(
+        &mut db,
+        "WITH src(a, v) AS (VALUES(1, 50), (2, 60)) \
+         UPDATE t SET b = src.v FROM src WHERE t.a = src.a \
+         RETURNING a, b, (SELECT max(v) FROM src)",
+    );
+    assert_eq!(count, 2);
+    rows.sort_by(|x, y| x[0].partial_cmp(&y[0]).unwrap());
+    assert_eq!(
+        rows,
+        vec![
+            vec![SqlValue::Integer(1), SqlValue::Integer(50), SqlValue::Integer(60)],
+            vec![SqlValue::Integer(2), SqlValue::Integer(60), SqlValue::Integer(60)],
+        ]
+    );
+    assert_eq!(
+        query(&db, "SELECT a, b FROM t ORDER BY a"),
+        vec![
+            vec![SqlValue::Integer(1), SqlValue::Integer(50)],
+            vec![SqlValue::Integer(2), SqlValue::Integer(60)],
+        ]
+    );
+}
+
+/// CTE names resolve ASCII case-insensitively in UPDATE ... FROM RETURNING
+/// (sqlite3: returns 7|100|100).
+#[test]
+fn test_update_from_returning_cte_case_insensitive() {
+    let mut db = vibesql_storage::Database::new();
+    setup_t_and_s(&mut db);
+
+    let (count, rows) = run_update_returning(
+        &mut db,
+        "WITH MyCte AS (SELECT 100 AS bonus) \
+         UPDATE t SET b = s.v FROM s WHERE t.a = s.a \
+         RETURNING b, (SELECT bonus FROM MYCTE), (SELECT bonus FROM mycte)",
+    );
+    assert_eq!(count, 1);
+    assert_eq!(
+        rows,
+        vec![vec![SqlValue::Integer(7), SqlValue::Integer(100), SqlValue::Integer(100)]]
+    );
+}
+
+/// A CTE shadows a same-named catalog table inside the RETURNING subquery
+/// (sqlite3: returns 7|100, not the catalog table's 999).
+#[test]
+fn test_update_from_returning_cte_shadows_catalog_table() {
+    let mut db = vibesql_storage::Database::new();
+    setup_t_and_s(&mut db);
+    run_stmt(&mut db, "CREATE TABLE c(bonus INTEGER)");
+    run_stmt(&mut db, "INSERT INTO c VALUES(999)");
+
+    let (count, rows) = run_update_returning(
+        &mut db,
+        "WITH c AS (SELECT 100 AS bonus) \
+         UPDATE t SET b = s.v FROM s WHERE t.a = s.a \
+         RETURNING b, (SELECT bonus FROM c)",
+    );
+    assert_eq!(count, 1);
+    assert_eq!(rows, vec![vec![SqlValue::Integer(7), SqlValue::Integer(100)]]);
+
+    // The catalog table is untouched.
+    assert_eq!(query(&db, "SELECT bonus FROM c"), vec![vec![SqlValue::Integer(999)]]);
+}
+
+/// Zero rows matched: RETURNING yields no rows and the CTE reference must
+/// not error (sqlite3: empty result, no error).
+#[test]
+fn test_update_from_returning_cte_zero_rows() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER, b INTEGER)");
+    run_stmt(&mut db, "INSERT INTO t VALUES(1, 0)");
+    run_stmt(&mut db, "CREATE TABLE s(a INTEGER, v INTEGER)");
+    // s is empty: the join matches nothing.
+
+    let (count, rows) = run_update_returning(
+        &mut db,
+        "WITH c AS (SELECT 100 AS bonus) \
+         UPDATE t SET b = s.v FROM s WHERE t.a = s.a \
+         RETURNING b, (SELECT bonus FROM c)",
+    );
+    assert_eq!(count, 0);
+    assert!(rows.is_empty());
+    assert_eq!(query(&db, "SELECT b FROM t"), vec![vec![SqlValue::Integer(0)]]);
+}
+
+/// Regression guard for the already-working paths: CTE subqueries in SET and
+/// WHERE of UPDATE ... FROM (sqlite3: b = 107, then b = 7 for the WHERE case).
+#[test]
+fn test_update_from_cte_in_set_and_where_regression() {
+    let mut db = vibesql_storage::Database::new();
+    setup_t_and_s(&mut db);
+
+    // SET subquery referencing the CTE (sqlite3: b = 107).
+    run_stmt(
+        &mut db,
+        "WITH c AS (SELECT 100 AS bonus) \
+         UPDATE t SET b = s.v + (SELECT bonus FROM c) FROM s WHERE t.a = s.a",
+    );
+    assert_eq!(query(&db, "SELECT b FROM t"), vec![vec![SqlValue::Integer(107)]]);
+
+    // WHERE subquery referencing the CTE (sqlite3: b = 7).
+    run_stmt(
+        &mut db,
+        "WITH c AS (SELECT 1 AS k) \
+         UPDATE t SET b = s.v FROM s WHERE t.a = s.a AND t.a = (SELECT k FROM c)",
+    );
+    assert_eq!(query(&db, "SELECT b FROM t"), vec![vec![SqlValue::Integer(7)]]);
+}


### PR DESCRIPTION
Closes #5363

## Root cause

`WITH c AS (SELECT 100 AS bonus) UPDATE t SET b = s.v FROM s WHERE t.a = s.a RETURNING b, (SELECT bonus FROM c)` failed with `Table 'c' not found` (sqlite3 3.51.0 returns `7|100`). `execute_internal` materializes the statement's CTEs before dispatching to `execute_update_from`, but never passed them along: the UPDATE ... FROM path's `project_returning` call and the zero-rows `empty_returning` helper both hardcoded `None` for the CTE param added in #5362 (the #5362 PR flagged this gap explicitly as out of scope).

SET and WHERE subqueries — and the FROM source itself — already see the CTEs because `execute_update_from_join` builds a synthetic SELECT that clones `stmt.with_clause`. Only the RETURNING projection (which runs outside the synthetic SELECT) was blind.

## Fix

`crates/vibesql-executor/src/update/executor.rs`, plumbing only:
- `execute_update_from` gains a `cte_results` param; the dispatch site in `execute_internal` passes `cte_results.as_ref()`
- the final `project_returning` call passes it through (was `None`)
- `empty_returning` (zero-rows RETURNING, called only from the UPDATE ... FROM path) gains the same param; both call sites pass it through (was `None`)

Audited the rest of the path: no other `None` placeholder sites. The view INSTEAD OF path (`update/triggers.rs`) intentionally keeps `None` per #5362. DELETE has no FROM/USING variant in the AST (`DeleteStmt` has no such field), so no analogous gap exists there. Precedence matches #5350/#5352 semantics: CTEs shadow same-named catalog tables and resolve ASCII case-insensitively.

## Tests

New integration file `crates/vibesql-executor/tests/with_update_from_cte_tests.rs` (7 tests, sibling of `with_insert_cte_tests.rs`); every expectation verified side by side with sqlite3 3.51.0:
- the issue repro (`7|100`)
- CTE in SET and RETURNING together (`107|101`)
- CTE as the FROM source itself with RETURNING (`1|50|60` / `2|60|60` — SQLite allows a WITH-clause CTE as the UPDATE ... FROM source, and VibeSQL already did too via the synthetic SELECT; now RETURNING can reference it as well)
- case-insensitive CTE resolution in RETURNING (`7|100|100`)
- CTE shadowing a same-named catalog table in RETURNING (`7|100`, catalog table untouched)
- zero rows matched: empty RETURNING, no error (exercises `empty_returning`)
- regression guard for the already-working SET/WHERE subquery paths

## Test evidence

- `cargo test -p vibesql-executor`: 48 suites, 674 tests passed, 0 failures
- New file: 7/7 pass
- TCL `with1/with2/with3/update/update2/upfrom1/upfrom2/upfrom3/returning1`: per-test results byte-identical to a baseline build of the same base commit without the fix (only diff: PID-stamped temp paths in returning1 error text). with2 40/68, with3 3/12, upfrom1 19/22, upfrom2 31/64, upfrom3 23/26, returning1 51/79, update 124/124 — all failures pre-existing; with1 and update2 abort mid-file on pre-existing TCL shim errors in both runs. Zero new failures, zero regressions.
- End-to-end CLI check: the issue repro returns `7|100` on the fixed build

🤖 Generated with [Claude Code](https://claude.com/claude-code)